### PR TITLE
Auto-discover the computers remote data plane via Convex

### DIFF
--- a/mcpjam-inspector/server/app.ts
+++ b/mcpjam-inspector/server/app.ts
@@ -60,6 +60,7 @@ import { initXAAIdpKeyPair } from "./services/xaa-idp-keypair.js";
 import { requestLogContextMiddleware } from "./middleware/request-log-context.js";
 import { registerSelfFetch } from "./utils/self-app.js";
 import { getInspectorFrontendUrl } from "./utils/inspector-frontend-url.js";
+import { initComputersRemoteDataPlaneDiscovery } from "./utils/computers/remote-data-plane.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -81,6 +82,10 @@ export function createHonoApp() {
 
   startGuestAuthProvisioningInBackground();
   startLocalBrowserRenderingSetupInBackground();
+  // Mirror of the call in server/index.ts — both production entries must
+  // wire this up so the Electron/embedded path also gets a working Computer
+  // tab. Memoized, so it's harmless if a process ever ran both.
+  void initComputersRemoteDataPlaneDiscovery();
 
   const app = new Hono();
   const strictModeResponse = (c: any, path: string) =>

--- a/mcpjam-inspector/server/index.ts
+++ b/mcpjam-inspector/server/index.ts
@@ -238,6 +238,9 @@ initXAAIdpKeyPair();
 
 startGuestAuthProvisioningInBackground();
 startLocalBrowserRenderingSetupInBackground();
+// Mirror of the call in server/app.ts::createHonoApp — both production
+// entries must wire this up. Memoized, so it's harmless if a process ever
+// ran both.
 void initComputersRemoteDataPlaneDiscovery();
 const app = new Hono().onError((err, c) => {
   appLogger.error("Unhandled error:", err);

--- a/mcpjam-inspector/server/index.ts
+++ b/mcpjam-inspector/server/index.ts
@@ -51,6 +51,7 @@ import { requestLogContextMiddleware } from "./middleware/request-log-context";
 import { getInspectorFrontendUrl } from "./utils/inspector-frontend-url";
 import { createComputerTerminalWsHandler } from "./routes/web/computer-terminal";
 import { createComputerUploadHandler } from "./routes/web/computer-upload";
+import { initComputersRemoteDataPlaneDiscovery } from "./utils/computers/remote-data-plane";
 import { registerSelfFetch } from "./utils/self-app";
 
 const sysLogger = getSystemLogger("process");
@@ -237,6 +238,7 @@ initXAAIdpKeyPair();
 
 startGuestAuthProvisioningInBackground();
 startLocalBrowserRenderingSetupInBackground();
+void initComputersRemoteDataPlaneDiscovery();
 const app = new Hono().onError((err, c) => {
   appLogger.error("Unhandled error:", err);
 

--- a/mcpjam-inspector/server/routes/web/computers.ts
+++ b/mcpjam-inspector/server/routes/web/computers.ts
@@ -4,11 +4,14 @@
  *   GET  /config  (open)    Which data plane serves this inspector: itself
  *                           (`localConfigured`, it holds the vendor key +
  *                           secrets) or a deployed one (`remoteDataPlaneUrl`,
- *                           the NON-secret COMPUTERS_REMOTE_DATA_PLANE_URL).
- *                           The client uses this to aim the terminal
- *                           WebSocket and to render an honest empty state
- *                           when neither is available. No secrets here — a
- *                           boolean and a public URL.
+ *                           the NON-secret COMPUTERS_REMOTE_DATA_PLANE_URL —
+ *                           explicit, or auto-discovered via Convex; see
+ *                           remote-data-plane.ts). Awaits any in-flight
+ *                           discovery so the client's cached first answer is
+ *                           never a false negative. The client uses this to
+ *                           aim the terminal WebSocket and to render an
+ *                           honest empty state when neither is available.
+ *                           No secrets here — a boolean and a public URL.
  *
  *   POST /exec    (bearer)  Run one command on the CALLER'S computer. This is
  *                           what a credential-less local inspector forwards
@@ -29,7 +32,7 @@ import { Hono } from "hono";
 import { z } from "zod";
 import { executionScopeSchema } from "../../utils/execution-scope.js";
 import { isComputersDataPlaneConfigured } from "../../utils/computers/control-plane-client.js";
-import { getComputersRemoteDataPlaneUrl } from "../../utils/computers/remote-data-plane.js";
+import { resolveComputersRemoteDataPlaneUrl } from "../../utils/computers/remote-data-plane.js";
 import {
   MAX_COMMAND_TIMEOUT_S,
   e2bRunner,
@@ -55,10 +58,13 @@ const execSchema = z.object({
 export function createComputersRoutes(runner: BashRunner = e2bRunner): Hono {
   const computers = new Hono();
 
-  computers.get("/config", (c) =>
+  computers.get("/config", async (c) =>
     c.json({
       localConfigured: isComputersDataPlaneConfigured(),
-      remoteDataPlaneUrl: getComputersRemoteDataPlaneUrl(),
+      // Awaits any in-flight startup discovery — the client caches this
+      // FIRST response for the whole SPA session, so it must never race a
+      // still-resolving lookup into a false "unconfigured".
+      remoteDataPlaneUrl: await resolveComputersRemoteDataPlaneUrl(),
     })
   );
 

--- a/mcpjam-inspector/server/utils/__tests__/computers-remote-data-plane.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/computers-remote-data-plane.test.ts
@@ -3,6 +3,7 @@ import {
   getComputersRemoteDataPlaneUrl,
   execViaRemoteDataPlane,
   initComputersRemoteDataPlaneDiscovery,
+  resolveComputersRemoteDataPlaneUrl,
   resetComputersRemoteDataPlaneDiscoveryForTests,
 } from "../computers/remote-data-plane";
 import { buildBashTool } from "../built-in-tools/bash";
@@ -134,6 +135,32 @@ describe("initComputersRemoteDataPlaneDiscovery", () => {
     expect(getComputersRemoteDataPlaneUrl()).toBeNull();
   });
 
+  it("does NOT skip discovery for an invalid override (a typo isn't a real override)", async () => {
+    vi.stubEnv("COMPUTERS_REMOTE_DATA_PLANE_URL", "not a url");
+    vi.stubEnv("CONVEX_HTTP_URL", "https://convex.example");
+    installFetchStub();
+    fetchResponse = () => jsonResponse(200, { url: REMOTE_URL });
+
+    await initComputersRemoteDataPlaneDiscovery();
+
+    expect(fetchCalls).toHaveLength(1);
+    expect(getComputersRemoteDataPlaneUrl()).toBe(REMOTE_URL);
+  });
+
+  it("memoizes: a second call does not re-fetch", async () => {
+    vi.stubEnv("CONVEX_HTTP_URL", "https://convex.example");
+    installFetchStub();
+    fetchResponse = () => jsonResponse(200, { url: REMOTE_URL });
+
+    await Promise.all([
+      initComputersRemoteDataPlaneDiscovery(),
+      initComputersRemoteDataPlaneDiscovery(),
+    ]);
+    await initComputersRemoteDataPlaneDiscovery();
+
+    expect(fetchCalls).toHaveLength(1);
+  });
+
   it("stays unconfigured when Convex has no canonical URL set", async () => {
     vi.stubEnv("CONVEX_HTTP_URL", "https://convex.example");
     installFetchStub();
@@ -141,6 +168,35 @@ describe("initComputersRemoteDataPlaneDiscovery", () => {
 
     await initComputersRemoteDataPlaneDiscovery();
     expect(getComputersRemoteDataPlaneUrl()).toBeNull();
+  });
+});
+
+describe("resolveComputersRemoteDataPlaneUrl", () => {
+  it("awaits a slow in-flight discovery instead of racing it", async () => {
+    vi.stubEnv("CONVEX_HTTP_URL", "https://convex.example");
+    installFetchStub();
+    let resolveFetch: (value: Response) => void;
+    fetchResponse = () =>
+      new Promise<Response>((resolve) => {
+        resolveFetch = resolve;
+      });
+
+    // Simulates server startup firing discovery without awaiting it.
+    void initComputersRemoteDataPlaneDiscovery();
+    const resolved = resolveComputersRemoteDataPlaneUrl();
+
+    // The lookup hasn't returned yet — resolveComputersRemoteDataPlaneUrl
+    // must not settle with a premature null.
+    resolveFetch!(jsonResponse(200, { url: REMOTE_URL }));
+    expect(await resolved).toBe(REMOTE_URL);
+  });
+
+  it("self-triggers discovery when nothing has started it yet", async () => {
+    vi.stubEnv("CONVEX_HTTP_URL", "https://convex.example");
+    installFetchStub();
+    fetchResponse = () => jsonResponse(200, { url: REMOTE_URL });
+
+    expect(await resolveComputersRemoteDataPlaneUrl()).toBe(REMOTE_URL);
   });
 });
 

--- a/mcpjam-inspector/server/utils/__tests__/computers-remote-data-plane.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/computers-remote-data-plane.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   getComputersRemoteDataPlaneUrl,
   execViaRemoteDataPlane,
+  initComputersRemoteDataPlaneDiscovery,
+  resetComputersRemoteDataPlaneDiscoveryForTests,
 } from "../computers/remote-data-plane";
 import { buildBashTool } from "../built-in-tools/bash";
 
@@ -48,6 +50,7 @@ afterEach(() => {
   vi.unstubAllGlobals();
   vi.unstubAllEnvs();
   vi.restoreAllMocks();
+  resetComputersRemoteDataPlaneDiscoveryForTests();
 });
 
 describe("getComputersRemoteDataPlaneUrl", () => {
@@ -71,6 +74,72 @@ describe("getComputersRemoteDataPlaneUrl", () => {
     vi.stubEnv("COMPUTERS_REMOTE_DATA_PLANE_URL", "not a url");
     expect(getComputersRemoteDataPlaneUrl()).toBeNull();
     vi.stubEnv("COMPUTERS_REMOTE_DATA_PLANE_URL", "ftp://dp.example.test");
+    expect(getComputersRemoteDataPlaneUrl()).toBeNull();
+  });
+});
+
+describe("initComputersRemoteDataPlaneDiscovery", () => {
+  it("fetches the canonical URL from Convex and caches it", async () => {
+    vi.stubEnv("CONVEX_HTTP_URL", "https://convex.example");
+    installFetchStub();
+    fetchResponse = () => jsonResponse(200, { url: REMOTE_URL });
+
+    await initComputersRemoteDataPlaneDiscovery();
+
+    expect(fetchCalls).toHaveLength(1);
+    expect(fetchCalls[0].url).toBe(
+      "https://convex.example/computers/data-plane-url"
+    );
+    expect(getComputersRemoteDataPlaneUrl()).toBe(REMOTE_URL);
+  });
+
+  it("skips the network call when an explicit override is set", async () => {
+    vi.stubEnv("COMPUTERS_REMOTE_DATA_PLANE_URL", REMOTE_URL);
+    vi.stubEnv("CONVEX_HTTP_URL", "https://convex.example");
+    installFetchStub();
+
+    await initComputersRemoteDataPlaneDiscovery();
+
+    expect(fetchCalls).toHaveLength(0);
+    expect(getComputersRemoteDataPlaneUrl()).toBe(REMOTE_URL);
+  });
+
+  it("skips the network call when this server already holds real secrets", async () => {
+    vi.stubEnv("CONVEX_HTTP_URL", "https://convex.example");
+    vi.stubEnv("COMPUTERS_DATA_PLANE_SECRET", "secret");
+    vi.stubEnv("E2B_API_KEY", "e2b_test");
+    installFetchStub();
+
+    await initComputersRemoteDataPlaneDiscovery();
+
+    expect(fetchCalls).toHaveLength(0);
+    expect(getComputersRemoteDataPlaneUrl()).toBeNull();
+  });
+
+  it("stays unconfigured (does not throw) when CONVEX_HTTP_URL is unset", async () => {
+    installFetchStub();
+    await expect(initComputersRemoteDataPlaneDiscovery()).resolves.toBeUndefined();
+    expect(fetchCalls).toHaveLength(0);
+    expect(getComputersRemoteDataPlaneUrl()).toBeNull();
+  });
+
+  it("stays unconfigured (does not throw) on a network failure", async () => {
+    vi.stubEnv("CONVEX_HTTP_URL", "https://convex.example");
+    installFetchStub();
+    fetchResponse = () => {
+      throw new TypeError("fetch failed");
+    };
+
+    await expect(initComputersRemoteDataPlaneDiscovery()).resolves.toBeUndefined();
+    expect(getComputersRemoteDataPlaneUrl()).toBeNull();
+  });
+
+  it("stays unconfigured when Convex has no canonical URL set", async () => {
+    vi.stubEnv("CONVEX_HTTP_URL", "https://convex.example");
+    installFetchStub();
+    fetchResponse = () => jsonResponse(200, { url: null });
+
+    await initComputersRemoteDataPlaneDiscovery();
     expect(getComputersRemoteDataPlaneUrl()).toBeNull();
   });
 });

--- a/mcpjam-inspector/server/utils/computers/control-plane-client.ts
+++ b/mcpjam-inspector/server/utils/computers/control-plane-client.ts
@@ -50,7 +50,7 @@ export type ControlPlaneResult<T> =
   | { ok: true; value: T }
   | { ok: false; status: number; error: string };
 
-function getConvexHttpUrl(): string | null {
+export function getConvexHttpUrl(): string | null {
   return process.env.CONVEX_HTTP_URL?.trim() || null;
 }
 

--- a/mcpjam-inspector/server/utils/computers/remote-data-plane.ts
+++ b/mcpjam-inspector/server/utils/computers/remote-data-plane.ts
@@ -18,6 +18,16 @@
  *
  * Local configuration (real secrets) always wins over the remote URL — a
  * deployed data plane never delegates, so there is no forwarding loop.
+ *
+ * `COMPUTERS_REMOTE_DATA_PLANE_URL` is an explicit override, not the primary
+ * path — hand-setting it per environment (per dev laptop, per PR preview) is
+ * exactly the manual-config problem this module exists to avoid. When it's
+ * unset, `initComputersRemoteDataPlaneDiscovery` (called once at server
+ * startup) asks THIS deployment's own Convex for the answer via the
+ * non-secret `/computers/data-plane-url` route (`mcpjam-backend
+ * convex/computersDataPlane.ts`) and caches it — every server pointed at the
+ * same Convex deployment auto-discovers the same data plane with zero
+ * per-environment config.
  */
 import { logger } from "../logger.js";
 import {
@@ -25,10 +35,12 @@ import {
   type RunComputerCommandResult,
 } from "./run-command.js";
 import { type ExecutionScope } from "../execution-scope.js";
+import {
+  getConvexHttpUrl,
+  isComputersDataPlaneConfigured,
+} from "./control-plane-client.js";
 
-/** Origin of the deployed data plane, or null when unset/invalid. */
-export function getComputersRemoteDataPlaneUrl(): string | null {
-  const raw = process.env.COMPUTERS_REMOTE_DATA_PLANE_URL?.trim();
+function normalizeDataPlaneUrl(raw: string | null | undefined): string | null {
   if (!raw) return null;
   try {
     const url = new URL(raw);
@@ -36,6 +48,57 @@ export function getComputersRemoteDataPlaneUrl(): string | null {
     return url.origin;
   } catch {
     return null;
+  }
+}
+
+/** Populated once by `initComputersRemoteDataPlaneDiscovery`; null until then
+ *  (or forever, if discovery is skipped/fails — same as today's unconfigured
+ *  state). */
+let discoveredRemoteUrl: string | null = null;
+
+/** Origin of the deployed data plane, or null when unset/undiscovered.
+ *  Stays synchronous — some callers (the harness pre-flight check) need a
+ *  cheap, non-network check — by reading a value resolved ahead of time
+ *  rather than fetching on every call. */
+export function getComputersRemoteDataPlaneUrl(): string | null {
+  const explicit = normalizeDataPlaneUrl(
+    process.env.COMPUTERS_REMOTE_DATA_PLANE_URL?.trim()
+  );
+  return explicit ?? discoveredRemoteUrl;
+}
+
+export function resetComputersRemoteDataPlaneDiscoveryForTests(): void {
+  discoveredRemoteUrl = null;
+}
+
+/**
+ * Resolves the auto-discovered data-plane URL once at server startup so
+ * `getComputersRemoteDataPlaneUrl` can stay synchronous everywhere else.
+ * Call once during boot, before the server starts accepting requests.
+ *
+ * Skips the network call entirely when an explicit override is already set,
+ * or when this server holds real secrets itself (`isComputersDataPlaneConfigured`)
+ * — a deployed data plane never delegates, so it has nothing to discover.
+ * Never throws: a failed or skipped lookup just leaves Computers
+ * unconfigured, same as today's behavior with no env var set.
+ */
+export async function initComputersRemoteDataPlaneDiscovery(): Promise<void> {
+  if (process.env.COMPUTERS_REMOTE_DATA_PLANE_URL?.trim()) return;
+  if (isComputersDataPlaneConfigured()) return;
+  const base = getConvexHttpUrl();
+  if (!base) return;
+  try {
+    const response = await fetch(
+      new URL("/computers/data-plane-url", base).toString(),
+      { signal: AbortSignal.timeout(5000) }
+    );
+    if (!response.ok) return;
+    const payload = (await response.json()) as { url?: unknown };
+    discoveredRemoteUrl = normalizeDataPlaneUrl(
+      typeof payload.url === "string" ? payload.url : null
+    );
+  } catch (error) {
+    logger.error("[computers] data-plane auto-discovery failed", error);
   }
 }
 

--- a/mcpjam-inspector/server/utils/computers/remote-data-plane.ts
+++ b/mcpjam-inspector/server/utils/computers/remote-data-plane.ts
@@ -51,55 +51,81 @@ function normalizeDataPlaneUrl(raw: string | null | undefined): string | null {
   }
 }
 
+/** The explicit env override, or null when unset/invalid. An invalid value
+ *  (e.g. a typo) is treated the same as unset — it does not suppress
+ *  discovery, since it isn't actually overriding anything. */
+function getExplicitRemoteDataPlaneUrl(): string | null {
+  return normalizeDataPlaneUrl(process.env.COMPUTERS_REMOTE_DATA_PLANE_URL?.trim());
+}
+
 /** Populated once by `initComputersRemoteDataPlaneDiscovery`; null until then
  *  (or forever, if discovery is skipped/fails — same as today's unconfigured
  *  state). */
 let discoveredRemoteUrl: string | null = null;
+
+/** Memoizes `initComputersRemoteDataPlaneDiscovery` so the underlying fetch
+ *  runs at most once per process no matter how many entrypoints call it. */
+let discoveryPromise: Promise<void> | null = null;
 
 /** Origin of the deployed data plane, or null when unset/undiscovered.
  *  Stays synchronous — some callers (the harness pre-flight check) need a
  *  cheap, non-network check — by reading a value resolved ahead of time
  *  rather than fetching on every call. */
 export function getComputersRemoteDataPlaneUrl(): string | null {
-  const explicit = normalizeDataPlaneUrl(
-    process.env.COMPUTERS_REMOTE_DATA_PLANE_URL?.trim()
-  );
-  return explicit ?? discoveredRemoteUrl;
+  return getExplicitRemoteDataPlaneUrl() ?? discoveredRemoteUrl;
 }
 
 export function resetComputersRemoteDataPlaneDiscoveryForTests(): void {
   discoveredRemoteUrl = null;
+  discoveryPromise = null;
 }
 
 /**
- * Resolves the auto-discovered data-plane URL once at server startup so
- * `getComputersRemoteDataPlaneUrl` can stay synchronous everywhere else.
- * Call once during boot, before the server starts accepting requests.
+ * Resolves the auto-discovered data-plane URL, memoized so repeated calls
+ * (from every process entrypoint that boots a Hono app, plus any request
+ * that needs to await an in-flight lookup) share one underlying fetch.
  *
- * Skips the network call entirely when an explicit override is already set,
- * or when this server holds real secrets itself (`isComputersDataPlaneConfigured`)
- * — a deployed data plane never delegates, so it has nothing to discover.
- * Never throws: a failed or skipped lookup just leaves Computers
- * unconfigured, same as today's behavior with no env var set.
+ * Skips the network call entirely when a valid explicit override is already
+ * set, or when this server holds real secrets itself
+ * (`isComputersDataPlaneConfigured`) — a deployed data plane never
+ * delegates, so it has nothing to discover. Never throws: a failed or
+ * skipped lookup just leaves Computers unconfigured, same as today's
+ * behavior with no env var set.
  */
-export async function initComputersRemoteDataPlaneDiscovery(): Promise<void> {
-  if (process.env.COMPUTERS_REMOTE_DATA_PLANE_URL?.trim()) return;
-  if (isComputersDataPlaneConfigured()) return;
-  const base = getConvexHttpUrl();
-  if (!base) return;
-  try {
-    const response = await fetch(
-      new URL("/computers/data-plane-url", base).toString(),
-      { signal: AbortSignal.timeout(5000) }
-    );
-    if (!response.ok) return;
-    const payload = (await response.json()) as { url?: unknown };
-    discoveredRemoteUrl = normalizeDataPlaneUrl(
-      typeof payload.url === "string" ? payload.url : null
-    );
-  } catch (error) {
-    logger.error("[computers] data-plane auto-discovery failed", error);
-  }
+export function initComputersRemoteDataPlaneDiscovery(): Promise<void> {
+  if (discoveryPromise) return discoveryPromise;
+  discoveryPromise = (async () => {
+    if (getExplicitRemoteDataPlaneUrl()) return;
+    if (isComputersDataPlaneConfigured()) return;
+    const base = getConvexHttpUrl();
+    if (!base) return;
+    try {
+      const response = await fetch(
+        new URL("/computers/data-plane-url", base).toString(),
+        { signal: AbortSignal.timeout(5000) }
+      );
+      if (!response.ok) return;
+      const payload = (await response.json()) as { url?: unknown };
+      discoveredRemoteUrl = normalizeDataPlaneUrl(
+        typeof payload.url === "string" ? payload.url : null
+      );
+    } catch (error) {
+      logger.error("[computers] data-plane auto-discovery failed", error);
+    }
+  })();
+  return discoveryPromise;
+}
+
+/**
+ * Awaits any in-flight/completed discovery (kicking it off if nothing has
+ * yet, e.g. in a test) then returns the resolved URL. Use this at the one
+ * call site whose FIRST answer the client caches for the whole SPA session
+ * (`GET /api/web/computers/config`) — that response must never be a false
+ * "unconfigured" raced against startup discovery still in flight.
+ */
+export async function resolveComputersRemoteDataPlaneUrl(): Promise<string | null> {
+  await initComputersRemoteDataPlaneDiscovery();
+  return getComputersRemoteDataPlaneUrl();
 }
 
 function isExecResult(payload: unknown): payload is RunComputerCommandResult {


### PR DESCRIPTION
## Summary
- `getComputersRemoteDataPlaneUrl()` now falls back to a value auto-discovered from this server's own Convex deployment (via the new `GET /computers/data-plane-url` route added in MCPJam/mcpjam-backend#671) when `COMPUTERS_REMOTE_DATA_PLANE_URL` isn't explicitly set.
- Discovery runs once at startup (`initComputersRemoteDataPlaneDiscovery`, fired from `server/index.ts`) and is cached, so `getComputersRemoteDataPlaneUrl()` stays synchronous — required by the harness pre-flight check in `harness-availability.ts`.
- Skips the lookup entirely when this server already holds real secrets (`isComputersDataPlaneConfigured`) or an explicit override is set, so a deployed data plane never delegates.
- Net effect: any local dev box or PR-preview environment pointed at the same Convex deployment as staging (all `pr-*` Railway environments already are) gets a working Computer tab with zero manual env var configuration, once the backend PR is merged and `COMPUTERS_DATA_PLANE_URL` is set on that Convex deployment.

## Test plan
- [x] `npx vitest run server/utils/__tests__/computers-remote-data-plane.test.ts server/utils/__tests__/computers-bash-tool.test.ts server/routes/web/__tests__/computers.test.ts server/utils/harness/__tests__/harness-availability.test.ts` — 45/45 passing, including 6 new tests for the discovery function
- [x] `npx tsc --noEmit -p server/tsconfig.json` — no new errors introduced (pre-existing unrelated errors on main confirmed via `git show origin/main`)
- [ ] Manual: once MCPJam/mcpjam-backend#671 merges and `COMPUTERS_DATA_PLANE_URL` is set on staging's Convex deployment, verify a local dev server pointed at staging's Convex auto-discovers `https://staging.mcpjam.com` and the Computer tab works with no `COMPUTERS_REMOTE_DATA_PLANE_URL` set

Depends on MCPJam/mcpjam-backend#671.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Computers routing and startup wiring across both server entrypoints; mis-discovery or races could misdirect terminal/exec, though failures degrade to today’s unconfigured behavior and discovery is skipped on deployed data planes.
> 
> **Overview**
> Adds **startup auto-discovery** of the Computers remote data plane when `COMPUTERS_REMOTE_DATA_PLANE_URL` is not set: `initComputersRemoteDataPlaneDiscovery()` fetches the canonical URL from Convex `GET /computers/data-plane-url`, caches it, and is invoked from **both** `server/index.ts` and `server/app.ts` (memoized).
> 
> `getComputersRemoteDataPlaneUrl()` still resolves **synchronously** (explicit env override, else discovered cache). Invalid overrides are ignored so discovery can still run. Discovery is skipped when this process is already a full local data plane (`isComputersDataPlaneConfigured`).
> 
> `GET /api/web/computers/config` now uses **`resolveComputersRemoteDataPlaneUrl()`** so the SPA’s first cached config does not race in-flight discovery into a false “unconfigured” state.
> 
> Tests cover discovery, memoization, skip paths, and the resolve race.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc3bcd73ad4a818278b579390d27e3e50b9e4e1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-discovers the Computers remote data plane URL from the app’s Convex deployment at startup, now wired for both the standalone server and Electron paths, and fixes a startup race so the Computer tab works out of the box without `COMPUTERS_REMOTE_DATA_PLANE_URL`.

- **New Features**
  - Added `initComputersRemoteDataPlaneDiscovery()` (called from `server/index.ts` and `server/app.ts`) to fetch `GET /computers/data-plane-url` from Convex, memoized to run once and cache the result.
  - `GET /api/web/computers/config` now awaits `resolveComputersRemoteDataPlaneUrl()` so the client’s first cached response doesn’t race a still-running discovery.
  - `getComputersRemoteDataPlaneUrl()` prefers a valid explicit env var, else returns the discovered URL; stays synchronous for the harness pre-flight check.
  - Skips discovery when this server has real secrets (`isComputersDataPlaneConfigured`) or a valid override is set; invalid overrides don’t suppress discovery.

- **Migration**
  - Requires backend support in `MCPJam/mcpjam-backend#671` and `COMPUTERS_DATA_PLANE_URL` set on that Convex deployment.
  - After that, local dev and PR-preview environments pointing at the same `CONVEX_HTTP_URL` auto-discover the URL; no `COMPUTERS_REMOTE_DATA_PLANE_URL` needed.

<sup>Written for commit dc3bcd73ad4a818278b579390d27e3e50b9e4e1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

