### PR TITLE
refactor(chat): route live MCPJam chat through shared runAssistantTurn

### DIFF
--- a/mcpjam-inspector/server/routes/web/__tests__/chat-v2.hosted.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chat-v2.hosted.test.ts
@@ -3,7 +3,7 @@ import { Hono } from "hono";
 
 const {
   prepareChatV2Mock,
-  handleMCPJamFreeChatModelMock,
+  runAssistantTurnMock,
   fetchHostRuntimeConfigMock,
   fetchChatboxRuntimeConfigMock,
   persistChatSessionToConvexMock,
@@ -20,7 +20,7 @@ const {
   WidgetModelContextValidationErrorMock,
 } = vi.hoisted(() => ({
   prepareChatV2Mock: vi.fn(),
-  handleMCPJamFreeChatModelMock: vi.fn(),
+  runAssistantTurnMock: vi.fn(),
   fetchHostRuntimeConfigMock: vi.fn(),
   fetchChatboxRuntimeConfigMock: vi.fn(),
   persistChatSessionToConvexMock: vi.fn(),
@@ -107,11 +107,21 @@ vi.mock("../../../utils/chat-v2-orchestration.js", () => ({
 }));
 
 vi.mock("../../../utils/mcpjam-stream-handler.js", () => ({
-  handleMCPJamFreeChatModel: handleMCPJamFreeChatModelMock,
+  // The live MCPJam path now dispatches through runAssistantTurn (mocked
+  // below), so this handler is no longer called directly — keep a stub so the
+  // module still exports the symbol.
+  handleMCPJamFreeChatModel: vi.fn(),
   // No-op dev-only diagnostic; tests don't need real signal-missing
   // logging behavior but must surface the symbol so the route module
   // can import it without ReferenceError.
   warnIfChatAbortSignalMissing: () => {},
+}));
+
+// The live MCPJam chat path routes through runAssistantTurn (streamSink "ui"),
+// which returns `{ response }`. Mock it here so the route's engine dispatch is
+// exercised without the real chat-engine loop.
+vi.mock("../../../utils/assistant-turn.js", () => ({
+  runAssistantTurn: runAssistantTurnMock,
 }));
 
 vi.mock("../../../utils/chat-ingestion.js", async () => {
@@ -180,7 +190,7 @@ describe("web routes — chat-v2 hosted mode", () => {
       config: {},
     });
 
-    handleMCPJamFreeChatModelMock.mockImplementation(async (options: any) => {
+    runAssistantTurnMock.mockImplementation(async (options: any) => {
       await options.onConversationComplete?.(
         [{ role: "user", content: "preview request" }],
         {
@@ -193,7 +203,7 @@ describe("web routes — chat-v2 hosted mode", () => {
         }
       );
       options.onStreamComplete?.();
-      return new Response("ok", { status: 200 });
+      return { response: new Response("ok", { status: 200 }) };
     });
 
     global.fetch = vi.fn(async (input, init) => {
@@ -360,7 +370,7 @@ describe("web routes — chat-v2 hosted mode", () => {
     expect(fetchHostRuntimeConfigMock).toHaveBeenCalledWith(
       expect.objectContaining({ hostId: "host-1" })
     );
-    expect(handleMCPJamFreeChatModelMock).toHaveBeenCalledTimes(1);
+    expect(runAssistantTurnMock).toHaveBeenCalledTimes(1);
   });
 
   it("FAILS CLOSED when the host runtime-config fetch fails — never runs the engine", async () => {
@@ -386,7 +396,7 @@ describe("web routes — chat-v2 hosted mode", () => {
     );
 
     expect(response.status).not.toBe(200);
-    expect(handleMCPJamFreeChatModelMock).not.toHaveBeenCalled();
+    expect(runAssistantTurnMock).not.toHaveBeenCalled();
   });
 
   it("FAILS CLOSED when the chatbox runtime-config fetch fails — never runs the engine", async () => {
@@ -426,7 +436,7 @@ describe("web routes — chat-v2 hosted mode", () => {
     expect(body.code).toBe("INTERNAL_ERROR");
     expect(body.message).toContain("Couldn't load this chatbox's settings");
     expect(body.message).toContain("backend unreachable");
-    expect(handleMCPJamFreeChatModelMock).not.toHaveBeenCalled();
+    expect(runAssistantTurnMock).not.toHaveBeenCalled();
   });
 
   it("a chatbox session ignores a stray hostId (chatbox path wins)", async () => {
@@ -475,7 +485,7 @@ describe("web routes — chat-v2 hosted mode", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(handleMCPJamFreeChatModelMock).toHaveBeenCalledWith(
+    expect(runAssistantTurnMock).toHaveBeenCalledWith(
       expect.objectContaining({
         chatboxId: "cbx_shared",
         accessVersion: 2,

--- a/mcpjam-inspector/server/routes/web/__tests__/chatbox-sessions.byok.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chatbox-sessions.byok.test.ts
@@ -69,6 +69,7 @@ describe("web routes — chatbox-sessions BYOK gate removed", () => {
       config: {
         chatboxId: "cbx-1",
         accessVersion: 0,
+        executionScope: { kind: "project", projectId: "proj-1" },
         // Bare gpt-4o (no openai/ prefix) is BYOK, not MCPJam-provided.
         modelId: "gpt-4o",
         systemPrompt: "",
@@ -103,6 +104,7 @@ describe("web routes — chatbox-sessions BYOK gate removed", () => {
       config: {
         chatboxId: "cbx-2",
         accessVersion: 0,
+        executionScope: { kind: "project", projectId: "proj-1" },
         modelId: "openai/gpt-4o-mini",
         systemPrompt: "",
         temperature: 0.7,
@@ -129,6 +131,7 @@ describe("web routes — chatbox-sessions BYOK gate removed", () => {
       config: {
         chatboxId: "cbx-computer",
         accessVersion: 0,
+        executionScope: { kind: "project", projectId: "proj-1" },
         modelId: "openai/gpt-4o-mini",
         systemPrompt: "",
         temperature: 0.7,
@@ -176,6 +179,7 @@ describe("web routes — chatbox-sessions BYOK gate removed", () => {
       config: {
         chatboxId: "cbx-images",
         accessVersion: 0,
+        executionScope: { kind: "project", projectId: "proj-1" },
         modelId: "openai/gpt-4o-mini",
         systemPrompt: "",
         temperature: 0.7,
@@ -203,5 +207,58 @@ describe("web routes — chatbox-sessions BYOK gate removed", () => {
         mcpToolResultImageRendering,
       })
     );
+  });
+
+  it("rejects a body projectId that mismatches the chatbox's project (403)", async () => {
+    fetchChatboxRuntimeConfigMock.mockResolvedValue({
+      ok: true,
+      config: {
+        chatboxId: "cbx-x",
+        accessVersion: 0,
+        // Chatbox actually belongs to a DIFFERENT project than the body.
+        executionScope: { kind: "project", projectId: "proj-OTHER" },
+        modelId: "openai/gpt-4o-mini",
+        systemPrompt: "",
+        temperature: 0.7,
+        requireToolApproval: false,
+        hostStyle: "default",
+      },
+    });
+
+    const response = await postJson(
+      app,
+      "/api/web/chatboxes/cbx-x/simulate-sessions/start",
+      validBody, // projectId: "proj-1"
+      token,
+    );
+    const { status } = await expectJson<{ runId?: string }>(response);
+    expect(status).toBe(403);
+    expect(createRunMock).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the runtime config can't surface the chatbox's project (403)", async () => {
+    fetchChatboxRuntimeConfigMock.mockResolvedValue({
+      ok: true,
+      config: {
+        chatboxId: "cbx-noscope",
+        accessVersion: 0,
+        // No executionScope -> project binding unverifiable.
+        modelId: "openai/gpt-4o-mini",
+        systemPrompt: "",
+        temperature: 0.7,
+        requireToolApproval: false,
+        hostStyle: "default",
+      },
+    });
+
+    const response = await postJson(
+      app,
+      "/api/web/chatboxes/cbx-noscope/simulate-sessions/start",
+      validBody,
+      token,
+    );
+    const { status } = await expectJson<{ runId?: string }>(response);
+    expect(status).toBe(403);
+    expect(createRunMock).not.toHaveBeenCalled();
   });
 });

--- a/mcpjam-inspector/server/routes/web/__tests__/chatbox-sessions.no-model.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chatbox-sessions.no-model.test.ts
@@ -63,6 +63,7 @@ describe("web routes — simulate-sessions/start on a modelless host", () => {
     config: {
       chatboxId: "cbx-1",
       accessVersion: 0,
+      executionScope: { kind: "project", projectId: "proj-1" },
       modelId,
       systemPrompt: "",
       temperature: 0.7,

--- a/mcpjam-inspector/server/routes/web/__tests__/chatbox-sessions.no-required-servers.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chatbox-sessions.no-required-servers.test.ts
@@ -46,6 +46,21 @@ describe("web routes — chatbox-sessions with no required servers", () => {
     createRunMock.mockReset();
     generatePersonasMock.mockReset();
     startSimulationMock.mockReset();
+    // Default runtime config so the provenance guard can verify the chatbox's
+    // project (generate-personas resolves it too). Per-test mocks override.
+    fetchChatboxRuntimeConfigMock.mockResolvedValue({
+      ok: true,
+      config: {
+        chatboxId: "cbx-1",
+        accessVersion: 0,
+        executionScope: { kind: "project", projectId: "proj-1" },
+        modelId: "openai/gpt-4o-mini",
+        systemPrompt: "",
+        temperature: 0.7,
+        requireToolApproval: false,
+        hostStyle: "default",
+      },
+    });
     createRunMock.mockResolvedValue({ runId: "run-1" });
     startSimulationMock.mockResolvedValue(undefined);
     generatePersonasMock.mockResolvedValue([
@@ -114,6 +129,7 @@ describe("web routes — chatbox-sessions with no required servers", () => {
       config: {
         chatboxId: "cbx-1",
         accessVersion: 0,
+        executionScope: { kind: "project", projectId: "proj-1" },
         modelId: "openai/gpt-4o-mini",
         systemPrompt: "",
         temperature: 0.7,

--- a/mcpjam-inspector/server/routes/web/chatbox-sessions.ts
+++ b/mcpjam-inspector/server/routes/web/chatbox-sessions.ts
@@ -81,6 +81,60 @@ const startSimulationSchema = z.object({
   maxTurns: z.number().int().min(1).max(20),
 });
 
+/**
+ * Provenance guard: the body `projectId` must match the chatbox's OWN project,
+ * resolved server-side from the chatbox runtime config's `executionScope`.
+ * `createAuthorizedManager` already verifies the bearer's membership of the
+ * supplied `projectId`, but NOT that the chatbox belongs to it — without this,
+ * a caller who is a member of both the chatbox's project A AND some project B
+ * could launch chatbox A's run/personas attributed to project B. Reject the
+ * mismatch before any run/manager/simulation exists.
+ *
+ * Fails CLOSED: if the runtime config didn't surface the chatbox's project
+ * (`executionScope.projectId` absent), we can't verify the chatbox↔project
+ * binding, so we reject rather than trust the caller-supplied `projectId`.
+ */
+function assertBodyProjectMatchesChatbox(
+  bodyProjectId: string,
+  executionScope: { projectId?: string } | undefined
+): void {
+  const scopeProjectId = executionScope?.projectId;
+  if (!scopeProjectId) {
+    throw new WebRouteError(
+      403,
+      ErrorCode.FORBIDDEN,
+      "Unable to verify this chatbox's project; refusing to run under an unverified projectId."
+    );
+  }
+  if (bodyProjectId !== scopeProjectId) {
+    throw new WebRouteError(
+      403,
+      ErrorCode.FORBIDDEN,
+      "projectId does not match this chatbox's project"
+    );
+  }
+}
+
+/**
+ * Map a chatbox runtime-config fetch's HTTP status onto the matching
+ * `ErrorCode` so an upstream 401/403/404 doesn't surface to the client as a
+ * generic `INTERNAL_ERROR`.
+ */
+function errorCodeForRuntimeStatus(
+  status: number
+): (typeof ErrorCode)[keyof typeof ErrorCode] {
+  switch (status) {
+    case 401:
+      return ErrorCode.UNAUTHORIZED;
+    case 403:
+      return ErrorCode.FORBIDDEN;
+    case 404:
+      return ErrorCode.NOT_FOUND;
+    default:
+      return ErrorCode.INTERNAL_ERROR;
+  }
+}
+
 function resolveRequiredServers(
   servers: Array<{ serverId: string; serverName?: string; optional?: boolean }>
 ): { selectedServerIds: string[]; selectedServerNames: string[] } {
@@ -109,6 +163,26 @@ chatboxSessions.post("/:chatboxId/generate-personas", async (c) =>
       await readJsonBody<unknown>(c)
     );
     const convexHttpUrl = requireConvexHttpUrl();
+
+    // Provenance guard (same as the start route): resolve the chatbox's own
+    // project server-side and reject a mismatched body projectId before the
+    // authorized manager + backend persona generation run under it.
+    const runtime = await fetchChatboxRuntimeConfig({
+      chatboxId,
+      bearer: bearerToken,
+    });
+    if (!runtime.ok) {
+      throw new WebRouteError(
+        runtime.status,
+        errorCodeForRuntimeStatus(runtime.status),
+        runtime.error
+      );
+    }
+    assertBodyProjectMatchesChatbox(
+      body.projectId,
+      runtime.config.executionScope
+    );
+
     // selectedServerIds may be empty (no required servers): the manager
     // comes back connection-less, the snapshot captures zero servers, and
     // the backend grounds personas in the chatbox name instead of tools.
@@ -196,10 +270,17 @@ chatboxSessions.post("/:chatboxId/simulate-sessions/start", async (c) =>
     if (!runtime.ok) {
       throw new WebRouteError(
         runtime.status,
-        ErrorCode.INTERNAL_ERROR,
+        errorCodeForRuntimeStatus(runtime.status),
         runtime.error
       );
     }
+
+    // Bind the run to the chatbox's own project (server-authoritative) before
+    // createRun/manager/startSimulation run under a caller-supplied projectId.
+    assertBodyProjectMatchesChatbox(
+      body.projectId,
+      runtime.config.executionScope
+    );
 
     // Fail fast before the run record exists. An unpinned host persists
     // modelId "" (a fully supported host state — Save never gates on it),

--- a/mcpjam-inspector/server/services/sessionSimulation/runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/runner.ts
@@ -36,7 +36,7 @@ import {
   persistChatSessionToConvex,
   type PersistedTurnTrace,
 } from "../../utils/chat-ingestion.js";
-import { exportConnectedServerToolSnapshotForEvalAuthoring } from "../../utils/export-helpers.js";
+import { persistHostSessionTurn } from "../../utils/persist-host-session-turn.js";
 import { captureMcpAppWidgetSnapshots } from "../../utils/mcp-app-widget-capture.js";
 import {
   createBrowserSessionContext,
@@ -769,51 +769,36 @@ async function runOneSession(args: {
 
       // Mirror chat-v2's per-turn persistence so the Trace tab and the
       // tool-snapshot/serverInspections fan-out work identically for
-      // synthetic sessions and Playground sessions. Snapshot failures
-      // must never block the persist.
-      let toolSnapshot: unknown;
-      try {
-        const liveManager = built.manager;
-        const knownIds =
-          typeof liveManager.hasServer === "function"
-            ? selectedServerIds.filter((id) => liveManager.hasServer(id))
-            : selectedServerIds;
-        if (knownIds.length > 0) {
-          toolSnapshot =
-            await exportConnectedServerToolSnapshotForEvalAuthoring(
-              liveManager,
-              knownIds,
-              { logPrefix: "sessionSimulation.persist" }
-            );
-        }
-      } catch {
-        toolSnapshot = undefined;
-      }
-
-      await persistChatSessionToConvex({
-        chatSessionId,
-        modelId: String(modelDefinition.id),
-        modelSource: sessionModelSource ?? "mcpjam",
-        authHeader,
-        projectId,
-        sourceType: "chatbox",
-        // Synthetic chatbox simulation — distinguished from real chatbox
-        // traffic by the `synthetic: true` flag already on the row, not by
-        // origin. Training filters should combine `origin === 'chatbox'`
-        // with `synthetic !== true` to keep these out.
-        origin: "chatbox",
-        surface: "share_link",
-        chatboxId,
-        sessionMessages: messageHistory,
-        startedAt: sessionStartedAt,
-        lastActivityAt: Date.now(),
-        synthetic: true,
-        personaId: persona.id,
-        personaLabel: persona.name,
-        synthesisRunId: runId,
-        turnTrace,
-        resumeConfig,
-        ...(toolSnapshot ? { toolSnapshot } : {}),
+      // synthetic sessions and Playground sessions. Snapshot capture +
+      // persist run through the shared `persistHostSessionTurn` helper
+      // (best-effort snapshot; failures never block the persist).
+      await persistHostSessionTurn(built.manager, {
+        selectedServerIds,
+        logPrefix: "sessionSimulation.persist",
+        persist: {
+          chatSessionId,
+          modelId: String(modelDefinition.id),
+          modelSource: sessionModelSource ?? "mcpjam",
+          authHeader,
+          projectId,
+          sourceType: "chatbox",
+          // Synthetic chatbox simulation — distinguished from real chatbox
+          // traffic by the `synthetic: true` flag already on the row, not by
+          // origin. Training filters should combine `origin === 'chatbox'`
+          // with `synthetic !== true` to keep these out.
+          origin: "chatbox",
+          surface: "share_link",
+          chatboxId,
+          sessionMessages: messageHistory,
+          startedAt: sessionStartedAt,
+          lastActivityAt: Date.now(),
+          synthetic: true,
+          personaId: persona.id,
+          personaLabel: persona.name,
+          synthesisRunId: runId,
+          turnTrace,
+          resumeConfig,
+        },
       });
       anyTurnPersisted = true;
 

--- a/mcpjam-inspector/server/utils/__tests__/web-chat-turn-dispatch.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/web-chat-turn-dispatch.test.ts
@@ -7,18 +7,24 @@
  * branched into org-BYOK handling and skipped `runHarnessTurn` even though
  * `persist.harness` was set.
  *
- * The stream handlers are mocked; these are pure dispatch tests.
+ * The MCPJam path now dispatches through the shared `runAssistantTurn` surface
+ * (streamSink "ui") instead of calling `handleMCPJamFreeChatModel` directly;
+ * live org-BYOK still uses its specialized streaming handlers. The engine +
+ * handlers are mocked; these are pure dispatch tests.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const handlers = vi.hoisted(() => ({
-  mcpjamFree: vi.fn(async () => new Response("mcpjam")),
+  assistantTurn: vi.fn(async () => ({ response: new Response("mcpjam") })),
   hostedOrg: vi.fn(async () => new Response("org-hosted")),
   localOrg: vi.fn(async () => new Response("org-local")),
 }));
 
+vi.mock("../assistant-turn.js", () => ({
+  runAssistantTurn: handlers.assistantTurn,
+}));
+
 vi.mock("../mcpjam-stream-handler.js", () => ({
-  handleMCPJamFreeChatModel: handlers.mcpjamFree,
   warnIfChatAbortSignalMissing: vi.fn(),
 }));
 
@@ -100,7 +106,7 @@ function args(modelDefinition: {
 
 describe("streamWebChatTurn model dispatch", () => {
   beforeEach(() => {
-    handlers.mcpjamFree.mockClear();
+    handlers.assistantTurn.mockClear();
     handlers.hostedOrg.mockClear();
     handlers.localOrg.mockClear();
     // stubEnv (not a bare assignment) so the value is restored after each
@@ -116,20 +122,22 @@ describe("streamWebChatTurn model dispatch", () => {
     await streamWebChatTurn(
       args({ id: "gpt-5-nano", provider: "openai" }) as never,
     );
-    expect(handlers.mcpjamFree).toHaveBeenCalledTimes(1);
+    expect(handlers.assistantTurn).toHaveBeenCalledTimes(1);
     expect(handlers.hostedOrg).not.toHaveBeenCalled();
-    const opts = handlers.mcpjamFree.mock.calls[0]?.[0] as Record<
+    const opts = handlers.assistantTurn.mock.calls[0]?.[0] as Record<
       string,
       unknown
     >;
     expect(opts.harness).toBe("claude-code");
+    // MCPJam live chat dispatches through runAssistantTurn's UI stream sink.
+    expect(opts.streamSink).toBe("ui");
   });
 
   it("routes a prefixed MCPJam id to the MCPJam path (sanity)", async () => {
     await streamWebChatTurn(
       args({ id: "openai/gpt-5-nano", provider: "openai" }) as never,
     );
-    expect(handlers.mcpjamFree).toHaveBeenCalledTimes(1);
+    expect(handlers.assistantTurn).toHaveBeenCalledTimes(1);
     expect(handlers.hostedOrg).not.toHaveBeenCalled();
   });
 
@@ -138,6 +146,6 @@ describe("streamWebChatTurn model dispatch", () => {
       args({ id: "gpt-4.1-mini-custom", provider: "openai" }) as never,
     );
     expect(handlers.hostedOrg).toHaveBeenCalledTimes(1);
-    expect(handlers.mcpjamFree).not.toHaveBeenCalled();
+    expect(handlers.assistantTurn).not.toHaveBeenCalled();
   });
 });

--- a/mcpjam-inspector/server/utils/assistant-turn.ts
+++ b/mcpjam-inspector/server/utils/assistant-turn.ts
@@ -148,6 +148,21 @@ export interface RunAssistantTurnOptions {
   heartbeatIntervalMs?: number;
   maxSteps?: number;
 
+  // --- Superset pass-throughs the live MCPJam chat path supplies today
+  //     (`web-chat-turn.ts` → `handleMCPJamFreeChatModel`) but which were
+  //     missing here. Required BEFORE routing the live path through
+  //     `runAssistantTurn`, or the live turn silently loses harness /
+  //     sandbox / built-in behavior. All flow verbatim into the handler. ---
+
+  /** Runtime-config execution scope (sandbox reserve, skills, broker, commit). */
+  executionScope?: MCPJamHandlerOptions["executionScope"];
+  /** UI tools exempt from the dispatch-time approval gate. */
+  approvalFreeUiToolNames?: MCPJamHandlerOptions["approvalFreeUiToolNames"];
+  /** Harness MCP-proxy strategy for the real-runtime path. */
+  harnessMcpProxy?: MCPJamHandlerOptions["harnessMcpProxy"];
+  /** Server-executed built-ins (e.g. `web_search`) handed to the harness. */
+  builtInTools?: MCPJamHandlerOptions["builtInTools"];
+
   /**
    * Callback invoked when the chat-ingestion handler path runs. Only
    * consumed when `persistMode === "handler"`; ignored when
@@ -315,13 +330,21 @@ function buildHandlerOptions(
   ) => void
 ): MCPJamHandlerOptions {
   const wrappedOnConversationComplete: MCPJamHandlerOptions["onConversationComplete"] =
-    async (fullHistory, turnTrace) => {
+    async (fullHistory, turnTrace, harnessSessionCommit) => {
       captureTranscript(fullHistory, turnTrace);
       if (
         opts.persistMode === "handler" &&
         typeof opts.onConversationComplete === "function"
       ) {
-        await opts.onConversationComplete(fullHistory, turnTrace);
+        // Forward `harnessSessionCommit` (3rd arg) so harness-backed live chat
+        // keeps its atomic transcript + resume-state commit. TypeScript won't
+        // catch a dropped trailing param (2-arg fn assignable to 3-param type),
+        // and the live MCPJam path now routes through here via runAssistantTurn.
+        await opts.onConversationComplete(
+          fullHistory,
+          turnTrace,
+          harnessSessionCommit
+        );
       }
     };
 
@@ -351,6 +374,17 @@ function buildHandlerOptions(
     // unified harness turns reach runHarnessTurn with harness=undefined (the old
     // `?? "claude-code"` default silently mis-ran a codex eval as claude-code).
     ...(opts.harness ? { harness: opts.harness } : {}),
+    // Superset pass-throughs (see `RunAssistantTurnOptions`): forward the
+    // runtime scope, harness proxy, built-ins, and approval-free UI tool
+    // set the live MCPJam path already supplies today.
+    ...(opts.executionScope ? { executionScope: opts.executionScope } : {}),
+    ...(opts.harnessMcpProxy
+      ? { harnessMcpProxy: opts.harnessMcpProxy }
+      : {}),
+    ...(opts.builtInTools ? { builtInTools: opts.builtInTools } : {}),
+    ...(opts.approvalFreeUiToolNames
+      ? { approvalFreeUiToolNames: opts.approvalFreeUiToolNames }
+      : {}),
     ...(opts.requireToolApproval !== undefined
       ? { requireToolApproval: opts.requireToolApproval }
       : {}),

--- a/mcpjam-inspector/server/utils/chat-ingestion.ts
+++ b/mcpjam-inspector/server/utils/chat-ingestion.ts
@@ -161,7 +161,7 @@ export interface PersistedTurnTrace {
 // inspector pins to the closed set.
 export type ChatOrigin = "playground" | "mcpjam_agent" | "chatbox" | "eval";
 
-interface PersistChatSessionOptions {
+export interface PersistChatSessionOptions {
   chatSessionId: string;
   modelId: string;
   modelSource: "mcpjam" | "byok" | "local_byok";

--- a/mcpjam-inspector/server/utils/persist-host-session-turn.ts
+++ b/mcpjam-inspector/server/utils/persist-host-session-turn.ts
@@ -1,0 +1,86 @@
+/**
+ * Shared persistence for one "session in a host" turn.
+ *
+ * Both the live-chat path (`web-chat-turn.ts` → `buildOnConversationComplete`)
+ * and the synthetic runner (`sessionSimulation/runner.ts` → `runOneSession`)
+ * persist a `chatSessions` row after each assistant turn. The tool-snapshot
+ * capture that precedes the write was duplicated byte-for-byte at both sites;
+ * this module owns it once. Each caller still constructs its OWN persist
+ * payload (direct chat: `resumeConfig` / `hostConfig` / `directVisibility`;
+ * synthetic: `synthetic` / `personaId` / `synthesisRunId`) — we deliberately
+ * do NOT fold those divergent shapes into one wide options union.
+ */
+
+import type { Context } from "hono";
+import type { MCPClientManager } from "@mcpjam/sdk";
+import { exportConnectedServerToolSnapshotForEvalAuthoring } from "./export-helpers.js";
+import {
+  persistChatSessionToConvex,
+  type PersistChatSessionOptions,
+} from "./chat-ingestion.js";
+
+type Manager = InstanceType<typeof MCPClientManager>;
+
+/**
+ * Best-effort tool-snapshot capture. Filters to servers the manager actually
+ * has connected, then exports the eval-authoring snapshot. Any failure resolves
+ * to `undefined` — capturing a snapshot must NEVER block the session persist.
+ */
+export async function captureToolSnapshotForPersist(
+  manager: Manager,
+  selectedServerIds: string[],
+  logPrefix: string,
+): Promise<unknown> {
+  try {
+    const knownIds =
+      typeof manager.hasServer === "function"
+        ? selectedServerIds.filter((id) => manager.hasServer(id))
+        : selectedServerIds;
+    if (knownIds.length === 0) return undefined;
+    return await exportConnectedServerToolSnapshotForEvalAuthoring(
+      manager,
+      knownIds,
+      { logPrefix },
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Capture the tool snapshot (best-effort) and persist the `chatSessions` row.
+ * The caller supplies the full persist payload minus `toolSnapshot`; the
+ * captured snapshot is merged in when present.
+ */
+export async function persistHostSessionTurn(
+  manager: Manager,
+  args: {
+    selectedServerIds: string[];
+    /** Default `true`; surfaces with synthetic server ids opt out. */
+    captureToolSnapshot?: boolean;
+    logPrefix: string;
+    persist: Omit<PersistChatSessionOptions, "toolSnapshot">;
+  },
+  c?: Context,
+): Promise<void> {
+  const toolSnapshot =
+    args.captureToolSnapshot !== false
+      ? await captureToolSnapshotForPersist(
+          manager,
+          args.selectedServerIds,
+          args.logPrefix,
+        )
+      : undefined;
+  const merged = {
+    ...args.persist,
+    ...(toolSnapshot ? { toolSnapshot } : {}),
+  };
+  // Preserve the original call arity — only forward the Hono context when one
+  // was actually supplied. Passing an explicit `undefined` second arg is both
+  // unnecessary and changes `toHaveBeenCalledWith` matching for callers.
+  if (c) {
+    await persistChatSessionToConvex(merged, c);
+  } else {
+    await persistChatSessionToConvex(merged);
+  }
+}

--- a/mcpjam-inspector/server/utils/web-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/web-chat-turn.ts
@@ -53,7 +53,6 @@ import {
   type WidgetModelContextEntry,
 } from "./chat-v2-orchestration.js";
 import {
-  persistChatSessionToConvex,
   pickEnrichmentHeaders,
   stampSenderUserIdsOnSessionMessages,
   type ChatOrigin,
@@ -61,7 +60,7 @@ import {
   type PersistedTurnTrace,
 } from "./chat-ingestion.js";
 import type { HarnessSessionCommitPayload } from "./harness/harness-session-state.js";
-import { exportConnectedServerToolSnapshotForEvalAuthoring } from "./export-helpers.js";
+import { persistHostSessionTurn } from "./persist-host-session-turn.js";
 import { ErrorCode, WebRouteError } from "./../routes/web/errors.js";
 import type { createHostedRpcLogCollector } from "./../routes/web/hosted-rpc-logs.js";
 import { bridgeHarnessRpcLogsToCollector } from "./../routes/web/hosted-rpc-logs.js";
@@ -333,76 +332,66 @@ export async function streamWebChatTurn(
       harnessSessionCommit?: HarnessSessionCommitPayload,
     ) => {
       const isDirectChat = !isChatboxSession;
-      // Capture the live tool catalog. Failures must never block the persist.
-      // Surfaces with synthetic server ids (mcpjam-agent) opt out via
+      // Snapshot capture (best-effort) + persist run through the shared
+      // `persistHostSessionTurn` helper. Surfaces with synthetic server ids
+      // (mcpjam-agent) opt out of the snapshot via
       // `persist.captureToolSnapshot === false`.
-      let toolSnapshot: unknown;
-      if (persist.captureToolSnapshot !== false) {
-        try {
-          const knownIds =
-            typeof manager.hasServer === "function"
-              ? persist.selectedServerIds.filter((id) => manager.hasServer(id))
-              : persist.selectedServerIds;
-          if (knownIds.length > 0) {
-            toolSnapshot =
-              await exportConnectedServerToolSnapshotForEvalAuthoring(
-                manager,
-                knownIds,
-                { logPrefix: "chat-v2.persist" },
-              );
-          }
-        } catch {
-          toolSnapshot = undefined;
-        }
-      }
-
-      await persistChatSessionToConvex({
-        chatSessionId: hostedChatSessionId,
-        modelId,
-        modelSource,
-        projectId: persist.projectId,
-        sourceType: persist.sourceType,
-        origin: persist.origin,
-        ...(isChatboxSession && persist.surface
-          ? { surface: persist.surface }
+      await persistHostSessionTurn(manager, {
+        selectedServerIds: persist.selectedServerIds,
+        ...(persist.captureToolSnapshot !== undefined
+          ? { captureToolSnapshot: persist.captureToolSnapshot }
           : {}),
-        chatboxId: persist.chatboxId,
-        accessVersion: persist.accessVersion,
-        authHeader: runtime.authHeader,
-        sessionMessages: stampSenderUserIdsOnSessionMessages(
-          fullHistory,
-          persist.originalMessages as unknown[],
-          { authenticatedUserId: persist.authenticatedUserId },
-        ),
-        startedAt: sessionStartedAt,
-        lastActivityAt: Date.now(),
-        ...(toolSnapshot ? { toolSnapshot } : {}),
-        ...(isDirectChat
-          ? {
-              directVisibility: persist.directVisibility,
-              resumeConfig: {
-                systemPrompt: persist.systemPrompt,
-                temperature: persist.temperature,
-                requireToolApproval: persist.requireToolApproval,
-                respectToolVisibility: persist.respectToolVisibility,
-                modelVisibleMcpToolResults: prepare.modelVisibleMcpToolResults,
-                mcpToolResultImageRendering:
-                  persist.mcpToolResultImageRendering,
-                selectedServers:
-                  Array.isArray(persist.selectedServerNames) &&
-                  persist.selectedServerNames.length ===
-                    persist.selectedServerIds.length
-                    ? persist.selectedServerNames
-                    : persist.selectedServerIds,
-              },
-              ...(resolvedHostConfig ? { hostConfig: resolvedHostConfig } : {}),
-            }
-          : {}),
-        turnTrace,
-        // §3: chat-backed harness resume-state commit, applied atomically with
-        // the transcript inside the ingest mutation.
-        ...(harnessSessionCommit ? { harnessSessionCommit } : {}),
-        forwardHeaders: pickEnrichmentHeaders(c.req.raw.headers),
+        logPrefix: "chat-v2.persist",
+        persist: {
+          chatSessionId: hostedChatSessionId,
+          modelId,
+          modelSource,
+          projectId: persist.projectId,
+          sourceType: persist.sourceType,
+          origin: persist.origin,
+          ...(isChatboxSession && persist.surface
+            ? { surface: persist.surface }
+            : {}),
+          chatboxId: persist.chatboxId,
+          accessVersion: persist.accessVersion,
+          authHeader: runtime.authHeader,
+          sessionMessages: stampSenderUserIdsOnSessionMessages(
+            fullHistory,
+            persist.originalMessages as unknown[],
+            { authenticatedUserId: persist.authenticatedUserId },
+          ),
+          startedAt: sessionStartedAt,
+          lastActivityAt: Date.now(),
+          ...(isDirectChat
+            ? {
+                directVisibility: persist.directVisibility,
+                resumeConfig: {
+                  systemPrompt: persist.systemPrompt,
+                  temperature: persist.temperature,
+                  requireToolApproval: persist.requireToolApproval,
+                  respectToolVisibility: persist.respectToolVisibility,
+                  modelVisibleMcpToolResults:
+                    prepare.modelVisibleMcpToolResults,
+                  mcpToolResultImageRendering:
+                    persist.mcpToolResultImageRendering,
+                  selectedServers:
+                    Array.isArray(persist.selectedServerNames) &&
+                    persist.selectedServerNames.length ===
+                      persist.selectedServerIds.length
+                      ? persist.selectedServerNames
+                      : persist.selectedServerIds,
+                },
+                ...(resolvedHostConfig
+                  ? { hostConfig: resolvedHostConfig }
+                  : {}),
+              }
+            : {}),
+          turnTrace,
+          // §3: chat-backed harness resume-state commit, applied atomically
+          // with the transcript inside the ingest mutation.
+          ...(harnessSessionCommit ? { harnessSessionCommit } : {}),
+          forwardHeaders: pickEnrichmentHeaders(c.req.raw.headers),
+        },
       });
     };
   };

--- a/mcpjam-inspector/server/utils/web-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/web-chat-turn.ts
@@ -32,10 +32,7 @@ import type {
   McpToolResultImageRenderingPolicy,
   ModelVisibleMcpToolResults,
 } from "@mcpjam/sdk/host-config/internal";
-import {
-  handleMCPJamFreeChatModel,
-  warnIfChatAbortSignalMissing,
-} from "./mcpjam-stream-handler.js";
+import { warnIfChatAbortSignalMissing } from "./mcpjam-stream-handler.js";
 import type { ExecutionScope } from "./execution-scope.js";
 import {
   handleHostedOrgChatModel,
@@ -70,6 +67,7 @@ import type { createHostedRpcLogCollector } from "./../routes/web/hosted-rpc-log
 import { bridgeHarnessRpcLogsToCollector } from "./../routes/web/hosted-rpc-logs.js";
 import type { CustomProviderConfig } from "./chat-helpers.js";
 import { getClientIp } from "./client-ip.js";
+import { runAssistantTurn } from "./assistant-turn.js";
 import { convertToMcpjamModelMessages } from "./mcp-tool-result-model-output.js";
 import {
   resolveWebAuthorizedHarnessStrategy,
@@ -531,30 +529,49 @@ export async function streamWebChatTurn(
   // leave a live subscription) and torn down with the stream.
   let stopHarnessRpcLogBridge: (() => void) | undefined;
 
-  return handleMCPJamFreeChatModel({
+  // Live MCPJam chat runs through the shared `runAssistantTurn` surface (the
+  // same engine seam the synthetic runner uses) rather than calling
+  // `handleMCPJamFreeChatModel` directly — `runAssistantTurn` is a faithful
+  // wrapper (streamSink "ui" → runChatEngineLoop / runHarnessTurn, identical to
+  // the direct call) and now carries the superset fields (executionScope,
+  // harnessMcpProxy, builtInTools, approvalFreeUiToolNames) the live path needs.
+  // Harness eligibility is already gated by the chat-v2 preflight, so the
+  // useHarness decision matches the old direct dispatch.
+  const engineResult = await runAssistantTurn({
     messages: modelMessages,
-    modelId: mcpjamModelId,
-    provider: prepare.modelDefinition.provider,
-    chatSessionId: hostedChatSessionId,
-    sourceType: persist.sourceType,
+    modelDefinition: prepare.modelDefinition,
     systemPrompt: effectiveEnhancedSystemPrompt,
-    temperature: resolvedTemperature,
+    ...(resolvedTemperature !== undefined
+      ? { temperature: resolvedTemperature }
+      : {}),
     tools: allTools as ToolSet,
-    progressivePlan,
-    discoveryState,
-    authHeader: runtime.authHeader,
-    clientIp: runtime.clientIp ?? getClientIp(c),
-    chatboxId: persist.chatboxId,
-    accessVersion: persist.accessVersion,
-    projectId: persist.projectId,
+    mcpClientManager: manager,
+    authContext: {
+      kind: "user_bearer",
+      token: runtime.authHeader ?? "",
+      clientIp: runtime.clientIp ?? getClientIp(c),
+    },
+    sourceType: persist.sourceType,
+    origin: persist.origin,
+    streamSink: "ui",
+    persistMode: "handler",
+    chatSessionId: hostedChatSessionId,
+    ...(persist.projectId ? { projectId: persist.projectId } : {}),
+    ...(persist.chatboxId ? { chatboxId: persist.chatboxId } : {}),
+    ...(persist.accessVersion !== undefined
+      ? { accessVersion: persist.accessVersion }
+      : {}),
     // Phase 3: thread the runtime-config execution scope into the harness path
     // (sandbox reserve, skills, broker, session-state, commit).
     ...(persist.executionScope
       ? { executionScope: persist.executionScope }
       : {}),
-    mcpClientManager: manager,
-    selectedServers: persist.selectedServerIds,
-    requireToolApproval: persist.requireToolApproval,
+    ...(persist.selectedServerIds
+      ? { selectedServerIds: persist.selectedServerIds }
+      : {}),
+    ...(persist.requireToolApproval !== undefined
+      ? { requireToolApproval: persist.requireToolApproval }
+      : {}),
     approvalFreeUiToolNames: approvalFreeUiToolNamesFrom(prepare.uiTools),
     modelVisibleMcpToolResults: prepare.modelVisibleMcpToolResults,
     ...(persist.harness ? { harness: persist.harness } : {}),
@@ -564,7 +581,9 @@ export async function streamWebChatTurn(
     // (web_search) to HarnessAgent without the MCP-server tools, which the
     // harness gets via .mcp.json.
     ...(prepare.builtInTools ? { builtInTools: prepare.builtInTools } : {}),
-    abortSignal: runtime.abortSignal,
+    ...(progressivePlan ? { progressivePlan } : {}),
+    ...(discoveryState ? { discoveryState } : {}),
+    ...(runtime.abortSignal ? { abortSignal: runtime.abortSignal } : {}),
     onConversationComplete,
     onStreamComplete: async () => {
       stopHarnessRpcLogBridge?.();
@@ -581,4 +600,12 @@ export async function streamWebChatTurn(
       }
     },
   });
+
+  if (!engineResult.response) {
+    throw new Error(
+      'runAssistantTurn(streamSink: "ui") returned no Response for the ' +
+        "MCPJam chat path",
+    );
+  }
+  return engineResult.response;
 }


### PR DESCRIPTION
**Stack 1/4** — swarm/chatbox split, shared-foundation slice.

Adds the four superset fields (`executionScope`, `harnessMcpProxy`, `builtInTools`, `approvalFreeUiToolNames`) to `RunAssistantTurnOptions`, then routes the **live MCPJam chat path** through `runAssistantTurn` instead of calling `handleMCPJamFreeChatModel` directly. Both the live and synthetic paths now share the same engine surface for MCPJam-model turns.

- `runAssistantTurn` is a faithful wrapper (streamSink `"ui"` → `runChatEngineLoop`/`runHarnessTurn`, identical to the direct call); harness eligibility is already gated by the chat-v2 preflight.
- Live org-BYOK stays on its specialized streaming handlers.
- **Behavior-preserving.** Dispatch test updated to assert the shared surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live chat dispatch, harness persistence, and authz on chatbox simulation; behavior is intended to be preserving but regressions could affect streaming, harness commits, or cross-project chatbox abuse.
> 
> **Overview**
> **Live MCPJam chat** no longer calls `handleMCPJamFreeChatModel` directly; it goes through **`runAssistantTurn`** (`streamSink: "ui"`, `persistMode: "handler"`) with the same harness, execution scope, built-ins, and proxy options wired via new **`RunAssistantTurnOptions`** pass-throughs. **`harnessSessionCommit`** is forwarded on `onConversationComplete` so harness resume state still commits atomically with the transcript.
> 
> **Per-turn persistence** for live chat and synthetic session simulation is deduplicated into **`persistHostSessionTurn`** (best-effort tool snapshot + `persistChatSessionToConvex`); **`PersistChatSessionOptions`** is exported for typing.
> 
> **Chatbox swarm routes** (`generate-personas`, `simulate-sessions/start`) now **fail closed** unless the request **`projectId`** matches the chatbox’s server-resolved **`executionScope.projectId`**, and runtime-config fetch errors map to the correct **`ErrorCode`** instead of always `INTERNAL_ERROR`.
> 
> Tests mock **`runAssistantTurn`** and cover the new 403 provenance cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b20fd1ae786ef5dccb73248cf199454c5cb1fbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes live MCPJam chat through the shared `runAssistantTurn` engine and centralizes host-session turn persistence, so live and synthetic paths use the same engine and ingest logic with no behavior change. Adds a server-side project-binding guard for chatbox simulations and persona generation to prevent cross‑project attribution.

- **Refactors**
  - Replaced direct `handleMCPJamFreeChatModel` calls with `runAssistantTurn` using `streamSink: "ui"` and `persistMode: "handler"`, passing `modelDefinition` and `authContext`.
  - Extended `RunAssistantTurnOptions` with `executionScope`, `harnessMcpProxy`, `builtInTools`, and `approvalFreeUiToolNames`; `onConversationComplete` now forwards `harnessSessionCommit`.
  - Introduced `persistHostSessionTurn` to share tool‑snapshot capture and `persistChatSessionToConvex` across live (`web-chat-turn.ts`) and synthetic (`sessionSimulation/runner.ts`); snapshot is best‑effort and never blocks persists, filters to connected `selectedServerIds`, and can forward the `Hono` context.
  - Exported `PersistChatSessionOptions`; routed optional fields (`temperature`, `progressivePlan`, `discoveryState`, `selectedServerIds`) and throw if `runAssistantTurn` returns no `response`.
  - Left org‑BYOK on its specialized streaming handlers; updated route and dispatch tests to mock `runAssistantTurn` and assert the shared path.

- **New Features**
  - Bind `simulate-sessions/start` and `generate-personas` to the chatbox’s own project by comparing the body `projectId` to the runtime config’s `executionScope.projectId`; return 403 on mismatch or when the runtime config omits it.
  - Map chatbox runtime‑config fetch failures to specific error codes (`UNAUTHORIZED`, `FORBIDDEN`, `NOT_FOUND`) instead of a generic `INTERNAL_ERROR`; added tests for both guards.

<sup>Written for commit 9b20fd1ae786ef5dccb73248cf199454c5cb1fbf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

