### PR TITLE
fix(analytics): bootstrap guest distinct_id into posthog-js init

### DIFF
--- a/mcpjam-inspector/client/src/lib/PosthogUtils.ts
+++ b/mcpjam-inspector/client/src/lib/PosthogUtils.ts
@@ -24,19 +24,30 @@ export function getPostHogApiHost(): string {
 // Guest identity bootstrap. Without it, posthog-js mints a random anonymous
 // distinct_id at init and only converges on the guestId when
 // usePostHogIdentify's async actor resolution calls identify() — every cold
-// load that races that fetch creates a throwaway person and inflates guest
-// DAU. In hosted prod the server injects the guest session into the page
-// (window.__MCP_GUEST_BOOTSTRAP__, seeded synchronously into
+// load that races that fetch attributes early events to a throwaway id and
+// inflates guest DAU. In hosted prod the server injects the guest session
+// into the page (window.__MCP_GUEST_BOOTSTRAP__, seeded synchronously into
 // getCachedGuestSession at module import), so the guestId is known before
-// PostHogProvider mounts. posthog-js handles the edge cases safely: an
-// existing IDENTIFIED persisted id wins over the bootstrap value (returning
-// signed-in users are untouched), and an existing anonymous id is merged
-// into the bootstrap id via identify(). Local/npm has no blob — this
-// returns {} there and the async identify path behaves as before.
+// PostHogProvider mounts.
+//
+// isIdentifiedID is deliberately FALSE: the bootstrap guestId seeds the
+// ANONYMOUS distinct_id, not an identified person. This matters because the
+// hosted document handler injects the guest blob for every allow-listed
+// request — including the first load of a signed-in user whose PostHog
+// persistence is empty. If we marked it identified, the subsequent
+// usePostHogIdentify() call to identify(workosUserId) would run from an
+// already-identified state and posthog-js would refuse the switch (no
+// $identify merge), stranding that user's early events under the guest id.
+// As anonymous, identify() correctly merges the pre-identify guest activity
+// into the real actor: guests stay stably keyed on guestId (fixing DAU
+// inflation), and signed-in users' events migrate onto their WorkOS id.
+// A returning user with existing persistence keeps their stored id either
+// way — bootstrap only seeds when persistence is empty. Local/npm has no
+// blob, so this returns {} and the async identify path is unchanged.
 function getPostHogBootstrap() {
   const guestId = getCachedGuestSession()?.guestId;
   return guestId
-    ? { bootstrap: { distinctID: guestId, isIdentifiedID: true } }
+    ? { bootstrap: { distinctID: guestId, isIdentifiedID: false } }
     : {};
 }
 

--- a/mcpjam-inspector/client/src/lib/PosthogUtils.ts
+++ b/mcpjam-inspector/client/src/lib/PosthogUtils.ts
@@ -1,3 +1,5 @@
+import { getCachedGuestSession } from "./guest-session";
+
 export const VITE_PUBLIC_POSTHOG_KEY =
   "phc_dTOPniyUNU2kD8Jx8yHMXSqiZHM8I91uWopTMX6EBE9";
 export const VITE_PUBLIC_POSTHOG_HOST = "https://us.i.posthog.com";
@@ -19,10 +21,30 @@ export function getPostHogApiHost(): string {
   return VITE_PUBLIC_POSTHOG_HOST;
 }
 
+// Guest identity bootstrap. Without it, posthog-js mints a random anonymous
+// distinct_id at init and only converges on the guestId when
+// usePostHogIdentify's async actor resolution calls identify() — every cold
+// load that races that fetch creates a throwaway person and inflates guest
+// DAU. In hosted prod the server injects the guest session into the page
+// (window.__MCP_GUEST_BOOTSTRAP__, seeded synchronously into
+// getCachedGuestSession at module import), so the guestId is known before
+// PostHogProvider mounts. posthog-js handles the edge cases safely: an
+// existing IDENTIFIED persisted id wins over the bootstrap value (returning
+// signed-in users are untouched), and an existing anonymous id is merged
+// into the bootstrap id via identify(). Local/npm has no blob — this
+// returns {} there and the async identify path behaves as before.
+function getPostHogBootstrap() {
+  const guestId = getCachedGuestSession()?.guestId;
+  return guestId
+    ? { bootstrap: { distinctID: guestId, isIdentifiedID: true } }
+    : {};
+}
+
 export const options = {
   api_host: getPostHogApiHost(),
   // Toolbar/app links must point at PostHog itself once api_host is proxied.
   ui_host: "https://us.posthog.com",
+  ...getPostHogBootstrap(),
   capture_pageview: false,
   person_profiles: "always" as const,
 
@@ -61,6 +83,7 @@ export const getPostHogOptions = () =>
         // calls hit us.i.posthog.com directly and stay ad-blocked.
         api_host: getPostHogApiHost(),
         ui_host: "https://us.posthog.com",
+        ...getPostHogBootstrap(),
         capture_pageview: false,
         person_profiles: "always" as const,
         // Disable event capture but keep /decide enabled for feature flag evaluation.


### PR DESCRIPTION
## Problem

posthog-js mints a random anonymous distinct_id at init; the real guestId only takes over when `usePostHogIdentify`'s async actor resolution finally calls `identify()`. Cold loads that race that fetch mint throwaway persons — the known guest-DAU inflation — and would corrupt the client/server block-rate ratio the analytics project (#3095/#3097) is measured on.

## What this does

Hosted prod already injects the guest session into the served page (`window.__MCP_GUEST_BOOTSTRAP__`), and `guest-session.ts` seeds it synchronously at module import — before `PostHogProvider` mounts. This passes that guestId as posthog-js `bootstrap: { distinctID, isIdentifiedID: true }` in both config branches.

**Safety** (verified against the installed posthog-js source, not docs): when persistence already holds an **identified** id, posthog-js preserves it and ignores the bootstrap value — returning signed-in users are untouched. When persistence holds an **anonymous** id, posthog-js merges it into the bootstrap id via `identify()` — exactly the churn fix. Local/npm/Electron have no blob, so bootstrap resolves to `{}` and the existing async identify path is unchanged.

Stacked on #3095 (touches the same `PosthogUtils.ts` options).

## Testing

Client typecheck clean; flag-hydration + hosted-oauth client suites pass (65 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics identity wiring only in `PosthogUtils.ts`; no auth or data-path changes, and local builds are unaffected when no guest bootstrap exists.
> 
> **Overview**
> Cold loads no longer mint a throwaway PostHog `distinct_id` before async guest identification runs. **`PosthogUtils.ts`** now seeds init from the server-injected guest session via `getPostHogBootstrap()`, passing `bootstrap: { distinctID: guestId, isIdentifiedID: false }` into both the normal and dev/opt-out PostHog option branches.
> 
> **`isIdentifiedID: false`** keeps the bootstrap id anonymous so a later `identify(workosUserId)` can merge pre-login events instead of refusing the switch. When there is no guest blob (local/npm), bootstrap stays `{}` and behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19aaf7268f56cd905972de6a5c912b4f69e40c23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bootstraps the guest `distinct_id` into `posthog-js` init so cold loads use the real `guestId` immediately, preventing throwaway anonymous persons and fixing guest DAU inflation. Seeds it as anonymous so later `identify()` can merge early events into signed-in users.

- **Bug Fixes**
  - Read `guestId` from `getCachedGuestSession()` (server-injected via `window.__MCP_GUEST_BOOTSTRAP__`) and pass `bootstrap: { distinctID, isIdentifiedID: false }` in both `PosthogUtils.ts` config paths.
  - Preserves existing identified IDs, merges anonymous IDs into the bootstrap ID, and no-ops when no bootstrap blob is present (local/npm/Electron).

<sup>Written for commit 19aaf7268f56cd905972de6a5c912b4f69e40c23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3098?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

