### PR TITLE
Harden computers data-plane: loopback-only http, owner/project check, token= redaction

### DIFF
--- a/mcpjam-inspector/server/middleware/__tests__/session-auth.test.ts
+++ b/mcpjam-inspector/server/middleware/__tests__/session-auth.test.ts
@@ -330,4 +330,18 @@ describe("scrubTokenFromUrl", () => {
     const url = "/api/test";
     expect(scrubTokenFromUrl(url)).toBe("/api/test");
   });
+
+  it("scrubs a bare token= param (e.g. a stray computer terminal token)", () => {
+    const url = "/api/web/computers/terminal?token=eyJhbGciOi.abc.def&cols=80";
+    expect(scrubTokenFromUrl(url)).toBe(
+      "/api/web/computers/terminal?token=[REDACTED]&cols=80",
+    );
+  });
+
+  it("scrubs token= without clobbering _token= in the same URL", () => {
+    const url = "/api/test?_token=session123&token=terminal456";
+    expect(scrubTokenFromUrl(url)).toBe(
+      "/api/test?_token=[REDACTED]&token=[REDACTED]",
+    );
+  });
 });

--- a/mcpjam-inspector/server/middleware/session-auth.ts
+++ b/mcpjam-inspector/server/middleware/session-auth.ts
@@ -61,15 +61,19 @@ const UNPROTECTED_PREFIXES = [
 
 /**
  * Scrub sensitive tokens from URLs for safe logging.
- * Replaces _token (session token), k (tunnel bearer secret), and t (the
- * retired harness `?t=` proxy-token fallback — still scrubbed in case a stale
- * URL carries one) query parameter values with [REDACTED].
+ * Replaces _token (session token), k (tunnel bearer secret), t (the retired
+ * harness `?t=` proxy-token fallback), and token (the computer terminal/
+ * upload token — routes/web/computer-terminal.ts takes it from the WS
+ * subprotocol only, never `?token=`, but this is scrubbed defensively in
+ * case a stale client, a proxy, or a future regression puts one in the URL)
+ * query parameter values with [REDACTED].
  */
 export function scrubTokenFromUrl(url: string): string {
   return url
     .replace(/([?&])_token=[^&]*/g, "$1_token=[REDACTED]")
     .replace(/([?&])k=[^&]*/g, "$1k=[REDACTED]")
-    .replace(/([?&])t=[^&]*/g, "$1t=[REDACTED]");
+    .replace(/([?&])t=[^&]*/g, "$1t=[REDACTED]")
+    .replace(/([?&])token=[^&]*/g, "$1token=[REDACTED]");
 }
 
 // Routes that typically use query param auth (SSE endpoints)

--- a/mcpjam-inspector/server/routes/web/__tests__/computer-terminal.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/computer-terminal.test.ts
@@ -66,7 +66,8 @@ async function signToken(
 }
 
 function installSandboxInfoStub(
-  providerComputerId: string | null = "sbx_42"
+  providerComputerId: string | null = "sbx_42",
+  overrides: { projectId?: string; ownerUserId?: string } = {}
 ) {
   vi.stubGlobal(
     "fetch",
@@ -79,8 +80,8 @@ function installSandboxInfoStub(
             providerComputerId,
             provider: "e2b",
             status: providerComputerId ? "ready" : "provisioning",
-            projectId: "projects_789",
-            ownerUserId: "users_123",
+            projectId: overrides.projectId ?? "projects_789",
+            ownerUserId: overrides.ownerUserId ?? "users_123",
           }),
           { status: 200, headers: { "content-type": "application/json" } }
         );
@@ -201,6 +202,34 @@ describe("GET /api/web/computers/terminal", () => {
     );
     const closed = await waitForClose(ws);
     expect(closed.code).toBe(4503);
+  });
+
+  it("rejects when the sandbox-info row's owner doesn't match the token's claims", async () => {
+    stubConfiguredEnv();
+    // Row belongs to a different user than the token claims — e.g. the
+    // computer's ownership changed after the token was minted.
+    installSandboxInfoStub("sbx_42", { ownerUserId: "users_other" });
+    const token = await signToken();
+    const ws = new WebSocket(
+      `ws://127.0.0.1:${port}/api/web/computers/terminal?cols=80&rows=24`,
+      [token]
+    );
+    const closed = await waitForClose(ws);
+    expect(closed.code).toBe(4401);
+    expect(vi.mocked(Sandbox.connect)).not.toHaveBeenCalled();
+  });
+
+  it("rejects when the sandbox-info row's project doesn't match the token's claims", async () => {
+    stubConfiguredEnv();
+    installSandboxInfoStub("sbx_42", { projectId: "projects_other" });
+    const token = await signToken();
+    const ws = new WebSocket(
+      `ws://127.0.0.1:${port}/api/web/computers/terminal?cols=80&rows=24`,
+      [token]
+    );
+    const closed = await waitForClose(ws);
+    expect(closed.code).toBe(4401);
+    expect(vi.mocked(Sandbox.connect)).not.toHaveBeenCalled();
   });
 
   it("opens a PTY and records the terminal session for a subprotocol token", async () => {

--- a/mcpjam-inspector/server/routes/web/__tests__/computer-upload.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/computer-upload.test.ts
@@ -330,6 +330,58 @@ describe("POST /api/web/computers/upload", () => {
     expect(res.status).toBe(503);
   });
 
+  it("401s when the sandbox-info row's owner doesn't match the token's claims", async () => {
+    stubConfiguredEnv();
+    installSandboxInfoStub((path) =>
+      path === "/computers/sandbox-info"
+        ? {
+            status: 200,
+            json: {
+              computerId: "computers_456",
+              providerComputerId: "sbx_42",
+              provider: "e2b",
+              status: "ready",
+              projectId: "projects_789",
+              ownerUserId: "users_other",
+            },
+          }
+        : undefined
+    );
+    const fake = fakeSandbox();
+    const app = createApp(async () => fake.sandbox);
+    const res = await uploadRequest(app, await signToken(), [
+      new File([new Uint8Array([1])], "a.txt"),
+    ]);
+    expect(res.status).toBe(401);
+    expect(fake.writes).toHaveLength(0);
+  });
+
+  it("401s when the sandbox-info row's project doesn't match the token's claims", async () => {
+    stubConfiguredEnv();
+    installSandboxInfoStub((path) =>
+      path === "/computers/sandbox-info"
+        ? {
+            status: 200,
+            json: {
+              computerId: "computers_456",
+              providerComputerId: "sbx_42",
+              provider: "e2b",
+              status: "ready",
+              projectId: "projects_other",
+              ownerUserId: "users_123",
+            },
+          }
+        : undefined
+    );
+    const fake = fakeSandbox();
+    const app = createApp(async () => fake.sandbox);
+    const res = await uploadRequest(app, await signToken(), [
+      new File([new Uint8Array([1])], "a.txt"),
+    ]);
+    expect(res.status).toBe(401);
+    expect(fake.writes).toHaveLength(0);
+  });
+
   it("503s when the computer is still provisioning (no providerComputerId)", async () => {
     stubConfiguredEnv();
     installSandboxInfoStub((path) =>

--- a/mcpjam-inspector/server/routes/web/computer-terminal.ts
+++ b/mcpjam-inspector/server/routes/web/computer-terminal.ts
@@ -123,6 +123,17 @@ export function createComputerTerminalWsHandler(
         if (!info.ok) {
           rejectCode = CLOSE_UNAVAILABLE;
           rejectMessage = `Computer unavailable: ${info.error}`;
+        } else if (
+          info.value.ownerUserId !== claims.userId ||
+          info.value.projectId !== claims.projectId
+        ) {
+          // Defense-in-depth: the token was already authorized for this
+          // computerId at mint time (~60s TTL), but re-check the row's
+          // current owner/project against the token's claims before ever
+          // touching the vendor sandbox — guards the (narrow) window where
+          // the row's ownership or project changes between mint and use.
+          rejectCode = CLOSE_UNAUTHORIZED;
+          rejectMessage = "Invalid or expired terminal token.";
         } else if (!info.value.providerComputerId) {
           rejectCode = CLOSE_UNAVAILABLE;
           rejectMessage = "Computer is still provisioning.";

--- a/mcpjam-inspector/server/routes/web/computer-upload.ts
+++ b/mcpjam-inspector/server/routes/web/computer-upload.ts
@@ -126,6 +126,17 @@ export function createComputerUploadHandler(deps: ComputerUploadDeps = {}) {
         503
       );
     }
+    // Defense-in-depth: see computer-terminal.ts for why this re-checks the
+    // row's current owner/project against the token's claims.
+    if (
+      info.value.ownerUserId !== claims.userId ||
+      info.value.projectId !== claims.projectId
+    ) {
+      return c.json(
+        { ok: false, error: "Invalid or expired terminal token." },
+        401
+      );
+    }
     if (!info.value.providerComputerId) {
       return c.json({ ok: false, error: "Computer is still provisioning." }, 503);
     }

--- a/mcpjam-inspector/server/utils/__tests__/computers-remote-data-plane.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/computers-remote-data-plane.test.ts
@@ -66,9 +66,16 @@ describe("getComputersRemoteDataPlaneUrl", () => {
     expect(getComputersRemoteDataPlaneUrl()).toBe(REMOTE_URL);
   });
 
-  it("keeps explicit ports and allows plain http", () => {
+  it("keeps explicit ports and allows plain http for loopback hosts", () => {
     vi.stubEnv("COMPUTERS_REMOTE_DATA_PLANE_URL", "http://localhost:3500");
     expect(getComputersRemoteDataPlaneUrl()).toBe("http://localhost:3500");
+    vi.stubEnv("COMPUTERS_REMOTE_DATA_PLANE_URL", "http://127.0.0.1:3500");
+    expect(getComputersRemoteDataPlaneUrl()).toBe("http://127.0.0.1:3500");
+  });
+
+  it("rejects plain http for a non-loopback host", () => {
+    vi.stubEnv("COMPUTERS_REMOTE_DATA_PLANE_URL", "http://staging.mcpjam.com");
+    expect(getComputersRemoteDataPlaneUrl()).toBeNull();
   });
 
   it("rejects invalid values and non-http(s) schemes", () => {
@@ -137,6 +144,18 @@ describe("initComputersRemoteDataPlaneDiscovery", () => {
 
   it("does NOT skip discovery for an invalid override (a typo isn't a real override)", async () => {
     vi.stubEnv("COMPUTERS_REMOTE_DATA_PLANE_URL", "not a url");
+    vi.stubEnv("CONVEX_HTTP_URL", "https://convex.example");
+    installFetchStub();
+    fetchResponse = () => jsonResponse(200, { url: REMOTE_URL });
+
+    await initComputersRemoteDataPlaneDiscovery();
+
+    expect(fetchCalls).toHaveLength(1);
+    expect(getComputersRemoteDataPlaneUrl()).toBe(REMOTE_URL);
+  });
+
+  it("does NOT skip discovery for a non-loopback http override (rejected, not a real override)", async () => {
+    vi.stubEnv("COMPUTERS_REMOTE_DATA_PLANE_URL", "http://staging.mcpjam.com");
     vi.stubEnv("CONVEX_HTTP_URL", "https://convex.example");
     installFetchStub();
     fetchResponse = () => jsonResponse(200, { url: REMOTE_URL });

--- a/mcpjam-inspector/server/utils/__tests__/computers-remote-data-plane.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/computers-remote-data-plane.test.ts
@@ -73,6 +73,11 @@ describe("getComputersRemoteDataPlaneUrl", () => {
     expect(getComputersRemoteDataPlaneUrl()).toBe("http://127.0.0.1:3500");
   });
 
+  it("allows plain http for the IPv6 loopback (bracketed by URL parsing)", () => {
+    vi.stubEnv("COMPUTERS_REMOTE_DATA_PLANE_URL", "http://[::1]:3500");
+    expect(getComputersRemoteDataPlaneUrl()).toBe("http://[::1]:3500");
+  });
+
   it("rejects plain http for a non-loopback host", () => {
     vi.stubEnv("COMPUTERS_REMOTE_DATA_PLANE_URL", "http://staging.mcpjam.com");
     expect(getComputersRemoteDataPlaneUrl()).toBeNull();

--- a/mcpjam-inspector/server/utils/computers/remote-data-plane.ts
+++ b/mcpjam-inspector/server/utils/computers/remote-data-plane.ts
@@ -40,11 +40,26 @@ import {
   isComputersDataPlaneConfigured,
 } from "./control-plane-client.js";
 
+function isLoopbackHost(hostname: string): boolean {
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+}
+
+/**
+ * Normalizes to a bare http(s) origin, matching the policy the backend
+ * already enforces on `/computers/data-plane-url` (mcpjam-backend
+ * `computersDataPlane.ts`): non-http(s) schemes are rejected outright, and
+ * plain `http:` is only allowed for a loopback host — a real deployment
+ * must be `https:`. Applies to BOTH the explicit env override and the
+ * Convex-discovered value, so a misconfigured `COMPUTERS_REMOTE_DATA_PLANE_URL`
+ * can't downgrade this server into forwarding a user's bearer token to a
+ * cleartext, non-loopback origin.
+ */
 function normalizeDataPlaneUrl(raw: string | null | undefined): string | null {
   if (!raw) return null;
   try {
     const url = new URL(raw);
     if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+    if (url.protocol === "http:" && !isLoopbackHost(url.hostname)) return null;
     return url.origin;
   } catch {
     return null;

--- a/mcpjam-inspector/server/utils/computers/remote-data-plane.ts
+++ b/mcpjam-inspector/server/utils/computers/remote-data-plane.ts
@@ -41,7 +41,14 @@ import {
 } from "./control-plane-client.js";
 
 function isLoopbackHost(hostname: string): boolean {
-  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+  // WHATWG URL bracket-wraps IPv6 hosts (new URL("http://[::1]").hostname
+  // === "[::1]"), so the literal form must be matched too.
+  return (
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "::1" ||
+    hostname === "[::1]"
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary
Three defense-in-depth hardening items for Project Computers, per review of the data-plane discovery work in #3080/#671:

- **Loopback-only `http:`** — `normalizeDataPlaneUrl()` in `remote-data-plane.ts` now rejects plain `http:` for any non-loopback host, matching the policy already enforced backend-side on `GET /computers/data-plane-url` (mcpjam-backend#671). Applies to both the explicit `COMPUTERS_REMOTE_DATA_PLANE_URL` override and the Convex-discovered value (same function, so both are covered by one change) — a misconfigured override can no longer downgrade this server into forwarding a user's bearer token to a cleartext, non-loopback origin.
- **Owner/project mismatch check** — `computer-terminal.ts` and `computer-upload.ts` now re-check the `/computers/sandbox-info` row's `ownerUserId`/`projectId` against the terminal token's claims before ever touching the vendor sandbox. The data's already fetched in the same round trip, so this is free. Real risk window is narrow (Convex already authorizes at token-mint time, ~60s TTL) — this is belt-and-suspenders for the row's ownership/project changing inside that window, not a fix for an active exploit.
- **`token=` redaction** — `scrubTokenFromUrl()` now also redacts a bare `token=` query param. Current routes only accept the terminal/upload token via the WS subprotocol or `Authorization` header (#3078 already removed the query-param fallback), so this is a backstop against a future regression or a stale client, not a currently-open hole.

## Test plan
- [x] `computers-remote-data-plane.test.ts` — updated the plain-http test to loopback-only, added non-loopback rejection + "invalid override doesn't suppress discovery" cases (25 tests)
- [x] `computer-terminal.test.ts` — added owner-mismatch and project-mismatch cases, asserting `Sandbox.connect` is never called (6 tests)
- [x] `computer-upload.test.ts` — same two cases, asserting 401 + zero writes (16 tests)
- [x] `session-auth.test.ts` — added `token=` redaction coverage, including alongside `_token=` in the same URL to confirm no cross-match (34 tests)
- [x] `npx tsc --noEmit -p server/tsconfig.json` — diffed against a fresh vanilla-`main` typecheck; every remaining diff is either a pre-existing unrelated error (identical on vanilla main) or a missing generated-bundle artifact from a fresh worktree, not from this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auth and outbound forwarding for computers (terminal, upload, remote exec); behavior is defensive and test-covered, but mistakes could block legitimate access or affect misconfigured deployments.
> 
> **Overview**
> Defense-in-depth hardening for Project Computers in three areas.
> 
> **Data plane URLs** — `normalizeDataPlaneUrl()` now allows plain `http:` only for loopback hosts (`localhost`, `127.0.0.1`, `::1`), for both `COMPUTERS_REMOTE_DATA_PLANE_URL` and Convex-discovered URLs. A non-loopback `http:` override is treated as invalid (discovery still runs). This aligns with backend policy and blocks forwarding user bearer tokens to cleartext remote origins.
> 
> **Terminal and upload** — After `/computers/sandbox-info`, `computer-terminal.ts` and `computer-upload.ts` compare the row’s `ownerUserId` and `projectId` to the JWT claims before `Sandbox.connect` or any writes. Mismatches return 401 / WS close 4401 without touching the vendor sandbox.
> 
> **Logging** — `scrubTokenFromUrl()` also redacts bare `token=` query values (alongside `_token`, `k`, `t`) so stray terminal tokens don’t appear in logs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a3ce26f42169ad8df360d8fcfe937a24fb313bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the Computers data plane to block insecure endpoints and prevent token leaks. Enforces loopback-only http (including IPv6), validates ownership before sandbox access, and redacts stray tokens in logs.

- **Security**
  - Only allow `http:` for loopback hosts in data-plane URLs; applies to both `COMPUTERS_REMOTE_DATA_PLANE_URL` and discovered URLs, matching backend policy. Correctly accepts IPv6 loopback `[::1]`.
  - Re-check `ownerUserId` and `projectId` from `/computers/sandbox-info` against token claims in terminal/upload routes; reject on mismatch before touching the vendor sandbox.
  - `scrubTokenFromUrl()` now redacts a bare `token=` query param (alongside `_token=`, `k=`, `t=`).

<sup>Written for commit 5a3ce26f42169ad8df360d8fcfe937a24fb313bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3088?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

