### PR TITLE
caniuse pollish num 2

### DIFF
--- a/mcpjam-inspector/.gitignore
+++ b/mcpjam-inspector/.gitignore
@@ -82,3 +82,6 @@ sdk/mcp-client-manager/dist/
 .idea/
 
 .env.local
+
+# local-only dev artifacts
+.local/

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -213,7 +213,14 @@ import {
   HOST_TEMPLATES,
   seedFromHostTemplate,
   type HostTemplateId,
-} from "@/lib/client-templates";
+} from "@mcpjam/sdk/host-config/templates";
+import {
+  HOST_VERIFY_TAB_PARAM,
+  HOST_VERIFY_TEMPLATE_PARAM,
+  hostFocusTabToVerifyParam,
+  parseHostVerifyTabParam,
+} from "./components/hosts/host-verify-deep-link";
+import type { HostFocusTabId } from "./components/hosts/redesigned/types";
 import {
   buildHostsPath,
   buildOrganizationPath,
@@ -708,11 +715,17 @@ function useTemplateVerifyDeepLink({
   const { createHost } = useHostMutations();
   const requestedTemplateId = useMemo<HostTemplateId | null>(() => {
     if (typeof window === "undefined") return null;
-    const raw = new URLSearchParams(window.location.search).get("template");
+    const raw = new URLSearchParams(window.location.search).get(
+      HOST_VERIFY_TEMPLATE_PARAM
+    );
     if (!raw) return null;
     return HOST_TEMPLATES.some((t) => t.id === raw)
       ? (raw as HostTemplateId)
       : null;
+  }, []);
+  const requestedFocusTab = useMemo<HostFocusTabId | null>(() => {
+    if (typeof window === "undefined") return null;
+    return parseHostVerifyTabParam(window.location.search);
   }, []);
   const handledRef = useRef(false);
 
@@ -728,7 +741,9 @@ function useTemplateVerifyDeepLink({
 
     const existing = hosts.find((h) => h.name === template.label);
     if (existing) {
-      navigate(buildHostsPath(existing.hostId), { replace: true });
+      navigate(buildHostVerifyLandingPath(existing.hostId, requestedFocusTab), {
+        replace: true,
+      });
       return;
     }
 
@@ -740,7 +755,9 @@ function useTemplateVerifyDeepLink({
           name: template.label,
           input: { ...seed, serverIds: [] },
         });
-        navigate(buildHostsPath(hostId), { replace: true });
+        navigate(buildHostVerifyLandingPath(hostId, requestedFocusTab), {
+          replace: true,
+        });
       } catch (err) {
         // Let the user retry (e.g. via the same link) after a transient failure.
         handledRef.current = false;
@@ -755,10 +772,23 @@ function useTemplateVerifyDeepLink({
     hostsLoading,
     hosts,
     projectId,
+    requestedFocusTab,
     themeMode,
     createHost,
     navigate,
   ]);
+}
+
+function buildHostVerifyLandingPath(
+  hostId: string,
+  tab: HostFocusTabId | null
+): string {
+  const path = buildHostsPath(hostId);
+  if (!tab) return path;
+  const tabParam = hostFocusTabToVerifyParam(tab);
+  if (!tabParam) return path;
+  const params = new URLSearchParams({ [HOST_VERIFY_TAB_PARAM]: tabParam });
+  return `${path}?${params.toString()}`;
 }
 
 export function HostCompareRoute({ bare = false }: { bare?: boolean } = {}) {

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -2008,9 +2008,16 @@ export default function App() {
   // reach HostsRoute so it can open/create that client's host. Without this
   // guard the first-run onboarding redirect below fires on the fresh load and
   // navigates to Playground, dropping the `?template` param before it's handled.
+  // Only a *known* template id suppresses onboarding — an unknown/stale value
+  // (e.g. `?template=bogus` from an old link) is never consumed by the deep-link
+  // handler, so treating it as a real deep-link would strand new users on an
+  // empty surface with onboarding silently disabled.
   const hasHostTemplateVerifyParam =
     typeof window !== "undefined" &&
-    new URLSearchParams(window.location.search).has("template");
+    (() => {
+      const raw = new URLSearchParams(window.location.search).get("template");
+      return raw != null && HOST_TEMPLATES.some((t) => t.id === raw);
+    })();
   const shouldRouteToFirstRunOnboarding =
     !isHostedChatRoute &&
     !isBareCaniuseRoute &&

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -204,6 +204,7 @@ import {
   type McpProtocolVersion,
 } from "@mcpjam/sdk/browser";
 import {
+  cloneHostTemplateInput,
   gateMcpToolResultImageRenderingByModelVisibility,
   resolveEffectiveMcpProtocolVersion,
 } from "./lib/client-config-v2";
@@ -749,7 +750,10 @@ function useTemplateVerifyDeepLink({
 
     void (async () => {
       try {
-        const seed = seedFromHostTemplate(template.id, { theme: themeMode });
+        const seed = cloneHostTemplateInput(
+          seedFromHostTemplate(template.id, { theme: themeMode }),
+          { themeMode }
+        );
         const { hostId } = await createHost({
           projectId,
           name: template.label,

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -49,6 +49,7 @@ import { SupportTab } from "./components/SupportTab";
 import { RegistryTab } from "./components/RegistryTab";
 import { HostsTab } from "./components/HostsTab";
 import { HostConfigCompareView } from "./components/hosts/comparison/HostConfigCompareView";
+import { CaniuseCapabilityPage } from "./components/hosts/comparison/CaniuseCapabilityPage";
 import { HostSectionTabs } from "./components/hosts/HostSectionTabs";
 import { ConnectViewHeader } from "./components/hosts/ConnectViewHeader";
 import { ComputerView } from "./components/computer/ComputerView";
@@ -207,6 +208,12 @@ import {
   resolveEffectiveMcpProtocolVersion,
 } from "./lib/client-config-v2";
 import type { ProjectServerConfigDto } from "./lib/project-server-config";
+import { useHostList, useHostMutations } from "@/hooks/useClients";
+import {
+  HOST_TEMPLATES,
+  seedFromHostTemplate,
+  type HostTemplateId,
+} from "@/lib/client-templates";
 import {
   buildHostsPath,
   buildOrganizationPath,
@@ -637,6 +644,12 @@ export function HostsRoute() {
     [navigate]
   );
 
+  useTemplateVerifyDeepLink({
+    isAuthenticated,
+    projectId: convexProjectId,
+    navigate,
+  });
+
   if (!isAuthenticated) {
     return <ServersTabBody />;
   }
@@ -650,6 +663,83 @@ export function HostsRoute() {
       serversTabElement={<ServersTabBody />}
     />
   );
+}
+
+/**
+ * "Verify against your server" deep-link from the public caniuse surface.
+ * `/hosts?template=claude` opens that client's host, creating it from the
+ * template (matched by name) when the account doesn't already have one — then
+ * navigates to `/hosts/:hostId`, which drops the query param. Runs once per
+ * mount; guests are covered because host creation doesn't require a full login.
+ */
+function useTemplateVerifyDeepLink({
+  isAuthenticated,
+  projectId,
+  navigate,
+}: {
+  isAuthenticated: boolean;
+  projectId: string;
+  navigate: (to: string, options?: { replace?: boolean }) => void;
+}) {
+  const themeMode = usePreferencesStore((s) => s.themeMode);
+  const { hosts, isLoading: hostsLoading } = useHostList({
+    isAuthenticated,
+    projectId,
+  });
+  const { createHost } = useHostMutations();
+  const requestedTemplateId = useMemo<HostTemplateId | null>(() => {
+    if (typeof window === "undefined") return null;
+    const raw = new URLSearchParams(window.location.search).get("template");
+    if (!raw) return null;
+    return HOST_TEMPLATES.some((t) => t.id === raw)
+      ? (raw as HostTemplateId)
+      : null;
+  }, []);
+  const handledRef = useRef(false);
+
+  useEffect(() => {
+    if (!requestedTemplateId || !isAuthenticated || handledRef.current) return;
+    // Wait for the host list before deciding create-vs-open. `useHostList`
+    // stays loading while `projectId` is still a placeholder, so this also
+    // guards `createHost` from firing with a not-yet-real project id.
+    if (hostsLoading) return;
+    const template = HOST_TEMPLATES.find((t) => t.id === requestedTemplateId);
+    if (!template) return;
+    handledRef.current = true;
+
+    const existing = hosts.find((h) => h.name === template.label);
+    if (existing) {
+      navigate(buildHostsPath(existing.hostId), { replace: true });
+      return;
+    }
+
+    void (async () => {
+      try {
+        const seed = seedFromHostTemplate(template.id, { theme: themeMode });
+        const { hostId } = await createHost({
+          projectId,
+          name: template.label,
+          input: { ...seed, serverIds: [] },
+        });
+        navigate(buildHostsPath(hostId), { replace: true });
+      } catch (err) {
+        // Let the user retry (e.g. via the same link) after a transient failure.
+        handledRef.current = false;
+        toast.error(
+          err instanceof Error ? err.message : "Couldn't open that client"
+        );
+      }
+    })();
+  }, [
+    requestedTemplateId,
+    isAuthenticated,
+    hostsLoading,
+    hosts,
+    projectId,
+    themeMode,
+    createHost,
+    navigate,
+  ]);
 }
 
 export function HostCompareRoute({ bare = false }: { bare?: boolean } = {}) {
@@ -711,6 +801,11 @@ export function HostCompareRoute({ bare = false }: { bare?: boolean } = {}) {
       <div className="min-h-0 flex-1">{compareView}</div>
     </motion.div>
   );
+}
+
+export function CaniuseCapabilityRoute() {
+  const params = useParams<{ capabilitySlug?: string }>();
+  return <CaniuseCapabilityPage capabilitySlug={params.capabilitySlug} />;
 }
 
 export function ComputerRoute() {
@@ -1384,11 +1479,11 @@ export default function App() {
   const isChatboxChatRoute =
     !exitedChatboxChat && hostedRouteKind === "chatbox";
 
-  // Chrome-less host-compare for vanity domains (caniuse.dev): rendered
-  // full-bleed without the sidebar/header, and the first-run onboarding
-  // redirect is suppressed so guests land directly on the comparison.
-  const isBareCompareRoute =
-    window.location.pathname === routePaths.embedHostCompare;
+  // Chrome-less caniuse.dev surfaces: render full-bleed without the
+  // sidebar/header, and suppress first-run onboarding so guests land directly.
+  const isBareCaniuseRoute =
+    window.location.pathname === routePaths.embedHostCompare ||
+    window.location.pathname.startsWith(`${routePaths.capabilities}/`);
 
   useEffect(() => {
     setEvaluateRunsFlagsLoaded(posthog.featureFlags?.hasLoadedFlags === true);
@@ -1890,9 +1985,17 @@ export default function App() {
       !areServersHydrated ||
       !activeProjectId ||
       activeProjectId === "none");
+  // A "Verify against your server" deep-link (`/hosts?template=claude`) must
+  // reach HostsRoute so it can open/create that client's host. Without this
+  // guard the first-run onboarding redirect below fires on the fresh load and
+  // navigates to Playground, dropping the `?template` param before it's handled.
+  const hasHostTemplateVerifyParam =
+    typeof window !== "undefined" &&
+    new URLSearchParams(window.location.search).has("template");
   const shouldRouteToFirstRunOnboarding =
     !isHostedChatRoute &&
-    !isBareCompareRoute &&
+    !isBareCaniuseRoute &&
+    !hasHostTemplateVerifyParam &&
     !isWorkOsLoading &&
     effectiveHostedShellGateState === "ready" &&
     !(isAuthenticated && currentUser === undefined) &&
@@ -3336,8 +3439,8 @@ export default function App() {
     </SidebarProvider>
   );
 
-  // Vanity-domain embed (caniuse.dev): render the matched route
-  // (`HostCompareRoute bare`) full-bleed without the sidebar/header chrome.
+  // Vanity-domain caniuse.dev pages: render the matched route full-bleed
+  // without the sidebar/header chrome.
   // Still nested inside every provider in the return below, so auth, project,
   // and the guest session resolve exactly as on the normal route.
   const bareCompareContent = (
@@ -3426,7 +3529,7 @@ export default function App() {
                     pathToken={chatboxPathToken}
                     onExitChatboxChat={() => setExitedChatboxChat(true)}
                   />
-                ) : isBareCompareRoute ? (
+                ) : isBareCaniuseRoute ? (
                   bareCompareContent
                 ) : (
                   appContent

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -617,25 +617,44 @@ export function HostsRoute() {
     isAuthenticated,
     setHostsTabSelectedHostId,
   } = useAppRouteContext();
-  const [previewedHostId] = usePreviewedHostId(convexProjectId);
+  const [previewedHostId, setPreviewedHostId] =
+    usePreviewedHostId(convexProjectId);
   const params = useParams<{ hostId?: string }>();
   const navigate = useAppNavigate();
+  const routeHostId =
+    params.hostId ??
+    (typeof window !== "undefined" &&
+    window.location.pathname.startsWith(`${routePaths.hosts}/`)
+      ? window.location.pathname
+          .slice(`${routePaths.hosts}/`.length)
+          .split("/")[0]
+      : null);
   const urlHostId = useMemo(() => {
-    if (!params.hostId) return null;
+    if (!routeHostId) return null;
     try {
-      return decodeURIComponent(params.hostId);
+      return decodeURIComponent(routeHostId);
     } catch {
-      return params.hostId;
+      return routeHostId;
     }
-  }, [params.hostId]);
+  }, [routeHostId]);
 
   // URL is the source of truth for the open host canvas. Sync into shared
   // state so `GlobalHostBar`, `onCanvasReplaceHost`, and other surfaces that
   // still read `hostsTabSelectedHostId` stay aligned.
   useEffect(() => {
-    if (hostsTabSelectedHostId === urlHostId) return;
-    setHostsTabSelectedHostId(urlHostId);
-  }, [urlHostId, hostsTabSelectedHostId, setHostsTabSelectedHostId]);
+    if (hostsTabSelectedHostId !== urlHostId) {
+      setHostsTabSelectedHostId(urlHostId);
+    }
+    if (urlHostId && previewedHostId !== urlHostId) {
+      setPreviewedHostId(urlHostId);
+    }
+  }, [
+    urlHostId,
+    hostsTabSelectedHostId,
+    previewedHostId,
+    setHostsTabSelectedHostId,
+    setPreviewedHostId,
+  ]);
 
   const handleSelectHost = useCallback(
     (next: string | null) => {
@@ -2766,7 +2785,7 @@ export default function App() {
         )} plan. Upgrade the organization to continue.`
       );
       navigateToTarget(defaultHubRoute, { replace: true });
-    } else if (activeTab === "clients" && !isAuthenticated) {
+    } else if (activeTab === "clients" && !isAuthenticated && !isAuthLoading) {
       navigateToTarget(defaultHubRoute, { replace: true });
     } else if (activeTab === "registry" && registryEnabled !== true) {
       navigateToTarget(defaultHubRoute, { replace: true });
@@ -2805,6 +2824,7 @@ export default function App() {
     evaluateRunsEnabled,
     xaaEnabled,
     isAuthenticated,
+    isAuthLoading,
     activeTab,
     navigateToTarget,
   ]);

--- a/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
@@ -2785,6 +2785,57 @@ describe("App hosted OAuth callback handling", () => {
     });
   });
 
+  it("keeps host template deep links in place while auth is loading", async () => {
+    clearHostedOAuthPendingState();
+    clearChatboxSession();
+    window.history.replaceState({}, "", "/hosts?template=slack");
+    mockHandleOAuthCallback.mockReset();
+    mockConvexAuthState.isAuthenticated = false;
+    mockConvexAuthState.isLoading = true;
+
+    render(<App />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(window.location.pathname).toBe("/hosts");
+    expect(window.location.search).toBe("?template=slack");
+    expect(screen.queryByTestId("home-tab")).not.toBeInTheDocument();
+  });
+
+  it("syncs direct host URLs into the global previewed host selection", async () => {
+    clearHostedOAuthPendingState();
+    clearChatboxSession();
+    mockUseAppState.mockImplementation(() => ({
+      ...createAppStateMock(),
+      activeProjectId: "project_local",
+      projects: {
+        project_local: {
+          id: "project_local",
+          name: "Project",
+          servers: {},
+          sharedProjectId: "project_shared",
+        },
+      },
+    }));
+    localStorage.setItem(
+      "mcp-previewed-host-id",
+      JSON.stringify({ project_shared: "host-claude" })
+    );
+    window.history.replaceState({}, "", "/hosts/host-slack");
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(JSON.parse(localStorage.getItem("mcp-previewed-host-id") ?? "{}"))
+        .toEqual({
+          project_shared: "host-slack",
+        });
+    });
+    expect(screen.getByTestId("hosts-tab")).toBeInTheDocument();
+  });
+
   it("redirects xaa-flow to home when the xaa flag is disabled", async () => {
     clearHostedOAuthPendingState();
     clearChatboxSession();

--- a/mcpjam-inspector/client/src/components/hosts/comparison/CaniuseCapabilityPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/CaniuseCapabilityPage.tsx
@@ -3,8 +3,10 @@ import { Button } from "@mcpjam/design-system/button";
 import { ChevronLeft } from "lucide-react";
 import { getChatboxHostLogo } from "@/lib/chatbox-client-style";
 import { useClaudeCodeHostEnabled } from "@/hooks/useClaudeCodeHostEnabled";
+import { useHostCatalog } from "@/lib/host-compat/use-host-catalog";
 import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
 import { cn } from "@/lib/utils";
+import { bundledHostCompatCatalog } from "@mcpjam/sdk/host-compat";
 import { SupportChip } from "./support-chip";
 import { buildPresetCompareEntries } from "./host-compare-presets";
 import {
@@ -29,21 +31,23 @@ export function CaniuseCapabilityPage({
   const capability = getCaniuseCapabilityBySlug(capabilitySlug);
   const themeMode = usePreferencesStore((s) => s.themeMode);
   const claudeCodeEnabled = useClaudeCodeHostEnabled();
+  const catalogState = useHostCatalog();
+  const compareCatalog = catalogState.catalog ?? bundledHostCompatCatalog();
   const excludedPresetTemplateIds = useMemo(() => {
-    const excluded = new Set<"claude-code">();
+    const excluded = new Set<string>();
     if (!claudeCodeEnabled) excluded.add("claude-code");
     return excluded;
   }, [claudeCodeEnabled]);
   const presets = useMemo(
     () =>
-      buildPresetCompareEntries(themeMode, {
+      buildPresetCompareEntries(compareCatalog, {
         excludedTemplateIds: excludedPresetTemplateIds,
       }),
-    [themeMode, excludedPresetTemplateIds],
+    [compareCatalog, excludedPresetTemplateIds]
   );
   const hosts = useMemo(
     () => sortCaniusePresetHosts(presets.hosts),
-    [presets.hosts],
+    [presets.hosts]
   );
 
   if (!capability) {
@@ -115,13 +119,13 @@ export function CaniuseCapabilityPage({
             if (!subject) return null;
             const level = getCaniuseSupportLevel(
               capability.field,
-              subject.config,
+              subject.config
             );
             const label = getCaniuseSupportLabel(level);
             const logoSrc = getChatboxHostLogo(
               subject.hostStyle,
               subject.config.chatUiOverride,
-              themeMode,
+              themeMode
             );
             return (
               <div
@@ -158,7 +162,7 @@ function PageShell({ children }: { children: ReactNode }) {
     <main
       className={cn(
         "min-h-[100dvh] bg-background px-4 py-5 text-foreground",
-        "sm:px-6 sm:py-8",
+        "sm:px-6 sm:py-8"
       )}
     >
       <div className="mx-auto w-full max-w-5xl">{children}</div>

--- a/mcpjam-inspector/client/src/components/hosts/comparison/CaniuseCapabilityPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/CaniuseCapabilityPage.tsx
@@ -1,0 +1,167 @@
+import { useMemo, type ReactNode } from "react";
+import { Button } from "@mcpjam/design-system/button";
+import { ChevronLeft } from "lucide-react";
+import { getChatboxHostLogo } from "@/lib/chatbox-client-style";
+import { useClaudeCodeHostEnabled } from "@/hooks/useClaudeCodeHostEnabled";
+import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
+import { cn } from "@/lib/utils";
+import { SupportChip } from "./support-chip";
+import { buildPresetCompareEntries } from "./host-compare-presets";
+import {
+  CANIUSE_LAST_VERIFIED_DATE,
+  buildCaniuseCapabilityPath,
+  getCaniuseCapabilityBySlug,
+  getCaniuseSupportLabel,
+  getCaniuseSupportLevel,
+  sortCaniusePresetHosts,
+} from "./caniuse-capability-catalog";
+
+const INSPECTOR_CTA_URL = "https://app.mcpjam.com";
+const FULL_MATRIX_PATH = "/embed/host-compare";
+
+interface CaniuseCapabilityPageProps {
+  capabilitySlug: string | null | undefined;
+}
+
+export function CaniuseCapabilityPage({
+  capabilitySlug,
+}: CaniuseCapabilityPageProps) {
+  const capability = getCaniuseCapabilityBySlug(capabilitySlug);
+  const themeMode = usePreferencesStore((s) => s.themeMode);
+  const claudeCodeEnabled = useClaudeCodeHostEnabled();
+  const excludedPresetTemplateIds = useMemo(() => {
+    const excluded = new Set<"claude-code">();
+    if (!claudeCodeEnabled) excluded.add("claude-code");
+    return excluded;
+  }, [claudeCodeEnabled]);
+  const presets = useMemo(
+    () =>
+      buildPresetCompareEntries(themeMode, {
+        excludedTemplateIds: excludedPresetTemplateIds,
+      }),
+    [themeMode, excludedPresetTemplateIds],
+  );
+  const hosts = useMemo(
+    () => sortCaniusePresetHosts(presets.hosts),
+    [presets.hosts],
+  );
+
+  if (!capability) {
+    return (
+      <PageShell>
+        <a
+          href={FULL_MATRIX_PATH}
+          className="inline-flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <ChevronLeft className="size-4" />
+          Full matrix
+        </a>
+        <div className="mt-8 rounded-lg border border-border bg-card p-8">
+          <h1 className="text-2xl font-semibold tracking-normal text-foreground">
+            Capability not found
+          </h1>
+          <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
+            This capability permalink does not exist yet.
+          </p>
+        </div>
+      </PageShell>
+    );
+  }
+
+  return (
+    <PageShell>
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <a
+          href={FULL_MATRIX_PATH}
+          className="inline-flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <ChevronLeft className="size-4" />
+          Full matrix
+        </a>
+        <Button asChild size="sm" className="h-9">
+          <a href={INSPECTOR_CTA_URL}>Verify against your server</a>
+        </Button>
+      </div>
+
+      <header className="mt-8">
+        <div className="text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
+          MCP client capability
+        </div>
+        <h1 className="mt-2 text-3xl font-semibold tracking-normal text-foreground sm:text-4xl">
+          {capability.field.label}
+        </h1>
+        {capability.field.description ? (
+          <p className="mt-3 max-w-3xl text-base leading-7 text-muted-foreground">
+            {capability.field.description}
+          </p>
+        ) : null}
+        <div className="mt-4 text-xs text-muted-foreground">
+          Permalink:{" "}
+          <code className="rounded bg-muted px-1.5 py-0.5 text-[11px]">
+            {buildCaniuseCapabilityPath(capability.slug)}
+          </code>
+        </div>
+      </header>
+
+      <section className="mt-8 overflow-hidden rounded-lg border border-border bg-card">
+        <div className="grid grid-cols-[minmax(0,1.5fr)_minmax(100px,0.7fr)_minmax(120px,0.8fr)] border-b border-border bg-muted/50 px-4 py-2 text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
+          <div>Client</div>
+          <div>Status</div>
+          <div>Last verified</div>
+        </div>
+        <div className="divide-y divide-border">
+          {hosts.map((host) => {
+            const subject = presets.subjects[host.hostId];
+            if (!subject) return null;
+            const level = getCaniuseSupportLevel(
+              capability.field,
+              subject.config,
+            );
+            const label = getCaniuseSupportLabel(level);
+            const logoSrc = getChatboxHostLogo(
+              subject.hostStyle,
+              subject.config.chatUiOverride,
+              themeMode,
+            );
+            return (
+              <div
+                key={host.hostId}
+                className="grid grid-cols-[minmax(0,1.5fr)_minmax(100px,0.7fr)_minmax(120px,0.8fr)] items-center gap-3 px-4 py-3 text-sm"
+              >
+                <div className="flex min-w-0 items-center gap-2">
+                  <img
+                    src={logoSrc}
+                    alt=""
+                    className="size-4 shrink-0 object-contain"
+                  />
+                  <span className="truncate font-medium text-foreground">
+                    {subject.hostName}
+                  </span>
+                </div>
+                <div>
+                  <SupportChip level={level} label={label} truncateLabel />
+                </div>
+                <div className="text-xs tabular-nums text-muted-foreground">
+                  {CANIUSE_LAST_VERIFIED_DATE}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+    </PageShell>
+  );
+}
+
+function PageShell({ children }: { children: ReactNode }) {
+  return (
+    <main
+      className={cn(
+        "min-h-[100dvh] bg-background px-4 py-5 text-foreground",
+        "sm:px-6 sm:py-8",
+      )}
+    >
+      <div className="mx-auto w-full max-w-5xl">{children}</div>
+    </main>
+  );
+}

--- a/mcpjam-inspector/client/src/components/hosts/comparison/HostCapabilityListView.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/HostCapabilityListView.tsx
@@ -6,6 +6,7 @@ import type { HostThemeMode } from "@/lib/client-styles";
 import {
   HOST_CONFIG_FIELDS,
   type HostComparisonSubject,
+  type HostConfigFieldDef,
 } from "@/lib/host-config-field-schema";
 import { SupportChip } from "./support-chip";
 import {
@@ -18,6 +19,7 @@ import {
 
 interface HostCapabilityListViewProps {
   subjects: ReadonlyArray<HostComparisonSubject>;
+  fields?: ReadonlyArray<HostConfigFieldDef>;
   divergingOnly?: boolean;
   supportFilter?: SupportFilterMode;
   searchQuery?: string;
@@ -39,6 +41,7 @@ const GROUPS: ReadonlyArray<{ level: SupportLevel; title: string }> = [
 
 export function HostCapabilityListView({
   subjects,
+  fields: allFields = HOST_CONFIG_FIELDS,
   divergingOnly = false,
   supportFilter = "all",
   searchQuery = "",
@@ -49,12 +52,13 @@ export function HostCapabilityListView({
   const visibleFieldIds = useMemo(
     () =>
       computeVisibleFieldIds({
+        fields: allFields,
         configs,
         divergingOnly,
         supportFilter,
         searchQuery,
       }),
-    [configs, divergingOnly, supportFilter, searchQuery]
+    [allFields, configs, divergingOnly, supportFilter, searchQuery]
   );
 
   // Support-shaped, currently-visible fields in registry order. Support-shape
@@ -63,10 +67,8 @@ export function HostCapabilityListView({
   // empty here even when hosts are selected).
   const fields = useMemo(
     () =>
-      HOST_CONFIG_FIELDS.filter(
-        (f) => visibleFieldIds.has(f.id) && isSupportField(f)
-      ),
-    [visibleFieldIds]
+      allFields.filter((f) => visibleFieldIds.has(f.id) && isSupportField(f)),
+    [allFields, visibleFieldIds]
   );
 
   if (subjects.length === 0) {
@@ -126,7 +128,7 @@ function HostListColumn({
 
   // Bucket every visible support-shaped field by its level for this host.
   const byLevel = useMemo(() => {
-    const map: Record<SupportLevel, string[]> = {
+    const map: Record<SupportLevel, HostConfigFieldDef[]> = {
       supported: [],
       partial: [],
       neutral: [],
@@ -134,7 +136,7 @@ function HostListColumn({
     };
     for (const f of fields) {
       const level = getSupportLevel(f, subject.config);
-      if (level) map[level].push(f.label);
+      if (level) map[level].push(f);
     }
     return map;
   }, [fields, subject.config]);
@@ -160,8 +162,8 @@ function HostListColumn({
       </div>
 
       {GROUPS.map(({ level, title }) => {
-        const labels = byLevel[level];
-        if (labels.length === 0) return null;
+        const levelFields = byLevel[level];
+        if (levelFields.length === 0) return null;
         return (
           <div key={level} className="flex flex-col gap-2">
             <div className="flex items-baseline gap-2">
@@ -169,15 +171,15 @@ function HostListColumn({
                 {title}
               </span>
               <span className="text-[10.5px] tabular-nums text-muted-foreground">
-                {labels.length}
+                {levelFields.length}
               </span>
             </div>
             <div className="flex flex-wrap gap-1.5">
-              {labels.map((label) => (
+              {levelFields.map((field) => (
                 <SupportChip
-                  key={label}
+                  key={field.id}
                   level={level}
-                  label={label}
+                  label={field.label}
                   className={cn(level === "neutral" && "opacity-90")}
                   truncateLabel={mobileOptimized}
                 />

--- a/mcpjam-inspector/client/src/components/hosts/comparison/HostCompareSelector.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/HostCompareSelector.tsx
@@ -21,7 +21,7 @@ import type { HostComparisonSubject } from "@/lib/host-config-field-schema";
 import type { HostThemeMode } from "@/lib/client-styles";
 import type { SupportFilterMode } from "./support-level";
 
-const INLINE_CHIP_LIMIT = 6;
+const INITIAL_INLINE_CHIP_LIMIT = 6;
 
 const SUPPORT_FILTERS: ReadonlyArray<{
   value: SupportFilterMode;
@@ -51,9 +51,6 @@ interface HostCompareSelectorProps {
   selectedHostIds: ReadonlyArray<string>;
   subjectsByHost: Readonly<Record<string, HostComparisonSubject>>;
   onToggleHost: (hostId: string) => void;
-  matchCount?: number;
-  totalCount?: number;
-  showCount?: boolean;
   viewMode?: "table" | "list";
   onViewModeChange?: (mode: "table" | "list") => void;
   disableListView?: boolean;
@@ -75,9 +72,6 @@ export function HostCompareSelector({
   selectedHostIds,
   subjectsByHost,
   onToggleHost,
-  matchCount,
-  totalCount,
-  showCount = false,
   viewMode,
   onViewModeChange,
   disableListView = false,
@@ -94,139 +88,97 @@ export function HostCompareSelector({
   mobileOptimized = false,
 }: HostCompareSelectorProps) {
   const selectedSet = new Set(selectedHostIds);
-  const inlineHosts = hosts.slice(0, INLINE_CHIP_LIMIT);
-  const overflowHosts = hosts.slice(INLINE_CHIP_LIMIT);
-  const showMobileViewMode =
-    mobileOptimized && viewMode !== undefined && onViewModeChange !== undefined;
+  const inlineHosts = getInlineCompareHosts(hosts, selectedSet);
+  const inlineHostIds = new Set(inlineHosts.map((host) => host.hostId));
+  const overflowHosts = hosts.filter((host) => !inlineHostIds.has(host.hostId));
 
   return (
     <div
       className={cn(
-        "mb-4 flex flex-wrap items-center gap-2",
+        "mb-4 flex flex-wrap items-start gap-2",
         mobileOptimized && "min-w-0"
       )}
     >
-      {inlineHosts.map((host) => (
-        <HostCompareChip
-          key={host.hostId}
-          host={host}
-          subject={subjectsByHost[host.hostId]}
-          selected={selectedSet.has(host.hostId)}
-          onToggle={() => onToggleHost(host.hostId)}
-          disabled={disabled}
-          themeMode={themeMode}
-        />
-      ))}
+      <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
+        {inlineHosts.map((host) => (
+          <HostCompareChip
+            key={host.hostId}
+            host={host}
+            subject={subjectsByHost[host.hostId]}
+            selected={selectedSet.has(host.hostId)}
+            onToggle={() => onToggleHost(host.hostId)}
+            disabled={disabled}
+            themeMode={themeMode}
+          />
+        ))}
 
-      {overflowHosts.length > 0 ? (
-        <HostCompareOverflowMenu
-          hosts={overflowHosts}
-          selectedSet={selectedSet}
-          subjectsByHost={subjectsByHost}
-          onToggleHost={onToggleHost}
-          disabled={disabled}
-          themeMode={themeMode}
-        />
-      ) : null}
+        {overflowHosts.length > 0 ? (
+          <HostCompareOverflowMenu
+            hosts={overflowHosts}
+            selectedSet={selectedSet}
+            subjectsByHost={subjectsByHost}
+            onToggleHost={onToggleHost}
+            disabled={disabled}
+            themeMode={themeMode}
+          />
+        ) : null}
+      </div>
 
-      {showMobileViewMode ? (
-        <>
-          {showCount && matchCount !== undefined && totalCount !== undefined ? (
-            <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground">
-              {matchCount} / {totalCount} fields
-            </span>
-          ) : null}
+      <div
+        className={cn(
+          "ml-auto flex shrink-0 items-center gap-4",
+          mobileOptimized &&
+            "ml-0 min-w-0 w-full flex-wrap justify-center gap-2 sm:ml-auto sm:w-auto sm:flex-nowrap sm:justify-end sm:gap-3"
+        )}
+      >
+        {mobileOptimized &&
+        viewMode !== undefined &&
+        onViewModeChange !== undefined ? (
+          <CompareViewModeToggle
+            viewMode={viewMode}
+            onViewModeChange={onViewModeChange}
+            disableListView={disableListView}
+            disabled={disabled}
+          />
+        ) : null}
+        {mobileOptimized ? null : (
           <div
             role="group"
-            aria-label="View mode"
-            className="flex shrink-0 items-center gap-0.5 rounded-full border border-border p-0.5"
+            aria-label="Filter by support level"
+            className="flex items-center gap-0.5 rounded-full border border-border p-0.5"
           >
-            {(
-              [
-                { value: "table", label: "Tables" },
-                { value: "list", label: "List" },
-              ] as const
-            ).map((v) => {
-              const active = viewMode === v.value;
-              const viewModeDisabled =
-                disabled || (v.value === "list" && disableListView);
+            {SUPPORT_FILTERS.map((f) => {
+              const active = supportFilter === f.value;
+              const filterDisabled = disabled || supportFiltersDisabled;
               return (
                 <button
-                  key={v.value}
+                  key={f.value}
                   type="button"
-                  aria-pressed={active}
-                  disabled={viewModeDisabled}
+                  disabled={filterDisabled}
                   title={
-                    viewModeDisabled
-                      ? "Turn descriptions off before switching to list view"
-                      : undefined
+                    supportFiltersDisabled
+                      ? "Search for a capability before filtering by support"
+                      : f.title
                   }
-                  data-testid={`compare-view-${v.value}`}
-                  onClick={() => onViewModeChange(v.value)}
+                  aria-pressed={active}
+                  data-testid={`support-filter-${f.value}`}
+                  onClick={() => onSupportFilterChange(f.value)}
                   className={cn(
                     "rounded-full px-2.5 py-0.5 text-[11px] transition-colors",
-                    "disabled:cursor-not-allowed disabled:opacity-40",
+                    mobileOptimized && "shrink-0",
+                    "disabled:cursor-not-allowed disabled:opacity-50",
                     "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
                     active
                       ? "bg-primary/10 text-foreground"
                       : "text-muted-foreground hover:text-foreground"
                   )}
                 >
-                  {v.label}
+                  {f.label}
                 </button>
               );
             })}
           </div>
-        </>
-      ) : null}
-
-      <div
-        className={cn(
-          "ml-auto flex items-center gap-4",
-          mobileOptimized &&
-            "ml-0 min-w-0 w-full flex-wrap gap-2 sm:ml-auto sm:w-auto sm:flex-nowrap sm:gap-4"
         )}
-      >
-        <div
-          role="group"
-          aria-label="Filter by support level"
-          className={cn(
-            "flex items-center gap-0.5 rounded-full border border-border p-0.5",
-            mobileOptimized &&
-              "max-w-full overflow-x-auto [-webkit-overflow-scrolling:touch]"
-          )}
-        >
-          {SUPPORT_FILTERS.map((f) => {
-            const active = supportFilter === f.value;
-            const filterDisabled = disabled || supportFiltersDisabled;
-            return (
-              <button
-                key={f.value}
-                type="button"
-                disabled={filterDisabled}
-                title={
-                  supportFiltersDisabled
-                    ? "Search for a capability before filtering by support"
-                    : f.title
-                }
-                aria-pressed={active}
-                data-testid={`support-filter-${f.value}`}
-                onClick={() => onSupportFilterChange(f.value)}
-                className={cn(
-                  "rounded-full px-2.5 py-0.5 text-[11px] transition-colors",
-                  mobileOptimized && "shrink-0",
-                  "disabled:cursor-not-allowed disabled:opacity-50",
-                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
-                  active
-                    ? "bg-primary/10 text-foreground"
-                    : "text-muted-foreground hover:text-foreground"
-                )}
-              >
-                {f.label}
-              </button>
-            );
-          })}
-        </div>
         <label
           className={cn(
             "flex cursor-pointer items-center gap-2 text-[12px] text-muted-foreground",
@@ -264,6 +216,89 @@ export function HostCompareSelector({
           <span>Only diverging</span>
         </label>
       </div>
+    </div>
+  );
+}
+
+function getInlineCompareHosts(
+  hosts: ReadonlyArray<HostListItem>,
+  selectedSet: ReadonlySet<string>
+): ReadonlyArray<HostListItem> {
+  if (hosts.length <= INITIAL_INLINE_CHIP_LIMIT) return hosts;
+
+  const selectedHosts = hosts.filter((host) => selectedSet.has(host.hostId));
+  if (selectedHosts.length === 0) {
+    return hosts.slice(0, INITIAL_INLINE_CHIP_LIMIT);
+  }
+
+  const fillerCount = Math.max(
+    0,
+    INITIAL_INLINE_CHIP_LIMIT - selectedHosts.length
+  );
+  const fillerIds = new Set(
+    hosts
+      .filter((host) => !selectedSet.has(host.hostId))
+      .slice(0, fillerCount)
+      .map((host) => host.hostId)
+  );
+
+  return hosts.filter(
+    (host) => selectedSet.has(host.hostId) || fillerIds.has(host.hostId)
+  );
+}
+
+function CompareViewModeToggle({
+  viewMode,
+  onViewModeChange,
+  disableListView,
+  disabled,
+}: {
+  viewMode: "table" | "list";
+  onViewModeChange: (mode: "table" | "list") => void;
+  disableListView: boolean;
+  disabled: boolean;
+}) {
+  return (
+    <div
+      role="group"
+      aria-label="View mode"
+      className="flex shrink-0 items-center gap-0.5 rounded-full border border-border p-0.5"
+    >
+      {(
+        [
+          { value: "table", label: "Tables" },
+          { value: "list", label: "List" },
+        ] as const
+      ).map((v) => {
+        const active = viewMode === v.value;
+        const viewModeDisabled =
+          disabled || (v.value === "list" && disableListView);
+        return (
+          <button
+            key={v.value}
+            type="button"
+            aria-pressed={active}
+            disabled={viewModeDisabled}
+            title={
+              viewModeDisabled
+                ? "Turn descriptions off before switching to list view"
+                : undefined
+            }
+            data-testid={`compare-view-${v.value}`}
+            onClick={() => onViewModeChange(v.value)}
+            className={cn(
+              "rounded-full px-2.5 py-0.5 text-[11px] transition-colors",
+              "disabled:cursor-not-allowed disabled:opacity-40",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
+              active
+                ? "bg-primary/10 text-foreground"
+                : "text-muted-foreground hover:text-foreground"
+            )}
+          >
+            {v.label}
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/mcpjam-inspector/client/src/components/hosts/comparison/HostCompareSelector.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/HostCompareSelector.tsx
@@ -61,6 +61,7 @@ interface HostCompareSelectorProps {
   onDivergingOnlyChange: (enabled: boolean) => void;
   supportFilter: SupportFilterMode;
   onSupportFilterChange: (mode: SupportFilterMode) => void;
+  supportFiltersDisabled?: boolean;
   showDescriptions: boolean;
   onShowDescriptionsChange: (enabled: boolean) => void;
   descriptionsDisabled?: boolean;
@@ -84,6 +85,7 @@ export function HostCompareSelector({
   onDivergingOnlyChange,
   supportFilter,
   onSupportFilterChange,
+  supportFiltersDisabled = false,
   showDescriptions,
   onShowDescriptionsChange,
   descriptionsDisabled = false,
@@ -196,12 +198,17 @@ export function HostCompareSelector({
         >
           {SUPPORT_FILTERS.map((f) => {
             const active = supportFilter === f.value;
+            const filterDisabled = disabled || supportFiltersDisabled;
             return (
               <button
                 key={f.value}
                 type="button"
-                disabled={disabled}
-                title={f.title}
+                disabled={filterDisabled}
+                title={
+                  supportFiltersDisabled
+                    ? "Search for a capability before filtering by support"
+                    : f.title
+                }
                 aria-pressed={active}
                 data-testid={`support-filter-${f.value}`}
                 onClick={() => onSupportFilterChange(f.value)}

--- a/mcpjam-inspector/client/src/components/hosts/comparison/HostConfigCompareView.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/HostConfigCompareView.tsx
@@ -1,10 +1,27 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type FormEvent,
+} from "react";
 import { Loader2 } from "lucide-react";
+import { Button } from "@mcpjam/design-system/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@mcpjam/design-system/dialog";
 import {
   Popover,
   PopoverAnchor,
   PopoverContent,
 } from "@mcpjam/design-system/popover";
+import { Textarea } from "@mcpjam/design-system/textarea";
 import {
   Command,
   CommandEmpty,
@@ -33,6 +50,12 @@ import {
   writeHostCompareSelection,
 } from "./host-compare-selection";
 import { buildPresetCompareEntries } from "./host-compare-presets";
+import {
+  PUBLIC_CAN_I_USE_FIELDS,
+  getCaniuseCapabilityBySlug,
+  getCaniuseCapabilityForField,
+  sortCaniusePresetHosts,
+} from "./caniuse-capability-catalog";
 import { HostConfigComparisonMatrix } from "./host-config-comparison-matrix";
 import { HostCapabilityListView } from "./HostCapabilityListView";
 import {
@@ -44,7 +67,6 @@ import {
 import {
   groupHostConfigFields,
   HOST_CONFIG_FIELDS,
-  hostConfigField,
 } from "@/lib/host-config-field-schema";
 import { SearchInput } from "@/components/ui/search-input";
 import { cn } from "@/lib/utils";
@@ -52,6 +74,8 @@ import { cn } from "@/lib/utils";
 type CompareViewMode = "table" | "list";
 
 const HOSTS_QUERY_PARAM = "hosts";
+const CAPABILITY_QUERY_PARAM = "capability";
+const SEARCH_QUERY_PARAM = "q";
 const MAIN_PRODUCT_URL = "https://app.mcpjam.com";
 const MOBILE_COMPARE_MEDIA_QUERY = "(max-width: 640px)";
 const SEARCH_PICKER_HIDDEN_FIELD_IDS = new Set([
@@ -74,6 +98,60 @@ function getInitialCompareViewMode(): CompareViewMode {
 
 function sameStringArray(a: ReadonlyArray<string>, b: ReadonlyArray<string>) {
   return a.length === b.length && a.every((value, index) => value === b[index]);
+}
+
+function normalizeSearchParamValue(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function capabilityForSearchQuery(
+  query: string,
+  fields: ReadonlyArray<HostConfigFieldDef>
+) {
+  const normalized = normalizeSearchParamValue(query);
+  if (!normalized) return null;
+
+  for (const field of fields) {
+    const capability = getCaniuseCapabilityForField(field);
+    if (!capability) continue;
+    const shortFieldId = field.id.replace(/^capabilities\./, "");
+    const exactMatches = [
+      field.label,
+      capability.slug,
+      field.id,
+      shortFieldId,
+    ].map(normalizeSearchParamValue);
+    if (exactMatches.includes(normalized)) return capability;
+  }
+
+  return null;
+}
+
+function fieldSearchQueryFromParams(searchParams: URLSearchParams): string {
+  const capability = getCaniuseCapabilityBySlug(
+    searchParams.get(CAPABILITY_QUERY_PARAM)
+  );
+  if (capability) return capability.field.label;
+  return searchParams.get(SEARCH_QUERY_PARAM) ?? "";
+}
+
+function writeFieldSearchParams(
+  next: URLSearchParams,
+  query: string,
+  fields: ReadonlyArray<HostConfigFieldDef>
+) {
+  const trimmed = query.trim();
+  next.delete(CAPABILITY_QUERY_PARAM);
+  next.delete(SEARCH_QUERY_PARAM);
+  if (!trimmed) return;
+
+  const capability = capabilityForSearchQuery(trimmed, fields);
+  if (capability) {
+    next.set(CAPABILITY_QUERY_PARAM, capability.slug);
+    return;
+  }
+
+  next.set(SEARCH_QUERY_PARAM, trimmed);
 }
 
 interface HostConfigCompareViewProps {
@@ -129,24 +207,28 @@ export function HostConfigCompareView({
   );
 
   // Real created hosts first, then presets — what the selector chips iterate.
-  const hosts = useMemo(
-    () => (presetOnly ? presets.hosts : [...liveHosts, ...presets.hosts]),
-    [liveHosts, presetOnly, presets.hosts]
-  );
+  const hosts = useMemo(() => {
+    if (!presetOnly) return [...liveHosts, ...presets.hosts];
+    return sortCaniusePresetHosts(presets.hosts);
+  }, [liveHosts, presetOnly, presets.hosts]);
 
   const [subjectsByHost, setSubjectsByHost] = useState<
     Record<string, HostComparisonSubject>
   >({});
+  const [searchParams, setSearchParams] = useSearchParams();
   const [selectedHostIds, setSelectedHostIds] = useState<string[]>([]);
   const [divergingOnly, setDivergingOnly] = useState(false);
   const [supportFilter, setSupportFilter] = useState<SupportFilterMode>("all");
-  const [fieldSearchQuery, setFieldSearchQuery] = useState("");
+  const [fieldSearchQuery, setFieldSearchQuery] = useState(() =>
+    fieldSearchQueryFromParams(searchParams)
+  );
   const [viewMode, setViewMode] = useState<CompareViewMode>(() =>
     getInitialCompareViewMode()
   );
   const [showDescriptions, setShowDescriptions] = useState(false);
-  const [searchParams, setSearchParams] = useSearchParams();
   const viewModeUserSetRef = useRef(false);
+  const hasFieldSearchQuery = fieldSearchQuery.trim().length > 0;
+  const effectiveSupportFilter = hasFieldSearchQuery ? supportFilter : "all";
   // Tracks whether the initial URL-driven selection has been applied.
   // After the first resolve, subsequent URL changes are ignored — Compare
   // becomes the source of truth and mirrors back into the URL.
@@ -171,6 +253,28 @@ export function HostConfigCompareView({
   // Every selectable id (real + preset). URL / stored selections reconcile
   // against this so a chosen preset column survives a reload.
   const knownHostIds = useMemo(() => hosts.map((host) => host.hostId), [hosts]);
+  const compareFields = useMemo(
+    () => (presetOnly ? PUBLIC_CAN_I_USE_FIELDS : HOST_CONFIG_FIELDS),
+    [presetOnly]
+  );
+  // Base for the per-column "Verify against your server" deep-link. In dev the
+  // caniuse surface and the hosted app share an origin, so stay on it (localhost)
+  // instead of bouncing to prod; on the prod vanity domain (caniuse.dev) the
+  // hosted app is a different origin, so use the absolute product URL.
+  const verifyBaseUrl = useMemo(() => {
+    if (!presetOnly) return undefined;
+    if (import.meta.env.DEV && typeof window !== "undefined") {
+      return window.location.origin;
+    }
+    return MAIN_PRODUCT_URL;
+  }, [presetOnly]);
+
+  useEffect(() => {
+    const nextQuery = fieldSearchQueryFromParams(searchParams);
+    setFieldSearchQuery((previous) =>
+      previous === nextQuery ? previous : nextQuery
+    );
+  }, [searchParams]);
 
   useEffect(() => {
     if (!presetOnly && !projectId) return;
@@ -205,8 +309,8 @@ export function HostConfigCompareView({
     writeHostCompareSelection(selectionScopeId, selectedHostIds);
   }, [presetOnly, projectId, selectionScopeId, selectedHostIds]);
 
-  // Mirror selection → ?hosts=. Suppress when the selection is the default
-  // (ChatGPT + Claude, in that order) so shared links stay clean.
+  // Mirror selection/search → URL. Suppress `hosts=` when the selection is the
+  // default (ChatGPT + Claude, in that order) so shared links stay clean.
   useEffect(() => {
     if (!presetOnly && !projectId) return;
     if (!urlConsumedRef.current) return;
@@ -221,23 +325,22 @@ export function HostConfigCompareView({
     // are unavailable; `toggleHostCompareSelection` keeps `minSelected=1`),
     // so an empty selection means "not yet resolved."
     if (selectedHostIds.length === 0) return;
+    const next = new URLSearchParams(searchParams);
     const isDefault =
       selectedHostIds.length === DEFAULT_COMPARE_HOST_IDS.length &&
       selectedHostIds.every((id, i) => id === DEFAULT_COMPARE_HOST_IDS[i]);
-    const current = searchParams.get(HOSTS_QUERY_PARAM);
     if (isDefault) {
-      if (current === null) return;
-      const next = new URLSearchParams(searchParams);
       next.delete(HOSTS_QUERY_PARAM);
-      setSearchParams(next, { replace: true });
-      return;
+    } else {
+      next.set(HOSTS_QUERY_PARAM, selectedHostIds.join(","));
     }
-    const desired = selectedHostIds.join(",");
-    if (current === desired) return;
-    const next = new URLSearchParams(searchParams);
-    next.set(HOSTS_QUERY_PARAM, desired);
+
+    writeFieldSearchParams(next, fieldSearchQuery, compareFields);
+    if (next.toString() === searchParams.toString()) return;
     setSearchParams(next, { replace: true });
   }, [
+    compareFields,
+    fieldSearchQuery,
     selectedHostIds,
     listLoading,
     presetOnly,
@@ -349,36 +452,47 @@ export function HostConfigCompareView({
     }
   }, []);
 
+  useEffect(() => {
+    if (hasFieldSearchQuery || supportFilter === "all") return;
+    setSupportFilter("all");
+  }, [hasFieldSearchQuery, supportFilter]);
+
   // "N / M fields" count for the search header — same predicate the matrix and
   // list view use, so the number always matches what's rendered. In list mode
   // only support-shaped rows render, so the count narrows to that subset too.
   const matchCount = useMemo(() => {
+    const useCellSupportFilter =
+      hasFieldSearchQuery && effectiveSupportFilter !== "all";
     const ids = computeVisibleFieldIds({
+      fields: compareFields,
       configs: orderedSubjects.map((s) => s.config),
       divergingOnly,
-      supportFilter,
+      supportFilter: useCellSupportFilter ? "all" : effectiveSupportFilter,
       searchQuery: fieldSearchQuery,
     });
     if (viewMode !== "list") return ids.size;
     let n = 0;
     for (const id of ids) {
-      if (isSupportField(hostConfigField(id))) n += 1;
+      const field = compareFields.find((candidate) => candidate.id === id);
+      if (field && isSupportField(field)) n += 1;
     }
     return n;
   }, [
+    compareFields,
     orderedSubjects,
     divergingOnly,
-    supportFilter,
+    effectiveSupportFilter,
     fieldSearchQuery,
+    hasFieldSearchQuery,
     viewMode,
   ]);
 
   const totalFieldCount = useMemo(
     () =>
       viewMode === "list"
-        ? HOST_CONFIG_FIELDS.filter(isSupportField).length
-        : HOST_CONFIG_FIELDS.length,
-    [viewMode]
+        ? compareFields.filter(isSupportField).length
+        : compareFields.length,
+    [compareFields, viewMode]
   );
 
   if (!presetOnly && !projectId) {
@@ -435,6 +549,7 @@ export function HostConfigCompareView({
             <CompareSearchBar
               query={fieldSearchQuery}
               onQueryChange={setFieldSearchQuery}
+              fields={compareFields}
               matchCount={matchCount}
               totalCount={totalFieldCount}
               showCount={orderedSubjects.length > 0}
@@ -459,6 +574,7 @@ export function HostConfigCompareView({
               onDivergingOnlyChange={setDivergingOnly}
               supportFilter={supportFilter}
               onSupportFilterChange={setSupportFilter}
+              supportFiltersDisabled={!hasFieldSearchQuery}
               showDescriptions={showDescriptions}
               onShowDescriptionsChange={handleShowDescriptionsChange}
               descriptionsDisabled={viewMode === "list"}
@@ -466,6 +582,12 @@ export function HostConfigCompareView({
               themeMode={themeMode}
               mobileOptimized={presetOnly}
             />
+
+            {presetOnly ? (
+              <div className="-mt-2 mb-4 flex justify-end">
+                <ReportInconsistencyDialog />
+              </div>
+            ) : null}
 
             {totalSelectedCount === 0 ? (
               <div className="rounded-xl border border-border bg-card p-10 text-center">
@@ -485,8 +607,9 @@ export function HostConfigCompareView({
                 {viewMode === "table" ? (
                   <HostConfigComparisonMatrix
                     subjects={orderedSubjects}
+                    fields={compareFields}
                     divergingOnly={divergingOnly}
-                    supportFilter={supportFilter}
+                    supportFilter={effectiveSupportFilter}
                     searchQuery={fieldSearchQuery}
                     showDescriptions={showDescriptions}
                     themeMode={themeMode}
@@ -494,12 +617,14 @@ export function HostConfigCompareView({
                     onRemoveHost={
                       selectedHostIdSet.size > 1 ? handleToggleHost : undefined
                     }
+                    verifyBaseUrl={verifyBaseUrl}
                   />
                 ) : (
                   <HostCapabilityListView
                     subjects={orderedSubjects}
+                    fields={compareFields}
                     divergingOnly={divergingOnly}
-                    supportFilter={supportFilter}
+                    supportFilter={effectiveSupportFilter}
                     searchQuery={fieldSearchQuery}
                     themeMode={themeMode}
                     mobileOptimized={presetOnly}
@@ -511,6 +636,131 @@ export function HostConfigCompareView({
         )}
       </div>
     </div>
+  );
+}
+
+function ReportInconsistencyDialog() {
+  const [open, setOpen] = useState(false);
+  const [message, setMessage] = useState("");
+  const [status, setStatus] = useState<
+    "idle" | "submitting" | "succeeded" | "error"
+  >("idle");
+
+  const trimmedMessage = message.trim();
+
+  const handleOpenChange = useCallback((nextOpen: boolean) => {
+    setOpen(nextOpen);
+    if (nextOpen) return;
+    setMessage("");
+    setStatus("idle");
+  }, []);
+
+  const handleSubmit = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (!trimmedMessage || status === "submitting") return;
+
+      setStatus("submitting");
+      try {
+        const response = await fetch("/api/web/caniuse/report-inconsistency", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ message: trimmedMessage }),
+        });
+        if (!response.ok) throw new Error("Report failed");
+        setStatus("succeeded");
+      } catch {
+        setStatus("error");
+      }
+    },
+    [status, trimmedMessage]
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="h-8 rounded-full px-3 text-[12px]"
+        onClick={() => setOpen(true)}
+      >
+        Report inconsistency
+      </Button>
+      <DialogContent className="sm:max-w-[440px]">
+        {status === "succeeded" ? (
+          <>
+            <DialogHeader>
+              <DialogTitle>Thanks for the heads up.</DialogTitle>
+              <DialogDescription>
+                We&apos;ve notified the MCPJam team.
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <Button type="button" onClick={() => handleOpenChange(false)}>
+                Close
+              </Button>
+            </DialogFooter>
+          </>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <DialogHeader>
+              <DialogTitle>Report inconsistency</DialogTitle>
+              <DialogDescription>
+                Tell us what looks inconsistent.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="space-y-2">
+              <label
+                htmlFor="caniuse-report-message"
+                className="text-sm font-medium text-foreground"
+              >
+                What looks inconsistent?
+              </label>
+              <Textarea
+                id="caniuse-report-message"
+                value={message}
+                onChange={(event) => {
+                  setMessage(event.target.value);
+                  if (status === "error") setStatus("idle");
+                }}
+                placeholder="Example: Claude supports this, but the table says it doesn't."
+                className="min-h-[120px] resize-none"
+                autoFocus
+              />
+              {status === "error" ? (
+                <p className="text-[12px] text-destructive">
+                  Couldn&apos;t send report. Please try again.
+                </p>
+              ) : null}
+            </div>
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => handleOpenChange(false)}
+                disabled={status === "submitting"}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                disabled={!trimmedMessage || status === "submitting"}
+              >
+                {status === "submitting" ? (
+                  <>
+                    <Loader2 className="size-4 animate-spin" />
+                    Sending
+                  </>
+                ) : (
+                  "Send report"
+                )}
+              </Button>
+            </DialogFooter>
+          </form>
+        )}
+      </DialogContent>
+    </Dialog>
   );
 }
 
@@ -551,6 +801,7 @@ function HostConfigFetcher({
 function CompareSearchBar({
   query,
   onQueryChange,
+  fields,
   matchCount,
   totalCount,
   showCount,
@@ -561,6 +812,7 @@ function CompareSearchBar({
 }: {
   query: string;
   onQueryChange: (q: string) => void;
+  fields: ReadonlyArray<HostConfigFieldDef>;
   matchCount: number;
   totalCount: number;
   /** Hidden while hosts are still loading — the count would be meaningless. */
@@ -578,11 +830,9 @@ function CompareSearchBar({
   const fieldGroups = useMemo(
     () =>
       groupHostConfigFields(
-        HOST_CONFIG_FIELDS.filter(
-          (field) => !SEARCH_PICKER_HIDDEN_FIELD_IDS.has(field.id)
-        )
+        fields.filter((field) => !SEARCH_PICKER_HIDDEN_FIELD_IDS.has(field.id))
       ),
-    []
+    [fields]
   );
   const filteredFieldGroups = useMemo(() => {
     const loweredQuery = query.trim().toLowerCase();
@@ -673,7 +923,7 @@ function CompareSearchBar({
         </PopoverAnchor>
         <PopoverContent
           align="start"
-          className="w-[min(420px,calc(100vw-2rem))] p-0"
+          className="w-[var(--radix-popover-trigger-width)] p-0"
           onFocusOutside={keepPickerOpenForSearchAnchor}
           onInteractOutside={keepPickerOpenForSearchAnchor}
           onOpenAutoFocus={(event) => event.preventDefault()}

--- a/mcpjam-inspector/client/src/components/hosts/comparison/HostConfigCompareView.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/HostConfigCompareView.tsx
@@ -5,8 +5,9 @@ import {
   useRef,
   useState,
   type FormEvent,
+  type ReactNode,
 } from "react";
-import { Check, Copy, Loader2, Share2 } from "lucide-react";
+import { Bell, Check, Copy, Filter, Flag, Loader2, Share2 } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
 import {
   Dialog,
@@ -20,7 +21,14 @@ import {
   Popover,
   PopoverAnchor,
   PopoverContent,
+  PopoverTrigger,
 } from "@mcpjam/design-system/popover";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@mcpjam/design-system/dropdown-menu";
 import { Textarea } from "@mcpjam/design-system/textarea";
 import {
   Command,
@@ -59,9 +67,7 @@ import {
 import { HostConfigComparisonMatrix } from "./host-config-comparison-matrix";
 import { HostCapabilityListView } from "./HostCapabilityListView";
 import {
-  computeVisibleFieldIds,
   fieldMatchesQuery,
-  isSupportField,
   type SupportFilterMode,
 } from "./support-level";
 import {
@@ -78,6 +84,8 @@ const CAPABILITY_QUERY_PARAM = "capability";
 const SEARCH_QUERY_PARAM = "q";
 const MAIN_PRODUCT_URL = "https://app.mcpjam.com";
 const MOBILE_COMPARE_MEDIA_QUERY = "(max-width: 640px)";
+const CANIUSE_ACTION_BUTTON_CLASS =
+  "h-8 rounded-full border-border bg-background px-3 text-[12px] font-medium text-foreground hover:border-border hover:bg-muted hover:text-foreground";
 const SEARCH_PICKER_HIDDEN_FIELD_IDS = new Set([
   "modelId",
   "systemPrompt",
@@ -205,7 +213,9 @@ export function HostConfigCompareView({
       projectId,
     });
   const catalogState = useHostCatalog();
-  const compareCatalog = catalogState.catalog ?? bundledHostCompatCatalog();
+  const compareCatalog = presetOnly
+    ? catalogState.catalog ?? bundledHostCompatCatalog()
+    : catalogState.catalog;
   const liveHosts = canQueryLiveHosts ? queriedLiveHosts : [];
   const listLoading = canQueryLiveHosts ? queriedListLoading : false;
   const selectionScopeId = presetOnly ? "public" : projectId ?? "";
@@ -221,14 +231,14 @@ export function HostConfigCompareView({
     if (!codexEnabled) excluded.add("codex");
     return excluded;
   }, [claudeCodeEnabled, codexEnabled]);
-  const presets = useMemo(
-    () =>
-      buildPresetCompareEntries(compareCatalog, {
+  const presets = useMemo(() => {
+    if (!compareCatalog) {
+      return { hosts: [], subjects: {} as Record<string, HostComparisonSubject> };
+    }
+    return buildPresetCompareEntries(compareCatalog, {
         excludedTemplateIds: excludedPresetTemplateIds,
-      }),
-    [compareCatalog, excludedPresetTemplateIds]
-  );
-
+    });
+  }, [compareCatalog, excludedPresetTemplateIds]);
   // Real created hosts first, then presets — what the selector chips iterate.
   const hosts = useMemo(() => {
     if (!presetOnly) return [...liveHosts, ...presets.hosts];
@@ -475,48 +485,15 @@ export function HostConfigCompareView({
     }
   }, []);
 
+  const handleResetCompareView = useCallback(() => {
+    setFieldSearchQuery("");
+    setSupportFilter("all");
+  }, []);
+
   useEffect(() => {
     if (hasFieldSearchQuery || supportFilter === "all") return;
     setSupportFilter("all");
   }, [hasFieldSearchQuery, supportFilter]);
-
-  // "N / M fields" count for the search header — same predicate the matrix and
-  // list view use, so the number always matches what's rendered. In list mode
-  // only support-shaped rows render, so the count narrows to that subset too.
-  const matchCount = useMemo(() => {
-    const useCellSupportFilter =
-      hasFieldSearchQuery && effectiveSupportFilter !== "all";
-    const ids = computeVisibleFieldIds({
-      fields: compareFields,
-      configs: orderedSubjects.map((s) => s.config),
-      divergingOnly,
-      supportFilter: useCellSupportFilter ? "all" : effectiveSupportFilter,
-      searchQuery: fieldSearchQuery,
-    });
-    if (viewMode !== "list") return ids.size;
-    let n = 0;
-    for (const id of ids) {
-      const field = compareFields.find((candidate) => candidate.id === id);
-      if (field && isSupportField(field)) n += 1;
-    }
-    return n;
-  }, [
-    compareFields,
-    orderedSubjects,
-    divergingOnly,
-    effectiveSupportFilter,
-    fieldSearchQuery,
-    hasFieldSearchQuery,
-    viewMode,
-  ]);
-
-  const totalFieldCount = useMemo(
-    () =>
-      viewMode === "list"
-        ? compareFields.filter(isSupportField).length
-        : compareFields.length,
-    [compareFields, viewMode]
-  );
 
   if (!presetOnly && !projectId) {
     return (
@@ -574,13 +551,26 @@ export function HostConfigCompareView({
               query={fieldSearchQuery}
               onQueryChange={setFieldSearchQuery}
               fields={compareFields}
-              matchCount={matchCount}
-              totalCount={totalFieldCount}
-              showCount={orderedSubjects.length > 0}
               viewMode={viewMode}
               onViewModeChange={handleViewModeChange}
               disableListView={showDescriptions}
               mobileOptimized={presetOnly}
+              onReset={handleResetCompareView}
+              supportFilter={supportFilter}
+              onSupportFilterChange={setSupportFilter}
+              actions={
+                presetOnly ? (
+                  <div className="flex items-center gap-1.5">
+                    <ReportInconsistencyDialog />
+                    <NotifyButton />
+                    <ShareComparisonDialog
+                      selectedHostIds={selectedHostIds}
+                      searchQuery={fieldSearchQuery}
+                      fields={compareFields}
+                    />
+                  </div>
+                ) : undefined
+              }
             />
 
             <HostCompareSelector
@@ -588,9 +578,6 @@ export function HostConfigCompareView({
               selectedHostIds={selectedHostIds}
               subjectsByHost={allSubjects}
               onToggleHost={handleToggleHost}
-              matchCount={matchCount}
-              totalCount={totalFieldCount}
-              showCount={orderedSubjects.length > 0}
               viewMode={viewMode}
               onViewModeChange={handleViewModeChange}
               disableListView={showDescriptions}
@@ -606,20 +593,6 @@ export function HostConfigCompareView({
               themeMode={themeMode}
               mobileOptimized={presetOnly}
             />
-
-            {presetOnly ? (
-              <>
-                <div className="-mt-2 mb-4 flex justify-end">
-                  <ReportInconsistencyDialog />
-                </div>
-                <ShareComparisonDialog
-                  selectedHostIds={selectedHostIds}
-                  subjects={orderedSubjects}
-                  searchQuery={fieldSearchQuery}
-                  fields={compareFields}
-                />
-              </>
-            ) : null}
 
             {totalSelectedCount === 0 ? (
               <div className="rounded-xl border border-border bg-card p-10 text-center">
@@ -671,6 +644,120 @@ export function HostConfigCompareView({
   );
 }
 
+function NotifyButton() {
+  const [open, setOpen] = useState(false);
+  const [email, setEmail] = useState("");
+  const [status, setStatus] = useState<
+    "idle" | "submitting" | "succeeded" | "error"
+  >("idle");
+  const trimmedEmail = email.trim();
+
+  const handleOpenChange = useCallback((nextOpen: boolean) => {
+    setOpen(nextOpen);
+    if (nextOpen) return;
+    setEmail("");
+    setStatus("idle");
+  }, []);
+
+  const handleSubmit = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (status === "submitting") return;
+      if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmedEmail)) {
+        setStatus("error");
+        return;
+      }
+      setStatus("submitting");
+      try {
+        const response = await fetch("/api/web/caniuse/subscribe", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email: trimmedEmail }),
+        });
+        if (!response.ok) throw new Error("Subscribe failed");
+        setStatus("succeeded");
+      } catch {
+        setStatus("error");
+      }
+    },
+    [status, trimmedEmail]
+  );
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          aria-label="Notify me of host changes"
+          title="Notify me of host changes"
+          className={cn(
+            "gap-1.5",
+            CANIUSE_ACTION_BUTTON_CLASS
+          )}
+        >
+          <Bell className="size-3.5" />
+          <span>Notify</span>
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-[300px]">
+        {status === "succeeded" ? (
+          <div className="flex items-center gap-2 text-sm font-medium text-emerald-600 dark:text-emerald-400">
+            <Check className="size-4 shrink-0" />
+            You&apos;re on the list — we&apos;ll email you when hosts change.
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-3" noValidate>
+            <div>
+              <div className="text-sm font-semibold text-foreground">
+                Stay up to date
+              </div>
+              <div className="text-[12px] text-muted-foreground">
+                Get an email when a host adds or changes a capability.
+              </div>
+            </div>
+            <div>
+              <input
+                type="email"
+                value={email}
+                onChange={(event) => {
+                  setEmail(event.target.value);
+                  if (status === "error") setStatus("idle");
+                }}
+                placeholder="you@company.com"
+                aria-label="Email"
+                autoFocus
+                className="h-9 w-full rounded-lg border border-border bg-background px-3 text-sm text-foreground outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+              />
+              {status === "error" ? (
+                <p className="mt-1 text-[11px] text-destructive">
+                  Enter a valid email address.
+                </p>
+              ) : null}
+            </div>
+            <Button
+              type="submit"
+              size="sm"
+              className="w-full"
+              disabled={status === "submitting"}
+            >
+              {status === "submitting" ? (
+                <>
+                  <Loader2 className="size-4 animate-spin" />
+                  Sending
+                </>
+              ) : (
+                "Notify me"
+              )}
+            </Button>
+          </form>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}
+
 function ReportInconsistencyDialog() {
   const [open, setOpen] = useState(false);
   const [message, setMessage] = useState("");
@@ -714,10 +801,16 @@ function ReportInconsistencyDialog() {
         type="button"
         variant="outline"
         size="sm"
-        className="h-8 rounded-full px-3 text-[12px]"
+        aria-label="Report inconsistency"
+        title="Report inconsistency"
+        className={cn(
+          "gap-1.5",
+          CANIUSE_ACTION_BUTTON_CLASS
+        )}
         onClick={() => setOpen(true)}
       >
-        Report inconsistency
+        <Flag className="size-3.5" />
+        <span>Report</span>
       </Button>
       <DialogContent className="sm:max-w-[440px]">
         {status === "succeeded" ? (
@@ -829,30 +922,98 @@ function HostConfigFetcher({
   return null;
 }
 
-/** caniuse-style "Can I use ___" search header + result count + view toggle. */
+/** caniuse-style "Can I use ___" search header + view toggle. */
+const SUPPORT_FILTER_OPTIONS: ReadonlyArray<{
+  value: SupportFilterMode;
+  label: string;
+}> = [
+  { value: "all", label: "All fields" },
+  { value: "missing", label: "Missing" },
+  { value: "partial", label: "Partial" },
+  { value: "supported", label: "Full" },
+];
+
+/**
+ * Support-level filter for the caniuse search line, rendered right after the
+ * "?" glyph. Always present; the funnel only takes the accent colour once a
+ * non-default filter is applied.
+ */
+function SupportFilterFunnel({
+  supportFilter,
+  onSupportFilterChange,
+  disabled = false,
+}: {
+  supportFilter: SupportFilterMode;
+  onSupportFilterChange: (mode: SupportFilterMode) => void;
+  disabled?: boolean;
+}) {
+  const active = !disabled && supportFilter !== "all";
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          aria-label="Filter fields by support level"
+          disabled={disabled}
+          title={disabled ? "Search first to filter" : undefined}
+          className={cn(
+            "inline-flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:text-muted-foreground",
+            active && "text-primary hover:text-primary"
+          )}
+        >
+          <Filter className="size-[18px]" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-44 p-1">
+        <div className="px-2 pb-1 pt-1.5 text-[9.5px] font-bold uppercase tracking-wider text-muted-foreground/70">
+          Show
+        </div>
+        {SUPPORT_FILTER_OPTIONS.map((option) => (
+          <DropdownMenuItem
+            key={option.value}
+            data-testid={`support-filter-${option.value}`}
+            disabled={disabled}
+            onClick={() => {
+              if (!disabled) onSupportFilterChange(option.value);
+            }}
+            className="h-8 gap-2 rounded-md px-2 text-[12.5px]"
+          >
+            {option.label}
+            {supportFilter === option.value ? (
+              <Check className="ml-auto size-3.5 text-primary" />
+            ) : null}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
 function CompareSearchBar({
   query,
   onQueryChange,
   fields,
-  matchCount,
-  totalCount,
-  showCount,
   viewMode,
   onViewModeChange,
   disableListView = false,
   mobileOptimized = false,
+  onReset,
+  actions,
+  supportFilter,
+  onSupportFilterChange,
 }: {
   query: string;
   onQueryChange: (q: string) => void;
   fields: ReadonlyArray<HostConfigFieldDef>;
-  matchCount: number;
-  totalCount: number;
-  /** Hidden while hosts are still loading — the count would be meaningless. */
-  showCount: boolean;
   viewMode: CompareViewMode;
   onViewModeChange: (mode: CompareViewMode) => void;
   disableListView?: boolean;
   mobileOptimized?: boolean;
+  onReset?: () => void;
+  /** Utility actions rendered at the trailing edge of the search row. */
+  actions?: ReactNode;
+  supportFilter?: SupportFilterMode;
+  onSupportFilterChange?: (mode: SupportFilterMode) => void;
 }) {
   const [pickerOpen, setPickerOpen] = useState(false);
   const searchAnchorRef = useRef<HTMLDivElement | null>(null);
@@ -891,6 +1052,16 @@ function CompareSearchBar({
     [onQueryChange]
   );
 
+  const handleResetClick = useCallback(() => {
+    setPickerOpen(false);
+    onReset?.();
+  }, [onReset]);
+
+  const canResetSearch = query.trim().length > 0;
+  const canIUseLabelClass = mobileOptimized
+    ? "shrink-0 cursor-pointer rounded-md border-0 bg-transparent p-0 text-[24px] font-semibold leading-none tracking-normal text-foreground transition-opacity hover:opacity-80 disabled:cursor-default disabled:opacity-100 disabled:hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+    : "shrink-0 cursor-pointer rounded-md border-0 bg-transparent p-0 text-[15px] font-medium tracking-tight text-foreground transition-opacity hover:opacity-80 disabled:cursor-default disabled:opacity-100 disabled:hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40";
+
   const keepPickerOpenForSearchAnchor = useCallback(
     (event: CustomEvent<{ originalEvent?: Event }>) => {
       const target = (event.detail.originalEvent?.target ??
@@ -904,12 +1075,19 @@ function CompareSearchBar({
 
   const searchRow = (
     <>
-      {mobileOptimized ? (
-        <span className="shrink-0 text-[24px] font-semibold leading-none tracking-normal text-foreground">
+      {onReset ? (
+        <button
+          type="button"
+          className={canIUseLabelClass}
+          aria-label="Show all clients and capabilities"
+          disabled={!canResetSearch}
+          title={canResetSearch ? "Show all clients and capabilities" : undefined}
+          onClick={handleResetClick}
+        >
           Can I use…
-        </span>
+        </button>
       ) : (
-        <span className="shrink-0 text-[15px] font-medium tracking-tight text-foreground">
+        <span className={canIUseLabelClass}>
           Can I use…
         </span>
       )}
@@ -1012,6 +1190,13 @@ function CompareSearchBar({
           >
             ?
           </span>
+          {supportFilter !== undefined && onSupportFilterChange ? (
+            <SupportFilterFunnel
+              supportFilter={supportFilter}
+              onSupportFilterChange={onSupportFilterChange}
+              disabled={query.trim().length === 0}
+            />
+          ) : null}
         </span>
       )}
     </>
@@ -1029,9 +1214,14 @@ function CompareSearchBar({
           <div className="flex w-full min-w-0 flex-nowrap items-center justify-center gap-2 sm:col-start-2">
             {searchRow}
           </div>
+          {actions ? (
+            <div className="flex items-center gap-1.5 sm:col-start-1 sm:row-start-1 sm:justify-self-start">
+              {actions}
+            </div>
+          ) : null}
           <a
             href={MAIN_PRODUCT_URL}
-            className="inline-flex min-w-0 shrink-0 items-center gap-1.5 text-[11px] leading-none text-muted-foreground transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 sm:col-start-3 sm:justify-self-end"
+            className="inline-flex min-w-0 shrink-0 items-center gap-1.5 text-[11px] leading-none text-muted-foreground transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 sm:col-start-3 sm:row-start-1 sm:justify-self-end"
             aria-label="Open MCPJam"
           >
             <span>Brought to you by</span>
@@ -1041,16 +1231,11 @@ function CompareSearchBar({
       ) : (
         searchRow
       )}
-      {showCount && !mobileOptimized && (
-        <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground">
-          {matchCount} / {totalCount} fields
-        </span>
-      )}
       {!mobileOptimized && (
         <div
           role="group"
           aria-label="View mode"
-          className="flex shrink-0 items-center gap-0.5 rounded-full border border-border p-0.5"
+          className="ml-auto flex shrink-0 items-center gap-0.5 rounded-full border border-border p-0.5"
         >
           {(
             [
@@ -1094,12 +1279,10 @@ function CompareSearchBar({
 
 function ShareComparisonDialog({
   selectedHostIds,
-  subjects,
   searchQuery,
   fields,
 }: {
   selectedHostIds: ReadonlyArray<string>;
-  subjects: ReadonlyArray<HostComparisonSubject>;
   searchQuery: string;
   fields: ReadonlyArray<HostConfigFieldDef>;
 }) {
@@ -1110,11 +1293,6 @@ function ShareComparisonDialog({
     () => buildShareComparisonUrl(selectedHostIds, searchQuery, fields),
     [selectedHostIds, searchQuery, fields]
   );
-  const capability = useMemo(
-    () => capabilityForSearchQuery(searchQuery, fields),
-    [searchQuery, fields]
-  );
-  const clientNames = subjects.map((subject) => subject.hostName);
 
   const handleCopy = useCallback(async () => {
     try {
@@ -1128,55 +1306,33 @@ function ShareComparisonDialog({
     window.setTimeout(() => setCopied(false), 2000);
   }, [shareUrl]);
 
-  const tweetHref = useMemo(() => {
-    const text = capability
-      ? `Can I use ${capability.field.label} across MCP clients?`
-      : "MCP client capability support";
-    return `https://twitter.com/intent/tweet?${new URLSearchParams({
-      text,
-      url: shareUrl,
-    }).toString()}`;
-  }, [capability, shareUrl]);
-
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <Button
         type="button"
+        variant="outline"
+        size="sm"
+        aria-label="Share"
+        title="Share"
         onClick={() => setOpen(true)}
-        className="fixed bottom-4 right-4 z-40 h-10 gap-2 rounded-full px-4 shadow-lg"
+        className={cn(
+          "gap-1.5",
+          CANIUSE_ACTION_BUTTON_CLASS
+        )}
       >
-        <Share2 className="size-4" />
-        Share
+        <Share2 className="size-3.5" />
+        <span>Share</span>
       </Button>
       <DialogContent className="sm:max-w-[460px]">
         <DialogHeader>
           <DialogTitle>Share this comparison</DialogTitle>
           <DialogDescription>
-            A link that opens exactly the clients and capability you&apos;re
-            viewing.
+            Anyone with this link will see the same comparison you&apos;re
+            looking at.
           </DialogDescription>
         </DialogHeader>
 
         <div className="space-y-3">
-          <div className="flex flex-wrap items-center gap-2 rounded-lg border border-border bg-muted/40 px-3 py-2 text-[12px]">
-            <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
-              Clients
-            </span>
-            <span className="text-foreground">
-              {clientNames.length > 0 ? clientNames.join(", ") : "None selected"}
-            </span>
-            {capability ? (
-              <>
-                <span className="ml-auto text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
-                  Capability
-                </span>
-                <span className="rounded-full bg-primary/10 px-2 py-0.5 text-[11px] font-medium text-primary">
-                  {capability.field.label}
-                </span>
-              </>
-            ) : null}
-          </div>
-
           <div className="flex items-center gap-2">
             <input
               readOnly
@@ -1197,14 +1353,6 @@ function ShareComparisonDialog({
                   Copy
                 </>
               )}
-            </Button>
-          </div>
-
-          <div className="flex justify-start">
-            <Button asChild variant="outline" size="sm" className="gap-2">
-              <a href={tweetHref} target="_blank" rel="noreferrer noopener">
-                Share on X
-              </a>
             </Button>
           </div>
         </div>

--- a/mcpjam-inspector/client/src/components/hosts/comparison/HostConfigCompareView.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/HostConfigCompareView.tsx
@@ -21,7 +21,6 @@ import {
   Popover,
   PopoverAnchor,
   PopoverContent,
-  PopoverTrigger,
 } from "@mcpjam/design-system/popover";
 import {
   DropdownMenu,
@@ -684,39 +683,41 @@ function NotifyButton() {
   );
 
   return (
-    <Popover open={open} onOpenChange={handleOpenChange}>
-      <PopoverTrigger asChild>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          aria-label="Notify me of host changes"
-          title="Notify me of host changes"
-          className={cn(
-            "gap-1.5",
-            CANIUSE_ACTION_BUTTON_CLASS
-          )}
-        >
-          <Bell className="size-3.5" />
-          <span>Notify</span>
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent align="end" className="w-[300px]">
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        aria-label="Notify me of host changes"
+        title="Notify me of host changes"
+        className={cn("gap-1.5", CANIUSE_ACTION_BUTTON_CLASS)}
+        onClick={() => setOpen(true)}
+      >
+        <Bell className="size-3.5" />
+        <span>Notify</span>
+      </Button>
+      <DialogContent className="sm:max-w-[420px]">
         {status === "succeeded" ? (
-          <div className="flex items-center gap-2 text-sm font-medium text-emerald-600 dark:text-emerald-400">
-            <Check className="size-4 shrink-0" />
-            You&apos;re on the list — we&apos;ll email you when hosts change.
-          </div>
+          <>
+            <DialogHeader>
+              <DialogTitle>You&apos;re on the list.</DialogTitle>
+              <DialogDescription>
+                We&apos;ll email you when hosts change.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="flex items-center gap-2 text-sm font-medium text-emerald-600 dark:text-emerald-400">
+              <Check className="size-4 shrink-0" />
+              Saved.
+            </div>
+          </>
         ) : (
           <form onSubmit={handleSubmit} className="space-y-3" noValidate>
-            <div>
-              <div className="text-sm font-semibold text-foreground">
-                Stay up to date
-              </div>
-              <div className="text-[12px] text-muted-foreground">
+            <DialogHeader>
+              <DialogTitle>Stay up to date</DialogTitle>
+              <DialogDescription>
                 Get an email when a host adds or changes a capability.
-              </div>
-            </div>
+              </DialogDescription>
+            </DialogHeader>
             <div>
               <input
                 type="email"
@@ -739,7 +740,6 @@ function NotifyButton() {
             <Button
               type="submit"
               size="sm"
-              className="w-full"
               disabled={status === "submitting"}
             >
               {status === "submitting" ? (
@@ -753,8 +753,8 @@ function NotifyButton() {
             </Button>
           </form>
         )}
-      </PopoverContent>
-    </Popover>
+      </DialogContent>
+    </Dialog>
   );
 }
 

--- a/mcpjam-inspector/client/src/components/hosts/comparison/HostConfigCompareView.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/HostConfigCompareView.tsx
@@ -83,7 +83,6 @@ const SEARCH_PICKER_HIDDEN_FIELD_IDS = new Set([
   "systemPrompt",
   "temperature",
 ]);
-
 function getInitialCompareViewMode(): CompareViewMode {
   if (
     typeof window === "undefined" ||
@@ -564,8 +563,9 @@ export function HostConfigCompareView({
         ) : hosts.length === 0 ? (
           <div className="rounded-xl border border-border bg-card p-10 text-center">
             <p className="text-sm text-muted-foreground">
-              No hosts yet. Create one from the Host tab to populate the
-              comparison.
+              {presetOnly
+                ? "No hosts are available in the live catalog."
+                : "No hosts yet. Create one from the Host tab to populate the comparison."}
             </p>
           </div>
         ) : (

--- a/mcpjam-inspector/client/src/components/hosts/comparison/HostConfigCompareView.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/HostConfigCompareView.tsx
@@ -6,7 +6,7 @@ import {
   useState,
   type FormEvent,
 } from "react";
-import { Loader2 } from "lucide-react";
+import { Check, Copy, Loader2, Share2 } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
 import {
   Dialog,
@@ -152,6 +152,30 @@ function writeFieldSearchParams(
   }
 
   next.set(SEARCH_QUERY_PARAM, trimmed);
+}
+
+/**
+ * Absolute, shareable URL for the current comparison. Unlike the URL the view
+ * mirrors into (which drops `hosts=` for the default selection to keep the bar
+ * clean), a shared link always pins the exact clients — so it opens the same
+ * comparison for the recipient even if the default set changes later.
+ */
+function buildShareComparisonUrl(
+  hostIds: ReadonlyArray<string>,
+  query: string,
+  fields: ReadonlyArray<HostConfigFieldDef>
+): string {
+  const params = new URLSearchParams();
+  if (hostIds.length > 0) {
+    params.set(HOSTS_QUERY_PARAM, hostIds.join(","));
+  }
+  writeFieldSearchParams(params, query, fields);
+  const search = params.toString();
+  if (typeof window === "undefined") {
+    return search ? `?${search}` : "";
+  }
+  const { origin, pathname } = window.location;
+  return `${origin}${pathname}${search ? `?${search}` : ""}`;
 }
 
 interface HostConfigCompareViewProps {
@@ -584,9 +608,17 @@ export function HostConfigCompareView({
             />
 
             {presetOnly ? (
-              <div className="-mt-2 mb-4 flex justify-end">
-                <ReportInconsistencyDialog />
-              </div>
+              <>
+                <div className="-mt-2 mb-4 flex justify-end">
+                  <ReportInconsistencyDialog />
+                </div>
+                <ShareComparisonDialog
+                  selectedHostIds={selectedHostIds}
+                  subjects={orderedSubjects}
+                  searchQuery={fieldSearchQuery}
+                  fields={compareFields}
+                />
+              </>
             ) : null}
 
             {totalSelectedCount === 0 ? (
@@ -1057,6 +1089,127 @@ function CompareSearchBar({
         </div>
       )}
     </div>
+  );
+}
+
+function ShareComparisonDialog({
+  selectedHostIds,
+  subjects,
+  searchQuery,
+  fields,
+}: {
+  selectedHostIds: ReadonlyArray<string>;
+  subjects: ReadonlyArray<HostComparisonSubject>;
+  searchQuery: string;
+  fields: ReadonlyArray<HostConfigFieldDef>;
+}) {
+  const [open, setOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const shareUrl = useMemo(
+    () => buildShareComparisonUrl(selectedHostIds, searchQuery, fields),
+    [selectedHostIds, searchQuery, fields]
+  );
+  const capability = useMemo(
+    () => capabilityForSearchQuery(searchQuery, fields),
+    [searchQuery, fields]
+  );
+  const clientNames = subjects.map((subject) => subject.hostName);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+    } catch {
+      // Clipboard blocked (e.g. insecure context) — the URL stays visible in
+      // the field, so the user can still select and copy it manually.
+      return;
+    }
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 2000);
+  }, [shareUrl]);
+
+  const tweetHref = useMemo(() => {
+    const text = capability
+      ? `Can I use ${capability.field.label} across MCP clients?`
+      : "MCP client capability support";
+    return `https://twitter.com/intent/tweet?${new URLSearchParams({
+      text,
+      url: shareUrl,
+    }).toString()}`;
+  }, [capability, shareUrl]);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <Button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="fixed bottom-4 right-4 z-40 h-10 gap-2 rounded-full px-4 shadow-lg"
+      >
+        <Share2 className="size-4" />
+        Share
+      </Button>
+      <DialogContent className="sm:max-w-[460px]">
+        <DialogHeader>
+          <DialogTitle>Share this comparison</DialogTitle>
+          <DialogDescription>
+            A link that opens exactly the clients and capability you&apos;re
+            viewing.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <div className="flex flex-wrap items-center gap-2 rounded-lg border border-border bg-muted/40 px-3 py-2 text-[12px]">
+            <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+              Clients
+            </span>
+            <span className="text-foreground">
+              {clientNames.length > 0 ? clientNames.join(", ") : "None selected"}
+            </span>
+            {capability ? (
+              <>
+                <span className="ml-auto text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                  Capability
+                </span>
+                <span className="rounded-full bg-primary/10 px-2 py-0.5 text-[11px] font-medium text-primary">
+                  {capability.field.label}
+                </span>
+              </>
+            ) : null}
+          </div>
+
+          <div className="flex items-center gap-2">
+            <input
+              readOnly
+              value={shareUrl}
+              onFocus={(event) => event.currentTarget.select()}
+              aria-label="Shareable link"
+              className="min-w-0 flex-1 rounded-lg border border-border bg-background px-3 py-2 font-mono text-[11.5px] text-muted-foreground"
+            />
+            <Button type="button" onClick={handleCopy} className="gap-2">
+              {copied ? (
+                <>
+                  <Check className="size-4" />
+                  Copied
+                </>
+              ) : (
+                <>
+                  <Copy className="size-4" />
+                  Copy
+                </>
+              )}
+            </Button>
+          </div>
+
+          <div className="flex justify-start">
+            <Button asChild variant="outline" size="sm" className="gap-2">
+              <a href={tweetHref} target="_blank" rel="noreferrer noopener">
+                Share on X
+              </a>
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
   );
 }
 

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/CaniuseCapabilityPage.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/CaniuseCapabilityPage.test.tsx
@@ -6,6 +6,18 @@ vi.mock("posthog-js/react", () => ({
   useFeatureFlagEnabled: () => false,
 }));
 
+vi.mock("@/lib/host-compat/use-host-catalog", async () => {
+  const { bundledHostCompatCatalog } = await import("@mcpjam/sdk/host-compat");
+  return {
+    useHostCatalog: () => ({
+      status: "live",
+      catalog: bundledHostCompatCatalog(),
+      version: 1,
+      source: "live",
+    }),
+  };
+});
+
 vi.mock("@/stores/preferences/preferences-provider", () => ({
   usePreferencesStore: (selector: (state: { themeMode: "light" }) => unknown) =>
     selector({ themeMode: "light" }),

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/CaniuseCapabilityPage.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/CaniuseCapabilityPage.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { CaniuseCapabilityPage } from "../CaniuseCapabilityPage";
+
+vi.mock("posthog-js/react", () => ({
+  useFeatureFlagEnabled: () => false,
+}));
+
+vi.mock("@/stores/preferences/preferences-provider", () => ({
+  usePreferencesStore: (selector: (state: { themeMode: "light" }) => unknown) =>
+    selector({ themeMode: "light" }),
+}));
+
+describe("CaniuseCapabilityPage", () => {
+  it("renders a capability permalink page with definition, statuses, and verified dates", () => {
+    render(<CaniuseCapabilityPage capabilitySlug="sampling" />);
+
+    expect(
+      screen.getByRole("heading", { name: "Sampling" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Server-initiated LLM calls.")).toBeInTheDocument();
+    expect(screen.getByText("/capabilities/sampling")).toBeInTheDocument();
+    expect(screen.getByText("ChatGPT")).toBeInTheDocument();
+    expect(screen.getByText("Claude")).toBeInTheDocument();
+    expect(screen.getAllByText("2026-07-07").length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText(/Supported|Partial|Not supported/).length,
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getByRole("link", { name: "Verify against your server" }),
+    ).toHaveAttribute("href", "https://app.mcpjam.com");
+    expect(screen.getByRole("link", { name: "Full matrix" })).toHaveAttribute(
+      "href",
+      "/embed/host-compare",
+    );
+  });
+
+  it("renders a not-found state for unknown capability slugs", () => {
+    render(<CaniuseCapabilityPage capabilitySlug="not-a-capability" />);
+
+    expect(
+      screen.getByRole("heading", { name: "Capability not found" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Full matrix" })).toHaveAttribute(
+      "href",
+      "/embed/host-compare",
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/HostCompareSelector.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/HostCompareSelector.test.tsx
@@ -101,6 +101,33 @@ describe("HostCompareSelector", () => {
     expect(onSupportFilterChange).toHaveBeenCalledWith("missing");
   });
 
+  it("does not emit support filter changes while support filters are disabled", async () => {
+    const user = userEvent.setup();
+    const onSupportFilterChange = vi.fn();
+
+    render(
+      <HostCompareSelector
+        hosts={[makeHost("h_a", "Claude")]}
+        selectedHostIds={["h_a"]}
+        subjectsByHost={{}}
+        onToggleHost={vi.fn()}
+        divergingOnly={false}
+        onDivergingOnlyChange={vi.fn()}
+        supportFilter="all"
+        onSupportFilterChange={onSupportFilterChange}
+        supportFiltersDisabled
+        showDescriptions={false}
+        onShowDescriptionsChange={vi.fn()}
+      />,
+    );
+
+    const missingFilter = screen.getByTestId("support-filter-missing");
+    expect(missingFilter).toBeDisabled();
+
+    await user.click(missingFilter);
+    expect(onSupportFilterChange).not.toHaveBeenCalled();
+  });
+
   it("disables the diverging toggle when the selector is disabled", () => {
     render(
       <HostCompareSelector

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/HostCompareSelector.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/HostCompareSelector.test.tsx
@@ -23,10 +23,7 @@ describe("HostCompareSelector", () => {
 
     render(
       <HostCompareSelector
-        hosts={[
-          makeHost("h_a", "Claude"),
-          makeHost("h_b", "Cursor"),
-        ]}
+        hosts={[makeHost("h_a", "Claude"), makeHost("h_b", "Cursor")]}
         selectedHostIds={["h_a"]}
         subjectsByHost={{}}
         onToggleHost={onToggleHost}
@@ -36,25 +33,53 @@ describe("HostCompareSelector", () => {
         onSupportFilterChange={vi.fn()}
         showDescriptions={false}
         onShowDescriptionsChange={vi.fn()}
-      />,
+      />
     );
 
     expect(screen.getByTestId("host-compare-chip-h_a")).toHaveAttribute(
       "data-selected",
-      "true",
+      "true"
     );
     expect(screen.getByTestId("host-compare-chip-h_b")).toHaveAttribute(
       "data-selected",
-      "false",
+      "false"
     );
 
     await user.click(screen.getByTestId("host-compare-chip-h_b"));
     expect(onToggleHost).toHaveBeenCalledWith("h_b");
   });
 
-  it("shows a More menu when there are more than six hosts", () => {
+  it("shows a More menu initially when there are more than six hosts", () => {
     const hosts = Array.from({ length: 7 }, (_, index) =>
-      makeHost(`h_${index}`, `Host ${index}`),
+      makeHost(`h_${index}`, `Host ${index}`)
+    );
+
+    render(
+      <HostCompareSelector
+        hosts={hosts}
+        selectedHostIds={[]}
+        subjectsByHost={{}}
+        onToggleHost={vi.fn()}
+        divergingOnly={false}
+        onDivergingOnlyChange={vi.fn()}
+        supportFilter="all"
+        onSupportFilterChange={vi.fn()}
+        showDescriptions={false}
+        onShowDescriptionsChange={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.getByTestId("host-compare-overflow-trigger")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("host-compare-chip-h_6")
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows selected hosts inline even past the initial compact limit", () => {
+    const hosts = Array.from({ length: 8 }, (_, index) =>
+      makeHost(`h_${index}`, `Host ${index}`)
     );
 
     render(
@@ -69,12 +94,12 @@ describe("HostCompareSelector", () => {
         onSupportFilterChange={vi.fn()}
         showDescriptions={false}
         onShowDescriptionsChange={vi.fn()}
-      />,
+      />
     );
 
-    expect(screen.getByTestId("host-compare-overflow-trigger")).toBeInTheDocument();
+    expect(screen.getByTestId("host-compare-chip-h_7")).toBeInTheDocument();
     expect(
-      screen.queryByTestId("host-compare-chip-h_6"),
+      screen.queryByTestId("host-compare-overflow-trigger")
     ).not.toBeInTheDocument();
   });
 
@@ -94,7 +119,7 @@ describe("HostCompareSelector", () => {
         onSupportFilterChange={onSupportFilterChange}
         showDescriptions={false}
         onShowDescriptionsChange={vi.fn()}
-      />,
+      />
     );
 
     await user.click(screen.getByTestId("support-filter-missing"));
@@ -118,7 +143,7 @@ describe("HostCompareSelector", () => {
         supportFiltersDisabled
         showDescriptions={false}
         onShowDescriptionsChange={vi.fn()}
-      />,
+      />
     );
 
     const missingFilter = screen.getByTestId("support-filter-missing");

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/HostConfigCompareView.public.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/HostConfigCompareView.public.test.tsx
@@ -112,6 +112,11 @@ describe("HostConfigCompareView public mode", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("Can I use…")).toBeInTheDocument();
     expect(
+      screen.getByRole("button", {
+        name: "Show all clients and capabilities",
+      })
+    ).toBeDisabled();
+    expect(
       screen.getByTestId("host-compare-chip-preset:claude")
     ).toBeInTheDocument();
 
@@ -165,7 +170,6 @@ describe("HostConfigCompareView public mode", () => {
     expect(screen.getByLabelText("Search host config fields")).toHaveValue(
       "Elicitation"
     );
-    expect(screen.getByText(/1 \/ \d+ fields/)).toBeInTheDocument();
     await waitFor(() => {
       expect(
         screen.queryByText(/Select at least one client/i)
@@ -201,6 +205,69 @@ describe("HostConfigCompareView public mode", () => {
         "/embed/host-compare?hosts=preset%3Aclaude%2Cpreset%3Avscode&capability=elicitation"
       );
     });
+  });
+
+  it("disables the support filter until a search is entered", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter>
+        <HostConfigCompareView
+          projectId={null}
+          isAuthenticated={false}
+          presetOnly
+        />
+      </MemoryRouter>
+    );
+
+    const filterButton = screen.getByLabelText("Filter fields by support level");
+    expect(filterButton).toBeDisabled();
+
+    await user.type(
+      screen.getByLabelText("Search host config fields"),
+      "Elicitation"
+    );
+
+    expect(filterButton).not.toBeDisabled();
+  });
+
+  it("clears search filtering without changing selected clients when Can I use is clicked", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter
+        initialEntries={[
+          "/embed/host-compare?hosts=preset%3Aclaude%2Cpreset%3Avscode&capability=elicitation",
+        ]}
+      >
+        <HostConfigCompareView
+          projectId={null}
+          isAuthenticated={false}
+          presetOnly
+        />
+      </MemoryRouter>
+    );
+
+    const search = screen.getByLabelText("Search host config fields");
+    const canIUseButton = screen.getByRole("button", {
+      name: "Show all clients and capabilities",
+    });
+    expect(search).toHaveValue("Elicitation");
+    expect(canIUseButton).not.toBeDisabled();
+    expect(screen.getByTestId("host-compare-chip-preset:chatgpt")).toHaveAttribute(
+      "data-selected",
+      "false"
+    );
+
+    await user.click(canIUseButton);
+
+    expect(search).toHaveValue("");
+    expect(canIUseButton).toBeDisabled();
+    expect(screen.getByLabelText("Filter fields by support level")).toBeDisabled();
+    expect(screen.getByTestId("host-compare-chip-preset:chatgpt")).toHaveAttribute(
+      "data-selected",
+      "false"
+    );
   });
 
   it("hides agent tuning and request timeout rows in public caniuse mode", async () => {

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/HostConfigCompareView.public.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/HostConfigCompareView.public.test.tsx
@@ -7,6 +7,9 @@ import { HostConfigCompareView } from "../HostConfigCompareView";
 const mockHostListState = vi.hoisted(() => ({
   hosts: [] as any[],
 }));
+const mockCatalogState = vi.hoisted(() => ({
+  current: null as any,
+}));
 
 const originalMatchMedia = window.matchMedia;
 
@@ -23,12 +26,13 @@ vi.mock("posthog-js/react", () => ({
 vi.mock("@/lib/host-compat/use-host-catalog", async () => {
   const { bundledHostCompatCatalog } = await import("@mcpjam/sdk/host-compat");
   return {
-    useHostCatalog: () => ({
-      status: "live",
-      catalog: bundledHostCompatCatalog(),
-      version: 1,
-      source: "live",
-    }),
+    useHostCatalog: () =>
+      mockCatalogState.current ?? {
+        status: "live",
+        catalog: bundledHostCompatCatalog(),
+        version: 1,
+        source: "live",
+      },
   };
 });
 
@@ -79,6 +83,7 @@ describe("HostConfigCompareView public mode", () => {
 
   beforeEach(() => {
     mockHostListState.hosts = [];
+    mockCatalogState.current = null;
     global.fetch = vi.fn();
   });
 
@@ -269,6 +274,30 @@ describe("HostConfigCompareView public mode", () => {
 
     expect(
       screen.getByText(/Sign in to compare your hosts/i)
+    ).toBeInTheDocument();
+  });
+
+  it("does not fall back to SDK preset hosts in the full app compare page", () => {
+    mockCatalogState.current = {
+      status: "fallback",
+      catalog: null,
+      version: 0,
+      source: "bundled",
+    };
+
+    render(
+      <MemoryRouter>
+        <HostConfigCompareView projectId="abc123" isAuthenticated />
+      </MemoryRouter>
+    );
+
+    expect(
+      screen.queryByTestId("host-compare-chip-preset:claude")
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "No hosts yet. Create one from the Host tab to populate the comparison."
+      )
     ).toBeInTheDocument();
   });
 

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/HostConfigCompareView.public.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/HostConfigCompareView.public.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter } from "react-router";
+import { MemoryRouter, useLocation } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { HostConfigCompareView } from "../HostConfigCompareView";
 
@@ -52,12 +52,26 @@ function mockMobileViewport() {
   });
 }
 
+function LocationProbe() {
+  const location = useLocation();
+  return (
+    <span data-testid="location">
+      {location.pathname}
+      {location.search}
+    </span>
+  );
+}
+
 describe("HostConfigCompareView public mode", () => {
+  const originalFetch = global.fetch;
+
   beforeEach(() => {
     mockHostListState.hosts = [];
+    global.fetch = vi.fn();
   });
 
   afterEach(() => {
+    global.fetch = originalFetch;
     Object.defineProperty(window, "matchMedia", {
       writable: true,
       value: originalMatchMedia,
@@ -89,6 +103,149 @@ describe("HostConfigCompareView public mode", () => {
         screen.queryByText(/Select at least one client/i)
       ).not.toBeInTheDocument();
     });
+  });
+
+  it("puts the preferred caniuse clients in the top chip row", () => {
+    render(
+      <MemoryRouter>
+        <HostConfigCompareView
+          projectId={null}
+          isAuthenticated={false}
+          presetOnly
+        />
+      </MemoryRouter>
+    );
+
+    const topChipIds = Array.from(
+      document.querySelectorAll('[data-testid^="host-compare-chip-"]')
+    ).map((node) => node.getAttribute("data-testid"));
+
+    expect(topChipIds).toEqual([
+      "host-compare-chip-preset:claude",
+      "host-compare-chip-preset:chatgpt",
+      "host-compare-chip-preset:copilot",
+      "host-compare-chip-preset:cursor",
+      "host-compare-chip-preset:slack",
+      "host-compare-chip-preset:vscode",
+    ]);
+  });
+
+  it("opens a shared public capability search from the URL", async () => {
+    render(
+      <MemoryRouter
+        initialEntries={[
+          "/embed/host-compare?hosts=preset%3Aclaude%2Cpreset%3Avscode&capability=elicitation",
+        ]}
+      >
+        <HostConfigCompareView
+          projectId={null}
+          isAuthenticated={false}
+          presetOnly
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByLabelText("Search host config fields")).toHaveValue(
+      "Elicitation"
+    );
+    expect(screen.getByText(/1 \/ \d+ fields/)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.queryByText(/Select at least one client/i)
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("writes an exact public capability search into the shareable URL", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter
+        initialEntries={[
+          "/embed/host-compare?hosts=preset%3Aclaude%2Cpreset%3Avscode",
+        ]}
+      >
+        <HostConfigCompareView
+          projectId={null}
+          isAuthenticated={false}
+          presetOnly
+        />
+        <LocationProbe />
+      </MemoryRouter>
+    );
+
+    await user.type(
+      screen.getByLabelText("Search host config fields"),
+      "Elicitation"
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("location")).toHaveTextContent(
+        "/embed/host-compare?hosts=preset%3Aclaude%2Cpreset%3Avscode&capability=elicitation"
+      );
+    });
+  });
+
+  it("hides agent tuning and request timeout rows in public caniuse mode", async () => {
+    render(
+      <MemoryRouter>
+        <HostConfigCompareView
+          projectId={null}
+          isAuthenticated={false}
+          presetOnly
+        />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText(/Select at least one client/i)
+      ).not.toBeInTheDocument();
+    });
+
+    expect(screen.queryByText("Model")).not.toBeInTheDocument();
+    expect(screen.queryByText("Temperature")).not.toBeInTheDocument();
+    expect(screen.queryByText("System prompt")).not.toBeInTheDocument();
+    expect(screen.queryByText("Request timeout")).not.toBeInTheDocument();
+  });
+
+  it("lets public users report an inconsistency", async () => {
+    const user = userEvent.setup();
+    vi.mocked(global.fetch).mockResolvedValue(
+      new Response(JSON.stringify({ success: true }), { status: 200 })
+    );
+
+    render(
+      <MemoryRouter>
+        <HostConfigCompareView
+          projectId={null}
+          isAuthenticated={false}
+          presetOnly
+        />
+      </MemoryRouter>
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Report inconsistency" })
+    );
+    await user.type(
+      screen.getByLabelText("What looks inconsistent?"),
+      "Claude supports this, but the table says it doesn't."
+    );
+    await user.click(screen.getByRole("button", { name: "Send report" }));
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/web/caniuse/report-inconsistency",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          message: "Claude supports this, but the table says it doesn't.",
+        }),
+      })
+    );
+    expect(
+      await screen.findByText("We've notified the MCPJam team.")
+    ).toBeInTheDocument();
   });
 
   it("keeps the full app no-project state behind sign-in", () => {

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/HostConfigCompareView.public.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/HostConfigCompareView.public.test.tsx
@@ -20,6 +20,18 @@ vi.mock("posthog-js/react", () => ({
   usePostHog: () => ({ capture: () => undefined }),
 }));
 
+vi.mock("@/lib/host-compat/use-host-catalog", async () => {
+  const { bundledHostCompatCatalog } = await import("@mcpjam/sdk/host-compat");
+  return {
+    useHostCatalog: () => ({
+      status: "live",
+      catalog: bundledHostCompatCatalog(),
+      version: 1,
+      source: "live",
+    }),
+  };
+});
+
 vi.mock("@/stores/preferences/preferences-provider", () => ({
   usePreferencesStore: () => "light",
 }));

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/HostConfigCompareView.public.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/HostConfigCompareView.public.test.tsx
@@ -332,6 +332,44 @@ describe("HostConfigCompareView public mode", () => {
     ).toBeInTheDocument();
   });
 
+  it("opens notify in a centered dialog and subscribes an email", async () => {
+    const user = userEvent.setup();
+    vi.mocked(global.fetch).mockResolvedValue(
+      new Response(JSON.stringify({ success: true }), { status: 200 })
+    );
+
+    render(
+      <MemoryRouter>
+        <HostConfigCompareView
+          projectId={null}
+          isAuthenticated={false}
+          presetOnly
+        />
+      </MemoryRouter>
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Notify me of host changes" })
+    );
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveTextContent("Stay up to date");
+
+    await user.type(screen.getByLabelText("Email"), "founders@mcpjam.com");
+    await user.click(screen.getByRole("button", { name: "Notify me" }));
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/web/caniuse/subscribe",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ email: "founders@mcpjam.com" }),
+      })
+    );
+    expect(
+      await screen.findByText("We'll email you when hosts change.")
+    ).toBeInTheDocument();
+  });
+
   it("keeps the full app no-project state behind sign-in", () => {
     render(
       <MemoryRouter>

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/caniuse-capability-catalog.test.ts
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/caniuse-capability-catalog.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+  CANIUSE_CAPABILITIES,
+  CANIUSE_LAST_VERIFIED_DATE,
+  PUBLIC_CAN_I_USE_FIELDS,
+  buildCaniuseCapabilityPath,
+  getCaniuseCapabilityForField,
+  getCaniuseCapabilityBySlug,
+} from "../caniuse-capability-catalog";
+import { hostConfigField } from "@/lib/host-config-field-schema";
+
+describe("caniuse capability catalog", () => {
+  it("includes stable public capability slugs", () => {
+    expect(getCaniuseCapabilityBySlug("sampling")?.field.id).toBe(
+      "capabilities.sampling",
+    );
+    expect(getCaniuseCapabilityBySlug("elicitation")?.field.id).toBe(
+      "capabilities.elicitation",
+    );
+    expect(getCaniuseCapabilityBySlug("roots")?.field.id).toBe(
+      "capabilities.roots",
+    );
+    expect(
+      getCaniuseCapabilityBySlug("mcp-apps-available-display-modes")?.field.id,
+    ).toBe("appsCap.availableDisplayModes");
+    expect(
+      getCaniuseCapabilityForField(hostConfigField("capabilities.elicitation"))
+        ?.slug,
+    ).toBe("elicitation");
+  });
+
+  it("excludes config-only fields from public capability pages", () => {
+    const ids = PUBLIC_CAN_I_USE_FIELDS.map((field) => field.id);
+    expect(ids).not.toContain("modelId");
+    expect(ids).not.toContain("temperature");
+    expect(ids).not.toContain("systemPrompt");
+    expect(ids).not.toContain("clientInfo.name");
+    expect(ids).not.toContain("connectionDefaults.headers");
+    expect(ids).not.toContain("connectionDefaults.requestTimeout");
+  });
+
+  it("keeps slugs unique and path-safe", () => {
+    const slugs = CANIUSE_CAPABILITIES.map((capability) => capability.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+    expect(slugs.every((slug) => /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(slug))).toBe(
+      true,
+    );
+    expect(buildCaniuseCapabilityPath("sampling")).toBe(
+      "/capabilities/sampling",
+    );
+  });
+
+  it("uses a static latest verification date for v1", () => {
+    expect(CANIUSE_LAST_VERIFIED_DATE).toBe("2026-07-07");
+  });
+});

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/host-compare-selection.test.ts
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/host-compare-selection.test.ts
@@ -60,6 +60,13 @@ describe("host-compare-selection", () => {
     expect(parseHostsParam(undefined)).toBeNull();
   });
 
+  it("parseHostsParam maps preset permalink aliases to current catalog ids", () => {
+    expect(parseHostsParam("preset:slackbot,preset:slack-bot")).toEqual([
+      "preset:slack",
+      "preset:slack",
+    ]);
+  });
+
   it("resolveInitialHostCompareSelection prefers urlSelection over storage", () => {
     writeHostCompareSelection("proj_1", ["b"]);
     expect(
@@ -96,6 +103,18 @@ describe("host-compare-selection", () => {
         urlSelection: ["a", "preset:claude"],
       }),
     ).toEqual(["a", "preset:claude"]);
+  });
+
+  it("resolveInitialHostCompareSelection keeps aliased preset ids from the URL", () => {
+    expect(
+      resolveInitialHostCompareSelection({
+        projectId: "proj_1",
+        liveHostIds: [],
+        knownHostIds: ["preset:slack"],
+        previousSelection: [],
+        urlSelection: parseHostsParam("preset:slackbot"),
+      }),
+    ).toEqual(["preset:slack"]);
   });
 
   it("resolveInitialHostCompareSelection resolves a preset selection with zero live hosts", () => {

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/host-compare-selection.test.ts
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/host-compare-selection.test.ts
@@ -63,7 +63,6 @@ describe("host-compare-selection", () => {
   it("parseHostsParam maps preset permalink aliases to current catalog ids", () => {
     expect(parseHostsParam("preset:slackbot,preset:slack-bot")).toEqual([
       "preset:slack",
-      "preset:slack",
     ]);
   });
 

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/host-config-comparison-matrix.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/host-config-comparison-matrix.test.tsx
@@ -246,6 +246,51 @@ describe("HostConfigComparisonMatrix", () => {
     expect(screen.queryByText("Model")).not.toBeInTheDocument();
   });
 
+  it("filters columns instead of rows for searched support filters", () => {
+    render(
+      <HostConfigComparisonMatrix
+        subjects={[
+          makeSubject("h_supported", "Supported Host", {
+            clientCapabilities: { sampling: {} },
+          }),
+          makeSubject("h_missing_a", "Missing A", { clientCapabilities: {} }),
+          makeSubject("h_missing_b", "Missing B", { clientCapabilities: {} }),
+        ]}
+        searchQuery="sampling"
+        supportFilter="missing"
+      />
+    );
+
+    expect(screen.getByText("Sampling")).toBeInTheDocument();
+    expect(screen.queryByText("Supported Host")).not.toBeInTheDocument();
+    expect(screen.getByText("Missing A")).toBeInTheDocument();
+    expect(screen.getByText("Missing B")).toBeInTheDocument();
+    expect(screen.getByTestId("coverage-capabilities.sampling")).toHaveTextContent(
+      "1/3"
+    );
+  });
+
+  it("shows supported columns for searched support filters", () => {
+    render(
+      <HostConfigComparisonMatrix
+        subjects={[
+          makeSubject("h_supported", "Supported Host", {
+            clientCapabilities: { sampling: {} },
+          }),
+          makeSubject("h_missing", "Missing Host", { clientCapabilities: {} }),
+        ]}
+        searchQuery="sampling"
+        supportFilter="supported"
+      />
+    );
+
+    expect(screen.getByText("Supported Host")).toBeInTheDocument();
+    expect(screen.queryByText("Missing Host")).not.toBeInTheDocument();
+    expect(screen.getByTestId("coverage-capabilities.sampling")).toHaveTextContent(
+      "1/2"
+    );
+  });
+
   it("renders column remove buttons when onRemoveHost is provided", async () => {
     const user = userEvent.setup();
     const onRemoveHost = vi.fn();

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/host-config-comparison-matrix.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/host-config-comparison-matrix.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { HostConfigDtoV2 } from "@/lib/client-config-v2";
@@ -28,18 +28,24 @@ function makeSubject(
   hostId: string,
   hostName: string,
   overrides: Partial<HostConfigDtoV2> = {},
-  configHashShort?: string
+  configHashShort?: string,
+  verifiedAt?: number
 ): HostComparisonSubject {
   return {
     hostId,
     hostName,
     hostStyle: overrides.hostStyle ?? "mcpjam",
     configHashShort: configHashShort ?? hostId.slice(-6),
+    verifiedAt,
     config: makeConfig(overrides),
   };
 }
 
 describe("HostConfigComparisonMatrix", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("renders the empty-state hint when no subjects are passed", () => {
     render(<HostConfigComparisonMatrix subjects={[]} />);
     expect(screen.getByText(/No hosts to compare/i)).toBeInTheDocument();
@@ -78,6 +84,86 @@ describe("HostConfigComparisonMatrix", () => {
     );
     expect(screen.getByText("Claude Code")).toBeInTheDocument();
     expect(screen.getByText("Cursor")).toBeInTheDocument();
+  });
+
+  it("links preset columns to the host verifier with the Agent tab selected", () => {
+    render(
+      <HostConfigComparisonMatrix
+        subjects={[makeSubject("preset:mcpjam", "MCPJam")]}
+        verifyBaseUrl="https://app.mcpjam.com"
+      />
+    );
+
+    expect(
+      screen.getByRole("link", {
+        name: "Verify MCPJam against your server",
+      })
+    ).toHaveAttribute(
+      "href",
+      "https://app.mcpjam.com/hosts?template=mcpjam&hostTab=agent"
+    );
+  });
+
+  it("shows per-host verified dates only in public caniuse mode", () => {
+    const subject = makeSubject(
+      "preset:claude",
+      "Claude",
+      { hostStyle: "claude" },
+      "claude",
+      Date.UTC(2026, 6, 8)
+    );
+
+    const { rerender } = render(
+      <HostConfigComparisonMatrix subjects={[subject]} />
+    );
+    expect(screen.queryByText("Verified at")).not.toBeInTheDocument();
+
+    rerender(
+      <HostConfigComparisonMatrix
+        subjects={[subject]}
+        verifyBaseUrl="https://app.mcpjam.com"
+      />
+    );
+
+    expect(screen.getByText("Verified at")).toBeInTheDocument();
+    expect(screen.getByText("2026-07-08")).toBeInTheDocument();
+  });
+
+  it("flags caniuse hosts checked over 30 days ago", () => {
+    const subject = makeSubject(
+      "preset:claude",
+      "Claude",
+      { hostStyle: "claude" },
+      "claude",
+      Date.UTC(2026, 6, 8)
+    );
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-10T00:00:00.000Z"));
+
+    const { rerender } = render(
+      <HostConfigComparisonMatrix
+        subjects={[subject]}
+        verifyBaseUrl="https://app.mcpjam.com"
+      />
+    );
+
+    expect(
+      screen.queryByText("Last checked over 30 days ago")
+    ).not.toBeInTheDocument();
+
+    vi.setSystemTime(new Date("2026-08-08T00:00:00.001Z"));
+    rerender(
+      <HostConfigComparisonMatrix
+        subjects={[subject]}
+        verifyBaseUrl="https://app.mcpjam.com"
+      />
+    );
+
+    expect(
+      screen.getByText("Last checked over 30 days ago")
+    ).toBeInTheDocument();
+    expect(screen.queryByText("2026-07-08")).not.toBeInTheDocument();
   });
 
   it("uses the dark Goose logo in dark theme column headers", () => {
@@ -265,9 +351,9 @@ describe("HostConfigComparisonMatrix", () => {
     expect(screen.queryByText("Supported Host")).not.toBeInTheDocument();
     expect(screen.getByText("Missing A")).toBeInTheDocument();
     expect(screen.getByText("Missing B")).toBeInTheDocument();
-    expect(screen.getByTestId("coverage-capabilities.sampling")).toHaveTextContent(
-      "1/3"
-    );
+    expect(
+      screen.getByTestId("coverage-capabilities.sampling")
+    ).toHaveTextContent("1/3");
   });
 
   it("shows supported columns for searched support filters", () => {
@@ -286,9 +372,9 @@ describe("HostConfigComparisonMatrix", () => {
 
     expect(screen.getByText("Supported Host")).toBeInTheDocument();
     expect(screen.queryByText("Missing Host")).not.toBeInTheDocument();
-    expect(screen.getByTestId("coverage-capabilities.sampling")).toHaveTextContent(
-      "1/2"
-    );
+    expect(
+      screen.getByTestId("coverage-capabilities.sampling")
+    ).toHaveTextContent("1/2");
   });
 
   it("renders column remove buttons when onRemoveHost is provided", async () => {

--- a/mcpjam-inspector/client/src/components/hosts/comparison/caniuse-capability-catalog.ts
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/caniuse-capability-catalog.ts
@@ -1,0 +1,147 @@
+import {
+  HOST_CONFIG_FIELDS,
+  type HostConfigFieldDef,
+  type SupportLevel,
+} from "@/lib/host-config-field-schema";
+import type { HostListItem } from "@/hooks/useClients";
+import {
+  getSupportLevel,
+  isSupportField,
+} from "./support-level";
+import type { HostConfigDtoV2 } from "@/lib/client-config-v2";
+
+export const CANIUSE_LAST_VERIFIED_DATE = "2026-07-07";
+
+export const PUBLIC_CAN_I_USE_INLINE_PRESET_IDS = [
+  "preset:claude",
+  "preset:chatgpt",
+  "preset:copilot",
+  "preset:cursor",
+  "preset:slack",
+  "preset:vscode",
+] as const;
+
+const PUBLIC_CAN_I_USE_EXCLUDED_FIELD_IDS = new Set([
+  "modelId",
+  "temperature",
+  "systemPrompt",
+  "mcpProtocolVersion",
+  "supportedProtocolVersions",
+  "clientInfo.name",
+  "clientInfo.version",
+  "connectionDefaults.requestTimeout",
+  "connectionDefaults.headers",
+  "uiInitialize.hostInfo",
+  "sandbox.csp.mode",
+  "sandbox.permissions.mode",
+  "sandbox.sandboxAttrs",
+  "sandbox.allowFeatures",
+]);
+
+export interface CaniuseCapability {
+  slug: string;
+  field: HostConfigFieldDef;
+}
+
+function toKebab(input: string): string {
+  return input
+    .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function slugForField(field: HostConfigFieldDef): string {
+  if (field.id.startsWith("capabilities.")) {
+    return toKebab(field.id.replace(/^capabilities\./, ""));
+  }
+  if (field.id.startsWith("appsCap.")) {
+    return `mcp-apps-${toKebab(field.label)}`;
+  }
+  if (field.id.startsWith("openaiShim.")) {
+    return `openai-shim-${toKebab(field.label)}`;
+  }
+  if (field.id.startsWith("sandboxPerm.")) {
+    return `sandbox-permission-${toKebab(field.label)}`;
+  }
+  return toKebab(field.label);
+}
+
+export function isPublicCaniuseCapabilityField(
+  field: HostConfigFieldDef,
+): boolean {
+  return (
+    isSupportField(field) && !PUBLIC_CAN_I_USE_EXCLUDED_FIELD_IDS.has(field.id)
+  );
+}
+
+export const PUBLIC_CAN_I_USE_FIELDS: ReadonlyArray<HostConfigFieldDef> =
+  HOST_CONFIG_FIELDS.filter(isPublicCaniuseCapabilityField);
+
+export const CANIUSE_CAPABILITIES: ReadonlyArray<CaniuseCapability> =
+  PUBLIC_CAN_I_USE_FIELDS.map((field) => ({
+    slug: slugForField(field),
+    field,
+  }));
+
+const capabilitiesBySlug = new Map<string, CaniuseCapability>();
+const capabilitiesByFieldId = new Map<string, CaniuseCapability>();
+for (const capability of CANIUSE_CAPABILITIES) {
+  const duplicate = capabilitiesBySlug.get(capability.slug);
+  if (duplicate) {
+    throw new Error(
+      `Duplicate caniuse capability slug "${capability.slug}" for ${duplicate.field.id} and ${capability.field.id}`,
+    );
+  }
+  capabilitiesBySlug.set(capability.slug, capability);
+  capabilitiesByFieldId.set(capability.field.id, capability);
+}
+
+export function getCaniuseCapabilityBySlug(
+  slug: string | null | undefined,
+): CaniuseCapability | null {
+  if (!slug) return null;
+  return capabilitiesBySlug.get(slug) ?? null;
+}
+
+export function getCaniuseCapabilityForField(
+  field: HostConfigFieldDef,
+): CaniuseCapability | null {
+  return capabilitiesByFieldId.get(field.id) ?? null;
+}
+
+export function buildCaniuseCapabilityPath(slug: string): string {
+  return `/capabilities/${encodeURIComponent(slug)}`;
+}
+
+export function sortCaniusePresetHosts<T extends Pick<HostListItem, "hostId">>(
+  hosts: ReadonlyArray<T>,
+): T[] {
+  const rank = new Map<string, number>(
+    PUBLIC_CAN_I_USE_INLINE_PRESET_IDS.map((hostId, index) => [hostId, index]),
+  );
+  return [...hosts].sort((a, b) => {
+    const aRank = rank.get(a.hostId) ?? Number.POSITIVE_INFINITY;
+    const bRank = rank.get(b.hostId) ?? Number.POSITIVE_INFINITY;
+    return aRank - bRank;
+  });
+}
+
+export function getCaniuseSupportLevel(
+  field: HostConfigFieldDef,
+  config: HostConfigDtoV2,
+): SupportLevel {
+  return getSupportLevel(field, config) ?? "neutral";
+}
+
+export function getCaniuseSupportLabel(level: SupportLevel): string {
+  switch (level) {
+    case "supported":
+      return "Supported";
+    case "partial":
+      return "Partial";
+    case "neutral":
+    case "unsupported":
+      return "Not supported";
+  }
+}

--- a/mcpjam-inspector/client/src/components/hosts/comparison/host-compare-presets.ts
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/host-compare-presets.ts
@@ -41,7 +41,7 @@ interface PresetCompareOptions {
  */
 export function buildPresetCompareEntries(
   catalog: HostCompatCatalog,
-  options: PresetCompareOptions = {},
+  options: PresetCompareOptions = {}
 ): PresetCompareEntries {
   const hosts: HostListItem[] = [];
   const subjects: Record<string, HostComparisonSubject> = {};
@@ -73,6 +73,7 @@ export function buildPresetCompareEntries(
       hostName: host.label,
       hostStyle: config.hostStyle,
       configHashShort: host.id,
+      verifiedAt: host.verifiedAt,
       config,
     };
   }

--- a/mcpjam-inspector/client/src/components/hosts/comparison/host-compare-selection.ts
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/host-compare-selection.ts
@@ -2,6 +2,13 @@ import { PRESET_HOST_ID_PREFIX } from "./host-compare-presets";
 
 const STORAGE_PREFIX = "host-compare-selected:";
 
+// Shared compare URLs should survive host id cleanups. Keep this scoped to
+// permalink parsing; catalog ids and host creation stay strict.
+const PRESET_HOST_ID_ALIASES: Record<string, string> = {
+  slackbot: "slack",
+  "slack-bot": "slack",
+};
+
 /**
  * Default compare columns when nothing else (URL param, stored preference,
  * prior in-memory selection) picks a selection. ChatGPT and Claude give fresh
@@ -67,8 +74,16 @@ export function parseHostsParam(raw: string | null | undefined): string[] | null
   const parts = raw
     .split(",")
     .map((s) => s.trim())
-    .filter((s) => s.length > 0);
+    .filter((s) => s.length > 0)
+    .map(normalizeHostComparePermalinkId);
   return parts.length > 0 ? parts : null;
+}
+
+function normalizeHostComparePermalinkId(hostId: string): string {
+  if (!hostId.startsWith(PRESET_HOST_ID_PREFIX)) return hostId;
+  const presetId = hostId.slice(PRESET_HOST_ID_PREFIX.length);
+  const canonicalId = PRESET_HOST_ID_ALIASES[presetId];
+  return canonicalId ? `${PRESET_HOST_ID_PREFIX}${canonicalId}` : hostId;
 }
 
 export function resolveInitialHostCompareSelection(args: {

--- a/mcpjam-inspector/client/src/components/hosts/comparison/host-compare-selection.ts
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/host-compare-selection.ts
@@ -76,7 +76,8 @@ export function parseHostsParam(raw: string | null | undefined): string[] | null
     .map((s) => s.trim())
     .filter((s) => s.length > 0)
     .map(normalizeHostComparePermalinkId);
-  return parts.length > 0 ? parts : null;
+  const deduped = [...new Set(parts)];
+  return deduped.length > 0 ? deduped : null;
 }
 
 function normalizeHostComparePermalinkId(hostId: string): string {

--- a/mcpjam-inspector/client/src/components/hosts/comparison/host-config-comparison-matrix.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/host-config-comparison-matrix.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { Info, X } from "lucide-react";
+import { Info, PlugZap, X } from "lucide-react";
 import { motion, useReducedMotion } from "framer-motion";
 import {
   Popover,
@@ -22,7 +22,9 @@ import {
   type HostConfigFieldDef,
 } from "@/lib/host-config-field-schema";
 import { SupportChip } from "./support-chip";
+import { PRESET_HOST_ID_PREFIX } from "./host-compare-presets";
 import {
+  cellPassesSupportFilter,
   computeVisibleFieldIds,
   getCapabilityCaveats,
   getSupportLevel,
@@ -33,6 +35,7 @@ import {
 
 interface HostConfigComparisonMatrixProps {
   subjects: ReadonlyArray<HostComparisonSubject>;
+  fields?: ReadonlyArray<HostConfigFieldDef>;
   /** When true, hide rows whose value is identical across every host. */
   divergingOnly?: boolean;
   /** caniuse-style row filter by aggregate support level. Default `"all"`. */
@@ -49,6 +52,13 @@ interface HostConfigComparisonMatrixProps {
   onRemoveHost?: (hostId: string) => void;
   themeMode?: HostThemeMode;
   mobileOptimized?: boolean;
+  /**
+   * When set, each column header gets a "Verify against your server" action
+   * deep-linking to `<verifyBaseUrl>/hosts?template=<templateId>` — the hosted
+   * app opens (or creates) that client's host. Used only on the public caniuse
+   * surface (`presetOnly`), where every column is a synthetic preset host.
+   */
+  verifyBaseUrl?: string;
 }
 
 /**
@@ -61,6 +71,7 @@ interface HostConfigComparisonMatrixProps {
  */
 export function HostConfigComparisonMatrix({
   subjects,
+  fields = HOST_CONFIG_FIELDS,
   divergingOnly = false,
   supportFilter = "all",
   searchQuery = "",
@@ -68,17 +79,20 @@ export function HostConfigComparisonMatrix({
   onRemoveHost,
   themeMode = "light",
   mobileOptimized = false,
+  verifyBaseUrl,
 }: HostConfigComparisonMatrixProps) {
-  const groups = useMemo(() => groupHostConfigFields(HOST_CONFIG_FIELDS), []);
+  const groups = useMemo(() => groupHostConfigFields(fields), [fields]);
   const configs = useMemo(() => subjects.map((s) => s.config), [subjects]);
 
   const divergingIds = useMemo(() => {
     const set = new Set<string>();
-    for (const field of HOST_CONFIG_FIELDS) {
+    for (const field of fields) {
       if (fieldDiverges(field, configs)) set.add(field.id);
     }
     return set;
-  }, [configs]);
+  }, [configs, fields]);
+  const useCellSupportFilter =
+    searchQuery.trim().length > 0 && supportFilter !== "all";
 
   // Rows surviving the diverging toggle, support filter, and search query.
   // Computed once here so the section/subsection passes stay in lockstep, and
@@ -86,13 +100,33 @@ export function HostConfigComparisonMatrix({
   const visibleFieldIds = useMemo(
     () =>
       computeVisibleFieldIds({
+        fields,
         configs,
         divergingOnly,
-        supportFilter,
+        supportFilter: useCellSupportFilter ? "all" : supportFilter,
         searchQuery,
       }),
-    [configs, divergingOnly, supportFilter, searchQuery]
+    [
+      fields,
+      configs,
+      divergingOnly,
+      supportFilter,
+      searchQuery,
+      useCellSupportFilter,
+    ]
   );
+  const visibleFields = useMemo(
+    () => fields.filter((field) => visibleFieldIds.has(field.id)),
+    [fields, visibleFieldIds]
+  );
+  const displaySubjects = useMemo(() => {
+    if (!useCellSupportFilter) return subjects;
+    return subjects.filter((subject) =>
+      visibleFields.some((field) =>
+        cellPassesSupportFilter(field, subject.config, supportFilter)
+      )
+    );
+  }, [subjects, supportFilter, useCellSupportFilter, visibleFields]);
 
   if (subjects.length === 0) {
     return (
@@ -106,6 +140,14 @@ export function HostConfigComparisonMatrix({
     return (
       <div className="flex h-full min-h-[160px] items-center justify-center rounded-xl border border-border bg-card text-sm text-muted-foreground">
         No fields match the current search and filters.
+      </div>
+    );
+  }
+
+  if (displaySubjects.length === 0) {
+    return (
+      <div className="flex h-full min-h-[160px] items-center justify-center rounded-xl border border-border bg-card text-sm text-muted-foreground">
+        No clients match the current search and filters.
       </div>
     );
   }
@@ -142,7 +184,7 @@ export function HostConfigComparisonMatrix({
                   : "w-[168px] sm:w-[300px]"
               }
             />
-            {subjects.map((s) => (
+            {displaySubjects.map((s) => (
               <col
                 key={s.hostId}
                 className={
@@ -161,12 +203,13 @@ export function HostConfigComparisonMatrix({
                   Field
                 </span>
               </th>
-              {subjects.map((s) => (
+              {displaySubjects.map((s) => (
                 <HostColumnHeader
                   key={s.hostId}
                   subject={s}
                   onRemove={onRemoveHost}
                   themeMode={themeMode}
+                  verifyBaseUrl={verifyBaseUrl}
                 />
               ))}
             </tr>
@@ -190,7 +233,8 @@ export function HostConfigComparisonMatrix({
                   sectionLabel={group.section.label}
                   divergeCount={groupDivergeCount}
                   subsections={group.subsections}
-                  subjects={subjects}
+                  subjects={displaySubjects}
+                  coverageSubjects={subjects}
                   divergingIds={divergingIds}
                   visibleFieldIds={visibleFieldIds}
                   showDescriptions={showDescriptions}
@@ -214,6 +258,7 @@ interface SectionRowsProps {
     fields: ReadonlyArray<HostConfigFieldDef>;
   }>;
   subjects: ReadonlyArray<HostComparisonSubject>;
+  coverageSubjects: ReadonlyArray<HostComparisonSubject>;
   divergingIds: ReadonlySet<string>;
   visibleFieldIds: ReadonlySet<string>;
   showDescriptions: boolean;
@@ -226,6 +271,7 @@ function SectionRows({
   divergeCount,
   subsections,
   subjects,
+  coverageSubjects,
   divergingIds,
   visibleFieldIds,
   showDescriptions,
@@ -283,6 +329,7 @@ function SectionRows({
             label={sub.label}
             fields={fields}
             subjects={subjects}
+            coverageSubjects={coverageSubjects}
             divergingIds={divergingIds}
             colSpan={colSpan}
             showDescriptions={showDescriptions}
@@ -298,6 +345,7 @@ function SubsectionRows({
   label,
   fields,
   subjects,
+  coverageSubjects,
   divergingIds,
   colSpan,
   showDescriptions,
@@ -306,6 +354,7 @@ function SubsectionRows({
   label: string;
   fields: ReadonlyArray<HostConfigFieldDef>;
   subjects: ReadonlyArray<HostComparisonSubject>;
+  coverageSubjects: ReadonlyArray<HostComparisonSubject>;
   divergingIds: ReadonlySet<string>;
   colSpan: number;
   showDescriptions: boolean;
@@ -326,6 +375,7 @@ function SubsectionRows({
           key={field.id}
           field={field}
           subjects={subjects}
+          coverageSubjects={coverageSubjects}
           diverges={divergingIds.has(field.id)}
           showDescriptions={showDescriptions}
           mobileOptimized={mobileOptimized}
@@ -338,24 +388,30 @@ function SubsectionRows({
 function FieldRow({
   field,
   subjects,
+  coverageSubjects,
   diverges,
   showDescriptions,
   mobileOptimized,
 }: {
   field: HostConfigFieldDef;
   subjects: ReadonlyArray<HostComparisonSubject>;
+  coverageSubjects: ReadonlyArray<HostComparisonSubject>;
   diverges: boolean;
   showDescriptions: boolean;
   mobileOptimized: boolean;
 }) {
   // caniuse "global support" equivalent — only meaningful when comparing ≥2 hosts.
   const coverage =
-    subjects.length >= 2
+    coverageSubjects.length >= 2
       ? rowCoverage(
           field,
-          subjects.map((s) => s.config)
+          coverageSubjects.map((s) => s.config)
         )
       : null;
+  const labelClassName = cn(
+    "text-[13px] font-medium leading-tight text-foreground",
+    mobileOptimized && "min-w-0 break-words"
+  );
   return (
     <tr className="border-b border-border last:border-b-0">
       <td
@@ -383,14 +439,7 @@ function FieldRow({
             mobileOptimized && "min-w-0"
           )}
         >
-          <span
-            className={cn(
-              "text-[13px] font-medium leading-tight text-foreground",
-              mobileOptimized && "min-w-0 break-words"
-            )}
-          >
-            {field.label}
-          </span>
+          <span className={labelClassName}>{field.label}</span>
           {coverage && (
             <span
               className="text-[10.5px] text-muted-foreground tabular-nums"
@@ -699,10 +748,12 @@ function HostColumnHeader({
   subject,
   onRemove,
   themeMode,
+  verifyBaseUrl,
 }: {
   subject: HostComparisonSubject;
   onRemove?: (hostId: string) => void;
   themeMode: HostThemeMode;
+  verifyBaseUrl?: string;
 }) {
   const logoSrc = getChatboxHostLogo(
     subject.hostStyle,
@@ -710,6 +761,7 @@ function HostColumnHeader({
     themeMode
   );
   const reduceMotion = useReducedMotion();
+  const verifyHref = buildVerifyHref(verifyBaseUrl, subject.hostId);
 
   return (
     <th className="sticky top-0 z-20 bg-card border-b border-l border-border px-3 py-3 sm:px-4 sm:py-4 text-left align-top">
@@ -740,14 +792,47 @@ function HostColumnHeader({
           className="mt-0.5 size-4 shrink-0 object-contain"
         />
         <div
-          className="min-w-0 font-medium text-[14px] truncate leading-tight"
+          className="min-w-0 flex-1 font-medium text-[14px] truncate leading-tight"
           title={subject.hostName}
         >
           {subject.hostName}
         </div>
+        {verifyHref ? (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <a
+                href={verifyHref}
+                data-testid={`host-compare-verify-${subject.hostId}`}
+                aria-label={`Verify ${subject.hostName} against your server`}
+                className="mt-0.5 inline-flex size-4 shrink-0 items-center justify-center rounded-sm text-muted-foreground/70 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+              >
+                <PlugZap className="size-3.5" />
+              </a>
+            </TooltipTrigger>
+            <TooltipContent side="top" variant="muted">
+              Verify against your server
+            </TooltipContent>
+          </Tooltip>
+        ) : null}
       </motion.div>
     </th>
   );
+}
+
+/**
+ * Deep-link a preset column to the hosted app's "verify" entry point:
+ * `<base>/hosts?template=claude`. Only preset columns carry a template id;
+ * a non-preset host (shouldn't happen on the public surface) falls back to
+ * the bare base URL. Returns null when verification is disabled.
+ */
+function buildVerifyHref(
+  baseUrl: string | undefined,
+  hostId: string
+): string | null {
+  if (!baseUrl) return null;
+  if (!hostId.startsWith(PRESET_HOST_ID_PREFIX)) return baseUrl;
+  const templateId = hostId.slice(PRESET_HOST_ID_PREFIX.length);
+  return `${baseUrl}/hosts?template=${encodeURIComponent(templateId)}`;
 }
 
 /** Compact one-line rendering of an object entry's value for inline display. */

--- a/mcpjam-inspector/client/src/components/hosts/comparison/host-config-comparison-matrix.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/host-config-comparison-matrix.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { Info, PlugZap, X } from "lucide-react";
+import { Info, TrendingUp, TriangleAlert, X } from "lucide-react";
 import { motion, useReducedMotion } from "framer-motion";
 import {
   Popover,
@@ -23,6 +23,7 @@ import {
 } from "@/lib/host-config-field-schema";
 import { SupportChip } from "./support-chip";
 import { PRESET_HOST_ID_PREFIX } from "./host-compare-presets";
+import { buildHostVerifySearch } from "../host-verify-deep-link";
 import {
   cellPassesSupportFilter,
   computeVisibleFieldIds,
@@ -32,6 +33,14 @@ import {
   type SupportFilterMode,
   type SupportLevel,
 } from "./support-level";
+
+const VERIFIED_DATE_FORMATTER = new Intl.DateTimeFormat("en-CA", {
+  timeZone: "UTC",
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+});
+const STALE_VERIFICATION_MS = 30 * 24 * 60 * 60 * 1000;
 
 interface HostConfigComparisonMatrixProps {
   subjects: ReadonlyArray<HostComparisonSubject>;
@@ -83,6 +92,7 @@ export function HostConfigComparisonMatrix({
 }: HostConfigComparisonMatrixProps) {
   const groups = useMemo(() => groupHostConfigFields(fields), [fields]);
   const configs = useMemo(() => subjects.map((s) => s.config), [subjects]);
+  const showVerifiedAtRow = verifyBaseUrl !== undefined;
 
   const divergingIds = useMemo(() => {
     const set = new Set<string>();
@@ -172,7 +182,7 @@ export function HostConfigComparisonMatrix({
       >
         <table
           className={cn(
-            "border-collapse text-[13px]",
+            "border-collapse text-center text-[13px]",
             mobileOptimized ? "w-max min-w-full" : "w-full"
           )}
         >
@@ -198,7 +208,7 @@ export function HostConfigComparisonMatrix({
 
           <thead>
             <tr>
-              <th className="sticky left-0 top-0 z-30 bg-card border-b border-r border-border px-3 py-3 sm:px-5 sm:py-4 text-left">
+              <th className="sticky left-0 top-0 z-30 bg-card border-b border-border px-3 py-3 text-left after:pointer-events-none after:absolute after:inset-y-0 after:right-0 after:w-px after:bg-border after:content-[''] sm:px-5 sm:py-4">
                 <span className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
                   Field
                 </span>
@@ -216,6 +226,12 @@ export function HostConfigComparisonMatrix({
           </thead>
 
           <tbody>
+            {showVerifiedAtRow ? (
+              <VerifiedAtRow
+                subjects={displaySubjects}
+                mobileOptimized={mobileOptimized}
+              />
+            ) : null}
             {groups.map((group, groupIndex) => {
               const visibleFieldsInGroup = group.subsections
                 .flatMap((sub) => sub.fields)
@@ -246,6 +262,58 @@ export function HostConfigComparisonMatrix({
         </table>
       </div>
     </motion.div>
+  );
+}
+
+function formatVerifiedAt(verifiedAt: number | undefined): string {
+  if (verifiedAt === undefined || !Number.isFinite(verifiedAt)) return "—";
+  return VERIFIED_DATE_FORMATTER.format(new Date(verifiedAt));
+}
+
+function isVerifiedAtStale(verifiedAt: number | undefined): boolean {
+  if (verifiedAt === undefined || !Number.isFinite(verifiedAt)) return false;
+  return Date.now() - verifiedAt > STALE_VERIFICATION_MS;
+}
+
+function VerifiedAtRow({
+  subjects,
+  mobileOptimized,
+}: {
+  subjects: ReadonlyArray<HostComparisonSubject>;
+  mobileOptimized: boolean;
+}) {
+  return (
+    <tr className="border-b border-border bg-card">
+      <td
+        className={cn(
+          "sticky left-0 z-10 bg-card px-3 py-1.5 text-left after:pointer-events-none after:absolute after:inset-y-0 after:right-0 after:w-px after:bg-border after:content-[''] sm:px-5",
+          mobileOptimized && "min-w-0"
+        )}
+      >
+        <span className="text-[12px] font-medium leading-tight text-muted-foreground">
+          Verified at
+        </span>
+      </td>
+      {subjects.map((subject) => (
+        <td
+          key={subject.hostId}
+          className="min-w-[220px] border-l border-border px-3 py-1.5 text-center align-top sm:px-4"
+        >
+          <div className="flex min-h-5 items-center justify-center">
+            {isVerifiedAtStale(subject.verifiedAt) ? (
+              <span className="inline-flex items-center gap-1 whitespace-nowrap text-[12px] leading-tight text-muted-foreground">
+                <TriangleAlert className="size-3.5 shrink-0" aria-hidden />
+                Last checked over 30 days ago
+              </span>
+            ) : (
+              <span className="text-[12px] tabular-nums text-muted-foreground">
+                {formatVerifiedAt(subject.verifiedAt)}
+              </span>
+            )}
+          </div>
+        </td>
+      ))}
+    </tr>
   );
 }
 
@@ -281,13 +349,14 @@ function SectionRows({
   return (
     <>
       <tr>
+        {/* Label lives in its own first-column cell so `sticky left-0` can pin
+            it — a colSpan cell spans the whole table and never sticks. */}
         <th
-          colSpan={colSpan}
           scope="colgroup"
-          className="sticky top-[64px] z-20 bg-muted border-y border-border px-5 py-2 text-left"
+          className="sticky left-0 z-20 border-y border-border bg-muted px-3 py-1 text-left after:pointer-events-none after:absolute after:inset-y-0 after:right-0 after:w-px after:bg-border after:content-[''] sm:px-5"
         >
           <motion.div
-            className="flex items-baseline gap-3"
+            className="flex items-baseline gap-2"
             initial={{ opacity: 0, x: -8 }}
             animate={{ opacity: 1, x: 0 }}
             transition={{
@@ -296,7 +365,7 @@ function SectionRows({
               ease: [0.22, 1, 0.36, 1],
             }}
           >
-            <span className="text-[15px] font-medium tracking-tight">
+            <span className="text-[13px] font-medium tracking-tight">
               {sectionLabel}
             </span>
             {divergeCount > 0 && (
@@ -313,11 +382,12 @@ function SectionRows({
                 }}
               />
             )}
-            <span className="ml-auto text-[10.5px] text-muted-foreground tabular-nums">
-              {divergeCount} diverging
-            </span>
           </motion.div>
         </th>
+        <td
+          colSpan={colSpan - 1}
+          className="border-y border-border bg-muted"
+        />
       </tr>
 
       {subsections.map((sub) => {
@@ -363,12 +433,13 @@ function SubsectionRows({
   return (
     <>
       <tr>
-        <td
-          colSpan={colSpan}
-          className="px-5 pt-5 pb-1 text-[10px] uppercase tracking-wider text-muted-foreground"
-        >
+        <td className="sticky left-0 z-10 border-b border-border bg-card px-3 py-1.5 text-left text-[10px] uppercase tracking-wider text-muted-foreground after:pointer-events-none after:absolute after:inset-y-0 after:right-0 after:w-px after:bg-border after:content-[''] sm:px-5">
           {label}
         </td>
+        <td
+          colSpan={colSpan - 1}
+          className="border-b border-border bg-card"
+        />
       </tr>
       {fields.map((field) => (
         <FieldRow
@@ -414,12 +485,10 @@ function FieldRow({
   );
   return (
     <tr className="border-b border-border last:border-b-0">
-      <td
-        className={cn(
-          "sticky left-0 z-10 bg-card border-r border-border px-3 sm:px-5 py-2.5",
-          "relative"
-        )}
-      >
+      {/* NOTE: no `relative` here — `cn` (tailwind-merge) treats it as
+          conflicting with `sticky` and would strip the sticky positioning.
+          `sticky` already anchors the absolute diverge gutter below. */}
+      <td className="sticky left-0 z-10 bg-card px-3 py-2.5 text-left after:pointer-events-none after:absolute after:inset-y-0 after:right-0 after:w-px after:bg-border after:content-[''] sm:px-5">
         {diverges && (
           <motion.span
             aria-hidden="true"
@@ -471,7 +540,7 @@ function FieldRow({
           )}
         </div>
         {field.description && showDescriptions && (
-          <div className="text-[11px] text-muted-foreground mt-1 leading-snug">
+          <div className="mt-1 text-[11px] leading-snug text-muted-foreground">
             {field.description}
           </div>
         )}
@@ -479,7 +548,7 @@ function FieldRow({
       {subjects.map((s) => (
         <td
           key={s.hostId}
-          className="border-l border-border px-3 sm:px-4 py-2.5 align-top"
+          className="border-l border-border px-3 py-2.5 text-center align-top sm:px-4"
         >
           <FieldCell
             field={field}
@@ -541,7 +610,7 @@ function FieldCell({
           ? Object.keys(value as Record<string, unknown>)
           : [];
       return (
-        <span className="inline-flex items-center gap-2">
+        <span className="inline-flex items-center justify-center gap-2">
           <SupportChip level={level} label="Supported" />
           <CapabilityInfoTooltip
             caveats={caveats}
@@ -590,7 +659,7 @@ function FieldCell({
     case "mode-set": {
       const present = new Set(Array.isArray(value) ? (value as string[]) : []);
       return (
-        <span className="inline-flex flex-wrap items-center gap-1">
+        <span className="inline-flex flex-wrap items-center justify-center gap-1">
           {kind.modes.map((mode) => (
             <SupportChip
               key={mode}
@@ -614,7 +683,7 @@ function FieldCell({
       const s = String(value);
       const firstLine = s.split("\n", 1)[0] ?? "";
       return (
-        <div className="flex flex-col gap-0.5">
+        <div className="flex flex-col items-center gap-0.5 text-center">
           <div className="text-[12px] truncate max-w-[200px]">
             {firstLine || (
               <span className="italic text-muted-foreground">empty</span>
@@ -685,7 +754,7 @@ function FieldCell({
         );
       }
       return (
-        <div className="flex flex-col gap-0.5 font-mono text-[11.5px] leading-snug">
+        <div className="flex flex-col items-center gap-0.5 text-center font-mono text-[11.5px] leading-snug">
           {entries.map(([k, v]) => (
             <div key={k} className="break-all">
               <span className="text-muted-foreground">{k}: </span>
@@ -764,10 +833,13 @@ function HostColumnHeader({
   const verifyHref = buildVerifyHref(verifyBaseUrl, subject.hostId);
 
   return (
-    <th className="sticky top-0 z-20 bg-card border-b border-l border-border px-3 py-3 sm:px-4 sm:py-4 text-left align-top">
+    <th className="sticky top-0 z-20 border-b border-l border-border bg-card px-3 py-3 text-center align-top sm:px-4 sm:py-4">
       <motion.div
         key={subject.hostId}
-        className="flex items-start gap-2"
+        className={cn(
+          "relative flex items-start justify-center gap-2",
+          onRemove && "pl-5"
+        )}
         initial={reduceMotion ? false : { opacity: 0, x: -6 }}
         animate={{ opacity: 1, x: 0 }}
         transition={{ duration: 0.32, ease: [0.22, 1, 0.36, 1] }}
@@ -777,7 +849,7 @@ function HostColumnHeader({
             type="button"
             aria-label={`Remove ${subject.hostName} from comparison`}
             data-testid={`host-compare-remove-${subject.hostId}`}
-            className="mt-0.5 inline-flex size-4 shrink-0 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+            className="absolute left-0 top-0 inline-flex size-4 shrink-0 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
             onClick={() => onRemove(subject.hostId)}
             whileHover={reduceMotion ? undefined : { scale: 1.15 }}
             whileTap={reduceMotion ? undefined : { scale: 0.85, rotate: 90 }}
@@ -792,7 +864,7 @@ function HostColumnHeader({
           className="mt-0.5 size-4 shrink-0 object-contain"
         />
         <div
-          className="min-w-0 flex-1 font-medium text-[14px] truncate leading-tight"
+          className="min-w-0 max-w-[160px] truncate text-center text-[14px] font-medium leading-tight"
           title={subject.hostName}
         >
           {subject.hostName}
@@ -806,7 +878,7 @@ function HostColumnHeader({
                 aria-label={`Verify ${subject.hostName} against your server`}
                 className="mt-0.5 inline-flex size-4 shrink-0 items-center justify-center rounded-sm text-muted-foreground/70 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
               >
-                <PlugZap className="size-3.5" />
+                <TrendingUp className="size-3.5" />
               </a>
             </TooltipTrigger>
             <TooltipContent side="top" variant="muted">
@@ -832,7 +904,7 @@ function buildVerifyHref(
   if (!baseUrl) return null;
   if (!hostId.startsWith(PRESET_HOST_ID_PREFIX)) return baseUrl;
   const templateId = hostId.slice(PRESET_HOST_ID_PREFIX.length);
-  return `${baseUrl}/hosts?template=${encodeURIComponent(templateId)}`;
+  return `${baseUrl}/hosts?${buildHostVerifySearch(templateId, "behavior")}`;
 }
 
 /** Compact one-line rendering of an object entry's value for inline display. */
@@ -857,7 +929,7 @@ function ExpandablePreview({
       <PopoverTrigger asChild>
         <button
           type="button"
-          className="text-left text-[11px] text-muted-foreground hover:text-foreground underline-offset-2 hover:underline"
+          className="text-center text-[11px] text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
         >
           {label}
         </button>

--- a/mcpjam-inspector/client/src/components/hosts/comparison/support-level.ts
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/support-level.ts
@@ -148,6 +148,24 @@ export function rowPassesSupportFilter(
   }
 }
 
+export function cellPassesSupportFilter(
+  field: HostConfigFieldDef,
+  config: HostConfigDtoV2,
+  mode: SupportFilterMode
+): boolean {
+  if (mode === "all") return true;
+  const level = getSupportLevel(field, config);
+  if (level === null) return false;
+  switch (mode) {
+    case "missing":
+      return level === "neutral" || level === "unsupported";
+    case "partial":
+      return level === "partial";
+    case "supported":
+      return level === "supported";
+  }
+}
+
 function normalizeFieldSearchText(value: string): string {
   return value
     .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
@@ -188,6 +206,7 @@ export function fieldMatchesQuery(
  * the container (the "N / M fields" count) so they never disagree.
  */
 export function computeVisibleFieldIds(args: {
+  fields?: ReadonlyArray<HostConfigFieldDef>;
   configs: ReadonlyArray<HostConfigDtoV2>;
   divergingOnly: boolean;
   supportFilter: SupportFilterMode;
@@ -195,7 +214,7 @@ export function computeVisibleFieldIds(args: {
 }): Set<string> {
   const q = args.searchQuery.trim().toLowerCase();
   const set = new Set<string>();
-  for (const field of HOST_CONFIG_FIELDS) {
+  for (const field of args.fields ?? HOST_CONFIG_FIELDS) {
     if (args.divergingOnly && !fieldDiverges(field, args.configs)) continue;
     if (!rowPassesSupportFilter(field, args.configs, args.supportFilter))
       continue;

--- a/mcpjam-inspector/client/src/components/hosts/host-verify-deep-link.ts
+++ b/mcpjam-inspector/client/src/components/hosts/host-verify-deep-link.ts
@@ -1,0 +1,65 @@
+import type { HostFocusTabId } from "./redesigned/types";
+
+export const HOST_VERIFY_TEMPLATE_PARAM = "template";
+export const HOST_VERIFY_TAB_PARAM = "hostTab";
+
+type HostVerifyTabParam =
+  | "agent"
+  | "tools"
+  | "computer"
+  | "protocol"
+  | "apps"
+  | "appearance";
+
+const HOST_VERIFY_TAB_TO_FOCUS_TAB: Record<
+  HostVerifyTabParam,
+  HostFocusTabId
+> = {
+  agent: "behavior",
+  tools: "tools",
+  computer: "computer",
+  protocol: "protocol",
+  apps: "apps",
+  appearance: "appearance",
+};
+
+const FOCUS_TAB_TO_HOST_VERIFY_TAB: Partial<
+  Record<HostFocusTabId, HostVerifyTabParam>
+> = {
+  behavior: "agent",
+  tools: "tools",
+  computer: "computer",
+  protocol: "protocol",
+  apps: "apps",
+  appearance: "appearance",
+};
+
+export function hostFocusTabToVerifyParam(
+  tab: HostFocusTabId
+): HostVerifyTabParam | null {
+  return FOCUS_TAB_TO_HOST_VERIFY_TAB[tab] ?? null;
+}
+
+export function parseHostVerifyTabParam(search: string): HostFocusTabId | null {
+  const params = new URLSearchParams(
+    search.startsWith("?") ? search : `?${search}`
+  );
+  const raw = params.get(HOST_VERIFY_TAB_PARAM);
+  if (!raw) return null;
+  if (raw === "behavior") return "behavior";
+  return raw in HOST_VERIFY_TAB_TO_FOCUS_TAB
+    ? HOST_VERIFY_TAB_TO_FOCUS_TAB[raw as HostVerifyTabParam]
+    : null;
+}
+
+export function buildHostVerifySearch(
+  templateId: string,
+  tab: HostFocusTabId = "behavior"
+): string {
+  const params = new URLSearchParams({
+    [HOST_VERIFY_TEMPLATE_PARAM]: templateId,
+  });
+  const tabParam = hostFocusTabToVerifyParam(tab);
+  if (tabParam) params.set(HOST_VERIFY_TAB_PARAM, tabParam);
+  return params.toString();
+}

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/HostBuilderViewRedesigned.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/HostBuilderViewRedesigned.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useNavigate } from "react-router";
+import { useLocation, useNavigate } from "react-router";
 import { Loader2, Save } from "lucide-react";
 import { toast } from "@/lib/toast";
 import { useConvexAuth } from "convex/react";
@@ -36,6 +36,7 @@ import {
 import { getChatboxShellStyle } from "@/lib/chatbox-client-style";
 import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
 import { RedesignedHostCanvas } from "./canvas/RedesignedHostCanvas";
+import { parseHostVerifyTabParam } from "../host-verify-deep-link";
 import { buildRedesignedHostCanvas } from "./canvas/canvasBuilder";
 import { HostFocusPanel } from "./focus/HostFocusPanel";
 import { useComputersEnabled } from "@/hooks/useComputersEnabled";
@@ -69,6 +70,7 @@ export function HostBuilderViewRedesigned({
   projectId,
 }: HostBuilderViewRedesignedProps) {
   const navigate = useNavigate();
+  const location = useLocation();
   const { isAuthenticated } = useConvexAuth();
   const { host } = useHost({
     isAuthenticated,
@@ -96,6 +98,11 @@ export function HostBuilderViewRedesigned({
     tab: "behavior",
     selectedServerId: null,
   });
+  const requestedFocusTab = useMemo(
+    () => parseHostVerifyTabParam(location.search),
+    [location.search]
+  );
+  const appliedFocusTabRef = useRef<string | null>(null);
   // Diff snapshot — populated for ONE render after a host switch so the
   // canvas can mark changed leaves/fields. Cleared after the flash
   // duration so subsequent in-place edits don't keep re-firing the
@@ -182,6 +189,18 @@ export function HostBuilderViewRedesigned({
         : null,
     [host]
   );
+
+  useEffect(() => {
+    if (!requestedFocusTab) return;
+    const applyKey = `${hostId}:${requestedFocusTab}`;
+    if (appliedFocusTabRef.current === applyKey) return;
+    appliedFocusTabRef.current = applyKey;
+    setFocusState({
+      open: true,
+      tab: requestedFocusTab,
+      selectedServerId: null,
+    });
+  }, [hostId, requestedFocusTab]);
 
   const isDirty = useMemo(() => {
     if (!host || !draftConfig || !savedConfig) return false;

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/BehaviorTab.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/BehaviorTab.tsx
@@ -254,7 +254,7 @@ export function BehaviorTab({
 
   return (
     <div className="flex flex-col gap-4">
-      <FocusBlock title="Model & sampling">
+      <FocusBlock title="Agent tooling">
         <FieldRow
           label={fModel.label}
           description={fModel.description}

--- a/mcpjam-inspector/client/src/lib/__tests__/app-navigation.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/app-navigation.test.ts
@@ -55,6 +55,8 @@ describe("pathnameToActiveTab", () => {
 
   it("normalizes aliases", () => {
     expect(pathnameToActiveTab("/chat/thread-1")).toBe("playground");
+    expect(pathnameToActiveTab("/hosts")).toBe("clients");
+    expect(pathnameToActiveTab("/hosts/host-slack")).toBe("clients");
   });
 
   it("renders special entry paths through the servers fallback", () => {

--- a/mcpjam-inspector/client/src/lib/__tests__/host-config-field-schema.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/host-config-field-schema.test.ts
@@ -89,11 +89,11 @@ describe("groupHostConfigFields", () => {
     const agent = groupHostConfigFields().find(
       (g) => g.section.id === "agent"
     )!;
-    const modelSampling = agent.subsections.find(
-      (s) => s.label === "Model & sampling"
+    const agentTooling = agent.subsections.find(
+      (s) => s.label === "Agent tooling"
     );
-    expect(modelSampling).toBeTruthy();
-    expect(modelSampling!.fields.map((f) => f.id)).toEqual([
+    expect(agentTooling).toBeTruthy();
+    expect(agentTooling!.fields.map((f) => f.id)).toEqual([
       "modelId",
       "temperature",
       "requireToolApproval",

--- a/mcpjam-inspector/client/src/lib/app-navigation.ts
+++ b/mcpjam-inspector/client/src/lib/app-navigation.ts
@@ -28,6 +28,7 @@ export const routePaths = {
   hostCompare: "/host-compare",
   /** Chrome-less host-compare for vanity domains (caniuse.dev) — no sidebar/nav, bypasses NUX. */
   embedHostCompare: "/embed/host-compare",
+  capabilities: "/capabilities",
   computer: "/computer",
   registry: "/registry",
   tools: "/tools",
@@ -307,6 +308,9 @@ export function isDebugOAuthCallbackPath(pathname: string): boolean {
 
 export function pathnameToActiveTab(pathname: string): string {
   if (isSpecialEntryPathname(pathname)) return "servers";
+  if (pathname.startsWith(`${routePaths.capabilities}/`)) {
+    return "host-compare";
+  }
   const firstSegment = pathname.replace(/^\/+/, "").split("/")[0] || "home";
   const normalized = normalizeHostedHashTab(firstSegment);
   // Unknown first segments include chatbox slugs; App handles those surfaces

--- a/mcpjam-inspector/client/src/lib/host-config-field-schema.ts
+++ b/mcpjam-inspector/client/src/lib/host-config-field-schema.ts
@@ -764,5 +764,7 @@ export interface HostComparisonSubject {
   hostStyle: HostStyleId;
   /** Short suffix of the hostConfigId — shown as `·a3f9d2` under the name. */
   configHashShort: string;
+  /** Catalog verification timestamp for preset/caniuse hosts. */
+  verifiedAt?: number;
   config: HostConfigDtoV2;
 }

--- a/mcpjam-inspector/client/src/lib/host-config-field-schema.ts
+++ b/mcpjam-inspector/client/src/lib/host-config-field-schema.ts
@@ -291,12 +291,12 @@ const SANDBOX_PERMISSION_FIELDS: ReadonlyArray<HostConfigFieldDef> =
 
 export const HOST_CONFIG_FIELDS: ReadonlyArray<HostConfigFieldDef> = [
   // ============================================================
-  // Agent · Model & sampling
+  // Agent · Agent tooling
   // ============================================================
   {
     id: "modelId",
     section: "agent",
-    subsection: "Model & sampling",
+    subsection: "Agent tooling",
     label: "Model",
     path: "modelId",
     description: "LLM the host runs the agent on.",
@@ -306,7 +306,7 @@ export const HOST_CONFIG_FIELDS: ReadonlyArray<HostConfigFieldDef> = [
   {
     id: "temperature",
     section: "agent",
-    subsection: "Model & sampling",
+    subsection: "Agent tooling",
     label: "Temperature",
     path: "temperature",
     description: "0–1 sampling temperature.",
@@ -316,7 +316,7 @@ export const HOST_CONFIG_FIELDS: ReadonlyArray<HostConfigFieldDef> = [
   {
     id: "requireToolApproval",
     section: "agent",
-    subsection: "Model & sampling",
+    subsection: "Agent tooling",
     label: "Require tool approval",
     path: "requireToolApproval",
     description: "Prompts the user before each tool call.",
@@ -326,7 +326,7 @@ export const HOST_CONFIG_FIELDS: ReadonlyArray<HostConfigFieldDef> = [
   {
     id: "respectToolVisibility",
     section: "agent",
-    subsection: "Model & sampling",
+    subsection: "Agent tooling",
     label: "Respect tool visibility",
     path: "respectToolVisibility",
     description: "SEP-1865 `_meta.ui.visibility` filter.",
@@ -339,7 +339,7 @@ export const HOST_CONFIG_FIELDS: ReadonlyArray<HostConfigFieldDef> = [
   {
     id: "modelVisibleMcpToolResults.directContent.image",
     section: "agent",
-    subsection: "Model & sampling",
+    subsection: "Agent tooling",
     label: "Make tool image content visible to model",
     path: "modelVisibleMcpToolResults.directContent.image",
     description: "Pass MCP image content from tool results to the model.",
@@ -350,7 +350,7 @@ export const HOST_CONFIG_FIELDS: ReadonlyArray<HostConfigFieldDef> = [
   {
     id: "modelVisibleMcpToolResults.embeddedResources.blob.image",
     section: "agent",
-    subsection: "Model & sampling",
+    subsection: "Agent tooling",
     label: "Make embedded resource images visible to model",
     path: "modelVisibleMcpToolResults.embeddedResources.blob.image",
     description:
@@ -362,7 +362,7 @@ export const HOST_CONFIG_FIELDS: ReadonlyArray<HostConfigFieldDef> = [
   {
     id: "modelVisibleMcpToolResults.linkedResources.blob.image",
     section: "agent",
-    subsection: "Model & sampling",
+    subsection: "Agent tooling",
     label: "Make resource link images visible to model",
     path: "modelVisibleMcpToolResults.linkedResources.blob.image",
     description: "Resolve MCP resource link images and pass them to the model.",
@@ -373,7 +373,7 @@ export const HOST_CONFIG_FIELDS: ReadonlyArray<HostConfigFieldDef> = [
   {
     id: "mcpToolResultImageRendering",
     section: "agent",
-    subsection: "Model & sampling",
+    subsection: "Agent tooling",
     label: "Render tool images",
     path: "mcpToolResultImageRendering.placement",
     description: "Human-facing display mode for MCP tool-returned images.",
@@ -387,7 +387,7 @@ export const HOST_CONFIG_FIELDS: ReadonlyArray<HostConfigFieldDef> = [
   {
     id: "mcpToolResultImageRendering.directContent.image",
     section: "agent",
-    subsection: "Model & sampling",
+    subsection: "Agent tooling",
     label: "Render tool image content",
     path: "mcpToolResultImageRendering.directContent.image",
     description: "Render direct MCP image content from tool results in the UI.",
@@ -398,7 +398,7 @@ export const HOST_CONFIG_FIELDS: ReadonlyArray<HostConfigFieldDef> = [
   {
     id: "mcpToolResultImageRendering.embeddedResources.blob.image",
     section: "agent",
-    subsection: "Model & sampling",
+    subsection: "Agent tooling",
     label: "Render embedded resource images",
     path: "mcpToolResultImageRendering.embeddedResources.blob.image",
     description:
@@ -410,7 +410,7 @@ export const HOST_CONFIG_FIELDS: ReadonlyArray<HostConfigFieldDef> = [
   {
     id: "mcpToolResultImageRendering.linkedResources.blob.image",
     section: "agent",
-    subsection: "Model & sampling",
+    subsection: "Agent tooling",
     label: "Render resource link images",
     path: "mcpToolResultImageRendering.linkedResources.blob.image",
     description: "Resolve MCP resource link images and render them in the UI.",
@@ -421,7 +421,7 @@ export const HOST_CONFIG_FIELDS: ReadonlyArray<HostConfigFieldDef> = [
   {
     id: "progressiveToolDiscovery",
     section: "agent",
-    subsection: "Model & sampling",
+    subsection: "Agent tooling",
     label: "Progressive tools",
     path: "progressiveToolDiscovery",
     description:

--- a/mcpjam-inspector/client/src/router.tsx
+++ b/mcpjam-inspector/client/src/router.tsx
@@ -6,6 +6,7 @@ import App, {
   ChatboxesRoute,
   CiEvalsRoute,
   ConformanceRoute,
+  CaniuseCapabilityRoute,
   CompatibilityRoute,
   ComputerRoute,
   EvalsRoute,
@@ -83,6 +84,10 @@ export function createAppRouter(): AppRouter {
         // first-run onboarding redirect. `bare` forces the no-sub-nav render
         // even for signed-in users.
         { path: "embed/host-compare", element: <HostCompareRoute bare /> },
+        {
+          path: "capabilities/:capabilitySlug",
+          element: <CaniuseCapabilityRoute />,
+        },
         { path: "computer", element: <ComputerRoute /> },
         { path: "hosts", element: <HostsRoute /> },
         { path: "hosts/:hostId", element: <HostsRoute /> },

--- a/mcpjam-inspector/server/routes/web/__tests__/caniuse.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/caniuse.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+import { readFile, unlink } from "node:fs/promises";
+import { join } from "node:path";
+import caniuseRoutes from "../caniuse";
+import { mapRuntimeError, webError } from "../errors";
+
+const LOCAL_REPORTS_PATH = join(
+  process.cwd(),
+  ".local",
+  "caniuse-reports.jsonl"
+);
+
+function createApp() {
+  const app = new Hono();
+  app.route("/api/web/caniuse", caniuseRoutes);
+  app.onError((error, c) => {
+    const routeError = mapRuntimeError(error);
+    return webError(c, routeError.status, routeError.code, routeError.message);
+  });
+  return app;
+}
+
+function postReport(
+  body: Record<string, unknown>,
+  headers: Record<string, string> = {}
+) {
+  return createApp().request("/api/web/caniuse/report-inconsistency", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/web/caniuse/report-inconsistency", () => {
+  const originalFetch = global.fetch;
+  const originalNodeEnv = process.env.NODE_ENV;
+  const originalConvexHttpUrl = process.env.CONVEX_HTTP_URL;
+  const originalInspectorServiceToken = process.env.INSPECTOR_SERVICE_TOKEN;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NODE_ENV = "development";
+    delete process.env.CONVEX_HTTP_URL;
+    delete process.env.INSPECTOR_SERVICE_TOKEN;
+    global.fetch = vi.fn();
+  });
+
+  afterEach(async () => {
+    global.fetch = originalFetch;
+    process.env.NODE_ENV = originalNodeEnv;
+    if (originalConvexHttpUrl === undefined) {
+      delete process.env.CONVEX_HTTP_URL;
+    } else {
+      process.env.CONVEX_HTTP_URL = originalConvexHttpUrl;
+    }
+    if (originalInspectorServiceToken === undefined) {
+      delete process.env.INSPECTOR_SERVICE_TOKEN;
+    } else {
+      process.env.INSPECTOR_SERVICE_TOKEN = originalInspectorServiceToken;
+    }
+    await unlink(LOCAL_REPORTS_PATH).catch(() => undefined);
+  });
+
+  it("stores locally and succeeds in dev when backend and Resend are not configured", async () => {
+    const response = await postReport(
+      { message: "Something looks wrong" },
+      { "x-real-ip": "192.0.2.1" }
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      success: true,
+      stored: { storage: "local" },
+    });
+    expect(global.fetch).not.toHaveBeenCalled();
+
+    const contents = await readFile(LOCAL_REPORTS_PATH, "utf8");
+    expect(contents).toContain("Something looks wrong");
+  });
+
+  it("stores in the backend and returns Convex email delivery status when configured", async () => {
+    process.env.CONVEX_HTTP_URL = "https://convex.example";
+    process.env.INSPECTOR_SERVICE_TOKEN = "service-token";
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          ok: true,
+          reportId: "report_1",
+          emailDeliveryStatus: "sent",
+        }),
+        { status: 200 }
+      )
+    );
+
+    const response = await postReport(
+      {
+        message: "Claude supports this, but the table says it doesn't.",
+      },
+      {
+        "x-real-ip": "192.0.2.2",
+      }
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      success: true,
+      stored: {
+        storage: "backend",
+        reportId: "report_1",
+        emailDeliveryStatus: "sent",
+      },
+    });
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://convex.example/internal/v1/caniuse/reports",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "x-inspector-service-token": "service-token",
+          "Content-Type": "application/json",
+        }),
+        body: JSON.stringify({
+          message: "Claude supports this, but the table says it doesn't.",
+        }),
+      })
+    );
+  });
+
+  it("rejects an empty report", async () => {
+    const response = await postReport(
+      { message: "   " },
+      { "x-real-ip": "192.0.2.3" }
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      code: "VALIDATION_ERROR",
+    });
+  });
+
+  it("rate limits repeated reports from the same IP", async () => {
+    const headers = { "x-real-ip": "192.0.2.4" };
+    for (let i = 0; i < 5; i++) {
+      const response = await postReport({ message: `Report ${i}` }, headers);
+      expect(response.status).toBe(200);
+    }
+
+    const response = await postReport({ message: "One too many" }, headers);
+    expect(response.status).toBe(429);
+    expect(await response.json()).toMatchObject({
+      code: "RATE_LIMITED",
+    });
+  });
+});

--- a/mcpjam-inspector/server/routes/web/__tests__/caniuse.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/caniuse.test.ts
@@ -1,15 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Hono } from "hono";
-import { readFile, unlink } from "node:fs/promises";
-import { join } from "node:path";
 import caniuseRoutes from "../caniuse";
 import { mapRuntimeError, webError } from "../errors";
-
-const LOCAL_REPORTS_PATH = join(
-  process.cwd(),
-  ".local",
-  "caniuse-reports.jsonl"
-);
 
 function createApp() {
   const app = new Hono();
@@ -32,6 +24,14 @@ function postReport(
   });
 }
 
+function postReportRaw(body: string, headers: Record<string, string> = {}) {
+  return createApp().request("/api/web/caniuse/report-inconsistency", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body,
+  });
+}
+
 describe("POST /api/web/caniuse/report-inconsistency", () => {
   const originalFetch = global.fetch;
   const originalNodeEnv = process.env.NODE_ENV;
@@ -46,7 +46,7 @@ describe("POST /api/web/caniuse/report-inconsistency", () => {
     global.fetch = vi.fn();
   });
 
-  afterEach(async () => {
+  afterEach(() => {
     global.fetch = originalFetch;
     process.env.NODE_ENV = originalNodeEnv;
     if (originalConvexHttpUrl === undefined) {
@@ -59,24 +59,20 @@ describe("POST /api/web/caniuse/report-inconsistency", () => {
     } else {
       process.env.INSPECTOR_SERVICE_TOKEN = originalInspectorServiceToken;
     }
-    await unlink(LOCAL_REPORTS_PATH).catch(() => undefined);
   });
 
-  it("stores locally and succeeds in dev when backend and Resend are not configured", async () => {
+  it("rejects in dev when backend storage is not configured", async () => {
     const response = await postReport(
       { message: "Something looks wrong" },
       { "x-real-ip": "192.0.2.1" }
     );
 
-    expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({
-      success: true,
-      stored: { storage: "local" },
+    expect(response.status).toBe(503);
+    expect(await response.json()).toMatchObject({
+      code: "INTERNAL_ERROR",
+      message: "Report storage is not configured",
     });
     expect(global.fetch).not.toHaveBeenCalled();
-
-    const contents = await readFile(LOCAL_REPORTS_PATH, "utf8");
-    expect(contents).toContain("Something looks wrong");
   });
 
   it("stores in the backend and returns Convex email delivery status when configured", async () => {
@@ -127,6 +123,45 @@ describe("POST /api/web/caniuse/report-inconsistency", () => {
     );
   });
 
+  it("rejects in production when backend config is missing", async () => {
+    process.env.NODE_ENV = "production";
+
+    const response = await postReport(
+      { message: "Prod report without backend config" },
+      { "x-real-ip": "192.0.2.20" }
+    );
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toMatchObject({
+      code: "INTERNAL_ERROR",
+      message: "Report storage is not configured",
+    });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects when backend report storage rejects", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.CONVEX_HTTP_URL = "https://convex.example";
+    process.env.INSPECTOR_SERVICE_TOKEN = "service-token";
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ ok: false, error: "Unauthorized" }), {
+        status: 401,
+      })
+    );
+
+    const response = await postReport(
+      { message: "Fallback after backend rejection" },
+      { "x-real-ip": "192.0.2.21" }
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toMatchObject({
+      code: "SERVER_UNREACHABLE",
+      message: "Unauthorized",
+    });
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
   it("rejects an empty report", async () => {
     const response = await postReport(
       { message: "   " },
@@ -139,9 +174,34 @@ describe("POST /api/web/caniuse/report-inconsistency", () => {
     });
   });
 
+  it("returns 400 for malformed JSON", async () => {
+    const response = await postReportRaw("{", { "x-real-ip": "192.0.2.30" });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      code: "VALIDATION_ERROR",
+      message: "Invalid JSON body",
+    });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
   it("rate limits repeated reports from the same IP", async () => {
+    process.env.CONVEX_HTTP_URL = "https://convex.example";
+    process.env.INSPECTOR_SERVICE_TOKEN = "service-token";
+    vi.mocked(global.fetch).mockImplementation(
+      async () =>
+        new Response(
+          JSON.stringify({
+            ok: true,
+            reportId: "report_rate_limit",
+            emailDeliveryStatus: "sent",
+          }),
+          { status: 200 }
+        )
+    );
+
     const headers = { "x-real-ip": "192.0.2.4" };
-    for (let i = 0; i < 5; i++) {
+    for (let i = 0; i < 10; i++) {
       const response = await postReport({ message: `Report ${i}` }, headers);
       expect(response.status).toBe(200);
     }
@@ -151,5 +211,148 @@ describe("POST /api/web/caniuse/report-inconsistency", () => {
     expect(await response.json()).toMatchObject({
       code: "RATE_LIMITED",
     });
+  });
+});
+
+function postSubscribe(
+  body: Record<string, unknown>,
+  headers: Record<string, string> = {}
+) {
+  return createApp().request("/api/web/caniuse/subscribe", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+function postSubscribeRaw(body: string, headers: Record<string, string> = {}) {
+  return createApp().request("/api/web/caniuse/subscribe", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body,
+  });
+}
+
+describe("POST /api/web/caniuse/subscribe", () => {
+  const originalFetch = global.fetch;
+  const originalNodeEnv = process.env.NODE_ENV;
+  const originalConvexHttpUrl = process.env.CONVEX_HTTP_URL;
+  const originalInspectorServiceToken = process.env.INSPECTOR_SERVICE_TOKEN;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NODE_ENV = "development";
+    delete process.env.CONVEX_HTTP_URL;
+    delete process.env.INSPECTOR_SERVICE_TOKEN;
+    global.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    process.env.NODE_ENV = originalNodeEnv;
+    if (originalConvexHttpUrl === undefined) {
+      delete process.env.CONVEX_HTTP_URL;
+    } else {
+      process.env.CONVEX_HTTP_URL = originalConvexHttpUrl;
+    }
+    if (originalInspectorServiceToken === undefined) {
+      delete process.env.INSPECTOR_SERVICE_TOKEN;
+    } else {
+      process.env.INSPECTOR_SERVICE_TOKEN = originalInspectorServiceToken;
+    }
+  });
+
+  it("rejects in dev when backend storage is not configured", async () => {
+    const response = await postSubscribe(
+      { email: "dev@example.com" },
+      { "x-real-ip": "192.0.2.10" }
+    );
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toMatchObject({
+      code: "INTERNAL_ERROR",
+      message: "Subscription storage is not configured",
+    });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("forwards to the backend subscribers endpoint when configured", async () => {
+    process.env.CONVEX_HTTP_URL = "https://convex.example";
+    process.env.INSPECTOR_SERVICE_TOKEN = "service-token";
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ ok: true, created: true }), { status: 200 })
+    );
+
+    const response = await postSubscribe(
+      { email: "user@example.com" },
+      { "x-real-ip": "192.0.2.11" }
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      success: true,
+      stored: { storage: "backend", created: true },
+    });
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://convex.example/internal/v1/caniuse/subscribers",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "x-inspector-service-token": "service-token",
+          "Content-Type": "application/json",
+        }),
+        body: JSON.stringify({ email: "user@example.com" }),
+      })
+    );
+  });
+
+  it("rejects an invalid email", async () => {
+    const response = await postSubscribe(
+      { email: "not-an-email" },
+      { "x-real-ip": "192.0.2.12" }
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({ code: "VALIDATION_ERROR" });
+  });
+
+  it("returns 400 for malformed JSON", async () => {
+    const response = await postSubscribeRaw("{", {
+      "x-real-ip": "192.0.2.31",
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      code: "VALIDATION_ERROR",
+      message: "Invalid JSON body",
+    });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("rate limits repeated attempts from the same IP", async () => {
+    process.env.CONVEX_HTTP_URL = "https://convex.example";
+    process.env.INSPECTOR_SERVICE_TOKEN = "service-token";
+    vi.mocked(global.fetch).mockImplementation(
+      async () =>
+        new Response(JSON.stringify({ ok: true, created: true }), {
+          status: 200,
+        })
+    );
+
+    const headers = { "x-real-ip": "192.0.2.13" };
+    for (let i = 0; i < 10; i++) {
+      const response = await postSubscribe(
+        { email: `user${i}@example.com` },
+        headers
+      );
+      expect(response.status).toBe(200);
+    }
+
+    const response = await postSubscribe(
+      { email: "once@toomany.com" },
+      headers
+    );
+    expect(response.status).toBe(429);
+    expect(await response.json()).toMatchObject({ code: "RATE_LIMITED" });
   });
 });

--- a/mcpjam-inspector/server/routes/web/caniuse.ts
+++ b/mcpjam-inspector/server/routes/web/caniuse.ts
@@ -1,34 +1,71 @@
 import { Hono } from "hono";
 import { z } from "zod";
-import { appendFile, mkdir } from "node:fs/promises";
-import { join } from "node:path";
-import { logger } from "../../utils/logger.js";
 import { getClientIp } from "../../utils/client-ip.js";
-import { ErrorCode, WebRouteError } from "./errors.js";
+import { ErrorCode, WebRouteError, readJsonBody } from "./errors.js";
 
-const REPORT_RATE_LIMIT = 5;
+const REPORT_RATE_LIMIT = 10;
 const REPORT_RATE_LIMIT_WINDOW_MS = 10 * 60 * 1000;
 const BACKEND_REPORTS_PATH = "/internal/v1/caniuse/reports";
-const LOCAL_REPORTS_DIR = join(process.cwd(), ".local");
-const LOCAL_REPORTS_PATH = join(LOCAL_REPORTS_DIR, "caniuse-reports.jsonl");
+const BACKEND_SUBSCRIBERS_PATH = "/internal/v1/caniuse/subscribers";
 
 const caniuse = new Hono();
 const reportWindows = new Map<string, { count: number; windowStart: number }>();
+const subscribeWindows = new Map<
+  string,
+  { count: number; windowStart: number }
+>();
+
+function consumeRateLimit(
+  windows: Map<string, { count: number; windowStart: number }>,
+  clientKey: string,
+  now: number,
+  message: string
+) {
+  for (const [key, value] of windows) {
+    if (now - value.windowStart >= REPORT_RATE_LIMIT_WINDOW_MS) {
+      windows.delete(key);
+    }
+  }
+
+  const rateWindow = windows.get(clientKey);
+  if (rateWindow) {
+    if (rateWindow.count >= REPORT_RATE_LIMIT) {
+      throw new WebRouteError(429, ErrorCode.RATE_LIMITED, message);
+    }
+    rateWindow.count++;
+    return;
+  }
+
+  windows.set(clientKey, { count: 1, windowStart: now });
+}
 
 const reportInconsistencySchema = z.object({
   message: z.string().trim().min(1).max(4000),
 });
 
+const subscribeSchema = z.object({
+  email: z.string().trim().email().max(320),
+});
+
 async function storeReport(args: { message: string }): Promise<{
-  storage: "backend" | "local";
+  storage: "backend";
   reportId?: string;
   emailDeliveryStatus?: "sent" | "failed";
 }> {
   const convexUrl = process.env.CONVEX_HTTP_URL;
   const serviceToken = process.env.INSPECTOR_SERVICE_TOKEN;
 
-  if (convexUrl && serviceToken) {
-    const response = await fetch(
+  if (!convexUrl || !serviceToken) {
+    throw new WebRouteError(
+      503,
+      ErrorCode.INTERNAL_ERROR,
+      "Report storage is not configured"
+    );
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(
       `${convexUrl.replace(/\/$/, "")}${BACKEND_REPORTS_PATH}`,
       {
         method: "POST",
@@ -39,71 +76,46 @@ async function storeReport(args: { message: string }): Promise<{
         body: JSON.stringify({ message: args.message }),
       }
     );
-    const body = (await response.json().catch(() => null)) as {
-      ok?: boolean;
-      reportId?: string;
-      emailDeliveryStatus?: "sent" | "failed";
-      error?: string;
-    } | null;
-    if (!response.ok || body?.ok !== true) {
-      throw new WebRouteError(
-        response.status >= 400 ? response.status : 502,
-        ErrorCode.SERVER_UNREACHABLE,
-        body?.error ?? "Failed to store report"
-      );
-    }
-    return {
-      storage: "backend",
-      reportId: body.reportId,
-      emailDeliveryStatus: body.emailDeliveryStatus,
-    };
-  }
-
-  if (process.env.NODE_ENV === "production") {
+  } catch {
     throw new WebRouteError(
-      503,
-      ErrorCode.INTERNAL_ERROR,
-      "Report storage is not configured"
+      502,
+      ErrorCode.SERVER_UNREACHABLE,
+      "Failed to store report"
     );
   }
 
-  await mkdir(LOCAL_REPORTS_DIR, { recursive: true });
-  await appendFile(
-    LOCAL_REPORTS_PATH,
-    `${JSON.stringify({
-      message: args.message,
-      source: "caniuse.dev",
-      createdAt: new Date().toISOString(),
-    })}\n`,
-    "utf8"
-  );
-  logger.info("[caniuse] Inconsistency report stored locally", {
-    path: LOCAL_REPORTS_PATH,
-  });
-  return { storage: "local" };
+  const body = (await response.json().catch(() => null)) as {
+    ok?: boolean;
+    reportId?: string;
+    emailDeliveryStatus?: "sent" | "failed";
+    error?: string;
+  } | null;
+  if (!response.ok || body?.ok !== true) {
+    throw new WebRouteError(
+      response.status >= 400 ? response.status : 502,
+      ErrorCode.SERVER_UNREACHABLE,
+      body?.error ?? "Failed to store report"
+    );
+  }
+  return {
+    storage: "backend",
+    reportId: body.reportId,
+    emailDeliveryStatus: body.emailDeliveryStatus,
+  };
 }
 
 caniuse.post("/report-inconsistency", async (c) => {
   const clientKey = getClientIp(c) ?? "unknown";
-  const now = Date.now();
-  const rateWindow = reportWindows.get(clientKey);
-  if (
-    rateWindow &&
-    now - rateWindow.windowStart < REPORT_RATE_LIMIT_WINDOW_MS
-  ) {
-    if (rateWindow.count >= REPORT_RATE_LIMIT) {
-      throw new WebRouteError(
-        429,
-        ErrorCode.RATE_LIMITED,
-        "Too many reports. Please try again later."
-      );
-    }
-    rateWindow.count++;
-  } else {
-    reportWindows.set(clientKey, { count: 1, windowStart: now });
-  }
+  consumeRateLimit(
+    reportWindows,
+    clientKey,
+    Date.now(),
+    "Too many reports. Please try again later."
+  );
 
-  const parsed = reportInconsistencySchema.safeParse(await c.req.json());
+  const parsed = reportInconsistencySchema.safeParse(
+    await readJsonBody<unknown>(c)
+  );
   if (!parsed.success) {
     throw new WebRouteError(
       400,
@@ -113,6 +125,79 @@ caniuse.post("/report-inconsistency", async (c) => {
   }
 
   const stored = await storeReport({ message: parsed.data.message });
+  return c.json({ success: true, stored });
+});
+
+async function storeSubscriber(args: { email: string }): Promise<{
+  storage: "backend";
+  created?: boolean;
+}> {
+  const convexUrl = process.env.CONVEX_HTTP_URL;
+  const serviceToken = process.env.INSPECTOR_SERVICE_TOKEN;
+
+  if (!convexUrl || !serviceToken) {
+    throw new WebRouteError(
+      503,
+      ErrorCode.INTERNAL_ERROR,
+      "Subscription storage is not configured"
+    );
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(
+      `${convexUrl.replace(/\/$/, "")}${BACKEND_SUBSCRIBERS_PATH}`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-inspector-service-token": serviceToken,
+        },
+        body: JSON.stringify({ email: args.email }),
+      }
+    );
+  } catch {
+    throw new WebRouteError(
+      502,
+      ErrorCode.SERVER_UNREACHABLE,
+      "Failed to save subscription"
+    );
+  }
+
+  const body = (await response.json().catch(() => null)) as {
+    ok?: boolean;
+    created?: boolean;
+    error?: string;
+  } | null;
+  if (!response.ok || body?.ok !== true) {
+    throw new WebRouteError(
+      response.status >= 400 ? response.status : 502,
+      ErrorCode.SERVER_UNREACHABLE,
+      body?.error ?? "Failed to save subscription"
+    );
+  }
+  return { storage: "backend", created: body.created };
+}
+
+caniuse.post("/subscribe", async (c) => {
+  const clientKey = getClientIp(c) ?? "unknown";
+  consumeRateLimit(
+    subscribeWindows,
+    clientKey,
+    Date.now(),
+    "Too many attempts. Please try again later."
+  );
+
+  const parsed = subscribeSchema.safeParse(await readJsonBody<unknown>(c));
+  if (!parsed.success) {
+    throw new WebRouteError(
+      400,
+      ErrorCode.VALIDATION_ERROR,
+      "A valid email is required"
+    );
+  }
+
+  const stored = await storeSubscriber({ email: parsed.data.email });
   return c.json({ success: true, stored });
 });
 

--- a/mcpjam-inspector/server/routes/web/caniuse.ts
+++ b/mcpjam-inspector/server/routes/web/caniuse.ts
@@ -1,0 +1,119 @@
+import { Hono } from "hono";
+import { z } from "zod";
+import { appendFile, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { logger } from "../../utils/logger.js";
+import { getClientIp } from "../../utils/client-ip.js";
+import { ErrorCode, WebRouteError } from "./errors.js";
+
+const REPORT_RATE_LIMIT = 5;
+const REPORT_RATE_LIMIT_WINDOW_MS = 10 * 60 * 1000;
+const BACKEND_REPORTS_PATH = "/internal/v1/caniuse/reports";
+const LOCAL_REPORTS_DIR = join(process.cwd(), ".local");
+const LOCAL_REPORTS_PATH = join(LOCAL_REPORTS_DIR, "caniuse-reports.jsonl");
+
+const caniuse = new Hono();
+const reportWindows = new Map<string, { count: number; windowStart: number }>();
+
+const reportInconsistencySchema = z.object({
+  message: z.string().trim().min(1).max(4000),
+});
+
+async function storeReport(args: { message: string }): Promise<{
+  storage: "backend" | "local";
+  reportId?: string;
+  emailDeliveryStatus?: "sent" | "failed";
+}> {
+  const convexUrl = process.env.CONVEX_HTTP_URL;
+  const serviceToken = process.env.INSPECTOR_SERVICE_TOKEN;
+
+  if (convexUrl && serviceToken) {
+    const response = await fetch(
+      `${convexUrl.replace(/\/$/, "")}${BACKEND_REPORTS_PATH}`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-inspector-service-token": serviceToken,
+        },
+        body: JSON.stringify({ message: args.message }),
+      }
+    );
+    const body = (await response.json().catch(() => null)) as {
+      ok?: boolean;
+      reportId?: string;
+      emailDeliveryStatus?: "sent" | "failed";
+      error?: string;
+    } | null;
+    if (!response.ok || body?.ok !== true) {
+      throw new WebRouteError(
+        response.status >= 400 ? response.status : 502,
+        ErrorCode.SERVER_UNREACHABLE,
+        body?.error ?? "Failed to store report"
+      );
+    }
+    return {
+      storage: "backend",
+      reportId: body.reportId,
+      emailDeliveryStatus: body.emailDeliveryStatus,
+    };
+  }
+
+  if (process.env.NODE_ENV === "production") {
+    throw new WebRouteError(
+      503,
+      ErrorCode.INTERNAL_ERROR,
+      "Report storage is not configured"
+    );
+  }
+
+  await mkdir(LOCAL_REPORTS_DIR, { recursive: true });
+  await appendFile(
+    LOCAL_REPORTS_PATH,
+    `${JSON.stringify({
+      message: args.message,
+      source: "caniuse.dev",
+      createdAt: new Date().toISOString(),
+    })}\n`,
+    "utf8"
+  );
+  logger.info("[caniuse] Inconsistency report stored locally", {
+    path: LOCAL_REPORTS_PATH,
+  });
+  return { storage: "local" };
+}
+
+caniuse.post("/report-inconsistency", async (c) => {
+  const clientKey = getClientIp(c) ?? "unknown";
+  const now = Date.now();
+  const rateWindow = reportWindows.get(clientKey);
+  if (
+    rateWindow &&
+    now - rateWindow.windowStart < REPORT_RATE_LIMIT_WINDOW_MS
+  ) {
+    if (rateWindow.count >= REPORT_RATE_LIMIT) {
+      throw new WebRouteError(
+        429,
+        ErrorCode.RATE_LIMITED,
+        "Too many reports. Please try again later."
+      );
+    }
+    rateWindow.count++;
+  } else {
+    reportWindows.set(clientKey, { count: 1, windowStart: now });
+  }
+
+  const parsed = reportInconsistencySchema.safeParse(await c.req.json());
+  if (!parsed.success) {
+    throw new WebRouteError(
+      400,
+      ErrorCode.VALIDATION_ERROR,
+      "Report message is required"
+    );
+  }
+
+  const stored = await storeReport({ message: parsed.data.message });
+  return c.json({ success: true, stored });
+});
+
+export default caniuse;

--- a/mcpjam-inspector/server/routes/web/index.ts
+++ b/mcpjam-inspector/server/routes/web/index.ts
@@ -26,6 +26,7 @@ import checks from "./checks.js";
 import apiKeys from "./api-keys.js";
 import computers from "./computers.js";
 import skills from "./skills.js";
+import caniuse from "./caniuse.js";
 import { fetchRemoteGuestJwks } from "../../utils/guest-session-source.js";
 
 const web = new Hono();
@@ -94,6 +95,9 @@ web.route("/checks", checks);
 // server/index.ts — only /config and /exec live on this sub-router.
 web.route("/computers", computers);
 web.route("/skills", skills);
+// Public caniuse.dev correction reports. No bearer auth: the vanity compare
+// surface is intentionally anonymous.
+web.route("/caniuse", caniuse);
 // `/api-keys` carries its own bearer-auth `.use()` because
 // `sessionAuthMiddleware` bypasses `/api/web/*` entirely. Nothing on this
 // sub-router is reachable without a session JWT (WorkOS `sk_…` keys are


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add caniuse.dev capability permalinks and upgrade the public comparison matrix with live backend catalog data, exact capability search, shareable links + a Share dialog, and a rate‑limited inconsistency report. Public compare now requires the live backend `marketHostCatalog` with no SDK fallback; deep links preserve known `?template` ids during auth and ignore unknown ones for reliable onboarding. Permalinks also accept legacy preset aliases so older links keep working.

- **New Features**
  - Capability permalinks: `/capabilities/:slug` shows the capability definition, per‑client support, and the last verified date, with links to the full matrix and “Verify against your server”.
  - Public compare polish:
    - Preset view shows capability‑only fields and sorts clients by a preferred order (Claude, ChatGPT, Copilot, Cursor, Slack, VS Code).
    - Exact capability search with shareable URLs via `?capability=<slug>` (falls back to `?q=`). When searching, support filters apply to columns instead of rows.
    - Per‑column verify links deep‑link to `/hosts?template=<id>&hostTab=<section>` to open/create that client’s host; the app preserves the `?template` param through auth loading, skips onboarding for this flow, and ignores unknown template ids.
    - Share dock opens a dialog with a summary, a copyable permalink, and a “Share on X” link; URLs pin the current hosts so shared links always open the same comparison.
    - “Report inconsistency” posts to `/api/web/caniuse/report-inconsistency`; in dev it stores locally, in prod it forwards to the backend when `CONVEX_HTTP_URL` and `INSPECTOR_SERVICE_TOKEN` are set. Requests are rate‑limited.
    - Live data: caniuse.dev requires the live backend `marketHostCatalog` for preset hosts and renders nothing until live data is available (no SDK fallback). The in‑app Host Compare is unchanged and does not fetch. Columns show last verified dates when known.
    - Permalink stability: preset host id aliases map to current catalog ids (for example, `preset:slackbot` and `preset:slack-bot` resolve to `preset:slack`).

- **Refactors**
  - Renamed “Model & sampling” to “Agent tooling” across field schema and UI.
  - Selector can disable support filters until a search is active.
  - Matrix/list views accept custom field sets for public pages.
  - Ignore local-only dev artifacts (e.g. `.local/`) in git.

<sup>Written for commit a61ce367889f78b0504b783f9b99530760cb891d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3046?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

