### PR TITLE
feat(swarm): multi-host fan-out + Run enablement (PR 3d)

### DIFF
--- a/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
@@ -277,25 +277,13 @@ export function SwarmsTab({ projectId, isAuthenticated }: SwarmsTabProps) {
 // ── persona track record ─────────────────────────────────────────────────────
 function PersonaTrackRecordStrip({ personaRefId }: { personaRefId: string }) {
   const record = usePersonaTrackRecord(personaRefId);
-  if (!record || record.totalSessions === 0) return null;
+  if (!record || record.sessionCount === 0) return null;
   return (
     <div className="mb-4 flex flex-wrap items-center gap-2 rounded-lg border bg-muted/30 px-3 py-2 text-xs">
       <span className="font-medium text-muted-foreground">Track record</span>
-      <span className="text-emerald-600 dark:text-emerald-400">
-        {record.succeeded} ok
-      </span>
-      {record.failed > 0 && (
-        <span className="text-red-600 dark:text-red-400">
-          {record.failed} failed
-        </span>
-      )}
-      {record.rateLimited > 0 && (
-        <span className="text-amber-600 dark:text-amber-400">
-          {record.rateLimited} rate-limited
-        </span>
-      )}
       <span className="text-muted-foreground">
-        across {record.totalSessions} sessions · {record.totalRuns} runs
+        {record.sessionCount} session{record.sessionCount === 1 ? "" : "s"} ·{" "}
+        {record.runCount} run{record.runCount === 1 ? "" : "s"}
       </span>
     </div>
   );
@@ -413,9 +401,9 @@ function JourneyCard({
             {journey.hostIds.map(hostName).join(", ")} ·{" "}
             {journey.config.sessionsPerHost}/host · {journey.config.maxTurns} turns
           </p>
-          {rollup && rollup.totalRuns > 0 && (
+          {rollup && rollup.runCount > 0 && (
             <p className="mt-1 text-[11px] text-muted-foreground">
-              {rollup.totalRuns} run{rollup.totalRuns === 1 ? "" : "s"} total
+              {rollup.runCount} run{rollup.runCount === 1 ? "" : "s"} total
             </p>
           )}
         </div>
@@ -505,7 +493,7 @@ function RunSessionsView({
   personaRefId: string;
   hosts: HostItem[];
   hostSummaries: JourneyRun["hostSummaries"];
-  /** Deep-link session (`_id`) to auto-select once it's on a loaded page. */
+  /** Deep-link session (`id`) to auto-select once it's on a loaded page. */
   initialThreadId?: string;
 }) {
   // Paginated sessions for this run; grouped/filterable by host client-side.
@@ -515,7 +503,8 @@ function RunSessionsView({
     loadMore,
   } = usePaginatedQuery(
     SWARM_QUERIES.listSessionsByJourneyRun as any,
-    { runId } as any,
+    // Backend arg name is `journeyRunId` (NOT `runId`).
+    { journeyRunId: runId } as any,
     { initialNumItems: DEFAULT_PAGE_SIZE }
   );
   const [filter, setFilter] = useState<SessionFilterState>(EMPTY_SESSION_FILTER);
@@ -537,7 +526,7 @@ function RunSessionsView({
   const appliedInitialThreadRef = useRef(false);
   useEffect(() => {
     if (appliedInitialThreadRef.current || !initialThreadId) return;
-    const match = rows.find((s) => s._id === initialThreadId);
+    const match = rows.find((s) => s.id === initialThreadId);
     if (match) {
       appliedInitialThreadRef.current = true;
       setSelected(match);
@@ -574,20 +563,20 @@ function RunSessionsView({
         <div className="flex flex-col divide-y">
           {visible.map((s) => (
             <button
-              key={s._id}
+              key={s.id}
               type="button"
               onClick={() => setSelected(s)}
               className={`flex items-center justify-between gap-2 px-1 py-1.5 text-left hover:bg-muted/50 ${
-                selected?._id === s._id ? "bg-muted" : ""
+                selected?.id === s.id ? "bg-muted" : ""
               }`}
             >
               <span className="flex min-w-0 flex-col">
                 <span className="truncate text-[11px] font-medium">
                   {hostName(s.hostId)}
-                  {s.personaLabel ? ` · ${s.personaLabel}` : ""}
                 </span>
                 <span className="truncate text-[10px] text-muted-foreground">
-                  {s.status ?? "—"} · {s.messageCount ?? 0} msgs
+                  {s.status ?? "—"}
+                  {s.modelId ? ` · ${s.modelId}` : ""}
                 </span>
               </span>
               <SessionReadinessBadge readiness={toSessionReadiness(s.readiness)} />
@@ -607,16 +596,16 @@ function RunSessionsView({
       )}
 
       {/* Reuse the existing project-scoped session viewer — do NOT build a new
-          one. `ShareUsageThreadDetail` takes the session row's `_id`. */}
+          one. `ShareUsageThreadDetail` takes the session row's `id`. */}
       {selected && (
         <div className="mt-2 h-[420px] overflow-hidden rounded-lg border">
           <ShareUsageThreadDetail
-            threadId={selected._id}
+            threadId={selected.id}
             sessionLink={`${getShareableAppOrigin()}${buildSwarmSessionPath({
               personaRefId,
               runId,
               hostId: selected.hostId,
-              threadId: selected._id,
+              threadId: selected.id,
             })}`}
           />
         </div>

--- a/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
@@ -7,7 +7,7 @@
  *
  * Consumes the project-scoped backend: personas:*, journeys:*, journeyRuns:*.
  */
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useQuery, useMutation, usePaginatedQuery } from "convex/react";
 import { Button } from "@mcpjam/design-system/button";
 import { toast } from "@/lib/toast";
@@ -32,8 +32,45 @@ import {
   type SessionReadiness,
 } from "@/components/chatboxes/session-readiness";
 import { ShareUsageThreadDetail } from "@/components/connection/share-usage/ShareUsageThreadDetail";
-import { buildChatboxSessionPath, routePaths } from "@/lib/app-navigation";
+import {
+  buildSwarmSessionPath,
+  parseSwarmSessionParams,
+} from "@/lib/app-navigation";
 import { getShareableAppOrigin } from "@/lib/chatbox-session";
+
+// Valid readiness enums (mirror `session-readiness.tsx`). The backend
+// denormalizes a WIDE `{ status?: string; verdict?: string }` subset onto the
+// session row, so guard it into a well-typed `SessionReadiness` before handing
+// it to the badge instead of an unchecked `as` cast — an unexpected string must
+// degrade to "no badge", not render a bogus pill.
+const READINESS_STATUSES = ["pending", "completed", "partial", "failed"] as const;
+const READINESS_VERDICTS = ["ready", "needs_attention", "not_ready"] as const;
+
+function toSessionReadiness(
+  raw: JourneySessionRow["readiness"],
+): SessionReadiness | undefined {
+  if (!raw) return undefined;
+  const status = (READINESS_STATUSES as readonly string[]).includes(
+    raw.status ?? "",
+  )
+    ? (raw.status as SessionReadiness["status"])
+    : undefined;
+  // Without a valid status the badge has nothing meaningful to show.
+  if (!status) return undefined;
+  const verdict = (READINESS_VERDICTS as readonly string[]).includes(
+    raw.verdict ?? "",
+  )
+    ? (raw.verdict as SessionReadiness["verdict"])
+    : undefined;
+  return {
+    status,
+    ...(verdict ? { verdict } : {}),
+    issueCount:
+      typeof raw.issueCount === "number" && Number.isFinite(raw.issueCount)
+        ? raw.issueCount
+        : 0,
+  };
+}
 
 type Persona = {
   _id: string;
@@ -90,7 +127,15 @@ export function SwarmsTab({ projectId, isAuthenticated }: SwarmsTabProps) {
   const effectiveProjectId = isAuthenticated ? projectId : null;
   const personas = usePersonas(effectiveProjectId);
   const hosts = useProjectHosts(effectiveProjectId);
-  const [selectedPersonaId, setSelectedPersonaId] = useState<string | null>(null);
+  // Restore a copied session deep-link (`/swarms?persona=&run=&host=&session=`).
+  // Parse ONCE on mount so later user navigation isn't clobbered by the URL.
+  const deepLink = useMemo(
+    () => parseSwarmSessionParams(window.location.search),
+    [],
+  );
+  const [selectedPersonaId, setSelectedPersonaId] = useState<string | null>(
+    () => deepLink.personaRefId ?? null,
+  );
   const journeys = useJourneys(selectedPersonaId);
 
   const createPersona = useMutation("personas:createPersona" as any);
@@ -216,6 +261,8 @@ export function SwarmsTab({ projectId, isAuthenticated }: SwarmsTabProps) {
                     journey={j}
                     hosts={hosts ?? []}
                     projectId={projectId}
+                    initialRunId={deepLink.runId}
+                    initialThreadId={deepLink.threadId}
                   />
                 ))}
               </div>
@@ -277,10 +324,16 @@ function JourneyCard({
   journey,
   hosts,
   projectId,
+  initialRunId,
+  initialThreadId,
 }: {
   journey: Journey;
   hosts: HostItem[];
   projectId: string;
+  /** Deep-link run to auto-open (only the card that owns it reacts). */
+  initialRunId?: string;
+  /** Deep-link session to auto-select inside the opened run. */
+  initialThreadId?: string;
 }) {
   // Real Convex pagination (numItems + cursor) over the journey's runs.
   const {
@@ -303,6 +356,18 @@ function JourneyCard({
   const [launching, setLaunching] = useState(false);
   const [launchError, setLaunchError] = useState<string | null>(null);
   const [openRunId, setOpenRunId] = useState<string | null>(null);
+
+  // Deep-link restore: once this journey's runs load, if the linked run belongs
+  // to THIS card, open it (so RunSessionsView mounts and can select the
+  // session). Runs itself once — later user toggling isn't overridden.
+  const appliedInitialRunRef = useRef(false);
+  useEffect(() => {
+    if (appliedInitialRunRef.current || !initialRunId) return;
+    if ((runs as JourneyRun[]).some((r) => r._id === initialRunId)) {
+      appliedInitialRunRef.current = true;
+      setOpenRunId(initialRunId);
+    }
+  }, [initialRunId, runs]);
 
   const hostName = (id: string) =>
     hosts.find((h) => h.hostId === id)?.name ?? id.slice(0, 8);
@@ -402,8 +467,12 @@ function JourneyCard({
               {openRunId === r._id && (
                 <RunSessionsView
                   runId={r._id}
+                  personaRefId={journey.personaRefId}
                   hosts={hosts}
                   hostSummaries={r.hostSummaries}
+                  initialThreadId={
+                    initialRunId === r._id ? initialThreadId : undefined
+                  }
                 />
               )}
             </div>
@@ -426,12 +495,18 @@ function JourneyCard({
 // ── sessions by host (per run) ───────────────────────────────────────────────
 function RunSessionsView({
   runId,
+  personaRefId,
   hosts,
   hostSummaries,
+  initialThreadId,
 }: {
   runId: string;
+  /** Owning persona — encoded into copied session links for deep-link restore. */
+  personaRefId: string;
   hosts: HostItem[];
   hostSummaries: JourneyRun["hostSummaries"];
+  /** Deep-link session (`_id`) to auto-select once it's on a loaded page. */
+  initialThreadId?: string;
 }) {
   // Paginated sessions for this run; grouped/filterable by host client-side.
   const {
@@ -454,6 +529,20 @@ function RunSessionsView({
     () => rows.filter((s) => sessionMatchesFilter(s, filter)),
     [rows, filter]
   );
+
+  // Deep-link restore: auto-select the linked session once it appears on a
+  // loaded page. Runs once. NOTE (remainder): a session on a not-yet-loaded
+  // page won't auto-select until the user pages to it — full cross-page
+  // restore would need the backend list query to accept a session cursor.
+  const appliedInitialThreadRef = useRef(false);
+  useEffect(() => {
+    if (appliedInitialThreadRef.current || !initialThreadId) return;
+    const match = rows.find((s) => s._id === initialThreadId);
+    if (match) {
+      appliedInitialThreadRef.current = true;
+      setSelected(match);
+    }
+  }, [initialThreadId, rows]);
 
   return (
     <div className="mt-2 rounded-lg border bg-muted/20 p-2">
@@ -501,9 +590,7 @@ function RunSessionsView({
                   {s.status ?? "—"} · {s.messageCount ?? 0} msgs
                 </span>
               </span>
-              <SessionReadinessBadge
-                readiness={s.readiness as SessionReadiness | undefined}
-              />
+              <SessionReadinessBadge readiness={toSessionReadiness(s.readiness)} />
             </button>
           ))}
         </div>
@@ -525,11 +612,12 @@ function RunSessionsView({
         <div className="mt-2 h-[420px] overflow-hidden rounded-lg border">
           <ShareUsageThreadDetail
             threadId={selected._id}
-            sessionLink={`${getShareableAppOrigin()}${buildChatboxSessionPath(
-              selected.hostId,
-              selected._id,
-              routePaths.swarms
-            )}`}
+            sessionLink={`${getShareableAppOrigin()}${buildSwarmSessionPath({
+              personaRefId,
+              runId,
+              hostId: selected.hostId,
+              threadId: selected._id,
+            })}`}
           />
         </div>
       )}

--- a/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
@@ -13,7 +13,6 @@ import { Button } from "@mcpjam/design-system/button";
 import { toast } from "@/lib/toast";
 import {
   launchJourneyRun,
-  LaunchJourneyRunError,
   SWARM_QUERIES,
   DEFAULT_PAGE_SIZE,
   type JourneyRun,
@@ -373,20 +372,18 @@ function JourneyCard({
         projectId,
         launchKey: launchKeyRef.current,
       });
-      // Accepted — a fresh key for the next launch.
+      // Accepted (confirmed 2xx {runId}) — the ONLY place we mint a fresh key.
       launchKeyRef.current = null;
       toast.success("Journey run started");
     } catch (e) {
-      if (e instanceof LaunchJourneyRunError && e.status >= 400 && e.status < 500) {
-        // 4xx: user-actionable (no hosts, cap edge). Surface inline; KEEP the
-        // launch key so a corrected retry stays idempotent.
-        setLaunchError(e.message);
-      } else {
-        launchKeyRef.current = null;
-        setLaunchError(
-          e instanceof Error ? e.message : "Failed to start run"
-        );
-      }
+      // RETAIN the launch key after ANY unsuccessful response — 4xx, 5xx, OR a
+      // network/transport failure — and reuse it on retry. A 5xx or a dropped
+      // connection can land AFTER the backend already created the run, so
+      // minting a new key would spawn a SECOND run (duplicate spend). The
+      // backend dedupes a reused key to the existing run (or, if the create
+      // never inserted, creates exactly one). The key is cleared only on a
+      // confirmed 2xx above.
+      setLaunchError(e instanceof Error ? e.message : "Failed to start run");
     } finally {
       setLaunching(false);
     }

--- a/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
@@ -7,10 +7,33 @@
  *
  * Consumes the project-scoped backend: personas:*, journeys:*, journeyRuns:*.
  */
-import { useMemo, useState } from "react";
-import { useQuery, useMutation } from "convex/react";
+import { useMemo, useRef, useState } from "react";
+import { useQuery, useMutation, usePaginatedQuery } from "convex/react";
 import { Button } from "@mcpjam/design-system/button";
 import { toast } from "@/lib/toast";
+import {
+  launchJourneyRun,
+  LaunchJourneyRunError,
+  SWARM_QUERIES,
+  DEFAULT_PAGE_SIZE,
+  type JourneyRun,
+  type JourneySessionRow,
+  type PersonaTrackRecord,
+  type JourneyRollup,
+} from "@/lib/swarm-api";
+import {
+  EMPTY_SESSION_FILTER,
+  sessionMatchesFilter,
+  toggleSessionFilter,
+  type SessionFilterState,
+} from "@/lib/session-usage-filters";
+import {
+  SessionReadinessBadge,
+  type SessionReadiness,
+} from "@/components/chatboxes/session-readiness";
+import { ShareUsageThreadDetail } from "@/components/connection/share-usage/ShareUsageThreadDetail";
+import { buildChatboxSessionPath, routePaths } from "@/lib/app-navigation";
+import { getShareableAppOrigin } from "@/lib/chatbox-session";
 
 type Persona = {
   _id: string;
@@ -27,19 +50,6 @@ type Journey = {
   hostIds: string[];
   config: { sessionsPerHost: number; maxTurns: number };
 };
-type JourneyRun = {
-  _id: string;
-  status: string;
-  summary: { total: number; succeeded: number; failed: number; rateLimited: number };
-  hostSummaries: Array<{
-    hostId: string;
-    total: number;
-    succeeded: number;
-    failed: number;
-    rateLimited: number;
-  }>;
-  createdAt: number;
-};
 type HostItem = { hostId: string; name: string };
 
 interface SwarmsTabProps {
@@ -50,21 +60,27 @@ interface SwarmsTabProps {
 // ── hooks ─────────────────────────────────────────────────────────────────
 function usePersonas(projectId: string | null) {
   return useQuery(
-    "personas:listPersonas" as any,
+    SWARM_QUERIES.listPersonas as any,
     projectId ? ({ projectId } as any) : "skip"
   ) as Persona[] | undefined;
 }
 function useJourneys(personaRefId: string | null) {
   return useQuery(
-    "journeys:listJourneysByPersona" as any,
+    SWARM_QUERIES.listJourneysByPersona as any,
     personaRefId ? ({ personaRefId } as any) : "skip"
   ) as Journey[] | undefined;
 }
 function useProjectHosts(projectId: string | null) {
   return useQuery(
-    "hosts:listHosts" as any,
+    SWARM_QUERIES.listHosts as any,
     projectId ? ({ projectId } as any) : "skip"
   ) as HostItem[] | undefined;
+}
+function usePersonaTrackRecord(personaRefId: string | null) {
+  return useQuery(
+    SWARM_QUERIES.personaTrackRecord as any,
+    personaRefId ? ({ personaRefId } as any) : "skip"
+  ) as PersonaTrackRecord | undefined;
 }
 
 export function SwarmsTab({ projectId, isAuthenticated }: SwarmsTabProps) {
@@ -169,6 +185,8 @@ export function SwarmsTab({ projectId, isAuthenticated }: SwarmsTabProps) {
               </Button>
             </div>
 
+            <PersonaTrackRecordStrip personaRefId={selectedPersona._id} />
+
             <div className="mb-3 flex items-center justify-between">
               <h3 className="text-sm font-semibold">Journeys</h3>
               <NewJourneyButton
@@ -193,7 +211,12 @@ export function SwarmsTab({ projectId, isAuthenticated }: SwarmsTabProps) {
             ) : (
               <div className="flex flex-col gap-3">
                 {journeys.map((j) => (
-                  <JourneyCard key={j._id} journey={j} hosts={hosts ?? []} />
+                  <JourneyCard
+                    key={j._id}
+                    journey={j}
+                    hosts={hosts ?? []}
+                    projectId={projectId}
+                  />
                 ))}
               </div>
             )}
@@ -204,22 +227,117 @@ export function SwarmsTab({ projectId, isAuthenticated }: SwarmsTabProps) {
   );
 }
 
+// ── persona track record ─────────────────────────────────────────────────────
+function PersonaTrackRecordStrip({ personaRefId }: { personaRefId: string }) {
+  const record = usePersonaTrackRecord(personaRefId);
+  if (!record || record.totalSessions === 0) return null;
+  return (
+    <div className="mb-4 flex flex-wrap items-center gap-2 rounded-lg border bg-muted/30 px-3 py-2 text-xs">
+      <span className="font-medium text-muted-foreground">Track record</span>
+      <span className="text-emerald-600 dark:text-emerald-400">
+        {record.succeeded} ok
+      </span>
+      {record.failed > 0 && (
+        <span className="text-red-600 dark:text-red-400">
+          {record.failed} failed
+        </span>
+      )}
+      {record.rateLimited > 0 && (
+        <span className="text-amber-600 dark:text-amber-400">
+          {record.rateLimited} rate-limited
+        </span>
+      )}
+      <span className="text-muted-foreground">
+        across {record.totalSessions} sessions · {record.totalRuns} runs
+      </span>
+    </div>
+  );
+}
+
+// ── run status treatment ─────────────────────────────────────────────────────
+function runStatusClass(status: string): string {
+  switch (status) {
+    case "completed":
+      return "text-emerald-600 dark:text-emerald-400";
+    case "partial":
+      return "text-amber-600 dark:text-amber-400";
+    case "rate_limited":
+      return "text-amber-600 dark:text-amber-400";
+    case "failed":
+      return "text-red-600 dark:text-red-400";
+    case "stale":
+      return "text-muted-foreground";
+    default:
+      return "text-foreground"; // running
+  }
+}
+
 // ── journey card + runs ──────────────────────────────────────────────────────
 function JourneyCard({
   journey,
   hosts,
+  projectId,
 }: {
   journey: Journey;
   hosts: HostItem[];
+  projectId: string;
 }) {
-  const runs = useQuery(
-    "journeyRuns:listJourneyRuns" as any,
-    { journeyRefId: journey._id, paginationOpts: { numItems: 10, cursor: null } } as any
-  ) as { page: JourneyRun[] } | undefined;
-  const createJourneyRun = useMutation("journeyRuns:createJourneyRun" as any);
-  const [running, setRunning] = useState(false);
+  // Real Convex pagination (numItems + cursor) over the journey's runs.
+  const {
+    results: runs,
+    status: runsStatus,
+    loadMore,
+  } = usePaginatedQuery(
+    SWARM_QUERIES.listJourneyRuns as any,
+    { journeyRefId: journey._id } as any,
+    { initialNumItems: DEFAULT_PAGE_SIZE }
+  );
+  const rollup = useQuery(
+    SWARM_QUERIES.journeyRollup as any,
+    { journeyRefId: journey._id } as any
+  ) as JourneyRollup | undefined;
+
+  // One launch key per click, reused verbatim if the HTTP call is retried so a
+  // network retry can't spawn a duplicate run.
+  const launchKeyRef = useRef<string | null>(null);
+  const [launching, setLaunching] = useState(false);
+  const [launchError, setLaunchError] = useState<string | null>(null);
+  const [openRunId, setOpenRunId] = useState<string | null>(null);
+
   const hostName = (id: string) =>
     hosts.find((h) => h.hostId === id)?.name ?? id.slice(0, 8);
+
+  const onRun = async () => {
+    if (launching) return;
+    setLaunchError(null);
+    setLaunching(true);
+    if (!launchKeyRef.current) {
+      launchKeyRef.current = crypto.randomUUID();
+    }
+    try {
+      await launchJourneyRun({
+        journeyId: journey._id,
+        projectId,
+        launchKey: launchKeyRef.current,
+      });
+      // Accepted — a fresh key for the next launch.
+      launchKeyRef.current = null;
+      toast.success("Journey run started");
+    } catch (e) {
+      if (e instanceof LaunchJourneyRunError && e.status >= 400 && e.status < 500) {
+        // 4xx: user-actionable (no hosts, cap edge). Surface inline; KEEP the
+        // launch key so a corrected retry stays idempotent.
+        setLaunchError(e.message);
+      } else {
+        launchKeyRef.current = null;
+        setLaunchError(
+          e instanceof Error ? e.message : "Failed to start run"
+        );
+      }
+    } finally {
+      setLaunching(false);
+    }
+  };
 
   return (
     <div className="rounded-lg border p-4">
@@ -230,43 +348,39 @@ function JourneyCard({
             {journey.hostIds.map(hostName).join(", ")} ·{" "}
             {journey.config.sessionsPerHost}/host · {journey.config.maxTurns} turns
           </p>
+          {rollup && rollup.totalRuns > 0 && (
+            <p className="mt-1 text-[11px] text-muted-foreground">
+              {rollup.totalRuns} run{rollup.totalRuns === 1 ? "" : "s"} total
+            </p>
+          )}
         </div>
-        <Button
-          type="button"
-          size="sm"
-          // Disabled until the fan-out execution runner + route land (next PR).
-          // Creating a run now would leave a permanently-`running` record with
-          // pending attempts and no executor.
-          disabled
-          title="Execution runner ships in the next PR"
-          onClick={async () => {
-            setRunning(true);
-            try {
-              await createJourneyRun({ journeyRefId: journey._id } as any);
-              toast.success("Journey run started");
-            } catch (e) {
-              toast.error(
-                e instanceof Error ? e.message : "Failed to start run"
-              );
-            } finally {
-              setRunning(false);
-            }
-          }}
-        >
-          {running ? "Starting…" : "Run (soon)"}
+        <Button type="button" size="sm" disabled={launching} onClick={onRun}>
+          {launching ? "Starting…" : "Run journey"}
         </Button>
       </div>
-      {runs && runs.page.length > 0 && (
+
+      {launchError && (
+        <p className="mt-2 rounded border border-red-500/40 bg-red-500/10 px-2 py-1 text-xs text-red-600 dark:text-red-400">
+          {launchError}
+        </p>
+      )}
+
+      {runs.length > 0 && (
         <div className="mt-3 border-t pt-3">
-          {runs.page.slice(0, 3).map((r) => (
-            <div key={r._id} className="mb-2 last:mb-0">
+          {(runs as JourneyRun[]).map((r) => (
+            <div key={r._id} className="mb-3 last:mb-0">
               <div className="flex items-center justify-between text-xs">
-                <span className="font-medium">{r.status}</span>
+                <span className={`font-medium ${runStatusClass(r.status)}`}>
+                  {r.status}
+                </span>
                 <span className="text-muted-foreground">
                   {r.summary.succeeded}/{r.summary.total} ok
+                  {r.summary.failed > 0 && ` · ${r.summary.failed} failed`}
+                  {r.summary.rateLimited > 0 &&
+                    ` · ${r.summary.rateLimited} rate-limited`}
                 </span>
               </div>
-              <div className="mt-1 flex flex-wrap gap-2">
+              <div className="mt-1 flex flex-wrap items-center gap-2">
                 {r.hostSummaries.map((hs) => (
                   <span
                     key={hs.hostId}
@@ -275,9 +389,148 @@ function JourneyCard({
                     {hostName(hs.hostId)}: {hs.succeeded}/{hs.total}
                   </span>
                 ))}
+                <button
+                  type="button"
+                  className="text-[11px] font-medium text-primary hover:underline"
+                  onClick={() =>
+                    setOpenRunId((cur) => (cur === r._id ? null : r._id))
+                  }
+                >
+                  {openRunId === r._id ? "Hide sessions" : "View sessions"}
+                </button>
               </div>
+              {openRunId === r._id && (
+                <RunSessionsView
+                  runId={r._id}
+                  hosts={hosts}
+                  hostSummaries={r.hostSummaries}
+                />
+              )}
             </div>
           ))}
+          {runsStatus === "CanLoadMore" && (
+            <button
+              type="button"
+              className="mt-1 text-[11px] font-medium text-primary hover:underline"
+              onClick={() => loadMore(DEFAULT_PAGE_SIZE)}
+            >
+              Load more runs
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── sessions by host (per run) ───────────────────────────────────────────────
+function RunSessionsView({
+  runId,
+  hosts,
+  hostSummaries,
+}: {
+  runId: string;
+  hosts: HostItem[];
+  hostSummaries: JourneyRun["hostSummaries"];
+}) {
+  // Paginated sessions for this run; grouped/filterable by host client-side.
+  const {
+    results: sessions,
+    status,
+    loadMore,
+  } = usePaginatedQuery(
+    SWARM_QUERIES.listSessionsByJourneyRun as any,
+    { runId } as any,
+    { initialNumItems: DEFAULT_PAGE_SIZE }
+  );
+  const [filter, setFilter] = useState<SessionFilterState>(EMPTY_SESSION_FILTER);
+  const [selected, setSelected] = useState<JourneySessionRow | null>(null);
+
+  const hostName = (id: string) =>
+    hosts.find((h) => h.hostId === id)?.name ?? id.slice(0, 8);
+
+  const rows = sessions as JourneySessionRow[];
+  const visible = useMemo(
+    () => rows.filter((s) => sessionMatchesFilter(s, filter)),
+    [rows, filter]
+  );
+
+  return (
+    <div className="mt-2 rounded-lg border bg-muted/20 p-2">
+      {/* Host filter chips */}
+      <div className="mb-2 flex flex-wrap gap-1.5">
+        {hostSummaries.map((hs) => (
+          <button
+            key={hs.hostId}
+            type="button"
+            onClick={() =>
+              setFilter((f) => toggleSessionFilter(f, "hostId", hs.hostId))
+            }
+            className={`rounded-full border px-2 py-0.5 text-[11px] ${
+              filter.hostId === hs.hostId
+                ? "border-primary bg-primary/10"
+                : "hover:bg-muted"
+            }`}
+          >
+            {hostName(hs.hostId)}
+          </button>
+        ))}
+      </div>
+
+      {rows.length === 0 ? (
+        <p className="px-1 py-2 text-[11px] text-muted-foreground">
+          No sessions recorded yet for this run.
+        </p>
+      ) : (
+        <div className="flex flex-col divide-y">
+          {visible.map((s) => (
+            <button
+              key={s._id}
+              type="button"
+              onClick={() => setSelected(s)}
+              className={`flex items-center justify-between gap-2 px-1 py-1.5 text-left hover:bg-muted/50 ${
+                selected?._id === s._id ? "bg-muted" : ""
+              }`}
+            >
+              <span className="flex min-w-0 flex-col">
+                <span className="truncate text-[11px] font-medium">
+                  {hostName(s.hostId)}
+                  {s.personaLabel ? ` · ${s.personaLabel}` : ""}
+                </span>
+                <span className="truncate text-[10px] text-muted-foreground">
+                  {s.status ?? "—"} · {s.messageCount ?? 0} msgs
+                </span>
+              </span>
+              <SessionReadinessBadge
+                readiness={s.readiness as SessionReadiness | undefined}
+              />
+            </button>
+          ))}
+        </div>
+      )}
+
+      {status === "CanLoadMore" && (
+        <button
+          type="button"
+          className="mt-1 text-[11px] font-medium text-primary hover:underline"
+          onClick={() => loadMore(DEFAULT_PAGE_SIZE)}
+        >
+          Load more sessions
+        </button>
+      )}
+
+      {/* Reuse the existing project-scoped session viewer — do NOT build a new
+          one. `ShareUsageThreadDetail` takes the session row's `_id`. */}
+      {selected && (
+        <div className="mt-2 h-[420px] overflow-hidden rounded-lg border">
+          <ShareUsageThreadDetail
+            threadId={selected._id}
+            sessionLink={`${getShareableAppOrigin()}${buildChatboxSessionPath(
+              selected.hostId,
+              selected._id,
+              routePaths.swarms
+            )}`}
+          />
         </div>
       )}
     </div>

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.launch.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.launch.test.tsx
@@ -1,0 +1,112 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const persona = {
+  _id: "persona-1",
+  personaId: "p1",
+  name: "Persona One",
+  role: "tester",
+  notes: "",
+};
+const journey = {
+  _id: "journey-1",
+  personaRefId: "persona-1",
+  goal: "Book a flight",
+  hostIds: ["host-1"],
+  config: { sessionsPerHost: 2, maxTurns: 6 },
+};
+const host = { hostId: "host-1", name: "Host One" };
+
+// Convex reads dispatched by query name; runs/sessions are empty.
+vi.mock("convex/react", () => ({
+  useQuery: (name: string, args: unknown) => {
+    if (args === "skip") return undefined;
+    switch (name) {
+      case "personas:listPersonas":
+        return [persona];
+      case "journeys:listJourneysByPersona":
+        return [journey];
+      case "hosts:listHosts":
+        return [host];
+      default:
+        return undefined; // track record + rollup
+    }
+  },
+  useMutation: () => vi.fn(),
+  usePaginatedQuery: () => ({
+    results: [],
+    status: "Exhausted",
+    loadMore: vi.fn(),
+    isLoading: false,
+  }),
+}));
+
+const launchJourneyRunMock = vi.fn();
+vi.mock("@/lib/swarm-api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/swarm-api")>();
+  return {
+    ...actual,
+    launchJourneyRun: (...args: unknown[]) => launchJourneyRunMock(...args),
+  };
+});
+
+// The session viewer is heavy (chat-ui + trace-viewer); stub it — the launch
+// flow never renders it.
+vi.mock("@/components/connection/share-usage/ShareUsageThreadDetail", () => ({
+  ShareUsageThreadDetail: () => null,
+}));
+vi.mock("@/lib/chatbox-session", () => ({
+  getShareableAppOrigin: () => "https://app.test",
+}));
+vi.mock("@/lib/toast", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import { SwarmsTab } from "../SwarmsTab";
+import { LaunchJourneyRunError } from "@/lib/swarm-api";
+
+function selectPersonaAndRun() {
+  render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+  fireEvent.click(screen.getByText("Persona One"));
+  return screen.getByRole("button", { name: "Run journey" });
+}
+
+beforeEach(() => {
+  launchJourneyRunMock.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("SwarmsTab — Run journey launch", () => {
+  it("POSTs via launchJourneyRun with the journeyId, projectId, and a generated launch key", async () => {
+    launchJourneyRunMock.mockResolvedValue({ runId: "run-1" });
+
+    const runBtn = selectPersonaAndRun();
+    expect(runBtn).not.toBeDisabled();
+    fireEvent.click(runBtn);
+
+    await waitFor(() => expect(launchJourneyRunMock).toHaveBeenCalledTimes(1));
+    const arg = launchJourneyRunMock.mock.calls[0]![0] as any;
+    expect(arg.journeyId).toBe("journey-1");
+    expect(arg.projectId).toBe("proj-1");
+    expect(typeof arg.launchKey).toBe("string");
+    expect(arg.launchKey.length).toBeGreaterThan(0);
+  });
+
+  it("surfaces a 4xx as an inline error", async () => {
+    launchJourneyRunMock.mockRejectedValue(
+      new LaunchJourneyRunError(400, "This journey has no pinned hosts to run")
+    );
+
+    const runBtn = selectPersonaAndRun();
+    fireEvent.click(runBtn);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("This journey has no pinned hosts to run")
+      ).toBeInTheDocument()
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.launch.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.launch.test.tsx
@@ -109,4 +109,38 @@ describe("SwarmsTab — Run journey launch", () => {
       ).toBeInTheDocument()
     );
   });
+
+  it("reuses the SAME launchKey on retry after a 5xx/network failure, and only clears it after a confirmed 2xx", async () => {
+    // A 5xx or dropped connection can land AFTER the backend created the run, so
+    // the key MUST survive to keep the retry idempotent (no duplicate run/spend).
+    launchJourneyRunMock.mockRejectedValueOnce(
+      new LaunchJourneyRunError(500, "upstream unavailable")
+    );
+
+    const runBtn = selectPersonaAndRun();
+    fireEvent.click(runBtn);
+    await waitFor(() =>
+      expect(launchJourneyRunMock).toHaveBeenCalledTimes(1)
+    );
+    const firstKey = (launchJourneyRunMock.mock.calls[0]![0] as any).launchKey;
+
+    // Retry succeeds — the SAME launch key is reused (backend dedupes to the
+    // already-created run rather than minting a second).
+    launchJourneyRunMock.mockResolvedValueOnce({ runId: "run-1" });
+    fireEvent.click(runBtn);
+    await waitFor(() =>
+      expect(launchJourneyRunMock).toHaveBeenCalledTimes(2)
+    );
+    const retryKey = (launchJourneyRunMock.mock.calls[1]![0] as any).launchKey;
+    expect(retryKey).toBe(firstKey);
+
+    // After the confirmed 2xx, a subsequent launch mints a FRESH key.
+    launchJourneyRunMock.mockResolvedValueOnce({ runId: "run-2" });
+    fireEvent.click(runBtn);
+    await waitFor(() =>
+      expect(launchJourneyRunMock).toHaveBeenCalledTimes(3)
+    );
+    const nextKey = (launchJourneyRunMock.mock.calls[2]![0] as any).launchKey;
+    expect(nextKey).not.toBe(firstKey);
+  });
 });

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.sessions.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.sessions.test.tsx
@@ -1,0 +1,167 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * CONTRACT (finding 4): the sessions-by-run view must call the backend query
+ * `journeyRuns:listSessionsByJourneyRun` with the arg name `journeyRunId` (NOT
+ * `runId`), and consume the REAL `JourneySessionDto` — whose identifier is `id`
+ * (there is no `_id` / `personaLabel` / `messageCount`). A test that mocked the
+ * query away wouldn't catch the wrong arg name (Convex would throw at runtime).
+ * Here we intercept `usePaginatedQuery` and assert the actual (name, args) the
+ * component dispatches, then assert the row's `id` is what the viewer opens.
+ */
+
+const persona = {
+  _id: "persona-1",
+  personaId: "p1",
+  name: "Persona One",
+  role: "tester",
+  notes: "",
+};
+const journey = {
+  _id: "journey-1",
+  personaRefId: "persona-1",
+  goal: "Book a flight",
+  hostIds: ["host-1"],
+  config: { sessionsPerHost: 2, maxTurns: 6 },
+};
+const host = { hostId: "host-1", name: "Host One" };
+
+const run = {
+  _id: "run-1",
+  status: "completed",
+  summary: { total: 1, succeeded: 1, failed: 0, rateLimited: 0 },
+  hostSummaries: [
+    { hostId: "host-1", total: 1, succeeded: 1, failed: 0, rateLimited: 0 },
+  ],
+  createdAt: 1,
+};
+
+// A real JourneySessionDto row — identifier is `id`.
+const session = {
+  id: "thread-xyz",
+  chatSessionId: "synth_run-1_host-1_0",
+  projectId: "proj-1",
+  hostId: "host-1",
+  personaRefId: "persona-1",
+  status: "completed",
+  modelId: "anthropic/claude-haiku-4.5",
+  startedAt: 1,
+  lastActivityAt: 2,
+  readiness: { status: "completed", verdict: "ready", issueCount: 0 },
+};
+
+// Capture every paginated-query dispatch so we can assert the session query's
+// arg NAME is `journeyRunId`.
+const paginatedCalls: Array<{ name: string; args: unknown }> = [];
+
+vi.mock("convex/react", () => ({
+  useQuery: (name: string, args: unknown) => {
+    if (args === "skip") return undefined;
+    switch (name) {
+      case "personas:listPersonas":
+        return [persona];
+      case "journeys:listJourneysByPersona":
+        return [journey];
+      case "hosts:listHosts":
+        return [host];
+      case "journeys:getJourneyRollup":
+        return { journeyRefId: "journey-1", runCount: 1, hosts: [] };
+      default:
+        return undefined;
+    }
+  },
+  useMutation: () => vi.fn(),
+  usePaginatedQuery: (name: string, args: unknown) => {
+    paginatedCalls.push({ name, args });
+    if (name === "journeyRuns:listJourneyRuns") {
+      return {
+        results: [run],
+        status: "Exhausted",
+        loadMore: vi.fn(),
+        isLoading: false,
+      };
+    }
+    if (name === "journeyRuns:listSessionsByJourneyRun") {
+      return {
+        results: [session],
+        status: "Exhausted",
+        loadMore: vi.fn(),
+        isLoading: false,
+      };
+    }
+    return {
+      results: [],
+      status: "Exhausted",
+      loadMore: vi.fn(),
+      isLoading: false,
+    };
+  },
+}));
+
+// Stub the heavy session viewer but SURFACE the threadId it's opened with so we
+// can assert the deep-link/viewer consumes the row's `id`.
+vi.mock("@/components/connection/share-usage/ShareUsageThreadDetail", () => ({
+  ShareUsageThreadDetail: ({
+    threadId,
+    sessionLink,
+  }: {
+    threadId: string;
+    sessionLink: string;
+  }) => (
+    <div data-testid="viewer" data-thread-id={threadId} data-link={sessionLink}>
+      viewer
+    </div>
+  ),
+}));
+vi.mock("@/lib/chatbox-session", () => ({
+  getShareableAppOrigin: () => "https://app.test",
+}));
+vi.mock("@/lib/toast", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import { SwarmsTab } from "../SwarmsTab";
+
+beforeEach(() => {
+  paginatedCalls.length = 0;
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("SwarmsTab — sessions-by-run query contract", () => {
+  it("queries listSessionsByJourneyRun with { journeyRunId } and opens the viewer on the row's `id`", async () => {
+    render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+    fireEvent.click(screen.getByText("Persona One"));
+
+    // Open the run's sessions.
+    fireEvent.click(await screen.findByText("View sessions"));
+
+    // CONTRACT: the session query is dispatched with the arg name `journeyRunId`
+    // (NOT `runId`) carrying the run's id.
+    await waitFor(() => {
+      const call = paginatedCalls.find(
+        (c) => c.name === "journeyRuns:listSessionsByJourneyRun"
+      );
+      expect(call).toBeTruthy();
+      expect(call!.args).toEqual({ journeyRunId: "run-1" });
+      // The wrong (old) arg name must not be present.
+      expect((call!.args as Record<string, unknown>).runId).toBeUndefined();
+    });
+
+    // The session row renders (its unique modelId is in the accessible name) —
+    // click it to open the viewer.
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: /anthropic\/claude-haiku-4\.5/i,
+      })
+    );
+
+    // CONTRACT: the viewer + deep-link consume the row's `id` (thread-xyz).
+    const viewer = await screen.findByTestId("viewer");
+    expect(viewer.getAttribute("data-thread-id")).toBe("thread-xyz");
+    expect(viewer.getAttribute("data-link")).toContain("thread-xyz");
+  });
+});

--- a/mcpjam-inspector/client/src/lib/__tests__/swarm-api.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/swarm-api.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const authFetchMock = vi.fn();
+vi.mock("@/lib/session-token", () => ({
+  authFetch: (...args: unknown[]) => authFetchMock(...args),
+}));
+
+import {
+  launchJourneyRun,
+  LaunchJourneyRunError,
+} from "@/lib/swarm-api";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+beforeEach(() => {
+  authFetchMock.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("launchJourneyRun", () => {
+  it("POSTs to the swarm REST route with projectId + launchKey and returns the runId on 202", async () => {
+    authFetchMock.mockResolvedValue(jsonResponse(202, { runId: "run-1" }));
+
+    const result = await launchJourneyRun({
+      journeyId: "journey-1",
+      projectId: "proj-1",
+      launchKey: "lk-abc",
+    });
+
+    expect(result).toEqual({ runId: "run-1" });
+    expect(authFetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = authFetchMock.mock.calls[0]!;
+    expect(url).toBe("/api/web/swarm/journeys/journey-1/runs");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body)).toEqual({
+      projectId: "proj-1",
+      launchKey: "lk-abc",
+    });
+  });
+
+  it("url-encodes the journeyId path segment", async () => {
+    authFetchMock.mockResolvedValue(jsonResponse(202, { runId: "run-2" }));
+    await launchJourneyRun({
+      journeyId: "a/b?c",
+      projectId: "proj-1",
+      launchKey: "lk",
+    });
+    expect(authFetchMock.mock.calls[0]![0]).toBe(
+      "/api/web/swarm/journeys/a%2Fb%3Fc/runs"
+    );
+  });
+
+  it("throws a LaunchJourneyRunError carrying the 4xx status + backend message", async () => {
+    authFetchMock.mockResolvedValue(
+      jsonResponse(400, { code: "VALIDATION_ERROR", message: "This journey has no pinned hosts to run" })
+    );
+
+    await expect(
+      launchJourneyRun({
+        journeyId: "journey-1",
+        projectId: "proj-1",
+        launchKey: "lk",
+      })
+    ).rejects.toMatchObject({
+      name: "LaunchJourneyRunError",
+      status: 400,
+      message: "This journey has no pinned hosts to run",
+    });
+  });
+
+  it("falls back to a generic message when the error body has none", async () => {
+    authFetchMock.mockResolvedValue(jsonResponse(500, {}));
+    let err: unknown;
+    try {
+      await launchJourneyRun({
+        journeyId: "j",
+        projectId: "p",
+        launchKey: "lk",
+      });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(LaunchJourneyRunError);
+    expect((err as LaunchJourneyRunError).status).toBe(500);
+    expect((err as LaunchJourneyRunError).message).toMatch(/500/);
+  });
+
+  it("throws when a 2xx returns no runId", async () => {
+    authFetchMock.mockResolvedValue(jsonResponse(202, {}));
+    await expect(
+      launchJourneyRun({ journeyId: "j", projectId: "p", launchKey: "lk" })
+    ).rejects.toBeInstanceOf(LaunchJourneyRunError);
+  });
+});

--- a/mcpjam-inspector/client/src/lib/__tests__/swarm-api.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/swarm-api.test.ts
@@ -9,6 +9,11 @@ import {
   launchJourneyRun,
   LaunchJourneyRunError,
 } from "@/lib/swarm-api";
+import type {
+  PersonaTrackRecord,
+  JourneyRollup,
+  JourneySessionRow,
+} from "@/lib/swarm-api";
 
 function jsonResponse(status: number, body: unknown): Response {
   return {
@@ -99,5 +104,85 @@ describe("launchJourneyRun", () => {
     await expect(
       launchJourneyRun({ journeyId: "j", projectId: "p", launchKey: "lk" })
     ).rejects.toBeInstanceOf(LaunchJourneyRunError);
+  });
+});
+
+/**
+ * CONTRACT: the client DTOs must match the backend `personas:getPersonaTrackRecord`
+ * / `journeys:getJourneyRollup` / `listSessionsBy*` shapes EXACTLY. The object
+ * literals below are checked structurally by TS (excess-property check fails on
+ * a wrong/extra key), and `Object.keys` asserts the shape at runtime. These are
+ * the fixtures a real backend row would deserialize into — if the backend key
+ * set drifts, this fails instead of silently rendering blank counts.
+ */
+describe("swarm rollup DTO contracts", () => {
+  it("PersonaTrackRecord = { personaRefId, runCount, sessionCount, readiness, sessionExamples }", () => {
+    const record: PersonaTrackRecord = {
+      personaRefId: "persona-1",
+      runCount: 3,
+      sessionCount: 12,
+      readiness: { ready: 8, needsAttention: 3, notReady: 1 },
+      sessionExamples: [{ chatSessionId: "synth_1" }],
+    };
+    expect(Object.keys(record).sort()).toEqual(
+      [
+        "personaRefId",
+        "readiness",
+        "runCount",
+        "sessionCount",
+        "sessionExamples",
+      ].sort()
+    );
+    // The old (wrong) keys must be gone.
+    expect(record).not.toHaveProperty("totalRuns");
+    expect(record).not.toHaveProperty("totalSessions");
+    expect(record).not.toHaveProperty("hostBreakdown");
+  });
+
+  it("JourneyRollup = { journeyRefId, runCount, hosts[] } with the per-host outcome rollup", () => {
+    const rollup: JourneyRollup = {
+      journeyRefId: "journey-1",
+      runCount: 2,
+      hosts: [
+        {
+          hostId: "host-1",
+          total: 4,
+          succeeded: 3,
+          failed: 1,
+          rateLimited: 0,
+          readiness: { ready: 3 },
+        },
+      ],
+    };
+    expect(Object.keys(rollup).sort()).toEqual(
+      ["hosts", "journeyRefId", "runCount"].sort()
+    );
+    expect(Object.keys(rollup.hosts[0]!).sort()).toEqual(
+      ["failed", "hostId", "rateLimited", "readiness", "succeeded", "total"].sort()
+    );
+    // Not the old flat `hostSummaries` / `totalRuns`.
+    expect(rollup).not.toHaveProperty("hostSummaries");
+    expect(rollup).not.toHaveProperty("totalRuns");
+  });
+
+  it("JourneySessionRow (JourneySessionDto) is keyed by `id`, with no personaLabel/messageCount", () => {
+    const row: JourneySessionRow = {
+      id: "thread-1",
+      chatSessionId: "synth_run_host_0",
+      projectId: "proj-1",
+      hostId: "host-1",
+      personaRefId: "persona-1",
+      status: "completed",
+      modelId: "anthropic/claude-haiku-4.5",
+      startedAt: 1,
+      lastActivityAt: 2,
+      readiness: { status: "completed", verdict: "ready", issueCount: 0 },
+    };
+    // The identifier the viewer + deep-link consume is `id`.
+    expect(row.id).toBe("thread-1");
+    expect(row).not.toHaveProperty("_id");
+    expect(row).not.toHaveProperty("personaLabel");
+    expect(row).not.toHaveProperty("messageCount");
+    expect(row).not.toHaveProperty("personaId");
   });
 });

--- a/mcpjam-inspector/client/src/lib/app-navigation.ts
+++ b/mcpjam-inspector/client/src/lib/app-navigation.ts
@@ -94,6 +94,53 @@ export function buildChatboxSessionPath(
   return `${basePath}?${search.toString()}`;
 }
 
+/**
+ * Build a Swarms deep-link to one synthetic session. Unlike the chatbox
+ * Sessions tab (host-anchored), the Swarms surface is Persona → Journey → Run →
+ * Session, so a link that only carried `host`/`session` couldn't restore the
+ * persona + run selection the recipient needs to reach the session. This
+ * encodes `persona` (personaRefId) and `run` (runId) alongside `host`/`session`
+ * so `SwarmsTab` can restore the full selection chain on load.
+ */
+export function buildSwarmSessionPath(args: {
+  personaRefId: string;
+  runId: string;
+  hostId: string;
+  threadId: string;
+}): string {
+  const search = new URLSearchParams({
+    persona: args.personaRefId,
+    run: args.runId,
+    host: args.hostId,
+    session: args.threadId,
+  });
+  return `${routePaths.swarms}?${search.toString()}`;
+}
+
+/**
+ * Parse a Swarms session deep-link's selection params (see
+ * {@link buildSwarmSessionPath}) from a search string. Every field is optional —
+ * a bare `/swarms` visit returns all-undefined.
+ */
+export function parseSwarmSessionParams(search: string): {
+  personaRefId?: string;
+  runId?: string;
+  hostId?: string;
+  threadId?: string;
+} {
+  const params = new URLSearchParams(search);
+  const pick = (key: string) => {
+    const value = params.get(key);
+    return value && value.trim() ? value : undefined;
+  };
+  return {
+    personaRefId: pick("persona"),
+    runId: pick("run"),
+    hostId: pick("host"),
+    threadId: pick("session"),
+  };
+}
+
 /** Build a path for a specific organization route. */
 export function buildOrganizationPath(
   orgId: string,

--- a/mcpjam-inspector/client/src/lib/session-usage-filters.ts
+++ b/mcpjam-inspector/client/src/lib/session-usage-filters.ts
@@ -1,0 +1,53 @@
+/**
+ * Generic session filter dimensions — surface-agnostic.
+ *
+ * The chatbox usage panel has its own rich, `SharedChatThread`-coupled filter
+ * model (`hooks/chatbox-usage-filters.ts`). The Swarms surface needs a much
+ * smaller, generic host/persona filter over synthetic session rows, so rather
+ * than grow the chatbox-named module with swarm concerns this holds the generic
+ * primitive: an AND-of-dimensions predicate over any row exposing `hostId` /
+ * `personaId`. Other surfaces can widen `SessionFilterDimension` as needed.
+ */
+
+export type SessionFilterDimension = "hostId" | "personaId";
+
+export interface SessionFilterState {
+  /** Active value per dimension; absent/null ⇒ that dimension is unfiltered. */
+  hostId?: string | null;
+  personaId?: string | null;
+}
+
+export const EMPTY_SESSION_FILTER: SessionFilterState = {};
+
+/** A row is any object that may carry the filterable dimensions. */
+export type FilterableSessionRow = Partial<
+  Record<SessionFilterDimension, string | undefined>
+>;
+
+/**
+ * True when `row` matches every ACTIVE dimension (dimensions are AND'd; an
+ * absent/null filter value matches everything for that dimension).
+ */
+export function sessionMatchesFilter(
+  row: FilterableSessionRow,
+  filter: SessionFilterState,
+): boolean {
+  if (filter.hostId != null && row.hostId !== filter.hostId) return false;
+  if (filter.personaId != null && row.personaId !== filter.personaId) {
+    return false;
+  }
+  return true;
+}
+
+/** Toggle a dimension value: selecting the active value again clears it. */
+export function toggleSessionFilter(
+  filter: SessionFilterState,
+  dimension: SessionFilterDimension,
+  value: string,
+): SessionFilterState {
+  const current = filter[dimension];
+  return {
+    ...filter,
+    [dimension]: current === value ? null : value,
+  };
+}

--- a/mcpjam-inspector/client/src/lib/swarm-api.ts
+++ b/mcpjam-inspector/client/src/lib/swarm-api.ts
@@ -61,23 +61,23 @@ export interface JourneyRun {
 }
 
 /**
- * A single synthetic session row for the sessions-by-host view. Shape mirrors
- * the backend `listSessionsBy*` page items; fields the readiness/diagnostics
- * strip needs are optional so the UI degrades gracefully when the backend
- * hasn't denormalized them yet.
+ * A single synthetic session row — the backend `JourneySessionDto` returned by
+ * `journeyRuns:listSessionsBy*` page items. The row identifier is `id`
+ * (`s._id` under the hood); there is NO `personaLabel` / `messageCount`.
+ * `readiness` is the server-denormalized WIDE subset the readiness badge reads
+ * (`session-readiness.tsx`).
  */
 export interface JourneySessionRow {
-  /** sharedChatThreads doc id — the id `ShareUsageThreadDetail` opens. */
-  _id: string;
+  /** `s._id` — the id `ShareUsageThreadDetail` opens + the deep-link threadId. */
+  id: string;
   chatSessionId: string;
+  projectId: string;
   hostId: string;
-  personaId?: string;
-  personaLabel?: string;
+  personaRefId?: string;
   status?: string;
   modelId?: string;
   startedAt: number;
   lastActivityAt?: number;
-  messageCount?: number;
   /** Server-denormalized readiness subset (see `session-readiness.tsx`). */
   readiness?: {
     status?: string;
@@ -86,22 +86,40 @@ export interface JourneySessionRow {
   };
 }
 
+/**
+ * `personas:getPersonaTrackRecord` result. The backend rolls the persona's
+ * history into aggregate COUNTS + a readiness summary + a few session examples;
+ * it does NOT return a succeeded/failed/rateLimited outcome breakdown at the
+ * persona level (that lives on the per-journey rollup's `hosts[]`).
+ * `readiness` / `sessionExamples` sub-shapes are left permissive on purpose —
+ * the contract fixes only the top-level keys.
+ */
 export interface PersonaTrackRecord {
-  personaId?: string;
-  totalRuns: number;
-  totalSessions: number;
+  personaRefId?: string;
+  runCount: number;
+  sessionCount: number;
+  readiness?: Record<string, unknown>;
+  sessionExamples?: unknown[];
+}
+
+/** One host's outcome rollup within {@link JourneyRollup}. */
+export interface JourneyHostRollup {
+  hostId: string;
+  total: number;
   succeeded: number;
   failed: number;
   rateLimited: number;
-  /** Optional per-host breakdown the backend may include. */
-  hostBreakdown?: JourneyHostSummary[];
+  readiness?: Record<string, unknown>;
 }
 
+/**
+ * `journeys:getJourneyRollup` result — `{ journeyRefId, runCount, hosts }`.
+ * `hosts[]` is the per-host outcome rollup (NOT the old flat `hostSummaries`).
+ */
 export interface JourneyRollup {
   journeyRefId?: string;
-  totalRuns: number;
-  hostSummaries: JourneyHostSummary[];
-  lastRunAt?: number;
+  runCount: number;
+  hosts: JourneyHostRollup[];
 }
 
 /** Convex pagination envelope. */

--- a/mcpjam-inspector/client/src/lib/swarm-api.ts
+++ b/mcpjam-inspector/client/src/lib/swarm-api.ts
@@ -22,8 +22,6 @@ export const SWARM_QUERIES = {
   listHosts: "hosts:listHosts",
   listJourneyRuns: "journeyRuns:listJourneyRuns",
   listSessionsByJourneyRun: "journeyRuns:listSessionsByJourneyRun",
-  listSessionsByHost: "journeyRuns:listSessionsByHost",
-  listSessionsByJourney: "journeyRuns:listSessionsByJourney",
 } as const;
 
 // ── DTOs ────────────────────────────────────────────────────────────────────

--- a/mcpjam-inspector/client/src/lib/swarm-api.ts
+++ b/mcpjam-inspector/client/src/lib/swarm-api.ts
@@ -1,0 +1,197 @@
+/**
+ * Swarm (journey-execution) client contract — the ONE place the Swarms surface
+ * reaches the backend.
+ *
+ * Centralizes: (1) the Inspector REST launch call (`POST /api/web/swarm/…`),
+ * (2) the project-scoped Convex query NAMES the UI subscribes to (Convex
+ * codegen doesn't run in the inspector, so these are string-keyed `as any`
+ * reads — keeping the names here stops them scattering through the component),
+ * and (3) the response DTOs those reads/writes return. Mirrors the backend
+ * `convex/journeyExecution/*` + `convex/{personas,journeys,journeyRuns}` by
+ * hand (two-repo layout).
+ */
+
+import { authFetch } from "@/lib/session-token";
+
+// ── Convex query names (string-keyed reads) ─────────────────────────────────
+export const SWARM_QUERIES = {
+  listPersonas: "personas:listPersonas",
+  personaTrackRecord: "personas:getPersonaTrackRecord",
+  listJourneysByPersona: "journeys:listJourneysByPersona",
+  journeyRollup: "journeys:getJourneyRollup",
+  listHosts: "hosts:listHosts",
+  listJourneyRuns: "journeyRuns:listJourneyRuns",
+  listSessionsByJourneyRun: "journeyRuns:listSessionsByJourneyRun",
+  listSessionsByHost: "journeyRuns:listSessionsByHost",
+  listSessionsByJourney: "journeyRuns:listSessionsByJourney",
+} as const;
+
+// ── DTOs ────────────────────────────────────────────────────────────────────
+
+/** Terminal + in-flight states a journey run can surface in the UI. */
+export type JourneyRunStatus =
+  | "running"
+  | "completed"
+  | "partial"
+  | "failed"
+  | "rate_limited"
+  | "stale";
+
+export interface JourneyRunSummary {
+  total: number;
+  succeeded: number;
+  failed: number;
+  rateLimited: number;
+}
+
+export interface JourneyHostSummary {
+  hostId: string;
+  total: number;
+  succeeded: number;
+  failed: number;
+  rateLimited: number;
+}
+
+export interface JourneyRun {
+  _id: string;
+  status: JourneyRunStatus | string;
+  summary: JourneyRunSummary;
+  hostSummaries: JourneyHostSummary[];
+  createdAt: number;
+}
+
+/**
+ * A single synthetic session row for the sessions-by-host view. Shape mirrors
+ * the backend `listSessionsBy*` page items; fields the readiness/diagnostics
+ * strip needs are optional so the UI degrades gracefully when the backend
+ * hasn't denormalized them yet.
+ */
+export interface JourneySessionRow {
+  /** sharedChatThreads doc id — the id `ShareUsageThreadDetail` opens. */
+  _id: string;
+  chatSessionId: string;
+  hostId: string;
+  personaId?: string;
+  personaLabel?: string;
+  status?: string;
+  modelId?: string;
+  startedAt: number;
+  lastActivityAt?: number;
+  messageCount?: number;
+  /** Server-denormalized readiness subset (see `session-readiness.tsx`). */
+  readiness?: {
+    status?: string;
+    verdict?: string;
+    issueCount?: number;
+  };
+}
+
+export interface PersonaTrackRecord {
+  personaId?: string;
+  totalRuns: number;
+  totalSessions: number;
+  succeeded: number;
+  failed: number;
+  rateLimited: number;
+  /** Optional per-host breakdown the backend may include. */
+  hostBreakdown?: JourneyHostSummary[];
+}
+
+export interface JourneyRollup {
+  journeyRefId?: string;
+  totalRuns: number;
+  hostSummaries: JourneyHostSummary[];
+  lastRunAt?: number;
+}
+
+/** Convex pagination envelope. */
+export interface Paginated<T> {
+  page: T[];
+  isDone: boolean;
+  continueCursor: string | null;
+}
+
+export const DEFAULT_PAGE_SIZE = 10;
+
+// ── REST launch ─────────────────────────────────────────────────────────────
+
+export interface LaunchJourneyRunArgs {
+  journeyId: string;
+  projectId: string;
+  /**
+   * One idempotency key per user click, REUSED verbatim if the HTTP call is
+   * retried, so a network retry can't spawn a duplicate run. Generate with
+   * `crypto.randomUUID()`.
+   */
+  launchKey: string;
+}
+
+export interface LaunchJourneyRunResult {
+  runId: string;
+}
+
+/**
+ * Error thrown by {@link launchJourneyRun} carrying the backend HTTP status so
+ * the UI can treat a 4xx (multi-host-cap edge, no hosts, duplicate launch) as
+ * an inline, user-actionable message rather than a hard failure.
+ */
+export class LaunchJourneyRunError extends Error {
+  readonly status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "LaunchJourneyRunError";
+    this.status = status;
+  }
+}
+
+/**
+ * Launch a journey run through the Inspector REST route. Resolves with the new
+ * `runId` on a 202; throws {@link LaunchJourneyRunError} on any non-2xx so the
+ * caller can branch on `.status`.
+ */
+export async function launchJourneyRun(
+  args: LaunchJourneyRunArgs,
+): Promise<LaunchJourneyRunResult> {
+  const response = await authFetch(
+    `/api/web/swarm/journeys/${encodeURIComponent(args.journeyId)}/runs`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        projectId: args.projectId,
+        launchKey: args.launchKey,
+      }),
+    },
+  );
+
+  let body: unknown = undefined;
+  try {
+    body = await response.json();
+  } catch {
+    body = undefined;
+  }
+
+  if (!response.ok) {
+    const rawMessage =
+      body && typeof body === "object"
+        ? (body as { message?: unknown }).message
+        : undefined;
+    const message =
+      typeof rawMessage === "string" && rawMessage.length > 0
+        ? rawMessage
+        : `Failed to launch journey run (${response.status})`;
+    throw new LaunchJourneyRunError(response.status, message);
+  }
+
+  const runId =
+    body && typeof body === "object"
+      ? (body as { runId?: unknown }).runId
+      : undefined;
+  if (typeof runId !== "string" || runId.length === 0) {
+    throw new LaunchJourneyRunError(
+      response.status,
+      "Launch accepted but the backend returned no run id",
+    );
+  }
+  return { runId };
+}

--- a/mcpjam-inspector/server/routes/web/__tests__/swarm-runs.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/swarm-runs.test.ts
@@ -100,12 +100,12 @@ describe("web routes — swarm single-host launch", () => {
     }
   });
 
-  it("passes maxHosts:1, returns 202 + runId, and starts the runner", async () => {
+  it("omits maxHosts, returns 202 + runId, and fans the runner over all hosts", async () => {
     createJourneyRunMock.mockResolvedValue({
       runId: "run-1",
       projectId: "proj-1",
       journeyRefId: "journey-1",
-      snapshot: snapshot(1),
+      snapshot: snapshot(3),
     });
 
     const response = await postJson(
@@ -119,7 +119,7 @@ describe("web routes — swarm single-host launch", () => {
     expect(status).toBe(202);
     expect(data.runId).toBe("run-1");
 
-    // maxHosts:1 (the single-host guard) + the journeyId as journeyRefId.
+    // No maxHosts cap — the backend pins the journey's full host set.
     expect(createJourneyRunMock).toHaveBeenCalledTimes(1);
     const createArgs = createJourneyRunMock.mock.calls[0]![2] as any;
     expect(createArgs).toMatchObject({
@@ -129,10 +129,10 @@ describe("web routes — swarm single-host launch", () => {
       projectId: "proj-1",
       journeyRefId: "journey-1",
       launchKey: "lk-1",
-      maxHosts: 1,
     });
+    expect(createArgs.maxHosts).toBeUndefined();
 
-    // The runner is started fire-and-forget after the response.
+    // The runner is started fire-and-forget with EVERY pinned host.
     await flushMacrotasks();
     expect(startJourneyRunMock).toHaveBeenCalledTimes(1);
     const startArgs = startJourneyRunMock.mock.calls[0]![0] as any;
@@ -142,7 +142,11 @@ describe("web routes — swarm single-host launch", () => {
       sessionsPerHost: 2,
       maxTurns: 3,
     });
-    expect(startArgs.host.hostId).toBe("host-0");
+    expect(startArgs.hosts.map((h: any) => h.hostId)).toEqual([
+      "host-0",
+      "host-1",
+      "host-2",
+    ]);
   });
 
   it("acknowledges a DEDUPED launch (launchKey replay) without starting a second runner", async () => {
@@ -177,11 +181,11 @@ describe("web routes — swarm single-host launch", () => {
     expect(startJourneyRunMock).not.toHaveBeenCalled();
   });
 
-  it("surfaces a multi-host journey rejection as a 4xx and never starts a runner", async () => {
+  it("surfaces a backend rejection (e.g. host-count ceiling) as a 4xx and never starts a runner", async () => {
     createJourneyRunMock.mockRejectedValue(
       new SwarmAgentError(
         400,
-        "journey has more than one host",
+        "journey exceeds the maximum host count",
         "swarm-agent create failed (400)"
       )
     );
@@ -197,7 +201,28 @@ describe("web routes — swarm single-host launch", () => {
     }>(response);
 
     expect(status).toBe(400);
-    expect(JSON.stringify(data)).toMatch(/more than one host/i);
+    expect(JSON.stringify(data)).toMatch(/maximum host count/i);
+    await flushMacrotasks();
+    expect(startJourneyRunMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a journey snapshot with no pinned hosts and never starts a runner", async () => {
+    createJourneyRunMock.mockResolvedValue({
+      runId: "run-1",
+      projectId: "proj-1",
+      journeyRefId: "journey-1",
+      snapshot: snapshot(0),
+    });
+
+    const response = await postJson(
+      app,
+      "/api/web/swarm/journeys/journey-1/runs",
+      { projectId: "proj-1", launchKey: "lk-1" },
+      token
+    );
+    const { status } = await expectJson(response);
+
+    expect(status).toBe(400);
     await flushMacrotasks();
     expect(startJourneyRunMock).not.toHaveBeenCalled();
   });

--- a/mcpjam-inspector/server/routes/web/__tests__/swarm-runs.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/swarm-runs.test.ts
@@ -288,10 +288,10 @@ describe("web routes — swarm single-host launch", () => {
     expect((await expectJson(response)).status).toBe(202);
     await flushMacrotasks();
 
-    // Invoke the captured managerFactory (startJourneyRun is mocked, so the
-    // route's closure never ran on its own).
+    // Invoke the captured host-aware managerFactory for the pinned host
+    // (startJourneyRun is mocked, so the route's closure never ran on its own).
     const startArgs = startJourneyRunMock.mock.calls[0]![0] as any;
-    await startArgs.managerFactory();
+    await startArgs.managerFactory(startArgs.hosts[0]);
 
     expect(createAuthorizedManagerMock).toHaveBeenCalledTimes(1);
     const call = createAuthorizedManagerMock.mock.calls[0]!;
@@ -326,7 +326,7 @@ describe("web routes — swarm single-host launch", () => {
     await flushMacrotasks();
 
     const startArgs = startJourneyRunMock.mock.calls[0]![0] as any;
-    await startArgs.managerFactory();
+    await startArgs.managerFactory(startArgs.hosts[0]);
 
     const options = createAuthorizedManagerMock.mock.calls[0]![7] as any;
     expect(options.xaaIssuer).toBe("https://issuer.test/api/web/xaa");

--- a/mcpjam-inspector/server/routes/web/swarm-runs.ts
+++ b/mcpjam-inspector/server/routes/web/swarm-runs.ts
@@ -170,13 +170,13 @@ function buildPinnedConnectionSettings(
 }
 
 /**
- * Launch a hidden single-host swarm (journey-execution) run (PR 3c).
+ * Launch a multi-host swarm (journey-execution) run (PR 3d).
  *
- * Creates a journey run capped to a single host (`maxHosts: 1` — a multi-host
- * journey is rejected transactionally before any run row exists), then starts
- * the runner fire-and-forget and returns HTTP 202 with the runId. The Run
- * button in the UI stays DISABLED; this route is the only way to exercise the
- * slice until fan-out (PR 3d).
+ * Creates a journey run (the backend pins the journey's full host set — no
+ * `maxHosts` cap; a backend rejection such as a hard host-count ceiling or a
+ * journey with no hosts surfaces as a 4xx), then starts the fan-out runner
+ * fire-and-forget and returns HTTP 202 with the runId. This is the route the
+ * enabled "Run journey" button in the UI calls.
  */
 swarmRuns.post("/journeys/:journeyId/runs", async (c) =>
   handleRoute(
@@ -207,16 +207,16 @@ swarmRuns.post("/journeys/:journeyId/runs", async (c) =>
       );
       const convexHttpUrl = requireConvexHttpUrl();
 
-      // Create the run capped to a single host. A journey with >1 host is
-      // rejected transactionally BEFORE any run row is created — surface the
-      // backend's 4xx as a clear client error instead of a bare 500.
+      // Create the run over the journey's full pinned host set (no maxHosts
+      // cap). A backend rejection (a hard host-count ceiling, a journey with no
+      // hosts, a duplicate launchKey, …) surfaces as a clear 4xx instead of a
+      // bare 500.
       let created;
       try {
         created = await createJourneyRun(convexHttpUrl, bearerToken, {
           projectId: body.projectId,
           journeyRefId: journeyId,
           launchKey: body.launchKey,
-          maxHosts: 1,
         });
       } catch (err) {
         if (
@@ -227,8 +227,7 @@ swarmRuns.post("/journeys/:journeyId/runs", async (c) =>
           throw new WebRouteError(
             err.status,
             ErrorCode.VALIDATION_ERROR,
-            err.bodyText ||
-              "This journey can't be launched by the single-host runner (it may have more than one host)."
+            err.bodyText || "This journey can't be launched."
           );
         }
         throw err;
@@ -258,24 +257,14 @@ swarmRuns.post("/journeys/:journeyId/runs", async (c) =>
         return { runId, deduped: true };
       }
 
-      if (!Array.isArray(snapshot.hosts) || snapshot.hosts.length !== 1) {
+      if (!Array.isArray(snapshot.hosts) || snapshot.hosts.length === 0) {
         throw new WebRouteError(
           400,
           ErrorCode.VALIDATION_ERROR,
-          "The single-host runner requires exactly one pinned host"
+          "This journey has no pinned hosts to run"
         );
       }
-      const host = snapshot.hosts[0]!;
-      // Connect ONLY the pinned required servers (optionalServerIds stay off,
-      // matching a real no-opt-in visitor's session).
-      const serverIds = host.serverIds;
-      // Reconnect with the snapshot's non-secret connection settings (timeout +
-      // protocol pins) so the run is reproducible — NOT whatever the host's
-      // current live config would negotiate. Secrets/headers stay live-resolved.
-      const connection = buildPinnedConnectionSettings(
-        host,
-        WEB_STREAM_TIMEOUT_MS
-      );
+      const hosts = snapshot.hosts;
 
       // Resolve the MCPJam test-IdP issuer NOW, while the request `Context` is
       // still live (it reads `x-forwarded-proto` off `c`). `createAuthorized
@@ -290,14 +279,25 @@ swarmRuns.post("/journeys/:journeyId/runs", async (c) =>
         startJourneyRun({
           runId,
           projectId,
-          host,
+          hosts,
           personaSnapshot: snapshot.personaSnapshot,
           sessionsPerHost: snapshot.sessionsPerHost,
           maxTurns: snapshot.maxTurns,
           convexHttpUrl,
           bearer: bearerToken,
           authHeader,
-          managerFactory: async () => {
+          // Host-aware: each host connects ONLY its own pinned required servers
+          // (optionalServerIds stay off, matching a real no-opt-in visitor).
+          managerFactory: async (host) => {
+            const serverIds = host.serverIds;
+            // Reconnect with THIS host's non-secret connection settings
+            // (per-request timeout + MCP protocol pins) so the run reproduces
+            // the pinned snapshot rather than the host's current live config.
+            // Secrets/headers stay live-resolved by the authorize batch.
+            const connection = buildPinnedConnectionSettings(
+              host,
+              WEB_STREAM_TIMEOUT_MS
+            );
             const { manager } = await createAuthorizedManager(
               callerContextFromHono(c),
               bearerToken,

--- a/mcpjam-inspector/server/services/sessionSimulation/__tests__/swarm-runner.integration.test.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/__tests__/swarm-runner.integration.test.ts
@@ -132,15 +132,17 @@ function baseOpts() {
   return {
     runId: "run-1",
     projectId: "proj-1",
-    host: {
-      hostId: "host-1",
-      hostName: "Host One",
-      hostConfigId: "hc-1",
-      modelId: "anthropic/claude-haiku-4.5",
-      systemPrompt: "sys",
-      requireToolApproval: false,
-      serverIds: ["server-1"],
-    },
+    hosts: [
+      {
+        hostId: "host-1",
+        hostName: "Host One",
+        hostConfigId: "hc-1",
+        modelId: "anthropic/claude-haiku-4.5",
+        systemPrompt: "sys",
+        requireToolApproval: false,
+        serverIds: ["server-1"],
+      },
+    ],
     personaSnapshot: {
       personaId: "p1",
       name: "Persona One",

--- a/mcpjam-inspector/server/services/sessionSimulation/__tests__/swarm-runner.integration.test.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/__tests__/swarm-runner.integration.test.ts
@@ -269,9 +269,10 @@ describe("swarm runner — real core integration", () => {
       harnessSessionCommit: swarmCommit,
     }));
 
+    const opts = baseOpts();
     await startJourneyRun({
-      ...baseOpts(),
-      host: { ...baseOpts().host, harness: "claude-code" as const },
+      ...opts,
+      hosts: [{ ...opts.hosts[0]!, harness: "claude-code" as const }],
     } as any);
 
     // (a) The harness turn was SUPPLIED a MCP-proxy plane strategy (without it

--- a/mcpjam-inspector/server/services/sessionSimulation/__tests__/swarm-runner.test.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/__tests__/swarm-runner.test.ts
@@ -483,6 +483,92 @@ describe("swarm fan-out runner — worker pool + host isolation", () => {
       errorCode: "spend_cap_exceeded",
     });
   });
+
+  it("an org cap phrased as 'quota exceeded' / 'budget exhausted' ALSO stops the whole run (finding 6)", async () => {
+    for (const capMessage of ["quota exceeded", "monthly budget exhausted"]) {
+      finalizePendingAttemptsMock.mockClear();
+      runSyntheticHostSessionMock.mockImplementation(async (adapter: any) => {
+        if (adapter.chatSessionId === "synth_run-1_host-1_0") {
+          return { outcome: "rate_limited", errorMessage: capMessage };
+        }
+        return { outcome: "succeeded" };
+      });
+
+      await startJourneyRun(
+        baseOpts({ hosts: [HOST, HOST_2], sessionsPerHost: 2 })
+      );
+
+      expect(
+        finalizePendingAttemptsMock,
+        `"${capMessage}" should trip the whole-run spend-cap stop`
+      ).toHaveBeenCalledTimes(1);
+      expect(finalizePendingAttemptsMock.mock.calls[0]![2]).toMatchObject({
+        errorCode: "spend_cap_exceeded",
+      });
+    }
+  });
+
+  it("a 'capacity' rate-limit is a PER-HOST provider stop, NOT a whole-run spend-cap (finding 7)", async () => {
+    // "capacity" must not be misread as a spend cap: only THIS host stops; the
+    // run does not finalize-pending.
+    runSyntheticHostSessionMock.mockImplementation(async (adapter: any) => {
+      if (adapter.chatSessionId === "synth_run-1_host-1_0") {
+        return {
+          outcome: "rate_limited",
+          errorMessage: "rate capacity exceeded",
+        };
+      }
+      return { outcome: "succeeded" };
+    });
+
+    await startJourneyRun(
+      baseOpts({ hosts: [HOST, HOST_2], sessionsPerHost: 2 })
+    );
+
+    // No whole-run finalize — it stayed a per-host provider rate-limit.
+    expect(finalizePendingAttemptsMock).not.toHaveBeenCalled();
+    // host-2 kept running to completion.
+    expect(executedForHost("host-2")).toHaveLength(2);
+    // host-1 short-circuited after session 0 (session 1 never executed).
+    expect(executedForHost("host-1")).toHaveLength(1);
+  });
+
+  it("a throwing host worker (e.g. model-less spec) finalizes ITS attempts failed and does not abort the other hosts (finding 8)", async () => {
+    // Force a worker-level throw for host-1 (a stand-in for a model-less pinned
+    // spec whose modelId can't resolve). host-2's worker must keep running.
+    runSyntheticHostSessionMock.mockImplementation(async (adapter: any) => {
+      if (adapter.persist.hostId === "host-1") {
+        throw new Error("model-less host: cannot resolve modelId");
+      }
+      return { outcome: "succeeded" };
+    });
+
+    await startJourneyRun(
+      baseOpts({ hosts: [HOST, HOST_2], sessionsPerHost: 2 })
+    );
+
+    // The other host completed all its sessions — the pool was not aborted.
+    expect(executedForHost("host-2")).toHaveLength(2);
+    const host2Terminals = terminals().filter((t) => t.hostId === "host-2");
+    expect(host2Terminals.map((t) => t.status)).toEqual([
+      "succeeded",
+      "succeeded",
+    ]);
+
+    // The failing host's attempts are all finalized failed(host_worker_failed)
+    // rather than left dangling.
+    const host1Failed = reportAttemptMock.mock.calls
+      .map((c) => c[2] as any)
+      .filter(
+        (a) =>
+          a.hostId === "host-1" &&
+          a.status === "failed" &&
+          a.errorCode === "host_worker_failed"
+      )
+      .map((a) => a.sessionIdx)
+      .sort();
+    expect(host1Failed).toEqual([0, 1]);
+  });
 });
 
 describe("swarm single-host runner — heartbeat", () => {

--- a/mcpjam-inspector/server/services/sessionSimulation/__tests__/swarm-runner.test.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/__tests__/swarm-runner.test.ts
@@ -571,6 +571,77 @@ describe("swarm fan-out runner — worker pool + host isolation", () => {
   });
 });
 
+describe("swarm fan-out runner — spend-cap abort reclassification (finding 5)", () => {
+  const HOST_3 = {
+    hostId: "host-3",
+    hostName: "Host Three",
+    hostConfigId: "hc-3",
+    modelId: "anthropic/claude-haiku-4.5",
+    systemPrompt: "sys",
+    requireToolApproval: false,
+    serverIds: ["server-3"],
+  };
+
+  it("reports an in-flight session that the spend-cap abort cancelled as rate_limited/spend_cap_exceeded (NOT session_failed), while a genuinely-succeeded session keeps its outcome", async () => {
+    // Concurrent barrier: host-1 trips the org spend cap while host-2 has a
+    // session PARKED in-flight. The cap's `runStop.abort()` cancels host-2's
+    // turns and the shared core returns `outcome: "failed"` — an abort artifact,
+    // NOT a genuine failure. host-3 genuinely succeeds and must be untouched.
+    runSyntheticHostSessionMock.mockImplementation(async (adapter: any) => {
+      const hostId = adapter.persist.hostId;
+      if (hostId === "host-1") {
+        // Trip the org spend cap.
+        return {
+          outcome: "rate_limited",
+          errorMessage: "Org daily spend cap exceeded",
+        };
+      }
+      if (hostId === "host-3") {
+        // Genuinely succeeds (before/independent of the cap).
+        return { outcome: "succeeded" };
+      }
+      // host-2: park until the run-stop aborts this session, then return the
+      // abort artifact the real core returns (`{ outcome: "failed" }`).
+      return await new Promise((resolve) => {
+        const finish = () => resolve({ outcome: "failed" });
+        if (adapter.abortSignal?.aborted) {
+          finish();
+          return;
+        }
+        adapter.abortSignal?.addEventListener("abort", finish, { once: true });
+      });
+    });
+
+    await startJourneyRun(
+      baseOpts({ hosts: [HOST, HOST_2, HOST_3], sessionsPerHost: 1 })
+    );
+
+    const terminals = reportAttemptMock.mock.calls
+      .map((c) => c[2] as any)
+      .filter((a) => a.status !== "running");
+
+    // host-2's aborted attempt: reported terminal rate_limited /
+    // spend_cap_exceeded — NOT the generic session_failed.
+    const host2 = terminals.find((t) => t.hostId === "host-2")!;
+    expect(host2.status).toBe("rate_limited");
+    expect(host2.errorCode).toBe("spend_cap_exceeded");
+    expect(host2.errorCode).not.toBe("session_failed");
+    // Persist-before-terminal invariant preserved: same deterministic id.
+    expect(host2.chatSessionId).toBe("synth_run-1_host-2_0");
+
+    // host-3's genuinely-succeeded session is untouched.
+    const host3 = terminals.find((t) => t.hostId === "host-3")!;
+    expect(host3.status).toBe("succeeded");
+
+    // The whole-run finalize still runs for the spend-cap breach.
+    expect(finalizePendingAttemptsMock).toHaveBeenCalledTimes(1);
+    expect(finalizePendingAttemptsMock.mock.calls[0]![2]).toMatchObject({
+      terminalStatus: "rate_limited",
+      errorCode: "spend_cap_exceeded",
+    });
+  });
+});
+
 describe("swarm single-host runner — heartbeat", () => {
   it("fires the heartbeat on an independent 30s schedule (not gated on turn completion) and stops it on finally", async () => {
     vi.useFakeTimers();

--- a/mcpjam-inspector/server/services/sessionSimulation/__tests__/swarm-runner.test.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/__tests__/swarm-runner.test.ts
@@ -15,6 +15,8 @@ const swarmPersonaNextTurnMock = vi.fn();
 const heartbeatJourneyRunMock = vi.fn();
 const runSyntheticHostSessionMock = vi.fn();
 
+const finalizePendingAttemptsMock = vi.fn();
+
 vi.mock("../../swarm-agent.js", async () => {
   const actual =
     await vi.importActual<typeof import("../../swarm-agent.js")>(
@@ -26,6 +28,8 @@ vi.mock("../../swarm-agent.js", async () => {
     swarmPersonaNextTurn: (...args: unknown[]) =>
       swarmPersonaNextTurnMock(...args),
     heartbeatJourneyRun: (...args: unknown[]) => heartbeatJourneyRunMock(...args),
+    finalizePendingAttempts: (...args: unknown[]) =>
+      finalizePendingAttemptsMock(...args),
   };
 });
 
@@ -42,6 +46,7 @@ vi.mock("../runner.js", async () => {
 import {
   startJourneyRun,
   shutdownRunningJourneyRuns,
+  MAX_CONCURRENT_HOSTS,
 } from "../swarm-runner.js";
 
 const HOST = {
@@ -54,11 +59,21 @@ const HOST = {
   serverIds: ["server-1"],
 };
 
+const HOST_2 = {
+  hostId: "host-2",
+  hostName: "Host Two",
+  hostConfigId: "hc-2",
+  modelId: "anthropic/claude-haiku-4.5",
+  systemPrompt: "sys",
+  requireToolApproval: false,
+  serverIds: ["server-2"],
+};
+
 function baseOpts(overrides: Record<string, unknown> = {}) {
   return {
     runId: "run-1",
     projectId: "proj-1",
-    host: HOST,
+    hosts: [HOST],
     personaSnapshot: {
       personaId: "p1",
       name: "Persona One",
@@ -85,6 +100,7 @@ beforeEach(() => {
   reportAttemptMock.mockReset().mockResolvedValue({ ok: true, applied: true });
   swarmPersonaNextTurnMock.mockReset();
   heartbeatJourneyRunMock.mockReset().mockResolvedValue(undefined);
+  finalizePendingAttemptsMock.mockReset().mockResolvedValue(undefined);
   runSyntheticHostSessionMock.mockReset().mockResolvedValue({
     outcome: "succeeded",
   });
@@ -233,7 +249,7 @@ describe("swarm single-host runner — outcome mapping + isolation", () => {
   });
 });
 
-describe("swarm single-host runner — shutdown unwinds via cancellable persona", () => {
+describe("swarm fan-out runner — shutdown unwinds via cancellable persona", () => {
   it("forwards the run signal into the persona call so a PARKED session unwinds and self-reports its terminal ONCE via the normal path (no eager runner_shutdown race)", async () => {
     // The persona driver models the previously-uncancellable park: it resolves
     // ONLY when its forwarded signal aborts (as `AbortSignal.any` → fetch abort
@@ -311,6 +327,161 @@ describe("swarm single-host runner — shutdown unwinds via cancellable persona"
     expect(terminals).toHaveLength(1);
     expect(terminals[0].status).toBe("succeeded");
     expect(terminals[0].chatSessionId).toBe("synth_run-1_host-1_0");
+  });
+});
+
+describe("swarm fan-out runner — worker pool + host isolation", () => {
+  const attemptAdapter = (call: unknown[]) => call[0] as any;
+  const executedForHost = (hostId: string) =>
+    runSyntheticHostSessionMock.mock.calls
+      .map(attemptAdapter)
+      .filter((a) => a.persist.hostId === hostId);
+  const terminals = () =>
+    reportAttemptMock.mock.calls
+      .map((c) => c[2] as any)
+      .filter((a) => a.status !== "running");
+
+  it("fans out sessionsPerHost sessions per host across a 2-host journey (2/host = 4)", async () => {
+    await startJourneyRun(
+      baseOpts({ hosts: [HOST, HOST_2], sessionsPerHost: 2 })
+    );
+
+    expect(runSyntheticHostSessionMock).toHaveBeenCalledTimes(4);
+    const sessionIds = runSyntheticHostSessionMock.mock.calls
+      .map((c) => (c[0] as any).chatSessionId)
+      .sort();
+    expect(sessionIds).toEqual([
+      "synth_run-1_host-1_0",
+      "synth_run-1_host-1_1",
+      "synth_run-1_host-2_0",
+      "synth_run-1_host-2_1",
+    ]);
+    // A fresh manager per attempt: managerFactory bound to each host.
+    expect(executedForHost("host-1")).toHaveLength(2);
+    expect(executedForHost("host-2")).toHaveLength(2);
+  });
+
+  it(`runs at most ${MAX_CONCURRENT_HOSTS} hosts concurrently (pool bound)`, async () => {
+    let active = 0;
+    let maxActive = 0;
+    runSyntheticHostSessionMock.mockImplementation(async () => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((r) => setTimeout(r, 5));
+      active--;
+      return { outcome: "succeeded" };
+    });
+    const hosts = Array.from({ length: 5 }, (_, i) => ({
+      ...HOST,
+      hostId: `host-${i}`,
+      serverIds: [`server-${i}`],
+    }));
+
+    await startJourneyRun(baseOpts({ hosts, sessionsPerHost: 1 }));
+
+    expect(runSyntheticHostSessionMock).toHaveBeenCalledTimes(5);
+    expect(maxActive).toBeLessThanOrEqual(MAX_CONCURRENT_HOSTS);
+    expect(maxActive).toBe(MAX_CONCURRENT_HOSTS);
+  });
+
+  it("keeps one active session per host (sessions run sequentially within a host)", async () => {
+    const activeByHost = new Map<string, number>();
+    let maxPerHost = 0;
+    runSyntheticHostSessionMock.mockImplementation(async (adapter: any) => {
+      const hostId = adapter.persist.hostId;
+      const n = (activeByHost.get(hostId) ?? 0) + 1;
+      activeByHost.set(hostId, n);
+      maxPerHost = Math.max(maxPerHost, n);
+      await new Promise((r) => setTimeout(r, 3));
+      activeByHost.set(hostId, n - 1);
+      return { outcome: "succeeded" };
+    });
+
+    await startJourneyRun(
+      baseOpts({ hosts: [HOST, HOST_2], sessionsPerHost: 3 })
+    );
+
+    expect(maxPerHost).toBe(1);
+    expect(runSyntheticHostSessionMock).toHaveBeenCalledTimes(6);
+  });
+
+  it("a forced failure on one host does not stop the other host", async () => {
+    runSyntheticHostSessionMock.mockImplementation(async (adapter: any) => {
+      if (adapter.persist.hostId === "host-1") {
+        return { outcome: "failed", errorMessage: "boom" };
+      }
+      return { outcome: "succeeded" };
+    });
+
+    await startJourneyRun(
+      baseOpts({ hosts: [HOST, HOST_2], sessionsPerHost: 2 })
+    );
+
+    // Every session on both hosts ran — a failure isolates to its attempt.
+    expect(executedForHost("host-1")).toHaveLength(2);
+    expect(executedForHost("host-2")).toHaveLength(2);
+    const host2 = terminals().filter((t) => t.hostId === "host-2");
+    expect(host2.map((t) => t.status)).toEqual(["succeeded", "succeeded"]);
+    const host1 = terminals().filter((t) => t.hostId === "host-1");
+    expect(host1.every((t) => t.status === "failed")).toBe(true);
+    // No run-level finalize on ordinary failures.
+    expect(finalizePendingAttemptsMock).not.toHaveBeenCalled();
+  });
+
+  it("a PROVIDER rate-limit stops that host's remaining sessions (rate_limited) but not other hosts", async () => {
+    runSyntheticHostSessionMock.mockImplementation(async (adapter: any) => {
+      if (adapter.chatSessionId === "synth_run-1_host-1_0") {
+        return {
+          outcome: "rate_limited",
+          errorMessage: "429 provider rate limit exceeded",
+        };
+      }
+      return { outcome: "succeeded" };
+    });
+
+    await startJourneyRun(
+      baseOpts({ hosts: [HOST, HOST_2], sessionsPerHost: 2 })
+    );
+
+    // host-1: only session 0 EXECUTED; session 1 short-circuited (never ran).
+    expect(executedForHost("host-1")).toHaveLength(1);
+    // host-2: both sessions still ran.
+    expect(executedForHost("host-2")).toHaveLength(2);
+    // host-1 sessions 0 AND 1 reach a rate_limited terminal (0 from its own
+    // outcome, 1 from the remaining-attempt sweep).
+    const host1RateLimited = reportAttemptMock.mock.calls
+      .map((c) => c[2] as any)
+      .filter((a) => a.hostId === "host-1" && a.status === "rate_limited")
+      .map((a) => a.sessionIdx)
+      .sort();
+    expect(host1RateLimited).toEqual([0, 1]);
+    // A provider rate-limit is per-host — no whole-run finalize.
+    expect(finalizePendingAttemptsMock).not.toHaveBeenCalled();
+  });
+
+  it("an ORG spend-cap stops the whole run and finalizes pending attempts", async () => {
+    runSyntheticHostSessionMock.mockImplementation(async (adapter: any) => {
+      if (adapter.chatSessionId === "synth_run-1_host-1_0") {
+        return {
+          outcome: "rate_limited",
+          errorMessage: "Org daily spend cap exceeded",
+        };
+      }
+      return { outcome: "succeeded" };
+    });
+
+    await startJourneyRun(
+      baseOpts({ hosts: [HOST, HOST_2], sessionsPerHost: 2 })
+    );
+
+    expect(finalizePendingAttemptsMock).toHaveBeenCalledTimes(1);
+    const finalizeArgs = finalizePendingAttemptsMock.mock.calls[0]![2] as any;
+    expect(finalizeArgs).toMatchObject({
+      projectId: "proj-1",
+      runId: "run-1",
+      terminalStatus: "rate_limited",
+      errorCode: "spend_cap_exceeded",
+    });
   });
 });
 

--- a/mcpjam-inspector/server/services/sessionSimulation/runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/runner.ts
@@ -996,9 +996,13 @@ export async function runSyntheticHostSession(
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     // Single source of truth for the spend-cap / rate-limit fold — shared with
-    // the per-runtime `classifyFailure` so the regex can't drift.
+    // the per-runtime `classifyFailure` so the regex can't drift. Return the
+    // message on the rate-limited branch too: the swarm fan-out runner inspects
+    // it to distinguish a provider 429 (stop THIS host) from an org spend-cap
+    // breach (stop the WHOLE run). The chatbox runner ignores it for
+    // rate-limited outcomes, so this is a safe additive change.
     if (classifyTurnFailure(message) === "rate_limited") {
-      return { outcome: "rate_limited" };
+      return { outcome: "rate_limited", errorMessage: message };
     }
     logger.warn("[sessionSimulation.runner] session failed", {
       runId,

--- a/mcpjam-inspector/server/services/sessionSimulation/swarm-runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/swarm-runner.ts
@@ -37,10 +37,12 @@ import {
  *   - An ORG SPEND-CAP breach (message looks like an org/spend cap) stops
  *     scheduling ALL hosts, cancels in-flight turns, and finalizes the run's
  *     remaining pending attempts (`errorCode: "spend_cap_exceeded"`).
- *   - Abort (shutdown / user cancel) stops new scheduling, cancels in-flight
- *     turns, and best-effort finalizes unfinished attempts
- *     (`errorCode: "runner_shutdown"`); the backend stale-run cron is the hard
- *     backstop.
+ *   - Abort (shutdown / user cancel) stops new scheduling and cancels in-flight
+ *     turns AND the (now-cancellable) persona driver, so every in-flight session
+ *     unwinds promptly and self-reports its own accurate terminal via the normal
+ *     path. The run-level `finalizeRun` best-effort finalizes only the remaining
+ *     never-claimed `pending` attempts (`errorCode: "runner_shutdown"`); the
+ *     backend stale-run cron is the hard backstop.
  */
 
 const HEARTBEAT_INTERVAL_MS = 30_000;
@@ -189,16 +191,21 @@ function terminalForOutcome(
 
 /**
  * Distinguish an ORG spend-cap breach from a PROVIDER rate-limit within the
- * shared core's `rate_limited` bucket (both fold there via `classifyTurnFailure`
- * `/rate.?limit|spend|cap/i`). A spend/cap/quota/budget message is the org cap
- * (WHOLE-RUN stop); anything else is a provider 429 (per-HOST stop). A missing
- * message defaults to the narrower per-host stop — never escalate to a
- * whole-run halt on ambiguous signal.
+ * shared core's `rate_limited` bucket (both fold there via `classifyTurnFailure`).
+ * A spend/cap/quota/budget message is the org cap (WHOLE-RUN stop); anything
+ * else (a provider 429 / rate limit) is a per-HOST stop. A missing message
+ * defaults to the narrower per-host stop — never escalate to a whole-run halt
+ * on ambiguous signal.
+ *
+ * `cap`/`quota`/`budget` are word-anchored so only genuine spend-cap wording
+ * matches: "spend cap exceeded" / "quota exceeded" / "budget exhausted" →
+ * org cap, but "capacity" / "rate capacity exceeded" / "recap" / "escape" →
+ * NOT a spend cap (they stay a per-host provider rate-limit).
  */
 function classifyRateLimit(
   message: string | undefined
 ): "org_spend_cap" | "provider_rate_limit" {
-  if (message && /spend|cap|quota|budget/i.test(message)) {
+  if (message && /spend|\bcap\b|\bquota\b|\bbudget\b/i.test(message)) {
     return "org_spend_cap";
   }
   return "provider_rate_limit";
@@ -285,13 +292,18 @@ async function runJourneyFanOut(
   const runHost = async (host: PinnedHostExecutionSpec): Promise<void> => {
     const hostId = host.hostId;
     const modelId = host.modelId;
+    // Hoisted so the worker-level catch below knows how far this host got and
+    // can finalize the attempts it left behind.
+    let sessionIdx = 0;
+    try {
     // Resolve the pinned host's modelId to a ModelDefinition once per host
     // (catalog hits pass through; BYOK shapes get a derived provider). NEVER
     // refetch the live host config — everything comes from the immutable
-    // snapshot.
+    // snapshot. A model-less / unresolvable pinned spec throws HERE, before any
+    // attempt is claimed — the catch finalizes this host's pending attempts.
     const modelDefinition = buildSyntheticModelDefinition(modelId);
 
-    for (let sessionIdx = 0; sessionIdx < sessionsPerHost; sessionIdx++) {
+    for (sessionIdx = 0; sessionIdx < sessionsPerHost; sessionIdx++) {
       // Run-level stop (spend cap or shutdown/cancel) halts THIS host too.
       if (stopScheduling()) return;
 
@@ -472,6 +484,33 @@ async function runJourneyFanOut(
         return;
       }
     }
+    } catch (err) {
+      // A worker-level throw (e.g. a model-less pinned spec whose modelId can't
+      // resolve) must NOT abort the pool or leave this host's attempts dangling.
+      // Finalize this host's not-yet-terminal attempts (`[sessionIdx..N)` — the
+      // in-flight claim, if any, plus every never-claimed pending) as `failed`
+      // and let the OTHER workers keep running (the pool continues; the run ends
+      // consistently). Best-effort; the stale-run cron backstops anything missed.
+      logEvent("host.worker_failed", { runId, hostId, sessionIdx });
+      logger.error(
+        "[swarm.runner] host worker failed; finalizing its attempts",
+        {
+          runId,
+          hostId,
+          sessionIdx,
+          error: err instanceof Error ? err.message : String(err),
+        }
+      );
+      // Finalize this host's not-yet-terminal attempts `[sessionIdx..N)`: the
+      // sweep re-claims the in-flight attempt (if the throw landed after a
+      // claim; an idempotent re-claim with the same chatSessionId) and every
+      // never-claimed pending, reporting each `failed`.
+      await markRemainingHostAttemptsFailed(
+        { convexHttpUrl, bearer, projectId, runId, hostId },
+        sessionIdx,
+        sessionsPerHost
+      );
+    }
   };
 
   try {
@@ -570,6 +609,63 @@ async function markRemainingHostAttemptsRateLimited(
     } catch (err) {
       logger.warn(
         "[swarm.runner] failed to mark remaining host attempt rate_limited",
+        {
+          runId,
+          hostId,
+          sessionIdx,
+          error: err instanceof Error ? err.message : String(err),
+        }
+      );
+    }
+  }
+}
+
+/**
+ * Mark a failed host-worker's not-yet-terminal attempts (`[fromIdx, toIdx)`)
+ * as `failed` (errorCode `host_worker_failed`). Sibling of
+ * {@link markRemainingHostAttemptsRateLimited}: walk the host's own attempts
+ * via the reportAttempt state machine (claim `running` + the deterministic
+ * chatSessionId, then report the terminal). Re-claiming an already-claimed
+ * `running` attempt with the SAME chatSessionId is idempotent; an already
+ * `succeeded`/`failed` attempt rejects the re-claim (terminal is immutable) and
+ * is skipped. Entirely best-effort — a failure is logged and the sweep
+ * continues; the backend stale-run cron backstops anything missed.
+ */
+async function markRemainingHostAttemptsFailed(
+  ctx: {
+    convexHttpUrl: string;
+    bearer: string;
+    projectId: string;
+    runId: string;
+    hostId: string;
+  },
+  fromIdx: number,
+  toIdx: number
+): Promise<void> {
+  const { convexHttpUrl, bearer, projectId, runId, hostId } = ctx;
+  for (let sessionIdx = fromIdx; sessionIdx < toIdx; sessionIdx++) {
+    const chatSessionId = `synth_${runId}_${hostId}_${sessionIdx}`;
+    try {
+      await reportAttempt(convexHttpUrl, bearer, {
+        projectId,
+        runId,
+        hostId,
+        sessionIdx,
+        status: "running",
+        chatSessionId,
+      });
+      await reportAttempt(convexHttpUrl, bearer, {
+        projectId,
+        runId,
+        hostId,
+        sessionIdx,
+        status: "failed",
+        chatSessionId,
+        errorCode: "host_worker_failed",
+      });
+    } catch (err) {
+      logger.warn(
+        "[swarm.runner] failed to mark remaining host attempt failed",
         {
           runId,
           hostId,

--- a/mcpjam-inspector/server/services/sessionSimulation/swarm-runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/swarm-runner.ts
@@ -5,6 +5,7 @@ import {
   type SimulationManagerFactory,
 } from "./runner.js";
 import {
+  finalizePendingAttempts,
   heartbeatJourneyRun,
   reportAttempt,
   swarmPersonaNextTurn,
@@ -14,29 +15,59 @@ import {
 } from "../swarm-agent.js";
 
 /**
- * Swarm (journey-execution) single-host runner — PR 3c.
+ * Swarm (journey-execution) multi-host fan-out runner — PR 3d.
  *
- * Executes `sessionsPerHost` synthetic persona-driven sessions against ONE
- * pinned host and reports each attempt through the backend runner-control API.
- * The per-session host-turn machinery is the shared {@link runSyntheticHostSession}
- * core (identical to chatbox session-simulation); this file owns the swarm
- * surface: the claim→run→persist→terminal attempt ordering, the swarm persona
- * driver, swarm transcript attribution, an independent heartbeat, and graceful
- * shutdown registration.
+ * Generalizes the PR-3c single-host runner to a bounded host-worker pool over
+ * `snapshot.hosts[]`. Each host runs its `sessionsPerHost` synthetic
+ * persona-driven sessions SEQUENTIALLY (one active session per host); at most
+ * {@link MAX_CONCURRENT_HOSTS} hosts are active concurrently. The per-session
+ * host-turn machinery is the shared {@link runSyntheticHostSession} core
+ * (identical to chatbox session-simulation); this file owns the swarm surface:
+ * the claim→run→persist→terminal attempt ordering, the swarm persona driver,
+ * swarm transcript attribution, an independent heartbeat, graceful shutdown
+ * registration, and the two run-level short-circuits below.
  *
- * Fan-out across multiple hosts is deliberately OUT OF SCOPE (PR 3d) — the
- * launch route caps the run to a single host via `maxHosts: 1`.
+ * Failure isolation + short-circuits:
+ *   - A normal session failure affects only that attempt; the host's other
+ *     sessions and every other host continue.
+ *   - A PROVIDER rate-limit (a 429 folded to `rate_limited`, message does NOT
+ *     look like an org/spend cap) stops scheduling further sessions FOR THAT
+ *     HOST and marks its remaining `pending` attempts `rate_limited`. Other
+ *     hosts continue.
+ *   - An ORG SPEND-CAP breach (message looks like an org/spend cap) stops
+ *     scheduling ALL hosts, cancels in-flight turns, and finalizes the run's
+ *     remaining pending attempts (`errorCode: "spend_cap_exceeded"`).
+ *   - Abort (shutdown / user cancel) stops new scheduling, cancels in-flight
+ *     turns, and best-effort finalizes unfinished attempts
+ *     (`errorCode: "runner_shutdown"`); the backend stale-run cron is the hard
+ *     backstop.
  */
 
 const HEARTBEAT_INTERVAL_MS = 30_000;
 const DEFAULT_SHUTDOWN_TIMEOUT_MS = 5_000;
 const MAX_ATTEMPT_ERROR_CHARS = 500;
+/** Bounded host-worker pool: at most this many hosts run concurrently. */
+export const MAX_CONCURRENT_HOSTS = 3;
+
+/**
+ * Builds a fresh, fully-connected manager scoped to one pinned host's
+ * `serverIds`. Host-aware (unlike the chatbox {@link SimulationManagerFactory})
+ * so a single fan-out run can connect different servers per host.
+ */
+export type JourneyManagerFactory = (
+  host: PinnedHostExecutionSpec
+) => Promise<{
+  manager: Awaited<ReturnType<SimulationManagerFactory>>["manager"];
+  connectedServerIds: string[];
+  connectedServerNames?: string[];
+  dispose: () => Promise<void>;
+}>;
 
 export interface StartJourneyRunOptions {
   runId: string;
   projectId: string;
-  /** The single pinned host this run executes against (`snapshot.hosts[0]`). */
-  host: PinnedHostExecutionSpec;
+  /** Every pinned host this run fans out across (`snapshot.hosts`). */
+  hosts: PinnedHostExecutionSpec[];
   personaSnapshot: PersonaSnapshot;
   sessionsPerHost: number;
   maxTurns: number;
@@ -45,9 +76,9 @@ export interface StartJourneyRunOptions {
   bearer: string;
   /** Full `Authorization` header (`Bearer …`) for the drain + transcript persist. */
   authHeader: string;
-  /** Builds a fresh connected manager scoped to the pinned `serverIds`. */
-  managerFactory: SimulationManagerFactory;
-  /** Aborts the run mid-batch on inspector shutdown. */
+  /** Builds a fresh connected manager scoped to one host's `serverIds`. */
+  managerFactory: JourneyManagerFactory;
+  /** Aborts the run mid-fan-out on inspector shutdown / user cancel. */
   abortSignal?: AbortSignal;
 }
 
@@ -65,8 +96,8 @@ export function getRunningJourneyRunCount(): number {
 
 /**
  * Graceful shutdown: abort every active journey run and await each loop's
- * `finally` (which stops the heartbeat and lets any in-flight session report a
- * terminal attempt) up to `timeoutMs`.
+ * `finally` (which stops the heartbeat, cancels in-flight turns, and
+ * best-effort finalizes remaining pending attempts) up to `timeoutMs`.
  */
 export async function shutdownRunningJourneyRuns(
   timeoutMs: number = DEFAULT_SHUTDOWN_TIMEOUT_MS
@@ -102,8 +133,8 @@ function composeAbortSignals(
 }
 
 /**
- * Register the run for graceful shutdown, execute the single-host loop, and
- * clear the registry on completion. Fire-and-forget from the route (via
+ * Register the run for graceful shutdown, execute the fan-out loop, and clear
+ * the registry on completion. Fire-and-forget from the route (via
  * `setImmediate`) — the HTTP 202 already returned.
  */
 export async function startJourneyRun(
@@ -120,7 +151,7 @@ export async function startJourneyRun(
     done,
   });
   try {
-    await runJourneySingleHost({ ...opts, abortSignal: composed });
+    await runJourneyFanOut({ ...opts, abortSignal: composed });
   } finally {
     runningJourneyRuns.delete(opts.runId);
     resolveDone();
@@ -156,13 +187,38 @@ function terminalForOutcome(
   };
 }
 
-async function runJourneySingleHost(
+/**
+ * Distinguish an ORG spend-cap breach from a PROVIDER rate-limit within the
+ * shared core's `rate_limited` bucket (both fold there via `classifyTurnFailure`
+ * `/rate.?limit|spend|cap/i`). A spend/cap/quota/budget message is the org cap
+ * (WHOLE-RUN stop); anything else is a provider 429 (per-HOST stop). A missing
+ * message defaults to the narrower per-host stop — never escalate to a
+ * whole-run halt on ambiguous signal.
+ */
+function classifyRateLimit(
+  message: string | undefined
+): "org_spend_cap" | "provider_rate_limit" {
+  if (message && /spend|cap|quota|budget/i.test(message)) {
+    return "org_spend_cap";
+  }
+  return "provider_rate_limit";
+}
+
+/** Concise structured log — ids + status only; NEVER prompts/transcripts/keys. */
+function logEvent(
+  event: string,
+  fields: Record<string, string | number | boolean | undefined>
+): void {
+  logger.info(`[swarm.runner] ${event}`, fields);
+}
+
+async function runJourneyFanOut(
   opts: StartJourneyRunOptions
 ): Promise<void> {
   const {
     runId,
     projectId,
-    host,
+    hosts,
     personaSnapshot,
     sessionsPerHost,
     maxTurns,
@@ -172,16 +228,22 @@ async function runJourneySingleHost(
     managerFactory,
     abortSignal,
   } = opts;
-  const hostId = host.hostId;
 
-  // Resolve the pinned host's modelId to a ModelDefinition (catalog hits pass
-  // through; BYOK shapes get a derived provider). NEVER refetch the live host
-  // config — everything comes from the immutable snapshot.
-  const modelDefinition = buildSyntheticModelDefinition(host.modelId);
+  const runStartedAt = Date.now();
+
+  // Run-level stop controller. Aborting it cancels every in-flight session's
+  // turns; composed with the incoming abort so a shutdown/cancel does the same.
+  const runStop = new AbortController();
+  const sessionSignal = composeAbortSignals(abortSignal, runStop.signal);
+  // Set on an org spend-cap breach — halts scheduling across ALL hosts.
+  let spendCapTripped = false;
+  let spendCapMessage: string | undefined;
+
+  const stopScheduling = () => spendCapTripped || abortSignal?.aborted === true;
 
   // Independent heartbeat: an interval timer (NOT gated on turn/attempt
   // completion) started before the first attempt and stopped in `finally`.
-  // Single-flight so a slow heartbeat can't stack.
+  // Single-flight so a slow heartbeat can't stack. One per run.
   let heartbeatInFlight = false;
   const heartbeat = setInterval(() => {
     if (abortSignal?.aborted) return;
@@ -199,20 +261,39 @@ async function runJourneySingleHost(
       });
   }, HEARTBEAT_INTERVAL_MS);
 
-  // On shutdown/abort the run's `abortSignal` is forwarded into BOTH the shared
-  // core's turn drain AND the persona driver (`swarmPersonaNextTurn`, below), so
-  // the one place a session could previously park uncancellably for up to 120s
-  // is now cancellable. A shutdown/cancel therefore unwinds every in-flight
-  // session promptly, and each reports its OWN accurate terminal via the normal
-  // path below (`failed` for an interrupted session, or its real outcome if it
-  // finished first) — with the transcript already persisted. There is no eager
-  // per-attempt abort report to race that normal terminal, so no session is
-  // misclassified on shutdown. The backend stale-run cron remains the hard
-  // backstop for anything that still can't unwind.
+  // On shutdown/abort (or a spend-cap short-circuit) the run's `sessionSignal`
+  // is forwarded into BOTH the shared core's turn drain AND the persona driver
+  // (`swarmPersonaNextTurn`, below), so the one place a session could previously
+  // park uncancellably for up to 120s is now cancellable. Every in-flight
+  // session therefore unwinds promptly and reports its OWN accurate terminal via
+  // the normal path below (`failed` for an interrupted session, or its real
+  // outcome if it finished first) — with the transcript already persisted. There
+  // is no eager per-attempt abort report to race that normal terminal, so no
+  // session is misclassified on shutdown. The run-level `finalizeRun` on abort
+  // still sweeps never-claimed `pending` attempts, and the backend stale-run
+  // cron remains the hard backstop for anything that still can't unwind.
 
-  try {
+  logEvent("run.start", {
+    runId,
+    hostCount: hosts.length,
+    sessionsPerHost,
+    maxTurns,
+    maxConcurrentHosts: Math.min(MAX_CONCURRENT_HOSTS, hosts.length),
+  });
+
+  // --- Run one host's sessions SEQUENTIALLY --------------------------------
+  const runHost = async (host: PinnedHostExecutionSpec): Promise<void> => {
+    const hostId = host.hostId;
+    const modelId = host.modelId;
+    // Resolve the pinned host's modelId to a ModelDefinition once per host
+    // (catalog hits pass through; BYOK shapes get a derived provider). NEVER
+    // refetch the live host config — everything comes from the immutable
+    // snapshot.
+    const modelDefinition = buildSyntheticModelDefinition(modelId);
+
     for (let sessionIdx = 0; sessionIdx < sessionsPerHost; sessionIdx++) {
-      if (abortSignal?.aborted) break;
+      // Run-level stop (spend cap or shutdown/cancel) halts THIS host too.
+      if (stopScheduling()) return;
 
       // Deterministic claim key — the immutable chatSessionId the attempt is
       // claimed with and every persist + terminal reuse.
@@ -259,12 +340,14 @@ async function runJourneySingleHost(
         continue;
       }
 
+      const attemptStartedAt = Date.now();
+      logEvent("attempt.start", { runId, hostId, sessionIdx, modelId });
+
       // Execute the session via the shared core. It owns manager lifecycle +
       // dispose, per-turn persona→drain→persist, browser/widget capture, and
       // failure classification, and NEVER throws (returns a SessionResult).
-      // Because it persists per-turn and returns only after the last persist
-      // (or the empty-session persist), the transcript is durable before we
-      // report the terminal below — the persist-before-terminal invariant.
+      // Because it persists per-turn and returns only after the last persist,
+      // the transcript is durable before we report the terminal below.
       const { outcome, errorMessage } = await runSyntheticHostSession({
         runId,
         projectId,
@@ -286,18 +369,23 @@ async function runJourneySingleHost(
           // version, no chatbox id.
         },
         authHeader,
-        managerFactory,
-        abortSignal,
+        // Each attempt gets a fresh manager + browser context, scoped to THIS
+        // host's pinned required servers.
+        managerFactory: () => managerFactory(host),
+        // Thread the run-level stop signal (composed with shutdown/cancel) so a
+        // spend-cap short-circuit cancels this host's in-flight turns.
+        abortSignal: sessionSignal,
         nextPersonaTurn: (transcriptSoFar) =>
           swarmPersonaNextTurn(convexHttpUrl, bearer, {
             projectId,
             runId,
             hostId,
             transcriptSoFar,
-            // Forward the run abort so a shutdown/cancel aborts a parked persona
-            // fetch immediately and the session unwinds (instead of lingering up
-            // to 120s in the persona call).
-            ...(abortSignal ? { signal: abortSignal } : {}),
+            // Forward the run-level stop (composed shutdown/cancel + spend-cap
+            // runStop) so a short-circuit aborts a parked persona fetch
+            // immediately and the session unwinds (instead of lingering up to
+            // 120s in the persona call).
+            signal: sessionSignal,
           }),
         persist: {
           sourceType: "swarm",
@@ -313,7 +401,7 @@ async function runJourneySingleHost(
 
       // Report the terminal with the SAME chatSessionId ONLY after the
       // transcript is persisted. Best-effort: a terminal write failure is
-      // logged and the batch continues with the remaining sessions.
+      // logged and the host loop continues.
       const terminal = terminalForOutcome(outcome, errorMessage);
       try {
         await reportAttempt(convexHttpUrl, bearer, {
@@ -329,6 +417,12 @@ async function runJourneySingleHost(
             : {}),
         });
       } catch (err) {
+        logEvent("attempt.report_failed", {
+          runId,
+          hostId,
+          sessionIdx,
+          status: terminal.status,
+        });
         logger.error("[swarm.runner] terminal attempt report failed", {
           runId,
           hostId,
@@ -337,16 +431,185 @@ async function runJourneySingleHost(
           error: err instanceof Error ? err.message : String(err),
         });
       }
+
+      logEvent("attempt.finish", {
+        runId,
+        hostId,
+        sessionIdx,
+        status: terminal.status,
+        durationMs: Date.now() - attemptStartedAt,
+        modelSource: modelId,
+      });
+
+      if (outcome === "rate_limited") {
+        const cause = classifyRateLimit(errorMessage);
+        if (cause === "org_spend_cap") {
+          // WHOLE-RUN stop: halt all hosts + cancel in-flight turns. The
+          // finalize sweep runs once the pool drains.
+          spendCapTripped = true;
+          spendCapMessage = errorMessage;
+          runStop.abort();
+          logEvent("run.spend_cap_short_circuit", {
+            runId,
+            hostId,
+            sessionIdx,
+          });
+          return;
+        }
+        // PROVIDER rate-limit: stop THIS host's remaining sessions and mark
+        // them rate_limited. Other hosts keep running.
+        logEvent("host.rate_limit_short_circuit", {
+          runId,
+          hostId,
+          fromSessionIdx: sessionIdx + 1,
+          remaining: sessionsPerHost - (sessionIdx + 1),
+        });
+        await markRemainingHostAttemptsRateLimited(
+          { convexHttpUrl, bearer, projectId, runId, hostId },
+          sessionIdx + 1,
+          sessionsPerHost
+        );
+        return;
+      }
+    }
+  };
+
+  try {
+    // Bounded worker pool: a shared host queue drained by ≤MAX_CONCURRENT_HOSTS
+    // workers. Each worker pulls the next host, runs it to completion (or its
+    // per-host short-circuit), then pulls the next — so no more than N hosts
+    // are ever active at once, and a slow host doesn't block others.
+    const hostQueue = [...hosts];
+    const workerCount = Math.min(MAX_CONCURRENT_HOSTS, hostQueue.length);
+    const worker = async (): Promise<void> => {
+      while (!stopScheduling()) {
+        const host = hostQueue.shift();
+        if (!host) return;
+        await runHost(host);
+      }
+    };
+    await Promise.all(
+      Array.from({ length: workerCount }, () => worker())
+    );
+
+    // Run-level finalize of any still-pending attempts.
+    if (spendCapTripped) {
+      await finalizeRun(
+        { convexHttpUrl, bearer, projectId, runId },
+        {
+          terminalStatus: "rate_limited",
+          errorCode: "spend_cap_exceeded",
+          errorMessage: spendCapMessage,
+        }
+      );
+    } else if (abortSignal?.aborted) {
+      await finalizeRun(
+        { convexHttpUrl, bearer, projectId, runId },
+        { errorCode: "runner_shutdown" }
+      );
     }
   } catch (error) {
-    // Defensive: the loop's per-session work is already guarded, so this only
-    // catches unexpected setup/heartbeat-adjacent failures.
+    // Defensive: per-host/per-session work is already guarded, so this only
+    // catches unexpected pool/heartbeat-adjacent failures.
     logger.error("[swarm.runner] journey run failed", {
       runId,
-      hostId,
       error: error instanceof Error ? error.message : String(error),
     });
   } finally {
     clearInterval(heartbeat);
+    logEvent("run.finish", {
+      runId,
+      hostCount: hosts.length,
+      durationMs: Date.now() - runStartedAt,
+      spendCapTripped,
+      aborted: abortSignal?.aborted === true,
+    });
+  }
+}
+
+/**
+ * Mark a rate-limited host's remaining `pending` attempts (`[fromIdx, toIdx)`)
+ * as `rate_limited`. The backend `finalize-pending` is whole-run scoped (no
+ * hostId), so we walk the host's own attempts via the reportAttempt state
+ * machine: claim (`running` + the deterministic chatSessionId) then report the
+ * terminal. Entirely best-effort — a failure here is logged and the sweep
+ * continues; the backend stale-run cron backstops anything missed.
+ */
+async function markRemainingHostAttemptsRateLimited(
+  ctx: {
+    convexHttpUrl: string;
+    bearer: string;
+    projectId: string;
+    runId: string;
+    hostId: string;
+  },
+  fromIdx: number,
+  toIdx: number
+): Promise<void> {
+  const { convexHttpUrl, bearer, projectId, runId, hostId } = ctx;
+  for (let sessionIdx = fromIdx; sessionIdx < toIdx; sessionIdx++) {
+    const chatSessionId = `synth_${runId}_${hostId}_${sessionIdx}`;
+    try {
+      await reportAttempt(convexHttpUrl, bearer, {
+        projectId,
+        runId,
+        hostId,
+        sessionIdx,
+        status: "running",
+        chatSessionId,
+      });
+      await reportAttempt(convexHttpUrl, bearer, {
+        projectId,
+        runId,
+        hostId,
+        sessionIdx,
+        status: "rate_limited",
+        chatSessionId,
+        errorCode: "rate_limited",
+      });
+    } catch (err) {
+      logger.warn(
+        "[swarm.runner] failed to mark remaining host attempt rate_limited",
+        {
+          runId,
+          hostId,
+          sessionIdx,
+          error: err instanceof Error ? err.message : String(err),
+        }
+      );
+    }
+  }
+}
+
+/** Best-effort whole-run finalize; logs and swallows any failure. */
+async function finalizeRun(
+  ctx: {
+    convexHttpUrl: string;
+    bearer: string;
+    projectId: string;
+    runId: string;
+  },
+  args: {
+    terminalStatus?: Exclude<SwarmAttemptStatus, "pending" | "running">;
+    errorCode?: string;
+    errorMessage?: string;
+  }
+): Promise<void> {
+  try {
+    await finalizePendingAttempts(ctx.convexHttpUrl, ctx.bearer, {
+      projectId: ctx.projectId,
+      runId: ctx.runId,
+      ...args,
+    });
+    logEvent("run.finalize_pending", {
+      runId: ctx.runId,
+      errorCode: args.errorCode,
+    });
+  } catch (err) {
+    logger.warn("[swarm.runner] finalize-pending failed", {
+      runId: ctx.runId,
+      errorCode: args.errorCode,
+      error: err instanceof Error ? err.message : String(err),
+    });
   }
 }

--- a/mcpjam-inspector/server/services/sessionSimulation/swarm-runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/swarm-runner.ts
@@ -414,7 +414,33 @@ async function runJourneyFanOut(
       // Report the terminal with the SAME chatSessionId ONLY after the
       // transcript is persisted. Best-effort: a terminal write failure is
       // logged and the host loop continues.
-      const terminal = terminalForOutcome(outcome, errorMessage);
+      //
+      // Spend-cap abort reclassification: when the org spend cap tripped on
+      // ANOTHER host, `runStop.abort()` cancels THIS host's in-flight turns and
+      // the shared core returns `outcome: "failed"` — an abort artifact, not a
+      // genuine session failure. Report those as the run-level terminal
+      // (`rate_limited` / `spend_cap_exceeded`) so a cap breach isn't miscounted
+      // as a generic `session_failed`. A session that genuinely SUCCEEDED, or
+      // failed for its OWN reason before the cap (i.e. it returned while the
+      // run-stop signal was NOT yet aborted), keeps its real outcome — we only
+      // reclassify a `failed` outcome whose turns were actually cancelled by the
+      // run-stop (`sessionSignal.aborted`).
+      const abortedBySpendCap =
+        spendCapTripped && outcome === "failed" && sessionSignal.aborted;
+      const terminal = abortedBySpendCap
+        ? {
+            status: "rate_limited" as SwarmAttemptStatus,
+            errorCode: "spend_cap_exceeded",
+            ...(spendCapMessage
+              ? {
+                  errorMessage: spendCapMessage.slice(
+                    0,
+                    MAX_ATTEMPT_ERROR_CHARS
+                  ),
+                }
+              : {}),
+          }
+        : terminalForOutcome(outcome, errorMessage);
       try {
         await reportAttempt(convexHttpUrl, bearer, {
           projectId,

--- a/mcpjam-inspector/server/services/swarm-agent.ts
+++ b/mcpjam-inspector/server/services/swarm-agent.ts
@@ -162,10 +162,13 @@ async function postJson<T>(
 }
 
 /**
- * Create a journey run and return the pinned execution snapshot. Pass
- * `maxHosts: 1` for the single-host slice — the backend rejects a journey with
- * more than one host transactionally BEFORE any run row is created (surfaced
- * here as a {@link SwarmAgentError} with a 4xx status).
+ * Create a journey run and return the pinned execution snapshot.
+ *
+ * `maxHosts` is an optional upper bound the backend enforces transactionally
+ * BEFORE any run row is created (a journey exceeding it is rejected — surfaced
+ * here as a {@link SwarmAgentError} with a 4xx status). The single-host slice
+ * (PR 3c) passed `maxHosts: 1`; the fan-out runner (PR 3d) omits it and lets
+ * the backend pin the journey's full host set.
  */
 export async function createJourneyRun(
   convexHttpUrl: string,
@@ -174,7 +177,7 @@ export async function createJourneyRun(
     projectId: string;
     journeyRefId: string;
     launchKey: string;
-    maxHosts: number;
+    maxHosts?: number;
   }
 ): Promise<CreateJourneyRunResult> {
   const data = await postJson<{
@@ -194,7 +197,7 @@ export async function createJourneyRun(
       projectId: args.projectId,
       journeyRefId: args.journeyRefId,
       launchKey: args.launchKey,
-      maxHosts: args.maxHosts,
+      ...(args.maxHosts !== undefined ? { maxHosts: args.maxHosts } : {}),
     },
     NON_LLM_TIMEOUT_MS
   );
@@ -303,6 +306,51 @@ export async function heartbeatJourneyRun(
   if (data.ok !== true) {
     throw new Error(
       `Invalid response from backend heartbeatJourneyRun: ${
+        data.error ?? "unknown error"
+      }`
+    );
+  }
+}
+
+/**
+ * Best-effort finalize of a run's still-`pending` attempts to a terminal state.
+ * WHOLE-RUN scoped (the backend body carries no `hostId`), used by the fan-out
+ * runner for the two run-level short-circuits:
+ *   - org spend-cap breach → `terminalStatus: "rate_limited"`,
+ *     `errorCode: "spend_cap_exceeded"`
+ *   - controlled shutdown / cancel → `errorCode: "runner_shutdown"`
+ *
+ * A provider rate-limit is per-HOST (it stops one host, not the run), so it does
+ * NOT use this — the runner marks that host's remaining attempts via
+ * {@link reportAttempt} instead. The backend stale-run cron is the hard backstop
+ * for anything this best-effort call misses.
+ */
+export async function finalizePendingAttempts(
+  convexHttpUrl: string,
+  bearer: string,
+  args: {
+    projectId: string;
+    runId: string;
+    terminalStatus?: Exclude<SwarmAttemptStatus, "pending" | "running">;
+    errorCode?: string;
+    errorMessage?: string;
+  }
+): Promise<void> {
+  const data = await postJson<{ ok?: boolean; error?: string }>(
+    `${convexHttpUrl}/journey-execution/runs/finalize-pending`,
+    bearer,
+    {
+      projectId: args.projectId,
+      runId: args.runId,
+      ...(args.terminalStatus ? { terminalStatus: args.terminalStatus } : {}),
+      ...(args.errorCode ? { errorCode: args.errorCode } : {}),
+      ...(args.errorMessage ? { errorMessage: args.errorMessage } : {}),
+    },
+    NON_LLM_TIMEOUT_MS
+  );
+  if (data.ok !== true) {
+    throw new Error(
+      `Invalid response from backend finalizePendingAttempts: ${
         data.error ?? "unknown error"
       }`
     );

--- a/mcpjam-inspector/server/utils/__tests__/resolve-turn-runtime.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/resolve-turn-runtime.test.ts
@@ -312,6 +312,25 @@ describe("classifyTurnFailure (exported single source of truth)", () => {
     expect(classifyTurnFailure("hard cap hit")).toBe("rate_limited");
   });
 
+  it("folds org spend-cap phrasings (quota / budget) into rate_limited", () => {
+    // An org spend-cap can surface as "quota"/"budget" wording; it must reach
+    // rate_limited so the swarm fan-out's whole-run stop can fire.
+    expect(classifyTurnFailure("Organization quota exceeded")).toBe(
+      "rate_limited",
+    );
+    expect(classifyTurnFailure("monthly budget exhausted")).toBe(
+      "rate_limited",
+    );
+  });
+
+  it("does NOT over-match 'capacity'/'recap'/'escape' as rate_limited", () => {
+    // `cap` is word-anchored — a provider capacity error is a hard failure.
+    expect(classifyTurnFailure("model capacity exceeded")).toBe("failed");
+    expect(classifyTurnFailure("rate capacity exceeded")).toBe("failed");
+    expect(classifyTurnFailure("here is a recap of the run")).toBe("failed");
+    expect(classifyTurnFailure("attempting to escape")).toBe("failed");
+  });
+
   it("maps everything else to failed", () => {
     expect(classifyTurnFailure("provider exploded")).toBe("failed");
     expect(classifyTurnFailure("")).toBe("failed");

--- a/mcpjam-inspector/server/utils/resolve-turn-runtime.ts
+++ b/mcpjam-inspector/server/utils/resolve-turn-runtime.ts
@@ -110,11 +110,21 @@ export interface ResolvedTurnRuntime {
  * the amber `rate_limited` outcome vs a hard `failed`. Both `runOneSession`'s
  * catch AND the per-runtime `classifyFailure` delegate here so the regex can't
  * drift between the two call sites.
+ *
+ * Matches provider rate-limits (`rate limit`, `429`-phrased) AND org spend-cap
+ * wording (`spend`, `cap`, `quota`, `budget`) — an org cap surfaced as
+ * "quota exceeded" / "budget exhausted" must land in `rate_limited` so the
+ * swarm fan-out's whole-run stop can fire on it (it re-inspects the message via
+ * `classifyRateLimit`). `cap`/`quota`/`budget` are word-anchored so genuine
+ * spend-cap wording matches but "capacity", "recap", "escape" do NOT
+ * (a provider capacity error is a hard `failed`, not a spend cap).
  */
 export function classifyTurnFailure(
   message: string,
 ): "rate_limited" | "failed" {
-  return /rate.?limit|spend|cap/i.test(message) ? "rate_limited" : "failed";
+  return /rate.?limit|spend|\bquota\b|\bbudget\b|\bcap\b/i.test(message)
+    ? "rate_limited"
+    : "failed";
 }
 
 const HOSTED_NOOP_FINALIZE = async (): Promise<void> => {


### PR DESCRIPTION
Stacked on **`swarm-redesign/3c-single-host`** (PR 3c, the single-host runner) — review/merge that first. Do not rebase.

## Part A — multi-host fan-out (server)

Generalizes the swarm runner from single-host to a **bounded host-worker pool** over `snapshot.hosts[]`.

**Worker-pool bounds**
- A shared host queue is drained by **≤3 workers** (`MAX_CONCURRENT_HOSTS = 3`) → at most 3 hosts active concurrently.
- **One active session per host**; a host's `sessionsPerHost` sessions run **sequentially** (`sessionIdx` 0..n-1).
- Each attempt gets a **fresh manager + browser context** — `managerFactory` is now host-aware (`(host) => …`), scoped to that host's pinned `serverIds`; the per-attempt `runSyntheticHostSession` core is unchanged and reused verbatim.
- One heartbeat per run (independent 30s single-flight), stopped in `finally`.

**Rate-limit-per-host vs spend-cap-whole-run** (the key distinction)

Both fold into the shared core's `rate_limited` bucket via `classifyTurnFailure` (`/rate.?limit|spend|cap/i`). To tell them apart the core now **returns the error message on the `rate_limited` branch** too (additive; the chatbox runner ignores it). The fan-out then classifies with `classifyRateLimit(message)`:
- **PROVIDER rate-limit** (message not spend/cap-shaped, e.g. a 429) → stop scheduling further sessions **for that host only**, mark its remaining `pending` attempts `rate_limited` (claim→report via `reportAttempt`, since the backend `finalize-pending` is whole-run scoped). **Other hosts continue.**
- **ORG spend-cap** (message matches `/spend|cap|quota|budget/i`) → **whole-run stop**: halt scheduling across all hosts, abort in-flight turns, and `finalizePendingAttempts({ terminalStatus: "rate_limited", errorCode: "spend_cap_exceeded" })`. Ambiguous/missing message defaults to the narrower per-host stop — never escalate on weak signal.

**Failure isolation / abort**
- A normal session failure isolates to its attempt; the host's other sessions and all other hosts continue.
- Shutdown/cancel threads the abort signal (cancels in-flight turns) and best-effort `finalizePendingAttempts({ errorCode: "runner_shutdown" })`; the backend stale-run cron is the hard backstop.
- Concise structured log events for run/attempt start+finish, rate-limit and spend-cap short-circuits, and report failures — ids/status/duration/modelSource only, **never** prompts, transcripts, keys, or headers.

The launch route drops `maxHosts: 1` and fans over the journey's full host set (a backend rejection — host-count ceiling, no hosts, duplicate launchKey — still surfaces as a 4xx). New `finalizePendingAttempts` client added to `swarm-agent.ts`.

## Part B — UI enablement (client)

- **"Run journey" enabled**: replaces the disabled direct `createJourneyRun` mutation with a POST to `POST /api/web/swarm/journeys/:journeyId/runs` (via `authFetch`) with body `{ projectId, launchKey }`. **One `crypto.randomUUID()` launch key per click**, reused if retried, **kept on a 4xx** so a corrected retry stays idempotent. Disabled only while a launch is in-flight; 4xx surfaced inline.
- **Paginated runs** via `usePaginatedQuery(journeyRuns:listJourneyRuns)` (numItems + cursor, "Load more"); status colored (completed / partial / failed / rate_limited / stale) with per-host `hostSummaries`.
- **Sessions by host** (`journeyRuns:listSessionsByJourneyRun`, paginated, host-filterable) with per-session readiness. Each session links into the **existing** session viewer — **reused `ShareUsageThreadDetail`** (and `SessionReadinessBadge`), no new viewer built.
- **Rollups**: persona track record (`personas:getPersonaTrackRecord`) + per-journey rollup (`journeys:getJourneyRollup`).
- **Contract module** `client/src/lib/swarm-api.ts` centralizes the REST call + Convex query names + DTOs (no scattered `as any` strings). Extracted a generic `client/src/lib/session-usage-filters.ts` rather than growing `chatbox-usage-filters`.
- Guest gate (#3128) untouched — members see the enabled surface.

## Reused vs built
- **Reused**: `runSyntheticHostSession` (per-attempt core), `ShareUsageThreadDetail` + `SessionReadinessBadge` (session viewer/readiness), `usePaginatedQuery`, `authFetch`, `buildChatboxSessionPath`/`routePaths.swarms`.
- **Built**: the host-worker pool + short-circuit logic, `finalizePendingAttempts` client, `swarm-api.ts`, `session-usage-filters.ts`, the sessions-by-host view.

## Tests
Fan-out: 2-host × `sessionsPerHost:2` → 4 sessions (2/host); pool bound (5 hosts → max 3 concurrent); one-active-session-per-host; forced failure on one host doesn't stop the other; provider rate-limit stops that host (remaining marked `rate_limited`) not others; org spend-cap stops the whole run (`finalize-pending` called). Route: omits `maxHosts`, fans all hosts, 4xx surfaces, no-hosts snapshot rejected. UI: `launchJourneyRun` POSTs with launch key + 4xx throws with status/message; Run-button click calls it with journeyId/projectId/launchKey; 4xx renders inline; guest gate still hides the surface (#3128 green).

`npm run typecheck:client` + `npm run build:client` clean; targeted vitest green (54 tests). `build:server` is not runnable in the worktree (`@mcpjam/sdk/dist` env gap) — verified via `tsc -p server/tsconfig.json` showing **no new errors in the swarm files** (66 pre-existing errors in unrelated evals-runner files) + CI.

## Backend contracts assumed (flagged — not verifiable from this repo)
Two-repo layout, so these string-keyed reads/writes are trusted from the plan and can't be run here:
- `POST /journey-execution/runs/finalize-pending` body `{ projectId, runId, terminalStatus?, errorCode?, errorMessage? }` (whole-run scoped — no per-host `hostId`).
- `journeyRuns:listSessionsByJourneyRun` invoked as `{ runId, paginationOpts }` returning page items with `_id` (the sharedChatThreads doc id `ShareUsageThreadDetail` opens), `hostId`, `personaLabel`, `status`, `messageCount`, `readiness`. If the arg name or the row `_id` semantics differ, the sessions view degrades gracefully but would need a one-line adjustment.
- `personas:getPersonaTrackRecord` / `journeys:getJourneyRollup` shapes per `swarm-api.ts` DTOs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes journey execution orchestration, org spend-cap shutdown, and synthetic session spend via idempotent launch; regressions could duplicate runs, mis-report terminals, or leave orphaned runs.
> 
> **Overview**
> **Multi-host swarm execution** replaces the single-host cap: the launch route drops `maxHosts: 1`, creates runs over the journey’s full pinned host set, and starts a **bounded fan-out runner** (≤3 concurrent hosts, sequential sessions per host, host-scoped `managerFactory`). Provider rate-limits stop only that host; org spend-cap messages stop the whole run via `finalizePendingAttempts`, with `classifyTurnFailure` / `classifyRateLimit` tightened so “capacity” is not mistaken for a cap. The shared session core now returns `errorMessage` on `rate_limited` outcomes for that split.
> 
> **Swarms UI** enables **Run journey** through `swarm-api.ts` (`POST …/runs` + centralized Convex query names/DTOs): idempotent `launchKey` (reused on any failed launch, cleared only on 2xx), paginated runs and per-run sessions with host filters, persona track record / journey rollup, reused `ShareUsageThreadDetail`, and `/swarms` deep links (`persona` + `run` + `host` + `session`) with one-time restore on load.
> 
> **Tests** cover fan-out pool behavior, launch route contracts, launch-key retry semantics, session query arg `journeyRunId`, and DTO shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b4d4a0eafe2804af89bde56bb0c5490e6d021d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables multi-host fan‑out for swarm runs and turns on the “Run journey” button. Hardens rate‑limit vs spend‑cap handling, makes launches fully idempotent, and adds deep links that reliably restore persona/run/session.

- **New Features**
  - Server: fan‑out across all pinned hosts with a bounded pool (≤3 concurrent), one active session per host, host‑aware `managerFactory`, one heartbeat per run, and concise logs. Provider rate‑limits stop only that host; org spend‑caps stop the whole run, cancel in‑flight turns, and finalize pending attempts.
  - Route: `POST /api/web/swarm/journeys/:journeyId/runs` fans all hosts (no `maxHosts`), rejects no‑host snapshots and duplicate `launchKey`s as 4xx, and starts the runner fire‑and‑forget.
  - UI: “Run journey” enabled via `launchJourneyRun` with a sticky `launchKey` reused after any unsuccessful response (4xx/5xx/network) and cleared only on a confirmed 2xx. Runs and per‑run sessions are paginated with a host filter, reuse the existing viewer/readiness badge (guarded to valid states), and support deep links that encode persona + run + session for reliable restore. Contracts centralized in `client/src/lib/swarm-api.ts` with generic filters in `client/src/lib/session-usage-filters.ts`.

- **Bug Fixes**
  - Classifiers: fold “quota”/“budget” into `rate_limited` and word‑anchor spend‑cap terms; `classifyRateLimit` escalates only on genuine spend‑cap wording (not “capacity”).
  - Spend‑cap aborts: in‑flight sessions aborted by an org cap are reported `rate_limited` with `spend_cap_exceeded` (not `failed`); shutdown finalizes claimed attempts; a host worker throw finalizes that host’s remaining attempts as `failed/host_worker_failed` without stopping others.
  - Contracts/UI: `journeyRuns:listSessionsByJourneyRun` called with `{ journeyRunId }`; session rows use the real DTO (`id`, `modelId`, `status`); persona track record and journey rollup DTOs aligned so counts render correctly; deep links now carry persona + run.

<sup>Written for commit 6b4d4a0eafe2804af89bde56bb0c5490e6d021d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

