### PR TITLE
refactor(chat): share host-session persistence across live + synthetic

### DIFF
--- a/mcpjam-inspector/server/services/sessionSimulation/runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/runner.ts
@@ -36,7 +36,7 @@ import {
   persistChatSessionToConvex,
   type PersistedTurnTrace,
 } from "../../utils/chat-ingestion.js";
-import { exportConnectedServerToolSnapshotForEvalAuthoring } from "../../utils/export-helpers.js";
+import { persistHostSessionTurn } from "../../utils/persist-host-session-turn.js";
 import { captureMcpAppWidgetSnapshots } from "../../utils/mcp-app-widget-capture.js";
 import {
   createBrowserSessionContext,
@@ -769,51 +769,36 @@ async function runOneSession(args: {
 
       // Mirror chat-v2's per-turn persistence so the Trace tab and the
       // tool-snapshot/serverInspections fan-out work identically for
-      // synthetic sessions and Playground sessions. Snapshot failures
-      // must never block the persist.
-      let toolSnapshot: unknown;
-      try {
-        const liveManager = built.manager;
-        const knownIds =
-          typeof liveManager.hasServer === "function"
-            ? selectedServerIds.filter((id) => liveManager.hasServer(id))
-            : selectedServerIds;
-        if (knownIds.length > 0) {
-          toolSnapshot =
-            await exportConnectedServerToolSnapshotForEvalAuthoring(
-              liveManager,
-              knownIds,
-              { logPrefix: "sessionSimulation.persist" }
-            );
-        }
-      } catch {
-        toolSnapshot = undefined;
-      }
-
-      await persistChatSessionToConvex({
-        chatSessionId,
-        modelId: String(modelDefinition.id),
-        modelSource: sessionModelSource ?? "mcpjam",
-        authHeader,
-        projectId,
-        sourceType: "chatbox",
-        // Synthetic chatbox simulation — distinguished from real chatbox
-        // traffic by the `synthetic: true` flag already on the row, not by
-        // origin. Training filters should combine `origin === 'chatbox'`
-        // with `synthetic !== true` to keep these out.
-        origin: "chatbox",
-        surface: "share_link",
-        chatboxId,
-        sessionMessages: messageHistory,
-        startedAt: sessionStartedAt,
-        lastActivityAt: Date.now(),
-        synthetic: true,
-        personaId: persona.id,
-        personaLabel: persona.name,
-        synthesisRunId: runId,
-        turnTrace,
-        resumeConfig,
-        ...(toolSnapshot ? { toolSnapshot } : {}),
+      // synthetic sessions and Playground sessions. Snapshot capture +
+      // persist run through the shared `persistHostSessionTurn` helper
+      // (best-effort snapshot; failures never block the persist).
+      await persistHostSessionTurn(built.manager, {
+        selectedServerIds,
+        logPrefix: "sessionSimulation.persist",
+        persist: {
+          chatSessionId,
+          modelId: String(modelDefinition.id),
+          modelSource: sessionModelSource ?? "mcpjam",
+          authHeader,
+          projectId,
+          sourceType: "chatbox",
+          // Synthetic chatbox simulation — distinguished from real chatbox
+          // traffic by the `synthetic: true` flag already on the row, not by
+          // origin. Training filters should combine `origin === 'chatbox'`
+          // with `synthetic !== true` to keep these out.
+          origin: "chatbox",
+          surface: "share_link",
+          chatboxId,
+          sessionMessages: messageHistory,
+          startedAt: sessionStartedAt,
+          lastActivityAt: Date.now(),
+          synthetic: true,
+          personaId: persona.id,
+          personaLabel: persona.name,
+          synthesisRunId: runId,
+          turnTrace,
+          resumeConfig,
+        },
       });
       anyTurnPersisted = true;
 

--- a/mcpjam-inspector/server/utils/chat-ingestion.ts
+++ b/mcpjam-inspector/server/utils/chat-ingestion.ts
@@ -161,7 +161,7 @@ export interface PersistedTurnTrace {
 // inspector pins to the closed set.
 export type ChatOrigin = "playground" | "mcpjam_agent" | "chatbox" | "eval";
 
-interface PersistChatSessionOptions {
+export interface PersistChatSessionOptions {
   chatSessionId: string;
   modelId: string;
   modelSource: "mcpjam" | "byok" | "local_byok";

--- a/mcpjam-inspector/server/utils/persist-host-session-turn.ts
+++ b/mcpjam-inspector/server/utils/persist-host-session-turn.ts
@@ -1,0 +1,86 @@
+/**
+ * Shared persistence for one "session in a host" turn.
+ *
+ * Both the live-chat path (`web-chat-turn.ts` → `buildOnConversationComplete`)
+ * and the synthetic runner (`sessionSimulation/runner.ts` → `runOneSession`)
+ * persist a `chatSessions` row after each assistant turn. The tool-snapshot
+ * capture that precedes the write was duplicated byte-for-byte at both sites;
+ * this module owns it once. Each caller still constructs its OWN persist
+ * payload (direct chat: `resumeConfig` / `hostConfig` / `directVisibility`;
+ * synthetic: `synthetic` / `personaId` / `synthesisRunId`) — we deliberately
+ * do NOT fold those divergent shapes into one wide options union.
+ */
+
+import type { Context } from "hono";
+import type { MCPClientManager } from "@mcpjam/sdk";
+import { exportConnectedServerToolSnapshotForEvalAuthoring } from "./export-helpers.js";
+import {
+  persistChatSessionToConvex,
+  type PersistChatSessionOptions,
+} from "./chat-ingestion.js";
+
+type Manager = InstanceType<typeof MCPClientManager>;
+
+/**
+ * Best-effort tool-snapshot capture. Filters to servers the manager actually
+ * has connected, then exports the eval-authoring snapshot. Any failure resolves
+ * to `undefined` — capturing a snapshot must NEVER block the session persist.
+ */
+export async function captureToolSnapshotForPersist(
+  manager: Manager,
+  selectedServerIds: string[],
+  logPrefix: string,
+): Promise<unknown> {
+  try {
+    const knownIds =
+      typeof manager.hasServer === "function"
+        ? selectedServerIds.filter((id) => manager.hasServer(id))
+        : selectedServerIds;
+    if (knownIds.length === 0) return undefined;
+    return await exportConnectedServerToolSnapshotForEvalAuthoring(
+      manager,
+      knownIds,
+      { logPrefix },
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Capture the tool snapshot (best-effort) and persist the `chatSessions` row.
+ * The caller supplies the full persist payload minus `toolSnapshot`; the
+ * captured snapshot is merged in when present.
+ */
+export async function persistHostSessionTurn(
+  manager: Manager,
+  args: {
+    selectedServerIds: string[];
+    /** Default `true`; surfaces with synthetic server ids opt out. */
+    captureToolSnapshot?: boolean;
+    logPrefix: string;
+    persist: Omit<PersistChatSessionOptions, "toolSnapshot">;
+  },
+  c?: Context,
+): Promise<void> {
+  const toolSnapshot =
+    args.captureToolSnapshot !== false
+      ? await captureToolSnapshotForPersist(
+          manager,
+          args.selectedServerIds,
+          args.logPrefix,
+        )
+      : undefined;
+  const merged = {
+    ...args.persist,
+    ...(toolSnapshot ? { toolSnapshot } : {}),
+  };
+  // Preserve the original call arity — only forward the Hono context when one
+  // was actually supplied. Passing an explicit `undefined` second arg is both
+  // unnecessary and changes `toHaveBeenCalledWith` matching for callers.
+  if (c) {
+    await persistChatSessionToConvex(merged, c);
+  } else {
+    await persistChatSessionToConvex(merged);
+  }
+}

--- a/mcpjam-inspector/server/utils/web-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/web-chat-turn.ts
@@ -53,7 +53,6 @@ import {
   type WidgetModelContextEntry,
 } from "./chat-v2-orchestration.js";
 import {
-  persistChatSessionToConvex,
   pickEnrichmentHeaders,
   stampSenderUserIdsOnSessionMessages,
   type ChatOrigin,
@@ -61,7 +60,7 @@ import {
   type PersistedTurnTrace,
 } from "./chat-ingestion.js";
 import type { HarnessSessionCommitPayload } from "./harness/harness-session-state.js";
-import { exportConnectedServerToolSnapshotForEvalAuthoring } from "./export-helpers.js";
+import { persistHostSessionTurn } from "./persist-host-session-turn.js";
 import { ErrorCode, WebRouteError } from "./../routes/web/errors.js";
 import type { createHostedRpcLogCollector } from "./../routes/web/hosted-rpc-logs.js";
 import { bridgeHarnessRpcLogsToCollector } from "./../routes/web/hosted-rpc-logs.js";
@@ -333,76 +332,66 @@ export async function streamWebChatTurn(
       harnessSessionCommit?: HarnessSessionCommitPayload,
     ) => {
       const isDirectChat = !isChatboxSession;
-      // Capture the live tool catalog. Failures must never block the persist.
-      // Surfaces with synthetic server ids (mcpjam-agent) opt out via
+      // Snapshot capture (best-effort) + persist run through the shared
+      // `persistHostSessionTurn` helper. Surfaces with synthetic server ids
+      // (mcpjam-agent) opt out of the snapshot via
       // `persist.captureToolSnapshot === false`.
-      let toolSnapshot: unknown;
-      if (persist.captureToolSnapshot !== false) {
-        try {
-          const knownIds =
-            typeof manager.hasServer === "function"
-              ? persist.selectedServerIds.filter((id) => manager.hasServer(id))
-              : persist.selectedServerIds;
-          if (knownIds.length > 0) {
-            toolSnapshot =
-              await exportConnectedServerToolSnapshotForEvalAuthoring(
-                manager,
-                knownIds,
-                { logPrefix: "chat-v2.persist" },
-              );
-          }
-        } catch {
-          toolSnapshot = undefined;
-        }
-      }
-
-      await persistChatSessionToConvex({
-        chatSessionId: hostedChatSessionId,
-        modelId,
-        modelSource,
-        projectId: persist.projectId,
-        sourceType: persist.sourceType,
-        origin: persist.origin,
-        ...(isChatboxSession && persist.surface
-          ? { surface: persist.surface }
+      await persistHostSessionTurn(manager, {
+        selectedServerIds: persist.selectedServerIds,
+        ...(persist.captureToolSnapshot !== undefined
+          ? { captureToolSnapshot: persist.captureToolSnapshot }
           : {}),
-        chatboxId: persist.chatboxId,
-        accessVersion: persist.accessVersion,
-        authHeader: runtime.authHeader,
-        sessionMessages: stampSenderUserIdsOnSessionMessages(
-          fullHistory,
-          persist.originalMessages as unknown[],
-          { authenticatedUserId: persist.authenticatedUserId },
-        ),
-        startedAt: sessionStartedAt,
-        lastActivityAt: Date.now(),
-        ...(toolSnapshot ? { toolSnapshot } : {}),
-        ...(isDirectChat
-          ? {
-              directVisibility: persist.directVisibility,
-              resumeConfig: {
-                systemPrompt: persist.systemPrompt,
-                temperature: persist.temperature,
-                requireToolApproval: persist.requireToolApproval,
-                respectToolVisibility: persist.respectToolVisibility,
-                modelVisibleMcpToolResults: prepare.modelVisibleMcpToolResults,
-                mcpToolResultImageRendering:
-                  persist.mcpToolResultImageRendering,
-                selectedServers:
-                  Array.isArray(persist.selectedServerNames) &&
-                  persist.selectedServerNames.length ===
-                    persist.selectedServerIds.length
-                    ? persist.selectedServerNames
-                    : persist.selectedServerIds,
-              },
-              ...(resolvedHostConfig ? { hostConfig: resolvedHostConfig } : {}),
-            }
-          : {}),
-        turnTrace,
-        // §3: chat-backed harness resume-state commit, applied atomically with
-        // the transcript inside the ingest mutation.
-        ...(harnessSessionCommit ? { harnessSessionCommit } : {}),
-        forwardHeaders: pickEnrichmentHeaders(c.req.raw.headers),
+        logPrefix: "chat-v2.persist",
+        persist: {
+          chatSessionId: hostedChatSessionId,
+          modelId,
+          modelSource,
+          projectId: persist.projectId,
+          sourceType: persist.sourceType,
+          origin: persist.origin,
+          ...(isChatboxSession && persist.surface
+            ? { surface: persist.surface }
+            : {}),
+          chatboxId: persist.chatboxId,
+          accessVersion: persist.accessVersion,
+          authHeader: runtime.authHeader,
+          sessionMessages: stampSenderUserIdsOnSessionMessages(
+            fullHistory,
+            persist.originalMessages as unknown[],
+            { authenticatedUserId: persist.authenticatedUserId },
+          ),
+          startedAt: sessionStartedAt,
+          lastActivityAt: Date.now(),
+          ...(isDirectChat
+            ? {
+                directVisibility: persist.directVisibility,
+                resumeConfig: {
+                  systemPrompt: persist.systemPrompt,
+                  temperature: persist.temperature,
+                  requireToolApproval: persist.requireToolApproval,
+                  respectToolVisibility: persist.respectToolVisibility,
+                  modelVisibleMcpToolResults:
+                    prepare.modelVisibleMcpToolResults,
+                  mcpToolResultImageRendering:
+                    persist.mcpToolResultImageRendering,
+                  selectedServers:
+                    Array.isArray(persist.selectedServerNames) &&
+                    persist.selectedServerNames.length ===
+                      persist.selectedServerIds.length
+                      ? persist.selectedServerNames
+                      : persist.selectedServerIds,
+                },
+                ...(resolvedHostConfig
+                  ? { hostConfig: resolvedHostConfig }
+                  : {}),
+              }
+            : {}),
+          turnTrace,
+          // §3: chat-backed harness resume-state commit, applied atomically
+          // with the transcript inside the ingest mutation.
+          ...(harnessSessionCommit ? { harnessSessionCommit } : {}),
+          forwardHeaders: pickEnrichmentHeaders(c.req.raw.headers),
+        },
       });
     };
   };


### PR DESCRIPTION
**Stack 2/4** — swarm/chatbox split. Base: #3109.

Extracts `persistHostSessionTurn` (best-effort tool-snapshot capture + persist) into a shared module, used by both the live-chat `onConversationComplete` path and the synthetic runner's per-turn persist.

- Each caller keeps its own divergent persist payload (direct: `resumeConfig`/`hostConfig`/`directVisibility`; synthetic: `synthetic`/`personaId`/`synthesisRunId`) — only the duplicated snapshot boilerplate is unified.
- Exports `PersistChatSessionOptions`.
- **Behavior-preserving.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor of chat session persistence; snapshot failures remain non-blocking and caller-specific ingest fields are unchanged.
> 
> **Overview**
> Pulls duplicated **best-effort MCP tool-snapshot capture** plus **`chatSessions` ingest** into `server/utils/persist-host-session-turn.ts` (`captureToolSnapshotForPersist`, `persistHostSessionTurn`). **Live chat** (`web-chat-turn.ts` → `onConversationComplete`) and **synthetic simulation** (`sessionSimulation/runner.ts` per-turn persist) now call that helper instead of inlining the same `hasServer` filter → `exportConnectedServerToolSnapshotForEvalAuthoring` → `persistChatSessionToConvex` sequence.
> 
> Callers still build their own persist payloads (direct: `resumeConfig` / `hostConfig` / `directVisibility`; synthetic: `synthetic` / persona / `synthesisRunId`). Live chat can still skip snapshots with `captureToolSnapshot: false`. Optional Hono `Context` is only passed through when present so ingest logging and tests match prior arity. **`PersistChatSessionOptions`** is exported from `chat-ingestion.ts` for the shared helper’s typing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b73013d4b0ef2e1b2a7b3a365f049ec5e00293b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies host-session turn persistence across live chat and synthetic runs with a shared helper for best-effort tool snapshot capture and turn persist. Behavior is unchanged; snapshot failures never block writes and duplicate code is removed.

- **Refactors**
  - Added `server/utils/persist-host-session-turn.ts` with `persistHostSessionTurn` and `captureToolSnapshotForPersist`.
  - Switched `web-chat-turn.ts` and `sessionSimulation/runner.ts` to use the helper; callers can opt out via `captureToolSnapshot: false`.
  - Preserves caller-specific payloads (direct: `resumeConfig`/`hostConfig`/`directVisibility`; synthetic: `synthetic`/`personaId`/`synthesisRunId`).
  - Exported `PersistChatSessionOptions` from `chat-ingestion.ts`.

<sup>Written for commit 5a2d567cc16b9de29f1d09de11256f8f8cb8987e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

