### PR TITLE
refactor(computers): RS256-only terminal-token verify (drop HS256)

### DIFF
--- a/mcpjam-inspector/server/routes/web/__tests__/computer-terminal.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/computer-terminal.test.ts
@@ -1,68 +1,68 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
 import http from "node:http";
 import type { AddressInfo } from "node:net";
 import { WebSocket } from "ws";
 import { Hono } from "hono";
 import { createNodeWebSocket } from "@hono/node-ws";
 import { Sandbox } from "e2b";
+import { SignJWT, exportJWK, generateKeyPair } from "jose";
 import { createComputerTerminalWsHandler } from "../computer-terminal.js";
+import { resetComputerTerminalJwksCacheForTests } from "../../../utils/computers/terminal-token.js";
 
 // Route-level tests for GET /api/web/computers/terminal. Auth mirrors
-// computer-upload.test.ts (locally-signed HS256 tokens, a fetch stub for the
-// control-plane `/computers/sandbox-info` lookup), but the transport under
-// test here is the WS handshake itself: a real http.Server + a real `ws`
-// client, since the token now rides the Sec-WebSocket-Protocol header
-// instead of a fetch-able query string.
+// computer-upload.test.ts (RS256 tokens verified against a stubbed JWKS at
+// `/computers/terminal-jwks`, plus a fetch stub for the control-plane
+// `/computers/sandbox-info` lookup), but the transport under test here is the
+// WS handshake itself: a real http.Server + a real `ws` client, since the
+// token rides the Sec-WebSocket-Protocol header.
 
 vi.mock("e2b", async () => {
   const actual = await vi.importActual<typeof import("e2b")>("e2b");
   return { ...actual, Sandbox: { connect: vi.fn() } };
 });
 
-const SECRET = "test-terminal-secret-0123456789";
 const ISSUER = "https://api.mcpjam.com/computer-terminal";
 const CONVEX_URL = "https://convex.example";
+const KID = "computer-terminal-1";
 
-function b64url(bytes: Uint8Array): string {
-  return Buffer.from(bytes)
-    .toString("base64")
-    .replace(/\+/g, "-")
-    .replace(/\//g, "_")
-    .replace(/=+$/g, "");
-}
+let signingKey: CryptoKey;
+let jwksDoc: unknown;
 
-async function signToken(
-  claims: Record<string, unknown> = {},
-  secret = SECRET
-): Promise<string> {
+beforeAll(async () => {
+  const kp = await generateKeyPair("RS256");
+  signingKey = kp.privateKey as CryptoKey;
+  const jwk = await exportJWK(kp.publicKey);
+  jwksDoc = { keys: [{ ...jwk, kid: KID, alg: "RS256", use: "sig" }] };
+});
+
+async function signToken(claims: Record<string, unknown> = {}): Promise<string> {
   const now = Math.floor(Date.now() / 1000);
-  const full = {
-    iss: ISSUER,
+  const {
+    iss = ISSUER,
+    iat = now,
+    exp = now + 60,
+    ...rest
+  } = {
     purpose: "computer-terminal",
     sub: "users_123",
     computerId: "computers_456",
     projectId: "projects_789",
-    iat: now,
-    exp: now + 60,
     ...claims,
-  };
-  const key = await crypto.subtle.importKey(
-    "raw",
-    new TextEncoder().encode(secret),
-    { name: "HMAC", hash: "SHA-256" },
-    false,
-    ["sign"]
-  );
-  const header = b64url(
-    new TextEncoder().encode(JSON.stringify({ alg: "HS256", typ: "JWT" }))
-  );
-  const payload = b64url(new TextEncoder().encode(JSON.stringify(full)));
-  const sig = await crypto.subtle.sign(
-    "HMAC",
-    key,
-    new TextEncoder().encode(`${header}.${payload}`)
-  );
-  return `${header}.${payload}.${b64url(new Uint8Array(sig))}`;
+  } as Record<string, unknown> & { iss?: string; iat?: number; exp?: number };
+  return new SignJWT(rest)
+    .setProtectedHeader({ alg: "RS256", kid: KID })
+    .setIssuer(iss)
+    .setIssuedAt(iat)
+    .setExpirationTime(exp)
+    .sign(signingKey);
 }
 
 function installSandboxInfoStub(
@@ -92,6 +92,12 @@ function installSandboxInfoStub(
           headers: { "content-type": "application/json" },
         });
       }
+      if (path === "/computers/terminal-jwks") {
+        return new Response(JSON.stringify(jwksDoc), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
       throw new Error(`unexpected path ${path}`);
     })
   );
@@ -101,7 +107,7 @@ function stubConfiguredEnv() {
   vi.stubEnv("CONVEX_HTTP_URL", CONVEX_URL);
   vi.stubEnv("INSPECTOR_SERVICE_TOKEN", "test-svc-token");
   vi.stubEnv("E2B_API_KEY", "e2b_test");
-  vi.stubEnv("COMPUTERS_TERMINAL_TOKEN_SECRET", SECRET);
+  vi.stubEnv("COMPUTERS_TERMINAL_TOKEN_SECRET", "test-terminal-secret-0123456789");
 }
 
 async function startServer(): Promise<{
@@ -166,6 +172,7 @@ describe("GET /api/web/computers/terminal", () => {
     vi.unstubAllGlobals();
     vi.unstubAllEnvs();
     vi.restoreAllMocks();
+    resetComputerTerminalJwksCacheForTests();
   });
 
   it("rejects a token only present in the ?token= query string", async () => {

--- a/mcpjam-inspector/server/routes/web/__tests__/computer-upload.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/computer-upload.test.ts
@@ -1,59 +1,59 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
 import { Hono } from "hono";
+import { SignJWT, exportJWK, generateKeyPair } from "jose";
 import {
   createComputerUploadHandler,
   type UploadSandbox,
 } from "../computer-upload";
+import { resetComputerTerminalJwksCacheForTests } from "../../../utils/computers/terminal-token.js";
 
 // Route-level tests for POST /api/web/computers/upload. The control plane
 // (`/computers/sandbox-info`) is a fetch stub; the E2B sandbox is an injected
-// fake that records makeDir/write calls. Terminal tokens are signed locally
-// with the shared HS256 secret, mirroring computers-terminal-token.test.ts.
+// fake that records makeDir/write calls. Terminal tokens are RS256, verified
+// against a stubbed JWKS at `/computers/terminal-jwks`.
 
-const SECRET = "test-terminal-secret-0123456789";
 const ISSUER = "https://api.mcpjam.com/computer-terminal";
 const CONVEX_URL = "https://convex.example";
+const KID = "computer-terminal-1";
 
-function b64url(bytes: Uint8Array): string {
-  return Buffer.from(bytes)
-    .toString("base64")
-    .replace(/\+/g, "-")
-    .replace(/\//g, "_")
-    .replace(/=+$/g, "");
-}
+let signingKey: CryptoKey;
+let jwksDoc: unknown;
 
-async function signToken(
-  claims: Record<string, unknown> = {},
-  secret = SECRET
-): Promise<string> {
+beforeAll(async () => {
+  const kp = await generateKeyPair("RS256");
+  signingKey = kp.privateKey as CryptoKey;
+  const jwk = await exportJWK(kp.publicKey);
+  jwksDoc = { keys: [{ ...jwk, kid: KID, alg: "RS256", use: "sig" }] };
+});
+
+async function signToken(claims: Record<string, unknown> = {}): Promise<string> {
   const now = Math.floor(Date.now() / 1000);
-  const full = {
-    iss: ISSUER,
+  const {
+    iss = ISSUER,
+    iat = now,
+    exp = now + 60,
+    ...rest
+  } = {
     purpose: "computer-terminal",
     sub: "users_123",
     computerId: "computers_456",
     projectId: "projects_789",
-    iat: now,
-    exp: now + 60,
     ...claims,
-  };
-  const key = await crypto.subtle.importKey(
-    "raw",
-    new TextEncoder().encode(secret),
-    { name: "HMAC", hash: "SHA-256" },
-    false,
-    ["sign"]
-  );
-  const header = b64url(
-    new TextEncoder().encode(JSON.stringify({ alg: "HS256", typ: "JWT" }))
-  );
-  const payload = b64url(new TextEncoder().encode(JSON.stringify(full)));
-  const sig = await crypto.subtle.sign(
-    "HMAC",
-    key,
-    new TextEncoder().encode(`${header}.${payload}`)
-  );
-  return `${header}.${payload}.${b64url(new Uint8Array(sig))}`;
+  } as Record<string, unknown> & { iss?: string; iat?: number; exp?: number };
+  return new SignJWT(rest)
+    .setProtectedHeader({ alg: "RS256", kid: KID })
+    .setIssuer(iss)
+    .setIssuedAt(iat)
+    .setExpirationTime(exp)
+    .sign(signingKey);
 }
 
 function fakeSandbox() {
@@ -106,6 +106,12 @@ function installSandboxInfoStub(
           { status: 200, headers: { "content-type": "application/json" } }
         );
       }
+      if (path === "/computers/terminal-jwks") {
+        return new Response(JSON.stringify(jwksDoc), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
       throw new Error(`unexpected path ${path}`);
     })
   );
@@ -115,7 +121,7 @@ function stubConfiguredEnv() {
   vi.stubEnv("CONVEX_HTTP_URL", CONVEX_URL);
   vi.stubEnv("INSPECTOR_SERVICE_TOKEN", "test-svc-token");
   vi.stubEnv("E2B_API_KEY", "e2b_test");
-  vi.stubEnv("COMPUTERS_TERMINAL_TOKEN_SECRET", SECRET);
+  vi.stubEnv("COMPUTERS_TERMINAL_TOKEN_SECRET", "test-terminal-secret-0123456789");
 }
 
 function createApp(connectSandbox: (id: string) => Promise<UploadSandbox>) {
@@ -153,6 +159,7 @@ afterEach(() => {
   vi.unstubAllGlobals();
   vi.unstubAllEnvs();
   vi.restoreAllMocks();
+  resetComputerTerminalJwksCacheForTests();
 });
 
 describe("POST /api/web/computers/upload", () => {

--- a/mcpjam-inspector/server/routes/web/computer-terminal.ts
+++ b/mcpjam-inspector/server/routes/web/computer-terminal.ts
@@ -13,10 +13,11 @@
  *     custom headers to a WS handshake, and a `?token=` query string would
  *     land in proxy/CDN access logs, so the subprotocol slot is the only
  *     place left to put it. There is no query-string fallback.
- *   - We verify the token LOCALLY (shared HS256 secret) — no Convex round
- *     trip — then exchange the token's `computerId` for the vendor sandbox id
- *     via the secret-gated `/computers/sandbox-info` route. The browser never
- *     sees vendor ids or credentials.
+ *   - We verify the token's RS256 signature against the backend-published
+ *     JWKS (`/computers/terminal-jwks`, short-cached), then exchange the
+ *     token's `computerId` for the vendor sandbox id via the secret-gated
+ *     `/computers/sandbox-info` route. The browser never sees vendor ids or
+ *     credentials.
  *   - Invalid/expired/missing token ⇒ the socket opens and immediately closes
  *     with code 4401 (createEvents cannot return an HTTP rejection once the
  *     client requested an upgrade).

--- a/mcpjam-inspector/server/routes/web/computer-upload.ts
+++ b/mcpjam-inspector/server/routes/web/computer-upload.ts
@@ -12,7 +12,8 @@
  *   - The browser mints a ~60s Convex terminal token and sends it as
  *     `Authorization: Bearer <jwt>` — headers stay out of access/proxy logs,
  *     query strings don't. No `?token=` fallback.
- *   - We verify it LOCALLY (shared HS256 secret) → `computerId`, then exchange
+ *   - We verify its RS256 signature against the backend-published JWKS
+ *     (`/computers/terminal-jwks`, short-cached) → `computerId`, then exchange
  *     it for the vendor sandbox id via the secret-gated `/computers/sandbox-info`
  *     control-plane route. The browser never sees vendor ids or credentials.
  *

--- a/mcpjam-inspector/server/utils/__tests__/computers-terminal-token.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/computers-terminal-token.test.ts
@@ -13,9 +13,8 @@ import {
   resetComputerTerminalJwksCacheForTests,
 } from "../computers/terminal-token";
 
-// Local HS256 signer reproducing the mcpjam-backend mint
-// (convex/lib/computerTerminalToken.ts) so verification is exercised against
-// the exact claim contract without importing across repos.
+// A local HS256 signer (the retired mint mode) — kept only to prove such
+// tokens are now REJECTED, and to build the alg-confusion probe below.
 
 const SECRET = "test-terminal-secret-0123456789";
 const ISSUER = "https://api.mcpjam.com/computer-terminal";
@@ -64,81 +63,19 @@ function baseClaims(): Record<string, unknown> {
   };
 }
 
-beforeEach(() => {
-  vi.stubEnv("COMPUTERS_TERMINAL_TOKEN_SECRET", SECRET);
-});
-
 afterEach(() => {
   vi.unstubAllEnvs();
 });
 
-describe("verifyComputerTerminalToken", () => {
-  it("accepts a valid token and returns its claims", async () => {
+describe("verifyComputerTerminalToken (alg gate)", () => {
+  it("rejects a well-formed HS256 token (RS256 only) before any network call", async () => {
+    // Even a validly-signed HS256 token in the retired shared-secret scheme
+    // is refused — mint is RS256-only now.
     const token = await sign(baseClaims());
-    expect(await verifyComputerTerminalToken(token)).toEqual({
-      userId: "users_123",
-      computerId: "computers_456",
-      projectId: "projects_789",
-    });
-  });
-
-  it("rejects an expired token", async () => {
-    const claims = baseClaims();
-    claims.exp = Math.floor(Date.now() / 1000) - 5;
-    expect(await verifyComputerTerminalToken(await sign(claims))).toBeNull();
-  });
-
-  it("rejects a token AT its exp second (JWT NumericDate: expired at exp, not after)", async () => {
-    const claims = baseClaims();
-    claims.exp = Math.floor(Date.now() / 1000);
-    expect(await verifyComputerTerminalToken(await sign(claims))).toBeNull();
-  });
-
-  it("rejects a missing/foreign purpose claim (other JWT populations)", async () => {
-    const noPurpose = { ...baseClaims() };
-    delete (noPurpose as { purpose?: unknown }).purpose;
-    expect(await verifyComputerTerminalToken(await sign(noPurpose))).toBeNull();
-
-    const wrongPurpose = { ...baseClaims(), purpose: "guest-promotion" };
-    expect(
-      await verifyComputerTerminalToken(await sign(wrongPurpose))
-    ).toBeNull();
-  });
-
-  it("rejects a wrong issuer", async () => {
-    const claims = { ...baseClaims(), iss: "https://evil.example" };
-    expect(await verifyComputerTerminalToken(await sign(claims))).toBeNull();
-  });
-
-  it("rejects a token signed with a different secret", async () => {
-    const token = await sign(baseClaims(), "a-completely-different-secret-xx");
     expect(await verifyComputerTerminalToken(token)).toBeNull();
   });
 
-  it("rejects a tampered payload", async () => {
-    const token = await sign(baseClaims());
-    const [h, p, s] = token.split(".");
-    const payload = JSON.parse(Buffer.from(p, "base64url").toString("utf8"));
-    payload.computerId = "computers_stolen";
-    const forged = b64url(new TextEncoder().encode(JSON.stringify(payload)));
-    expect(await verifyComputerTerminalToken(`${h}.${forged}.${s}`)).toBeNull();
-  });
-
-  it("fails closed when the secret is unconfigured or weak", async () => {
-    const token = await sign(baseClaims());
-    vi.stubEnv("COMPUTERS_TERMINAL_TOKEN_SECRET", "");
-    expect(await verifyComputerTerminalToken(token)).toBeNull();
-    vi.stubEnv("COMPUTERS_TERMINAL_TOKEN_SECRET", "short");
-    expect(await verifyComputerTerminalToken(token)).toBeNull();
-  });
-
-  it("rejects malformed tokens without throwing", async () => {
-    expect(await verifyComputerTerminalToken("")).toBeNull();
-    expect(await verifyComputerTerminalToken("a.b")).toBeNull();
-    expect(await verifyComputerTerminalToken("not!.b64.!!!")).toBeNull();
-  });
-
-  it("rejects unknown algs including none", async () => {
+  it("rejects alg:none and malformed tokens without throwing", async () => {
     const header = b64url(
       new TextEncoder().encode(JSON.stringify({ alg: "none", typ: "JWT" }))
     );
@@ -148,6 +85,9 @@ describe("verifyComputerTerminalToken", () => {
     expect(
       await verifyComputerTerminalToken(`${header}.${payload}.sig`)
     ).toBeNull();
+    expect(await verifyComputerTerminalToken("")).toBeNull();
+    expect(await verifyComputerTerminalToken("a.b")).toBeNull();
+    expect(await verifyComputerTerminalToken("not!.b64.!!!")).toBeNull();
   });
 });
 
@@ -244,9 +184,9 @@ describe("verifyComputerTerminalToken (RS256 via JWKS)", () => {
     ).toBeNull();
   });
 
-  it("rejects an RS256 token that carries no exp (parity with the HS256 path)", async () => {
+  it("rejects an RS256 token that carries no exp", async () => {
     // jose rejects an expired exp but does not require one to be present; the
-    // verifier must, or RS256 tokens would be accepted as never-expiring.
+    // verifier must (requiredClaims), or tokens would verify as never-expiring.
     const token = await signRs256(baseClaims(), { omitExp: true });
     expect(await verifyComputerTerminalToken(token)).toBeNull();
   });
@@ -265,8 +205,8 @@ describe("verifyComputerTerminalToken (RS256 via JWKS)", () => {
 
   it("forecloses alg-confusion: an HS256 token keyed on the public JWK bytes is rejected", async () => {
     // The classic RS256→HS256 downgrade: attacker HMACs with the public key
-    // material. Our dispatch sends alg:HS256 to the shared-secret path only,
-    // so this never meets the public key.
+    // material. The verifier rejects any non-RS256 alg outright, so this never
+    // reaches signature verification.
     const publicJwkBytes = JSON.stringify(await exportJWK(keys.publicKey));
     const token = await sign(baseClaims(), publicJwkBytes);
     expect(await verifyComputerTerminalToken(token)).toBeNull();

--- a/mcpjam-inspector/server/utils/computers/terminal-token.ts
+++ b/mcpjam-inspector/server/utils/computers/terminal-token.ts
@@ -9,21 +9,13 @@
  *   purpose  'computer-terminal'  (REQUIRED — rejects every other JWT population)
  *   sub      Convex users id (owner)   computerId / projectId   exp ~60s
  *
- * Verification dispatches on the token's own `alg` header, and the key
- * material is selected BY algorithm — which forecloses alg-confusion (an
- * HS256 token HMAC'd with the public-key bytes finds only the shared secret
- * on the HS256 path, never the public key):
+ * RS256 only: the token is verified against the backend-published JWKS
+ * (`GET {CONVEX_HTTP_URL}/computers/terminal-jwks`, kid `computer-terminal-1`),
+ * fetched with a short cache. The inspector holds verify-only material and can
+ * never mint. Any other `alg` (including `HS256` and `none`) is rejected.
  *
- *   RS256 — verified against the backend-published JWKS
- *     (`GET {CONVEX_HTTP_URL}/computers/terminal-jwks`, kid
- *     `computer-terminal-1`), fetched with a short cache. This is the
- *     endgame: the inspector holds verify-only material and can never mint.
- *   HS256 — the shared `COMPUTERS_TERMINAL_TOKEN_SECRET`, kept as the
- *     migration fallback until the backend key flip.
- *   anything else (including `none`) — rejected.
- *
- * Fails closed (`null`) whenever the matching key material is unavailable —
- * secret unconfigured, `CONVEX_HTTP_URL` unset, or JWKS unreachable.
+ * Fails closed (`null`) whenever the key material is unavailable —
+ * `CONVEX_HTTP_URL` unset, or JWKS unreachable/empty.
  *
  * The token deliberately carries only MCPJam row ids. The vendor sandbox id
  * is resolved server-side via the secret-gated `/computers/sandbox-info`
@@ -39,7 +31,6 @@ import { logger } from "../logger.js";
 
 const ISSUER = "https://api.mcpjam.com/computer-terminal";
 const PURPOSE = "computer-terminal";
-const MIN_SECRET_LENGTH = 16;
 
 const JWKS_PATH = "/computers/terminal-jwks";
 const JWKS_FETCH_TIMEOUT_MS = 5_000;
@@ -53,16 +44,6 @@ export interface ComputerTerminalClaims {
   userId: string;
   computerId: string;
   projectId: string;
-}
-
-function base64UrlToBytes(input: string): Uint8Array {
-  const padLen = (4 - (input.length % 4)) % 4;
-  const base64 =
-    input.replace(/-/g, "+").replace(/_/g, "/") + "=".repeat(padLen);
-  const binary = atob(base64);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
-  return bytes;
 }
 
 let cachedJwks: {
@@ -183,70 +164,19 @@ async function verifyRs256TerminalToken(
 }
 
 /**
- * Verify a terminal token per the header-alg dispatch documented above.
- * Returns the claims or `null`; never throws on malformed input.
+ * Verify a terminal token (RS256 only, per the doc above). Rejects any other
+ * `alg` before touching the network; returns the claims or `null` and never
+ * throws on malformed input.
  */
 export async function verifyComputerTerminalToken(
   token: string
 ): Promise<ComputerTerminalClaims | null> {
-  const parts = token.split(".");
-  if (parts.length !== 3) return null;
-  const [h, p, s] = parts;
-  if (!h || !p || !s) return null;
-
   let alg: unknown;
   try {
     alg = decodeProtectedHeader(token).alg;
   } catch {
     return null;
   }
-  if (alg === "RS256") {
-    return verifyRs256TerminalToken(token);
-  }
-  if (alg !== "HS256") {
-    return null;
-  }
-
-  const secret = process.env.COMPUTERS_TERMINAL_TOKEN_SECRET?.trim();
-  if (!secret || secret.length < MIN_SECRET_LENGTH) return null;
-
-  let valid: boolean;
-  try {
-    const key = await crypto.subtle.importKey(
-      "raw",
-      new TextEncoder().encode(secret),
-      { name: "HMAC", hash: "SHA-256" },
-      false,
-      ["verify"]
-    );
-    const sigBytes = base64UrlToBytes(s);
-    // Copy into a standalone ArrayBuffer — the server tsconfig has no DOM
-    // lib, so subtle.verify's BufferSource parameter needs an exact match.
-    const signature = sigBytes.buffer.slice(
-      sigBytes.byteOffset,
-      sigBytes.byteOffset + sigBytes.byteLength
-    ) as ArrayBuffer;
-    valid = await crypto.subtle.verify(
-      "HMAC",
-      key,
-      signature,
-      new TextEncoder().encode(`${h}.${p}`)
-    );
-  } catch {
-    return null;
-  }
-  if (!valid) return null;
-
-  let payload: Record<string, unknown>;
-  try {
-    payload = JSON.parse(new TextDecoder().decode(base64UrlToBytes(p)));
-  } catch {
-    return null;
-  }
-  if (payload.iss !== ISSUER) return null;
-  if (typeof payload.exp !== "number") return null;
-  // JWT NumericDate semantics: the token is expired AT `exp`, not after it.
-  if (Math.floor(Date.now() / 1000) >= payload.exp) return null;
-
-  return toTerminalClaims(payload);
+  if (alg !== "RS256") return null;
+  return verifyRs256TerminalToken(token);
 }


### PR DESCRIPTION
**DRAFT — merge only at the cleanup cutover.** PR 4 of the internal-only cleanup stack (inspector side).

## What
`verifyComputerTerminalToken` is RS256 only: it rejects any non-RS256 `alg` (HS256 + `none`) before any network call, then verifies against the published JWKS (`/computers/terminal-jwks`). Drops the HS256 branch, `MIN_SECRET_LENGTH`, and `base64UrlToBytes`; verify no longer reads `COMPUTERS_TERMINAL_TOKEN_SECRET` (that secret now serves only harness proxy tokens).

## Cutover prerequisite (do NOT merge before this)
The RS256 keypair must be set on the deployment(s) — so mint is RS256 (backend #683) — before this verifier-only-RS256 change deploys. Since it's internal, the same coordinated flip covers all data planes.

## Tests
- `computers-terminal-token.test.ts`: keeps a *valid-HS256-token-is-rejected* case + the alg-confusion probe; the RS256/JWKS suite (accept, unknown-kid, expired, no-exp, fail-closed, cooldown, in-flight-memoization) is unchanged.
- `computer-terminal.test.ts` + `computer-upload.test.ts`: mint RS256 tokens with a generated keypair; their fetch stubs serve the JWKS.
- 32 tests across the 3 suites pass; `tsc -p server` unchanged (69 pre-existing; the one `req` unused in the terminal test predates this change and just shifted lines).

Part of the cleanup stack: service-token auth #682 · RS256-only mint #683 · inspector service-token auth #3102 · **[this] inspector RS256-only verify**. That completes the 4-PR stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make terminal-token verification RS256-only and validate against the backend JWKS. Drops the HS256 path and shared-secret dependency, and rejects non-RS256 tokens before any network call.

- **Refactors**
  - `verifyComputerTerminalToken` verifies RS256 via JWKS at `/computers/terminal-jwks` and fails closed if JWKS is unavailable.
  - Rejects `HS256` and `none` upfront to prevent alg confusion.
  - Removed HS256 code, `MIN_SECRET_LENGTH`, and `base64UrlToBytes`; no longer reads `COMPUTERS_TERMINAL_TOKEN_SECRET`.
  - Updated route comments in `computer-terminal.ts` and `computer-upload.ts` to document RS256/JWKS verification.
  - Tests mint RS256 tokens with `jose`, stub the JWKS, and reset the JWKS cache between cases.

- **Migration**
  - Configure the RS256 keypair and switch minting to RS256 in the backend before deploying this change.
  - `COMPUTERS_TERMINAL_TOKEN_SECRET` is no longer used for terminal tokens (still used for harness proxy tokens).

<sup>Written for commit ca347ff4dc1afe4ece678f88916319807e82435a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Auth cutover risk: deploying before backend RS256 mint breaks terminal WebSocket and upload access; the change is security-positive but requires coordinated rollout.
> 
> **Overview**
> **Inspector terminal auth is RS256-only.** `verifyComputerTerminalToken` no longer accepts HS256 tokens signed with `COMPUTERS_TERMINAL_TOKEN_SECRET`; it rejects any `alg` other than RS256 before fetching JWKS, then verifies against `/computers/terminal-jwks` (existing cache/memoization unchanged).
> 
> The HS256 verification branch and related helpers are removed from `terminal-token.ts`. Route docs for the terminal WebSocket and file upload now describe JWKS verification instead of local shared-secret verify.
> 
> Tests mint RS256 JWTs with `jose`, stub the JWKS endpoint, reset the JWKS cache between cases, and keep focused coverage that valid HS256/`none`/malformed tokens are rejected; the RS256/JWKS suite is largely unchanged.
> 
> **Deploy only after the backend mints RS256 terminal tokens** (paired cleanup PR); otherwise terminal and upload auth will fail closed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca347ff4dc1afe4ece678f88916319807e82435a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->