### PR TITLE
feat(skills): gate hosted Cloud Skills behind skills-enabled flag

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -53,6 +53,7 @@ import { HostSectionTabs } from "./components/hosts/HostSectionTabs";
 import { ConnectViewHeader } from "./components/hosts/ConnectViewHeader";
 import { ComputerView } from "./components/computer/ComputerView";
 import { useComputersEnabledState } from "./hooks/useComputersEnabled";
+import { useSkillsEnabledState } from "./hooks/useSkillsEnabled";
 import { motion } from "framer-motion";
 import { SNAPPY_RAIL } from "./components/hosts/transition-tokens";
 import OAuthDebugCallback from "./components/oauth/OAuthDebugCallback";
@@ -960,15 +961,30 @@ export function PromptsRoute() {
 export function SkillsRoute() {
   const { convexProjectId } = useAppRouteContext();
   const computersEnabled = useComputersEnabledState();
+  const skillsEnabled = useSkillsEnabledState();
 
   // Hosted skills are a project-MEMBERSHIP resource (authored in Convex,
-  // available even without a Computer) — NOT gated on the Computer flag. Access
-  // is enforced server-side. We only wait for the project to resolve, since
-  // hosted skills have no local FS to fall back to (rendering early would hit
-  // the unavailable /api/mcp/skills/* routes). `computersEnabled` is passed
-  // through only for the local-mode Local/Cloud toggle.
-  if (HOSTED_MODE && !convexProjectId) {
-    return null;
+  // available even without a Computer) but gated behind the `skills-enabled`
+  // PostHog flag until QA completes. Access is also enforced server-side.
+  // `computersEnabled` is passed through only for the local-mode Local/Cloud
+  // toggle; the skills flag applies to hosted mode only (local FS skills are
+  // always available).
+  if (HOSTED_MODE) {
+    // Wait for the project to resolve before rendering, since hosted skills
+    // have no local FS to fall back to (rendering early would hit the
+    // unavailable /api/mcp/skills/* routes).
+    if (!convexProjectId) {
+      return null;
+    }
+    // Only redirect on an explicit `false`. While PostHog hydrates the flag is
+    // `undefined`; bouncing then would strand a flagged-in user who cold-loads
+    // /skills directly. Render nothing until it settles.
+    if (skillsEnabled === false) {
+      return <Navigate to={routePaths.servers} replace />;
+    }
+    if (skillsEnabled === undefined) {
+      return null;
+    }
   }
 
   return (

--- a/mcpjam-inspector/client/src/components/__tests__/mcp-sidebar-feature-flags.test.ts
+++ b/mcpjam-inspector/client/src/components/__tests__/mcp-sidebar-feature-flags.test.ts
@@ -4,6 +4,7 @@ import {
   filterByFeatureFlags,
   getEvalsSubnavItems,
   getHostedNavigationSections,
+  resolveHostedSkillsNav,
 } from "../mcp-sidebar";
 import { HOSTED_LOCAL_ONLY_TOOLTIP } from "@/lib/hosted-ui";
 
@@ -405,6 +406,34 @@ describe("getHostedNavigationSections", () => {
         evalsSubnav: true,
       },
     ]);
+  });
+});
+
+describe("resolveHostedSkillsNav (skills-enabled gate)", () => {
+  const hostedSections = () =>
+    getHostedNavigationSections([
+      {
+        id: "others",
+        items: [
+          { title: "Skills", url: "#skills", icon: FakeIcon },
+          { title: "Tools", url: "#tools", icon: FakeIcon },
+        ],
+      },
+    ]);
+
+  it("enables the Skills item when the flag is on", () => {
+    const result = resolveHostedSkillsNav(hostedSections(), true);
+    const skills = result[0].items.find((i) => i.title === "Skills");
+    expect(skills).toBeDefined();
+    expect(skills?.disabled).toBe(false);
+    expect(skills?.disabledTooltip).toBeUndefined();
+  });
+
+  it("drops the Skills item entirely when the flag is off", () => {
+    const result = resolveHostedSkillsNav(hostedSections(), false);
+    expect(result[0].items.find((i) => i.title === "Skills")).toBeUndefined();
+    // Sibling items are untouched.
+    expect(result[0].items.find((i) => i.title === "Tools")).toBeDefined();
   });
 });
 

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input.tsx
@@ -6,6 +6,7 @@ import {
   useMemo,
 } from "react";
 import { HOSTED_MODE } from "@/lib/config";
+import { useSkillsEnabled } from "@/hooks/useSkillsEnabled";
 import type { SkillsSource } from "@/lib/apis/mcp-skills-api";
 import type {
   ChangeEvent,
@@ -292,14 +293,17 @@ export function ChatInput({
 }: ChatInputProps) {
   // Cloud skill source for the `/` picker: in hosted mode, list/load skills
   // from the project's Convex/Computer source (Playground carries projectId via
-  // `clientSelector`). Local mode keeps the default (filesystem) path. Memoized
-  // so the popover's fetch effects don't re-run every render.
+  // `clientSelector`). Gated behind the `skills-enabled` flag until QA completes
+  // (flag off ⇒ no cloud source, so the picker lists no cloud skills). Local
+  // mode keeps the default (filesystem) path. Memoized so the popover's fetch
+  // effects don't re-run every render.
+  const skillsEnabled = useSkillsEnabled();
   const skillsSource = useMemo<SkillsSource | undefined>(
     () =>
-      HOSTED_MODE && clientSelector?.cloudProjectId
+      HOSTED_MODE && skillsEnabled && clientSelector?.cloudProjectId
         ? { kind: "cloud", projectId: clientSelector.cloudProjectId }
         : undefined,
-    [clientSelector?.cloudProjectId],
+    [clientSelector?.cloudProjectId, skillsEnabled],
   );
   const chatboxHostStyle = useChatboxHostStyle();
   const chatboxHostTheme = useChatboxHostTheme();

--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -376,21 +376,32 @@ const hostedNavigationSections =
   getHostedNavigationSections(navigationSections);
 
 /**
- * Enable the hosted Skills nav item. `getHostedNavigationSections` runs at
- * module load (no hooks) and marks Skills disabled by default; hosted skills are
- * a **project-membership** resource (authored in Convex, available even without
- * a Computer), so for any hosted member we flip it to enabled. Access is
- * enforced server-side, not by this nav state.
+ * Resolve the hosted Skills nav item against the `skills-enabled` PostHog flag.
+ * `getHostedNavigationSections` runs at module load (no hooks) and marks Skills
+ * disabled by default. Hosted skills are a **project-membership** resource
+ * (authored in Convex, available even without a Computer), but are gated behind
+ * the flag until QA completes:
+ *   - flag on  ⇒ flip the item to enabled (access is still enforced server-side);
+ *   - flag off ⇒ drop the item entirely, rather than leave it grayed with the
+ *     "local only" tooltip, which would misrepresent why it's unavailable.
  */
-function enableHostedSkillsNav(sections: NavSection[]): NavSection[] {
-  return sections.map((section) => ({
-    ...section,
-    items: section.items.map((item) =>
-      normalizeHostedHashTab(item.url.replace(/^[#/]+/, "")) === "skills"
-        ? { ...item, disabled: false, disabledTooltip: undefined }
-        : item,
-    ),
-  }));
+export function resolveHostedSkillsNav(
+  sections: NavSection[],
+  enabled: boolean,
+): NavSection[] {
+  return sections
+    .map((section) => ({
+      ...section,
+      items: section.items.flatMap((item) => {
+        const isSkills =
+          normalizeHostedHashTab(item.url.replace(/^[#/]+/, "")) === "skills";
+        if (!isSkills) return [item];
+        return enabled
+          ? [{ ...item, disabled: false, disabledTooltip: undefined }]
+          : [];
+      }),
+    }))
+    .filter((section) => section.items.length > 0);
 }
 
 interface MCPSidebarProps extends React.ComponentProps<typeof Sidebar> {
@@ -585,6 +596,9 @@ export function MCPSidebar({
   const learnMoreEnabled = useFeatureFlagEnabled("learn-more-enabled");
   const conformanceEnabled = useFeatureFlagEnabled("mcpjam-conformance");
   const compatibilityEnabled = useFeatureFlagEnabled("mcpjam-compatibility");
+  // Hosted Cloud Skills nav is gated until QA completes; fail-closed (absent /
+  // loading flag ⇒ hidden). See `useSkillsEnabled`.
+  const skillsEnabled = useFeatureFlagEnabled("skills-enabled");
   const { isAuthenticated, isLoading: isConvexAuthLoading } = useConvexAuth();
   const { user, isLoading: isWorkOsAuthLoading } = useAuth();
   // Until WorkOS + Convex resolve the session we don't yet know guest-vs-authed
@@ -673,7 +687,7 @@ export function MCPSidebar({
   const hubNavHash = "#servers";
   const visibleNavigationSections = filterByFeatureFlags(
     HOSTED_MODE
-      ? enableHostedSkillsNav(hostedNavigationSections)
+      ? resolveHostedSkillsNav(hostedNavigationSections, skillsEnabled === true)
       : navigationSections,
     featureFlags
   );

--- a/mcpjam-inspector/client/src/hooks/useSkillsEnabled.ts
+++ b/mcpjam-inspector/client/src/hooks/useSkillsEnabled.ts
@@ -1,0 +1,31 @@
+import { useFeatureFlagEnabled } from "posthog-js/react";
+
+/**
+ * PostHog rollout gate for hosted Cloud Skills (the Skills nav tab + route and
+ * the Playground `/` skill picker). Flag off ⇒ hosted skills are invisible and
+ * the Playground never lists/loads cloud skills, so we can QA + roll them out
+ * per-user / by percentage without a deploy.
+ *
+ * Fail-closed: `useFeatureFlagEnabled` returns `undefined` while flags load AND
+ * when the flag does not exist. Both are treated as "not enabled" (`=== true`),
+ * so hosted skills stay hidden until the flag is deliberately created and
+ * flipped on. This gates hosted mode only; local-mode filesystem skills are
+ * unaffected (their call sites never read this flag).
+ */
+export const SKILLS_FEATURE_FLAG = "skills-enabled";
+
+/**
+ * Tri-state flag: `true` enabled, `false` explicitly disabled, `undefined`
+ * while PostHog is still loading (or the flag is absent). Route guards must
+ * distinguish "disabled" from "not resolved yet" so a direct /skills cold load
+ * doesn't redirect a flagged-in user before the flag hydrates (see
+ * `SkillsRoute`). Visibility gates that only hide UI should use
+ * `useSkillsEnabled` instead.
+ */
+export function useSkillsEnabledState(): boolean | undefined {
+  return useFeatureFlagEnabled(SKILLS_FEATURE_FLAG);
+}
+
+export function useSkillsEnabled(): boolean {
+  return useSkillsEnabledState() === true;
+}

--- a/mcpjam-inspector/client/src/lib/hosted-tab-policy.ts
+++ b/mcpjam-inspector/client/src/lib/hosted-tab-policy.ts
@@ -38,11 +38,12 @@ export const HOSTED_HASH_ALLOWED_TABS = [
   // server-side, not by this list). Reached via the Connect tab switcher, not
   // a standalone sidebar item, so it needs the hash allow-list only — see PR.
   "computer",
-  // Cloud Skills are supported in hosted mode when the Computer feature is on
-  // (skills live on the project's Computer). Kept OUT of the sidebar-allowed
-  // list so the nav item stays disabled-by-default until the Computer flag
-  // flips it on at render time (see `withCloudSkillsGate`); the route guard
-  // (`SkillsRoute`) enforces the flag on direct navigation.
+  // Cloud Skills are a project-membership resource (Convex-backed, usable in
+  // the Playground without a Computer) but gated behind the `skills-enabled`
+  // PostHog flag until QA completes. Kept OUT of the sidebar-allowed list so the
+  // nav item is disabled-by-default; `resolveHostedSkillsNav` (mcp-sidebar)
+  // enables it only when the flag is on, and the route guard (`SkillsRoute`)
+  // redirects direct navigation when the flag is off.
   "skills",
 ] as const;
 


### PR DESCRIPTION
## Summary

Hosted Cloud Skills — the **Skills nav item**, the **`/skills` route**, and the **Playground `/` skill picker** — were live for every hosted member. This gates all three behind a new `skills-enabled` PostHog flag until QA completes.

**Fail-closed:** an absent or still-loading flag reads as *off*, so hosted skills stay hidden until the flag is deliberately ramped. The PostHog flag ([`skills-enabled`, id 752832](https://us.posthog.com/project/212744/feature_flags/752832)) already exists at **0% rollout**, so merging + deploying immediately hides skills for everyone; QA by adding a person/cohort release condition.

Hosted-only — local-mode filesystem skills are untouched.

## Changes

- **`useSkillsEnabled.ts`** (new) — tri-state PostHog hook mirroring `useComputersEnabled`.
- **`SkillsRoute`** (`App.tsx`) — hosted branch redirects to `servers` on explicit `false`, waits on `undefined` (same tri-state pattern as `ComputerRoute`, so a flagged-in user cold-loading `/skills` isn't bounced before the flag hydrates).
- **`resolveHostedSkillsNav`** (`mcp-sidebar.tsx`, renamed from `enableHostedSkillsNav`) — flag on ⇒ enable the nav item; flag off ⇒ **drop it entirely** rather than show it grayed with a misleading "local only" tooltip.
- **`chat-input.tsx`** — gates the cloud `skillsSource` so the Playground `/` picker lists/loads no cloud skills when off.
- Fixes two **stale gate-comments** that claimed skills gated on the Computer flag.

## Scope note

Server-side `shouldEnableCloudSkillTools` (`web/chat-v2.ts`) is intentionally **not** gated — this is a client visibility/QA gate, not a security boundary. With the picker hidden, nothing reaches that path. A hard server-side gate can be a follow-up if needed.

## Testing

- `typecheck:client` clean.
- 63 tests pass across `mcp-sidebar-feature-flags` + `ChatInput` (added 2 cases for `resolveHostedSkillsNav` on/off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only feature-flag visibility for hosted skills; no auth or server enforcement changes in this PR.
> 
> **Overview**
> Hosted **Cloud Skills** are now behind the PostHog **`skills-enabled`** flag (fail-closed until QA rollout). **Local filesystem skills are unchanged.**
> 
> A new **`useSkillsEnabled`** hook mirrors the computers flag pattern: boolean helpers for UI, tri-state for routes.
> 
> **`SkillsRoute`** (hosted only) waits for project + flag hydration, redirects to servers on explicit `false`, and avoids bouncing flagged-in users on cold `/skills` loads while the flag is still `undefined`.
> 
> **Sidebar:** `enableHostedSkillsNav` becomes **`resolveHostedSkillsNav`** — flag on enables Skills; flag off **removes** the nav item instead of showing a misleading “local only” disabled state.
> 
> **Playground** `chat-input` only sets cloud `skillsSource` when the flag is on, so the `/` picker does not list or load cloud skills when gated.
> 
> Comments in **`hosted-tab-policy`** are updated to describe skills gating via this flag, not the Computer flag. Tests cover `resolveHostedSkillsNav` on/off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d05b0711ee25d5ca17852c46bfbed6f6bd0b868b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gated hosted Cloud Skills (Skills nav item, /skills route, and the Playground “/” picker) behind the `skills-enabled` PostHog flag for staged QA rollout. The flag fails closed, so skills are hidden by default; local filesystem skills are unchanged.

- **New Features**
  - Added `useSkillsEnabledState` (tri-state) and `useSkillsEnabled` hooks using `posthog-js/react` and the `skills-enabled` flag.
  - Updated `SkillsRoute` to wait on the flag in hosted mode, redirect to `servers` when false, and avoid redirect while the flag is loading.
  - Replaced `enableHostedSkillsNav` with `resolveHostedSkillsNav`; when off, drop the Skills nav item entirely, when on, enable it.
  - Gated the chat “/” picker’s cloud `skillsSource` so it lists no cloud skills when the flag is off.
  - Hosted-only visibility gate; server access remains unchanged (not a security boundary).

<sup>Written for commit d05b0711ee25d5ca17852c46bfbed6f6bd0b868b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3087?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

