### PR TITLE
fix(evals): show SDK/CI-created suites in the Evaluate tab

### DIFF
--- a/mcpjam-inspector/client/src/components/EvalsTab.tsx
+++ b/mcpjam-inspector/client/src/components/EvalsTab.tsx
@@ -51,7 +51,10 @@ import { useEvalHandlers } from "./evals/use-eval-handlers";
 import { isDraftTestCaseId } from "./evals/draft-test-case";
 import { getBillingErrorMessage } from "@/lib/billing-entitlements";
 import { SuiteSwitcher } from "./evals/suite-switcher";
-import { stripTimestampSuffix } from "./evals/suite-overview-presentation";
+import {
+  sortSuiteOverviewEntries,
+  stripTimestampSuffix,
+} from "./evals/suite-overview-presentation";
 import {
   CreateSuiteDialog,
   type CreateSuitePayload,
@@ -190,13 +193,9 @@ function EvalsTabContent({
     isDirectGuest,
   });
 
-  const visibleSuites = useMemo(
-    () =>
-      overviewQueries.sortedSuites.filter(
-        (entry) => entry.suite.source !== "sdk"
-      ),
-    [overviewQueries.sortedSuites]
-  );
+  // All suites are visible in Evaluate regardless of origin (ui or sdk/CI).
+  // SDK-created suites get a CI badge in the switcher instead of being hidden.
+  const visibleSuites = overviewQueries.sortedSuites;
 
   const selectedSuiteEntry = useMemo(() => {
     if (!selectedSuiteId) {
@@ -313,8 +312,10 @@ function EvalsTabContent({
   ]);
 
   // No standalone suites list: landing on /evals jumps straight into the most
-  // recent suite's dashboard (suites are switched via the breadcrumb dropdown).
-  // Only the empty-state (no suites) keeps the bare list route.
+  // recently RUN suite's dashboard (suites are switched via the breadcrumb
+  // dropdown). Never-run suites all tie, so a project with no runs falls back
+  // to the sortedSuites recency order. Only the empty-state (no suites) keeps
+  // the bare list route.
   useEffect(() => {
     if (route.type !== "list") {
       return;
@@ -322,7 +323,7 @@ function EvalsTabContent({
     if (overviewQueries.isOverviewLoading) {
       return;
     }
-    const mostRecent = visibleSuites[0];
+    const mostRecent = sortSuiteOverviewEntries(visibleSuites, "recently_run")[0];
     if (mostRecent) {
       navigatePlaygroundEvalsRoute(
         { type: "suite-overview", suiteId: mostRecent.suite._id },

--- a/mcpjam-inspector/client/src/components/__tests__/EvalsTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/EvalsTab.test.tsx
@@ -189,7 +189,14 @@ vi.mock("../evals/use-eval-queries", () => ({
 
 import { EvalsTab } from "../EvalsTab";
 
-function makeSuiteEntry(serverNames: string[], suiteId: string) {
+function makeSuiteEntry(
+  serverNames: string[],
+  suiteId: string,
+  overrides?: {
+    source?: "ui" | "sdk";
+    latestRun?: { _id: string; completedAt: number } | null;
+  },
+) {
   return {
     suite: {
       _id: suiteId,
@@ -200,10 +207,10 @@ function makeSuiteEntry(serverNames: string[], suiteId: string) {
       environment: { servers: serverNames },
       createdAt: 1,
       updatedAt: 1,
-      source: "ui" as const,
+      source: overrides?.source ?? ("ui" as const),
       tags: ["explore"],
     },
-    latestRun: null,
+    latestRun: overrides?.latestRun ?? null,
     recentRuns: [],
     passRateTrend: [],
     totals: { passed: 0, failed: 0, runs: 0 },
@@ -289,6 +296,59 @@ describe("EvalsTab", () => {
       );
     });
     expect(screen.queryByTestId("suite-sidebar")).toBeNull();
+  });
+
+  it("redirects the bare eval list route into the most recently run suite", async () => {
+    mocks.route.current = { type: "list" };
+    mocks.useEvalQueries.mockImplementation(() => {
+      const suiteA = makeSuiteEntry(["server-a"], "suite-a");
+      const suiteB = makeSuiteEntry(["server-b"], "suite-b", {
+        latestRun: { _id: "run-b", completedAt: 500 },
+      });
+      const state = makeQueryState(null);
+      return { ...state, sortedSuites: [suiteA, suiteB] };
+    });
+
+    render(<EvalsTab projectId="ws-1" />);
+
+    await waitFor(() => {
+      expect(mocks.navigatePlaygroundEvalsRoute).toHaveBeenCalledWith(
+        { type: "suite-overview", suiteId: "suite-b" },
+        { replace: true }
+      );
+    });
+  });
+
+  it("renders sdk-created suites instead of redirecting them away", () => {
+    mocks.route.current = { type: "suite-overview", suiteId: "suite-sdk" };
+    mocks.useEvalQueries.mockImplementation(
+      ({ selectedSuiteId }: { selectedSuiteId: string | null }) => {
+        const sdkEntry = makeSuiteEntry(["server-a"], "suite-sdk", {
+          source: "sdk",
+        });
+        const state = makeQueryState(selectedSuiteId);
+        return {
+          ...state,
+          sortedSuites: [sdkEntry],
+          selectedSuiteEntry: selectedSuiteId === "suite-sdk" ? sdkEntry : null,
+          selectedSuite:
+            selectedSuiteId === "suite-sdk" ? sdkEntry.suite : null,
+          suiteDetails:
+            selectedSuiteId === "suite-sdk"
+              ? { testCases: [], iterations: [] }
+              : undefined,
+          suiteRuns: selectedSuiteId === "suite-sdk" ? [] : undefined,
+        };
+      }
+    );
+
+    render(<EvalsTab projectId="ws-1" />);
+
+    expect(mocks.navigatePlaygroundEvalsRoute).not.toHaveBeenCalled();
+    expect(mocks.suiteIterationsView).toHaveBeenCalled();
+    expect(mocks.suiteIterationsView.mock.calls.at(-1)?.[0]).toMatchObject({
+      suite: expect.objectContaining({ _id: "suite-sdk", source: "sdk" }),
+    });
   });
 
   it("switches suites from the breadcrumb dropdown", async () => {

--- a/mcpjam-inspector/client/src/components/evals/__tests__/evals-suite-list-sidebar.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/evals-suite-list-sidebar.test.tsx
@@ -319,7 +319,7 @@ describe("EvalsSuiteListSidebar", () => {
 
     const row = screen.getByTestId("suite-row-s1");
     expect(within(row).getByText("4/10")).toBeInTheDocument();
-    expect(within(row).getByText("SDK")).toBeInTheDocument();
+    expect(within(row).getByText("CI")).toBeInTheDocument();
   });
 
   it("filters suites with failures-only toggle", async () => {

--- a/mcpjam-inspector/client/src/components/evals/__tests__/suite-switcher.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/suite-switcher.test.tsx
@@ -3,7 +3,11 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { SuiteSwitcher } from "../suite-switcher";
 
-function makeEntry(suiteId: string, name: string) {
+function makeEntry(
+  suiteId: string,
+  name: string,
+  source: "ui" | "sdk" = "ui",
+) {
   return {
     suite: {
       _id: suiteId,
@@ -14,7 +18,7 @@ function makeEntry(suiteId: string, name: string) {
       environment: { servers: ["server-a"] },
       createdAt: 1,
       updatedAt: 1,
-      source: "ui" as const,
+      source,
       tags: [],
     },
     latestRun: null,
@@ -67,5 +71,36 @@ describe("SuiteSwitcher", () => {
     await user.click(screen.getByRole("button", { name: /other/ }));
 
     expect(onSelectSuite).toHaveBeenCalledWith("suite-b");
+  });
+
+  it("badges CI-created suites and hides their delete action", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <SuiteSwitcher
+        suites={[
+          makeEntry("suite-a", "amazon"),
+          makeEntry("suite-ci", "nightly", "sdk"),
+        ]}
+        currentSuiteId="suite-a"
+        onSelectSuite={vi.fn()}
+        onCreateSuite={vi.fn()}
+        onDeleteSuite={vi.fn()}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", {
+        name: /Switch suite \(current: amazon\)/,
+      }),
+    );
+
+    expect(screen.getByText("CI")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Delete suite amazon" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Delete suite nightly" }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/components/evals/suite-overview-presentation.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-overview-presentation.tsx
@@ -218,8 +218,9 @@ export function SuiteSourceBadge({ source }: { source?: "ui" | "sdk" }) {
     <Badge
       variant="outline"
       className="shrink-0 px-1.5 py-0 text-[10px] font-normal uppercase tracking-wide"
+      title="Created via the MCPJam SDK"
     >
-      SDK
+      CI
     </Badge>
   );
 }

--- a/mcpjam-inspector/client/src/components/evals/suite-switcher.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-switcher.tsx
@@ -12,6 +12,7 @@ import {
   formatOverviewRelativeTime,
   getSuitePassFailCounts,
   stripTimestampSuffix,
+  SuiteSourceBadge,
 } from "./suite-overview-presentation";
 
 interface SuiteSwitcherProps {
@@ -126,8 +127,11 @@ export function SuiteSwitcher({
                       {name.slice(0, 1)}
                     </span>
                     <span className="min-w-0 flex-1">
-                      <span className="block truncate text-[13px] font-medium text-foreground">
-                        {name}
+                      <span className="flex min-w-0 items-center gap-1.5">
+                        <span className="truncate text-[13px] font-medium text-foreground">
+                          {name}
+                        </span>
+                        <SuiteSourceBadge source={entry.suite.source} />
                       </span>
                       <span className="block truncate text-[11px] text-muted-foreground">
                         {entry.latestRun
@@ -156,7 +160,10 @@ export function SuiteSwitcher({
                   {isActive ? (
                     <Check className="h-4 w-4 shrink-0 text-primary" />
                   ) : null}
-                  {onDeleteSuite ? (
+                  {/* CI-created suites can't be deleted from the switcher:
+                      their history is CI's record, and the next report would
+                      recreate the suite anyway. */}
+                  {onDeleteSuite && entry.suite.source !== "sdk" ? (
                     <button
                       type="button"
                       onClick={(e) => {


### PR DESCRIPTION
## Why

SDK/CI-created eval suites have been invisible in the product since the March UI split (#1652): `EvalsTab` filtered out `source === "sdk"` suites, and the CI surface meant to show them (`/ci-evals`) is gated behind the `evaluate-ci` flag, which is off for everyone. Customers returning to their CI eval history found what looked like wiped data (the Asana incident on 2026-07-08 — all 190+ suites were intact on prod, just unreachable).

This is PR 1 of the "one dataset, two lenses" plan: Evaluate shows everything; the CI tab becomes a commit-grouped lens later (backend PR for immutable `suite.source` + `lastSdkRunAt`, then CI-tab scoping, then flag flip).

## What

- **Evaluate lists all suites regardless of origin.** The `visibleSuites` filter is gone; SDK-created suites get a **CI** badge in the suite switcher (`SuiteSourceBadge`, "SDK" kept in the tooltip).
- **`/evals` landing picks the most recently *run* suite** (reuses `sortSuiteOverviewEntries(…, "recently_run")`), so landing on a freshly created run-less suite no longer reads as empty history. Never-run suites tie and fall back to the existing recency order.
- **Deletion disabled in the switcher for CI-created suites** — their history is CI's record and the next report would recreate the suite; one-click erasure is too sharp right after a data-loss scare.
- CI runs already interleave in suite run history (the runs query never filtered by source and the CI metadata column exists) — they were just unreachable.

## Notes for review

- SDK suites become editable/runnable in Evaluate. Server authz is unchanged; rerun without attached servers degrades to the existing "attach a host" toast.
- `suite_viewed` analytics now fire for sdk suites under `location: "evals_tab"`.
- Chat→test-case destination pickers still exclude sdk suites (deliberate; revisit with the case-provenance work).

## Testing

- `npm run typecheck:client` clean.
- Full client vitest project: 518 files / 4,961 tests green.
- New tests: sdk suite renders instead of redirecting away; bare `/evals` redirects to the most recently run suite (and keeps the stable fallback when nothing has run); switcher badges CI suites and hides their delete action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior change affects default navigation and exposes CI suites to edit/run in Evaluate; deletion is only restricted in the switcher, not globally.
> 
> **Overview**
> **Evaluate now surfaces SDK/CI suites** that were previously dropped by a `source === "sdk"` filter on `visibleSuites`, so CI history is reachable again without the gated CI tab.
> 
> Bare **`/evals` landing** picks the suite with the **most recent completed run** via `sortSuiteOverviewEntries(…, "recently_run")` instead of the first entry in the default list order (never-run suites still fall back to existing recency).
> 
> **CI provenance in the UI:** `SuiteSourceBadge` label changes from **SDK** to **CI** (tooltip still mentions the MCPJam SDK). The suite switcher shows that badge and **omits delete** for `source === "sdk"` suites; sidebar tests expect **CI** on sdk rows.
> 
> Tests cover sdk suite rendering (no redirect away), recently-run landing redirect, and switcher badge/delete behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae257dca14eefa6a06a41378822c34278996d3f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show SDK/CI-created eval suites in the Evaluate tab so CI history is visible again. Landing on `/evals` now opens the most recently run suite; CI suites are badged and protected from deletion in the switcher.

- **Bug Fixes**
  - Evaluate lists all suites (UI and SDK/CI); no source filter.
  - Suite switcher shows a CI badge for SDK-created suites (tooltip: created via SDK).
  - Disable delete action for CI suites in the switcher.
  - `/evals` redirects to the most recently run suite (not the newest).

<sup>Written for commit ae257dca14eefa6a06a41378822c34278996d3f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3075?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

