### PR TITLE
feat(evals): scope CI tab by run history; metric labels follow run source

### DIFF
--- a/mcpjam-inspector/client/src/components/CiEvalsTab.tsx
+++ b/mcpjam-inspector/client/src/components/CiEvalsTab.tsx
@@ -131,14 +131,33 @@ export function CiEvalsTab({
     organizationId: null,
   });
 
+  // The CI tab is a lens over CI-active suites: SDK-registered ones (even
+  // before their first run) plus any suite CI has actually reported into
+  // (suite.lastSdkRunAt is the durable server-side signal — backfilled, so
+  // mixed suites whose sdk runs fell out of the recent-runs window still
+  // qualify). Playground-only suites live in the Evaluate tab.
   const visibleSuites = useMemo(
-    () => queries.sortedSuites.filter((entry) => !isExploreSuite(entry.suite)),
+    () =>
+      queries.sortedSuites.filter(
+        (entry) =>
+          !isExploreSuite(entry.suite) &&
+          (entry.suite.source === "sdk" ||
+            entry.suite.lastSdkRunAt != null),
+      ),
     [queries.sortedSuites],
   );
   const hasVisibleSuites = visibleSuites.length > 0;
 
+  // Commit rail groups CI runs only — playground runs on mixed suites would
+  // otherwise flood it as "manual" pseudo-commit groups.
   const commitGroups = useMemo(
-    () => groupRunsByCommit(visibleSuites),
+    () =>
+      groupRunsByCommit(
+        visibleSuites.map((entry) => ({
+          ...entry,
+          recentRuns: entry.recentRuns.filter((run) => run.source === "sdk"),
+        })),
+      ),
     [visibleSuites],
   );
 

--- a/mcpjam-inspector/client/src/components/__tests__/CiEvalsTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/CiEvalsTab.test.tsx
@@ -179,6 +179,9 @@ function makeSuite(overrides: Partial<EvalSuite> = {}): EvalSuite {
     environment: { servers: [] },
     createdAt: 1,
     updatedAt: 1,
+    // The CI tab only lists CI-active suites; fixtures default to
+    // sdk-created so existing scenarios stay in scope.
+    source: "sdk",
     ...overrides,
   };
 }
@@ -280,6 +283,38 @@ describe("CiEvalsTab first-run NUX", () => {
     mocks.useEvalQueries.mockReturnValue(
       makeQueries({
         sortedSuites: [makeEntry({ latestRun: run, recentRuns: [run] })],
+      }),
+    );
+
+    render(<CiEvalsTab convexProjectId="ws-1" />);
+
+    expect(screen.queryByText("Run your first eval")).not.toBeInTheDocument();
+    expect(screen.getByTestId("suite-iterations-view")).toBeInTheDocument();
+  });
+
+  it("excludes playground-only suites from the CI tab", () => {
+    mocks.useEvalQueries.mockReturnValue(
+      makeQueries({
+        sortedSuites: [makeEntry({ suite: makeSuite({ source: "ui" }) })],
+      }),
+    );
+
+    render(<CiEvalsTab convexProjectId="ws-1" />);
+
+    // The only suite is playground-only, so the CI tab treats the project
+    // as having no CI evals yet.
+    expect(screen.getByText("Run your first eval")).toBeInTheDocument();
+  });
+
+  it("includes ui-created suites that CI has reported into", () => {
+    mocks.route.current = { type: "suite-overview", suiteId: "suite-1" };
+    mocks.useEvalQueries.mockReturnValue(
+      makeQueries({
+        sortedSuites: [
+          makeEntry({
+            suite: makeSuite({ source: "ui", lastSdkRunAt: 123 }),
+          }),
+        ],
       }),
     );
 

--- a/mcpjam-inspector/client/src/components/evals/__tests__/helpers-run-metric-source.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/helpers-run-metric-source.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { getLatestRunMetricSource, getRunMetricSource } from "../helpers";
+import type { EvalSuiteRun } from "../types";
+
+function makeRun(overrides: Partial<EvalSuiteRun> = {}): EvalSuiteRun {
+  return {
+    _id: "run-1",
+    suiteId: "suite-1",
+    createdBy: "user-1",
+    runNumber: 1,
+    configRevision: "rev-1",
+    configSnapshot: { tests: [], environment: { servers: [] } },
+    status: "completed",
+    result: "passed",
+    summary: { total: 1, passed: 1, failed: 0, passRate: 1 },
+    createdAt: 1,
+    completedAt: 2,
+    ...overrides,
+  };
+}
+
+describe("getRunMetricSource", () => {
+  it("keys off the run's own source", () => {
+    expect(getRunMetricSource(makeRun({ source: "sdk" }), "ui")).toBe("sdk");
+    expect(getRunMetricSource(makeRun({ source: "ui" }), "sdk")).toBe("ui");
+  });
+
+  it("collapses api and schedule runs to the manual label", () => {
+    expect(getRunMetricSource(makeRun({ source: "api" }), "sdk")).toBe("ui");
+    expect(getRunMetricSource(makeRun({ source: "schedule" }), "sdk")).toBe(
+      "ui",
+    );
+  });
+
+  it("falls back to the suite's source for legacy runs without one", () => {
+    expect(getRunMetricSource(makeRun(), "sdk")).toBe("sdk");
+    expect(getRunMetricSource(makeRun(), "ui")).toBe("ui");
+    expect(getRunMetricSource(null, "sdk")).toBe("sdk");
+    expect(getRunMetricSource(undefined, undefined)).toBe("ui");
+  });
+});
+
+describe("getLatestRunMetricSource", () => {
+  it("labels by the newest run's source on a mixed suite", () => {
+    const runs = [
+      makeRun({ _id: "old-ci", source: "sdk", completedAt: 100 }),
+      makeRun({ _id: "new-ui", source: "ui", completedAt: 200 }),
+    ];
+    expect(getLatestRunMetricSource(runs, "sdk")).toBe("ui");
+  });
+
+  it("uses createdAt when completedAt is missing", () => {
+    const runs = [
+      makeRun({ _id: "a", source: "ui", completedAt: undefined, createdAt: 10 }),
+      makeRun({
+        _id: "b",
+        source: "sdk",
+        completedAt: undefined,
+        createdAt: 20,
+      }),
+    ];
+    expect(getLatestRunMetricSource(runs, "ui")).toBe("sdk");
+  });
+
+  it("falls back to the suite source when there are no runs", () => {
+    expect(getLatestRunMetricSource([], "sdk")).toBe("sdk");
+    expect(getLatestRunMetricSource([], undefined)).toBe("ui");
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/__tests__/suite-switcher.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/suite-switcher.test.tsx
@@ -103,4 +103,33 @@ describe("SuiteSwitcher", () => {
       screen.queryByRole("button", { name: "Delete suite nightly" }),
     ).not.toBeInTheDocument();
   });
+
+  it("hides delete for ui suites that CI has reported into", async () => {
+    const user = userEvent.setup();
+    const mixedEntry = makeEntry("suite-mixed", "mixed");
+    (mixedEntry.suite as { lastSdkRunAt?: number }).lastSdkRunAt = 123;
+
+    render(
+      <SuiteSwitcher
+        suites={[makeEntry("suite-a", "amazon"), mixedEntry]}
+        currentSuiteId="suite-a"
+        onSelectSuite={vi.fn()}
+        onCreateSuite={vi.fn()}
+        onDeleteSuite={vi.fn()}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", {
+        name: /Switch suite \(current: amazon\)/,
+      }),
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Delete suite amazon" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Delete suite mixed" }),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/mcpjam-inspector/client/src/components/evals/helpers.ts
+++ b/mcpjam-inspector/client/src/components/evals/helpers.ts
@@ -649,6 +649,39 @@ export function orderCommitGroupRunsByOutcome(
 }
 
 /**
+ * Metric-label source for a run: CI ('sdk') runs report "Pass Rate"
+ * (per-case summary), everything else — ui/api/schedule — "Accuracy"
+ * (per-iteration). Legacy runs without `source` fall back to the suite's
+ * creation provenance.
+ */
+export function getRunMetricSource(
+  run: { source?: EvalSuiteRun["source"] } | null | undefined,
+  suiteSource?: "ui" | "sdk",
+): "ui" | "sdk" {
+  return (run?.source ?? suiteSource) === "sdk" ? "sdk" : "ui";
+}
+
+/**
+ * Suite-scoped views (hero stats, runs-table header, chart grid) label by
+ * the newest run's source — a mixed suite reads as whatever it did last.
+ */
+export function getLatestRunMetricSource(
+  runs: EvalSuiteRun[],
+  suiteSource?: "ui" | "sdk",
+): "ui" | "sdk" {
+  let latest: EvalSuiteRun | null = null;
+  let latestTs = -1;
+  for (const run of runs) {
+    const ts = run.completedAt ?? run.createdAt ?? 0;
+    if (ts > latestTs) {
+      latest = run;
+      latestTs = ts;
+    }
+  }
+  return getRunMetricSource(latest, suiteSource);
+}
+
+/**
  * Flatten recentRuns across all suites and group by commitSha.
  * Runs without a commitSha go into a "manual" group.
  */

--- a/mcpjam-inspector/client/src/components/evals/run-diff-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-diff-view.tsx
@@ -149,7 +149,10 @@ function RunDiffLoaded({
     [diff.cases]
   );
 
-  const metricLabel = diff.suite.source === "sdk" ? "Pass rate" : "Accuracy";
+  const metricLabel =
+    (diff.compareRun.source ?? diff.suite.source) === "sdk"
+      ? "Pass rate"
+      : "Accuracy";
 
   const summaryMetrics = useMemo(
     () =>

--- a/mcpjam-inspector/client/src/components/evals/run-overview.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-overview.tsx
@@ -26,6 +26,7 @@ import {
   compareRunsBySequence,
   evalStatusLeftBorderClasses,
   formatRunId,
+  getLatestRunMetricSource,
 } from "./helpers";
 import type { SuiteOverviewView } from "@/lib/eval-route-types";
 import { computeIterationResult } from "./pass-criteria";
@@ -442,11 +443,14 @@ export function RunOverview({
       });
   }, [selectedRunIds, onDirectDeleteRun]);
 
+  // Mixed suites label by the newest run's origin, not suite provenance.
+  const metricSource = getLatestRunMetricSource(runs, suite.source);
+
   return (
     <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-4">
       {runs.length > 0 && (
         <SuiteRunsChartGrid
-          suiteSource={suite.source}
+          suiteSource={metricSource}
           runTrendData={runTrendData}
           modelStats={modelStats}
           runsLoading={runsLoading}
@@ -625,7 +629,7 @@ export function RunOverview({
                   <div className="text-right">Failed</div>
                   <div className="text-right">Total</div>
                   <div className="text-right">
-                    {suite.source === "sdk" ? "Pass Rate" : "Accuracy"}
+                    {metricSource === "sdk" ? "Pass Rate" : "Accuracy"}
                   </div>
                   {hasTokenData && responsiveLayout.showTokens && (
                     <div className="text-right">Tokens</div>

--- a/mcpjam-inspector/client/src/components/evals/suite-header.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-header.tsx
@@ -32,7 +32,11 @@ import {
 import { buildEvalsPath, navigateApp } from "@/lib/app-navigation";
 import posthog from "posthog-js";
 import { detectEnvironment, detectPlatform } from "@/lib/PosthogUtils";
-import { formatRunId, getEffectiveSuiteServers } from "./helpers";
+import {
+  formatRunId,
+  getEffectiveSuiteServers,
+  getRunMetricSource,
+} from "./helpers";
 import {
   EvalSuite,
   EvalSuiteRun,
@@ -337,7 +341,10 @@ export function SuiteHeader(props: SuiteHeaderProps) {
   }
 
   if (viewMode === "run-detail" && selectedRunDetails) {
-    const badgeMetricLabel = suite.source === "sdk" ? "Pass Rate" : "Accuracy";
+    const badgeMetricLabel =
+      getRunMetricSource(selectedRunDetails, suite.source) === "sdk"
+        ? "Pass Rate"
+        : "Accuracy";
 
     if (omitRunDetailIdentity) {
       if (hideRunActions) {

--- a/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
@@ -6,7 +6,11 @@ import { useComputersEnabled } from "@/hooks/useComputersEnabled";
 import { useEnvironments } from "@/hooks/useComputerEnvironments";
 import { toast } from "sonner";
 import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
-import { compareRunsBySequence } from "./helpers";
+import {
+  compareRunsBySequence,
+  getLatestRunMetricSource,
+  getRunMetricSource,
+} from "./helpers";
 import { SuiteHeader } from "./suite-header";
 import { SuiteHeroStats } from "./suite-hero-stats";
 import { RunOverview } from "./run-overview";
@@ -842,7 +846,7 @@ export function SuiteIterationsView({
       caseGroupsForSelectedRun={caseGroupsForSelectedRun}
       onExportTraces={projectId ? () => setTracesExportOpen(true) : undefined}
       currentSuiteJudgeConfig={suite.judgeConfig ?? null}
-      source={suite.source}
+      source={getRunMetricSource(selectedRunDetails, suite.source)}
       runDetailSortBy={effectiveRunDetailSortBy}
       onSortChange={effectiveRunDetailSortChange}
       serverNames={suite.environment?.servers || []}
@@ -1129,7 +1133,10 @@ export function SuiteIterationsView({
                           runTrendData={runTrendData}
                           modelStats={modelStats}
                           testCaseCount={cases.length}
-                          isSDK={suite.source === "sdk"}
+                          isSDK={
+                            getLatestRunMetricSource(runs, suite.source) ===
+                            "sdk"
+                          }
                           onRunClick={handleRunClick}
                           onReplayLatestRun={
                             onReplayRun

--- a/mcpjam-inspector/client/src/components/evals/suite-switcher.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-switcher.tsx
@@ -160,10 +160,13 @@ export function SuiteSwitcher({
                   {isActive ? (
                     <Check className="h-4 w-4 shrink-0 text-primary" />
                   ) : null}
-                  {/* CI-created suites can't be deleted from the switcher:
-                      their history is CI's record, and the next report would
-                      recreate the suite anyway. */}
-                  {onDeleteSuite && entry.suite.source !== "sdk" ? (
+                  {/* CI-active suites (created by CI, or reported into by
+                      CI) can't be deleted from the switcher: their history
+                      is CI's record, and the next report would recreate the
+                      suite anyway. */}
+                  {onDeleteSuite &&
+                  entry.suite.source !== "sdk" &&
+                  entry.suite.lastSdkRunAt == null ? (
                     <button
                       type="button"
                       onClick={(e) => {

--- a/mcpjam-inspector/client/src/components/evals/test-cases-overview.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-cases-overview.tsx
@@ -833,8 +833,18 @@ export function TestCasesOverview({
 
                   const caseAndLast = (
                     <>
-                      <span className="min-w-0 flex-1 truncate text-left text-xs font-semibold text-foreground">
-                        {caseTitle}
+                      <span className="flex min-w-0 flex-1 items-center gap-1.5">
+                        <span className="min-w-0 truncate text-left text-xs font-semibold text-foreground">
+                          {caseTitle}
+                        </span>
+                        {testCase.lastSdkWriteAt != null ? (
+                          <span
+                            className="inline-flex shrink-0 items-center rounded border border-border/50 px-1 py-px text-[9px] font-medium uppercase tracking-wide text-muted-foreground"
+                            title="Synced from CI — the next CI report may overwrite manual edits"
+                          >
+                            CI
+                          </span>
+                        ) : null}
                       </span>
                       {showClientRail ? null : lastPart}
                     </>

--- a/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
@@ -2712,6 +2712,13 @@ export function TestTemplateEditor({
                     </h2>
                   </button>
                 )}
+                {(currentTestCase as { lastSdkWriteAt?: number })
+                  ?.lastSdkWriteAt != null ? (
+                  <p className="mt-0.5 text-[11px] text-muted-foreground">
+                    Synced from CI — the next CI report may overwrite manual
+                    edits.
+                  </p>
+                ) : null}
               </div>
               <div className="flex shrink-0 flex-wrap items-center gap-1.5">
                 {onExportDraft ? (

--- a/mcpjam-inspector/client/src/components/evals/types.ts
+++ b/mcpjam-inspector/client/src/components/evals/types.ts
@@ -124,6 +124,11 @@ export type EvalSuite = {
   updatedAt: number;
   latestRunId?: string;
   source?: "ui" | "sdk";
+  /**
+   * Epoch ms of the newest CI (SDK-ingested) run — the durable server-side
+   * "suite has CI runs" signal (backfilled). The CI tab scopes on this.
+   */
+  lastSdkRunAt?: number;
   runCounter?: number;
   defaultPassCriteria?: {
     minimumPassRate: number;
@@ -251,6 +256,12 @@ export type EvalCase = {
   /** Pinned tool call for widget_probe cases. */
   probeConfig?: import("@/shared/probe-config").ProbeConfig;
   lastMessageRun?: string | null;
+  /**
+   * Epoch ms of the last SDK-ingest write to this case's definition.
+   * Present ⇒ the case is synced from CI and manual edits may be
+   * overwritten by the next CI report.
+   */
+  lastSdkWriteAt?: number;
   _creationTime?: number; // Convex auto field
 };
 


### PR DESCRIPTION
## Why

Part 3 of the "one dataset, two lenses" eval unification (after #3075 and [mcpjam-backend#672](https://github.com/MCPJam/mcpjam-backend/pull/672)). With Evaluate showing all suites and `suite.source` now immutable creation provenance, the CI tab needs to scope by *run history* rather than a mutable suite field, and the "Pass Rate"/"Accuracy" labels need to follow the run that's actually on screen — suites can now legitimately hold both CI and playground runs.

## What

- **CI tab scoping**: `visibleSuites` = sdk-created **or** `suite.lastSdkRunAt` set — the durable, backfilled signal from backend#672 that survives sdk runs falling out of the capped recent-runs window. Playground-only suites live in Evaluate; a project with no CI evals sees the quickstart NUX.
- **Commit rail**: `recentRuns` are filtered to `source: "sdk"` before `groupRunsByCommit`, so playground runs on mixed suites no longer flood the rail as `manual-*` pseudo-commit groups (also makes the all-manual → By Suite auto-switch accurate).
- **Metric labels keyed on run source** via new `getRunMetricSource` / `getLatestRunMetricSource` helpers (suite fallback for legacy sourceless runs; `api`/`schedule` keep manual labels): run-detail chain, suite-header badge, run-diff (`compareRun`), run-overview table header + chart grid, and hero stats now follow the newest run on mixed suites.
- **Delete guard** in the suite switcher extends to CI-active mixed suites (`lastSdkRunAt` set).
- **"Synced from CI" notice** on ingest-written cases (`lastSdkWriteAt`): CI chip in the test-cases list, subtitle in the case editor — "the next CI report may overwrite manual edits."
- **Deliberately unchanged**: `pick-trace-repair-source-run` keeps its suite-level sdk block. The backend still rejects trace repair for sdk-created suites (ingest re-upserts steps and would clobber repairs); removing the client check would render a button the server refuses. Mixed UI suites were already eligible via the existing per-run skip.

## Rollout gate

⚠️ **Merge/deploy after backend#672 is deployed to prod and both `migrations/backfillEvalSdkPresence` entrypoints have run** — otherwise `lastSdkRunAt` is unpopulated and historical CI suites vanish from the (still flag-gated) CI tab. The `evaluate-ci` flag flip is the step after this.

## Testing

- New: 6 helper unit tests (run-source keying, api/schedule collapse, latest-run selection); CI-tab inclusion/exclusion tests (playground-only excluded, ui-suite-with-CI-runs included); switcher hides delete for CI-active mixed suites.
- `npm run typecheck:client` clean; full client project green: 519 files / 4,970 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI tab visibility depends on backend `lastSdkRunAt` backfill; metric labeling changes affect mixed-suite UX across several eval views.
> 
> **Overview**
> **CI tab** now lists only CI-active suites: `source === "sdk"` or `lastSdkRunAt` set (not playground-only). The commit rail groups **sdk runs only**, so mixed suites no longer show playground runs as manual commit groups.
> 
> **Pass Rate vs Accuracy** is driven by run provenance via `getRunMetricSource` / `getLatestRunMetricSource` (per-run labels; suite-level views use the newest run). Wired through run detail, header badge, diff view, runs table/charts, and hero stats. Legacy runs without `source` still fall back to suite creation source.
> 
> **Suite switcher** blocks delete when `lastSdkRunAt` is set (CI-active mixed suites), not only sdk-created suites. **Test cases** with `lastSdkWriteAt` show a CI chip and editor warning that the next CI report may overwrite edits.
> 
> Types add `lastSdkRunAt` on suites and `lastSdkWriteAt` on cases. New unit tests cover helpers, CI tab filtering, and switcher delete rules.
> 
> **Deploy after** backend backfill populates `lastSdkRunAt`, or historical CI suites can disappear from the CI tab.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2efdc7e49061f0bdcacaf84960fbbc8a05a5bea9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes the CI tab to CI-active suites and makes metric labels follow the run’s source, so mixed suites display correctly. Also filters the commit rail to CI runs and protects CI-managed suites from deletion.

- New Features
  - CI tab shows suites created by SDK or with `lastSdkRunAt`; playground-only suites stay in Evaluate. Shows quickstart if a project has no CI evals.
  - Commit rail groups only CI runs by filtering `recentRuns` to `source: "sdk"` before `groupRunsByCommit`.
  - Metric labels follow run source via `getRunMetricSource` and `getLatestRunMetricSource`; `api`/`schedule` use manual labels. Updated run detail, suite header badge, run diff, run overview table and charts, and hero stats.
  - Suite switcher: delete is disabled for CI-active suites (including UI suites with `lastSdkRunAt`).
  - CI-synced cases show a small “CI” chip and an editor note when `lastSdkWriteAt` is set.

- Migration
  - Deploy backend PR 672 and run both `migrations/backfillEvalSdkPresence` entry points to populate `lastSdkRunAt`/`lastSdkWriteAt`.
  - Flip the `evaluate-ci` flag after the backfill completes.

<sup>Written for commit 2efdc7e49061f0bdcacaf84960fbbc8a05a5bea9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

