### PR TITLE
feat(sdk/oauth): show CIMD support in summary

### DIFF
--- a/sdk/src/oauth/state-machines/debug-oauth-2025-11-25.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-11-25.ts
@@ -1180,6 +1180,17 @@ export const createDebugOAuthStateMachine = (
               metadata["Registration Endpoint"] =
                 authServerMetadata.registration_endpoint;
             }
+            // CIMD support gates the CIMD registration strategy (see the
+            // client_id_metadata_document_supported check below), so surface it
+            // in the summary. Guard on typeof to distinguish "not advertised"
+            // from an explicit `false`.
+            if (
+              typeof authServerMetadata.client_id_metadata_document_supported ===
+              "boolean"
+            ) {
+              metadata["CIMD Supported"] =
+                authServerMetadata.client_id_metadata_document_supported;
+            }
             if (authServerMetadata.code_challenge_methods_supported) {
               metadata["PKCE Methods"] =
                 authServerMetadata.code_challenge_methods_supported;


### PR DESCRIPTION
The OAuth Debugger's step-6 Authorization Server Metadata summary shows a curated subset of the AS metadata, but it left out `client_id_metadata_document_supported`. That flag actually decides whether the CIMD registration strategy is viable at all — the 2025-11-25 debug flow already gates on it and fails early when the AS doesn't advertise it — so anyone debugging a CIMD problem had to drop into the raw response body to find out. This surfaces it as a "CIMD Supported" row in the summary, guarded on `typeof === "boolean"` so an explicit `false` renders as unsupported while an absent field stays hidden, matching how the other optional fields behave.

<img width="2366" height="2534" alt="2026-07-07 at 20 15 49" src="https://github.com/user-attachments/assets/79e09cc9-937e-4070-97c0-c75204cff5e3" />