### PR TITLE
feat(swarm): gate the Swarms surface to project members (guest access notice)

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -11,7 +11,7 @@ import {
   type ComponentProps,
 } from "react";
 import { useAuth } from "@workos-inc/authkit-react";
-import { AlertTriangle, Loader2 } from "lucide-react";
+import { AlertTriangle, Loader2, Users } from "lucide-react";
 import { toast } from "@/lib/toast";
 import { MCPJamLimitDialog } from "./components/mcpjam-limit-dialog";
 import { HomeTab } from "./components/HomeTab";
@@ -28,6 +28,8 @@ import { EvalsTab } from "./components/EvalsTab";
 import { CiEvalsTab } from "./components/CiEvalsTab";
 import { ChatboxesTab } from "./components/ChatboxesTab";
 import { SwarmsTab } from "./components/swarms/SwarmsTab";
+import { EmptyState } from "./components/ui/empty-state";
+import { canViewSwarms, useViewerProjectRole } from "./hooks/useProjects";
 import { SettingsTab } from "./components/SettingsTab";
 import { ApiKeysRoute } from "./components/settings/ApiKeysRoute";
 import { ProjectSettingsTab } from "./components/ProjectSettingsTab";
@@ -1098,9 +1100,48 @@ export function SwarmsRoute() {
     convexProjectId,
     isAuthenticated,
   } = useAppRouteContext();
+  const { user } = useAuth();
+
+  // The backend made the entire Swarm surface member-only: personas, journeys,
+  // journeyRuns, session lists and transcript reads all reject a project
+  // **guest**. Mirror that here — resolve the authenticated viewer's project
+  // role and, when they're a guest/non-member, show an access notice INSTEAD of
+  // mounting `SwarmsTab` so none of the member-only queries ever fire.
+  //
+  // Only engage for an authenticated viewer on a real (Convex) project. An
+  // unauthenticated / guest-mode local user (no `convexProjectId`) has no
+  // project membership to check and keeps its existing behavior.
+  const roleGateActive = isAuthenticated && !!convexProjectId;
+  const { role, isLoading: roleLoading } = useViewerProjectRole({
+    isAuthenticated,
+    projectId: convexProjectId,
+    viewerEmail: user?.email,
+  });
 
   if (billingUiEnabled && activeTabBillingLocked && activeTabBillingFeature) {
     return <ActiveBillingUpsellGate />;
+  }
+
+  if (roleGateActive) {
+    // Wait for the members list to resolve before deciding, so a guest never
+    // briefly mounts `SwarmsTab` (which would fire the member-only queries).
+    if (roleLoading) {
+      return (
+        <div className="flex h-full items-center justify-center">
+          <Loader2 className="size-5 animate-spin text-muted-foreground" />
+        </div>
+      );
+    }
+
+    if (!canViewSwarms(role)) {
+      return (
+        <EmptyState
+          icon={Users}
+          title="Swarms is available to project members"
+          description="You have guest access to this project. Swarms — personas, journeys and their runs — can only be viewed and run by project members. Ask a project admin to add you as a member to get access."
+        />
+      );
+    }
   }
 
   return (

--- a/mcpjam-inspector/client/src/__tests__/SwarmsRoute.guest-gate.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/SwarmsRoute.guest-gate.test.tsx
@@ -1,0 +1,159 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ProjectMembershipRole } from "../hooks/useProjects";
+
+const { mockSwarmsTab, mockRouteContext, mockViewerRole, mockUseAuth } =
+  vi.hoisted(() => ({
+    mockSwarmsTab: vi.fn(() => <div>Swarms Tab</div>),
+    mockViewerRole: {
+      role: undefined as ProjectMembershipRole | undefined,
+      isLoading: false,
+    },
+    mockUseAuth: vi.fn(() => ({ user: { email: "guest@example.com" } })),
+    mockRouteContext: {
+      billingUiEnabled: true,
+      activeTabBillingLocked: false,
+      activeTabBillingFeature: "chatboxes" as string | null,
+      convexProjectId: "project-1" as string | null,
+      isAuthenticated: true,
+    },
+  }));
+
+vi.mock("react-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router")>();
+  return {
+    ...actual,
+    useOutletContext: () => mockRouteContext,
+  };
+});
+
+vi.mock("@workos-inc/authkit-react", () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+// Keep the real `canViewSwarms` decision + `EmptyState`; only the viewer-role
+// signal is controlled per test.
+vi.mock("../hooks/useProjects", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../hooks/useProjects")>();
+  return {
+    ...actual,
+    useViewerProjectRole: () => mockViewerRole,
+  };
+});
+
+// App.tsx pulls the chatbox surface (and its codemirror deps) through its
+// module graph; stub them so importing the route is cheap.
+vi.mock("../components/swarms/SwarmsTab", () => ({
+  SwarmsTab: (props: unknown) => mockSwarmsTab(props),
+}));
+vi.mock("../components/ChatboxesTab", () => ({
+  ChatboxesTab: () => null,
+}));
+vi.mock("../components/ui/json-editor/codemirror-json-editor", () => ({
+  CodemirrorJsonEditor: () => null,
+}));
+vi.mock("@codemirror/lang-json", () => ({ json: () => ({}) }));
+vi.mock("@codemirror/view", () => ({
+  EditorView: class {},
+  lineNumbers: () => ({}),
+  highlightActiveLine: () => ({}),
+  highlightSpecialChars: () => ({}),
+  keymap: () => ({}),
+}));
+vi.mock("@codemirror/state", () => ({ EditorState: { create: vi.fn() } }));
+vi.mock("@codemirror/commands", () => ({
+  defaultKeymap: [],
+  history: () => ({}),
+  historyKeymap: [],
+}));
+vi.mock("@codemirror/language", () => ({
+  bracketMatching: () => ({}),
+  foldGutter: () => ({}),
+  indentOnInput: () => ({}),
+  syntaxHighlighting: () => ({}),
+  defaultHighlightStyle: {},
+}));
+vi.mock("@codemirror/lint", () => ({
+  linter: () => ({}),
+  lintGutter: () => ({}),
+}));
+
+import { SwarmsRoute } from "../App";
+
+describe("SwarmsRoute member-only gate", () => {
+  beforeEach(() => {
+    mockSwarmsTab.mockClear();
+    mockUseAuth.mockClear();
+    mockRouteContext.billingUiEnabled = true;
+    mockRouteContext.activeTabBillingLocked = false;
+    mockRouteContext.activeTabBillingFeature = "chatboxes";
+    mockRouteContext.convexProjectId = "project-1";
+    mockRouteContext.isAuthenticated = true;
+    mockViewerRole.role = undefined;
+    mockViewerRole.isLoading = false;
+    mockUseAuth.mockReturnValue({ user: { email: "guest@example.com" } });
+  });
+
+  it("shows the access notice and does NOT mount SwarmsTab for a guest", () => {
+    mockViewerRole.role = "guest";
+
+    render(<SwarmsRoute />);
+
+    expect(
+      screen.getByText("Swarms is available to project members"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Swarms Tab")).not.toBeInTheDocument();
+    expect(mockSwarmsTab).not.toHaveBeenCalled();
+  });
+
+  it("renders SwarmsTab for a project member", () => {
+    mockViewerRole.role = "member";
+
+    render(<SwarmsRoute />);
+
+    expect(screen.getByText("Swarms Tab")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Swarms is available to project members"),
+    ).not.toBeInTheDocument();
+    expect(mockSwarmsTab).toHaveBeenCalledWith({
+      projectId: "project-1",
+      isAuthenticated: true,
+    });
+  });
+
+  it("renders SwarmsTab for an owner/admin", () => {
+    mockViewerRole.role = "admin";
+
+    render(<SwarmsRoute />);
+
+    expect(screen.getByText("Swarms Tab")).toBeInTheDocument();
+    expect(mockSwarmsTab).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT mount SwarmsTab while the viewer's role is still loading", () => {
+    mockViewerRole.role = undefined;
+    mockViewerRole.isLoading = true;
+
+    render(<SwarmsRoute />);
+
+    expect(screen.queryByText("Swarms Tab")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Swarms is available to project members"),
+    ).not.toBeInTheDocument();
+    expect(mockSwarmsTab).not.toHaveBeenCalled();
+  });
+
+  it("keeps existing behavior (renders SwarmsTab) for an unauthenticated local user", () => {
+    mockRouteContext.isAuthenticated = false;
+    mockRouteContext.convexProjectId = null;
+    mockUseAuth.mockReturnValue({ user: null });
+
+    render(<SwarmsRoute />);
+
+    expect(screen.getByText("Swarms Tab")).toBeInTheDocument();
+    expect(mockSwarmsTab).toHaveBeenCalledWith({
+      projectId: null,
+      isAuthenticated: false,
+    });
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/__tests__/canViewSwarms.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/canViewSwarms.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { canViewSwarms } from "../useProjects";
+import { canViewSwarms, isViewerRolePending } from "../useProjects";
 
 // The Swarms surface is member-only on the backend; `canViewSwarms` is the
 // pure decision the route gate keys off. Owners/admins/members may view;
@@ -17,5 +17,29 @@ describe("canViewSwarms", () => {
 
   it("denies an unresolved role (loading / not a member)", () => {
     expect(canViewSwarms(undefined)).toBe(false);
+  });
+});
+
+// Regression: WorkOS `user.email` hydrates AFTER auth flips true. The members
+// list can resolve first, so the gate must keep "loading" (not deny) until the
+// viewer's email is available — otherwise a real member flashes access-denied.
+describe("isViewerRolePending", () => {
+  it("is pending while the members list is loading", () => {
+    expect(isViewerRolePending(true, true, "a@b.com")).toBe(true);
+  });
+
+  it("is pending when authenticated but the email has not hydrated yet", () => {
+    // The exact interval the TL flagged: members resolved, email still empty.
+    expect(isViewerRolePending(false, true, undefined)).toBe(true);
+    expect(isViewerRolePending(false, true, null)).toBe(true);
+    expect(isViewerRolePending(false, true, "   ")).toBe(true);
+  });
+
+  it("is resolved once the email hydrates and members are loaded", () => {
+    expect(isViewerRolePending(false, true, "a@b.com")).toBe(false);
+  });
+
+  it("is not pending for an unauthenticated viewer (no email expected)", () => {
+    expect(isViewerRolePending(false, false, undefined)).toBe(false);
   });
 });

--- a/mcpjam-inspector/client/src/hooks/__tests__/canViewSwarms.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/canViewSwarms.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { canViewSwarms } from "../useProjects";
+
+// The Swarms surface is member-only on the backend; `canViewSwarms` is the
+// pure decision the route gate keys off. Owners/admins/members may view;
+// guests — and any unresolved (loading / not-a-member) role — may not.
+describe("canViewSwarms", () => {
+  it("allows member-or-above roles", () => {
+    expect(canViewSwarms("owner")).toBe(true);
+    expect(canViewSwarms("admin")).toBe(true);
+    expect(canViewSwarms("member")).toBe(true);
+  });
+
+  it("denies a project guest", () => {
+    expect(canViewSwarms("guest")).toBe(false);
+  });
+
+  it("denies an unresolved role (loading / not a member)", () => {
+    expect(canViewSwarms(undefined)).toBe(false);
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/useProjects.ts
+++ b/mcpjam-inspector/client/src/hooks/useProjects.ts
@@ -257,7 +257,27 @@ export function useViewerProjectRole({
     )?.role;
   }, [activeMembers, viewerEmail]);
 
-  return { role, isLoading };
+  return {
+    role,
+    isLoading: isViewerRolePending(isLoading, isAuthenticated, viewerEmail),
+  };
+}
+
+/**
+ * Is the viewer's project role still "not yet decided"? True while the members
+ * list is loading OR while the viewer's identity is still hydrating — WorkOS
+ * `user.email` arrives asynchronously AFTER `isAuthenticated` flips true, so if
+ * the members list resolves first we'd otherwise report a real member as
+ * `{ role: undefined, isLoading: false }` and callers would wrongly deny them.
+ * Treat "authenticated but no viewer email yet" as still-loading so the gate
+ * shows a spinner, not access-denied, until the identity is available.
+ */
+export function isViewerRolePending(
+  membersLoading: boolean,
+  isAuthenticated: boolean,
+  viewerEmail: string | null | undefined
+): boolean {
+  return membersLoading || (isAuthenticated && !viewerEmail?.trim());
 }
 
 export function useProjectMutations() {

--- a/mcpjam-inspector/client/src/hooks/useProjects.ts
+++ b/mcpjam-inspector/client/src/hooks/useProjects.ts
@@ -219,6 +219,47 @@ export function useProjectMembers({
   };
 }
 
+// The Swarms surface (personas / journeys / journeyRuns) is *member-only* on
+// the backend: every persona/journey/run query rejects a project **guest**.
+// Mirror that gate in the UI so a guest never fires the (now-erroring)
+// member-only queries. A viewer may access Swarms only when they hold a
+// resolved member-or-above role; a guest — or any unresolved role — is denied.
+export function canViewSwarms(
+  role: ProjectMembershipRole | undefined
+): boolean {
+  return role === "owner" || role === "admin" || role === "member";
+}
+
+// Resolve the *current viewer's* project-membership role for a project, reusing
+// the same members-list signal `ProjectSettingsTab` keys off. Returns
+// `role: undefined` while the members list is still loading (or when the viewer
+// isn't found among the active members). Callers should treat `isLoading` as
+// "not yet decided" rather than firing member-only queries.
+export function useViewerProjectRole({
+  isAuthenticated,
+  projectId,
+  viewerEmail,
+}: {
+  isAuthenticated: boolean;
+  projectId: string | null;
+  viewerEmail: string | null | undefined;
+}): { role: ProjectMembershipRole | undefined; isLoading: boolean } {
+  const { activeMembers, isLoading } = useProjectMembers({
+    isAuthenticated,
+    projectId,
+  });
+
+  const role = useMemo(() => {
+    const email = viewerEmail?.trim().toLowerCase();
+    if (!email) return undefined;
+    return activeMembers.find(
+      (member) => member.email.toLowerCase() === email
+    )?.role;
+  }, [activeMembers, viewerEmail]);
+
+  return { role, isLoading };
+}
+
 export function useProjectMutations() {
   const createProject = useMutation("projects:createProject" as any);
   const ensureDefaultProject = useMutation(


### PR DESCRIPTION
## Problem

The backend just made the entire **Swarm** surface **member-only**: `personas`, `journeys`, `journeyRuns`, session lists, and transcript reads all now require the project `member` role — a project **guest** is rejected. But the merged **SwarmsTab** UI had **no role gate**, so a project guest could open `/swarms` and the page would fire persona/journey/run queries that now all error.

## What was gated

- **`SwarmsRoute` (client/src/App.tsx):** when an authenticated viewer is a **guest / non-member** of the active Convex project, it now renders a friendly access notice (`EmptyState`: "Swarms is available to project members") **instead of** mounting `<SwarmsTab>`, so **none** of the member-only persona/journey/run queries ever fire for a guest. It waits for the members list to resolve before deciding (brief loading spinner) so a guest never momentarily mounts the tab.
- Unauthenticated / local (no `convexProjectId`) users keep their **existing behavior** — the role gate only engages for an authenticated viewer on a real Convex project.
- The existing `ActiveBillingUpsellGate` gate and the `key={convexProjectId ?? "no-project"}` per-project remount are **untouched** — the role gate layers alongside them.
- **Sidebar:** the Swarms sidebar entry was **not** changed. `mcp-sidebar.tsx` only supports `featureFlag` / `billingFeature` / `hiddenByFlag` gating — there is no per-tab role-gating mechanism, and adding one would be inventing a framework. The route-level gate is the enforcement point (server-side is the real enforcement).

## Role signal reused

The viewer role is derived from the **existing** members-list signal that `ProjectSettingsTab` already keys off: `useProjectMembers({ isAuthenticated, projectId })` → find the active member whose email matches the WorkOS viewer email → read its `role: ProjectMembershipRole` (`owner | admin | member | guest`). A **guest** is `role === "guest"`; member-or-above is `owner | admin | member`.

Two small additions in `client/src/hooks/useProjects.ts`:
- `canViewSwarms(role)` — pure decision (true only for owner/admin/member; false for guest or unresolved role).
- `useViewerProjectRole({ isAuthenticated, projectId, viewerEmail })` — thin hook over `useProjectMembers` returning `{ role, isLoading }`.

## Tests

- `client/src/hooks/__tests__/canViewSwarms.test.ts` — unit-tests the pure gate decision across all roles.
- `client/src/__tests__/SwarmsRoute.guest-gate.test.tsx` — proves `SwarmsRoute` renders the access notice and does **not** mount `SwarmsTab` for a guest (and while the role is loading), and renders `SwarmsTab` for member/admin and for the unauthenticated local path.

`npm run typecheck:client` clean; targeted vitest green (8/8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only access gating aligned with existing backend enforcement; unauthenticated/local paths unchanged and tests cover loading and role edge cases.
> 
> **Overview**
> Adds a **client-side member-only gate** on `/swarms` so project guests no longer mount `SwarmsTab` and trigger backend queries that now reject guest access.
> 
> For authenticated users on a Convex project, `SwarmsRoute` resolves the viewer’s role via **`useViewerProjectRole`** (project members list + WorkOS email), shows a spinner while role or email is still pending, then either renders an **`EmptyState`** for guests or **`SwarmsTab`** for owner/admin/member. Unauthenticated users without a `convexProjectId` are unchanged. Billing upsell behavior is unchanged.
> 
> **`useProjects`** gains **`canViewSwarms`**, **`useViewerProjectRole`**, and **`isViewerRolePending`** (avoids flashing access-denied when email hydrates after auth). New unit and route tests cover the decision helpers and guest/member/loading paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b9ed430e00e47328687fc044130f13a4b2d7eb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate the Swarms surface to project members and show a guest access notice instead of mounting `SwarmsTab`. Fixes a brief access-denied flash by keeping the gate loading until the viewer’s email hydrates.

- **New Features**
  - Route-level gate in `SwarmsRoute` uses `useViewerProjectRole` + `canViewSwarms`; guests see `EmptyState` and `SwarmsTab` is not mounted.
  - Only engages for authenticated users on a Convex project; unauth/local users unchanged; works with the billing upsell gate and per-project remount.
  - Tests added for `canViewSwarms` and the route gate.

- **Bug Fixes**
  - Introduced `isViewerRolePending` and updated `useViewerProjectRole` to wait for WorkOS `user.email`, preventing an access-denied flash for real members.
  - Unit tests cover the email hydration/pending state.

<sup>Written for commit 1b9ed430e00e47328687fc044130f13a4b2d7eb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

