### PR TITLE
feat(computers): verify RS256 terminal tokens against the backend JWKS

### DIFF
--- a/mcpjam-inspector/server/utils/__tests__/computers-terminal-token.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/computers-terminal-token.test.ts
@@ -1,5 +1,17 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { verifyComputerTerminalToken } from "../computers/terminal-token";
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
+import { SignJWT, exportJWK, generateKeyPair } from "jose";
+import {
+  verifyComputerTerminalToken,
+  resetComputerTerminalJwksCacheForTests,
+} from "../computers/terminal-token";
 
 // Local HS256 signer reproducing the mcpjam-backend mint
 // (convex/lib/computerTerminalToken.ts) so verification is exercised against
@@ -124,5 +136,145 @@ describe("verifyComputerTerminalToken", () => {
     expect(await verifyComputerTerminalToken("")).toBeNull();
     expect(await verifyComputerTerminalToken("a.b")).toBeNull();
     expect(await verifyComputerTerminalToken("not!.b64.!!!")).toBeNull();
+  });
+
+  it("rejects unknown algs including none", async () => {
+    const header = b64url(
+      new TextEncoder().encode(JSON.stringify({ alg: "none", typ: "JWT" }))
+    );
+    const payload = b64url(
+      new TextEncoder().encode(JSON.stringify(baseClaims()))
+    );
+    expect(
+      await verifyComputerTerminalToken(`${header}.${payload}.sig`)
+    ).toBeNull();
+  });
+});
+
+describe("verifyComputerTerminalToken (RS256 via JWKS)", () => {
+  const KID = "computer-terminal-1";
+  let keys: Awaited<ReturnType<typeof generateKeyPair>>;
+  let otherKeys: Awaited<ReturnType<typeof generateKeyPair>>;
+  let jwksDoc: unknown;
+  let fetchCalls: string[];
+  let jwksResponse: () => Response | Promise<Response>;
+
+  beforeAll(async () => {
+    keys = await generateKeyPair("RS256");
+    otherKeys = await generateKeyPair("RS256");
+    const jwk = await exportJWK(keys.publicKey);
+    jwksDoc = { keys: [{ ...jwk, kid: KID, alg: "RS256", use: "sig" }] };
+  });
+
+  beforeEach(() => {
+    vi.stubEnv("CONVEX_HTTP_URL", "https://convex.example.test");
+    resetComputerTerminalJwksCacheForTests();
+    fetchCalls = [];
+    jwksResponse = () =>
+      new Response(JSON.stringify(jwksDoc), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string | URL) => {
+        fetchCalls.push(String(url));
+        return jwksResponse();
+      })
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    resetComputerTerminalJwksCacheForTests();
+  });
+
+  async function signRs256(
+    claims: Record<string, unknown>,
+    opts: { kid?: string; privateKey?: CryptoKey } = {}
+  ): Promise<string> {
+    const { exp, iat, iss, ...rest } = claims as Record<string, unknown> & {
+      exp: number;
+      iat: number;
+      iss: string;
+    };
+    return new SignJWT(rest)
+      .setProtectedHeader({ alg: "RS256", kid: opts.kid ?? KID })
+      .setIssuer(iss)
+      .setIssuedAt(iat)
+      .setExpirationTime(exp)
+      .sign(opts.privateKey ?? (keys.privateKey as CryptoKey));
+  }
+
+  it("accepts a backend-minted RS256 token against the published JWKS", async () => {
+    const token = await signRs256(baseClaims());
+    expect(await verifyComputerTerminalToken(token)).toEqual({
+      userId: "users_123",
+      computerId: "computers_456",
+      projectId: "projects_789",
+    });
+    expect(fetchCalls).toEqual([
+      "https://convex.example.test/computers/terminal-jwks",
+    ]);
+    // Second verify uses the cached JWKS — no refetch.
+    expect(
+      await verifyComputerTerminalToken(await signRs256(baseClaims()))
+    ).not.toBeNull();
+    expect(fetchCalls).toHaveLength(1);
+  });
+
+  it("rejects an RS256 token signed by a different key (unknown kid or wrong key)", async () => {
+    const wrongKey = await signRs256(baseClaims(), {
+      privateKey: otherKeys.privateKey as CryptoKey,
+    });
+    expect(await verifyComputerTerminalToken(wrongKey)).toBeNull();
+    const unknownKid = await signRs256(baseClaims(), { kid: "rogue-kid" });
+    expect(await verifyComputerTerminalToken(unknownKid)).toBeNull();
+  });
+
+  it("rejects an expired RS256 token and a foreign purpose", async () => {
+    const expired = {
+      ...baseClaims(),
+      exp: Math.floor(Date.now() / 1000) - 5,
+    };
+    expect(await verifyComputerTerminalToken(await signRs256(expired))).toBeNull();
+    const wrongPurpose = { ...baseClaims(), purpose: "guest-promotion" };
+    expect(
+      await verifyComputerTerminalToken(await signRs256(wrongPurpose))
+    ).toBeNull();
+  });
+
+  it("forecloses alg-confusion: an HS256 token keyed on the public JWK bytes is rejected", async () => {
+    // The classic RS256→HS256 downgrade: attacker HMACs with the public key
+    // material. Our dispatch sends alg:HS256 to the shared-secret path only,
+    // so this never meets the public key.
+    const publicJwkBytes = JSON.stringify(await exportJWK(keys.publicKey));
+    const token = await sign(baseClaims(), publicJwkBytes);
+    expect(await verifyComputerTerminalToken(token)).toBeNull();
+  });
+
+  it("fails closed when the JWKS is unreachable, empty, or CONVEX_HTTP_URL is unset", async () => {
+    jwksResponse = () => {
+      throw new TypeError("fetch failed");
+    };
+    const token = await signRs256(baseClaims());
+    expect(await verifyComputerTerminalToken(token)).toBeNull();
+
+    resetComputerTerminalJwksCacheForTests();
+    jwksResponse = () =>
+      new Response(JSON.stringify({ keys: [] }), { status: 200 });
+    expect(await verifyComputerTerminalToken(token)).toBeNull();
+
+    vi.stubEnv("CONVEX_HTTP_URL", "");
+    resetComputerTerminalJwksCacheForTests();
+    expect(await verifyComputerTerminalToken(token)).toBeNull();
+  });
+
+  it("remembers a failed JWKS fetch briefly instead of hammering Convex", async () => {
+    jwksResponse = () => new Response("nope", { status: 500 });
+    const token = await signRs256(baseClaims());
+    expect(await verifyComputerTerminalToken(token)).toBeNull();
+    expect(await verifyComputerTerminalToken(token)).toBeNull();
+    expect(fetchCalls).toHaveLength(1);
   });
 });

--- a/mcpjam-inspector/server/utils/__tests__/computers-terminal-token.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/computers-terminal-token.test.ts
@@ -191,19 +191,19 @@ describe("verifyComputerTerminalToken (RS256 via JWKS)", () => {
 
   async function signRs256(
     claims: Record<string, unknown>,
-    opts: { kid?: string; privateKey?: CryptoKey } = {}
+    opts: { kid?: string; privateKey?: CryptoKey; omitExp?: boolean } = {}
   ): Promise<string> {
     const { exp, iat, iss, ...rest } = claims as Record<string, unknown> & {
       exp: number;
       iat: number;
       iss: string;
     };
-    return new SignJWT(rest)
+    const jwt = new SignJWT(rest)
       .setProtectedHeader({ alg: "RS256", kid: opts.kid ?? KID })
       .setIssuer(iss)
-      .setIssuedAt(iat)
-      .setExpirationTime(exp)
-      .sign(opts.privateKey ?? (keys.privateKey as CryptoKey));
+      .setIssuedAt(iat);
+    if (!opts.omitExp) jwt.setExpirationTime(exp);
+    return jwt.sign(opts.privateKey ?? (keys.privateKey as CryptoKey));
   }
 
   it("accepts a backend-minted RS256 token against the published JWKS", async () => {
@@ -242,6 +242,25 @@ describe("verifyComputerTerminalToken (RS256 via JWKS)", () => {
     expect(
       await verifyComputerTerminalToken(await signRs256(wrongPurpose))
     ).toBeNull();
+  });
+
+  it("rejects an RS256 token that carries no exp (parity with the HS256 path)", async () => {
+    // jose rejects an expired exp but does not require one to be present; the
+    // verifier must, or RS256 tokens would be accepted as never-expiring.
+    const token = await signRs256(baseClaims(), { omitExp: true });
+    expect(await verifyComputerTerminalToken(token)).toBeNull();
+  });
+
+  it("collapses a burst of concurrent cold-cache verifies onto one JWKS fetch", async () => {
+    const tokens = await Promise.all(
+      Array.from({ length: 5 }, () => signRs256(baseClaims()))
+    );
+    const results = await Promise.all(
+      tokens.map((t) => verifyComputerTerminalToken(t))
+    );
+    expect(results.every((r) => r !== null)).toBe(true);
+    // Without in-flight memoization this would be 5 fetches.
+    expect(fetchCalls).toHaveLength(1);
   });
 
   it("forecloses alg-confusion: an HS256 token keyed on the public JWK bytes is rejected", async () => {

--- a/mcpjam-inspector/server/utils/computers/terminal-token.ts
+++ b/mcpjam-inspector/server/utils/computers/terminal-token.ts
@@ -72,30 +72,22 @@ let cachedJwks: {
   keyset: ReturnType<typeof createLocalJWKSet> | null;
 } | null = null;
 
+type TerminalKeySet = ReturnType<typeof createLocalJWKSet>;
+
+/** A fetch in progress, shared by every concurrent caller for the same URL so
+ *  a cold cache under a burst of handshakes triggers ONE network call, not
+ *  one per handshake (and a broken endpoint one per cooldown window, not one
+ *  per handshake). Reset to null once it settles into `cachedJwks`. */
+let inFlightJwks: { url: string; promise: Promise<TerminalKeySet | null> } | null =
+  null;
+
 export function resetComputerTerminalJwksCacheForTests(): void {
   cachedJwks = null;
+  inFlightJwks = null;
 }
 
-/** The backend-published terminal JWKS, cached per URL. Returns null (fail
- *  closed) when CONVEX_HTTP_URL is unset, the fetch fails, or the document
- *  has no keys (backend keypair not configured/validated yet). */
-async function getTerminalJwks(): Promise<ReturnType<
-  typeof createLocalJWKSet
-> | null> {
-  const base = process.env.CONVEX_HTTP_URL?.trim();
-  if (!base) return null;
-  let url: string;
-  try {
-    url = new URL(JWKS_PATH, base).toString();
-  } catch {
-    return null;
-  }
-  if (cachedJwks && cachedJwks.url === url) {
-    const age = Date.now() - cachedJwks.fetchedAt;
-    const ttl = cachedJwks.keyset ? JWKS_CACHE_MS : JWKS_FAILURE_COOLDOWN_MS;
-    if (age < ttl) return cachedJwks.keyset;
-  }
-  let keyset: ReturnType<typeof createLocalJWKSet> | null = null;
+async function fetchTerminalJwks(url: string): Promise<TerminalKeySet | null> {
+  let keyset: TerminalKeySet | null = null;
   try {
     const response = await fetch(url, {
       signal: AbortSignal.timeout(JWKS_FETCH_TIMEOUT_MS),
@@ -117,6 +109,34 @@ async function getTerminalJwks(): Promise<ReturnType<
   }
   cachedJwks = { url, fetchedAt: Date.now(), keyset };
   return keyset;
+}
+
+/** The backend-published terminal JWKS, cached per URL. Returns null (fail
+ *  closed) when CONVEX_HTTP_URL is unset, the fetch fails, or the document
+ *  has no keys (backend keypair not configured/validated yet). */
+async function getTerminalJwks(): Promise<TerminalKeySet | null> {
+  const base = process.env.CONVEX_HTTP_URL?.trim();
+  if (!base) return null;
+  let url: string;
+  try {
+    url = new URL(JWKS_PATH, base).toString();
+  } catch {
+    return null;
+  }
+  if (cachedJwks && cachedJwks.url === url) {
+    const age = Date.now() - cachedJwks.fetchedAt;
+    const ttl = cachedJwks.keyset ? JWKS_CACHE_MS : JWKS_FAILURE_COOLDOWN_MS;
+    if (age < ttl) return cachedJwks.keyset;
+  }
+  // Collapse concurrent cold fetches onto one in-flight request.
+  if (inFlightJwks && inFlightJwks.url === url) return inFlightJwks.promise;
+  const promise = fetchTerminalJwks(url);
+  inFlightJwks = { url, promise };
+  try {
+    return await promise;
+  } finally {
+    if (inFlightJwks?.promise === promise) inFlightJwks = null;
+  }
 }
 
 /** Shape-checks the shared claim contract and narrows to our claims type. */
@@ -147,9 +167,14 @@ async function verifyRs256TerminalToken(
   const jwks = await getTerminalJwks();
   if (!jwks) return null;
   try {
+    // `requiredClaims: ["exp"]` keeps the RS256 path as strict about token
+    // lifetime as the HS256 path below: jose rejects an EXPIRED exp but does
+    // not, on its own, require exp to be PRESENT — a token minted without one
+    // would otherwise verify as never-expiring.
     const { payload } = await jwtVerify(token, jwks, {
       issuer: ISSUER,
       algorithms: ["RS256"],
+      requiredClaims: ["exp"],
     });
     return toTerminalClaims(payload as Record<string, unknown>);
   } catch {

--- a/mcpjam-inspector/server/utils/computers/terminal-token.ts
+++ b/mcpjam-inspector/server/utils/computers/terminal-token.ts
@@ -3,22 +3,51 @@
  *
  * Convex mints these (mcpjam-backend `projectComputers.mintTerminalToken`,
  * lib `computerTerminalToken.ts`) and the browser presents one when opening
- * the terminal WebSocket. We verify locally with the shared
- * `COMPUTERS_TERMINAL_TOKEN_SECRET` (HS256) — no Convex round trip on the
- * hot handshake path. The claim contract is owned by the backend lib; this
- * file is its verify-only mirror and must stay in lockstep:
+ * the terminal WebSocket. The claim contract is owned by the backend lib;
+ * this file is its verify-only mirror and must stay in lockstep:
  *   iss      'https://api.mcpjam.com/computer-terminal'
  *   purpose  'computer-terminal'  (REQUIRED — rejects every other JWT population)
  *   sub      Convex users id (owner)   computerId / projectId   exp ~60s
+ *
+ * Verification dispatches on the token's own `alg` header, and the key
+ * material is selected BY algorithm — which forecloses alg-confusion (an
+ * HS256 token HMAC'd with the public-key bytes finds only the shared secret
+ * on the HS256 path, never the public key):
+ *
+ *   RS256 — verified against the backend-published JWKS
+ *     (`GET {CONVEX_HTTP_URL}/computers/terminal-jwks`, kid
+ *     `computer-terminal-1`), fetched with a short cache. This is the
+ *     endgame: the inspector holds verify-only material and can never mint.
+ *   HS256 — the shared `COMPUTERS_TERMINAL_TOKEN_SECRET`, kept as the
+ *     migration fallback until the backend key flip.
+ *   anything else (including `none`) — rejected.
+ *
+ * Fails closed (`null`) whenever the matching key material is unavailable —
+ * secret unconfigured, `CONVEX_HTTP_URL` unset, or JWKS unreachable.
  *
  * The token deliberately carries only MCPJam row ids. The vendor sandbox id
  * is resolved server-side via the secret-gated `/computers/sandbox-info`
  * Convex route, so a browser holding this token learns nothing vendor-side.
  */
+import {
+  createLocalJWKSet,
+  decodeProtectedHeader,
+  jwtVerify,
+  type JSONWebKeySet,
+} from "jose";
+import { logger } from "../logger.js";
 
 const ISSUER = "https://api.mcpjam.com/computer-terminal";
 const PURPOSE = "computer-terminal";
 const MIN_SECRET_LENGTH = 16;
+
+const JWKS_PATH = "/computers/terminal-jwks";
+const JWKS_FETCH_TIMEOUT_MS = 5_000;
+/** Matches the endpoint's own Cache-Control (max-age=300). */
+const JWKS_CACHE_MS = 5 * 60_000;
+/** A failed/empty fetch is remembered briefly so a burst of RS256 handshakes
+ *  against a broken JWKS can't hammer Convex. */
+const JWKS_FAILURE_COOLDOWN_MS = 30_000;
 
 export interface ComputerTerminalClaims {
   userId: string;
@@ -36,21 +65,125 @@ function base64UrlToBytes(input: string): Uint8Array {
   return bytes;
 }
 
+let cachedJwks: {
+  url: string;
+  fetchedAt: number;
+  /** Null records a failed/empty fetch (kept for the failure cooldown). */
+  keyset: ReturnType<typeof createLocalJWKSet> | null;
+} | null = null;
+
+export function resetComputerTerminalJwksCacheForTests(): void {
+  cachedJwks = null;
+}
+
+/** The backend-published terminal JWKS, cached per URL. Returns null (fail
+ *  closed) when CONVEX_HTTP_URL is unset, the fetch fails, or the document
+ *  has no keys (backend keypair not configured/validated yet). */
+async function getTerminalJwks(): Promise<ReturnType<
+  typeof createLocalJWKSet
+> | null> {
+  const base = process.env.CONVEX_HTTP_URL?.trim();
+  if (!base) return null;
+  let url: string;
+  try {
+    url = new URL(JWKS_PATH, base).toString();
+  } catch {
+    return null;
+  }
+  if (cachedJwks && cachedJwks.url === url) {
+    const age = Date.now() - cachedJwks.fetchedAt;
+    const ttl = cachedJwks.keyset ? JWKS_CACHE_MS : JWKS_FAILURE_COOLDOWN_MS;
+    if (age < ttl) return cachedJwks.keyset;
+  }
+  let keyset: ReturnType<typeof createLocalJWKSet> | null = null;
+  try {
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(JWKS_FETCH_TIMEOUT_MS),
+    });
+    if (response.ok) {
+      const doc = (await response.json()) as JSONWebKeySet;
+      if (Array.isArray(doc?.keys) && doc.keys.length > 0) {
+        keyset = createLocalJWKSet(doc);
+      }
+    } else {
+      logger.warn(
+        `[computers] terminal JWKS fetch failed (status ${response.status})`
+      );
+    }
+  } catch (error) {
+    logger.warn("[computers] terminal JWKS fetch error", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+  cachedJwks = { url, fetchedAt: Date.now(), keyset };
+  return keyset;
+}
+
+/** Shape-checks the shared claim contract and narrows to our claims type. */
+function toTerminalClaims(
+  payload: Record<string, unknown>
+): ComputerTerminalClaims | null {
+  if (payload.purpose !== PURPOSE) return null;
+  if (typeof payload.sub !== "string" || payload.sub.length === 0) return null;
+  if (
+    typeof payload.computerId !== "string" ||
+    payload.computerId.length === 0
+  ) {
+    return null;
+  }
+  if (typeof payload.projectId !== "string" || payload.projectId.length === 0) {
+    return null;
+  }
+  return {
+    userId: payload.sub,
+    computerId: payload.computerId,
+    projectId: payload.projectId,
+  };
+}
+
+async function verifyRs256TerminalToken(
+  token: string
+): Promise<ComputerTerminalClaims | null> {
+  const jwks = await getTerminalJwks();
+  if (!jwks) return null;
+  try {
+    const { payload } = await jwtVerify(token, jwks, {
+      issuer: ISSUER,
+      algorithms: ["RS256"],
+    });
+    return toTerminalClaims(payload as Record<string, unknown>);
+  } catch {
+    return null;
+  }
+}
+
 /**
- * Verify a terminal token: HMAC-SHA256 signature, issuer, required purpose
- * claim, and expiry. Returns the claims or `null`; never throws on malformed
- * input. Fails closed (null) when the shared secret is unconfigured.
+ * Verify a terminal token per the header-alg dispatch documented above.
+ * Returns the claims or `null`; never throws on malformed input.
  */
 export async function verifyComputerTerminalToken(
   token: string
 ): Promise<ComputerTerminalClaims | null> {
-  const secret = process.env.COMPUTERS_TERMINAL_TOKEN_SECRET?.trim();
-  if (!secret || secret.length < MIN_SECRET_LENGTH) return null;
-
   const parts = token.split(".");
   if (parts.length !== 3) return null;
   const [h, p, s] = parts;
   if (!h || !p || !s) return null;
+
+  let alg: unknown;
+  try {
+    alg = decodeProtectedHeader(token).alg;
+  } catch {
+    return null;
+  }
+  if (alg === "RS256") {
+    return verifyRs256TerminalToken(token);
+  }
+  if (alg !== "HS256") {
+    return null;
+  }
+
+  const secret = process.env.COMPUTERS_TERMINAL_TOKEN_SECRET?.trim();
+  if (!secret || secret.length < MIN_SECRET_LENGTH) return null;
 
   let valid: boolean;
   try {
@@ -86,24 +219,9 @@ export async function verifyComputerTerminalToken(
     return null;
   }
   if (payload.iss !== ISSUER) return null;
-  if (payload.purpose !== PURPOSE) return null;
-  if (typeof payload.sub !== "string" || payload.sub.length === 0) return null;
-  if (
-    typeof payload.computerId !== "string" ||
-    payload.computerId.length === 0
-  ) {
-    return null;
-  }
-  if (typeof payload.projectId !== "string" || payload.projectId.length === 0) {
-    return null;
-  }
   if (typeof payload.exp !== "number") return null;
   // JWT NumericDate semantics: the token is expired AT `exp`, not after it.
   if (Math.floor(Date.now() / 1000) >= payload.exp) return null;
 
-  return {
-    userId: payload.sub,
-    computerId: payload.computerId,
-    projectId: payload.projectId,
-  };
+  return toTerminalClaims(payload);
 }


### PR DESCRIPTION
## What

Inspector half of the terminal-token RS256/JWKS migration (backend mint half: MCPJam/mcpjam-backend#677). The endgame: inspectors hold **verify-only** material for terminal tokens and can never mint.

## Changes

`server/utils/computers/terminal-token.ts` — verification dispatches on the token's own `alg` header:

- **RS256** → verified against `GET {CONVEX_HTTP_URL}/computers/terminal-jwks` (kid `computer-terminal-1`), fetched with jose's `createLocalJWKSet` + our own fetch: 5-minute success cache (matches the endpoint's `Cache-Control`), 30s failure cooldown so a burst of handshakes can't hammer a broken endpoint. Claims contract (issuer, required `purpose`, row ids, exp) unchanged.
- **HS256** → existing shared-secret path, kept as the migration fallback.
- **Anything else (incl. `none`)** → rejected.

Key material is selected **by algorithm** — the classic RS256→HS256 alg-confusion downgrade (HMAC with the public-key bytes) never meets the public key. Fails closed when the matching material is unavailable (secret unconfigured / `CONVEX_HTTP_URL` unset / JWKS unreachable or `{ keys: [] }`).

## Rollout

Safe to deploy anytime — the backend still mints HS256. The ops RS256 key flip happens only after this verifier is deployed everywhere (the one dangerous half-state in the plan, and it's reversible by unsetting the backend keys).

## Tests

16 passing in `computers-terminal-token.test.ts`: all existing HS256 cases, plus RS256 accept + JWKS caching, wrong-key/unknown-kid/expired/foreign-purpose rejection, **alg-confusion rejection**, `alg: none` rejection, fail-closed on unreachable/empty JWKS + unset `CONVEX_HTTP_URL`, failure-cooldown behavior. Terminal WS + upload consumer suites green (22). `tsc -p server` error count unchanged vs main (66).

Part of the computers one-credential/cloud-only plan (PR 6 of 7; siblings #3091, #3092).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication on the terminal WebSocket and upload hot paths; misconfiguration or JWKS outages would reject valid RS256 handshakes until rollout is aligned with the backend mint flip.
> 
> **Overview**
> **Computer terminal JWT verification** now routes by the token header `alg` instead of assuming HS256 only. **RS256** tokens are checked with `jose` against `GET {CONVEX_HTTP_URL}/computers/terminal-jwks`, with a 5-minute success cache, 30s failure cooldown, and in-flight dedup so concurrent handshakes share one fetch. **HS256** still uses `COMPUTERS_TERMINAL_TOKEN_SECRET` as the migration path; other algs (including `none`) are rejected, and key material is tied to alg to block RS256→HS256 confusion.
> 
> Claim parsing is centralized in `toTerminalClaims`; RS256 verification requires `exp` via `requiredClaims` so tokens without expiry cannot pass. Verification returns `null` when JWKS is missing, empty, unreachable, or `CONVEX_HTTP_URL` is unset.
> 
> Tests add a full RS256/JWKS suite (caching, concurrency, alg confusion, fail-closed) plus `alg: none` rejection on the HS256 describe block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bec2240c324f38a17d576572a1b2e89e3c59b3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Verify computer terminal JWTs with RS256 against the backend JWKS, dispatching by the token’s alg header to prevent alg-confusion. HS256 stays as a fallback during migration; verification fails closed when keys or config are missing.

- **New Features**
  - RS256 verification against GET {CONVEX_HTTP_URL}/computers/terminal-jwks (kid `computer-terminal-1`) using `jose` `createLocalJWKSet`.
  - JWKS caching: 5m success TTL, 30s failure cooldown, and in-flight memoization to collapse concurrent cold-cache fetches into one request.

- **Bug Fixes**
  - RS256 path now requires the `exp` claim to match HS256 lifetime rules.

<sup>Written for commit 2bec2240c324f38a17d576572a1b2e89e3c59b3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

