### PR TITLE
docs(analytics): flag audit + migration guide + backend twins plan

### DIFF
--- a/mcpjam-inspector/docs/analytics-backend-twins-plan.md
+++ b/mcpjam-inspector/docs/analytics-backend-twins-plan.md
@@ -1,0 +1,96 @@
+# Backend server-side capture plan (signup + billing + chatbox)
+
+Completes the analytics-capture-resilience project: the events that fire in
+the **Convex backend** (mcpjam-backend), not the inspector. These are the
+highest-value gap — signup and revenue events currently only fire client-side
+and are ad-blockable. This lives in the other repo, so it's a separate PR
+there. It needs a connected Convex deployment (`npx convex codegen` + typecheck
++ deploy) — it can't be verified from the inspector repo.
+
+## What's already there (reuse, don't reinvent)
+
+- `posthog-node@^5.10.2` is a backend dependency.
+- **A working capture pattern exists**: `convex/usage/telemetry.ts` — a
+  `'use node'` module with a warm module-level `PostHog` singleton
+  (`new PostHog(process.env.POSTHOG_API_KEY, { host: 'https://us.i.posthog.com' })`),
+  an `internalAction captureLlmUsagePostHog` that does `posthog.capture(...)`
+  then `await posthog.flush()` (never `shutdown()` — reused workers), and
+  `$insert_id` for idempotency. The scheduling side is
+  `scheduleLlmUsagePostHogCapture` (`convex/usage/create.ts:57`) via
+  `ctx.scheduler.runAfter(0, internal.usage.telemetry.captureLlmUsagePostHog, …)`.
+- `POSTHOG_API_KEY` already holds the public `phc_` token (`.env.local`;
+  add it to `.env.example` and set it as a prod Convex env var).
+
+## Step 1 — generalize into `convex/usage/serverAnalytics.ts` (`'use node'`)
+
+Mirror `telemetry.ts` but generic:
+
+```ts
+'use node';
+import { v } from 'convex/values';
+import { internalAction } from '../_generated/server';
+import { PostHog } from 'posthog-node';
+import { emitOperationalEvent } from '../lib/operationalEvents';
+
+const posthog = process.env.POSTHOG_API_KEY
+  ? new PostHog(process.env.POSTHOG_API_KEY, { host: 'https://us.i.posthog.com' })
+  : null;
+
+export const captureServerEvent = internalAction({
+  args: {
+    distinctId: v.string(),          // MUST be users.externalId (WorkOS id) — see below
+    event: v.string(),
+    insertId: v.string(),            // dedupe key
+    properties: v.optional(v.any()),
+    orgId: v.optional(v.string()),
+  },
+  handler: async (_ctx, args) => {
+    if (!posthog) { emitOperationalEvent('warn', 'server_event_capture_failed', { event: args.event, reason: 'missing_posthog_api_key' }); return; }
+    posthog.capture({
+      distinctId: args.distinctId,
+      event: args.event,
+      properties: { $insert_id: args.insertId, source: 'server', ...(args.orgId ? { organization_id: args.orgId } : {}), ...(args.properties ?? {}) },
+    });
+    await posthog.flush();
+  },
+});
+```
+
+## Step 2 — identity rule (critical)
+
+**`distinctId` MUST be `users.externalId`** (the WorkOS user id / guest JWT
+subject) — the SAME id the inspector client sends. Do **not** use the Convex
+`users._id`. The existing `captureLlmUsagePostHog` uses `_id` for signed-in
+users, which does NOT match the client and splits the person — don't copy that
+choice. Where you only hold a Convex `userId` (billing), resolve externalId
+with a `ctx.runQuery` (add an internal `getUserExternalId(userId)` in
+`convex/users.ts`).
+
+## Step 3 — wire the events
+
+| Event | Site | How | distinctId |
+|-------|------|-----|-----------|
+| `signup_server` | `runWorkOsFirstLoginSideEffects` (`convex/users.ts:339`), next to the `emitDomainEvent('signup.completed')` at `:364` | mutation → `ctx.scheduler.runAfter`. Thread `externalId` into the helper args (caller `upsertUserFromIdentity:221` has it) | `externalId` (already in scope upstream) |
+| `credit_purchased_server` | after the `[billing.credit_purchased]` log, `convex/billingNode.ts:1658` | already a `'use node'` action → capture **inline** (`ctx.runAction(internal.usage.serverAnalytics.captureServerEvent, …)` or import the client). Resolve externalId from `log.purchasedByUserId` via runQuery; if `unknown`, fall back to org-keyed | resolved externalId; else org id + `orgId` |
+| `subscription_created_server` | `checkout.session.completed` (subscription) convergence `convex/billingNode.ts:2394` | inline (Node action). Org-level — key on the purchasing user's externalId if available, else org | externalId or org |
+| `chatbox_published_server` | `createHost` (`convex/hosts.ts:274`), also `duplicateHost:502` | userMutation → schedule. `requireAdminAccess` returns `user` Doc with `user.externalId` | `user.externalId` |
+
+`insertId` suggestions: `signup:<userId>`, `credit_purchased:<stripeSessionId>`,
+`subscription:<stripeSubscriptionId>`, `chatbox_published:<chatboxId>` — stable
+so retries dedupe.
+
+Naming: `_server` suffix matches the inspector's parallel-run policy (the
+client/server pair ratio is the block-rate metric). Mirror these names by hand
+into the inspector's `shared/analytics-events.ts` (the two repos mirror by
+hand) and into the block-rate dashboard.
+
+⚠️ `chatbox_published_server` touches `convex/hosts.ts`, which had uncommitted
+parallel edits as of 2026-07-10 — coordinate to avoid a conflict, or land it
+in a follow-up.
+
+## Step 4 — verify (needs Convex env)
+
+`npx convex codegen` (registers the new action) → `npx tsc --noEmit` → deploy to
+staging → trigger a real signup + a test credit purchase → confirm
+`signup_server` / `credit_purchased_server` land in PostHog with a `distinctId`
+that **matches the same person's client events**.

--- a/mcpjam-inspector/docs/analytics-flag-defaults.md
+++ b/mcpjam-inspector/docs/analytics-flag-defaults.md
@@ -1,0 +1,72 @@
+# Feature-flag defaults audit (ACR-6)
+
+Part of the analytics-capture-resilience project. When PostHog's `/flags`
+endpoint is unreachable, `useFeatureFlagEnabled(flag)` returns `undefined`,
+and every gate in the app resolves that to "off." This audits what each gate
+does in the blocked/unresolved state and whether that default is safe.
+
+## The blocked state is now rare
+
+Before the relay, ad blockers blocked `/decide` at `us.i.posthog.com`, so
+for ~25–40% of web users **every** flag stayed `undefined` and all gated
+surfaces silently disappeared. Since the relay landed (#3095), `/flags`
+resolves same-origin and is no longer ad-blockable, so the blocked state is
+now limited to genuine network failure or the brief first-paint window before
+the flag response returns. The guest-bootstrap change (#3098) further shrinks
+that window. So the defaults below are mostly a **first-paint-flicker**
+concern now, not a "blocked user loses the feature" concern.
+
+## Default behavior: fail-closed everywhere
+
+Every gate resolves `undefined` → **hidden/off**. Two shapes:
+
+- **Boolean gates** (`useFeatureFlagEnabled(flag) === true`): hidden until the
+  flag resolves `true`. The dominant pattern.
+- **Tri-state hooks** (`useSkillsEnabledState`, `useComputersEnabledState`):
+  return `boolean | undefined` so route guards can tell "explicitly disabled"
+  from "not yet resolved" and avoid redirecting a flagged-in user who cold-loads
+  a deep link before flags resolve. The visibility variant (`useSkillsEnabled`)
+  still fails closed.
+
+| Flag | Gates (representative) | Blocked-state default | Safe? |
+|------|------------------------|-----------------------|-------|
+| `billing-entitlements-ui` | `App.tsx:1321`, `OrganizationsTab.tsx:561`, `ShareProjectDialog.tsx:235` | Billing/entitlements UI hidden | ⚠️ see below |
+| `evaluate-ci` | `App.tsx`, `mcp-sidebar.tsx` | Evals-CI nav hidden | ✅ |
+| `mcpjam-learning` | `mcp-sidebar.tsx` | Learning nav hidden | ✅ |
+| `registry-enabled` | `mcp-sidebar.tsx` | Registry nav hidden | ✅ |
+| `mcpjam-conformance` / `mcpjam-compatibility` | `mcp-sidebar.tsx` | Nav hidden | ✅ |
+| `xaa` / `xaa-registration` | `mcp-sidebar.tsx`, XAA components | XAA surfaces hidden | ✅ |
+| `sandboxes-enabled` / `learn-more-enabled` | `mcp-sidebar.tsx` | Nav hidden | ✅ |
+| `skills-enabled` | `useSkillsEnabled(State)` | Skills hidden; route guard waits on tri-state | ✅ |
+| `computers-enabled` | `useComputersEnabled(State)` | Computers hidden; route guard waits on tri-state | ✅ |
+| `claude-code-host-enabled` / `codex-host-enabled` | host hooks | Host template hidden | ✅ |
+| `tool-quality-enabled` | `useToolQualityEnabled` | Quality badges hidden | ✅ |
+| `synthetic-monitors` | evals suite views | Monitors hidden | ✅ |
+| `stateless-mcp-enabled` | per-server protocol toggle | Opt-in stays off | ✅ |
+| `mcp-inspector-multi-host/model-enabled` | playground | Feature off | ✅ |
+
+For every beta/nav/opt-in feature, fail-closed is **correct**: a not-yet-GA
+surface briefly not showing is strictly better than flickering it on for a
+user who shouldn't have it.
+
+## The one to watch: `billing-entitlements-ui`
+
+This gates billing/entitlements UI for **paying** orgs. Fail-closed means: if
+the flag hasn't resolved, a customer who has paid briefly doesn't see the
+billing surface they're entitled to. With the relay + bootstrap this window is
+now small (same-origin, no ad-block), so the residual risk is only the
+first-paint moment on a cold load.
+
+**Recommendation:** leave it fail-closed (showing billing UI to a
+not-entitled org would be worse), but confirm the gate renders a neutral
+loading state — not an "upgrade" CTA — while the flag is `undefined`, so a
+paying customer never momentarily sees an upsell for something they already
+have. The tri-state pattern (`billingUiFlag === undefined` → skeleton, not
+CTA) is the fix if any gate currently shows the un-entitled variant during
+load.
+
+## Verdict
+
+Post-relay, the fail-closed defaults are safe. No gate needs to change its
+default. The only follow-up is the `billing-entitlements-ui` loading-state
+check above — a UX nicety, not a data-loss issue.

--- a/mcpjam-inspector/docs/analytics-migration-guide.md
+++ b/mcpjam-inspector/docs/analytics-migration-guide.md
@@ -1,0 +1,71 @@
+# Migrating raw `posthog.capture()` to `track()` (analytics registry)
+
+Turnkey guide for the incremental migration behind the ratchet fence. This is
+**coverage-neutral** — it changes how events are *called*, not whether they
+fire — so it's safe, mechanical, area-by-area work. Good first issue.
+
+## Why
+
+~75 files still call `posthog.capture("free-string", …)` directly. The typed
+registry (`shared/analytics-events.ts`) + `track()` wrapper
+(`client/src/lib/analytics.ts`) give: one authoritative list of every event,
+compile-time checking of names, auto-injected standard props, and a client
+that can't emit server-authoritative events. The ratchet test
+(`client/src/lib/__tests__/analytics-ratchet.test.ts`) freezes the legacy
+files: no *new* file may add a raw capture, and migrating a file requires
+removing it from the list.
+
+## Per-file recipe
+
+1. **Register the events.** Add each event name this file fires to
+   `shared/analytics-events.ts` with `{ source: "client" }`.
+2. **Swap the import.** Remove `usePostHog` from `posthog-js/react` and
+   `standardEventProps` from `@/lib/PosthogUtils`; add
+   `import { track } from "@/lib/analytics"`.
+3. **Delete `const posthog = usePostHog()`.**
+4. **Convert each call:**
+   ```ts
+   // before
+   posthog?.capture("skill_viewed", { ...standardEventProps("skills_tab"), skill_name });
+   // after
+   track("skill_viewed", { location: "skills_tab", skill_name });
+   ```
+   - `track()` injects `standardEventProps(location)` for you — pass `location`
+     as a prop, drop the spread.
+   - For calls that **don't** currently include `standardEventProps` (some
+     areas omit it — e.g. `PaymentsHistorySection`, `useCreditTopup`), pick a
+     sensible `location` string. This *adds* `platform`/`environment` to those
+     events — a deliberate, beneficial consistency improvement; note it in the
+     PR since it slightly changes the event shape.
+5. **Remove the file from `LEGACY_RAW_CAPTURE_FILES`** in the ratchet test.
+6. **Update any test that mocks `usePostHog`** for this file: mock
+   `@/lib/analytics`'s `track` instead and assert on it. Pattern in
+   `client/src/lib/__tests__/analytics.test.ts`.
+7. Run `npx vitest run --project client src/lib/__tests__/analytics-ratchet.test.ts`
+   — it fails loudly if the file still has a raw capture or the list is stale.
+
+## Reference migration
+
+`client/src/components/SkillsTab.tsx` (commit in #3096) — the canonical
+example: three calls converted, no test coupling.
+
+## Special cases (do last / discuss first)
+
+- **Dynamic event names** — `logger-view.tsx:365`,
+  `shared/ClientContextHeader.tsx:151`, `MultiHostPicker.tsx:212` wrap
+  `useCallback((event, props) => …)` with a runtime event string. `track()`
+  needs a statically-known name, so these need the names hoisted to constants
+  or a small typed dispatcher. Not a straight swap.
+- **`posthogRef.current.capture`** — `hosted/ChatboxChatPage.tsx` holds a ref;
+  migrate the ref usage to `track()` directly (the singleton is fine).
+
+## Suggested order (funnel-first)
+
+1. `billing/` + `useCreditTopup*` — revenue events (7 events).
+2. `signup/OccupationGate.tsx`, `auth/auth-upper-area.tsx`, `use-onboarding.ts`
+   — activation funnel.
+3. `ChatTabV2.tsx`, `ui-playground/PlaygroundMain.tsx` — chat funnel (pairs
+   with the server twins).
+4. Everything else, area by area.
+
+The full frozen list is `LEGACY_RAW_CAPTURE_FILES` in the ratchet test.


### PR DESCRIPTION
Fast-follow docs for the analytics-capture-resilience project (after #3095–#3098 merged and were verified live in prod).

- **`analytics-flag-defaults.md`** (ACR-6) — audit of all ~20 feature-flag gates. Conclusion: now that the relay makes `/flags` reachable same-origin, the fail-closed defaults are safe everywhere; the only follow-up is confirming `billing-entitlements-ui` shows a neutral loading state (not an upsell) while the flag resolves.
- **`analytics-migration-guide.md`** — turnkey recipe for migrating the ~75 remaining raw `posthog.capture()` call sites to `track()` behind the ratchet fence. Coverage-neutral, good first issue.
- **`analytics-backend-twins-plan.md`** — exact implementation plan for the server-side signup/billing/chatbox twins in `mcpjam-backend`: capture points (file:line), the critical identity rule (`users.externalId`, not the Convex `_id`), and how to reuse the existing `telemetry.ts` posthog-node pattern. Documented here because it needs a connected Convex deployment (`codegen` + typecheck + deploy) that can't run from this repo.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no application code, config, or tests change in this PR.
> 
> **Overview**
> Adds three **docs-only** follow-ups for analytics-capture-resilience (no runtime changes).
> 
> **`analytics-flag-defaults.md` (ACR-6)** reframes the PostHog flag audit for the post-relay world: unresolved flags are mostly first-paint flicker, not ad-block loss. It documents that gates still **fail closed** (`undefined` → off) and calls out **`billing-entitlements-ui`** as the only UX follow-up—use a neutral loading state, not an upsell, while the flag is unresolved.
> 
> **`analytics-migration-guide.md`** is a step-by-step recipe to move ~75 legacy `posthog.capture()` sites to typed **`track()`** + **`shared/analytics-events.ts`**, including ratchet test updates (`LEGACY_RAW_CAPTURE_FILES`), test mocking, funnel-first ordering, and called-out dynamic-event exceptions.
> 
> **`analytics-backend-twins-plan.md`** specifies the **mcpjam-backend** work (separate repo): generic **`captureServerEvent`** modeled on existing telemetry, **`users.externalId`** as `distinctId`, wire-up for **`signup_server`**, **`credit_purchased_server`**, **`subscription_created_server`**, and **`chatbox_published_server`**, plus verification steps that need a live Convex deploy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 142c7586c97a33ff5e5d20d4f44f8db26289f2d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds fast-follow analytics docs: flag defaults audit (ACR-6), a migration guide from raw `posthog.capture()` to typed `track()`, and a backend capture plan for signup/billing/chatbox events in `mcpjam-backend`.
Confirms fail-closed gates (with a `billing-entitlements-ui` loading-state check), outlines event registration and testing for the migration, and specifies server capture points plus the `users.externalId` identity rule.

<sup>Written for commit 142c7586c97a33ff5e5d20d4f44f8db26289f2d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

