### PR TITLE
feat(evals): support pinned tool-call turns with hosted models

### DIFF
--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -106,6 +106,7 @@ import type {
   LocalEvalTurnSinks,
 } from "./evals/drive-local-eval-turn.js";
 import { sanitizeForConvexTransport } from "./evals/convex-sanitize.js";
+import { emitPinnedTurnSse } from "./evals/pinned-turn-sse.js";
 import {
   finalizeEvalIteration,
   buildIterationFinishParams,
@@ -2608,65 +2609,11 @@ const runLocalIteration = async ({
               status: "ok",
             });
           },
-          onPinnedTurn: ({
-            prompt: pinnedPrompt,
-            messages,
-            spans,
-            usage,
-            toolCall,
-            toolCallId,
-            toolResult,
-            toolResultIsError,
-            toolError,
-            iterationError: pinnedErr,
-          }) => {
-            const failureDetail =
-              pinnedErr ??
-              toolError?.message ??
-              (toolResultIsError ? "Pinned tool call failed" : undefined);
-            emit({ type: "turn_start", turnIndex, prompt: pinnedPrompt });
-            emit({
-              type: "step_status",
-              turnIndex,
-              kind: "toolCall",
-              status: "running",
-            });
-            if (toolCall && toolCallId) {
-              emit({
-                type: "tool_call",
-                toolName: toolCall.toolName,
-                toolCallId,
-                args: toolCall.arguments,
-              });
-              emit({
-                type: "tool_result",
-                toolCallId,
-                result: toolResult,
-                ...(toolResultIsError ? { isError: true } : {}),
-              });
-            }
-            emit(
-              buildTraceSnapshotEvent({
-                turnIndex,
-                snapshotKind: failureDetail ? "failure" : "turn_finish",
-                messages: withSystemPrefix(messages),
-                spans,
-                actualToolCalls: toolCall ? [toolCall] : [],
-                usage,
-              })
-            );
-            emit({ type: "turn_finish", turnIndex });
-            emit({
-              type: "step_status",
-              turnIndex,
-              kind: "toolCall",
-              status: failureDetail ? "fail" : "ok",
-              ...(failureDetail ? { detail: failureDetail } : {}),
-            });
-            if (failureDetail) {
-              emit({ type: "error", message: failureDetail });
-            }
-          },
+          onPinnedTurn: (ctx) =>
+            emitPinnedTurnSse(
+              { emit, withSystemPrefix, buildTraceSnapshotEvent },
+              { turnIndex, ...ctx }
+            ),
         })
       : undefined;
 

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -106,7 +106,10 @@ import type {
   LocalEvalTurnSinks,
 } from "./evals/drive-local-eval-turn.js";
 import { sanitizeForConvexTransport } from "./evals/convex-sanitize.js";
-import { emitPinnedTurnSse } from "./evals/pinned-turn-sse.js";
+import {
+  emitPinnedTurnSse,
+  type PinnedTurnSsePayload,
+} from "./evals/pinned-turn-sse.js";
 import {
   finalizeEvalIteration,
   buildIterationFinishParams,
@@ -1221,10 +1224,21 @@ async function resolveOrgByokEvalRuntime(args: {
 const runHostedIteration = async (
   params: RunIterationBackendParams & { emit?: StreamEmit }
 ): Promise<EvalIterationOutcome> => {
+  // First pinned turn's per-call render-budget override (mirrors the local
+  // runner's harness creation).
+  const pinnedRenderTimeoutMs = resolveEvalTestCase(
+    params.test
+  ).promptTurns.find(
+    (t) =>
+      isPinnedTurn(t) && typeof t.pinnedToolCall?.renderTimeoutMs === "number"
+  )?.pinnedToolCall?.renderTimeoutMs;
   const browser = await createBrowserSessionContext({
     model: params.test.model,
     mcpClientManager: params.mcpClientManager,
     injectOpenAiCompat: params.injectOpenAiCompat,
+    ...(pinnedRenderTimeoutMs
+      ? { renderTimeoutMs: pinnedRenderTimeoutMs }
+      : {}),
   });
   try {
     return await runHostedIterationWithBrowser(params, browser);
@@ -1396,10 +1410,10 @@ const executeTestCase = async (params: {
   /** Raw suite hostConfig record. PR 4d — see RunIterationBaseParams. */
   suiteHostConfig?: Record<string, unknown> | null;
   /**
-   * Run environment snapshot (servers + serverBindings). Only consulted by
-   * the widget-probe fork below to resolve the probe's pinned server
-   * reference to a manager key; the LLM path receives its servers
-   * pre-resolved via `selectedServers`.
+   * Run environment snapshot (servers + serverBindings). Consulted to resolve
+   * pinned (`toolCall`) server references to a manager key — by the model-free
+   * fork below and by both iteration paths' step handlers; the LLM path
+   * receives its servers pre-resolved via `selectedServers`.
    */
   environment?: RunEvalSuiteOptions["config"]["environment"];
 }) => {
@@ -1525,16 +1539,6 @@ const executeTestCase = async (params: {
     return outcomes;
   }
 
-  // Hybrid (model turns + pinned turns) on a hosted model is not yet wired:
-  // the backend engine drives turns server-side and cannot interleave a
-  // locally-executed pinned turn. Local BYOK hybrids work (the pinned branch
-  // lives in runIterationWithAiSdk). Fail loudly rather than silently send a
-  // pinned turn's empty prompt to the model.
-  // Steps-aware: resolveEvalTestCase bridges `steps` → turns, so a `toolCall`
-  // step is correctly seen as a pinned turn here.
-  const caseHasPinnedTurn =
-    resolveEvalTestCase(normalizedTest).promptTurns.some(isPinnedTurn);
-
   const modelDefinition = buildModelDefinition(test);
   const resolvedModelId = getCanonicalModelId(
     String(modelDefinition.id),
@@ -1559,12 +1563,6 @@ const executeTestCase = async (params: {
   const jamBillingTarget = isJamModel
     ? resolveOrgTargetForEval(test, orgModelConfigTarget)
     : undefined;
-
-  if (caseHasPinnedTurn && (isJamModel || orgByokRuntime?.kind === "cloud")) {
-    throw new Error(
-      "Pinned tool-call turns are not yet supported with hosted models. Use a BYOK (local) model for cases that pin a tool call."
-    );
-  }
 
   const outcomes: EvalIterationOutcome[] = [];
 
@@ -3392,6 +3390,10 @@ const runHostedIterationWithBrowser = async (
   let hostedStepSkippedSteps: unknown[] = [];
   let hostedStepResults: unknown[] = [];
   let hostedStepScriptedFailures: { toolName: string; reason: string }[] = [];
+  // Pinned (`toolCall`) steps run model-free inspector-side; their tool
+  // failures accumulate here for the verdict's `failOnToolError` gate (the
+  // hosted analogue of `LocalEvalTurnAcc.pinnedToolErrors`).
+  const pinnedToolErrors: ToolErrorRecord[] = [];
   // Hosted unify: drive the iteration through executeSteps; the handlers wrap
   // driveHostedEvalTurn (which mutates the acc), so the post-loop verdict +
   // finishParams below consume `acc` + the executor's StepExecutionState.
@@ -3426,6 +3428,24 @@ const runHostedIterationWithBrowser = async (
       toolsCalledByPrompt,
     },
     buildSinks: hostedBuildSinks,
+    // Same closure shape the local step handlers use (see runLocalIteration).
+    resolvePinnedServerKey: (pinned) =>
+      resolvePinnedServerKey(
+        pinned,
+        environment,
+        selectedServers,
+        mcpClientManager
+      ),
+    pinnedToolErrors,
+    ...(emit
+      ? {
+          emitPinnedTurn: (payload: PinnedTurnSsePayload) =>
+            emitPinnedTurnSse(
+              { emit, withSystemPrefix, buildTraceSnapshotEvent },
+              payload
+            ),
+        }
+      : {}),
   });
   const stepState = createStepExecutionState();
   let result: Awaited<ReturnType<typeof executeSteps>>;
@@ -3460,6 +3480,9 @@ const runHostedIterationWithBrowser = async (
     iterationError = result.iterationError;
     iterationErrorDetails = result.iterationErrorDetails;
   }
+  // Pinned setup failure (server not connected) — drives status:"failed" below,
+  // mirroring the local runner.
+  const pinnedSetupFailure = result.setupFailure;
   hostedStepSkippedSteps = stepState.skippedSteps;
   hostedStepResults = buildStepResultRecords(stepState, steps);
   hostedStepScriptedFailures = buildStepScriptedCheckFailures(stepState);
@@ -3510,9 +3533,10 @@ const runHostedIterationWithBrowser = async (
     renderObservations: summarizeRenderObservations(
       browser.widgetRenderObservations
     ),
+    toolErrors: pinnedToolErrors,
     iterationError,
     failOnToolError,
-    pinnedToolErrors: [],
+    pinnedToolErrors,
     // §2: legacy push-model failures + executeSteps interact/widget-assert failures.
     scriptedCheckFailures: [
       ...browser.scriptedCheckFailures,
@@ -3554,7 +3578,10 @@ const runHostedIterationWithBrowser = async (
     // (see the non-stream backend runner).
     widgetRenderObservations: browser.widgetRenderObservations,
     browserInteractionSteps: browser.browserInteractionSteps,
-    status: "completed",
+    // A model-free pinned setup failure (server not connected) records as
+    // "failed"; everything else completes (a failed verdict is still a
+    // completed run). Mirrors the local runner.
+    status: pinnedSetupFailure ? "failed" : "completed",
     startedAt: runStartedAt,
     ...(iterationError ? { error: iterationError } : {}),
     ...(iterationErrorDetails ? { errorDetails: iterationErrorDetails } : {}),

--- a/mcpjam-inspector/server/services/evals/__tests__/__snapshots__/runner-parity.test.ts.snap
+++ b/mcpjam-inspector/server/services/evals/__tests__/__snapshots__/runner-parity.test.ts.snap
@@ -1,5 +1,341 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`runner parity (golden Convex payload + event sequence) > hosted-batch hybrid pinned (toolCall + prompt): convex payload > convex 1`] = `
+[
+  {
+    "payload": {
+      "iterationId": "iter-1",
+      "lastActivityAt": "<scrubbed>",
+      "modelId": "eval/unknown",
+      "modelSource": "mcpjam",
+      "startedAt": "<scrubbed>",
+      "turn": {
+        "promptIndex": 0,
+        "prompts": [
+          {
+            "actualToolCalls": [
+              {
+                "arguments": {
+                  "city": "SF",
+                },
+                "toolName": "show_map",
+              },
+            ],
+            "argumentMismatches": [],
+            "expectedOutput": undefined,
+            "expectedToolCalls": [],
+            "missing": [],
+            "passed": true,
+            "prompt": "",
+            "promptIndex": 0,
+            "unexpected": [],
+          },
+        ],
+        "sessionMessages": [
+          {
+            "content": "Pinned tool call: show_map on "srv-1"",
+            "role": "user",
+          },
+          {
+            "content": "Pinned tool call show_map executed",
+            "role": "assistant",
+          },
+        ],
+        "spans": [],
+        "turnEndedAt": "<scrubbed>",
+        "turnStartedAt": "<scrubbed>",
+        "widgets": [],
+      },
+    },
+    "ref": "testSuites:appendEvalTurnTrace",
+  },
+  {
+    "payload": {
+      "iterationId": "iter-1",
+      "lastActivityAt": "<scrubbed>",
+      "modelId": "eval/unknown",
+      "modelSource": "mcpjam",
+      "startedAt": "<scrubbed>",
+      "turn": {
+        "promptIndex": 1,
+        "prompts": [
+          {
+            "actualToolCalls": [],
+            "argumentMismatches": [],
+            "expectedOutput": undefined,
+            "expectedToolCalls": [],
+            "missing": [],
+            "passed": true,
+            "prompt": "Describe the widget",
+            "promptIndex": 1,
+            "unexpected": [],
+          },
+        ],
+        "sessionMessages": [
+          {
+            "content": "Pinned tool call: show_map on "srv-1"",
+            "role": "user",
+          },
+          {
+            "content": "Pinned tool call show_map executed",
+            "role": "assistant",
+          },
+          {
+            "content": "Describe the widget",
+            "role": "user",
+          },
+          {
+            "content": [
+              {
+                "text": "Done",
+                "type": "text",
+              },
+            ],
+            "role": "assistant",
+          },
+        ],
+        "spans": [
+          {
+            "category": "step",
+            "endMs": "<scrubbed>",
+            "finishReason": "stop",
+            "id": "eval-backend-prompt-1-step-0",
+            "inputTokens": 1,
+            "messageEndIndex": 3,
+            "messageStartIndex": 3,
+            "modelId": "anthropic/claude-haiku-4.5",
+            "name": "Step 1",
+            "outputTokens": 2,
+            "promptIndex": 1,
+            "provider": "anthropic",
+            "startMs": "<scrubbed>",
+            "status": "ok",
+            "stepIndex": 0,
+            "totalTokens": 3,
+            "ttfcMs": "<scrubbed>",
+          },
+          {
+            "category": "llm",
+            "endMs": "<scrubbed>",
+            "finishReason": "stop",
+            "id": "eval-backend-prompt-1-step-0-llm",
+            "inputTokens": 1,
+            "messageEndIndex": 3,
+            "messageStartIndex": 3,
+            "modelId": "anthropic/claude-haiku-4.5",
+            "name": "anthropic/claude-haiku-4.5 · response",
+            "outputTokens": 2,
+            "parentId": "eval-backend-prompt-1-step-0",
+            "promptIndex": 1,
+            "provider": "anthropic",
+            "startMs": "<scrubbed>",
+            "status": "ok",
+            "stepIndex": 0,
+            "totalTokens": 3,
+            "ttfcMs": "<scrubbed>",
+          },
+        ],
+        "turnEndedAt": "<scrubbed>",
+        "turnStartedAt": "<scrubbed>",
+        "widgets": [],
+      },
+    },
+    "ref": "testSuites:appendEvalTurnTrace",
+  },
+  {
+    "payload": {
+      "actualToolCalls": [
+        {
+          "arguments": {
+            "city": "SF",
+          },
+          "toolName": "show_map",
+        },
+      ],
+      "error": undefined,
+      "errorDetails": undefined,
+      "iterationId": "iter-1",
+      "metadata": {
+        "argumentMismatchCount": 0,
+        "failedTurnCount": 0,
+        "inputTokens": 1,
+        "mismatchCount": 0,
+        "missingCount": 0,
+        "multiTurn": true,
+        "outputTokens": 2,
+        "stepResults": [
+          {
+            "kind": "toolCall",
+            "status": "ok",
+            "stepId": "turn-1",
+            "stepIndex": 0,
+          },
+          {
+            "kind": "prompt",
+            "status": "ok",
+            "stepId": "turn-2",
+            "stepIndex": 1,
+          },
+        ],
+        "turnCount": 2,
+        "unexpectedCount": 0,
+      },
+      "result": "passed",
+      "resultSource": "reported",
+      "status": "completed",
+      "tokensUsed": 3,
+    },
+    "ref": "testSuites:updateTestIteration",
+  },
+  {
+    "payload": {
+      "iterationId": "iter-1",
+      "reason": "eval_completed",
+    },
+    "ref": "testSuites:lockEvalSession",
+  },
+]
+`;
+
+exports[`runner parity (golden Convex payload + event sequence) > hosted-batch hybrid pinned setup failure (server not connected): convex payload + status > convex 1`] = `
+[
+  {
+    "payload": {
+      "iterationId": "iter-1",
+      "lastActivityAt": "<scrubbed>",
+      "modelId": "eval/unknown",
+      "modelSource": "mcpjam",
+      "startedAt": "<scrubbed>",
+      "turn": {
+        "promptIndex": 0,
+        "prompts": [
+          {
+            "actualToolCalls": [],
+            "argumentMismatches": [],
+            "expectedOutput": undefined,
+            "expectedToolCalls": [],
+            "missing": [],
+            "passed": true,
+            "prompt": "",
+            "promptIndex": 0,
+            "unexpected": [],
+          },
+        ],
+        "sessionMessages": [
+          {
+            "content": "Pinned tool call: search on "Asana"",
+            "role": "user",
+          },
+          {
+            "content": "Pinned tool call skipped: server "Asana" not connected",
+            "role": "assistant",
+          },
+        ],
+        "spans": [],
+        "turnEndedAt": "<scrubbed>",
+        "turnStartedAt": "<scrubbed>",
+        "widgets": [],
+      },
+    },
+    "ref": "testSuites:appendEvalTurnTrace",
+  },
+  {
+    "payload": {
+      "iterationId": "iter-1",
+      "lastActivityAt": "<scrubbed>",
+      "modelId": "eval/unknown",
+      "modelSource": "mcpjam",
+      "startedAt": "<scrubbed>",
+      "turn": {
+        "promptIndex": 1,
+        "prompts": [
+          {
+            "actualToolCalls": [],
+            "argumentMismatches": [],
+            "expectedOutput": undefined,
+            "expectedToolCalls": [],
+            "missing": [],
+            "passed": true,
+            "prompt": "Describe it",
+            "promptIndex": 1,
+            "unexpected": [],
+          },
+        ],
+        "sessionMessages": [
+          {
+            "content": "Pinned tool call: search on "Asana"",
+            "role": "user",
+          },
+          {
+            "content": "Pinned tool call skipped: server "Asana" not connected",
+            "role": "assistant",
+          },
+        ],
+        "spans": [],
+        "turnEndedAt": "<scrubbed>",
+        "turnStartedAt": "<scrubbed>",
+        "widgets": [],
+      },
+    },
+    "ref": "testSuites:appendEvalTurnTrace",
+  },
+  {
+    "payload": {
+      "actualToolCalls": [],
+      "error": "pinned_server_not_connected: "Asana" is not connected in this run's environment",
+      "errorDetails": undefined,
+      "iterationId": "iter-1",
+      "metadata": {
+        "argumentMismatchCount": 0,
+        "failedTurnCount": 0,
+        "inputTokens": 0,
+        "mismatchCount": 0,
+        "missingCount": 0,
+        "multiTurn": true,
+        "outputTokens": 0,
+        "skippedSteps": [
+          {
+            "kind": "prompt",
+            "reason": "step 0 errored: pinned_server_not_connected: "Asana" is not connected in this run's environment",
+            "stepId": "turn-2",
+            "stepIndex": 1,
+          },
+        ],
+        "stepResults": [
+          {
+            "kind": "toolCall",
+            "status": "ok",
+            "stepId": "turn-1",
+            "stepIndex": 0,
+          },
+          {
+            "kind": "prompt",
+            "reason": "step 0 errored: pinned_server_not_connected: "Asana" is not connected in this run's environment",
+            "status": "skipped",
+            "stepId": "turn-2",
+            "stepIndex": 1,
+          },
+        ],
+        "turnCount": 2,
+        "unexpectedCount": 0,
+      },
+      "result": "failed",
+      "resultSource": "reported",
+      "status": "failed",
+      "tokensUsed": 0,
+    },
+    "ref": "testSuites:updateTestIteration",
+  },
+  {
+    "payload": {
+      "iterationId": "iter-1",
+      "reason": "eval_failed",
+    },
+    "ref": "testSuites:lockEvalSession",
+  },
+]
+`;
+
 exports[`runner parity (golden Convex payload + event sequence) > hosted-batch multi-turn: convex payload > convex 1`] = `
 [
   {
@@ -357,6 +693,254 @@ exports[`runner parity (golden Convex payload + event sequence) > hosted-batch p
       "reason": "eval_completed",
     },
     "ref": "testSuites:lockEvalSession",
+  },
+]
+`;
+
+exports[`runner parity (golden Convex payload + event sequence) > hosted-stream hybrid pinned (toolCall + prompt): events + convex payload > convex 1`] = `
+[
+  {
+    "payload": {
+      "iterationId": "iter-1",
+      "lastActivityAt": "<scrubbed>",
+      "modelId": "eval/unknown",
+      "modelSource": "mcpjam",
+      "startedAt": "<scrubbed>",
+      "turn": {
+        "promptIndex": 0,
+        "prompts": [
+          {
+            "actualToolCalls": [
+              {
+                "arguments": {
+                  "city": "SF",
+                },
+                "toolName": "show_map",
+              },
+            ],
+            "argumentMismatches": [],
+            "expectedOutput": undefined,
+            "expectedToolCalls": [],
+            "missing": [],
+            "passed": true,
+            "prompt": "",
+            "promptIndex": 0,
+            "unexpected": [],
+          },
+        ],
+        "sessionMessages": [
+          {
+            "content": "Pinned tool call: show_map on "srv-1"",
+            "role": "user",
+          },
+          {
+            "content": "Pinned tool call show_map executed",
+            "role": "assistant",
+          },
+        ],
+        "spans": [],
+        "turnEndedAt": "<scrubbed>",
+        "turnStartedAt": "<scrubbed>",
+        "widgets": [],
+      },
+    },
+    "ref": "testSuites:appendEvalTurnTrace",
+  },
+  {
+    "payload": {
+      "iterationId": "iter-1",
+      "lastActivityAt": "<scrubbed>",
+      "modelId": "eval/unknown",
+      "modelSource": "mcpjam",
+      "startedAt": "<scrubbed>",
+      "turn": {
+        "promptIndex": 1,
+        "prompts": [
+          {
+            "actualToolCalls": [],
+            "argumentMismatches": [],
+            "expectedOutput": undefined,
+            "expectedToolCalls": [],
+            "missing": [],
+            "passed": true,
+            "prompt": "Describe the widget",
+            "promptIndex": 1,
+            "unexpected": [],
+          },
+        ],
+        "sessionMessages": [
+          {
+            "content": "Pinned tool call: show_map on "srv-1"",
+            "role": "user",
+          },
+          {
+            "content": "Pinned tool call show_map executed",
+            "role": "assistant",
+          },
+          {
+            "content": "Describe the widget",
+            "role": "user",
+          },
+          {
+            "content": [
+              {
+                "text": "Done",
+                "type": "text",
+              },
+            ],
+            "role": "assistant",
+          },
+        ],
+        "spans": [
+          {
+            "category": "step",
+            "endMs": "<scrubbed>",
+            "finishReason": "stop",
+            "id": "eval-backend-prompt-1-step-0",
+            "inputTokens": 1,
+            "messageEndIndex": 3,
+            "messageStartIndex": 3,
+            "modelId": "anthropic/claude-haiku-4.5",
+            "name": "Step 1",
+            "outputTokens": 2,
+            "promptIndex": 1,
+            "provider": "anthropic",
+            "startMs": "<scrubbed>",
+            "status": "ok",
+            "stepIndex": 0,
+            "totalTokens": 3,
+            "ttfcMs": "<scrubbed>",
+          },
+          {
+            "category": "llm",
+            "endMs": "<scrubbed>",
+            "finishReason": "stop",
+            "id": "eval-backend-prompt-1-step-0-llm",
+            "inputTokens": 1,
+            "messageEndIndex": 3,
+            "messageStartIndex": 3,
+            "modelId": "anthropic/claude-haiku-4.5",
+            "name": "anthropic/claude-haiku-4.5 · response",
+            "outputTokens": 2,
+            "parentId": "eval-backend-prompt-1-step-0",
+            "promptIndex": 1,
+            "provider": "anthropic",
+            "startMs": "<scrubbed>",
+            "status": "ok",
+            "stepIndex": 0,
+            "totalTokens": 3,
+            "ttfcMs": "<scrubbed>",
+          },
+        ],
+        "turnEndedAt": "<scrubbed>",
+        "turnStartedAt": "<scrubbed>",
+        "widgets": [],
+      },
+    },
+    "ref": "testSuites:appendEvalTurnTrace",
+  },
+  {
+    "payload": {
+      "actualToolCalls": [
+        {
+          "arguments": {
+            "city": "SF",
+          },
+          "toolName": "show_map",
+        },
+      ],
+      "error": undefined,
+      "errorDetails": undefined,
+      "iterationId": "iter-1",
+      "metadata": {
+        "argumentMismatchCount": 0,
+        "failedTurnCount": 0,
+        "inputTokens": 1,
+        "mismatchCount": 0,
+        "missingCount": 0,
+        "multiTurn": true,
+        "outputTokens": 2,
+        "stepResults": [
+          {
+            "kind": "toolCall",
+            "status": "ok",
+            "stepId": "turn-1",
+            "stepIndex": 0,
+          },
+          {
+            "kind": "prompt",
+            "status": "ok",
+            "stepId": "turn-2",
+            "stepIndex": 1,
+          },
+        ],
+        "turnCount": 2,
+        "unexpectedCount": 0,
+      },
+      "result": "passed",
+      "resultSource": "reported",
+      "status": "completed",
+      "tokensUsed": 3,
+    },
+    "ref": "testSuites:updateTestIteration",
+  },
+  {
+    "payload": {
+      "iterationId": "iter-1",
+      "reason": "eval_completed",
+    },
+    "ref": "testSuites:lockEvalSession",
+  },
+]
+`;
+
+exports[`runner parity (golden Convex payload + event sequence) > hosted-stream hybrid pinned (toolCall + prompt): events + convex payload > events 1`] = `
+[
+  {
+    "kind": "toolCall",
+    "status": "running",
+    "type": "step_status",
+  },
+  "turn_start",
+  {
+    "kind": "toolCall",
+    "status": "running",
+    "type": "step_status",
+  },
+  "tool_call",
+  "tool_result",
+  "trace_snapshot",
+  "turn_finish",
+  {
+    "kind": "toolCall",
+    "status": "ok",
+    "type": "step_status",
+  },
+  {
+    "kind": "toolCall",
+    "status": "ok",
+    "type": "step_status",
+  },
+  {
+    "kind": "prompt",
+    "status": "running",
+    "type": "step_status",
+  },
+  "turn_start",
+  "text_delta",
+  "step_finish",
+  "trace_snapshot",
+  "trace_snapshot",
+  "turn_finish",
+  {
+    "kind": "prompt",
+    "status": "ok",
+    "type": "step_status",
+  },
+  {
+    "kind": "prompt",
+    "status": "ok",
+    "type": "step_status",
   },
 ]
 `;
@@ -1742,6 +2326,211 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch wi
       "reason": "eval_completed",
     },
     "ref": "testSuites:lockEvalSession",
+  },
+]
+`;
+
+exports[`runner parity (golden Convex payload + event sequence) > local-stream hybrid pinned (toolCall + prompt): events + convex payload > convex 1`] = `
+[
+  {
+    "payload": {
+      "iterationId": "iter-1",
+      "lastActivityAt": "<scrubbed>",
+      "modelId": "eval/unknown",
+      "modelSource": "mcpjam",
+      "startedAt": "<scrubbed>",
+      "turn": {
+        "promptIndex": 0,
+        "prompts": [
+          {
+            "actualToolCalls": [
+              {
+                "arguments": {
+                  "city": "SF",
+                },
+                "toolName": "show_map",
+              },
+            ],
+            "argumentMismatches": [],
+            "expectedOutput": undefined,
+            "expectedToolCalls": [],
+            "missing": [],
+            "passed": true,
+            "prompt": "",
+            "promptIndex": 0,
+            "unexpected": [],
+          },
+        ],
+        "sessionMessages": [
+          {
+            "content": "Pinned tool call: show_map on "srv-1"",
+            "role": "user",
+          },
+          {
+            "content": "Pinned tool call show_map executed",
+            "role": "assistant",
+          },
+        ],
+        "spans": [],
+        "turnEndedAt": "<scrubbed>",
+        "turnStartedAt": "<scrubbed>",
+        "widgets": [],
+      },
+    },
+    "ref": "testSuites:appendEvalTurnTrace",
+  },
+  {
+    "payload": {
+      "iterationId": "iter-1",
+      "lastActivityAt": "<scrubbed>",
+      "modelId": "eval/unknown",
+      "modelSource": "mcpjam",
+      "startedAt": "<scrubbed>",
+      "turn": {
+        "promptIndex": 1,
+        "prompts": [
+          {
+            "actualToolCalls": [],
+            "argumentMismatches": [],
+            "expectedOutput": undefined,
+            "expectedToolCalls": [],
+            "missing": [],
+            "passed": true,
+            "prompt": "Describe the widget",
+            "promptIndex": 1,
+            "unexpected": [],
+          },
+        ],
+        "sessionMessages": [
+          {
+            "content": "Pinned tool call: show_map on "srv-1"",
+            "role": "user",
+          },
+          {
+            "content": "Pinned tool call show_map executed",
+            "role": "assistant",
+          },
+          {
+            "content": "Describe the widget",
+            "role": "user",
+          },
+          {
+            "content": "Done",
+            "role": "assistant",
+          },
+        ],
+        "spans": [],
+        "turnEndedAt": "<scrubbed>",
+        "turnStartedAt": "<scrubbed>",
+        "widgets": [],
+      },
+    },
+    "ref": "testSuites:appendEvalTurnTrace",
+  },
+  {
+    "payload": {
+      "actualToolCalls": [
+        {
+          "arguments": {
+            "city": "SF",
+          },
+          "toolName": "show_map",
+        },
+      ],
+      "error": undefined,
+      "errorDetails": undefined,
+      "iterationId": "iter-1",
+      "metadata": {
+        "argumentMismatchCount": 0,
+        "failedTurnCount": 0,
+        "inputTokens": 1,
+        "mismatchCount": 0,
+        "missingCount": 0,
+        "multiTurn": true,
+        "outputTokens": 2,
+        "stepResults": [
+          {
+            "kind": "toolCall",
+            "status": "ok",
+            "stepId": "turn-1",
+            "stepIndex": 0,
+          },
+          {
+            "kind": "prompt",
+            "status": "ok",
+            "stepId": "turn-2",
+            "stepIndex": 1,
+          },
+        ],
+        "turnCount": 2,
+        "unexpectedCount": 0,
+      },
+      "result": "passed",
+      "resultSource": "reported",
+      "status": "completed",
+      "tokensUsed": 3,
+    },
+    "ref": "testSuites:updateTestIteration",
+  },
+  {
+    "payload": {
+      "iterationId": "iter-1",
+      "reason": "eval_completed",
+    },
+    "ref": "testSuites:lockEvalSession",
+  },
+]
+`;
+
+exports[`runner parity (golden Convex payload + event sequence) > local-stream hybrid pinned (toolCall + prompt): events + convex payload > events 1`] = `
+[
+  {
+    "kind": "toolCall",
+    "status": "running",
+    "type": "step_status",
+  },
+  "turn_start",
+  {
+    "kind": "toolCall",
+    "status": "running",
+    "type": "step_status",
+  },
+  "tool_call",
+  "tool_result",
+  "trace_snapshot",
+  "turn_finish",
+  {
+    "kind": "toolCall",
+    "status": "ok",
+    "type": "step_status",
+  },
+  {
+    "kind": "toolCall",
+    "status": "ok",
+    "type": "step_status",
+  },
+  {
+    "kind": "prompt",
+    "status": "running",
+    "type": "step_status",
+  },
+  "turn_start",
+  {
+    "kind": "prompt",
+    "status": "running",
+    "type": "step_status",
+  },
+  "trace_snapshot",
+  "turn_finish",
+  {
+    "kind": "prompt",
+    "status": "ok",
+    "type": "step_status",
+  },
+  {
+    "kind": "prompt",
+    "status": "ok",
+    "type": "step_status",
   },
 ]
 `;

--- a/mcpjam-inspector/server/services/evals/__tests__/pinned-turn-sse.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/pinned-turn-sse.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import {
+  emitPinnedTurnSse,
+  type PinnedTurnSseDeps,
+  type PinnedTurnSsePayload,
+} from "../pinned-turn-sse";
+import type { EvalStreamEvent } from "@/shared/eval-stream-events";
+
+function makeDeps() {
+  const events: EvalStreamEvent[] = [];
+  const deps: PinnedTurnSseDeps = {
+    emit: (event) => events.push(event),
+    withSystemPrefix: (msgs) => msgs,
+    buildTraceSnapshotEvent: ({ turnIndex, snapshotKind, actualToolCalls }) =>
+      ({
+        type: "trace_snapshot",
+        turnIndex,
+        snapshotKind,
+        actualToolCalls,
+      }) as unknown as EvalStreamEvent,
+  };
+  return { events, deps };
+}
+
+const basePayload: PinnedTurnSsePayload = {
+  turnIndex: 2,
+  prompt: 'Pinned tool call: show_map on "Weather"',
+  messages: [{ role: "user", content: "hi" }],
+  spans: [],
+  usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+};
+
+describe("emitPinnedTurnSse", () => {
+  it("emits the full success sequence with tool events", () => {
+    const { events, deps } = makeDeps();
+    emitPinnedTurnSse(deps, {
+      ...basePayload,
+      toolCall: { toolName: "show_map", arguments: { city: "SF" } },
+      toolCallId: "pinned-2-1",
+      toolResult: { content: [] },
+    });
+    expect(events.map((e) => (e as { type: string }).type)).toEqual([
+      "turn_start",
+      "step_status",
+      "tool_call",
+      "tool_result",
+      "trace_snapshot",
+      "turn_finish",
+      "step_status",
+    ]);
+    expect(events[0]).toMatchObject({
+      turnIndex: 2,
+      prompt: basePayload.prompt,
+    });
+    expect(events[1]).toMatchObject({ kind: "toolCall", status: "running" });
+    expect(events[2]).toMatchObject({
+      toolName: "show_map",
+      toolCallId: "pinned-2-1",
+      args: { city: "SF" },
+    });
+    expect(events[3]).toMatchObject({ toolCallId: "pinned-2-1" });
+    expect(events[3]).not.toHaveProperty("isError");
+    expect(events[4]).toMatchObject({ snapshotKind: "turn_finish" });
+    expect(events[6]).toMatchObject({ kind: "toolCall", status: "ok" });
+  });
+
+  it("emits failure snapshot + error for a tool error", () => {
+    const { events, deps } = makeDeps();
+    emitPinnedTurnSse(deps, {
+      ...basePayload,
+      toolCall: { toolName: "show_map", arguments: {} },
+      toolCallId: "pinned-2-1",
+      toolResult: { error: "boom", kind: "content-error" },
+      toolResultIsError: true,
+      toolError: {
+        toolName: "show_map",
+        kind: "content-error",
+        message: "boom",
+      },
+    });
+    expect(events.map((e) => (e as { type: string }).type)).toEqual([
+      "turn_start",
+      "step_status",
+      "tool_call",
+      "tool_result",
+      "trace_snapshot",
+      "turn_finish",
+      "step_status",
+      "error",
+    ]);
+    expect(events[3]).toMatchObject({ isError: true });
+    expect(events[4]).toMatchObject({ snapshotKind: "failure" });
+    expect(events[6]).toMatchObject({ status: "fail", detail: "boom" });
+    expect(events[7]).toMatchObject({ message: "boom" });
+  });
+
+  it("omits tool events entirely for a not-connected setup failure", () => {
+    const { events, deps } = makeDeps();
+    emitPinnedTurnSse(deps, {
+      ...basePayload,
+      iterationError: 'pinned_server_not_connected: "Weather" is not connected',
+    });
+    expect(events.map((e) => (e as { type: string }).type)).toEqual([
+      "turn_start",
+      "step_status",
+      "trace_snapshot",
+      "turn_finish",
+      "step_status",
+      "error",
+    ]);
+    expect(events[2]).toMatchObject({
+      snapshotKind: "failure",
+      actualToolCalls: [],
+    });
+    expect(events[4]).toMatchObject({ status: "fail" });
+  });
+});

--- a/mcpjam-inspector/server/services/evals/__tests__/pinned-turn.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/pinned-turn.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import { runPinnedTurn } from "../pinned-turn";
+import {
+  buildPinnedTurnAccounting,
+  runPinnedTurn,
+  type PinnedTurnResult,
+} from "../pinned-turn";
 import { evaluateMultiTurnResults } from "../types";
 import { legacyProbeToPinnedTurn } from "@/shared/steps";
 import type { ProbeConfig } from "@/shared/probe-config";
@@ -84,6 +88,85 @@ describe("runPinnedTurn", () => {
     expect(executeTool).not.toHaveBeenCalled();
     expect(result.toolCall).toBeNull();
     expect(result.iterationError).toContain("not connected");
+  });
+});
+
+describe("buildPinnedTurnAccounting", () => {
+  const successResult: PinnedTurnResult = {
+    toolCall: { toolName: "show_map", arguments: { city: "SF" } },
+    toolCallId: "pinned-0-123",
+    toolResult: { content: [] },
+    summary: "Pinned tool call show_map executed",
+  };
+
+  it("derives the message pair and tool call on success", () => {
+    const accounting = buildPinnedTurnAccounting(probe, successResult);
+    expect(accounting.prompt).toBe('Pinned tool call: show_map on "Weather"');
+    expect(accounting.userMessage).toEqual({
+      role: "user",
+      content: 'Pinned tool call: show_map on "Weather"',
+    });
+    expect(accounting.assistantMessage).toEqual({
+      role: "assistant",
+      content: "Pinned tool call show_map executed",
+    });
+    expect(accounting.summary).toBe("Pinned tool call show_map executed");
+    expect(accounting.toolCalls).toEqual([
+      { toolName: "show_map", arguments: { city: "SF" } },
+    ]);
+    expect(accounting.toolErrors).toEqual([]);
+    expect(accounting.iterationError).toBeUndefined();
+    expect(accounting.setupFailure).toBe(false);
+  });
+
+  it("carries a content-error as a toolError without setup failure", () => {
+    const accounting = buildPinnedTurnAccounting(probe, {
+      ...successResult,
+      toolResultIsError: true,
+      toolError: {
+        toolName: "show_map",
+        kind: "content-error",
+        message: "boom",
+      },
+      summary: "Pinned tool call show_map failed: boom",
+    });
+    expect(accounting.toolErrors).toEqual([
+      { toolName: "show_map", kind: "content-error", message: "boom" },
+    ]);
+    expect(accounting.toolCalls).toHaveLength(1);
+    expect(accounting.iterationError).toBeUndefined();
+    expect(accounting.setupFailure).toBe(false);
+  });
+
+  it("carries a protocol-error as a toolError without setup failure", () => {
+    const accounting = buildPinnedTurnAccounting(probe, {
+      ...successResult,
+      toolResultIsError: true,
+      toolError: {
+        toolName: "show_map",
+        kind: "protocol-error",
+        message: "transport down",
+      },
+      summary: "Pinned tool call show_map failed: transport down",
+    });
+    expect(accounting.toolErrors[0]?.kind).toBe("protocol-error");
+    expect(accounting.setupFailure).toBe(false);
+  });
+
+  it("maps not-connected to iterationError + setupFailure and no phantom call", () => {
+    const accounting = buildPinnedTurnAccounting(probe, {
+      toolCall: null,
+      iterationError:
+        'pinned_server_not_connected: "Weather" is not connected in this run\'s environment',
+      summary: 'Pinned tool call skipped: server "Weather" not connected',
+    });
+    expect(accounting.toolCalls).toEqual([]);
+    expect(accounting.toolErrors).toEqual([]);
+    expect(accounting.iterationError).toContain("not connected");
+    expect(accounting.setupFailure).toBe(true);
+    // The transcript pair is still produced (transcript honesty on failure).
+    expect(accounting.userMessage.role).toBe("user");
+    expect(accounting.assistantMessage.content).toContain("skipped");
   });
 });
 

--- a/mcpjam-inspector/server/services/evals/__tests__/runner-parity.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/runner-parity.test.ts
@@ -151,6 +151,12 @@ function scrub(value: unknown): unknown {
         /^eval-ai-err-\d+$/.test(v)
       ) {
         out[k] = "eval-ai-err-<scrubbed>";
+      } else if (
+        typeof v === "string" &&
+        /^pinned-\d+-\d+$/.test(v)
+      ) {
+        // Synthetic pinned toolCallIds embed Date.now().
+        out[k] = "pinned-<scrubbed>";
       } else {
         out[k] = scrub(v);
       }
@@ -195,6 +201,8 @@ describe("runner parity (golden Convex payload + event sequence)", () => {
     getToolsForAiSdk: vi.fn(),
     listServers: vi.fn(),
     getAllToolsMetadata: vi.fn().mockReturnValue({}),
+    // Pinned (`toolCall`) turns execute directly; inert for prompt-only cases.
+    executeTool: vi.fn(),
   };
 
   beforeEach(() => {
@@ -267,6 +275,9 @@ describe("runner parity (golden Convex payload + event sequence)", () => {
     promptTurns: unknown[];
     modelApiKeys?: Record<string, string>;
     emit: (e: EvalStreamEvent) => void;
+    /** Connected-server set + run environment, for pinned-server resolution. */
+    selectedServers?: string[];
+    environment?: unknown;
   }) {
     return streamTestCase({
       test: {
@@ -280,7 +291,8 @@ describe("runner parity (golden Convex payload + event sequence)", () => {
         testCaseId: "case-1",
       },
       tools: {},
-      selectedServers: [],
+      selectedServers: args.selectedServers ?? [],
+      ...(args.environment ? { environment: args.environment } : {}),
       mcpClientManager: mcpClientManager as any,
       recorder: null,
       modelApiKeys: args.modelApiKeys ?? {},
@@ -448,6 +460,99 @@ describe("runner parity (golden Convex payload + event sequence)", () => {
         },
       ],
     });
+    expect(summarizeConvexActions(convexClient.action)).toMatchSnapshot(
+      "convex"
+    );
+  });
+
+  // ── Hosted pinned turns: hybrid (pinned toolCall + model prompt) cases ────
+  // The pinned turn executes inspector-side (model-free) on BOTH paths; only
+  // the prompt turn hits the model (local streamText / hosted /stream). The
+  // local-stream case exists so its pinned SSE slice is diffable side-by-side
+  // with the hosted-stream one (both synthesize via emitPinnedTurnSse).
+
+  const HYBRID_PINNED = [
+    {
+      id: "turn-1",
+      prompt: "",
+      expectedToolCalls: [],
+      pinnedToolCall: {
+        serverName: "srv-1",
+        toolName: "show_map",
+        arguments: { city: "SF" },
+      },
+    },
+    { id: "turn-2", prompt: "Describe the widget", expectedToolCalls: [] },
+  ];
+
+  it("local-stream hybrid pinned (toolCall + prompt): events + convex payload", async () => {
+    mcpClientManager.executeTool.mockResolvedValue({ content: [] });
+    const emitted: EvalStreamEvent[] = [];
+    await streamCase({
+      model: LOCAL_MODEL,
+      modelApiKeys: { openai: "sk-test" },
+      promptTurns: HYBRID_PINNED,
+      selectedServers: ["srv-1"],
+      environment: { servers: ["srv-1"] },
+      emit: (e) => emitted.push(e),
+    });
+    expect(summarizeEvents(emitted)).toMatchSnapshot("events");
+    expect(summarizeConvexActions(convexClient.action)).toMatchSnapshot(
+      "convex"
+    );
+  });
+
+  it("hosted-batch hybrid pinned (toolCall + prompt): convex payload", async () => {
+    mcpClientManager.executeTool.mockResolvedValue({ content: [] });
+    fetchMock.mockImplementation(async () => backendStreamResponse());
+    await batchSuite({ model: HOSTED_MODEL, promptTurns: HYBRID_PINNED });
+    // The pinned turn never touches the backend; only the prompt turn streams.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(summarizeConvexActions(convexClient.action)).toMatchSnapshot(
+      "convex"
+    );
+  });
+
+  it("hosted-stream hybrid pinned (toolCall + prompt): events + convex payload", async () => {
+    mcpClientManager.executeTool.mockResolvedValue({ content: [] });
+    fetchMock.mockImplementation(async () => backendStreamResponse());
+    const emitted: EvalStreamEvent[] = [];
+    await streamCase({
+      model: HOSTED_MODEL,
+      promptTurns: HYBRID_PINNED,
+      selectedServers: ["srv-1"],
+      environment: { servers: ["srv-1"] },
+      emit: (e) => emitted.push(e),
+    });
+    expect(summarizeEvents(emitted)).toMatchSnapshot("events");
+    expect(summarizeConvexActions(convexClient.action)).toMatchSnapshot(
+      "convex"
+    );
+  });
+
+  it("hosted-batch hybrid pinned setup failure (server not connected): convex payload + status", async () => {
+    // Hosted mirror of the local pinned setup-failure golden: the pinned server
+    // "Asana" is NOT connected → setup failure halts the executor, the prompt
+    // step is skipped (no /stream call), and the iteration persists as
+    // status:"failed".
+    fetchMock.mockImplementation(async () => backendStreamResponse());
+    await batchSuite({
+      model: HOSTED_MODEL,
+      promptTurns: [
+        {
+          id: "turn-1",
+          prompt: "",
+          expectedToolCalls: [],
+          pinnedToolCall: {
+            serverName: "Asana",
+            toolName: "search",
+            arguments: { q: "x" },
+          },
+        },
+        { id: "turn-2", prompt: "Describe it", expectedToolCalls: [] },
+      ],
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
     expect(summarizeConvexActions(convexClient.action)).toMatchSnapshot(
       "convex"
     );

--- a/mcpjam-inspector/server/services/evals/__tests__/step-handlers-hosted-pinned.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/step-handlers-hosted-pinned.test.ts
@@ -1,0 +1,289 @@
+// Hosted pinned (`toolCall`) step handling: buildHostedStepHandlers executes
+// the pinned turn inspector-side (model-free) and injects a plain-text
+// user+assistant pair into the hosted acc's messageHistory. The backend driver
+// is mocked — a pinned turn must never reach it; the follow-up test asserts
+// the executor drains widget `ui/message` follow-ups into it afterwards.
+import { describe, it, expect, vi } from "vitest";
+import { buildHostedStepHandlers } from "../step-handlers";
+import {
+  createStepExecutionState,
+  executeSteps,
+} from "../step-executor";
+import { driveHostedEvalTurn } from "../drive-hosted-eval-turn";
+
+vi.mock("../drive-hosted-eval-turn", () => ({
+  driveHostedEvalTurn: vi.fn(async () => ({ kind: "completed" })),
+  MAX_WIDGET_FOLLOWUP_TURNS: 3,
+}));
+
+const PINNED_STEP = {
+  id: "tc1",
+  kind: "toolCall",
+  serverName: "Weather",
+  toolName: "show_map",
+  arguments: { city: "SF" },
+} as any;
+
+function makeAcc() {
+  return {
+    messageHistory: [] as any[],
+    capturedSpans: [] as any[],
+    accumulatedUsage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+    toolsCalledByPrompt: [] as any[][],
+  };
+}
+
+function makeBrowser() {
+  return {
+    setActivePromptIndex: vi.fn(),
+    setActiveAuthoredStepId: vi.fn(),
+    setActiveWidgetChecks: vi.fn(),
+    setKeepWidgetsMountedForSteps: vi.fn(),
+    dismissCarriedWidget: vi.fn(async () => {}),
+    renderPinnedToolResult: vi.fn(async () => {}),
+    replayInteractStep: vi.fn(),
+    evaluateWidgetAssertion: vi.fn(),
+    drainFollowUps: vi.fn(() => [] as string[]),
+    widgetRenderObservations: [] as any[],
+  };
+}
+
+function makeCtx(
+  acc: ReturnType<typeof makeAcc>,
+  browser: ReturnType<typeof makeBrowser>,
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    acc,
+    browser: browser as any,
+    mcpClientManager: {
+      executeTool: vi.fn(async () => ({ content: [], isError: false })),
+    } as any,
+    selectedServers: ["srv-1"],
+    resolvePinnedServerKey: () => "srv-1",
+    pinnedToolErrors: [],
+    prepared: { allTools: {} } as any,
+    modelDefinition: { id: "claude-haiku-4.5", provider: "anthropic" } as any,
+    modelId: "anthropic/claude-haiku-4.5",
+    evalAuthContext: { kind: "user_bearer", token: "Bearer t" } as any,
+    endpointPath: "/stream",
+    extraBodyFields: undefined,
+    toolChoice: undefined,
+    abortSignal: undefined,
+    maxSteps: 8,
+    runStartedAt: 0,
+    isAborted: () => false,
+    extractToolCalls: () => [],
+    ...overrides,
+  } as any;
+}
+
+describe("buildHostedStepHandlers — pinned toolCall", () => {
+  it("executes the pinned tool, appends the text pair, and never touches the backend", async () => {
+    const acc = makeAcc();
+    const browser = makeBrowser();
+    // Pre-existing bucket at the same ordinal (e.g. a widget call) — the
+    // handler must get-or-create-and-push, not clobber (the sparse-array trap).
+    acc.toolsCalledByPrompt[1] = [{ toolName: "widget_click", arguments: {} }];
+    const ctx = makeCtx(acc, browser);
+    const handlers = buildHostedStepHandlers(ctx);
+
+    const outcome = await handlers.onToolCall({
+      step: PINNED_STEP,
+      stepIndex: 2,
+      turnOrdinal: 1,
+    });
+
+    expect(ctx.mcpClientManager.executeTool).toHaveBeenCalledWith(
+      "srv-1",
+      "show_map",
+      { city: "SF" },
+    );
+    expect(vi.mocked(driveHostedEvalTurn)).not.toHaveBeenCalled();
+    // Plain-text user+assistant pair injected for the next /stream turn.
+    expect(acc.messageHistory).toEqual([
+      { role: "user", content: 'Pinned tool call: show_map on "Weather"' },
+      { role: "assistant", content: "Pinned tool call show_map executed" },
+    ]);
+    expect(acc.toolsCalledByPrompt[1]).toEqual([
+      { toolName: "widget_click", arguments: {} },
+      { toolName: "show_map", arguments: { city: "SF" } },
+    ]);
+    expect(browser.renderPinnedToolResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolCallId: expect.stringMatching(/^pinned-1-/),
+        toolName: "show_map",
+        serverId: "srv-1",
+      }),
+    );
+    expect(browser.dismissCarriedWidget).toHaveBeenCalledOnce();
+    expect(browser.setActiveWidgetChecks).toHaveBeenCalledWith([]);
+    expect(outcome.usage).toEqual({
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+    });
+    expect(outcome.iterationError).toBeUndefined();
+    expect(outcome.toolCalls).toEqual([
+      { toolName: "show_map", arguments: { city: "SF" } },
+    ]);
+  });
+
+  it("records a content-error into the iteration-level sink without failing the run", async () => {
+    const acc = makeAcc();
+    const browser = makeBrowser();
+    const ctx = makeCtx(acc, browser, {
+      mcpClientManager: {
+        executeTool: vi.fn(async () => ({
+          isError: true,
+          content: [{ type: "text", text: "boom" }],
+        })),
+      },
+    });
+    const handlers = buildHostedStepHandlers(ctx);
+
+    const outcome = await handlers.onToolCall({
+      step: PINNED_STEP,
+      stepIndex: 0,
+      turnOrdinal: 0,
+    });
+
+    expect(outcome.toolErrors).toEqual([
+      { toolName: "show_map", kind: "content-error", message: "boom" },
+    ]);
+    expect(ctx.pinnedToolErrors).toEqual(outcome.toolErrors);
+    // A tool error is a graded failure, not a fatal one — the run continues.
+    expect(outcome.iterationError).toBeUndefined();
+    expect(outcome.setupFailure).toBeUndefined();
+    expect(browser.renderPinnedToolResult).not.toHaveBeenCalled();
+  });
+
+  it("maps a not-connected server to iterationError + setupFailure with no phantom call", async () => {
+    const acc = makeAcc();
+    const browser = makeBrowser();
+    const ctx = makeCtx(acc, browser, {
+      resolvePinnedServerKey: () => undefined,
+    });
+    const handlers = buildHostedStepHandlers(ctx);
+
+    const outcome = await handlers.onToolCall({
+      step: PINNED_STEP,
+      stepIndex: 0,
+      turnOrdinal: 0,
+    });
+
+    expect(outcome.iterationError).toMatch(/not connected/i);
+    expect(outcome.setupFailure).toBe(true);
+    expect(outcome.toolCalls).toBeUndefined();
+    // Transcript honesty: the pair is still appended on failure.
+    expect(acc.messageHistory).toHaveLength(2);
+  });
+
+  it("emits the pinned SSE payload when streaming", async () => {
+    const acc = makeAcc();
+    const browser = makeBrowser();
+    const emitPinnedTurn = vi.fn();
+    const ctx = makeCtx(acc, browser, { emitPinnedTurn });
+    const handlers = buildHostedStepHandlers(ctx);
+
+    await handlers.onToolCall({
+      step: PINNED_STEP,
+      stepIndex: 1,
+      turnOrdinal: 2,
+    });
+
+    expect(emitPinnedTurn).toHaveBeenCalledOnce();
+    expect(emitPinnedTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        turnIndex: 2,
+        prompt: 'Pinned tool call: show_map on "Weather"',
+        messages: acc.messageHistory,
+        toolCall: { toolName: "show_map", arguments: { city: "SF" } },
+        toolCallId: expect.stringMatching(/^pinned-2-/),
+      }),
+    );
+  });
+
+  // Nothing wraps executeSteps on the hosted path (local has a broad
+  // iteration catch) — a throw from dismiss/render must be mapped to a failed
+  // outcome, not escape persistence.
+  it("maps a dismissCarriedWidget throw to a failed outcome instead of escaping", async () => {
+    const acc = makeAcc();
+    const browser = makeBrowser();
+    browser.dismissCarriedWidget.mockRejectedValue(
+      new Error("host page crashed"),
+    );
+    const handlers = buildHostedStepHandlers(makeCtx(acc, browser));
+
+    const outcome = await handlers.onToolCall({
+      step: PINNED_STEP,
+      stepIndex: 0,
+      turnOrdinal: 0,
+    });
+
+    expect(outcome.iterationError).toContain("host page crashed");
+    expect(outcome.setupFailure).toBeUndefined();
+  });
+
+  it("maps a renderPinnedToolResult throw to a failed outcome instead of escaping", async () => {
+    const acc = makeAcc();
+    const browser = makeBrowser();
+    browser.renderPinnedToolResult.mockRejectedValue(
+      new Error("render timed out hard"),
+    );
+    const handlers = buildHostedStepHandlers(makeCtx(acc, browser));
+
+    const outcome = await handlers.onToolCall({
+      step: PINNED_STEP,
+      stepIndex: 0,
+      turnOrdinal: 0,
+    });
+
+    expect(outcome.iterationError).toContain("render timed out hard");
+    expect(outcome.setupFailure).toBeUndefined();
+  });
+});
+
+describe("executeSteps + hosted handlers — widget follow-ups after a pinned step", () => {
+  it("drains ui/message follow-ups from the pinned widget into the hosted model driver", async () => {
+    const acc = makeAcc();
+    const browser = makeBrowser();
+    browser.drainFollowUps
+      .mockReturnValueOnce(["hi from widget"])
+      .mockReturnValue([]);
+    const handlers = buildHostedStepHandlers(makeCtx(acc, browser));
+    vi.mocked(driveHostedEvalTurn).mockClear();
+
+    const result = await executeSteps({
+      steps: [PINNED_STEP],
+      state: createStepExecutionState(),
+      browser: browser as any,
+      handlers,
+    });
+
+    expect(result.iterationError).toBeUndefined();
+    expect(vi.mocked(driveHostedEvalTurn)).toHaveBeenCalledOnce();
+    expect(vi.mocked(driveHostedEvalTurn)).toHaveBeenCalledWith(
+      expect.objectContaining({ prompt: "hi from widget", promptIndex: 0 }),
+    );
+  });
+
+  it("bounds follow-up drains to MAX_WIDGET_FOLLOWUP_TURNS", async () => {
+    const acc = makeAcc();
+    const browser = makeBrowser();
+    browser.drainFollowUps
+      .mockReturnValueOnce(["a", "b", "c", "d"])
+      .mockReturnValue([]);
+    const handlers = buildHostedStepHandlers(makeCtx(acc, browser));
+    vi.mocked(driveHostedEvalTurn).mockClear();
+
+    await executeSteps({
+      steps: [PINNED_STEP],
+      state: createStepExecutionState(),
+      browser: browser as any,
+      handlers,
+    });
+
+    expect(vi.mocked(driveHostedEvalTurn)).toHaveBeenCalledTimes(3);
+  });
+});

--- a/mcpjam-inspector/server/services/evals/drive-local-eval-turn.ts
+++ b/mcpjam-inspector/server/services/evals/drive-local-eval-turn.ts
@@ -17,7 +17,8 @@ import {
 } from "../../utils/direct-chat-turn.js";
 import type { createLlmModel } from "../../utils/chat-helpers.js";
 import type { PrepareChatV2Result } from "../../utils/chat-v2-orchestration.js";
-import { runPinnedTurn } from "./pinned-turn.js";
+import { buildPinnedTurnAccounting, runPinnedTurn } from "./pinned-turn.js";
+import type { PinnedTurnSsePayload } from "./pinned-turn-sse.js";
 import { EVAL_WIDGET_MODEL_CONTEXT } from "../../config.js";
 import { withWidgetContextSystemPrompt } from "./widget-interaction-context.js";
 import {
@@ -85,23 +86,14 @@ export type LocalEvalTurnSinks = {
   /**
    * PR5 — a model-free pinned (`toolCall`) turn ran. There is no model stream
    * to translate, so the streaming runner synthesizes the SSE sequence from
-   * this. `messages` is the persisted shape (user "Pinned tool call …" +
-   * assistant summary) so the live trace matches the finalized iteration.
-   * `iterationError` set ⇒ the pinned call failed before an MCP call ran
-   * (server not connected, etc.).
+   * this (via `emitPinnedTurnSse`). `messages` is the persisted shape (user
+   * "Pinned tool call …" + assistant summary) so the live trace matches the
+   * finalized iteration. `iterationError` set ⇒ the pinned call failed before
+   * an MCP call ran (server not connected, etc.). Typed as the shared SSE
+   * payload (minus the runner-owned `turnIndex`) so the sink and the emitter
+   * cannot drift.
    */
-  onPinnedTurn?: (ctx: {
-    prompt: string;
-    messages: ModelMessage[];
-    spans: EvalTraceSpan[];
-    usage: UsageTotals;
-    toolCall?: ToolCall;
-    toolCallId?: string;
-    toolResult?: unknown;
-    toolResultIsError?: boolean;
-    toolError?: ToolErrorRecord;
-    iterationError?: string;
-  }) => void;
+  onPinnedTurn?: (ctx: Omit<PinnedTurnSsePayload, "turnIndex">) => void;
 };
 
 export type DriveLocalEvalTurnParams = {
@@ -214,32 +206,25 @@ export async function driveLocalEvalTurn(
       browser,
       promptIndex,
     });
-    acc.conversationMessages.push({
-      role: "user",
-      content: `Pinned tool call: ${pinned.toolName} on "${pinned.serverName}"`,
-    });
-    acc.conversationMessages.push({
-      role: "assistant",
-      content: pinnedResult.summary,
-    });
+    const accounting = buildPinnedTurnAccounting(pinned, pinnedResult);
+    acc.conversationMessages.push(
+      accounting.userMessage,
+      accounting.assistantMessage
+    );
     appendToolCallsForPrompt(
       acc.toolsCalledByPrompt,
       promptIndex,
-      pinnedResult.toolCall ? [pinnedResult.toolCall] : []
+      accounting.toolCalls
     );
-    acc.assistantMessageByPrompt[promptIndex] = pinnedResult.summary;
-    acc.toolErrorsByPrompt[promptIndex] = pinnedResult.toolError
-      ? [pinnedResult.toolError]
-      : [];
-    if (pinnedResult.toolError) {
-      acc.pinnedToolErrors.push(pinnedResult.toolError);
-    }
-    if (pinnedResult.iterationError && !acc.iterationError) {
-      acc.iterationError = pinnedResult.iterationError;
+    acc.assistantMessageByPrompt[promptIndex] = accounting.summary;
+    acc.toolErrorsByPrompt[promptIndex] = accounting.toolErrors;
+    acc.pinnedToolErrors.push(...accounting.toolErrors);
+    if (accounting.iterationError && !acc.iterationError) {
+      acc.iterationError = accounting.iterationError;
       acc.pinnedSetupFailure = true;
     }
     sinks?.onPinnedTurn?.({
-      prompt: `Pinned tool call: ${pinned.toolName} on "${pinned.serverName}"`,
+      prompt: accounting.prompt,
       messages: acc.conversationMessages,
       spans: acc.capturedSpans,
       usage: acc.accumulatedUsage,

--- a/mcpjam-inspector/server/services/evals/iteration-verdict.ts
+++ b/mcpjam-inspector/server/services/evals/iteration-verdict.ts
@@ -15,11 +15,9 @@
 // Per-turn check RESULTS are passed in rather than computed here: the legacy
 // runner already computes them from runner-only signals (`buildTurnCheckResults`),
 // and the step path will supply already-executed check facts — this is the
-// `checkResultsOverride` seam. The local-only behaviors (per-turn checks, the
-// pinned `widgetRendered` default, threaded pinned tool errors) are expressed by
-// what the caller passes: the hosted path passes `turnCheckResults: []`,
-// `effectivePredicates: test.successPredicates`, `pinnedToolErrors: []`,
-// `toolErrors: undefined` — making the shared body byte-identical to today.
+// `checkResultsOverride` seam. Caller-specific behaviors are expressed by what
+// the caller passes; both paths now thread pinned tool errors
+// (`pinnedToolErrors` / `toolErrors`) since hosted runs pinned turns too.
 
 import {
   evaluateMultiTurnResults,
@@ -57,13 +55,14 @@ export interface EvalIterationVerdictInput {
   trace: FinalizeTrace;
   usage: TranscriptArgs["usage"];
   renderObservations: TranscriptArgs["renderObservations"];
-  /** Pinned tool errors threaded into the case-predicate transcript (local only; omit for hosted). */
+  /** Pinned tool errors threaded into the case-predicate transcript. */
   toolErrors?: ToolErrorRecord[];
 
   // ── gates ──
   iterationError: string | undefined;
   failOnToolError: boolean;
-  /** Pinned (model-free) tool errors — invisible to the trace gate (local only; `[]` for hosted). */
+  /** Pinned (model-free) tool errors — invisible to the trace gate, so they
+   *  need this explicit channel to the `failOnToolError` gate. */
   pinnedToolErrors: ToolErrorRecord[];
   /** Widget interaction-check failures, AFTER the caller flushed active checks. */
   scriptedCheckFailures: { toolName: string; reason: string }[];
@@ -103,7 +102,6 @@ export function buildEvalIterationVerdict(
           usage: input.usage,
           renderObservations: input.renderObservations,
           // Pinned turns have no trace; thread their tool errors explicitly.
-          // Hosted omits the key entirely (parity), so include it only when given.
           ...(input.toolErrors !== undefined
             ? { toolErrors: input.toolErrors }
             : {}),
@@ -127,8 +125,7 @@ export function buildEvalIterationVerdict(
   });
 
   // A pinned (model-free) tool call's error never enters the trace, so the
-  // `failOnToolError` trace gate is blind to it — apply it explicitly. Hosted
-  // passes `pinnedToolErrors: []`, making this inert there (byte-identical).
+  // `failOnToolError` trace gate is blind to it — apply it explicitly.
   if (passed && input.failOnToolError && input.pinnedToolErrors.length > 0) {
     passed = false;
   }

--- a/mcpjam-inspector/server/services/evals/pinned-turn-sse.ts
+++ b/mcpjam-inspector/server/services/evals/pinned-turn-sse.ts
@@ -1,0 +1,118 @@
+/**
+ * pinned-turn-sse.ts — synthesize the live SSE sequence for a model-free
+ * pinned (`toolCall`) turn. A pinned turn has no model stream to translate,
+ * so the streaming runners emit this fixed sequence instead:
+ *
+ *   turn_start → step_status(toolCall, running) → tool_call → tool_result →
+ *   trace_snapshot(failure|turn_finish) → turn_finish →
+ *   step_status(toolCall, ok|fail[, detail]) → error?
+ *
+ * This module owns `PinnedTurnSsePayload`; the local and hosted streaming
+ * paths both call `emitPinnedTurnSse`, so the event ordering cannot drift
+ * between them.
+ */
+
+import type { ModelMessage } from "ai";
+import type { EvalTraceSpan } from "@/shared/eval-trace";
+import type { ToolCall, ToolErrorRecord } from "@/shared/eval-matching";
+import type { EvalStreamEvent } from "@/shared/eval-stream-events";
+import type { UsageTotals } from "./types";
+
+export interface PinnedTurnSseDeps {
+  emit: (event: EvalStreamEvent) => void;
+  withSystemPrefix: (msgs: ModelMessage[]) => ModelMessage[];
+  /** The runner's local `buildTraceSnapshotEvent` (unexported → passed in to
+   *  avoid a cycle, same pattern as `HostedEvalSinksDeps`). */
+  buildTraceSnapshotEvent: (params: {
+    turnIndex: number;
+    stepIndex?: number;
+    snapshotKind: "step_finish" | "failure" | "turn_finish";
+    messages: ModelMessage[];
+    spans: EvalTraceSpan[];
+    usage: UsageTotals;
+    actualToolCalls: ToolCall[];
+  }) => EvalStreamEvent;
+}
+
+export interface PinnedTurnSsePayload {
+  turnIndex: number;
+  /** The synthesized user line (`PinnedTurnAccounting.prompt`). */
+  prompt: string;
+  /** Iteration-cumulative transcript including the pinned message pair. */
+  messages: ModelMessage[];
+  spans: EvalTraceSpan[];
+  usage: UsageTotals;
+  toolCall?: ToolCall;
+  toolCallId?: string;
+  toolResult?: unknown;
+  toolResultIsError?: boolean;
+  toolError?: ToolErrorRecord;
+  /** Set ⇒ the pinned call failed before an MCP call ran (server not connected). */
+  iterationError?: string;
+}
+
+export function emitPinnedTurnSse(
+  deps: PinnedTurnSseDeps,
+  payload: PinnedTurnSsePayload
+): void {
+  const { emit, withSystemPrefix, buildTraceSnapshotEvent } = deps;
+  const {
+    turnIndex,
+    prompt,
+    messages,
+    spans,
+    usage,
+    toolCall,
+    toolCallId,
+    toolResult,
+    toolResultIsError,
+    toolError,
+    iterationError,
+  } = payload;
+  const failureDetail =
+    iterationError ??
+    toolError?.message ??
+    (toolResultIsError ? "Pinned tool call failed" : undefined);
+  emit({ type: "turn_start", turnIndex, prompt });
+  emit({
+    type: "step_status",
+    turnIndex,
+    kind: "toolCall",
+    status: "running",
+  });
+  if (toolCall && toolCallId) {
+    emit({
+      type: "tool_call",
+      toolName: toolCall.toolName,
+      toolCallId,
+      args: toolCall.arguments,
+    });
+    emit({
+      type: "tool_result",
+      toolCallId,
+      result: toolResult,
+      ...(toolResultIsError ? { isError: true } : {}),
+    });
+  }
+  emit(
+    buildTraceSnapshotEvent({
+      turnIndex,
+      snapshotKind: failureDetail ? "failure" : "turn_finish",
+      messages: withSystemPrefix(messages),
+      spans,
+      actualToolCalls: toolCall ? [toolCall] : [],
+      usage,
+    })
+  );
+  emit({ type: "turn_finish", turnIndex });
+  emit({
+    type: "step_status",
+    turnIndex,
+    kind: "toolCall",
+    status: failureDetail ? "fail" : "ok",
+    ...(failureDetail ? { detail: failureDetail } : {}),
+  });
+  if (failureDetail) {
+    emit({ type: "error", message: failureDetail });
+  }
+}

--- a/mcpjam-inspector/server/services/evals/pinned-turn.ts
+++ b/mcpjam-inspector/server/services/evals/pinned-turn.ts
@@ -13,6 +13,7 @@
  * transcript and verdict exactly as it does for model turns.
  */
 
+import type { ModelMessage } from "ai";
 import type { MCPClientManager } from "@mcpjam/sdk";
 import type { ToolCall, ToolErrorRecord } from "@/shared/eval-matching";
 import type { PinnedToolCall } from "@/shared/steps";
@@ -71,6 +72,51 @@ export interface PinnedTurnResult {
   iterationError?: string;
   /** Human-readable one-line outcome for the synthesized assistant message. */
   summary: string;
+}
+
+/**
+ * Everything a pinned turn contributes to an iteration, derived once from the
+ * pinned spec + `runPinnedTurn`'s result. Engine-agnostic: the local and
+ * hosted step handlers apply the same accounting to their own acc shapes
+ * (local's rich acc vs hosted's narrow one), so the semantics — message
+ * shapes, phantom-call suppression, error classification — live here and
+ * cannot drift between paths.
+ */
+export interface PinnedTurnAccounting {
+  /** The synthesized user line, `Pinned tool call: <tool> on "<server>"`.
+   *  Doubles as the SSE `turn_start` prompt. */
+  prompt: string;
+  userMessage: ModelMessage;
+  /** Assistant message carrying the one-line outcome summary. Plain TEXT by
+   *  contract: hosted injects this pair into the `/stream` input history,
+   *  which only round-trips untouched for text-only messages. */
+  assistantMessage: ModelMessage;
+  summary: string;
+  /** [] when no MCP call happened (not-connected / no tool selected). */
+  toolCalls: ToolCall[];
+  toolErrors: ToolErrorRecord[];
+  /** Set ⇒ fatal setup failure (server not connected). */
+  iterationError?: string;
+  setupFailure: boolean;
+}
+
+export function buildPinnedTurnAccounting(
+  pinned: PinnedToolCall,
+  result: PinnedTurnResult
+): PinnedTurnAccounting {
+  const prompt = `Pinned tool call: ${pinned.toolName} on "${pinned.serverName}"`;
+  return {
+    prompt,
+    userMessage: { role: "user", content: prompt },
+    assistantMessage: { role: "assistant", content: result.summary },
+    summary: result.summary,
+    toolCalls: result.toolCall ? [result.toolCall] : [],
+    toolErrors: result.toolError ? [result.toolError] : [],
+    ...(result.iterationError
+      ? { iterationError: result.iterationError }
+      : {}),
+    setupFailure: result.iterationError !== undefined,
+  };
 }
 
 /**

--- a/mcpjam-inspector/server/services/evals/step-handlers.ts
+++ b/mcpjam-inspector/server/services/evals/step-handlers.ts
@@ -19,8 +19,13 @@ import {
   driveHostedEvalTurn,
   type DriveHostedEvalTurnParams,
 } from "./drive-hosted-eval-turn";
-import type { PromptTurn } from "@/shared/steps";
-import { extractToolErrors } from "@/shared/eval-matching";
+import type { PinnedToolCall, PromptTurn, ToolCallStep } from "@/shared/steps";
+import {
+  extractToolErrors,
+  type ToolErrorRecord,
+} from "@/shared/eval-matching";
+import { buildPinnedTurnAccounting, runPinnedTurn } from "./pinned-turn";
+import type { PinnedTurnSsePayload } from "./pinned-turn-sse";
 import type {
   StepEngineOutcome,
   StepExecutorHandlers,
@@ -192,16 +197,29 @@ export function buildLocalStepHandlers(
 export type HostedStepHandlerContext = Omit<
   DriveHostedEvalTurnParams,
   "promptIndex" | "prompt" | "widgetChecks"
->;
+> & {
+  /** Mirrors `DriveLocalEvalTurnParams.resolvePinnedServerKey`: resolve a pinned
+   *  server ref to a connected manager key (`undefined` ⇒ not-connected setup
+   *  failure). */
+  resolvePinnedServerKey: (pinned: PinnedToolCall) => string | undefined;
+  /** Iteration-level pinned tool failures, kept OFF the driver acc so
+   *  `driveHostedEvalTurn` stays pinned-agnostic. The runner threads this into
+   *  the verdict's `failOnToolError` gate (the hosted analogue of
+   *  `LocalEvalTurnAcc.pinnedToolErrors`). */
+  pinnedToolErrors: ToolErrorRecord[];
+  /** Streaming only: the shared pinned SSE synthesis (absent ⇒ batch, headless). */
+  emitPinnedTurn?: (payload: PinnedTurnSsePayload) => void;
+};
 
 /**
  * Production `StepExecutorHandlers` for the HOSTED (MCPJam / org cloud) path — the
  * hosted analogue of {@link buildLocalStepHandlers}. `driveHostedEvalTurn` also
  * mutates a shared `acc` (`{messageHistory, capturedSpans, accumulatedUsage,
  * toolsCalledByPrompt}`) and returns a `completed`/`cancelled`/`failed` outcome;
- * the bridge reports the per-step delta. Hosted has no pinned-turn path (the
- * runner rejects pinned+model mixing), so `onToolCall` is unreachable and errors
- * loudly if a case ever routes one here.
+ * the bridge reports the per-step delta. Pinned (`toolCall`) steps never touch
+ * the backend: `runPinnedTurn` is model-free, so `onToolCall` executes it
+ * inspector-side and injects the resulting plain-text message pair into
+ * `messageHistory` for the next model turn to carry through `/stream`.
  */
 export function buildHostedStepHandlers(
   ctx: HostedStepHandlerContext,
@@ -297,14 +315,91 @@ export function buildHostedStepHandlers(
     };
   }
 
+  // Model-free pinned turn, executed inspector-side (mirrors the local pinned
+  // branch in driveLocalEvalTurn). The whole body is caught: local is shielded
+  // by runLocalIteration's broad iteration catch, but nothing wraps
+  // executeSteps on the hosted path — a throw from `dismissCarriedWidget` /
+  // `renderPinnedToolResult` would otherwise escape persistence entirely.
+  async function drivePinned(
+    step: ToolCallStep,
+    turnOrdinal: number,
+  ): Promise<StepEngineOutcome> {
+    const pinned: PinnedToolCall = {
+      serverName: step.serverName,
+      toolName: step.toolName,
+      arguments: step.arguments,
+    };
+    try {
+      // Mirror the local pinned branch's pre-steps; the executor already
+      // stamped `setActivePromptIndex(turnOrdinal)` before dispatching here.
+      ctx.browser.setActiveWidgetChecks([]);
+      await ctx.browser.dismissCarriedWidget();
+      const result = await runPinnedTurn({
+        pinned,
+        resolvedServerKey: ctx.resolvePinnedServerKey(pinned),
+        mcpClientManager: ctx.mcpClientManager,
+        browser: ctx.browser,
+        promptIndex: turnOrdinal,
+      });
+      const accounting = buildPinnedTurnAccounting(pinned, result);
+      // messageHistory invariant: append only a COMPLETE plain-TEXT
+      // user+assistant pair. The next driveHostedEvalTurn snapshots the full
+      // history as `/stream` input; text-only messages round-trip the backend
+      // untouched — tool-call parts would NOT.
+      acc.messageHistory.push(
+        accounting.userMessage,
+        accounting.assistantMessage,
+      );
+      (acc.toolsCalledByPrompt[turnOrdinal] ??= []).push(
+        ...accounting.toolCalls,
+      );
+      ctx.pinnedToolErrors.push(...accounting.toolErrors);
+      ctx.emitPinnedTurn?.({
+        turnIndex: turnOrdinal,
+        prompt: accounting.prompt,
+        messages: acc.messageHistory,
+        spans: acc.capturedSpans,
+        usage: acc.accumulatedUsage,
+        ...(result.toolCall ? { toolCall: result.toolCall } : {}),
+        ...(result.toolCallId ? { toolCallId: result.toolCallId } : {}),
+        ...("toolResult" in result ? { toolResult: result.toolResult } : {}),
+        ...(result.toolResultIsError
+          ? { toolResultIsError: result.toolResultIsError }
+          : {}),
+        ...(result.toolError ? { toolError: result.toolError } : {}),
+        ...(result.iterationError
+          ? { iterationError: result.iterationError }
+          : {}),
+      });
+      return {
+        messages: [accounting.userMessage, accounting.assistantMessage],
+        ...(accounting.toolCalls.length
+          ? { toolCalls: accounting.toolCalls }
+          : {}),
+        ...(accounting.toolErrors.length
+          ? { toolErrors: accounting.toolErrors }
+          : {}),
+        usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        ...(accounting.iterationError
+          ? { iterationError: accounting.iterationError, setupFailure: true }
+          : {}),
+      };
+    } catch (error) {
+      // Not a setup failure (that flag means "pinned server not connected");
+      // a failed outcome halts the executor, records the remaining steps as
+      // skipped, and lets the iteration persist with the error.
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        iterationError: `pinned tool call "${step.toolName}" failed: ${message}`,
+      };
+    }
+  }
+
   return {
     onPrompt: ({ step, turnOrdinal }) =>
       drivePrompt(step.prompt, turnOrdinal),
-    onToolCall: ({ step }) => {
-      throw new Error(
-        `hosted eval path does not support pinned toolCall steps (step "${step.id}")`,
-      );
-    },
+    onToolCall: ({ step, turnOrdinal }) => drivePinned(step, turnOrdinal),
     onFollowUp: ({ text, turnOrdinal }) => driveTurn(text, turnOrdinal),
   };
 }


### PR DESCRIPTION
## Summary
Stacked on #3076. Removes the *"Pinned tool-call turns are not yet supported with hosted models"* guard by actually implementing them: **hybrid cases (model turns + pinned turns) now run on free MCPJam models (`/stream`) and org cloud BYOK (`/stream/org`)**. Pinned-only cases were never affected (they already route to the local model-free runner before model resolution).

## Why no backend change is needed
The hosted step loop already runs inspector-side (`buildHostedStepHandlers`); only model turns are delegated to the backend. A pinned turn is model-free — `runPinnedTurn` executes the MCP tool via the inspector's client manager and renders the widget in the local browser harness. Its transcript contribution is a plain-text user+assistant pair, which the next model turn's full-history `/stream` request carries through verbatim (the backend casts no-`parts` messages straight to `ModelMessage[]`; `normalizeToolResultOrdering` is a no-op for text). Verified the deployed backend matches source — the message-parse path hasn't changed since 2026-06-28.

## Changes
- `buildHostedStepHandlers.onToolCall`: executes `runPinnedTurn` inspector-side, applies the shared `buildPinnedTurnAccounting` (from #3076), injects the text pair into `messageHistory`, records the call into the executor's per-ordinal bucket (get-or-create, not clobber).
- **Error containment**: the handler body is caught. Local is shielded by `runLocalIteration`'s broad iteration catch, but nothing wraps `executeSteps` on the hosted path — a throw from `dismissCarriedWidget`/`renderPinnedToolResult` would have escaped persistence. It now maps to a failed outcome (halt + skipped steps + persisted error).
- Hosted runner wiring: `resolvePinnedServerKey` closure (same shape as local), `pinnedToolErrors` → verdict `failOnToolError` gate + predicate transcript, `setupFailure` → `status:"failed"`, pinned `renderTimeoutMs` → hosted browser harness, `emitPinnedTurnSse` for streaming (the same emitter local uses — event ordering cannot drift).
- Widget `ui/message` follow-ups after a pinned turn already drain into the hosted model driver via the executor; covered by tests including the `MAX_WIDGET_FOLLOWUP_TURNS` bound.

## Tests
- New `step-handlers-hosted-pinned.test.ts` (8 tests): success accounting + backend-never-touched, content-error, not-connected setup failure, streaming payload, dismiss-throw and render-throw mapping, follow-up drain + budget.
- Parity goldens: `local-stream` / `hosted-batch` / `hosted-stream` hybrid pinned (the pinned SSE slice is byte-identical between local-stream and hosted-stream), plus hosted setup-failure (`status:"failed"`, prompt step skipped, `/stream` never called). Synthetic `pinned-<ts>` toolCallIds scrubbed.
- All 27 files / 304 tests in `server/services/evals/__tests__` green; pre-existing goldens unchanged.

## Notes
- Kept a pre-existing parity quirk rather than widening scope: the step→pinned bridge drops `step.serverId` (serverName-only resolution), matching the local handler. Worth a follow-up.
- Manual E2E still recommended before release: run a hybrid pinned case against a free model on dev (pinned step ticks → widget renders → model turn streams with the "Pinned tool call: …" line in its transcript), and the same against an org cloud-BYOK model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core eval iteration routing, persistence status, and verdict gates for hosted runs; behavior is heavily snapshot-tested but affects production eval outcomes for MCPJam and org cloud models.
> 
> **Overview**
> **Hybrid eval cases** (pinned `toolCall` steps plus model prompts) can now run on **hosted** paths (MCPJam `/stream` and org cloud BYOK) instead of failing upfront with *"Pinned tool-call turns are not yet supported with hosted models."*
> 
> Pinned steps stay **inspector-side and model-free**: `buildHostedStepHandlers.onToolCall` runs `runPinnedTurn`, applies `buildPinnedTurnAccounting`, and appends a plain-text user/assistant pair to `messageHistory` for the next `/stream` turn. The handler is wrapped in **try/catch** so browser harness failures map to persisted iteration errors (hosted `executeSteps` had no outer catch like local). The hosted runner threads **`resolvePinnedServerKey`**, **`pinnedToolErrors`** into the verdict (`failOnToolError` + predicates), **`setupFailure` → `status: "failed"`**, optional **`renderTimeoutMs`** on the browser harness, and **`emitPinnedTurnSse`** when streaming.
> 
> Tests add `step-handlers-hosted-pinned.test.ts`, hybrid **local/hosted batch/stream parity** snapshots, and a hosted setup-failure golden (`/stream` not called when the pinned server is disconnected).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6757a47e0d9e216e5bfb396cc390b0d1cd741312. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for pinned tool-call turns with hosted models. Hybrid evals (pinned tool + model turn) now run on Jam `/stream` and org cloud BYOK `/stream/org`.

- **New Features**
  - `buildHostedStepHandlers.onToolCall` runs `runPinnedTurn` inspector-side and never hits the backend.
  - Injects a plain-text user+assistant pair into `messageHistory` so the next model turn carries it through `/stream`.
  - Threads pinned tool errors into the verdict via `failOnToolError`; parity with local.
  - Adds hosted wiring: `resolvePinnedServerKey`, `emitPinnedTurnSse` for streaming, and passes pinned `renderTimeoutMs` to the browser harness. Removes the old guard in `executeTestCase`.

- **Bug Fixes**
  - Catches `dismissCarriedWidget`/`renderPinnedToolResult` throws and maps them to a failed outcome instead of escaping persistence.
  - Marks not-connected server setup as `status:"failed"` and skips the following prompt step; no backend calls are made in this case.

<sup>Written for commit 6757a47e0d9e216e5bfb396cc390b0d1cd741312. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

