### PR TITLE
fix(computers): guest sign-in affordance fires for anonymous actors (COMP-3)

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -888,10 +888,16 @@ export function CaniuseCapabilityRoute() {
 }
 
 export function ComputerRoute() {
-  const { convexProjectId, isAuthenticated } = useAppRouteContext();
+  const { convexProjectId, isAuthenticated, isGuestProjectActor } =
+    useAppRouteContext();
   const [previewedHostId] = usePreviewedHostId(convexProjectId);
   const navigate = useAppNavigate();
   const computersEnabled = useComputersEnabledState();
+
+  // A personal computer is account-scoped. Anonymous guests are provisioned
+  // Convex actors (`isAuthenticated === true`), so member-ness — not raw auth —
+  // is what gates the feature vs. the guest sign-in affordance.
+  const isSignedInMember = isAuthenticated && !isGuestProjectActor;
 
   // Only redirect on an explicit `false`. While PostHog hydrates the flag is
   // `undefined`; bouncing then would strand a flagged-in user who cold-loads
@@ -907,11 +913,11 @@ export function ComputerRoute() {
   const computerView = (
     <ComputerView
       projectId={convexProjectId}
-      isAuthenticated={isAuthenticated}
+      isSignedInMember={isSignedInMember}
     />
   );
 
-  if (!isAuthenticated) {
+  if (!isSignedInMember) {
     return computerView;
   }
 
@@ -3768,6 +3774,7 @@ export default function App() {
     hostsTabSelectedHostId,
     isAuthLoading,
     isAuthenticated,
+    isGuestProjectActor,
     isBillingContextPending,
     isLoadingRemoteProjects,
     areServersHydrated,

--- a/mcpjam-inspector/client/src/components/auth/GuestSignInMessage.tsx
+++ b/mcpjam-inspector/client/src/components/auth/GuestSignInMessage.tsx
@@ -1,7 +1,6 @@
 import { useAuth } from "@workos-inc/authkit-react";
-import { usePostHog } from "posthog-js/react";
 import { Button } from "@mcpjam/design-system/button";
-import { detectEnvironment, detectPlatform } from "@/lib/PosthogUtils";
+import { track } from "@/lib/analytics";
 
 /**
  * The one honest empty state for a guest who reaches a surface that only a
@@ -34,13 +33,12 @@ export function GuestSignInMessage({
   compact?: boolean;
 }) {
   const { signIn } = useAuth();
-  const posthog = usePostHog();
 
   const handleSignIn = () => {
-    posthog?.capture("login_button_clicked", {
+    // track() injects platform/environment/location (standardEventProps); the
+    // analytics ratchet forbids raw posthog.capture outside lib/analytics.ts.
+    track("login_button_clicked", {
       location: location ?? "guest_signin_message",
-      platform: detectPlatform(),
-      environment: detectEnvironment(),
     });
     signIn();
   };

--- a/mcpjam-inspector/client/src/components/auth/GuestSignInMessage.tsx
+++ b/mcpjam-inspector/client/src/components/auth/GuestSignInMessage.tsx
@@ -1,0 +1,64 @@
+import { useAuth } from "@workos-inc/authkit-react";
+import { usePostHog } from "posthog-js/react";
+import { Button } from "@mcpjam/design-system/button";
+import { detectEnvironment, detectPlatform } from "@/lib/PosthogUtils";
+
+/**
+ * The one honest empty state for a guest who reaches a surface that only a
+ * signed-in account can use — the personal cloud computer and the Claude Code
+ * harness that runs inside it.
+ *
+ * A guest actor's server-resolved runtime config OMITS `harness`/`computer`
+ * (the backend gates them behind account-scoped PHASE3 flags — see
+ * `mcpjam-backend convex/lib/executionAccess.ts` and this inspector's
+ * `server/utils/host-runtime-config.ts`). Without this affordance the guest
+ * either sees the control silently missing or hits an opaque runtime error.
+ * Instead we name the situation and offer the exact next step — WorkOS
+ * sign-in — wired to the same `useAuth().signIn` flow the header uses.
+ *
+ * Surface-agnostic: pass a `message` naming what THIS surface gates. Mirrors
+ * {@link ComputersUnavailableMessage}'s tone (state the fact, don't blame the
+ * user), but this is an AUTH state — sign-in fixes it — not the data-plane /
+ * operator state that component covers.
+ */
+export function GuestSignInMessage({
+  message = "Sign in to use this — it's off for guests.",
+  location,
+  compact = false,
+}: {
+  /** Honest one-liner naming what's gated. Defaults to the harness copy. */
+  message?: string;
+  /** PostHog `login_button_clicked` location tag for this surface. */
+  location?: string;
+  /** Inline (in-tab) layout instead of a full-height centered pane. */
+  compact?: boolean;
+}) {
+  const { signIn } = useAuth();
+  const posthog = usePostHog();
+
+  const handleSignIn = () => {
+    posthog?.capture("login_button_clicked", {
+      location: location ?? "guest_signin_message",
+      platform: detectPlatform(),
+      environment: detectEnvironment(),
+    });
+    signIn();
+  };
+
+  return (
+    <div
+      className={
+        compact
+          ? "flex flex-col items-start gap-3 rounded-md border border-dashed bg-muted/10 p-4 text-sm text-muted-foreground"
+          : "flex h-full flex-col items-center justify-center gap-3 rounded-md border border-dashed bg-muted/10 p-4 text-sm text-muted-foreground"
+      }
+    >
+      <span className={compact ? "max-w-md" : "max-w-md text-center"}>
+        {message}
+      </span>
+      <Button size="sm" onClick={handleSignIn}>
+        Sign in
+      </Button>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/auth/__tests__/GuestSignInMessage.test.tsx
+++ b/mcpjam-inspector/client/src/components/auth/__tests__/GuestSignInMessage.test.tsx
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+const signInMock = vi.fn();
+const captureMock = vi.fn();
+
+vi.mock("@workos-inc/authkit-react", () => ({
+  useAuth: () => ({ signIn: signInMock }),
+}));
+
+vi.mock("posthog-js/react", () => ({
+  usePostHog: () => ({ capture: captureMock }),
+}));
+
+import { GuestSignInMessage } from "../GuestSignInMessage";
+
+describe("GuestSignInMessage", () => {
+  beforeEach(() => {
+    signInMock.mockReset();
+    captureMock.mockReset();
+  });
+
+  it("renders the honest one-liner and an actionable Sign in button", () => {
+    render(<GuestSignInMessage message="Sign in to use the harness." />);
+    expect(screen.getByText(/Sign in to use the harness\./)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Sign in/i })
+    ).toBeInTheDocument();
+  });
+
+  it("triggers the WorkOS sign-in flow on click (not a silent/dead-end state)", () => {
+    render(<GuestSignInMessage location="computer_view" />);
+    screen.getByRole("button", { name: /Sign in/i }).click();
+    expect(signInMock).toHaveBeenCalledTimes(1);
+    // Analytics tag carries the surface so we can see where guests convert.
+    expect(captureMock).toHaveBeenCalledWith(
+      "login_button_clicked",
+      expect.objectContaining({ location: "computer_view" })
+    );
+  });
+
+  it("falls back to the default location tag when none is passed", () => {
+    render(<GuestSignInMessage />);
+    screen.getByRole("button", { name: /Sign in/i }).click();
+    expect(captureMock).toHaveBeenCalledWith(
+      "login_button_clicked",
+      expect.objectContaining({ location: "guest_signin_message" })
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/components/auth/__tests__/GuestSignInMessage.test.tsx
+++ b/mcpjam-inspector/client/src/components/auth/__tests__/GuestSignInMessage.test.tsx
@@ -2,22 +2,22 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 
 const signInMock = vi.fn();
-const captureMock = vi.fn();
 
 vi.mock("@workos-inc/authkit-react", () => ({
   useAuth: () => ({ signIn: signInMock }),
 }));
 
-vi.mock("posthog-js/react", () => ({
-  usePostHog: () => ({ capture: captureMock }),
-}));
+// Analytics goes through lib/analytics.ts#track (the ratchet forbids raw
+// posthog.capture in components); mock it to assert the surface tag.
+vi.mock("@/lib/analytics", () => ({ track: vi.fn() }));
 
+import { track } from "@/lib/analytics";
 import { GuestSignInMessage } from "../GuestSignInMessage";
 
 describe("GuestSignInMessage", () => {
   beforeEach(() => {
     signInMock.mockReset();
-    captureMock.mockReset();
+    vi.mocked(track).mockReset();
   });
 
   it("renders the honest one-liner and an actionable Sign in button", () => {
@@ -33,7 +33,7 @@ describe("GuestSignInMessage", () => {
     screen.getByRole("button", { name: /Sign in/i }).click();
     expect(signInMock).toHaveBeenCalledTimes(1);
     // Analytics tag carries the surface so we can see where guests convert.
-    expect(captureMock).toHaveBeenCalledWith(
+    expect(track).toHaveBeenCalledWith(
       "login_button_clicked",
       expect.objectContaining({ location: "computer_view" })
     );
@@ -42,7 +42,7 @@ describe("GuestSignInMessage", () => {
   it("falls back to the default location tag when none is passed", () => {
     render(<GuestSignInMessage />);
     screen.getByRole("button", { name: /Sign in/i }).click();
-    expect(captureMock).toHaveBeenCalledWith(
+    expect(track).toHaveBeenCalledWith(
       "login_button_clicked",
       expect.objectContaining({ location: "guest_signin_message" })
     );

--- a/mcpjam-inspector/client/src/components/computer/ComputerView.tsx
+++ b/mcpjam-inspector/client/src/components/computer/ComputerView.tsx
@@ -51,12 +51,19 @@ import { GuestSignInMessage } from "@/components/auth/GuestSignInMessage";
  */
 export function ComputerView({
   projectId,
-  isAuthenticated,
+  isSignedInMember,
 }: {
   projectId: string | null;
-  isAuthenticated: boolean;
+  /**
+   * True only for a signed-in member — NOT merely "has a Convex identity".
+   * Anonymous guests are `useConvexAuth().isAuthenticated === true` (they're
+   * provisioned as anonymous actors), so gating the personal computer on raw
+   * auth would let guests through; the caller must pass member-ness
+   * (`!currentUser.isAnonymous`) so the guest sign-in affordance below fires.
+   */
+  isSignedInMember: boolean;
 }) {
-  const effectiveProjectId = isAuthenticated ? projectId : null;
+  const effectiveProjectId = isSignedInMember ? projectId : null;
   const status = useComputerStatus(effectiveProjectId);
   const reserve = useReserveComputer();
   const deleteComputer = useDeleteComputer();
@@ -369,11 +376,11 @@ export function ComputerView({
     },
   });
 
-  if (!isAuthenticated) {
-    // Guest actor: the personal computer (and the Claude Code harness that
-    // runs inside it) is account-scoped, so the backend omits it from a
-    // guest's runtime config. Offer the honest next step with a working
-    // sign-in button instead of a dead-end line of copy.
+  if (!isSignedInMember) {
+    // Guest actor (anonymous or not signed in): the personal computer (and the
+    // Claude Code harness that runs inside it) is account-scoped, so the
+    // backend omits it from a guest's runtime config. Offer the honest next
+    // step with a working sign-in button instead of a dead-end line of copy.
     return (
       <div className="flex h-full items-center justify-center p-6">
         <GuestSignInMessage

--- a/mcpjam-inspector/client/src/components/computer/ComputerView.tsx
+++ b/mcpjam-inspector/client/src/components/computer/ComputerView.tsx
@@ -42,6 +42,7 @@ import { ComputerStatusChip } from "./ComputerStatusChip";
 import { ComputerTerminal } from "./ComputerTerminal";
 import { ComputersUnavailableMessage } from "./ComputersUnavailableMessage";
 import { PaneMessage } from "./PaneMessage";
+import { GuestSignInMessage } from "@/components/auth/GuestSignInMessage";
 
 /**
  * The "Computer" tab — manage the project's personal cloud computer (one per
@@ -369,7 +370,19 @@ export function ComputerView({
   });
 
   if (!isAuthenticated) {
-    return <Empty>Sign in to use a personal computer for this project.</Empty>;
+    // Guest actor: the personal computer (and the Claude Code harness that
+    // runs inside it) is account-scoped, so the backend omits it from a
+    // guest's runtime config. Offer the honest next step with a working
+    // sign-in button instead of a dead-end line of copy.
+    return (
+      <div className="flex h-full items-center justify-center p-6">
+        <GuestSignInMessage
+          compact
+          location="computer_view"
+          message="Sign in to use a personal computer for this project — it runs on a per-account cloud workstation, so it's off for guests."
+        />
+      </div>
+    );
   }
   if (!projectId) {
     return (

--- a/mcpjam-inspector/client/src/components/computer/__tests__/ComputerView.agent.test.tsx
+++ b/mcpjam-inspector/client/src/components/computer/__tests__/ComputerView.agent.test.tsx
@@ -8,8 +8,8 @@
  * - start reserves through the same path and honors the daily cap: a cap
  *   rejection comes back as execution_failed naming the cap, NEVER a bypass;
  * - hibernate/reset/delete map to their hooks;
- * - unavailable (no data plane, or signed out) → unsupported_in_mode with the
- *   action hook never called;
+ * - unavailable (no data plane, or a non-member actor) → unsupported_in_mode
+ *   with the action hook never called;
  * - the snapshot reports redacted status and never a terminal token.
  */
 import { act, render } from "@testing-library/react";
@@ -50,6 +50,16 @@ vi.mock("@/hooks/useComputerEnvironments", () => ({
   useResetComputer: () => resetComputer,
 }));
 
+// The non-member state renders <GuestSignInMessage>, which reads the WorkOS +
+// PostHog hooks. Stub both so it mounts without an AuthKitProvider / PostHog
+// provider.
+vi.mock("@workos-inc/authkit-react", () => ({
+  useAuth: () => ({ signIn: vi.fn() }),
+}));
+vi.mock("posthog-js/react", () => ({
+  usePostHog: () => ({ capture: vi.fn() }),
+}));
+
 vi.mock("../EnvironmentsDrawer", () => ({
   EnvironmentsDrawer: ({ open }: { open: boolean }) =>
     open ? <div data-testid="env-drawer" /> : null,
@@ -84,13 +94,13 @@ async function dispatch(command: Omit<InspectorCommand, "id">) {
 }
 
 function renderComputer(props?: {
-  isAuthenticated?: boolean;
+  isSignedInMember?: boolean;
   projectId?: string | null;
 }) {
   render(
     <ComputerView
       projectId={props?.projectId ?? "proj-1"}
-      isAuthenticated={props?.isAuthenticated ?? true}
+      isSignedInMember={props?.isSignedInMember ?? true}
     />,
   );
 }
@@ -165,8 +175,10 @@ describe("ComputerView — agent bridge handlers", () => {
     expect(deleteComputer).toHaveBeenCalledWith({ projectId: "proj-1" });
   });
 
-  it("refuses every command as unsupported_in_mode when signed out (hooks never called)", async () => {
-    renderComputer({ isAuthenticated: false });
+  it("refuses every command as unsupported_in_mode for a non-member (hooks never called)", async () => {
+    // Guests (anonymous actors) and signed-out visitors alike: the bridge still
+    // registers, but every handler refuses because there's no member project.
+    renderComputer({ isSignedInMember: false });
     for (const type of [
       "startComputer",
       "hibernateComputer",

--- a/mcpjam-inspector/client/src/components/computer/__tests__/ComputerView.test.tsx
+++ b/mcpjam-inspector/client/src/components/computer/__tests__/ComputerView.test.tsx
@@ -99,7 +99,7 @@ mockDataPlane = { localConfigured: true, remoteDataPlaneUrl: null };
 describe("ComputerView", () => {
   it("prompts to sign in when unauthenticated with an actionable Sign in button", () => {
     const { getByText, getByRole } = render(
-      <ComputerView projectId="p1" isAuthenticated={false} />
+      <ComputerView projectId="p1" isSignedInMember={false} />
     );
     // Honest one-liner naming why it's off for guests...
     expect(getByText(/Sign in to use a personal computer/i)).toBeTruthy();
@@ -111,7 +111,7 @@ describe("ComputerView", () => {
 
   it("asks for a synced project when there is no projectId", () => {
     const { getByText } = render(
-      <ComputerView projectId={null} isAuthenticated />
+      <ComputerView projectId={null} isSignedInMember />
     );
     expect(getByText(/need a synced project/i)).toBeTruthy();
   });
@@ -131,7 +131,7 @@ describe("ComputerView", () => {
   it("opening the terminal reserves the computer", async () => {
     mockStatus = null; // no computer yet
     const { getByText } = render(
-      <ComputerView projectId="p1" isAuthenticated />
+      <ComputerView projectId="p1" isSignedInMember />
     );
     fireEvent.click(getByText("Open terminal"));
     await waitFor(() =>
@@ -146,7 +146,7 @@ describe("ComputerView", () => {
       provider: "e2b",
     };
     const { getByText, getByTestId, queryByTestId } = render(
-      <ComputerView projectId="p1" isAuthenticated />
+      <ComputerView projectId="p1" isSignedInMember />
     );
     expect(queryByTestId("terminal-stub")).toBeNull();
     fireEvent.click(getByText("Open terminal"));
@@ -159,7 +159,7 @@ describe("ComputerView", () => {
   it("delete requires confirmation then calls deleteComputer", async () => {
     mockStatus = { computerId: "c1", status: "ready", provider: "e2b" };
     const { getByText } = render(
-      <ComputerView projectId="p1" isAuthenticated />
+      <ComputerView projectId="p1" isSignedInMember />
     );
     fireEvent.click(getByText("Delete"));
     expect(getByText(/Delete this computer\? All files on it will be deleted/i)).toBeTruthy();
@@ -195,7 +195,7 @@ describe("ComputerView", () => {
   it("does not offer Delete once the computer is deleted", () => {
     mockStatus = { computerId: "c1", status: "deleted", provider: "e2b" };
     const { queryByText } = render(
-      <ComputerView projectId="p1" isAuthenticated />
+      <ComputerView projectId="p1" isSignedInMember />
     );
     expect(queryByText("Delete")).toBeNull();
   });
@@ -203,7 +203,7 @@ describe("ComputerView", () => {
   it("shows a retry/close pane (not a stuck spinner) when the computer errors with the terminal open", () => {
     mockStatus = { computerId: "c1", status: "ready", provider: "e2b" };
     const { getByText, queryByText, queryByTestId, rerender } = render(
-      <ComputerView projectId="p1" isAuthenticated />
+      <ComputerView projectId="p1" isSignedInMember />
     );
     fireEvent.click(getByText("Open terminal"));
     expect(queryByTestId("terminal-stub")).toBeTruthy();
@@ -214,7 +214,7 @@ describe("ComputerView", () => {
       provider: "e2b",
       lastError: "kaboom",
     };
-    rerender(<ComputerView projectId="p1" isAuthenticated />);
+    rerender(<ComputerView projectId="p1" isSignedInMember />);
 
     expect(queryByTestId("terminal-stub")).toBeNull();
     expect(queryByText(/Starting your computer/i)).toBeNull();
@@ -226,7 +226,7 @@ describe("ComputerView", () => {
     mockDataPlane = { localConfigured: false, remoteDataPlaneUrl: null };
     mockStatus = { computerId: "c1", status: "ready", provider: "e2b" };
     const { getByText, queryByText } = render(
-      <ComputerView projectId="p1" isAuthenticated />
+      <ComputerView projectId="p1" isSignedInMember />
     );
     expect(getByText(/Computers aren't available here/i)).toBeTruthy();
     expect(queryByText("Open terminal")).toBeNull();
@@ -242,7 +242,7 @@ describe("ComputerView", () => {
     };
     mockStatus = { computerId: "c1", status: "ready", provider: "e2b" };
     const { getByText, getByTestId } = render(
-      <ComputerView projectId="p1" isAuthenticated />
+      <ComputerView projectId="p1" isSignedInMember />
     );
     fireEvent.click(getByText("Open terminal"));
     expect(getByTestId("terminal-stub").getAttribute("data-base-url")).toBe(
@@ -254,7 +254,7 @@ describe("ComputerView", () => {
     mockDataPlane = undefined; // /config still in flight
     mockStatus = { computerId: "c1", status: "ready", provider: "e2b" };
     const { getByText, queryByTestId, getByTestId, rerender } = render(
-      <ComputerView projectId="p1" isAuthenticated />
+      <ComputerView projectId="p1" isSignedInMember />
     );
     fireEvent.click(getByText("Open terminal"));
     // Mounting now would dial the page origin and never re-dial once the
@@ -265,7 +265,7 @@ describe("ComputerView", () => {
       localConfigured: false,
       remoteDataPlaneUrl: "https://dp.example.test",
     };
-    rerender(<ComputerView projectId="p1" isAuthenticated />);
+    rerender(<ComputerView projectId="p1" isSignedInMember />);
     expect(getByTestId("terminal-stub").getAttribute("data-base-url")).toBe(
       "wss://dp.example.test"
     );
@@ -279,7 +279,7 @@ describe("ComputerView", () => {
     };
     mockStatus = { computerId: "c1", status: "ready", provider: "e2b" };
     const { getByText, getByTestId } = render(
-      <ComputerView projectId="p1" isAuthenticated />
+      <ComputerView projectId="p1" isSignedInMember />
     );
     fireEvent.click(getByText("Open terminal"));
     expect(getByTestId("terminal-stub").getAttribute("data-base-url")).toBe("");
@@ -288,13 +288,13 @@ describe("ComputerView", () => {
   it("shows a 'no longer available' pane when the computer disappears with the terminal open", () => {
     mockStatus = { computerId: "c1", status: "ready", provider: "e2b" };
     const { getByText, queryByText, queryByTestId, rerender } = render(
-      <ComputerView projectId="p1" isAuthenticated />
+      <ComputerView projectId="p1" isSignedInMember />
     );
     fireEvent.click(getByText("Open terminal"));
     expect(queryByTestId("terminal-stub")).toBeTruthy();
 
     mockStatus = null; // removed out from under us (e.g. membership revoked)
-    rerender(<ComputerView projectId="p1" isAuthenticated />);
+    rerender(<ComputerView projectId="p1" isSignedInMember />);
 
     expect(queryByTestId("terminal-stub")).toBeNull();
     expect(queryByText(/Starting your computer/i)).toBeNull();
@@ -306,7 +306,7 @@ describe("ComputerView image strip", () => {
   it("shows the base image when no environment is attached", () => {
     mockStatus = { computerId: "c1", status: "ready", provider: "e2b" };
     const { getByText } = render(
-      <ComputerView projectId="p1" isAuthenticated />
+      <ComputerView projectId="p1" isSignedInMember />
     );
     expect(getByText("Base image")).toBeTruthy();
   });
@@ -320,7 +320,7 @@ describe("ComputerView image strip", () => {
     };
     mockEnvironments = []; // still loading / not visible to this caller
     const { getByText, queryByText } = render(
-      <ComputerView projectId="p1" isAuthenticated />
+      <ComputerView projectId="p1" isSignedInMember />
     );
     expect(getByText("Custom image")).toBeTruthy();
     expect(queryByText("Base image")).toBeNull();
@@ -335,7 +335,7 @@ describe("ComputerView image strip", () => {
     };
     mockEnvironments = [{ environmentId: "env1", name: "ml-toolkit" }];
     const { getByText } = render(
-      <ComputerView projectId="p1" isAuthenticated />
+      <ComputerView projectId="p1" isSignedInMember />
     );
     expect(getByText("ml-toolkit")).toBeTruthy();
   });
@@ -343,7 +343,7 @@ describe("ComputerView image strip", () => {
   it("Change opens the environments drawer", () => {
     mockStatus = { computerId: "c1", status: "ready", provider: "e2b" };
     const { getByText, queryByTestId, getByTestId } = render(
-      <ComputerView projectId="p1" isAuthenticated />
+      <ComputerView projectId="p1" isSignedInMember />
     );
     expect(queryByTestId("env-drawer")).toBeNull();
     fireEvent.click(getByText("Change"));
@@ -353,7 +353,7 @@ describe("ComputerView image strip", () => {
   it("Reset confirms then resets the computer to its image", async () => {
     mockStatus = { computerId: "c1", status: "ready", provider: "e2b" };
     const { getByText } = render(
-      <ComputerView projectId="p1" isAuthenticated />
+      <ComputerView projectId="p1" isSignedInMember />
     );
     fireEvent.click(getByText("Reset"));
     expect(
@@ -368,7 +368,7 @@ describe("ComputerView image strip", () => {
   it("disables Reset while the computer is mid-provision", () => {
     mockStatus = { computerId: "c1", status: "provisioning", provider: "e2b" };
     const { getByText } = render(
-      <ComputerView projectId="p1" isAuthenticated />
+      <ComputerView projectId="p1" isSignedInMember />
     );
     expect(
       (getByText("Reset", { selector: "button" }) as HTMLButtonElement).disabled
@@ -380,7 +380,7 @@ describe("ComputerView usage meter", () => {
   it("shows awake time against the free allowance with the posted rate", () => {
     mockUsage = usage({ awakeMs: 4.2 * HOUR_MS });
     const { getByTestId, getByText } = render(
-      <ComputerView projectId="p1" isAuthenticated />
+      <ComputerView projectId="p1" isSignedInMember />
     );
     expect(getByTestId("computer-usage-meter")).toBeTruthy();
     expect(getByText("4.2 h")).toBeTruthy();
@@ -392,7 +392,7 @@ describe("ComputerView usage meter", () => {
   it("reads sub-hour usage in minutes", () => {
     mockUsage = usage({ awakeMs: 12 * 60 * 1000 });
     const { getByText } = render(
-      <ComputerView projectId="p1" isAuthenticated />
+      <ComputerView projectId="p1" isSignedInMember />
     );
     expect(getByText("12 min")).toBeTruthy();
   });
@@ -404,7 +404,7 @@ describe("ComputerView usage meter", () => {
       billedCredits: 10,
     });
     const { getByText, queryByText } = render(
-      <ComputerView projectId="p1" isAuthenticated />
+      <ComputerView projectId="p1" isSignedInMember />
     );
     expect(getByText("10 credits")).toBeTruthy();
     expect(queryByText(/^then /)).toBeNull();
@@ -413,7 +413,7 @@ describe("ComputerView usage meter", () => {
   it("shows a full over-limit bar for zero-allowance plans with usage", () => {
     mockUsage = usage({ allowanceMs: 0, awakeMs: 10 * 60 * 1000 });
     const { getByTestId } = render(
-      <ComputerView projectId="p1" isAuthenticated />
+      <ComputerView projectId="p1" isSignedInMember />
     );
     const fill = getByTestId("computer-usage-meter-fill");
     expect(fill.style.width).toBe("100%");
@@ -423,7 +423,7 @@ describe("ComputerView usage meter", () => {
   it("says hours are included when the plan is uncapped", () => {
     mockUsage = usage({ allowanceMs: null, awakeMs: 2 * HOUR_MS });
     const { getByText, queryByText } = render(
-      <ComputerView projectId="p1" isAuthenticated />
+      <ComputerView projectId="p1" isSignedInMember />
     );
     expect(getByText(/included with your plan/i)).toBeTruthy();
     expect(queryByText(/credits\/hour/i)).toBeNull();
@@ -431,12 +431,12 @@ describe("ComputerView usage meter", () => {
 
   it("hides the meter when the backend is not metering or has no answer", () => {
     mockUsage = usage({ mode: "off" });
-    const first = render(<ComputerView projectId="p1" isAuthenticated />);
+    const first = render(<ComputerView projectId="p1" isSignedInMember />);
     expect(first.queryByTestId("computer-usage-meter")).toBeNull();
     first.unmount();
 
     mockUsage = null;
-    const second = render(<ComputerView projectId="p1" isAuthenticated />);
+    const second = render(<ComputerView projectId="p1" isSignedInMember />);
     expect(second.queryByTestId("computer-usage-meter")).toBeNull();
   });
 });

--- a/mcpjam-inspector/client/src/components/computer/__tests__/ComputerView.test.tsx
+++ b/mcpjam-inspector/client/src/components/computer/__tests__/ComputerView.test.tsx
@@ -119,7 +119,7 @@ describe("ComputerView", () => {
   it("always shows the honest no-backup durability note", () => {
     mockStatus = { computerId: "c1", status: "ready", provider: "e2b" };
     const { getByText } = render(
-      <ComputerView projectId="p1" isAuthenticated />
+      <ComputerView projectId="p1" isSignedInMember />
     );
     expect(
       getByText(
@@ -173,7 +173,7 @@ describe("ComputerView", () => {
   it("hibernate requires confirmation then calls hibernateComputer", async () => {
     mockStatus = { computerId: "c1", status: "ready", provider: "e2b" };
     const { getByText } = render(
-      <ComputerView projectId="p1" isAuthenticated />
+      <ComputerView projectId="p1" isSignedInMember />
     );
     fireEvent.click(getByText("Hibernate now"));
     expect(getByText("Hibernate now?")).toBeTruthy();
@@ -187,7 +187,7 @@ describe("ComputerView", () => {
   it("does not offer Hibernate unless the computer is ready", () => {
     mockStatus = { computerId: "c1", status: "hibernating", provider: "e2b" };
     const { queryByText } = render(
-      <ComputerView projectId="p1" isAuthenticated />
+      <ComputerView projectId="p1" isSignedInMember />
     );
     expect(queryByText("Hibernate now")).toBeNull();
   });
@@ -446,7 +446,7 @@ describe("ComputerView billing-pause warning banner (COMP-7)", () => {
     mockStatus = { computerId: "c1", status: "ready", provider: "e2b" };
     mockUsage = usage({ awakeMs: 24 * HOUR_MS, billingPauseWarning: true });
     const { getByTestId, getByText } = render(
-      <ComputerView projectId="p1" isAuthenticated />
+      <ComputerView projectId="p1" isSignedInMember />
     );
     expect(getByTestId("computer-billing-warning")).toBeTruthy();
     expect(
@@ -462,7 +462,7 @@ describe("ComputerView billing-pause warning banner (COMP-7)", () => {
     mockStatus = { computerId: "c1", status: "ready", provider: "e2b" };
     mockUsage = usage({ awakeMs: 24 * HOUR_MS, billingPauseWarning: false });
     const { queryByTestId } = render(
-      <ComputerView projectId="p1" isAuthenticated />
+      <ComputerView projectId="p1" isSignedInMember />
     );
     expect(queryByTestId("computer-billing-warning")).toBeNull();
   });
@@ -472,7 +472,7 @@ describe("ComputerView billing-pause warning banner (COMP-7)", () => {
     // No billingPauseWarning key at all (older backend).
     mockUsage = usage({ awakeMs: 24 * HOUR_MS });
     const { queryByTestId } = render(
-      <ComputerView projectId="p1" isAuthenticated />
+      <ComputerView projectId="p1" isSignedInMember />
     );
     expect(queryByTestId("computer-billing-warning")).toBeNull();
   });
@@ -484,13 +484,13 @@ describe("ComputerView billing-pause warning banner (COMP-7)", () => {
       billingPauseWarning: true,
       windowStartAt: 1000,
     });
-    const first = render(<ComputerView projectId="p1" isAuthenticated />);
+    const first = render(<ComputerView projectId="p1" isSignedInMember />);
     fireEvent.click(first.getByLabelText("Dismiss"));
     expect(first.queryByTestId("computer-billing-warning")).toBeNull();
     first.unmount();
 
     // A later mount in the same billing window stays dismissed (localStorage).
-    const second = render(<ComputerView projectId="p1" isAuthenticated />);
+    const second = render(<ComputerView projectId="p1" isSignedInMember />);
     expect(second.queryByTestId("computer-billing-warning")).toBeNull();
   });
 
@@ -501,7 +501,7 @@ describe("ComputerView billing-pause warning banner (COMP-7)", () => {
       billingPauseWarning: true,
       windowStartAt: 1000,
     });
-    const first = render(<ComputerView projectId="p1" isAuthenticated />);
+    const first = render(<ComputerView projectId="p1" isSignedInMember />);
     fireEvent.click(first.getByLabelText("Dismiss"));
     first.unmount();
 
@@ -511,7 +511,7 @@ describe("ComputerView billing-pause warning banner (COMP-7)", () => {
       billingPauseWarning: true,
       windowStartAt: 2000,
     });
-    const second = render(<ComputerView projectId="p1" isAuthenticated />);
+    const second = render(<ComputerView projectId="p1" isSignedInMember />);
     expect(second.queryByTestId("computer-billing-warning")).toBeTruthy();
   });
 });
@@ -525,7 +525,7 @@ describe("ComputerView post-hibernate billing state (COMP-7)", () => {
       hibernatedReason: "billing",
     };
     const { getByTestId, queryByText } = render(
-      <ComputerView projectId="p1" isAuthenticated />
+      <ComputerView projectId="p1" isSignedInMember />
     );
     const notice = getByTestId("computer-paused-for-billing");
     // The status chip also reads "Paused for billing"; scope to the notice.
@@ -546,7 +546,7 @@ describe("ComputerView post-hibernate billing state (COMP-7)", () => {
       hibernatedReason: "idle",
     };
     const { queryByTestId, queryByText } = render(
-      <ComputerView projectId="p1" isAuthenticated />
+      <ComputerView projectId="p1" isSignedInMember />
     );
     expect(queryByTestId("computer-paused-for-billing")).toBeNull();
     expect(queryByText("Paused for billing")).toBeNull();

--- a/mcpjam-inspector/client/src/components/computer/__tests__/ComputerView.test.tsx
+++ b/mcpjam-inspector/client/src/components/computer/__tests__/ComputerView.test.tsx
@@ -47,6 +47,17 @@ vi.mock("sonner", () => ({
   toast: { success: vi.fn(), error: vi.fn() },
 }));
 
+// The unauthenticated state now renders <GuestSignInMessage>, which reads the
+// WorkOS + PostHog hooks. Stub both so the guest sign-in affordance mounts
+// without an AuthKitProvider / PostHog provider.
+const signInMock = vi.fn();
+vi.mock("@workos-inc/authkit-react", () => ({
+  useAuth: () => ({ signIn: signInMock }),
+}));
+vi.mock("posthog-js/react", () => ({
+  usePostHog: () => ({ capture: vi.fn() }),
+}));
+
 // Stub the xterm terminal so the orchestration test needs no real terminal.
 vi.mock("../ComputerTerminal", () => ({
   ComputerTerminal: (props: { baseUrl?: string }) => (
@@ -86,11 +97,16 @@ function usage(overrides: Partial<ComputerUsageView> = {}): ComputerUsageView {
 mockDataPlane = { localConfigured: true, remoteDataPlaneUrl: null };
 
 describe("ComputerView", () => {
-  it("prompts to sign in when unauthenticated", () => {
-    const { getByText } = render(
+  it("prompts to sign in when unauthenticated with an actionable Sign in button", () => {
+    const { getByText, getByRole } = render(
       <ComputerView projectId="p1" isAuthenticated={false} />
     );
+    // Honest one-liner naming why it's off for guests...
     expect(getByText(/Sign in to use a personal computer/i)).toBeTruthy();
+    // ...and a working sign-in affordance, not a dead-end message.
+    const button = getByRole("button", { name: /Sign in/i });
+    fireEvent.click(button);
+    expect(signInMock).toHaveBeenCalledTimes(1);
   });
 
   it("asks for a synced project when there is no projectId", () => {

--- a/mcpjam-inspector/server/routes/mcp/__tests__/chat-v2.harness.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/chat-v2.harness.test.ts
@@ -6,6 +6,7 @@ const {
   handleMCPJamFreeChatModelMock,
   fetchHostRuntimeConfigMock,
   checkHarnessRuntimeAvailableMock,
+  resolveHostToolsMock,
   validateAppToolEntriesMock,
   validateUiToolEntriesMock,
   validateWidgetModelContextEntriesMock,
@@ -18,6 +19,7 @@ const {
   handleMCPJamFreeChatModelMock: vi.fn(),
   fetchHostRuntimeConfigMock: vi.fn(),
   checkHarnessRuntimeAvailableMock: vi.fn(),
+  resolveHostToolsMock: vi.fn(() => ({})),
   validateAppToolEntriesMock: vi.fn(() => []),
   validateUiToolEntriesMock: vi.fn(() => []),
   validateWidgetModelContextEntriesMock: vi.fn(() => []),
@@ -70,7 +72,7 @@ vi.mock("../../../utils/harness/harness-availability.js", () => ({
 }));
 
 vi.mock("../../../utils/built-in-tools/registry.js", () => ({
-  resolveHostTools: vi.fn(() => ({})),
+  resolveHostTools: resolveHostToolsMock,
 }));
 
 import chatV2 from "../chat-v2.js";
@@ -163,5 +165,68 @@ describe("POST /api/mcp/chat-v2 harness host routing", () => {
     expect(handleMCPJamFreeChatModelMock).toHaveBeenCalledWith(
       expect.objectContaining({ harness: "claude-code" }),
     );
+  });
+
+  it("routes a guest turn through the emulated engine (runtime-config omits harness/computer)", async () => {
+    // COMP-3 guest-gate regression. A guest actor's server-resolved runtime
+    // config OMITS `harness` and `computer` (the backend gates them behind the
+    // account-scoped PHASE3 flags — see mcpjam-backend convex/lib/
+    // executionAccess.ts). The route must then run the EMULATED engine: no
+    // harness threaded to prepare/stream, no harness preflight, and no
+    // computer-backed capability. Even a body that tries to smuggle a harness/
+    // computer can't win — the resolver never reads them from the body.
+    fetchHostRuntimeConfigMock.mockResolvedValueOnce({
+      ok: true,
+      config: {
+        hostId: "host-guest",
+        modelId: "anthropic/claude-haiku-4.5",
+        systemPrompt: "host system",
+        temperature: 0.2,
+        requireToolApproval: false,
+        respectToolVisibility: true,
+        selectedServerIds: ["server-id-1"],
+        // harness + computer intentionally omitted (guest actor).
+      },
+    });
+
+    const app = createApp();
+
+    const response = await app.request("/api/mcp/chat-v2", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer guest-test-token",
+      },
+      body: JSON.stringify({
+        projectId: "project-1",
+        hostId: "host-guest",
+        selectedServers: ["server-1"],
+        selectedServerIds: ["server-id-1"],
+        messages: [{ role: "user", content: "create empty.txt" }],
+        model: {
+          id: "anthropic/claude-haiku-4.5",
+          provider: "anthropic",
+          name: "Claude Haiku 4.5",
+        },
+        // Tampered body: a guest tries to force the real harness + a computer.
+        harness: "claude-code",
+        computer: { kind: "personal" },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    // Emulated path: harness is never threaded into prepare or the stream.
+    expect(prepareChatV2Mock).toHaveBeenCalledWith(
+      expect.not.objectContaining({ harness: expect.anything() }),
+    );
+    expect(handleMCPJamFreeChatModelMock).toHaveBeenCalledWith(
+      expect.not.objectContaining({ harness: expect.anything() }),
+    );
+    // No harness ⇒ no availability preflight runs.
+    expect(checkHarnessRuntimeAvailableMock).not.toHaveBeenCalled();
+    // No computer capability: resolveHostTools sees `computer: undefined`
+    // (sourced from the runtime config, never the tampered body).
+    expect(resolveHostToolsMock).toHaveBeenCalled();
+    expect(resolveHostToolsMock.mock.calls[0][0].computer).toBeUndefined();
   });
 });

--- a/mcpjam-inspector/server/utils/__tests__/host-execution-context.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/host-execution-context.test.ts
@@ -86,6 +86,41 @@ describe("resolveExecutionContext — harness (host-only, server-authoritative)"
     });
     expect(result.harness).toBeUndefined();
   });
+
+  it("yields no harness capability for a guest-shaped runtime config (harness/computer omitted)", () => {
+    // COMP-3 guest gate. The backend OMITS `harness` and `computer` from a
+    // guest actor's runtime config (account-scoped PHASE3 flags — see
+    // mcpjam-backend convex/lib/executionAccess.ts), while still returning the
+    // rest of the host's execution fields. The resolver must then surface no
+    // harness (emulated fallback), even if a tampered body tries to smuggle
+    // one — `ExecutionOverrides` has no `harness`/`computer` field, so the
+    // body structurally cannot inject them. `computer` is not part of the
+    // resolver's output at all; the call site reads it off the runtime config
+    // (undefined for a guest) separately.
+    const result = resolveExecutionContext({
+      hostConfig: {
+        systemPrompt: "host prompt",
+        temperature: 0.2,
+        requireToolApproval: false,
+        respectToolVisibility: true,
+        modelId: "anthropic/claude-haiku-4.5",
+        selectedServerIds: ["srv-1"],
+        // harness + computer intentionally absent (guest actor).
+      },
+      overrides: {
+        // A guest body cannot carry harness/computer through overrides — the
+        // type has no such field — so the strongest test is that the
+        // non-harness fields still resolve while harness stays undefined.
+        systemPrompt: "body prompt",
+      },
+      precedence: "override-wins",
+    });
+    expect(result.harness).toBeUndefined();
+    expect(result.systemPrompt).toBe("body prompt");
+    expect(result.modelId).toBe("anthropic/claude-haiku-4.5");
+    // `computer` is never a resolved-execution field.
+    expect("computer" in result).toBe(false);
+  });
 });
 
 const IMAGE_POLICY_DISABLED = {


### PR DESCRIPTION
## What

Ships the guest-facing **"Sign in to use this"** affordance for the Project Computers / Claude Code harness surface, and fixes the gate so it actually fires for real guests.

## Why

A "guest" in the inspector is a **provisioned authenticated *anonymous* Convex actor** — `useConvexAuth().isAuthenticated === true`, `currentUser.isAnonymous === true`. The affordance originally gated on `!isAuthenticated`, which no real guest ever satisfies, so guests **skipped the sign-in state and got a full working personal computer** (repro below). `GuestSignInMessage` only rendered in the sub-second pre-provisioning window — the affordance was effectively dead in prod.

### Repro (before)
Incognito → `/computer` → a `Ready` personal computer with a live terminal, no sign-in prompt.

## Change

- **`GuestSignInMessage`** — reusable auth affordance (WorkOS `signIn` + PostHog tag), wired into `ComputerView`'s guest branch, replacing the buttonless empty state.
- **Gate on member-ness, not raw auth:**
  - `ComputerView` prop `isAuthenticated` → `isSignedInMember` (documents the anonymous-guest trap); guest branch is now `if (!isSignedInMember)`.
  - `ComputerRoute` passes `isSignedInMember = isAuthenticated && !isGuestProjectActor` and exposes `isGuestProjectActor` (`currentUser?.isAnonymous === true`) on the route context.
- Routes only render after `currentUser` resolves (`App.tsx` `LoadingScreen` guard), so the anonymous flag is reliable at render time — no first-paint flash of the computer UI.

## Scope / non-goals

This is a **UX affordance, not a security control**. The Claude Code harness gate remains server-authoritative and fail-closed (backend PR #654): the backend omits `harness`/`computer` from a guest's runtime config, and `harness` is read from the persisted host config, never the request body.

## Tests

- `GuestSignInMessage` + `ComputerView` component tests (prop renamed across cases) — **24/24 pass**.
- Regression tests locking the server-authoritative guest gate:
  - `chat-v2` route: a runtime-config omitting harness/computer routes through the emulated engine; a tampered body carrying `harness`/`computer` cannot override it.
  - `host-execution-context` resolver: a guest-shaped hostConfig yields no harness and never surfaces a `computer` field.

Entry-point audit found no bypass: `harness`/`computer` come only from the server-authoritative runtime-config fetch in both chat routes (and evals' Convex loader), never the client body.


https://github.com/user-attachments/assets/3f1f1be5-cd01-4e5a-8dc9-a13e5a2a03dc



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Computers/Claude Code guest gate so anonymous actors see an actionable “Sign in to use this” prompt instead of getting a personal computer. Adds a reusable guest sign-in affordance and gates on member status to meet COMP-3.

- New Features
  - Added `GuestSignInMessage` with `@workos-inc/authkit-react` sign-in and `@/lib/analytics` tracking; used in `ComputerView` for non-members to replace the buttonless empty state.

- Bug Fixes
  - Gate on member-ness: `ComputerRoute` computes `isSignedInMember = isAuthenticated && !isGuestProjectActor`, passes to `ComputerView` (prop renamed); routes wait for `currentUser` to avoid first-paint flash.
  - Server-authoritative guest behavior locked by tests: chat-v2 routes guest runtime-configs (no harness/computer) through the emulated engine; a tampered body cannot inject them; `resolveHostTools` sees `computer: undefined`; `host-execution-context` yields no harness.

<sup>Written for commit 1f4c544c4c22be7ac9ab8b48aaa76d379162e9d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



