### PR TITLE
fix(computers): honest cloud-only unconfigured message, shared component

### DIFF
--- a/mcpjam-inspector/client/src/components/computer/ComputerTerminalPane.tsx
+++ b/mcpjam-inspector/client/src/components/computer/ComputerTerminalPane.tsx
@@ -2,6 +2,8 @@ import { Button } from "@mcpjam/design-system/button";
 import { Loader2, RotateCcw } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { ComputerTerminal } from "./ComputerTerminal";
+import { ComputersUnavailableMessage } from "./ComputersUnavailableMessage";
+import { PaneMessage } from "./PaneMessage";
 import type { ComputerTerminalController } from "./useComputerTerminal";
 
 /**
@@ -39,17 +41,7 @@ export function ComputerTerminalPane({
 
   const body = () => {
     if (dataPlaneUnavailable) {
-      return (
-        <PaneMessage dashed>
-          <span className="max-w-md text-center">
-            This inspector server isn't set up to run computers: it has no
-            data-plane credentials and no remote data plane to delegate to. Set{" "}
-            <code>COMPUTERS_REMOTE_DATA_PLANE_URL</code> (or the data-plane
-            secrets) in the server environment to enable the terminal and the
-            bash tool.
-          </span>
-        </PaneMessage>
-      );
+      return <ComputersUnavailableMessage />;
     }
     if (!terminalOpen) {
       return (
@@ -143,22 +135,4 @@ export function ComputerTerminalPane({
   };
 
   return <div className={cn("min-h-0 flex-1", className)}>{body()}</div>;
-}
-
-export function PaneMessage({
-  children,
-  dashed = false,
-}: {
-  children: React.ReactNode;
-  dashed?: boolean;
-}) {
-  return (
-    <div
-      className={`flex h-full flex-col items-center justify-center gap-3 rounded-md border text-sm text-muted-foreground ${
-        dashed ? "border-dashed bg-muted/10" : "bg-muted/20"
-      }`}
-    >
-      {children}
-    </div>
-  );
 }

--- a/mcpjam-inspector/client/src/components/computer/ComputerView.tsx
+++ b/mcpjam-inspector/client/src/components/computer/ComputerView.tsx
@@ -25,6 +25,8 @@ import {
 import { useMCPJamLimitDialogStore } from "@/stores/mcpjam-limit-dialog-store";
 import { ComputerStatusChip } from "./ComputerStatusChip";
 import { ComputerTerminal } from "./ComputerTerminal";
+import { ComputersUnavailableMessage } from "./ComputersUnavailableMessage";
+import { PaneMessage } from "./PaneMessage";
 
 /**
  * The "Computer" tab — manage the project's personal cloud computer (one per
@@ -180,17 +182,7 @@ export function ComputerView({
 
   const renderTerminalPane = () => {
     if (dataPlaneUnavailable) {
-      return (
-        <PaneMessage dashed>
-          <span className="max-w-md text-center">
-            This inspector server isn't set up to run computers: it has no
-            data-plane credentials and no remote data plane to delegate to. Set{" "}
-            <code>COMPUTERS_REMOTE_DATA_PLANE_URL</code> (or the data-plane
-            secrets) in the server environment to enable the terminal and the
-            bash tool.
-          </span>
-        </PaneMessage>
-      );
+      return <ComputersUnavailableMessage />;
     }
     if (!terminalOpen) {
       return (
@@ -544,20 +536,3 @@ function Empty({ children }: { children: React.ReactNode }) {
   );
 }
 
-function PaneMessage({
-  children,
-  dashed = false,
-}: {
-  children: React.ReactNode;
-  dashed?: boolean;
-}) {
-  return (
-    <div
-      className={`flex h-full flex-col items-center justify-center gap-3 rounded-md border text-sm text-muted-foreground ${
-        dashed ? "border-dashed bg-muted/10" : "bg-muted/20"
-      }`}
-    >
-      {children}
-    </div>
-  );
-}

--- a/mcpjam-inspector/client/src/components/computer/ComputersUnavailableMessage.tsx
+++ b/mcpjam-inspector/client/src/components/computer/ComputersUnavailableMessage.tsx
@@ -1,0 +1,23 @@
+import { PaneMessage } from "./PaneMessage";
+
+/**
+ * The one honest empty state for `dataPlaneUnavailable` (no local data-plane
+ * credentials AND discovery found no remote data plane to delegate to).
+ *
+ * Computers are cloud-only: an inspector gets them either by being an
+ * MCPJam-deployed data plane or by delegating to one advertised by its Convex
+ * deployment. Neither is something a user at this screen can change, so the
+ * copy names the situation without instructing anyone to set server env vars
+ * (operator setup lives in mcpjam-backend docs/project-computers.md).
+ */
+export function ComputersUnavailableMessage() {
+  return (
+    <PaneMessage dashed>
+      <span className="max-w-md text-center">
+        Computers aren't available here — the MCPJam deployment this inspector
+        is connected to hasn't enabled Project Computers, so the terminal and
+        the bash tool are off.
+      </span>
+    </PaneMessage>
+  );
+}

--- a/mcpjam-inspector/client/src/components/computer/PaneMessage.tsx
+++ b/mcpjam-inspector/client/src/components/computer/PaneMessage.tsx
@@ -1,0 +1,18 @@
+/** Centered message box used by the terminal-pane state machines. */
+export function PaneMessage({
+  children,
+  dashed = false,
+}: {
+  children: React.ReactNode;
+  dashed?: boolean;
+}) {
+  return (
+    <div
+      className={`flex h-full flex-col items-center justify-center gap-3 rounded-md border text-sm text-muted-foreground ${
+        dashed ? "border-dashed bg-muted/10" : "bg-muted/20"
+      }`}
+    >
+      {children}
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/computer/__tests__/ComputerView.test.tsx
+++ b/mcpjam-inspector/client/src/components/computer/__tests__/ComputerView.test.tsx
@@ -175,7 +175,7 @@ describe("ComputerView", () => {
     const { getByText, queryByText } = render(
       <ComputerView projectId="p1" isAuthenticated />
     );
-    expect(getByText(/isn't set up to run computers/i)).toBeTruthy();
+    expect(getByText(/Computers aren't available here/i)).toBeTruthy();
     expect(queryByText("Open terminal")).toBeNull();
     // The computer itself still exists (it lives in Convex/E2B, not on this
     // server), so Delete must stay available.

--- a/mcpjam-inspector/client/src/components/computer/__tests__/ComputersUnavailableMessage.test.tsx
+++ b/mcpjam-inspector/client/src/components/computer/__tests__/ComputersUnavailableMessage.test.tsx
@@ -1,0 +1,17 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ComputersUnavailableMessage } from "../ComputersUnavailableMessage";
+
+describe("ComputersUnavailableMessage", () => {
+  it("names the situation without instructing users to set env vars", () => {
+    const text =
+      render(<ComputersUnavailableMessage />).container.textContent ?? "";
+    expect(text).toMatch(/Computers aren't available here/i);
+    expect(text).toMatch(/hasn't enabled Project Computers/i);
+    // The old copy told everyone (including OSS users who can't act on it) to
+    // set server env vars — that guidance must never come back.
+    expect(text).not.toMatch(/COMPUTERS_/);
+    expect(text).not.toMatch(/env/i);
+    expect(text).not.toMatch(/\bset\b/i);
+  });
+});


### PR DESCRIPTION
## What

The `dataPlaneUnavailable` empty state (Computer tab + Playground Shell tab) told every user to set `COMPUTERS_REMOTE_DATA_PLANE_URL` or the data-plane secrets — guidance an OSS user pointed at MCPJam cloud can't act on (it misrouted an employee last week too). Computers are cloud-only: an inspector either is a deployed data plane or delegates to the one its Convex deployment advertises via auto-discovery (#3080), so the honest message is that the connected MCPJam deployment hasn't enabled Project Computers. Operator setup stays in `mcpjam-backend/docs/project-computers.md`.

## Changes

- New shared `ComputersUnavailableMessage` replaces the two duplicated message blocks (`ComputerView`, `ComputerTerminalPane`).
- `PaneMessage` moves to its own module — `ComputerView` carried a byte-identical private copy; both now import the one component.
- No behavior change: the `dataPlaneUnavailable` trigger condition is untouched.

## Tests

- New `ComputersUnavailableMessage.test.tsx` locks the copy to naming-the-situation (and asserts env-var instructions never come back).
- Updated the `ComputerView` empty-state assertion to the new copy. `vitest run client/src/components/computer/__tests__/` → 41 passed.

Part of the computers one-credential/cloud-only plan (PR 1 of 7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI copy and small component extraction only; no auth, API, or data-plane logic changes.
> 
> **Overview**
> Replaces the **`dataPlaneUnavailable`** empty state in the Computer tab and Playground Shell terminal with a shared **`ComputersUnavailableMessage`**. Copy now states that the connected MCPJam deployment has not enabled Project Computers, instead of telling users to set server env vars they cannot change.
> 
> **`PaneMessage`** is extracted into its own module so **`ComputerView`** and **`ComputerTerminalPane`** share one implementation (previously duplicated locally). The condition that triggers this state is unchanged.
> 
> Tests lock the new wording and assert env-var setup instructions do not return.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd51d2c947f75113ecd31477cc28834aa6fb4f00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the misleading Computers empty state with an accurate cloud-only message and deduplicated the UI. Users now see that Project Computers aren’t enabled for the connected deployment, instead of being told to set server env vars.

- Bug Fixes
  - Updated the `dataPlaneUnavailable` message in the Computer tab and Playground Shell to: “Computers aren’t available here… the deployment hasn’t enabled Project Computers,” removing env-var guidance.
  - Tests updated: added `ComputersUnavailableMessage.test.tsx` and adjusted `ComputerView` copy assertion.

- Refactors
  - Extracted shared `ComputersUnavailableMessage` and `PaneMessage` components.
  - Replaced duplicated message blocks in `ComputerView` and `ComputerTerminalPane`.

<sup>Written for commit cd51d2c947f75113ecd31477cc28834aa6fb4f00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3091?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

