### PR TITLE
feat(protocol): default hosts to Auto + actionable -32022 error copy

### DIFF
--- a/.changeset/auto-protocol-default-and-error-copy.md
+++ b/.changeset/auto-protocol-default-and-error-copy.md
@@ -1,0 +1,29 @@
+---
+"@mcpjam/sdk": patch
+"@mcpjam/inspector": minor
+---
+
+Default hosts to Auto protocol detection + actionable `-32022` error copy.
+
+**Inspector:** unpinned hosts now connect with the `"auto"` sentinel instead
+of the legacy `initialize` client. When neither a per-server override nor a
+host pin has an opinion, the client sends `"auto"` on the wire so the SDK
+probes each HTTP server for the stateless RC and falls back to the legacy
+handshake. Auto's fallback negotiates with the same SDK defaults the old "no
+pin" path used, so this is a migration-free change — stored `undefined` rows
+resolve to Auto at connect time (no data backfill), and behavior for existing
+unpinned hosts changes only by adding the probe. The host Protocol dropdown
+and the effective-version chip now show Auto for unpinned hosts; picking
+"Latest" writes an explicit `2025-11-25` pin (absence means Auto). Hosted
+flows apply the same default, gated behind the `stateless-mcp-enabled` flag
+(off → unchanged legacy behavior, so production only flips once the backend
+accepts `"auto"`); the flag is forced on in the dev server via
+`useStatelessMcpEnabled` so the feature is exercisable locally without
+PostHog.
+
+**SDK:** the error describer classifies JSON-RPC `-32022` (protocol version
+rejected) with actionable copy. It reads the server's `data.supported` /
+`data.requested` off the error and surfaces "the server does not support
+version X; it supports Y — set this server to Auto (or pin a supported
+version)", replacing the raw, unactionable JSON-RPC error a legacy pin
+against a stateless-only server used to produce.

--- a/docs/troubleshooting/error-codes.mdx
+++ b/docs/troubleshooting/error-codes.mdx
@@ -22,6 +22,7 @@ These come from the MCP transport itself. Numeric codes are defined by the [JSON
 | `-32000` | [Connection closed](#connection-closed) |
 | `-32001` | [Request timed out](#request-timeout) / [Header mismatch](#header-mismatch) |
 | `-32004` | [Unsupported protocol version](#unsupported-protocol-version) |
+| `-32022` | [Protocol version rejected](#protocol-version-rejected) |
 | `-32042` | [URL elicitation required](#url-elicitation-required) |
 
 ### Parse error
@@ -158,6 +159,27 @@ The server does not support any protocol version this inspector offered.
 **Next steps**
 - Update the inspector to a newer build.
 - Check the supported versions list in the server's `initialize` response.
+
+### Protocol version rejected
+
+`-32022 — jsonrpc/protocol_version_rejected`
+
+The server rejected the MCP protocol version this connection is pinned to. Unlike `-32004`, the server reports exactly which versions it supports — the inspector surfaces that list in the error so you can pick a working version.
+
+This is the error you hit when a host or per-server override pins a **legacy** version (e.g. `2025-11-25`) against a **stateless-only** server built on the 2026 RC (`2026-07-28`). The raw JSON-RPC payload looks like:
+
+```json
+{"code":-32022,"message":"Unsupported protocol version: 2025-11-25","data":{"supported":["2026-07-28"],"requested":"2025-11-25"}}
+```
+
+**Likely causes**
+- The pinned protocol version is not one the server supports.
+- The server is stateless-only (2026 RC) but this connection is pinned to a legacy version.
+- A per-server or host protocol-version override is stricter than what the server actually speaks.
+
+**Next steps**
+- Set this server's protocol version to **Auto** so the inspector detects the right version at connect time (it probes for the stateless RC and falls back to the legacy handshake).
+- Or pin one of the versions the server reports as supported in the protocol setting (host **Protocol** tab, or the per-server Advanced connection settings).
 
 ### URL elicitation required
 

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -192,11 +192,13 @@ import {
   handleOAuthCallback,
 } from "./lib/oauth/mcp-oauth";
 import { buildElectronMcpCallbackUrl } from "./hooks/use-server-state";
+import { useStatelessMcpEnabled } from "./hooks/use-stateless-mcp-enabled";
 import { disconnectAllRuntimeServers } from "./state/mcp-api";
 import { getEffectiveProjectClientCapabilities } from "./lib/client-config";
 import {
   getDefaultClientCapabilities,
   isKnownProtocolVersionPin,
+  MCP_PROTOCOL_VERSION_AUTO,
   type McpProtocolVersionPin,
 } from "@mcpjam/sdk/browser";
 import { resolveEffectiveMcpProtocolVersion } from "./lib/client-config-v2";
@@ -1176,6 +1178,9 @@ export default function App() {
   );
   const learningEnabled = useFeatureFlagEnabled("mcpjam-learning");
   const registryEnabled = useFeatureFlagEnabled("registry-enabled");
+  // Master switch for the Auto / stateless-MCP feature (forced on in the dev
+  // server). Gates the hosted connect-time Auto default below.
+  const statelessMcpEnabled = useStatelessMcpEnabled();
   const conformanceEnabled = useFeatureFlagEnabled("mcpjam-conformance");
   const hostsEnabled = useFeatureFlagEnabled("hosts-enabled");
   // Desktop builds default the Hosts/Connect rollout on (PostHog may be
@@ -2065,10 +2070,19 @@ export default function App() {
         isKnownProtocolVersionPin(rawServerOverride)
           ? rawServerOverride
           : undefined;
-      const effective = resolveEffectiveMcpProtocolVersion(
+      const resolved = resolveEffectiveMcpProtocolVersion(
         serverOverride,
         hostPin
       );
+      // Auto is the host default once the stateless-MCP feature is live: an
+      // unpinned hosted server connects with the `"auto"` sentinel (probe +
+      // legacy fallback per server) instead of the SDK default. Gated on the
+      // same flag as the hosted Auto UI so production only flips this once the
+      // backend accepts `"auto"` — with the flag off, unpinned stays legacy
+      // (byte-identical to prior behavior). Mirrors the local-mode default in
+      // `buildResolverConnectionDefaults`.
+      const effective =
+        resolved ?? (statelessMcpEnabled ? MCP_PROTOCOL_VERSION_AUTO : undefined);
       if (!effective) continue;
       mcpProtocolVersionsByServerId[serverId] = effective;
     }
@@ -2086,6 +2100,7 @@ export default function App() {
     activeMcpProfile,
     hostedServerIdsByName,
     projectServerConfigDto?.overrides,
+    statelessMcpEnabled,
   ]);
   useApiContext({
     projectId: convexProjectId,

--- a/mcpjam-inspector/client/src/components/connection/EditServerFormContent.tsx
+++ b/mcpjam-inspector/client/src/components/connection/EditServerFormContent.tsx
@@ -7,7 +7,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@mcpjam/design-system/select";
-import { useFeatureFlagEnabled } from "posthog-js/react";
+import { useStatelessMcpEnabled } from "@/hooks/use-stateless-mcp-enabled";
 import { AdvancedConnectionSettingsSection } from "./shared/AdvancedConnectionSettingsSection";
 import { AuthenticationSection } from "./shared/AuthenticationSection";
 import { EnvVarsSection } from "./shared/EnvVarsSection";
@@ -44,7 +44,7 @@ export function EditServerFormContent({
   onMcpProtocolVersionOverrideChange,
 }: EditServerFormContentProps) {
   const hostedUrlPlaceholder = "https://example.com/mcp";
-  const statelessMcpEnabled = useFeatureFlagEnabled("stateless-mcp-enabled");
+  const statelessMcpEnabled = useStatelessMcpEnabled();
   const [revealingEnv, setRevealingEnv] = useState(false);
   const [revealingHeaders, setRevealingHeaders] = useState(false);
   const [envRevealError, setEnvRevealError] = useState<string | null>(null);

--- a/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
@@ -47,6 +47,7 @@ import type {
 } from "@/lib/project-server-config";
 import { EffectiveProtocolVersionChip } from "./shared/EffectiveProtocolVersionChip";
 import { useFeatureFlagEnabled } from "posthog-js/react";
+import { useStatelessMcpEnabled } from "@/hooks/use-stateless-mcp-enabled";
 import { useActiveMcpProfile } from "@/contexts/active-mcp-profile-context";
 
 export type ServerDetailTab =
@@ -190,7 +191,7 @@ export function ServerDetailModal({
   // round-trip rather than a server-update. Read/write here so the
   // form control inside `EditServerFormContent` can stay a pure prop
   // consumer.
-  const statelessMcpEnabled = useFeatureFlagEnabled("stateless-mcp-enabled");
+  const statelessMcpEnabled = useStatelessMcpEnabled();
   const serverHistoryEnabled = useFeatureFlagEnabled("server-history-tab");
   const projectServerConfigDto = useQuery(
     "projectServerConfig:getConfig" as never,

--- a/mcpjam-inspector/client/src/components/connection/shared/EffectiveProtocolVersionChip.tsx
+++ b/mcpjam-inspector/client/src/components/connection/shared/EffectiveProtocolVersionChip.tsx
@@ -30,9 +30,13 @@ export function EffectiveProtocolVersionChip({
   const effective: McpProtocolVersionPin | undefined =
     serverOverride ?? hostDefault;
 
+  // Unpinned (`undefined`) now resolves to Auto at connect time — it probes
+  // the stateless RC and falls back to the legacy handshake — so render it as
+  // "Auto" to match the actual wire behavior. Only an explicit wire-version
+  // pin surfaces a concrete version label.
   return (
     <span className="inline-flex items-center px-1 text-[11px] text-muted-foreground">
-      {effective === "auto" ? "Auto" : effective ?? "Latest"}
+      {!effective || effective === "auto" ? "Auto" : effective}
     </span>
   );
 }

--- a/mcpjam-inspector/client/src/components/connection/shared/__tests__/EffectiveProtocolVersionChip.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/shared/__tests__/EffectiveProtocolVersionChip.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { EffectiveProtocolVersionChip } from "../EffectiveProtocolVersionChip";
+
+describe("EffectiveProtocolVersionChip", () => {
+  it("renders nothing when the flag is off", () => {
+    const { container } = render(<EffectiveProtocolVersionChip />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders 'Auto' when unpinned (the new host default)", () => {
+    render(<EffectiveProtocolVersionChip flagEnabled />);
+    expect(screen.getByText("Auto")).toBeInTheDocument();
+  });
+
+  it("renders 'Auto' for the explicit auto sentinel", () => {
+    render(<EffectiveProtocolVersionChip flagEnabled hostDefault="auto" />);
+    expect(screen.getByText("Auto")).toBeInTheDocument();
+  });
+
+  it("renders the concrete version for an explicit pin", () => {
+    render(
+      <EffectiveProtocolVersionChip flagEnabled hostDefault="2026-07-28" />
+    );
+    expect(screen.getByText("2026-07-28")).toBeInTheDocument();
+  });
+
+  it("prefers a per-server override over the host default", () => {
+    render(
+      <EffectiveProtocolVersionChip
+        flagEnabled
+        hostDefault="auto"
+        serverOverride="2025-11-25"
+      />
+    );
+    expect(screen.getByText("2025-11-25")).toBeInTheDocument();
+  });
+});

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ProtocolTab.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ProtocolTab.tsx
@@ -8,7 +8,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@mcpjam/design-system/select";
-import { useFeatureFlagEnabled } from "posthog-js/react";
+import { useStatelessMcpEnabled } from "@/hooks/use-stateless-mcp-enabled";
 import {
   isKnownProtocolVersion,
   isKnownProtocolVersionPin,
@@ -280,22 +280,24 @@ export function ProtocolTab({
     applyParsedToDraft: applyJsonToDraft,
     onDraftChange,
   });
-  const statelessMcpEnabled = useFeatureFlagEnabled("stateless-mcp-enabled");
-  // Stored stateful literals (legacy carry-over) collapse to "Latest"
-  // since they route to the same code path; saving normalizes back to
-  // undefined.
+  const statelessMcpEnabled = useStatelessMcpEnabled();
+  // Auto is the host default: an absent pin (`undefined`) means "detect per
+  // server at connect" and is shown — and behaves — as Auto. `"auto"` maps to
+  // it explicitly. Any concrete stateful literal (2025-*, legacy carry-over)
+  // surfaces as "Latest"; the 2026 RC surfaces as its own option.
+  const storedPin = draft.mcpProfile?.mcpProtocolVersion;
   const selectedDropdownValue: HostProtocolDropdownValue =
-    draft.mcpProfile?.mcpProtocolVersion === "2026-07-28"
+    storedPin === "2026-07-28"
       ? "rc"
-      : draft.mcpProfile?.mcpProtocolVersion === "auto"
+      : storedPin === "auto" || storedPin === undefined
       ? "auto"
       : "latest";
 
   // Dropdown handler. Writes through to `draft.mcpProfile.mcpProtocolVersion`
   // directly (parallel to the JSON editor's applyJsonToDraft path) so the
-  // JSON view round-trips immediately. Maps the UI-only "default" sentinel
-  // to `undefined` — preserves canonical-hash stability so the SDK can
-  // upgrade its default version without churning every stored host config.
+  // JSON view round-trips immediately. Auto is written as the `"auto"`
+  // sentinel; unpinned rows (`undefined`) also resolve to Auto at connect, so
+  // the two are equivalent and the dropdown never needs to write `undefined`.
   const setProtocolVersion = (next: McpProtocolVersionPin | undefined) => {
     onDraftChange((prev) => {
       const base: HostConfigMcpProfileV1 = prev.mcpProfile ?? {
@@ -363,7 +365,11 @@ export function ProtocolTab({
                     ? "2026-07-28"
                     : next === "auto"
                     ? "auto"
-                    : undefined
+                    : // "Latest" pins the current stable wire version
+                      // explicitly. It must NOT map to `undefined` any more:
+                      // absence now means Auto (the default), so an explicit
+                      // "Latest" choice has to carry a concrete version.
+                      "2025-11-25"
                 );
               }}
               disabled={readOnly}

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/ProtocolTab.pin-derivation.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/ProtocolTab.pin-derivation.test.tsx
@@ -75,6 +75,26 @@ describe("ProtocolTab — pin change vs derived supportedProtocolVersions", () =
     ).toEqual(["2025-06-18", "2025-03-26"]);
   });
 
+  it("shows Auto as the selected option for an unpinned host (default)", async () => {
+    renderWithDraft(emptyHostConfigInputV2());
+
+    // The combobox reflects the effective default without the user having
+    // picked anything — unpinned hosts now default to Auto.
+    expect(screen.getByRole("combobox")).toHaveTextContent(
+      "Auto (detect per server)"
+    );
+  });
+
+  it("pins the explicit stable version when switching to Latest", async () => {
+    const { getDraft } = renderWithDraft(emptyHostConfigInputV2());
+
+    await pickOption("Latest (2025-11-25)");
+
+    // "Latest" must carry a concrete version — absence now means Auto, so it
+    // can't collapse back to undefined.
+    expect(getDraft().mcpProfile?.mcpProtocolVersion).toBe("2025-11-25");
+  });
+
   it("preserves clientInfo when only the derived list is dropped", async () => {
     const { getDraft } = renderWithDraft({
       ...emptyHostConfigInputV2(),

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -45,6 +45,7 @@ import {
   writeHostedOAuthPendingMarker,
 } from "@/lib/hosted-oauth-callback";
 import { HOSTED_MODE } from "@/lib/config";
+import { useStatelessMcpEnabled } from "@/hooks/use-stateless-mcp-enabled";
 import {
   injectHostedServerMapping,
   tryGetHostedServerDisplayName,
@@ -603,6 +604,12 @@ export function useServerState({
 }: UseServerStateParams) {
   const isUserReady = useDbUserReady();
   const convex = useConvex();
+  // Master switch for defaulting unpinned connections to "auto". Gating the
+  // connect-time default here (not just the hosted App.tsx path) is required:
+  // `buildResolverConnectionDefaults` feeds BOTH local resolver connects and
+  // hosted validation/reconnect (via `testConnection` when HOSTED_MODE), so an
+  // unconditional default would emit "auto" to hosted regardless of the flag.
+  const statelessMcpEnabled = useStatelessMcpEnabled();
   const {
     createServerIfMissing: convexCreateServerIfMissing,
     updateServer: convexUpdateServer,
@@ -1049,17 +1056,26 @@ export function useServerState({
         serverOverride,
         hostPin
       );
-      // Auto is the host default: when neither the per-server override nor the
-      // host pin has an opinion, connect with the `"auto"` sentinel so the SDK
-      // probes for the stateless RC and falls back to the legacy `initialize`
-      // handshake per server. Auto's legacy fallback negotiates with the same
-      // SDK defaults the old "no pin" path used, so this changes behavior for
-      // unpinned hosts only by adding the probe — no stored-config migration
-      // needed (undefined rows resolve to auto here at connect time).
-      defaults.mcpProtocolVersion = effective ?? MCP_PROTOCOL_VERSION_AUTO;
+      // Auto is the host default (once the stateless-MCP feature is live):
+      // when neither the per-server override nor the host pin has an opinion,
+      // connect with the `"auto"` sentinel so the SDK probes for the stateless
+      // RC and falls back to the legacy `initialize` handshake per server.
+      // Auto's legacy fallback negotiates with the same SDK defaults the old
+      // "no pin" path used, so it changes behavior for unpinned hosts only by
+      // adding the probe — no stored-config migration needed.
+      //
+      // Gated on `stateless-mcp-enabled`: this default flows into hosted
+      // validation/reconnect (via `testConnection` when HOSTED_MODE), so with
+      // the flag off it MUST stay `undefined` (legacy) to honor the staged
+      // backend rollout. Flag off → unchanged legacy behavior everywhere.
+      const withAutoDefault =
+        effective ?? (statelessMcpEnabled ? MCP_PROTOCOL_VERSION_AUTO : undefined);
+      if (withAutoDefault !== undefined) {
+        defaults.mcpProtocolVersion = withAutoDefault;
+      }
       return Object.keys(defaults).length > 0 ? defaults : undefined;
     },
-    [activeHostConfig]
+    [activeHostConfig, statelessMcpEnabled]
   );
 
   const guardedTestConnection = useCallback(
@@ -1767,13 +1783,13 @@ export function useServerState({
         serverOverride,
         hostPin
       );
-      // Gate removed — stateless-mcp-enabled goes permanent 2026-05-27.
-      // Mirror `buildResolverConnectionDefaults`: an unpinned server resolves
-      // to the `"auto"` default on the wire, so normalize here too. Otherwise
-      // change-detection would compare `undefined` against the `"auto"` that
-      // actually gets sent and either miss or spuriously trigger a re-test.
-      const effective: McpProtocolVersionPin =
-        resolvedPin ?? MCP_PROTOCOL_VERSION_AUTO;
+      // Mirror `buildResolverConnectionDefaults` exactly (including the
+      // `stateless-mcp-enabled` gate): an unpinned server resolves to the
+      // `"auto"` default on the wire only when the flag is on. Normalizing the
+      // same way here keeps change-detection comparing the value that actually
+      // gets sent — otherwise it would miss or spuriously trigger a re-test.
+      const effective: McpProtocolVersionPin | undefined =
+        resolvedPin ?? (statelessMcpEnabled ? MCP_PROTOCOL_VERSION_AUTO : undefined);
 
       const seenBefore = lastAppliedProtocolVersionRef.current.has(name);
       const previous = lastAppliedProtocolVersionRef.current.get(name);
@@ -1855,6 +1871,7 @@ export function useServerState({
     dispatch,
     guardedReconnectServer,
     storeInitInfo,
+    statelessMcpEnabled,
   ]);
 
   const testConnectionAfterOAuth = useCallback(

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -6,7 +6,10 @@ import type {
   MCPServerConfig,
   NormalizedError,
 } from "@mcpjam/sdk/browser";
-import { isKnownProtocolVersionPin } from "@mcpjam/sdk/browser";
+import {
+  isKnownProtocolVersionPin,
+  MCP_PROTOCOL_VERSION_AUTO,
+} from "@mcpjam/sdk/browser";
 import type {
   AppAction,
   AppState,
@@ -1046,9 +1049,14 @@ export function useServerState({
         serverOverride,
         hostPin
       );
-      if (effective !== undefined) {
-        defaults.mcpProtocolVersion = effective;
-      }
+      // Auto is the host default: when neither the per-server override nor the
+      // host pin has an opinion, connect with the `"auto"` sentinel so the SDK
+      // probes for the stateless RC and falls back to the legacy `initialize`
+      // handshake per server. Auto's legacy fallback negotiates with the same
+      // SDK defaults the old "no pin" path used, so this changes behavior for
+      // unpinned hosts only by adding the probe — no stored-config migration
+      // needed (undefined rows resolve to auto here at connect time).
+      defaults.mcpProtocolVersion = effective ?? MCP_PROTOCOL_VERSION_AUTO;
       return Object.keys(defaults).length > 0 ? defaults : undefined;
     },
     [activeHostConfig]
@@ -1760,7 +1768,12 @@ export function useServerState({
         hostPin
       );
       // Gate removed — stateless-mcp-enabled goes permanent 2026-05-27.
-      const effective: McpProtocolVersionPin | undefined = resolvedPin;
+      // Mirror `buildResolverConnectionDefaults`: an unpinned server resolves
+      // to the `"auto"` default on the wire, so normalize here too. Otherwise
+      // change-detection would compare `undefined` against the `"auto"` that
+      // actually gets sent and either miss or spuriously trigger a re-test.
+      const effective: McpProtocolVersionPin =
+        resolvedPin ?? MCP_PROTOCOL_VERSION_AUTO;
 
       const seenBefore = lastAppliedProtocolVersionRef.current.has(name);
       const previous = lastAppliedProtocolVersionRef.current.get(name);

--- a/mcpjam-inspector/client/src/hooks/use-stateless-mcp-enabled.ts
+++ b/mcpjam-inspector/client/src/hooks/use-stateless-mcp-enabled.ts
@@ -1,0 +1,18 @@
+import { useFeatureFlagEnabled } from "posthog-js/react";
+
+/**
+ * Master switch for the stateless-MCP / "Auto" protocol feature in the
+ * inspector UI (host + per-server protocol dropdowns, and the hosted
+ * connect-time Auto default).
+ *
+ * Backed by the `stateless-mcp-enabled` PostHog flag, but forced on in the
+ * dev server so the feature is exercisable locally (including `dev:hosted`)
+ * without a PostHog project. Gated on `MODE === "development"` specifically —
+ * vitest runs under `MODE === "test"` and production builds under
+ * `"production"`, so unit tests keep full control of the flag via their
+ * `useFeatureFlagEnabled` mock and prod still honors the real flag.
+ */
+export function useStatelessMcpEnabled(): boolean {
+  const flag = useFeatureFlagEnabled("stateless-mcp-enabled");
+  return flag === true || import.meta.env.MODE === "development";
+}

--- a/sdk/src/error-describer/catalog.ts
+++ b/sdk/src/error-describer/catalog.ts
@@ -177,6 +177,21 @@ export const ERROR_CATALOG: Record<string, ErrorCatalogEntry> = {
     ],
     "unsupported-protocol-version",
   ),
+  "jsonrpc/protocol_version_rejected": entry(
+    "jsonrpc/protocol_version_rejected",
+    "Protocol version rejected (-32022)",
+    "The server rejected the MCP protocol version this connection is pinned to.",
+    [
+      "The pinned protocol version is not one the server supports.",
+      "The server is stateless-only (2026 RC) but this connection is pinned to a legacy version.",
+      "A per-server or host protocol-version override is stricter than what the server actually speaks.",
+    ],
+    [
+      "Set this server's protocol version to Auto so the inspector detects the right version at connect.",
+      "Or pin one of the versions the server reports as supported in the protocol setting.",
+    ],
+    "protocol-version-rejected",
+  ),
   "jsonrpc/url_elicitation_required": entry(
     "jsonrpc/url_elicitation_required",
     "URL elicitation required (-32042)",

--- a/sdk/src/error-describer/describe.ts
+++ b/sdk/src/error-describer/describe.ts
@@ -190,6 +190,11 @@ function extractProtocolVersionData(
  * because it's per-server. Falls back to the catalog `oneLine` when the
  * error carries no usable `data`.
  */
+/** Max chars kept per server-supplied version value before ellipsizing. */
+const PV_VALUE_MAX = 24;
+/** Max number of `supported` versions listed before collapsing to "+N more". */
+const PV_SUPPORTED_MAX = 6;
+
 function maybeEnrichProtocolVersionRejected(
   entry: ErrorCatalogEntry,
   slug: string,
@@ -198,18 +203,37 @@ function maybeEnrichProtocolVersionRejected(
   if (slug !== "jsonrpc/protocol_version_rejected") return entry;
   const data = extractProtocolVersionData(error);
   if (!data) return entry;
+
+  // `requested` / `supported` are server-controlled. Redact (a hostile or
+  // misconfigured server could echo a bearer token / secret back in `data`)
+  // and clamp length so one pathological value can't blow the one-line budget.
+  const clamp = (v: string): string => {
+    const redacted = redactString(v);
+    return redacted.length > PV_VALUE_MAX
+      ? `${redacted.slice(0, PV_VALUE_MAX - 1)}…`
+      : redacted;
+  };
+
+  const requested = data.requested ? clamp(data.requested) : undefined;
+  const allSupported = data.supported ?? [];
+  const supported = allSupported.slice(0, PV_SUPPORTED_MAX).map(clamp);
+  const overflow = allSupported.length - supported.length;
+
   const parts: string[] = [];
   parts.push(
-    data.requested
-      ? `The server does not support MCP protocol version "${data.requested}".`
+    requested
+      ? `The server does not support MCP protocol version "${requested}".`
       : "The server does not support the pinned MCP protocol version.",
   );
-  if (data.supported && data.supported.length > 0) {
-    parts.push(`It supports: ${data.supported.join(", ")}.`);
-  }
+  // Actionable fix goes BEFORE the server-controlled list so truncation of a
+  // long/numerous `supported` list can never drop the "set to Auto" guidance.
   parts.push(
     "Set this server's protocol version to Auto (or pin a supported version) in the connection settings.",
   );
+  if (supported.length > 0) {
+    const suffix = overflow > 0 ? `, +${overflow} more` : "";
+    parts.push(`Server supports: ${supported.join(", ")}${suffix}.`);
+  }
   return { ...entry, oneLine: truncateOneLine(parts.join(" ")) };
 }
 

--- a/sdk/src/error-describer/describe.ts
+++ b/sdk/src/error-describer/describe.ts
@@ -183,6 +183,11 @@ function extractProtocolVersionData(
   return { supported, requested };
 }
 
+/** Max chars kept per server-supplied version value before ellipsizing. */
+const PV_VALUE_MAX = 24;
+/** Max number of `supported` versions listed before collapsing to "+N more". */
+const PV_SUPPORTED_MAX = 6;
+
 /**
  * `-32022` promotes the server's own `supported` / `requested` version data
  * into the visible one-line so the user reads exactly which versions the
@@ -190,11 +195,6 @@ function extractProtocolVersionData(
  * because it's per-server. Falls back to the catalog `oneLine` when the
  * error carries no usable `data`.
  */
-/** Max chars kept per server-supplied version value before ellipsizing. */
-const PV_VALUE_MAX = 24;
-/** Max number of `supported` versions listed before collapsing to "+N more". */
-const PV_SUPPORTED_MAX = 6;
-
 function maybeEnrichProtocolVersionRejected(
   entry: ErrorCatalogEntry,
   slug: string,

--- a/sdk/src/error-describer/describe.ts
+++ b/sdk/src/error-describer/describe.ts
@@ -153,6 +153,66 @@ function maybePromoteRawMessage(
   return { ...entry, oneLine: truncateOneLine(rawMessage) };
 }
 
+/**
+ * Extract the `{ supported, requested }` payload a `-32022` JSON-RPC error
+ * carries in its `data` field. The upstream `McpError` exposes it at
+ * `error.data`; some wrappers nest the JSON-RPC error under `.error`, so we
+ * check `error.error.data` too. Everything is defensively shape-guarded — a
+ * malformed `data` yields `undefined` and the caller keeps the static copy.
+ */
+function extractProtocolVersionData(
+  error: unknown,
+): { supported?: string[]; requested?: string } | undefined {
+  if (!error || typeof error !== "object") return undefined;
+  const container = error as Record<string, unknown>;
+  const nestedErr = container.error as { data?: unknown } | undefined;
+  const rawData =
+    container.data && typeof container.data === "object"
+      ? container.data
+      : nestedErr && typeof nestedErr === "object" && nestedErr.data &&
+          typeof nestedErr.data === "object"
+        ? nestedErr.data
+        : undefined;
+  if (!rawData || typeof rawData !== "object") return undefined;
+  const d = rawData as Record<string, unknown>;
+  const supported = Array.isArray(d.supported)
+    ? d.supported.filter((v): v is string => typeof v === "string" && v !== "")
+    : undefined;
+  const requested = typeof d.requested === "string" ? d.requested : undefined;
+  if ((!supported || supported.length === 0) && !requested) return undefined;
+  return { supported, requested };
+}
+
+/**
+ * `-32022` promotes the server's own `supported` / `requested` version data
+ * into the visible one-line so the user reads exactly which versions the
+ * server speaks and can act — the static catalog copy can't name the list
+ * because it's per-server. Falls back to the catalog `oneLine` when the
+ * error carries no usable `data`.
+ */
+function maybeEnrichProtocolVersionRejected(
+  entry: ErrorCatalogEntry,
+  slug: string,
+  error: unknown,
+): ErrorCatalogEntry {
+  if (slug !== "jsonrpc/protocol_version_rejected") return entry;
+  const data = extractProtocolVersionData(error);
+  if (!data) return entry;
+  const parts: string[] = [];
+  parts.push(
+    data.requested
+      ? `The server does not support MCP protocol version "${data.requested}".`
+      : "The server does not support the pinned MCP protocol version.",
+  );
+  if (data.supported && data.supported.length > 0) {
+    parts.push(`It supports: ${data.supported.join(", ")}.`);
+  }
+  parts.push(
+    "Set this server's protocol version to Auto (or pin a supported version) in the connection settings.",
+  );
+  return { ...entry, oneLine: truncateOneLine(parts.join(" ")) };
+}
+
 function inspectorSentinelSlug(message: string): string | undefined {
   if (/NotYetSupportedInStateless/i.test(message)) {
     return "sdk/not_yet_supported_in_stateless";
@@ -174,6 +234,7 @@ const JSONRPC_SLUG_BY_CODE: Record<number, string> = {
   [-32603]: "jsonrpc/internal_error",
   [-32000]: "jsonrpc/connection_closed",
   [-32004]: "jsonrpc/unsupported_protocol_version",
+  [-32022]: "jsonrpc/protocol_version_rejected",
   [-32042]: "jsonrpc/url_elicitation_required",
 };
 
@@ -437,10 +498,10 @@ export function describeError(error: unknown): NormalizedError {
   try {
     const rawMessage = redactString(getErrorMessage(error));
     const { slug, rawCode } = resolveSlug(error);
-    const entry = maybePromoteRawMessage(
-      lookupCatalog(slug),
+    const entry = maybeEnrichProtocolVersionRejected(
+      maybePromoteRawMessage(lookupCatalog(slug), slug, rawMessage),
       slug,
-      rawMessage,
+      error,
     );
     const cause = captureCause(error);
     return {

--- a/sdk/tests/error-describer/describe.test.ts
+++ b/sdk/tests/error-describer/describe.test.ts
@@ -100,6 +100,13 @@ const CASES: Case[] = [
     expectRawCode: -32004,
   },
   {
+    name: "-32022 protocol version rejected",
+    build: () =>
+      makeError("Unsupported protocol version: 2025-11-25", { code: -32022 }),
+    expectSlug: "jsonrpc/protocol_version_rejected",
+    expectRawCode: -32022,
+  },
+  {
     name: "-32042 url elicitation required",
     build: () => makeError("URL elicitation required", { code: -32042 }),
     expectSlug: "jsonrpc/url_elicitation_required",
@@ -239,6 +246,59 @@ describe("describeError — table-driven", () => {
       expect(out.rawMessage.length).toBeGreaterThan(0);
     });
   }
+});
+
+describe("describeError — -32022 protocol version rejected enrichment", () => {
+  it("names the server's supported versions and the requested version", () => {
+    const out = describeError(
+      makeError("Unsupported protocol version: 2025-11-25", {
+        code: -32022,
+        data: { supported: ["2026-07-28"], requested: "2025-11-25" },
+      }),
+    );
+    expect(out.slug).toBe("jsonrpc/protocol_version_rejected");
+    expect(out.oneLine).toContain("2025-11-25");
+    expect(out.oneLine).toContain("2026-07-28");
+    // Points the user at the actionable fix (Auto / protocol setting).
+    expect(out.oneLine.toLowerCase()).toContain("auto");
+    expect(out.nextSteps.join(" ").toLowerCase()).toContain("auto");
+  });
+
+  it("reads JSON-RPC data nested under .error.data", () => {
+    const out = describeError({
+      error: {
+        code: -32022,
+        message: "Unsupported protocol version: 2025-06-18",
+        data: { supported: ["2026-07-28", "2025-11-25"], requested: "2025-06-18" },
+      },
+    });
+    expect(out.slug).toBe("jsonrpc/protocol_version_rejected");
+    expect(out.oneLine).toContain("2025-06-18");
+    expect(out.oneLine).toContain("2026-07-28, 2025-11-25");
+  });
+
+  it("falls back to the static catalog copy when data is absent", () => {
+    const out = describeError(
+      makeError("Unsupported protocol version", { code: -32022 }),
+    );
+    expect(out.slug).toBe("jsonrpc/protocol_version_rejected");
+    expect(out.oneLine).toBe(
+      ERROR_CATALOG["jsonrpc/protocol_version_rejected"].oneLine,
+    );
+  });
+
+  it("ignores malformed data (non-array supported / non-string requested)", () => {
+    const out = describeError(
+      makeError("Unsupported protocol version", {
+        code: -32022,
+        data: { supported: "nope", requested: 7 },
+      }),
+    );
+    expect(out.slug).toBe("jsonrpc/protocol_version_rejected");
+    expect(out.oneLine).toBe(
+      ERROR_CATALOG["jsonrpc/protocol_version_rejected"].oneLine,
+    );
+  });
 });
 
 describe("describeError — fallback shapes (>= 8)", () => {

--- a/sdk/tests/error-describer/describe.test.ts
+++ b/sdk/tests/error-describer/describe.test.ts
@@ -274,7 +274,39 @@ describe("describeError — -32022 protocol version rejected enrichment", () => 
     });
     expect(out.slug).toBe("jsonrpc/protocol_version_rejected");
     expect(out.oneLine).toContain("2025-06-18");
-    expect(out.oneLine).toContain("2026-07-28, 2025-11-25");
+    expect(out.oneLine).toContain("2026-07-28");
+    expect(out.oneLine.toLowerCase()).toContain("auto");
+  });
+
+  it("keeps the actionable fix even when the supported list is huge", () => {
+    const many = Array.from(
+      { length: 40 },
+      (_, i) => `2099-12-${String((i % 28) + 1).padStart(2, "0")}`,
+    );
+    const out = describeError(
+      makeError("Unsupported protocol version", {
+        code: -32022,
+        data: { supported: many, requested: "2025-11-25" },
+      }),
+    );
+    // The fix text is placed before the server-controlled list, so the 200-char
+    // truncation drops the list — never the "set to Auto" guidance.
+    expect(out.oneLine.toLowerCase()).toContain("auto");
+    expect(out.oneLine).toContain("2025-11-25");
+  });
+
+  it("redacts secrets echoed back in server-supplied version data", () => {
+    const out = describeError(
+      makeError("Unsupported protocol version", {
+        code: -32022,
+        data: {
+          supported: ["2026-07-28"],
+          requested: "Bearer sk-live-deadbeef.secret.value",
+        },
+      }),
+    );
+    expect(out.slug).toBe("jsonrpc/protocol_version_rejected");
+    expect(out.oneLine).not.toContain("sk-live-deadbeef.secret.value");
   });
 
   it("falls back to the static catalog copy when data is absent", () => {


### PR DESCRIPTION
## What

Two pieces of the "stateless MCP connect" plan, on top of the Auto foundation in #2552:

1. **Auto is now the default for hosts.** A new host with zero protocol config connects to a mixed fleet — stateless-only 2026 RC, stateful `2025-11-25`, STDIO — without per-server overrides.
2. **Actionable `-32022` error copy.** When a legacy pin hits a stateless-only server, the inspector surfaces the server's supported versions and points at the fix instead of dumping raw JSON-RPC.

> Stacked on **#2552** (base branch `claude/loving-euler-49s1m7`) — it retargets to `main` automatically once #2552 merges. Backend companion is **mcpjam/mcpjam-backend#493** (already accepts `"auto"` in the Convex validators; no new backend code needed for this PR).

## How Auto-as-default works

Making Auto the default is **migration-free** — no stored-data change:

- **Connect-time, not storage.** Unpinned (`undefined`) host configs stay `undefined` in Convex (no hash churn, no backfill). The `"auto"` sentinel is applied when the wire pin is computed at connect:
  - **Local mode** — `buildResolverConnectionDefaults` (`use-server-state.ts`): `effective ?? MCP_PROTOCOL_VERSION_AUTO`.
  - **Hosted mode** — `hostedMcpProfilePins` (`App.tsx`): `resolved ?? (statelessMcpEnabled ? MCP_PROTOCOL_VERSION_AUTO : undefined)`.
- **Superset of the old behavior.** `auto`'s legacy fallback negotiates with the same SDK defaults the old "no pin" path used (per #2552), so unpinned hosts change behavior *only* by adding the `server/discover` probe. Existing hosts get Auto without a re-test on upgrade.
- **Flag-gated in hosted.** The hosted default is behind the same `stateless-mcp-enabled` flag as the hosted Auto UI (via a new `useStatelessMcpEnabled` hook). Flag off → unchanged legacy behavior, so production only flips once the backend accepts `"auto"`. The hook forces the flag on in the dev server (`MODE === "development"`, so vitest and prod are unaffected) so the feature is exercisable in `dev:hosted` without PostHog.
- **UI coherence.** The host Protocol dropdown and `EffectiveProtocolVersionChip` render **Auto** for unpinned hosts. Because absence now means Auto, picking **"Latest"** writes an explicit `2025-11-25` pin (aligns the host dropdown with the existing per-server dropdown, which already did this).

## `-32022` actionable copy

`-32022` used to fall through to `internal/unknown` (the raw error in the linked report). Now the SDK error describer:
- Maps `-32022` → new `jsonrpc/protocol_version_rejected` catalog entry.
- Reads `data.supported` / `data.requested` off the error and promotes them into the visible one-line: *"The server does not support MCP protocol version 2025-11-25. It supports: 2026-07-28. Set this server's protocol version to Auto…"* — falling back to static copy when the error carries no usable `data`.
- Docs: new `-32022` section in `troubleshooting/error-codes.mdx`.

## What we tested

**Manual, end-to-end in `dev:hosted`** (stateless-only fixture `test-servers/stateless-mcp-server.ts` tunneled over HTTPS):

- ✅ **New host, zero config → connects to a stateless-only server.** Protocol dropdown reads "Auto (detect per server)"; `server/discover` probe at `2026-07-28` succeeds with **no `initialize`** in the wire log.
- ✅ New host / Auto → classic **stateful** server still connects (probe fails → legacy `initialize` fallback).
- ✅ Explicit **Latest (2025-11-25)** pin vs the stateless-only server → **fails** (no silent downgrade).
- ✅ Explicit **2026 RC** pin vs a stateful server → **fails hard**.
- ✅ **STDIO** under Auto → connects (auto stripped for stdio, degrades to legacy).

**Automated:**
- SDK error describer — `describe.test.ts`: `-32022` classification + enrichment (names supported/requested, static fallback, malformed-data guard). 74/74.
- `ProtocolTab.pin-derivation` — Auto shown for unpinned; "Latest" writes `2025-11-25`; derived accept-list dropped on switch to Auto.
- `EffectiveProtocolVersionChip` — unpinned + `"auto"` render "Auto"; explicit pins render the version.
- `use-server-state.protocol-revalidation` — unpinned normalizes to `auto`, no spurious re-tests (incl. the typo-string case).
- `ServerDetailModal` (18) + `EditServerFormContent.hosted` — unaffected by the `useStatelessMcpEnabled` swap.
- Client typecheck clean.

## Acceptance criteria

- [x] New host + stateless-only (`legacy:'reject'`) connects with zero protocol config
- [x] New host + classic stateful server still connects (probe → legacy `initialize`)
- [x] STDIO degrades gracefully under Auto (no hard throw)
- [x] Explicit `2026-07-28` pin against a stateful server still fails hard
- [x] Failed probes visible in the wire log
- [x] `-32022` on the legacy path produces actionable copy naming the supported versions

https://github.com/user-attachments/assets/97497d84-aa99-46f0-9106-040f789492f9





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default hosts to Auto protocol detection and add safer, actionable `-32022` error messaging. Unpinned hosts now negotiate per server with no setup, and the SDK explains version mismatches with supported versions and a clear fix.

- **New Features**
  - Unpinned hosts send `"auto"` at connect time to probe per server and fall back to legacy; STDIO degrades gracefully. UI shows Auto for unpinned; choosing “Latest” writes an explicit `2025-11-25`; the effective-version chip shows “Auto” for undefined/`"auto"`.
  - `@mcpjam/sdk`: classify `-32022` as `jsonrpc/protocol_version_rejected` and surface `data.supported`/`data.requested`; docs updated in `troubleshooting/error-codes.mdx` and JSDoc attached to the enrichment helper.

- **Bug Fixes**
  - Gate the connect-time Auto default on `stateless-mcp-enabled` in both local and hosted paths (via `useStatelessMcpEnabled`), so production stays legacy until the backend accepts `"auto"`.
  - Harden `-32022` copy: redact and length‑cap server-provided values, limit the supported list, place the “set to Auto” guidance before the list, and read data from either `error.data` or `.error.data`.

<sup>Written for commit eb4d0e606e7d42624859ee56268ddcf877810937. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3064?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



