### PR TITLE
feat(sdk/oauth): show CIMD support in summary when the AS omits the field

### DIFF
--- a/.changeset/oauth-cimd-absence-row.md
+++ b/.changeset/oauth-cimd-absence-row.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/sdk": patch
+---
+
+The OAuth Debugger's Authorization Server Metadata summary now shows "CIMD Supported" even when the AS omits `client_id_metadata_document_supported`, rendering it as `false (not advertised, defaults to false per spec)` — the common case for servers without CIMD support, which previously showed no row at all.

--- a/sdk/src/oauth/state-machines/debug-oauth-2025-11-25.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-11-25.ts
@@ -1182,14 +1182,18 @@ export const createDebugOAuthStateMachine = (
             }
             // CIMD support gates the CIMD registration strategy (see the
             // client_id_metadata_document_supported check below), so surface it
-            // in the summary. Guard on typeof to distinguish "not advertised"
-            // from an explicit `false`.
+            // in the summary. Per draft-parecki-oauth-client-id-metadata-document
+            // an omitted field defaults to false, so absence is still reported —
+            // with provenance, to distinguish it from an advertised boolean.
             if (
               typeof authServerMetadata.client_id_metadata_document_supported ===
               "boolean"
             ) {
               metadata["CIMD Supported"] =
                 authServerMetadata.client_id_metadata_document_supported;
+            } else {
+              metadata["CIMD Supported"] =
+                "false (not advertised, defaults to false per spec)";
             }
             if (authServerMetadata.code_challenge_methods_supported) {
               metadata["PKCE Methods"] =

--- a/sdk/tests/oauth/state-machine-regressions.test.ts
+++ b/sdk/tests/oauth/state-machine-regressions.test.ts
@@ -403,4 +403,73 @@ describe("OAuth state machine regressions", () => {
     expect(state.tokenEndpointAuthMethod).toBe("none");
     expect(state.error).toBeUndefined();
   });
+
+  it.each<[boolean | undefined, boolean | string]>([
+    [true, true],
+    [false, false],
+    [undefined, "false (not advertised, defaults to false per spec)"],
+  ])(
+    "2025-11-25 AS metadata summary reports CIMD support when the field is %s",
+    async (advertised, expectedRow) => {
+      const asMetadata: Record<string, unknown> = {
+        issuer: "https://auth.example.com",
+        authorization_endpoint: "https://auth.example.com/authorize",
+        token_endpoint: "https://auth.example.com/token",
+        response_types_supported: ["code"],
+        code_challenge_methods_supported: ["S256"],
+      };
+      if (advertised !== undefined) {
+        asMetadata.client_id_metadata_document_supported = advertised;
+      }
+
+      let state = {
+        ...EMPTY_OAUTH_FLOW_STATE,
+        currentStep: "request_authorization_server_metadata" as const,
+        authorizationServerUrl: "https://auth.example.com",
+        httpHistory: [
+          {
+            step: "request_authorization_server_metadata" as const,
+            timestamp: Date.now(),
+            request: {
+              method: "GET",
+              url: "https://auth.example.com/.well-known/oauth-authorization-server",
+              headers: {},
+            },
+          },
+        ],
+        infoLogs: [],
+        isInitiatingAuth: true,
+      };
+
+      const machine = createOAuthStateMachine({
+        protocolVersion: "2025-11-25",
+        registrationStrategy: "dcr",
+        state,
+        getState: () => state,
+        updateState: (updates) => {
+          state = { ...state, ...updates };
+        },
+        serverUrl: SERVER_URL,
+        serverName: "Test Server",
+        redirectUrl: REDIRECT_URI,
+        requestExecutor: jest.fn().mockResolvedValue({
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          body: asMetadata,
+        }),
+        dynamicRegistration: {
+          client_name: "Test Client",
+        },
+      });
+
+      await machine.proceedToNextStep();
+
+      expect(state.currentStep).toBe("received_authorization_server_metadata");
+      const summary = state.infoLogs?.find((log) => log.id === "as-metadata");
+      expect(summary).toBeDefined();
+      expect(summary?.data["CIMD Supported"]).toBe(expectedRow);
+    },
+  );
 });


### PR DESCRIPTION
Follow-up to #3055. That PR added the "CIMD Supported" row to the step-6 Authorization Server Metadata summary, but only when the AS explicitly includes `client_id_metadata_document_supported` — and most authorization servers that don't support CIMD simply omit the field, so the row still didn't appear in the exact scenario the PR was motivated by.

Per the CIMD draft (draft-parecki-oauth-client-id-metadata-document), an omitted `client_id_metadata_document_supported` defaults to `false`, so absence is a spec-defined value the debugger can state definitively. The summary now renders the absent case as `"false (not advertised, defaults to false per spec)"` — a string with provenance, so it stays distinguishable from an advertised boolean `false`/`true`, which continue to render as real booleans.

Scope notes:
- Only the 2025-11-25 state machine changes; CIMD doesn't exist in the 2025-03-26/2025-06-18 flows, so no row is added there.
- The registration-gate error ("client_id_metadata_document_supported is not advertised in AS metadata") is untouched — it already covers the failure path. This is about seeing CIMD viability at a glance during metadata discovery, regardless of strategy.
- Adds a regression test covering all three cases (advertised true, advertised false, omitted) driven through `request_authorization_server_metadata` with a mocked request executor, plus a patch changeset for @mcpjam/sdk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Debugger-only metadata display and tests; no changes to registration logic or token flows.
> 
> **Overview**
> The **2025-11-25** OAuth debugger’s Authorization Server Metadata summary always includes a **CIMD Supported** row. When `client_id_metadata_document_supported` is missing from AS metadata, it now shows `false (not advertised, defaults to false per spec)` instead of hiding the row—matching the CIMD draft default while staying visually distinct from an explicit `true`/`false`.
> 
> Advertised booleans are unchanged. CIMD registration gating and older protocol flows are untouched. A parameterized regression test covers advertised true, false, and omitted cases; `@mcpjam/sdk` gets a patch changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit addcbe0520fed1f3f7d00ab4b6d81aa46a944e4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show "CIMD Supported" in the OAuth Debugger’s AS metadata summary even when the server omits `client_id_metadata_document_supported`. When absent, it now renders as `false (not advertised, defaults to false per spec)` for clarity.

- New Features
  - Applies to the 2025-11-25 flow only; earlier flows are unchanged.
  - Adds regression tests for advertised true, advertised false, and omitted.
  - Patch release for `@mcpjam/sdk`.

<sup>Written for commit addcbe0520fed1f3f7d00ab4b6d81aa46a944e4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

