### PR TITLE
feat(analytics): server-side capture for critical events

### DIFF
--- a/mcpjam-inspector/client/src/components/SkillsTab.tsx
+++ b/mcpjam-inspector/client/src/components/SkillsTab.tsx
@@ -20,8 +20,7 @@ import {
   Pencil,
   Laptop,
 } from "lucide-react";
-import { usePostHog } from "posthog-js/react";
-import { standardEventProps } from "@/lib/PosthogUtils";
+import { track } from "@/lib/analytics";
 import { EmptyState } from "./ui/empty-state";
 import {
   listSkills,
@@ -66,7 +65,6 @@ export function SkillsTab({
   projectId,
   computersEnabled,
 }: SkillsTabProps = {}) {
-  const posthog = usePostHog();
   // Skills data source. Hosted mode has no local FS, so it's always cloud.
   // Locally, when the Computer feature is on, the user can toggle Local⇄Cloud.
   const showSourceToggle = !HOSTED_MODE && !!computersEnabled && !!projectId;
@@ -236,8 +234,8 @@ export function SkillsTab({
     setIsDeleting(true);
     try {
       await deleteSkill(skillToDelete, skillsSource);
-      posthog.capture("skill_deleted", {
-        ...standardEventProps("skills_tab"),
+      track("skill_deleted", {
+        location: "skills_tab",
         skill_name: skillToDelete,
       });
       // Refresh skills list
@@ -274,8 +272,8 @@ export function SkillsTab({
     if (!projectId || !selectedItem) return;
     try {
       await promoteSkill(selectedItem.name, projectId);
-      posthog.capture("skill_promoted", {
-        ...standardEventProps("skills_tab"),
+      track("skill_promoted", {
+        location: "skills_tab",
         skill_name: selectedItem.name,
       });
       await fetchSkills();
@@ -289,8 +287,8 @@ export function SkillsTab({
     setSelectedFilePath("SKILL.md");
     setRawMode(false);
     setDescriptionExpanded(false);
-    posthog.capture("skill_viewed", {
-      ...standardEventProps("skills_tab"),
+    track("skill_viewed", {
+      location: "skills_tab",
       skill_name: name,
     });
     fetchFileContent(name, "SKILL.md");

--- a/mcpjam-inspector/client/src/lib/__tests__/analytics-ratchet.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/analytics-ratchet.test.ts
@@ -102,6 +102,7 @@ const LEGACY_RAW_CAPTURE_FILES = new Set([
   "hooks/useCreditTopup.ts",
   "hooks/useCreditTopupReturnFlow.ts",
   "lib/evals/excalidraw-quickstart.ts",
+  "lib/host-compat/use-host-catalog.ts",
   "lib/mcpjam-agent/agent-chat-instances.ts",
   "lib/session-token.ts",
 ]);

--- a/mcpjam-inspector/client/src/lib/__tests__/analytics-ratchet.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/analytics-ratchet.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import { readdirSync, readFileSync } from "fs";
+import { join, relative, resolve } from "path";
+import { fileURLToPath } from "url";
+
+/**
+ * Ratchet fence for raw PostHog captures.
+ *
+ * All NEW analytics calls must go through `client/src/lib/analytics.ts#track`
+ * (typed against shared/analytics-events.ts). The legacy raw
+ * `posthog.capture(...)` call sites below are frozen: they may be migrated
+ * (remove the file from the list when its last raw capture goes), but no new
+ * file may add a raw capture.
+ *
+ * If this test fails because you added `posthog.capture(...)` in a new file:
+ * register the event in shared/analytics-events.ts and call track() instead.
+ * If it fails because you migrated a file: delete that file's entry from
+ * LEGACY_RAW_CAPTURE_FILES — thanks for shrinking the list.
+ */
+
+const CLIENT_SRC = resolve(fileURLToPath(import.meta.url), "../../..");
+
+const RAW_CAPTURE_PATTERN =
+  /\bposthog(\?)?\.capture\(|\bposthogRef\.current(\?)?\.capture\(/;
+
+// The one legitimate raw-capture site.
+const ALLOWED_FILES = new Set(["lib/analytics.ts"]);
+
+const LEGACY_RAW_CAPTURE_FILES = new Set([
+  "App.tsx",
+  "components/ActiveServerSelector.tsx",
+  "components/auth/auth-upper-area.tsx",
+  "components/billing/BillingUpsellGate.tsx",
+  "components/billing/PaymentsHistorySection.tsx",
+  "components/chat-v2/chat-input.tsx",
+  "components/chat-v2/chat-input/model-selector.tsx",
+  "components/chat-v2/chat-input/skills/skill-upload-dialog.tsx",
+  "components/chat-v2/chat-input/skills/skills-popover-section.tsx",
+  "components/chat-v2/thread/parts/tool-part.tsx",
+  "components/chatboxes/GenerateSessionsDialog.tsx",
+  "components/ChatTabV2.tsx",
+  "components/compat/HostCompatContent.tsx",
+  "components/computer/ComputerView.tsx",
+  "components/computer/useComputerTerminal.ts",
+  "components/connection/AddServerModal.tsx",
+  "components/connection/JsonImportModal.tsx",
+  "components/connection/ServerConnectionCard.tsx",
+  "components/connection/ServerDetailModal.tsx",
+  "components/evals/cross-host/cross-host-dashboard.tsx",
+  "components/evals/eval-export-modal.tsx",
+  "components/evals/eval-runner.tsx",
+  "components/evals/evals-suite-list-sidebar.tsx",
+  "components/evals/suite-header.tsx",
+  "components/evals/suite-insights-collapsible.tsx",
+  "components/evals/test-cases-overview.tsx",
+  "components/evals/test-template-editor.tsx",
+  "components/evals/TestCaseListSidebar.tsx",
+  "components/evals/trace-raw-view.tsx",
+  "components/evals/trace-timeline.tsx",
+  "components/evals/trace-view-mode-tabs.tsx",
+  "components/evals/use-eval-handlers.ts",
+  "components/EvalsTab.tsx",
+  "components/HomeTab.tsx",
+  "components/hosted/ChatboxChatPage.tsx",
+  "components/hosts/CreateHostDialog.tsx",
+  "components/hosts/HostOverlayBar.tsx",
+  "components/hosts/HostPicker.tsx",
+  "components/hosts/MultiHostPicker.tsx",
+  "components/hosts/redesigned/HostBuilderViewRedesigned.tsx",
+  "components/logger-view.tsx",
+  "components/mcp-sidebar.tsx",
+  "components/mcpjam-agent/AgentSidePanel.tsx",
+  "components/mcpjam-agent/AgentSidePanelMount.tsx",
+  "components/mcpjam-agent/AgentSidePanelTrigger.tsx",
+  "components/mcpjam-agent/McpjamAgentHero.tsx",
+  "components/OAuthFlowTab.tsx",
+  "components/playground/PlaygroundLeftRail.tsx",
+  "components/playground/PlaygroundRightRail.tsx",
+  "components/playground/PlaygroundTab.tsx",
+  "components/project/ProjectMembersFacepile.tsx",
+  "components/project/ProjectShareButton.tsx",
+  "components/project/ShareProjectDialog.tsx",
+  "components/ServersTab.tsx",
+  "components/setting/ProviderConfigDialog.tsx",
+  "components/SettingsTab.tsx",
+  "components/shared/ClientContextHeader.tsx",
+  "components/signup/OccupationGate.tsx",
+  "components/tools/ParametersPanel.tsx",
+  "components/tools/SavedRequestItem.tsx",
+  "components/tools/ToolsSidebar.tsx",
+  "components/ToolsTab.tsx",
+  "components/ui-playground/hooks/use-playground-state.ts",
+  "components/ui-playground/hooks/useToolExecution.ts",
+  "components/ui-playground/PlaygroundMain.tsx",
+  "components/ui-playground/TabHeader.tsx",
+  "components/xaa/registration/XAARegistrationWizard.tsx",
+  "components/xaa/XAAFlowTab.tsx",
+  "hooks/use-chat.ts",
+  "hooks/use-mcpjam-agent-session.ts",
+  "hooks/use-onboarding.ts",
+  "hooks/use-server-state.ts",
+  "hooks/useCreditTopup.ts",
+  "hooks/useCreditTopupReturnFlow.ts",
+  "lib/evals/excalidraw-quickstart.ts",
+  "lib/mcpjam-agent/agent-chat-instances.ts",
+  "lib/session-token.ts",
+]);
+
+function sourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules" || entry.name === "__tests__")
+        continue;
+      out.push(...sourceFiles(full));
+    } else if (/\.(ts|tsx)$/.test(entry.name) && !/\.test\./.test(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe("analytics ratchet", () => {
+  const offenders = sourceFiles(CLIENT_SRC)
+    .filter((file) => RAW_CAPTURE_PATTERN.test(readFileSync(file, "utf8")))
+    .map((file) => relative(CLIENT_SRC, file))
+    .filter((file) => !ALLOWED_FILES.has(file));
+
+  it("no NEW files call posthog.capture directly — use lib/analytics.ts track()", () => {
+    const newOffenders = offenders.filter(
+      (file) => !LEGACY_RAW_CAPTURE_FILES.has(file),
+    );
+    expect(newOffenders).toEqual([]);
+  });
+
+  it("migrated files are removed from the legacy list", () => {
+    const current = new Set(offenders);
+    const stale = [...LEGACY_RAW_CAPTURE_FILES].filter(
+      (file) => !current.has(file),
+    );
+    expect(stale).toEqual([]);
+  });
+});

--- a/mcpjam-inspector/client/src/lib/__tests__/analytics.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/analytics.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { captureMock } = vi.hoisted(() => ({ captureMock: vi.fn() }));
+vi.mock("posthog-js", () => ({ default: { capture: captureMock } }));
+vi.mock("../PosthogUtils", () => ({
+  standardEventProps: (location: string) => ({
+    location,
+    platform: "web",
+    environment: "test",
+  }),
+}));
+
+import { track } from "../analytics";
+
+describe("track()", () => {
+  afterEach(() => captureMock.mockClear());
+
+  it("injects standard props from the location argument", () => {
+    track("skill_viewed", { location: "skills_tab", skill_name: "x" });
+    expect(captureMock).toHaveBeenCalledWith("skill_viewed", {
+      location: "skills_tab",
+      platform: "web",
+      environment: "test",
+      skill_name: "x",
+    });
+  });
+
+  it("does not let callers override the authoritative standard props", () => {
+    track("skill_viewed", {
+      location: "skills_tab",
+      platform: "spoofed",
+      environment: "spoofed",
+    } as Record<string, unknown> & { location: string });
+    const props = captureMock.mock.calls[0][1];
+    expect(props.platform).toBe("web");
+    expect(props.environment).toBe("test");
+    expect(props.location).toBe("skills_tab");
+  });
+});

--- a/mcpjam-inspector/client/src/lib/analytics.ts
+++ b/mcpjam-inspector/client/src/lib/analytics.ts
@@ -1,11 +1,14 @@
 import posthog from "posthog-js";
-import type { AnalyticsEventName } from "@/shared/analytics-events";
+import type { ClientAnalyticsEventName } from "@/shared/analytics-events";
 import { standardEventProps } from "./PosthogUtils";
 
 /**
- * The single client-side capture entrypoint. Only event names registered in
- * shared/analytics-events.ts are accepted; standard props (location,
- * platform, environment) are injected automatically.
+ * The single client-side capture entrypoint. Only client-authoritative event
+ * names registered in shared/analytics-events.ts are accepted (server twins
+ * like `send_message_server` are rejected at the type level so the browser
+ * can't emit them); standard props (location, platform, environment) are
+ * injected automatically and are authoritative — a caller cannot override
+ * them via props.
  *
  * Raw `posthog.capture(...)` calls outside this file are frozen by the
  * ratchet test (__tests__/analytics-ratchet.test.ts): legacy call sites stay
@@ -18,9 +21,11 @@ import { standardEventProps } from "./PosthogUtils";
  * — no disabled-state branching needed here.
  */
 export function track(
-  event: AnalyticsEventName,
+  event: ClientAnalyticsEventName,
   props: Record<string, unknown> & { location?: string } = {},
 ): void {
   const { location = "unknown", ...rest } = props;
-  posthog.capture(event, { ...standardEventProps(location), ...rest });
+  // Standard props spread LAST so location/platform/environment stay
+  // authoritative even if a caller passes them in `rest`.
+  posthog.capture(event, { ...rest, ...standardEventProps(location) });
 }

--- a/mcpjam-inspector/client/src/lib/analytics.ts
+++ b/mcpjam-inspector/client/src/lib/analytics.ts
@@ -1,0 +1,26 @@
+import posthog from "posthog-js";
+import type { AnalyticsEventName } from "@/shared/analytics-events";
+import { standardEventProps } from "./PosthogUtils";
+
+/**
+ * The single client-side capture entrypoint. Only event names registered in
+ * shared/analytics-events.ts are accepted; standard props (location,
+ * platform, environment) are injected automatically.
+ *
+ * Raw `posthog.capture(...)` calls outside this file are frozen by the
+ * ratchet test (__tests__/analytics-ratchet.test.ts): legacy call sites stay
+ * where they are until their area migrates, but new ones must go through
+ * here.
+ *
+ * The posthog-js singleton is the same instance PostHogProvider initializes
+ * (the provider is given an apiKey, which inits the global instance), and it
+ * already honors VITE_DISABLE_POSTHOG_LOCAL via opt_out_capturing_by_default
+ * — no disabled-state branching needed here.
+ */
+export function track(
+  event: AnalyticsEventName,
+  props: Record<string, unknown> & { location?: string } = {},
+): void {
+  const { location = "unknown", ...rest } = props;
+  posthog.capture(event, { ...standardEventProps(location), ...rest });
+}

--- a/mcpjam-inspector/server/index.ts
+++ b/mcpjam-inspector/server/index.ts
@@ -53,6 +53,7 @@ import { createComputerTerminalWsHandler } from "./routes/web/computer-terminal"
 import { createComputerUploadHandler } from "./routes/web/computer-upload";
 import { initComputersStartup } from "./utils/computers/remote-data-plane";
 import { registerSelfFetch } from "./utils/self-app";
+import { shutdownAnalytics } from "./utils/analytics";
 
 const sysLogger = getSystemLogger("process");
 
@@ -746,6 +747,9 @@ async function shutdown() {
     await shutdownRunningSimulations();
     await tunnelManager.closeAll();
     server.close();
+    // Flush queued server-side analytics (bounded internally; forceExitTimer
+    // is the backstop). Billing/funnel events must not die in the queue.
+    await shutdownAnalytics();
     await appLogger.flush();
     clearTimeout(forceExitTimer);
     process.exit(0);

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -467,8 +467,18 @@ chatV2.post("/", async (c) => {
       const isDirectChat = !isChatboxSession;
 
       // Server twin of the client's `send_message` — fires even when the
-      // browser can't reach PostHog. Identity comes from the authorize
-      // exchange above (createAuthorizedManager populated the log context).
+      // browser can't reach PostHog. Identity: guests always resolve (the
+      // bearer-auth middleware sets c.get("guestId") before this handler,
+      // independent of the authorize exchange); signed-in identity comes from
+      // the authorize exchange above. One slice is intentionally not twinned:
+      // a signed-in user chatting with ZERO MCP servers selected, where
+      // createAuthorizedManager short-circuits before the exchange so no
+      // client-matching WorkOS id is available — capturing with the Convex
+      // internal id would split the person from their client events. That
+      // slice is small (model-only chats are dominated by guests, who are
+      // covered) and captureServerEvent drops it rather than mis-attribute;
+      // the client `send_message` still fires, so the block-rate ratio stays
+      // directionally correct.
       captureServerEvent(c, "send_message_server", {
         origin,
         source_type: sourceType,

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -15,6 +15,7 @@ import {
 } from "../../utils/chat-v2-orchestration.js";
 import { buildDirectHostConfig } from "../../utils/chat-ingestion.js";
 import { streamWebChatTurn } from "../../utils/web-chat-turn.js";
+import { captureServerEvent } from "../../utils/analytics.js";
 import {
   hostedChatSchema,
   createAuthorizedManager,
@@ -464,6 +465,14 @@ chatV2.post("/", async (c) => {
       // own route (mcpjam-agent.ts) and never lands here.
       const origin = isChatboxSession ? "chatbox" : "playground";
       const isDirectChat = !isChatboxSession;
+
+      // Server twin of the client's `send_message` — fires even when the
+      // browser can't reach PostHog. Identity comes from the authorize
+      // exchange above (createAuthorizedManager populated the log context).
+      captureServerEvent(c, "send_message_server", {
+        origin,
+        source_type: sourceType,
+      });
 
       return await streamWebChatTurn({
         manager,

--- a/mcpjam-inspector/server/routes/web/evals.ts
+++ b/mcpjam-inspector/server/routes/web/evals.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { captureServerEvent } from "../../utils/analytics.js";
 import { z } from "zod";
 import { createConvexClient } from "../../services/evals/route-helpers.js";
 import { detachPreparedEvalRun } from "../../services/evals/detached-run.js";
@@ -136,6 +137,12 @@ evals.post("/run", async (c) =>
           projectId: body.projectId,
         },
         cleanup: () => manager.disconnectAllServers(),
+      });
+
+      // Server twin of the client's `eval_suite_run_started`.
+      captureServerEvent(c, "eval_suite_run_started_server", {
+        suite_id: prepared.suiteId,
+        run_id: prepared.runId,
       });
 
       return {

--- a/mcpjam-inspector/server/routes/web/tools.ts
+++ b/mcpjam-inspector/server/routes/web/tools.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { captureServerEvent } from "../../utils/analytics.js";
 import {
   toolsListSchema,
   toolsExecuteSchema,
@@ -27,6 +28,13 @@ tools.post("/execute", async (c) =>
         "Task-augmented tool execution is not supported in hosted mode",
       );
     }
+
+    // Server twin of the client's `execute_tool` — captured at attempt time
+    // (like the client) so the pair ratio isn't skewed by failures.
+    captureServerEvent(c, "execute_tool_server", {
+      tool_name: body.toolName,
+      server_id: body.serverId,
+    });
 
     try {
       const result = await manager.executeTool(

--- a/mcpjam-inspector/server/utils/__tests__/analytics.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/analytics.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Context } from "hono";
+
+const captureMock = vi.fn();
+const shutdownMock = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("posthog-node", () => ({
+  PostHog: vi.fn(() => ({ capture: captureMock, shutdown: shutdownMock })),
+}));
+
+import { captureServerEvent, shutdownAnalytics } from "../analytics.js";
+
+function fakeContext(overrides: {
+  requestLogContext?: Record<string, unknown>;
+  guestId?: string;
+}): Context {
+  return {
+    var: { requestLogContext: overrides.requestLogContext },
+    get: (key: string) =>
+      key === "guestId" ? (overrides.guestId ?? undefined) : undefined,
+  } as unknown as Context;
+}
+
+describe("captureServerEvent", () => {
+  beforeEach(() => {
+    captureMock.mockClear();
+    delete process.env.VITE_DISABLE_POSTHOG_LOCAL;
+    delete process.env.DO_NOT_TRACK;
+  });
+
+  afterEach(async () => {
+    await shutdownAnalytics();
+  });
+
+  it("uses the WorkOS external id (client actorKey), never the Convex userId", () => {
+    captureServerEvent(
+      fakeContext({
+        requestLogContext: {
+          userExternalId: "user_workos_1",
+          userId: "convex_internal_id",
+        },
+      }),
+      "send_message_server",
+      { origin: "playground" },
+    );
+
+    expect(captureMock).toHaveBeenCalledTimes(1);
+    const call = captureMock.mock.calls[0][0];
+    expect(call.distinctId).toBe("user_workos_1");
+    expect(call.event).toBe("send_message_server");
+    expect(call.properties.origin).toBe("playground");
+    expect(call.properties.$insert_id).toEqual(expect.any(String));
+    expect(call.properties.source).toBe("server");
+  });
+
+  it("falls back to guestExternalId then the guestId context var", () => {
+    captureServerEvent(
+      fakeContext({ requestLogContext: { guestExternalId: "guest_ctx" } }),
+      "execute_tool_server",
+    );
+    captureServerEvent(
+      fakeContext({ guestId: "guest_var" }),
+      "execute_tool_server",
+    );
+
+    expect(captureMock.mock.calls[0][0].distinctId).toBe("guest_ctx");
+    expect(captureMock.mock.calls[1][0].distinctId).toBe("guest_var");
+  });
+
+  it("drops events with no resolvable actor instead of capturing anonymously", () => {
+    captureServerEvent(fakeContext({}), "send_message_server");
+    expect(captureMock).not.toHaveBeenCalled();
+  });
+
+  it("honors the opt-out env vars", () => {
+    process.env.DO_NOT_TRACK = "1";
+    captureServerEvent(
+      fakeContext({ requestLogContext: { userExternalId: "u1" } }),
+      "send_message_server",
+    );
+    expect(captureMock).not.toHaveBeenCalled();
+  });
+
+  it("attaches org/project attribution when present", () => {
+    captureServerEvent(
+      fakeContext({
+        requestLogContext: {
+          userExternalId: "u1",
+          orgId: "org_1",
+          projectId: "proj_1",
+        },
+      }),
+      "eval_suite_run_started_server",
+    );
+    const props = captureMock.mock.calls[0][0].properties;
+    expect(props.organization_id).toBe("org_1");
+    expect(props.project_id).toBe("proj_1");
+  });
+
+  it("generates a fresh $insert_id per event", () => {
+    const ctx = fakeContext({ requestLogContext: { userExternalId: "u1" } });
+    captureServerEvent(ctx, "send_message_server");
+    captureServerEvent(ctx, "send_message_server");
+    expect(captureMock.mock.calls[0][0].properties.$insert_id).not.toBe(
+      captureMock.mock.calls[1][0].properties.$insert_id,
+    );
+  });
+});

--- a/mcpjam-inspector/server/utils/__tests__/analytics.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/analytics.test.ts
@@ -72,8 +72,17 @@ describe("captureServerEvent", () => {
     expect(captureMock).not.toHaveBeenCalled();
   });
 
-  it("honors the opt-out env vars", () => {
+  it("honors DO_NOT_TRACK", () => {
     process.env.DO_NOT_TRACK = "1";
+    captureServerEvent(
+      fakeContext({ requestLogContext: { userExternalId: "u1" } }),
+      "send_message_server",
+    );
+    expect(captureMock).not.toHaveBeenCalled();
+  });
+
+  it("honors VITE_DISABLE_POSTHOG_LOCAL", () => {
+    process.env.VITE_DISABLE_POSTHOG_LOCAL = "true";
     captureServerEvent(
       fakeContext({ requestLogContext: { userExternalId: "u1" } }),
       "send_message_server",

--- a/mcpjam-inspector/server/utils/analytics.ts
+++ b/mcpjam-inspector/server/utils/analytics.ts
@@ -1,7 +1,7 @@
 import { PostHog } from "posthog-node";
 import type { Context } from "hono";
 import { randomUUID } from "crypto";
-import type { AnalyticsEventName } from "@/shared/analytics-events";
+import type { ServerAnalyticsEventName } from "@/shared/analytics-events";
 import type { RequestLogContext } from "./log-events.js";
 import { resolveEnvironment } from "./log-events.js";
 import { HOSTED_MODE } from "../config.js";
@@ -76,7 +76,7 @@ function getClient(): PostHog | null {
  */
 export function captureServerEvent(
   c: Context,
-  event: AnalyticsEventName,
+  event: ServerAnalyticsEventName,
   properties: Record<string, unknown> = {},
 ): void {
   try {
@@ -92,6 +92,10 @@ export function captureServerEvent(
       distinctId,
       event,
       properties: {
+        // Caller props spread FIRST so the generated dedupe key, source
+        // marker, platform/environment, and request-context attribution below
+        // always win — a caller can't override them by passing the same keys.
+        ...properties,
         // Retry-dedupe key: posthog-node may resend on transient failures.
         $insert_id: randomUUID(),
         platform: serverPlatform(),
@@ -99,7 +103,6 @@ export function captureServerEvent(
         source: "server",
         ...(ctx?.orgId ? { organization_id: ctx.orgId } : {}),
         ...(ctx?.projectId ? { project_id: ctx.projectId } : {}),
-        ...properties,
       },
     });
   } catch {

--- a/mcpjam-inspector/server/utils/analytics.ts
+++ b/mcpjam-inspector/server/utils/analytics.ts
@@ -1,0 +1,122 @@
+import { PostHog } from "posthog-node";
+import type { Context } from "hono";
+import { randomUUID } from "crypto";
+import type { AnalyticsEventName } from "@/shared/analytics-events";
+import type { RequestLogContext } from "./log-events.js";
+import { resolveEnvironment } from "./log-events.js";
+import { HOSTED_MODE } from "../config.js";
+
+/**
+ * Server-side PostHog capture for business-critical events.
+ *
+ * Client-side capture is ad-blockable even through the /relay proxy (a user
+ * can disable JS, block the app origin, or race a page close); events that
+ * feed funnel/billing/activation decisions get a server-side twin fired from
+ * the route that performs the action. During the parallel-run window the
+ * server twin is named `<event>_server` (see shared/analytics-events.ts) and
+ * the client/server pair ratio per platform is the live block-rate metric.
+ *
+ * Identity contract: distinct_id MUST match the client's actorKey — the
+ * WorkOS user id for signed-in users, the guestId for guests. Those arrive
+ * in the request log context as userExternalId / guestExternalId after the
+ * Convex authorize exchange (see routes/web/auth.ts). The Convex-internal
+ * `userId` (also on the context) does NOT match and must never be used.
+ * Events with no resolvable actor are dropped rather than captured
+ * anonymously — an unmatched distinct_id would pollute person profiles.
+ *
+ * Server events go straight to us.i.posthog.com (server egress is never
+ * ad-blocked) — NOT through /relay.
+ */
+
+// Public project token — same one shipped in the client bundle
+// (client/src/lib/PosthogUtils.ts); it can only ingest, not read.
+const POSTHOG_PROJECT_KEY = "phc_dTOPniyUNU2kD8Jx8yHMXSqiZHM8I91uWopTMX6EBE9";
+const POSTHOG_HOST = "https://us.i.posthog.com";
+
+// Same opt-outs the client honors, plus the conventional DO_NOT_TRACK for
+// npm/local installs where the server runs on the user's machine.
+function isAnalyticsDisabled(): boolean {
+  const dnt = process.env.DO_NOT_TRACK;
+  return (
+    process.env.VITE_DISABLE_POSTHOG_LOCAL === "true" ||
+    dnt === "1" ||
+    dnt === "true"
+  );
+}
+
+// Mirrors the pairing dimension of the client's detectPlatform(): hosted
+// serves the "web" platform; the Electron-embedded and npm servers pair with
+// their local clients.
+function serverPlatform(): string {
+  if (HOSTED_MODE) return "web";
+  if (process.env.ELECTRON_APP === "true") return "electron";
+  return "npm";
+}
+
+let client: PostHog | null = null;
+
+function getClient(): PostHog | null {
+  if (isAnalyticsDisabled()) return null;
+  if (!client) {
+    client = new PostHog(POSTHOG_PROJECT_KEY, {
+      host: POSTHOG_HOST,
+      // Low-volume, high-value stream: flush each event promptly rather than
+      // batching, so a process exit can't drop a queued critical event.
+      flushAt: 1,
+      flushInterval: 3000,
+    });
+  }
+  return client;
+}
+
+/**
+ * Capture a server-authoritative event for the actor behind a request.
+ * Never throws; silently drops when analytics is disabled or the request
+ * has no resolvable actor identity.
+ */
+export function captureServerEvent(
+  c: Context,
+  event: AnalyticsEventName,
+  properties: Record<string, unknown> = {},
+): void {
+  try {
+    const posthog = getClient();
+    if (!posthog) return;
+
+    const ctx = c.var.requestLogContext as RequestLogContext | undefined;
+    const distinctId =
+      ctx?.userExternalId ?? ctx?.guestExternalId ?? c.get("guestId") ?? null;
+    if (!distinctId) return;
+
+    posthog.capture({
+      distinctId,
+      event,
+      properties: {
+        // Retry-dedupe key: posthog-node may resend on transient failures.
+        $insert_id: randomUUID(),
+        platform: serverPlatform(),
+        environment: resolveEnvironment(),
+        source: "server",
+        ...(ctx?.orgId ? { organization_id: ctx.orgId } : {}),
+        ...(ctx?.projectId ? { project_id: ctx.projectId } : {}),
+        ...properties,
+      },
+    });
+  } catch {
+    // Analytics must never break the request path.
+  }
+}
+
+/**
+ * Flush and close the client. Wire into graceful shutdown (bounded — the
+ * caller's force-exit timer is the backstop).
+ */
+export async function shutdownAnalytics(): Promise<void> {
+  if (!client) return;
+  try {
+    await client.shutdown(2000);
+  } catch {
+    // Losing a final flush beats hanging shutdown.
+  }
+  client = null;
+}

--- a/mcpjam-inspector/shared/analytics-events.ts
+++ b/mcpjam-inspector/shared/analytics-events.ts
@@ -1,0 +1,49 @@
+/**
+ * Shared analytics event registry.
+ *
+ * Every product analytics event name lives here, typed, with its
+ * authoritative capture source. Client code sends events through
+ * `client/src/lib/analytics.ts#track`, which only accepts names from this
+ * registry; server code sends through `server/utils/analytics.ts` the same
+ * way. Free-string `posthog.capture("...")` calls are frozen by the ratchet
+ * test in `client/src/lib/__tests__/analytics-ratchet.test.ts` — new call
+ * sites must register here and use `track()`.
+ *
+ * `source` marks the ONE authoritative capture point for the event:
+ *  - "client": fired from the browser (reaches PostHog via the /relay proxy)
+ *  - "server": fired from the Hono server / backend (cannot be ad-blocked)
+ *
+ * Server twins: while a client event migrates to server-side capture, the
+ * server fires `<name>_server` in parallel. The client/server pair ratio per
+ * platform IS the live ad-block rate (see the block-rate dashboard). After
+ * the parallel-run window, the server event takes the canonical name and the
+ * client twin is deleted.
+ *
+ * Events are migrated into this registry incrementally, area by area — the
+ * ratchet test keeps unmigrated legacy call sites frozen at their current
+ * files in the meantime.
+ */
+
+export const ANALYTICS_EVENTS = {
+  // --- Chat (paired: client event + server twin) ---
+  send_message: { source: "client" },
+  send_message_server: { source: "server" },
+
+  // --- Tool execution (paired) ---
+  execute_tool: { source: "client" },
+  execute_tool_server: { source: "server" },
+
+  // --- Eval runs (paired) ---
+  eval_suite_run_started: { source: "client" },
+  eval_suite_run_started_server: { source: "server" },
+
+  // --- Skills (exemplar migrated area) ---
+  skill_deleted: { source: "client" },
+  skill_promoted: { source: "client" },
+  skill_viewed: { source: "client" },
+  skill_uploaded: { source: "client" },
+  skill_injected: { source: "client" },
+  skill_loaded: { source: "client" },
+} as const satisfies Record<string, { source: "client" | "server" }>;
+
+export type AnalyticsEventName = keyof typeof ANALYTICS_EVENTS;

--- a/mcpjam-inspector/shared/analytics-events.ts
+++ b/mcpjam-inspector/shared/analytics-events.ts
@@ -47,3 +47,20 @@ export const ANALYTICS_EVENTS = {
 } as const satisfies Record<string, { source: "client" | "server" }>;
 
 export type AnalyticsEventName = keyof typeof ANALYTICS_EVENTS;
+
+type EventNamesBySource<S extends "client" | "server"> = {
+  [K in AnalyticsEventName]: (typeof ANALYTICS_EVENTS)[K]["source"] extends S
+    ? K
+    : never;
+}[AnalyticsEventName];
+
+/**
+ * Event names whose authoritative source is the browser. The client `track()`
+ * wrapper accepts only these, so server-authoritative twins (e.g.
+ * `send_message_server`) can't be emitted from the client and corrupt the
+ * client/server block-rate ratio.
+ */
+export type ClientAnalyticsEventName = EventNamesBySource<"client">;
+
+/** Event names whose authoritative source is the server. */
+export type ServerAnalyticsEventName = EventNamesBySource<"server">;


### PR DESCRIPTION
## What this does

Server-side PostHog capture for business-critical events, fired from the routes that perform the action — the half of the analytics-resilience project that ad blockers can't touch at all. Stacked on #3096 (uses the shared event registry); companion to the relay in #3095.

- **`server/utils/analytics.ts`** — `captureServerEvent(c, event, props)` on posthog-node (already a dependency, previously unused; goes straight to `us.i.posthog.com`, not through `/relay`).
- **Identity contract** (the subtle part): distinct_id = `userExternalId ?? guestExternalId ?? guestId` from the request log context — the exact ids the client's `actorKey` uses (WorkOS user id / guest id), so client and server events land on the same person. The Convex-internal `userId` also present on the context does **not** match and is deliberately never used. Events with no resolvable actor are dropped, not captured anonymously.
- **Delivery semantics**: `$insert_id` per event (retry dedupe), `flushAt: 1` (low-volume/high-value — nothing sits in a queue), `shutdownAnalytics()` wired into graceful shutdown (bounded 2s inside the existing force-exit budget), opt-outs honored (`VITE_DISABLE_POSTHOG_LOCAL`, `DO_NOT_TRACK`), never throws into the request path.
- **Capture points** (named `*_server` per the parallel-run policy — the client/server pair ratio per platform is the live block-rate dashboard metric):
  - `send_message_server` — chat-v2 turn start (after the authorize exchange populates identity)
  - `execute_tool_server` — hosted tools `/execute`, at attempt time to mirror the client event
  - `eval_suite_run_started_server` — evals `/run`, with suite/run ids

Out of scope here: signup + billing twins fire in the Convex backend (mcpjam-backend) — separate PR there; chatbox publish also lives backend-side.

## Testing

6 unit tests: WorkOS-id-not-Convex-id selection, guest fallbacks, anonymous drop, opt-out envs, org/project attribution, per-event `$insert_id`. Server typecheck clean on touched files.

## Merge sequencing

Ideally deploys a few days **before** #3095's client cutover so the pair ratio records the true pre-relay block rate (baseline for the project's success metric).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only path with fail-safe semantics (no throws, drops bad identity); no auth, billing, or request-handling logic changes beyond firing events at existing route entry points.
> 
> **Overview**
> Adds **server-side PostHog twins** for funnel-critical actions so metrics survive ad blockers, disabled JS, and tab closes. New `server/utils/analytics.ts` wires `posthog-node` (direct to PostHog, not `/relay`) with `captureServerEvent` and bounded `shutdownAnalytics` on graceful exit.
> 
> **Capture points:** `send_message_server` (chat-v2 turn start), `execute_tool_server` (hosted tools execute, at attempt time), and `eval_suite_run_started_server` (evals `/run`). Events use the `*_server` naming during parallel run so client/server pair ratios measure block rate.
> 
> **Identity & delivery:** `distinct_id` follows the client `actorKey` (`userExternalId` → `guestExternalId` → `guestId`); Convex `userId` is never used, and events with no actor are dropped. Each event gets `$insert_id`, `source: "server"`, platform/environment, optional org/project, `flushAt: 1`, and honors `DO_NOT_TRACK` / `VITE_DISABLE_POSTHOG_LOCAL`; capture never throws on the request path.
> 
> Unit tests cover identity selection, opt-outs, attribution, and dedupe keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 933350d8cdf81533baf8db0aadf7ad6350a80aae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds server-side PostHog capture for critical events so metrics persist even with ad blockers or closed tabs. Routes now emit server twins with correct identity, immediate flush, authoritative props, and safe shutdown.

- **New Features**
  - Added `captureServerEvent` (typed `ServerAnalyticsEventName`) and `shutdownAnalytics` in `server/utils/analytics.ts` using `posthog-node` (direct to `https://us.i.posthog.com`, not `/relay`), with per-event `$insert_id`, `source: "server"`, platform/environment props that callers can’t override, `flushAt: 1`, opt-outs via `VITE_DISABLE_POSTHOG_LOCAL` and `DO_NOT_TRACK`, and no-throw semantics; wired into graceful shutdown.
  - Wired capture points: `send_message_server` (chat-v2 turn start), `execute_tool_server` (tools `/execute`, at attempt time), and `eval_suite_run_started_server` (evals `/run`), each with relevant props.
  - Identity: `distinct_id = userExternalId ?? guestExternalId ?? guestId` (matches client `actorKey`), never uses Convex `userId`, drops when no actor (including signed-in zero-server chats), and adds `organization_id`/`project_id` when available.

<sup>Written for commit 933350d8cdf81533baf8db0aadf7ad6350a80aae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3097?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

