### PR TITLE
fix(hosts): make New Client name follow the selected template under StrictMode

### DIFF
--- a/mcpjam-inspector/client/src/components/hosts/CreateHostDialog.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/CreateHostDialog.tsx
@@ -74,7 +74,12 @@ export function CreateHostDialog({
     [visibleCatalogHosts]
   );
   const [name, setName] = useState("");
-  const defaultedNameRef = useRef<string | null>(null);
+  // True once the user hand-types a (non-empty) name; the template-label
+  // defaulting effect below must not clobber it. Tracked outside the
+  // setName updater: mutating a ref inside an updater is impure, and
+  // StrictMode's double-invoke made the old ref-inside-updater guard
+  // misread the defaulted name as user-typed, pinning it forever.
+  const userEditedNameRef = useRef(false);
   const [selectedTemplateId, setSelectedTemplateId] = useState<string>(
     initialTemplateId ?? DEFAULT_CATALOG_HOST_ID
   );
@@ -111,18 +116,13 @@ export function CreateHostDialog({
 
   useEffect(() => {
     if (!isOpen) return;
-    setName((current) => {
-      if (current.trim() !== "" && current !== defaultedNameRef.current) {
-        return current;
-      }
-      defaultedNameRef.current = selectedTemplateLabel;
-      return selectedTemplateLabel;
-    });
+    if (userEditedNameRef.current) return;
+    setName(selectedTemplateLabel);
   }, [isOpen, selectedTemplateId, selectedTemplateLabel]);
 
   const handleClose = () => {
     setName("");
-    defaultedNameRef.current = null;
+    userEditedNameRef.current = false;
     setSelectedTemplateId(initialTemplateId ?? DEFAULT_CATALOG_HOST_ID);
     onClose();
   };
@@ -233,7 +233,11 @@ export function CreateHostDialog({
               id="host-name"
               placeholder="My Client"
               value={name}
-              onChange={(e) => setName(e.target.value)}
+              onChange={(e) => {
+                setName(e.target.value);
+                // Clearing the field re-arms template defaulting.
+                userEditedNameRef.current = e.target.value.trim() !== "";
+              }}
               onKeyDown={(e) =>
                 e.key === "Enter" && canCreate && handleCreate()
               }


### PR DESCRIPTION
## Problem

In the New Client dialog, selecting a template tile (e.g. Claude Code) did not update the Name field in dev builds — it stayed pinned to the default "MCPJam", so the created client showed up named "MCPJam" even though the Claude Code template was correctly applied.

## Root cause

The name-defaulting effect mutated `defaultedNameRef` **inside** its `setName` updater. The app renders under `<StrictMode>`, which double-invokes state updaters in development to surface exactly this kind of impurity:

1. First invocation: the current name matches the ref, so it mutates the ref to the new template label and returns the label — result discarded.
2. Second invocation (the one React uses): the current name no longer matches the mutated ref, so the guard concludes the user hand-typed it and keeps the stale name.

Production builds don't double-invoke, which is why this survived review (introduced in #3083).

## Fix

Track "has the user hand-typed a name" in the input's `onChange` via a ref (clearing the field re-arms defaulting), leaving the effect a pure `setName(selectedTemplateLabel)`. Intended behavior is preserved: a hand-typed name is never clobbered by switching tiles.

## Testing

- Manually verified: selecting the Claude Code tile now flips the Name field to "Claude Code"; typing a custom name and switching tiles keeps it; clearing the field and switching tiles re-defaults.
- `tsc --noEmit` clean for the touched file (remaining errors are pre-existing in `App.hosted-oauth.test.tsx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI state fix in the create-host dialog with no auth, API, or data-model changes.
> 
> **Overview**
> Fixes the **New Client** dialog so the **Name** field updates when you pick a different template tile in dev (React StrictMode), instead of staying stuck on the first default (e.g. "MCPJam").
> 
> The old logic tried to detect user edits by mutating a ref **inside** the `setName` updater. StrictMode runs that updater twice, so the second pass treated the auto-filled label as hand-typed and stopped syncing. The change tracks **user-edited** state in the name input’s `onChange` via `userEditedNameRef`, resets it on close, and makes the template effect a pure `setName(selectedTemplateLabel)` when the user hasn’t typed a non-empty name. Clearing the name field turns template defaulting back on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f0d7f654c79027cb765ab2dfe3bca624133887b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the New Client dialog so the Name field follows the selected template under React StrictMode. Dev builds now match production, and user-typed names are never overwritten.

- **Bug Fixes**
  - Removed ref mutation inside `setName` to avoid StrictMode double-invoke issues.
  - Track user edits via `onChange` with `userEditedNameRef`; default to `selectedTemplateLabel` only when the field isn’t user-edited. Clearing the field re-enables defaulting, and closing the dialog resets the flag.

<sup>Written for commit 4f0d7f654c79027cb765ab2dfe3bca624133887b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

