### PR TITLE
chore(oauth): unify debug-callback predicate and theme the standalone popup

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -212,6 +212,7 @@ import {
   buildEvalsPath,
   getInvalidOrganizationRouteNavigationTarget,
   getProjectSwitchNavigationTarget,
+  isDebugOAuthCallbackPath,
   navigationTargetToPath,
   navigateApp,
   pathnameToActiveTab,
@@ -1579,9 +1580,7 @@ export default function App() {
   // Set up Electron OAuth callback handling
   useElectronOAuth();
 
-  const isDebugCallback = window.location.pathname.startsWith(
-    "/oauth/callback/debug"
-  );
+  const isDebugCallback = isDebugOAuthCallbackPath(window.location.pathname);
   const isOAuthCallback = window.location.pathname === "/callback";
   const electronMcpCallbackUrl = buildElectronMcpCallbackUrl();
 

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -60,6 +60,7 @@ import type { OAuthTestProfile } from "@/lib/oauth/profile";
 import { authFetch } from "@/lib/session-token";
 import {
   captureCurrentReturnPath,
+  isDebugOAuthCallbackPath,
   navigateApp,
   normalizeReturnTargetPath,
   routePaths,
@@ -2558,7 +2559,7 @@ export function useServerState({
   );
 
   useEffect(() => {
-    if (window.location.pathname.startsWith("/oauth/callback/debug")) {
+    if (isDebugOAuthCallbackPath(window.location.pathname)) {
       return;
     }
 

--- a/mcpjam-inspector/client/src/main.tsx
+++ b/mcpjam-inspector/client/src/main.tsx
@@ -23,6 +23,12 @@ import {
   normalizeInitialLegacyHashBookmark,
 } from "./lib/app-navigation";
 import OAuthDebugCallback from "./components/oauth/OAuthDebugCallback";
+import {
+  getInitialThemeMode,
+  getInitialThemePreset,
+  updateThemeMode,
+  updateThemePreset,
+} from "./lib/theme-utils";
 import { useEnsureDbUser } from "./hooks/useEnsureDbUser";
 import { DbUserReadyProvider } from "./contexts/db-user-ready-context";
 import {
@@ -94,6 +100,9 @@ if (isInIframe) {
 } else if (isDebugOAuthCallbackPath(window.location.pathname)) {
   // Throwaway popup: render without <AuthKitProvider>/Convex so it can't fire a
   // WorkOS refresh that logs the opener window out. See isDebugOAuthCallbackPath.
+  // App's theme bootstrap doesn't run here, so apply the stored theme directly.
+  updateThemeMode(getInitialThemeMode());
+  updateThemePreset(getInitialThemePreset());
   const root = createRoot(document.getElementById("root")!);
   root.render(
     <StrictMode>


### PR DESCRIPTION
Follow-up to #3062, addressing the review nits:

- **One predicate, three sites.** `App.tsx` and `use-server-state.ts` had their own broader `startsWith("/oauth/callback/debug")` checks, which disagreed with `isDebugOAuthCallbackPath()` on look-alike paths (e.g. `/oauth/callback/debugger` matched the old checks but not the helper). All three sites now call the shared helper. The App-level branch and effect guards are kept as defense-in-depth: they reproduce the pre-#3062 behavior if the `main.tsx` short-circuit ever changes.
- **Standalone popup respects the theme.** The debug-callback popup renders outside App, so App's theme bootstrap (`updateThemeMode`/`updateThemePreset` on mount) never runs and the popup always rendered light. `main.tsx` now applies the stored theme mode/preset before rendering the popup — mainly visible in the Electron cold-start case, where the callback window persists.

No behavior change on the real `/oauth/callback/debug` path in the browser popup flow.

Tested: `typecheck:client`, targeted vitest (app-navigation, use-server-state, ChatboxPublishClientBar, OAuthDebugCallback — 86/86), and the full suite. The full suite has 10 pre-existing failures in `client/src/lib/host-compat/__tests__/use-host-catalog.test.ts` (missing `bundledHostCompatCatalog` on the `@mcpjam/sdk/host-compat` mock) that reproduce identically on `main` without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow path-matching fix plus cosmetic theme bootstrap on an isolated popup route; no change to the real `/oauth/callback/debug` browser flow per the PR description.
> 
> **Overview**
> **OAuth debug route detection** is centralized: `App.tsx` and `use-server-state.ts` no longer use `pathname.startsWith("/oauth/callback/debug")` and instead call **`isDebugOAuthCallbackPath`**, so look-alike paths like `/oauth/callback/debugger` are not treated as the debug popup (the helper only matches `/oauth/callback/debug` and `/oauth/callback/debug/…`).
> 
> The **standalone OAuth debug popup** in `main.tsx` still mounts outside the main app shell, so it now runs **`updateThemeMode` / `updateThemePreset`** from stored preferences before rendering `OAuthDebugCallback`, matching the theme users see when the full app boots (notably on Electron when that window persists).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2693f841c7f31e13b26ebf0245305ec1b8ef81d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the OAuth debug-callback path check and makes the standalone debug popup respect the saved theme. Prevents false matches like `/oauth/callback/debugger` and fixes the popup rendering light during Electron cold starts.

- **Bug Fixes**
  - Use `isDebugOAuthCallbackPath()` in `App.tsx` and `use-server-state.ts` instead of `startsWith("/oauth/callback/debug")` for consistent routing.
  - Apply stored theme mode and preset in `main.tsx` before rendering `OAuthDebugCallback`, so the standalone popup matches the user’s theme.

<sup>Written for commit 2693f841c7f31e13b26ebf0245305ec1b8ef81d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

