### PR TITLE
fix(evals): thread host progressiveToolDiscovery toggle into prepareChatV2

### DIFF
--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -2423,6 +2423,17 @@ const runLocalIteration = async ({
         ...(resolvedExecution.harness
           ? { harness: resolvedExecution.harness }
           : {}),
+        // Host progressive-discovery toggle, same conversion as the chat-v2
+        // routes and the session-sim runner. Only an explicit host value is
+        // forwarded — absent stays undefined so prepareChatV2 keeps its
+        // "auto" threshold behavior.
+        ...(resolvedExecution.progressiveToolDiscovery !== undefined
+          ? {
+              progressiveToolDiscovery: {
+                enabled: resolvedExecution.progressiveToolDiscovery,
+              },
+            }
+          : {}),
         customProviders: modelRuntime!.customProviders,
         priorMessages: [],
       });
@@ -3284,6 +3295,17 @@ const runHostedIterationWithBrowser = async (
       modelVisibleMcpToolResults: hostPolicy?.modelVisibleMcpToolResults,
       ...(resolvedExecution.harness
         ? { harness: resolvedExecution.harness }
+        : {}),
+      // Host progressive-discovery toggle, same conversion as the chat-v2
+      // routes and the session-sim runner. Only an explicit host value is
+      // forwarded — absent stays undefined so prepareChatV2 keeps its
+      // "auto" threshold behavior.
+      ...(resolvedExecution.progressiveToolDiscovery !== undefined
+        ? {
+            progressiveToolDiscovery: {
+              enabled: resolvedExecution.progressiveToolDiscovery,
+            },
+          }
         : {}),
       ...(backendCustomProviders?.length
         ? { customProviders: backendCustomProviders }

--- a/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
@@ -1297,6 +1297,135 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
     expect(Object.keys(options.builtInTools!)).toEqual(["web_search"]);
   });
 
+  it("threads the host progressiveToolDiscovery toggle into prepareChatV2 on the backend path", async () => {
+    // The host page's "progressive tool discovery" switch must reach the
+    // eval engine. Pre-fix the runner dropped it, so prepareChatV2 fell
+    // back to "auto" and minted search/load meta-tools whenever the tool
+    // set crossed the auto thresholds — even for hosts that disabled it.
+    fetchMock.mockResolvedValue(createBackendStreamResponse());
+    const orchestration = await import("../../../utils/chat-v2-orchestration");
+    const prepareMock = vi.mocked(orchestration.prepareChatV2);
+
+    await runEvalSuiteWithAiSdk({
+      suiteId: "suite-1",
+      runId: null,
+      config: {
+        tests: [
+          {
+            title: "Case",
+            query: "Hello",
+            runs: 1,
+            model: "claude-haiku-4.5",
+            provider: "anthropic",
+            expectedToolCalls: [],
+            promptTurns: [
+              { id: "turn-1", prompt: "Hello", expectedToolCalls: [] },
+            ],
+            testCaseId: "case-1",
+          },
+        ],
+        environment: { servers: ["srv-1"] },
+      },
+      modelApiKeys: {},
+      convexClient: convexClient as any,
+      convexHttpUrl: "https://example.convex.site",
+      convexAuthToken: "token",
+      mcpClientManager: mcpClientManager as any,
+      testCaseId: "case-1",
+      suiteHostConfig: { progressiveToolDiscovery: false },
+    });
+
+    expect(prepareMock).toHaveBeenCalled();
+    const options = prepareMock.mock.calls[0]?.[0] as {
+      progressiveToolDiscovery?: { enabled?: boolean };
+    };
+    expect(options.progressiveToolDiscovery).toEqual({ enabled: false });
+  });
+
+  it("threads an enabled progressiveToolDiscovery toggle into prepareChatV2 on the local BYOK path", async () => {
+    const orchestration = await import("../../../utils/chat-v2-orchestration");
+    const prepareMock = vi.mocked(orchestration.prepareChatV2);
+
+    await runEvalSuiteWithAiSdk({
+      suiteId: "suite-1",
+      runId: null,
+      config: {
+        tests: [
+          {
+            title: "Case",
+            query: "Hello",
+            runs: 1,
+            model: "gpt-4-turbo",
+            provider: "openai",
+            expectedToolCalls: [],
+            promptTurns: [
+              { id: "turn-1", prompt: "Hello", expectedToolCalls: [] },
+            ],
+            testCaseId: "case-1",
+          },
+        ],
+        environment: { servers: ["srv-1"] },
+      },
+      modelApiKeys: { openai: "sk-test" },
+      convexClient: convexClient as any,
+      convexHttpUrl: "https://example.convex.site",
+      convexAuthToken: "token",
+      mcpClientManager: mcpClientManager as any,
+      testCaseId: "case-1",
+      suiteHostConfig: { progressiveToolDiscovery: true },
+    });
+
+    expect(prepareMock).toHaveBeenCalled();
+    const options = prepareMock.mock.calls[0]?.[0] as {
+      progressiveToolDiscovery?: { enabled?: boolean };
+    };
+    expect(options.progressiveToolDiscovery).toEqual({ enabled: true });
+  });
+
+  it("omits progressiveToolDiscovery when the host config has no explicit value", async () => {
+    // Absent must stay absent — prepareChatV2's "auto" thresholds are the
+    // intended default when a host never touched the toggle (a host UI
+    // "default" serializes to undefined, not false).
+    fetchMock.mockResolvedValue(createBackendStreamResponse());
+    const orchestration = await import("../../../utils/chat-v2-orchestration");
+    const prepareMock = vi.mocked(orchestration.prepareChatV2);
+
+    await runEvalSuiteWithAiSdk({
+      suiteId: "suite-1",
+      runId: null,
+      config: {
+        tests: [
+          {
+            title: "Case",
+            query: "Hello",
+            runs: 1,
+            model: "claude-haiku-4.5",
+            provider: "anthropic",
+            expectedToolCalls: [],
+            promptTurns: [
+              { id: "turn-1", prompt: "Hello", expectedToolCalls: [] },
+            ],
+            testCaseId: "case-1",
+          },
+        ],
+        environment: { servers: ["srv-1"] },
+      },
+      modelApiKeys: {},
+      convexClient: convexClient as any,
+      convexHttpUrl: "https://example.convex.site",
+      convexAuthToken: "token",
+      mcpClientManager: mcpClientManager as any,
+      testCaseId: "case-1",
+      suiteHostConfig: { systemPrompt: "hi" },
+    });
+
+    expect(prepareMock).toHaveBeenCalled();
+    const options = prepareMock.mock.calls[0]?.[0] as {
+      progressiveToolDiscovery?: { enabled?: boolean };
+    };
+    expect(options.progressiveToolDiscovery).toBeUndefined();
+  });
+
   it("runs org BYOK cloud eval models through Convex without raw provider keys", async () => {
     // Same migration as the previous test: assert against the engine's
     // `mode:"stream"` SSE request, not the legacy `mode:"step"` JSON. The


### PR DESCRIPTION
## Problem

Eval runs ignored the host's progressive tool discovery setting. Both eval `prepareChatV2` call sites (local BYOK and hosted) omitted the `progressiveToolDiscovery` option, so the engine fell back to `"auto"` mode and switched discovery on whenever the tool set crossed the auto thresholds (≥30 tools, ≥10k tool tokens, or 3% of model context) — even for hosts that explicitly disabled it.

Symptom: eval runs against tool-heavy servers fail with `WRONG TOOL` diffs because the model calls the `search_mcp_tools` / `load_mcp_tools` meta-tools before the expected real tools.

Aggravating detail: iteration metadata *does* read the host policy and stamps `progressiveDiscoveryEnabled` on every iteration for the cross-host dashboard — so runs were labeled "discovery off" while actually executing with it on.

The chat-v2 routes and the session-sim (swarm) runner already thread this correctly; evals were the only broken surface.

## Fix

Forward `resolvedExecution.progressiveToolDiscovery` as `{ enabled }` into both eval `prepareChatV2` sites, using the same conversion as `server/routes/web/chat-v2.ts` and `sessionSimulation/runner.ts`. Only an explicit host value is forwarded — a host that never touched the toggle serializes to `undefined`, which keeps the existing `"auto"` threshold behavior.

## Tests

Three new cases in `evals-runner.test.ts`, mirroring the existing `builtInToolIds` threading tests:
- explicit `false` reaches `prepareChatV2` on the backend path
- explicit `true` reaches `prepareChatV2` on the local BYOK path
- absent host value stays `undefined` (auto preserved)

`evals-runner` (80), `runner-parity` (23), `chat-v2-orchestration` (51), `drive-hosted-eval-turn` (3), and `host-execution-context` (35) suites all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow wiring change with parity to existing chat routes; explicit undefined preserves prior auto behavior and tests cover the three host toggle states.
> 
> **Overview**
> Eval runs now honor the suite host’s **progressive tool discovery** setting when building tools via `prepareChatV2`, matching chat-v2 and session-sim behavior.
> 
> Both eval `prepareChatV2` call sites (local BYOK and hosted backend) forward `resolvedExecution.progressiveToolDiscovery` as `{ enabled }` only when the host sets an explicit boolean; leaving it **undefined** preserves `prepareChatV2`’s existing auto-threshold mode. Previously evals omitted this option, so large tool sets could still inject `search_mcp_tools` / `load_mcp_tools` meta-tools and cause spurious **WRONG TOOL** failures even when discovery was disabled on the host.
> 
> Three unit tests assert `false`, `true`, and absent values are passed through correctly on the backend and local paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a02b292718d76954594030a2692ac6597fbcc34b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Eval runs now respect the host’s progressive tool discovery setting. This threads the toggle into prepareChatV2 for both local BYOK and hosted paths to avoid unwanted meta-tool calls and WRONG TOOL diffs.

- **Bug Fixes**
  - Forward `resolvedExecution.progressiveToolDiscovery` as `{ enabled }` to `prepareChatV2` on both eval paths, matching the chat-v2 routes and session-sim runner.
  - Omit the option when the host never set it, preserving the existing "auto" thresholds as the default.

<sup>Written for commit a02b292718d76954594030a2692ac6597fbcc34b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

