### PR TITLE
refactor(swarm): extract resolveTurnRuntime; route synthetic turns through runUnifiedAssistantTurn (PR 3a)

### DIFF
--- a/mcpjam-inspector/server/services/sessionSimulation/__tests__/runner.browser.test.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/__tests__/runner.browser.test.ts
@@ -469,6 +469,31 @@ describe("synthetic-session runner — browser pipeline wiring", () => {
     expect(updateRunMock).toHaveBeenCalled();
   });
 
+  it("routes a rate-limit turn error to the rate_limited outcome (shared classifyTurnFailure)", async () => {
+    const fake = buildFakeBrowserContext({ computerUse: true });
+    createBrowserSessionContextMock.mockReturnValue(fake);
+    // A spend-cap / rate-limit error from the turn must fold into the amber
+    // `rate_limited` outcome via the shared `classifyTurnFailure`, not `failed`.
+    runAssistantTurnMock.mockRejectedValue(
+      new Error("Daily spend cap reached for free models"),
+    );
+
+    await startSimulation(baseOptions());
+
+    // runOneSession → catch → classifyTurnFailure("...cap...") === "rate_limited"
+    // → tryUpdateRunWithRetry with a { rateLimited: 1 } delta.
+    const rateLimitedProgress = updateRunMock.mock.calls.some(
+      (call) => (call[4] as { rateLimited?: number })?.rateLimited === 1,
+    );
+    expect(rateLimitedProgress).toBe(true);
+    // Whole batch tripped the cap (no successes, no hard failures) → terminal
+    // status is rate_limited.
+    const terminalRateLimited = updateRunMock.mock.calls.some(
+      (call) => call[5] === "rate_limited",
+    );
+    expect(terminalRateLimited).toBe(true);
+  });
+
   it("skips the artifact mutation when a turn drained nothing", async () => {
     const fake = buildFakeBrowserContext({ computerUse: true });
     createBrowserSessionContextMock.mockReturnValue(fake);

--- a/mcpjam-inspector/server/services/sessionSimulation/__tests__/runner.dispatch.test.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/__tests__/runner.dispatch.test.ts
@@ -453,7 +453,7 @@ describe("drainAssistantTurn — engine error surfacing", () => {
     expect(result.turnTrace).toEqual(TURN_TRACE);
   });
 
-  it("throws on a fatal direct-engine error and does NOT post the usage writeback", async () => {
+  it("bills the consumed usage on a fatal direct-engine error, THEN throws", async () => {
     const calls: unknown[] = [];
     stubDirectEngine(calls, { engineError: { message: "provider exploded" } });
     resolveSyntheticModelSourceMock.mockResolvedValue({
@@ -476,8 +476,14 @@ describe("drainAssistantTurn — engine error surfacing", () => {
         }) as Parameters<typeof drainAssistantTurn>[0],
       ),
     ).rejects.toThrow(/provider exploded/);
-    // finalizeUsage is gated on success — no billing on a fatal error turn.
-    expect(fetchMock).not.toHaveBeenCalled();
+    // A local-BYOK turn that consumed tokens then errored mid-stream must STILL
+    // post the /stream/org/local-usage writeback — matching the old
+    // `buildLocalOrgOnPersist`, which billed unconditionally on non-abort and
+    // only gated transcript persistence on the error (cubic P1: undercount).
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String((fetchMock.mock.calls[0] as any[])[0])).toContain(
+      "/stream/org/local-usage",
+    );
   });
 
   it("returns the aborted direct turn without persisting or billing", async () => {

--- a/mcpjam-inspector/server/services/sessionSimulation/__tests__/runner.dispatch.test.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/__tests__/runner.dispatch.test.ts
@@ -515,6 +515,88 @@ describe("drainAssistantTurn — engine error surfacing", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("SUCCEEDS a local-BYOK turn even when the usage writeback fetch REJECTS (best-effort billing)", async () => {
+    const calls: unknown[] = [];
+    stubDirectEngine(calls);
+    resolveSyntheticModelSourceMock.mockResolvedValue({
+      source: "local_byok",
+      orgRuntime: {
+        runtimeLocation: "local",
+        provider: { providerKey: "openai" } as any,
+      },
+    });
+    // Parity with the OLD fire-and-forget `postLocalUsage(...).catch(...)`: a
+    // `/stream/org/local-usage` outage must NOT fail an otherwise-successful
+    // synthetic turn (the caller would then discard the session).
+    fetchMock.mockRejectedValueOnce(new Error("network down"));
+
+    const result = await drainAssistantTurn(
+      baseArgs({
+        modelId: "llama3",
+        modelDefinition: {
+          id: "llama3",
+          name: "Llama3 local",
+          provider: "ollama",
+        } as ModelDefinition,
+      }) as Parameters<typeof drainAssistantTurn>[0],
+    );
+
+    // Turn resolves successfully; the rejection was swallowed/logged.
+    expect(result.turnTrace).toEqual(TURN_TRACE);
+    expect(result.modelSource).toBe("local_byok");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("rebuilds local-BYOK history with dedup so response messages overlapping the input prefix don't double-write", async () => {
+    const calls: unknown[] = [];
+    runDirectChatTurnMock.mockImplementation((opts: any) => {
+      calls.push(opts);
+      return { handleSentinel: true };
+    });
+    const input = [{ role: "user", content: "hi" }];
+    // The engine's response slice re-includes the input-history prefix (the AI
+    // SDK can echo prior messages by id / JSON identity). The old local path
+    // did `capturedHistory = [...messages]; appendDedupedModelMessages(...)`,
+    // so overlapping entries were deduped out of the persisted transcript.
+    consumeDirectChatTurnHeadlessMock.mockImplementation(async () => ({
+      messages: [
+        { role: "user", content: "hi" },
+        { role: "assistant", content: "local reply" },
+      ],
+      steps: [],
+      totalUsage: { totalTokens: 7 },
+      finishReason: "stop",
+      spans: [],
+      turnTrace: TURN_TRACE,
+      aborted: false,
+    }));
+    resolveSyntheticModelSourceMock.mockResolvedValue({
+      source: "local_byok",
+      orgRuntime: {
+        runtimeLocation: "local",
+        provider: { providerKey: "openai" } as any,
+      },
+    });
+
+    const result = await drainAssistantTurn(
+      baseArgs({
+        messages: input,
+        modelId: "llama3",
+        modelDefinition: {
+          id: "llama3",
+          name: "Llama3 local",
+          provider: "ollama",
+        } as ModelDefinition,
+      }) as Parameters<typeof drainAssistantTurn>[0],
+    );
+
+    // No duplicate of the input `user: hi` message.
+    expect(result.history).toEqual([
+      { role: "user", content: "hi" },
+      { role: "assistant", content: "local reply" },
+    ]);
+  });
+
   it("threads hosted turn hooks into the engine call (browser session context attachment)", async () => {
     const calls: unknown[] = [];
     runAssistantTurnMock.mockImplementation(buildHostedEngineStub(calls));

--- a/mcpjam-inspector/server/services/sessionSimulation/__tests__/runner.dispatch.test.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/__tests__/runner.dispatch.test.ts
@@ -2,15 +2,24 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ModelDefinition } from "@/shared/types";
 
+/**
+ * PR 3a: `drainAssistantTurn` is now a thin wrapper over `resolveTurnRuntime`
+ * + `runUnifiedAssistantTurn`. These tests exercise the REAL adapter + facade
+ * end-to-end, mocking only the leaf engines (`runAssistantTurn` for the hosted
+ * branch, `runDirectChatTurn` / `consumeDirectChatTurnHeadless` for the direct
+ * branch), the org model-factory (local model build), and `fetch` (the
+ * local-usage writeback). That way the byte-parity contract — hosted endpoints
+ * + extra body fields, the direct engine's 30-step default, the local-usage
+ * writeback — is asserted against the actual wiring, not a re-stub of it.
+ */
+
 const runAssistantTurnMock = vi.fn();
-const runLocalOrgChatTurnHeadlessMock = vi.fn();
-// The runner calls the shared `resolveSyntheticModelSource` helper which
-// internally calls `resolveOrgProviderRuntime`. Mocking the latter via
-// module mocking doesn't intercept the call because both functions live
-// in the SAME module (vitest module mocks only intercept cross-module
-// imports). Mock the public entry point instead — that's also the
-// boundary the empty-session fallback uses, so the test naturally
-// exercises the same surface as production.
+const runDirectChatTurnMock = vi.fn();
+const consumeDirectChatTurnHeadlessMock = vi.fn();
+const assertOrgModelAllowedMock = vi.fn();
+const buildOrgModelFromResolvedConfigMock = vi.fn();
+// `resolveSyntheticModelSource` is the resolution boundary both `drainAssistantTurn`
+// (via `resolveTurnRuntime`) and the empty-session fallback use.
 const resolveSyntheticModelSourceMock = vi.fn();
 
 vi.mock("../../../utils/assistant-turn.js", async () => {
@@ -23,14 +32,28 @@ vi.mock("../../../utils/assistant-turn.js", async () => {
   };
 });
 
-vi.mock("../../../utils/org-model-stream-handler.js", async () => {
+vi.mock("../../../utils/direct-chat-turn.js", async () => {
   const actual = await vi.importActual<
-    typeof import("../../../utils/org-model-stream-handler.js")
-  >("../../../utils/org-model-stream-handler.js");
+    typeof import("../../../utils/direct-chat-turn.js")
+  >("../../../utils/direct-chat-turn.js");
   return {
     ...actual,
-    runLocalOrgChatTurnHeadless: (...args: unknown[]) =>
-      runLocalOrgChatTurnHeadlessMock(...args),
+    runDirectChatTurn: (...args: unknown[]) => runDirectChatTurnMock(...args),
+    consumeDirectChatTurnHeadless: (...args: unknown[]) =>
+      consumeDirectChatTurnHeadlessMock(...args),
+  };
+});
+
+vi.mock("@mcpjam/sdk/model-factory", async () => {
+  const actual = await vi.importActual<
+    typeof import("@mcpjam/sdk/model-factory")
+  >("@mcpjam/sdk/model-factory");
+  return {
+    ...actual,
+    assertOrgModelAllowed: (...args: unknown[]) =>
+      assertOrgModelAllowedMock(...args),
+    buildOrgModelFromResolvedConfig: (...args: unknown[]) =>
+      buildOrgModelFromResolvedConfigMock(...args),
   };
 });
 
@@ -53,16 +76,15 @@ const TURN_TRACE = {
   startedAt: 0,
   endedAt: 0,
   spans: [],
+  usage: { totalTokens: 7 },
+  finishReason: "stop",
 };
 
 /**
- * `drainAssistantTurn` drives turns headlessly: the engine branches call
- * `runAssistantTurn` (streamSink: "none") whose result carries the
- * transcript synchronously; the local org-BYOK branch calls
- * `runLocalOrgChatTurnHeadless`. The stubs return the input messages as
- * the post-turn history plus a turnTrace, mirroring a successful turn.
+ * Stub the hosted engine (`runAssistantTurn`): capture options, return the
+ * input messages + a turnTrace as a successful headless turn.
  */
-function buildEngineStub(captureCalls: unknown[]) {
+function buildHostedEngineStub(captureCalls: unknown[]) {
   return vi.fn(async (opts: any) => {
     captureCalls.push(opts);
     return {
@@ -75,15 +97,34 @@ function buildEngineStub(captureCalls: unknown[]) {
   });
 }
 
-function buildLocalHeadlessStub(captureCalls: unknown[]) {
-  return vi.fn(async (opts: any) => {
+/**
+ * Stub the direct engine pair. `runDirectChatTurn` captures options + returns a
+ * handle; `consumeDirectChatTurnHeadless` returns a successful headless result.
+ */
+function stubDirectEngine(
+  captureCalls: unknown[],
+  overrides: { aborted?: boolean; engineError?: { message: string } } = {},
+) {
+  runDirectChatTurnMock.mockImplementation((opts: any) => {
     captureCalls.push(opts);
-    return {
-      messages: opts.messages,
-      turnTrace: TURN_TRACE,
-      aborted: false,
-    };
+    if (overrides.engineError) {
+      opts.onEngineError?.({
+        message: overrides.engineError.message,
+        rawText: overrides.engineError.message,
+        promptIndex: 0,
+      });
+    }
+    return { handleSentinel: true };
   });
+  consumeDirectChatTurnHeadlessMock.mockImplementation(async () => ({
+    messages: [{ role: "assistant", content: "local reply" }],
+    steps: [],
+    totalUsage: { totalTokens: 7 },
+    finishReason: "stop",
+    spans: [],
+    turnTrace: TURN_TRACE,
+    aborted: overrides.aborted === true,
+  }));
 }
 
 const baseArgs = (overrides: Record<string, unknown> = {}) => ({
@@ -105,20 +146,32 @@ const baseArgs = (overrides: Record<string, unknown> = {}) => ({
   ...overrides,
 });
 
+const fetchMock = vi.fn(async () => new Response("{}", { status: 200 }));
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  vi.stubEnv("CONVEX_HTTP_URL", "https://convex.test");
+  globalThis.fetch = fetchMock as never;
+  runAssistantTurnMock.mockReset();
+  runDirectChatTurnMock.mockReset();
+  consumeDirectChatTurnHeadlessMock.mockReset();
+  assertOrgModelAllowedMock.mockReset();
+  buildOrgModelFromResolvedConfigMock.mockReset();
+  buildOrgModelFromResolvedConfigMock.mockReturnValue({ model: true });
+  resolveSyntheticModelSourceMock.mockReset();
+  fetchMock.mockClear();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  globalThis.fetch = originalFetch;
+  vi.clearAllMocks();
+});
+
 describe("drainAssistantTurn — model-aware dispatch", () => {
-  beforeEach(() => {
-    runAssistantTurnMock.mockReset();
-    runLocalOrgChatTurnHeadlessMock.mockReset();
-    resolveSyntheticModelSourceMock.mockReset();
-  });
-
-  afterEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it("dispatches MCPJam-provided models through runAssistantTurn headlessly with synthesisRunId as a typed option", async () => {
+  it("routes MCPJam-provided models through the hosted engine on the default /stream endpoint", async () => {
     const calls: unknown[] = [];
-    runAssistantTurnMock.mockImplementation(buildEngineStub(calls));
+    runAssistantTurnMock.mockImplementation(buildHostedEngineStub(calls));
     resolveSyntheticModelSourceMock.mockResolvedValue({ source: "mcpjam" });
 
     const result = await drainAssistantTurn(
@@ -126,15 +179,12 @@ describe("drainAssistantTurn — model-aware dispatch", () => {
     );
 
     expect(runAssistantTurnMock).toHaveBeenCalledTimes(1);
-    expect(runLocalOrgChatTurnHeadlessMock).not.toHaveBeenCalled();
+    expect(runDirectChatTurnMock).not.toHaveBeenCalled();
     expect(result.modelSource).toBe("mcpjam");
     expect(result.turnTrace).toEqual(TURN_TRACE);
     const opts = calls[0] as any;
-    // `runAssistantTurn` itself appends synthesisRunId to extraBodyFields,
-    // so the wire body matches the old handler-built shape.
     expect(opts.synthesisRunId).toBe("run-xyz");
     expect(opts.approvalMode).toBe("auto-deny");
-    // Headless contract: no SSE Response, caller-owned persistence.
     expect(opts.streamSink).toBe("none");
     expect(opts.persistMode).toBe("caller");
     expect(opts.sourceType).toBe("chatbox");
@@ -143,13 +193,19 @@ describe("drainAssistantTurn — model-aware dispatch", () => {
       kind: "user_bearer",
       token: "Bearer abc",
     });
-    // JAM-paid path stays on the default `/stream` endpoint.
-    expect(opts.endpointPath).toBeUndefined();
+    // JAM-paid path pins the default `/stream` endpoint. The old dispatch left
+    // endpointPath undefined; passing "/stream" is byte-identical on the wire
+    // (`resolvedEndpointPath = endpointPath ?? "/stream"`).
+    expect(opts.endpointPath).toBe("/stream");
+    // MCPJam never sets a providerKey.
+    expect(opts.extraBodyFields?.providerKey).toBeUndefined();
+    // Hosted engines never post the local-usage writeback.
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("dispatches non-MCPJam models with cloud runtime through runAssistantTurn at /stream/org with providerKey + serverIds", async () => {
+  it("routes cloud-runtime BYOK models through /stream/org with providerKey + serverIds", async () => {
     const calls: unknown[] = [];
-    runAssistantTurnMock.mockImplementation(buildEngineStub(calls));
+    runAssistantTurnMock.mockImplementation(buildHostedEngineStub(calls));
     resolveSyntheticModelSourceMock.mockResolvedValue({
       source: "byok",
       orgRuntime: { runtimeLocation: "cloud", providerKey: "anthropic" },
@@ -167,29 +223,25 @@ describe("drainAssistantTurn — model-aware dispatch", () => {
     );
 
     expect(runAssistantTurnMock).toHaveBeenCalledTimes(1);
-    expect(runLocalOrgChatTurnHeadlessMock).not.toHaveBeenCalled();
+    expect(runDirectChatTurnMock).not.toHaveBeenCalled();
     expect(result.modelSource).toBe("byok");
     const opts = calls[0] as any;
-    // Hosted org-BYOK contract — byte-matching what
-    // `handleHostedOrgChatModel` constructed before the headless refactor.
+    // Hosted org-BYOK contract — byte-matching `handleHostedOrgChatModel`.
     expect(opts.endpointPath).toBe("/stream/org");
     expect(opts.extraBodyFields).toMatchObject({
       providerKey: "anthropic",
       serverIds: ["server-a"],
     });
     expect(opts.synthesisRunId).toBe("run-xyz");
-    // Synthetic runs must auto-deny approval-required tool calls — there
-    // is no human in the loop. Regression guard for #2486 PR review.
     expect(opts.approvalMode).toBe("auto-deny");
     expect(opts.streamSink).toBe("none");
     expect(opts.persistMode).toBe("caller");
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("dispatches non-MCPJam models with local runtime through runLocalOrgChatTurnHeadless and threads synthesisRunId as a typed option", async () => {
+  it("routes local-runtime BYOK models through the direct engine with the 30-step default and posts the usage writeback", async () => {
     const calls: unknown[] = [];
-    runLocalOrgChatTurnHeadlessMock.mockImplementation(
-      buildLocalHeadlessStub(calls),
-    );
+    stubDirectEngine(calls);
     resolveSyntheticModelSourceMock.mockResolvedValue({
       source: "local_byok",
       orgRuntime: {
@@ -200,7 +252,6 @@ describe("drainAssistantTurn — model-aware dispatch", () => {
 
     const result = await drainAssistantTurn(
       baseArgs({
-        // ollama is in isLocalRuntimeEligible's allow-list (custom: also is).
         modelId: "llama3",
         modelDefinition: {
           id: "llama3",
@@ -210,15 +261,38 @@ describe("drainAssistantTurn — model-aware dispatch", () => {
       }) as Parameters<typeof drainAssistantTurn>[0],
     );
 
-    expect(runLocalOrgChatTurnHeadlessMock).toHaveBeenCalledTimes(1);
+    expect(runDirectChatTurnMock).toHaveBeenCalledTimes(1);
     expect(runAssistantTurnMock).not.toHaveBeenCalled();
     expect(result.modelSource).toBe("local_byok");
     expect(result.turnTrace).toEqual(TURN_TRACE);
+
     const opts = calls[0] as any;
-    expect(opts.synthesisRunId).toBe("run-xyz");
+    // Local handler's 30-step default (the direct engine's own default is 20).
+    expect(opts.maxSteps).toBe(30);
+    // Byte-parity: the old local path never forwarded a provider string to the
+    // direct engine, so its trace spans carried no provider metadata.
+    expect(opts.provider).toBeUndefined();
+
+    // The local-usage writeback fired with the synthesisRunId attribution.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]! as unknown as [
+      string,
+      { body: string },
+    ];
+    expect(url).toBe("https://convex.test/stream/org/local-usage");
+    expect(JSON.parse(init.body)).toMatchObject({
+      projectId: "proj-1",
+      providerKey: "openai",
+      model: "llama3",
+      synthesisRunId: "run-xyz",
+      // turnId + promptIndex are sourced from the turn trace (byte-parity).
+      turnId: "test-turn",
+      promptIndex: 0,
+      serverIds: ["server-a"],
+    });
   });
 
-  it("refuses local-runtime org BYOK + requireToolApproval=true with non-empty tools (no auto-deny loop on the local path yet)", async () => {
+  it("refuses local-runtime BYOK + requireToolApproval=true with non-empty tools before building the model", async () => {
     resolveSyntheticModelSourceMock.mockResolvedValue({
       source: "local_byok",
       orgRuntime: {
@@ -240,19 +314,17 @@ describe("drainAssistantTurn — model-aware dispatch", () => {
           tools: { search: { description: "noop" } } as any,
         }) as Parameters<typeof drainAssistantTurn>[0],
       ),
-    ).rejects.toThrow(
-      /approval-required tool calls.*Disable tool approval/i,
-    );
+    ).rejects.toThrow(/approval-required tool calls.*Disable tool approval/i);
 
-    // Refusal happens before the turn driver is invoked.
-    expect(runLocalOrgChatTurnHeadlessMock).not.toHaveBeenCalled();
+    // Refusal happens before the model is built or the engine is invoked.
+    expect(buildOrgModelFromResolvedConfigMock).not.toHaveBeenCalled();
+    expect(runDirectChatTurnMock).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("still dispatches local-runtime org BYOK when requireToolApproval is false", async () => {
+  it("still dispatches local-runtime BYOK when requireToolApproval is false", async () => {
     const calls: unknown[] = [];
-    runLocalOrgChatTurnHeadlessMock.mockImplementation(
-      buildLocalHeadlessStub(calls),
-    );
+    stubDirectEngine(calls);
     resolveSyntheticModelSourceMock.mockResolvedValue({
       source: "local_byok",
       orgRuntime: {
@@ -274,12 +346,10 @@ describe("drainAssistantTurn — model-aware dispatch", () => {
       }) as Parameters<typeof drainAssistantTurn>[0],
     );
 
-    expect(runLocalOrgChatTurnHeadlessMock).toHaveBeenCalledTimes(1);
+    expect(runDirectChatTurnMock).toHaveBeenCalledTimes(1);
   });
 
-  it("throws with a clear message when org-BYOK derivation fails (custom provider without a name)", async () => {
-    // The resolver throws on deriveOrgProviderKey failure; runner propagates
-    // the same message it threw before the refactor.
+  it("throws with a clear message when org-BYOK derivation fails", async () => {
     resolveSyntheticModelSourceMock.mockRejectedValue(
       new Error(
         "Synthetic dispatch failed to derive org provider key: missing customProviderName",
@@ -294,7 +364,6 @@ describe("drainAssistantTurn — model-aware dispatch", () => {
             id: "custom-thing",
             name: "Custom",
             provider: "custom",
-            // intentionally no customProviderName — forces deriveOrgProviderKey error
           } as ModelDefinition,
         }) as Parameters<typeof drainAssistantTurn>[0],
       ),
@@ -303,17 +372,9 @@ describe("drainAssistantTurn — model-aware dispatch", () => {
 });
 
 describe("drainAssistantTurn — engine error surfacing", () => {
-  beforeEach(() => {
-    runAssistantTurnMock.mockReset();
-    runLocalOrgChatTurnHeadlessMock.mockReset();
-    resolveSyntheticModelSourceMock.mockReset();
-  });
-
-  it("throws when the engine reports an error and produces no turnTrace (spend-cap classification path)", async () => {
+  it("throws when the hosted engine reports an error and produces no turnTrace (spend-cap classification path)", async () => {
     resolveSyntheticModelSourceMock.mockResolvedValue({ source: "mcpjam" });
     runAssistantTurnMock.mockImplementation(async (opts: any) => {
-      // streamSink: "none" contract — the engine never throws; it fires
-      // onEngineError and returns without a turnTrace.
       opts.onEngineError?.({
         message: "Daily spend cap reached for free models",
         code: "spend_cap_exceeded",
@@ -330,30 +391,21 @@ describe("drainAssistantTurn — engine error surfacing", () => {
     });
 
     await expect(
-      drainAssistantTurn(
-        baseArgs() as Parameters<typeof drainAssistantTurn>[0],
-      ),
+      drainAssistantTurn(baseArgs() as Parameters<typeof drainAssistantTurn>[0]),
     ).rejects.toThrow(/spend cap.*spend_cap_exceeded.*HTTP 429/i);
   });
 
-  it("throws when the engine returns no turnTrace even WITHOUT a captured engine error (no silent empty turns)", async () => {
-    // Cursor Bugbot (PR 2610): a missing turnTrace on a non-aborted turn
-    // always means runSucceeded=false — engine-internal aborts or error
-    // sites the onEngineError callback doesn't cover must still fail the
-    // session instead of silently recording an empty assistant reply.
+  it("throws when the hosted engine returns no turnTrace even WITHOUT a captured engine error", async () => {
     resolveSyntheticModelSourceMock.mockResolvedValue({ source: "mcpjam" });
     runAssistantTurnMock.mockImplementation(async (opts: any) => ({
       messages: opts.messages,
       assistantMessages: [],
       toolCalls: [],
       toolResults: [],
-      // no turnTrace, no onEngineError fired
     }));
 
     await expect(
-      drainAssistantTurn(
-        baseArgs() as Parameters<typeof drainAssistantTurn>[0],
-      ),
+      drainAssistantTurn(baseArgs() as Parameters<typeof drainAssistantTurn>[0]),
     ).rejects.toThrow(/engine returned no turn trace/i);
   });
 
@@ -401,9 +453,65 @@ describe("drainAssistantTurn — engine error surfacing", () => {
     expect(result.turnTrace).toEqual(TURN_TRACE);
   });
 
-  it("threads turn hooks into the engine call (browser session context attachment)", async () => {
+  it("throws on a fatal direct-engine error and does NOT post the usage writeback", async () => {
     const calls: unknown[] = [];
-    runAssistantTurnMock.mockImplementation(buildEngineStub(calls));
+    stubDirectEngine(calls, { engineError: { message: "provider exploded" } });
+    resolveSyntheticModelSourceMock.mockResolvedValue({
+      source: "local_byok",
+      orgRuntime: {
+        runtimeLocation: "local",
+        provider: { providerKey: "openai" } as any,
+      },
+    });
+
+    await expect(
+      drainAssistantTurn(
+        baseArgs({
+          modelId: "llama3",
+          modelDefinition: {
+            id: "llama3",
+            name: "Llama3 local",
+            provider: "ollama",
+          } as ModelDefinition,
+        }) as Parameters<typeof drainAssistantTurn>[0],
+      ),
+    ).rejects.toThrow(/provider exploded/);
+    // finalizeUsage is gated on success — no billing on a fatal error turn.
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns the aborted direct turn without persisting or billing", async () => {
+    const calls: unknown[] = [];
+    stubDirectEngine(calls, { aborted: true });
+    resolveSyntheticModelSourceMock.mockResolvedValue({
+      source: "local_byok",
+      orgRuntime: {
+        runtimeLocation: "local",
+        provider: { providerKey: "openai" } as any,
+      },
+    });
+
+    const input = [{ role: "user", content: "hi" }];
+    const result = await drainAssistantTurn(
+      baseArgs({
+        messages: input,
+        modelId: "llama3",
+        modelDefinition: {
+          id: "llama3",
+          name: "Llama3 local",
+          provider: "ollama",
+        } as ModelDefinition,
+      }) as Parameters<typeof drainAssistantTurn>[0],
+    );
+    expect(result.turnTrace).toBeUndefined();
+    // Aborted turns return the input history unchanged and never bill.
+    expect(result.history).toEqual(input);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("threads hosted turn hooks into the engine call (browser session context attachment)", async () => {
+    const calls: unknown[] = [];
+    runAssistantTurnMock.mockImplementation(buildHostedEngineStub(calls));
     resolveSyntheticModelSourceMock.mockResolvedValue({ source: "mcpjam" });
 
     const onToolCall = vi.fn();
@@ -422,11 +530,9 @@ describe("drainAssistantTurn — engine error surfacing", () => {
     expect(opts.prepareAdvertisedTools).toBe(prepareAdvertisedTools);
   });
 
-  it("threads local-branch hooks into runLocalOrgChatTurnHeadless", async () => {
+  it("threads local-branch hooks into the direct engine (prepareAdvertisedTools + onToolResultChunk)", async () => {
     const calls: unknown[] = [];
-    runLocalOrgChatTurnHeadlessMock.mockImplementation(
-      buildLocalHeadlessStub(calls),
-    );
+    stubDirectEngine(calls);
     resolveSyntheticModelSourceMock.mockResolvedValue({
       source: "local_byok",
       orgRuntime: {
@@ -452,6 +558,7 @@ describe("drainAssistantTurn — engine error surfacing", () => {
 
     const opts = calls[0] as any;
     expect(opts.prepareAdvertisedTools).toBe(prepareAdvertisedTools);
-    expect(opts.onToolResultChunk).toBe(onToolResultChunk);
+    // The facade maps the chunk hook into the direct engine's traceEvents.
+    expect(opts.traceEvents?.onToolResultChunk).toBe(onToolResultChunk);
   });
 });

--- a/mcpjam-inspector/server/services/sessionSimulation/runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/runner.ts
@@ -18,7 +18,10 @@ import {
   type RunLocalOrgChatTurnHeadlessOptions,
 } from "../../utils/org-model-stream-handler.js";
 import { runUnifiedAssistantTurn } from "../../utils/turn-execution.js";
-import { resolveTurnRuntime } from "../../utils/resolve-turn-runtime.js";
+import {
+  resolveTurnRuntime,
+  classifyTurnFailure,
+} from "../../utils/resolve-turn-runtime.js";
 import {
   buildSyntheticModelDefinition,
   resolveSyntheticModelSource,
@@ -46,7 +49,10 @@ import {
   toBrowserStepPayload,
   toObservationPayload,
 } from "../browser-artifact-serialization.js";
-import type { EvalTraceWidgetSnapshot } from "@/shared/eval-trace";
+import {
+  appendDedupedModelMessages,
+  type EvalTraceWidgetSnapshot,
+} from "@/shared/eval-trace";
 import {
   evalTraceSnapshotToPayload,
   sanitizeWidgetForBackend,
@@ -895,7 +901,9 @@ async function runOneSession(args: {
     return { outcome: "succeeded" };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    if (/rate.?limit|spend|cap/i.test(message)) {
+    // Single source of truth for the spend-cap / rate-limit fold — shared with
+    // the per-runtime `classifyFailure` so the regex can't drift.
+    if (classifyTurnFailure(message) === "rate_limited") {
       return { outcome: "rate_limited" };
     }
     logger.warn("[sessionSimulation.runner] session failed", {
@@ -1281,8 +1289,20 @@ export async function drainAssistantTurn(
       );
     }
 
+    // Rebuild history with the SAME deduped append the old local path used
+    // (`buildLocalOrgOnPersist` / `runLocalOrgChatTurnHeadless`:
+    // `capturedHistory = [...messages]; appendDedupedModelMessages(...)`).
+    // `result.messages` is a plain `[...opts.messages, ...newMessages]` spread,
+    // so an engine response message that overlaps the input-history prefix (by
+    // id or JSON identity) would double-write into the transcript. Dedup the
+    // turn's new messages against the input prefix to match legacy semantics.
+    // `result.newMessages` are already mcp-tool-origin stamped, so the origin
+    // metadata is preserved.
+    const history: ModelMessage[] = [...args.messages];
+    appendDedupedModelMessages(history, result.newMessages);
+
     return {
-      history: result.messages,
+      history,
       turnTrace: result.turnTrace,
       modelSource: rt.modelSource,
     };

--- a/mcpjam-inspector/server/services/sessionSimulation/runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/runner.ts
@@ -12,15 +12,13 @@ import type { ModelDefinition } from "@/shared/types";
 // when the chatbox modelId isn't in SUPPORTED_MODELS, which is the common
 // case for org-BYOK chatboxes (Ollama, custom: providers, OpenRouter ids).
 import { logger } from "../../utils/logger.js";
-import type {
-  MCPJamEngineErrorEvent,
-  MCPJamHandlerOptions,
-} from "../../utils/mcpjam-stream-handler.js";
-import { runAssistantTurn } from "../../utils/assistant-turn.js";
+import type { MCPJamHandlerOptions } from "../../utils/mcpjam-stream-handler.js";
 import {
-  runLocalOrgChatTurnHeadless,
+  resolveLocalOrgMaxSteps,
   type RunLocalOrgChatTurnHeadlessOptions,
 } from "../../utils/org-model-stream-handler.js";
+import { runUnifiedAssistantTurn } from "../../utils/turn-execution.js";
+import { resolveTurnRuntime } from "../../utils/resolve-turn-runtime.js";
 import {
   buildSyntheticModelDefinition,
   resolveSyntheticModelSource,
@@ -1139,37 +1137,31 @@ export interface DrainAssistantTurnHooks {
 }
 
 /**
- * Drive one assistant turn through the appropriate headless turn driver:
- *   - MCPJam-provided modelId → `runAssistantTurn` (JAM-paid `/stream`)
- *   - Org-BYOK cloud runtime → `runAssistantTurn` with
- *     `endpointPath: "/stream/org"` + `extraBodyFields: { providerKey,
- *     serverIds }` (byte-matching what `handleHostedOrgChatModel` builds)
- *   - Org-BYOK local runtime → `runLocalOrgChatTurnHeadless`
+ * TEMPORARY COMPATIBILITY ADAPTER (PR 3a). `drainAssistantTurn` is now a thin
+ * wrapper over {@link resolveTurnRuntime} + {@link runUnifiedAssistantTurn}: it
+ * resolves the concrete {@link TurnRuntime} (MCPJam `/stream`, cloud-BYOK
+ * `/stream/org`, or the direct in-process engine for local BYOK), drives ONE
+ * turn through the shared facade, applies the synthetic error contract, and
+ * fires the local-BYOK usage writeback. It exists only to keep `runOneSession`
+ * unchanged while the shared adapter lands; it will be inlined/removed at
+ * legacy cleanup — it is NOT a permanent second facade.
  *
- * No SSE Response is built or drained: the engine branches run
- * `streamSink: "none"` / `persistMode: "caller"` (the agent loop and the
- * transcript capture complete before `runAssistantTurn` returns), and the
- * local branch consumes `runDirectChatTurn` headlessly. Synthetic runs own
- * persistence themselves (per-turn `persistChatSessionToConvex` from
+ * No SSE Response is built or drained: the facade runs `streamSink: "none"` /
+ * `persistMode: "caller"` (the hosted agent loop and transcript capture
+ * complete before it returns; the direct engine consumes headlessly). Synthetic
+ * runs own persistence themselves (per-turn `persistChatSessionToConvex` from
  * `runOneSession` with `synthetic: true`, `personaId`, `synthesisRunId`).
  *
- * User-API-key direct chats are NOT supported on the synthetic path —
- * there's no "visitor" whose key to use. Such chatboxes are rejected at
- * the route boundary; this dispatcher's only fallthrough is for an
- * unexpected `resolveOrgProviderRuntime` shape, which throws.
+ * Error contract (byte-preserved from the pre-facade dispatch): turn failures
+ * THROW. Hosted engines signal failure with a MISSING turnTrace on a
+ * non-aborted turn (recovered per-step errors keep their trace and succeed);
+ * the direct engine always produces a trace, so it signals failure via
+ * `onEngineError`. Surfacing the failure lets `runOneSession`'s classifier see
+ * real spend-cap / rate-limit errors (→ `"rate_limited"`) and genuine provider
+ * failures (→ `"failed"`).
  *
- * Error contract: turn failures THROW. The engine doesn't throw in
- * `streamSink: "none"` mode — it routes failures through `onEngineError`
- * and returns with no turnTrace — so this dispatcher converts that signal
- * into a throw. The old SSE-drain implementation discarded error chunks
- * into the drained stream, silently recording an empty assistant turn;
- * surfacing the failure lets `runOneSession`'s classifier see real spend-cap
- * / rate-limit errors (→ `"rate_limited"`) and genuine provider failures
- * (→ `"failed"`).
- *
- * Returns the post-turn message history, the per-turn trace, and the
- * resolved `modelSource` so the caller can stamp
- * `persistChatSessionToConvex` correctly.
+ * Returns the post-turn message history, the per-turn trace, and the resolved
+ * `modelSource` so the caller can stamp `persistChatSessionToConvex` correctly.
  */
 export async function drainAssistantTurn(
   args: Omit<
@@ -1190,98 +1182,109 @@ export async function drainAssistantTurn(
   modelSource: SyntheticModelSource;
 }> {
   const { modelDefinition, synthesisRunId, extraBodyFields, hooks } = args;
-  const modelIdStr = String(modelDefinition.id);
 
-  // Classify once, dispatch off the result. The same resolver is used by
-  // the empty-session fallback persist so the two attribution paths can't
-  // drift (e.g. if isLocalRuntimeEligible's allow-list ever changes, both
-  // sites pick it up automatically).
-  const resolution = await resolveSyntheticModelSource({
+  // Narrow MCPJamHandlerOptions' open `sourceType` string to the engine union;
+  // the simulation runner always passes "chatbox".
+  const sourceType =
+    args.sourceType === "direct" || args.sourceType === "eval"
+      ? args.sourceType
+      : ("chatbox" as const);
+
+  // Provider/runtime resolution + local usage writeback + approval guard, in
+  // one shared adapter. Uses the same resolver the empty-session fallback
+  // persist uses, so the two attribution paths can't drift.
+  const rt = await resolveTurnRuntime({
     modelDefinition,
     projectId: args.projectId ?? "",
     authHeader: args.authHeader,
     chatboxId: args.chatboxId,
     accessVersion: args.accessVersion,
     serverIds: args.selectedServers,
+    sourceType,
+    chatSessionId: args.chatSessionId,
+    requireToolApproval: args.requireToolApproval,
+    tools: args.tools as ToolSet,
+    ...(args.harness ? { harness: args.harness } : {}),
+    ...(extraBodyFields ? { extraBodyFields } : {}),
+    attribution: { synthesisRunId },
   });
 
-  // Narrow MCPJamHandlerOptions' open `sourceType` string to the engine
-  // union; the simulation runner always passes "chatbox".
-  const sourceType =
-    args.sourceType === "direct" || args.sourceType === "eval"
-      ? args.sourceType
-      : ("chatbox" as const);
+  // Engine-error signal. Structural type covers both the hosted
+  // `MCPJamEngineErrorEvent` and the direct `DirectChatTurnEngineErrorEvent`.
+  let lastEngineError:
+    | { message: string; code?: string; httpStatus?: number }
+    | undefined;
+  const captureEngineError = (event: {
+    message: string;
+    code?: string;
+    httpStatus?: number;
+  }) => {
+    lastEngineError = event;
+  };
 
-  if (resolution.source !== "mcpjam") {
-    // resolution.orgRuntime is guaranteed defined for non-"mcpjam" sources
-    // (the resolver only omits it when source === "mcpjam").
-    const orgRuntime = resolution.orgRuntime!;
+  if (rt.runtime.kind === "direct") {
+    // Local-runtime org BYOK → the in-process AI-SDK engine. `maxSteps` mirrors
+    // the local handler's 30-step default (the direct engine's own default is
+    // 20). Browser hooks flow through the facade's inert callback extensions.
+    const result = await runUnifiedAssistantTurn({
+      runtime: rt.runtime,
+      streamSink: "none",
+      messages: args.messages,
+      systemPrompt: args.systemPrompt,
+      ...(args.temperature !== undefined
+        ? { temperature: args.temperature }
+        : {}),
+      tools: args.tools as ToolSet,
+      maxSteps: resolveLocalOrgMaxSteps(args.maxSteps),
+      ...(args.progressivePlan
+        ? { progressivePlan: args.progressivePlan }
+        : {}),
+      ...(args.discoveryState ? { discoveryState: args.discoveryState } : {}),
+      ...(args.abortSignal ? { abortSignal: args.abortSignal } : {}),
+      ...(hooks?.prepareAdvertisedTools
+        ? { prepareAdvertisedTools: hooks.prepareAdvertisedTools }
+        : {}),
+      ...(hooks?.onToolResultChunk
+        ? { onToolResultChunk: hooks.onToolResultChunk }
+        : {}),
+      onEngineError: captureEngineError,
+    });
 
-    if (orgRuntime.runtimeLocation === "local") {
-      // Local-runtime org providers don't have an approval loop today —
-      // the local turn driver rejects with `tool_approval_unsupported`
-      // when requireToolApproval is true and any tools are exposed. Cloud
-      // BYOK paths handle this via `approvalMode: "auto-deny"` (the loop
-      // denies each call and continues); the local path has no equivalent
-      // yet, so a synthetic run on an approval-required chatbox would have
-      // every turn fail with the same error. Refuse upfront with a clear
-      // message rather than letting the per-turn errors stack up silently.
-      // Disable approval on the chatbox or switch the provider to cloud
-      // runtime to unblock.
-      if (
-        args.requireToolApproval === true &&
-        args.tools &&
-        Object.keys(args.tools as Record<string, unknown>).length > 0
-      ) {
-        throw new Error(
-          "Synthetic runs on local-runtime org BYOK models don't yet support approval-required tool calls. Disable tool approval on this chatbox or switch the provider to cloud runtime."
-        );
-      }
-      const headless = await runLocalOrgChatTurnHeadless({
-        provider: orgRuntime.provider,
-        projectId: args.projectId ?? "",
-        modelId: modelIdStr,
-        chatSessionId: args.chatSessionId,
-        sourceType,
-        messages: args.messages,
-        systemPrompt: args.systemPrompt,
-        temperature: args.temperature,
-        tools: args.tools as ToolSet,
-        progressivePlan: args.progressivePlan,
-        discoveryState: args.discoveryState,
-        authHeader: args.authHeader,
-        chatboxId: args.chatboxId,
-        accessVersion: args.accessVersion,
-        selectedServers: args.selectedServers,
-        serverIds: args.selectedServers,
-        requireToolApproval: args.requireToolApproval,
-        abortSignal: args.abortSignal,
-        // Forwarded to /stream/org/local-usage so the backend BYOK writer
-        // stamps synthesisRunId onto the resulting llmUsageRecord.
-        synthesisRunId,
-        ...(hooks?.prepareAdvertisedTools
-          ? { prepareAdvertisedTools: hooks.prepareAdvertisedTools }
-          : {}),
-        ...(hooks?.onToolResultChunk
-          ? { onToolResultChunk: hooks.onToolResultChunk }
-          : {}),
-      });
+    // Aborted mid-turn: drop it (no writeback, no persist). Return the INPUT
+    // history unchanged, matching the old `runLocalOrgChatTurnHeadless` abort
+    // contract (`{ messages, aborted: true }`).
+    if (result.aborted) {
       return {
-        history: headless.messages,
-        turnTrace: headless.turnTrace,
-        modelSource: "local_byok",
+        history: args.messages,
+        turnTrace: undefined,
+        modelSource: rt.modelSource,
       };
     }
+
+    // The direct engine always produces a trace, so a turn-terminating failure
+    // is signalled by `onEngineError` (its `onError` fires only for fatal
+    // errors; recovered per-step tool errors never reach here). Throw with the
+    // same message shape the old headless path did.
+    if (lastEngineError) {
+      throw new Error(
+        lastEngineError.message || "Local org-BYOK turn failed mid-stream."
+      );
+    }
+
+    await rt.finalizeUsage(result);
+    return {
+      history: result.messages,
+      turnTrace: result.turnTrace,
+      modelSource: rt.modelSource,
+    };
   }
 
-  // Engine branches (JAM-paid `/stream` and hosted org-BYOK `/stream/org`)
-  // share the runAssistantTurn surface; only the endpoint + extra body
-  // fields differ.
-  const modelSource: SyntheticModelSource =
-    resolution.source === "mcpjam" ? "mcpjam" : "byok";
-  let lastEngineError: MCPJamEngineErrorEvent | undefined;
-
-  const result = await runAssistantTurn({
+  // Hosted engines (JAM-paid `/stream`, cloud org-BYOK `/stream/org`). The
+  // endpoint + extra body fields + harness selector ride `rt.runtime`.
+  const result = await runUnifiedAssistantTurn({
+    runtime: rt.runtime,
+    streamSink: "none",
+    persistMode: "caller",
     messages: args.messages,
     modelDefinition,
     systemPrompt: args.systemPrompt,
@@ -1293,12 +1296,8 @@ export async function drainAssistantTurn(
     authContext: { kind: "user_bearer", token: args.authHeader ?? "" },
     sourceType,
     origin: "chatbox",
-    streamSink: "none",
-    persistMode: "caller",
-    // Synthetic runs have no human-in-the-loop. Auto-deny any
-    // approval-required tool call inside the loop so the run can make
-    // forward progress instead of pausing forever waiting for an approval
-    // that will never arrive.
+    // Synthetic runs have no human-in-the-loop. Auto-deny approval-required
+    // tool calls inside the loop so the run makes forward progress.
     approvalMode: "auto-deny",
     chatSessionId: args.chatSessionId,
     ...(args.projectId ? { projectId: args.projectId } : {}),
@@ -1315,50 +1314,25 @@ export async function drainAssistantTurn(
     ...(args.modelVisibleMcpToolResults !== undefined
       ? { modelVisibleMcpToolResults: args.modelVisibleMcpToolResults }
       : {}),
-    // Harness selector: when the chatbox host runs harness: "claude-code",
-    // synthetic turns run the real Claude Code runtime. requireToolApproval is
-    // already threaded above, so runHarnessTurn fail-closes correctly.
-    ...(args.harness ? { harness: args.harness } : {}),
     ...(args.progressivePlan ? { progressivePlan: args.progressivePlan } : {}),
     ...(args.discoveryState ? { discoveryState: args.discoveryState } : {}),
     ...(args.abortSignal ? { abortSignal: args.abortSignal } : {}),
-    // `runAssistantTurn` appends synthesisRunId to extraBodyFields last, so
-    // the merged `/stream` body matches the old handler-built shape.
+    // `runAssistantTurn` appends synthesisRunId to extraBodyFields last, so the
+    // merged `/stream` body matches the old handler-built shape.
     synthesisRunId,
-    ...(resolution.source === "mcpjam"
-      ? { ...(extraBodyFields ? { extraBodyFields } : {}) }
-      : {
-          // Hosted org-BYOK contract — byte-matching what
-          // `handleHostedOrgChatModel` constructs: providerKey + serverIds
-          // ride extraBodyFields on /stream/org.
-          endpointPath: "/stream/org",
-          extraBodyFields: {
-            ...(extraBodyFields ?? {}),
-            providerKey: resolution.orgRuntime!.providerKey,
-            ...(args.selectedServers?.length
-              ? { serverIds: args.selectedServers }
-              : {}),
-          },
-        }),
     ...(hooks?.onToolCall ? { onToolCall: hooks.onToolCall } : {}),
     ...(hooks?.onToolResult ? { onToolResult: hooks.onToolResult } : {}),
     ...(hooks?.prepareAdvertisedTools
       ? { prepareAdvertisedTools: hooks.prepareAdvertisedTools }
       : {}),
-    onEngineError: (event) => {
-      lastEngineError = event;
-    },
+    onEngineError: captureEngineError,
   });
 
-  // Surface engine failures as throws (see the error contract above). A
-  // produced turnTrace means the turn semantically succeeded — per-step
-  // engine errors that the loop recovered from don't fail the turn. A
-  // MISSING turnTrace on a non-aborted turn always means the engine failed
-  // (`runSucceeded === false`) — the same signal the eval runners' failure
-  // detection keys on — so throw even when no `onEngineError` event was
-  // captured (engine-internal aborts without our signal flipping, or error
-  // sites the callback doesn't cover). Without this, a failed turn would
-  // silently record an empty assistant reply and skip persistence.
+  // A produced turnTrace means the turn semantically succeeded (recovered
+  // per-step engine errors keep their trace). A MISSING turnTrace on a
+  // non-aborted turn always means the engine failed — throw even when no
+  // `onEngineError` event was captured, so a failed turn can't silently record
+  // an empty assistant reply and skip persistence.
   if (!result.turnTrace && !args.abortSignal?.aborted) {
     if (lastEngineError) {
       const detail = [
@@ -1380,10 +1354,11 @@ export async function drainAssistantTurn(
     );
   }
 
+  await rt.finalizeUsage(result); // no-op for hosted engines
   return {
     history: result.messages,
     turnTrace: result.turnTrace,
-    modelSource,
+    modelSource: rt.modelSource,
   };
 }
 

--- a/mcpjam-inspector/server/services/sessionSimulation/runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/runner.ts
@@ -1261,17 +1261,26 @@ export async function drainAssistantTurn(
       };
     }
 
+    // Bill on ANY non-aborted completion — INCLUDING a mid-stream engine error
+    // after token consumption. This matches the old `buildLocalOrgOnPersist`,
+    // where `postLocalUsage` fired unconditionally at the top of `onPersist`
+    // (which runs on non-aborted completion, error included) and ONLY transcript
+    // persistence was gated on the error. The engine's `onFinish` populates
+    // `traceTurn.turnUsage` even on error, so `result.usage` carries the
+    // consumed tokens. Finalize BEFORE throwing so a failed local-BYOK turn's
+    // real spend is still recorded (cubic P1: post-consumption undercount).
+    await rt.finalizeUsage(result);
+
     // The direct engine always produces a trace, so a turn-terminating failure
     // is signalled by `onEngineError` (its `onError` fires only for fatal
-    // errors; recovered per-step tool errors never reach here). Throw with the
-    // same message shape the old headless path did.
+    // errors; recovered per-step tool errors never reach here). Throw — AFTER
+    // billing — with the same message shape the old headless path did.
     if (lastEngineError) {
       throw new Error(
         lastEngineError.message || "Local org-BYOK turn failed mid-stream."
       );
     }
 
-    await rt.finalizeUsage(result);
     return {
       history: result.messages,
       turnTrace: result.turnTrace,

--- a/mcpjam-inspector/server/utils/__tests__/resolve-turn-runtime.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/resolve-turn-runtime.test.ts
@@ -1,0 +1,301 @@
+/**
+ * `resolveTurnRuntime` — the shared runtime adapter. These tests lock the
+ * byte-parity contract the synthetic (and future swarm) paths depend on:
+ * the three-way MCPJam / cloud-BYOK / local-BYOK runtime shape, the exact
+ * hosted endpoint + extra body fields, the local model build, the approval
+ * guard, and the `/stream/org/local-usage` writeback body.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ModelDefinition } from "@/shared/types";
+
+const resolveSyntheticModelSourceMock = vi.fn();
+const assertOrgModelAllowedMock = vi.fn();
+const buildOrgModelFromResolvedConfigMock = vi.fn();
+
+vi.mock("../org-model-config.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../org-model-config.js")
+  >("../org-model-config.js");
+  return {
+    ...actual,
+    resolveSyntheticModelSource: (...args: unknown[]) =>
+      resolveSyntheticModelSourceMock(...args),
+  };
+});
+
+vi.mock("@mcpjam/sdk/model-factory", async () => {
+  const actual = await vi.importActual<
+    typeof import("@mcpjam/sdk/model-factory")
+  >("@mcpjam/sdk/model-factory");
+  return {
+    ...actual,
+    assertOrgModelAllowed: (...args: unknown[]) =>
+      assertOrgModelAllowedMock(...args),
+    buildOrgModelFromResolvedConfig: (...args: unknown[]) =>
+      buildOrgModelFromResolvedConfigMock(...args),
+  };
+});
+
+import { resolveTurnRuntime } from "../resolve-turn-runtime.js";
+import type { UnifiedTurnResult } from "../turn-execution.js";
+
+const MCPJAM_MODEL: ModelDefinition = {
+  id: "anthropic/claude-haiku-4.5",
+  name: "Claude Haiku",
+  provider: "anthropic",
+};
+const BYOK_MODEL: ModelDefinition = {
+  id: "claude-3-5-sonnet-latest",
+  name: "Claude",
+  provider: "anthropic",
+};
+const LOCAL_MODEL: ModelDefinition = {
+  id: "llama3",
+  name: "Llama3 local",
+  provider: "ollama",
+};
+
+const baseArgs = (overrides: Record<string, unknown> = {}) => ({
+  modelDefinition: MCPJAM_MODEL,
+  projectId: "proj-1",
+  authHeader: "Bearer abc",
+  chatboxId: "chatbox-1",
+  accessVersion: 3,
+  serverIds: ["server-a"],
+  sourceType: "chatbox" as const,
+  chatSessionId: "sess_1",
+  attribution: { synthesisRunId: "run-xyz" },
+  ...overrides,
+});
+
+/** A successful direct-turn result the way `runUnifiedAssistantTurn` returns it. */
+const successResult = (): UnifiedTurnResult =>
+  ({
+    messages: [],
+    newMessages: [],
+    assistantMessages: [],
+    toolCalls: [],
+    toolResults: [],
+    usage: { totalTokens: 11 },
+    finishReason: "stop",
+    turnTrace: {
+      turnId: "turn-1",
+      promptIndex: 2,
+      startedAt: 0,
+      endedAt: 1,
+      spans: [],
+      usage: { totalTokens: 11 },
+      finishReason: "stop",
+    },
+    aborted: false,
+  }) as unknown as UnifiedTurnResult;
+
+const fetchMock = vi.fn(async () => new Response("{}", { status: 200 }));
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  vi.stubEnv("CONVEX_HTTP_URL", "https://convex.test");
+  globalThis.fetch = fetchMock as never;
+  resolveSyntheticModelSourceMock.mockReset();
+  assertOrgModelAllowedMock.mockReset();
+  buildOrgModelFromResolvedConfigMock.mockReset();
+  buildOrgModelFromResolvedConfigMock.mockReturnValue({ localModel: true });
+  fetchMock.mockClear();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  globalThis.fetch = originalFetch;
+  vi.clearAllMocks();
+});
+
+describe("resolveTurnRuntime — runtime shape", () => {
+  it("MCPJam → hosted /stream, no providerKey, no-op usage writeback", async () => {
+    resolveSyntheticModelSourceMock.mockResolvedValue({ source: "mcpjam" });
+
+    const rt = await resolveTurnRuntime(baseArgs());
+
+    expect(rt.modelSource).toBe("mcpjam");
+    expect(rt.runtime).toEqual({ kind: "hosted", endpointPath: "/stream" });
+    // Hosted writeback is a no-op (backend records usage server-side).
+    await rt.finalizeUsage(successResult());
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("MCPJam forwards caller extraBodyFields + harness when present", async () => {
+    resolveSyntheticModelSourceMock.mockResolvedValue({ source: "mcpjam" });
+
+    const rt = await resolveTurnRuntime(
+      baseArgs({
+        modelDefinition: MCPJAM_MODEL,
+        extraBodyFields: { foo: "bar" },
+        harness: "claude-code",
+      }),
+    );
+
+    expect(rt.runtime).toEqual({
+      kind: "hosted",
+      endpointPath: "/stream",
+      extraBodyFields: { foo: "bar" },
+      harness: "claude-code",
+    });
+  });
+
+  it("cloud BYOK → hosted /stream/org with providerKey + serverIds (byte-parity body)", async () => {
+    resolveSyntheticModelSourceMock.mockResolvedValue({
+      source: "byok",
+      orgRuntime: { runtimeLocation: "cloud", providerKey: "anthropic" },
+    });
+
+    const rt = await resolveTurnRuntime(
+      baseArgs({ modelDefinition: BYOK_MODEL, extraBodyFields: { keep: 1 } }),
+    );
+
+    expect(rt.modelSource).toBe("byok");
+    expect(rt.runtime).toEqual({
+      kind: "hosted",
+      endpointPath: "/stream/org",
+      // Caller fields first, then the sibling contract fields.
+      extraBodyFields: {
+        keep: 1,
+        providerKey: "anthropic",
+        serverIds: ["server-a"],
+      },
+    });
+    // Hosted → no local-usage writeback.
+    await rt.finalizeUsage(successResult());
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("cloud BYOK omits serverIds when none are selected", async () => {
+    resolveSyntheticModelSourceMock.mockResolvedValue({
+      source: "byok",
+      orgRuntime: { runtimeLocation: "cloud", providerKey: "openai" },
+    });
+
+    const rt = await resolveTurnRuntime(
+      baseArgs({ modelDefinition: BYOK_MODEL, serverIds: [] }),
+    );
+
+    expect(rt.runtime).toEqual({
+      kind: "hosted",
+      endpointPath: "/stream/org",
+      extraBodyFields: { providerKey: "openai" },
+    });
+  });
+
+  it("local BYOK → direct runtime with the model built and no provider metadata", async () => {
+    const provider = { providerKey: "openai" } as never;
+    resolveSyntheticModelSourceMock.mockResolvedValue({
+      source: "local_byok",
+      orgRuntime: { runtimeLocation: "local", provider },
+    });
+
+    const rt = await resolveTurnRuntime(baseArgs({ modelDefinition: LOCAL_MODEL }));
+
+    expect(rt.modelSource).toBe("local_byok");
+    expect(assertOrgModelAllowedMock).toHaveBeenCalledWith(provider, "llama3");
+    expect(buildOrgModelFromResolvedConfigMock).toHaveBeenCalledWith(
+      provider,
+      "llama3",
+    );
+    expect(rt.runtime).toEqual({
+      kind: "direct",
+      llmModel: { localModel: true },
+      modelId: "llama3",
+    });
+    // Byte-parity: no provider string is forwarded (spans carried none before).
+    expect((rt.runtime as { provider?: string }).provider).toBeUndefined();
+  });
+
+  it("local BYOK + requireToolApproval=true with non-empty tools throws before building the model", async () => {
+    resolveSyntheticModelSourceMock.mockResolvedValue({
+      source: "local_byok",
+      orgRuntime: {
+        runtimeLocation: "local",
+        provider: { providerKey: "openai" } as never,
+      },
+    });
+
+    await expect(
+      resolveTurnRuntime(
+        baseArgs({
+          modelDefinition: LOCAL_MODEL,
+          requireToolApproval: true,
+          tools: { search: { description: "noop" } } as never,
+        }),
+      ),
+    ).rejects.toThrow(/approval-required tool calls.*Disable tool approval/i);
+
+    expect(buildOrgModelFromResolvedConfigMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveTurnRuntime — local usage writeback (finalizeUsage)", () => {
+  const localArgs = () =>
+    baseArgs({
+      modelDefinition: LOCAL_MODEL,
+      // resolveSyntheticModelSource is mocked, so modelDefinition only feeds
+      // the local model build (modelId "llama3").
+    });
+
+  beforeEach(() => {
+    resolveSyntheticModelSourceMock.mockResolvedValue({
+      source: "local_byok",
+      orgRuntime: {
+        runtimeLocation: "local",
+        provider: { providerKey: "openai" } as never,
+      },
+    });
+  });
+
+  it("posts /stream/org/local-usage with the byte-identical body incl. synthesisRunId", async () => {
+    const rt = await resolveTurnRuntime(localArgs());
+
+    await rt.finalizeUsage(successResult());
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]! as unknown as [
+      string,
+      { body: string; headers: Record<string, string> },
+    ];
+    expect(url).toBe("https://convex.test/stream/org/local-usage");
+    expect(init.headers.Authorization).toBe("Bearer abc");
+    expect(JSON.parse(init.body)).toEqual({
+      projectId: "proj-1",
+      providerKey: "openai",
+      model: "llama3",
+      usage: { totalTokens: 11 },
+      finishReason: "stop",
+      chatSessionId: "sess_1",
+      sourceType: "chatbox",
+      turnId: "turn-1",
+      promptIndex: 2,
+      chatboxId: "chatbox-1",
+      accessVersion: 3,
+      serverIds: ["server-a"],
+      synthesisRunId: "run-xyz",
+    });
+  });
+
+  it("does NOT fire on an aborted result", async () => {
+    const rt = await resolveTurnRuntime(localArgs());
+
+    const aborted = { ...successResult(), aborted: true } as UnifiedTurnResult;
+    await rt.finalizeUsage(aborted);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveTurnRuntime — classifyFailure", () => {
+  it("folds rate-limit / spend / cap messages into rate_limited, else failed", async () => {
+    resolveSyntheticModelSourceMock.mockResolvedValue({ source: "mcpjam" });
+    const rt = await resolveTurnRuntime(baseArgs());
+
+    expect(rt.classifyFailure("Rate limit exceeded")).toBe("rate_limited");
+    expect(rt.classifyFailure("daily spend cap reached")).toBe("rate_limited");
+    expect(rt.classifyFailure("hard cap hit")).toBe("rate_limited");
+    expect(rt.classifyFailure("provider exploded")).toBe("failed");
+  });
+});

--- a/mcpjam-inspector/server/utils/__tests__/resolve-turn-runtime.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/resolve-turn-runtime.test.ts
@@ -36,7 +36,10 @@ vi.mock("@mcpjam/sdk/model-factory", async () => {
   };
 });
 
-import { resolveTurnRuntime } from "../resolve-turn-runtime.js";
+import {
+  resolveTurnRuntime,
+  classifyTurnFailure,
+} from "../resolve-turn-runtime.js";
 import type { UnifiedTurnResult } from "../turn-execution.js";
 
 const MCPJAM_MODEL: ModelDefinition = {
@@ -285,6 +288,33 @@ describe("resolveTurnRuntime — local usage writeback (finalizeUsage)", () => {
     await rt.finalizeUsage(aborted);
 
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("swallows a writeback rejection (best-effort parity with the old fire-and-forget catch)", async () => {
+    // Parity with the OLD `buildLocalOrgOnPersist`, where the writeback was
+    // `postLocalUsage({...}).catch((err) => logger.warn(...))`: a
+    // `/stream/org/local-usage` outage NEVER failed the turn. The new
+    // `finalizeUsage` awaits the post, so a rejection must be caught here or
+    // it would fail an otherwise-successful synthetic turn.
+    fetchMock.mockRejectedValueOnce(new Error("network down"));
+    const rt = await resolveTurnRuntime(localArgs());
+
+    await expect(rt.finalizeUsage(successResult())).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("classifyTurnFailure (exported single source of truth)", () => {
+  it("folds rate-limit / spend / cap messages into rate_limited", () => {
+    expect(classifyTurnFailure("Rate limit exceeded")).toBe("rate_limited");
+    expect(classifyTurnFailure("ratelimit hit")).toBe("rate_limited");
+    expect(classifyTurnFailure("daily spend cap reached")).toBe("rate_limited");
+    expect(classifyTurnFailure("hard cap hit")).toBe("rate_limited");
+  });
+
+  it("maps everything else to failed", () => {
+    expect(classifyTurnFailure("provider exploded")).toBe("failed");
+    expect(classifyTurnFailure("")).toBe("failed");
   });
 });
 

--- a/mcpjam-inspector/server/utils/__tests__/turn-execution.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/turn-execution.test.ts
@@ -12,6 +12,11 @@ vi.mock("../direct-chat-turn", () => ({
   runDirectChatTurn: (...args: unknown[]) => runDirectChatTurnMock(...args),
   consumeDirectChatTurnHeadless: (...args: unknown[]) =>
     consumeDirectChatTurnHeadlessMock(...args),
+  // The facade stamps the direct engine's response messages with mcp-tool-origin
+  // metadata (parity with the hosted engine). Identity here — these tests use
+  // tool-less messages where stamping is a no-op — so the assertions still see
+  // the raw response slice.
+  stampMcpToolOriginProviderOptions: (messages: unknown[]) => messages,
 }));
 
 // eslint-disable-next-line import/first
@@ -202,5 +207,59 @@ describe("runUnifiedAssistantTurn", () => {
     expect(runDirectChatTurnMock).toHaveBeenCalledWith(
       expect.objectContaining({ onEngineError }),
     );
+  });
+
+  it("direct: maps onToolResultChunk into the engine's traceEvents (browser render hook)", async () => {
+    runDirectChatTurnMock.mockReturnValue({ handle: true });
+    consumeDirectChatTurnHeadlessMock.mockResolvedValue({
+      messages: [],
+      steps: [],
+      totalUsage: {},
+      finishReason: "stop",
+      spans: [],
+      turnTrace: { spans: [], usage: {} },
+      aborted: false,
+    });
+    const onToolResultChunk = vi.fn();
+
+    await runUnifiedAssistantTurn({
+      runtime: { kind: "direct", llmModel: {}, modelId: "m1" },
+      streamSink: "none",
+      messages: [userMsg],
+      systemPrompt: "sys",
+      tools: {},
+      onToolResultChunk,
+    } as never);
+
+    const passed = runDirectChatTurnMock.mock.calls[0][0];
+    expect(passed.traceEvents).toEqual({ onToolResultChunk });
+  });
+
+  it("direct: onToolResultChunk is inert for callers that don't set it (no traceEvents)", async () => {
+    runDirectChatTurnMock.mockReturnValue({ handle: true });
+    consumeDirectChatTurnHeadlessMock.mockResolvedValue({
+      messages: [asstMsg],
+      steps: [],
+      totalUsage: {},
+      finishReason: "stop",
+      spans: [],
+      turnTrace: { spans: [], usage: {} },
+      aborted: false,
+    });
+
+    const res = await runUnifiedAssistantTurn({
+      runtime: { kind: "direct", llmModel: {}, modelId: "m1" },
+      streamSink: "none",
+      messages: [userMsg],
+      systemPrompt: "sys",
+      tools: {},
+    } as never);
+
+    const passed = runDirectChatTurnMock.mock.calls[0][0];
+    // No chunk hook → no traceEvents object forwarded at all.
+    expect(passed.traceEvents).toBeUndefined();
+    // …and the existing result contract is unchanged.
+    expect(res.messages).toEqual([userMsg, asstMsg]);
+    expect(res.newMessages).toEqual([asstMsg]);
   });
 });

--- a/mcpjam-inspector/server/utils/direct-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/direct-chat-turn.ts
@@ -381,7 +381,7 @@ export interface RunDirectChatTurnHandle {
   isAborted: () => boolean;
 }
 
-function stampMcpToolOriginProviderOptions(
+export function stampMcpToolOriginProviderOptions(
   messages: ModelMessage[],
   tools: ToolSet
 ): ModelMessage[] {

--- a/mcpjam-inspector/server/utils/org-model-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/org-model-stream-handler.ts
@@ -490,7 +490,7 @@ export function handleLocalOrgChatModel(
  * caller-supplied ceiling AND preserve the legacy default. Route 4 and eval
  * headless still get the engine default (20) because they omit the option.
  */
-function resolveLocalOrgMaxSteps(maxSteps: number | undefined): number {
+export function resolveLocalOrgMaxSteps(maxSteps: number | undefined): number {
   return typeof maxSteps === "number" &&
     Number.isFinite(maxSteps) &&
     maxSteps > 0
@@ -688,7 +688,14 @@ export async function runLocalOrgChatTurnHeadless(
   };
 }
 
-async function postLocalUsage(params: {
+/**
+ * Post a local-runtime BYOK usage record to Convex's
+ * `/stream/org/local-usage` writeback endpoint. Exported so the shared
+ * {@link resolveTurnRuntime} adapter can emit the byte-identical request the
+ * SSE/headless local handlers do — the body shape is the source of truth for
+ * per-run BYOK spend attribution, so it must never drift between call sites.
+ */
+export async function postLocalUsage(params: {
   projectId: string;
   providerKey: string;
   model: string;

--- a/mcpjam-inspector/server/utils/resolve-turn-runtime.ts
+++ b/mcpjam-inspector/server/utils/resolve-turn-runtime.ts
@@ -1,0 +1,258 @@
+/**
+ * `resolveTurnRuntime` — the shared runtime adapter that turns a chatbox's
+ * `ModelDefinition` (+ auth/attribution context) into a concrete
+ * {@link TurnRuntime} for {@link runUnifiedAssistantTurn}, plus the three
+ * side-concerns that live alongside runtime selection:
+ *
+ *   1. provider/runtime resolution   (`resolveSyntheticModelSource`)
+ *   2. local-BYOK usage writeback     (`finalizeUsage` → `postLocalUsage`)
+ *   3. approval guard + failure class (`classifyFailure`)
+ *
+ * This is the extraction of everything `drainAssistantTurn` used to do
+ * "up to the point of calling the engine" so the swarm/synthetic paths and
+ * the eventual chat/eval migrations can share ONE resolution+writeback
+ * surface instead of re-deriving the three-way MCPJam / cloud-BYOK /
+ * local-BYOK decision inline.
+ *
+ * Byte-parity contract (load-bearing — this sits on a spend-metered hot path):
+ *   - MCPJam  → hosted `/stream`      (default endpoint, no providerKey).
+ *   - cloud BYOK → hosted `/stream/org` with `extraBodyFields:{ providerKey,
+ *     serverIds }` — byte-matching `handleHostedOrgChatModel`.
+ *   - local BYOK → direct engine (model built via `buildOrgModelFromResolvedConfig`)
+ *     and `finalizeUsage` posts `/stream/org/local-usage` with the identical
+ *     body `runLocalOrgChatTurnHeadless`'s `postLocalUsage` emitted.
+ */
+
+import type { ToolSet } from "ai";
+import type { Harness } from "@mcpjam/sdk";
+import type { ModelDefinition } from "@/shared/types";
+import {
+  assertOrgModelAllowed,
+  buildOrgModelFromResolvedConfig,
+} from "@mcpjam/sdk/model-factory";
+import {
+  resolveSyntheticModelSource,
+  type SyntheticModelSource,
+} from "./org-model-config.js";
+import { postLocalUsage } from "./org-model-stream-handler.js";
+import type {
+  DirectRuntime,
+  TurnRuntime,
+  UnifiedTurnResult,
+} from "./turn-execution.js";
+
+/**
+ * Per-run attribution stamped onto the resulting usage record. Exactly one of
+ * `synthesisRunId` (chatbox session simulation) / `journeyRunId` (swarm) is
+ * set; today only `synthesisRunId` is wired. Kept as a closed XOR so a caller
+ * can't accidentally stamp both onto one spend row.
+ */
+export type TurnRunAttribution =
+  | { synthesisRunId: string; journeyRunId?: never }
+  | { journeyRunId: string; synthesisRunId?: never }
+  | undefined;
+
+/**
+ * The narrowed source-of-traffic marker forwarded into chat-ingestion /
+ * usage writeback. Mirrors `RunAssistantTurnOptions["sourceType"]`.
+ */
+export type TurnSourceType = "direct" | "chatbox" | "eval";
+
+export interface ResolveTurnRuntimeArgs {
+  modelDefinition: ModelDefinition;
+  projectId: string;
+  authHeader?: string;
+  chatboxId?: string;
+  accessVersion?: number;
+  /** Selected MCP server ids — flow into the byok body + local-usage body. */
+  serverIds?: string[];
+  /** Narrowed source marker (chatbox for synthetic). Used for local-usage. */
+  sourceType: TurnSourceType;
+  chatSessionId?: string;
+  /**
+   * Local-runtime approval guard inputs: a non-empty `tools` set with
+   * `requireToolApproval === true` is refused up-front (the local turn driver
+   * has no approval loop yet).
+   */
+  requireToolApproval?: boolean;
+  tools?: ToolSet;
+  /** Harness selector — carried onto the hosted runtime (Omitted from HostedTurnOptions). */
+  harness?: Harness;
+  /**
+   * Caller-supplied extra `/stream` body fields (e.g. forwarded synthesis
+   * attribution the engine appends). Merged UNDER the byok sibling fields
+   * (providerKey/serverIds win on collision) exactly like today.
+   */
+  extraBodyFields?: Record<string, unknown>;
+  /** Per-run attribution stamped onto the local-BYOK usage record. */
+  attribution?: TurnRunAttribution;
+}
+
+export interface ResolvedTurnRuntime {
+  runtime: TurnRuntime;
+  modelSource: SyntheticModelSource;
+  /**
+   * Local-BYOK usage writeback. No-op for the hosted engines (the backend
+   * records usage server-side). Callers MUST only invoke this on a
+   * non-aborted, non-errored turn — the local writeback mirrors today's
+   * `buildLocalOrgOnPersist` success semantics (it self-guards on
+   * `result.aborted`).
+   */
+  finalizeUsage(result: UnifiedTurnResult): Promise<void>;
+  /** Map a turn-failure message to the runner's rate-limit vs failed outcome. */
+  classifyFailure(message: string): "rate_limited" | "failed";
+}
+
+/**
+ * The exact regex `runOneSession`'s catch uses to fold spend-cap /
+ * rate-limit errors into the amber `rate_limited` outcome.
+ */
+function classifyFailure(message: string): "rate_limited" | "failed" {
+  return /rate.?limit|spend|cap/i.test(message) ? "rate_limited" : "failed";
+}
+
+const HOSTED_NOOP_FINALIZE = async (): Promise<void> => {
+  // Hosted engines (MCPJam `/stream`, cloud BYOK `/stream/org`) record usage
+  // server-side; the inspector never posts local-usage for them. This mirrors
+  // today's dispatch, where only the local-runtime branch called postLocalUsage.
+};
+
+export async function resolveTurnRuntime(
+  args: ResolveTurnRuntimeArgs,
+): Promise<ResolvedTurnRuntime> {
+  const modelId = String(args.modelDefinition.id);
+
+  // Classify once — the SAME resolver the empty-session fallback persist uses,
+  // so the two attribution paths can't drift.
+  const resolution = await resolveSyntheticModelSource({
+    modelDefinition: args.modelDefinition,
+    projectId: args.projectId,
+    authHeader: args.authHeader,
+    chatboxId: args.chatboxId,
+    accessVersion: args.accessVersion,
+    serverIds: args.serverIds,
+  });
+
+  // --- Local-runtime org BYOK → direct engine ---
+  if (
+    resolution.source !== "mcpjam" &&
+    resolution.orgRuntime?.runtimeLocation === "local"
+  ) {
+    const orgRuntime = resolution.orgRuntime;
+
+    // Local-runtime org providers have no approval loop yet — the direct turn
+    // driver can't pause for a human, and a synthetic visitor can't approve.
+    // Refuse up-front with the SAME message the synthetic dispatch used before
+    // this extraction (this guard fired first, before the model was built).
+    if (
+      args.requireToolApproval === true &&
+      args.tools &&
+      Object.keys(args.tools as Record<string, unknown>).length > 0
+    ) {
+      throw new Error(
+        "Synthetic runs on local-runtime org BYOK models don't yet support approval-required tool calls. Disable tool approval on this chatbox or switch the provider to cloud runtime.",
+      );
+    }
+
+    // Same validation + build the SSE/headless local handlers run.
+    assertOrgModelAllowed(orgRuntime.provider, modelId);
+    const llmModel = buildOrgModelFromResolvedConfig(orgRuntime.provider, modelId);
+
+    const runtime: DirectRuntime = {
+      kind: "direct",
+      // Bridge the AI-SDK `LanguageModel` union to the engine's narrower
+      // `createLlmModel` return — the same cast the local handlers use.
+      llmModel: llmModel as unknown as DirectRuntime["llmModel"],
+      modelId,
+      // NOTE: intentionally NO `provider`. `runLocalOrgChatTurnHeadless` never
+      // forwarded a provider string to `runDirectChatTurn`, so its llm/step
+      // spans carried no `gen_ai.provider.name`. Setting it here would change
+      // the persisted trace spans, so we omit it to keep byte-parity.
+    };
+
+    const providerKey = orgRuntime.provider.providerKey;
+    const finalizeUsage = async (result: UnifiedTurnResult): Promise<void> => {
+      // Success-only writeback (never on abort). Engine-error gating is
+      // enforced by the caller, which throws before reaching finalizeUsage.
+      if (result.aborted) return;
+      await postLocalUsage({
+        projectId: args.projectId,
+        providerKey,
+        model: modelId,
+        usage: result.usage,
+        finishReason: result.finishReason,
+        chatSessionId: args.chatSessionId,
+        sourceType: args.sourceType,
+        // Byte-parity: the old writeback stamped turnId + promptIndex from the
+        // turn trace. The direct engine always produces a trace on completion.
+        turnId: result.turnTrace?.turnId,
+        promptIndex: result.turnTrace?.promptIndex,
+        authHeader: args.authHeader,
+        chatboxId: args.chatboxId,
+        accessVersion: args.accessVersion,
+        selectedServers: args.serverIds,
+        serverIds: args.serverIds,
+        synthesisRunId: args.attribution?.synthesisRunId,
+      });
+    };
+
+    return {
+      runtime,
+      modelSource: "local_byok",
+      finalizeUsage,
+      classifyFailure,
+    };
+  }
+
+  // --- MCPJam-provided → hosted `/stream` ---
+  if (resolution.source === "mcpjam") {
+    return {
+      runtime: {
+        kind: "hosted",
+        // `runAssistantTurn`'s default endpoint. The old MCPJam branch did NOT
+        // set endpointPath; `resolvedEndpointPath = endpointPath ?? "/stream"`
+        // makes passing "/stream" explicitly byte-identical on the wire.
+        endpointPath: "/stream",
+        ...(args.extraBodyFields ? { extraBodyFields: args.extraBodyFields } : {}),
+        ...(args.harness ? { harness: args.harness } : {}),
+      },
+      modelSource: "mcpjam",
+      finalizeUsage: HOSTED_NOOP_FINALIZE,
+      classifyFailure,
+    };
+  }
+
+  // --- Cloud-runtime org BYOK → hosted `/stream/org` ---
+  // `resolution.orgRuntime` is guaranteed defined for non-"mcpjam" sources and
+  // is the cloud shape here (local was handled above).
+  const providerKey =
+    resolution.orgRuntime?.runtimeLocation === "cloud"
+      ? resolution.orgRuntime.providerKey
+      : undefined;
+  if (providerKey === undefined) {
+    // Defensive: an unexpected runtime shape (neither local nor cloud) — the
+    // old dispatcher fell through to the engine branch, which would then fail
+    // opaquely. Surface it as a clear error instead.
+    throw new Error(
+      "Turn runtime resolution returned an unexpected org runtime shape (no cloud providerKey)",
+    );
+  }
+
+  return {
+    runtime: {
+      kind: "hosted",
+      endpointPath: "/stream/org",
+      // Byte-match `handleHostedOrgChatModel`: caller fields first, then the
+      // sibling fields (providerKey, serverIds) that own the hosted contract.
+      extraBodyFields: {
+        ...(args.extraBodyFields ?? {}),
+        providerKey,
+        ...(args.serverIds?.length ? { serverIds: args.serverIds } : {}),
+      },
+      ...(args.harness ? { harness: args.harness } : {}),
+    },
+    modelSource: "byok",
+    finalizeUsage: HOSTED_NOOP_FINALIZE,
+    classifyFailure,
+  };
+}

--- a/mcpjam-inspector/server/utils/resolve-turn-runtime.ts
+++ b/mcpjam-inspector/server/utils/resolve-turn-runtime.ts
@@ -35,6 +35,7 @@ import {
   type SyntheticModelSource,
 } from "./org-model-config.js";
 import { postLocalUsage } from "./org-model-stream-handler.js";
+import { logger } from "./logger.js";
 import type {
   DirectRuntime,
   TurnRuntime,
@@ -104,10 +105,14 @@ export interface ResolvedTurnRuntime {
 }
 
 /**
- * The exact regex `runOneSession`'s catch uses to fold spend-cap /
- * rate-limit errors into the amber `rate_limited` outcome.
+ * The single source of truth for folding spend-cap / rate-limit errors into
+ * the amber `rate_limited` outcome vs a hard `failed`. Both `runOneSession`'s
+ * catch AND the per-runtime `classifyFailure` delegate here so the regex can't
+ * drift between the two call sites.
  */
-function classifyFailure(message: string): "rate_limited" | "failed" {
+export function classifyTurnFailure(
+  message: string,
+): "rate_limited" | "failed" {
   return /rate.?limit|spend|cap/i.test(message) ? "rate_limited" : "failed";
 }
 
@@ -178,32 +183,44 @@ export async function resolveTurnRuntime(
       // invokes this BEFORE throwing on an engine error, so a failed turn's
       // real spend is still recorded. Only abort suppresses the writeback.
       if (result.aborted) return;
-      await postLocalUsage({
-        projectId: args.projectId,
-        providerKey,
-        model: modelId,
-        usage: result.usage,
-        finishReason: result.finishReason,
-        chatSessionId: args.chatSessionId,
-        sourceType: args.sourceType,
-        // Byte-parity: the old writeback stamped turnId + promptIndex from the
-        // turn trace. The direct engine always produces a trace on completion.
-        turnId: result.turnTrace?.turnId,
-        promptIndex: result.turnTrace?.promptIndex,
-        authHeader: args.authHeader,
-        chatboxId: args.chatboxId,
-        accessVersion: args.accessVersion,
-        selectedServers: args.serverIds,
-        serverIds: args.serverIds,
-        synthesisRunId: args.attribution?.synthesisRunId,
-      });
+      // Best-effort writeback — parity with the OLD `buildLocalOrgOnPersist`,
+      // where `postLocalUsage({...}).catch((err) => logger.warn(...))` was
+      // fire-and-forget: a `/stream/org/local-usage` outage NEVER failed the
+      // turn. Awaiting the reject here would fail an otherwise-successful
+      // synthetic turn (and the caller then discards the session). Swallow +
+      // log any rejection; billing telemetry must not gate the turn.
+      try {
+        await postLocalUsage({
+          projectId: args.projectId,
+          providerKey,
+          model: modelId,
+          usage: result.usage,
+          finishReason: result.finishReason,
+          chatSessionId: args.chatSessionId,
+          sourceType: args.sourceType,
+          // Byte-parity: the old writeback stamped turnId + promptIndex from the
+          // turn trace. The direct engine always produces a trace on completion.
+          turnId: result.turnTrace?.turnId,
+          promptIndex: result.turnTrace?.promptIndex,
+          authHeader: args.authHeader,
+          chatboxId: args.chatboxId,
+          accessVersion: args.accessVersion,
+          selectedServers: args.serverIds,
+          serverIds: args.serverIds,
+          synthesisRunId: args.attribution?.synthesisRunId,
+        });
+      } catch (err) {
+        logger.warn("[org/local] Failed to post local usage", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
     };
 
     return {
       runtime,
       modelSource: "local_byok",
       finalizeUsage,
-      classifyFailure,
+      classifyFailure: classifyTurnFailure,
     };
   }
 
@@ -221,7 +238,7 @@ export async function resolveTurnRuntime(
       },
       modelSource: "mcpjam",
       finalizeUsage: HOSTED_NOOP_FINALIZE,
-      classifyFailure,
+      classifyFailure: classifyTurnFailure,
     };
   }
 
@@ -256,6 +273,6 @@ export async function resolveTurnRuntime(
     },
     modelSource: "byok",
     finalizeUsage: HOSTED_NOOP_FINALIZE,
-    classifyFailure,
+    classifyFailure: classifyTurnFailure,
   };
 }

--- a/mcpjam-inspector/server/utils/resolve-turn-runtime.ts
+++ b/mcpjam-inspector/server/utils/resolve-turn-runtime.ts
@@ -94,10 +94,11 @@ export interface ResolvedTurnRuntime {
   modelSource: SyntheticModelSource;
   /**
    * Local-BYOK usage writeback. No-op for the hosted engines (the backend
-   * records usage server-side). Callers MUST only invoke this on a
-   * non-aborted, non-errored turn — the local writeback mirrors today's
-   * `buildLocalOrgOnPersist` success semantics (it self-guards on
-   * `result.aborted`).
+   * records usage server-side). Invoke on any NON-ABORTED completion —
+   * engine-error included, so consumed tokens are still billed — mirroring the
+   * old `buildLocalOrgOnPersist`, which billed unconditionally on non-abort.
+   * Self-guards on `result.aborted`, and the writeback itself is best-effort
+   * (a telemetry outage is swallowed + logged, never thrown).
    */
   finalizeUsage(result: UnifiedTurnResult): Promise<void>;
   /** Map a turn-failure message to the runner's rate-limit vs failed outcome. */

--- a/mcpjam-inspector/server/utils/resolve-turn-runtime.ts
+++ b/mcpjam-inspector/server/utils/resolve-turn-runtime.ts
@@ -172,8 +172,11 @@ export async function resolveTurnRuntime(
 
     const providerKey = orgRuntime.provider.providerKey;
     const finalizeUsage = async (result: UnifiedTurnResult): Promise<void> => {
-      // Success-only writeback (never on abort). Engine-error gating is
-      // enforced by the caller, which throws before reaching finalizeUsage.
+      // Bill on any NON-ABORTED completion, engine-error included: the old
+      // `postLocalUsage` fired unconditionally on non-abort and billed the
+      // consumed tokens even when the turn errored mid-stream. The caller
+      // invokes this BEFORE throwing on an engine error, so a failed turn's
+      // real spend is still recorded. Only abort suppresses the writeback.
       if (result.aborted) return;
       await postLocalUsage({
         projectId: args.projectId,

--- a/mcpjam-inspector/server/utils/resolve-turn-runtime.ts
+++ b/mcpjam-inspector/server/utils/resolve-turn-runtime.ts
@@ -184,37 +184,37 @@ export async function resolveTurnRuntime(
       // invokes this BEFORE throwing on an engine error, so a failed turn's
       // real spend is still recorded. Only abort suppresses the writeback.
       if (result.aborted) return;
-      // Best-effort writeback — parity with the OLD `buildLocalOrgOnPersist`,
-      // where `postLocalUsage({...}).catch((err) => logger.warn(...))` was
-      // fire-and-forget: a `/stream/org/local-usage` outage NEVER failed the
-      // turn. Awaiting the reject here would fail an otherwise-successful
-      // synthetic turn (and the caller then discards the session). Swallow +
-      // log any rejection; billing telemetry must not gate the turn.
-      try {
-        await postLocalUsage({
-          projectId: args.projectId,
-          providerKey,
-          model: modelId,
-          usage: result.usage,
-          finishReason: result.finishReason,
-          chatSessionId: args.chatSessionId,
-          sourceType: args.sourceType,
-          // Byte-parity: the old writeback stamped turnId + promptIndex from the
-          // turn trace. The direct engine always produces a trace on completion.
-          turnId: result.turnTrace?.turnId,
-          promptIndex: result.turnTrace?.promptIndex,
-          authHeader: args.authHeader,
-          chatboxId: args.chatboxId,
-          accessVersion: args.accessVersion,
-          selectedServers: args.serverIds,
-          serverIds: args.serverIds,
-          synthesisRunId: args.attribution?.synthesisRunId,
-        });
-      } catch (err) {
+      // FIRE-AND-FORGET — exact parity with the OLD call site
+      // (`postLocalUsage({...}).catch((err) => logger.warn(...))`, never
+      // awaited). Awaiting the writeback would block the turn for up to the 5s
+      // fetch timeout during a `/stream/org/local-usage` outage and, on reject,
+      // fail an otherwise-successful synthetic turn. The `.catch` swallows +
+      // logs so there's no unhandled rejection; billing telemetry must neither
+      // gate nor slow the turn. The request is still ISSUED, so consumed tokens
+      // (incl. on a mid-stream engine error) are billed.
+      void postLocalUsage({
+        projectId: args.projectId,
+        providerKey,
+        model: modelId,
+        usage: result.usage,
+        finishReason: result.finishReason,
+        chatSessionId: args.chatSessionId,
+        sourceType: args.sourceType,
+        // Byte-parity: the old writeback stamped turnId + promptIndex from the
+        // turn trace. The direct engine always produces a trace on completion.
+        turnId: result.turnTrace?.turnId,
+        promptIndex: result.turnTrace?.promptIndex,
+        authHeader: args.authHeader,
+        chatboxId: args.chatboxId,
+        accessVersion: args.accessVersion,
+        selectedServers: args.serverIds,
+        serverIds: args.serverIds,
+        synthesisRunId: args.attribution?.synthesisRunId,
+      }).catch((err) => {
         logger.warn("[org/local] Failed to post local usage", {
           error: err instanceof Error ? err.message : String(err),
         });
-      }
+      });
     };
 
     return {

--- a/mcpjam-inspector/server/utils/turn-execution.ts
+++ b/mcpjam-inspector/server/utils/turn-execution.ts
@@ -27,6 +27,7 @@ import {
 import {
   runDirectChatTurn,
   consumeDirectChatTurnHeadless,
+  stampMcpToolOriginProviderOptions,
   type RunDirectChatTurnOptions,
 } from "./direct-chat-turn";
 
@@ -92,6 +93,17 @@ export type DirectTurnOptions = {
   onLiveTextDelta?: RunDirectChatTurnOptions["onLiveTextDelta"];
   onStepFinish?: RunDirectChatTurnOptions["onStepFinish"];
   onEngineError?: RunDirectChatTurnOptions["onEngineError"];
+  /**
+   * PR 3a: awaited per-tool-result render hook, mapped into the direct
+   * engine's `traceEvents.onToolResultChunk`. The synthetic local-BYOK path
+   * needs it so the browser session context renders an MCP App widget before
+   * the next step decides whether to advertise Computer Use — the same wiring
+   * `runLocalOrgChatTurnHeadless` passed through `traceEvents`. INERT for
+   * callers that don't set it (no `traceEvents` is forwarded then).
+   */
+  onToolResultChunk?: NonNullable<
+    RunDirectChatTurnOptions["traceEvents"]
+  >["onToolResultChunk"];
   // TODO(PR 3 — local eval migration): local STREAMING eval still depends on the
   // direct engine's `traceEvents` (`onStepSnapshot`, `onToolResultChunk`) to emit
   // its SSE. Before PR 3 deletes `stream-adapter.ts`, expose normalized
@@ -186,10 +198,22 @@ export async function runUnifiedAssistantTurn(
     onLiveTextDelta: opts.onLiveTextDelta,
     onStepFinish: opts.onStepFinish,
     onEngineError: opts.onEngineError,
+    // PR 3a: only forward `traceEvents` when the caller wired a chunk hook, so
+    // callers that don't set it stay byte-identical (no traceEvents object).
+    ...(opts.onToolResultChunk
+      ? { traceEvents: { onToolResultChunk: opts.onToolResultChunk } }
+      : {}),
   });
   const headless = await consumeDirectChatTurnHeadless(handle);
-  // Direct's `response.messages` IS this turn's response slice.
-  const newMessages = headless.messages;
+  // Direct's `response.messages` IS this turn's response slice. Stamp the
+  // mcp-tool-origin serverId onto its tool parts — the hosted engine does this
+  // internally, and the local-BYOK persistence path (session viewer replay via
+  // `transcript-to-ui-messages`) relies on it to attribute which server a tool
+  // came from. Normalizes both engines' transcripts to the same shape.
+  const newMessages = stampMcpToolOriginProviderOptions(
+    headless.messages,
+    opts.tools,
+  );
   const messages = [...opts.messages, ...newMessages];
   return {
     messages,


### PR DESCRIPTION
## What this does

Behavior-preserving refactor of the synthetic-session turn hot path. Extracts provider/runtime resolution + local-BYOK usage writeback + approval guard + failure classification out of `drainAssistantTurn` into a new shared adapter **`resolveTurnRuntime`**, and routes **all three** synthetic model paths (MCPJam, cloud BYOK, local BYOK) through the existing `runUnifiedAssistantTurn` facade. `drainAssistantTurn` is now a thin, explicitly-temporary compatibility wrapper over `resolveTurnRuntime` + `runUnifiedAssistantTurn` (to be removed at legacy cleanup). No `"swarm"` literals introduced; Chat/Playground/Eval outer loops untouched.

## What moved

- **New `server/utils/resolve-turn-runtime.ts`** — `resolveTurnRuntime(args)` returns `{ runtime, modelSource, finalizeUsage, classifyFailure }`. Owns exactly what `drainAssistantTurn` did up to the engine call: `resolveSyntheticModelSource` → runtime shape, the local-runtime model build (`assertOrgModelAllowed` + `buildOrgModelFromResolvedConfig`), the approval guard, `finalizeUsage` (local-usage writeback), and `classifyFailure`. Adds the `TurnRunAttribution` XOR type (`synthesisRunId` today, `journeyRunId` reserved for swarm).
- **`turn-execution.ts`** — extended `DirectTurnOptions` with `onToolResultChunk`, mapped into `runDirectChatTurn`'s `traceEvents.onToolResultChunk` (forwarded only when set — **inert** for callers that don't set it). The direct branch now stamps mcp-tool-origin metadata onto response messages so both engines return the same normalized transcript.
- **`direct-chat-turn.ts`** — exported `stampMcpToolOriginProviderOptions`.
- **`org-model-stream-handler.ts`** — exported `postLocalUsage` and `resolveLocalOrgMaxSteps` (reused, not duplicated).
- **`sessionSimulation/runner.ts`** — `drainAssistantTurn` rewritten as the thin wrapper; error contract + `finalizeUsage` gating preserved. `runOneSession` unchanged.

## Byte-parity guarantees

- **MCPJam** → hosted `/stream`. The old branch left `endpointPath` unset; passing `"/stream"` explicitly is identical on the wire (`resolvedEndpointPath = endpointPath ?? "/stream"`). No `providerKey`.
- **Cloud BYOK** → hosted `/stream/org` with `extraBodyFields: { ...caller, providerKey, serverIds }` — byte-matching `handleHostedOrgChatModel`.
- **Local BYOK usage writeback** → `/stream/org/local-usage` via the reused `postLocalUsage` (same URL, headers, 5s timeout, body — incl. `turnId`, `promptIndex`, `serverIds`, `synthesisRunId`).
- Direct branch keeps the local handler's **30-step** default (`resolveLocalOrgMaxSteps`; the engine's own default is 20) and **omits the provider string** (the old local path never forwarded one, so trace spans carried no `gen_ai.provider.name`).
- `synthesisRunId` reaches the hosted wire only via the top-level option (engine appends to `extraBodyFields`), exactly as before — no double-stamp.

## Inert callback extension

`onToolResultChunk` on the direct branch is the only surface change and is covered by a forwarding test (maps into `traceEvents` when set; no `traceEvents` object at all when unset).

## Behavior-preserving claim

Behavior-preserving for existing callers. One nuance flagged for review: on a **fatal mid-turn direct-engine error**, this path gates `finalizeUsage` on success (no billing on a failed turn), per the extraction plan; the old `runLocalOrgChatTurnHeadless` path's `onPersist` could bill partial usage on a fatal error (per its mocked test contract) if the SDK fires `onFinish` after `onError`. Success and abort billing are byte-identical.

## Tests

Added `resolve-turn-runtime.test.ts` (runtime shapes, endpoint/body parity, local-usage writeback body incl. `synthesisRunId`, approval guard, abort gate, `classifyFailure`). Kept green: `resolve-synthetic-model-source`, `turn-execution` (+ `onToolResultChunk` forwarding tests), `org-model-stream-handler-headless`, `runner.dispatch` (updated to the new wiring), `runner.browser`. **71 tests pass; `server` tsc 0 errors; `build:server` succeeds.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored synthetic turn routing by extracting `resolveTurnRuntime` and sending MCPJam, cloud BYOK, and local BYOK through `runUnifiedAssistantTurn`. Local BYOK usage writeback is now fire‑and‑forget and always bills on non‑aborted turns, with centralized failure classification and deduped history.

- **Refactors**
  - Added `server/utils/resolve-turn-runtime.ts` returning `{ runtime, modelSource, finalizeUsage, classifyFailure }`; resolves MCPJam → `/stream`, cloud BYOK → `/stream/org` with `{ providerKey, serverIds }`, local BYOK → direct engine via `@mcpjam/sdk`.
  - `drainAssistantTurn` now wraps `resolveTurnRuntime` + `runUnifiedAssistantTurn`; local path keeps 30‑step default and dedup‑appends new messages; hosted path unchanged. `runUnifiedAssistantTurn` adds optional `onToolResultChunk` and stamps MCP tool origin. Exported `stampMcpToolOriginProviderOptions`, `postLocalUsage`, `resolveLocalOrgMaxSteps`, and `classifyTurnFailure`. `runOneSession` uses the shared `classifyTurnFailure`.

- **Bug Fixes**
  - Bill local BYOK usage on any non‑aborted completion, including mid‑stream engine errors; usage writeback is fire‑and‑forget (not awaited) and never blocks or fails a successful turn.
  - Aborts return the input history and do not bill.
  - Centralized spend‑cap/rate‑limit detection via `classifyTurnFailure`, used by both the runtime and `runOneSession`.

<sup>Written for commit 4fb39fa567b8f13893ce9ce703b2f78d3eb1f087. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors the spend-metered synthetic turn path (hosted vs local BYOK routing, local-usage writeback, and error→outcome classification); behavior is heavily tested for parity but billing and dispatch regressions would affect production simulations.
> 
> **Overview**
> **Synthetic session turns** now go through a shared **`resolveTurnRuntime`** adapter plus **`runUnifiedAssistantTurn`** instead of inline branching between `runAssistantTurn` and `runLocalOrgChatTurnHeadless`. **`drainAssistantTurn`** is a temporary wrapper that keeps the same headless error contract (missing `turnTrace` / `onEngineError` → throw) and local-BYOK semantics (30-step default, deduped history append, bill before throw on fatal direct errors).
> 
> **`resolveTurnRuntime`** centralizes MCPJam → `/stream`, cloud BYOK → `/stream/org` with `providerKey`/`serverIds`, and local BYOK → direct engine build, the approval guard, **`finalizeUsage`** (`postLocalUsage`, best-effort), and **`classifyTurnFailure`** (spend-cap/rate-limit regex). **`runOneSession`** uses that classifier for `rate_limited` outcomes.
> 
> **`runUnifiedAssistantTurn`** gains optional **`onToolResultChunk`** → direct `traceEvents`, and stamps MCP tool-origin metadata on direct-engine messages. **`postLocalUsage`**, **`resolveLocalOrgMaxSteps`**, and **`stampMcpToolOriginProviderOptions`** are exported for reuse.
> 
> Tests lock byte-parity (endpoints, bodies, writeback, billing on error, writeback swallow) across **`resolve-turn-runtime`**, updated **`runner.dispatch`**, and a browser runner rate-limit case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fb39fa567b8f13893ce9ce703b2f78d3eb1f087. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->