### PR TITLE
feat(computers): bootstrap data-plane credentials from INSPECTOR_SERVICE_TOKEN at boot

### DIFF
--- a/mcpjam-inspector/server/app.ts
+++ b/mcpjam-inspector/server/app.ts
@@ -60,12 +60,12 @@ import { initXAAIdpKeyPair } from "./services/xaa-idp-keypair.js";
 import { requestLogContextMiddleware } from "./middleware/request-log-context.js";
 import { registerSelfFetch } from "./utils/self-app.js";
 import { getInspectorFrontendUrl } from "./utils/inspector-frontend-url.js";
-import { initComputersRemoteDataPlaneDiscovery } from "./utils/computers/remote-data-plane.js";
+import { initComputersStartup } from "./utils/computers/remote-data-plane.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-export function createHonoApp() {
+export async function createHonoApp() {
   // Load environment variables early so route handlers can read CONVEX_HTTP_URL
   const loadedEnv = loadInspectorEnv(__dirname);
   warnOnConvexDevMisconfiguration(loadedEnv);
@@ -84,8 +84,11 @@ export function createHonoApp() {
   startLocalBrowserRenderingSetupInBackground();
   // Mirror of the call in server/index.ts — both production entries must
   // wire this up so the Electron/embedded path also gets a working Computer
-  // tab. Memoized, so it's harmless if a process ever ran both.
-  void initComputersRemoteDataPlaneDiscovery();
+  // tab. Memoized, so it's harmless if a process ever ran both. AWAITED (the
+  // factory is async for exactly this): synchronous gates read
+  // `isComputersDataPlaneConfigured()`, which is only truthful once the
+  // credential bootstrap has resolved — no requests before that.
+  await initComputersStartup();
 
   const app = new Hono();
   const strictModeResponse = (c: any, path: string) =>

--- a/mcpjam-inspector/server/index.ts
+++ b/mcpjam-inspector/server/index.ts
@@ -51,7 +51,7 @@ import { requestLogContextMiddleware } from "./middleware/request-log-context";
 import { getInspectorFrontendUrl } from "./utils/inspector-frontend-url";
 import { createComputerTerminalWsHandler } from "./routes/web/computer-terminal";
 import { createComputerUploadHandler } from "./routes/web/computer-upload";
-import { initComputersRemoteDataPlaneDiscovery } from "./utils/computers/remote-data-plane";
+import { initComputersStartup } from "./utils/computers/remote-data-plane";
 import { registerSelfFetch } from "./utils/self-app";
 
 const sysLogger = getSystemLogger("process");
@@ -240,8 +240,11 @@ startGuestAuthProvisioningInBackground();
 startLocalBrowserRenderingSetupInBackground();
 // Mirror of the call in server/app.ts::createHonoApp — both production
 // entries must wire this up. Memoized, so it's harmless if a process ever
-// ran both.
-void initComputersRemoteDataPlaneDiscovery();
+// ran both. Kicked off here so it overlaps route setup; AWAITED before
+// `serve()` below — synchronous gates (harness pre-flight, evals) read
+// `isComputersDataPlaneConfigured()`, which is only truthful once the
+// credential bootstrap has resolved.
+const computersStartup = initComputersStartup();
 const app = new Hono().onError((err, c) => {
   appLogger.error("Unhandled error:", err);
 
@@ -669,6 +672,11 @@ const isDocker = process.env.DOCKER_CONTAINER === "true";
 const hostname = isDocker ? "0.0.0.0" : "127.0.0.1";
 
 appLogger.info(`🎵 MCPJam: http://127.0.0.1:${displayPort}`);
+
+// Readiness gate: computers credential bootstrap + data-plane discovery must
+// resolve before the first request — see initComputersStartup. Bounded (~11s
+// worst case, sub-second typical) and never throws.
+await computersStartup;
 
 // Start the Hono server
 const server = serve({

--- a/mcpjam-inspector/server/routes/web/__tests__/computers.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/computers.test.ts
@@ -85,6 +85,7 @@ function stubLocalDataPlaneEnv() {
   vi.stubEnv("CONVEX_HTTP_URL", CONVEX_URL);
   vi.stubEnv("COMPUTERS_DATA_PLANE_SECRET", "test-secret");
   vi.stubEnv("E2B_API_KEY", "e2b_test");
+  vi.stubEnv("COMPUTERS_TERMINAL_TOKEN_SECRET", "terminal-secret-16+");
 }
 
 beforeEach(() => {

--- a/mcpjam-inspector/server/routes/web/computers.ts
+++ b/mcpjam-inspector/server/routes/web/computers.ts
@@ -31,7 +31,7 @@
 import { Hono } from "hono";
 import { z } from "zod";
 import { executionScopeSchema } from "../../utils/execution-scope.js";
-import { isComputersDataPlaneConfigured } from "../../utils/computers/control-plane-client.js";
+import { resolveComputersLocalConfigured } from "../../utils/computers/runtime-config.js";
 import { resolveComputersRemoteDataPlaneUrl } from "../../utils/computers/remote-data-plane.js";
 import {
   MAX_COMMAND_TIMEOUT_S,
@@ -58,15 +58,16 @@ const execSchema = z.object({
 export function createComputersRoutes(runner: BashRunner = e2bRunner): Hono {
   const computers = new Hono();
 
-  computers.get("/config", async (c) =>
-    c.json({
-      localConfigured: isComputersDataPlaneConfigured(),
-      // Awaits any in-flight startup discovery — the client caches this
-      // FIRST response for the whole SPA session, so it must never race a
-      // still-resolving lookup into a false "unconfigured".
-      remoteDataPlaneUrl: await resolveComputersRemoteDataPlaneUrl(),
-    })
-  );
+  computers.get("/config", async (c) => {
+    // Await any in-flight startup bootstrap/discovery — the client caches
+    // this FIRST response for the whole SPA session, so it must never race
+    // a still-resolving lookup into a false "unconfigured".
+    const [localConfigured, remoteDataPlaneUrl] = await Promise.all([
+      resolveComputersLocalConfigured(),
+      resolveComputersRemoteDataPlaneUrl(),
+    ]);
+    return c.json({ localConfigured, remoteDataPlaneUrl });
+  });
 
   computers.post("/exec", async (c) =>
     handleRoute(c, async () => {

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -2505,12 +2505,12 @@ const runLocalIteration = async ({
       if (pinnedEnvironmentId && runId !== null) {
         // Don't provision unless this server is a fully-configured data plane.
         // Provisioning only needs the user bearer, but EXEC needs E2B_API_KEY
-        // and RELEASE needs COMPUTERS_DATA_PLANE_SECRET — without them
+        // and RELEASE needs a server-to-server credential — without them
         // releaseEvalSandbox silently no-ops, so each iteration would boot a
         // paid box only the backend TTL GC could reap. Fail loudly instead.
         if (!isComputersDataPlaneConfigured()) {
           throw new Error(
-            "This eval pins a reproducible computer environment, but this server isn't configured as a computers data plane (needs CONVEX_HTTP_URL, COMPUTERS_DATA_PLANE_SECRET, and E2B_API_KEY) — it could provision a sandbox but not exec or release it."
+            "This eval pins a reproducible computer environment, but this server isn't a computers data plane (deployed servers bootstrap credentials from INSPECTOR_SERVICE_TOKEN; see docs/project-computers.md) — it could provision a sandbox but not exec or release it."
           );
         }
         evalSandbox = await provisionEvalSandbox({
@@ -3313,7 +3313,7 @@ const runHostedIterationWithBrowser = async (
     if (pinnedEnvironmentId && runId !== null) {
       if (!isComputersDataPlaneConfigured()) {
         throw new Error(
-          "This eval pins a reproducible computer environment, but this server isn't configured as a computers data plane (needs CONVEX_HTTP_URL, COMPUTERS_DATA_PLANE_SECRET, and E2B_API_KEY) — it could provision a sandbox but not exec or release it."
+          "This eval pins a reproducible computer environment, but this server isn't a computers data plane (deployed servers bootstrap credentials from INSPECTOR_SERVICE_TOKEN; see docs/project-computers.md) — it could provision a sandbox but not exec or release it."
         );
       }
       evalSandbox = await provisionEvalSandbox({

--- a/mcpjam-inspector/server/utils/__tests__/computers-bash-tool.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/computers-bash-tool.test.ts
@@ -82,6 +82,7 @@ function execTool(
 beforeEach(() => {
   vi.stubEnv("CONVEX_HTTP_URL", CONVEX_URL);
   vi.stubEnv("COMPUTERS_DATA_PLANE_SECRET", "test-data-plane-secret-000000");
+  vi.stubEnv("COMPUTERS_TERMINAL_TOKEN_SECRET", "terminal-secret-16+");
   vi.stubEnv("E2B_API_KEY", "e2b_test");
   installFetchStub();
 });

--- a/mcpjam-inspector/server/utils/__tests__/computers-remote-data-plane.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/computers-remote-data-plane.test.ts
@@ -3,9 +3,11 @@ import {
   getComputersRemoteDataPlaneUrl,
   execViaRemoteDataPlane,
   initComputersRemoteDataPlaneDiscovery,
+  initComputersStartup,
   resolveComputersRemoteDataPlaneUrl,
   resetComputersRemoteDataPlaneDiscoveryForTests,
 } from "../computers/remote-data-plane";
+import { resetComputersRuntimeConfigBootstrapForTests } from "../computers/runtime-config";
 import { buildBashTool } from "../built-in-tools/bash";
 
 // The remote data plane is reached through global fetch; stub it and assert
@@ -121,6 +123,7 @@ describe("initComputersRemoteDataPlaneDiscovery", () => {
     vi.stubEnv("CONVEX_HTTP_URL", "https://convex.example");
     vi.stubEnv("COMPUTERS_DATA_PLANE_SECRET", "secret");
     vi.stubEnv("E2B_API_KEY", "e2b_test");
+    vi.stubEnv("COMPUTERS_TERMINAL_TOKEN_SECRET", "terminal-secret-16+");
     installFetchStub();
 
     await initComputersRemoteDataPlaneDiscovery();
@@ -134,6 +137,41 @@ describe("initComputersRemoteDataPlaneDiscovery", () => {
     await expect(initComputersRemoteDataPlaneDiscovery()).resolves.toBeUndefined();
     expect(fetchCalls).toHaveLength(0);
     expect(getComputersRemoteDataPlaneUrl()).toBeNull();
+  });
+
+  it("initComputersStartup: a bootstrap-configured server never discovers/delegates", async () => {
+    // Only the service token — the boot bootstrap supplies the rest. The
+    // startup wrapper must resolve the bootstrap BEFORE discovery runs, so
+    // this soon-to-be data plane skips discovery instead of racing into a
+    // remote URL while also being locally configured.
+    vi.stubEnv("CONVEX_HTTP_URL", "https://convex.example");
+    vi.stubEnv("INSPECTOR_SERVICE_TOKEN", "svc-tok");
+    resetComputersRuntimeConfigBootstrapForTests();
+    installFetchStub();
+    fetchResponse = () =>
+      jsonResponse(200, {
+        enabled: true,
+        e2bApiKey: "boot-key",
+        e2bApiUrl: null,
+        e2bDomain: null,
+        e2bTemplateId: null,
+        terminalTokenSecret: "boot-terminal-secret",
+      });
+
+    try {
+      await initComputersStartup();
+
+      // Exactly one fetch: the runtime-config bootstrap. No discovery call.
+      expect(fetchCalls).toHaveLength(1);
+      expect(fetchCalls[0]!.url).toContain(
+        "/internal/v1/computers/runtime-config"
+      );
+      expect(getComputersRemoteDataPlaneUrl()).toBeNull();
+    } finally {
+      resetComputersRuntimeConfigBootstrapForTests();
+      delete process.env.E2B_API_KEY;
+      delete process.env.COMPUTERS_TERMINAL_TOKEN_SECRET;
+    }
   });
 
   it("stays unconfigured (does not throw) on a network failure", async () => {
@@ -358,6 +396,7 @@ describe("bash tool delegation", () => {
     vi.stubEnv("CONVEX_HTTP_URL", "https://convex.example");
     vi.stubEnv("COMPUTERS_DATA_PLANE_SECRET", "secret");
     vi.stubEnv("E2B_API_KEY", "e2b_test");
+    vi.stubEnv("COMPUTERS_TERMINAL_TOKEN_SECRET", "terminal-secret-16+");
     fetchResponse = () =>
       jsonResponse(200, {
         computerId: "comp_1",

--- a/mcpjam-inspector/server/utils/__tests__/computers-runtime-config.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/computers-runtime-config.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
+import {
+  initComputersRuntimeConfigBootstrap,
+  resolveComputersLocalConfigured,
+  resetComputersRuntimeConfigBootstrapForTests,
+} from "../computers/runtime-config";
+import { isComputersDataPlaneConfigured } from "../computers/control-plane-client";
+
+// The bootstrap talks to Convex through global fetch; stub it and assert the
+// env-mutation semantics (atomic, only-if-unset, fail-closed).
+
+const ENV_KEYS = [
+  "INSPECTOR_SERVICE_TOKEN",
+  "CONVEX_HTTP_URL",
+  "E2B_API_KEY",
+  "E2B_API_URL",
+  "E2B_DOMAIN",
+  "E2B_TEMPLATE_ID",
+  "COMPUTERS_TERMINAL_TOKEN_SECRET",
+  "COMPUTERS_DATA_PLANE_SECRET",
+] as const;
+
+const savedEnv: Record<string, string | undefined> = {};
+let fetchCalls: Array<{ url: string; headers: Record<string, string> }>;
+let fetchImpl: () => Response | Promise<Response>;
+
+const instantSleep = async () => {};
+
+const ENABLED_PAYLOAD = {
+  enabled: true,
+  e2bApiKey: "boot-e2b-key",
+  e2bApiUrl: null,
+  e2bDomain: null,
+  e2bTemplateId: "tmpl-boot",
+  terminalTokenSecret: "boot-terminal-secret",
+};
+
+function jsonResponse(status: number, json: unknown): Response {
+  return new Response(JSON.stringify(json), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+beforeEach(() => {
+  for (const key of ENV_KEYS) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+  process.env.INSPECTOR_SERVICE_TOKEN = "svc-tok";
+  process.env.CONVEX_HTTP_URL = "https://convex.example.test";
+  resetComputersRuntimeConfigBootstrapForTests();
+  fetchCalls = [];
+  fetchImpl = () => jsonResponse(200, ENABLED_PAYLOAD);
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string | URL, init?: RequestInit) => {
+      fetchCalls.push({
+        url: String(url),
+        headers: (init?.headers ?? {}) as Record<string, string>,
+      });
+      return fetchImpl();
+    })
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  for (const key of ENV_KEYS) {
+    if (savedEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = savedEnv[key];
+  }
+  resetComputersRuntimeConfigBootstrapForTests();
+});
+
+describe("initComputersRuntimeConfigBootstrap", () => {
+  it("fetches with the service token and populates env atomically", async () => {
+    const outcome = await initComputersRuntimeConfigBootstrap({
+      sleep: instantSleep,
+    });
+    expect(outcome).toBe("applied");
+    expect(fetchCalls).toHaveLength(1);
+    expect(fetchCalls[0]!.url).toBe(
+      "https://convex.example.test/internal/v1/computers/runtime-config"
+    );
+    expect(fetchCalls[0]!.headers["x-inspector-service-token"]).toBe("svc-tok");
+    expect(process.env.E2B_API_KEY).toBe("boot-e2b-key");
+    expect(process.env.E2B_TEMPLATE_ID).toBe("tmpl-boot");
+    expect(process.env.COMPUTERS_TERMINAL_TOKEN_SECRET).toBe(
+      "boot-terminal-secret"
+    );
+    // Nulls in the payload set nothing.
+    expect(process.env.E2B_API_URL).toBeUndefined();
+    // The bootstrap never manufactures the legacy secret.
+    expect(process.env.COMPUTERS_DATA_PLANE_SECRET).toBeUndefined();
+    // ...and the server now reports configured via the service token.
+    expect(isComputersDataPlaneConfigured()).toBe(true);
+  });
+
+  it("never overwrites env vars that are already set", async () => {
+    process.env.E2B_API_KEY = "operator-key";
+    await initComputersRuntimeConfigBootstrap({ sleep: instantSleep });
+    expect(process.env.E2B_API_KEY).toBe("operator-key");
+    expect(process.env.COMPUTERS_TERMINAL_TOKEN_SECRET).toBe(
+      "boot-terminal-secret"
+    );
+  });
+
+  it("skips the fetch entirely without a service token", async () => {
+    delete process.env.INSPECTOR_SERVICE_TOKEN;
+    expect(
+      await initComputersRuntimeConfigBootstrap({ sleep: instantSleep })
+    ).toBe("skipped");
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  it("skips the fetch when the legacy trio is already complete", async () => {
+    process.env.E2B_API_KEY = "k";
+    process.env.COMPUTERS_TERMINAL_TOKEN_SECRET = "s";
+    process.env.COMPUTERS_DATA_PLANE_SECRET = "d";
+    expect(
+      await initComputersRuntimeConfigBootstrap({ sleep: instantSleep })
+    ).toBe("skipped");
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  it("treats 404 (old backend) and enabled:false as unavailable without retrying", async () => {
+    fetchImpl = () => jsonResponse(404, { ok: false });
+    expect(
+      await initComputersRuntimeConfigBootstrap({ sleep: instantSleep })
+    ).toBe("unavailable");
+    expect(fetchCalls).toHaveLength(1);
+    expect(process.env.E2B_API_KEY).toBeUndefined();
+
+    resetComputersRuntimeConfigBootstrapForTests();
+    fetchCalls = [];
+    fetchImpl = () => jsonResponse(200, { enabled: false });
+    expect(
+      await initComputersRuntimeConfigBootstrap({ sleep: instantSleep })
+    ).toBe("unavailable");
+    expect(fetchCalls).toHaveLength(1);
+    expect(process.env.E2B_API_KEY).toBeUndefined();
+  });
+
+  it("writes NOTHING when the payload fails validation (atomic apply)", async () => {
+    fetchImpl = () =>
+      jsonResponse(200, { enabled: true, e2bApiKey: "key-but-missing-rest" });
+    const outcome = await initComputersRuntimeConfigBootstrap({
+      sleep: instantSleep,
+    });
+    expect(outcome).toBe("failed");
+    expect(process.env.E2B_API_KEY).toBeUndefined();
+    expect(process.env.COMPUTERS_TERMINAL_TOKEN_SECRET).toBeUndefined();
+  });
+
+  it("retries network-ish failures (3 attempts) then fails closed", async () => {
+    fetchImpl = () => {
+      throw new Error("ECONNREFUSED");
+    };
+    const outcome = await initComputersRuntimeConfigBootstrap({
+      sleep: instantSleep,
+    });
+    expect(outcome).toBe("failed");
+    expect(fetchCalls).toHaveLength(3);
+    expect(isComputersDataPlaneConfigured()).toBe(false);
+  });
+
+  it("memoizes: concurrent and repeat callers share one fetch", async () => {
+    const [a, b] = await Promise.all([
+      initComputersRuntimeConfigBootstrap({ sleep: instantSleep }),
+      initComputersRuntimeConfigBootstrap({ sleep: instantSleep }),
+    ]);
+    expect(a).toBe("applied");
+    expect(b).toBe("applied");
+    await initComputersRuntimeConfigBootstrap({ sleep: instantSleep });
+    expect(fetchCalls).toHaveLength(1);
+  });
+
+  it("re-inits after the failure cooldown, but not before", async () => {
+    vi.useFakeTimers();
+    try {
+      fetchImpl = () => {
+        throw new Error("ECONNREFUSED");
+      };
+      expect(
+        await initComputersRuntimeConfigBootstrap({ sleep: instantSleep })
+      ).toBe("failed");
+      expect(fetchCalls).toHaveLength(3);
+
+      // Within cooldown: no new fetch.
+      expect(
+        await initComputersRuntimeConfigBootstrap({ sleep: instantSleep })
+      ).toBe("failed");
+      expect(fetchCalls).toHaveLength(3);
+
+      vi.advanceTimersByTime(61_000);
+      fetchImpl = () => jsonResponse(200, ENABLED_PAYLOAD);
+      expect(
+        await initComputersRuntimeConfigBootstrap({ sleep: instantSleep })
+      ).toBe("applied");
+      expect(fetchCalls).toHaveLength(4);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("resolveComputersLocalConfigured", () => {
+  it("awaits the bootstrap before answering", async () => {
+    expect(await resolveComputersLocalConfigured()).toBe(true);
+    expect(fetchCalls).toHaveLength(1);
+  });
+
+  it("answers false when nothing is configured and no token exists", async () => {
+    delete process.env.INSPECTOR_SERVICE_TOKEN;
+    expect(await resolveComputersLocalConfigured()).toBe(false);
+  });
+});

--- a/mcpjam-inspector/server/utils/__tests__/computers-runtime-config.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/computers-runtime-config.test.ts
@@ -4,7 +4,10 @@ import {
   resolveComputersLocalConfigured,
   resetComputersRuntimeConfigBootstrapForTests,
 } from "../computers/runtime-config";
-import { isComputersDataPlaneConfigured } from "../computers/control-plane-client";
+import {
+  isComputersDataPlaneConfigured,
+  resetServiceTokenRejectedForTests,
+} from "../computers/control-plane-client";
 
 // The bootstrap talks to Convex through global fetch; stub it and assert the
 // env-mutation semantics (atomic, only-if-unset, fail-closed).
@@ -50,6 +53,7 @@ beforeEach(() => {
   process.env.INSPECTOR_SERVICE_TOKEN = "svc-tok";
   process.env.CONVEX_HTTP_URL = "https://convex.example.test";
   resetComputersRuntimeConfigBootstrapForTests();
+  resetServiceTokenRejectedForTests();
   fetchCalls = [];
   fetchImpl = () => jsonResponse(200, ENABLED_PAYLOAD);
   vi.stubGlobal(
@@ -71,6 +75,7 @@ afterEach(() => {
     else process.env[key] = savedEnv[key];
   }
   resetComputersRuntimeConfigBootstrapForTests();
+  resetServiceTokenRejectedForTests();
 });
 
 describe("initComputersRuntimeConfigBootstrap", () => {
@@ -214,5 +219,21 @@ describe("resolveComputersLocalConfigured", () => {
   it("answers false when nothing is configured and no token exists", async () => {
     delete process.env.INSPECTOR_SERVICE_TOKEN;
     expect(await resolveComputersLocalConfigured()).toBe(false);
+  });
+
+  it("reports NOT configured after a 401 even with stray E2B + terminal secret in env", async () => {
+    // Hybrid config: a wrong service token, no legacy secret, but leftover
+    // hand-set E2B key + terminal secret. Without marking the token rejected,
+    // the predicate would report localConfigured:true while every
+    // secret-gated /computers/* call hard-401s.
+    process.env.E2B_API_KEY = "stray-key";
+    process.env.COMPUTERS_TERMINAL_TOKEN_SECRET = "stray-terminal-secret";
+    delete process.env.COMPUTERS_DATA_PLANE_SECRET;
+    fetchImpl = () => jsonResponse(401, { error: "Unauthorized" });
+
+    expect(await resolveComputersLocalConfigured()).toBe(false);
+    // A legacy secret is an independent credential and still counts.
+    process.env.COMPUTERS_DATA_PLANE_SECRET = "legacy-secret";
+    expect(isComputersDataPlaneConfigured()).toBe(true);
   });
 });

--- a/mcpjam-inspector/server/utils/computers/control-plane-client.ts
+++ b/mcpjam-inspector/server/utils/computers/control-plane-client.ts
@@ -58,7 +58,31 @@ function getDataPlaneSecret(): string | null {
   return process.env.COMPUTERS_DATA_PLANE_SECRET?.trim() || null;
 }
 
+/**
+ * Set once the boot bootstrap gets a 401 from this server's Convex
+ * (`runtime-config.ts` calls `markServiceTokenRejected`): the
+ * `INSPECTOR_SERVICE_TOKEN` this process holds is NOT a valid data-plane
+ * credential. The runtime-config route and every secret-gated `/computers/*`
+ * route gate on the SAME check, so a token the bootstrap rejected will also
+ * 401 the data-plane calls — it must not count toward
+ * `isComputersDataPlaneConfigured()` or be presented on requests, or the
+ * server would advertise `localConfigured: true` while every computer call
+ * hard-401s. Sticky for the process lifetime: a wrong token only becomes
+ * right via an env change + restart, and a 401 bootstrap never re-runs.
+ */
+let serviceTokenRejected = false;
+
+/** Called by the bootstrap on a 401. */
+export function markServiceTokenRejected(): void {
+  serviceTokenRejected = true;
+}
+
+export function resetServiceTokenRejectedForTests(): void {
+  serviceTokenRejected = false;
+}
+
 function getServiceToken(): string | null {
+  if (serviceTokenRejected) return null;
   return process.env.INSPECTOR_SERVICE_TOKEN?.trim() || null;
 }
 

--- a/mcpjam-inspector/server/utils/computers/control-plane-client.ts
+++ b/mcpjam-inspector/server/utils/computers/control-plane-client.ts
@@ -58,10 +58,31 @@ function getDataPlaneSecret(): string | null {
   return process.env.COMPUTERS_DATA_PLANE_SECRET?.trim() || null;
 }
 
-/** True when every env var the computers data plane needs is present. */
+function getServiceToken(): string | null {
+  return process.env.INSPECTOR_SERVICE_TOKEN?.trim() || null;
+}
+
+/**
+ * True when everything the computers data plane needs is present: a Convex
+ * to talk to, a server-to-server credential for it (legacy shared secret or
+ * the inspector service token), the vendor key, and the terminal-token
+ * secret. The last one is deliberately part of "configured": the terminal
+ * verifier (`terminal-token.ts`) fails closed without it, so a server that
+ * can exec but can't verify terminal tokens would be lying if it reported
+ * configured. (It leaves the predicate once RS256/JWKS verification is fully
+ * rolled out and harness proxy tokens have migrated.)
+ *
+ * Values may arrive from the environment OR from the boot bootstrap
+ * (`runtime-config.ts`, which fills env in place) — callers that can run
+ * before startup finishes must await `initComputersRuntimeConfigBootstrap`
+ * first (see `initComputersStartup` in `remote-data-plane.ts`).
+ */
 export function isComputersDataPlaneConfigured(): boolean {
   return Boolean(
-    getConvexHttpUrl() && getDataPlaneSecret() && process.env.E2B_API_KEY
+    getConvexHttpUrl() &&
+      (getDataPlaneSecret() || getServiceToken()) &&
+      process.env.E2B_API_KEY &&
+      process.env.COMPUTERS_TERMINAL_TOKEN_SECRET?.trim()
   );
 }
 
@@ -103,9 +124,18 @@ async function postJson<T>(
   return { ok: true, value: payload as T };
 }
 
-function secretHeaders(): Record<string, string> | null {
+/**
+ * Server-to-server auth headers for the secret-gated `/computers/*` routes.
+ * The legacy shared secret wins when present (matches the backend's
+ * dual-accept precedence and keeps three-var setups byte-identical);
+ * otherwise the inspector service token. Null when the server holds neither
+ * — callers treat that as unconfigured.
+ */
+function authHeaders(): Record<string, string> | null {
   const secret = getDataPlaneSecret();
-  return secret ? { [SECRET_HEADER]: secret } : null;
+  if (secret) return { [SECRET_HEADER]: secret };
+  const token = getServiceToken();
+  return token ? { "x-inspector-service-token": token } : null;
 }
 
 function bearerHeader(raw: string): Record<string, string> {
@@ -148,7 +178,7 @@ export async function releaseEvalSandbox(args: {
   sandboxRowId: string;
   signal?: AbortSignal;
 }): Promise<void> {
-  const headers = secretHeaders();
+  const headers = authHeaders();
   if (!headers) return;
   const result = await postJson(
     "/evals/sandbox/release",
@@ -194,7 +224,7 @@ export async function getComputerSandboxInfo(args: {
   computerId: string;
   signal?: AbortSignal;
 }): Promise<ControlPlaneResult<ComputerSandboxInfo>> {
-  const headers = secretHeaders();
+  const headers = authHeaders();
   if (!headers) {
     return {
       ok: false,
@@ -220,7 +250,7 @@ export async function recordComputerCommand(args: {
   exitCode?: number;
   outputPreview?: string;
 }): Promise<void> {
-  const headers = secretHeaders();
+  const headers = authHeaders();
   if (!headers) return;
   const result = await postJson("/computers/commands", headers, { ...args });
   if (!result.ok) {
@@ -240,7 +270,7 @@ export async function recordTerminalSession(args: {
   action: "open" | "close";
   computerId?: string;
 }): Promise<void> {
-  const headers = secretHeaders();
+  const headers = authHeaders();
   if (!headers) return;
   const result = await postJson("/computers/terminal-sessions", headers, {
     sessionId: args.sessionId,

--- a/mcpjam-inspector/server/utils/computers/remote-data-plane.ts
+++ b/mcpjam-inspector/server/utils/computers/remote-data-plane.ts
@@ -39,6 +39,26 @@ import {
   getConvexHttpUrl,
   isComputersDataPlaneConfigured,
 } from "./control-plane-client.js";
+import { initComputersRuntimeConfigBootstrap } from "./runtime-config.js";
+
+/**
+ * The one computers startup entrypoint. Order matters: the credential
+ * bootstrap must resolve BEFORE discovery, because discovery skips itself on
+ * `isComputersDataPlaneConfigured()` — and bootstrap is what makes that true
+ * for a service-token-only server. Run the other way, a soon-to-be data
+ * plane could race into discovering (and delegating to) a remote while also
+ * being locally configured.
+ *
+ * Both production entries (server/index.ts, server/app.ts) AWAIT this before
+ * accepting traffic: several gates read the sync predicate (harness
+ * pre-flight, evals), and a fire-and-forget init would let first requests
+ * see a false "unconfigured". Bounded by the bootstrap's fetch timeout and
+ * two retries (~11s worst case, sub-second typical).
+ */
+export async function initComputersStartup(): Promise<void> {
+  await initComputersRuntimeConfigBootstrap();
+  await initComputersRemoteDataPlaneDiscovery();
+}
 
 function isLoopbackHost(hostname: string): boolean {
   // WHATWG URL bracket-wraps IPv6 hosts (new URL("http://[::1]").hostname

--- a/mcpjam-inspector/server/utils/computers/runtime-config.ts
+++ b/mcpjam-inspector/server/utils/computers/runtime-config.ts
@@ -32,6 +32,7 @@ import { logger } from "../logger.js";
 import {
   getConvexHttpUrl,
   isComputersDataPlaneConfigured,
+  markServiceTokenRejected,
 } from "./control-plane-client.js";
 
 export const INSPECTOR_SERVICE_TOKEN_HEADER = "x-inspector-service-token";
@@ -126,13 +127,22 @@ async function fetchRuntimeConfigOnce(
   if (response.status === 401 || response.status === 404) {
     // Old backend (no route) or a token this deployment doesn't recognize:
     // nothing to bootstrap — same end state as today's unconfigured server.
-    // 401 additionally suggests a misconfigured token, so say so.
-    logger.warn(
-      `[computers] runtime-config bootstrap unavailable (status ${response.status})` +
-        (response.status === 401
-          ? " — INSPECTOR_SERVICE_TOKEN does not match this Convex deployment"
-          : "")
-    );
+    if (response.status === 401) {
+      // The token is present but rejected. Mark it so a stray E2B key +
+      // terminal secret in env can't make isComputersDataPlaneConfigured()
+      // report a working local data plane that every /computers/* call
+      // (same auth gate) would then hard-401.
+      markServiceTokenRejected();
+      logger.warn(
+        "[computers] runtime-config bootstrap unavailable (status 401) — " +
+          "INSPECTOR_SERVICE_TOKEN does not match this Convex deployment"
+      );
+    } else {
+      logger.warn(
+        "[computers] runtime-config bootstrap unavailable (status 404) — " +
+          "backend predates the runtime-config route"
+      );
+    }
     return "unavailable";
   }
   if (!response.ok) {

--- a/mcpjam-inspector/server/utils/computers/runtime-config.ts
+++ b/mcpjam-inspector/server/utils/computers/runtime-config.ts
@@ -1,0 +1,226 @@
+/**
+ * Boot-time bootstrap of the computers data-plane credentials from Convex.
+ *
+ * A deployed inspector holds ONE computers-related credential — the
+ * environment-root `INSPECTOR_SERVICE_TOKEN` — and derives the rest here:
+ * `GET /internal/v1/computers/runtime-config` (service-token gated,
+ * mcpjam-backend `convex/http.ts`) returns the vendor key + terminal-token
+ * secret, which this module writes into `process.env` so every downstream
+ * consumer (the E2B SDK reads `process.env.E2B_API_KEY` ambiently; the token
+ * helpers read their env keys) works unchanged and the cheap synchronous
+ * `isComputersDataPlaneConfigured()` gate stays synchronous.
+ *
+ * Invariants:
+ *   - Env always wins: a key is only written when currently unset, and the
+ *     fetch is skipped entirely when the legacy hand-mirrored trio is already
+ *     present — zero behavior change for existing three-var setups.
+ *   - Atomic apply: the whole response must validate (zod) before ANY env key
+ *     is written; a malformed payload writes nothing, so the process can
+ *     never run on mixed old/new credentials.
+ *   - Fail closed, quietly: a 401/404 (old backend) or `enabled: false`
+ *     resolves as "nothing to bootstrap" — indistinguishable from today's
+ *     unconfigured state. Only network-ish failures are retried (3 attempts
+ *     in-flight, then a 60s cooldown before a later caller may re-init).
+ *   - The response body is never logged; failures log status codes only.
+ *
+ * The init/memoized-promise/sync-getter shape deliberately mirrors
+ * `remote-data-plane.ts` — see `initComputersStartup` there for ordering
+ * (bootstrap MUST resolve before discovery decides whether to delegate).
+ */
+import { z } from "zod";
+import { logger } from "../logger.js";
+import {
+  getConvexHttpUrl,
+  isComputersDataPlaneConfigured,
+} from "./control-plane-client.js";
+
+export const INSPECTOR_SERVICE_TOKEN_HEADER = "x-inspector-service-token";
+
+const FETCH_TIMEOUT_MS = 5_000;
+const RETRY_DELAYS_MS = [1_000, 3_000];
+const FAILURE_COOLDOWN_MS = 60_000;
+
+const runtimeConfigSchema = z.union([
+  z.object({ enabled: z.literal(false) }),
+  z.object({
+    enabled: z.literal(true),
+    e2bApiKey: z.string().min(1),
+    e2bApiUrl: z.string().nullable(),
+    e2bDomain: z.string().nullable(),
+    e2bTemplateId: z.string().nullable(),
+    terminalTokenSecret: z.string().nullable(),
+  }),
+]);
+
+export function getInspectorServiceToken(): string | null {
+  return process.env.INSPECTOR_SERVICE_TOKEN?.trim() || null;
+}
+
+/** The env keys bootstrap may fill. COMPUTERS_DATA_PLANE_SECRET is absent on
+ *  purpose: a bootstrapped server authenticates to Convex with the service
+ *  token itself (control-plane-client `authHeaders`), so the legacy secret
+ *  never needs to exist on it. */
+function applyRuntimeConfigToEnv(config: {
+  e2bApiKey: string;
+  e2bApiUrl: string | null;
+  e2bDomain: string | null;
+  e2bTemplateId: string | null;
+  terminalTokenSecret: string | null;
+}): void {
+  const entries: Array<[string, string | null]> = [
+    ["E2B_API_KEY", config.e2bApiKey],
+    ["E2B_API_URL", config.e2bApiUrl],
+    ["E2B_DOMAIN", config.e2bDomain],
+    ["E2B_TEMPLATE_ID", config.e2bTemplateId],
+    ["COMPUTERS_TERMINAL_TOKEN_SECRET", config.terminalTokenSecret],
+  ];
+  for (const [key, value] of entries) {
+    if (value && !process.env[key]?.trim()) {
+      process.env[key] = value;
+    }
+  }
+}
+
+type BootstrapOutcome =
+  | "applied"
+  | "skipped" // env already complete, or no service token / convex url
+  | "unavailable" // backend said enabled:false, or 401/404 (old backend)
+  | "failed"; // network-ish; eligible for cooldown re-init
+
+let bootstrapPromise: Promise<BootstrapOutcome> | null = null;
+let lastFailureAtMs: number | null = null;
+
+export function resetComputersRuntimeConfigBootstrapForTests(): void {
+  bootstrapPromise = null;
+  lastFailureAtMs = null;
+}
+
+function hasCompleteLegacyEnv(): boolean {
+  return Boolean(
+    process.env.E2B_API_KEY?.trim() &&
+      process.env.COMPUTERS_TERMINAL_TOKEN_SECRET?.trim() &&
+      process.env.COMPUTERS_DATA_PLANE_SECRET?.trim()
+  );
+}
+
+async function fetchRuntimeConfigOnce(
+  base: string,
+  token: string
+): Promise<BootstrapOutcome> {
+  let response: Response;
+  try {
+    response = await fetch(
+      new URL("/internal/v1/computers/runtime-config", base).toString(),
+      {
+        headers: { [INSPECTOR_SERVICE_TOKEN_HEADER]: token },
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      }
+    );
+  } catch (error) {
+    logger.error(
+      "[computers] runtime-config bootstrap network error",
+      error instanceof Error ? error.message : String(error)
+    );
+    return "failed";
+  }
+  if (response.status === 401 || response.status === 404) {
+    // Old backend (no route) or a token this deployment doesn't recognize:
+    // nothing to bootstrap — same end state as today's unconfigured server.
+    // 401 additionally suggests a misconfigured token, so say so.
+    logger.warn(
+      `[computers] runtime-config bootstrap unavailable (status ${response.status})` +
+        (response.status === 401
+          ? " — INSPECTOR_SERVICE_TOKEN does not match this Convex deployment"
+          : "")
+    );
+    return "unavailable";
+  }
+  if (!response.ok) {
+    logger.error(
+      `[computers] runtime-config bootstrap failed (status ${response.status})`
+    );
+    return "failed";
+  }
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch {
+    logger.error("[computers] runtime-config bootstrap returned non-JSON");
+    return "failed";
+  }
+  const parsed = runtimeConfigSchema.safeParse(payload);
+  if (!parsed.success) {
+    // Shape mismatch (never the body itself) — atomic apply means we write
+    // nothing rather than a partial credential set.
+    logger.error("[computers] runtime-config bootstrap payload failed validation");
+    return "failed";
+  }
+  if (!parsed.data.enabled) {
+    return "unavailable";
+  }
+  applyRuntimeConfigToEnv(parsed.data);
+  logger.info("[computers] data-plane credentials bootstrapped from Convex");
+  return "applied";
+}
+
+async function runBootstrap(sleep: (ms: number) => Promise<void>): Promise<BootstrapOutcome> {
+  const token = getInspectorServiceToken();
+  if (!token) return "skipped";
+  const base = getConvexHttpUrl();
+  if (!base) return "skipped";
+  if (hasCompleteLegacyEnv()) return "skipped";
+
+  for (let attempt = 0; ; attempt += 1) {
+    const outcome = await fetchRuntimeConfigOnce(base, token);
+    if (outcome !== "failed") return outcome;
+    const delay = RETRY_DELAYS_MS[attempt];
+    if (delay === undefined) {
+      lastFailureAtMs = Date.now();
+      return "failed";
+    }
+    await sleep(delay);
+  }
+}
+
+const defaultSleep = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Kicks off (or joins) the bootstrap. Memoized like
+ * `initComputersRemoteDataPlaneDiscovery`; a run that ended in a NETWORK
+ * failure becomes eligible to re-init after a 60s cooldown — outcomes that
+ * are answers ("skipped", "unavailable", "applied") never re-run.
+ */
+export function initComputersRuntimeConfigBootstrap(
+  deps: { sleep?: (ms: number) => Promise<void> } = {}
+): Promise<BootstrapOutcome> {
+  if (bootstrapPromise) {
+    const promise = bootstrapPromise;
+    return promise.then((outcome) => {
+      if (
+        outcome === "failed" &&
+        lastFailureAtMs !== null &&
+        Date.now() - lastFailureAtMs >= FAILURE_COOLDOWN_MS &&
+        bootstrapPromise === promise
+      ) {
+        bootstrapPromise = runBootstrap(deps.sleep ?? defaultSleep);
+        return bootstrapPromise;
+      }
+      return outcome;
+    });
+  }
+  bootstrapPromise = runBootstrap(deps.sleep ?? defaultSleep);
+  return bootstrapPromise;
+}
+
+/**
+ * Awaits any in-flight/completed bootstrap (kicking it off if nothing has
+ * yet) then answers the sync predicate. Use at call sites whose FIRST answer
+ * gets cached (the `/api/web/computers/config` route — the client keeps that
+ * response for the whole SPA session) or that can otherwise run before
+ * `initComputersStartup` has resolved.
+ */
+export async function resolveComputersLocalConfigured(): Promise<boolean> {
+  await initComputersRuntimeConfigBootstrap();
+  return isComputersDataPlaneConfigured();
+}

--- a/mcpjam-inspector/server/utils/harness/__tests__/harness-availability.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/harness-availability.test.ts
@@ -8,6 +8,7 @@ import type { HarnessId } from "../registry";
 const ENV_KEYS = [
   "CONVEX_HTTP_URL",
   "COMPUTERS_DATA_PLANE_SECRET",
+  "COMPUTERS_TERMINAL_TOKEN_SECRET",
   "E2B_API_KEY",
 ] as const;
 
@@ -29,6 +30,7 @@ function setFullyAvailable() {
   // the preflight only checks the computers data plane + capability gates.
   process.env.CONVEX_HTTP_URL = "https://convex.example.com";
   process.env.COMPUTERS_DATA_PLANE_SECRET = "secret";
+  process.env.COMPUTERS_TERMINAL_TOKEN_SECRET = "terminal-secret-16+";
   process.env.E2B_API_KEY = "e2b-test";
 }
 

--- a/mcpjam-inspector/server/utils/harness/harness-availability.ts
+++ b/mcpjam-inspector/server/utils/harness/harness-availability.ts
@@ -46,9 +46,9 @@ export function checkHarnessRuntimeAvailable(args: {
     return {
       ok: false,
       reason:
-        `the ${name} harness needs a computer, but the computers data plane ` +
-        "is not configured (need CONVEX_HTTP_URL, COMPUTERS_DATA_PLANE_SECRET, " +
-        "and E2B_API_KEY)",
+        `the ${name} harness needs a computer, but this server is not a ` +
+        "computers data plane (deployed servers bootstrap credentials from " +
+        "INSPECTOR_SERVICE_TOKEN; see docs/project-computers.md)",
     };
   }
 

--- a/mcpjam-inspector/server/utils/harness/resolve-sandbox.ts
+++ b/mcpjam-inspector/server/utils/harness/resolve-sandbox.ts
@@ -53,8 +53,9 @@ export async function resolveHarnessSandbox(args: {
 }): Promise<ResolvedHarnessSandbox> {
   if (!isComputersDataPlaneConfigured()) {
     throw new HarnessSandboxResolutionError(
-      "computers data plane is not configured (need CONVEX_HTTP_URL, " +
-        "COMPUTERS_DATA_PLANE_SECRET, and E2B_API_KEY)",
+      "this server is not a computers data plane (deployed servers " +
+        "bootstrap credentials from INSPECTOR_SERVICE_TOKEN; see " +
+        "docs/project-computers.md)",
       503,
     );
   }

--- a/mcpjam-inspector/src/main.ts
+++ b/mcpjam-inspector/src/main.ts
@@ -314,7 +314,7 @@ async function startHonoServer(): Promise<number> {
     // Node's cache; subsequent calls just return the cached exports, which
     // is exactly what we want now that we're reusing the same port.
     const { createHonoApp } = await import("../server/app.js");
-    const honoApp = createHonoApp();
+    const honoApp = await createHonoApp();
 
     server = serve({
       fetch: honoApp.fetch,


### PR DESCRIPTION
## What

The core inspector-side step of the computers **one-credential bootstrap** plan: a deployed inspector needs exactly one computers-related credential — the environment-root `INSPECTOR_SERVICE_TOKEN` — and derives the rest at boot from mcpjam-backend's service-token-gated `GET /internal/v1/computers/runtime-config` (backend PRs MCPJam/mcpjam-backend#675 + MCPJam/mcpjam-backend#676; those must be **deployed** before this takes effect — against an older backend the fetch 404s and behavior is byte-identical to today).

## How it works

- **New `server/utils/computers/runtime-config.ts`** (modeled on `remote-data-plane.ts`'s init/memoized-promise/sync-getter shape): fetches with the service token, then writes `E2B_API_KEY`, optional `E2B_*` overrides, and `COMPUTERS_TERMINAL_TOKEN_SECRET` into `process.env` **only-if-unset** — the E2B SDK reads env ambiently, so everything downstream works unchanged and env always wins. Three-var setups skip the fetch entirely.
- **Atomic apply**: the whole payload zod-validates before any env write — a malformed payload writes nothing, never a mixed credential set.
- **Fail closed**: 401/404/`enabled:false` resolve as today's unconfigured state (no retry — they're answers); network failures retry 3× (1s/3s) then respect a 60s re-init cooldown. Status codes only in logs, never the body.
- **Readiness guarantee**: new `initComputersStartup()` (bootstrap **then** discovery — so a soon-to-be data plane can't race into delegating while also being locally configured) is *awaited* before `serve()` in `server/index.ts` (top-level await; ESM/node22 bundle verified) and inside the now-async `createHonoApp` for the Electron path. The synchronous `isComputersDataPlaneConfigured()` gates (harness pre-flight, evals) are truthful from the first request; `/api/web/computers/config` additionally awaits the resolver since the client caches its first answer for the whole SPA session.
- **Predicate tightened**: configured now also requires `COMPUTERS_TERMINAL_TOKEN_SECRET` (the terminal verifier fails closed without it — 'configured but can't verify terminal tokens' was a lie) and accepts service token OR legacy secret as the server-to-server credential. Control-plane calls send the legacy secret when present, else the service token — matching the backend's dual-accept precedence (invalid new credential hard-401s there; no silent downgrade).
- Harness/evals gate error copy now points at the service-token story instead of telling users to hand-mirror three env vars.

## Tests

- New `computers-runtime-config.test.ts` (11): env population + atomicity, only-if-unset, skip conditions, 404/enabled:false → unavailable, 3-attempt retry + fail-closed, memoization, cooldown re-init, resolver.
- `computers-remote-data-plane.test.ts`: new `initComputersStartup` ordering test (bootstrap-configured server never discovers/delegates).
- Existing computers/harness fixtures updated for the tightened predicate (add the terminal secret).
- 50 computers-suite + 145 harness-suite tests green; `tsc -p server` error count unchanged vs main (77 pre-existing); `tsup` server bundle builds (validates the top-level await).

Part of the computers one-credential/cloud-only plan (PR 4 of 7; PR 1 was #3091).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches startup readiness, credential env mutation, and computers/eval gating; wrong ordering or bootstrap semantics could misreport configuration or delay serve by up to ~11s, but legacy three-var setups are unchanged and failures are fail-closed.
> 
> **Overview**
> **Deployed inspectors can act as a computers data plane with only `INSPECTOR_SERVICE_TOKEN`**, by bootstrapping E2B and terminal secrets from Convex `GET /internal/v1/computers/runtime-config` into `process.env` (only-if-unset, zod-validated atomic apply).
> 
> **Startup ordering is fixed:** `initComputersStartup()` runs credential bootstrap **before** remote data-plane discovery, and both `server/index.ts` and async `createHonoApp()` **await** it before accepting traffic so harness/evals gates and `isComputersDataPlaneConfigured()` are accurate from the first request. `/api/web/computers/config` now awaits `resolveComputersLocalConfigured()` so the SPA’s cached first answer cannot race bootstrap.
> 
> **“Configured” is stricter and auth is dual-path:** requires `COMPUTERS_TERMINAL_TOKEN_SECRET`; accepts legacy `COMPUTERS_DATA_PLANE_SECRET` or service token on secret-gated Convex calls (legacy wins). A bootstrap **401** marks the service token rejected so stray env keys cannot advertise `localConfigured: true` while `/computers/*` hard-401s.
> 
> Harness/evals error copy points at the service-token bootstrap story instead of hand-mirroring three env vars. New and updated tests cover runtime-config bootstrap, startup ordering, and the tightened predicate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7393938e2ef49cc431af0318009daa02ce54294f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bootstraps computers credentials at startup using `INSPECTOR_SERVICE_TOKEN`, so a deployed inspector needs only one credential. Startup now awaits bootstrap then discovery to avoid races and ensure truthful readiness from the first request.

- **New Features**
  - Bootstraps `E2B_API_KEY` (+ optional `E2B_*` overrides) and `COMPUTERS_TERMINAL_TOKEN_SECRET` from Convex’s service-token-gated runtime-config; writes to `process.env` only if unset. Existing three-var env setups skip the fetch.
  - Atomic and fail-closed: payload must validate before any write; 401/404/enabled:false resolve as “unavailable”; network errors retry 3× with a 60s cooldown; never logs response bodies.
  - Readiness: added `initComputersStartup()` (bootstrap then remote discovery) and await it before `serve()` and inside the now-async `createHonoApp`. `/api/web/computers/config` awaits local config and remote URL.
  - Predicate tightened: requires `COMPUTERS_TERMINAL_TOKEN_SECRET` and accepts service token or legacy secret; control-plane calls prefer the legacy secret, else use the service token.
  - Updated error copy in harness/evals; added `computers-runtime-config.test.ts` and related tests; fixed bash-tool test fixture for the tightened predicate.

- **Bug Fixes**
  - A bootstrap 401 now marks the `INSPECTOR_SERVICE_TOKEN` as rejected for the process lifetime. It no longer counts toward “configured” and isn’t sent on control-plane calls, avoiding false localConfigured:true in hybrid setups.

- **Migration**
  - Set `INSPECTOR_SERVICE_TOKEN` on deployed inspectors.
  - Deploy backend changes MCPJam/mcpjam-backend#675 and #676 first. On older backends the fetch 404s and behavior stays unchanged.
  - No changes needed for environments already using the three env vars.

<sup>Written for commit 7393938e2ef49cc431af0318009daa02ce54294f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3092?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

