### PR TITLE
feat(evals): offer harness system tools in assertion dropdowns

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/__tests__/harness-system-tools.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/harness-system-tools.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import {
+  mergeSystemToolsIntoAvailableTools,
+  systemToolsToAssertable,
+  type AssertableTool,
+} from "../harness-system-tools";
+import type { HarnessBuiltinToolInfo } from "@/hooks/useHarnessBuiltinTools";
+
+const CATALOG: HarnessBuiltinToolInfo[] = [
+  {
+    key: "bash",
+    name: "Bash",
+    commonName: "bash",
+    toolUseKind: "bash",
+    description: "Execute a shell command",
+    inputSchema: { type: "object", properties: { command: { type: "string" } } },
+  },
+  { key: "read", name: "Read", commonName: "read", toolUseKind: "readonly" },
+  // Native-only tool: keyed by native name, no commonName.
+  {
+    key: "WebFetch",
+    name: "WebFetch",
+    description: "Fetch a URL and run a prompt against its content",
+  },
+];
+
+const MCP_TOOLS: AssertableTool[] = [
+  { name: "get_transactions", serverId: "srv_1" },
+];
+
+describe("systemToolsToAssertable", () => {
+  it("emits the catalog KEY as the tool name — the wire name the bridge streams (toCommonName), never the display nativeName", () => {
+    const names = systemToolsToAssertable(CATALOG).map((t) => t.name);
+    expect(names).toEqual(["bash", "read", "WebFetch"]);
+    expect(names).not.toContain("Bash");
+  });
+
+  it("marks entries as system, keeps input schemas, and brands the description", () => {
+    const bash = systemToolsToAssertable(CATALOG).find(
+      (t) => t.name === "bash",
+    );
+    expect(bash?.source).toBe("system");
+    expect(bash?.inputSchema?.properties?.command).toEqual({ type: "string" });
+    expect(bash?.description).toContain("System tool");
+    expect(bash?.description).toContain("Execute a shell command");
+    const read = systemToolsToAssertable(CATALOG).find(
+      (t) => t.name === "read",
+    );
+    expect(read?.description).toBe("System tool (runs in harness)");
+  });
+});
+
+describe("mergeSystemToolsIntoAvailableTools", () => {
+  it("appends system tools after MCP tools", () => {
+    const merged = mergeSystemToolsIntoAvailableTools(MCP_TOOLS, CATALOG);
+    expect(merged.map((t) => t.name)).toEqual([
+      "get_transactions",
+      "bash",
+      "read",
+      "WebFetch",
+    ]);
+  });
+
+  it("returns the input list untouched for an empty catalog (non-harness suite)", () => {
+    expect(mergeSystemToolsIntoAvailableTools(MCP_TOOLS, [])).toBe(MCP_TOOLS);
+  });
+
+  it("drops a system tool whose name collides with an MCP tool — the name-based matcher couldn't tell them apart", () => {
+    const merged = mergeSystemToolsIntoAvailableTools(
+      [{ name: "bash", serverId: "srv_1" }],
+      CATALOG,
+    );
+    expect(merged.filter((t) => t.name === "bash")).toHaveLength(1);
+    expect(merged.find((t) => t.name === "bash")?.source).toBeUndefined();
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/__tests__/test-template-editor-validation.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/test-template-editor-validation.test.tsx
@@ -51,6 +51,7 @@ vi.mock("convex/react", () => ({
   useMutation: (_name: unknown) => useMutationMock(),
   useQuery: (name: unknown, args: unknown) => useQueryMock(name, args),
   useAction: () => vi.fn(),
+  useConvexAuth: () => ({ isAuthenticated: false, isLoading: false }),
 }));
 
 describe("getStepsBlockReason", () => {

--- a/mcpjam-inspector/client/src/components/evals/checks-section.tsx
+++ b/mcpjam-inspector/client/src/components/evals/checks-section.tsx
@@ -253,6 +253,14 @@ export interface CheckRowProps {
   onChange: (next: Predicate) => void;
   onRemove?: () => void;
   availableTools?: string[];
+  /**
+   * Names for the widget-filter dropdowns (`widgetRendered`,
+   * `widgetRenderLatencyUnder`, `widgetNoConsoleErrors`). Defaults to
+   * `availableTools`; callers whose `availableTools` include harness system
+   * tools (bash, read, …) pass the MCP-only subset here — system tools never
+   * render widgets.
+   */
+  widgetToolNames?: string[];
   toolArgSchemas?: ToolArgSchemas;
   readOnly?: boolean;
   /** Strip outer card chrome + kind header when nested inside a step row. */
@@ -268,6 +276,7 @@ export function CheckRow({
   onChange,
   onRemove,
   availableTools,
+  widgetToolNames,
   toolArgSchemas,
   readOnly = false,
   embedded = false,
@@ -319,6 +328,7 @@ export function CheckRow({
             predicate={predicate}
             onChange={onChange}
             availableTools={availableTools}
+            widgetToolNames={widgetToolNames}
             toolArgSchemas={toolArgSchemas}
             readOnly={readOnly}
             compactGlobalGate={globalGate}
@@ -356,6 +366,7 @@ function CheckFields({
   predicate,
   onChange,
   availableTools,
+  widgetToolNames,
   toolArgSchemas,
   readOnly,
   compactGlobalGate = false,
@@ -363,10 +374,12 @@ function CheckFields({
   predicate: Predicate;
   onChange: (next: Predicate) => void;
   availableTools?: string[];
+  widgetToolNames?: string[];
   toolArgSchemas?: ToolArgSchemas;
   readOnly: boolean;
   compactGlobalGate?: boolean;
 }) {
+  const widgetTools = widgetToolNames ?? availableTools;
   switch (predicate.type) {
     case "toolCalledWith":
       return (
@@ -446,7 +459,7 @@ function CheckFields({
                   : { type: "widgetRendered", toolName },
               )
             }
-            availableTools={availableTools}
+            availableTools={widgetTools}
             readOnly={readOnly}
           />
         </div>
@@ -456,7 +469,7 @@ function CheckFields({
         <WidgetLatencyFields
           predicate={predicate}
           onChange={onChange}
-          availableTools={availableTools}
+          availableTools={widgetTools}
           readOnly={readOnly}
         />
       );
@@ -472,7 +485,7 @@ function CheckFields({
                   : { type: "widgetNoConsoleErrors", toolName },
               )
             }
-            availableTools={availableTools}
+            availableTools={widgetTools}
             readOnly={readOnly}
           />
         );
@@ -492,7 +505,7 @@ function CheckFields({
                   : { type: "widgetNoConsoleErrors", toolName },
               )
             }
-            availableTools={availableTools}
+            availableTools={widgetTools}
             readOnly={readOnly}
           />
         </div>

--- a/mcpjam-inspector/client/src/components/evals/harness-system-tools.ts
+++ b/mcpjam-inspector/client/src/components/evals/harness-system-tools.ts
@@ -1,0 +1,63 @@
+import type { HarnessBuiltinToolInfo } from "@/hooks/useHarnessBuiltinTools";
+
+/**
+ * A tool the case editor can assert on: an MCP-server tool (from
+ * `listEvalTools`) or a harness-native "system" tool (Bash, read, …) merged in
+ * by {@link mergeSystemToolsIntoAvailableTools}. `source: "system"` marks the
+ * latter so pickers that need an MCPJam-invokable tool (pinned tool calls,
+ * widget "View (tool)" selects) can exclude them — system tools run inside the
+ * harness sandbox and never render widgets or accept pinned invocation.
+ */
+export type AssertableTool = {
+  name: string;
+  description?: string;
+  inputSchema?: any;
+  serverId?: string;
+  source?: "system";
+};
+
+/**
+ * Map a harness's built-in tool catalog into assertable dropdown entries.
+ *
+ * `name` MUST be the catalog `key`, never the display `name` (nativeName).
+ * The Claude Code bridge emits stream tool-call parts through
+ * `toCommonName(nativeName)`, which is exactly the `builtinTools` record key
+ * (`bash`, `read`, `webSearch`, … for aliased tools; `WebFetch`,
+ * `NotebookEdit`, … for native-only ones), and `parseHarnessToolName` passes
+ * non-MCP names through untouched — so the key is the name the eval matcher
+ * sees in `toolsCalledByPrompt`. An entry minted from the display name
+ * ("Bash") would silently never match.
+ */
+export function systemToolsToAssertable(
+  catalog: HarnessBuiltinToolInfo[],
+): AssertableTool[] {
+  return catalog
+    .map((tool) => ({
+      name: tool.key,
+      description: ["System tool (runs in harness)", tool.description]
+        .filter(Boolean)
+        .join(" — "),
+      ...(tool.inputSchema ? { inputSchema: tool.inputSchema } : {}),
+      source: "system" as const,
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * Append the harness system tools to the MCP-server tool list. An MCP tool
+ * that happens to share a name with a system tool wins — the matcher compares
+ * bare names, so a second entry with the same value would be indistinguishable
+ * anyway.
+ */
+export function mergeSystemToolsIntoAvailableTools(
+  availableTools: AssertableTool[],
+  catalog: HarnessBuiltinToolInfo[],
+): AssertableTool[] {
+  if (catalog.length === 0) return availableTools;
+  const taken = new Set(availableTools.map((tool) => tool.name));
+  const systemTools = systemToolsToAssertable(catalog).filter(
+    (tool) => !taken.has(tool.name),
+  );
+  if (systemTools.length === 0) return availableTools;
+  return [...availableTools, ...systemTools];
+}

--- a/mcpjam-inspector/client/src/components/evals/step-list-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/step-list-editor.tsx
@@ -63,7 +63,17 @@ type AvailableTool = {
   description?: string;
   inputSchema?: any;
   serverId?: string;
+  /** "system" = harness-native built-in (bash, read, …). Assertable by name,
+   *  but not invokable through MCPJam and never a widget view — the pinned
+   *  tool-call and "View (tool)" pickers filter these back out. */
+  source?: "system";
 };
+
+/** Tools MCPJam can actually invoke / render as a widget view — everything
+ *  except harness system tools. */
+function invokableTools(tools: AvailableTool[]): AvailableTool[] {
+  return tools.filter((t) => t.source !== "system");
+}
 
 type StepListEditorProps = {
   steps: TestStep[];
@@ -386,12 +396,13 @@ function WidgetAssertionFields({
 }) {
   const target =
     "target" in value ? (value.target as ElementLocator) : undefined;
+  const viewTools = invokableTools(availableTools);
   return (
     <div className="flex flex-col gap-2">
       <div className="grid gap-2 sm:grid-cols-2">
         <div className="space-y-1">
           <Label className="text-[11px]">View (tool)</Label>
-          {availableTools.length > 0 ? (
+          {viewTools.length > 0 ? (
             <Select
               value={value.toolName || undefined}
               onValueChange={(next) => onChange({ ...value, toolName: next })}
@@ -400,7 +411,7 @@ function WidgetAssertionFields({
                 <SelectValue placeholder="Pick a view tool…" />
               </SelectTrigger>
               <SelectContent>
-                {Array.from(new Set(availableTools.map((t) => t.name))).map(
+                {Array.from(new Set(viewTools.map((t) => t.name))).map(
                   (name) => (
                     <SelectItem key={name} value={name} className="text-[11px]">
                       {name}
@@ -523,6 +534,7 @@ function AssertStepBody({
       predicate={a}
       onChange={(next: Predicate) => setAssertion(next)}
       availableTools={availableTools.map((t) => t.name)}
+      widgetToolNames={invokableTools(availableTools).map((t) => t.name)}
       toolArgSchemas={Object.fromEntries(
         availableTools.map((t) => [t.name, t.inputSchema?.properties ?? {}])
       )}
@@ -691,7 +703,7 @@ function StepRow({
               <div className="grid gap-2 sm:grid-cols-2">
                 <div className="space-y-1">
                   <Label className="text-[11px]">View (tool)</Label>
-                  {availableTools.length > 0 ? (
+                  {invokableTools(availableTools).length > 0 ? (
                     <Select
                       value={step.toolName || undefined}
                       onValueChange={(next) =>
@@ -703,7 +715,9 @@ function StepRow({
                       </SelectTrigger>
                       <SelectContent>
                         {Array.from(
-                          new Set(availableTools.map((t) => t.name))
+                          new Set(
+                            invokableTools(availableTools).map((t) => t.name)
+                          )
                         ).map((name) => (
                           <SelectItem
                             key={name}
@@ -795,7 +809,7 @@ function ToolCallStepBody({
           })
         }
         suiteServers={suiteServers}
-        availableTools={availableTools}
+        availableTools={invokableTools(availableTools)}
         projectServers={projectServers}
         readOnly={readOnly}
       />

--- a/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
@@ -6,7 +6,7 @@ import {
   useState,
   type KeyboardEvent,
 } from "react";
-import { useMutation, useQuery } from "convex/react";
+import { useConvexAuth, useMutation, useQuery } from "convex/react";
 import posthog from "posthog-js";
 import {
   Circle,
@@ -124,6 +124,9 @@ import {
   getEffectiveSuiteServers,
   getSelectedSuiteHostRunPlan,
 } from "./helpers";
+import { useHost } from "@/hooks/useClients";
+import { useHarnessBuiltinToolCatalog } from "@/hooks/useHarnessBuiltinTools";
+import { mergeSystemToolsIntoAvailableTools } from "./harness-system-tools";
 import { parseDraftTestCaseId } from "./draft-test-case";
 import { collectUniqueModelsFromTestCases } from "@/lib/evals/collect-unique-suite-models";
 import { computeIterationResult } from "./pass-criteria";
@@ -1079,6 +1082,31 @@ export function TestTemplateEditor({
     return map;
   }, [suite?.hostAttachments]);
   const hasHostAttachments = (suite?.hostAttachments?.length ?? 0) > 0;
+
+  // ── Harness system tools (assertable built-ins) ──────────────────────────
+  // Mirror the server's `loadSuiteHostConfig` precedence: with host
+  // attachments the run executes under the SELECTED attached host's config;
+  // only an attachment-less suite runs under the suite hostConfig. Gate the
+  // system-tool merge on whichever of those actually carries a harness, so
+  // emulated suites never see bash/read/… in the assertion dropdowns.
+  const { isAuthenticated } = useConvexAuth();
+  const { host: selectedQuickRunHost } = useHost({
+    isAuthenticated,
+    hostId: hasHostAttachments ? (selectedQuickRunHostId ?? null) : null,
+  });
+  const suiteRunHarnessId = hasHostAttachments
+    ? (selectedQuickRunHost?.config?.harness ?? null)
+    : (hostConfigBaseline?.harness ?? null);
+  const { tools: harnessBuiltinCatalog } =
+    useHarnessBuiltinToolCatalog(suiteRunHarnessId);
+  // MCP-server tools plus the harness's native built-ins — what the expected
+  // tool calls / check pickers offer. Pickers needing an MCPJam-invokable tool
+  // (pinned tool calls, widget selects) filter `source === "system"` back out.
+  const assertableTools = useMemo(
+    () =>
+      mergeSystemToolsIntoAvailableTools(availableTools, harnessBuiltinCatalog),
+    [availableTools, harnessBuiltinCatalog],
+  );
 
   const missingServers = useMemo(
     () =>
@@ -2995,7 +3023,7 @@ export function TestTemplateEditor({
                       <StepListEditor
                         steps={editForm.steps}
                         onStepsChange={setSteps}
-                        availableTools={availableTools}
+                        availableTools={assertableTools}
                         // Thread the effective argumentMatching mode (suite
                         // default merged with case override) so the per-leaf
                         // placeholder picker offers the right options and


### PR DESCRIPTION
## What

When a suite runs under a harness host (Claude Code / Codex), the case editor's tool assertion pickers now also offer the harness's native **system tools** (`bash`, `read`, `edit`, `glob`, `grep`, `webSearch`, `WebFetch`, `NotebookEdit`, `TodoWrite`, `Agent`, …) so evals can assert on them — e.g. `toolNeverCalled("bash")` or `toolCalledWith("read", { file_path: … })`.

The eval engine already supported this: `run-harness-turn` records native harness tool calls in the same `toolsCalledByPrompt` accumulator as MCP tool calls (with `serverId: undefined`), and the matcher/predicates compare by bare tool name. The dropdowns just never offered these names, so asserting on them required knowing the wire name and free-typing it.

## The naming trap this codifies

The dropdown entries use the builtin catalog **`key`** (`bash`, `read`, `WebFetch`), NOT the display `name` (`Bash`, `Read`). The Claude Code bridge emits stream tool-call parts through `toCommonName(nativeName)` — exactly the `builtinTools` record key — and `parseHarnessToolName` passes non-MCP names through untouched, so the key is what the matcher sees. An entry minted from the display name would silently never match. `harness-system-tools.ts` documents this and the unit test pins it.

## Gating

Mirrors the server's `loadSuiteHostConfig` precedence: when the suite has host attachments, the selected quick-run host's `config.harness` decides; only an attachment-less suite falls back to the suite hostConfig's `harness`. Emulated suites see no change. The catalog comes from the existing `GET /api/v1/harness/:id/builtin-tools` via `useHarnessBuiltinToolCatalog` (cached per harness id).

## Where system tools do NOT appear

They are assertable but not MCPJam-invokable and never render widgets, so they're filtered out of:
- the pinned tool-call step picker (`PinnedToolCallFields`)
- the interact/widget-assertion "View (tool)" selects
- the widget predicate filters (`widgetRendered` / `widgetRenderLatencyUnder` / `widgetNoConsoleErrors`), via a new optional `widgetToolNames` override on `CheckRow`
- the case pass-criteria "Global gates" popover (its only tool fields are widget filters)

## Notes

- MCP tools win name collisions (an MCP tool literally named `bash` shadows the system entry — the name-based matcher couldn't tell them apart anyway).
- System tools ship their input schemas, so `toolCalledWith` argument dropdowns work (e.g. `bash.command`).
- No server/SDK changes — matching semantics are untouched.

## Tests

- New `harness-system-tools.test.ts` pins key-not-name mapping, source marking, schema pass-through, empty-catalog no-op, and collision dedupe.
- `vitest run client/src/components/evals`: 120 files / 902 tests pass.
- `npm run typecheck:client` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only eval editor UX; no matcher or server changes. Main pitfall (wrong tool display name) is documented and unit-tested.
> 
> **Overview**
> Harness-hosted eval suites now **merge native built-in tools** (`bash`, `read`, `WebFetch`, …) into the case editor’s assertable tool list, so predicates like `toolNeverCalled` / `toolCalledWith` can be picked from dropdowns instead of free-typing wire names.
> 
> New **`harness-system-tools`** helpers map the builtin catalog using each tool’s **`key`** (stream/matcher name, not display `name`), tag entries with `source: "system"`, pass through input schemas, append after MCP tools, and skip empty catalogs or name collisions (MCP wins).
> 
> **`TestTemplateEditor`** loads the harness id from the selected quick-run host or suite host config (same precedence as server `loadSuiteHostConfig`), fetches the catalog via `useHarnessBuiltinToolCatalog`, and passes **`assertableTools`** into `StepListEditor`.
> 
> **`StepListEditor`** and **`CheckRow`** keep system tools in general assertion pickers but **exclude** them from pinned tool calls, interact/widget “View (tool)” selects, and widget predicate filters via `invokableTools` / optional **`widgetToolNames`**.
> 
> Tests add **`harness-system-tools.test.ts`**; **`test-template-editor-validation`** mocks **`useConvexAuth`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73253250d6ad70002e96325bd198fccaab2230a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose harness system tools in eval assertion dropdowns so you can assert on tools like `bash`, `read`, and `WebFetch` without free-typing. Names match the engine’s wire names and include input schemas; invokable pickers still only show MCP tools.

- New Features
  - Merge harness builtin tools into assertion pickers when a harness is active (`bash`, `read`, `webSearch`, `WebFetch`, …).
  - Match by catalog key (wire/common name), not display name; schemas flow through so `toolCalledWith` args are selectable.
  - Honor host precedence: use the selected attached host’s `config.harness` when attachments exist; else the suite `hostConfig.harness`. Emulated suites show none.
  - System tools are not invokable: they are hidden from pinned tool-call picker, widget “View (tool)” selects, and widget predicates (via a new `widgetToolNames` override). MCP tools win name collisions; no server/SDK changes.

<sup>Written for commit 73253250d6ad70002e96325bd198fccaab2230a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3071?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

