### PR TITLE
feat(analytics): typed event registry + track() wrapper with ratchet fence

### DIFF
--- a/mcpjam-inspector/client/src/components/SkillsTab.tsx
+++ b/mcpjam-inspector/client/src/components/SkillsTab.tsx
@@ -20,8 +20,7 @@ import {
   Pencil,
   Laptop,
 } from "lucide-react";
-import { usePostHog } from "posthog-js/react";
-import { standardEventProps } from "@/lib/PosthogUtils";
+import { track } from "@/lib/analytics";
 import { EmptyState } from "./ui/empty-state";
 import {
   listSkills,
@@ -66,7 +65,6 @@ export function SkillsTab({
   projectId,
   computersEnabled,
 }: SkillsTabProps = {}) {
-  const posthog = usePostHog();
   // Skills data source. Hosted mode has no local FS, so it's always cloud.
   // Locally, when the Computer feature is on, the user can toggle Local⇄Cloud.
   const showSourceToggle = !HOSTED_MODE && !!computersEnabled && !!projectId;
@@ -236,8 +234,8 @@ export function SkillsTab({
     setIsDeleting(true);
     try {
       await deleteSkill(skillToDelete, skillsSource);
-      posthog.capture("skill_deleted", {
-        ...standardEventProps("skills_tab"),
+      track("skill_deleted", {
+        location: "skills_tab",
         skill_name: skillToDelete,
       });
       // Refresh skills list
@@ -274,8 +272,8 @@ export function SkillsTab({
     if (!projectId || !selectedItem) return;
     try {
       await promoteSkill(selectedItem.name, projectId);
-      posthog.capture("skill_promoted", {
-        ...standardEventProps("skills_tab"),
+      track("skill_promoted", {
+        location: "skills_tab",
         skill_name: selectedItem.name,
       });
       await fetchSkills();
@@ -289,8 +287,8 @@ export function SkillsTab({
     setSelectedFilePath("SKILL.md");
     setRawMode(false);
     setDescriptionExpanded(false);
-    posthog.capture("skill_viewed", {
-      ...standardEventProps("skills_tab"),
+    track("skill_viewed", {
+      location: "skills_tab",
       skill_name: name,
     });
     fetchFileContent(name, "SKILL.md");

--- a/mcpjam-inspector/client/src/lib/__tests__/analytics-ratchet.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/analytics-ratchet.test.ts
@@ -102,6 +102,7 @@ const LEGACY_RAW_CAPTURE_FILES = new Set([
   "hooks/useCreditTopup.ts",
   "hooks/useCreditTopupReturnFlow.ts",
   "lib/evals/excalidraw-quickstart.ts",
+  "lib/host-compat/use-host-catalog.ts",
   "lib/mcpjam-agent/agent-chat-instances.ts",
   "lib/session-token.ts",
 ]);

--- a/mcpjam-inspector/client/src/lib/__tests__/analytics-ratchet.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/analytics-ratchet.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import { readdirSync, readFileSync } from "fs";
+import { join, relative, resolve } from "path";
+import { fileURLToPath } from "url";
+
+/**
+ * Ratchet fence for raw PostHog captures.
+ *
+ * All NEW analytics calls must go through `client/src/lib/analytics.ts#track`
+ * (typed against shared/analytics-events.ts). The legacy raw
+ * `posthog.capture(...)` call sites below are frozen: they may be migrated
+ * (remove the file from the list when its last raw capture goes), but no new
+ * file may add a raw capture.
+ *
+ * If this test fails because you added `posthog.capture(...)` in a new file:
+ * register the event in shared/analytics-events.ts and call track() instead.
+ * If it fails because you migrated a file: delete that file's entry from
+ * LEGACY_RAW_CAPTURE_FILES — thanks for shrinking the list.
+ */
+
+const CLIENT_SRC = resolve(fileURLToPath(import.meta.url), "../../..");
+
+const RAW_CAPTURE_PATTERN =
+  /\bposthog(\?)?\.capture\(|\bposthogRef\.current(\?)?\.capture\(/;
+
+// The one legitimate raw-capture site.
+const ALLOWED_FILES = new Set(["lib/analytics.ts"]);
+
+const LEGACY_RAW_CAPTURE_FILES = new Set([
+  "App.tsx",
+  "components/ActiveServerSelector.tsx",
+  "components/auth/auth-upper-area.tsx",
+  "components/billing/BillingUpsellGate.tsx",
+  "components/billing/PaymentsHistorySection.tsx",
+  "components/chat-v2/chat-input.tsx",
+  "components/chat-v2/chat-input/model-selector.tsx",
+  "components/chat-v2/chat-input/skills/skill-upload-dialog.tsx",
+  "components/chat-v2/chat-input/skills/skills-popover-section.tsx",
+  "components/chat-v2/thread/parts/tool-part.tsx",
+  "components/chatboxes/GenerateSessionsDialog.tsx",
+  "components/ChatTabV2.tsx",
+  "components/compat/HostCompatContent.tsx",
+  "components/computer/ComputerView.tsx",
+  "components/computer/useComputerTerminal.ts",
+  "components/connection/AddServerModal.tsx",
+  "components/connection/JsonImportModal.tsx",
+  "components/connection/ServerConnectionCard.tsx",
+  "components/connection/ServerDetailModal.tsx",
+  "components/evals/cross-host/cross-host-dashboard.tsx",
+  "components/evals/eval-export-modal.tsx",
+  "components/evals/eval-runner.tsx",
+  "components/evals/evals-suite-list-sidebar.tsx",
+  "components/evals/suite-header.tsx",
+  "components/evals/suite-insights-collapsible.tsx",
+  "components/evals/test-cases-overview.tsx",
+  "components/evals/test-template-editor.tsx",
+  "components/evals/TestCaseListSidebar.tsx",
+  "components/evals/trace-raw-view.tsx",
+  "components/evals/trace-timeline.tsx",
+  "components/evals/trace-view-mode-tabs.tsx",
+  "components/evals/use-eval-handlers.ts",
+  "components/EvalsTab.tsx",
+  "components/HomeTab.tsx",
+  "components/hosted/ChatboxChatPage.tsx",
+  "components/hosts/CreateHostDialog.tsx",
+  "components/hosts/HostOverlayBar.tsx",
+  "components/hosts/HostPicker.tsx",
+  "components/hosts/MultiHostPicker.tsx",
+  "components/hosts/redesigned/HostBuilderViewRedesigned.tsx",
+  "components/logger-view.tsx",
+  "components/mcp-sidebar.tsx",
+  "components/mcpjam-agent/AgentSidePanel.tsx",
+  "components/mcpjam-agent/AgentSidePanelMount.tsx",
+  "components/mcpjam-agent/AgentSidePanelTrigger.tsx",
+  "components/mcpjam-agent/McpjamAgentHero.tsx",
+  "components/OAuthFlowTab.tsx",
+  "components/playground/PlaygroundLeftRail.tsx",
+  "components/playground/PlaygroundRightRail.tsx",
+  "components/playground/PlaygroundTab.tsx",
+  "components/project/ProjectMembersFacepile.tsx",
+  "components/project/ProjectShareButton.tsx",
+  "components/project/ShareProjectDialog.tsx",
+  "components/ServersTab.tsx",
+  "components/setting/ProviderConfigDialog.tsx",
+  "components/SettingsTab.tsx",
+  "components/shared/ClientContextHeader.tsx",
+  "components/signup/OccupationGate.tsx",
+  "components/tools/ParametersPanel.tsx",
+  "components/tools/SavedRequestItem.tsx",
+  "components/tools/ToolsSidebar.tsx",
+  "components/ToolsTab.tsx",
+  "components/ui-playground/hooks/use-playground-state.ts",
+  "components/ui-playground/hooks/useToolExecution.ts",
+  "components/ui-playground/PlaygroundMain.tsx",
+  "components/ui-playground/TabHeader.tsx",
+  "components/xaa/registration/XAARegistrationWizard.tsx",
+  "components/xaa/XAAFlowTab.tsx",
+  "hooks/use-chat.ts",
+  "hooks/use-mcpjam-agent-session.ts",
+  "hooks/use-onboarding.ts",
+  "hooks/use-server-state.ts",
+  "hooks/useCreditTopup.ts",
+  "hooks/useCreditTopupReturnFlow.ts",
+  "lib/evals/excalidraw-quickstart.ts",
+  "lib/mcpjam-agent/agent-chat-instances.ts",
+  "lib/session-token.ts",
+]);
+
+function sourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules" || entry.name === "__tests__")
+        continue;
+      out.push(...sourceFiles(full));
+    } else if (/\.(ts|tsx)$/.test(entry.name) && !/\.test\./.test(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe("analytics ratchet", () => {
+  const offenders = sourceFiles(CLIENT_SRC)
+    .filter((file) => RAW_CAPTURE_PATTERN.test(readFileSync(file, "utf8")))
+    .map((file) => relative(CLIENT_SRC, file))
+    .filter((file) => !ALLOWED_FILES.has(file));
+
+  it("no NEW files call posthog.capture directly — use lib/analytics.ts track()", () => {
+    const newOffenders = offenders.filter(
+      (file) => !LEGACY_RAW_CAPTURE_FILES.has(file),
+    );
+    expect(newOffenders).toEqual([]);
+  });
+
+  it("migrated files are removed from the legacy list", () => {
+    const current = new Set(offenders);
+    const stale = [...LEGACY_RAW_CAPTURE_FILES].filter(
+      (file) => !current.has(file),
+    );
+    expect(stale).toEqual([]);
+  });
+});

--- a/mcpjam-inspector/client/src/lib/__tests__/analytics.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/analytics.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { captureMock } = vi.hoisted(() => ({ captureMock: vi.fn() }));
+vi.mock("posthog-js", () => ({ default: { capture: captureMock } }));
+vi.mock("../PosthogUtils", () => ({
+  standardEventProps: (location: string) => ({
+    location,
+    platform: "web",
+    environment: "test",
+  }),
+}));
+
+import { track } from "../analytics";
+
+describe("track()", () => {
+  afterEach(() => captureMock.mockClear());
+
+  it("injects standard props from the location argument", () => {
+    track("skill_viewed", { location: "skills_tab", skill_name: "x" });
+    expect(captureMock).toHaveBeenCalledWith("skill_viewed", {
+      location: "skills_tab",
+      platform: "web",
+      environment: "test",
+      skill_name: "x",
+    });
+  });
+
+  it("does not let callers override the authoritative standard props", () => {
+    track("skill_viewed", {
+      location: "skills_tab",
+      platform: "spoofed",
+      environment: "spoofed",
+    } as Record<string, unknown> & { location: string });
+    const props = captureMock.mock.calls[0][1];
+    expect(props.platform).toBe("web");
+    expect(props.environment).toBe("test");
+    expect(props.location).toBe("skills_tab");
+  });
+});

--- a/mcpjam-inspector/client/src/lib/analytics.ts
+++ b/mcpjam-inspector/client/src/lib/analytics.ts
@@ -1,11 +1,14 @@
 import posthog from "posthog-js";
-import type { AnalyticsEventName } from "@/shared/analytics-events";
+import type { ClientAnalyticsEventName } from "@/shared/analytics-events";
 import { standardEventProps } from "./PosthogUtils";
 
 /**
- * The single client-side capture entrypoint. Only event names registered in
- * shared/analytics-events.ts are accepted; standard props (location,
- * platform, environment) are injected automatically.
+ * The single client-side capture entrypoint. Only client-authoritative event
+ * names registered in shared/analytics-events.ts are accepted (server twins
+ * like `send_message_server` are rejected at the type level so the browser
+ * can't emit them); standard props (location, platform, environment) are
+ * injected automatically and are authoritative — a caller cannot override
+ * them via props.
  *
  * Raw `posthog.capture(...)` calls outside this file are frozen by the
  * ratchet test (__tests__/analytics-ratchet.test.ts): legacy call sites stay
@@ -18,9 +21,11 @@ import { standardEventProps } from "./PosthogUtils";
  * — no disabled-state branching needed here.
  */
 export function track(
-  event: AnalyticsEventName,
+  event: ClientAnalyticsEventName,
   props: Record<string, unknown> & { location?: string } = {},
 ): void {
   const { location = "unknown", ...rest } = props;
-  posthog.capture(event, { ...standardEventProps(location), ...rest });
+  // Standard props spread LAST so location/platform/environment stay
+  // authoritative even if a caller passes them in `rest`.
+  posthog.capture(event, { ...rest, ...standardEventProps(location) });
 }

--- a/mcpjam-inspector/client/src/lib/analytics.ts
+++ b/mcpjam-inspector/client/src/lib/analytics.ts
@@ -1,0 +1,26 @@
+import posthog from "posthog-js";
+import type { AnalyticsEventName } from "@/shared/analytics-events";
+import { standardEventProps } from "./PosthogUtils";
+
+/**
+ * The single client-side capture entrypoint. Only event names registered in
+ * shared/analytics-events.ts are accepted; standard props (location,
+ * platform, environment) are injected automatically.
+ *
+ * Raw `posthog.capture(...)` calls outside this file are frozen by the
+ * ratchet test (__tests__/analytics-ratchet.test.ts): legacy call sites stay
+ * where they are until their area migrates, but new ones must go through
+ * here.
+ *
+ * The posthog-js singleton is the same instance PostHogProvider initializes
+ * (the provider is given an apiKey, which inits the global instance), and it
+ * already honors VITE_DISABLE_POSTHOG_LOCAL via opt_out_capturing_by_default
+ * — no disabled-state branching needed here.
+ */
+export function track(
+  event: AnalyticsEventName,
+  props: Record<string, unknown> & { location?: string } = {},
+): void {
+  const { location = "unknown", ...rest } = props;
+  posthog.capture(event, { ...standardEventProps(location), ...rest });
+}

--- a/mcpjam-inspector/shared/analytics-events.ts
+++ b/mcpjam-inspector/shared/analytics-events.ts
@@ -1,0 +1,49 @@
+/**
+ * Shared analytics event registry.
+ *
+ * Every product analytics event name lives here, typed, with its
+ * authoritative capture source. Client code sends events through
+ * `client/src/lib/analytics.ts#track`, which only accepts names from this
+ * registry; server code sends through `server/utils/analytics.ts` the same
+ * way. Free-string `posthog.capture("...")` calls are frozen by the ratchet
+ * test in `client/src/lib/__tests__/analytics-ratchet.test.ts` — new call
+ * sites must register here and use `track()`.
+ *
+ * `source` marks the ONE authoritative capture point for the event:
+ *  - "client": fired from the browser (reaches PostHog via the /relay proxy)
+ *  - "server": fired from the Hono server / backend (cannot be ad-blocked)
+ *
+ * Server twins: while a client event migrates to server-side capture, the
+ * server fires `<name>_server` in parallel. The client/server pair ratio per
+ * platform IS the live ad-block rate (see the block-rate dashboard). After
+ * the parallel-run window, the server event takes the canonical name and the
+ * client twin is deleted.
+ *
+ * Events are migrated into this registry incrementally, area by area — the
+ * ratchet test keeps unmigrated legacy call sites frozen at their current
+ * files in the meantime.
+ */
+
+export const ANALYTICS_EVENTS = {
+  // --- Chat (paired: client event + server twin) ---
+  send_message: { source: "client" },
+  send_message_server: { source: "server" },
+
+  // --- Tool execution (paired) ---
+  execute_tool: { source: "client" },
+  execute_tool_server: { source: "server" },
+
+  // --- Eval runs (paired) ---
+  eval_suite_run_started: { source: "client" },
+  eval_suite_run_started_server: { source: "server" },
+
+  // --- Skills (exemplar migrated area) ---
+  skill_deleted: { source: "client" },
+  skill_promoted: { source: "client" },
+  skill_viewed: { source: "client" },
+  skill_uploaded: { source: "client" },
+  skill_injected: { source: "client" },
+  skill_loaded: { source: "client" },
+} as const satisfies Record<string, { source: "client" | "server" }>;
+
+export type AnalyticsEventName = keyof typeof ANALYTICS_EVENTS;

--- a/mcpjam-inspector/shared/analytics-events.ts
+++ b/mcpjam-inspector/shared/analytics-events.ts
@@ -47,3 +47,20 @@ export const ANALYTICS_EVENTS = {
 } as const satisfies Record<string, { source: "client" | "server" }>;
 
 export type AnalyticsEventName = keyof typeof ANALYTICS_EVENTS;
+
+type EventNamesBySource<S extends "client" | "server"> = {
+  [K in AnalyticsEventName]: (typeof ANALYTICS_EVENTS)[K]["source"] extends S
+    ? K
+    : never;
+}[AnalyticsEventName];
+
+/**
+ * Event names whose authoritative source is the browser. The client `track()`
+ * wrapper accepts only these, so server-authoritative twins (e.g.
+ * `send_message_server`) can't be emitted from the client and corrupt the
+ * client/server block-rate ratio.
+ */
+export type ClientAnalyticsEventName = EventNamesBySource<"client">;
+
+/** Event names whose authoritative source is the server. */
+export type ServerAnalyticsEventName = EventNamesBySource<"server">;


### PR DESCRIPTION
## Problem

~150 raw `posthog.capture("free-string", ...)` call sites across `client/src` — no registry, no types, no way to audit which events exist or which capture point is authoritative. Part of the analytics-capture-resilience project (with #3095).

## What this does

- **`shared/analytics-events.ts`** — typed registry of event names + authoritative source (`client | server`), imported by both sides via `@/shared`. Seeded with the critical paired events (`send_message`, `execute_tool`, `eval_suite_run_started` + their `_server` twins for the upcoming server-capture PR) and the first migrated area.
- **`client/src/lib/analytics.ts`** — single `track()` entrypoint: only registered names typecheck, standard props (location/platform/environment) injected automatically.
- **Ratchet test** (`analytics-ratchet.test.ts`, runs in the client vitest project in CI): the current 77 raw-capture files are frozen as a legacy list. A *new* file adding raw `posthog.capture()` fails CI with instructions to register + use `track()`; migrating a file requires deleting its entry (the list only shrinks). ESLint wasn't usable as the fence — the flat config only covers `server/routes/web/**` and there's no lint script.
- **`SkillsTab.tsx`** migrated as the exemplar (3 call sites) — the remaining areas migrate incrementally behind the fence (good first issues).

## Testing

- Ratchet test passes (and was verified to fail when a raw capture is added to a new file).
- Client typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics plumbing and tests only; SkillsTab events keep the same names with standardized props via track().
> 
> **Overview**
> Introduces a **shared typed analytics registry** (`shared/analytics-events.ts`) with per-event authoritative source (`client` vs `server`), including paired `_server` twins for upcoming server-side capture work.
> 
> Adds a single client **`track()`** entrypoint (`client/src/lib/analytics.ts`) that only accepts registered client event names and **auto-injects** `location` / `platform` / `environment` so callers cannot override them.
> 
> A **ratchet Vitest** scans `client/src` and blocks **new** raw `posthog.capture` call sites while freezing the existing legacy file list; migrating a file means removing it from that list.
> 
> **`SkillsTab`** is migrated as the exemplar (delete, promote, view skill events). Unit tests cover `track()` behavior and the ratchet rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8876eb6ba4f40d62b24ab1608f855e929b25cd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a typed analytics event registry and a single client `track()` helper that enforces client-only events and authoritative standard props. Adds a ratchet test to block new raw `posthog.capture` calls, and migrates `SkillsTab` to the new API with seeded core events.

- **New Features**
  - Shared typed registry (`shared/analytics-events.ts`) with authoritative source per event and paired server twins for `send_message`, `execute_tool`, and `eval_suite_run_started`.
  - Client `track()` (`client/src/lib/analytics.ts`) accepts only `ClientAnalyticsEventName`, injects `location`/`platform`/`environment` that cannot be overridden, and uses `posthog-js`; tests lock these behaviors.
  - Ratchet test freezes legacy raw-capture files, blocks new ones, and requires removing migrated files from the list; `SkillsTab.tsx` moved to `track()` (3 call sites).

<sup>Written for commit a8876eb6ba4f40d62b24ab1608f855e929b25cd4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3096?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

