### PR TITLE
feat(xaa): org-scoped mock-IdP issuers (/api/web/xaa/o/<orgId>)

### DIFF
--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -429,13 +429,13 @@ export function XAAFlowTab({
   >(undefined);
   useEffect(() => {
     const controller = new AbortController();
-    void fetchXaaIdpUrls(controller.signal).then((urls) => {
+    void fetchXaaIdpUrls(controller.signal, organizationId).then((urls) => {
       if (urls && !controller.signal.aborted) {
         setResolvedIssuerBaseUrl(urls.issuerBaseUrl);
       }
     });
     return () => controller.abort();
-  }, []);
+  }, [organizationId]);
 
   const xaaStateMachine = useMemo(() => {
     return createInspectorXAAStateMachine({
@@ -456,8 +456,9 @@ export function XAAFlowTab({
         ? { serverId: target.serverId, projectId: target.projectId }
         : {}),
       issuerBaseUrl: resolvedIssuerBaseUrl,
+      organizationId,
     });
-  }, [runInput, target, updateFlowState, resolvedIssuerBaseUrl]);
+  }, [runInput, target, updateFlowState, resolvedIssuerBaseUrl, organizationId]);
 
   const handleAdvance = useCallback(async () => {
     if (!isTestable) {
@@ -550,7 +551,7 @@ export function XAAFlowTab({
 
   return (
     <div className="h-full flex flex-col bg-background">
-      <XAAIdpCard />
+      <XAAIdpCard organizationId={organizationId ?? null} />
       <XAAResourceAppsSection
         organizationId={organizationId ?? null}
         selectedId={selectedRegistrationId}
@@ -676,7 +677,11 @@ export function XAAFlowTab({
 
       {isTestable && (
         <NegativeTestScorecard
-          input={scorecard.input}
+          input={
+            scorecard.input
+              ? { ...scorecard.input, organizationId: organizationId ?? null }
+              : null
+          }
           unlocked={positiveRunTargets.has(targetKey)}
           unavailableReason={scorecard.unavailableReason}
         />

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -429,6 +429,12 @@ export function XAAFlowTab({
   >(undefined);
   useEffect(() => {
     const controller = new AbortController();
+    // Reset synchronously on org change (mirrors XAAIdpCard). Otherwise the
+    // prior org's issuer lingers until the async fetch resolves — and stays
+    // forever if it returns null — so the ID-JAG inspection would compare the
+    // new org's `iss` against the old issuer and report a spurious mismatch.
+    // With it cleared, the machine falls back to the correct current-org guess.
+    setResolvedIssuerBaseUrl(undefined);
     void fetchXaaIdpUrls(controller.signal, organizationId).then((urls) => {
       if (urls && !controller.signal.aborted) {
         setResolvedIssuerBaseUrl(urls.issuerBaseUrl);

--- a/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
@@ -161,9 +161,17 @@ export function XAAIdpCard({
 
   // Resolve the real issuer from the server's discovery doc once on mount —
   // the URLs are always visible now, so there's no expand to defer it to.
+  const isFirstResolve = useRef(true);
   useEffect(() => {
     const controller = new AbortController();
-    setUrls(getXaaIdpUrls(organizationId));
+    // The useState initializer already produced this value on first render;
+    // only reset synchronously when the org actually changes (so a stale
+    // prior-org URL never flashes) to avoid a wasted render on mount.
+    if (isFirstResolve.current) {
+      isFirstResolve.current = false;
+    } else {
+      setUrls(getXaaIdpUrls(organizationId));
+    }
     void fetchXaaIdpUrls(controller.signal, organizationId).then(
       (serverUrls) => {
         if (controller.signal.aborted || !serverUrls) {

--- a/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
@@ -143,25 +143,39 @@ function IdpInfo() {
  * mints assertions with MCPJam as the IdP, so this surfaces the issuer + JWKS
  * URLs a developer registers with their own authorization server, inline with
  * copy buttons. The how-and-why detail lives behind the info icon.
+ *
+ * Hosted signed-in users get the org-scoped issuer (/o/<orgId>): minting under
+ * it requires org membership, so it is the issuer to register with a real
+ * authorization server. The legacy unscoped issuer is mintable by anyone and
+ * should be treated as test-only.
  */
-export function XAAIdpCard() {
+export function XAAIdpCard({
+  organizationId,
+}: {
+  organizationId?: string | null;
+}) {
   // Start from the browser-origin guess, then swap in the server-advertised
   // issuer once resolved — see fetchXaaIdpUrls for why the guess can be wrong.
-  const [urls, setUrls] = useState(() => getXaaIdpUrls());
+  const [urls, setUrls] = useState(() => getXaaIdpUrls(organizationId));
   const { issuerBaseUrl, openidConfigUrl, jwksUrl } = urls;
 
   // Resolve the real issuer from the server's discovery doc once on mount —
   // the URLs are always visible now, so there's no expand to defer it to.
   useEffect(() => {
     const controller = new AbortController();
-    void fetchXaaIdpUrls(controller.signal).then((serverUrls) => {
-      if (controller.signal.aborted || !serverUrls) {
-        return;
-      }
-      setUrls(serverUrls);
-    });
+    setUrls(getXaaIdpUrls(organizationId));
+    void fetchXaaIdpUrls(controller.signal, organizationId).then(
+      (serverUrls) => {
+        if (controller.signal.aborted || !serverUrls) {
+          return;
+        }
+        setUrls(serverUrls);
+      },
+    );
     return () => controller.abort();
-  }, []);
+  }, [organizationId]);
+
+  const isOrgScoped = HOSTED_MODE && Boolean(organizationId);
 
   return (
     <div className="border-b border-border bg-background px-4 py-3">
@@ -189,6 +203,13 @@ export function XAAIdpCard() {
             cannot reach <code className="font-mono">localhost</code>. Expose
             MCPJam with a public tunnel (e.g. ngrok) first.
           </span>
+        </div>
+      )}
+
+      {isOrgScoped && (
+        <div className="mt-3 text-xs text-muted-foreground">
+          This issuer is scoped to your organization — only its members can
+          mint assertions under it.
         </div>
       )}
     </div>

--- a/mcpjam-inspector/client/src/components/xaa/__tests__/XAAIdpCard.test.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/__tests__/XAAIdpCard.test.tsx
@@ -110,6 +110,23 @@ describe("XAAIdpCard", () => {
       screen.getByRole("button", { name: /copy jwks url/i })
     ).toHaveAttribute("title", `${serverIssuer}/.well-known/jwks.json`);
   });
+
+  it("shows the org-scoped issuer for signed-in org members", () => {
+    render(<XAAIdpCard organizationId="org_a1B2" />);
+
+    expect(
+      screen.getByRole("button", { name: /copy issuer url/i })
+    ).toHaveAttribute("title", `${issuer}/o/org_a1B2`);
+    expect(
+      screen.getByRole("button", { name: /copy jwks url/i })
+    ).toHaveAttribute(
+      "title",
+      `${issuer}/o/org_a1B2/.well-known/jwks.json`
+    );
+    expect(
+      screen.getByText(/scoped to your organization/i)
+    ).toBeInTheDocument();
+  });
 });
 
 describe("XAAIdpCard (non-hosted mode)", () => {

--- a/mcpjam-inspector/client/src/lib/xaa/debug-state-machine-adapter.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/debug-state-machine-adapter.ts
@@ -84,17 +84,28 @@ export function createXAADebugRequestExecutor(): XAARequestExecutor {
 }
 
 export function createInspectorXAAStateMachine(
-  config: Omit<BaseXAAStateMachineConfig, "issuerBaseUrl" | "requestExecutor"> & {
+  config: Omit<
+    BaseXAAStateMachineConfig,
+    "issuerBaseUrl" | "mintPathPrefix" | "requestExecutor"
+  > & {
     // Ground-truth issuer resolved from the server's OpenID config. Falls back
     // to the browser-origin guess, which is wrong when the browser reaches the
     // API through the Vite dev proxy (browser :5173, backend :6274).
     issuerBaseUrl?: string;
+    // Hosted runs mint under the org-scoped issuer (/o/<orgId>) when the user
+    // belongs to an organization; local runs and guests stay unscoped.
+    organizationId?: string | null;
   },
 ): XAAStateMachine {
-  const { issuerBaseUrl, ...rest } = config;
+  const { issuerBaseUrl, organizationId, ...rest } = config;
+  const mintPathPrefix =
+    HOSTED_MODE && organizationId ? `/o/${organizationId}` : "";
   return createXAAStateMachine({
     ...rest,
-    issuerBaseUrl: issuerBaseUrl ?? `${window.location.origin}${XAA_API_BASE}`,
+    issuerBaseUrl:
+      issuerBaseUrl ??
+      `${window.location.origin}${XAA_API_BASE}${mintPathPrefix}`,
+    mintPathPrefix,
     requestExecutor: createXAADebugRequestExecutor(),
   });
 }

--- a/mcpjam-inspector/client/src/lib/xaa/discovery-client.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/discovery-client.ts
@@ -1,6 +1,7 @@
 import { HOSTED_MODE } from "@/lib/config";
 import { authFetch } from "@/lib/session-token";
 import type { NegativeTestDiff } from "@/shared/xaa.js";
+import { getOrgScopedIssuerSegment } from "./idp-endpoints";
 
 const XAA_API_BASE = HOSTED_MODE ? "/api/web/xaa" : "/api/mcp/xaa";
 
@@ -110,6 +111,9 @@ export interface NegativeTestsInput {
   // the token endpoint from the server's own config.
   serverId?: string;
   projectId?: string;
+  // Hosted runs mint the broken assertions under the org-scoped issuer so
+  // they carry the same `iss` the positive run used.
+  organizationId?: string | null;
 }
 
 /**
@@ -121,11 +125,16 @@ export interface NegativeTestsInput {
 export async function runNegativeTests(
   input: NegativeTestsInput
 ): Promise<NegativeTestsResult> {
-  const response = await authFetch(`${XAA_API_BASE}/negative-tests`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(input),
-  });
+  const { organizationId, ...requestBody } = input;
+  const scopedSegment = getOrgScopedIssuerSegment(organizationId);
+  const response = await authFetch(
+    `${XAA_API_BASE}${scopedSegment}/negative-tests`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(requestBody),
+    }
+  );
 
   const body = (await response.json().catch(() => null)) as
     | (NegativeTestsResult & { message?: string })

--- a/mcpjam-inspector/client/src/lib/xaa/idp-endpoints.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/idp-endpoints.ts
@@ -11,6 +11,19 @@ function getIssuerBasePath(): string {
 }
 
 /**
+ * Org-scoped issuer path segment, e.g. `/o/<orgId>`. Hosted-only: the local
+ * router has no org concept, so a missing org (or local mode) yields "" and
+ * every caller falls back to the unscoped issuer. Signed-in hosted users
+ * should always prefer the scoped issuer — minting under it is gated on org
+ * membership, unlike the legacy unscoped issuer.
+ */
+export function getOrgScopedIssuerSegment(
+  organizationId?: string | null,
+): string {
+  return HOSTED_MODE && organizationId ? `/o/${organizationId}` : "";
+}
+
+/**
  * Resolve the MCPJam-as-IdP endpoints the user pastes into their own
  * authorization server, derived from the browser origin. This is a synchronous
  * best-effort guess used for the initial render and as a fallback — in local
@@ -18,9 +31,9 @@ function getIssuerBasePath(): string {
  * that actually mints the ID-JAG `iss`, so prefer `fetchXaaIdpUrls` when an
  * accurate value matters (registration, issuer-trust comparisons).
  */
-export function getXaaIdpUrls(): XaaIdpUrls {
+export function getXaaIdpUrls(organizationId?: string | null): XaaIdpUrls {
   const origin = typeof window === "undefined" ? "" : window.location.origin;
-  const issuerBaseUrl = `${origin}${getIssuerBasePath()}`;
+  const issuerBaseUrl = `${origin}${getIssuerBasePath()}${getOrgScopedIssuerSegment(organizationId)}`;
   return {
     issuerBaseUrl,
     openidConfigUrl: `${issuerBaseUrl}/.well-known/openid-configuration`,
@@ -38,8 +51,9 @@ export function getXaaIdpUrls(): XaaIdpUrls {
  */
 export async function fetchXaaIdpUrls(
   signal?: AbortSignal,
+  organizationId?: string | null,
 ): Promise<XaaIdpUrls | null> {
-  const { openidConfigUrl } = getXaaIdpUrls();
+  const { openidConfigUrl } = getXaaIdpUrls(organizationId);
   try {
     const response = await fetch(openidConfigUrl, { signal });
     if (!response.ok) {

--- a/mcpjam-inspector/client/src/lib/xaa/state-machine.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/state-machine.ts
@@ -374,6 +374,7 @@ export function createXAAStateMachine(
     updateState,
     serverUrl,
     issuerBaseUrl,
+    mintPathPrefix = "",
     requestExecutor,
     negativeTestMode,
     userId,
@@ -739,7 +740,7 @@ export function createXAAStateMachine(
     const activeEmail = email ?? state.email;
     const request = {
       method: "POST",
-      url: "/authenticate",
+      url: `${mintPathPrefix}/authenticate`,
       headers: {
         "Content-Type": "application/json",
       },
@@ -752,7 +753,7 @@ export function createXAAStateMachine(
 
     try {
       const result = await runRequest("user_authentication", request, () =>
-        requestExecutor.internalRequest("/authenticate", {
+        requestExecutor.internalRequest(`${mintPathPrefix}/authenticate`, {
           method: "POST",
           headers: request.headers,
           body: JSON.stringify(request.body),
@@ -830,7 +831,7 @@ export function createXAAStateMachine(
 
     const request = {
       method: "POST",
-      url: "/token-exchange",
+      url: `${mintPathPrefix}/token-exchange`,
       headers: {
         "Content-Type": "application/json",
       },
@@ -846,7 +847,7 @@ export function createXAAStateMachine(
 
     try {
       const result = await runRequest("token_exchange_request", request, () =>
-        requestExecutor.internalRequest("/token-exchange", {
+        requestExecutor.internalRequest(`${mintPathPrefix}/token-exchange`, {
           method: "POST",
           headers: request.headers,
           body: JSON.stringify(request.body),

--- a/mcpjam-inspector/client/src/lib/xaa/types.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/types.ts
@@ -151,6 +151,10 @@ export interface BaseXAAStateMachineConfig {
   updateState: (updates: Partial<XAAFlowState>) => void;
   serverUrl: string;
   issuerBaseUrl: string;
+  /** Path prefix for the mint endpoints (`/authenticate`, `/token-exchange`),
+   * e.g. `/o/<orgId>` for the hosted org-scoped issuer. Never applied to the
+   * token proxy, which has no scoped variant. Defaults to "" (unscoped). */
+  mintPathPrefix?: string;
   requestExecutor: XAARequestExecutor;
   scheduleAutoAdvance?: (next: () => void) => void;
   negativeTestMode?: NegativeTestMode;

--- a/mcpjam-inspector/server/routes/mcp/__tests__/xaa.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/xaa.test.ts
@@ -727,3 +727,28 @@ describe("POST /negative-tests", () => {
     expect(body.message).toContain("its own auth server");
   });
 });
+
+describe("org-scoped issuer paths on the local router", () => {
+  it("does not register /o/:orgId routes when authorizeOrgIssuer is absent", async () => {
+    const app = new Hono();
+    app.route(
+      "/api/mcp/xaa",
+      createXaaRouter({
+        issuerBasePath: "/api/mcp",
+        httpsOnlyProxy: false,
+      })
+    );
+
+    const discovery = await app.request(
+      "/api/mcp/xaa/o/org-123/.well-known/openid-configuration"
+    );
+    const mint = await app.request("/api/mcp/xaa/o/org-123/authenticate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ userId: "user-12345" }),
+    });
+
+    expect(discovery.status).toBe(404);
+    expect(mint.status).toBe(404);
+  });
+});

--- a/mcpjam-inspector/server/routes/mcp/xaa.ts
+++ b/mcpjam-inspector/server/routes/mcp/xaa.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import type { MiddlewareHandler } from "hono";
+import type { Context, MiddlewareHandler } from "hono";
 import { z } from "zod";
 import {
   DEFAULT_NEGATIVE_TEST_MODE,
@@ -71,6 +71,12 @@ function checkNegativeTestHostCap(host: string): boolean {
   existing.count += 1;
   return true;
 }
+
+// Path-segment allowlist for the org-scoped issuer. The segment is embedded
+// into the ID-JAG `iss`, so it must be validated before URL-embedding. Convex
+// org ids are opaque strings; real ones fit [A-Za-z0-9_-], and anything else
+// is rejected rather than normalized.
+const ORG_ID_RE = /^[A-Za-z0-9_-]{1,64}$/;
 
 const authenticateSchema = z.object({
   userId: z.string().trim().min(1).optional(),
@@ -281,6 +287,13 @@ interface CreateXaaRouterOptions {
     projectId: string;
     bearerToken: string;
   }) => Promise<ServerClientSecretResult>;
+  // Confirms the caller is a member of the organization before minting under
+  // the org-scoped issuer path (/o/:orgId/...). When absent, the scoped
+  // routes are not registered at all — the local router has no org concept.
+  authorizeOrgIssuer?: (args: {
+    organizationId: string;
+    bearerToken: string;
+  }) => Promise<void>;
 }
 
 type ParsedJwtPayload = {
@@ -356,6 +369,7 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
   const router = new Hono();
   const protectedMiddlewares = options.protectedMiddlewares ?? [];
   const trustForwardedHeaders = options.trustForwardedHeaders ?? false;
+  const authorizeOrgIssuer = options.authorizeOrgIssuer;
 
   if (protectedMiddlewares.length > 0) {
     router.use("/authenticate", ...protectedMiddlewares);
@@ -364,23 +378,66 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
     router.use("/discover-as", ...protectedMiddlewares);
     router.use("/health-check", ...protectedMiddlewares);
     router.use("/negative-tests", ...protectedMiddlewares);
+    if (authorizeOrgIssuer) {
+      router.use("/o/:orgId/authenticate", ...protectedMiddlewares);
+      router.use("/o/:orgId/token-exchange", ...protectedMiddlewares);
+      router.use("/o/:orgId/negative-tests", ...protectedMiddlewares);
+    }
   }
 
-  router.get("/.well-known/jwks.json", (c) => {
+  const unscopedIssuer = (c: Context): string =>
+    getIssuerForRequest(c, options.issuerBasePath, trustForwardedHeaders);
+
+  // Gate for the org-scoped mint routes: validate the path segment (it is
+  // embedded into the ID-JAG `iss`), require a bearer, and confirm org
+  // membership via the backend. Returns the validated orgId, or the error
+  // Response to send. Fail-closed: any backend failure blocks the mint.
+  const requireScopedOrg = async (c: Context): Promise<string | Response> => {
+    const orgId = c.req.param("orgId");
+    if (!orgId || !ORG_ID_RE.test(orgId)) {
+      return toJsonError("Invalid organization id in issuer path", {
+        status: 400,
+        code: "VALIDATION_ERROR",
+      });
+    }
+    const authHeader = c.req.header("authorization");
+    if (!authHeader?.startsWith("Bearer ")) {
+      return toJsonError(
+        "Minting under an organization issuer requires signing in",
+        { status: 401, code: "UNAUTHORIZED" }
+      );
+    }
+    try {
+      await authorizeOrgIssuer!({
+        organizationId: orgId,
+        bearerToken: authHeader.slice("Bearer ".length),
+      });
+    } catch (error) {
+      if (error instanceof WebRouteError) {
+        return toJsonError(error.message, {
+          status: error.status,
+          code: error.code,
+          details: error.details,
+        });
+      }
+      logger.error("[XAA Org Issuer] authorization failed", error);
+      return toJsonError("Couldn't authorize the organization issuer", {
+        status: 500,
+        code: "INTERNAL_ERROR",
+      });
+    }
+    return orgId;
+  };
+
+  const serveJwks = (c: Context) => {
     initXAAIdpKeyPair();
     return c.json(getXAAIdpJwks(), 200, {
       "Cache-Control": "public, max-age=300",
     });
-  });
+  };
 
-  router.get("/.well-known/openid-configuration", (c) => {
+  const serveOpenidConfiguration = (c: Context, issuer: string) => {
     initXAAIdpKeyPair();
-    const issuer = getIssuerForRequest(
-      c,
-      options.issuerBasePath,
-      trustForwardedHeaders
-    );
-
     return c.json(
       {
         issuer,
@@ -400,19 +457,20 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
         "Cache-Control": "public, max-age=300",
       }
     );
-  });
+  };
 
-  router.post("/authenticate", async (c) => {
+  router.get("/.well-known/jwks.json", (c) => serveJwks(c));
+
+  router.get("/.well-known/openid-configuration", (c) =>
+    serveOpenidConfiguration(c, unscopedIssuer(c))
+  );
+
+  const handleAuthenticate = async (c: Context, issuer: string) => {
     try {
       const body = await c.req.json();
       const { userId, email, audience } = parseRequest(
         authenticateSchema,
         body
-      );
-      const issuer = getIssuerForRequest(
-        c,
-        options.issuerBasePath,
-        trustForwardedHeaders
       );
       const subject = userId || "user-12345";
       const resolvedEmail = email || "demo.user@example.com";
@@ -441,18 +499,15 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
         { status: 400, code: "VALIDATION_ERROR" }
       );
     }
-  });
+  };
 
-  router.post("/token-exchange", async (c) => {
+  router.post("/authenticate", (c) => handleAuthenticate(c, unscopedIssuer(c)));
+
+  const handleTokenExchange = async (c: Context, issuer: string) => {
     try {
       const body = await c.req.json();
       const parsed = parseRequest(tokenExchangeSchema, body);
       const negativeTestMode = resolveNegativeTestMode(parsed.negativeTestMode);
-      const issuer = getIssuerForRequest(
-        c,
-        options.issuerBasePath,
-        trustForwardedHeaders
-      );
       const identityPayload = decodeJwtPayloadUnsafe(parsed.identityAssertion);
       const subject = identityPayload.sub || "user-12345";
       // Carry the ID token's email into the ID-JAG (spec RECOMMENDED) so the
@@ -504,7 +559,11 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
         { status: 400, code: "VALIDATION_ERROR" }
       );
     }
-  });
+  };
+
+  router.post("/token-exchange", (c) =>
+    handleTokenExchange(c, unscopedIssuer(c))
+  );
 
   router.post("/proxy/token", async (c) => {
     try {
@@ -757,7 +816,7 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
   // Negative-test scorecard: fire each deliberately-broken ID-JAG mode at the
   // user's authorization server and report whether the server correctly
   // rejected it (pass) or wrongly issued a token (fail — a real finding).
-  router.post("/negative-tests", async (c) => {
+  const handleNegativeTests = async (c: Context, issuer: string) => {
     let parsed;
     try {
       parsed = parseRequest(negativeTestsSchema, await c.req.json());
@@ -874,11 +933,6 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
       );
     }
 
-    const issuer = getIssuerForRequest(
-      c,
-      options.issuerBasePath,
-      trustForwardedHeaders
-    );
     const subject = parsed.subject || "user-12345";
 
     const runCase = async (
@@ -998,7 +1052,64 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
       results,
       failures: results.filter((r) => r.verdict === "fail").length,
     });
-  });
+  };
+
+  router.post("/negative-tests", (c) =>
+    handleNegativeTests(c, unscopedIssuer(c))
+  );
+
+  // Org-scoped issuer surface: the same mock IdP under /o/:orgId, where the
+  // path segment becomes part of `iss` and minting requires org membership.
+  // The well-known documents stay public — remote authorization servers fetch
+  // them unauthenticated — and serve the same global JWKS (one signing key;
+  // containment comes from gating the mint, not from key separation). Each
+  // org-scoped issuer is modeled as a single-tenant issuer: `iss` alone
+  // identifies the tenant, so ID-JAGs carry no `tenant` claim.
+  if (authorizeOrgIssuer) {
+    const scopedIssuer = (c: Context, orgId: string): string =>
+      `${unscopedIssuer(c)}/o/${orgId}`;
+
+    const validateOrgSegment = (c: Context): string | Response => {
+      const orgId = c.req.param("orgId");
+      if (!orgId || !ORG_ID_RE.test(orgId)) {
+        return toJsonError("Invalid organization id in issuer path", {
+          status: 400,
+          code: "VALIDATION_ERROR",
+        });
+      }
+      return orgId;
+    };
+
+    router.get("/o/:orgId/.well-known/jwks.json", (c) => {
+      const orgIdOrError = validateOrgSegment(c);
+      if (orgIdOrError instanceof Response) return orgIdOrError;
+      return serveJwks(c);
+    });
+
+    router.get("/o/:orgId/.well-known/openid-configuration", (c) => {
+      const orgIdOrError = validateOrgSegment(c);
+      if (orgIdOrError instanceof Response) return orgIdOrError;
+      return serveOpenidConfiguration(c, scopedIssuer(c, orgIdOrError));
+    });
+
+    router.post("/o/:orgId/authenticate", async (c) => {
+      const orgIdOrError = await requireScopedOrg(c);
+      if (orgIdOrError instanceof Response) return orgIdOrError;
+      return handleAuthenticate(c, scopedIssuer(c, orgIdOrError));
+    });
+
+    router.post("/o/:orgId/token-exchange", async (c) => {
+      const orgIdOrError = await requireScopedOrg(c);
+      if (orgIdOrError instanceof Response) return orgIdOrError;
+      return handleTokenExchange(c, scopedIssuer(c, orgIdOrError));
+    });
+
+    router.post("/o/:orgId/negative-tests", async (c) => {
+      const orgIdOrError = await requireScopedOrg(c);
+      if (orgIdOrError instanceof Response) return orgIdOrError;
+      return handleNegativeTests(c, scopedIssuer(c, orgIdOrError));
+    });
+  }
 
   return router;
 }

--- a/mcpjam-inspector/server/routes/mcp/xaa.ts
+++ b/mcpjam-inspector/server/routes/mcp/xaa.ts
@@ -78,6 +78,20 @@ function checkNegativeTestHostCap(host: string): boolean {
 // is rejected rather than normalized.
 const ORG_ID_RE = /^[A-Za-z0-9_-]{1,64}$/;
 
+// Single source of truth for the `:orgId` path check, shared by the public
+// well-known routes and the gated mint routes so they can never validate org
+// ids differently. Returns the validated id or the 400 Response to send.
+function validateOrgSegment(c: Context): string | Response {
+  const orgId = c.req.param("orgId");
+  if (!orgId || !ORG_ID_RE.test(orgId)) {
+    return toJsonError("Invalid organization id in issuer path", {
+      status: 400,
+      code: "VALIDATION_ERROR",
+    });
+  }
+  return orgId;
+}
+
 const authenticateSchema = z.object({
   userId: z.string().trim().min(1).optional(),
   email: z.string().trim().email().optional(),
@@ -393,13 +407,9 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
   // membership via the backend. Returns the validated orgId, or the error
   // Response to send. Fail-closed: any backend failure blocks the mint.
   const requireScopedOrg = async (c: Context): Promise<string | Response> => {
-    const orgId = c.req.param("orgId");
-    if (!orgId || !ORG_ID_RE.test(orgId)) {
-      return toJsonError("Invalid organization id in issuer path", {
-        status: 400,
-        code: "VALIDATION_ERROR",
-      });
-    }
+    const orgIdOrError = validateOrgSegment(c);
+    if (orgIdOrError instanceof Response) return orgIdOrError;
+    const orgId = orgIdOrError;
     const authHeader = c.req.header("authorization");
     if (!authHeader?.startsWith("Bearer ")) {
       return toJsonError(
@@ -1068,17 +1078,6 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
   if (authorizeOrgIssuer) {
     const scopedIssuer = (c: Context, orgId: string): string =>
       `${unscopedIssuer(c)}/o/${orgId}`;
-
-    const validateOrgSegment = (c: Context): string | Response => {
-      const orgId = c.req.param("orgId");
-      if (!orgId || !ORG_ID_RE.test(orgId)) {
-        return toJsonError("Invalid organization id in issuer path", {
-          status: 400,
-          code: "VALIDATION_ERROR",
-        });
-      }
-      return orgId;
-    };
 
     router.get("/o/:orgId/.well-known/jwks.json", (c) => {
       const orgIdOrError = validateOrgSegment(c);

--- a/mcpjam-inspector/server/routes/web/__tests__/xaa.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/xaa.test.ts
@@ -1,9 +1,13 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Hono } from "hono";
 import { mkdtempSync, rmSync } from "fs";
 import os from "os";
 import path from "path";
 import xaaWeb from "../xaa.js";
+import { createXaaRouter } from "../../mcp/xaa.js";
+import { bearerAuthMiddleware } from "../../../middleware/bearer-auth.js";
+import { guestRateLimitMiddleware } from "../../../middleware/guest-rate-limit.js";
+import { ErrorCode, WebRouteError } from "../errors.js";
 import {
   initXAAIdpKeyPair,
   resetXAAIdpKeyPairForTests,
@@ -162,5 +166,181 @@ describe("web xaa routes", () => {
     const payload = decodeJwtPayload(tokenExchangeBody.id_jag);
     expect(payload.client_id).toBe("mcpjam-debugger");
     expect(tokenExchangeBody.negative_test_mode).toBe("unknown_kid");
+  });
+});
+
+describe("org-scoped issuer routes", () => {
+  const originalKeyDir = process.env.XAA_IDP_KEY_DIR;
+  const ORG_ID = "org_a1B2-c3";
+  let tempDir: string;
+  let app: Hono;
+  let authorizeOrgIssuer: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), "xaa-scoped-route-"));
+    process.env.XAA_IDP_KEY_DIR = tempDir;
+    resetXAAIdpKeyPairForTests();
+    initXAAIdpKeyPair();
+
+    authorizeOrgIssuer = vi.fn().mockResolvedValue(undefined);
+    app = new Hono();
+    app.route(
+      "/api/web/xaa",
+      createXaaRouter({
+        issuerBasePath: "/api/web",
+        httpsOnlyProxy: true,
+        trustForwardedHeaders: true,
+        protectedMiddlewares: [bearerAuthMiddleware, guestRateLimitMiddleware],
+        authorizeOrgIssuer,
+      }),
+    );
+  });
+
+  afterEach(() => {
+    resetXAAIdpKeyPairForTests();
+    rmSync(tempDir, { recursive: true, force: true });
+    if (originalKeyDir === undefined) {
+      delete process.env.XAA_IDP_KEY_DIR;
+    } else {
+      process.env.XAA_IDP_KEY_DIR = originalKeyDir;
+    }
+  });
+
+  it("serves scoped discovery publicly with the scoped issuer and shared JWKS", async () => {
+    const discoveryResponse = await app.request(
+      `https://app.mcpjam.com/api/web/xaa/o/${ORG_ID}/.well-known/openid-configuration`,
+    );
+    const jwksResponse = await app.request(
+      `https://app.mcpjam.com/api/web/xaa/o/${ORG_ID}/.well-known/jwks.json`,
+    );
+    const unscopedJwksResponse = await app.request(
+      "https://app.mcpjam.com/api/web/xaa/.well-known/jwks.json",
+    );
+
+    expect(discoveryResponse.status).toBe(200);
+    const discoveryBody = await discoveryResponse.json();
+    expect(discoveryBody.issuer).toBe(
+      `https://app.mcpjam.com/api/web/xaa/o/${ORG_ID}`,
+    );
+    expect(discoveryBody.jwks_uri).toBe(
+      `https://app.mcpjam.com/api/web/xaa/o/${ORG_ID}/.well-known/jwks.json`,
+    );
+
+    expect(jwksResponse.status).toBe(200);
+    // Same signing key on every issuer path — containment comes from gating
+    // the mint, not from key separation.
+    expect(await jwksResponse.json()).toEqual(await unscopedJwksResponse.json());
+    // Public documents never trigger a membership check.
+    expect(authorizeOrgIssuer).not.toHaveBeenCalled();
+  });
+
+  it("rejects a malformed org segment on public and mint routes", async () => {
+    const badSegment = encodeURIComponent("org/../../etc");
+    const discoveryResponse = await app.request(
+      `/api/web/xaa/o/${badSegment}/.well-known/openid-configuration`,
+    );
+    expect(discoveryResponse.status).toBe(400);
+
+    const mintResponse = await app.request(
+      `/api/web/xaa/o/${badSegment}/authenticate`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer workos-token",
+        },
+        body: JSON.stringify({ userId: "user-12345" }),
+      },
+    );
+    expect(mintResponse.status).toBe(400);
+    expect(authorizeOrgIssuer).not.toHaveBeenCalled();
+  });
+
+  it("requires a bearer on scoped mint endpoints", async () => {
+    const response = await app.request(`/api/web/xaa/o/${ORG_ID}/authenticate`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ userId: "user-12345" }),
+    });
+
+    expect(response.status).toBe(401);
+    expect(authorizeOrgIssuer).not.toHaveBeenCalled();
+  });
+
+  it("rejects the mint when the membership check fails", async () => {
+    authorizeOrgIssuer.mockRejectedValueOnce(
+      new WebRouteError(403, ErrorCode.FORBIDDEN, "Not a member"),
+    );
+
+    const response = await app.request(`/api/web/xaa/o/${ORG_ID}/authenticate`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer workos-token",
+      },
+      body: JSON.stringify({ userId: "user-12345" }),
+    });
+
+    expect(response.status).toBe(403);
+    expect(authorizeOrgIssuer).toHaveBeenCalledWith({
+      organizationId: ORG_ID,
+      bearerToken: "workos-token",
+    });
+  });
+
+  it("mints the ID token and ID-JAG with the org-scoped issuer", async () => {
+    const headers = {
+      "Content-Type": "application/json",
+      Authorization: "Bearer workos-token",
+      "x-forwarded-proto": "https",
+    };
+
+    const authenticateResponse = await app.request(
+      `http://app.mcpjam.com/api/web/xaa/o/${ORG_ID}/authenticate`,
+      {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ userId: "user-12345" }),
+      },
+    );
+    expect(authenticateResponse.status).toBe(200);
+    const authenticateBody = await authenticateResponse.json();
+    expect(decodeJwtPayload(authenticateBody.id_token).iss).toBe(
+      `https://app.mcpjam.com/api/web/xaa/o/${ORG_ID}`,
+    );
+
+    const tokenExchangeResponse = await app.request(
+      `http://app.mcpjam.com/api/web/xaa/o/${ORG_ID}/token-exchange`,
+      {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          identityAssertion: authenticateBody.id_token,
+          audience: "https://auth.example.com",
+          resource: "https://mcp.example.com",
+          clientId: "mcpjam-debugger",
+        }),
+      },
+    );
+
+    expect(tokenExchangeResponse.status).toBe(200);
+    const payload = decodeJwtPayload(
+      (await tokenExchangeResponse.json()).id_jag,
+    );
+    expect(payload.iss).toBe(
+      `https://app.mcpjam.com/api/web/xaa/o/${ORG_ID}`,
+    );
+    expect(authorizeOrgIssuer).toHaveBeenCalledTimes(2);
+  });
+
+  it("leaves the unscoped endpoints unchanged", async () => {
+    const response = await app.request(
+      "https://app.mcpjam.com/api/web/xaa/.well-known/openid-configuration",
+    );
+    expect(response.status).toBe(200);
+    expect((await response.json()).issuer).toBe(
+      "https://app.mcpjam.com/api/web/xaa",
+    );
+    expect(authorizeOrgIssuer).not.toHaveBeenCalled();
   });
 });

--- a/mcpjam-inspector/server/routes/web/xaa.ts
+++ b/mcpjam-inspector/server/routes/web/xaa.ts
@@ -1,6 +1,7 @@
 import { bearerAuthMiddleware } from "../../middleware/bearer-auth.js";
 import { guestRateLimitMiddleware } from "../../middleware/guest-rate-limit.js";
 import {
+  authorizeXaaOrgIssuer,
   fetchServerClientSecret,
   fetchXaaResourceAppSecret,
 } from "../../utils/server-secrets.js";
@@ -13,6 +14,9 @@ const xaaWeb = createXaaRouter({
   protectedMiddlewares: [bearerAuthMiddleware, guestRateLimitMiddleware],
   resolveRegistrationSecret: (args) => fetchXaaResourceAppSecret(args),
   resolveServerSecret: (args) => fetchServerClientSecret(args),
+  // Org-scoped issuer minting (/o/:orgId/...) is hosted-only: membership is
+  // enforced by Convex with the caller's bearer.
+  authorizeOrgIssuer: (args) => authorizeXaaOrgIssuer(args),
 });
 
 export default xaaWeb;

--- a/mcpjam-inspector/server/utils/server-secrets.ts
+++ b/mcpjam-inspector/server/utils/server-secrets.ts
@@ -67,6 +67,7 @@ async function postToConvexAuthorized(args: {
     CONVEX_POST_TIMEOUT_MS
   );
 
+  let body: any = null;
   let response: Response;
   try {
     response = await fetch(`${convexUrl}${args.path}`, {
@@ -78,6 +79,15 @@ async function postToConvexAuthorized(args: {
       body: JSON.stringify(args.body),
       signal: controller.signal,
     });
+    // Read the body while the abort signal is still armed: a Convex action
+    // that flushes headers and then stalls the body would otherwise hang here
+    // indefinitely (the timeout only covered the header round-trip).
+    const text = await response.text();
+    try {
+      body = text ? JSON.parse(text) : null;
+    } catch {
+      // non-JSON body; body stays null
+    }
   } catch (error) {
     const isAbort =
       error instanceof Error &&
@@ -85,20 +95,13 @@ async function postToConvexAuthorized(args: {
         (error as { code?: string }).code === "ABORT_ERR");
     throw new WebRouteError(
       isAbort ? 504 : 502,
-      ErrorCode.SERVER_UNREACHABLE,
+      isAbort ? ErrorCode.TIMEOUT : ErrorCode.SERVER_UNREACHABLE,
       isAbort
         ? `The ${args.serviceName} timed out after ${CONVEX_POST_TIMEOUT_MS}ms`
         : `Failed to reach the ${args.serviceName}: ${parseErrorMessage(error)}`
     );
   } finally {
     clearTimeout(timeoutId);
-  }
-
-  let body: any = null;
-  try {
-    body = await response.json();
-  } catch {
-    // ignored
   }
 
   if (!response.ok || !body?.success) {

--- a/mcpjam-inspector/server/utils/server-secrets.ts
+++ b/mcpjam-inspector/server/utils/server-secrets.ts
@@ -37,6 +37,84 @@ function statusToErrorCode(status: number): ErrorCode {
   return ErrorCode.INTERNAL_ERROR;
 }
 
+const CONVEX_POST_TIMEOUT_MS = 10_000;
+
+/**
+ * POST to a Convex authorized HTTP endpoint, forwarding the caller's bearer so
+ * Convex resolves the identity and enforces membership/ownership. Shared by
+ * every secret-reveal / authorization gate here so the CONVEX_HTTP_URL guard,
+ * timeout, abort/unreachable classification, and `{ success }` envelope check
+ * can't drift across copies. Returns the parsed success body; throws
+ * WebRouteError on any failure. `serviceName` only shapes error copy.
+ */
+async function postToConvexAuthorized(args: {
+  path: string;
+  bearerToken: string;
+  body: Record<string, unknown>;
+  serviceName: string;
+}): Promise<any> {
+  const convexUrl = process.env.CONVEX_HTTP_URL;
+  if (!convexUrl) {
+    throw new WebRouteError(
+      500,
+      ErrorCode.INTERNAL_ERROR,
+      "Server missing CONVEX_HTTP_URL configuration"
+    );
+  }
+  const controller = new AbortController();
+  const timeoutId = setTimeout(
+    () => controller.abort(),
+    CONVEX_POST_TIMEOUT_MS
+  );
+
+  let response: Response;
+  try {
+    response = await fetch(`${convexUrl}${args.path}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${args.bearerToken}`,
+      },
+      body: JSON.stringify(args.body),
+      signal: controller.signal,
+    });
+  } catch (error) {
+    const isAbort =
+      error instanceof Error &&
+      (error.name === "AbortError" ||
+        (error as { code?: string }).code === "ABORT_ERR");
+    throw new WebRouteError(
+      isAbort ? 504 : 502,
+      ErrorCode.SERVER_UNREACHABLE,
+      isAbort
+        ? `The ${args.serviceName} timed out after ${CONVEX_POST_TIMEOUT_MS}ms`
+        : `Failed to reach the ${args.serviceName}: ${parseErrorMessage(error)}`
+    );
+  } finally {
+    clearTimeout(timeoutId);
+  }
+
+  let body: any = null;
+  try {
+    body = await response.json();
+  } catch {
+    // ignored
+  }
+
+  if (!response.ok || !body?.success) {
+    const message =
+      typeof body?.error === "string"
+        ? body.error
+        : `The ${args.serviceName} request failed (${response.status})`;
+    throw new WebRouteError(
+      response.ok ? 500 : response.status,
+      statusToErrorCode(response.ok ? 500 : response.status),
+      message
+    );
+  }
+  return body;
+}
+
 export async function fetchRuntimeServerSecrets(args: {
   bearerToken: string;
   projectId: string;
@@ -180,63 +258,12 @@ export async function fetchXaaResourceAppSecret(args: {
   bearerToken: string;
   registrationId: string;
 }): Promise<XaaResourceAppSecretResult> {
-  const convexUrl = process.env.CONVEX_HTTP_URL;
-  if (!convexUrl) {
-    throw new WebRouteError(
-      500,
-      ErrorCode.INTERNAL_ERROR,
-      "Server missing CONVEX_HTTP_URL configuration"
-    );
-  }
-  const REVEAL_TIMEOUT_MS = 10_000;
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), REVEAL_TIMEOUT_MS);
-
-  let response: Response;
-  try {
-    response = await fetch(`${convexUrl}/web/xaa/resource-app/reveal-secret`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${args.bearerToken}`,
-      },
-      body: JSON.stringify({ id: args.registrationId }),
-      signal: controller.signal,
-    });
-  } catch (error) {
-    const isAbort =
-      error instanceof Error &&
-      (error.name === "AbortError" ||
-        (error as { code?: string }).code === "ABORT_ERR");
-    throw new WebRouteError(
-      isAbort ? 504 : 502,
-      ErrorCode.SERVER_UNREACHABLE,
-      isAbort
-        ? `Secret reveal service timed out after ${REVEAL_TIMEOUT_MS}ms`
-        : `Failed to reach secret reveal service: ${parseErrorMessage(error)}`
-    );
-  } finally {
-    clearTimeout(timeoutId);
-  }
-
-  let body: any = null;
-  try {
-    body = await response.json();
-  } catch {
-    // ignored
-  }
-
-  if (!response.ok || !body?.success) {
-    const message =
-      typeof body?.error === "string"
-        ? body.error
-        : `Secret reveal failed (${response.status})`;
-    throw new WebRouteError(
-      response.ok ? 500 : response.status,
-      statusToErrorCode(response.ok ? 500 : response.status),
-      message
-    );
-  }
+  const body = await postToConvexAuthorized({
+    path: "/web/xaa/resource-app/reveal-secret",
+    bearerToken: args.bearerToken,
+    body: { id: args.registrationId },
+    serviceName: "secret-reveal service",
+  });
 
   if (typeof body.clientSecret !== "string") {
     throw new WebRouteError(
@@ -286,66 +313,12 @@ export async function fetchServerClientSecret(args: {
   serverId: string;
   projectId: string;
 }): Promise<ServerClientSecretResult> {
-  const convexUrl = process.env.CONVEX_HTTP_URL;
-  if (!convexUrl) {
-    throw new WebRouteError(
-      500,
-      ErrorCode.INTERNAL_ERROR,
-      "Server missing CONVEX_HTTP_URL configuration"
-    );
-  }
-  const REVEAL_TIMEOUT_MS = 10_000;
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), REVEAL_TIMEOUT_MS);
-
-  let response: Response;
-  try {
-    response = await fetch(`${convexUrl}/web/xaa/server/reveal-secret`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${args.bearerToken}`,
-      },
-      body: JSON.stringify({
-        serverId: args.serverId,
-        projectId: args.projectId,
-      }),
-      signal: controller.signal,
-    });
-  } catch (error) {
-    const isAbort =
-      error instanceof Error &&
-      (error.name === "AbortError" ||
-        (error as { code?: string }).code === "ABORT_ERR");
-    throw new WebRouteError(
-      isAbort ? 504 : 502,
-      ErrorCode.SERVER_UNREACHABLE,
-      isAbort
-        ? `Secret reveal service timed out after ${REVEAL_TIMEOUT_MS}ms`
-        : `Failed to reach secret reveal service: ${parseErrorMessage(error)}`
-    );
-  } finally {
-    clearTimeout(timeoutId);
-  }
-
-  let body: any = null;
-  try {
-    body = await response.json();
-  } catch {
-    // ignored
-  }
-
-  if (!response.ok || !body?.success) {
-    const message =
-      typeof body?.error === "string"
-        ? body.error
-        : `Secret reveal failed (${response.status})`;
-    throw new WebRouteError(
-      response.ok ? 500 : response.status,
-      statusToErrorCode(response.ok ? 500 : response.status),
-      message
-    );
-  }
+  const body = await postToConvexAuthorized({
+    path: "/web/xaa/server/reveal-secret",
+    bearerToken: args.bearerToken,
+    body: { serverId: args.serverId, projectId: args.projectId },
+    serviceName: "secret-reveal service",
+  });
 
   return {
     clientSecret:
@@ -371,61 +344,10 @@ export async function authorizeXaaOrgIssuer(args: {
   bearerToken: string;
   organizationId: string;
 }): Promise<void> {
-  const convexUrl = process.env.CONVEX_HTTP_URL;
-  if (!convexUrl) {
-    throw new WebRouteError(
-      500,
-      ErrorCode.INTERNAL_ERROR,
-      "Server missing CONVEX_HTTP_URL configuration"
-    );
-  }
-  const AUTHORIZE_TIMEOUT_MS = 10_000;
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), AUTHORIZE_TIMEOUT_MS);
-
-  let response: Response;
-  try {
-    response = await fetch(`${convexUrl}/web/xaa/issuer/authorize`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${args.bearerToken}`,
-      },
-      body: JSON.stringify({ organizationId: args.organizationId }),
-      signal: controller.signal,
-    });
-  } catch (error) {
-    const isAbort =
-      error instanceof Error &&
-      (error.name === "AbortError" ||
-        (error as { code?: string }).code === "ABORT_ERR");
-    throw new WebRouteError(
-      isAbort ? 504 : 502,
-      ErrorCode.SERVER_UNREACHABLE,
-      isAbort
-        ? `Issuer authorization timed out after ${AUTHORIZE_TIMEOUT_MS}ms`
-        : `Failed to reach issuer authorization service: ${parseErrorMessage(error)}`
-    );
-  } finally {
-    clearTimeout(timeoutId);
-  }
-
-  let body: any = null;
-  try {
-    body = await response.json();
-  } catch {
-    // ignored
-  }
-
-  if (!response.ok || !body?.success) {
-    const message =
-      typeof body?.error === "string"
-        ? body.error
-        : `Issuer authorization failed (${response.status})`;
-    throw new WebRouteError(
-      response.ok ? 500 : response.status,
-      statusToErrorCode(response.ok ? 500 : response.status),
-      message
-    );
-  }
+  await postToConvexAuthorized({
+    path: "/web/xaa/issuer/authorize",
+    bearerToken: args.bearerToken,
+    body: { organizationId: args.organizationId },
+    serviceName: "issuer-authorization service",
+  });
 }

--- a/mcpjam-inspector/server/utils/server-secrets.ts
+++ b/mcpjam-inspector/server/utils/server-secrets.ts
@@ -359,3 +359,73 @@ export async function fetchServerClientSecret(args: {
     xaaAllowPathScopedIssuer: body.xaaAllowPathScopedIssuer === true,
   };
 }
+
+/**
+ * Membership gate for the org-scoped MCPJam XAA test issuer
+ * (`/api/web/xaa/o/<orgId>`). Forwards the caller's bearer to Convex, which
+ * resolves the identity and requires org membership (guests are always
+ * rejected there). Throws a WebRouteError on any failure — minting under a
+ * scoped issuer is fail-closed.
+ */
+export async function authorizeXaaOrgIssuer(args: {
+  bearerToken: string;
+  organizationId: string;
+}): Promise<void> {
+  const convexUrl = process.env.CONVEX_HTTP_URL;
+  if (!convexUrl) {
+    throw new WebRouteError(
+      500,
+      ErrorCode.INTERNAL_ERROR,
+      "Server missing CONVEX_HTTP_URL configuration"
+    );
+  }
+  const AUTHORIZE_TIMEOUT_MS = 10_000;
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), AUTHORIZE_TIMEOUT_MS);
+
+  let response: Response;
+  try {
+    response = await fetch(`${convexUrl}/web/xaa/issuer/authorize`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${args.bearerToken}`,
+      },
+      body: JSON.stringify({ organizationId: args.organizationId }),
+      signal: controller.signal,
+    });
+  } catch (error) {
+    const isAbort =
+      error instanceof Error &&
+      (error.name === "AbortError" ||
+        (error as { code?: string }).code === "ABORT_ERR");
+    throw new WebRouteError(
+      isAbort ? 504 : 502,
+      ErrorCode.SERVER_UNREACHABLE,
+      isAbort
+        ? `Issuer authorization timed out after ${AUTHORIZE_TIMEOUT_MS}ms`
+        : `Failed to reach issuer authorization service: ${parseErrorMessage(error)}`
+    );
+  } finally {
+    clearTimeout(timeoutId);
+  }
+
+  let body: any = null;
+  try {
+    body = await response.json();
+  } catch {
+    // ignored
+  }
+
+  if (!response.ok || !body?.success) {
+    const message =
+      typeof body?.error === "string"
+        ? body.error
+        : `Issuer authorization failed (${response.status})`;
+    throw new WebRouteError(
+      response.ok ? 500 : response.status,
+      statusToErrorCode(response.ok ? 500 : response.status),
+      message
+    );
+  }
+}


### PR DESCRIPTION
## What

Per-organization XAA test issuers: `https://app.mcpjam.com/api/web/xaa/o/<orgId>`. Discovery + JWKS stay public under the scoped path; the mint endpoints (`authenticate`, `token-exchange`, `negative-tests`) require a bearer and org membership.

## Why

The hosted mock IdP is one global issuer + one signing key that **any** caller (guests included) can mint under, so a customer who trusts `https://app.mcpjam.com/api/web/xaa` in their authorization server would accept forged assertions from any other MCPJam user. Scoping the issuer per org + gating the mint on membership makes it safe to register with a real AS. Signed-in hosted debugger runs now mint under their org's issuer automatically.

## How

- `createXaaRouter` gains `authorizeOrgIssuer?`; handler bodies refactored to `(c, issuer)` so scoped `/o/:orgId/...` variants reuse them. Same global key/kid — containment comes from gating the mint, not key separation. Each scoped issuer is a **single-tenant** issuer (`iss` alone identifies the tenant; no `tenant` claim).
- `orgId` is format-validated (`/^[A-Za-z0-9_-]{1,64}$/`) before URL-embedding. Issuer host still never taken from forwarded headers.
- `authorizeXaaOrgIssuer` (server-secrets.ts) forwards the caller's bearer to the backend `/web/xaa/issuer/authorize` gate (**depends on MCPJam/mcpjam-backend#684 — deploy first**).
- Client: `mintPathPrefix` scopes the mint calls; IdP card shows the scoped URLs; negative tests fire under the same scoped `iss`.

## Tests

Scoped discovery/JWKS parity, 401 without bearer, 403 on gate rejection, scoped `iss` on success, 400 on bad orgId, local router registers no scoped paths, unscoped unchanged. Full XAA server + client suites green.

## Notes

- Stacked: `xaa-hosted-issuer-local` and `xaa-mock-oidc-idp` build on this.
- Deliberately does **not** touch `XaaCredentialFields.tsx` (in-flight #3049 owns it); expect textual conflicts with #3049 in `xaa.ts`/`xaa-mint.ts` — rebase after it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication-adjacent mint gating and issuer URLs customers trust in external AS config; depends on deploying the Convex `/web/xaa/issuer/authorize` endpoint first.
> 
> **Overview**
> **Per-organization mock IdP issuers** so customers can register a tenant-scoped `iss` with a real authorization server instead of the global issuer any guest could mint under.
> 
> **Server:** When `authorizeOrgIssuer` is set (hosted web router only), `createXaaRouter` registers `/o/:orgId` discovery and JWKS (public, shared signing key) plus gated `authenticate`, `token-exchange`, and `negative-tests`. `orgId` is validated with a strict allowlist before it is embedded in `iss`; mint routes require a bearer and a Convex membership check via `authorizeXaaOrgIssuer`. Handler logic is refactored to `(c, issuer)` so scoped and unscoped paths share the same code; the local MCP router does not register scoped routes.
> 
> **Client:** Hosted flows with an `organizationId` use `mintPathPrefix` `/o/<orgId>` for mint calls, org-scoped IdP URLs in `XAAIdpCard`, issuer resolution that clears on org switch, and org-scoped negative-test endpoints so broken assertions match the positive run’s `iss`.
> 
> **Refactor:** Secret-reveal and issuer authorization share `postToConvexAuthorized` in `server-secrets.ts` for consistent timeouts and error handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 406a4bd7d77870e07d2e845927a14a2a69da7dad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-organization XAA mock IdP issuers at `/api/web/xaa/o/<orgId>` and auto-scopes hosted debugger flows so real authorization servers can trust a tenant-scoped `iss`. Also hardens the Convex POST helper to keep the timeout armed through body reads and return 504 TIMEOUTs on aborts.

- **New Features**
  - Server: adds scoped `/o/:orgId` discovery/JWKS (shared key) and bearer-gated mint routes; unified `orgId` validation; scoped `iss` in ID token and ID-JAG; gating via `authorizeXaaOrgIssuer` using shared `postToConvexAuthorized` (now keeps abort armed and classifies timeouts as 504); unscoped routes unchanged; local router registers no scoped paths.
  - Client: IdP card and flows auto-scope to `/o/<orgId>` when `organizationId` is set; synchronously clears issuer on org switch; state machine adds `mintPathPrefix`; negative tests run under the same scoped `iss`.
  - Tests: cover public scoped discovery/JWKS parity, 401 without bearer, 403 on gate rejection, 400 on bad `orgId`, scoped `iss` propagation, and absence of scoped routes in local mode.

- **Migration**
  - Deploy the backend issuer-authorization endpoint and set `CONVEX_HTTP_URL`.
  - Ensure hosted requests forward a bearer; guests cannot mint under scoped issuers.
  - If you registered the global issuer, switch your AS trust to your org-scoped issuer.

<sup>Written for commit 406a4bd7d77870e07d2e845927a14a2a69da7dad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

