### PR TITLE
refactor(computers): service-token-only auth + drop three-var compat (inspector)

### DIFF
--- a/mcpjam-inspector/server/routes/web/__tests__/computer-terminal.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/computer-terminal.test.ts
@@ -99,7 +99,7 @@ function installSandboxInfoStub(
 
 function stubConfiguredEnv() {
   vi.stubEnv("CONVEX_HTTP_URL", CONVEX_URL);
-  vi.stubEnv("COMPUTERS_DATA_PLANE_SECRET", "test-secret");
+  vi.stubEnv("INSPECTOR_SERVICE_TOKEN", "test-svc-token");
   vi.stubEnv("E2B_API_KEY", "e2b_test");
   vi.stubEnv("COMPUTERS_TERMINAL_TOKEN_SECRET", SECRET);
 }

--- a/mcpjam-inspector/server/routes/web/__tests__/computer-upload.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/computer-upload.test.ts
@@ -113,7 +113,7 @@ function installSandboxInfoStub(
 
 function stubConfiguredEnv() {
   vi.stubEnv("CONVEX_HTTP_URL", CONVEX_URL);
-  vi.stubEnv("COMPUTERS_DATA_PLANE_SECRET", "test-secret");
+  vi.stubEnv("INSPECTOR_SERVICE_TOKEN", "test-svc-token");
   vi.stubEnv("E2B_API_KEY", "e2b_test");
   vi.stubEnv("COMPUTERS_TERMINAL_TOKEN_SECRET", SECRET);
 }

--- a/mcpjam-inspector/server/routes/web/__tests__/computers.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/computers.test.ts
@@ -83,7 +83,7 @@ function postExec(
 
 function stubLocalDataPlaneEnv() {
   vi.stubEnv("CONVEX_HTTP_URL", CONVEX_URL);
-  vi.stubEnv("COMPUTERS_DATA_PLANE_SECRET", "test-secret");
+  vi.stubEnv("INSPECTOR_SERVICE_TOKEN", "test-svc-token");
   vi.stubEnv("E2B_API_KEY", "e2b_test");
   vi.stubEnv("COMPUTERS_TERMINAL_TOKEN_SECRET", "terminal-secret-16+");
 }

--- a/mcpjam-inspector/server/utils/__tests__/computers-bash-tool.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/computers-bash-tool.test.ts
@@ -81,7 +81,7 @@ function execTool(
 
 beforeEach(() => {
   vi.stubEnv("CONVEX_HTTP_URL", CONVEX_URL);
-  vi.stubEnv("COMPUTERS_DATA_PLANE_SECRET", "test-data-plane-secret-000000");
+  vi.stubEnv("INSPECTOR_SERVICE_TOKEN", "test-svc-token");
   vi.stubEnv("COMPUTERS_TERMINAL_TOKEN_SECRET", "terminal-secret-16+");
   vi.stubEnv("E2B_API_KEY", "e2b_test");
   installFetchStub();
@@ -121,9 +121,9 @@ describe(`${BASH_TOOL_NAME} tool`, () => {
       "/computers/sandbox-info",
       "/computers/commands",
     ]);
-    // Reserve uses the user's bearer; the secret routes use the shared secret.
+    // Reserve uses the user's bearer; the secret routes use the service token.
     expect(fetchCalls[0].headers.authorization).toBe("Bearer user-token");
-    expect(fetchCalls[1].headers["x-computers-data-plane-secret"]).toBeTruthy();
+    expect(fetchCalls[1].headers["x-inspector-service-token"]).toBeTruthy();
     expect(fetchCalls[2].body).toMatchObject({
       computerId: "comp_1",
       commandId: "call_1",
@@ -191,7 +191,7 @@ describe(`${BASH_TOOL_NAME} tool`, () => {
   });
 
   it("returns a clean error when computers are unconfigured", async () => {
-    vi.stubEnv("COMPUTERS_DATA_PLANE_SECRET", "");
+    vi.stubEnv("INSPECTOR_SERVICE_TOKEN", "");
     const runner = vi.fn();
     const tool = buildBashTool(toolOpts, runner);
     const result = await execTool(tool, { command: "ls" });

--- a/mcpjam-inspector/server/utils/__tests__/computers-remote-data-plane.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/computers-remote-data-plane.test.ts
@@ -121,7 +121,7 @@ describe("initComputersRemoteDataPlaneDiscovery", () => {
 
   it("skips the network call when this server already holds real secrets", async () => {
     vi.stubEnv("CONVEX_HTTP_URL", "https://convex.example");
-    vi.stubEnv("COMPUTERS_DATA_PLANE_SECRET", "secret");
+    vi.stubEnv("INSPECTOR_SERVICE_TOKEN", "test-svc-token");
     vi.stubEnv("E2B_API_KEY", "e2b_test");
     vi.stubEnv("COMPUTERS_TERMINAL_TOKEN_SECRET", "terminal-secret-16+");
     installFetchStub();
@@ -394,7 +394,7 @@ describe("bash tool delegation", () => {
 
   it("prefers the local data plane when both are configured", async () => {
     vi.stubEnv("CONVEX_HTTP_URL", "https://convex.example");
-    vi.stubEnv("COMPUTERS_DATA_PLANE_SECRET", "secret");
+    vi.stubEnv("INSPECTOR_SERVICE_TOKEN", "test-svc-token");
     vi.stubEnv("E2B_API_KEY", "e2b_test");
     vi.stubEnv("COMPUTERS_TERMINAL_TOKEN_SECRET", "terminal-secret-16+");
     fetchResponse = () =>

--- a/mcpjam-inspector/server/utils/__tests__/computers-runtime-config.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/computers-runtime-config.test.ts
@@ -20,7 +20,6 @@ const ENV_KEYS = [
   "E2B_DOMAIN",
   "E2B_TEMPLATE_ID",
   "COMPUTERS_TERMINAL_TOKEN_SECRET",
-  "COMPUTERS_DATA_PLANE_SECRET",
 ] as const;
 
 const savedEnv: Record<string, string | undefined> = {};
@@ -96,9 +95,7 @@ describe("initComputersRuntimeConfigBootstrap", () => {
     );
     // Nulls in the payload set nothing.
     expect(process.env.E2B_API_URL).toBeUndefined();
-    // The bootstrap never manufactures the legacy secret.
-    expect(process.env.COMPUTERS_DATA_PLANE_SECRET).toBeUndefined();
-    // ...and the server now reports configured via the service token.
+    // The server now reports configured via the service token.
     expect(isComputersDataPlaneConfigured()).toBe(true);
   });
 
@@ -113,16 +110,6 @@ describe("initComputersRuntimeConfigBootstrap", () => {
 
   it("skips the fetch entirely without a service token", async () => {
     delete process.env.INSPECTOR_SERVICE_TOKEN;
-    expect(
-      await initComputersRuntimeConfigBootstrap({ sleep: instantSleep })
-    ).toBe("skipped");
-    expect(fetchCalls).toHaveLength(0);
-  });
-
-  it("skips the fetch when the legacy trio is already complete", async () => {
-    process.env.E2B_API_KEY = "k";
-    process.env.COMPUTERS_TERMINAL_TOKEN_SECRET = "s";
-    process.env.COMPUTERS_DATA_PLANE_SECRET = "d";
     expect(
       await initComputersRuntimeConfigBootstrap({ sleep: instantSleep })
     ).toBe("skipped");
@@ -222,18 +209,13 @@ describe("resolveComputersLocalConfigured", () => {
   });
 
   it("reports NOT configured after a 401 even with stray E2B + terminal secret in env", async () => {
-    // Hybrid config: a wrong service token, no legacy secret, but leftover
-    // hand-set E2B key + terminal secret. Without marking the token rejected,
-    // the predicate would report localConfigured:true while every
-    // secret-gated /computers/* call hard-401s.
+    // Wrong service token + leftover hand-set E2B key + terminal secret.
+    // Without marking the token rejected, the predicate would report
+    // localConfigured:true while every /computers/* call hard-401s.
     process.env.E2B_API_KEY = "stray-key";
     process.env.COMPUTERS_TERMINAL_TOKEN_SECRET = "stray-terminal-secret";
-    delete process.env.COMPUTERS_DATA_PLANE_SECRET;
     fetchImpl = () => jsonResponse(401, { error: "Unauthorized" });
 
     expect(await resolveComputersLocalConfigured()).toBe(false);
-    // A legacy secret is an independent credential and still counts.
-    process.env.COMPUTERS_DATA_PLANE_SECRET = "legacy-secret";
-    expect(isComputersDataPlaneConfigured()).toBe(true);
   });
 });

--- a/mcpjam-inspector/server/utils/computers/control-plane-client.ts
+++ b/mcpjam-inspector/server/utils/computers/control-plane-client.ts
@@ -237,10 +237,13 @@ export async function getComputerSandboxInfo(args: {
 }): Promise<ControlPlaneResult<ComputerSandboxInfo>> {
   const headers = authHeaders();
   if (!headers) {
+    // authHeaders() is null when the token is unset OR was rejected by the
+    // bootstrap (markServiceTokenRejected) — name both so operators don't
+    // chase a "not set" that is actually a wrong token.
     return {
       ok: false,
       status: 0,
-      error: "INSPECTOR_SERVICE_TOKEN is not set",
+      error: "INSPECTOR_SERVICE_TOKEN is not set or was rejected",
     };
   }
   return postJson<ComputerSandboxInfo>(

--- a/mcpjam-inspector/server/utils/computers/control-plane-client.ts
+++ b/mcpjam-inspector/server/utils/computers/control-plane-client.ts
@@ -9,16 +9,14 @@
  *
  *   reserve           user-bearer auth — reserve/wake/poll the acting user's
  *                     computer (idempotent; each poll also counts as activity)
- *   sandbox-info      shared-secret auth — Convex row id → vendor sandbox id.
- *                     The secret marks us as the deployed server; browsers
+ *   sandbox-info      service-token auth — Convex row id → vendor sandbox id.
+ *                     The token marks us as the deployed server; browsers
  *                     must never be able to make this exchange.
- *   commands          shared-secret auth — durable command log (idempotent)
- *   terminal-sessions shared-secret auth — session open/close records
+ *   commands          service-token auth — durable command log (idempotent)
+ *   terminal-sessions service-token auth — session open/close records
  */
 import { logger } from "../logger.js";
 import { type ExecutionScope } from "../execution-scope.js";
-
-const SECRET_HEADER = "x-computers-data-plane-secret";
 
 export type ComputerStatus =
   | "requested"
@@ -54,10 +52,6 @@ export function getConvexHttpUrl(): string | null {
   return process.env.CONVEX_HTTP_URL?.trim() || null;
 }
 
-function getDataPlaneSecret(): string | null {
-  return process.env.COMPUTERS_DATA_PLANE_SECRET?.trim() || null;
-}
-
 /**
  * Set once the boot bootstrap gets a 401 from this server's Convex
  * (`runtime-config.ts` calls `markServiceTokenRejected`): the
@@ -87,14 +81,11 @@ function getServiceToken(): string | null {
 }
 
 /**
- * True when everything the computers data plane needs is present: a Convex
- * to talk to, a server-to-server credential for it (legacy shared secret or
- * the inspector service token), the vendor key, and the terminal-token
- * secret. The last one is deliberately part of "configured": the terminal
- * verifier (`terminal-token.ts`) fails closed without it, so a server that
- * can exec but can't verify terminal tokens would be lying if it reported
- * configured. (It leaves the predicate once RS256/JWKS verification is fully
- * rolled out and harness proxy tokens have migrated.)
+ * True when everything the computers data plane needs is present: a Convex to
+ * talk to, the inspector service token, the vendor key, and the terminal-token
+ * secret. The secret is still required because it signs/verifies harness proxy
+ * tokens (`harness-proxy-token.ts`) even though terminal tokens are now
+ * RS256/JWKS.
  *
  * Values may arrive from the environment OR from the boot bootstrap
  * (`runtime-config.ts`, which fills env in place) — callers that can run
@@ -104,7 +95,7 @@ function getServiceToken(): string | null {
 export function isComputersDataPlaneConfigured(): boolean {
   return Boolean(
     getConvexHttpUrl() &&
-      (getDataPlaneSecret() || getServiceToken()) &&
+      getServiceToken() &&
       process.env.E2B_API_KEY &&
       process.env.COMPUTERS_TERMINAL_TOKEN_SECRET?.trim()
   );
@@ -149,15 +140,11 @@ async function postJson<T>(
 }
 
 /**
- * Server-to-server auth headers for the secret-gated `/computers/*` routes.
- * The legacy shared secret wins when present (matches the backend's
- * dual-accept precedence and keeps three-var setups byte-identical);
- * otherwise the inspector service token. Null when the server holds neither
- * — callers treat that as unconfigured.
+ * Server-to-server auth headers for the secret-gated `/computers/*` routes:
+ * the inspector service token. Null when the server holds no (valid) token —
+ * callers treat that as unconfigured.
  */
 function authHeaders(): Record<string, string> | null {
-  const secret = getDataPlaneSecret();
-  if (secret) return { [SECRET_HEADER]: secret };
   const token = getServiceToken();
   return token ? { "x-inspector-service-token": token } : null;
 }
@@ -197,7 +184,7 @@ export async function provisionEvalSandbox(args: {
   );
 }
 
-/** Release an eval sandbox (shared-secret auth; idempotent). */
+/** Release an eval sandbox (service-token auth; idempotent). */
 export async function releaseEvalSandbox(args: {
   sandboxRowId: string;
   signal?: AbortSignal;
@@ -243,7 +230,7 @@ export async function reserveComputer(args: {
   );
 }
 
-/** Exchange a computer row id for its vendor sandbox info (secret auth). */
+/** Exchange a computer row id for its vendor sandbox info (service-token auth). */
 export async function getComputerSandboxInfo(args: {
   computerId: string;
   signal?: AbortSignal;
@@ -253,7 +240,7 @@ export async function getComputerSandboxInfo(args: {
     return {
       ok: false,
       status: 0,
-      error: "COMPUTERS_DATA_PLANE_SECRET is not set",
+      error: "INSPECTOR_SERVICE_TOKEN is not set",
     };
   }
   return postJson<ComputerSandboxInfo>(
@@ -264,7 +251,7 @@ export async function getComputerSandboxInfo(args: {
   );
 }
 
-/** Record an executed command (secret auth; idempotent on commandId). */
+/** Record an executed command (service-token auth; idempotent on commandId). */
 export async function recordComputerCommand(args: {
   computerId: string;
   commandId: string;
@@ -288,7 +275,7 @@ export async function recordComputerCommand(args: {
   }
 }
 
-/** Record a terminal session transition (secret auth; idempotent). */
+/** Record a terminal session transition (service-token auth; idempotent). */
 export async function recordTerminalSession(args: {
   sessionId: string;
   action: "open" | "close";

--- a/mcpjam-inspector/server/utils/computers/runtime-config.ts
+++ b/mcpjam-inspector/server/utils/computers/runtime-config.ts
@@ -57,10 +57,9 @@ export function getInspectorServiceToken(): string | null {
   return process.env.INSPECTOR_SERVICE_TOKEN?.trim() || null;
 }
 
-/** The env keys bootstrap may fill. COMPUTERS_DATA_PLANE_SECRET is absent on
- *  purpose: a bootstrapped server authenticates to Convex with the service
- *  token itself (control-plane-client `authHeaders`), so the legacy secret
- *  never needs to exist on it. */
+/** The env keys bootstrap may fill. No data-plane secret here: the data plane
+ *  authenticates to Convex with the service token (control-plane-client
+ *  `authHeaders`). */
 function applyRuntimeConfigToEnv(config: {
   e2bApiKey: string;
   e2bApiUrl: string | null;
@@ -84,7 +83,7 @@ function applyRuntimeConfigToEnv(config: {
 
 type BootstrapOutcome =
   | "applied"
-  | "skipped" // env already complete, or no service token / convex url
+  | "skipped" // no service token / convex url
   | "unavailable" // backend said enabled:false, or 401/404 (old backend)
   | "failed"; // network-ish; eligible for cooldown re-init
 
@@ -94,14 +93,6 @@ let lastFailureAtMs: number | null = null;
 export function resetComputersRuntimeConfigBootstrapForTests(): void {
   bootstrapPromise = null;
   lastFailureAtMs = null;
-}
-
-function hasCompleteLegacyEnv(): boolean {
-  return Boolean(
-    process.env.E2B_API_KEY?.trim() &&
-      process.env.COMPUTERS_TERMINAL_TOKEN_SECRET?.trim() &&
-      process.env.COMPUTERS_DATA_PLANE_SECRET?.trim()
-  );
 }
 
 async function fetchRuntimeConfigOnce(
@@ -178,7 +169,6 @@ async function runBootstrap(sleep: (ms: number) => Promise<void>): Promise<Boots
   if (!token) return "skipped";
   const base = getConvexHttpUrl();
   if (!base) return "skipped";
-  if (hasCompleteLegacyEnv()) return "skipped";
 
   for (let attempt = 0; ; attempt += 1) {
     const outcome = await fetchRuntimeConfigOnce(base, token);

--- a/mcpjam-inspector/server/utils/computers/runtime-config.ts
+++ b/mcpjam-inspector/server/utils/computers/runtime-config.ts
@@ -11,9 +11,9 @@
  * `isComputersDataPlaneConfigured()` gate stays synchronous.
  *
  * Invariants:
- *   - Env always wins: a key is only written when currently unset, and the
- *     fetch is skipped entirely when the legacy hand-mirrored trio is already
- *     present — zero behavior change for existing three-var setups.
+ *   - Env always wins: a key is only written when currently unset, so a
+ *     hand-set value is never overwritten (the fetch still runs, but applies
+ *     nothing it can't overwrite).
  *   - Atomic apply: the whole response must validate (zod) before ANY env key
  *     is written; a malformed payload writes nothing, so the process can
  *     never run on mixed old/new credentials.

--- a/mcpjam-inspector/server/utils/harness/__tests__/harness-availability.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/harness-availability.test.ts
@@ -7,7 +7,7 @@ import type { HarnessId } from "../registry";
 
 const ENV_KEYS = [
   "CONVEX_HTTP_URL",
-  "COMPUTERS_DATA_PLANE_SECRET",
+  "INSPECTOR_SERVICE_TOKEN",
   "COMPUTERS_TERMINAL_TOKEN_SECRET",
   "E2B_API_KEY",
 ] as const;
@@ -29,7 +29,7 @@ function setFullyAvailable() {
   // Model credential is NOT an env var anymore (resolved from Convex per turn);
   // the preflight only checks the computers data plane + capability gates.
   process.env.CONVEX_HTTP_URL = "https://convex.example.com";
-  process.env.COMPUTERS_DATA_PLANE_SECRET = "secret";
+  process.env.INSPECTOR_SERVICE_TOKEN = "test-svc-token";
   process.env.COMPUTERS_TERMINAL_TOKEN_SECRET = "terminal-secret-16+";
   process.env.E2B_API_KEY = "e2b-test";
 }


### PR DESCRIPTION
**DRAFT — merge only at the cleanup cutover.** PR 3 of the internal-only cleanup stack (inspector side).

## What
- `authHeaders()` presents only `x-inspector-service-token` — drops the legacy `x-computers-data-plane-secret` path, `SECRET_HEADER`, and `getDataPlaneSecret`.
- `isComputersDataPlaneConfigured()` drops the legacy-secret alternative: `CONVEX_HTTP_URL` + service token + `E2B_API_KEY` + `COMPUTERS_TERMINAL_TOKEN_SECRET` (the terminal secret stays — it still signs/verifies **harness proxy** tokens).
- Bootstrap loses the `hasCompleteLegacyEnv` skip: bootstrap is the only credential path now, and `applyRuntimeConfigToEnv` is already only-if-unset, so a preset env just no-ops.
- Stale `shared-secret auth` comments + the `sandbox-info` error string updated to the service token.

## Cutover prerequisite (do NOT merge before this)
Every data-plane inspector must hold `INSPECTOR_SERVICE_TOKEN` (they do) before this deploys; `COMPUTERS_DATA_PLANE_SECRET` can then be dropped from Convex + Railway.

## Tests
Fixtures across the computers/harness suites now mark a server configured via `INSPECTOR_SERVICE_TOKEN` instead of the data-plane secret; the bash tool asserts the `x-inspector-service-token` header. Removed the legacy-trio-skip test; the 401-hybrid test drops the legacy-secret leg. 86 tests across 7 suites pass; `tsc -p server` unchanged (69 pre-existing, none in changed files).

Part of the cleanup stack: service-token auth #682 · RS256-only mint #683 · **[this] inspector service-token auth + drop three-var compat** · inspector RS256-only verify (next).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches inspector-side computers auth to service-token only. Removes legacy `COMPUTERS_DATA_PLANE_SECRET` support and the three-var compatibility path.

- **Refactors**
  - `authHeaders()` now sends only `x-inspector-service-token`; removed the `x-computers-data-plane-secret` path and helpers.
  - `isComputersDataPlaneConfigured()` now requires `CONVEX_HTTP_URL`, `INSPECTOR_SERVICE_TOKEN`, `E2B_API_KEY`, and `COMPUTERS_TERMINAL_TOKEN_SECRET`.
  - Bootstrap no longer checks legacy env; it’s the only credential path and no-ops if env is already set.
  - Clearer error when headers are missing: "INSPECTOR_SERVICE_TOKEN is not set or was rejected"; updated comments; tests assert `x-inspector-service-token`.

- **Migration**
  - Set `INSPECTOR_SERVICE_TOKEN` on all inspectors before deploy.
  - After deploy, remove `COMPUTERS_DATA_PLANE_SECRET` from Convex and Railway.

<sup>Written for commit af4dd7374a8d6cc9e27cecdbb30ec9ea47102721. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> This is a breaking auth cutover: inspectors without a valid `INSPECTOR_SERVICE_TOKEN` will stop authenticating to Convex computers routes until deploy prerequisites are met.
> 
> **Overview**
> **Computers data-plane auth is service-token only.** `authHeaders()` no longer sends `x-computers-data-plane-secret`; secret-gated `/computers/*` routes use `x-inspector-service-token` only. `isComputersDataPlaneConfigured()` requires `INSPECTOR_SERVICE_TOKEN` (plus Convex URL, E2B key, and terminal secret for harness proxy tokens)—not the legacy shared secret.
> 
> **Bootstrap and errors align with the cutover.** Runtime-config bootstrap no longer skips when a full “legacy trio” env was set; it still only writes unset keys. `sandbox-info` failures report `INSPECTOR_SERVICE_TOKEN is not set or was rejected` instead of the old secret message.
> 
> **Tests** stub `INSPECTOR_SERVICE_TOKEN`, assert the service-token header on bash-tool control-plane calls, and drop legacy-trio skip / hybrid-secret cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af4dd7374a8d6cc9e27cecdbb30ec9ea47102721. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->