### PR TITLE
feat(swarm): bind synthetic runs to the chatbox's own project (server-side)

### DIFF
--- a/mcpjam-inspector/server/routes/web/__tests__/chatbox-sessions.byok.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chatbox-sessions.byok.test.ts
@@ -69,6 +69,7 @@ describe("web routes — chatbox-sessions BYOK gate removed", () => {
       config: {
         chatboxId: "cbx-1",
         accessVersion: 0,
+        executionScope: { kind: "project", projectId: "proj-1" },
         // Bare gpt-4o (no openai/ prefix) is BYOK, not MCPJam-provided.
         modelId: "gpt-4o",
         systemPrompt: "",
@@ -103,6 +104,7 @@ describe("web routes — chatbox-sessions BYOK gate removed", () => {
       config: {
         chatboxId: "cbx-2",
         accessVersion: 0,
+        executionScope: { kind: "project", projectId: "proj-1" },
         modelId: "openai/gpt-4o-mini",
         systemPrompt: "",
         temperature: 0.7,
@@ -129,6 +131,7 @@ describe("web routes — chatbox-sessions BYOK gate removed", () => {
       config: {
         chatboxId: "cbx-computer",
         accessVersion: 0,
+        executionScope: { kind: "project", projectId: "proj-1" },
         modelId: "openai/gpt-4o-mini",
         systemPrompt: "",
         temperature: 0.7,
@@ -176,6 +179,7 @@ describe("web routes — chatbox-sessions BYOK gate removed", () => {
       config: {
         chatboxId: "cbx-images",
         accessVersion: 0,
+        executionScope: { kind: "project", projectId: "proj-1" },
         modelId: "openai/gpt-4o-mini",
         systemPrompt: "",
         temperature: 0.7,
@@ -203,5 +207,58 @@ describe("web routes — chatbox-sessions BYOK gate removed", () => {
         mcpToolResultImageRendering,
       })
     );
+  });
+
+  it("rejects a body projectId that mismatches the chatbox's project (403)", async () => {
+    fetchChatboxRuntimeConfigMock.mockResolvedValue({
+      ok: true,
+      config: {
+        chatboxId: "cbx-x",
+        accessVersion: 0,
+        // Chatbox actually belongs to a DIFFERENT project than the body.
+        executionScope: { kind: "project", projectId: "proj-OTHER" },
+        modelId: "openai/gpt-4o-mini",
+        systemPrompt: "",
+        temperature: 0.7,
+        requireToolApproval: false,
+        hostStyle: "default",
+      },
+    });
+
+    const response = await postJson(
+      app,
+      "/api/web/chatboxes/cbx-x/simulate-sessions/start",
+      validBody, // projectId: "proj-1"
+      token,
+    );
+    const { status } = await expectJson<{ runId?: string }>(response);
+    expect(status).toBe(403);
+    expect(createRunMock).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the runtime config can't surface the chatbox's project (403)", async () => {
+    fetchChatboxRuntimeConfigMock.mockResolvedValue({
+      ok: true,
+      config: {
+        chatboxId: "cbx-noscope",
+        accessVersion: 0,
+        // No executionScope -> project binding unverifiable.
+        modelId: "openai/gpt-4o-mini",
+        systemPrompt: "",
+        temperature: 0.7,
+        requireToolApproval: false,
+        hostStyle: "default",
+      },
+    });
+
+    const response = await postJson(
+      app,
+      "/api/web/chatboxes/cbx-noscope/simulate-sessions/start",
+      validBody,
+      token,
+    );
+    const { status } = await expectJson<{ runId?: string }>(response);
+    expect(status).toBe(403);
+    expect(createRunMock).not.toHaveBeenCalled();
   });
 });

--- a/mcpjam-inspector/server/routes/web/__tests__/chatbox-sessions.no-model.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chatbox-sessions.no-model.test.ts
@@ -63,6 +63,7 @@ describe("web routes — simulate-sessions/start on a modelless host", () => {
     config: {
       chatboxId: "cbx-1",
       accessVersion: 0,
+      executionScope: { kind: "project", projectId: "proj-1" },
       modelId,
       systemPrompt: "",
       temperature: 0.7,

--- a/mcpjam-inspector/server/routes/web/__tests__/chatbox-sessions.no-required-servers.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chatbox-sessions.no-required-servers.test.ts
@@ -46,6 +46,21 @@ describe("web routes — chatbox-sessions with no required servers", () => {
     createRunMock.mockReset();
     generatePersonasMock.mockReset();
     startSimulationMock.mockReset();
+    // Default runtime config so the provenance guard can verify the chatbox's
+    // project (generate-personas resolves it too). Per-test mocks override.
+    fetchChatboxRuntimeConfigMock.mockResolvedValue({
+      ok: true,
+      config: {
+        chatboxId: "cbx-1",
+        accessVersion: 0,
+        executionScope: { kind: "project", projectId: "proj-1" },
+        modelId: "openai/gpt-4o-mini",
+        systemPrompt: "",
+        temperature: 0.7,
+        requireToolApproval: false,
+        hostStyle: "default",
+      },
+    });
     createRunMock.mockResolvedValue({ runId: "run-1" });
     startSimulationMock.mockResolvedValue(undefined);
     generatePersonasMock.mockResolvedValue([
@@ -114,6 +129,7 @@ describe("web routes — chatbox-sessions with no required servers", () => {
       config: {
         chatboxId: "cbx-1",
         accessVersion: 0,
+        executionScope: { kind: "project", projectId: "proj-1" },
         modelId: "openai/gpt-4o-mini",
         systemPrompt: "",
         temperature: 0.7,

--- a/mcpjam-inspector/server/routes/web/chatbox-sessions.ts
+++ b/mcpjam-inspector/server/routes/web/chatbox-sessions.ts
@@ -81,6 +81,60 @@ const startSimulationSchema = z.object({
   maxTurns: z.number().int().min(1).max(20),
 });
 
+/**
+ * Provenance guard: the body `projectId` must match the chatbox's OWN project,
+ * resolved server-side from the chatbox runtime config's `executionScope`.
+ * `createAuthorizedManager` already verifies the bearer's membership of the
+ * supplied `projectId`, but NOT that the chatbox belongs to it — without this,
+ * a caller who is a member of both the chatbox's project A AND some project B
+ * could launch chatbox A's run/personas attributed to project B. Reject the
+ * mismatch before any run/manager/simulation exists.
+ *
+ * Fails CLOSED: if the runtime config didn't surface the chatbox's project
+ * (`executionScope.projectId` absent), we can't verify the chatbox↔project
+ * binding, so we reject rather than trust the caller-supplied `projectId`.
+ */
+function assertBodyProjectMatchesChatbox(
+  bodyProjectId: string,
+  executionScope: { projectId?: string } | undefined
+): void {
+  const scopeProjectId = executionScope?.projectId;
+  if (!scopeProjectId) {
+    throw new WebRouteError(
+      403,
+      ErrorCode.FORBIDDEN,
+      "Unable to verify this chatbox's project; refusing to run under an unverified projectId."
+    );
+  }
+  if (bodyProjectId !== scopeProjectId) {
+    throw new WebRouteError(
+      403,
+      ErrorCode.FORBIDDEN,
+      "projectId does not match this chatbox's project"
+    );
+  }
+}
+
+/**
+ * Map a chatbox runtime-config fetch's HTTP status onto the matching
+ * `ErrorCode` so an upstream 401/403/404 doesn't surface to the client as a
+ * generic `INTERNAL_ERROR`.
+ */
+function errorCodeForRuntimeStatus(
+  status: number
+): (typeof ErrorCode)[keyof typeof ErrorCode] {
+  switch (status) {
+    case 401:
+      return ErrorCode.UNAUTHORIZED;
+    case 403:
+      return ErrorCode.FORBIDDEN;
+    case 404:
+      return ErrorCode.NOT_FOUND;
+    default:
+      return ErrorCode.INTERNAL_ERROR;
+  }
+}
+
 function resolveRequiredServers(
   servers: Array<{ serverId: string; serverName?: string; optional?: boolean }>
 ): { selectedServerIds: string[]; selectedServerNames: string[] } {
@@ -109,6 +163,26 @@ chatboxSessions.post("/:chatboxId/generate-personas", async (c) =>
       await readJsonBody<unknown>(c)
     );
     const convexHttpUrl = requireConvexHttpUrl();
+
+    // Provenance guard (same as the start route): resolve the chatbox's own
+    // project server-side and reject a mismatched body projectId before the
+    // authorized manager + backend persona generation run under it.
+    const runtime = await fetchChatboxRuntimeConfig({
+      chatboxId,
+      bearer: bearerToken,
+    });
+    if (!runtime.ok) {
+      throw new WebRouteError(
+        runtime.status,
+        errorCodeForRuntimeStatus(runtime.status),
+        runtime.error
+      );
+    }
+    assertBodyProjectMatchesChatbox(
+      body.projectId,
+      runtime.config.executionScope
+    );
+
     // selectedServerIds may be empty (no required servers): the manager
     // comes back connection-less, the snapshot captures zero servers, and
     // the backend grounds personas in the chatbox name instead of tools.
@@ -196,10 +270,17 @@ chatboxSessions.post("/:chatboxId/simulate-sessions/start", async (c) =>
     if (!runtime.ok) {
       throw new WebRouteError(
         runtime.status,
-        ErrorCode.INTERNAL_ERROR,
+        errorCodeForRuntimeStatus(runtime.status),
         runtime.error
       );
     }
+
+    // Bind the run to the chatbox's own project (server-authoritative) before
+    // createRun/manager/startSimulation run under a caller-supplied projectId.
+    assertBodyProjectMatchesChatbox(
+      body.projectId,
+      runtime.config.executionScope
+    );
 
     // Fail fast before the run record exists. An unpinned host persists
     // modelId "" (a fully supported host state — Save never gates on it),

--- a/mcpjam-inspector/server/services/sessionSimulation/runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/runner.ts
@@ -36,7 +36,7 @@ import {
   persistChatSessionToConvex,
   type PersistedTurnTrace,
 } from "../../utils/chat-ingestion.js";
-import { exportConnectedServerToolSnapshotForEvalAuthoring } from "../../utils/export-helpers.js";
+import { persistHostSessionTurn } from "../../utils/persist-host-session-turn.js";
 import { captureMcpAppWidgetSnapshots } from "../../utils/mcp-app-widget-capture.js";
 import {
   createBrowserSessionContext,
@@ -769,51 +769,36 @@ async function runOneSession(args: {
 
       // Mirror chat-v2's per-turn persistence so the Trace tab and the
       // tool-snapshot/serverInspections fan-out work identically for
-      // synthetic sessions and Playground sessions. Snapshot failures
-      // must never block the persist.
-      let toolSnapshot: unknown;
-      try {
-        const liveManager = built.manager;
-        const knownIds =
-          typeof liveManager.hasServer === "function"
-            ? selectedServerIds.filter((id) => liveManager.hasServer(id))
-            : selectedServerIds;
-        if (knownIds.length > 0) {
-          toolSnapshot =
-            await exportConnectedServerToolSnapshotForEvalAuthoring(
-              liveManager,
-              knownIds,
-              { logPrefix: "sessionSimulation.persist" }
-            );
-        }
-      } catch {
-        toolSnapshot = undefined;
-      }
-
-      await persistChatSessionToConvex({
-        chatSessionId,
-        modelId: String(modelDefinition.id),
-        modelSource: sessionModelSource ?? "mcpjam",
-        authHeader,
-        projectId,
-        sourceType: "chatbox",
-        // Synthetic chatbox simulation — distinguished from real chatbox
-        // traffic by the `synthetic: true` flag already on the row, not by
-        // origin. Training filters should combine `origin === 'chatbox'`
-        // with `synthetic !== true` to keep these out.
-        origin: "chatbox",
-        surface: "share_link",
-        chatboxId,
-        sessionMessages: messageHistory,
-        startedAt: sessionStartedAt,
-        lastActivityAt: Date.now(),
-        synthetic: true,
-        personaId: persona.id,
-        personaLabel: persona.name,
-        synthesisRunId: runId,
-        turnTrace,
-        resumeConfig,
-        ...(toolSnapshot ? { toolSnapshot } : {}),
+      // synthetic sessions and Playground sessions. Snapshot capture +
+      // persist run through the shared `persistHostSessionTurn` helper
+      // (best-effort snapshot; failures never block the persist).
+      await persistHostSessionTurn(built.manager, {
+        selectedServerIds,
+        logPrefix: "sessionSimulation.persist",
+        persist: {
+          chatSessionId,
+          modelId: String(modelDefinition.id),
+          modelSource: sessionModelSource ?? "mcpjam",
+          authHeader,
+          projectId,
+          sourceType: "chatbox",
+          // Synthetic chatbox simulation — distinguished from real chatbox
+          // traffic by the `synthetic: true` flag already on the row, not by
+          // origin. Training filters should combine `origin === 'chatbox'`
+          // with `synthetic !== true` to keep these out.
+          origin: "chatbox",
+          surface: "share_link",
+          chatboxId,
+          sessionMessages: messageHistory,
+          startedAt: sessionStartedAt,
+          lastActivityAt: Date.now(),
+          synthetic: true,
+          personaId: persona.id,
+          personaLabel: persona.name,
+          synthesisRunId: runId,
+          turnTrace,
+          resumeConfig,
+        },
       });
       anyTurnPersisted = true;
 

--- a/mcpjam-inspector/server/utils/chat-ingestion.ts
+++ b/mcpjam-inspector/server/utils/chat-ingestion.ts
@@ -161,7 +161,7 @@ export interface PersistedTurnTrace {
 // inspector pins to the closed set.
 export type ChatOrigin = "playground" | "mcpjam_agent" | "chatbox" | "eval";
 
-interface PersistChatSessionOptions {
+export interface PersistChatSessionOptions {
   chatSessionId: string;
   modelId: string;
   modelSource: "mcpjam" | "byok" | "local_byok";

--- a/mcpjam-inspector/server/utils/persist-host-session-turn.ts
+++ b/mcpjam-inspector/server/utils/persist-host-session-turn.ts
@@ -1,0 +1,86 @@
+/**
+ * Shared persistence for one "session in a host" turn.
+ *
+ * Both the live-chat path (`web-chat-turn.ts` → `buildOnConversationComplete`)
+ * and the synthetic runner (`sessionSimulation/runner.ts` → `runOneSession`)
+ * persist a `chatSessions` row after each assistant turn. The tool-snapshot
+ * capture that precedes the write was duplicated byte-for-byte at both sites;
+ * this module owns it once. Each caller still constructs its OWN persist
+ * payload (direct chat: `resumeConfig` / `hostConfig` / `directVisibility`;
+ * synthetic: `synthetic` / `personaId` / `synthesisRunId`) — we deliberately
+ * do NOT fold those divergent shapes into one wide options union.
+ */
+
+import type { Context } from "hono";
+import type { MCPClientManager } from "@mcpjam/sdk";
+import { exportConnectedServerToolSnapshotForEvalAuthoring } from "./export-helpers.js";
+import {
+  persistChatSessionToConvex,
+  type PersistChatSessionOptions,
+} from "./chat-ingestion.js";
+
+type Manager = InstanceType<typeof MCPClientManager>;
+
+/**
+ * Best-effort tool-snapshot capture. Filters to servers the manager actually
+ * has connected, then exports the eval-authoring snapshot. Any failure resolves
+ * to `undefined` — capturing a snapshot must NEVER block the session persist.
+ */
+export async function captureToolSnapshotForPersist(
+  manager: Manager,
+  selectedServerIds: string[],
+  logPrefix: string,
+): Promise<unknown> {
+  try {
+    const knownIds =
+      typeof manager.hasServer === "function"
+        ? selectedServerIds.filter((id) => manager.hasServer(id))
+        : selectedServerIds;
+    if (knownIds.length === 0) return undefined;
+    return await exportConnectedServerToolSnapshotForEvalAuthoring(
+      manager,
+      knownIds,
+      { logPrefix },
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Capture the tool snapshot (best-effort) and persist the `chatSessions` row.
+ * The caller supplies the full persist payload minus `toolSnapshot`; the
+ * captured snapshot is merged in when present.
+ */
+export async function persistHostSessionTurn(
+  manager: Manager,
+  args: {
+    selectedServerIds: string[];
+    /** Default `true`; surfaces with synthetic server ids opt out. */
+    captureToolSnapshot?: boolean;
+    logPrefix: string;
+    persist: Omit<PersistChatSessionOptions, "toolSnapshot">;
+  },
+  c?: Context,
+): Promise<void> {
+  const toolSnapshot =
+    args.captureToolSnapshot !== false
+      ? await captureToolSnapshotForPersist(
+          manager,
+          args.selectedServerIds,
+          args.logPrefix,
+        )
+      : undefined;
+  const merged = {
+    ...args.persist,
+    ...(toolSnapshot ? { toolSnapshot } : {}),
+  };
+  // Preserve the original call arity — only forward the Hono context when one
+  // was actually supplied. Passing an explicit `undefined` second arg is both
+  // unnecessary and changes `toHaveBeenCalledWith` matching for callers.
+  if (c) {
+    await persistChatSessionToConvex(merged, c);
+  } else {
+    await persistChatSessionToConvex(merged);
+  }
+}

--- a/mcpjam-inspector/server/utils/web-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/web-chat-turn.ts
@@ -53,7 +53,6 @@ import {
   type WidgetModelContextEntry,
 } from "./chat-v2-orchestration.js";
 import {
-  persistChatSessionToConvex,
   pickEnrichmentHeaders,
   stampSenderUserIdsOnSessionMessages,
   type ChatOrigin,
@@ -61,7 +60,7 @@ import {
   type PersistedTurnTrace,
 } from "./chat-ingestion.js";
 import type { HarnessSessionCommitPayload } from "./harness/harness-session-state.js";
-import { exportConnectedServerToolSnapshotForEvalAuthoring } from "./export-helpers.js";
+import { persistHostSessionTurn } from "./persist-host-session-turn.js";
 import { ErrorCode, WebRouteError } from "./../routes/web/errors.js";
 import type { createHostedRpcLogCollector } from "./../routes/web/hosted-rpc-logs.js";
 import { bridgeHarnessRpcLogsToCollector } from "./../routes/web/hosted-rpc-logs.js";
@@ -333,76 +332,66 @@ export async function streamWebChatTurn(
       harnessSessionCommit?: HarnessSessionCommitPayload,
     ) => {
       const isDirectChat = !isChatboxSession;
-      // Capture the live tool catalog. Failures must never block the persist.
-      // Surfaces with synthetic server ids (mcpjam-agent) opt out via
+      // Snapshot capture (best-effort) + persist run through the shared
+      // `persistHostSessionTurn` helper. Surfaces with synthetic server ids
+      // (mcpjam-agent) opt out of the snapshot via
       // `persist.captureToolSnapshot === false`.
-      let toolSnapshot: unknown;
-      if (persist.captureToolSnapshot !== false) {
-        try {
-          const knownIds =
-            typeof manager.hasServer === "function"
-              ? persist.selectedServerIds.filter((id) => manager.hasServer(id))
-              : persist.selectedServerIds;
-          if (knownIds.length > 0) {
-            toolSnapshot =
-              await exportConnectedServerToolSnapshotForEvalAuthoring(
-                manager,
-                knownIds,
-                { logPrefix: "chat-v2.persist" },
-              );
-          }
-        } catch {
-          toolSnapshot = undefined;
-        }
-      }
-
-      await persistChatSessionToConvex({
-        chatSessionId: hostedChatSessionId,
-        modelId,
-        modelSource,
-        projectId: persist.projectId,
-        sourceType: persist.sourceType,
-        origin: persist.origin,
-        ...(isChatboxSession && persist.surface
-          ? { surface: persist.surface }
+      await persistHostSessionTurn(manager, {
+        selectedServerIds: persist.selectedServerIds,
+        ...(persist.captureToolSnapshot !== undefined
+          ? { captureToolSnapshot: persist.captureToolSnapshot }
           : {}),
-        chatboxId: persist.chatboxId,
-        accessVersion: persist.accessVersion,
-        authHeader: runtime.authHeader,
-        sessionMessages: stampSenderUserIdsOnSessionMessages(
-          fullHistory,
-          persist.originalMessages as unknown[],
-          { authenticatedUserId: persist.authenticatedUserId },
-        ),
-        startedAt: sessionStartedAt,
-        lastActivityAt: Date.now(),
-        ...(toolSnapshot ? { toolSnapshot } : {}),
-        ...(isDirectChat
-          ? {
-              directVisibility: persist.directVisibility,
-              resumeConfig: {
-                systemPrompt: persist.systemPrompt,
-                temperature: persist.temperature,
-                requireToolApproval: persist.requireToolApproval,
-                respectToolVisibility: persist.respectToolVisibility,
-                modelVisibleMcpToolResults: prepare.modelVisibleMcpToolResults,
-                mcpToolResultImageRendering:
-                  persist.mcpToolResultImageRendering,
-                selectedServers:
-                  Array.isArray(persist.selectedServerNames) &&
-                  persist.selectedServerNames.length ===
-                    persist.selectedServerIds.length
-                    ? persist.selectedServerNames
-                    : persist.selectedServerIds,
-              },
-              ...(resolvedHostConfig ? { hostConfig: resolvedHostConfig } : {}),
-            }
-          : {}),
-        turnTrace,
-        // §3: chat-backed harness resume-state commit, applied atomically with
-        // the transcript inside the ingest mutation.
-        ...(harnessSessionCommit ? { harnessSessionCommit } : {}),
-        forwardHeaders: pickEnrichmentHeaders(c.req.raw.headers),
+        logPrefix: "chat-v2.persist",
+        persist: {
+          chatSessionId: hostedChatSessionId,
+          modelId,
+          modelSource,
+          projectId: persist.projectId,
+          sourceType: persist.sourceType,
+          origin: persist.origin,
+          ...(isChatboxSession && persist.surface
+            ? { surface: persist.surface }
+            : {}),
+          chatboxId: persist.chatboxId,
+          accessVersion: persist.accessVersion,
+          authHeader: runtime.authHeader,
+          sessionMessages: stampSenderUserIdsOnSessionMessages(
+            fullHistory,
+            persist.originalMessages as unknown[],
+            { authenticatedUserId: persist.authenticatedUserId },
+          ),
+          startedAt: sessionStartedAt,
+          lastActivityAt: Date.now(),
+          ...(isDirectChat
+            ? {
+                directVisibility: persist.directVisibility,
+                resumeConfig: {
+                  systemPrompt: persist.systemPrompt,
+                  temperature: persist.temperature,
+                  requireToolApproval: persist.requireToolApproval,
+                  respectToolVisibility: persist.respectToolVisibility,
+                  modelVisibleMcpToolResults:
+                    prepare.modelVisibleMcpToolResults,
+                  mcpToolResultImageRendering:
+                    persist.mcpToolResultImageRendering,
+                  selectedServers:
+                    Array.isArray(persist.selectedServerNames) &&
+                    persist.selectedServerNames.length ===
+                      persist.selectedServerIds.length
+                      ? persist.selectedServerNames
+                      : persist.selectedServerIds,
+                },
+                ...(resolvedHostConfig
+                  ? { hostConfig: resolvedHostConfig }
+                  : {}),
+              }
+            : {}),
+          turnTrace,
+          // §3: chat-backed harness resume-state commit, applied atomically
+          // with the transcript inside the ingest mutation.
+          ...(harnessSessionCommit ? { harnessSessionCommit } : {}),
+          forwardHeaders: pickEnrichmentHeaders(c.req.raw.headers),
+        },
       });
     };
   };


### PR DESCRIPTION
**Stack 3/4** — swarm/chatbox split. Base: #3110. Backend: MCPJam/mcpjam-backend#685.

Adds a **provenance guard** to the `simulate-sessions/start` and `generate-personas` routes: the body `projectId` must match the chatbox's own project, resolved server-side from the runtime config's `executionScope`.

`createAuthorizedManager` already checks the bearer's membership of the supplied `projectId`, but not that the chatbox belongs to it — without this, a caller who is a member of two projects could launch one chatbox's run/personas attributed to the other.

The host-attribution schema (`chatSessions.hostId`, derived server-side at ingest) ships in backend #685.

> **Deferred** (not in this PR): switching the synthetic runner's config source to `internalGetHostRuntimeConfig` / `kind:'project'` scope — deploy-gated (server-list plumbing + billing verification). Owner-initiated synthetic runs already resolve as `project_member`, so this is a cleanup, not a fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Authorization fix on swarm entry points that prevents cross-project attribution; behavior change (403) when runtime config lacks project binding.
> 
> **Overview**
> Adds a **provenance guard** so synthetic swarm work cannot be attributed to the wrong project: request `projectId` must equal the chatbox's project from runtime config `executionScope`, checked **before** `createRun`, persona generation, or simulation start.
> 
> The same check now runs on **`generate-personas`** (which previously only validated membership via `createAuthorizedManager`). **`simulate-sessions/start`** gains the guard after loading runtime config. Missing `executionScope.projectId` **fails closed** with 403 instead of trusting the client.
> 
> Runtime-config fetch failures now map upstream **401/403/404** to matching `ErrorCode` values instead of always `INTERNAL_ERROR`. Tests add `executionScope` to mocks and cover mismatch and no-scope 403 cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e882d12c833971e17e829d6ff784c7d60ec9d503. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bind synthetic runs and persona generation to the chatbox’s own project by enforcing a server-side projectId match from the chatbox runtime config. Reject mismatches or missing project binding with 403 to prevent cross-project attribution.

- **Bug Fixes**
  - Enforce body.projectId === runtime.config.executionScope.projectId on simulate-sessions/start and generate-personas; check before any run/manager/persona/simulation work and map runtime-config fetch 401/403/404 to matching error codes.
  - Fail closed with 403 when the chatbox runtime config lacks executionScope.projectId.

<sup>Written for commit e882d12c833971e17e829d6ff784c7d60ec9d503. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

