### PR TITLE
feat(computers): honest data-durability copy + unblock custom environments (COMP-12)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -84,6 +84,11 @@
             ]
           },
           {
+            "group": "Computer",
+            "icon": "monitor",
+            "pages": ["inspector/computer"]
+          },
+          {
             "group": "Embedding",
             "icon": "code",
             "pages": ["inspector/launch-from-code"]

--- a/docs/inspector/computer.mdx
+++ b/docs/inspector/computer.mdx
@@ -1,0 +1,72 @@
+---
+title: "Computer"
+description: "A personal cloud Linux workstation for your project — open a terminal, run tools, and give your agents a real bash environment"
+icon: "monitor"
+---
+
+Each project gives every member an opt-in **Computer**: a personal cloud Linux
+workstation with a web terminal and a `bash` tool your agents can call. It boots
+from a base image (Debian + Node + Python) or a custom [environment](#environments)
+you define, sleeps when idle, and wakes on first use.
+
+Open it from the **Computer** tab. The first time you open the terminal, MCPJam
+provisions the machine; after that it resumes in about a second.
+
+## Environments
+
+An environment is a custom Docker image your computer boots from, defined by a
+small Dockerfile (allowlisted base images, `FROM` + `RUN` only). Build it, then
+**Use on computer** to boot from it. Environments can be kept private to you or
+shared with the whole project. Manage them from **Change** on the image strip.
+
+<Note>
+  Environment definitions (their Dockerfiles) live in the project database, not
+  on any one computer's disk — see [Data & persistence](#data-and-persistence).
+</Note>
+
+## Data & persistence
+
+Your computer is **scratch space, not durable storage.** Treat it like a fresh
+dev box you can rebuild at any time — convenient and fast, but not a place to
+keep the only copy of anything.
+
+<Warning>
+  Files persist when your computer sleeps, but they aren't backed up — keep
+  anything important in git or elsewhere.
+</Warning>
+
+### What persists
+
+- **The filesystem.** When your computer sleeps, its entire disk and memory are
+  captured in a pause snapshot and restored on wake, so files you created and
+  tools you installed are still there when you come back.
+
+### What wipes it
+
+Each of these rebuilds the machine from its image and **deletes every file on
+the disk**:
+
+- **Reset** — restores the computer to a clean copy of its current image.
+- **Changing the image** — switching to a different environment (or back to the
+  base image) rebuilds from that image.
+- **Delete** — tears the computer down entirely.
+- **Guest inactivity** — computers owned by signed-out (guest) sessions are
+  deleted when idle instead of paused, so their files don't carry over between
+  sessions. Sign in for a computer that sleeps and resumes with its disk intact.
+
+### What survives independently
+
+These live in the project database (Convex), not on the computer's disk, so they
+are unaffected by reset, image changes, or deletion:
+
+- **Cloud skills** attached to the project.
+- **Environment Dockerfiles** — the definitions of your custom images. Deleting
+  a computer never deletes your environments; you can boot a fresh computer from
+  the same image again.
+
+### The no-backup caveat
+
+There is no backup and no volume behind the computer — the pause snapshot *is*
+the storage. Once the disk is wiped by any of the actions above, its contents
+are gone for good. Anything you want to keep should live in version control, a
+remote, or another durable store.

--- a/mcpjam-inspector/client/src/components/computer/ComputerView.tsx
+++ b/mcpjam-inspector/client/src/components/computer/ComputerView.tsx
@@ -2,7 +2,14 @@ import { Component, useCallback, useState } from "react";
 import { toast } from "@/lib/toast";
 import { usePostHog } from "posthog-js/react";
 import { Button } from "@mcpjam/design-system/button";
-import { Boxes, Loader2, RotateCcw, TerminalSquare, Trash2 } from "lucide-react";
+import {
+  Boxes,
+  Info,
+  Loader2,
+  RotateCcw,
+  TerminalSquare,
+  Trash2,
+} from "lucide-react";
 import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
 import {
   useComputersDataPlaneConfig,
@@ -299,7 +306,7 @@ export function ComputerView({
           {hasComputer ? (
             confirmingDelete ? (
               <span className="inline-flex items-center gap-2 text-sm text-muted-foreground">
-                Delete this computer?
+                Delete this computer? All files on it will be deleted.
                 <Button
                   size="sm"
                   variant="destructive"
@@ -334,10 +341,19 @@ export function ComputerView({
         </div>
       </div>
 
-      <p className="text-sm text-muted-foreground">
-        A personal Linux workstation for this project — files and installed
-        tools persist between sessions; it sleeps when idle and wakes on use.
-      </p>
+      <div className="flex flex-col gap-1.5">
+        <p className="text-sm text-muted-foreground">
+          A personal Linux workstation for this project — it sleeps when idle
+          and wakes on use.
+        </p>
+        <p className="flex items-start gap-1.5 text-xs text-muted-foreground">
+          <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          <span>
+            Files persist when your computer sleeps, but they aren't backed up —
+            keep anything important in git or elsewhere.
+          </span>
+        </p>
+      </div>
 
       {status !== undefined ? (
         <div className="flex flex-wrap items-center justify-between gap-2 rounded-md border bg-muted/10 px-3 py-2 text-sm">
@@ -362,7 +378,8 @@ export function ComputerView({
             {hasComputer ? (
               confirmingReset ? (
                 <span className="inline-flex items-center gap-2 text-xs text-muted-foreground">
-                  Reset to the image? Installed files are wiped.
+                  Reset to the image? All files on this computer will be
+                  deleted.
                   <Button
                     size="sm"
                     variant="destructive"

--- a/mcpjam-inspector/client/src/components/computer/EnvironmentsDrawer.tsx
+++ b/mcpjam-inspector/client/src/components/computer/EnvironmentsDrawer.tsx
@@ -92,7 +92,7 @@ export function EnvironmentsDrawer({
           <SheetTitle>Environments</SheetTitle>
           <SheetDescription>
             A custom Docker image your computer boots from. Changing the image
-            rebuilds the computer.
+            rebuilds the computer — all files on it will be deleted.
           </SheetDescription>
         </SheetHeader>
 
@@ -163,6 +163,10 @@ function EnvironmentList({
   onUseBase: () => void;
   attachToBaseDisabled: boolean;
 }) {
+  // Switching to the base image rebuilds the sandbox and wipes its disk, so
+  // confirm the data loss before doing it (mirrors Reset / "Use on computer").
+  const [confirmingBase, setConfirmingBase] = useState(false);
+
   if (environments === undefined) {
     return (
       <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
@@ -177,7 +181,7 @@ function EnvironmentList({
         {/* Base image row */}
         <button
           type="button"
-          onClick={onUseBase}
+          onClick={() => setConfirmingBase(true)}
           disabled={attachToBaseDisabled}
           className="flex w-full items-center justify-between rounded-md px-3 py-2 text-left text-sm hover:bg-muted/50 disabled:cursor-default disabled:opacity-100"
         >
@@ -196,6 +200,33 @@ function EnvironmentList({
             <span className="text-xs text-muted-foreground">Use</span>
           ) : null}
         </button>
+        {confirmingBase ? (
+          <div className="mx-1 mt-1 flex flex-wrap items-center justify-between gap-2 rounded-md bg-muted/50 px-3 py-2 text-xs text-muted-foreground">
+            <span>
+              Switch to the base image? All files on this computer will be
+              deleted.
+            </span>
+            <span className="flex items-center gap-2">
+              <Button
+                size="sm"
+                variant="destructive"
+                onClick={() => {
+                  setConfirmingBase(false);
+                  onUseBase();
+                }}
+              >
+                Switch
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => setConfirmingBase(false)}
+              >
+                Cancel
+              </Button>
+            </span>
+          </div>
+        ) : null}
 
         {environments.length === 0 ? (
           <div className="px-3 py-8 text-center text-sm text-muted-foreground">
@@ -332,6 +363,7 @@ function EnvironmentDetail({
   const [saving, setSaving] = useState(false);
   const [building, setBuilding] = useState(false);
   const [attaching, setAttaching] = useState(false);
+  const [confirmingUse, setConfirmingUse] = useState(false);
   const [confirmingDelete, setConfirmingDelete] = useState(false);
 
   // Re-seed local buffers if the underlying env changes identity (the parent
@@ -397,6 +429,7 @@ function EnvironmentDetail({
       toast.error(errMessage(err, "Could not use this environment."));
     } finally {
       setAttaching(false);
+      setConfirmingUse(false);
     }
   };
 
@@ -476,24 +509,46 @@ function EnvironmentDetail({
           )}
           Build
         </Button>
-        <Button
-          size="sm"
-          variant="outline"
-          onClick={() => void useOnComputer()}
-          disabled={!readyToAttach || attaching || isAttached || !canAttach}
-          title={
-            !canAttach
-              ? "Wait for the computer to be ready or asleep before changing its image"
-              : readyToAttach
-              ? undefined
-              : "Build the environment (and save changes) before using it"
-          }
-        >
-          {attaching ? (
-            <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-          ) : null}
-          {isAttached ? "In use" : "Use on computer"}
-        </Button>
+        {confirmingUse ? (
+          <span className="inline-flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+            Change the image? All files on this computer will be deleted.
+            <Button
+              size="sm"
+              variant="destructive"
+              onClick={() => void useOnComputer()}
+              disabled={attaching}
+            >
+              {attaching ? (
+                <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+              ) : null}
+              Change
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => setConfirmingUse(false)}
+              disabled={attaching}
+            >
+              Cancel
+            </Button>
+          </span>
+        ) : (
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => setConfirmingUse(true)}
+            disabled={!readyToAttach || attaching || isAttached || !canAttach}
+            title={
+              !canAttach
+                ? "Wait for the computer to be ready or asleep before changing its image"
+                : readyToAttach
+                ? undefined
+                : "Build the environment (and save changes) before using it"
+            }
+          >
+            {isAttached ? "In use" : "Use on computer"}
+          </Button>
+        )}
       </div>
 
       <div className="mt-auto flex items-center justify-between border-t pt-3">

--- a/mcpjam-inspector/client/src/components/computer/EnvironmentsDrawer.tsx
+++ b/mcpjam-inspector/client/src/components/computer/EnvironmentsDrawer.tsx
@@ -30,15 +30,31 @@ import {
 } from "@/hooks/useComputerEnvironments";
 import { EnvironmentBuildBadge } from "./EnvironmentBuildBadge";
 
-const NEW_ENVIRONMENT_TEMPLATE = `# Base must be an allowlisted official image (debian, ubuntu, node, python)
-# pinned by @sha256 digest. Only FROM + RUN are supported today.
-FROM debian:bookworm-slim@sha256:REPLACE_WITH_DIGEST
+// Ships a real, buildable default so "Create → Build" works out of the box.
+// The base must be an allowlisted official image (debian, ubuntu, node,
+// python) pinned by @sha256 digest — swap in your own base/digest as needed.
+// Only FROM + RUN are supported today.
+const NEW_ENVIRONMENT_TEMPLATE = `# Allowlisted official base (debian, ubuntu, node, python) pinned by digest.
+# Only FROM + RUN are supported today. Change the base or digest as needed.
+FROM debian:bookworm-slim@sha256:60eac759739651111db372c07be67863818726f754804b8707c90979bda511df
 RUN echo "customize me"
 `;
 
 function errMessage(err: unknown, fallback: string): string {
+  // Convex `ConvexError` payloads land on `err.data` (a string, or a record
+  // with `message`) — e.g. the backend's DockerfileValidationError. Prefer that
+  // over `err.message`, which for an application error is the redacted
+  // "Server Error"/Request-ID string.
+  if (err && typeof err === "object" && "data" in err) {
+    const data = (err as { data: unknown }).data;
+    if (typeof data === "string" && data.trim()) return data.slice(0, 400);
+    if (data && typeof data === "object" && "message" in data) {
+      const msg = (data as { message: unknown }).message;
+      if (typeof msg === "string" && msg.trim()) return msg.slice(0, 400);
+    }
+  }
   if (err instanceof Error && err.message) {
-    // Convex surfaces the thrown message; strip the noisy server prefix.
+    // Fallback: strip the noisy server prefix from a plain thrown message.
     return err.message.replace(/^\[.*?\]\s*/, "").slice(0, 400) || fallback;
   }
   return fallback;
@@ -287,6 +303,12 @@ function NewEnvironmentForm({
   const create = async () => {
     if (!name.trim()) {
       toast.error("Give the environment a name.");
+      return;
+    }
+    if (/REPLACE_WITH_DIGEST/.test(dockerfile)) {
+      toast.error(
+        "Pin the base image to a real @sha256 digest before creating."
+      );
       return;
     }
     setSaving(true);

--- a/mcpjam-inspector/client/src/components/computer/__tests__/ComputerView.test.tsx
+++ b/mcpjam-inspector/client/src/components/computer/__tests__/ComputerView.test.tsx
@@ -97,6 +97,18 @@ describe("ComputerView", () => {
     expect(getByText(/need a synced project/i)).toBeTruthy();
   });
 
+  it("always shows the honest no-backup durability note", () => {
+    mockStatus = { computerId: "c1", status: "ready", provider: "e2b" };
+    const { getByText } = render(
+      <ComputerView projectId="p1" isAuthenticated />
+    );
+    expect(
+      getByText(
+        /Files persist when your computer sleeps, but they aren't backed up/i
+      )
+    ).toBeTruthy();
+  });
+
   it("opening the terminal reserves the computer", async () => {
     mockStatus = null; // no computer yet
     const { getByText } = render(
@@ -131,7 +143,7 @@ describe("ComputerView", () => {
       <ComputerView projectId="p1" isAuthenticated />
     );
     fireEvent.click(getByText("Delete"));
-    expect(getByText("Delete this computer?")).toBeTruthy();
+    expect(getByText(/Delete this computer\? All files on it will be deleted/i)).toBeTruthy();
     // The confirm button is the second "Delete" — click via the confirm row.
     fireEvent.click(getByText("Delete", { selector: "button" }));
     await waitFor(() =>
@@ -303,7 +315,9 @@ describe("ComputerView image strip", () => {
       <ComputerView projectId="p1" isAuthenticated />
     );
     fireEvent.click(getByText("Reset"));
-    expect(getByText(/Installed files are wiped/i)).toBeTruthy();
+    expect(
+      getByText(/All files on this computer will be deleted/i)
+    ).toBeTruthy();
     fireEvent.click(getByText("Reset", { selector: "button" }));
     await waitFor(() =>
       expect(resetComputer).toHaveBeenCalledWith({ projectId: "p1" })

--- a/mcpjam-inspector/client/src/components/computer/__tests__/EnvironmentsDrawer.test.tsx
+++ b/mcpjam-inspector/client/src/components/computer/__tests__/EnvironmentsDrawer.test.tsx
@@ -207,17 +207,33 @@ describe("EnvironmentsDrawer", () => {
     expect(promote).not.toHaveBeenCalled();
   });
 
-  it("attaches a ready environment to the computer", async () => {
+  it("confirms the data loss before changing the image, then attaches", async () => {
     mockEnvironments = [env()];
     const { getByText } = renderDrawer();
     fireEvent.click(getByText("ml-toolkit"));
+    // First click only asks for confirmation — no mutation yet.
     fireEvent.click(getByText("Use on computer"));
+    expect(
+      getByText(/All files on this computer will be deleted/i)
+    ).toBeTruthy();
+    expect(setComputerEnvironment).not.toHaveBeenCalled();
+    // Confirm.
+    fireEvent.click(getByText("Change"));
     await waitFor(() =>
       expect(setComputerEnvironment).toHaveBeenCalledWith({
         projectId: "p1",
         environmentId: "env1",
       })
     );
+  });
+
+  it("cancelling the image-change confirm does not attach", () => {
+    mockEnvironments = [env()];
+    const { getByText } = renderDrawer();
+    fireEvent.click(getByText("ml-toolkit"));
+    fireEvent.click(getByText("Use on computer"));
+    fireEvent.click(getByText("Cancel"));
+    expect(setComputerEnvironment).not.toHaveBeenCalled();
   });
 
   it("surfaces an attach rejection as an error toast", async () => {
@@ -228,10 +244,31 @@ describe("EnvironmentsDrawer", () => {
     const { getByText } = renderDrawer();
     fireEvent.click(getByText("ml-toolkit"));
     fireEvent.click(getByText("Use on computer"));
+    fireEvent.click(getByText("Change"));
     await waitFor(() =>
       expect(toastError).toHaveBeenCalledWith(
         expect.stringContaining("incompatible builder")
       )
+    );
+  });
+
+  it("confirms the data loss before switching to the base image", async () => {
+    mockEnvironments = [env()];
+    // A custom env is attached, so the base row is actionable ("Use").
+    const { getByText } = renderDrawer("env1");
+    fireEvent.click(getByText("Base image"));
+    expect(
+      getByText(
+        /Switch to the base image\? All files on this computer will be deleted/i
+      )
+    ).toBeTruthy();
+    expect(setComputerEnvironment).not.toHaveBeenCalled();
+    fireEvent.click(getByText("Switch"));
+    await waitFor(() =>
+      expect(setComputerEnvironment).toHaveBeenCalledWith({
+        projectId: "p1",
+        environmentId: null,
+      })
     );
   });
 });


### PR DESCRIPTION
## What

COMP-12 — set honest data-durability expectations in the Computers UI and docs, and fix the change-image flow that surfaced while testing it.

### Durability copy (the task itself)
- Non-alarmist, always-visible note that files persist between sessions but are **not backed up** — keep anything important in git or elsewhere.
- Destructive actions state data loss explicitly: Reset, Change-image, switch-to-base, and Delete confirmations say **"all files on this computer will be deleted."**
- Docs: Computer page gains a **"Data & persistence"** section (what persists via pause snapshots, what wipes it — reset / image change / delete / guest 2h lifetime — and what survives independently in Convex).
- Consistent with COMP-7 hibernate messaging ("files are preserved when your computer pauses"): preserved-on-pause and not-backed-up are both stated without contradiction.

### Change-image fix (found while testing the copy)
The "New environment" starter template hardcoded a literal `REPLACE_WITH_DIGEST`, so **Create failed every time** unless the user knew to hand-paste a real sha256 digest — nothing in the UI told them how.
- Ship a real, current `debian:bookworm-slim` digest so **Create → Build** works out of the box.
- `errMessage()` now reads `ConvexError` `err.data` (string or `{ message }`) before falling back to `err.message`, matching how the rest of the client reads Convex errors.
- Guard against a lingering placeholder with a friendly toast.

## Companion

Depends on **MCPJam/mcpjam-backend#688**, which makes the Dockerfile-validation and env-attach errors reach the client as `ConvexError` (they were being redacted to "Server Error"). The `errMessage()` change here reads those payloads.

## Testing notes

- Create → Build now succeeds from the default template.
- The destructive-action confirmation copy renders on Change-image / switch-to-base.
- Full attach on an **e2b** computer still requires real e2b builds (`COMPUTERS_ENV_BUILDER=e2b` + rebuild) — that gate is by design and unrelated to this copy; backend#688 makes the reason legible.
- Typecheck (`tsconfig.typecheck.json`) passes clean.

## Follow-up

- [ ] Copy reviewed by Marcelo before merge (product-voice call, per the task).


https://github.com/user-attachments/assets/cee94754-bdcb-4e99-a47c-098c6a77bd6f



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets honest data-durability expectations in Computers and adds confirmations before any disk-wiping action. Also unblocks custom environment creation by shipping a valid default image digest and surfacing real build/validation errors. (COMP-12)

- **New Features**
  - Always-visible note: files persist on sleep but aren’t backed up.
  - Clear confirms: Reset, Delete, Change image, and Switch to base say “All files on this computer will be deleted.”
  - Environments drawer now prompts before changing images (including switching to base).
  - Added Computer docs page with a “Data & persistence” section.

- **Bug Fixes**
  - Default environment template uses a real debian:bookworm-slim digest, so Create → Build works out of the box.
  - Error handling reads Convex `err.data` (string or `{ message }`) before `err.message`; shows a helpful toast if a placeholder digest is detected.
  - Updated component tests for the new copy and confirmation steps.

<sup>Written for commit b5d0df2f4a6ccb352a9325a9ae34073ffb06c444. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

