### PR TITLE
fix(reconnect): don't toast client-switch reconnects as failed while in progress

### DIFF
--- a/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
@@ -1810,6 +1810,65 @@ describe("useServerState OAuth callback failures", () => {
     });
   });
 
+  it("treats a superseded client-switch reconnect as in-progress, not a failure", async () => {
+    // Repro of the client-switch toast bug: when the user switches clients
+    // faster than a reconnect completes, the in-flight reconnect's op token
+    // goes stale (a newer op now owns the server). That must NOT surface as a
+    // reconnect failure — `reconnectServerForClientSwitch` should resolve, so
+    // the auto-connect recycle never toasts "Failed to reconnect".
+    const { ensureAuthorizedForReconnect } = await import(
+      "@/state/oauth-orchestrator"
+    );
+    vi.mocked(ensureAuthorizedForReconnect).mockResolvedValue({
+      kind: "ready",
+      serverConfig: createAppState().projects.default.servers["demo-server"]
+        .config,
+      tokens: undefined,
+    } as any);
+
+    // The first reconnect hangs inside guardedReconnectServer so a second op
+    // can bump the per-server op token and mark the first one stale.
+    let releaseFirst: (value: unknown) => void = () => {};
+    const firstReconnect = new Promise((resolve) => {
+      releaseFirst = resolve;
+    });
+    reconnectServerMock
+      .mockReturnValueOnce(firstReconnect)
+      .mockResolvedValue({
+        success: true,
+        initInfo: { clientCapabilities: {} },
+      } as any);
+
+    const dispatch = vi.fn();
+    const { result } = renderUseServerState(dispatch, createAppState());
+
+    let firstOpOutcome: unknown = "pending";
+    await act(async () => {
+      // op1: starts, calls reconnectServer, then blocks on `firstReconnect`.
+      const firstOp = result.current
+        .reconnectServerForClientSwitch("demo-server")
+        .then(() => {
+          firstOpOutcome = "resolved";
+        })
+        .catch((error) => {
+          firstOpOutcome = error;
+        });
+      await flushAsyncWork();
+
+      // op2: a newer reconnect for the SAME server bumps the op token, which
+      // makes op1 stale. It completes on its own success path.
+      await result.current.reconnectServerForClientSwitch("demo-server");
+
+      // Let op1 resume; it observes the stale token and returns "superseded".
+      releaseFirst({ success: true, initInfo: { clientCapabilities: {} } });
+      await firstOp;
+    });
+
+    // Superseded is not a failure: op1 resolves (does not reject), so the
+    // caller has nothing to aggregate into a "Failed to reconnect" toast.
+    expect(firstOpOutcome).toBe("resolved");
+  });
+
   it("strips OAuth bearer headers from reconnect fallback configs", async () => {
     const { reconnectServer } = await import("@/state/mcp-api");
     const { ensureAuthorizedForReconnect } = await import(

--- a/mcpjam-inspector/client/src/hooks/__tests__/useAutoConnectProjectServers.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useAutoConnectProjectServers.test.tsx
@@ -12,6 +12,8 @@ import {
 
 const mocks = vi.hoisted(() => ({
   toastError: vi.fn(),
+  toastLoading: vi.fn(() => "reconnect-toast"),
+  toastSuccess: vi.fn(),
   logger: {
     error: vi.fn(),
     warn: vi.fn(),
@@ -25,6 +27,8 @@ const mocks = vi.hoisted(() => ({
 vi.mock("sonner", () => ({
   toast: {
     error: mocks.toastError,
+    loading: mocks.toastLoading,
+    success: mocks.toastSuccess,
   },
 }));
 
@@ -88,6 +92,8 @@ describe("useAutoConnectProjectServers", () => {
     resetAutoConnectAttempts();
     localStorage.removeItem("mcpjam-auto-connect-servers");
     mocks.toastError.mockClear();
+    mocks.toastLoading.mockClear();
+    mocks.toastSuccess.mockClear();
     mocks.logger.error.mockClear();
     mocks.logger.warn.mockClear();
     mocks.logger.info.mockClear();
@@ -345,14 +351,58 @@ describe("useAutoConnectProjectServers", () => {
     await flushMicrotasks();
 
     expect(reconnectServer).toHaveBeenCalledTimes(2);
+    // A single progress toast opens as "Reconnecting…" and, on partial failure,
+    // is replaced in place (same id) by the failure message.
+    expect(mocks.toastLoading).toHaveBeenCalledWith("Reconnecting 2 servers…");
     expect(mocks.logger.error).toHaveBeenCalledWith(
       "Failed to reconnect server after client switch",
       { serverName: "beta", error: "beta exploded" }
     );
     expect(mocks.toastError).toHaveBeenCalledWith(
       errorToastMessage("Failed to reconnect 1 server."),
-      { duration: Infinity }
+      { duration: Infinity, id: "reconnect-toast" }
     );
+    expect(mocks.toastSuccess).not.toHaveBeenCalled();
+  });
+
+  it("shows a Reconnecting… → Reconnected progress toast on client switch", async () => {
+    const ensureServersReady = vi.fn().mockResolvedValue({
+      readyServerNames: [],
+      failedServerNames: [],
+      missingServerNames: [],
+      reauthServerNames: [],
+    });
+    const reconnectServer = vi.fn().mockResolvedValue(undefined);
+    const appState = {
+      servers: {
+        alpha: { name: "alpha", connectionStatus: "connected" },
+        beta: { name: "beta", connectionStatus: "connected" },
+      },
+    } as any;
+
+    renderHook(
+      () =>
+        useAutoConnectProjectServers({
+          projectId: "proj-reconnect-progress",
+          hostScopeKey: "host-a",
+          requiredServerNames: [],
+        }),
+      {
+        wrapper: ({ children }) =>
+          wrapper({ children, ensureServersReady, appState, reconnectServer }),
+      }
+    );
+
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(reconnectServer).toHaveBeenCalledTimes(2);
+    expect(mocks.toastLoading).toHaveBeenCalledWith("Reconnecting 2 servers…");
+    // Same toast id → the loading toast becomes the success toast in place.
+    expect(mocks.toastSuccess).toHaveBeenCalledWith("Reconnected 2 servers.", {
+      id: "reconnect-toast",
+    });
+    expect(mocks.toastError).not.toHaveBeenCalled();
   });
 
   it("reconnects connected servers even when the active host requires none", async () => {

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -670,7 +670,13 @@ type EnsureServerConnectionStatus =
   | "connected"
   | "failed"
   | "missing"
-  | "reauth";
+  | "reauth"
+  // A newer connect/reconnect op for the same server started while this one
+  // was in flight (stale op token). The connection isn't failing — it's just
+  // still in progress under the newer op, which now owns the outcome. Callers
+  // should treat this as "leave it alone", NOT as a reconnect failure, so it
+  // never surfaces a spurious "Failed to reconnect" toast.
+  | "superseded";
 
 interface EnsureServerConnectionResult {
   status: EnsureServerConnectionStatus;
@@ -4081,7 +4087,7 @@ export function useServerState({
         } catch (error) {
           if (isStaleOp(serverName, token)) {
             return {
-              status: "failed",
+              status: "superseded",
               error:
                 error instanceof Error ? error.message : "OAuth flow failed",
             };
@@ -4111,7 +4117,7 @@ export function useServerState({
         if (!oauthResult.success) {
           if (isStaleOp(serverName, token)) {
             return {
-              status: "failed",
+              status: "superseded",
               error: oauthResult.error || "OAuth flow failed",
             };
           }
@@ -4138,7 +4144,7 @@ export function useServerState({
         );
         if (isStaleOp(serverName, token)) {
           return {
-            status: "failed",
+            status: "superseded",
             error: result.error || "Reconnection failed after OAuth",
           };
         }
@@ -4185,7 +4191,7 @@ export function useServerState({
           );
           if (isStaleOp(serverName, token)) {
             return {
-              status: "failed",
+              status: "superseded",
               error: result.error || "Reconnection failed",
             };
           }
@@ -4230,7 +4236,7 @@ export function useServerState({
         } catch (error) {
           if (isStaleOp(serverName, token)) {
             return {
-              status: "failed",
+              status: "superseded",
               error: error instanceof Error ? error.message : "Unknown error",
             };
           }
@@ -4308,7 +4314,7 @@ export function useServerState({
         if (authResult.kind === "error") {
           if (isStaleOp(serverName, token)) {
             return {
-              status: "failed",
+              status: "superseded",
               error: authResult.error,
             };
           }
@@ -4335,7 +4341,7 @@ export function useServerState({
         );
         if (isStaleOp(serverName, token)) {
           return {
-            status: "failed",
+            status: "superseded",
             error: result.error || "Reconnection failed",
           };
         }
@@ -4376,7 +4382,7 @@ export function useServerState({
           error instanceof Error ? error.message : "Unknown error";
         if (isStaleOp(serverName, token)) {
           return {
-            status: "failed",
+            status: "superseded",
             error: errorMessage,
           };
         }
@@ -4446,9 +4452,16 @@ export function useServerState({
         select: false,
         suppressErrors: true,
       });
-      if (result.status !== "connected") {
-        throw new Error(result.error || `Failed to reconnect ${serverName}`);
+      // "superseded" means a newer connect/reconnect op for this server took
+      // over while this one was in flight (e.g. the user kept switching
+      // clients). The connection is just in progress under the newer op, which
+      // owns the outcome — not a failure. Treat it as a no-op so the
+      // client-switch recycle doesn't surface a spurious "Failed to reconnect"
+      // toast.
+      if (result.status === "connected" || result.status === "superseded") {
+        return;
       }
+      throw new Error(result.error || `Failed to reconnect ${serverName}`);
     },
     [reconnectServerInternal]
   );
@@ -4573,6 +4586,12 @@ export function useServerState({
             break;
           case "reauth":
             reauthServerNames.push(serverName);
+            break;
+          case "superseded":
+            // A newer op is already handling this server; it owns the
+            // outcome. Don't classify it as failed — that would produce a
+            // false "failed to connect" signal for a connection that's just
+            // still in progress.
             break;
           case "failed":
           default:

--- a/mcpjam-inspector/client/src/hooks/useAutoConnectProjectServers.ts
+++ b/mcpjam-inspector/client/src/hooks/useAutoConnectProjectServers.ts
@@ -47,6 +47,18 @@ function reconnectFailureToastMessage(count: number): string {
     : `Failed to reconnect ${count} servers.`;
 }
 
+function reconnectingToastMessage(count: number): string {
+  return count === 1
+    ? "Reconnecting 1 server…"
+    : `Reconnecting ${count} servers…`;
+}
+
+function reconnectSuccessToastMessage(count: number): string {
+  return count === 1
+    ? "Reconnected 1 server."
+    : `Reconnected ${count} servers.`;
+}
+
 function buildAttemptKey(hostScopeKey: string, serverNamesKey: string): string {
   return `${hostScopeKey}${serverNamesKey}`;
 }
@@ -218,6 +230,17 @@ export function useAutoConnectProjectServers({
     const connectedNow = Object.entries(sharedAppState.servers)
       .filter(([, server]) => server.connectionStatus === "connected")
       .map(([name]) => name);
+    if (connectedNow.length === 0) return;
+
+    // Surface the client-switch recycle as one progress toast so the dev can
+    // see it happening: a "Reconnecting…" spinner flips in place to
+    // "Reconnected" (or a failure message) once the batch settles. Reusing the
+    // same toast id keeps the loading → result transition on a single toast
+    // instead of stacking a second one.
+    const toastId = toast.loading(
+      reconnectingToastMessage(connectedNow.length)
+    );
+
     void Promise.allSettled(
       connectedNow.map(async (name) => {
         await reconnectServer(name);
@@ -234,12 +257,19 @@ export function useAutoConnectProjectServers({
         ];
       });
 
-      if (failures.length === 0) return;
+      if (failures.length === 0) {
+        toast.success(reconnectSuccessToastMessage(connectedNow.length), {
+          id: toastId,
+        });
+        return;
+      }
 
       for (const failure of failures) {
         logger.error("Failed to reconnect server after client switch", failure);
       }
-      toast.error(reconnectFailureToastMessage(failures.length));
+      toast.error(reconnectFailureToastMessage(failures.length), {
+        id: toastId,
+      });
     });
     // `sharedAppState.servers` is read via closure but excluded from deps on
     // purpose: this must fire only on scope transitions, not whenever the


### PR DESCRIPTION
## Problem

Switching clients/hosts recycles every connected server through the MCP `initialize` handshake under the new client identity. When a switch happens faster than a reconnect completes, the in-flight op's per-server token goes **stale** (a newer op now owns that server) — i.e. the connection is *just still in progress*.

But every stale-op branch in `reconnectServerInternal` returned `status: "failed"` with the bare fallback `"Reconnection failed"`, so `reconnectServerForClientSwitch` threw and the auto-connect recycle surfaced a spurious:

```
ERROR [AutoConnectProjectServers] Failed to reconnect server after client switch
  { serverName: "Excalidraw (App)", error: "Reconnection failed" }
```

…plus a **"Failed to reconnect N server(s)."** toast. On top of that, a *successful* client-switch reconnect was completely silent, so devs got no feedback that anything happened.

## Changes

- **New `superseded` connection status.** The stale-op branches of `reconnectServerInternal` now return `superseded` instead of `failed` (the one intentional `reauth` branch is unchanged). A superseded op means a newer op is in flight and owns the outcome.
- `reconnectServerForClientSwitch` treats `superseded` as a no-op (returns instead of throwing); `ensureServersReady` no longer classifies it as a failure.
- **Progress toast.** The client-switch recycle now opens one `Reconnecting…` toast that transitions **in place** (same toast id) to `Reconnected` on success, or to the existing failure message on error. Each switch gets its own toast id so rapid switches don't cross-resolve.

Genuine reconnect failures (backend errors, missing servers, timeouts) still toast exactly as before.

## Tests

- Regression test proving a superseded client-switch reconnect resolves instead of rejecting (fails on `main` with the exact `"Reconnection failed"` error).
- Test for the `Reconnecting 2 servers… → Reconnected 2 servers.` progress toast, plus the updated partial-failure test.
- `client` typecheck clean; all reconnect-related suites green (96 + 17).


https://github.com/user-attachments/assets/8b3b4247-0bb2-42f8-a74f-a242df63b272



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix reconnect toasts during client/host switches. Superseded reconnects are treated as in-progress, and we show a single progress toast that flips to success or failure.

- **Bug Fixes**
  - Added a `superseded` connection status for stale reconnect ops so they don’t count as failures.
  - `reconnectServerForClientSwitch` treats `superseded` as a no-op; `ensureServersReady` no longer classifies it as failed.

- **New Features**
  - One `sonner` toast shows progress: “Reconnecting…” updates in place to “Reconnected” or a failure message using the same toast id.
  - Each switch uses a unique toast id to avoid cross-resolving during rapid switches.

<sup>Written for commit fa77032e5041befd5cc20bd5529bb7dccebd70e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

