### PR TITLE
feat(xaa): opt-in support for path-scoped authorization servers (Scalekit)

### DIFF
--- a/mcpjam-inspector/client/src/components/connection/AddServerModal.tsx
+++ b/mcpjam-inspector/client/src/components/connection/AddServerModal.tsx
@@ -449,6 +449,10 @@ export function AddServerModal({
               clientSecretError={formState.clientSecretError}
               xaaAuthzIssuer={formState.xaaAuthzIssuer}
               onXaaAuthzIssuerChange={formState.setXaaAuthzIssuer}
+              xaaAllowPathScopedIssuer={formState.xaaAllowPathScopedIssuer}
+              onXaaAllowPathScopedIssuerChange={
+                formState.setXaaAllowPathScopedIssuer
+              }
               xaaSubject={formState.xaaSubject}
               onXaaSubjectChange={formState.setXaaSubject}
               xaaEmail={formState.xaaEmail}

--- a/mcpjam-inspector/client/src/components/connection/EditServerFormContent.tsx
+++ b/mcpjam-inspector/client/src/components/connection/EditServerFormContent.tsx
@@ -270,6 +270,10 @@ export function EditServerFormContent({
             hostedServerId={hostedServerId}
             xaaAuthzIssuer={formState.xaaAuthzIssuer}
             onXaaAuthzIssuerChange={formState.setXaaAuthzIssuer}
+            xaaAllowPathScopedIssuer={formState.xaaAllowPathScopedIssuer}
+            onXaaAllowPathScopedIssuerChange={
+              formState.setXaaAllowPathScopedIssuer
+            }
             xaaSubject={formState.xaaSubject}
             onXaaSubjectChange={formState.setXaaSubject}
             xaaEmail={formState.xaaEmail}

--- a/mcpjam-inspector/client/src/components/connection/hooks/use-server-form.ts
+++ b/mcpjam-inspector/client/src/components/connection/hooks/use-server-form.ts
@@ -35,6 +35,7 @@ interface InitialFormValues {
   clientCapabilitiesOverrideEnabled: boolean;
   clientCapabilitiesOverrideText: string;
   xaaAuthzIssuer: string;
+  xaaAllowPathScopedIssuer: boolean;
   xaaSubject: string;
   xaaEmail: string;
 }
@@ -151,6 +152,8 @@ export function useServerForm(
   // Cross-App Access (XAA) fields. Client id / secret / scopes are shared with
   // the OAuth preregistered path; these three are XAA-specific.
   const [xaaAuthzIssuer, setXaaAuthzIssuer] = useState("");
+  const [xaaAllowPathScopedIssuer, setXaaAllowPathScopedIssuer] =
+    useState(false);
   const [xaaSubject, setXaaSubject] = useState("");
   const [xaaEmail, setXaaEmail] = useState("");
 
@@ -376,6 +379,9 @@ export function useServerForm(
       // record so edit mode round-trips them. Client id / scopes reuse the
       // OAuth-credential reads above.
       setXaaAuthzIssuer(isHttpServer ? server.xaaAuthzIssuer ?? "" : "");
+      setXaaAllowPathScopedIssuer(
+        isHttpServer ? server.xaaAllowPathScopedIssuer === true : false
+      );
       setXaaSubject(server.xaaSubject ?? "");
       setXaaEmail(server.xaaEmail ?? "");
 
@@ -481,6 +487,9 @@ export function useServerForm(
           2
         ),
         xaaAuthzIssuer: isHttpServer ? server.xaaAuthzIssuer ?? "" : "",
+        xaaAllowPathScopedIssuer: isHttpServer
+          ? server.xaaAllowPathScopedIssuer === true
+          : false,
         xaaSubject: server.xaaSubject ?? "",
         xaaEmail: server.xaaEmail ?? "",
       };
@@ -828,6 +837,7 @@ export function useServerForm(
         ? submittedClearClientSecret
         : undefined,
       xaaAuthzIssuer: useXaa ? xaaAuthzIssuer.trim() || undefined : undefined,
+      xaaAllowPathScopedIssuer: useXaa ? xaaAllowPathScopedIssuer : undefined,
       // Default the simulated identity to the signed-in user when blank, so the
       // mint asserts a real subject instead of a placeholder test user. The
       // resource server still decides what subject it accepts — this is just a
@@ -908,6 +918,7 @@ export function useServerForm(
         iv.clientCapabilitiesOverrideEnabled ||
       clientCapabilitiesOverrideText !== iv.clientCapabilitiesOverrideText ||
       xaaAuthzIssuer !== iv.xaaAuthzIssuer ||
+      xaaAllowPathScopedIssuer !== iv.xaaAllowPathScopedIssuer ||
       xaaSubject !== iv.xaaSubject ||
       xaaEmail !== iv.xaaEmail ||
       JSON.stringify(envVars) !== JSON.stringify(iv.envVars) ||
@@ -983,6 +994,8 @@ export function useServerForm(
     // XAA-specific fields (client id / secret / scopes are shared above)
     xaaAuthzIssuer,
     setXaaAuthzIssuer,
+    xaaAllowPathScopedIssuer,
+    setXaaAllowPathScopedIssuer,
     xaaSubject,
     setXaaSubject,
     xaaEmail,

--- a/mcpjam-inspector/client/src/components/connection/hooks/use-server-form.ts
+++ b/mcpjam-inspector/client/src/components/connection/hooks/use-server-form.ts
@@ -865,6 +865,7 @@ export function useServerForm(
     setHasStoredClientSecret(false);
     setClearClientSecret(false);
     setXaaAuthzIssuer("");
+    setXaaAllowPathScopedIssuer(false);
     setXaaSubject("");
     setXaaEmail("");
     setBearerToken("");

--- a/mcpjam-inspector/client/src/components/connection/shared/AuthenticationSection.tsx
+++ b/mcpjam-inspector/client/src/components/connection/shared/AuthenticationSection.tsx
@@ -67,6 +67,8 @@ interface AuthenticationSectionProps {
   // above; these are XAA-specific.
   xaaAuthzIssuer?: string;
   onXaaAuthzIssuerChange?: (value: string) => void;
+  xaaAllowPathScopedIssuer?: boolean;
+  onXaaAllowPathScopedIssuerChange?: (value: boolean) => void;
   xaaSubject?: string;
   onXaaSubjectChange?: (value: string) => void;
   xaaEmail?: string;
@@ -127,6 +129,8 @@ export function AuthenticationSection({
   hostedServerId = null,
   xaaAuthzIssuer = "",
   onXaaAuthzIssuerChange,
+  xaaAllowPathScopedIssuer = false,
+  onXaaAllowPathScopedIssuerChange,
   xaaSubject = "",
   onXaaSubjectChange,
   xaaEmail = "",
@@ -724,6 +728,10 @@ export function AuthenticationSection({
               onScopesChange={onOauthScopesChange}
               xaaAuthzIssuer={xaaAuthzIssuer}
               onXaaAuthzIssuerChange={(v) => onXaaAuthzIssuerChange?.(v)}
+              xaaAllowPathScopedIssuer={xaaAllowPathScopedIssuer}
+              onXaaAllowPathScopedIssuerChange={(v) =>
+                onXaaAllowPathScopedIssuerChange?.(v)
+              }
               xaaSubject={xaaSubject}
               onXaaSubjectChange={(v) => onXaaSubjectChange?.(v)}
               xaaEmail={xaaEmail}

--- a/mcpjam-inspector/client/src/components/connection/shared/XaaCredentialFields.tsx
+++ b/mcpjam-inspector/client/src/components/connection/shared/XaaCredentialFields.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useId, useState } from "react";
 import { Button } from "@mcpjam/design-system/button";
 import { Input } from "@mcpjam/design-system/input";
+import { Switch } from "@mcpjam/design-system/switch";
 import {
   Check,
   ChevronDown,
@@ -52,6 +53,10 @@ export interface XaaCredentialFieldsProps {
   // Advanced
   xaaAuthzIssuer: string;
   onXaaAuthzIssuerChange: (value: string) => void;
+  /** Opt-in: accept a path-scoped authorization server whose metadata
+   * advertises the same-origin root as issuer (e.g. Scalekit). */
+  xaaAllowPathScopedIssuer: boolean;
+  onXaaAllowPathScopedIssuerChange: (value: boolean) => void;
   xaaSubject: string;
   onXaaSubjectChange: (value: string) => void;
   xaaEmail: string;
@@ -85,6 +90,8 @@ export function XaaCredentialFields({
   onScopesChange,
   xaaAuthzIssuer,
   onXaaAuthzIssuerChange,
+  xaaAllowPathScopedIssuer,
+  onXaaAllowPathScopedIssuerChange,
   xaaSubject,
   onXaaSubjectChange,
   xaaEmail,
@@ -191,6 +198,7 @@ export function XaaCredentialFields({
     clientSecret: `${baseId}-client-secret`,
     scopes: `${baseId}-scopes`,
     issuer: `${baseId}-issuer`,
+    pathScoped: `${baseId}-path-scoped`,
     subject: `${baseId}-subject`,
     email: `${baseId}-email`,
   };
@@ -500,6 +508,28 @@ export function XaaCredentialFields({
               autoComplete="off"
               className="h-10"
             />
+            <div className="flex items-start gap-2 pt-1">
+              <Switch
+                id={ids.pathScoped}
+                checked={xaaAllowPathScopedIssuer}
+                onCheckedChange={onXaaAllowPathScopedIssuerChange}
+              />
+              <div className="space-y-0.5">
+                <label
+                  htmlFor={ids.pathScoped}
+                  className="block text-xs font-medium text-foreground"
+                >
+                  Path-scoped authorization server
+                </label>
+                <p className="text-xs text-muted-foreground">
+                  Allow the metadata to advertise the origin root as issuer
+                  while the OAuth endpoints live under a path (multi-tenant
+                  setups like Scalekit&apos;s{" "}
+                  <code className="font-mono">/resources/…</code>). Off keeps
+                  the strict RFC 8414 issuer match.
+                </p>
+              </div>
+            </div>
           </div>
 
           <div className="rounded-md border border-border bg-background/40 p-3 space-y-2">

--- a/mcpjam-inspector/client/src/components/xaa/XAAServerModal.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAServerModal.tsx
@@ -51,6 +51,7 @@ export function XAAServerModal({
   const [clientId, setClientId] = useState("");
   const [scopes, setScopes] = useState("");
   const [authzIssuer, setAuthzIssuer] = useState("");
+  const [allowPathScopedIssuer, setAllowPathScopedIssuer] = useState(false);
   // Client-secret state mirrors the Connect-page model (shared component):
   // a typed value replaces the saved secret, the Clear toggle removes it.
   const [clientSecret, setClientSecret] = useState("");
@@ -72,6 +73,7 @@ export function XAAServerModal({
     // the space-separated form this modal edits.
     setScopes((derived.scopes ?? "").replace(/,/g, " ").trim());
     setAuthzIssuer(server?.xaaAuthzIssuer ?? "");
+    setAllowPathScopedIssuer(server?.xaaAllowPathScopedIssuer === true);
     setClientSecret("");
     setClearClientSecret(false);
     setXaaSubject(server?.xaaSubject ?? "");
@@ -155,6 +157,7 @@ export function XAAServerModal({
       oauthScopes: scopesArray,
       // Always send the issuer (possibly empty) so clearing it persists.
       xaaAuthzIssuer: trimmedIssuer,
+      xaaAllowPathScopedIssuer: allowPathScopedIssuer,
       // Per-server simulated identity, defaulting to the signed-in user when
       // blank — identical to the Connect page so the two surfaces stay synced.
       xaaSubject: xaaSubject.trim() || signedInEmail || undefined,
@@ -243,6 +246,8 @@ export function XAAServerModal({
               onScopesChange={setScopes}
               xaaAuthzIssuer={authzIssuer}
               onXaaAuthzIssuerChange={setAuthzIssuer}
+              xaaAllowPathScopedIssuer={allowPathScopedIssuer}
+              onXaaAllowPathScopedIssuerChange={setAllowPathScopedIssuer}
               xaaSubject={xaaSubject}
               onXaaSubjectChange={setXaaSubject}
               xaaEmail={xaaEmail}

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -1429,6 +1429,9 @@ export function useServerState({
         ...(serverEntry.xaaAuthzIssuer !== undefined
           ? { xaaAuthzIssuer: serverEntry.xaaAuthzIssuer }
           : {}),
+        ...(serverEntry.xaaAllowPathScopedIssuer !== undefined
+          ? { xaaAllowPathScopedIssuer: serverEntry.xaaAllowPathScopedIssuer }
+          : {}),
         ...(serverEntry.useXaa !== undefined
           ? { useXaa: serverEntry.useXaa }
           : {}),
@@ -2243,6 +2246,7 @@ export function useServerState({
             oauthFlowProfile: resolvedOAuthProfile,
             hasClientSecret: existingServer?.hasClientSecret,
             xaaAuthzIssuer: existingServer?.xaaAuthzIssuer,
+            xaaAllowPathScopedIssuer: existingServer?.xaaAllowPathScopedIssuer,
             initializationInfo: existingServer?.initializationInfo,
             useOAuth: true,
             lastOAuthTrace: result.oauthTrace,
@@ -2611,6 +2615,9 @@ export function useServerState({
             : getServerBearerTokenState(existingServerForSave),
         xaaAuthzIssuer:
           formData.xaaAuthzIssuer ?? existingServerForSave?.xaaAuthzIssuer,
+        xaaAllowPathScopedIssuer:
+          formData.xaaAllowPathScopedIssuer ??
+          existingServerForSave?.xaaAllowPathScopedIssuer,
         useXaa: formData.useXaa ?? false,
         authServerMode: formData.useXaa
           ? formData.authServerMode ?? "mcpjam"
@@ -3022,6 +3029,9 @@ export function useServerState({
             : getServerBearerTokenState(existingServer),
         xaaAuthzIssuer:
           formData.xaaAuthzIssuer ?? existingServer?.xaaAuthzIssuer,
+        xaaAllowPathScopedIssuer:
+          formData.xaaAllowPathScopedIssuer ??
+          existingServer?.xaaAllowPathScopedIssuer,
         useXaa: formData.useXaa ?? false,
         authServerMode: formData.useXaa
           ? formData.authServerMode ?? "mcpjam"
@@ -4477,6 +4487,9 @@ export function useServerState({
           useOAuth: formData.useOAuth ?? false,
           xaaAuthzIssuer:
             formData.xaaAuthzIssuer ?? originalServer?.xaaAuthzIssuer,
+          xaaAllowPathScopedIssuer:
+            formData.xaaAllowPathScopedIssuer ??
+            originalServer?.xaaAllowPathScopedIssuer,
           useXaa: formData.useXaa ?? false,
           authServerMode: formData.useXaa
             ? formData.authServerMode ?? "mcpjam"

--- a/mcpjam-inspector/client/src/lib/project-serialization.ts
+++ b/mcpjam-inspector/client/src/lib/project-serialization.ts
@@ -59,6 +59,10 @@ function serializeServersInternal(
     if (server.xaaAuthzIssuer !== undefined) {
       serializedServer.xaaAuthzIssuer = server.xaaAuthzIssuer;
     }
+    if (server.xaaAllowPathScopedIssuer !== undefined) {
+      serializedServer.xaaAllowPathScopedIssuer =
+        server.xaaAllowPathScopedIssuer;
+    }
     if (server.useXaa !== undefined) {
       serializedServer.useXaa = server.useXaa;
     }
@@ -245,6 +249,12 @@ export function deserializeServersFromConvex(
     if (xaaAuthzIssuer !== undefined) {
       server.xaaAuthzIssuer = xaaAuthzIssuer;
     }
+    const xaaAllowPathScopedIssuer =
+      serverData.xaaAllowPathScopedIssuer ??
+      serverData.config?.xaaAllowPathScopedIssuer;
+    if (xaaAllowPathScopedIssuer !== undefined) {
+      server.xaaAllowPathScopedIssuer = xaaAllowPathScopedIssuer === true;
+    }
     if (serverData.useXaa !== undefined) {
       server.useXaa = serverData.useXaa === true;
     }
@@ -334,6 +344,15 @@ export function serversHaveChanged(
     const remoteXaaAuthzIssuer =
       remoteServer.xaaAuthzIssuer ?? remoteServer.config?.xaaAuthzIssuer;
     if ((localServer.xaaAuthzIssuer ?? undefined) !== (remoteXaaAuthzIssuer ?? undefined))
+      return true;
+
+    const remoteXaaAllowPathScopedIssuer =
+      remoteServer.xaaAllowPathScopedIssuer ??
+      remoteServer.config?.xaaAllowPathScopedIssuer;
+    if (
+      (localServer.xaaAllowPathScopedIssuer ?? undefined) !==
+      (remoteXaaAllowPathScopedIssuer ?? undefined)
+    )
       return true;
 
     // Get local URL

--- a/mcpjam-inspector/client/src/state/app-reducer.ts
+++ b/mcpjam-inspector/client/src/state/app-reducer.ts
@@ -64,6 +64,9 @@ const buildProjectServerProjection = (
   ...(server.xaaAuthzIssuer === undefined
     ? {}
     : { xaaAuthzIssuer: server.xaaAuthzIssuer }),
+  ...(server.xaaAllowPathScopedIssuer === undefined
+    ? {}
+    : { xaaAllowPathScopedIssuer: server.xaaAllowPathScopedIssuer }),
   ...(server.xaaSubject === undefined ? {} : { xaaSubject: server.xaaSubject }),
   ...(server.xaaEmail === undefined ? {} : { xaaEmail: server.xaaEmail }),
   ...(server.hasClientSecret === undefined

--- a/mcpjam-inspector/client/src/state/app-types.ts
+++ b/mcpjam-inspector/client/src/state/app-types.ts
@@ -71,6 +71,9 @@ export interface ServerWithName {
    * XAA metadata only — intentionally NOT part of MCPServerConfig / toMCPConfig.
    */
   xaaAuthzIssuer?: string;
+  /** Opt-in: accept a path-scoped authorization server (same-origin root
+   * advertised as issuer). XAA metadata only, like xaaAuthzIssuer. */
+  xaaAllowPathScopedIssuer?: boolean;
   /**
    * Cross-App Access (XAA) connect flag. When true the server authenticates via
    * the XAA token-exchange flow (server mints the token) rather than standard

--- a/mcpjam-inspector/client/src/test/setup.ts
+++ b/mcpjam-inspector/client/src/test/setup.ts
@@ -28,12 +28,15 @@ Object.defineProperty(window, "matchMedia", {
   })),
 });
 
-// Mock ResizeObserver (required for some UI components)
-global.ResizeObserver = vi.fn().mockImplementation(() => ({
-  observe: vi.fn(),
-  unobserve: vi.fn(),
-  disconnect: vi.fn(),
-}));
+// Mock ResizeObserver (required for some UI components). A plain class — NOT
+// a vi.fn() — so a suite-level vi.restoreAllMocks() can't strip its
+// implementation and break every later test that mounts a measuring
+// component (Radix Switch/Slider use it via useSize).
+global.ResizeObserver = class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+} as unknown as typeof ResizeObserver;
 
 // cmdk / Command dialogs call scrollIntoView on active items
 Element.prototype.scrollIntoView = vi.fn();

--- a/mcpjam-inspector/server/routes/mcp/__tests__/xaa-server-target.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/xaa-server-target.test.ts
@@ -446,6 +446,58 @@ describe("server-target /proxy/token", () => {
     expect(tokenUrl).toBe("https://env.example.com/resources/res_1/oauth/token");
   });
 
+  it("rejects an opted-in path-scoped AS whose token endpoint escapes the issuer origin", async () => {
+    // Opt-in is ON and the issuer prefix matches, but the metadata points
+    // token_endpoint at a different public host — the confidential secret must
+    // NOT be posted off-origin.
+    const app = buildApp(pathScopedResolver(true));
+    let tokenPosted = false;
+    const fetchMock = vi.fn(async (_url: any, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET") {
+        return new Response(
+          JSON.stringify({
+            issuer: "https://env.example.com",
+            // Off-origin token endpoint — an attacker-controlled host.
+            token_endpoint: "https://attacker.example.net/oauth/token",
+            grant_types_supported: [
+              "urn:ietf:params:oauth:grant-type:jwt-bearer",
+            ],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        );
+      }
+      tokenPosted = true;
+      return new Response(
+        JSON.stringify({ access_token: "tok", token_type: "Bearer" }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await app.request("/api/web/xaa/proxy/token", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer user-token",
+      },
+      body: JSON.stringify({
+        serverId: "srv_1",
+        projectId: "proj_1",
+        assertion: "aaa.bbb.ccc",
+      }),
+    });
+
+    expect(response.status).toBe(409);
+    const body = (await response.json()) as {
+      message?: string;
+      details?: Record<string, unknown>;
+    };
+    expect(body.details).toMatchObject({ tokenEndpointOffOrigin: true });
+    expect(body.message).toContain("off-origin");
+    expect(tokenPosted).toBe(false);
+  });
+
   it("returns 404 when no authorization server can be discovered", async () => {
     const resolver = vi.fn(async () => ({
       clientSecret: "stored-secret",

--- a/mcpjam-inspector/server/routes/mcp/__tests__/xaa-server-target.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/xaa-server-target.test.ts
@@ -353,6 +353,99 @@ describe("server-target /proxy/token", () => {
     expect(tokenPosted).toBe(false);
   });
 
+  // The Scalekit shape: OAuth endpoints scoped under /resources/res_x while
+  // the metadata advertises the origin root as issuer. Rejected by the strict
+  // check unless the per-server opt-in is stored.
+  function stubPathScopedAs(onTokenPost?: (url: string) => void) {
+    const fetchMock = vi.fn(async (url: any, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET") {
+        return new Response(
+          JSON.stringify({
+            issuer: "https://env.example.com",
+            token_endpoint:
+              "https://env.example.com/resources/res_1/oauth/token",
+            grant_types_supported: [
+              "urn:ietf:params:oauth:grant-type:jwt-bearer",
+            ],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        );
+      }
+      onTokenPost?.(String(url));
+      return new Response(
+        JSON.stringify({ access_token: "tok", token_type: "Bearer" }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    return fetchMock;
+  }
+
+  function pathScopedResolver(allow: boolean) {
+    return vi.fn(async () => ({
+      clientSecret: "stored-secret",
+      clientId: "stored-client-id",
+      serverUrl: "https://mcp.example.com/mcp",
+      xaaAuthzIssuer: "https://env.example.com/resources/res_1",
+      xaaAllowPathScopedIssuer: allow,
+    }));
+  }
+
+  it("rejects a path-scoped AS with a 409 naming the opt-in when the server has not opted in", async () => {
+    const app = buildApp(pathScopedResolver(false));
+    let tokenPosted = false;
+    stubPathScopedAs(() => {
+      tokenPosted = true;
+    });
+
+    const response = await app.request("/api/web/xaa/proxy/token", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer user-token",
+      },
+      body: JSON.stringify({
+        serverId: "srv_1",
+        projectId: "proj_1",
+        assertion: "aaa.bbb.ccc",
+      }),
+    });
+
+    expect(response.status).toBe(409);
+    const body = (await response.json()) as {
+      message?: string;
+      details?: Record<string, unknown>;
+    };
+    expect(body.details).toMatchObject({ originPrefix: true });
+    expect(body.message).toContain("Path-scoped authorization server");
+    expect(tokenPosted).toBe(false);
+  });
+
+  it("accepts a path-scoped AS under the per-server opt-in and posts to its scoped token endpoint", async () => {
+    const app = buildApp(pathScopedResolver(true));
+    let tokenUrl = "";
+    stubPathScopedAs((url) => {
+      tokenUrl = url;
+    });
+
+    const response = await app.request("/api/web/xaa/proxy/token", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer user-token",
+      },
+      body: JSON.stringify({
+        serverId: "srv_1",
+        projectId: "proj_1",
+        assertion: "aaa.bbb.ccc",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(tokenUrl).toBe("https://env.example.com/resources/res_1/oauth/token");
+  });
+
   it("returns 404 when no authorization server can be discovered", async () => {
     const resolver = vi.fn(async () => ({
       clientSecret: "stored-secret",

--- a/mcpjam-inspector/server/services/__tests__/xaa-discovery.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/xaa-discovery.test.ts
@@ -142,6 +142,7 @@ describe("evaluateDiscovery", () => {
       requested: "https://as.example.com",
       advertised: "http://as.example.com",
       schemeOnly: true,
+      originPrefix: false,
     });
   });
 
@@ -152,5 +153,63 @@ describe("evaluateDiscovery", () => {
     );
 
     expect(verdict.issuerMismatch?.schemeOnly).toBe(false);
+    expect(verdict.issuerMismatch?.originPrefix).toBe(false);
+  });
+
+  it("classifies a same-origin root issuer over a path-scoped AS as originPrefix", () => {
+    // The Scalekit shape: endpoints scoped under /resources/res_x, issuer at
+    // the origin root.
+    const verdict = evaluateDiscovery(
+      { issuer: "https://env.example.com" },
+      {
+        requestedIssuer: "https://env.example.com/resources/res_1",
+        metadataUrl,
+      },
+    );
+
+    expect(verdict.issuerMismatch?.originPrefix).toBe(true);
+    expect(verdict.issuerMismatch?.schemeOnly).toBe(false);
+  });
+
+  it("classifies a same-origin path-prefix ancestor as originPrefix (segment-aware)", () => {
+    const prefixed = evaluateDiscovery(
+      { issuer: "https://env.example.com/tenants/acme" },
+      {
+        requestedIssuer: "https://env.example.com/tenants/acme/resources/res_1",
+        metadataUrl,
+      },
+    );
+    expect(prefixed.issuerMismatch?.originPrefix).toBe(true);
+
+    // /tenants/acme is NOT an ancestor of /tenants/acme-evil.
+    const sibling = evaluateDiscovery(
+      { issuer: "https://env.example.com/tenants/acme" },
+      {
+        requestedIssuer: "https://env.example.com/tenants/acme-evil",
+        metadataUrl,
+      },
+    );
+    expect(sibling.issuerMismatch?.originPrefix).toBe(false);
+  });
+
+  it("never classifies a cross-origin or scheme-differing issuer as originPrefix", () => {
+    const crossOrigin = evaluateDiscovery(
+      { issuer: "https://evil.example.com" },
+      {
+        requestedIssuer: "https://env.example.com/resources/res_1",
+        metadataUrl,
+      },
+    );
+    expect(crossOrigin.issuerMismatch?.originPrefix).toBe(false);
+
+    // Same host but http root vs https path — origin differs, so no prefix.
+    const schemeDiffers = evaluateDiscovery(
+      { issuer: "http://env.example.com" },
+      {
+        requestedIssuer: "https://env.example.com/resources/res_1",
+        metadataUrl,
+      },
+    );
+    expect(schemeDiffers.issuerMismatch?.originPrefix).toBe(false);
   });
 });

--- a/mcpjam-inspector/server/services/xaa-discovery.ts
+++ b/mcpjam-inspector/server/services/xaa-discovery.ts
@@ -116,6 +116,15 @@ export interface IssuerMismatch {
   requested: string;
   advertised: string;
   schemeOnly: boolean;
+  /**
+   * The advertised issuer is a same-origin path-prefix ancestor of the
+   * requested URL (e.g. requested https://env.example.com/resources/res_x,
+   * advertised https://env.example.com). The shape of multi-tenant
+   * authorization servers that scope endpoints under a path while issuing
+   * from the origin root — acceptable only under the per-server
+   * path-scoped-issuer opt-in.
+   */
+  originPrefix: boolean;
 }
 
 export interface DiscoveryVerdict {
@@ -150,6 +159,27 @@ function fullIdentity(value: string): string {
   } catch {
     return stripTrailingSlash(value);
   }
+}
+
+// True when `advertised` is the origin root or a path-prefix ancestor of
+// `requested` on the SAME origin (scheme + host + port). Segment-aware:
+// /resources is an ancestor of /resources/res_x but not of /resources-evil.
+function isOriginPrefix(advertised: string, requested: string): boolean {
+  let adv: URL;
+  let req: URL;
+  try {
+    adv = new URL(advertised);
+    req = new URL(requested);
+  } catch {
+    return false;
+  }
+  if (adv.origin !== req.origin) return false;
+  const advPath = stripTrailingSlash(adv.pathname);
+  const reqPath = stripTrailingSlash(req.pathname);
+  if (advPath === reqPath) return false;
+  return advPath === "" || advPath === "/"
+    ? reqPath.length > 0
+    : reqPath.startsWith(`${advPath}/`);
 }
 
 /**
@@ -202,6 +232,7 @@ export function evaluateDiscovery(
       // Same host/path, different scheme → almost always a proxy that
       // terminates TLS but advertises an http:// issuer.
       schemeOnly: hostAndPath(issuer) === hostAndPath(context.requestedIssuer),
+      originPrefix: isOriginPrefix(issuer, context.requestedIssuer),
     };
   }
 

--- a/mcpjam-inspector/server/services/xaa-mint.ts
+++ b/mcpjam-inspector/server/services/xaa-mint.ts
@@ -85,6 +85,12 @@ export async function discoverServerTargetTokenEndpoint(
   args: {
     resource?: string;
     explicitIssuer?: string;
+    /**
+     * Per-server opt-in: accept an advertised issuer that is a same-origin
+     * path-prefix ancestor of the requested URL (multi-tenant AS deployments
+     * like Scalekit's /resources/res_x). Off = strict RFC 8414 match.
+     */
+    allowPathScopedIssuer?: boolean;
   },
   httpsOnly: boolean
 ): Promise<{ issuer: string; tokenEndpoint: string }> {
@@ -128,19 +134,31 @@ export async function discoverServerTargetTokenEndpoint(
       // abort must NOT wear a 502/504 — CDN edges (Cloudflare in hosted)
       // replace origin 502/504 bodies with their own branded error page, which
       // would hide this message from the user entirely.
-      if (verdict.issuerMismatch) {
-        const { requested, advertised, schemeOnly } = verdict.issuerMismatch;
+      // A same-origin path-prefix "mismatch" is the multi-tenant AS shape
+      // (issuer at the origin root, endpoints scoped under a path). Only the
+      // per-server opt-in accepts it; the origin check still binds the token
+      // endpoint to the issuer's own host, so the secret never crosses
+      // origins.
+      const acceptedPathScoped =
+        args.allowPathScopedIssuer === true &&
+        verdict.issuerMismatch?.originPrefix === true;
+      if (verdict.issuerMismatch && !acceptedPathScoped) {
+        const { requested, advertised, schemeOnly, originPrefix } =
+          verdict.issuerMismatch;
+        const hint = schemeOnly
+          ? "Only the scheme differs — the authorization server is likely behind a TLS-terminating proxy but advertises an http:// issuer."
+          : originPrefix
+            ? "The advertised issuer is the same-origin root of the requested URL — a multi-tenant, path-scoped authorization server. Enable \"Path-scoped authorization server\" in the server's XAA settings to allow this."
+            : "Set the server's Authorization Server issuer to the advertised value (or fix the server URL).";
         throw new WebRouteError(
           409,
           ErrorCode.VALIDATION_ERROR,
-          `Authorization server issuer mismatch: the stored config expects "${requested}" but the server's metadata advertises "${advertised}". ` +
-            (schemeOnly
-              ? "Only the scheme differs — the authorization server is likely behind a TLS-terminating proxy but advertises an http:// issuer."
-              : "Set the server's Authorization Server issuer to the advertised value (or fix the server URL)."),
+          `Authorization server issuer mismatch: the stored config expects "${requested}" but the server's metadata advertises "${advertised}". ${hint}`,
           {
             requestedIssuer: requested,
             advertisedIssuer: advertised,
             schemeOnly,
+            originPrefix,
           }
         );
       }
@@ -212,6 +230,7 @@ export async function resolveServerTarget(deps: {
     {
       resource: resolved.serverUrl ?? undefined,
       explicitIssuer: resolved.xaaAuthzIssuer ?? undefined,
+      allowPathScopedIssuer: resolved.xaaAllowPathScopedIssuer === true,
     },
     deps.httpsOnly
   );

--- a/mcpjam-inspector/server/services/xaa-mint.ts
+++ b/mcpjam-inspector/server/services/xaa-mint.ts
@@ -81,6 +81,17 @@ async function discoverIssuerFromResourceMetadata(
 //      protected-resource metadata;
 //   3. otherwise the resource URL itself (legacy behavior — covers servers that
 //      self-host RFC 8414 metadata at the resource origin and serve no PRM).
+// Same scheme + host + port. Used to bind a path-scoped AS's token endpoint
+// to its issuer origin before the confidential secret is posted. Unparseable
+// input fails closed (not same origin).
+function isSameOrigin(a: string, b: string): boolean {
+  try {
+    return new URL(a).origin === new URL(b).origin;
+  } catch {
+    return false;
+  }
+}
+
 export async function discoverServerTargetTokenEndpoint(
   args: {
     resource?: string;
@@ -136,20 +147,32 @@ export async function discoverServerTargetTokenEndpoint(
       // would hide this message from the user entirely.
       // A same-origin path-prefix "mismatch" is the multi-tenant AS shape
       // (issuer at the origin root, endpoints scoped under a path). Only the
-      // per-server opt-in accepts it; the origin check still binds the token
-      // endpoint to the issuer's own host, so the secret never crosses
-      // origins.
-      const acceptedPathScoped =
+      // per-server opt-in accepts it.
+      const originPrefixOptIn =
         args.allowPathScopedIssuer === true &&
         verdict.issuerMismatch?.originPrefix === true;
+      // Even under the opt-in, the token endpoint must stay on the advertised
+      // issuer's own origin. Otherwise a same-origin tenant's metadata (the
+      // exact scenario this feature relaxes trust for) could advertise the
+      // origin-root issuer to pass the prefix check yet point token_endpoint
+      // at an arbitrary public host, redirecting the confidential client
+      // secret off-origin. Bind it explicitly; the strict path never reaches
+      // this branch.
+      const tokenEndpointEscapesOrigin =
+        originPrefixOptIn &&
+        verdict.tokenEndpoint != null &&
+        !isSameOrigin(verdict.tokenEndpoint, verdict.issuerMismatch!.advertised);
+      const acceptedPathScoped = originPrefixOptIn && !tokenEndpointEscapesOrigin;
       if (verdict.issuerMismatch && !acceptedPathScoped) {
         const { requested, advertised, schemeOnly, originPrefix } =
           verdict.issuerMismatch;
-        const hint = schemeOnly
-          ? "Only the scheme differs — the authorization server is likely behind a TLS-terminating proxy but advertises an http:// issuer."
-          : originPrefix
-            ? "The advertised issuer is the same-origin root of the requested URL — a multi-tenant, path-scoped authorization server. Enable \"Path-scoped authorization server\" in the server's XAA settings to allow this."
-            : "Set the server's Authorization Server issuer to the advertised value (or fix the server URL).";
+        const hint = tokenEndpointEscapesOrigin
+          ? `The path-scoped authorization server's token endpoint ("${verdict.tokenEndpoint}") is on a different origin than its issuer ("${advertised}"); refusing to send the client secret off-origin.`
+          : schemeOnly
+            ? "Only the scheme differs — the authorization server is likely behind a TLS-terminating proxy but advertises an http:// issuer."
+            : originPrefix
+              ? "The advertised issuer is the same-origin root of the requested URL — a multi-tenant, path-scoped authorization server. Enable \"Path-scoped authorization server\" in the server's XAA settings to allow this."
+              : "Set the server's Authorization Server issuer to the advertised value (or fix the server URL).";
         throw new WebRouteError(
           409,
           ErrorCode.VALIDATION_ERROR,
@@ -159,6 +182,9 @@ export async function discoverServerTargetTokenEndpoint(
             advertisedIssuer: advertised,
             schemeOnly,
             originPrefix,
+            ...(tokenEndpointEscapesOrigin
+              ? { tokenEndpointOffOrigin: true }
+              : {}),
           }
         );
       }

--- a/mcpjam-inspector/server/utils/server-secrets.ts
+++ b/mcpjam-inspector/server/utils/server-secrets.ts
@@ -268,6 +268,10 @@ export interface ServerClientSecretResult {
   serverUrl: string | null;
   /** Optional issuer override; takes precedence over serverUrl for discovery. */
   xaaAuthzIssuer: string | null;
+  /** Per-server opt-in: accept a same-origin path-scoped authorization server
+   * whose metadata advertises the origin root as issuer. Absent/false =
+   * strict; the guard only relaxes on an explicit true. */
+  xaaAllowPathScopedIssuer?: boolean;
 }
 
 /**
@@ -350,5 +354,8 @@ export async function fetchServerClientSecret(args: {
     serverUrl: typeof body.serverUrl === "string" ? body.serverUrl : null,
     xaaAuthzIssuer:
       typeof body.xaaAuthzIssuer === "string" ? body.xaaAuthzIssuer : null,
+    // Strict by default: only an explicit true from the stored config relaxes
+    // the issuer check (older backends simply omit the field).
+    xaaAllowPathScopedIssuer: body.xaaAllowPathScopedIssuer === true,
   };
 }

--- a/mcpjam-inspector/shared/types.ts
+++ b/mcpjam-inspector/shared/types.ts
@@ -894,6 +894,12 @@ export interface ServerFormData {
   /** Optional issuer override for the cross-app authorization test target. */
   xaaAuthzIssuer?: string;
   /**
+   * Opt-in: accept a path-scoped authorization server whose metadata
+   * advertises the same-origin root as issuer (multi-tenant AS deployments
+   * like Scalekit). Off = strict RFC 8414 issuer match.
+   */
+  xaaAllowPathScopedIssuer?: boolean;
+  /**
    * Cross-App Access (XAA) connect flag. When true the server authenticates via
    * the XAA token-exchange flow rather than standard OAuth. Mutually exclusive
    * with `useOAuth` — the form only ever sets one.


### PR DESCRIPTION
## What

Field report (Scalekit): their multi-tenant layout scopes OAuth endpoints under a path (`https://env.scalekit.cloud/resources/res_x`) while the metadata advertises the origin root as `issuer` — and discovery is served **only** at the scoped path, so neither the strict check nor a config workaround can ever pass. This adds a **per-server opt-in** that accepts exactly that shape, and nothing else.

Companion to mcpjam-backend#662 (must deploy first; while the backend omits the field, behavior stays strict everywhere).

## Changes

**Server**
- `evaluateDiscovery` classifies mismatches with a new `originPrefix` flag: advertised issuer is a same-origin (scheme+host+port) path-prefix ancestor of the requested URL, segment-aware (`/tenants/acme` ≠ ancestor of `/tenants/acme-evil`).
- The fail-closed guard in `discoverServerTargetTokenEndpoint` accepts an `originPrefix` mismatch only when the stored server config carries `xaaAllowPathScopedIssuer: true` (resolved server-side via the reveal endpoint — never client-supplied). The ID-JAG `aud` uses the advertised issuer, which is what the AS validates.
- When the guard still rejects a path-scoped shape (opt-in off), the 409 message now names the toggle, and `details.originPrefix` rides along.

**Client**
- "Path-scoped authorization server" switch under the issuer field in the shared `XaaCredentialFields` (Connect page + XAA debugger modal), persisted through the same save paths as `xaaAuthzIssuer` (form hook, save assembly, app state, project import/export parity).

**Test infra**
- The global `ResizeObserver` stub is now a plain class: it was a `vi.fn()`, and any suite calling `vi.restoreAllMocks()` stripped its implementation, breaking every later test that mounts a measuring Radix component (the new Switch surfaced this).

## Security

- The relaxation never crosses origins: the token endpoint host is still bound to the issuer's own origin, so the stored secret cannot be redirected off-host.
- Opt-in is per server, off by default, stored server-side, and read only from the reveal response — a request cannot enable it.
- Residual risk is same-origin tenant confusion (a malicious PRM pointing at a sibling resource path on the same AS); the secret still only reaches that AS, and the user explicitly opted the server into path-scoped trust.
- Strict RFC 8414 behavior is unchanged for every server that doesn't opt in; regression tests assert the no-opt-in path still 409s without posting the secret.

## Tests

- Discovery: originPrefix classification (root, nested prefix, segment-aware sibling rejection, cross-origin, scheme-differs) — 16 pass.
- Server-target e2e: opt-in off → 409 naming the toggle, secret never posted; opt-in on → 200, posted to the scoped token endpoint — 11 pass.
- 55 server XAA tests + 56 client tests (modal, form hook, serialization) green; typecheck clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes XAA discovery and when confidential client secrets are posted, with an explicit security opt-in; mistakes could weaken issuer binding for opted-in servers.
> 
> **Overview**
> Adds **per-server opt-in** for XAA when OAuth metadata advertises the **origin root** as `issuer` but endpoints live under a path (e.g. Scalekit-style `/resources/…`), while default behavior stays **strict RFC 8414**.
> 
> **Server:** `evaluateDiscovery` now sets `originPrefix` on issuer mismatches; `discoverServerTargetTokenEndpoint` accepts that shape only when stored `xaaAllowPathScopedIssuer` is true (from the secrets reveal path, not the client). Rejections still 409 with clearer copy and `details.originPrefix`; even with opt-in, **off-origin `token_endpoint` values are blocked** so the client secret cannot be posted elsewhere.
> 
> **Client:** New **Path-scoped authorization server** switch in shared `XaaCredentialFields`, wired through Connect add/edit, the XAA debugger modal, form save/state, and project import/export via `xaaAllowPathScopedIssuer`.
> 
> **Tests / infra:** Discovery and proxy/token e2e coverage for opt-in on/off and off-origin endpoints; global `ResizeObserver` test stub is a plain class so `vi.restoreAllMocks()` does not break Radix `Switch` tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bf7f2b4632d4351a3655c642a441ee1e39ec5ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in support for same-origin, path-scoped authorization servers (e.g., Scalekit) with a per-server XAA toggle and strict default. Under the opt-in, we enforce the token endpoint stays on the issuer’s origin; older backends without the stored flag remain strict.

- **New Features**
  - Server: Classifies same-origin path-prefix as `originPrefix`; accepts only when `xaaAllowPathScopedIssuer` is true; 409 includes `details.originPrefix`.
  - UI: Adds “Path-scoped authorization server” switch next to the issuer in XAA fields (Connect and XAA modal); persisted and included in import/export.

- **Bug Fixes**
  - Security: Rejects opted-in servers whose `token_endpoint` is off the issuer origin (409 with `details.tokenEndpointOffOrigin`); secret is never posted off-origin.
  - Forms/Tests: Reset now clears the path-scoped toggle; `ResizeObserver` test stub changed to a class to avoid restore-all-mocks breakage.

<sup>Written for commit 1bf7f2b4632d4351a3655c642a441ee1e39ec5ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3049?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

