### PR TITLE
refactor(evals): extract shared pinned-turn accounting + SSE synthesis

### DIFF
--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -106,6 +106,7 @@ import type {
   LocalEvalTurnSinks,
 } from "./evals/drive-local-eval-turn.js";
 import { sanitizeForConvexTransport } from "./evals/convex-sanitize.js";
+import { emitPinnedTurnSse } from "./evals/pinned-turn-sse.js";
 import {
   finalizeEvalIteration,
   buildIterationFinishParams,
@@ -2608,65 +2609,11 @@ const runLocalIteration = async ({
               status: "ok",
             });
           },
-          onPinnedTurn: ({
-            prompt: pinnedPrompt,
-            messages,
-            spans,
-            usage,
-            toolCall,
-            toolCallId,
-            toolResult,
-            toolResultIsError,
-            toolError,
-            iterationError: pinnedErr,
-          }) => {
-            const failureDetail =
-              pinnedErr ??
-              toolError?.message ??
-              (toolResultIsError ? "Pinned tool call failed" : undefined);
-            emit({ type: "turn_start", turnIndex, prompt: pinnedPrompt });
-            emit({
-              type: "step_status",
-              turnIndex,
-              kind: "toolCall",
-              status: "running",
-            });
-            if (toolCall && toolCallId) {
-              emit({
-                type: "tool_call",
-                toolName: toolCall.toolName,
-                toolCallId,
-                args: toolCall.arguments,
-              });
-              emit({
-                type: "tool_result",
-                toolCallId,
-                result: toolResult,
-                ...(toolResultIsError ? { isError: true } : {}),
-              });
-            }
-            emit(
-              buildTraceSnapshotEvent({
-                turnIndex,
-                snapshotKind: failureDetail ? "failure" : "turn_finish",
-                messages: withSystemPrefix(messages),
-                spans,
-                actualToolCalls: toolCall ? [toolCall] : [],
-                usage,
-              })
-            );
-            emit({ type: "turn_finish", turnIndex });
-            emit({
-              type: "step_status",
-              turnIndex,
-              kind: "toolCall",
-              status: failureDetail ? "fail" : "ok",
-              ...(failureDetail ? { detail: failureDetail } : {}),
-            });
-            if (failureDetail) {
-              emit({ type: "error", message: failureDetail });
-            }
-          },
+          onPinnedTurn: (ctx) =>
+            emitPinnedTurnSse(
+              { emit, withSystemPrefix, buildTraceSnapshotEvent },
+              { turnIndex, ...ctx }
+            ),
         })
       : undefined;
 

--- a/mcpjam-inspector/server/services/evals/__tests__/pinned-turn-sse.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/pinned-turn-sse.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import {
+  emitPinnedTurnSse,
+  type PinnedTurnSseDeps,
+  type PinnedTurnSsePayload,
+} from "../pinned-turn-sse";
+import type { EvalStreamEvent } from "@/shared/eval-stream-events";
+
+function makeDeps() {
+  const events: EvalStreamEvent[] = [];
+  const deps: PinnedTurnSseDeps = {
+    emit: (event) => events.push(event),
+    withSystemPrefix: (msgs) => msgs,
+    buildTraceSnapshotEvent: ({ turnIndex, snapshotKind, actualToolCalls }) =>
+      ({
+        type: "trace_snapshot",
+        turnIndex,
+        snapshotKind,
+        actualToolCalls,
+      }) as unknown as EvalStreamEvent,
+  };
+  return { events, deps };
+}
+
+const basePayload: PinnedTurnSsePayload = {
+  turnIndex: 2,
+  prompt: 'Pinned tool call: show_map on "Weather"',
+  messages: [{ role: "user", content: "hi" }],
+  spans: [],
+  usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+};
+
+describe("emitPinnedTurnSse", () => {
+  it("emits the full success sequence with tool events", () => {
+    const { events, deps } = makeDeps();
+    emitPinnedTurnSse(deps, {
+      ...basePayload,
+      toolCall: { toolName: "show_map", arguments: { city: "SF" } },
+      toolCallId: "pinned-2-1",
+      toolResult: { content: [] },
+    });
+    expect(events.map((e) => (e as { type: string }).type)).toEqual([
+      "turn_start",
+      "step_status",
+      "tool_call",
+      "tool_result",
+      "trace_snapshot",
+      "turn_finish",
+      "step_status",
+    ]);
+    expect(events[0]).toMatchObject({
+      turnIndex: 2,
+      prompt: basePayload.prompt,
+    });
+    expect(events[1]).toMatchObject({ kind: "toolCall", status: "running" });
+    expect(events[2]).toMatchObject({
+      toolName: "show_map",
+      toolCallId: "pinned-2-1",
+      args: { city: "SF" },
+    });
+    expect(events[3]).toMatchObject({ toolCallId: "pinned-2-1" });
+    expect(events[3]).not.toHaveProperty("isError");
+    expect(events[4]).toMatchObject({ snapshotKind: "turn_finish" });
+    expect(events[6]).toMatchObject({ kind: "toolCall", status: "ok" });
+  });
+
+  it("emits failure snapshot + error for a tool error", () => {
+    const { events, deps } = makeDeps();
+    emitPinnedTurnSse(deps, {
+      ...basePayload,
+      toolCall: { toolName: "show_map", arguments: {} },
+      toolCallId: "pinned-2-1",
+      toolResult: { error: "boom", kind: "content-error" },
+      toolResultIsError: true,
+      toolError: {
+        toolName: "show_map",
+        kind: "content-error",
+        message: "boom",
+      },
+    });
+    expect(events.map((e) => (e as { type: string }).type)).toEqual([
+      "turn_start",
+      "step_status",
+      "tool_call",
+      "tool_result",
+      "trace_snapshot",
+      "turn_finish",
+      "step_status",
+      "error",
+    ]);
+    expect(events[3]).toMatchObject({ isError: true });
+    expect(events[4]).toMatchObject({ snapshotKind: "failure" });
+    expect(events[6]).toMatchObject({ status: "fail", detail: "boom" });
+    expect(events[7]).toMatchObject({ message: "boom" });
+  });
+
+  it("omits tool events entirely for a not-connected setup failure", () => {
+    const { events, deps } = makeDeps();
+    emitPinnedTurnSse(deps, {
+      ...basePayload,
+      iterationError: 'pinned_server_not_connected: "Weather" is not connected',
+    });
+    expect(events.map((e) => (e as { type: string }).type)).toEqual([
+      "turn_start",
+      "step_status",
+      "trace_snapshot",
+      "turn_finish",
+      "step_status",
+      "error",
+    ]);
+    expect(events[2]).toMatchObject({
+      snapshotKind: "failure",
+      actualToolCalls: [],
+    });
+    expect(events[4]).toMatchObject({ status: "fail" });
+  });
+});

--- a/mcpjam-inspector/server/services/evals/__tests__/pinned-turn.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/pinned-turn.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import { runPinnedTurn } from "../pinned-turn";
+import {
+  buildPinnedTurnAccounting,
+  runPinnedTurn,
+  type PinnedTurnResult,
+} from "../pinned-turn";
 import { evaluateMultiTurnResults } from "../types";
 import { legacyProbeToPinnedTurn } from "@/shared/steps";
 import type { ProbeConfig } from "@/shared/probe-config";
@@ -84,6 +88,85 @@ describe("runPinnedTurn", () => {
     expect(executeTool).not.toHaveBeenCalled();
     expect(result.toolCall).toBeNull();
     expect(result.iterationError).toContain("not connected");
+  });
+});
+
+describe("buildPinnedTurnAccounting", () => {
+  const successResult: PinnedTurnResult = {
+    toolCall: { toolName: "show_map", arguments: { city: "SF" } },
+    toolCallId: "pinned-0-123",
+    toolResult: { content: [] },
+    summary: "Pinned tool call show_map executed",
+  };
+
+  it("derives the message pair and tool call on success", () => {
+    const accounting = buildPinnedTurnAccounting(probe, successResult);
+    expect(accounting.prompt).toBe('Pinned tool call: show_map on "Weather"');
+    expect(accounting.userMessage).toEqual({
+      role: "user",
+      content: 'Pinned tool call: show_map on "Weather"',
+    });
+    expect(accounting.assistantMessage).toEqual({
+      role: "assistant",
+      content: "Pinned tool call show_map executed",
+    });
+    expect(accounting.summary).toBe("Pinned tool call show_map executed");
+    expect(accounting.toolCalls).toEqual([
+      { toolName: "show_map", arguments: { city: "SF" } },
+    ]);
+    expect(accounting.toolErrors).toEqual([]);
+    expect(accounting.iterationError).toBeUndefined();
+    expect(accounting.setupFailure).toBe(false);
+  });
+
+  it("carries a content-error as a toolError without setup failure", () => {
+    const accounting = buildPinnedTurnAccounting(probe, {
+      ...successResult,
+      toolResultIsError: true,
+      toolError: {
+        toolName: "show_map",
+        kind: "content-error",
+        message: "boom",
+      },
+      summary: "Pinned tool call show_map failed: boom",
+    });
+    expect(accounting.toolErrors).toEqual([
+      { toolName: "show_map", kind: "content-error", message: "boom" },
+    ]);
+    expect(accounting.toolCalls).toHaveLength(1);
+    expect(accounting.iterationError).toBeUndefined();
+    expect(accounting.setupFailure).toBe(false);
+  });
+
+  it("carries a protocol-error as a toolError without setup failure", () => {
+    const accounting = buildPinnedTurnAccounting(probe, {
+      ...successResult,
+      toolResultIsError: true,
+      toolError: {
+        toolName: "show_map",
+        kind: "protocol-error",
+        message: "transport down",
+      },
+      summary: "Pinned tool call show_map failed: transport down",
+    });
+    expect(accounting.toolErrors[0]?.kind).toBe("protocol-error");
+    expect(accounting.setupFailure).toBe(false);
+  });
+
+  it("maps not-connected to iterationError + setupFailure and no phantom call", () => {
+    const accounting = buildPinnedTurnAccounting(probe, {
+      toolCall: null,
+      iterationError:
+        'pinned_server_not_connected: "Weather" is not connected in this run\'s environment',
+      summary: 'Pinned tool call skipped: server "Weather" not connected',
+    });
+    expect(accounting.toolCalls).toEqual([]);
+    expect(accounting.toolErrors).toEqual([]);
+    expect(accounting.iterationError).toContain("not connected");
+    expect(accounting.setupFailure).toBe(true);
+    // The transcript pair is still produced (transcript honesty on failure).
+    expect(accounting.userMessage.role).toBe("user");
+    expect(accounting.assistantMessage.content).toContain("skipped");
   });
 });
 

--- a/mcpjam-inspector/server/services/evals/drive-local-eval-turn.ts
+++ b/mcpjam-inspector/server/services/evals/drive-local-eval-turn.ts
@@ -17,7 +17,8 @@ import {
 } from "../../utils/direct-chat-turn.js";
 import type { createLlmModel } from "../../utils/chat-helpers.js";
 import type { PrepareChatV2Result } from "../../utils/chat-v2-orchestration.js";
-import { runPinnedTurn } from "./pinned-turn.js";
+import { buildPinnedTurnAccounting, runPinnedTurn } from "./pinned-turn.js";
+import type { PinnedTurnSsePayload } from "./pinned-turn-sse.js";
 import { EVAL_WIDGET_MODEL_CONTEXT } from "../../config.js";
 import { withWidgetContextSystemPrompt } from "./widget-interaction-context.js";
 import {
@@ -85,23 +86,14 @@ export type LocalEvalTurnSinks = {
   /**
    * PR5 — a model-free pinned (`toolCall`) turn ran. There is no model stream
    * to translate, so the streaming runner synthesizes the SSE sequence from
-   * this. `messages` is the persisted shape (user "Pinned tool call …" +
-   * assistant summary) so the live trace matches the finalized iteration.
-   * `iterationError` set ⇒ the pinned call failed before an MCP call ran
-   * (server not connected, etc.).
+   * this (via `emitPinnedTurnSse`). `messages` is the persisted shape (user
+   * "Pinned tool call …" + assistant summary) so the live trace matches the
+   * finalized iteration. `iterationError` set ⇒ the pinned call failed before
+   * an MCP call ran (server not connected, etc.). Typed as the shared SSE
+   * payload (minus the runner-owned `turnIndex`) so the sink and the emitter
+   * cannot drift.
    */
-  onPinnedTurn?: (ctx: {
-    prompt: string;
-    messages: ModelMessage[];
-    spans: EvalTraceSpan[];
-    usage: UsageTotals;
-    toolCall?: ToolCall;
-    toolCallId?: string;
-    toolResult?: unknown;
-    toolResultIsError?: boolean;
-    toolError?: ToolErrorRecord;
-    iterationError?: string;
-  }) => void;
+  onPinnedTurn?: (ctx: Omit<PinnedTurnSsePayload, "turnIndex">) => void;
 };
 
 export type DriveLocalEvalTurnParams = {
@@ -214,32 +206,25 @@ export async function driveLocalEvalTurn(
       browser,
       promptIndex,
     });
-    acc.conversationMessages.push({
-      role: "user",
-      content: `Pinned tool call: ${pinned.toolName} on "${pinned.serverName}"`,
-    });
-    acc.conversationMessages.push({
-      role: "assistant",
-      content: pinnedResult.summary,
-    });
+    const accounting = buildPinnedTurnAccounting(pinned, pinnedResult);
+    acc.conversationMessages.push(
+      accounting.userMessage,
+      accounting.assistantMessage
+    );
     appendToolCallsForPrompt(
       acc.toolsCalledByPrompt,
       promptIndex,
-      pinnedResult.toolCall ? [pinnedResult.toolCall] : []
+      accounting.toolCalls
     );
-    acc.assistantMessageByPrompt[promptIndex] = pinnedResult.summary;
-    acc.toolErrorsByPrompt[promptIndex] = pinnedResult.toolError
-      ? [pinnedResult.toolError]
-      : [];
-    if (pinnedResult.toolError) {
-      acc.pinnedToolErrors.push(pinnedResult.toolError);
-    }
-    if (pinnedResult.iterationError && !acc.iterationError) {
-      acc.iterationError = pinnedResult.iterationError;
+    acc.assistantMessageByPrompt[promptIndex] = accounting.summary;
+    acc.toolErrorsByPrompt[promptIndex] = accounting.toolErrors;
+    acc.pinnedToolErrors.push(...accounting.toolErrors);
+    if (accounting.iterationError && !acc.iterationError) {
+      acc.iterationError = accounting.iterationError;
       acc.pinnedSetupFailure = true;
     }
     sinks?.onPinnedTurn?.({
-      prompt: `Pinned tool call: ${pinned.toolName} on "${pinned.serverName}"`,
+      prompt: accounting.prompt,
       messages: acc.conversationMessages,
       spans: acc.capturedSpans,
       usage: acc.accumulatedUsage,

--- a/mcpjam-inspector/server/services/evals/pinned-turn-sse.ts
+++ b/mcpjam-inspector/server/services/evals/pinned-turn-sse.ts
@@ -1,0 +1,118 @@
+/**
+ * pinned-turn-sse.ts — synthesize the live SSE sequence for a model-free
+ * pinned (`toolCall`) turn. A pinned turn has no model stream to translate,
+ * so the streaming runners emit this fixed sequence instead:
+ *
+ *   turn_start → step_status(toolCall, running) → tool_call → tool_result →
+ *   trace_snapshot(failure|turn_finish) → turn_finish →
+ *   step_status(toolCall, ok|fail[, detail]) → error?
+ *
+ * This module owns `PinnedTurnSsePayload`; the local and hosted streaming
+ * paths both call `emitPinnedTurnSse`, so the event ordering cannot drift
+ * between them.
+ */
+
+import type { ModelMessage } from "ai";
+import type { EvalTraceSpan } from "@/shared/eval-trace";
+import type { ToolCall, ToolErrorRecord } from "@/shared/eval-matching";
+import type { EvalStreamEvent } from "@/shared/eval-stream-events";
+import type { UsageTotals } from "./types";
+
+export interface PinnedTurnSseDeps {
+  emit: (event: EvalStreamEvent) => void;
+  withSystemPrefix: (msgs: ModelMessage[]) => ModelMessage[];
+  /** The runner's local `buildTraceSnapshotEvent` (unexported → passed in to
+   *  avoid a cycle, same pattern as `HostedEvalSinksDeps`). */
+  buildTraceSnapshotEvent: (params: {
+    turnIndex: number;
+    stepIndex?: number;
+    snapshotKind: "step_finish" | "failure" | "turn_finish";
+    messages: ModelMessage[];
+    spans: EvalTraceSpan[];
+    usage: UsageTotals;
+    actualToolCalls: ToolCall[];
+  }) => EvalStreamEvent;
+}
+
+export interface PinnedTurnSsePayload {
+  turnIndex: number;
+  /** The synthesized user line (`PinnedTurnAccounting.prompt`). */
+  prompt: string;
+  /** Iteration-cumulative transcript including the pinned message pair. */
+  messages: ModelMessage[];
+  spans: EvalTraceSpan[];
+  usage: UsageTotals;
+  toolCall?: ToolCall;
+  toolCallId?: string;
+  toolResult?: unknown;
+  toolResultIsError?: boolean;
+  toolError?: ToolErrorRecord;
+  /** Set ⇒ the pinned call failed before an MCP call ran (server not connected). */
+  iterationError?: string;
+}
+
+export function emitPinnedTurnSse(
+  deps: PinnedTurnSseDeps,
+  payload: PinnedTurnSsePayload
+): void {
+  const { emit, withSystemPrefix, buildTraceSnapshotEvent } = deps;
+  const {
+    turnIndex,
+    prompt,
+    messages,
+    spans,
+    usage,
+    toolCall,
+    toolCallId,
+    toolResult,
+    toolResultIsError,
+    toolError,
+    iterationError,
+  } = payload;
+  const failureDetail =
+    iterationError ??
+    toolError?.message ??
+    (toolResultIsError ? "Pinned tool call failed" : undefined);
+  emit({ type: "turn_start", turnIndex, prompt });
+  emit({
+    type: "step_status",
+    turnIndex,
+    kind: "toolCall",
+    status: "running",
+  });
+  if (toolCall && toolCallId) {
+    emit({
+      type: "tool_call",
+      toolName: toolCall.toolName,
+      toolCallId,
+      args: toolCall.arguments,
+    });
+    emit({
+      type: "tool_result",
+      toolCallId,
+      result: toolResult,
+      ...(toolResultIsError ? { isError: true } : {}),
+    });
+  }
+  emit(
+    buildTraceSnapshotEvent({
+      turnIndex,
+      snapshotKind: failureDetail ? "failure" : "turn_finish",
+      messages: withSystemPrefix(messages),
+      spans,
+      actualToolCalls: toolCall ? [toolCall] : [],
+      usage,
+    })
+  );
+  emit({ type: "turn_finish", turnIndex });
+  emit({
+    type: "step_status",
+    turnIndex,
+    kind: "toolCall",
+    status: failureDetail ? "fail" : "ok",
+    ...(failureDetail ? { detail: failureDetail } : {}),
+  });
+  if (failureDetail) {
+    emit({ type: "error", message: failureDetail });
+  }
+}

--- a/mcpjam-inspector/server/services/evals/pinned-turn.ts
+++ b/mcpjam-inspector/server/services/evals/pinned-turn.ts
@@ -13,6 +13,7 @@
  * transcript and verdict exactly as it does for model turns.
  */
 
+import type { ModelMessage } from "ai";
 import type { MCPClientManager } from "@mcpjam/sdk";
 import type { ToolCall, ToolErrorRecord } from "@/shared/eval-matching";
 import type { PinnedToolCall } from "@/shared/steps";
@@ -71,6 +72,51 @@ export interface PinnedTurnResult {
   iterationError?: string;
   /** Human-readable one-line outcome for the synthesized assistant message. */
   summary: string;
+}
+
+/**
+ * Everything a pinned turn contributes to an iteration, derived once from the
+ * pinned spec + `runPinnedTurn`'s result. Engine-agnostic: the local and
+ * hosted step handlers apply the same accounting to their own acc shapes
+ * (local's rich acc vs hosted's narrow one), so the semantics — message
+ * shapes, phantom-call suppression, error classification — live here and
+ * cannot drift between paths.
+ */
+export interface PinnedTurnAccounting {
+  /** The synthesized user line, `Pinned tool call: <tool> on "<server>"`.
+   *  Doubles as the SSE `turn_start` prompt. */
+  prompt: string;
+  userMessage: ModelMessage;
+  /** Assistant message carrying the one-line outcome summary. Plain TEXT by
+   *  contract: hosted injects this pair into the `/stream` input history,
+   *  which only round-trips untouched for text-only messages. */
+  assistantMessage: ModelMessage;
+  summary: string;
+  /** [] when no MCP call happened (not-connected / no tool selected). */
+  toolCalls: ToolCall[];
+  toolErrors: ToolErrorRecord[];
+  /** Set ⇒ fatal setup failure (server not connected). */
+  iterationError?: string;
+  setupFailure: boolean;
+}
+
+export function buildPinnedTurnAccounting(
+  pinned: PinnedToolCall,
+  result: PinnedTurnResult
+): PinnedTurnAccounting {
+  const prompt = `Pinned tool call: ${pinned.toolName} on "${pinned.serverName}"`;
+  return {
+    prompt,
+    userMessage: { role: "user", content: prompt },
+    assistantMessage: { role: "assistant", content: result.summary },
+    summary: result.summary,
+    toolCalls: result.toolCall ? [result.toolCall] : [],
+    toolErrors: result.toolError ? [result.toolError] : [],
+    ...(result.iterationError
+      ? { iterationError: result.iterationError }
+      : {}),
+    setupFailure: result.iterationError !== undefined,
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary
Pure extraction refactor — **no behavior change** (all 23 pre-existing runner-parity goldens byte-identical, verified by running the suite without `-u`). Groundwork for hosted-model pinned tool-call turns (stacked PR follows).

- **`buildPinnedTurnAccounting`** (in `pinned-turn.ts`): derives everything a pinned turn contributes to an iteration — the synthesized user/assistant text pair, tool calls/errors, setup-failure classification — so the local and (upcoming) hosted step handlers share one source of semantics instead of copy-pasting the accounting.
- **New `pinned-turn-sse.ts`**: owns `emitPinnedTurnSse` + `PinnedTurnSsePayload`. The local streaming runner's inline ~60-line pinned SSE synthesis in `evals-runner.ts` now calls it. `buildTraceSnapshotEvent` is passed in as a dep (same pattern as `HostedEvalSinksDeps`) to avoid a module cycle.
- `drive-local-eval-turn.ts`'s pinned branch applies the shared accounting; its `onPinnedTurn` sink is now typed as `Omit<PinnedTurnSsePayload, "turnIndex">` so the sink and emitter cannot drift.
- New exports live only in `pinned-turn.ts` / `pinned-turn-sse.ts` — deliberately NOT in `drive-local-eval-turn.ts` or `assistant-turn.ts`, whose non-spread `vi.mock` factories would silently drop new exports.

## Tests
- `buildPinnedTurnAccounting` unit cases (success / content-error / protocol-error / not-connected) in `pinned-turn.test.ts`.
- New `pinned-turn-sse.test.ts` asserting the exact event sequence for success, tool-error, and setup-failure payloads.
- Full `server/services/evals/__tests__` suite green (292 tests); runner-parity goldens unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor with dedicated tests and claimed runner-parity golden stability; no new runtime paths beyond moving existing eval streaming logic.
> 
> **Overview**
> Pure extraction refactor for model-free **pinned tool-call** eval turns, intended to keep local and upcoming hosted streaming paths aligned without changing behavior.
> 
> **`buildPinnedTurnAccounting`** in `pinned-turn.ts` now derives the synthesized user/assistant transcript, tool calls/errors, and setup-failure classification from `runPinnedTurn` output. `drive-local-eval-turn.ts` uses it instead of inline message and acc updates.
> 
> **New `pinned-turn-sse.ts`** owns `emitPinnedTurnSse` and `PinnedTurnSsePayload`. The local streaming runner’s large inline `onPinnedTurn` handler in `evals-runner.ts` delegates to this helper; `onPinnedTurn` is typed as `Omit<PinnedTurnSsePayload, "turnIndex">` so sinks and the emitter share one contract.
> 
> Unit tests cover accounting (success, tool errors, not-connected) and the exact SSE event sequences for success, tool failure, and setup failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e50540f509dafc574818436830f441fc2cfe461c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted shared pinned-turn accounting and SSE synthesis so local and future hosted runners use the same logic. No behavior change; runner-parity goldens unchanged.

- **Refactors**
  - Added `buildPinnedTurnAccounting` in `pinned-turn.ts` to derive prompt, transcript messages, tool calls/errors, and setup-failure once.
  - Introduced `emitPinnedTurnSse` and `PinnedTurnSsePayload` in `pinned-turn-sse.ts`; replaced inline SSE logic in `evals-runner.ts`.
  - Updated `drive-local-eval-turn.ts` to use the shared accounting and typed `onPinnedTurn` as `Omit<PinnedTurnSsePayload, "turnIndex">`.
  - Passed `buildTraceSnapshotEvent` as a dep to avoid a module cycle.

<sup>Written for commit e50540f509dafc574818436830f441fc2cfe461c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3076?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

