### PR TITLE
feat(swarm): split Chatbox (human) and Swarm (agent) surfaces

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -473,6 +473,8 @@ function NoRouterRouteBody({ activeTab }: { activeTab: string }) {
       return <ComputerRoute />;
     case "chatboxes":
       return <ChatboxesRoute />;
+    case "swarms":
+      return <SwarmsRoute />;
     case "playground":
       return <PlaygroundRoute />;
     case "support":
@@ -905,7 +907,11 @@ export function CompatibilityRoute() {
 // Navigation between chatboxes flows through the global host bar — pick
 // a host, manage its chatbox here. There is no chatbox list; the host
 // list lives in Connect.
-export function ChatboxesRoute() {
+// Both the human Chatbox surface (`/chatboxes`) and the agent Swarm surface
+// (`/swarms`) render `ChatboxesTab` over the same underlying chatbox; only the
+// `product` (tab set + affordances) differs. Both share the `chatboxes`
+// billing feature + `sandboxes-enabled` flag.
+function ChatboxProductRoute({ product }: { product: "chatbox" | "swarm" }) {
   const {
     billingUiEnabled,
     activeTabBillingLocked,
@@ -922,8 +928,17 @@ export function ChatboxesRoute() {
     <ChatboxesTab
       projectId={convexProjectId}
       isAuthenticated={isAuthenticated}
+      product={product}
     />
   );
+}
+
+export function ChatboxesRoute() {
+  return <ChatboxProductRoute product="chatbox" />;
+}
+
+export function SwarmsRoute() {
+  return <ChatboxProductRoute product="swarm" />;
 }
 
 export function ResourcesRoute() {

--- a/mcpjam-inspector/client/src/__tests__/ChatboxesRoute.billing.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/ChatboxesRoute.billing.test.tsx
@@ -121,6 +121,7 @@ describe("ChatboxesRoute billing gate", () => {
     expect(mockChatboxesTab).toHaveBeenCalledWith({
       projectId: "project-1",
       isAuthenticated: true,
+      product: "chatbox",
     });
   });
 
@@ -138,6 +139,7 @@ describe("ChatboxesRoute billing gate", () => {
     expect(mockChatboxesTab).toHaveBeenCalledWith({
       projectId: "project-1",
       isAuthenticated: true,
+      product: "chatbox",
     });
   });
 

--- a/mcpjam-inspector/client/src/components/ChatboxesTab.tsx
+++ b/mcpjam-inspector/client/src/components/ChatboxesTab.tsx
@@ -49,19 +49,40 @@ import { cn } from "@/lib/utils";
  * every visit to this (landing) tab starts a guest session — preview
  * traffic shows up in Sessions and guest analytics.
  */
+/**
+ * Product variant. Both surfaces render this same component over the same
+ * underlying chatbox (1:1 with the selected host); they differ only in which
+ * tabs/affordances are exposed:
+ *   - `chatbox` (human): Publish + Sessions + Clusters. No Personas / no
+ *     AI-generate / no synthetic-session controls.
+ *   - `swarm` (agent): Publish + Personas + Sessions. No Clusters.
+ */
+export type ChatboxProduct = "chatbox" | "swarm";
+
 interface ChatboxesTabProps {
   projectId: string | null;
   isAuthenticated: boolean;
+  /** Defaults to `chatbox` (the human publish surface). */
+  product?: ChatboxProduct;
 }
 
 type ChatboxTab = "publish" | "personas" | "sessions" | "clusters";
 
-const TAB_OPTIONS: ReadonlyArray<{ value: ChatboxTab; label: string }> = [
-  { value: "publish", label: "Publish" },
-  { value: "personas", label: "Personas" },
-  { value: "sessions", label: "Sessions" },
-  { value: "clusters", label: "Clusters" },
-];
+const TAB_OPTIONS_BY_PRODUCT: Record<
+  ChatboxProduct,
+  ReadonlyArray<{ value: ChatboxTab; label: string }>
+> = {
+  chatbox: [
+    { value: "publish", label: "Publish" },
+    { value: "sessions", label: "Sessions" },
+    { value: "clusters", label: "Clusters" },
+  ],
+  swarm: [
+    { value: "publish", label: "Publish" },
+    { value: "personas", label: "Personas" },
+    { value: "sessions", label: "Sessions" },
+  ],
+};
 
 type PublishPanelView = "preview" | "graph";
 
@@ -74,7 +95,9 @@ const PUBLISH_PANEL_OPTIONS: Array<{ value: PublishPanelView; label: string }> =
 export function ChatboxesTab({
   projectId,
   isAuthenticated,
+  product = "chatbox",
 }: ChatboxesTabProps) {
+  const tabOptions = TAB_OPTIONS_BY_PRODUCT[product];
   const [searchParams, setSearchParams] = useSearchParams();
   // Deep link: `/chatboxes?host=<id>&session=<threadId>` (the Sessions tab's
   // "Copy session link"). The params stay in the URL until the user navigates
@@ -86,6 +109,12 @@ export function ChatboxesTab({
   const [tab, setTab] = useState<ChatboxTab>(() =>
     sessionDeepLinkThreadId ? "sessions" : "publish"
   );
+  // Clamp to a tab valid for this product — a deep link (or a product switch)
+  // could otherwise land on a tab this surface doesn't expose (e.g. `personas`
+  // on the human Chatbox, `clusters` on the agent Swarm).
+  const activeTab: ChatboxTab = tabOptions.some((t) => t.value === tab)
+    ? tab
+    : "publish";
   const [panelView, setPanelView] = useState<PublishPanelView>("preview");
   const [previewedHostId, setPreviewedHostId] = usePreviewedHostId(projectId);
   // Apply the host half of the deep link once the project is known —
@@ -272,8 +301,8 @@ export function ChatboxesTab({
       >
         <div className="flex min-w-0 items-center justify-center">
           <ViewModeSelector
-            value={tab}
-            ariaLabel="Swarm view"
+            value={activeTab}
+            ariaLabel={product === "swarm" ? "Swarm view" : "Chatbox view"}
             onChange={(next) => {
               setTab(next as ChatboxTab);
               // Manual navigation supersedes the deep link — drop the params
@@ -282,12 +311,12 @@ export function ChatboxesTab({
                 setSearchParams({}, { replace: true });
               }
             }}
-            options={TAB_OPTIONS}
+            options={tabOptions}
           />
         </div>
       </div>
       <div className="min-h-0 flex-1 overflow-hidden">
-        {tab === "publish" ? (
+        {activeTab === "publish" ? (
           <ResizablePanelGroup direction="horizontal" className="h-full">
             <ResizablePanel defaultSize={50} minSize={32}>
               <div className="h-full overflow-y-auto px-6 py-6">
@@ -374,13 +403,17 @@ export function ChatboxesTab({
               </div>
             </ResizablePanel>
           </ResizablePanelGroup>
-        ) : tab === "personas" ? (
+        ) : activeTab === "personas" ? (
           <PersonasTab chatbox={chatbox} />
-        ) : tab === "sessions" ? (
+        ) : activeTab === "sessions" ? (
           <ChatboxUsagePanel
             chatbox={chatbox}
             section="sessions"
             initialThreadId={sessionDeepLinkThreadId}
+            // Synthetic-session affordances (AI-generate + "Hide synthetic")
+            // belong to the agent Swarm product only; the human Chatbox has
+            // no synthetic traffic.
+            allowSynthetic={product === "swarm"}
           />
         ) : (
           <ChatboxUsagePanel

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxUsagePanel.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxUsagePanel.tsx
@@ -23,7 +23,7 @@ import { ShareUsageThreadList } from "@/components/connection/share-usage/ShareU
 import { ShareUsageThreadDetail } from "@/components/connection/share-usage/ShareUsageThreadDetail";
 import { ChatboxTopicMapPanel } from "@/components/chatboxes/ChatboxTopicMapPanel";
 import { GenerateSessionsDialog } from "@/components/chatboxes/GenerateSessionsDialog";
-import { buildChatboxSessionPath } from "@/lib/app-navigation";
+import { buildChatboxSessionPath, routePaths } from "@/lib/app-navigation";
 import { getShareableAppOrigin } from "@/lib/chatbox-session";
 
 export type ChatboxUsagePanelSection = "sessions" | "insights";
@@ -38,6 +38,13 @@ interface ChatboxUsagePanelProps {
    */
   initialThreadId?: string | null;
   /**
+   * Whether synthetic-session affordances (the "Generate with AI" dialog and
+   * the "Hide synthetic" filter toggle) are shown. Only the agent Swarm product
+   * generates synthetic traffic; the human Chatbox passes `false`. Defaults to
+   * `true` for existing callers.
+   */
+  allowSynthetic?: boolean;
+  /**
    * Called when the topic map asks to open a session in the Sessions tab.
    * The parent owns the tab switch; this panel handles the thread selection
    * itself (the same instance survives the insights → sessions flip).
@@ -45,10 +52,19 @@ interface ChatboxUsagePanelProps {
   onOpenSession?: (threadId: string) => void;
 }
 
+/** Filter chip that excludes synthetic (AI-generated) sessions from the list. */
+const HIDE_SYNTHETIC_CHIP: UsageFilterChip = {
+  kind: "dimension",
+  key: "synthetic",
+  value: "hide",
+  label: "Hide synthetic",
+};
+
 export function ChatboxUsagePanel({
   chatbox,
   section,
   initialThreadId,
+  allowSynthetic = true,
   onOpenSession,
 }: ChatboxUsagePanelProps) {
   // Scope selection to the current chatbox so switching chatboxes can't briefly
@@ -58,6 +74,19 @@ export function ChatboxUsagePanel({
     threadId: string | null;
   }>({ chatboxId: chatbox.chatboxId, threadId: initialThreadId ?? null });
   const [filter, setFilter] = useState<UsageFilterState>(EMPTY_USAGE_FILTER);
+  // The human Chatbox product has no synthetic traffic, so force synthetic
+  // sessions out of the fetched + rendered list regardless of the user's own
+  // filter chips. Only the data path uses this; the filter UI still shows the
+  // user's chips.
+  const effectiveFilter = useMemo<UsageFilterState>(() => {
+    if (allowSynthetic) return filter;
+    if (
+      filter.chips.some((c) => chipKey(c) === chipKey(HIDE_SYNTHETIC_CHIP))
+    ) {
+      return filter;
+    }
+    return { ...filter, chips: [...filter.chips, HIDE_SYNTHETIC_CHIP] };
+  }, [filter, allowSynthetic]);
   const [rebuildBusy, setRebuildBusy] = useState(false);
   const [generateOpen, setGenerateOpen] = useState(false);
   // Synchronous latch so double-clicks can't queue two concurrent rebuilds
@@ -81,7 +110,7 @@ export function ChatboxUsagePanel({
   const { threads, rebuild } = useUsageInsights({
     sourceType: "chatbox",
     sourceId: chatbox.chatboxId,
-    filters: filter,
+    filters: effectiveFilter,
     enabled: section === "sessions",
   });
 
@@ -91,9 +120,9 @@ export function ChatboxUsagePanel({
   const sortedThreads = useMemo(() => {
     if (!threads) return undefined;
     return threads
-      .filter((t) => threadMatchesFilterState(t, filter))
+      .filter((t) => threadMatchesFilterState(t, effectiveFilter))
       .sort(compareThreadsForUsageList);
-  }, [threads, filter]);
+  }, [threads, effectiveFilter]);
 
   // Reset below only on chatbox *switches*. Guarded by comparing against the
   // previous chatboxId (not a mount-skip flag) so the effect is idempotent:
@@ -218,23 +247,19 @@ export function ChatboxUsagePanel({
     );
   }
 
-  const hideSyntheticChip: UsageFilterChip = {
-    kind: "dimension",
-    key: "synthetic",
-    value: "hide",
-    label: "Hide synthetic",
-  };
   const isHideSyntheticActive = filter.chips.some(
-    (c) => chipKey(c) === chipKey(hideSyntheticChip)
+    (c) => chipKey(c) === chipKey(HIDE_SYNTHETIC_CHIP)
   );
 
   return (
     <div className="flex h-full flex-col">
-      <GenerateSessionsDialog
-        isOpen={generateOpen}
-        onClose={() => setGenerateOpen(false)}
-        chatbox={chatbox}
-      />
+      {allowSynthetic ? (
+        <GenerateSessionsDialog
+          isOpen={generateOpen}
+          onClose={() => setGenerateOpen(false)}
+          chatbox={chatbox}
+        />
+      ) : null}
 
       <div className="min-h-0 flex-1">
         <ResizablePanelGroup direction="horizontal">
@@ -243,32 +268,36 @@ export function ChatboxUsagePanel({
               {/* min-h matches the thread-detail header across the resize
                   handle so the two border-b lines read as one. */}
               <div className="flex min-h-[60px] shrink-0 flex-wrap items-center gap-2 border-b px-3 py-2">
-                <Button
-                  type="button"
-                  size="sm"
-                  variant={isHideSyntheticActive ? "secondary" : "outline"}
-                  className="rounded-full"
-                  onClick={() => handleToggleChip(hideSyntheticChip)}
-                >
-                  Hide synthetic
-                </Button>
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="outline"
-                  className="rounded-full"
-                  onClick={() => setGenerateOpen(true)}
-                >
-                  <Sparkles className="mr-1 size-3" />
-                  Generate with AI
-                </Button>
+                {allowSynthetic ? (
+                  <>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant={isHideSyntheticActive ? "secondary" : "outline"}
+                      className="rounded-full"
+                      onClick={() => handleToggleChip(HIDE_SYNTHETIC_CHIP)}
+                    >
+                      Hide synthetic
+                    </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      className="rounded-full"
+                      onClick={() => setGenerateOpen(true)}
+                    >
+                      <Sparkles className="mr-1 size-3" />
+                      Generate with AI
+                    </Button>
+                  </>
+                ) : null}
               </div>
               <div className="min-h-0 flex-1 overflow-hidden">
                 <ShareUsageThreadList
                   threads={sortedThreads}
                   selectedThreadId={selectedThreadId}
                   onSelectThread={setSelectedThreadId}
-                  filterState={filter}
+                  filterState={effectiveFilter}
                 />
               </div>
             </div>
@@ -281,7 +310,10 @@ export function ChatboxUsagePanel({
                   threadId={selectedThreadId}
                   sessionLink={`${getShareableAppOrigin()}${buildChatboxSessionPath(
                     chatbox.namedHostId,
-                    selectedThreadId
+                    selectedThreadId,
+                    // `allowSynthetic` distinguishes the agent Swarm product —
+                    // keep its session links on /swarms.
+                    allowSynthetic ? routePaths.swarms : routePaths.chatboxes
                   )}`}
                 />
               ) : (

--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -206,8 +206,15 @@ const navigationSections: NavSection[] = [
     id: "mcp-apps",
     items: [
       {
-        title: "Swarms",
+        title: "Chatbox",
         url: "/chatboxes",
+        icon: Box,
+        featureFlag: "sandboxes-enabled",
+        billingFeature: "chatboxes",
+      },
+      {
+        title: "Swarms",
+        url: "/swarms",
         icon: Box,
         featureFlag: "sandboxes-enabled",
         billingFeature: "chatboxes",

--- a/mcpjam-inspector/client/src/lib/app-navigation.ts
+++ b/mcpjam-inspector/client/src/lib/app-navigation.ts
@@ -43,6 +43,7 @@ export const routePaths = {
   xaaFlow: "/xaa-flow",
   tracing: "/tracing",
   chatboxes: "/chatboxes",
+  swarms: "/swarms",
   playground: "/playground",
   support: "/support",
   settings: "/settings",
@@ -82,9 +83,14 @@ export function buildHostComparePath(
 export function buildChatboxSessionPath(
   hostId: string,
   threadId: string,
+  // Which product surface the session link should open on. Both surfaces host
+  // a Sessions tab over the same chatbox; the agent Swarm keeps links on
+  // `/swarms` so a shared link doesn't bounce the recipient to the human
+  // Chatbox surface.
+  basePath: string = routePaths.chatboxes,
 ): string {
   const search = new URLSearchParams({ host: hostId, session: threadId });
-  return `${routePaths.chatboxes}?${search.toString()}`;
+  return `${basePath}?${search.toString()}`;
 }
 
 /** Build a path for a specific organization route. */

--- a/mcpjam-inspector/client/src/lib/billing-entitlements.ts
+++ b/mcpjam-inspector/client/src/lib/billing-entitlements.ts
@@ -36,6 +36,8 @@ export const BILLING_FEATURE_BY_TAB = {
   evals: "evals",
   "ci-evals": "cicd",
   chatboxes: "chatboxes",
+  // The agent Swarm surface shares the human Chatbox's billing feature.
+  swarms: "chatboxes",
 } as const satisfies Record<string, BillingFeatureName>;
 
 export function getRequiredBillingFeatureForTab(

--- a/mcpjam-inspector/client/src/lib/hosted-tab-policy.ts
+++ b/mcpjam-inspector/client/src/lib/hosted-tab-policy.ts
@@ -13,6 +13,7 @@ export const HOSTED_SIDEBAR_ALLOWED_TABS = [
   "host-compare",
   "registry",
   "chatboxes",
+  "swarms",
   "playground",
   "client-config",
   "evals",

--- a/mcpjam-inspector/client/src/router.tsx
+++ b/mcpjam-inspector/client/src/router.tsx
@@ -26,6 +26,7 @@ import App, {
   SettingsRoute,
   SkillsRoute,
   SupportRoute,
+  SwarmsRoute,
   TasksRoute,
   ToolsRoute,
   TracingRoute,
@@ -110,6 +111,10 @@ export function createAppRouter(): AppRouter {
         // exercise the hosted-OAuth callback path via `/hosts` rather
         // than this route directly.
         { path: "chatboxes", element: <ChatboxesRoute /> },
+        // `/swarms` — agent Swarm surface (Publish / Personas / Sessions) over
+        // the same host-backed chatbox as `/chatboxes`. Same billing feature +
+        // `sandboxes-enabled` flag.
+        { path: "swarms", element: <SwarmsRoute /> },
         { path: "playground", element: <PlaygroundRoute /> },
         { path: "support", element: <SupportRoute /> },
         { path: "settings", element: <SettingsRoute /> },


### PR DESCRIPTION
**Stack 4/4** — swarm/chatbox split (frontend; independent of #3109–#3111).

Introduces a `product` prop on `ChatboxesTab` so the same host-backed chatbox renders two product surfaces:

- **Chatbox** (`/chatboxes`): Publish + Sessions + Clusters — no Personas, no AI-generate, no synthetic-session controls.
- **Swarm** (`/swarms`): Publish + Personas + Sessions — no Clusters.

Includes the `/swarms` route (`router.tsx` + App switch + `SwarmsRoute`), `routePaths` / `hosted-tab-policy` / `BILLING_FEATURE_BY_TAB` wiring (shares the `chatboxes` billing feature + `sandboxes-enabled` flag), a second sidebar item, and an `allowSynthetic` gate that hides the "Generate with AI" + "Hide synthetic" controls on the human Chatbox.

Client typecheck clean; nav/billing/sidebar tests pass.

> **Note:** the `sandboxes-enabled` PostHog flag gates both surfaces. Copy rename ("swarm" → "chatbox" on the human guest page) deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Frontend routing and UI gating only; no auth or data-model changes. Worth confirming billing redirect logic still treats `/swarms` like `/chatboxes` when the tab is locked (App currently exempts only `chatboxes` from auto-redirect).
> 
> **Overview**
> Splits the former single chatbox admin experience into **two product surfaces** on the same underlying host-backed chatbox.
> 
> **Chatbox** (`/chatboxes`, `product="chatbox"`): Publish, Sessions, and Clusters — no Personas tab and no synthetic-session tooling. **Swarm** (`/swarms`, `product="swarm"`): Publish, Personas, and Sessions — no Clusters. `ChatboxProductRoute` wraps both routes; invalid deep-link tabs are clamped to Publish.
> 
> `ChatboxUsagePanel` gains `allowSynthetic` (Swarm-only UI for “Generate with AI” / “Hide synthetic”; Chatbox always filters synthetic sessions out). Copied session links use `/chatboxes` or `/swarms` via an optional `basePath` on `buildChatboxSessionPath`.
> 
> Navigation updates: sidebar **Chatbox** + **Swarms** entries, `routePaths.swarms`, hosted tab allowlist, and `swarms` mapped to the `chatboxes` billing feature (same `sandboxes-enabled` flag).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fc45bc1d68c33d8460a385b5bd438f4a686f381. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the Chatbox (human) and Swarm (agent) into two product surfaces on the same host-backed chatbox. Adds the `/swarms` route and gates synthetic-session controls to the Swarm surface.

- **New Features**
  - `ChatboxesTab` accepts `product` (`chatbox` | `swarm`) to switch tabs: Chatbox = Publish, Sessions, Clusters; Swarm = Publish, Personas, Sessions. Deep links to invalid tabs are clamped.
  - Introduced shared `ChatboxProductRoute` used by `ChatboxesRoute` and new `SwarmsRoute`; router and `NoRouterRouteBody` handle `/swarms`.
  - Sidebar: separate "Chatbox" (`/chatboxes`) and "Swarms" (`/swarms`) items.
  - `ChatboxUsagePanel` adds `allowSynthetic`; hides "Generate with AI" and "Hide synthetic" when `product="chatbox"`, and filters synthetic sessions by default on the Chatbox surface.
  - Billing/flags: `/swarms` uses the `chatboxes` billing feature and `sandboxes-enabled` flag; updated `routePaths`, `BILLING_FEATURE_BY_TAB`, hosted tab policy, and `buildChatboxSessionPath` so Swarm session links stay on `/swarms`.

<sup>Written for commit 8fc45bc1d68c33d8460a385b5bd438f4a686f381. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

