### PR TITLE
fix: render OAuth debug callback without AuthKit

### DIFF
--- a/mcpjam-inspector/client/src/lib/__tests__/app-navigation.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/app-navigation.test.ts
@@ -2,6 +2,7 @@ import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   captureCurrentReturnPath,
+  isDebugOAuthCallbackPath,
   legacyHashBookmarkToPath,
   navigationTargetToPath,
   normalizeInitialLegacyHashBookmark,
@@ -9,6 +10,25 @@ import {
   pathnameToActiveTab,
   useActiveTab,
 } from "../app-navigation";
+
+describe("isDebugOAuthCallbackPath", () => {
+  it("matches the OAuth debugger callback popup route", () => {
+    expect(isDebugOAuthCallbackPath("/oauth/callback/debug")).toBe(true);
+    expect(isDebugOAuthCallbackPath("/oauth/callback/debug/")).toBe(true);
+  });
+
+  it("does not match the WorkOS or connect callbacks", () => {
+    // These load in the main window and legitimately need <AuthKitProvider>.
+    expect(isDebugOAuthCallbackPath("/callback")).toBe(false);
+    expect(isDebugOAuthCallbackPath("/oauth/callback")).toBe(false);
+  });
+
+  it("does not match unrelated or look-alike paths", () => {
+    expect(isDebugOAuthCallbackPath("/oauth/callback/debugger")).toBe(false);
+    expect(isDebugOAuthCallbackPath("/servers")).toBe(false);
+    expect(isDebugOAuthCallbackPath("/")).toBe(false);
+  });
+});
 
 describe("pathnameToActiveTab", () => {
   beforeEach(() => {

--- a/mcpjam-inspector/client/src/lib/app-navigation.ts
+++ b/mcpjam-inspector/client/src/lib/app-navigation.ts
@@ -285,6 +285,20 @@ function isSpecialEntryPathname(pathname: string): boolean {
   );
 }
 
+/**
+ * The OAuth debugger callback (`/oauth/callback/debug`) runs in a throwaway
+ * popup that only relays its code to the opener and closes. It must render
+ * WITHOUT `<AuthKitProvider>` (see main.tsx): AuthKit's on-load refresh rotates
+ * the shared WorkOS token from this short-lived context, intermittently
+ * dropping the opener window's session.
+ */
+export function isDebugOAuthCallbackPath(pathname: string): boolean {
+  return (
+    pathname === "/oauth/callback/debug" ||
+    pathname.startsWith("/oauth/callback/debug/")
+  );
+}
+
 export function pathnameToActiveTab(pathname: string): string {
   if (isSpecialEntryPathname(pathname)) return "servers";
   const firstSegment = pathname.replace(/^\/+/, "").split("/")[0] || "home";

--- a/mcpjam-inspector/client/src/main.tsx
+++ b/mcpjam-inspector/client/src/main.tsx
@@ -18,7 +18,11 @@ import {
 } from "./lib/electron-hosted-auth";
 import { useUnifiedConvexAuth } from "./lib/unified-convex-auth";
 import { getRuntimeConvexUrl } from "./lib/runtime-config";
-import { normalizeInitialLegacyHashBookmark } from "./lib/app-navigation";
+import {
+  isDebugOAuthCallbackPath,
+  normalizeInitialLegacyHashBookmark,
+} from "./lib/app-navigation";
+import OAuthDebugCallback from "./components/oauth/OAuthDebugCallback";
 import { useEnsureDbUser } from "./hooks/useEnsureDbUser";
 import { DbUserReadyProvider } from "./contexts/db-user-ready-context";
 import {
@@ -85,6 +89,15 @@ if (isInIframe) {
   root.render(
     <StrictMode>
       <IframeRouterError />
+    </StrictMode>
+  );
+} else if (isDebugOAuthCallbackPath(window.location.pathname)) {
+  // Throwaway popup: render without <AuthKitProvider>/Convex so it can't fire a
+  // WorkOS refresh that logs the opener window out. See isDebugOAuthCallbackPath.
+  const root = createRoot(document.getElementById("root")!);
+  root.render(
+    <StrictMode>
+      <OAuthDebugCallback />
     </StrictMode>
   );
 } else {


### PR DESCRIPTION
Using the OAuth Debugger would intermittently log you out of MCPJam, most noticeably when returning to Connect or Playground afterward. The cause is that the debugger's callback route (`/oauth/callback/debug`) is a throwaway popup whose only job is to postMessage the authorization code back to its opener and close, but it was loading the full app under `<AuthKitProvider>`. On mount AuthKit runs its `initialize()`, which fires a WorkOS session refresh and rotates the shared refresh token from that transient context; the popup then closes ~100ms later, and if the rotated token's `Set-Cookie` is lost as it tears down, the opener window's next refresh replays an already-consumed token, WorkOS reuse-detection rejects it, and the proxy clears the session. This renders the debug callback standalone, without `<AuthKitProvider>`/Convex, so a disposable popup never touches the WorkOS session — mirroring the existing `isInIframe` short-circuit in `main.tsx`. The routing decision is extracted into a pure `isDebugOAuthCallbackPath()` helper with unit tests.

<img width="1280" height="1267" alt="repro-2-debug-callback-fires-workos-refresh" src="https://github.com/user-attachments/assets/f552edf4-6e43-4e5f-801e-504434bb04c4" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes intermittent logouts after using the OAuth Debugger by rendering the `/oauth/callback/debug` popup standalone, so it can’t trigger a WorkOS refresh or rotate tokens.

- **Bug Fixes**
  - Route `/oauth/callback/debug` now bypasses AuthKit/Convex and renders `OAuthDebugCallback` directly to avoid session rotation from the popup.
  - Extracted `isDebugOAuthCallbackPath()` with unit tests to drive this routing, mirroring the existing iframe short-circuit.

<sup>Written for commit 140890c0535068c2f9937d8b9193b50262f02e2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3062?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

