### PR TITLE
feat(oauth): warn on hosted connect when the authorization server is local

### DIFF
--- a/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
@@ -20,6 +20,7 @@ import { readCliSignInReturnPath } from "@/lib/cli-signin-return-path";
 const {
   toastError,
   toastSuccess,
+  toastWarning,
   completeHostedOAuthCallbackMock,
   handleOAuthCallbackMock,
   initiateOAuthMock,
@@ -42,6 +43,7 @@ const {
 } = vi.hoisted(() => ({
   toastError: vi.fn(),
   toastSuccess: vi.fn(),
+  toastWarning: vi.fn(),
   completeHostedOAuthCallbackMock: vi.fn(),
   handleOAuthCallbackMock: vi.fn(),
   initiateOAuthMock: vi.fn(),
@@ -69,6 +71,7 @@ vi.mock("sonner", () => ({
   toast: {
     error: toastError,
     success: toastSuccess,
+    warning: toastWarning,
   },
 }));
 
@@ -986,6 +989,89 @@ describe("useServerState OAuth callback failures", () => {
         authorizationServerUrl: "http://127.0.0.1:8000",
       })
     );
+  });
+
+  it("warns after hosted connect when the authorization server is on a private address", async () => {
+    mockHostedMode.mockReturnValue(true);
+    reconnectServerMock.mockResolvedValueOnce({
+      success: true,
+      initInfo: null,
+    });
+    const dispatch = vi.fn();
+    const { result } = renderUseServerState(dispatch);
+
+    await act(async () => {
+      await result.current.handleConnectWithTokensFromOAuthFlow(
+        "demo-server",
+        {
+          accessToken: "hosted-access-token",
+          tokenType: "Bearer",
+          expiresIn: 300,
+          clientId: "hosted-client-id",
+          authorizationServerUrl: "http://127.0.0.1:8000",
+        },
+        "http://127.0.0.1:8000/mcp"
+      );
+    });
+
+    expect(toastSuccess).toHaveBeenCalledWith("Connected to demo-server!");
+    expect(toastWarning).toHaveBeenCalledWith(
+      expect.stringContaining("can't auto-refresh in hosted mode")
+    );
+  });
+
+  it("does not warn after hosted connect when the authorization server is publicly reachable", async () => {
+    mockHostedMode.mockReturnValue(true);
+    reconnectServerMock.mockResolvedValueOnce({
+      success: true,
+      initInfo: null,
+    });
+    const dispatch = vi.fn();
+    const { result } = renderUseServerState(dispatch);
+
+    await act(async () => {
+      await result.current.handleConnectWithTokensFromOAuthFlow(
+        "demo-server",
+        {
+          accessToken: "hosted-access-token",
+          tokenType: "Bearer",
+          expiresIn: 300,
+          clientId: "hosted-client-id",
+          authorizationServerUrl: "https://auth.example.com",
+        },
+        "http://127.0.0.1:8000/mcp"
+      );
+    });
+
+    expect(toastSuccess).toHaveBeenCalledWith("Connected to demo-server!");
+    expect(toastWarning).not.toHaveBeenCalled();
+  });
+
+  it("does not warn about refresh outside hosted mode even for a localhost authorization server", async () => {
+    mockHostedMode.mockReturnValue(false);
+    reconnectServerMock.mockResolvedValueOnce({
+      success: true,
+      initInfo: null,
+    });
+    const dispatch = vi.fn();
+    const { result } = renderUseServerState(dispatch);
+
+    await act(async () => {
+      await result.current.handleConnectWithTokensFromOAuthFlow(
+        "demo-server",
+        {
+          accessToken: "local-access-token",
+          tokenType: "Bearer",
+          expiresIn: 300,
+          clientId: "local-client-id",
+          authorizationServerUrl: "http://127.0.0.1:8000",
+        },
+        "http://127.0.0.1:8000/mcp"
+      );
+    });
+
+    expect(toastSuccess).toHaveBeenCalledWith("Connected to demo-server!");
+    expect(toastWarning).not.toHaveBeenCalled();
   });
 
   it("marks the pending server as failed when authorization is denied", async () => {

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -49,6 +49,7 @@ import {
   writeHostedOAuthPendingMarker,
 } from "@/lib/hosted-oauth-callback";
 import { HOSTED_MODE } from "@/lib/config";
+import { isPrivateNetworkUrl } from "@/lib/oauth/private-address";
 import { validateServerFormData } from "@/lib/server-form-validation";
 import {
   injectHostedServerMapping,
@@ -3431,6 +3432,22 @@ export function useServerState({
     ]
   );
 
+  // The hosted backend refreshes imported OAuth tokens from its cloud
+  // environment, so an authorization server on the user's machine (or LAN)
+  // is unreachable at refresh time even though the browser could reach it
+  // during the debugger flow. Warn up front instead of letting the first
+  // refresh fail with a discovery error.
+  const warnIfHostedCannotRefresh = useCallback(
+    (authorizationServerUrl?: string) => {
+      if (!HOSTED_MODE || !authorizationServerUrl) return;
+      if (!isPrivateNetworkUrl(authorizationServerUrl)) return;
+      toast.warning(
+        "This server's authorization server runs on your machine, so tokens can't auto-refresh in hosted mode. Re-run the OAuth flow when they expire, or use local mode for fully-local servers."
+      );
+    },
+    []
+  );
+
   const handleConnectWithTokensFromOAuthFlow = useCallback(
     async (
       serverName: string,
@@ -3459,6 +3476,7 @@ export function useServerState({
       );
       if (result.success) {
         toast.success(`Connected to ${serverName}!`);
+        warnIfHostedCannotRefresh(tokens.authorizationServerUrl);
       } else {
         toast.error(`Connection failed: ${result.error}`);
       }
@@ -3467,6 +3485,7 @@ export function useServerState({
       applyTokensFromOAuthFlow,
       notifyIfClientConfigSyncPending,
       notifyIfProjectNotProvisioned,
+      warnIfHostedCannotRefresh,
     ]
   );
 
@@ -3498,6 +3517,7 @@ export function useServerState({
       );
       if (result.success) {
         toast.success(`Tokens refreshed for ${serverName}!`);
+        warnIfHostedCannotRefresh(tokens.authorizationServerUrl);
       } else {
         toast.error(`Token refresh failed: ${result.error}`);
       }
@@ -3506,6 +3526,7 @@ export function useServerState({
       applyTokensFromOAuthFlow,
       notifyIfClientConfigSyncPending,
       notifyIfProjectNotProvisioned,
+      warnIfHostedCannotRefresh,
     ]
   );
 

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/private-address.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/private-address.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { isPrivateNetworkUrl } from "../private-address";
+
+describe("isPrivateNetworkUrl", () => {
+  it.each([
+    "http://localhost:8000",
+    "http://127.0.0.1:8000",
+    "http://127.8.4.2/auth",
+    "https://myserver.localhost/tenant",
+    "http://[::1]:9000",
+    "http://10.0.0.5",
+    "http://192.168.1.20:3000",
+    "http://172.16.0.1",
+    "http://172.31.255.255",
+    "http://169.254.10.10",
+    "http://0.0.0.0:8080",
+    "https://printer.local",
+    "https://auth.internal",
+    "http://[fd12:3456:789a::1]",
+    "http://[fe80::1]",
+  ])("classifies %s as private", (url) => {
+    expect(isPrivateNetworkUrl(url)).toBe(true);
+  });
+
+  it.each([
+    "https://auth.example.com",
+    "https://tenant.scalekit.dev/resources/res_123",
+    "http://172.15.0.1", // just below the RFC 1918 172.16/12 block
+    "http://172.32.0.1", // just above it
+    "http://11.0.0.1",
+    "https://mylocal.host.example.com",
+    "https://localhost.example.com", // "localhost" label but public domain
+    "http://[2001:db8::1]",
+  ])("classifies %s as public", (url) => {
+    expect(isPrivateNetworkUrl(url)).toBe(false);
+  });
+
+  it("returns false for unparseable input", () => {
+    expect(isPrivateNetworkUrl("not a url")).toBe(false);
+    expect(isPrivateNetworkUrl("")).toBe(false);
+  });
+});

--- a/mcpjam-inspector/client/src/lib/oauth/private-address.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/private-address.ts
@@ -1,0 +1,51 @@
+/**
+ * Detects URLs the hosted backend can never reach from its cloud
+ * environment: loopback, RFC 1918 private ranges, link-local, and
+ * local-only name suffixes. Used to warn that OAuth tokens imported for
+ * such an authorization server cannot be auto-refreshed server-side.
+ *
+ * Mirrored by hand in the backend repo (convex/lib/privateNetworkUrl.ts);
+ * keep the classifications in sync.
+ */
+
+const LOCAL_HOSTNAMES = new Set(["localhost", "0.0.0.0", "::1"]);
+const LOCAL_SUFFIXES = [".localhost", ".local", ".internal"];
+
+function isPrivateIpv4(hostname: string): boolean {
+  const match = hostname.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (!match) return false;
+  const octets = match.slice(1).map(Number);
+  if (octets.some((o) => o > 255)) return false;
+  const [a, b] = octets;
+  return (
+    a === 127 || // loopback
+    a === 10 || // RFC 1918
+    (a === 192 && b === 168) || // RFC 1918
+    (a === 172 && b >= 16 && b <= 31) || // RFC 1918
+    (a === 169 && b === 254) // link-local
+  );
+}
+
+function isPrivateIpv6(hostname: string): boolean {
+  return (
+    hostname === "::1" ||
+    hostname.startsWith("fc") || // ULA fc00::/7
+    hostname.startsWith("fd") ||
+    hostname.startsWith("fe80") // link-local
+  );
+}
+
+export function isPrivateNetworkUrl(url: string): boolean {
+  let hostname: string;
+  try {
+    hostname = new URL(url).hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+  // WHATWG URL keeps brackets around IPv6 hostnames.
+  const host = hostname.replace(/^\[|\]$/g, "");
+  if (LOCAL_HOSTNAMES.has(host)) return true;
+  if (LOCAL_SUFFIXES.some((suffix) => host.endsWith(suffix))) return true;
+  if (host.includes(":")) return isPrivateIpv6(host);
+  return isPrivateIpv4(host);
+}


### PR DESCRIPTION
Follow-up to #3056. That PR made the debugger→hosted connect forward the discovered authorization server URL so the cloud backend can refresh tokens for a local resource server fronted by a **public** AS. But when the authorization server itself is on localhost/LAN, the connect still succeeds and then the first refresh fails later with a generic discovery error — the cloud can know *where* the AS is without being able to *reach* it.

This adds the client half of the fix: after a successful connect (or debugger token refresh) in hosted mode, if the discovered AS URL is on a private address (loopback, RFC 1918, link-local, `.local`/`.internal`/`.localhost`), show a one-line warning that tokens can't auto-refresh and suggest local mode for fully-local servers. Local mode and public-AS setups are unaffected.

- New `isPrivateNetworkUrl` helper in `client/src/lib/oauth/private-address.ts` (mirrored by hand in the backend repo's `convex/lib/privateNetworkUrl.ts`, which gains the matching actionable refresh error).
- Warning wired into `handleConnectWithTokensFromOAuthFlow` and `handleRefreshTokensFromOAuthFlow`, gated on `HOSTED_MODE`.
- Tests: helper classification table (24 cases) + hook tests for warn/no-warn in hosted and local mode.

Backend counterpart: MCPJam/mcpjam-backend PR making the refresh path fail fast with the same actionable message instead of "Authorization server metadata discovery failed".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing warning only after successful OAuth connect/refresh in hosted mode; no changes to token import, refresh logic, or local mode behavior.
> 
> **Overview**
> In **hosted mode**, a successful debugger OAuth connect or token refresh can still leave users surprised when cloud-side refresh later fails because the authorization server is on localhost or the LAN.
> 
> This PR adds **`isPrivateNetworkUrl`** (`private-address.ts`) to classify loopback, RFC 1918, link-local, and `.local`/`.internal`/`.localhost` hosts, and wires **`warnIfHostedCannotRefresh`** into `handleConnectWithTokensFromOAuthFlow` and `handleRefreshTokensFromOAuthFlow` so a **toast warning** appears when the discovered AS URL is private. **Local mode** and **public** authorization servers are unchanged.
> 
> Tests cover the classifier (24 cases) and hook behavior for warn vs no-warn across hosted and local mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4880184a4f00f6ecb55d6cc6a3bfe4b330a0c2e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Warns users in hosted mode when the discovered OAuth authorization server is on a private/localhost address so they know tokens won’t auto-refresh and can switch to local mode if needed.

- **New Features**
  - Added `isPrivateNetworkUrl` to detect loopback, RFC1918, link-local, and local-only suffixes (e.g., `.localhost`, `.local`, `.internal`).
  - In hosted mode, show a warning toast after successful connect or refresh when `authorizationServerUrl` is private.
  - Integrated into `handleConnectWithTokensFromOAuthFlow` and `handleRefreshTokensFromOAuthFlow`; local mode and public AS are unchanged.
  - Tests added for URL classification (24 cases) and hosted/local warn behavior.

<sup>Written for commit 4880184a4f00f6ecb55d6cc6a3bfe4b330a0c2e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

