### PR TITLE
fix: forward discovered AS url from oauth debugger connect

### DIFF
--- a/mcpjam-inspector/client/src/components/OAuthFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/OAuthFlowTab.tsx
@@ -29,6 +29,10 @@ export interface OAuthTokensFromFlow {
   expiresIn?: number;
   clientId?: string;
   clientSecret?: string;
+  // AS URL discovered during the debugger flow. Forwarded to the hosted
+  // backend so it can refresh without re-discovering against a resource it
+  // can't reach itself (e.g. localhost).
+  authorizationServerUrl?: string;
 }
 
 declare global {
@@ -369,6 +373,7 @@ export const OAuthFlowTab = ({
       expiresIn: oauthFlowState.expiresIn,
       clientId: oauthFlowState.clientId,
       clientSecret: oauthFlowState.clientSecret,
+      authorizationServerUrl: oauthFlowState.authorizationServerUrl,
     }),
     [
       oauthFlowState.accessToken,
@@ -377,6 +382,7 @@ export const OAuthFlowTab = ({
       oauthFlowState.expiresIn,
       oauthFlowState.clientId,
       oauthFlowState.clientSecret,
+      oauthFlowState.authorizationServerUrl,
     ],
   );
 

--- a/mcpjam-inspector/client/src/components/e2e/OAuthDebuggerE2EHarness.tsx
+++ b/mcpjam-inspector/client/src/components/e2e/OAuthDebuggerE2EHarness.tsx
@@ -286,6 +286,9 @@ export function OAuthDebuggerE2EHarness() {
         projectId: PROJECT_ID,
         serverId: serverIdForName(serverName),
         serverUrl,
+        ...(tokens.authorizationServerUrl
+          ? { authorizationServerUrl: tokens.authorizationServerUrl }
+          : {}),
         kind: "generic",
         clientInformation: {
           clientId: tokens.clientId,

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
@@ -957,6 +957,37 @@ describe("useServerState OAuth callback failures", () => {
     expect(toastSuccess).toHaveBeenCalledWith("Connected to demo-server!");
   });
 
+  it("forwards the discovered authorization server url so the hosted backend can refresh unreachable (e.g. localhost) targets", async () => {
+    mockHostedMode.mockReturnValue(true);
+    reconnectServerMock.mockResolvedValueOnce({
+      success: true,
+      initInfo: null,
+    });
+    const dispatch = vi.fn();
+    const { result } = renderUseServerState(dispatch);
+
+    await act(async () => {
+      await result.current.handleConnectWithTokensFromOAuthFlow(
+        "demo-server",
+        {
+          accessToken: "hosted-access-token",
+          tokenType: "Bearer",
+          expiresIn: 300,
+          clientId: "hosted-client-id",
+          authorizationServerUrl: "http://127.0.0.1:8000",
+        },
+        "http://127.0.0.1:8000/mcp"
+      );
+    });
+
+    expect(importHostedOAuthTokensMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serverUrl: "http://127.0.0.1:8000/mcp",
+        authorizationServerUrl: "http://127.0.0.1:8000",
+      })
+    );
+  });
+
   it("marks the pending server as failed when authorization is denied", async () => {
     localStorage.setItem("mcp-oauth-pending", "demo-server");
     localStorage.setItem("mcp-oauth-return-hash", "#demo-server");

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -3279,6 +3279,7 @@ export function useServerState({
         expiresIn?: number;
         clientId?: string;
         clientSecret?: string;
+        authorizationServerUrl?: string;
       },
       serverUrl: string
     ): Promise<{ success: boolean; error?: string }> => {
@@ -3336,6 +3337,13 @@ export function useServerState({
         serverUrl,
         ...(storedOAuthConfig.resourceUrl
           ? { oauthResourceUrl: storedOAuthConfig.resourceUrl }
+          : {}),
+        // Forward the AS URL discovered by the debugger flow so the hosted
+        // backend can refresh without re-discovering against a resource it
+        // can't reach itself (e.g. localhost). Mirrors the live OAuth path in
+        // MCPOAuthProvider.saveTokens.
+        ...(tokens.authorizationServerUrl
+          ? { authorizationServerUrl: tokens.authorizationServerUrl }
           : {}),
         kind: isRegistry ? "registry" : "generic",
         ...(isRegistry
@@ -3433,6 +3441,7 @@ export function useServerState({
         expiresIn?: number;
         clientId?: string;
         clientSecret?: string;
+        authorizationServerUrl?: string;
       },
       serverUrl: string
     ) => {
@@ -3471,6 +3480,7 @@ export function useServerState({
         expiresIn?: number;
         clientId?: string;
         clientSecret?: string;
+        authorizationServerUrl?: string;
       },
       serverUrl: string
     ) => {


### PR DESCRIPTION
When you finish the OAuth Debugger flow against a local server and click "Connect Server" in hosted mode, the connection always failed with "Authorization server metadata discovery failed", regardless of the registration strategy. The debugger's 11 steps run in the browser (which can reach `127.0.0.1`), but "Connect Server" hands the tokens to the hosted Convex backend, which then resolves/refreshes the credential from its own cloud environment and can't reach your localhost — so re-discovering the authorization server metadata against the resource URL blows up. The live OAuth path (`MCPOAuthProvider.saveTokens`) already forwards the `authorizationServerUrl` it discovered precisely so the backend can refresh without re-discovering, but the debugger's connect path (`applyTokensFromOAuthFlow`) was dropping it even though `oauthFlowState.authorizationServerUrl` was already available. This threads that value through `OAuthTokensFromFlow` → `applyTokensFromOAuthFlow` → `importHostedOAuthTokens` so the debugger behaves like the live path. Note this fixes the re-discovery failure; a fully-local setup where the authorization server itself is on localhost still can't be refreshed by the cloud backend.

<img width="2170" height="2614" alt="2026-07-07 at 20 34 09" src="https://github.com/user-attachments/assets/09fa2534-e1d5-46f0-a113-cf079d07e36d" />



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the “Authorization server metadata discovery failed” error when connecting from the OAuth Debugger in hosted mode by forwarding the discovered `authorizationServerUrl` to the backend, avoiding re-discovery against localhost.

- **Bug Fixes**
  - Threads `authorizationServerUrl` through `OAuthTokensFromFlow` → `applyTokensFromOAuthFlow` → `importHostedOAuthTokens` to mirror the live OAuth path.
  - Updates the E2E harness to include `authorizationServerUrl` when present.
  - Adds a test to verify the URL is forwarded in `use-server-state`.

<sup>Written for commit d1033d2970cdc7bb81bb324c1dc28a6514556cd6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3056?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

