### PR TITLE
fix: address follow-up review findings on API-key readiness/listing

### DIFF
--- a/.changeset/workos-readiness-timeout-pagination.md
+++ b/.changeset/workos-readiness-timeout-pagination.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Fixed the API key readiness check hanging past its configured timeout when WorkOS sent response headers but stalled the body — the abort signal now stays armed through body consumption, not just until `fetch()` resolves. Also fixed `/api/web/api-keys` returning only the first page of a user's WorkOS API keys; it now walks `list_metadata.after` across pages instead of silently dropping keys past page one.

--- a/mcpjam-inspector/server/routes/web/__tests__/api-keys.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/api-keys.test.ts
@@ -343,4 +343,39 @@ describe("web routes — API key listing is not scoped by session org", () => {
     expect(status).toBe(200);
     expect(data.items).toHaveLength(2);
   });
+
+  it("pages through a multi-page key list instead of returning only the first page", async () => {
+    const fetchMock = vi.fn(async (input: string | URL) => {
+      const url = new URL(String(input));
+      const after = url.searchParams.get("after");
+      if (!after) {
+        return workosJson({
+          object: "list",
+          data: [keyRecord("api_key_page_1")],
+          list_metadata: { before: null, after: "cursor_1" },
+        });
+      }
+      expect(after).toBe("cursor_1");
+      return workosJson({
+        object: "list",
+        data: [keyRecord("api_key_page_2")],
+        list_metadata: { before: null, after: null },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { status, data } = await expectJson(
+      await app.request("/api/web/api-keys", {
+        method: "GET",
+        headers: { Authorization: "Bearer session-jwt" },
+      }),
+    );
+
+    expect(status).toBe(200);
+    expect(data.items.map((k: { id: string }) => k.id)).toEqual([
+      "api_key_page_1",
+      "api_key_page_2",
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
 });

--- a/mcpjam-inspector/server/routes/web/api-keys.ts
+++ b/mcpjam-inspector/server/routes/web/api-keys.ts
@@ -443,21 +443,40 @@ apiKeys.get("/", async (c) =>
     // two orgs didn't match. WorkOS keys are already user-scoped by this
     // endpoint; the MCPJam-org boundary is enforced at USE time via the
     // workosApiKeyBindings lookup in bearer-auth.ts, not at listing time.
-    const { status, body } = await callWorkOS(
-      "GET",
-      `/user_management/users/${encodeURIComponent(session.userId)}/api_keys`,
-    );
-
-    if (status < 200 || status >= 300) {
-      mapWorkOSError(status, body, "Failed to list API keys");
+    //
+    // Unscoped-by-org means a user's keys can now span enough pages for
+    // WorkOS to paginate (`list_metadata.after`) — same page-walk pattern
+    // as `userOwnsApiKey` below, so a key on a later page doesn't silently
+    // disappear from Settings the same way the org filter used to hide one.
+    const items: any[] = [];
+    let after: string | null = null;
+    for (let page = 0; page < 10; page++) {
+      const params = new URLSearchParams({ limit: "100" });
+      if (after) {
+        params.set("after", after);
+      }
+      const { status, body } = await callWorkOS(
+        "GET",
+        `/user_management/users/${encodeURIComponent(session.userId)}/api_keys?${params.toString()}`,
+      );
+      if (status < 200 || status >= 300) {
+        mapWorkOSError(status, body, "Failed to list API keys");
+      }
+      // WorkOS returns `{ data: [...] }` or `{ data: [...], list_metadata: ... }`.
+      const pageItems = Array.isArray(body?.data)
+        ? body.data
+        : Array.isArray(body)
+          ? body
+          : [];
+      items.push(...pageItems);
+      after =
+        typeof body?.list_metadata?.after === "string"
+          ? body.list_metadata.after
+          : null;
+      if (!after) {
+        break;
+      }
     }
-
-    // WorkOS returns `{ data: [...] }` or `{ data: [...], list_metadata: ... }`.
-    const items = Array.isArray(body?.data)
-      ? body.data
-      : Array.isArray(body)
-        ? body
-        : [];
     return { items };
   }),
 );

--- a/mcpjam-inspector/server/services/organizations.ts
+++ b/mcpjam-inspector/server/services/organizations.ts
@@ -68,15 +68,57 @@ export async function resolveApiKeyReadiness(
     mcpjamOrganizationId,
   )}&userId=${encodeURIComponent(mcpjamUserId)}`;
 
+  // The timeout must stay armed through body consumption, not just until
+  // `fetch()` resolves — `fetch()` only settles once headers arrive, so a
+  // backend that sends headers and then stalls the body would otherwise
+  // hang `response.json()` / `isEntityNotFound`'s own `.json()` call
+  // indefinitely despite the "timeout" existing in name only.
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), READINESS_TIMEOUT_MS);
-  let response: Response;
   try {
-    response = await fetch(url, {
+    const response = await fetch(url, {
       method: "GET",
       headers: { "x-inspector-service-token": serviceToken },
       signal: controller.signal,
     });
+
+    if (response.status === 404) {
+      if (await isEntityNotFound(response, "Organization not found")) {
+        throw new ApiKeyReadinessError(404, "Organization not found");
+      }
+      throw new Error(
+        `Readiness route not found at ${convexUrl}${READINESS_PATH} — is it deployed?`,
+      );
+    }
+    if (response.status === 403) {
+      throw new ApiKeyReadinessError(403, "Not a member of this organization");
+    }
+    if (response.status === 400) {
+      throw new ApiKeyReadinessError(400, "Invalid organization or user id");
+    }
+    if (!response.ok) {
+      throw new Error(`API key readiness check failed (${response.status})`);
+    }
+
+    const body = (await response.json()) as {
+      ready?: unknown;
+      workosOrganizationId?: unknown;
+      reason?: unknown;
+    };
+    if (typeof body?.ready !== "boolean") {
+      throw new Error("API key readiness check returned an invalid body");
+    }
+    return {
+      ready: body.ready,
+      workosOrganizationId:
+        typeof body.workosOrganizationId === "string"
+          ? body.workosOrganizationId
+          : null,
+      reason:
+        typeof body.reason === "string"
+          ? (body.reason as ApiKeyReadinessReason)
+          : undefined,
+    };
   } catch (error) {
     if (error instanceof DOMException && error.name === "AbortError") {
       throw new Error("API key readiness check timed out");
@@ -85,42 +127,4 @@ export async function resolveApiKeyReadiness(
   } finally {
     clearTimeout(timeout);
   }
-
-  if (response.status === 404) {
-    if (await isEntityNotFound(response, "Organization not found")) {
-      throw new ApiKeyReadinessError(404, "Organization not found");
-    }
-    throw new Error(
-      `Readiness route not found at ${convexUrl}${READINESS_PATH} — is it deployed?`,
-    );
-  }
-  if (response.status === 403) {
-    throw new ApiKeyReadinessError(403, "Not a member of this organization");
-  }
-  if (response.status === 400) {
-    throw new ApiKeyReadinessError(400, "Invalid organization or user id");
-  }
-  if (!response.ok) {
-    throw new Error(`API key readiness check failed (${response.status})`);
-  }
-
-  const body = (await response.json()) as {
-    ready?: unknown;
-    workosOrganizationId?: unknown;
-    reason?: unknown;
-  };
-  if (typeof body?.ready !== "boolean") {
-    throw new Error("API key readiness check returned an invalid body");
-  }
-  return {
-    ready: body.ready,
-    workosOrganizationId:
-      typeof body.workosOrganizationId === "string"
-        ? body.workosOrganizationId
-        : null,
-    reason:
-      typeof body.reason === "string"
-        ? (body.reason as ApiKeyReadinessReason)
-        : undefined,
-  };
 }


### PR DESCRIPTION
## Summary

Follow-up to #3057 (already merged) — these fixes were still in review when #3057 got merged, so they never landed. Reviewed and tested here on top of current `main`.

Two reviewers caught residual bugs in #3057's own fixes:
- **cubic**: the readiness timeout's `clearTimeout` ran right after `fetch()` settled (headers only) — body reads (`response.json()`, `isEntityNotFound`) were unprotected, so a backend that sends headers then stalls the body could still hang the key-mint request despite the comment claiming otherwise. Moved all body consumption inside the same `try` block the timeout guards.
- **Codex**: dropping the org filter on `GET /api/web/api-keys` (to fix keys vanishing across orgs) surfaced a latent bug — WorkOS paginates the user-level key list, and only the first page was being fetched, so a user with enough keys to span pages would have later ones vanish from Settings the same way the org filter used to hide them. Now pages through `list_metadata.after`, mirroring the existing walk in `userOwnsApiKey`.

## Test plan
- [x] `tsc --noEmit -p server/tsconfig.json` — clean on touched files
- [x] New pagination regression test — `server/routes/web/__tests__/api-keys.test.ts`, 11/11 passing
- [x] `npx eslint` on touched files — clean (pre-existing warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the API key mint path (readiness) and Settings listing; behavior fixes are localized but affect user-visible key management.
> 
> **Overview**
> **`GET /api/web/api-keys`** now walks WorkOS pagination (`list_metadata.after`, up to 10 pages at `limit=100`) and merges results, matching the existing **`userOwnsApiKey`** pattern so keys beyond the first page still show in Settings after org-scoped listing was removed.
> 
> **`resolveApiKeyReadiness`** keeps the abort timeout active while the response body is read—status handling, **`isEntityNotFound`**, and **`response.json()`** all run inside the same **`try`** guarded by **`AbortController`**, so a backend that returns headers then stalls cannot hang key mint indefinitely.
> 
> Adds a regression test that a two-page WorkOS list returns both key ids and triggers two fetches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29652b35d3cbab9761d0f43a4e7210a0da6db9e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an API-key readiness hang by keeping the timeout active through body reads, and adds pagination to the WorkOS user API-key list so all keys show in Settings.

- **Bug Fixes**
  - Readiness: keep the timeout armed through `response.json()` and body checks by moving all body handling into the timeout-guarded try block; preserves existing 404/403/400 mappings.
  - Listing: walk WorkOS pagination using `list_metadata.after` (limit 100, up to 10 pages) so `/api/web/api-keys` returns all user keys, matching `userOwnsApiKey`.

<sup>Written for commit c6604e603e374248bbe48516efe4f9feaedcb490. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3067?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

