### PR TITLE
feat(analytics): same-origin PostHog relay to survive ad blockers

### DIFF
--- a/mcpjam-inspector/client/src/lib/PosthogUtils.ts
+++ b/mcpjam-inspector/client/src/lib/PosthogUtils.ts
@@ -2,8 +2,27 @@ export const VITE_PUBLIC_POSTHOG_KEY =
   "phc_dTOPniyUNU2kD8Jx8yHMXSqiZHM8I91uWopTMX6EBE9";
 export const VITE_PUBLIC_POSTHOG_HOST = "https://us.i.posthog.com";
 
+// posthog-js talks to the same-origin /relay reverse proxy (server/routes/
+// relay.ts) instead of *.posthog.com directly: ad blockers block PostHog by
+// hostname, which drops events AND breaks feature-flag evaluation for
+// blocker users. Same-origin works on every platform — hosted web, local
+// npm, and packaged Electron are all served by the Hono server that hosts
+// /relay; Vite dev (web and Electron renderer) proxies /relay to it.
+export function getPostHogApiHost(): string {
+  if (
+    typeof window !== "undefined" &&
+    window.location?.origin?.startsWith("http")
+  ) {
+    return `${window.location.origin}/relay`;
+  }
+  // Non-browser context (tests) — no relay origin to derive.
+  return VITE_PUBLIC_POSTHOG_HOST;
+}
+
 export const options = {
-  api_host: VITE_PUBLIC_POSTHOG_HOST,
+  api_host: getPostHogApiHost(),
+  // Toolbar/app links must point at PostHog itself once api_host is proxied.
+  ui_host: "https://us.posthog.com",
   capture_pageview: false,
   person_profiles: "always" as const,
 
@@ -38,7 +57,10 @@ export const getPostHogKey = () => VITE_PUBLIC_POSTHOG_KEY;
 export const getPostHogOptions = () =>
   isPostHogDisabled
     ? {
-        api_host: VITE_PUBLIC_POSTHOG_HOST,
+        // Same relay host as the enabled branch — otherwise dev-mode /flags
+        // calls hit us.i.posthog.com directly and stay ad-blocked.
+        api_host: getPostHogApiHost(),
+        ui_host: "https://us.posthog.com",
         capture_pageview: false,
         person_profiles: "always" as const,
         // Disable event capture but keep /decide enabled for feature flag evaluation.

--- a/mcpjam-inspector/client/vite.config.ts
+++ b/mcpjam-inspector/client/vite.config.ts
@@ -171,6 +171,14 @@ export default defineConfig(({ mode }) => {
           changeOrigin: true,
           secure: false,
         },
+        // PostHog same-origin relay (server/routes/relay.ts). In dev the
+        // client origin is Vite, not the Hono server, so /relay must be
+        // proxied or analytics/flags silently break in dev only.
+        "/relay": {
+          target: env.VITE_API_BASE_URL || "http://localhost:6274",
+          changeOrigin: true,
+          secure: false,
+        },
         ...(() => {
           const siteUrlFromEnv = env.VITE_CONVEX_SITE_URL;
           const cloudUrl = env.VITE_CONVEX_URL || "";

--- a/mcpjam-inspector/server/app.ts
+++ b/mcpjam-inspector/server/app.ts
@@ -16,6 +16,7 @@ import appsRoutes from "./routes/apps/index.js";
 import webRoutes from "./routes/web/index.js";
 import v1Routes from "./routes/v1/index.js";
 import cliAuthRoutes from "./routes/cli-auth/index.js";
+import relayRoutes, { relayBodyLimit } from "./routes/relay.js";
 import workosAuthkitRoutes from "./routes/workos-authkit.js";
 import { MCPClientManager } from "@mcpjam/sdk";
 import { initElicitationCallback } from "./routes/mcp/elicitation.js";
@@ -274,6 +275,15 @@ export function createHonoApp() {
   // set. Mirror of the mount in server/index.ts — both production entries
   // must wire this up.
   app.route("/api/cli/auth", cliAuthRoutes);
+
+  // Same-origin PostHog reverse proxy (ad-blocker resilience). Deliberately
+  // OUTSIDE /api so it bypasses session auth (analytics flows before any
+  // session exists), and mounted before the static/SPA fallback, whose
+  // catch-all only skips /api/* and would otherwise swallow /relay GETs
+  // with index.html. Mirror of the mount in server/index.ts — both
+  // production entries must wire this up.
+  app.use("/relay/*", relayBodyLimit());
+  app.route("/relay", relayRoutes);
 
   // Health check
   app.get("/health", (c) => {

--- a/mcpjam-inspector/server/index.ts
+++ b/mcpjam-inspector/server/index.ts
@@ -118,6 +118,7 @@ import appsRoutes from "./routes/apps/index";
 import webRoutes from "./routes/web/index";
 import v1Routes from "./routes/v1/index";
 import cliAuthRoutes from "./routes/cli-auth/index";
+import relayRoutes, { relayBodyLimit } from "./routes/relay";
 import workosAuthkitRoutes from "./routes/workos-authkit";
 import { rpcLogBus } from "./services/rpc-log-bus";
 import { tunnelManager } from "./services/tunnel-manager";
@@ -430,6 +431,15 @@ registerSelfFetch((request) => app.fetch(request));
 // set. Mirror of the mount in server/app.ts::createHonoApp — both
 // production entries must wire this up.
 app.route("/api/cli/auth", cliAuthRoutes);
+
+// Same-origin PostHog reverse proxy (ad-blocker resilience). Deliberately
+// OUTSIDE /api so it bypasses session auth (analytics flows before any
+// session exists), and mounted before the production static/SPA fallback,
+// whose catch-all only skips /api/* and would otherwise swallow /relay GETs
+// with index.html. Mirror of the mount in server/app.ts::createHonoApp —
+// both production entries must wire this up.
+app.use("/relay/*", relayBodyLimit());
+app.route("/relay", relayRoutes);
 
 // Fallback for clients that post to "/sse/message" instead of the rewritten proxy messages URL.
 // We resolve the upstream messages endpoint via sessionId and forward with any injected auth.

--- a/mcpjam-inspector/server/middleware/session-auth.ts
+++ b/mcpjam-inspector/server/middleware/session-auth.ts
@@ -38,6 +38,11 @@ const UNPROTECTED_ROUTES = [
  * SECURITY: Each prefix here must have a documented reason for being unprotected.
  */
 const UNPROTECTED_PREFIXES = [
+  // NOTE: only /api/* paths need listing here — everything else already
+  // bypasses this middleware (see the startsWith("/api/") check below).
+  // /relay (the PostHog reverse proxy, routes/relay.ts) relies on that
+  // non-/api bypass: analytics must flow before any session exists. It must
+  // never be moved under /api/ or it would silently gain session auth.
   "/assets/", // Static assets (JS, CSS, images) - no sensitive data
   "/api/apps/mcp-apps/", // MCP Apps widgets - loaded in sandboxed iframes, can't send headers
   // Widget file DOWNLOAD only. The download URL is fetched directly from

--- a/mcpjam-inspector/server/routes/__tests__/relay-rate-limit.test.ts
+++ b/mcpjam-inspector/server/routes/__tests__/relay-rate-limit.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+
+// The relay rate limiter only runs in hosted mode; HOSTED_MODE is a
+// module-load-time const, so it has to be mocked before importing the route.
+// Kept in its own file so the main relay tests run with the real (local)
+// config.
+vi.mock("../../config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config.js")>();
+  return { ...actual, HOSTED_MODE: true };
+});
+
+import relayRoutes, { relayBodyLimit } from "../relay.js";
+
+const ORIGINAL_FETCH = global.fetch;
+
+function createTestApp() {
+  const app = new Hono();
+  app.use("/relay/*", relayBodyLimit());
+  app.route("/relay", relayRoutes);
+  return app;
+}
+
+describe("posthog relay rate limit (hosted mode)", () => {
+  beforeEach(() => {
+    global.fetch = vi.fn().mockResolvedValue(new Response("ok"));
+  });
+
+  afterEach(() => {
+    global.fetch = ORIGINAL_FETCH;
+  });
+
+  it("keys on the trusted edge IP — spoofed rotating X-Forwarded-For cannot reset the bucket", async () => {
+    const app = createTestApp();
+
+    // x-real-ip (trusted edge header) is fixed; the client rotates its own
+    // XFF every request trying to dodge the limiter. getClientIp prefers
+    // x-real-ip, so all requests land in one bucket and the 601st is 429.
+    let lastStatus = 0;
+    for (let i = 0; i < 601; i++) {
+      const res = await app.request("http://localhost:6274/relay/i/v0/e/", {
+        method: "POST",
+        body: "{}",
+        headers: {
+          "X-Real-IP": "203.0.113.7",
+          "X-Forwarded-For": `10.0.${Math.floor(i / 250)}.${i % 250}`,
+        },
+      });
+      lastStatus = res.status;
+    }
+
+    expect(lastStatus).toBe(429);
+    expect(vi.mocked(fetch).mock.calls.length).toBe(600);
+
+    // A different edge IP is a different bucket and still passes.
+    const other = await app.request("http://localhost:6274/relay/i/v0/e/", {
+      method: "POST",
+      body: "{}",
+      headers: { "X-Real-IP": "203.0.113.8" },
+    });
+    expect(other.status).toBe(200);
+  });
+});

--- a/mcpjam-inspector/server/routes/__tests__/relay-rate-limit.test.ts
+++ b/mcpjam-inspector/server/routes/__tests__/relay-rate-limit.test.ts
@@ -36,9 +36,9 @@ describe("posthog relay rate limit (hosted mode)", () => {
     // x-real-ip (trusted edge header) is fixed; the client rotates its own
     // XFF every request trying to dodge the limiter. getClientIp prefers
     // x-real-ip, so all requests land in one bucket and the 601st is 429.
-    let lastStatus = 0;
+    let lastRes: Response | undefined;
     for (let i = 0; i < 601; i++) {
-      const res = await app.request("http://localhost:6274/relay/i/v0/e/", {
+      lastRes = await app.request("http://localhost:6274/relay/i/v0/e/", {
         method: "POST",
         body: "{}",
         headers: {
@@ -46,10 +46,10 @@ describe("posthog relay rate limit (hosted mode)", () => {
           "X-Forwarded-For": `10.0.${Math.floor(i / 250)}.${i % 250}`,
         },
       });
-      lastStatus = res.status;
     }
 
-    expect(lastStatus).toBe(429);
+    expect(lastRes?.status).toBe(429);
+    expect(await lastRes!.json()).toEqual({ error: "rate_limited" });
     expect(vi.mocked(fetch).mock.calls.length).toBe(600);
 
     // A different edge IP is a different bucket and still passes.

--- a/mcpjam-inspector/server/routes/__tests__/relay.test.ts
+++ b/mcpjam-inspector/server/routes/__tests__/relay.test.ts
@@ -172,6 +172,7 @@ describe("posthog relay proxy", () => {
       body: threeMb,
     });
     expect(eventRes.status).toBe(413);
+    expect(await eventRes.json()).toEqual({ error: "payload_too_large" });
     expect(fetch).not.toHaveBeenCalled();
 
     const replayRes = await app.request("http://localhost:6274/relay/s/", {

--- a/mcpjam-inspector/server/routes/__tests__/relay.test.ts
+++ b/mcpjam-inspector/server/routes/__tests__/relay.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+import relayRoutes, { relayBodyLimit } from "../relay.js";
+import { securityHeadersMiddleware } from "../../middleware/security-headers.js";
+import { originValidationMiddleware } from "../../middleware/origin-validation.js";
+import { sessionAuthMiddleware } from "../../middleware/session-auth.js";
+
+const ORIGINAL_FETCH = global.fetch;
+
+// Mount via app.route("/relay", ...) exactly like both production entries so
+// the tests exercise the mounted-path behavior: inside the sub-app
+// c.req.path still includes the /relay prefix, and the route must strip it
+// before forwarding.
+function createTestApp() {
+  const app = new Hono();
+  app.use("/relay/*", relayBodyLimit());
+  app.route("/relay", relayRoutes);
+  return app;
+}
+
+function upstreamResponse(
+  body = "ok",
+  status = 200,
+  headers: Record<string, string> = {},
+) {
+  return new Response(body, { status, headers });
+}
+
+function mockedFetchUrl(callIndex = 0): string {
+  const call = vi.mocked(fetch).mock.calls[callIndex];
+  const input = call[0];
+  return input instanceof Request ? input.url : String(input);
+}
+
+function mockedFetchInit(callIndex = 0): RequestInit {
+  return vi.mocked(fetch).mock.calls[callIndex][1] as RequestInit;
+}
+
+describe("posthog relay proxy", () => {
+  beforeEach(() => {
+    global.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    global.fetch = ORIGINAL_FETCH;
+  });
+
+  it("forwards ingest POSTs with the /relay prefix stripped, preserving trailing slash, query, and body bytes", async () => {
+    const app = createTestApp();
+    vi.mocked(fetch).mockResolvedValueOnce(upstreamResponse());
+
+    const payload = "compressed-event-batch";
+    const res = await app.request(
+      "http://localhost:6274/relay/i/v0/e/?compression=gzip-js&ip=1&ver=1.2.3",
+      {
+        method: "POST",
+        headers: { "Content-Type": "text/plain" },
+        body: payload,
+      },
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockedFetchUrl()).toBe(
+      "https://us.i.posthog.com/i/v0/e/?compression=gzip-js&ip=1&ver=1.2.3",
+    );
+    const init = mockedFetchInit();
+    expect(init.method).toBe("POST");
+    expect(new TextDecoder().decode(init.body as ArrayBuffer)).toBe(payload);
+    expect(new Headers(init.headers).get("content-type")).toBe("text/plain");
+  });
+
+  it("routes /static and /array to the assets host and /flags to the ingest host", async () => {
+    const app = createTestApp();
+    vi.mocked(fetch).mockResolvedValue(upstreamResponse());
+
+    await app.request("http://localhost:6274/relay/static/recorder.js");
+    await app.request("http://localhost:6274/relay/array/phc_x/config.js");
+    await app.request("http://localhost:6274/relay/flags/?v=2", {
+      method: "POST",
+      body: "{}",
+    });
+
+    expect(mockedFetchUrl(0)).toBe(
+      "https://us-assets.i.posthog.com/static/recorder.js",
+    );
+    expect(mockedFetchUrl(1)).toBe(
+      "https://us-assets.i.posthog.com/array/phc_x/config.js",
+    );
+    expect(mockedFetchUrl(2)).toBe("https://us.i.posthog.com/flags/?v=2");
+  });
+
+  it("strips cookie/host/session-auth headers and forwards the trusted client IP", async () => {
+    const app = createTestApp();
+    vi.mocked(fetch).mockResolvedValueOnce(upstreamResponse());
+
+    await app.request("http://localhost:6274/relay/i/v0/e/", {
+      method: "POST",
+      body: "{}",
+      headers: {
+        Cookie: "mcpjam_session=secret",
+        "X-MCP-Session-Auth": "token",
+        "User-Agent": "test-agent",
+        // Edge chain: first hop is the real client per client-ip.ts.
+        "X-Forwarded-For": "1.2.3.4, 10.0.0.1",
+      },
+    });
+
+    const headers = new Headers(mockedFetchInit().headers);
+    expect(headers.get("cookie")).toBeNull();
+    expect(headers.get("x-mcp-session-auth")).toBeNull();
+    expect(headers.get("host")).toBeNull();
+    expect(headers.get("user-agent")).toBe("test-agent");
+    expect(headers.get("x-forwarded-for")).toBe("1.2.3.4");
+    expect(headers.get("x-real-ip")).toBe("1.2.3.4");
+  });
+
+  it("scrubs encoding/cookie/CORS headers from the upstream response and passes status through", async () => {
+    const app = createTestApp();
+    vi.mocked(fetch).mockResolvedValueOnce(
+      upstreamResponse("too many", 429, {
+        "content-encoding": "gzip",
+        "content-length": "999",
+        "set-cookie": "ph=1",
+        "access-control-allow-origin": "*",
+        "content-type": "application/json",
+        "cache-control": "no-store",
+      }),
+    );
+
+    const res = await app.request("http://localhost:6274/relay/i/v0/e/", {
+      method: "POST",
+      body: "{}",
+    });
+
+    expect(res.status).toBe(429);
+    expect(res.headers.get("content-encoding")).toBeNull();
+    expect(res.headers.get("set-cookie")).toBeNull();
+    expect(res.headers.get("access-control-allow-origin")).toBeNull();
+    expect(res.headers.get("content-type")).toBe("application/json");
+    expect(res.headers.get("cache-control")).toBe("no-store");
+    expect(await res.text()).toBe("too many");
+  });
+
+  it("returns 504 on upstream timeout and 502 on upstream network failure", async () => {
+    const app = createTestApp();
+
+    const timeoutError = new Error("timed out");
+    timeoutError.name = "TimeoutError";
+    vi.mocked(fetch).mockRejectedValueOnce(timeoutError);
+    const timedOut = await app.request("http://localhost:6274/relay/i/v0/e/", {
+      method: "POST",
+      body: "{}",
+    });
+    expect(timedOut.status).toBe(504);
+
+    vi.mocked(fetch).mockRejectedValueOnce(new Error("ECONNREFUSED"));
+    const failed = await app.request("http://localhost:6274/relay/i/v0/e/", {
+      method: "POST",
+      body: "{}",
+    });
+    expect(failed.status).toBe(502);
+  });
+
+  it("rejects >2MB bodies on event paths but accepts them on the session-recording path", async () => {
+    const app = createTestApp();
+    vi.mocked(fetch).mockResolvedValue(upstreamResponse());
+
+    const threeMb = "x".repeat(3 * 1024 * 1024);
+
+    const eventRes = await app.request("http://localhost:6274/relay/i/v0/e/", {
+      method: "POST",
+      body: threeMb,
+    });
+    expect(eventRes.status).toBe(413);
+    expect(fetch).not.toHaveBeenCalled();
+
+    const replayRes = await app.request("http://localhost:6274/relay/s/", {
+      method: "POST",
+      body: threeMb,
+    });
+    expect(replayRes.status).toBe(200);
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(mockedFetchUrl()).toBe("https://us.i.posthog.com/s/");
+  });
+
+  it("passes the full security middleware stack without any session token", async () => {
+    const app = new Hono();
+    app.use("*", securityHeadersMiddleware);
+    app.use("*", originValidationMiddleware);
+    app.use("*", sessionAuthMiddleware);
+    app.use("/relay/*", relayBodyLimit());
+    app.route("/relay", relayRoutes);
+    vi.mocked(fetch).mockResolvedValueOnce(upstreamResponse());
+
+    const res = await app.request("http://localhost:6274/relay/i/v0/e/", {
+      method: "POST",
+      body: "{}",
+      headers: { Origin: "http://localhost:6274" },
+    });
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/mcpjam-inspector/server/routes/relay.ts
+++ b/mcpjam-inspector/server/routes/relay.ts
@@ -1,0 +1,322 @@
+import { Hono, type Context, type Next } from "hono";
+import { bodyLimit } from "hono/body-limit";
+import { HOSTED_MODE } from "../config.js";
+import { getClientIp } from "../utils/client-ip.js";
+import { getSystemLogger } from "../utils/request-logger.js";
+
+/**
+ * Same-origin PostHog reverse proxy.
+ *
+ * posthog-js in the client points its api_host at `/relay` on the app origin
+ * (see client/src/lib/PosthogUtils.ts). Ad blockers block `*.posthog.com` by
+ * hostname, which silently drops 25-40% of web events AND breaks feature-flag
+ * evaluation (/flags) for those users; first-party traffic to our own origin
+ * passes. This route forwards everything under /relay to PostHog Cloud US,
+ * per https://posthog.com/docs/advanced/proxy: static assets go to the assets
+ * host, ingest/flags/replay go to the ingest host.
+ *
+ * Security shape: the route is deliberately OUTSIDE /api so it bypasses
+ * session auth (analytics must flow before any session exists — see the note
+ * in middleware/session-auth.ts). The upstream hosts are hardcoded constants,
+ * never derived from the request, so there is no SSRF surface. Abuse is
+ * bounded by path-scoped body limits, a hosted-only per-IP rate limit, and
+ * the 30s upstream timeout.
+ */
+
+const INGEST_HOST = "https://us.i.posthog.com";
+const ASSET_HOST = "https://us-assets.i.posthog.com";
+const PROXY_TIMEOUT_MS = 30_000;
+
+// Session-recording batches (/s/) legitimately exceed the default cap;
+// events, flags, and asset fetches never come close to it. Keeping the
+// default small limits what an unauthenticated caller can make us buffer.
+const DEFAULT_MAX_BODY_BYTES = 2 * 1024 * 1024;
+const REPLAY_MAX_BODY_BYTES = 20 * 1024 * 1024;
+
+// Hop-by-hop and app-specific headers that must not reach PostHog. Host is
+// derived by fetch() from the target URL; cookie may carry our session;
+// accept-encoding is dropped so undici negotiates (and transparently
+// decompresses) its own encoding.
+const STRIPPED_REQUEST_HEADERS = new Set([
+  "host",
+  "cookie",
+  "connection",
+  "content-length",
+  "accept-encoding",
+  "x-mcp-session-auth",
+]);
+
+// fetch() already decompressed the body, so the upstream encoding headers
+// would corrupt the piped response. Upstream CORS headers are stripped so the
+// app-level hono/cors middleware stays authoritative; set-cookie is dropped
+// so PostHog can never set cookies on our origin.
+const STRIPPED_RESPONSE_HEADERS = new Set([
+  "content-encoding",
+  "content-length",
+  "transfer-encoding",
+  "connection",
+  "set-cookie",
+  "access-control-allow-origin",
+  "access-control-allow-credentials",
+]);
+
+// ---------------------------------------------------------------------------
+// Observability: low-cardinality aggregate counters, flushed as one system
+// log line per interval (never per-request — hosted relay volume would drown
+// Axiom). This is the only signal that the relay is up but PostHog is
+// rejecting, so keep it accurate: every early return below increments one.
+// ---------------------------------------------------------------------------
+
+const STATS_FLUSH_INTERVAL_MS = 60_000;
+
+const relayLogger = getSystemLogger("relay");
+
+const stats = {
+  requests: 0,
+  res2xx: 0,
+  res3xx: 0,
+  res4xx: 0,
+  res5xx: 0,
+  upstream4xx: 0,
+  upstream5xx: 0,
+  timeouts: 0,
+  upstreamErrors: 0,
+  bodyLimitRejects: 0,
+  rateLimitRejects: 0,
+  latenciesMs: [] as number[],
+};
+
+function recordResponseStatus(status: number): void {
+  if (status < 300) stats.res2xx++;
+  else if (status < 400) stats.res3xx++;
+  else if (status < 500) stats.res4xx++;
+  else stats.res5xx++;
+}
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.min(
+    sorted.length - 1,
+    Math.ceil((p / 100) * sorted.length) - 1,
+  );
+  return Math.round(sorted[Math.max(0, idx)]);
+}
+
+export function flushRelayStats(): void {
+  if (stats.requests === 0) return;
+  const sorted = [...stats.latenciesMs].sort((a, b) => a - b);
+  relayLogger.event("relay.stats", {
+    requests: stats.requests,
+    res2xx: stats.res2xx,
+    res3xx: stats.res3xx,
+    res4xx: stats.res4xx,
+    res5xx: stats.res5xx,
+    upstream4xx: stats.upstream4xx,
+    upstream5xx: stats.upstream5xx,
+    timeouts: stats.timeouts,
+    upstreamErrors: stats.upstreamErrors,
+    bodyLimitRejects: stats.bodyLimitRejects,
+    rateLimitRejects: stats.rateLimitRejects,
+    latencyP50Ms: percentile(sorted, 50),
+    latencyP95Ms: percentile(sorted, 95),
+  });
+  stats.requests = 0;
+  stats.res2xx = 0;
+  stats.res3xx = 0;
+  stats.res4xx = 0;
+  stats.res5xx = 0;
+  stats.upstream4xx = 0;
+  stats.upstream5xx = 0;
+  stats.timeouts = 0;
+  stats.upstreamErrors = 0;
+  stats.bodyLimitRejects = 0;
+  stats.rateLimitRejects = 0;
+  stats.latenciesMs = [];
+}
+
+setInterval(flushRelayStats, STATS_FLUSH_INTERVAL_MS).unref();
+
+// ---------------------------------------------------------------------------
+// Rate limit (hosted only). Local installs are single-user; hosted is a
+// public unauthenticated endpoint. Keyed on getClientIp, whose header
+// precedence (cf-connecting-ip > x-real-ip > x-forwarded-for > socket) means
+// the key comes from trusted-edge headers on hosted — a client rotating its
+// own X-Forwarded-For cannot rotate buckets there because the edge headers
+// win. 600/min is ~10x the busiest real posthog-js client.
+// ---------------------------------------------------------------------------
+
+const RATE_LIMIT_PER_MIN = 600;
+const RATE_WINDOW_MS = 60_000;
+
+const ipWindows = new Map<string, { count: number; windowStart: number }>();
+
+setInterval(
+  () => {
+    const now = Date.now();
+    for (const [ip, entry] of ipWindows) {
+      if (now - entry.windowStart > RATE_WINDOW_MS * 2) {
+        ipWindows.delete(ip);
+      }
+    }
+  },
+  5 * 60_000,
+).unref();
+
+function relayRateLimit(c: Context): Response | null {
+  if (!HOSTED_MODE) return null;
+  const ip = getClientIp(c) ?? "unknown";
+  const now = Date.now();
+  const entry = ipWindows.get(ip);
+  if (entry && now - entry.windowStart < RATE_WINDOW_MS) {
+    if (entry.count >= RATE_LIMIT_PER_MIN) {
+      stats.rateLimitRejects++;
+      return c.json({ error: "rate_limited" }, 429);
+    }
+    entry.count++;
+  } else {
+    ipWindows.set(ip, { count: 1, windowStart: now });
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Body limit, exported for the mount sites in server/index.ts and
+// server/app.ts (both production entries must wire it in front of the route).
+// Path-scoped: replay gets the high cap, everything else the low one.
+// ---------------------------------------------------------------------------
+
+function makeBodyLimit(maxSize: number) {
+  return bodyLimit({
+    maxSize,
+    onError: (c) => {
+      stats.bodyLimitRejects++;
+      return c.json({ error: "payload_too_large" }, 413);
+    },
+  });
+}
+
+const defaultBodyLimit = makeBodyLimit(DEFAULT_MAX_BODY_BYTES);
+const replayBodyLimit = makeBodyLimit(REPLAY_MAX_BODY_BYTES);
+
+export function relayBodyLimit() {
+  return (c: Context, next: Next) => {
+    const subpath = stripRelayPrefix(c.req.path);
+    const limiter = subpath.startsWith("/s/")
+      ? replayBodyLimit
+      : defaultBodyLimit;
+    return limiter(c, next);
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The proxy itself.
+// ---------------------------------------------------------------------------
+
+// Inside a sub-app mounted via app.route("/relay", ...), c.req.path is still
+// the full request path including the mount prefix. PostHog must receive
+// /i/v0/e/, /static/array.js, etc. — never /relay/... — so strip explicitly.
+function stripRelayPrefix(path: string): string {
+  const stripped = path.startsWith("/relay")
+    ? path.slice("/relay".length)
+    : path;
+  return stripped === "" ? "/" : stripped;
+}
+
+function isTimeoutError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.name === "TimeoutError" ||
+      error.name === "AbortError" ||
+      (error as { code?: string }).code === "ABORT_ERR")
+  );
+}
+
+const relayRoutes = new Hono();
+
+relayRoutes.all("*", async (c) => {
+  const limited = relayRateLimit(c);
+  if (limited) {
+    return limited;
+  }
+
+  stats.requests++;
+  const startedAt = Date.now();
+
+  const url = new URL(c.req.url);
+  const subpath = stripRelayPrefix(url.pathname);
+  // Static assets (recorder.js, array config) live on the assets host; all
+  // other endpoints (/i/v0/e/, /flags/, /decide/, /s/) on the ingest host.
+  // Unknown subpaths forward to ingest rather than 404ing here: the
+  // posthog-js endpoint set changes across SDK versions.
+  const upstreamBase =
+    subpath.startsWith("/static/") || subpath.startsWith("/array/")
+      ? ASSET_HOST
+      : INGEST_HOST;
+  // Preserve the subpath verbatim (trailing slashes matter to PostHog) and
+  // the full query string (compression=gzip-js, ver, ip flags).
+  const target = `${upstreamBase}${subpath}${url.search}`;
+
+  const headers = new Headers();
+  for (const [key, value] of Object.entries(c.req.header())) {
+    if (!STRIPPED_REQUEST_HEADERS.has(key.toLowerCase())) {
+      headers.set(key, value);
+    }
+  }
+  // Client IP for PostHog geo attribution. getClientIp prefers the trusted
+  // edge headers over anything the client sent itself.
+  const clientIp = getClientIp(c);
+  if (clientIp) {
+    headers.set("X-Forwarded-For", clientIp);
+    headers.set("X-Real-IP", clientIp);
+  }
+
+  // Buffer the body (bounded by relayBodyLimit at the mount site) rather
+  // than streaming: undici streaming request bodies require duplex:"half"
+  // and posthog batches are small enough that buffering is simpler.
+  const method = c.req.method;
+  const body =
+    method === "GET" || method === "HEAD"
+      ? undefined
+      : await c.req.arrayBuffer();
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(target, {
+      method,
+      headers,
+      body,
+      signal: AbortSignal.timeout(PROXY_TIMEOUT_MS),
+      redirect: "follow",
+    });
+  } catch (error) {
+    if (isTimeoutError(error)) {
+      stats.timeouts++;
+      stats.res5xx++;
+      return c.json({ error: "relay_upstream_timeout" }, 504);
+    }
+    stats.upstreamErrors++;
+    stats.res5xx++;
+    return c.json({ error: "relay_upstream_unavailable" }, 502);
+  }
+
+  if (upstream.status >= 500) stats.upstream5xx++;
+  else if (upstream.status >= 400) stats.upstream4xx++;
+
+  const responseHeaders = new Headers();
+  upstream.headers.forEach((value, key) => {
+    if (!STRIPPED_RESPONSE_HEADERS.has(key.toLowerCase())) {
+      responseHeaders.set(key, value);
+    }
+  });
+
+  stats.latenciesMs.push(Date.now() - startedAt);
+  recordResponseStatus(upstream.status);
+
+  // Stream the upstream body through (recorder.js is ~300KB).
+  return new Response(upstream.body, {
+    status: upstream.status,
+    headers: responseHeaders,
+  });
+});
+
+export default relayRoutes;

--- a/mcpjam-inspector/server/utils/log-events.ts
+++ b/mcpjam-inspector/server/utils/log-events.ts
@@ -152,6 +152,24 @@ export type RequestEventMap = {
 export type SystemEventMap = {
   "mcp.connection.closed_with_pending_requests": { errorCode: string };
   "process.unhandled_rejection": { errorCode: string };
+  // Aggregated PostHog relay proxy counters, one line per flush interval
+  // (see routes/relay.ts). Low-cardinality by construction; never emitted
+  // per-request.
+  "relay.stats": {
+    requests: number;
+    res2xx: number;
+    res3xx: number;
+    res4xx: number;
+    res5xx: number;
+    upstream4xx: number;
+    upstream5xx: number;
+    timeouts: number;
+    upstreamErrors: number;
+    bodyLimitRejects: number;
+    rateLimitRejects: number;
+    latencyP50Ms: number;
+    latencyP95Ms: number;
+  };
 };
 
 export type LogEventName = keyof RequestEventMap | keyof SystemEventMap;

--- a/mcpjam-inspector/vite.renderer.config.mts
+++ b/mcpjam-inspector/vite.renderer.config.mts
@@ -63,6 +63,13 @@ export default defineConfig(({ mode }) => {
           changeOrigin: true,
           secure: true,
         },
+        // PostHog same-origin relay (server/routes/relay.ts) — matches the
+        // web client Vite config; without it Electron dev requests to /relay
+        // fall through to Vite's SPA fallback and return index.html with 200.
+        "/relay": {
+          target: "http://localhost:6274",
+          changeOrigin: true,
+        },
       },
     },
     define: {


### PR DESCRIPTION
## Problem

posthog-js points straight at `us.i.posthog.com` (hardcoded in `PosthogUtils.ts`). uBlock/Brave/AdGuard block that hostname, so:
- an estimated 25–40% of web events never arrive, and
- blocked `/flags` calls silently hide every fail-closed feature-flag gate (`skills-enabled`, `billing-entitlements-ui`, …) for blocker users.

**Baseline snapshot (14d ending 2026-07-09, PostHog):** web = 83.7 events/user vs ~206 events/user on packaged desktop (mac/win), where extension blockers can't run — consistent with the 25–40% loss estimate.

## What this does

Adds a same-origin reverse proxy at `/relay` in the Hono server (the pattern from [PostHog's proxy docs](https://posthog.com/docs/advanced/proxy), self-hosted variant) and points the client at it. First-party paths on our own origin can't be blocked by hostname, and unlike a CNAME proxy they survive CNAME-uncloaking (uBlock on Firefox, Brave).

- **`server/routes/relay.ts`**: `/static` + `/array` → assets host, everything else → ingest host, `/relay` prefix stripped. Strips cookies/hop-by-hop headers upstream; strips encoding/`set-cookie`/CORS headers downstream; forwards the trusted client IP (`getClientIp`) for geo attribution; 30s timeout → 504/502. Upstream hosts are hardcoded constants — no SSRF surface.
- **Abuse bounds**: path-scoped body limits (2MB events/flags, 20MB for `/s/` session recording), hosted-only 600/min rate limit keyed on the trusted edge IP (spoofed rotating XFF cannot rotate buckets — tested).
- **Observability**: aggregated `relay.stats` counters (status classes, upstream statuses, timeouts, rejects, p50/p95 latency) flushed once per minute through the system logger — zero per-request logs.
- **Wiring**: mounted in BOTH production entries (`server/index.ts` + `server/app.ts`), outside `/api` (no session exists before analytics; documented in `session-auth.ts`) and before the SPA fallback that would otherwise swallow `/relay` GETs.
- **Client**: `api_host = ${origin}/relay` + `ui_host` kept on `us.posthog.com`, in both the normal and `VITE_DISABLE_POSTHOG_LOCAL` branches (so dev-mode flags stop being blocked too). `/relay` dev proxies added to `client/vite.config.ts` and `vite.renderer.config.mts` (Electron dev).

Identity note: distinct_id is keyed by project token in posthog-js persistence, not by api_host — existing users keep their ids across the cutover.

## Testing

- 8 new unit tests (`server/routes/__tests__/relay*.test.ts`): prefix strip via mounted sub-app, asset-host split, header rewrite/scrub, XFF first-hop, 504/502 mapping, path-scoped 413s, rate-limit spoof resistance, full security-middleware stack with no session token.
- Live smoke: real loader config and real `/flags/?v=2` (30 flags) round-tripped through the relay.
- Client typecheck clean; server tsc errors are pre-existing on base.

## Merge sequencing

The server-side capture PR (follow-up) should ideally deploy a few days **before** this one merges, so the client/server event ratio records the true pre-relay block rate. Manual acceptance before merge: uBlock at defaults on hosted web, npx, Vite dev, and Electron — events + flags flowing, no `*.posthog.com` requests from the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a public unauthenticated proxy with bounded limits; upstream hosts are hardcoded (no SSRF), but hosted abuse and operational dependency on PostHog forwarding are new exposure.
> 
> **Overview**
> Routes **posthog-js** through a first-party **`/relay`** reverse proxy so analytics and **`/flags`** keep working when blockers target `*.posthog.com`.
> 
> **Server:** New `server/routes/relay.ts` forwards ingest/flags/replay to `us.i.posthog.com` and static/array assets to the assets host, with header scrubbing, trusted client IP forwarding, path-scoped body limits (2MB vs 20MB for `/s/`), hosted-only 600/min rate limiting, and minute **`relay.stats`** aggregates. Mounted on **`server/index.ts`** and **`server/app.ts`** outside **`/api`** and before the SPA fallback.
> 
> **Client:** `getPostHogApiHost()` sets **`api_host`** to `${origin}/relay` (including the dev-disabled capture branch) and keeps **`ui_host`** on PostHog. Vite/Electron dev configs proxy **`/relay`** to the Hono server.
> 
> **Tests:** Relay forwarding, limits, middleware stack, and rate-limit keying.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cf24706986afc4b03f45de1c76f6a3525ab4e94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route `posthog-js` through a same-origin `/relay` reverse proxy to bypass ad blockers, restoring analytics and `/flags` evaluation for users with blockers. Updates the client and dev configs, and adds limits and metrics to keep the relay safe and observable.

- **New Features**
  - Add `/relay` reverse proxy in `Hono`; `/static` and `/array` → `us-assets.i.posthog.com`, everything else → `us.i.posthog.com`.
  - Security/limits: strip hop‑by‑hop and cookie headers; forward trusted client IP; 30s timeout → 504/502; 2MB body cap (events/flags), 20MB for `/s/`; hosted‑only 600/min per‑IP rate limit.
  - Observability: minute `relay.stats` with status classes, timeouts/upstream errors, and p50/p95 latency.
  - Mount outside `/api` and before the SPA fallback in both `server/index.ts` and `server/app.ts`.
  - Client: `api_host = ${origin}/relay`, `ui_host` stays `https://us.posthog.com`; same in the disabled‑local branch.
  - Dev: add `/relay` proxies to web and Electron Vite configs.
  - Tests: cover forwarding/splitting, header scrub, timeout mapping, body caps, rate‑limit keying, full middleware stack, and assert 413/429 JSON bodies (`payload_too_large`/`rate_limited`).

- **Migration**
  - No action needed; existing `distinct_id`s persist across the switch.
  - Pre‑merge check: with uBlock/Brave defaults on hosted web, `npm run dev`, and Electron, events and `/flags` flow and no `*.posthog.com` requests appear in the browser.

<sup>Written for commit 0cf24706986afc4b03f45de1c76f6a3525ab4e94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3095?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

