### PR TITLE
fix(api-keys): resolve WorkOS org from request, not the session

### DIFF
--- a/mcpjam-inspector/server/routes/web/__tests__/api-keys.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/api-keys.test.ts
@@ -25,6 +25,24 @@ vi.mock("../../../services/workos-key-bindings.js", async (importOriginal) => {
   };
 });
 
+vi.mock("../../../services/identity.js", async (importOriginal) => {
+  const actual = await importOriginal<object>();
+  return {
+    ...actual,
+    resolveUserByExternalId: vi.fn().mockResolvedValue({ _id: "mcpjam_user_1" }),
+  };
+});
+
+const mockResolveApiKeyReadiness = vi.fn();
+vi.mock("../../../services/organizations.js", async (importOriginal) => {
+  const actual = await importOriginal<object>();
+  return {
+    ...actual,
+    resolveApiKeyReadiness: (...args: unknown[]) =>
+      mockResolveApiKeyReadiness(...args),
+  };
+});
+
 const OWNED_KEY_ID = "api_key_owned_1";
 const USER_KEYS_PATH = "/user_management/users/user_session_1/api_keys";
 
@@ -156,5 +174,116 @@ describe("web routes — API key revoke ownership", () => {
       message: "Could not verify API key ownership",
     });
     expect(deleted).toEqual([]);
+  });
+});
+
+async function mintKey(
+  app: ReturnType<typeof createWebTestApp>["app"],
+  organizationId = "org_convex_1",
+) {
+  return app.request("/api/web/api-keys", {
+    method: "POST",
+    headers: {
+      Authorization: "Bearer session-jwt",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ name: "my key", organizationId }),
+  });
+}
+
+describe("web routes — API key mint readiness", () => {
+  const { app } = createWebTestApp();
+
+  beforeEach(() => {
+    vi.stubEnv("WORKOS_API_KEY", "sk_test_admin");
+    mockResolveApiKeyReadiness.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it("mints a key once the backend reports the org+member ready", async () => {
+    mockResolveApiKeyReadiness.mockResolvedValue({
+      ready: true,
+      workosOrganizationId: "org_workos_1",
+    });
+    const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+      const url = new URL(String(input));
+      if (init?.method === "POST" && url.pathname === USER_KEYS_PATH) {
+        const body = JSON.parse(String(init.body));
+        expect(body.organization_id).toBe("org_workos_1");
+        return workosJson(keyRecord("api_key_new"));
+      }
+      return workosJson({ message: "unexpected WorkOS call" }, 500);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { status } = await expectJson(await mintKey(app));
+
+    expect(status).toBe(200);
+    expect(mockResolveApiKeyReadiness).toHaveBeenCalledWith(
+      "org_convex_1",
+      "mcpjam_user_1",
+    );
+  });
+
+  it("409s with a sync-timing message when the org is still pending", async () => {
+    mockResolveApiKeyReadiness.mockResolvedValue({
+      ready: false,
+      workosOrganizationId: null,
+      reason: "org_pending",
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => workosJson({ message: "should not be called" }, 500)),
+    );
+
+    const { status, data } = await expectJson(await mintKey(app));
+
+    expect(status).toBe(409);
+    expect(data).toMatchObject({ code: "VALIDATION_ERROR" });
+  });
+
+  it("409s with a sync-timing message when the caller's membership is still pending", async () => {
+    mockResolveApiKeyReadiness.mockResolvedValue({
+      ready: false,
+      workosOrganizationId: "org_workos_1",
+      reason: "membership_pending",
+    });
+
+    const { status, data } = await expectJson(await mintKey(app));
+
+    expect(status).toBe(409);
+    expect(data).toMatchObject({ code: "VALIDATION_ERROR" });
+  });
+
+  it("403s when the caller has no membership row in the requested org", async () => {
+    const { ApiKeyReadinessError } = await import(
+      "../../../services/organizations.js"
+    );
+    mockResolveApiKeyReadiness.mockRejectedValue(
+      new ApiKeyReadinessError(403, "Not a member of this organization"),
+    );
+
+    const { status, data } = await expectJson(await mintKey(app));
+
+    expect(status).toBe(403);
+    expect(data).toMatchObject({ code: "FORBIDDEN" });
+  });
+
+  it("404s when the requested org doesn't exist", async () => {
+    const { ApiKeyReadinessError } = await import(
+      "../../../services/organizations.js"
+    );
+    mockResolveApiKeyReadiness.mockRejectedValue(
+      new ApiKeyReadinessError(404, "Organization not found"),
+    );
+
+    const { status, data } = await expectJson(await mintKey(app));
+
+    expect(status).toBe(404);
+    expect(data).toMatchObject({ code: "NOT_FOUND" });
   });
 });

--- a/mcpjam-inspector/server/routes/web/__tests__/api-keys.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/api-keys.test.ts
@@ -252,6 +252,10 @@ describe("web routes — API key mint readiness", () => {
       workosOrganizationId: "org_workos_1",
       reason: "membership_pending",
     });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => workosJson({ message: "should not be called" }, 500)),
+    );
 
     const { status, data } = await expectJson(await mintKey(app));
 
@@ -285,5 +289,58 @@ describe("web routes — API key mint readiness", () => {
 
     expect(status).toBe(404);
     expect(data).toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("400s when the readiness check reports malformed ids", async () => {
+    const { ApiKeyReadinessError } = await import(
+      "../../../services/organizations.js"
+    );
+    mockResolveApiKeyReadiness.mockRejectedValue(
+      new ApiKeyReadinessError(400, "Invalid organization or user id"),
+    );
+
+    const { status, data } = await expectJson(await mintKey(app));
+
+    expect(status).toBe(400);
+    expect(data).toMatchObject({ code: "VALIDATION_ERROR" });
+  });
+});
+
+describe("web routes — API key listing is not scoped by session org", () => {
+  const { app } = createWebTestApp();
+
+  beforeEach(() => {
+    vi.stubEnv("WORKOS_API_KEY", "sk_test_admin");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it("lists all of the user's keys without an organization_id filter", async () => {
+    const fetchMock = vi.fn(async (input: string | URL) => {
+      const url = new URL(String(input));
+      expect(url.pathname).toBe(USER_KEYS_PATH);
+      // Regression guard: a key minted under org B while the session is
+      // scoped to org A must not be filtered out of this list.
+      expect(url.searchParams.has("organization_id")).toBe(false);
+      return workosJson({
+        object: "list",
+        data: [keyRecord("api_key_org_a"), keyRecord("api_key_org_b")],
+        list_metadata: { before: null, after: null },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { status, data } = await expectJson(
+      await app.request("/api/web/api-keys", {
+        method: "GET",
+        headers: { Authorization: "Bearer session-jwt" },
+      }),
+    );
+
+    expect(status).toBe(200);
+    expect(data.items).toHaveLength(2);
   });
 });

--- a/mcpjam-inspector/server/routes/web/api-keys.ts
+++ b/mcpjam-inspector/server/routes/web/api-keys.ts
@@ -21,6 +21,10 @@ import {
   verifyAuthKitToken,
   AuthKitConfigError,
 } from "../../services/authkit-jwt.js";
+import {
+  resolveApiKeyReadiness,
+  ApiKeyReadinessError,
+} from "../../services/organizations.js";
 
 /**
  * `/api/web/api-keys/*` — WorkOS API Key management.
@@ -186,36 +190,51 @@ function mapWorkOSError(status: number, body: any, fallback: string): never {
 
 /**
  * WorkOS REQUIRES `organization_id` when minting a user API key (422
- * "Validation failed" without it). Org-scoped sessions carry the org in the
- * JWT's `org_id` claim; sessions signed in outside an organization context
- * don't, so fall back to the user's active WorkOS memberships. Which WorkOS
- * org hosts the key doesn't affect authorization — that's enforced by the
- * MCPJam org binding — so the first active membership is fine.
+ * "Validation failed" without it). The dialog already requires the caller to
+ * select the target MCPJam (Convex) organization for the key
+ * (`createSchema.organizationId` below) — that selection, not anything
+ * derived from the session JWT, is what authoritatively determines which
+ * WorkOS org the key gets minted into. Deriving it from the session instead
+ * (a JWT `org_id` claim, or "first active WorkOS membership") gets MORE
+ * ambiguous, not less, once a user can belong to several synced WorkOS orgs —
+ * it doesn't reflect which org the user actually intends to act as.
+ *
+ * So this resolves the WorkOS org id via the backend's readiness check,
+ * keyed on the request's own `organizationId` + the caller's resolved MCPJam
+ * user id. Throws `ApiKeyReadinessError` (403 not-a-member, 404 org-not-found)
+ * or `OrganizationNotReadyError` (sync still in flight) — the POST handler
+ * translates both.
  */
-async function resolveWorkosOrgId(session: SessionContext): Promise<string> {
-  if (session.organizationId) {
-    return session.organizationId;
+class OrganizationNotReadyError extends Error {
+  readonly reason?: string;
+  constructor(message: string, reason?: string) {
+    super(message);
+    this.name = "OrganizationNotReadyError";
+    this.reason = reason;
   }
-  const { status, body } = await callWorkOS(
-    "GET",
-    `/user_management/organization_memberships?user_id=${encodeURIComponent(
-      session.userId,
-    )}&statuses=active`,
+}
+
+async function resolveWorkosOrgId(
+  mcpjamOrganizationId: string,
+  mcpjamUserId: string,
+): Promise<string> {
+  const readiness = await resolveApiKeyReadiness(
+    mcpjamOrganizationId,
+    mcpjamUserId,
   );
-  if (status < 200 || status >= 300) {
-    mapWorkOSError(status, body, "Failed to resolve your organization");
-  }
-  const first = Array.isArray(body?.data) ? body.data[0] : undefined;
-  const orgId =
-    typeof first?.organization_id === "string" ? first.organization_id : null;
-  if (!orgId) {
-    throw new WebRouteError(
-      400,
-      ErrorCode.VALIDATION_ERROR,
-      "Your account does not belong to a WorkOS organization, which is required to create API keys",
+  if (!readiness.ready || !readiness.workosOrganizationId) {
+    const messages: Record<string, string> = {
+      org_pending: "This organization is still being set up for API keys — please try again shortly.",
+      org_failed: "This organization couldn't be set up for API keys. Please try again or contact support.",
+      membership_pending: "Your access to this organization is still syncing — please try again shortly.",
+      membership_failed: "Your access to this organization couldn't be synced. Please try again or contact support.",
+    };
+    throw new OrganizationNotReadyError(
+      readiness.reason ? messages[readiness.reason] : "This organization isn't ready to create API keys yet.",
+      readiness.reason,
     );
   }
-  return orgId;
+  return readiness.workosOrganizationId;
 }
 
 /**
@@ -289,9 +308,30 @@ apiKeys.post("/", async (c) =>
       );
     }
 
+    let workosOrgId: string;
+    try {
+      workosOrgId = await resolveWorkosOrgId(organizationId, mcpjamUser._id);
+    } catch (error) {
+      if (error instanceof ApiKeyReadinessError) {
+        throw new WebRouteError(
+          error.status,
+          error.status === 403 ? ErrorCode.FORBIDDEN : ErrorCode.NOT_FOUND,
+          error.message,
+        );
+      }
+      if (error instanceof OrganizationNotReadyError) {
+        throw new WebRouteError(
+          409,
+          ErrorCode.VALIDATION_ERROR,
+          error.message,
+        );
+      }
+      throw error;
+    }
+
     const payload: Record<string, unknown> = {
       name,
-      organization_id: await resolveWorkosOrgId(session),
+      organization_id: workosOrgId,
     };
 
     const { status, body } = await callWorkOS(

--- a/mcpjam-inspector/server/routes/web/api-keys.ts
+++ b/mcpjam-inspector/server/routes/web/api-keys.ts
@@ -91,13 +91,12 @@ function getWorkOSRestKey(): string {
 
 interface SessionContext {
   userId: string;
-  organizationId?: string;
 }
 
 /**
  * Authenticate a key-management request by VERIFYING the WorkOS AuthKit access
  * token (signature, issuer, audience, exp/nbf) and returning only the trusted
- * `sub` / `org_id`.
+ * `sub`.
  *
  * These routes act on the caller's behalf using the server's admin
  * `WORKOS_API_KEY` and write Convex org bindings, so the token MUST be verified
@@ -127,7 +126,7 @@ async function resolveSessionContext(c: any): Promise<SessionContext> {
       "Invalid or expired session token",
     );
   }
-  return { userId: session.sub, organizationId: session.orgId };
+  return { userId: session.sub };
 }
 
 async function callWorkOS(
@@ -313,11 +312,13 @@ apiKeys.post("/", async (c) =>
       workosOrgId = await resolveWorkosOrgId(organizationId, mcpjamUser._id);
     } catch (error) {
       if (error instanceof ApiKeyReadinessError) {
-        throw new WebRouteError(
-          error.status,
-          error.status === 403 ? ErrorCode.FORBIDDEN : ErrorCode.NOT_FOUND,
-          error.message,
-        );
+        const code =
+          error.status === 403
+            ? ErrorCode.FORBIDDEN
+            : error.status === 400
+              ? ErrorCode.VALIDATION_ERROR
+              : ErrorCode.NOT_FOUND;
+        throw new WebRouteError(error.status, code, error.message);
       }
       if (error instanceof OrganizationNotReadyError) {
         throw new WebRouteError(
@@ -434,16 +435,17 @@ apiKeys.post("/", async (c) =>
 apiKeys.get("/", async (c) =>
   handleRoute(c, async () => {
     const session = await resolveSessionContext(c);
-    const params = new URLSearchParams();
-    if (session.organizationId) {
-      params.set("organization_id", session.organizationId);
-    }
-    const qs = params.toString();
+    // Deliberately NOT filtered by `session.organizationId`: a key is now
+    // minted into whichever MCPJam org the caller selected in the dialog
+    // (see POST above), which can differ from the WorkOS org the session
+    // happens to be scoped to. Filtering here caused a minted key to vanish
+    // from this list (and become unrevokeable from the UI) whenever those
+    // two orgs didn't match. WorkOS keys are already user-scoped by this
+    // endpoint; the MCPJam-org boundary is enforced at USE time via the
+    // workosApiKeyBindings lookup in bearer-auth.ts, not at listing time.
     const { status, body } = await callWorkOS(
       "GET",
-      `/user_management/users/${encodeURIComponent(session.userId)}/api_keys${
-        qs ? `?${qs}` : ""
-      }`,
+      `/user_management/users/${encodeURIComponent(session.userId)}/api_keys`,
     );
 
     if (status < 200 || status >= 300) {

--- a/mcpjam-inspector/server/services/organizations.ts
+++ b/mcpjam-inspector/server/services/organizations.ts
@@ -36,8 +36,8 @@ export interface ApiKeyReadiness {
 
 /**
  * Carries the backend HTTP status so the mint handler can map a
- * not-a-member (403) or malformed-id (400) rejection to the right client
- * status instead of flattening everything to a 502.
+ * not-a-member (403), org-not-found (404), or malformed-id (400) rejection
+ * to the right client status instead of flattening everything to a 502.
  */
 export class ApiKeyReadinessError extends Error {
   readonly status: number;
@@ -48,12 +48,16 @@ export class ApiKeyReadinessError extends Error {
   }
 }
 
+// The readiness check runs on the user's synchronous key-mint request path —
+// a hung backend must not hang that request indefinitely.
+const READINESS_TIMEOUT_MS = 5_000;
+
 /**
  * Ask the backend whether `mcpjamUserId` can mint a WorkOS-backed API key
  * scoped to `mcpjamOrganizationId` right now. Throws `ApiKeyReadinessError`
  * with the backend's status (403 not-a-member, 404 org-not-found, 400
  * malformed ids) so the route can translate it; throws a plain `Error` on
- * transport failures or an undeployed route.
+ * transport failures, a timeout, or an undeployed route.
  */
 export async function resolveApiKeyReadiness(
   mcpjamOrganizationId: string,
@@ -63,10 +67,24 @@ export async function resolveApiKeyReadiness(
   const url = `${convexUrl}${READINESS_PATH}?organizationId=${encodeURIComponent(
     mcpjamOrganizationId,
   )}&userId=${encodeURIComponent(mcpjamUserId)}`;
-  const response = await fetch(url, {
-    method: "GET",
-    headers: { "x-inspector-service-token": serviceToken },
-  });
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), READINESS_TIMEOUT_MS);
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "GET",
+      headers: { "x-inspector-service-token": serviceToken },
+      signal: controller.signal,
+    });
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "AbortError") {
+      throw new Error("API key readiness check timed out");
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
 
   if (response.status === 404) {
     if (await isEntityNotFound(response, "Organization not found")) {
@@ -78,6 +96,9 @@ export async function resolveApiKeyReadiness(
   }
   if (response.status === 403) {
     throw new ApiKeyReadinessError(403, "Not a member of this organization");
+  }
+  if (response.status === 400) {
+    throw new ApiKeyReadinessError(400, "Invalid organization or user id");
   }
   if (!response.ok) {
     throw new Error(`API key readiness check failed (${response.status})`);

--- a/mcpjam-inspector/server/services/organizations.ts
+++ b/mcpjam-inspector/server/services/organizations.ts
@@ -1,0 +1,105 @@
+/**
+ * Inspector-side client for the backend's service-token-gated API-key
+ * readiness check (`/internal/v1/organizations/api-key-readiness`; see
+ * mcpjam-backend `convex/http.ts` + `convex/organizationsWorkos.ts`).
+ *
+ * WorkOS API keys require the calling user to have an active WorkOS
+ * organization membership. MCPJam orgs/members are synced to matching WorkOS
+ * Organizations/Memberships in the background (org-sync and membership-sync
+ * complete on independent timelines and can each fail/retry), so before
+ * minting a key we ask the backend "is *this* org, for *this* caller, ready
+ * right now" rather than assuming readiness from the session.
+ *
+ * Authenticated with `INSPECTOR_SERVICE_TOKEN` via the
+ * `x-inspector-service-token` header — the same channel `workos-key-bindings.ts`
+ * / `identity.ts` use for their sibling routes.
+ */
+
+import {
+  getInternalBackendConfig,
+  isEntityNotFound,
+} from "./internal-backend.js";
+
+const READINESS_PATH = "/internal/v1/organizations/api-key-readiness";
+
+export type ApiKeyReadinessReason =
+  | "org_pending"
+  | "org_failed"
+  | "membership_pending"
+  | "membership_failed";
+
+export interface ApiKeyReadiness {
+  ready: boolean;
+  workosOrganizationId: string | null;
+  reason?: ApiKeyReadinessReason;
+}
+
+/**
+ * Carries the backend HTTP status so the mint handler can map a
+ * not-a-member (403) or malformed-id (400) rejection to the right client
+ * status instead of flattening everything to a 502.
+ */
+export class ApiKeyReadinessError extends Error {
+  readonly status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "ApiKeyReadinessError";
+    this.status = status;
+  }
+}
+
+/**
+ * Ask the backend whether `mcpjamUserId` can mint a WorkOS-backed API key
+ * scoped to `mcpjamOrganizationId` right now. Throws `ApiKeyReadinessError`
+ * with the backend's status (403 not-a-member, 404 org-not-found, 400
+ * malformed ids) so the route can translate it; throws a plain `Error` on
+ * transport failures or an undeployed route.
+ */
+export async function resolveApiKeyReadiness(
+  mcpjamOrganizationId: string,
+  mcpjamUserId: string,
+): Promise<ApiKeyReadiness> {
+  const { convexUrl, serviceToken } = getInternalBackendConfig();
+  const url = `${convexUrl}${READINESS_PATH}?organizationId=${encodeURIComponent(
+    mcpjamOrganizationId,
+  )}&userId=${encodeURIComponent(mcpjamUserId)}`;
+  const response = await fetch(url, {
+    method: "GET",
+    headers: { "x-inspector-service-token": serviceToken },
+  });
+
+  if (response.status === 404) {
+    if (await isEntityNotFound(response, "Organization not found")) {
+      throw new ApiKeyReadinessError(404, "Organization not found");
+    }
+    throw new Error(
+      `Readiness route not found at ${convexUrl}${READINESS_PATH} — is it deployed?`,
+    );
+  }
+  if (response.status === 403) {
+    throw new ApiKeyReadinessError(403, "Not a member of this organization");
+  }
+  if (!response.ok) {
+    throw new Error(`API key readiness check failed (${response.status})`);
+  }
+
+  const body = (await response.json()) as {
+    ready?: unknown;
+    workosOrganizationId?: unknown;
+    reason?: unknown;
+  };
+  if (typeof body?.ready !== "boolean") {
+    throw new Error("API key readiness check returned an invalid body");
+  }
+  return {
+    ready: body.ready,
+    workosOrganizationId:
+      typeof body.workosOrganizationId === "string"
+        ? body.workosOrganizationId
+        : null,
+    reason:
+      typeof body.reason === "string"
+        ? (body.reason as ApiKeyReadinessReason)
+        : undefined,
+  };
+}


### PR DESCRIPTION
## Summary
- `resolveWorkosOrgId` derived the WorkOS org from the session JWT's `org_id` claim or "first active WorkOS membership" — but no signup flow ever puts a normal user into a WorkOS org, so this 400'd for every customer except the 3 internal team members.
- Fixes it by resolving the WorkOS org from the request's own `organizationId` (which the dialog already requires) via a new backend readiness check, keyed on that org id + the caller's resolved MCPJam user id.
- Companion PR: MCPJam/mcpjam-backend (adds the org/membership sync + the `api-key-readiness` route this depends on — **deploy that one first**).

## What's in this PR
- New `server/services/organizations.ts` (`resolveApiKeyReadiness`), mirroring the existing `identity.ts`/`workos-key-bindings.ts` service pattern
- `server/routes/web/api-keys.ts`: deleted the JWT/membership-fallback logic; POST now checks readiness before minting (zero WorkOS side effects on a not-ready org), mapping 403 (not a member) / 409 (org or membership still syncing) / 404 (org not found) distinctly instead of one generic 400
- 5 new tests covering the mint path (ready, org-pending, membership-pending, not-a-member, org-not-found) — previously only DELETE had coverage

## Test plan
- [x] `tsc --noEmit -p server/tsconfig.json` — clean on touched files
- [x] `eslint` on touched files — clean (pre-existing warnings only)
- [x] `vitest run server/routes/web/__tests__/api-keys.test.ts` — 9/9 passing
- [ ] Deploy alongside the backend PR; create an API key as a fresh non-internal test user, confirm 200 not 400
- [ ] Confirm the minted key authenticates against `GET /api/v1/me`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authenticated API key mint/list and adds a synchronous backend dependency on the mint path; behavior change is intentional but needs the companion backend readiness route deployed first.
> 
> **Overview**
> Fixes API key minting for users who are not in a WorkOS org on the session by **choosing the WorkOS `organization_id` from the request’s MCPJam `organizationId`**, not from JWT `org_id` or “first active WorkOS membership.”
> 
> Adds **`server/services/organizations.ts`** with `resolveApiKeyReadiness`, calling the backend `/internal/v1/organizations/api-key-readiness` (service token, 5s timeout). **POST** runs readiness before any WorkOS mint and maps **403** (not a member), **404** (org missing), **400** (bad ids), and **409** (org/membership still syncing) instead of a generic failure. Session context no longer carries `organizationId`.
> 
> **GET list** drops the `organization_id` query filter so keys minted for a different org than the session still appear and can be revoked.
> 
> Tests add mint readiness cases and a regression that listing must not pass `organization_id` to WorkOS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4102ca774910f08c3de795bba37bb88a0bdef3b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix API key creation by resolving the WorkOS org from the request’s `organizationId` via a backend readiness check, and make listing show all user keys regardless of session org. Prevents 400s for normal users, returns clear 403/404/409, and avoids hangs with a 5s readiness timeout.

- **Bug Fixes**
  - Added `server/services/organizations.ts` readiness client with a 5s timeout; maps 400/403/404 errors.
  - `POST /api/web/api-keys` uses readiness to choose the WorkOS org id and skips WorkOS calls when not ready; returns 403/404/409 with clear messages.
  - `GET /api/web/api-keys` no longer filters by session org; lists all of the user’s keys.
  - Removed session-based org plumbing; tests updated for ready, org-pending, membership-pending, not-a-member, org-not-found.

- **Migration**
  - Deploy the `mcpjam-backend` companion (org/membership sync + `api-key-readiness`) first.
  - After deploy, mint a key as a fresh non-internal user and verify it authenticates.

<sup>Written for commit 4102ca774910f08c3de795bba37bb88a0bdef3b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3057?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

