### PR TITLE
feat(xaa): opt-in hosted issuer for local debugger runs — no tunnel needed

### DIFF
--- a/mcpjam-inspector/client/src/components/xaa/NegativeTestScorecard.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/NegativeTestScorecard.tsx
@@ -136,6 +136,10 @@ export function NegativeTestScorecard({
         input.registrationId ?? input.serverId ?? input.tokenEndpoint ?? "",
         input.audience,
         input.resource,
+        // Issuer mode + org change the minted `iss`, so they are part of the
+        // target identity: switching them must reset a prior run's results.
+        input.issuerMode ?? "local",
+        input.organizationId ?? "",
       ].join("|")
     : "";
   useEffect(() => {

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -41,6 +41,7 @@ import {
 } from "@/lib/xaa/types";
 import { createInspectorXAAStateMachine } from "@/lib/xaa/debug-state-machine-adapter";
 import { fetchXaaIdpUrls } from "@/lib/xaa/idp-endpoints";
+import { HOSTED_MODE } from "@/lib/config";
 import { hashXaaTargetId } from "@/lib/xaa/target-telemetry";
 
 // Captured at module load: the XAA route returns null while the feature flag
@@ -142,6 +143,12 @@ export function XAAFlowTab({
   // ── Global run settings + resolved target ──────────────────────────
   const runSettings = useXaaRunSettings();
   const { user: signedInUser } = useAuth();
+  // Local-only hosted-issuer opt-in: mints route through app.mcpjam.com so a
+  // cloud AS can discover the issuer. Requires a signed-in session — a local
+  // guest bearer is signed with a local key the hosted issuer rejects.
+  const canUseHostedIssuer = !HOSTED_MODE && Boolean(signedInUser);
+  const hostedIssuerOptIn =
+    canUseHostedIssuer && runSettings.issuerMode === "hosted";
   const target = useXaaTestTarget({
     server: selectedServer,
     selectedServerName,
@@ -461,10 +468,20 @@ export function XAAFlowTab({
       ...(target.usesServerSideSecret && target.serverId
         ? { serverId: target.serverId, projectId: target.projectId }
         : {}),
-      issuerBaseUrl: resolvedIssuerBaseUrl,
+      // Hosted-issuer runs let the adapter derive the app.mcpjam.com issuer;
+      // the locally-fetched discovery doc would lint against the wrong `iss`.
+      issuerBaseUrl: hostedIssuerOptIn ? undefined : resolvedIssuerBaseUrl,
       organizationId,
+      issuerMode: hostedIssuerOptIn ? "hosted" : "local",
     });
-  }, [runInput, target, updateFlowState, resolvedIssuerBaseUrl, organizationId]);
+  }, [
+    runInput,
+    target,
+    updateFlowState,
+    resolvedIssuerBaseUrl,
+    organizationId,
+    hostedIssuerOptIn,
+  ]);
 
   const handleAdvance = useCallback(async () => {
     if (!isTestable) {
@@ -557,7 +574,12 @@ export function XAAFlowTab({
 
   return (
     <div className="h-full flex flex-col bg-background">
-      <XAAIdpCard organizationId={organizationId ?? null} />
+      <XAAIdpCard
+        organizationId={organizationId ?? null}
+        issuerMode={runSettings.issuerMode}
+        onIssuerModeChange={runSettings.setIssuerMode}
+        canUseHostedIssuer={canUseHostedIssuer}
+      />
       <XAAResourceAppsSection
         organizationId={organizationId ?? null}
         selectedId={selectedRegistrationId}
@@ -685,7 +707,11 @@ export function XAAFlowTab({
         <NegativeTestScorecard
           input={
             scorecard.input
-              ? { ...scorecard.input, organizationId: organizationId ?? null }
+              ? {
+                  ...scorecard.input,
+                  organizationId: organizationId ?? null,
+                  ...(hostedIssuerOptIn ? { issuerMode: "hosted" as const } : {}),
+                }
               : null
           }
           unlocked={positiveRunTargets.has(targetKey)}

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -163,6 +163,14 @@ export function XAAFlowTab({
   const runInput = target.runInput;
   const { targetKey, isTestable } = target;
 
+  // The positive-run unlock must be specific to the exact issuer the run
+  // exercised: switching issuer mode (local↔hosted) or organization changes
+  // the minted `iss`, so a green run under one must NOT unlock negative tests
+  // under another. Key the gate on target + issuer mode + org.
+  const runGateKey = `${targetKey}|${
+    hostedIssuerOptIn ? "hosted" : "local"
+  }|${organizationId ?? ""}`;
+
   const [flowState, setFlowState] = useState<XAAFlowState>(() =>
     buildFlowStateFromInput(target.runInput)
   );
@@ -227,13 +235,13 @@ export function XAAFlowTab({
       // A green run proves the user holds valid client credentials the AS
       // issued — that authorizes broken-token testing against it.
       setPositiveRunTargets((current) => {
-        if (current.has(targetKey)) return current;
+        if (current.has(runGateKey)) return current;
         const next = new Set(current);
-        next.add(targetKey);
+        next.add(runGateKey);
         return next;
       });
     }
-  }, [flowState.currentStep, authServerModeForTelemetry, targetKey]);
+  }, [flowState.currentStep, authServerModeForTelemetry, runGateKey]);
 
   // ── Negative-test scorecard input ───────────────────────────────────
   const scorecard = useMemo((): {
@@ -718,7 +726,7 @@ export function XAAFlowTab({
                 }
               : null
           }
-          unlocked={positiveRunTargets.has(targetKey)}
+          unlocked={positiveRunTargets.has(runGateKey)}
           unavailableReason={scorecard.unavailableReason}
         />
       )}

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -151,6 +151,14 @@ export function XAAFlowTab({
   // signed with a local key the hosted issuer rejects.)
   const canUseHostedIssuer =
     !HOSTED_MODE && Boolean(signedInUser) && Boolean(organizationId);
+  // Why the toggle is disabled — the two gates fail for different reasons and
+  // the hint must name the one the user can act on.
+  const hostedIssuerDisabledReason =
+    HOSTED_MODE || canUseHostedIssuer
+      ? undefined
+      : !signedInUser
+      ? "sign in to mint through the hosted issuer"
+      : "select an organization to mint through the hosted issuer";
   const hostedIssuerOptIn =
     canUseHostedIssuer && runSettings.issuerMode === "hosted";
   const target = useXaaTestTarget({
@@ -591,6 +599,7 @@ export function XAAFlowTab({
         issuerMode={runSettings.issuerMode}
         onIssuerModeChange={runSettings.setIssuerMode}
         canUseHostedIssuer={canUseHostedIssuer}
+        hostedIssuerDisabledReason={hostedIssuerDisabledReason}
       />
       <XAAResourceAppsSection
         organizationId={organizationId ?? null}

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -144,9 +144,13 @@ export function XAAFlowTab({
   const runSettings = useXaaRunSettings();
   const { user: signedInUser } = useAuth();
   // Local-only hosted-issuer opt-in: mints route through app.mcpjam.com so a
-  // cloud AS can discover the issuer. Requires a signed-in session — a local
-  // guest bearer is signed with a local key the hosted issuer rejects.
-  const canUseHostedIssuer = !HOSTED_MODE && Boolean(signedInUser);
+  // cloud AS can discover the issuer. Requires a signed-in session AND an
+  // active org — the hosted mint targets the membership-gated org-scoped
+  // issuer (/o/<orgId>), and the server fails closed without one rather than
+  // downgrading to the forgeable unscoped issuer. (A local guest bearer is
+  // signed with a local key the hosted issuer rejects.)
+  const canUseHostedIssuer =
+    !HOSTED_MODE && Boolean(signedInUser) && Boolean(organizationId);
   const hostedIssuerOptIn =
     canUseHostedIssuer && runSettings.issuerMode === "hosted";
   const target = useXaaTestTarget({

--- a/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
@@ -160,14 +160,17 @@ export function XAAIdpCard({
   issuerMode = "local",
   onIssuerModeChange,
   canUseHostedIssuer = false,
+  hostedIssuerDisabledReason,
 }: {
   organizationId?: string | null;
   /** LOCAL builds only: which issuer mints this run's assertions. */
   issuerMode?: XaaIssuerMode;
   onIssuerModeChange?: (mode: XaaIssuerMode) => void;
-  /** Signed-in gate: a local guest bearer is signed with a local key and the
-   * hosted issuer would reject it, so the toggle needs a real session. */
+  /** Signed-in + active-org gate: a local guest bearer is signed with a local
+   * key the hosted issuer rejects, and the mint targets the org-scoped issuer. */
   canUseHostedIssuer?: boolean;
+  /** Why the toggle is disabled (signed out vs no active org), for the hint. */
+  hostedIssuerDisabledReason?: string;
 }) {
   const hostedIssuerOn =
     !HOSTED_MODE && issuerMode === "hosted" && canUseHostedIssuer;
@@ -251,8 +254,8 @@ export function XAAIdpCard({
               <span className="font-medium text-foreground">
                 Use hosted issuer (app.mcpjam.com)
               </span>
-              {!canUseHostedIssuer && (
-                <span>— sign in to mint through the hosted issuer</span>
+              {!canUseHostedIssuer && hostedIssuerDisabledReason && (
+                <span>— {hostedIssuerDisabledReason}</span>
               )}
             </label>
           )}

--- a/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
@@ -185,17 +185,25 @@ export function XAAIdpCard({
   // the URLs are always visible now, so there's no expand to defer it to.
   const isFirstResolve = useRef(true);
   useEffect(() => {
+    // Clear the first-render flag up front, regardless of mode. Otherwise a
+    // mount in hosted mode (which takes the early return below) would leave it
+    // set, and a later hosted→local toggle would skip the synchronous reset —
+    // leaving the copy fields showing the hosted issuer/JWKS while the run
+    // mints locally. The useState initializer already produced the correct
+    // value for the first render, so only the reset on *changes* is needed.
+    const wasFirstRender = isFirstResolve.current;
+    isFirstResolve.current = false;
+
     if (hostedIssuerOn) {
-      setUrls(getHostedXaaIdpUrls(organizationId));
+      if (!wasFirstRender) {
+        setUrls(getHostedXaaIdpUrls(organizationId));
+      }
       return;
     }
     const controller = new AbortController();
-    // The useState initializer already produced this value on first render;
-    // only reset synchronously when the org actually changes (so a stale
-    // prior-org URL never flashes) to avoid a wasted render on mount.
-    if (isFirstResolve.current) {
-      isFirstResolve.current = false;
-    } else {
+    // Reset synchronously on any change (org switch or a hosted→local toggle)
+    // so a stale hosted/prior-org URL never lingers before discovery resolves.
+    if (!wasFirstRender) {
       setUrls(getXaaIdpUrls(organizationId));
     }
     void fetchXaaIdpUrls(controller.signal, organizationId).then(

--- a/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
@@ -5,9 +5,15 @@ import {
   HoverCardContent,
   HoverCardTrigger,
 } from "@mcpjam/design-system/hover-card";
+import { Switch } from "@mcpjam/design-system/switch";
 import { HOSTED_MODE } from "@/lib/config";
 import { copyToClipboard } from "@/lib/clipboard";
-import { fetchXaaIdpUrls, getXaaIdpUrls } from "@/lib/xaa/idp-endpoints";
+import {
+  fetchXaaIdpUrls,
+  getHostedXaaIdpUrls,
+  getXaaIdpUrls,
+} from "@/lib/xaa/idp-endpoints";
+import type { XaaIssuerMode } from "@/hooks/useXaaRunSettings";
 
 // A compact click-to-copy chip: shows only the label to keep the bar minimal —
 // the long URL stays hidden (revealed on hover via the native title) and the
@@ -151,18 +157,38 @@ function IdpInfo() {
  */
 export function XAAIdpCard({
   organizationId,
+  issuerMode = "local",
+  onIssuerModeChange,
+  canUseHostedIssuer = false,
 }: {
   organizationId?: string | null;
+  /** LOCAL builds only: which issuer mints this run's assertions. */
+  issuerMode?: XaaIssuerMode;
+  onIssuerModeChange?: (mode: XaaIssuerMode) => void;
+  /** Signed-in gate: a local guest bearer is signed with a local key and the
+   * hosted issuer would reject it, so the toggle needs a real session. */
+  canUseHostedIssuer?: boolean;
 }) {
+  const hostedIssuerOn =
+    !HOSTED_MODE && issuerMode === "hosted" && canUseHostedIssuer;
+
   // Start from the browser-origin guess, then swap in the server-advertised
   // issuer once resolved — see fetchXaaIdpUrls for why the guess can be wrong.
-  const [urls, setUrls] = useState(() => getXaaIdpUrls(organizationId));
+  // With the hosted-issuer opt-in on, the URLs are constructed instead:
+  // hosted CORS blocks a local browser from fetching the hosted discovery doc.
+  const [urls, setUrls] = useState(() =>
+    hostedIssuerOn ? getHostedXaaIdpUrls(organizationId) : getXaaIdpUrls(organizationId),
+  );
   const { issuerBaseUrl, openidConfigUrl, jwksUrl } = urls;
 
   // Resolve the real issuer from the server's discovery doc once on mount —
   // the URLs are always visible now, so there's no expand to defer it to.
   const isFirstResolve = useRef(true);
   useEffect(() => {
+    if (hostedIssuerOn) {
+      setUrls(getHostedXaaIdpUrls(organizationId));
+      return;
+    }
     const controller = new AbortController();
     // The useState initializer already produced this value on first render;
     // only reset synchronously when the org actually changes (so a stale
@@ -181,7 +207,7 @@ export function XAAIdpCard({
       },
     );
     return () => controller.abort();
-  }, [organizationId]);
+  }, [organizationId, hostedIssuerOn]);
 
   const isOrgScoped = HOSTED_MODE && Boolean(organizationId);
 
@@ -203,14 +229,51 @@ export function XAAIdpCard({
       </div>
 
       {!HOSTED_MODE && (
-        <div className="mt-3 flex items-start gap-2 text-xs text-muted-foreground">
-          <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-500" />
-          <span>
-            These are local URLs. Your authorization server can only fetch them
-            if it can reach this machine — a cloud-hosted Okta or Auth0 tenant
-            cannot reach <code className="font-mono">localhost</code>. Expose
-            MCPJam with a public tunnel (e.g. ngrok) first.
-          </span>
+        <div className="mt-3 space-y-2 text-xs text-muted-foreground">
+          {onIssuerModeChange && (
+            <label className="flex items-center gap-2">
+              <Switch
+                checked={hostedIssuerOn}
+                disabled={!canUseHostedIssuer}
+                onCheckedChange={(checked) =>
+                  onIssuerModeChange(checked ? "hosted" : "local")
+                }
+                aria-label="Use hosted issuer"
+              />
+              <span className="font-medium text-foreground">
+                Use hosted issuer (app.mcpjam.com)
+              </span>
+              {!canUseHostedIssuer && (
+                <span>— sign in to mint through the hosted issuer</span>
+              )}
+            </label>
+          )}
+          {hostedIssuerOn ? (
+            <div className="flex items-start gap-2">
+              <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+              <span>
+                ID tokens and ID-JAGs are minted by{" "}
+                <code className="font-mono">app.mcpjam.com</code>, so a cloud
+                authorization server can discover this issuer and fetch its
+                JWKS — no tunnel needed. Token requests and MCP calls still run
+                from this machine; your authorization server must be reachable
+                over https.
+              </span>
+            </div>
+          ) : (
+            <div className="flex items-start gap-2">
+              <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-500" />
+              <span>
+                These are local URLs. Your authorization server can only fetch
+                them if it can reach this machine — a cloud-hosted Okta or
+                Auth0 tenant cannot reach{" "}
+                <code className="font-mono">localhost</code>.
+                {onIssuerModeChange
+                  ? " Flip on the hosted issuer above, or expose MCPJam with a public tunnel (e.g. ngrok)."
+                  : " Expose MCPJam with a public tunnel (e.g. ngrok) first."}
+              </span>
+            </div>
+          )}
         </div>
       )}
 

--- a/mcpjam-inspector/client/src/hooks/useXaaRunSettings.ts
+++ b/mcpjam-inspector/client/src/hooks/useXaaRunSettings.ts
@@ -13,20 +13,32 @@ const RUN_SETTINGS_KEY = "mcpjam-xaa-run-settings/v1";
 // once, on first load (mirrors profile.ts XAA_PROFILE_STORAGE_KEY).
 const LEGACY_PROFILE_KEY = "mcpjam-xaa-debugger-profile/v1";
 
+/** Which issuer mints the mock ID token + ID-JAG on a local run. "hosted"
+ * routes the mint through app.mcpjam.com so a cloud authorization server can
+ * discover/validate the issuer — no tunnel needed. Meaningless on hosted
+ * builds (hosted IS the hosted issuer). */
+export type XaaIssuerMode = "local" | "hosted";
+
 export interface XaaRunSettings {
   userId: string;
   email: string;
   negativeTestMode: NegativeTestMode;
+  issuerMode: XaaIssuerMode;
 }
 
 export const DEFAULT_XAA_RUN_SETTINGS: XaaRunSettings = {
   userId: "user-12345",
   email: "demo.user@example.com",
   negativeTestMode: DEFAULT_NEGATIVE_TEST_MODE,
+  issuerMode: "local",
 };
 
 function sanitizeMode(value: unknown): NegativeTestMode {
   return isNegativeTestMode(value) ? value : DEFAULT_NEGATIVE_TEST_MODE;
+}
+
+function sanitizeIssuerMode(value: unknown): XaaIssuerMode {
+  return value === "hosted" ? "hosted" : "local";
 }
 
 function readString(value: unknown, fallback: string): string {
@@ -48,6 +60,7 @@ function loadInitialRunSettings(): XaaRunSettings {
         userId: readString(parsed.userId, DEFAULT_XAA_RUN_SETTINGS.userId),
         email: readString(parsed.email, DEFAULT_XAA_RUN_SETTINGS.email),
         negativeTestMode: sanitizeMode(parsed.negativeTestMode),
+        issuerMode: sanitizeIssuerMode(parsed.issuerMode),
       };
     }
 
@@ -58,6 +71,7 @@ function loadInitialRunSettings(): XaaRunSettings {
         userId: readString(legacy.userId, DEFAULT_XAA_RUN_SETTINGS.userId),
         email: readString(legacy.email, DEFAULT_XAA_RUN_SETTINGS.email),
         negativeTestMode: sanitizeMode(legacy.negativeTestMode),
+        issuerMode: "local",
       };
       try {
         localStorage.setItem(RUN_SETTINGS_KEY, JSON.stringify(migrated));
@@ -114,19 +128,29 @@ export function useXaaRunSettings() {
     [],
   );
 
+  const setIssuerMode = useCallback((mode: XaaIssuerMode) => {
+    setSettings((current) => ({
+      ...current,
+      issuerMode: sanitizeIssuerMode(mode),
+    }));
+  }, []);
+
   return useMemo(
     () => ({
       userId: settings.userId,
       email: settings.email,
       negativeTestMode: settings.negativeTestMode,
+      issuerMode: settings.issuerMode,
       isDefaultIdentity: isDefaultIdentity(settings),
       setNegativeTestMode,
       setIdentity,
+      setIssuerMode,
     }),
     [
       settings,
       setNegativeTestMode,
       setIdentity,
+      setIssuerMode,
     ],
   );
 }

--- a/mcpjam-inspector/client/src/lib/session-token.ts
+++ b/mcpjam-inspector/client/src/lib/session-token.ts
@@ -310,6 +310,14 @@ const HOSTED_AUTH_PATH_PREFIXES = [
   // equivalents are already covered by the `/api/web/` prefix above).
   "/api/mcp/xaa/proxy/token",
   "/api/mcp/xaa/negative-tests",
+  // Local XAA mint paths for the "use hosted issuer" opt-in: the local
+  // server forwards these to app.mcpjam.com with the caller's bearer.
+  // Attaching via authFetch (rather than injecting the header manually) keeps
+  // the on-401 bearer-refresh-and-retry so a stale/expired hosted token
+  // self-heals instead of stranding the flow until a page refresh. Harmless
+  // in pure-local mode: the local mint ignores the header.
+  "/api/mcp/xaa/authenticate",
+  "/api/mcp/xaa/token-exchange",
   // Convex HTTP actions called via absolute URL (OAuth completion, etc.).
   "/web/oauth/",
 ];

--- a/mcpjam-inspector/client/src/lib/xaa/debug-state-machine-adapter.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/debug-state-machine-adapter.ts
@@ -72,12 +72,29 @@ export function createXAADebugRequestExecutor(options?: {
       let requestInit = init;
       if (options?.attachHostedBearer && isMintPath(path)) {
         const authorization = await getApiAuthorizationHeader();
-        if (authorization) {
-          requestInit = {
-            ...init,
-            headers: { ...normalizeHeaders(init?.headers), Authorization: authorization },
+        if (!authorization) {
+          // Fail loudly instead of sending an unauthenticated mint that the
+          // hosted issuer rejects with a bare 401 — which reads as "not signed
+          // in" to a user who is. Happens transiently right after sign-in or
+          // when the cached bearer expired mid-session.
+          return {
+            status: 401,
+            statusText: "Unauthorized",
+            headers: {},
+            ok: false,
+            body: {
+              error:
+                "Couldn't attach your session to the hosted issuer. Sign in again and retry.",
+            },
           };
         }
+        requestInit = {
+          ...init,
+          headers: {
+            ...normalizeHeaders(init?.headers),
+            Authorization: authorization,
+          },
+        };
       }
       const response = await authFetch(`${XAA_API_BASE}${path}`, requestInit);
       const body = await readResponseBody(response);

--- a/mcpjam-inspector/client/src/lib/xaa/debug-state-machine-adapter.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/debug-state-machine-adapter.ts
@@ -1,6 +1,5 @@
 import { HOSTED_MODE } from "@/lib/config";
 import { authFetch } from "@/lib/session-token";
-import { getApiAuthorizationHeader } from "@/lib/apis/web/context";
 import { getHostedXaaIdpUrls } from "./idp-endpoints";
 import { createDebugRequestExecutor } from "@/lib/oauth/debug-state-machine-adapter";
 import { createXAAStateMachine } from "./state-machine";
@@ -52,51 +51,20 @@ async function readResponseBody(response: Response): Promise<any> {
   }
 }
 
-export function createXAADebugRequestExecutor(options?: {
-  /** Local hosted-issuer runs: the mint endpoints need the Convex/WorkOS
-   * bearer so the local server can forward it to app.mcpjam.com. authFetch
-   * doesn't attach it to the local mint paths on its own (they aren't in its
-   * hosted-path allowlist), so set it explicitly — same-origin loopback, and
-   * caller-provided Authorization is preserved by authFetch. */
-  attachHostedBearer?: boolean;
-}): XAARequestExecutor {
+export function createXAADebugRequestExecutor(): XAARequestExecutor {
   const debugRequestExecutor = createDebugRequestExecutor();
-  const isMintPath = (path: string) =>
-    path.endsWith("/authenticate") || path.endsWith("/token-exchange");
 
   return {
     internalRequest: async (
       path: string,
       init?: RequestInit,
     ): Promise<XAARequestResult> => {
-      let requestInit = init;
-      if (options?.attachHostedBearer && isMintPath(path)) {
-        const authorization = await getApiAuthorizationHeader();
-        if (!authorization) {
-          // Fail loudly instead of sending an unauthenticated mint that the
-          // hosted issuer rejects with a bare 401 — which reads as "not signed
-          // in" to a user who is. Happens transiently right after sign-in or
-          // when the cached bearer expired mid-session.
-          return {
-            status: 401,
-            statusText: "Unauthorized",
-            headers: {},
-            ok: false,
-            body: {
-              error:
-                "Couldn't attach your session to the hosted issuer. Sign in again and retry.",
-            },
-          };
-        }
-        requestInit = {
-          ...init,
-          headers: {
-            ...normalizeHeaders(init?.headers),
-            Authorization: authorization,
-          },
-        };
-      }
-      const response = await authFetch(`${XAA_API_BASE}${path}`, requestInit);
+      // authFetch attaches the hosted bearer to the local mint paths (see
+      // HOSTED_AUTH_PATH_PREFIXES) and, crucially, refreshes-and-retries on a
+      // 401 — so a stale/expired hosted token self-heals rather than stranding
+      // the flow. Manual header injection would have made authFetch treat the
+      // auth as caller-provided and skip that retry.
+      const response = await authFetch(`${XAA_API_BASE}${path}`, init);
       const body = await readResponseBody(response);
 
       return {
@@ -151,8 +119,6 @@ export function createInspectorXAAStateMachine(
     issuerBaseUrl: issuerBaseUrl ?? defaultIssuerBaseUrl,
     mintPathPrefix,
     ...(hostedIssuerOptIn ? { issuerMode: "hosted", organizationId } : {}),
-    requestExecutor: createXAADebugRequestExecutor({
-      attachHostedBearer: hostedIssuerOptIn,
-    }),
+    requestExecutor: createXAADebugRequestExecutor(),
   });
 }

--- a/mcpjam-inspector/client/src/lib/xaa/debug-state-machine-adapter.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/debug-state-machine-adapter.ts
@@ -1,5 +1,7 @@
 import { HOSTED_MODE } from "@/lib/config";
 import { authFetch } from "@/lib/session-token";
+import { getApiAuthorizationHeader } from "@/lib/apis/web/context";
+import { getHostedXaaIdpUrls } from "./idp-endpoints";
 import { createDebugRequestExecutor } from "@/lib/oauth/debug-state-machine-adapter";
 import { createXAAStateMachine } from "./state-machine";
 import type {
@@ -50,15 +52,34 @@ async function readResponseBody(response: Response): Promise<any> {
   }
 }
 
-export function createXAADebugRequestExecutor(): XAARequestExecutor {
+export function createXAADebugRequestExecutor(options?: {
+  /** Local hosted-issuer runs: the mint endpoints need the Convex/WorkOS
+   * bearer so the local server can forward it to app.mcpjam.com. authFetch
+   * doesn't attach it to the local mint paths on its own (they aren't in its
+   * hosted-path allowlist), so set it explicitly — same-origin loopback, and
+   * caller-provided Authorization is preserved by authFetch. */
+  attachHostedBearer?: boolean;
+}): XAARequestExecutor {
   const debugRequestExecutor = createDebugRequestExecutor();
+  const isMintPath = (path: string) =>
+    path.endsWith("/authenticate") || path.endsWith("/token-exchange");
 
   return {
     internalRequest: async (
       path: string,
       init?: RequestInit,
     ): Promise<XAARequestResult> => {
-      const response = await authFetch(`${XAA_API_BASE}${path}`, init);
+      let requestInit = init;
+      if (options?.attachHostedBearer && isMintPath(path)) {
+        const authorization = await getApiAuthorizationHeader();
+        if (authorization) {
+          requestInit = {
+            ...init,
+            headers: { ...normalizeHeaders(init?.headers), Authorization: authorization },
+          };
+        }
+      }
+      const response = await authFetch(`${XAA_API_BASE}${path}`, requestInit);
       const body = await readResponseBody(response);
 
       return {
@@ -95,17 +116,26 @@ export function createInspectorXAAStateMachine(
     // Hosted runs mint under the org-scoped issuer (/o/<orgId>) when the user
     // belongs to an organization; local runs and guests stay unscoped.
     organizationId?: string | null;
+    // LOCAL runs only: "hosted" mints via app.mcpjam.com (forwarded by the
+    // local server) so a cloud AS can discover the issuer. Ignored on hosted
+    // builds — hosted IS the hosted issuer.
+    issuerMode?: "local" | "hosted";
   },
 ): XAAStateMachine {
-  const { issuerBaseUrl, organizationId, ...rest } = config;
+  const { issuerBaseUrl, organizationId, issuerMode, ...rest } = config;
+  const hostedIssuerOptIn = !HOSTED_MODE && issuerMode === "hosted";
   const mintPathPrefix =
     HOSTED_MODE && organizationId ? `/o/${organizationId}` : "";
+  const defaultIssuerBaseUrl = hostedIssuerOptIn
+    ? getHostedXaaIdpUrls(organizationId).issuerBaseUrl
+    : `${window.location.origin}${XAA_API_BASE}${mintPathPrefix}`;
   return createXAAStateMachine({
     ...rest,
-    issuerBaseUrl:
-      issuerBaseUrl ??
-      `${window.location.origin}${XAA_API_BASE}${mintPathPrefix}`,
+    issuerBaseUrl: issuerBaseUrl ?? defaultIssuerBaseUrl,
     mintPathPrefix,
-    requestExecutor: createXAADebugRequestExecutor(),
+    ...(hostedIssuerOptIn ? { issuerMode: "hosted", organizationId } : {}),
+    requestExecutor: createXAADebugRequestExecutor({
+      attachHostedBearer: hostedIssuerOptIn,
+    }),
   });
 }

--- a/mcpjam-inspector/client/src/lib/xaa/discovery-client.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/discovery-client.ts
@@ -114,6 +114,11 @@ export interface NegativeTestsInput {
   // Hosted runs mint the broken assertions under the org-scoped issuer so
   // they carry the same `iss` the positive run used.
   organizationId?: string | null;
+  // LOCAL runs only: "hosted" asks the local server to forward the whole run
+  // to the hosted issuer, so the broken assertions carry the hosted `iss` the
+  // AS actually trusts (a local `iss` would make every case "pass" on issuer
+  // mismatch alone).
+  issuerMode?: "local" | "hosted";
 }
 
 /**
@@ -125,14 +130,20 @@ export interface NegativeTestsInput {
 export async function runNegativeTests(
   input: NegativeTestsInput
 ): Promise<NegativeTestsResult> {
-  const { organizationId, ...requestBody } = input;
+  const { organizationId, issuerMode, ...requestBody } = input;
+  // Hosted builds hit the scoped PATH; local hosted-issuer runs carry the
+  // opt-in in the BODY and the local server forwards server-to-server.
   const scopedSegment = getOrgScopedIssuerSegment(organizationId);
+  const forwardExtras =
+    !HOSTED_MODE && issuerMode === "hosted"
+      ? { issuerMode, ...(organizationId ? { organizationId } : {}) }
+      : {};
   const response = await authFetch(
     `${XAA_API_BASE}${scopedSegment}/negative-tests`,
     {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(requestBody),
+      body: JSON.stringify({ ...requestBody, ...forwardExtras }),
     }
   );
 

--- a/mcpjam-inspector/client/src/lib/xaa/idp-endpoints.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/idp-endpoints.ts
@@ -33,8 +33,20 @@ export function getOrgScopedIssuerSegment(
  * These URLs are constructed, not fetched — hosted CORS blocks a local
  * browser from reading the hosted discovery doc directly.
  */
+// The LOCAL server relays hosted-issuer mints to its MCPJAM_HOSTED_ORIGIN
+// (server env), and we advertise THAT issuer's discovery/JWKS URLs — so the
+// client must resolve the same origin, not a hardcoded one. Read
+// VITE_MCPJAM_HOSTED_ORIGIN, defaulting to app.mcpjam.com exactly like the
+// server; set both together when pointing at a staging/self-hosted origin,
+// otherwise the advertised URLs would name a different key than signs the token.
+const HOSTED_ISSUER_ORIGIN =
+  (import.meta.env.VITE_MCPJAM_HOSTED_ORIGIN as string | undefined)?.replace(
+    /\/+$/,
+    "",
+  ) || MCPJAM_HOSTED_APP_ORIGIN;
+
 export function getHostedXaaIdpUrls(organizationId?: string | null): XaaIdpUrls {
-  const issuerBaseUrl = `${MCPJAM_HOSTED_APP_ORIGIN}/api/web/xaa${
+  const issuerBaseUrl = `${HOSTED_ISSUER_ORIGIN}/api/web/xaa${
     organizationId ? `/o/${organizationId}` : ""
   }`;
   return {

--- a/mcpjam-inspector/client/src/lib/xaa/idp-endpoints.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/idp-endpoints.ts
@@ -1,4 +1,5 @@
 import { HOSTED_MODE } from "@/lib/config";
+import { MCPJAM_HOSTED_APP_ORIGIN } from "@/lib/oauth/constants";
 
 export interface XaaIdpUrls {
   issuerBaseUrl: string;
@@ -21,6 +22,26 @@ export function getOrgScopedIssuerSegment(
   organizationId?: string | null,
 ): string {
   return HOSTED_MODE && organizationId ? `/o/${organizationId}` : "";
+}
+
+/**
+ * The hosted issuer a LOCAL run advertises when the "Use hosted issuer"
+ * opt-in is on: minting is forwarded server-to-server to app.mcpjam.com, so
+ * the token's `iss` (and the JWKS a remote AS fetches) live on the hosted
+ * origin regardless of this build's mode. Signed-in users mint under their
+ * org-scoped issuer; without an org the legacy unscoped issuer applies.
+ * These URLs are constructed, not fetched — hosted CORS blocks a local
+ * browser from reading the hosted discovery doc directly.
+ */
+export function getHostedXaaIdpUrls(organizationId?: string | null): XaaIdpUrls {
+  const issuerBaseUrl = `${MCPJAM_HOSTED_APP_ORIGIN}/api/web/xaa${
+    organizationId ? `/o/${organizationId}` : ""
+  }`;
+  return {
+    issuerBaseUrl,
+    openidConfigUrl: `${issuerBaseUrl}/.well-known/openid-configuration`,
+    jwksUrl: `${issuerBaseUrl}/.well-known/jwks.json`,
+  };
 }
 
 /**

--- a/mcpjam-inspector/client/src/lib/xaa/state-machine.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/state-machine.ts
@@ -375,6 +375,8 @@ export function createXAAStateMachine(
     serverUrl,
     issuerBaseUrl,
     mintPathPrefix = "",
+    issuerMode,
+    organizationId,
     requestExecutor,
     negativeTestMode,
     userId,
@@ -387,6 +389,14 @@ export function createXAAStateMachine(
     serverId,
     projectId,
   } = config;
+
+  // Body fields the LOCAL server uses to forward the mint to the hosted
+  // issuer (server-to-server); stripped before the upstream call. Hosted
+  // routers ignore them.
+  const hostedIssuerBodyExtras =
+    issuerMode === "hosted"
+      ? { issuerMode, ...(organizationId ? { organizationId } : {}) }
+      : {};
 
   const state: Partial<XAAFlowState> = initialState ?? {};
 
@@ -748,6 +758,7 @@ export function createXAAStateMachine(
         userId: activeUserId,
         email: activeEmail,
         audience: state.clientId || "mcpjam-xaa-debugger",
+        ...hostedIssuerBodyExtras,
       },
     };
 
@@ -842,6 +853,7 @@ export function createXAAStateMachine(
         clientId: state.clientId,
         scope: state.scope,
         negativeTestMode: state.negativeTestMode,
+        ...hostedIssuerBodyExtras,
       },
     };
 

--- a/mcpjam-inspector/client/src/lib/xaa/types.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/types.ts
@@ -155,6 +155,10 @@ export interface BaseXAAStateMachineConfig {
    * e.g. `/o/<orgId>` for the hosted org-scoped issuer. Never applied to the
    * token proxy, which has no scoped variant. Defaults to "" (unscoped). */
   mintPathPrefix?: string;
+  /** LOCAL runs only: "hosted" adds `issuerMode`/`organizationId` to the mint
+   * request bodies so the local server forwards them to the hosted issuer. */
+  issuerMode?: "local" | "hosted";
+  organizationId?: string | null;
   requestExecutor: XAARequestExecutor;
   scheduleAutoAdvance?: (next: () => void) => void;
   negativeTestMode?: NegativeTestMode;

--- a/mcpjam-inspector/docs/xaa-hosted-issuer.md
+++ b/mcpjam-inspector/docs/xaa-hosted-issuer.md
@@ -1,0 +1,65 @@
+# Testing XAA with a local MCP server and a cloud authorization server — no tunnel
+
+The most common Cross-App Access (XAA) dev setup is:
+
+- your **MCP server** running on `localhost`,
+- your **authorization server** running in the cloud (Scalekit, Okta, Auth0, …),
+- MCPJam running locally as the debugger.
+
+Out of the box this breaks at issuer discovery: a local MCPJam run advertises an
+issuer like `http://127.0.0.1:6274/api/mcp/xaa`, and a cloud authorization
+server validating the ID-JAG can't fetch that issuer's discovery document or
+JWKS. Historically the workaround was moving everything to
+`app.mcpjam.com` and exposing your MCP server with ngrok.
+
+The **"Use hosted issuer"** toggle (XAA tab → identity-provider bar) removes
+the tunnel entirely. Only the *minting* of the mock ID token and ID-JAG needs a
+publicly reachable issuer — so with the toggle on, your local MCPJam forwards
+just those mint calls, server-to-server, to `app.mcpjam.com` using your
+signed-in session. Everything else stays on your machine:
+
+| Step | Where it runs |
+| --- | --- |
+| Mock SSO + ID-JAG mint | `app.mcpjam.com` (forwarded, signed by the hosted key) |
+| ID-JAG → access token at *your* AS | your machine → your cloud AS |
+| MCP request with the access token | your machine → `localhost` MCP server |
+
+## Setup
+
+1. Sign in to MCPJam locally (the toggle is disabled for guests — a local
+   guest session can't authenticate to the hosted issuer).
+2. In the XAA tab, flip **Use hosted issuer (app.mcpjam.com)**. The issuer /
+   OpenID config / JWKS chips switch to your **organization-scoped** hosted
+   issuer:
+
+   ```
+   https://app.mcpjam.com/api/web/xaa/o/<your-org-id>
+   ```
+
+3. In your authorization server, trust that issuer for ID-JAGs (issuer URL or
+   JWKS URL — both resolve to the same keys) and register the client ID the
+   debugger presents.
+4. Run the flow. The decoded ID-JAG's `iss` is the hosted issuer; the token
+   request and the final MCP call originate from your machine.
+
+## Why the issuer is organization-scoped
+
+Minting under `…/xaa/o/<orgId>` requires being a signed-in member of that
+organization, so an authorization server that trusts your scoped issuer can
+only receive assertions minted by your org's members. The legacy unscoped
+issuer (`https://app.mcpjam.com/api/web/xaa`) is mintable by anyone with an
+MCPJam session — treat it as throwaway/test-only and prefer the scoped issuer
+whenever you register MCPJam in a real authorization server.
+
+## Notes and limits
+
+- **Negative tests** are forwarded too. They mint deliberately-broken
+  assertions, and those must carry the same hosted `iss` as the positive run —
+  otherwise every case would be rejected for issuer mismatch and the scorecard
+  would "pass" without testing anything.
+- Because forwarded runs execute the outbound token calls from the hosted
+  service, your authorization server must be reachable over **https** for the
+  negative-test scorecard. The positive flow's token request still runs
+  locally, so a localhost AS keeps working with the toggle **off**.
+- The hosted origin can be overridden for staging with the
+  `MCPJAM_HOSTED_ORIGIN` env var on the local inspector server.

--- a/mcpjam-inspector/docs/xaa-hosted-issuer.md
+++ b/mcpjam-inspector/docs/xaa-hosted-issuer.md
@@ -51,6 +51,19 @@ issuer (`https://app.mcpjam.com/api/web/xaa`) is mintable by anyone with an
 MCPJam session — treat it as throwaway/test-only and prefer the scoped issuer
 whenever you register MCPJam in a real authorization server.
 
+## Known limitation: runtime XAA connect still uses the unscoped issuer
+
+The **debugger** advertises and mints under the org-scoped issuer
+(`…/o/<orgId>`). The **runtime** XAA connect path (a normal server connection
+that authenticates via XAA, in `server/routes/web/auth.ts` /
+`server/utils/local-server-resolver.ts`) still mints under the unscoped issuer
+(`resolveXaaIssuer` → `/api/web/xaa`). So a customer who registers the
+org-scoped issuer from the debugger can pass the debugger but have a real
+connect/token-exchange fail on `iss` mismatch. Plumbing org-scoped issuers into
+runtime connect (with the same membership gate) is a follow-up; until then, for
+a live connection register the unscoped issuer, or use the debugger only for
+issuer/JWKS validation.
+
 ## Notes and limits
 
 - **This mode is for a *remote* authorization server.** The hosted issuer only

--- a/mcpjam-inspector/docs/xaa-hosted-issuer.md
+++ b/mcpjam-inspector/docs/xaa-hosted-issuer.md
@@ -53,13 +53,25 @@ whenever you register MCPJam in a real authorization server.
 
 ## Notes and limits
 
-- **Negative tests** are forwarded too. They mint deliberately-broken
-  assertions, and those must carry the same hosted `iss` as the positive run —
-  otherwise every case would be rejected for issuer mismatch and the scorecard
-  would "pass" without testing anything.
-- Because forwarded runs execute the outbound token calls from the hosted
-  service, your authorization server must be reachable over **https** for the
-  negative-test scorecard. The positive flow's token request still runs
-  locally, so a localhost AS keeps working with the toggle **off**.
-- The hosted origin can be overridden for staging with the
-  `MCPJAM_HOSTED_ORIGIN` env var on the local inspector server.
+- **This mode is for a *remote* authorization server.** The hosted issuer only
+  helps when your AS is somewhere it can reach — i.e. a public https AS. A
+  `localhost`/plain-http AS is contradictory here: the positive flow's token
+  request still runs from your machine and may reach it, but the **negative
+  test scorecard** is fired from the hosted service and will reject a
+  loopback/http endpoint (`URL not allowed`). If your AS is local, keep the
+  toggle **off** and use the local issuer.
+- **Negative tests** are forwarded too, so the broken assertions carry the same
+  hosted `iss` as the positive run — otherwise every case would be rejected for
+  issuer mismatch and the scorecard would "pass" without testing anything.
+- **Sign in to the same organization the hosted issuer validates against.** The
+  mint targets `…/o/<your-org-id>`, and app.mcpjam.com checks org membership
+  against its own (production) backend. Point your local inspector's
+  `VITE_CONVEX_URL` at the same backend and be a member of that org, or the
+  hosted mint fails closed with an authorization error. The toggle is disabled
+  when you have no active organization.
+- **Staging / self-hosted origin:** override the hosted origin with
+  `MCPJAM_HOSTED_ORIGIN` on the inspector **server** and the matching
+  `VITE_MCPJAM_HOSTED_ORIGIN` at **client** build time. Set both — the server
+  relays the mint there and the client advertises that origin's discovery/JWKS
+  URLs, so a mismatch would name a different key than signs the token. Both
+  default to `https://app.mcpjam.com`.

--- a/mcpjam-inspector/server/config.ts
+++ b/mcpjam-inspector/server/config.ts
@@ -86,6 +86,13 @@ export const WEB_CONNECT_TIMEOUT_MS = 10_000;
 export const WEB_CALL_TIMEOUT_MS = 30_000;
 export const WEB_STREAM_TIMEOUT_MS = 120_000;
 
+// Hosted app origin the LOCAL inspector server forwards XAA hosted-issuer
+// mint requests to (server-to-server; hosted CORS blocks the browser from
+// calling it directly). Override for staging. Never derived from a request.
+export const MCPJAM_HOSTED_ORIGIN =
+  process.env.MCPJAM_HOSTED_ORIGIN?.replace(/\/+$/, "") ||
+  "https://app.mcpjam.com";
+
 // Allowed hosts for token delivery in hosted mode (comma-separated)
 // These hosts will be allowed to receive session tokens in addition to localhost
 export const ALLOWED_HOSTS = process.env.MCPJAM_ALLOWED_HOSTS

--- a/mcpjam-inspector/server/routes/mcp/__tests__/xaa.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/xaa.test.ts
@@ -752,3 +752,226 @@ describe("org-scoped issuer paths on the local router", () => {
     expect(mint.status).toBe(404);
   });
 });
+
+describe("hosted-issuer forwarding on the local router", () => {
+  const HOSTED_ORIGIN = "https://app.example.com";
+
+  function buildApp() {
+    const app = new Hono();
+    app.route(
+      "/api/mcp/xaa",
+      createXaaRouter({
+        issuerBasePath: "/api/mcp",
+        httpsOnlyProxy: false,
+        forwardHostedIssuer: { origin: HOSTED_ORIGIN },
+      })
+    );
+    return app;
+  }
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("forwards issuerMode:hosted mints to the scoped hosted endpoint with the bearer", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({ id_token: "hosted-token", token_type: "Bearer" })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const app = buildApp();
+    const response = await app.request("/api/mcp/xaa/authenticate", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer workos-token",
+      },
+      body: JSON.stringify({
+        userId: "user-12345",
+        issuerMode: "hosted",
+        organizationId: "org_123",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ id_token: "hosted-token" });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(`${HOSTED_ORIGIN}/api/web/xaa/o/org_123/authenticate`);
+    expect((init.headers as Record<string, string>).Authorization).toBe(
+      "Bearer workos-token"
+    );
+    // The opt-in fields are stripped before the upstream call.
+    const forwarded = JSON.parse(String(init.body));
+    expect(forwarded).toEqual({ userId: "user-12345" });
+  });
+
+  it("falls back to the legacy unscoped issuer when no organizationId is sent", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ id_token: "x" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const app = buildApp();
+    const response = await app.request("/api/mcp/xaa/authenticate", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer workos-token",
+      },
+      body: JSON.stringify({ userId: "user-12345", issuerMode: "hosted" }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      `${HOSTED_ORIGIN}/api/web/xaa/authenticate`
+    );
+  });
+
+  it("rejects a hosted mint without a bearer, without calling upstream", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const app = buildApp();
+    const response = await app.request("/api/mcp/xaa/token-exchange", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        identityAssertion: "a.b.c",
+        audience: "https://auth.example.com",
+        resource: "https://mcp.example.com",
+        clientId: "mcpjam-debugger",
+        issuerMode: "hosted",
+      }),
+    });
+
+    expect(response.status).toBe(401);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a malformed organizationId before calling upstream", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const app = buildApp();
+    const response = await app.request("/api/mcp/xaa/authenticate", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer workos-token",
+      },
+      body: JSON.stringify({
+        issuerMode: "hosted",
+        organizationId: "not/valid",
+      }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the upstream status verbatim", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse(
+          { code: "RATE_LIMITED", message: "Too many requests" },
+          { status: 429 }
+        )
+      )
+    );
+
+    const app = buildApp();
+    const response = await app.request("/api/mcp/xaa/authenticate", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer workos-token",
+      },
+      body: JSON.stringify({ issuerMode: "hosted", organizationId: "org1" }),
+    });
+
+    expect(response.status).toBe(429);
+    expect((await response.json()).code).toBe("RATE_LIMITED");
+  });
+
+  it("mints locally when issuerMode is absent, without touching fetch", async () => {
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), "xaa-fwd-local-"));
+    const originalDir = process.env.XAA_IDP_KEY_DIR;
+    process.env.XAA_IDP_KEY_DIR = tempDir;
+    resetXAAIdpKeyPairForTests();
+    initXAAIdpKeyPair();
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      const app = buildApp();
+      const response = await app.request(
+        "http://127.0.0.1:6274/api/mcp/xaa/authenticate",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ userId: "user-12345" }),
+        }
+      );
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(decodeJwtPayload(body.id_token).iss).toBe(
+        "http://127.0.0.1:6274/api/mcp/xaa"
+      );
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      resetXAAIdpKeyPairForTests();
+      rmSync(tempDir, { recursive: true, force: true });
+      if (originalDir === undefined) {
+        delete process.env.XAA_IDP_KEY_DIR;
+      } else {
+        process.env.XAA_IDP_KEY_DIR = originalDir;
+      }
+    }
+  });
+
+  it("ignores issuerMode on a router without forwarding configured (hosted)", async () => {
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), "xaa-fwd-hosted-"));
+    const originalDir = process.env.XAA_IDP_KEY_DIR;
+    process.env.XAA_IDP_KEY_DIR = tempDir;
+    resetXAAIdpKeyPairForTests();
+    initXAAIdpKeyPair();
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      const app = new Hono();
+      app.route(
+        "/api/web/xaa",
+        createXaaRouter({
+          issuerBasePath: "/api/web",
+          httpsOnlyProxy: true,
+        })
+      );
+      const response = await app.request(
+        "https://app.mcpjam.com/api/web/xaa/authenticate",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ userId: "user-12345", issuerMode: "hosted" }),
+        }
+      );
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(decodeJwtPayload(body.id_token).iss).toBe(
+        "https://app.mcpjam.com/api/web/xaa"
+      );
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      resetXAAIdpKeyPairForTests();
+      rmSync(tempDir, { recursive: true, force: true });
+      if (originalDir === undefined) {
+        delete process.env.XAA_IDP_KEY_DIR;
+      } else {
+        process.env.XAA_IDP_KEY_DIR = originalDir;
+      }
+    }
+  });
+});

--- a/mcpjam-inspector/server/routes/mcp/__tests__/xaa.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/xaa.test.ts
@@ -807,8 +807,8 @@ describe("hosted-issuer forwarding on the local router", () => {
     expect(forwarded).toEqual({ userId: "user-12345" });
   });
 
-  it("falls back to the legacy unscoped issuer when no organizationId is sent", async () => {
-    const fetchMock = vi.fn(async () => jsonResponse({ id_token: "x" }));
+  it("fails closed (no unscoped fallback) when organizationId is missing", async () => {
+    const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
 
     const app = buildApp();
@@ -821,9 +821,40 @@ describe("hosted-issuer forwarding on the local router", () => {
       body: JSON.stringify({ userId: "user-12345", issuerMode: "hosted" }),
     });
 
-    expect(response.status).toBe(200);
-    expect(fetchMock.mock.calls[0][0]).toBe(
-      `${HOSTED_ORIGIN}/api/web/xaa/authenticate`
+    // No org → reject rather than silently mint under the forgeable unscoped
+    // issuer; never calls upstream.
+    expect(response.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("preserves the upstream status + WWW-Authenticate on a non-JSON hosted error", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response("forbidden", {
+          status: 403,
+          headers: { "WWW-Authenticate": "Bearer error=\"insufficient_scope\"" },
+        })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const app = buildApp();
+    const response = await app.request("/api/mcp/xaa/authenticate", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer workos-token",
+      },
+      body: JSON.stringify({
+        userId: "user-12345",
+        issuerMode: "hosted",
+        organizationId: "org_123",
+      }),
+    });
+
+    // The real hosted 403 must survive the relay, not become a 502 outage.
+    expect(response.status).toBe(403);
+    expect(response.headers.get("www-authenticate")).toContain(
+      "insufficient_scope"
     );
   });
 

--- a/mcpjam-inspector/server/routes/mcp/xaa.ts
+++ b/mcpjam-inspector/server/routes/mcp/xaa.ts
@@ -79,12 +79,17 @@ function checkNegativeTestHostCap(host: string): boolean {
 // is rejected rather than normalized.
 const ORG_ID_RE = /^[A-Za-z0-9_-]{1,64}$/;
 
-// Single source of truth for the `:orgId` path check, shared by the public
-// well-known routes and the gated mint routes so they can never validate org
-// ids differently. Returns the validated id or the 400 Response to send.
+// Single source of truth for what a legal org path segment looks like, shared
+// by the well-known routes, the gated mint routes, and the hosted-issuer
+// forward so they can never validate org ids differently.
+function isValidOrgId(value: unknown): value is string {
+  return typeof value === "string" && ORG_ID_RE.test(value);
+}
+
+// Validates the `:orgId` route param; returns the id or the 400 Response.
 function validateOrgSegment(c: Context): string | Response {
   const orgId = c.req.param("orgId");
-  if (!orgId || !ORG_ID_RE.test(orgId)) {
+  if (!isValidOrgId(orgId)) {
     return toJsonError("Invalid organization id in issuer path", {
       status: 400,
       code: "VALIDATION_ERROR",
@@ -429,25 +434,17 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
     }
 
     const { issuerMode: _issuerMode, organizationId, ...forwardBody } = body;
-    let scopedSegment = "";
-    if (organizationId !== undefined) {
-      if (
-        typeof organizationId !== "string" ||
-        !ORG_ID_RE.test(organizationId)
-      ) {
-        return toJsonError("Invalid organization id", {
-          status: 400,
-          code: "VALIDATION_ERROR",
-        });
-      }
-      scopedSegment = `/o/${organizationId}`;
-    } else {
-      // Signed-in users should always have an org; the legacy unscoped hosted
-      // issuer is mintable by anyone, so a fall-through is worth noticing.
-      logger.info(
-        "[XAA] hosted-issuer forward without organizationId — using the legacy unscoped issuer"
+    // Fail closed: the hosted issuer must be the caller's membership-gated
+    // org-scoped issuer. Falling back to the unscoped issuer (mintable by
+    // anyone) would silently mint a forgeable token under the wrong `iss`, so
+    // a missing/invalid org is rejected rather than quietly downgraded.
+    if (!isValidOrgId(organizationId)) {
+      return toJsonError(
+        "Hosted issuer minting requires an active organization",
+        { status: 400, code: "VALIDATION_ERROR" }
       );
     }
+    const scopedSegment = `/o/${organizationId}`;
 
     let upstream: Response;
     try {
@@ -477,14 +474,51 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
       );
     }
 
-    const upstreamBody = await upstream.json().catch(() => null);
-    if (upstreamBody === null) {
+    const upstreamText = await upstream.text();
+    let upstreamJson: unknown = null;
+    if (upstreamText) {
+      try {
+        upstreamJson = JSON.parse(upstreamText);
+      } catch {
+        // non-JSON body; handled below
+      }
+    }
+
+    // Preserve auth-relevant upstream headers so a hosted challenge survives
+    // the relay instead of being silently dropped.
+    const relayHeaders: Record<string, string> = {};
+    for (const name of ["www-authenticate", "retry-after"]) {
+      const value = upstream.headers.get(name);
+      if (value) relayHeaders[name] = value;
+    }
+
+    // Forward the hosted status verbatim. The normal case (incl. hosted's
+    // own {code,message} error envelopes) is JSON and passes through. A
+    // non-JSON/empty body still keeps the real status, so a hosted 401/403/429
+    // is never masked as a 502 "unreachable" outage.
+    if (upstreamJson !== null && typeof upstreamJson === "object") {
+      return Response.json(upstreamJson, {
+        status: upstream.status,
+        headers: relayHeaders,
+      });
+    }
+    if (upstream.ok) {
       return toJsonError("The hosted issuer returned a non-JSON response", {
         status: 502,
         code: "SERVER_UNREACHABLE",
       });
     }
-    return Response.json(upstreamBody, { status: upstream.status });
+    const message =
+      upstreamText.trim().slice(0, 300) ||
+      `The hosted issuer returned HTTP ${upstream.status}`;
+    return Response.json(
+      {
+        code: upstream.status >= 500 ? "SERVER_UNREACHABLE" : "HOSTED_ISSUER_ERROR",
+        message,
+        error: message,
+      },
+      { status: upstream.status, headers: relayHeaders }
+    );
   };
 
   // Reads the body (Hono caches it, so the handler's own c.req.json() still

--- a/mcpjam-inspector/server/routes/mcp/xaa.ts
+++ b/mcpjam-inspector/server/routes/mcp/xaa.ts
@@ -44,6 +44,7 @@ import type {
   XaaResourceAppSecretResult,
 } from "../../utils/server-secrets.js";
 import { logger } from "../../utils/logger.js";
+import { MCPJAM_HOSTED_ORIGIN } from "../../config.js";
 
 const HEALTH_CHECK_TIMEOUT_MS = 10_000;
 const NEGATIVE_TEST_CASE_TIMEOUT_MS = 8_000;
@@ -308,6 +309,12 @@ interface CreateXaaRouterOptions {
     organizationId: string;
     bearerToken: string;
   }) => Promise<void>;
+  // LOCAL-only: when a mint request carries `issuerMode: "hosted"`, forward it
+  // server-to-server to this hosted origin so the token is signed by the key
+  // the hosted JWKS serves and carries a publicly discoverable `iss`. The
+  // origin is config, never derived from the request. The hosted router never
+  // sets this — hosted IS the hosted issuer and ignores `issuerMode`.
+  forwardHostedIssuer?: { origin: string };
 }
 
 type ParsedJwtPayload = {
@@ -398,6 +405,106 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
       router.use("/o/:orgId/negative-tests", ...protectedMiddlewares);
     }
   }
+
+  const HOSTED_FORWARD_TIMEOUT_MS = 15_000;
+
+  // Server-to-server relay of a mint request to the hosted issuer. The local
+  // server is a pure relay: the caller's bearer is forwarded verbatim (only
+  // to the fixed config origin, never to an AS or MCP server) and the hosted
+  // side's middleware + Convex membership check remain the real authz. The
+  // upstream response body/status surface unchanged so hosted 401/403/429
+  // stay explainable in the debugger.
+  const forwardToHostedIssuer = async (
+    c: Context,
+    path: "/authenticate" | "/token-exchange" | "/negative-tests",
+    body: Record<string, unknown>
+  ): Promise<Response> => {
+    const origin = options.forwardHostedIssuer!.origin;
+    const authHeader = c.req.header("authorization");
+    if (!authHeader?.startsWith("Bearer ")) {
+      return toJsonError(
+        "Minting through the hosted issuer requires signing in",
+        { status: 401, code: "UNAUTHORIZED" }
+      );
+    }
+
+    const { issuerMode: _issuerMode, organizationId, ...forwardBody } = body;
+    let scopedSegment = "";
+    if (organizationId !== undefined) {
+      if (
+        typeof organizationId !== "string" ||
+        !ORG_ID_RE.test(organizationId)
+      ) {
+        return toJsonError("Invalid organization id", {
+          status: 400,
+          code: "VALIDATION_ERROR",
+        });
+      }
+      scopedSegment = `/o/${organizationId}`;
+    } else {
+      // Signed-in users should always have an org; the legacy unscoped hosted
+      // issuer is mintable by anyone, so a fall-through is worth noticing.
+      logger.info(
+        "[XAA] hosted-issuer forward without organizationId — using the legacy unscoped issuer"
+      );
+    }
+
+    let upstream: Response;
+    try {
+      upstream = await fetch(
+        `${origin}/api/web/xaa${scopedSegment}${path}`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: authHeader,
+          },
+          body: JSON.stringify(forwardBody),
+          signal: AbortSignal.timeout(HOSTED_FORWARD_TIMEOUT_MS),
+        }
+      );
+    } catch (error) {
+      const isTimeout =
+        error instanceof Error &&
+        (error.name === "TimeoutError" || error.name === "AbortError");
+      return toJsonError(
+        isTimeout
+          ? `The hosted issuer did not respond within ${HOSTED_FORWARD_TIMEOUT_MS}ms`
+          : `Failed to reach the hosted issuer: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+        { status: isTimeout ? 504 : 502, code: "SERVER_UNREACHABLE" }
+      );
+    }
+
+    const upstreamBody = await upstream.json().catch(() => null);
+    if (upstreamBody === null) {
+      return toJsonError("The hosted issuer returned a non-JSON response", {
+        status: 502,
+        code: "SERVER_UNREACHABLE",
+      });
+    }
+    return Response.json(upstreamBody, { status: upstream.status });
+  };
+
+  // Reads the body (Hono caches it, so the handler's own c.req.json() still
+  // works) and returns the forwarded Response when the request opts into the
+  // hosted issuer; null means "mint locally as usual".
+  const maybeForwardHostedIssuer = async (
+    c: Context,
+    path: "/authenticate" | "/token-exchange" | "/negative-tests"
+  ): Promise<Response | null> => {
+    if (!options.forwardHostedIssuer) return null;
+    const body = await c.req.json().catch(() => null);
+    if (
+      !body ||
+      typeof body !== "object" ||
+      (body as Record<string, unknown>).issuerMode !== "hosted"
+    ) {
+      return null;
+    }
+    return forwardToHostedIssuer(c, path, body as Record<string, unknown>);
+  };
 
   const unscopedIssuer = (c: Context): string =>
     getIssuerForRequest(c, options.issuerBasePath, trustForwardedHeaders);
@@ -511,7 +618,11 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
     }
   };
 
-  router.post("/authenticate", (c) => handleAuthenticate(c, unscopedIssuer(c)));
+  router.post("/authenticate", async (c) => {
+    const forwarded = await maybeForwardHostedIssuer(c, "/authenticate");
+    if (forwarded) return forwarded;
+    return handleAuthenticate(c, unscopedIssuer(c));
+  });
 
   const handleTokenExchange = async (c: Context, issuer: string) => {
     try {
@@ -571,9 +682,11 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
     }
   };
 
-  router.post("/token-exchange", (c) =>
-    handleTokenExchange(c, unscopedIssuer(c))
-  );
+  router.post("/token-exchange", async (c) => {
+    const forwarded = await maybeForwardHostedIssuer(c, "/token-exchange");
+    if (forwarded) return forwarded;
+    return handleTokenExchange(c, unscopedIssuer(c));
+  });
 
   router.post("/proxy/token", async (c) => {
     try {
@@ -1064,9 +1177,15 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
     });
   };
 
-  router.post("/negative-tests", (c) =>
-    handleNegativeTests(c, unscopedIssuer(c))
-  );
+  // Forwarding matters most here: negative tests mint AND fire in one
+  // endpoint, so a local mint would carry the local `iss` and a strict AS
+  // would reject every case for issuer mismatch — a scorecard that "passes"
+  // without testing anything.
+  router.post("/negative-tests", async (c) => {
+    const forwarded = await maybeForwardHostedIssuer(c, "/negative-tests");
+    if (forwarded) return forwarded;
+    return handleNegativeTests(c, unscopedIssuer(c));
+  });
 
   // Org-scoped issuer surface: the same mock IdP under /o/:orgId, where the
   // path segment becomes part of `iss` and minting requires org membership.
@@ -1122,6 +1241,10 @@ const xaa = createXaaRouter({
   // Convex using the caller's bearer; works locally when the user is signed in.
   resolveRegistrationSecret: (args) => fetchXaaResourceAppSecret(args),
   resolveServerSecret: (args) => fetchServerClientSecret(args),
+  // Opt-in per request (issuerMode: "hosted"): mint via app.mcpjam.com so a
+  // cloud AS can discover the issuer — no tunnel needed for the common
+  // local-MCP-server + remote-AS setup.
+  forwardHostedIssuer: { origin: MCPJAM_HOSTED_ORIGIN },
 });
 
 export default xaa;


### PR DESCRIPTION
## What

A signed-in-only **"Use hosted issuer"** toggle on local XAA runs. When on, the local inspector forwards just the mint calls (`authenticate`, `token-exchange`, `negative-tests`) server-to-server to `app.mcpjam.com`, targeting the caller's org-scoped issuer. The AS token request and the localhost MCP call stay on the machine.

## Why

The common XAA dev setup is a localhost MCP server + a cloud authorization server. Local runs advertised a `127.0.0.1` issuer the cloud AS can't discover, forcing users onto hosted + ngrok. Only the *mint* legs need a public issuer, so this removes the tunnel for that setup entirely.

## How

- Hosted CORS is an exact origin allowlist, so the browser can't call the hosted issuer directly — the local server relays. `forwardHostedIssuer: { origin: MCPJAM_HOSTED_ORIGIN }` (config, **never** request-derived); the caller's bearer is forwarded only to that fixed origin; upstream status/body surface verbatim so hosted 401/403/429 stay explainable.
- Client: `issuerMode` run-setting (default `local`), toggle in the IdP card gated on a signed-in session (a local guest bearer is signed with a local key the hosted issuer rejects). Bearer attached explicitly in the adapter for the two mint paths (not by widening `HOSTED_AUTH_PATH_PREFIXES`).
- Negative tests forward too — a locally-minted negative would carry the local `iss` and "pass" on issuer mismatch alone. Hosted routers ignore `issuerMode`.
- Ships `docs/xaa-hosted-issuer.md`.

## Tests

Forward targets the scoped path with the bearer + strips opt-in fields; 401 without bearer (no upstream call); malformed org 400; upstream status surfaced verbatim; `issuerMode` absent → local mint unchanged; hosted router ignores the field. Client state-machine + IdP card tests updated.

## Notes

Stacked on #3103. **Requires MCPJam/mcpjam-backend#684 + #3103 deployed to hosted before this ships** (else the forward 404s). Base will retarget to `main` once #3103 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth forwarding (bearer relay to a fixed hosted origin) and org-scoped mint gating; mistakes could affect token `iss` or negative-test validity, but scope is limited to local XAA debugger paths with fail-closed org validation.
> 
> **Overview**
> Adds a **"Use hosted issuer"** path for local XAA debugging so a cloud authorization server can discover MCPJam’s issuer **without ngrok**, while token exchange and MCP calls still run from the machine.
> 
> **UI & settings:** Persisted `issuerMode` (`local` | `hosted`) in run settings; toggle on the IdP card (signed-in + active org only). IdP chips show constructed `app.mcpjam.com` org-scoped URLs when hosted mode is on. Positive-run unlock and scorecard reset key off issuer mode + org so a green local run does not unlock hosted negative tests.
> 
> **Client flow:** Mint requests carry `issuerMode` / `organizationId`; state machine and negative-test client forward the same opt-in. `authFetch` attaches the hosted bearer to local `/api/mcp/xaa/authenticate` and `token-exchange` (with 401 refresh). Issuer linting uses the hosted issuer URL when opted in.
> 
> **Local server:** `MCPJAM_HOSTED_ORIGIN` config; `forwardHostedIssuer` relays `authenticate`, `token-exchange`, and `negative-tests` to `/api/web/xaa/o/<orgId>` with the caller’s bearer, strips opt-in fields, requires valid org (no unscoped fallback), and preserves upstream status/headers.
> 
> **Docs & tests:** `docs/xaa-hosted-issuer.md`; server tests for forwarding, auth, and error handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 013cb0e1ccc94ea2296122c840a5c56d69ba128b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in “Use hosted issuer” for local XAA runs. Mint calls are relayed to your org‑scoped hosted issuer so a cloud authorization server can discover the issuer without a tunnel; adds a signed‑in + active‑org UI, fail‑closed forwarding, and auto‑healing auth.

- **New Features**
  - XAA: Signed‑in + active‑org toggle saved as `issuerMode`; IdP card shows hosted org‑scoped URLs and a clear disabled reason; positive‑run unlock and scorecard reset are keyed to issuer mode + org.
  - Forwarding: Local server relays `/authenticate`, `/token-exchange`, and `/negative-tests` to fixed `MCPJAM_HOSTED_ORIGIN` with the caller’s bearer via `authFetch` (refreshes on 401); rejects missing/invalid `organizationId` (400), preserves upstream status and `WWW-Authenticate`/`Retry-After`, and never falls back to the unscoped issuer; hosted routers ignore `issuerMode`.
  - Issuer URLs: Client advertises hosted URLs from `VITE_MCPJAM_HOSTED_ORIGIN`; server forwards to `MCPJAM_HOSTED_ORIGIN` (set both together for staging).

- **Migration**
  - Sign in, select an organization, enable “Use hosted issuer,” and trust `https://app.mcpjam.com/api/web/xaa/o/<orgId>` (and its JWKS) in your AS.
  - No tunnel needed; your AS must be reachable over https. This mode targets a remote AS; keep the toggle off for a local/plain‑http AS.
  - For staging/self‑hosted, set both `MCPJAM_HOSTED_ORIGIN` (server) and `VITE_MCPJAM_HOSTED_ORIGIN` (client).
  - Note: Runtime XAA connect still mints under the unscoped hosted issuer; org‑scoped runtime connect is a follow‑up.

<sup>Written for commit 013cb0e1ccc94ea2296122c840a5c56d69ba128b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

