### PR TITLE
fix(swarm): fail fast + surface real errors when the host has no model

### DIFF
--- a/mcpjam-inspector/client/src/components/chatboxes/GenerateSessionsDialog.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/GenerateSessionsDialog.tsx
@@ -143,13 +143,23 @@ export function GenerateSessionsDialog({
   }));
   const hasRequiredServers = serversPayload.some((s) => !s.optional);
 
+  // An unpinned host persists modelId "" — synthetic sessions have no
+  // visitor picker to fall back to (unlike interactive chat), so the run
+  // is doomed before it starts. Gate both action buttons and show the
+  // fix-it notice instead of letting the user sail into a run where every
+  // session fails. The /start route enforces the same guard server-side.
+  const hasNoModel = !chatbox.modelId.trim();
+
   // BYOK is now supported on synthetic runs — the runner dispatches
   // org-BYOK models through /stream/org (or local-usage writeback) and
   // the backend forwarder stamps synthesisRunId onto the resulting
   // llmUsageRecord. The flag is kept to (a) show a spend-warning
   // notice so users know provider credits will be consumed, and (b)
-  // render the rough cost preview below.
-  const isByokChatbox = !isMCPJamProvidedModel(chatbox.modelId);
+  // render the rough cost preview below. A modelless chatbox is NOT
+  // BYOK — without the hasNoModel exclusion, isMCPJamProvidedModel("")
+  // → false used to show the org-key spend warning for a chatbox that
+  // has no model at all.
+  const isByokChatbox = !hasNoModel && !isMCPJamProvidedModel(chatbox.modelId);
 
   // Rough cost estimate (not an upper bound — uses a single blended
   // midpoint rate with no safety multiplier, so it can under-estimate
@@ -388,6 +398,16 @@ export function GenerateSessionsDialog({
 
         {stage === "configure" ? (
           <div className="space-y-4">
+            {hasNoModel ? (
+              <div className="flex items-start gap-2 rounded-md border border-destructive/50 bg-destructive/10 p-3 text-xs text-destructive">
+                <AlertTriangle className="mt-0.5 size-4 shrink-0" />
+                <span>
+                  This chatbox&apos;s host has no model selected. Pick a model
+                  on the host&apos;s Behavior tab, then come back to run
+                  sessions.
+                </span>
+              </div>
+            ) : null}
             {/* Stage 1 — roster selection. Pick saved characters to run, or
                 generate a fresh slate below. */}
             {roster && roster.length > 0 ? (
@@ -538,7 +558,14 @@ export function GenerateSessionsDialog({
               <Button variant="outline" size="sm" onClick={onClose}>
                 Cancel
               </Button>
-              <Button size="sm" onClick={handleGenerate} disabled={generating}>
+              <Button
+                size="sm"
+                onClick={handleGenerate}
+                // hasNoModel: persona generation itself would succeed (it
+                // runs on the backend's own LLM), but the subsequent run
+                // can't — block here so the user isn't led into a dead end.
+                disabled={generating || hasNoModel}
+              >
                 {generating ? (
                   <>
                     <Loader2 className="mr-1 size-3 animate-spin" /> Generating
@@ -553,6 +580,19 @@ export function GenerateSessionsDialog({
 
         {stage === "review" ? (
           <div className="space-y-3">
+            {/* No-model notice — also shown here because the Personas-tab
+                "Run swarm" path opens straight at Review, bypassing the
+                configure-stage notice. */}
+            {hasNoModel ? (
+              <div className="flex items-start gap-2 rounded-md border border-destructive/50 bg-destructive/10 p-3 text-xs text-destructive">
+                <AlertTriangle className="mt-0.5 size-4 shrink-0" />
+                <span>
+                  This chatbox&apos;s host has no model selected. Pick a model
+                  on the host&apos;s Behavior tab, then come back to run
+                  sessions.
+                </span>
+              </div>
+            ) : null}
             {/* BYOK spend warning — also shown here because the Personas-tab
                 "Run swarm" path opens straight at Review, bypassing the
                 configure-stage warning. */}
@@ -645,6 +685,7 @@ export function GenerateSessionsDialog({
                   onClick={handleRun}
                   disabled={
                     starting ||
+                    hasNoModel ||
                     selectedReviewCount === 0 ||
                     selectedReviewCount > MAX_PERSONAS
                   }

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/GenerateSessionsDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/GenerateSessionsDialog.test.tsx
@@ -155,4 +155,30 @@ describe("GenerateSessionsDialog — plan v4 §J affordances", () => {
         .disabled,
     ).toBe(false);
   });
+
+  it("blocks a modelless chatbox: fix-it notice shown, Generate disabled, no false BYOK warning", () => {
+    // An unpinned host persists modelId "" — synthetic runs have no picker
+    // fallback, so the dialog gates instead of leading into a doomed run.
+    // Pre-fix, isMCPJamProvidedModel("") → false also showed the misleading
+    // org-key spend warning for a chatbox with no model at all.
+    const modellessChatbox = { ...baseChatbox, modelId: "" };
+    render(
+      <GenerateSessionsDialog
+        isOpen
+        onClose={() => {}}
+        chatbox={modellessChatbox}
+      />,
+    );
+    expect(
+      screen.getByText(/host has no model selected/i),
+    ).toBeInTheDocument();
+    expect(
+      (screen.getByRole("button", { name: "Generate personas" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+    expect(
+      screen.queryByText(/will consume your provider credits/i),
+    ).toBeNull();
+    expect(screen.queryByText(/Rough cost estimate/i)).toBeNull();
+  });
 });

--- a/mcpjam-inspector/client/src/components/hosts/HostOverlayBar.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/HostOverlayBar.tsx
@@ -14,7 +14,10 @@ import {
 } from "@mcpjam/design-system/dropdown-menu";
 import { cn } from "@/lib/utils";
 import { useHostList, useHostMutations } from "@/hooks/useClients";
-import { emptyHostConfigInputV2 } from "@/lib/client-config-v2";
+import {
+  DEFAULT_SEEDED_HOST_MODEL_ID,
+  emptyHostConfigInputV2,
+} from "@/lib/client-config-v2";
 import { standardEventProps } from "@/lib/PosthogUtils";
 import {
   HOST_TEMPLATES,
@@ -62,7 +65,9 @@ export function HostOverlayBar({
   // Lazily seed a "MCPJam" host with SDK defaults only when the project has
   // no hosts at all. Once any host exists (including after the user deletes
   // MCPJam), we stop seeding — otherwise a deleted MCPJam respawns on every
-  // mount and duplicates accumulate.
+  // mount and duplicates accumulate. Pin a cheap default model: interactive
+  // chat would paper over "" via the picker fallback, but synthetic/swarm
+  // runs consume the pinned value directly and fail on a modelless host.
   const seededRef = useRef(false);
   useEffect(() => {
     if (
@@ -77,7 +82,7 @@ export function HostOverlayBar({
     createHost({
       projectId,
       name: MCPJAM_HOST_NAME,
-      input: emptyHostConfigInputV2(),
+      input: emptyHostConfigInputV2({ modelId: DEFAULT_SEEDED_HOST_MODEL_ID }),
     }).catch(() => {
       seededRef.current = false;
     });

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -104,6 +104,7 @@ import {
   type HostDetail,
 } from "@/hooks/useClients";
 import {
+  DEFAULT_SEEDED_HOST_MODEL_ID,
   emptyHostConfigInputV2,
   gateMcpToolResultImageRenderingByModelVisibility,
 } from "@/lib/client-config-v2";
@@ -1062,7 +1063,9 @@ export function PlaygroundMain({
     createPlaygroundHost({
       projectId: multiHostProjectId,
       name: "MCPJam",
-      input: emptyHostConfigInputV2(),
+      // Pin a cheap default model — see HostOverlayBar's seed for why a
+      // modelless default host breaks synthetic/swarm runs.
+      input: emptyHostConfigInputV2({ modelId: DEFAULT_SEEDED_HOST_MODEL_ID }),
     })
       .then(({ hostId }) => {
         setPreviewedHostId(hostId);

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.multi-host.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.multi-host.test.tsx
@@ -593,6 +593,11 @@ describe("PlaygroundMain — multi-host render path", () => {
         expect.objectContaining({
           projectId: "default",
           name: "MCPJam",
+          // The seed pins a cheap default model — a modelless host breaks
+          // synthetic/swarm runs (no picker fallback on that path).
+          input: expect.objectContaining({
+            modelId: "anthropic/claude-haiku-4.5",
+          }),
         }),
       );
     });

--- a/mcpjam-inspector/client/src/lib/client-config-v2.ts
+++ b/mcpjam-inspector/client/src/lib/client-config-v2.ts
@@ -291,6 +291,15 @@ export type HostConfigDtoV2 = {
 
 export const DEFAULT_HOST_STYLE_V2: HostStyleId = "mcpjam";
 
+// Cheap MCPJam-provided model pinned onto auto-seeded "MCPJam" hosts (the
+// host bar / playground backstops for empty projects). Interactive chat
+// papers over an unset host model via getDefaultModel's picker fallback,
+// but synthetic/swarm runs consume the pinned value directly and fail on
+// "" — seeding a real model keeps the default host runnable everywhere.
+// Matches the top of getDefaultModel's priority list and the dominant
+// template choice; keep the three in sync.
+export const DEFAULT_SEEDED_HOST_MODEL_ID = "anthropic/claude-haiku-4.5";
+
 // Delegates to the Node-safe SDK builder so the empty-config defaults have a
 // single source of truth shared with the server `--template` resolver and the
 // CLI. Cast to the strict client aggregate — the runtime object is

--- a/mcpjam-inspector/server/routes/web/__tests__/chatbox-sessions.no-model.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chatbox-sessions.no-model.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createWebTestApp, postJson, expectJson } from "./helpers/test-app.js";
+
+const ORIGINAL_CONVEX_HTTP_URL = process.env.CONVEX_HTTP_URL;
+
+const fetchChatboxRuntimeConfigMock = vi.fn();
+const createRunMock = vi.fn();
+const startSimulationMock = vi.fn();
+
+vi.mock("../../../utils/chatbox-runtime-config.js", () => ({
+  fetchChatboxRuntimeConfig: (...args: unknown[]) =>
+    fetchChatboxRuntimeConfigMock(...args),
+}));
+
+vi.mock("../../../services/session-agent.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../services/session-agent.js")
+  >("../../../services/session-agent.js");
+  return {
+    ...actual,
+    createRun: (...args: unknown[]) => createRunMock(...args),
+  };
+});
+
+vi.mock("../../../services/sessionSimulation/runner.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../services/sessionSimulation/runner.js")
+  >("../../../services/sessionSimulation/runner.js");
+  return {
+    ...actual,
+    startSimulation: (...args: unknown[]) => startSimulationMock(...args),
+  };
+});
+
+// An unpinned host persists modelId "" (a fully supported host state), and
+// the synthetic runner has no visitor picker to fall back to. The /start
+// route must fail fast with an actionable 400 BEFORE the run record exists —
+// pre-guard, every session died downstream on an opaque backend
+// "model is required" that only reached server logs.
+describe("web routes — simulate-sessions/start on a modelless host", () => {
+  const { app, token } = createWebTestApp();
+
+  beforeEach(() => {
+    process.env.CONVEX_HTTP_URL = "https://test-deployment.convex.site";
+    fetchChatboxRuntimeConfigMock.mockReset();
+    createRunMock.mockReset();
+    startSimulationMock.mockReset();
+    createRunMock.mockResolvedValue({ runId: "run-1" });
+    startSimulationMock.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    if (ORIGINAL_CONVEX_HTTP_URL === undefined) {
+      delete process.env.CONVEX_HTTP_URL;
+    } else {
+      process.env.CONVEX_HTTP_URL = ORIGINAL_CONVEX_HTTP_URL;
+    }
+  });
+
+  const runtimeConfigWithModel = (modelId: string) => ({
+    ok: true,
+    config: {
+      chatboxId: "cbx-1",
+      accessVersion: 0,
+      modelId,
+      systemPrompt: "",
+      temperature: 0.7,
+      requireToolApproval: false,
+      hostStyle: "default",
+    },
+  });
+
+  const startBody = {
+    projectId: "proj-1",
+    servers: [],
+    personas: [{ id: "p-1", name: "Alice", role: "user", notes: "tries it" }],
+    sessionsPerPersona: 1,
+    maxTurns: 3,
+  };
+
+  it.each([
+    ["empty", ""],
+    ["whitespace", "   "],
+  ])(
+    "400s with an actionable message and never creates a run (%s modelId)",
+    async (_label, modelId) => {
+      fetchChatboxRuntimeConfigMock.mockResolvedValue(
+        runtimeConfigWithModel(modelId)
+      );
+
+      const response = await postJson(
+        app,
+        "/api/web/chatboxes/cbx-1/simulate-sessions/start",
+        startBody,
+        token
+      );
+      const { status, data } = await expectJson<{
+        error?: { message?: string };
+      }>(response);
+
+      expect(status).toBe(400);
+      expect(JSON.stringify(data)).toMatch(/no model selected/i);
+      // The guard must fire before the run record exists — otherwise the
+      // dialog polls a doomed "running" run.
+      expect(createRunMock).not.toHaveBeenCalled();
+      expect(startSimulationMock).not.toHaveBeenCalled();
+    }
+  );
+
+  it("still starts the run when the host pins a model", async () => {
+    fetchChatboxRuntimeConfigMock.mockResolvedValue(
+      runtimeConfigWithModel("anthropic/claude-haiku-4.5")
+    );
+
+    const response = await postJson(
+      app,
+      "/api/web/chatboxes/cbx-1/simulate-sessions/start",
+      startBody,
+      token
+    );
+    const { status, data } = await expectJson<{ runId?: string }>(response);
+
+    expect(status).toBe(200);
+    expect(data.runId).toBe("run-1");
+    expect(createRunMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mcpjam-inspector/server/routes/web/chatbox-sessions.ts
+++ b/mcpjam-inspector/server/routes/web/chatbox-sessions.ts
@@ -201,6 +201,21 @@ chatboxSessions.post("/:chatboxId/simulate-sessions/start", async (c) =>
       );
     }
 
+    // Fail fast before the run record exists. An unpinned host persists
+    // modelId "" (a fully supported host state — Save never gates on it),
+    // and unlike interactive chat there is no visitor picker to fall back
+    // to: without this guard the runner misclassifies "" as an Ollama BYOK
+    // model and every session dies on an opaque backend "model is required"
+    // that never reaches the dialog.
+    const modelId = runtime.config.modelId?.trim();
+    if (!modelId) {
+      throw new WebRouteError(
+        400,
+        ErrorCode.VALIDATION_ERROR,
+        "This chatbox's host has no model selected. Pick a model on the host's Behavior tab, then run sessions again."
+      );
+    }
+
     // selectedServerIds may be empty (no required servers): the manager
     // factory returns a connection-less manager and the sessions run
     // toolless, exactly like a real no-opt-in visitor's chat.
@@ -237,7 +252,6 @@ chatboxSessions.post("/:chatboxId/simulate-sessions/start", async (c) =>
     const personas = body.personas as PersonaSlate[];
     const sessionsPerPersona = body.sessionsPerPersona;
     const maxTurns = body.maxTurns;
-    const modelId = runtime.config.modelId;
     const systemPrompt = runtime.config.systemPrompt;
     const temperature = runtime.config.temperature;
     const requireToolApproval = runtime.config.requireToolApproval;

--- a/mcpjam-inspector/server/services/session-agent.ts
+++ b/mcpjam-inspector/server/services/session-agent.ts
@@ -248,7 +248,12 @@ export async function updateRun(
   projectId: string,
   runId: string,
   deltaSummary: DeltaSummary,
-  status?: RunRecord["status"]
+  status?: RunRecord["status"],
+  // Persisted onto the run record (`RunRecord.error`) so the dialog's
+  // running/terminal stage can show a real diagnostic instead of a bare
+  // "Failed". The backend runs/update route already accepts and patches
+  // this field; the write path was the only missing link.
+  errorMessage?: string
 ): Promise<void> {
   const data = await postJson<{ ok?: boolean; error?: string }>(
     `${convexHttpUrl}/session-simulation/runs/update`,
@@ -258,6 +263,7 @@ export async function updateRun(
       runId,
       deltaSummary,
       ...(status ? { status } : {}),
+      ...(errorMessage !== undefined ? { error: errorMessage } : {}),
     },
     NON_LLM_TIMEOUT_MS
   );

--- a/mcpjam-inspector/server/services/sessionSimulation/runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/runner.ts
@@ -84,7 +84,8 @@ async function tryUpdateRunWithRetry(
     | "failed"
     | "rate_limited"
     | undefined,
-  context: string
+  context: string,
+  errorMessage?: string
 ): Promise<void> {
   try {
     await updateRun(
@@ -93,7 +94,8 @@ async function tryUpdateRunWithRetry(
       projectId,
       runId,
       delta,
-      status
+      status,
+      errorMessage
     );
     return;
   } catch (err) {
@@ -113,7 +115,8 @@ async function tryUpdateRunWithRetry(
       projectId,
       runId,
       delta,
-      status
+      status,
+      errorMessage
     );
   } catch (err) {
     logger.error("[sessionSimulation.runner] updateRun failed after retry", {
@@ -354,6 +357,10 @@ async function runSimulationLoop(opts: RunSimulationOptions): Promise<void> {
   let totalSucceeded = 0;
   let totalFailed = 0;
   let totalRateLimited = 0;
+  // First failure diagnostic — persisted onto the run record so the dialog
+  // can show *why* sessions failed (e.g. an org-resolve rejection) instead
+  // of a bare "Failed" while the real message rots in server logs.
+  let firstErrorMessage: string | undefined;
 
   const heartbeat = setInterval(() => {
     if (abortSignal?.aborted) return;
@@ -371,7 +378,7 @@ async function runSimulationLoop(opts: RunSimulationOptions): Promise<void> {
     outer: for (const persona of personas) {
       for (let sessionIdx = 0; sessionIdx < sessionsPerPersona; sessionIdx++) {
         if (abortSignal?.aborted) break outer;
-        const outcome = await runOneSession({
+        const { outcome, errorMessage } = await runOneSession({
           persona,
           sessionIdx,
           runId,
@@ -401,6 +408,13 @@ async function runSimulationLoop(opts: RunSimulationOptions): Promise<void> {
         else if (outcome === "rate_limited") totalRateLimited++;
         else totalFailed++;
 
+        // Persist the first failure's message with its own progress write
+        // so the dialog surfaces the diagnostic while the run is still
+        // going, not only at the terminal update.
+        const carriesFirstError =
+          outcome === "failed" && !firstErrorMessage && !!errorMessage;
+        if (carriesFirstError) firstErrorMessage = errorMessage;
+
         await tryUpdateRunWithRetry(
           convexHttpUrl,
           convexAuthToken,
@@ -412,7 +426,8 @@ async function runSimulationLoop(opts: RunSimulationOptions): Promise<void> {
             rateLimited: outcome === "rate_limited" ? 1 : 0,
           },
           undefined,
-          "per-session-progress"
+          "per-session-progress",
+          carriesFirstError ? firstErrorMessage : undefined
         );
 
         if (outcome === "rate_limited") {
@@ -441,12 +456,14 @@ async function runSimulationLoop(opts: RunSimulationOptions): Promise<void> {
       runId,
       {},
       status,
-      "final-status"
+      "final-status",
+      totalFailed > 0 ? firstErrorMessage : undefined
     );
   } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
     logger.error("[sessionSimulation.runner] run failed", {
       runId,
-      error: error instanceof Error ? error.message : String(error),
+      error: message,
     });
     await tryUpdateRunWithRetry(
       convexHttpUrl,
@@ -455,7 +472,10 @@ async function runSimulationLoop(opts: RunSimulationOptions): Promise<void> {
       runId,
       {},
       "failed",
-      "run-failed"
+      "run-failed",
+      // Run-level abort (setup/heartbeat-adjacent crash) trumps any earlier
+      // per-session diagnostic — it explains why the run stopped.
+      message
     );
   } finally {
     clearInterval(heartbeat);
@@ -463,6 +483,14 @@ async function runSimulationLoop(opts: RunSimulationOptions): Promise<void> {
 }
 
 type SessionOutcome = "succeeded" | "failed" | "rate_limited";
+
+// `errorMessage` rides along on failures so the batch loop can persist the
+// first one onto the run record (RunRecord.error) — previously the message
+// only reached server logs and the dialog rendered a bare "Failed".
+interface SessionResult {
+  outcome: SessionOutcome;
+  errorMessage?: string;
+}
 
 async function runOneSession(args: {
   persona: PersonaSlate;
@@ -488,7 +516,7 @@ async function runOneSession(args: {
   authHeader: string;
   managerFactory: SimulationManagerFactory;
   abortSignal?: AbortSignal;
-}): Promise<SessionOutcome> {
+}): Promise<SessionResult> {
   const {
     persona,
     sessionIdx,
@@ -646,7 +674,7 @@ async function runOneSession(args: {
     let sessionModelSource: SyntheticModelSource | undefined;
 
     for (let turn = 0; turn < maxTurns; turn++) {
-      if (abortSignal?.aborted) return "failed";
+      if (abortSignal?.aborted) return { outcome: "failed" };
 
       const next = await personaNextTurn(
         convexHttpUrl,
@@ -866,11 +894,11 @@ async function runOneSession(args: {
       });
     }
 
-    return "succeeded";
+    return { outcome: "succeeded" };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     if (/rate.?limit|spend|cap/i.test(message)) {
-      return "rate_limited";
+      return { outcome: "rate_limited" };
     }
     logger.warn("[sessionSimulation.runner] session failed", {
       runId,
@@ -878,7 +906,7 @@ async function runOneSession(args: {
       sessionIdx,
       error: message,
     });
-    return "failed";
+    return { outcome: "failed", errorMessage: message };
   } finally {
     // Tear down the browser harness (and its headless Chromium, if launched)
     // before the manager: the harness's widget bridge dispatches tools/call

--- a/mcpjam-inspector/server/utils/__tests__/resolve-synthetic-model-source.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/resolve-synthetic-model-source.test.ts
@@ -203,6 +203,18 @@ describe("buildSyntheticModelDefinition", () => {
     );
     expect(result.provider).toBe("ollama");
   });
+
+  it("throws on an empty/whitespace modelId instead of misclassifying it as Ollama", () => {
+    // An unpinned host persists modelId "" — pre-guard this fell into the
+    // bare-id branch, produced a bogus ollama definition, and the failure
+    // surfaced many hops later as an opaque backend "model is required".
+    expect(() => buildSyntheticModelDefinition("")).toThrow(
+      /no model selected/i,
+    );
+    expect(() => buildSyntheticModelDefinition("   ")).toThrow(
+      /no model selected/i,
+    );
+  });
 });
 
 describe("matchOrgProviderForModelId", () => {

--- a/mcpjam-inspector/server/utils/org-model-config.ts
+++ b/mcpjam-inspector/server/utils/org-model-config.ts
@@ -850,6 +850,17 @@ const ID_PREFIX_TO_PROVIDER: Record<string, ModelProvider> = {
 export function buildSyntheticModelDefinition(
   modelId: string,
 ): ModelDefinition {
+  // An unpinned host persists modelId "" — without this guard the bare-id
+  // fallback below silently classifies it as an Ollama BYOK model and the
+  // failure surfaces many hops later as an opaque backend "model is
+  // required". Both interactive host-wins call sites gate on a truthy
+  // modelId before reaching here, so only genuinely modelless flows throw.
+  if (!modelId.trim()) {
+    throw new Error(
+      "No model selected for this chat. Pick a model on the host before running."
+    );
+  }
+
   const supported = getModelById(modelId);
   if (supported) return supported;
 


### PR DESCRIPTION
## Problem

When a chatbox's host has no model selected (`modelId: ""` — a fully supported host state; Save never gates on it), every swarm/synthetic session fails. The failure chain was invisible to the user:

1. `/simulate-sessions/start` took `runtime.config.modelId` verbatim and created the run record before any validation, so the dialog always showed a live "running" run.
2. `buildSyntheticModelDefinition("")` fell into the bare-id fallback and silently classified the empty string as an **Ollama BYOK model**, which the backend org-resolve rejected with 400 `model is required`.
3. The runner's per-session catch only pattern-matches rate limits; the real message went to server logs only. The `updateRun` write path had no error field, so the dialog rendered a bare **"Failed"** with zero diagnostic.
4. Bonus: `isMCPJamProvidedModel("")` → false, so a modelless chatbox showed the misleading *"will consume your provider credits"* BYOK warning.

Interactive chat never hits this because the composer falls back to `getDefaultModel(...)` and the server's host-wins override is gated on a truthy modelId — swarm has no visitor picker to fall back to.

## Why hosts end up modelless

Every fresh project gets an auto-seeded default `"MCPJam"` host (host overlay bar + playground backstops) built from `emptyHostConfigInputV2()`, which mints `modelId: ""`.

## Fix (five layers)

- **Pre-flight 400**: `/simulate-sessions/start` rejects an empty/whitespace modelId *before* `createRun`, with an actionable message pointing at the host's Behavior tab.
- **Dialog gate**: `GenerateSessionsDialog` disables *Generate personas* and *Run simulation* on a modelless chatbox, shows a fix-it notice on both the configure and review stages (the Personas-tab "Run swarm" path skips configure), and no longer shows the false BYOK spend warning.
- **Errors reach the dialog**: the runner persists the first per-session failure message through `updateRun` onto `RunRecord.error` — mid-run, at the terminal write, and on run-level aborts. The backend `runs/update` route, schema field, and dialog rendering all already existed; only the write path was missing. Older deployed backends ignore the extra body field harmlessly.
- **Fail-fast guard**: `buildSyntheticModelDefinition("")` now throws "No model selected…" instead of returning a phantom Ollama definition. Both interactive host-wins call sites (`web/chat-v2.ts`, `mcp/chat-v2.ts`) gate on a truthy modelId before reaching it, so only genuinely modelless flows throw.
- **Root cause**: the auto-seeded "MCPJam" host now pins `DEFAULT_SEEDED_HOST_MODEL_ID = "anthropic/claude-haiku-4.5"` (cheap, MCPJam-provided; matches `getDefaultModel`'s top priority and the dominant template choice), so fresh projects' default host is swarm-runnable out of the box.

## Not in scope

The raw-config API/CLI create paths (`z.record` config schema) and `duplicateHost` can still mint modelless hosts — those are now caught at run time by the route guard and dialog gate. Creation-time enforcement there is a possible follow-up.

## Tests

- New route test: empty/whitespace modelId → 400 with actionable message, `createRun`/`startSimulation` never called; pinned model still starts.
- New dialog test: modelless chatbox → notice shown, Generate disabled, no false BYOK warning/cost tile.
- New unit test: `buildSyntheticModelDefinition` throws on `""`/whitespace.
- Extended playground seed test: asserts the seeded host carries the default model.
- Full `routes/web` + `sessionSimulation` + affected client suites pass (297 + 29). Client typecheck clean; server typecheck errors unchanged vs main (all pre-existing, none in touched files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches synthetic session start validation, simulation runner persistence, and default host seeding; behavior changes are guarded and tested but affect a user-visible swarm path and LLM routing.
> 
> **Overview**
> Synthetic/swarm sessions used to fail silently when the chatbox host had an empty `modelId`: the start route created a doomed run, empty ids were misclassified as Ollama BYOK, and the dialog showed only **Failed** with no message.
> 
> **Server:** `/simulate-sessions/start` now returns **400** with guidance to pick a model on the host Behavior tab before `createRun`. `buildSyntheticModelDefinition` throws on blank `modelId` instead of building a phantom Ollama definition. The simulation runner persists the first per-session failure (and run-level aborts) through `updateRun` into `RunRecord.error` so polling can show real diagnostics.
> 
> **Client:** `GenerateSessionsDialog` detects `hasNoModel`, shows a fix-it notice on configure and review, disables **Generate personas** and **Run simulation**, and stops treating `""` as BYOK (no false spend warning). Auto-seeded **MCPJam** hosts in the host overlay and playground now pin `DEFAULT_SEEDED_HOST_MODEL_ID` (`anthropic/claude-haiku-4.5`) so new projects can run swarms without manual model selection.
> 
> Tests cover the route guard, dialog gating, model-definition throw, and seeded host model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e3f55d42f51521b97a6530f350408ef5aec8d46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes swarm simulations failing when a host has no model by failing fast and surfacing clear errors. New projects now get a default model so swarm runs work out of the box.

- **Bug Fixes**
  - Route guard: `/simulate-sessions/start` 400s on empty/whitespace `modelId` before `createRun` with a clear message.
  - Dialog gating: `GenerateSessionsDialog` blocks Generate/Run on modelless hosts, shows a fix-it notice on both stages, and removes the false BYOK warning/cost.
  - Error surfacing: runner writes the first failure message via `updateRun` to `RunRecord.error` during progress and at terminal status; `runOneSession` now returns `{ outcome, errorMessage }`.
  - Fail-fast model build: `buildSyntheticModelDefinition` throws on empty/whitespace IDs instead of misclassifying as Ollama.
  - Seeded default: auto-seeded “MCPJam” host pins `DEFAULT_SEEDED_HOST_MODEL_ID` to `anthropic/claude-haiku-4.5` (also in playground seed) so fresh projects can run swarm immediately.
  - Tests added for the route guard, dialog behavior, model guard, and seeded host.

<sup>Written for commit 8e3f55d42f51521b97a6530f350408ef5aec8d46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3085?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

