### PR TITLE
feat(sdk): extract shared DCR core + ID-JAG client identity + CIMD draft-02 URL validation

### DIFF
--- a/.changeset/xaa-dcr-shared-core.md
+++ b/.changeset/xaa-dcr-shared-core.md
@@ -1,0 +1,14 @@
+---
+"@mcpjam/sdk": minor
+---
+
+Extract the OAuth debug state machines' duplicated Dynamic Client Registration (RFC 7591) logic into a shared, exported helper, and add the XAA (ID-JAG) client-identity building blocks.
+
+New exports (browser + node entry points):
+
+- `buildDynamicClientRegistrationRequest` / `executeDynamicClientRegistration` — the DCR request builder and executor previously inlined in all three debug OAuth machines. The executor now redacts credential-bearing fields (`client_secret`, `registration_access_token`, `access_token`, `refresh_token`) from every diagnostic surface (lastResponse, HTTP history, info logs); raw credentials travel only through the returned `credentials`/`clientInfo`. A 2xx response with a null/non-object body is now classified as `invalid_response` and takes the pre-registered-fallback path instead of proceeding with undefined credentials.
+- `getXaaDebugClientMetadata`, `evaluateIdJagClientMetadata`, `ID_JAG_GRANT_PROFILE`, `TOKEN_EXCHANGE_GRANT`, `JWT_BEARER_GRANT`, `XAA_DEBUG_CLIENT_ID_METADATA_URL` — ID-JAG (draft-ietf-oauth-identity-assertion-authz-grant-04) client metadata builder and evidence evaluator for the XAA debugger.
+- `validateClientIdMetadataUrl` — Client Identifier URL validation updated to draft-ietf-oauth-client-id-metadata-document-02: requires a path component, rejects userinfo/fragment/raw dot segments, accepts a query, and returns the original string unchanged (simple string comparison identity; the previous CIMD validator `URL.toString()`-normalized the URL).
+- `OAuthProxyRequest.redirect` / `OAuthHttpRequest.redirect` (`"follow" | "manual"`) — explicit redirect control for proxy execution. `httpsOnly` still always forces `manual` and cannot be weakened; omission preserves the historical `follow`.
+
+The three debug OAuth machines keep their orchestration, transitions, fallback behavior, and user-facing error strings; the intentional visible changes are the credential redaction, the truncated-secret info log becoming a `Client Secret Issued: true` boolean, and the invalid-response classification above.

--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -111,9 +111,19 @@ export type {
 
 export {
   DEFAULT_MCPJAM_CLIENT_ID_METADATA_URL,
+  ID_JAG_GRANT_PROFILE,
+  JWT_BEARER_GRANT,
   MCPJAM_CLIENT_URI,
   MCPJAM_LOGO_URI,
+  TOKEN_EXCHANGE_GRANT,
+  XAA_DEBUG_CLIENT_ID_METADATA_URL,
+  evaluateIdJagClientMetadata,
   getBrowserDebugDynamicRegistrationMetadata,
+  getXaaDebugClientMetadata,
+} from "./oauth/client-identity.js";
+export type {
+  IdJagClientMetadataEvaluation,
+  IdJagMetadataEvidence,
 } from "./oauth/client-identity.js";
 export {
   resolveAuthorizationPlan,
@@ -163,6 +173,15 @@ export {
   getStepInfo,
   getStepIndex,
 } from "./oauth/state-machines/shared/step-metadata.js";
+export {
+  buildDynamicClientRegistrationRequest,
+  executeDynamicClientRegistration,
+} from "./oauth/state-machines/shared/dynamic-client-registration.js";
+export type {
+  DynamicClientRegistrationCredentials,
+  DynamicClientRegistrationOutcome,
+} from "./oauth/state-machines/shared/dynamic-client-registration.js";
+export { validateClientIdMetadataUrl } from "./oauth/state-machines/shared/client-id-metadata.js";
 export { EMPTY_OAUTH_FLOW_STATE } from "./oauth/state-machines/types.js";
 export type {
   HttpHistoryEntry,

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -265,6 +265,30 @@ export type {
   OAuthTraceStepSnapshot,
   OAuthTraceStepStatus,
 } from "./oauth/state-machines/trace.js";
+// XAA (ID-JAG) client identity + shared client registration. Exported from
+// the Node entry too: the inspector server hosts the XAA client-metadata
+// document and needs the builder/evaluator server-side.
+export {
+  ID_JAG_GRANT_PROFILE,
+  JWT_BEARER_GRANT,
+  TOKEN_EXCHANGE_GRANT,
+  XAA_DEBUG_CLIENT_ID_METADATA_URL,
+  evaluateIdJagClientMetadata,
+  getXaaDebugClientMetadata,
+} from "./oauth/client-identity.js";
+export type {
+  IdJagClientMetadataEvaluation,
+  IdJagMetadataEvidence,
+} from "./oauth/client-identity.js";
+export {
+  buildDynamicClientRegistrationRequest,
+  executeDynamicClientRegistration,
+} from "./oauth/state-machines/shared/dynamic-client-registration.js";
+export type {
+  DynamicClientRegistrationCredentials,
+  DynamicClientRegistrationOutcome,
+} from "./oauth/state-machines/shared/dynamic-client-registration.js";
+export { validateClientIdMetadataUrl } from "./oauth/state-machines/shared/client-id-metadata.js";
 
 // HostExecutor interface (for deterministic testing without concrete HostRunner)
 export type { HostExecutor, PromptOptions } from "./HostExecutor.js";

--- a/sdk/src/oauth-proxy.ts
+++ b/sdk/src/oauth-proxy.ts
@@ -15,6 +15,10 @@ export interface OAuthProxyRequest {
   body?: unknown;
   headers?: Record<string, string>;
   httpsOnly?: boolean;
+  /** Redirect handling. httpsOnly always forces "manual" (cannot be
+   * weakened); otherwise an explicit value is honored and omission preserves
+   * the historical "follow". */
+  redirect?: "follow" | "manual";
 }
 
 export interface OAuthProxyResponse {
@@ -210,7 +214,7 @@ export async function executeOAuthProxy(
   const response = await fetch(buildFetchUrl(targetUrl), {
     method,
     headers: requestHeaders,
-    redirect: req.httpsOnly ? "manual" : "follow",
+    redirect: req.httpsOnly ? "manual" : req.redirect ?? "follow",
     body: encodeRequestBody(method, req.body, contentType),
   });
 
@@ -245,7 +249,7 @@ export async function executeDebugOAuthProxy(
   const response = await fetch(buildFetchUrl(targetUrl), {
     method,
     headers: requestHeaders,
-    redirect: req.httpsOnly ? "manual" : "follow",
+    redirect: req.httpsOnly ? "manual" : req.redirect ?? "follow",
     body: encodeRequestBody(method, req.body, contentType),
   });
 

--- a/sdk/src/oauth/client-identity.ts
+++ b/sdk/src/oauth/client-identity.ts
@@ -44,3 +44,89 @@ export function getConformanceClientCredentialsDynamicRegistrationMetadata(): Pa
     token_endpoint_auth_method: "client_secret_post",
   };
 }
+
+// Cross-App Access (ID-JAG) client identity.
+// Pinned to draft-ietf-oauth-identity-assertion-authz-grant-04: a client that
+// advertises the ID-JAG grant profile MUST include both the Token Exchange
+// grant (Client<->IdP leg) and the JWT Bearer grant (Client<->RAS leg).
+export const ID_JAG_GRANT_PROFILE =
+  "urn:ietf:params:oauth:grant-profile:id-jag";
+export const TOKEN_EXCHANGE_GRANT =
+  "urn:ietf:params:oauth:grant-type:token-exchange";
+export const JWT_BEARER_GRANT = "urn:ietf:params:oauth:grant-type:jwt-bearer";
+
+// The XAA debugger's Client ID Metadata Document. This is a DIFFERENT client
+// identity from DEFAULT_MCPJAM_CLIENT_ID_METADATA_URL (the authorization-code
+// login client); changing that document's grants would change the login
+// client, so XAA publishes its own document.
+export const XAA_DEBUG_CLIENT_ID_METADATA_URL =
+  "https://app.mcpjam.com/.well-known/oauth/xaa-client-metadata.json";
+
+export function getXaaDebugClientMetadata(options: {
+  tokenEndpointAuthMethod: "client_secret_post" | "none";
+}): Partial<OAuthDynamicRegistrationMetadata> {
+  return {
+    client_name: "MCPJam XAA Debugger",
+    client_uri: MCPJAM_CLIENT_URI,
+    logo_uri: MCPJAM_LOGO_URI,
+    authorization_grant_profiles_supported: [ID_JAG_GRANT_PROFILE],
+    grant_types: [TOKEN_EXCHANGE_GRANT, JWT_BEARER_GRANT],
+    token_endpoint_auth_method: options.tokenEndpointAuthMethod,
+    // Deliberately NO redirect_uris/response_types - jwt-bearer has no redirect.
+  };
+}
+
+export type IdJagMetadataEvidence = "present" | "omitted" | "contradicted";
+
+export interface IdJagClientMetadataEvaluation {
+  profile: IdJagMetadataEvidence;
+  jwtBearerGrant: IdJagMetadataEvidence;
+  tokenExchangeGrant: IdJagMetadataEvidence;
+  /** Raw value; auth-method policy is the caller's. */
+  tokenEndpointAuthMethod: string | undefined;
+}
+
+function classifyListMembership(
+  value: unknown,
+  expected: string
+): IdJagMetadataEvidence {
+  if (value === undefined || value === null) {
+    return "omitted";
+  }
+  if (Array.isArray(value) && value.includes(expected)) {
+    return "present";
+  }
+  // The property exists but the expected value does not: an explicit
+  // statement, not an omission.
+  return "contradicted";
+}
+
+/**
+ * Classifies ID-JAG client-metadata evidence in a DCR response or a Client ID
+ * Metadata Document. Evidence only - policy differs by caller: RFC 7591 lets
+ * an AS ignore unknown request metadata, so a DCR response may treat
+ * "omitted" as a warning, while a CIMD document is the authoritative client
+ * metadata and "omitted" means the document is insufficient.
+ */
+export function evaluateIdJagClientMetadata(
+  metadata: Record<string, unknown>
+): IdJagClientMetadataEvaluation {
+  return {
+    profile: classifyListMembership(
+      metadata.authorization_grant_profiles_supported,
+      ID_JAG_GRANT_PROFILE
+    ),
+    jwtBearerGrant: classifyListMembership(
+      metadata.grant_types,
+      JWT_BEARER_GRANT
+    ),
+    tokenExchangeGrant: classifyListMembership(
+      metadata.grant_types,
+      TOKEN_EXCHANGE_GRANT
+    ),
+    tokenEndpointAuthMethod:
+      typeof metadata.token_endpoint_auth_method === "string"
+        ? metadata.token_endpoint_auth_method
+        : undefined,
+  };
+}

--- a/sdk/src/oauth/state-machines/debug-oauth-2025-03-26.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-03-26.ts
@@ -44,6 +44,10 @@ import {
   normalizeRegisteredClientAuthMethod,
   resolvePreregisteredClientAuthMethod,
 } from "./shared/client-auth.js";
+import {
+  buildDynamicClientRegistrationRequest,
+  executeDynamicClientRegistration,
+} from "./shared/dynamic-client-registration.js";
 
 // Re-export types for backward compatibility
 export type { OAuthFlowStep, OAuthFlowState };
@@ -837,33 +841,14 @@ export const createDebugOAuthStateMachine = (
                 supportedScopes: scopesSupported,
               });
 
-              const clientMetadata: Record<string, any> = {
-                ...dynamicRegistrationDefaults,
-                redirect_uris:
-                  dynamicRegistrationDefaults.redirect_uris ?? [redirectUri],
-                grant_types: dynamicRegistrationDefaults.grant_types ?? [
-                  "authorization_code",
-                  "refresh_token",
-                ],
-                response_types:
-                  dynamicRegistrationDefaults.response_types ?? ["code"],
-                token_endpoint_auth_method:
-                  dynamicRegistrationDefaults.token_endpoint_auth_method ??
-                  "none",
-              };
-
-              if (requestedScopeValue) {
-                clientMetadata.scope = requestedScopeValue;
-              }
-
-              const registrationRequest = {
-                method: "POST",
-                url: state.authorizationServerMetadata.registration_endpoint,
-                headers: mergeHeadersForAuthServer(customHeaders, {
-                  "Content-Type": "application/json",
-                }),
-                body: clientMetadata,
-              };
+              const registrationRequest = buildDynamicClientRegistrationRequest({
+                registrationEndpoint:
+                  state.authorizationServerMetadata.registration_endpoint,
+                redirectUri,
+                dynamicRegistrationDefaults,
+                scope: requestedScopeValue,
+                customHeaders,
+              });
 
               updateState({
                 currentStep: "request_client_registration",
@@ -929,56 +914,33 @@ export const createDebugOAuthStateMachine = (
               throw new Error("No client metadata in request");
             }
 
-            try {
-              const response = await executeRequest(
-                state.authorizationServerMetadata.registration_endpoint,
-                {
-                  method: "POST",
-                  headers: mergeHeadersForAuthServer(customHeaders, {
-                    "Content-Type": "application/json",
-                  }),
-                  body: JSON.stringify(state.lastRequest.body),
-                },
-              );
+            {
+              // Execute the exact request recorded in lastRequest so the
+              // displayed request and the executed request cannot drift.
+              const dcr = await executeDynamicClientRegistration({
+                request: state.lastRequest,
+                requestExecutor,
+                httpHistory: state.httpHistory,
+              });
 
-              const registrationResponseData = {
-                status: response.status,
-                statusText: response.statusText,
-                headers: response.headers,
-                body: response.body,
-              };
-
-              const updatedHistoryReg = [...(state.httpHistory || [])];
-              if (updatedHistoryReg.length > 0) {
-                const lastEntry =
-                  updatedHistoryReg[updatedHistoryReg.length - 1];
-                lastEntry.response = registrationResponseData;
-                lastEntry.duration =
-                  Date.now() - (lastEntry.timestamp || Date.now());
-              }
-
-              if (!response.ok) {
-                const registrationError = `Dynamic Client Registration failed (${response.status}).`;
-
+              if (dcr.status !== "registered") {
                 updateState({
-                  lastResponse: registrationResponseData,
-                  httpHistory: updatedHistoryReg,
-                  error: registrationError,
+                  lastResponse: dcr.response,
+                  httpHistory: dcr.httpHistory,
+                  error: dcr.error,
                 });
 
                 if (strictConformance) {
                   return;
                 }
 
-                const fallbackClient =
-                  await loadFallbackPreregisteredClient(
-                    `Dynamic Client Registration failed (${response.status}); using pre-registered client credentials.`,
-                  );
+                const fallbackClient = await loadFallbackPreregisteredClient(
+                  dcr.fallbackNote,
+                );
 
                 if (!fallbackClient) {
                   updateState({
-                    error:
-                      `${registrationError} Configure a pre-registered client or enable DCR on the authorization server.`,
+                    error: dcr.errorWithFallbackHint,
                     isInitiatingAuth: false,
                   });
                   return;
@@ -994,112 +956,38 @@ export const createDebugOAuthStateMachine = (
                   error: undefined,
                   isInitiatingAuth: false,
                 });
-              } else {
-                const clientInfo = response.body;
-                if (
-                  strictConformance &&
-                  typeof clientInfo?.client_id !== "string"
-                ) {
-                  updateState({
-                    lastResponse: registrationResponseData,
-                    httpHistory: updatedHistoryReg,
-                    error:
-                      "Dynamic Client Registration response is missing a client_id.",
-                    isInitiatingAuth: false,
-                  });
-                  return;
-                }
+                break;
+              }
 
-                const dcrInfo: Record<string, any> = {
-                  "Client ID": clientInfo.client_id,
-                  "Client Name": clientInfo.client_name,
-                  "Token Auth Method":
-                    clientInfo.token_endpoint_auth_method || "none",
-                  "Redirect URIs": clientInfo.redirect_uris,
-                  "Grant Types": clientInfo.grant_types,
-                  "Response Types": clientInfo.response_types,
-                };
-
-                if (clientInfo.client_secret) {
-                  dcrInfo["Client Secret"] =
-                    clientInfo.client_secret.substring(0, 20) + "...";
-                  dcrInfo["Note"] =
-                    "Server issued client_secret - this will be used in token requests";
-                }
-
-                const infoLogs = addInfoLog(
-                  getCurrentState(),
-                  "received_client_credentials",
-                  "dcr",
-                  "Dynamic Client Registration",
-                  dcrInfo,
-                );
-
+              if (strictConformance && dcr.missingClientId) {
                 updateState({
-                  currentStep: "received_client_credentials",
-                  clientId: clientInfo.client_id,
-                  clientSecret: clientInfo.client_secret,
-                  tokenEndpointAuthMethod:
-                    normalizeRegisteredClientAuthMethod(clientInfo),
-                  lastResponse: registrationResponseData,
-                  httpHistory: updatedHistoryReg,
-                  infoLogs,
-                  error: undefined,
-                  isInitiatingAuth: false,
-                });
-              }
-            } catch (error) {
-              const errorResponse = {
-                status: 0,
-                statusText: "Network Error",
-                headers: {},
-                body: {
-                  error: error instanceof Error ? error.message : String(error),
-                },
-              };
-
-              const updatedHistoryError = [...(state.httpHistory || [])];
-              if (updatedHistoryError.length > 0) {
-                const lastEntry =
-                  updatedHistoryError[updatedHistoryError.length - 1];
-                lastEntry.response = errorResponse;
-                lastEntry.duration =
-                  Date.now() - (lastEntry.timestamp || Date.now());
-              }
-
-              const registrationError = `Client registration failed: ${error instanceof Error ? error.message : String(error)}`;
-
-              updateState({
-                lastResponse: errorResponse,
-                httpHistory: updatedHistoryError,
-                error: registrationError,
-              });
-
-              if (strictConformance) {
-                return;
-              }
-
-              const fallbackClient =
-                await loadFallbackPreregisteredClient(
-                  "Client registration failed; using pre-registered client credentials.",
-                );
-
-              if (!fallbackClient) {
-                updateState({
+                  lastResponse: dcr.response,
+                  httpHistory: dcr.httpHistory,
                   error:
-                    `${registrationError}. Configure a pre-registered client or enable DCR on the authorization server.`,
+                    "Dynamic Client Registration response is missing a client_id.",
                   isInitiatingAuth: false,
                 });
                 return;
               }
+
+              const infoLogs = addInfoLog(
+                getCurrentState(),
+                "received_client_credentials",
+                "dcr",
+                "Dynamic Client Registration",
+                dcr.infoLogData,
+              );
 
               updateState({
                 currentStep: "received_client_credentials",
-                clientId: fallbackClient.clientId,
-                clientSecret: fallbackClient.clientSecret,
-                tokenEndpointAuthMethod:
-                  fallbackClient.tokenEndpointAuthMethod,
-                infoLogs: fallbackClient.infoLogs,
+                clientId: dcr.credentials.clientId,
+                clientSecret: dcr.credentials.clientSecret,
+                tokenEndpointAuthMethod: normalizeRegisteredClientAuthMethod(
+                  dcr.clientInfo,
+                ),
+                lastResponse: dcr.response,
+                httpHistory: dcr.httpHistory,
+                infoLogs,
                 error: undefined,
                 isInitiatingAuth: false,
               });

--- a/sdk/src/oauth/state-machines/debug-oauth-2025-03-26.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-03-26.ts
@@ -931,6 +931,13 @@ export const createDebugOAuthStateMachine = (
                 });
 
                 if (strictConformance) {
+                  // A 2xx-but-unusable registration body previously reached the
+                  // strict missing-client_id path, which cleared
+                  // isInitiatingAuth. Preserve that so a failed strict run isn't
+                  // left "initiating".
+                  if (dcr.status === "invalid_response") {
+                    updateState({ isInitiatingAuth: false });
+                  }
                   return;
                 }
 

--- a/sdk/src/oauth/state-machines/debug-oauth-2025-06-18.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-06-18.ts
@@ -1266,6 +1266,12 @@ export const createDebugOAuthStateMachine = (
               });
 
               if (strictConformance) {
+                // A 2xx-but-unusable registration body previously reached the
+                // strict missing-client_id path, which cleared isInitiatingAuth.
+                // Preserve that so a failed strict run isn't left "initiating".
+                if (dcr.status === "invalid_response") {
+                  updateState({ isInitiatingAuth: false });
+                }
                 return;
               }
 

--- a/sdk/src/oauth/state-machines/debug-oauth-2025-06-18.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-06-18.ts
@@ -49,6 +49,10 @@ import {
   normalizeRegisteredClientAuthMethod,
   resolvePreregisteredClientAuthMethod,
 } from "./shared/client-auth.js";
+import {
+  buildDynamicClientRegistrationRequest,
+  executeDynamicClientRegistration,
+} from "./shared/dynamic-client-registration.js";
 import { discoverOAuthProtectedResourceMetadata } from "../browser-auth.js";
 
 // Re-export types for backward compatibility
@@ -1170,33 +1174,14 @@ export const createDebugOAuthStateMachine = (
                 supportedScopes: scopesSupported,
               });
 
-              const clientMetadata: Record<string, any> = {
-                ...dynamicRegistrationDefaults,
-                redirect_uris:
-                  dynamicRegistrationDefaults.redirect_uris ?? [redirectUri],
-                grant_types: dynamicRegistrationDefaults.grant_types ?? [
-                  "authorization_code",
-                  "refresh_token",
-                ],
-                response_types:
-                  dynamicRegistrationDefaults.response_types ?? ["code"],
-                token_endpoint_auth_method:
-                  dynamicRegistrationDefaults.token_endpoint_auth_method ??
-                  "none",
-              };
-
-              if (requestedScopeValue) {
-                clientMetadata.scope = requestedScopeValue;
-              }
-
-              const registrationRequest = {
-                method: "POST",
-                url: state.authorizationServerMetadata.registration_endpoint,
-                headers: mergeHeadersForAuthServer(customHeaders, {
-                  "Content-Type": "application/json",
-                }),
-                body: clientMetadata,
-              };
+              const registrationRequest = buildDynamicClientRegistrationRequest({
+                registrationEndpoint:
+                  state.authorizationServerMetadata.registration_endpoint,
+                redirectUri,
+                dynamicRegistrationDefaults,
+                scope: requestedScopeValue,
+                customHeaders,
+              });
 
               // Update state with the request
               updateState({
@@ -1254,7 +1239,7 @@ export const createDebugOAuthStateMachine = (
             }
             break;
 
-          case "request_client_registration":
+          case "request_client_registration": {
             // Step 6: Dynamic Client Registration (RFC 7591)
             if (!state.authorizationServerMetadata?.registration_endpoint) {
               throw new Error("No registration endpoint available");
@@ -1264,172 +1249,33 @@ export const createDebugOAuthStateMachine = (
               throw new Error("No client metadata in request");
             }
 
-            try {
-              // Make actual POST request to registration endpoint via backend proxy
-              const response = await executeRequest(
-                state.authorizationServerMetadata.registration_endpoint,
-                {
-                  method: "POST",
-                  headers: mergeHeadersForAuthServer(customHeaders, {
-                    "Content-Type": "application/json",
-                  }),
-                  body: JSON.stringify(state.lastRequest.body),
-                },
-              );
+            // Execute the exact request recorded in lastRequest so the
+            // displayed request and the executed request cannot drift.
+            const dcr = await executeDynamicClientRegistration({
+              request: state.lastRequest,
+              requestExecutor,
+              httpHistory: state.httpHistory,
+            });
 
-              const registrationResponseData = {
-                status: response.status,
-                statusText: response.statusText,
-                headers: response.headers,
-                body: response.body,
-              };
-
-              // Update the last history entry with the response
-              const updatedHistoryReg = [...(state.httpHistory || [])];
-              if (updatedHistoryReg.length > 0) {
-                const lastEntry =
-                  updatedHistoryReg[updatedHistoryReg.length - 1];
-                lastEntry.response = registrationResponseData;
-                lastEntry.duration =
-                  Date.now() - (lastEntry.timestamp || Date.now());
-              }
-
-              if (!response.ok) {
-                // Registration failed - could be server doesn't support DCR or request was invalid
-                const registrationError = `Dynamic Client Registration failed (${response.status}).`;
-
-                // Update state with error but continue with fallback
-                updateState({
-                  lastResponse: registrationResponseData,
-                  httpHistory: updatedHistoryReg,
-                  error: registrationError,
-                });
-
-                if (strictConformance) {
-                  return;
-                }
-
-                const fallbackClient =
-                  await loadFallbackPreregisteredClient(
-                    `Dynamic Client Registration failed (${response.status}); using pre-registered client credentials.`,
-                  );
-
-                if (!fallbackClient) {
-                  updateState({
-                    error:
-                      `${registrationError} Configure a pre-registered client or enable DCR on the authorization server.`,
-                    isInitiatingAuth: false,
-                  });
-                  return;
-                }
-
-                updateState({
-                  currentStep: "received_client_credentials",
-                  clientId: fallbackClient.clientId,
-                  clientSecret: fallbackClient.clientSecret,
-                  tokenEndpointAuthMethod:
-                    fallbackClient.tokenEndpointAuthMethod,
-                  infoLogs: fallbackClient.infoLogs,
-                  error: undefined,
-                  isInitiatingAuth: false,
-                });
-              } else {
-                // Registration successful
-                const clientInfo = response.body;
-                if (
-                  strictConformance &&
-                  typeof clientInfo?.client_id !== "string"
-                ) {
-                  updateState({
-                    lastResponse: registrationResponseData,
-                    httpHistory: updatedHistoryReg,
-                    error:
-                      "Dynamic Client Registration response is missing a client_id.",
-                    isInitiatingAuth: false,
-                  });
-                  return;
-                }
-
-                // Add info log for DCR
-                const dcrInfo: Record<string, any> = {
-                  "Client ID": clientInfo.client_id,
-                  "Client Name": clientInfo.client_name,
-                  "Token Auth Method":
-                    clientInfo.token_endpoint_auth_method || "none",
-                  "Redirect URIs": clientInfo.redirect_uris,
-                  "Grant Types": clientInfo.grant_types,
-                  "Response Types": clientInfo.response_types,
-                };
-
-                if (clientInfo.client_secret) {
-                  dcrInfo["Client Secret"] =
-                    clientInfo.client_secret.substring(0, 20) + "...";
-                  dcrInfo["Note"] =
-                    "Server issued client_secret - this will be used in token requests";
-                }
-
-                const infoLogs = addInfoLog(
-                  getCurrentState(),
-                  "received_client_credentials",
-                  "dcr",
-                  "Dynamic Client Registration",
-                  dcrInfo,
-                );
-
-                updateState({
-                  currentStep: "received_client_credentials",
-                  clientId: clientInfo.client_id,
-                  clientSecret: clientInfo.client_secret,
-                  tokenEndpointAuthMethod:
-                    normalizeRegisteredClientAuthMethod(clientInfo),
-                  lastResponse: registrationResponseData,
-                  httpHistory: updatedHistoryReg,
-                  infoLogs,
-                  error: undefined,
-                  isInitiatingAuth: false,
-                });
-              }
-            } catch (error) {
-              // Capture the error but continue with fallback
-              const errorResponse = {
-                status: 0,
-                statusText: "Network Error",
-                headers: {},
-                body: {
-                  error: error instanceof Error ? error.message : String(error),
-                },
-              };
-
-              const updatedHistoryError = [...(state.httpHistory || [])];
-              if (updatedHistoryError.length > 0) {
-                const lastEntry =
-                  updatedHistoryError[updatedHistoryError.length - 1];
-                lastEntry.response = errorResponse;
-                lastEntry.duration =
-                  Date.now() - (lastEntry.timestamp || Date.now());
-              }
-
-              const registrationError = `Client registration failed: ${error instanceof Error ? error.message : String(error)}`;
-
+            if (dcr.status !== "registered") {
+              // Update state with error but continue with fallback
               updateState({
-                lastResponse: errorResponse,
-                httpHistory: updatedHistoryError,
-                error: registrationError,
+                lastResponse: dcr.response,
+                httpHistory: dcr.httpHistory,
+                error: dcr.error,
               });
 
               if (strictConformance) {
                 return;
               }
 
-              const fallbackClient =
-                await loadFallbackPreregisteredClient(
-                  "Client registration failed; using pre-registered client credentials.",
-                );
+              const fallbackClient = await loadFallbackPreregisteredClient(
+                dcr.fallbackNote,
+              );
 
               if (!fallbackClient) {
                 updateState({
-                  error:
-                    `${registrationError}. Configure a pre-registered client or enable DCR on the authorization server.`,
+                  error: dcr.errorWithFallbackHint,
                   isInitiatingAuth: false,
                 });
                 return;
@@ -1445,8 +1291,44 @@ export const createDebugOAuthStateMachine = (
                 error: undefined,
                 isInitiatingAuth: false,
               });
+              break;
             }
+
+            // Registration successful
+            if (strictConformance && dcr.missingClientId) {
+              updateState({
+                lastResponse: dcr.response,
+                httpHistory: dcr.httpHistory,
+                error:
+                  "Dynamic Client Registration response is missing a client_id.",
+                isInitiatingAuth: false,
+              });
+              return;
+            }
+
+            const infoLogs = addInfoLog(
+              getCurrentState(),
+              "received_client_credentials",
+              "dcr",
+              "Dynamic Client Registration",
+              dcr.infoLogData,
+            );
+
+            updateState({
+              currentStep: "received_client_credentials",
+              clientId: dcr.credentials.clientId,
+              clientSecret: dcr.credentials.clientSecret,
+              tokenEndpointAuthMethod: normalizeRegisteredClientAuthMethod(
+                dcr.clientInfo,
+              ),
+              lastResponse: dcr.response,
+              httpHistory: dcr.httpHistory,
+              infoLogs,
+              error: undefined,
+              isInitiatingAuth: false,
+            });
             break;
+          }
 
           case "received_client_credentials":
             // Step 7: Generate PKCE parameters

--- a/sdk/src/oauth/state-machines/debug-oauth-2025-11-25.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-11-25.ts
@@ -52,6 +52,11 @@ import {
   normalizeRegisteredClientAuthMethod,
   resolvePreregisteredClientAuthMethod,
 } from "./shared/client-auth.js";
+import {
+  buildDynamicClientRegistrationRequest,
+  executeDynamicClientRegistration,
+} from "./shared/dynamic-client-registration.js";
+import { validateClientIdMetadataUrl } from "./shared/client-id-metadata.js";
 import { discoverOAuthProtectedResourceMetadata } from "../browser-auth.js";
 
 export type { OAuthFlowStep, OAuthFlowState };
@@ -63,20 +68,6 @@ export interface DebugOAuthStateMachineConfig
   registrationStrategy?: RegistrationStrategy2025_11_25; // cimd | dcr | preregistered
 }
 
-function validateCimdClientIdMetadataUrl(clientIdMetadataUrl: string): string {
-  let parsedUrl: URL;
-  try {
-    parsedUrl = new URL(clientIdMetadataUrl);
-  } catch {
-    throw new Error("Client ID metadata URL must be a valid absolute URL");
-  }
-
-  if (parsedUrl.protocol !== "https:" || !parsedUrl.hostname) {
-    throw new Error("Client ID metadata URL must be an absolute HTTPS URL");
-  }
-
-  return parsedUrl.toString();
-}
 
 /**
  * Build the sequence of actions for the 2025-11-25 OAuth flow
@@ -569,7 +560,7 @@ export const createDebugOAuthStateMachine = (
   }
 
   if (registrationStrategy === "cimd") {
-    cimdClientId = validateCimdClientIdMetadataUrl(cimdClientId);
+    cimdClientId = validateClientIdMetadataUrl(cimdClientId);
   }
 
   // Helper to get current state (use getState if provided, otherwise use initial state)
@@ -1356,34 +1347,14 @@ export const createDebugOAuthStateMachine = (
                 supportedScopes: scopesSupported,
               });
 
-              const clientMetadata: Record<string, any> = {
-                ...dynamicRegistrationDefaults,
-                redirect_uris:
-                  dynamicRegistrationDefaults.redirect_uris ?? [redirectUri],
-                grant_types: dynamicRegistrationDefaults.grant_types ?? [
-                  "authorization_code",
-                  "refresh_token",
-                ],
-                response_types:
-                  dynamicRegistrationDefaults.response_types ?? ["code"],
-                token_endpoint_auth_method:
-                  dynamicRegistrationDefaults.token_endpoint_auth_method ??
-                  "none",
-              };
-
-              // Include scopes if supported by the server
-              if (requestedScopeValue) {
-                clientMetadata.scope = requestedScopeValue;
-              }
-
-              const registrationRequest = {
-                method: "POST",
-                url: state.authorizationServerMetadata.registration_endpoint,
-                headers: mergeHeadersForAuthServer(customHeaders, {
-                  "Content-Type": "application/json",
-                }),
-                body: clientMetadata,
-              };
+              const registrationRequest = buildDynamicClientRegistrationRequest({
+                registrationEndpoint:
+                  state.authorizationServerMetadata.registration_endpoint,
+                redirectUri,
+                dynamicRegistrationDefaults,
+                scope: requestedScopeValue,
+                customHeaders,
+              });
 
               // Update state with the request
               updateState({
@@ -1451,45 +1422,21 @@ export const createDebugOAuthStateMachine = (
               throw new Error("No client metadata in request");
             }
 
-            try {
-              // Make actual POST request to registration endpoint via backend proxy
-              const response = await executeRequest(
-                state.authorizationServerMetadata.registration_endpoint,
-                {
-                  method: "POST",
-                  headers: mergeHeadersForAuthServer(customHeaders, {
-                    "Content-Type": "application/json",
-                  }),
-                  body: JSON.stringify(state.lastRequest.body),
-                }
-              );
+            {
+              // Execute the exact request recorded in lastRequest so the
+              // displayed request and the executed request cannot drift.
+              const dcr = await executeDynamicClientRegistration({
+                request: state.lastRequest,
+                requestExecutor,
+                httpHistory: state.httpHistory,
+              });
 
-              const registrationResponseData = {
-                status: response.status,
-                statusText: response.statusText,
-                headers: response.headers,
-                body: response.body,
-              };
-
-              // Update the last history entry with the response
-              const updatedHistoryReg = [...(state.httpHistory || [])];
-              if (updatedHistoryReg.length > 0) {
-                const lastEntry =
-                  updatedHistoryReg[updatedHistoryReg.length - 1];
-                lastEntry.response = registrationResponseData;
-                lastEntry.duration =
-                  Date.now() - (lastEntry.timestamp || Date.now());
-              }
-
-              if (!response.ok) {
-                // Registration failed - could be server doesn't support DCR or request was invalid
-                const registrationError = `Dynamic Client Registration failed (${response.status}).`;
-
+              if (dcr.status !== "registered") {
                 // Update state with error but continue with fallback
                 updateState({
-                  lastResponse: registrationResponseData,
-                  httpHistory: updatedHistoryReg,
-                  error: registrationError,
+                  lastResponse: dcr.response,
+                  httpHistory: dcr.httpHistory,
+                  error: dcr.error,
                   isInitiatingAuth: false,
                 });
 
@@ -1497,15 +1444,13 @@ export const createDebugOAuthStateMachine = (
                   return;
                 }
 
-                const fallbackClient =
-                  await loadFallbackPreregisteredClient(
-                    `Dynamic Client Registration failed (${response.status}); using pre-registered client credentials.`,
-                  );
+                const fallbackClient = await loadFallbackPreregisteredClient(
+                  dcr.fallbackNote,
+                );
 
                 if (!fallbackClient) {
                   updateState({
-                    error:
-                      `${registrationError} Configure a pre-registered client or enable DCR on the authorization server.`,
+                    error: dcr.errorWithFallbackHint,
                     isInitiatingAuth: false,
                   });
                   return;
@@ -1521,116 +1466,39 @@ export const createDebugOAuthStateMachine = (
                   error: undefined,
                   isInitiatingAuth: false,
                 });
-              } else {
-                // Registration successful
-                const clientInfo = response.body;
-                if (
-                  strictConformance &&
-                  typeof clientInfo?.client_id !== "string"
-                ) {
-                  updateState({
-                    lastResponse: registrationResponseData,
-                    httpHistory: updatedHistoryReg,
-                    error:
-                      "Dynamic Client Registration response is missing a client_id.",
-                    isInitiatingAuth: false,
-                  });
-                  return;
-                }
+                break;
+              }
 
-                // Add info log for DCR
-                const dcrInfo: Record<string, any> = {
-                  "Client ID": clientInfo.client_id,
-                  "Client Name": clientInfo.client_name,
-                  "Token Auth Method":
-                    clientInfo.token_endpoint_auth_method || "none",
-                  "Redirect URIs": clientInfo.redirect_uris,
-                  "Grant Types": clientInfo.grant_types,
-                  "Response Types": clientInfo.response_types,
-                };
-
-                if (clientInfo.client_secret) {
-                  dcrInfo["Client Secret"] =
-                    clientInfo.client_secret.substring(0, 20) + "...";
-                  dcrInfo["Note"] =
-                    "Server issued client_secret - this will be used in token requests";
-                }
-
-                const infoLogs = addInfoLog(
-                  getCurrentState(),
-                  "received_client_credentials",
-                  "dcr",
-                  "Dynamic Client Registration",
-                  dcrInfo
-                );
-
+              // Registration successful
+              if (strictConformance && dcr.missingClientId) {
                 updateState({
-                  currentStep: "received_client_credentials",
-                  clientId: clientInfo.client_id,
-                  clientSecret: clientInfo.client_secret,
-                  tokenEndpointAuthMethod:
-                    normalizeRegisteredClientAuthMethod(clientInfo),
-                  lastResponse: registrationResponseData,
-                  httpHistory: updatedHistoryReg,
-                  infoLogs,
-                  error: undefined,
-                  isInitiatingAuth: false,
-                });
-              }
-            } catch (error) {
-              // Capture the error but continue with fallback
-              const errorResponse = {
-                status: 0,
-                statusText: "Network Error",
-                headers: {},
-                body: {
-                  error: error instanceof Error ? error.message : String(error),
-                },
-              };
-
-              const updatedHistoryError = [...(state.httpHistory || [])];
-              if (updatedHistoryError.length > 0) {
-                const lastEntry =
-                  updatedHistoryError[updatedHistoryError.length - 1];
-                lastEntry.response = errorResponse;
-                lastEntry.duration =
-                  Date.now() - (lastEntry.timestamp || Date.now());
-              }
-
-              const registrationError = `Client registration failed: ${error instanceof Error ? error.message : String(error)}`;
-
-              updateState({
-                lastResponse: errorResponse,
-                httpHistory: updatedHistoryError,
-                error: registrationError,
-                isInitiatingAuth: false,
-              });
-
-              if (strictConformance) {
-                return;
-              }
-
-              const fallbackClient =
-                await loadFallbackPreregisteredClient(
-                  "Client registration failed; using pre-registered client credentials.",
-                );
-
-              if (!fallbackClient) {
-                updateState({
+                  lastResponse: dcr.response,
+                  httpHistory: dcr.httpHistory,
                   error:
-                    `${registrationError}. Configure a pre-registered client or enable DCR on the authorization server.`,
+                    "Dynamic Client Registration response is missing a client_id.",
                   isInitiatingAuth: false,
                 });
                 return;
               }
+
+              const infoLogs = addInfoLog(
+                getCurrentState(),
+                "received_client_credentials",
+                "dcr",
+                "Dynamic Client Registration",
+                dcr.infoLogData
+              );
 
               updateState({
                 currentStep: "received_client_credentials",
-                clientId: fallbackClient.clientId,
-                clientSecret: fallbackClient.clientSecret,
-                tokenEndpointAuthMethod:
-                  fallbackClient.tokenEndpointAuthMethod,
-                infoLogs: fallbackClient.infoLogs,
+                clientId: dcr.credentials.clientId,
+                clientSecret: dcr.credentials.clientSecret,
+                tokenEndpointAuthMethod: normalizeRegisteredClientAuthMethod(
+                  dcr.clientInfo,
+                ),
+                lastResponse: dcr.response,
+                httpHistory: dcr.httpHistory,
+                infoLogs,
                 error: undefined,
                 isInitiatingAuth: false,
               });

--- a/sdk/src/oauth/state-machines/shared/client-id-metadata.ts
+++ b/sdk/src/oauth/state-machines/shared/client-id-metadata.ts
@@ -20,10 +20,12 @@ export function validateClientIdMetadataUrl(
     throw new Error("Client ID metadata URL must be an absolute HTTPS URL");
   }
 
-  // The Client Identifier URL is compared by simple string equality, and we
-  // return the raw string unchanged — so it must already be EXACTLY what fetch
-  // would request. Reject any spelling WHATWG would transport-normalize into a
-  // different URL than the raw bytes:
+  // The Client Identifier URL is compared by simple string equality and we
+  // return it unchanged, so a spelling WHATWG would transport-normalize makes
+  // fetch request a different URL than the identity string. Reject the
+  // structural cases below. This is NOT exhaustive over every WHATWG
+  // normalization — host lowercasing, percent-encoding, and IDNA/Unicode host
+  // normalization are out of scope for these draft-02 structural checks:
   //  - not the canonical literal `https://` prefix (rejects single-slash
   //    `https:/…`, backslash scheme `https:\…`, and non-lowercase schemes).
   if (!clientIdMetadataUrl.startsWith("https://")) {

--- a/sdk/src/oauth/state-machines/shared/client-id-metadata.ts
+++ b/sdk/src/oauth/state-machines/shared/client-id-metadata.ts
@@ -62,6 +62,16 @@ export function validateClientIdMetadataUrl(
     slashIndex === -1 ? afterScheme : afterScheme.slice(0, slashIndex);
   const rawPath = slashIndex === -1 ? "" : afterScheme.slice(slashIndex);
 
+  // Extra slashes after `https://` (e.g. `https:///host`, `https:////host`)
+  // leave the authority empty in the raw string while new URL() promotes the
+  // next token to the hostname — so fetch would hit a host the identity string
+  // doesn't name. Reject an empty authority.
+  if (!rawAuthority) {
+    throw new Error(
+      "Client ID metadata URL must contain a host immediately after https://"
+    );
+  }
+
   // Userinfo: the parsed check catches any NON-empty spelling (WHATWG populates
   // username even for non-canonical forms), while the raw `@` scan catches the
   // EMPTY spelling `https://@host` that leaves username/password as "" (falsy).

--- a/sdk/src/oauth/state-machines/shared/client-id-metadata.ts
+++ b/sdk/src/oauth/state-machines/shared/client-id-metadata.ts
@@ -26,11 +26,13 @@ export function validateClientIdMetadataUrl(
   // structural cases below. This is NOT exhaustive over every WHATWG
   // normalization — host lowercasing, percent-encoding, and IDNA/Unicode host
   // normalization are out of scope for these draft-02 structural checks:
-  //  - not the canonical literal `https://` prefix (rejects single-slash
-  //    `https:/…`, backslash scheme `https:\…`, and non-lowercase schemes).
-  if (!clientIdMetadataUrl.startsWith("https://")) {
+  //  - not an `https://` prefix with exactly two slashes (rejects single-slash
+  //    `https:/…` and backslash scheme `https:\…`). The scheme is matched
+  //    case-insensitively — RFC 3986 schemes are case-insensitive and the case
+  //    doesn't change which host fetch contacts, so `HTTPS://` is allowed.
+  if (!/^https:\/\//i.test(clientIdMetadataUrl)) {
     throw new Error(
-      "Client ID metadata URL must begin with a literal https:// scheme"
+      "Client ID metadata URL must use the https:// scheme (with two slashes)"
     );
   }
   //  - ASCII controls (0x00–0x1F), space (0x20), DEL (0x7F), and backslashes:
@@ -53,10 +55,10 @@ export function validateClientIdMetadataUrl(
   // Parse the authority and path off the RAW string. new URL() collapses dot
   // segments and normalizes an empty userinfo away — either would silently
   // change the client identity before we could reject it. The guards above
-  // guarantee a literal `https://` prefix with no backslashes, so a plain
+  // guarantee an `https://` prefix (any case) with no backslashes, so a plain
   // split is sufficient here.
   const rawWithoutQuery = clientIdMetadataUrl.split(/[?#]/, 1)[0];
-  const afterScheme = rawWithoutQuery.replace(/^https:\/\//, "");
+  const afterScheme = rawWithoutQuery.replace(/^https:\/\//i, "");
   const slashIndex = afterScheme.indexOf("/");
   const rawAuthority =
     slashIndex === -1 ? afterScheme : afterScheme.slice(0, slashIndex);

--- a/sdk/src/oauth/state-machines/shared/client-id-metadata.ts
+++ b/sdk/src/oauth/state-machines/shared/client-id-metadata.ts
@@ -59,8 +59,14 @@ export function validateClientIdMetadataUrl(
     throw new Error("Client ID metadata URL must contain a path component");
   }
 
-  const segments = rawPath.split("/");
-  if (segments.some((segment) => segment === "." || segment === "..")) {
+  // WHATWG dot-segment detection decodes %2e (any case) first: "%2e%2e",
+  // "%2e.", ".%2e" all collapse like "..". Match that so an encoded spelling
+  // can't slip past what the parser would normalize away.
+  const isDotSegment = (segment: string) => {
+    const normalized = segment.replace(/%2e/gi, ".");
+    return normalized === "." || normalized === "..";
+  };
+  if (rawPath.split("/").some(isDotSegment)) {
     throw new Error(
       "Client ID metadata URL must not contain single-dot or double-dot path segments"
     );

--- a/sdk/src/oauth/state-machines/shared/client-id-metadata.ts
+++ b/sdk/src/oauth/state-machines/shared/client-id-metadata.ts
@@ -1,0 +1,56 @@
+/**
+ * Client Identifier URL validation per draft-ietf-oauth-client-id-metadata-document-02.
+ *
+ * Client Identifier URLs are compared with simple string comparison (RFC 3986
+ * section 6.2.1), so validation MUST NOT normalize the input: `:443`, percent
+ * escaping, and other distinguishable spellings are distinct client
+ * identities. The validated original string is returned unchanged.
+ */
+export function validateClientIdMetadataUrl(
+  clientIdMetadataUrl: string
+): string {
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(clientIdMetadataUrl);
+  } catch {
+    throw new Error("Client ID metadata URL must be a valid absolute URL");
+  }
+
+  if (parsedUrl.protocol !== "https:" || !parsedUrl.hostname) {
+    throw new Error("Client ID metadata URL must be an absolute HTTPS URL");
+  }
+
+  if (parsedUrl.username || parsedUrl.password) {
+    throw new Error(
+      "Client ID metadata URL must not contain a userinfo component"
+    );
+  }
+
+  if (parsedUrl.hash || clientIdMetadataUrl.includes("#")) {
+    throw new Error(
+      "Client ID metadata URL must not contain a fragment component"
+    );
+  }
+
+  // Detect dot segments on the RAW string: new URL() collapses them, which
+  // would silently change the client identity before we could reject it.
+  const rawWithoutQuery = clientIdMetadataUrl.split(/[?#]/, 1)[0];
+  const authorityStart = rawWithoutQuery.indexOf("//") + 2;
+  const pathStart = rawWithoutQuery.indexOf("/", authorityStart);
+  const rawPath = pathStart === -1 ? "" : rawWithoutQuery.slice(pathStart);
+
+  if (!rawPath || rawPath === "/") {
+    throw new Error("Client ID metadata URL must contain a path component");
+  }
+
+  const segments = rawPath.split("/");
+  if (segments.some((segment) => segment === "." || segment === "..")) {
+    throw new Error(
+      "Client ID metadata URL must not contain single-dot or double-dot path segments"
+    );
+  }
+
+  // A query component is SHOULD NOT in the draft, not MUST NOT: accept it.
+
+  return clientIdMetadataUrl;
+}

--- a/sdk/src/oauth/state-machines/shared/client-id-metadata.ts
+++ b/sdk/src/oauth/state-machines/shared/client-id-metadata.ts
@@ -29,26 +29,33 @@ export function validateClientIdMetadataUrl(
   // Parse the authority and path off the RAW string. new URL() both collapses
   // dot segments and normalizes an empty userinfo away — either would silently
   // change the client identity (Client Identifier URLs compare by simple
-  // string equality) before we could reject it.
+  // string equality) before we could reject it. Normalize the scheme prefix
+  // the way WHATWG does for special schemes (backslashes act as slashes; any
+  // number of slashes may follow the scheme) so a non-canonical spelling can't
+  // hide the authority from this scan.
   const rawWithoutQuery = clientIdMetadataUrl.split(/[?#]/, 1)[0];
-  const authorityStart = rawWithoutQuery.indexOf("//") + 2;
-  const pathStart = rawWithoutQuery.indexOf("/", authorityStart);
+  const afterScheme = rawWithoutQuery
+    .replace(/\\/g, "/")
+    .replace(/^https:\/*/i, "");
+  const slashIndex = afterScheme.indexOf("/");
   const rawAuthority =
-    pathStart === -1
-      ? rawWithoutQuery.slice(authorityStart)
-      : rawWithoutQuery.slice(authorityStart, pathStart);
-  const rawPath = pathStart === -1 ? "" : rawWithoutQuery.slice(pathStart);
+    slashIndex === -1 ? afterScheme : afterScheme.slice(0, slashIndex);
+  const rawPath = slashIndex === -1 ? "" : afterScheme.slice(slashIndex);
 
-  // WHATWG URL sets username/password to "" for `https://@host` (both falsy),
-  // so parsedUrl.username/password miss an empty-userinfo spelling. Inspect the
-  // raw authority for the `@` delimiter to reject any userinfo, empty or not.
-  if (rawAuthority.includes("@")) {
+  // Userinfo: the parsed check catches any NON-empty spelling (WHATWG populates
+  // username even for non-canonical forms like `https:/user@host`), while the
+  // raw `@` scan catches the EMPTY spelling `https://@host` that leaves
+  // username/password as "" (falsy). Both are needed.
+  if (parsedUrl.username || parsedUrl.password || rawAuthority.includes("@")) {
     throw new Error(
       "Client ID metadata URL must not contain a userinfo component"
     );
   }
 
-  if (!rawPath || rawPath === "/") {
+  // Require a path component. A root path ("/") is permitted — draft-02 §3
+  // marks it NOT RECOMMENDED, not invalid — so only reject a genuinely absent
+  // path.
+  if (!rawPath) {
     throw new Error("Client ID metadata URL must contain a path component");
   }
 

--- a/sdk/src/oauth/state-machines/shared/client-id-metadata.ts
+++ b/sdk/src/oauth/state-machines/shared/client-id-metadata.ts
@@ -20,32 +20,49 @@ export function validateClientIdMetadataUrl(
     throw new Error("Client ID metadata URL must be an absolute HTTPS URL");
   }
 
+  // The Client Identifier URL is compared by simple string equality, and we
+  // return the raw string unchanged — so it must already be EXACTLY what fetch
+  // would request. Reject any spelling WHATWG would transport-normalize into a
+  // different URL than the raw bytes:
+  //  - not the canonical literal `https://` prefix (rejects single-slash
+  //    `https:/…`, backslash scheme `https:\…`, and non-lowercase schemes).
+  if (!clientIdMetadataUrl.startsWith("https://")) {
+    throw new Error(
+      "Client ID metadata URL must begin with a literal https:// scheme"
+    );
+  }
+  //  - ASCII controls (0x00–0x1F), space (0x20), DEL (0x7F), and backslashes:
+  //    WHATWG strips tabs/newlines/leading-trailing controls and percent-encodes
+  //    spaces, and treats backslashes as slashes — each changes the URL fetch
+  //    actually uses.
+  // eslint-disable-next-line no-control-regex
+  if (/[\u0000-\u0020\u007f\\]/.test(clientIdMetadataUrl)) {
+    throw new Error(
+      "Client ID metadata URL must not contain control characters, whitespace, or backslashes"
+    );
+  }
+
   if (parsedUrl.hash || clientIdMetadataUrl.includes("#")) {
     throw new Error(
       "Client ID metadata URL must not contain a fragment component"
     );
   }
 
-  // Parse the authority and path off the RAW string. new URL() both collapses
-  // dot segments and normalizes an empty userinfo away — either would silently
-  // change the client identity (Client Identifier URLs compare by simple
-  // string equality) before we could reject it. Normalize the scheme prefix
-  // the way WHATWG does for special schemes (backslashes act as slashes; any
-  // number of slashes may follow the scheme) so a non-canonical spelling can't
-  // hide the authority from this scan.
+  // Parse the authority and path off the RAW string. new URL() collapses dot
+  // segments and normalizes an empty userinfo away — either would silently
+  // change the client identity before we could reject it. The guards above
+  // guarantee a literal `https://` prefix with no backslashes, so a plain
+  // split is sufficient here.
   const rawWithoutQuery = clientIdMetadataUrl.split(/[?#]/, 1)[0];
-  const afterScheme = rawWithoutQuery
-    .replace(/\\/g, "/")
-    .replace(/^https:\/*/i, "");
+  const afterScheme = rawWithoutQuery.replace(/^https:\/\//, "");
   const slashIndex = afterScheme.indexOf("/");
   const rawAuthority =
     slashIndex === -1 ? afterScheme : afterScheme.slice(0, slashIndex);
   const rawPath = slashIndex === -1 ? "" : afterScheme.slice(slashIndex);
 
   // Userinfo: the parsed check catches any NON-empty spelling (WHATWG populates
-  // username even for non-canonical forms like `https:/user@host`), while the
-  // raw `@` scan catches the EMPTY spelling `https://@host` that leaves
-  // username/password as "" (falsy). Both are needed.
+  // username even for non-canonical forms), while the raw `@` scan catches the
+  // EMPTY spelling `https://@host` that leaves username/password as "" (falsy).
   if (parsedUrl.username || parsedUrl.password || rawAuthority.includes("@")) {
     throw new Error(
       "Client ID metadata URL must not contain a userinfo component"

--- a/sdk/src/oauth/state-machines/shared/client-id-metadata.ts
+++ b/sdk/src/oauth/state-machines/shared/client-id-metadata.ts
@@ -20,24 +20,33 @@ export function validateClientIdMetadataUrl(
     throw new Error("Client ID metadata URL must be an absolute HTTPS URL");
   }
 
-  if (parsedUrl.username || parsedUrl.password) {
-    throw new Error(
-      "Client ID metadata URL must not contain a userinfo component"
-    );
-  }
-
   if (parsedUrl.hash || clientIdMetadataUrl.includes("#")) {
     throw new Error(
       "Client ID metadata URL must not contain a fragment component"
     );
   }
 
-  // Detect dot segments on the RAW string: new URL() collapses them, which
-  // would silently change the client identity before we could reject it.
+  // Parse the authority and path off the RAW string. new URL() both collapses
+  // dot segments and normalizes an empty userinfo away — either would silently
+  // change the client identity (Client Identifier URLs compare by simple
+  // string equality) before we could reject it.
   const rawWithoutQuery = clientIdMetadataUrl.split(/[?#]/, 1)[0];
   const authorityStart = rawWithoutQuery.indexOf("//") + 2;
   const pathStart = rawWithoutQuery.indexOf("/", authorityStart);
+  const rawAuthority =
+    pathStart === -1
+      ? rawWithoutQuery.slice(authorityStart)
+      : rawWithoutQuery.slice(authorityStart, pathStart);
   const rawPath = pathStart === -1 ? "" : rawWithoutQuery.slice(pathStart);
+
+  // WHATWG URL sets username/password to "" for `https://@host` (both falsy),
+  // so parsedUrl.username/password miss an empty-userinfo spelling. Inspect the
+  // raw authority for the `@` delimiter to reject any userinfo, empty or not.
+  if (rawAuthority.includes("@")) {
+    throw new Error(
+      "Client ID metadata URL must not contain a userinfo component"
+    );
+  }
 
   if (!rawPath || rawPath === "/") {
     throw new Error("Client ID metadata URL must contain a path component");

--- a/sdk/src/oauth/state-machines/shared/dynamic-client-registration.ts
+++ b/sdk/src/oauth/state-machines/shared/dynamic-client-registration.ts
@@ -1,0 +1,294 @@
+import type {
+  OAuthDynamicRegistrationMetadata,
+  OAuthHttpRequest,
+  OAuthHttpResponse,
+  OAuthRequestExecutor,
+} from "../types.js";
+import { mergeHeadersForAuthServer } from "./headers.js";
+
+const REDACTED_VALUE = "***REDACTED***";
+
+// Response-body fields that carry credentials an AS may include in an RFC 7591
+// registration response. Redacted recursively so nested shapes can't leak.
+const CREDENTIAL_FIELD_NAMES = new Set([
+  "client_secret",
+  "registration_access_token",
+  "access_token",
+  "refresh_token",
+]);
+
+export interface DynamicClientRegistrationRequestInput {
+  registrationEndpoint: string;
+  redirectUri: string;
+  dynamicRegistrationDefaults: Partial<OAuthDynamicRegistrationMetadata>;
+  /** Already-resolved scope value; scope sourcing is version/caller-specific. */
+  scope?: string;
+  customHeaders?: Record<string, string>;
+}
+
+/**
+ * Builds the RFC 7591 registration POST exactly as the debug OAuth machines
+ * historically did: caller-supplied metadata defaults win, with
+ * authorization-code-flavored fallbacks for anything absent. Callers that are
+ * not authorization-code clients (e.g. XAA jwt-bearer clients) must build
+ * their own request instead of using these fallbacks.
+ */
+export function buildDynamicClientRegistrationRequest(
+  input: DynamicClientRegistrationRequestInput
+): OAuthHttpRequest {
+  const { dynamicRegistrationDefaults } = input;
+
+  const clientMetadata: Record<string, any> = {
+    ...dynamicRegistrationDefaults,
+    redirect_uris: dynamicRegistrationDefaults.redirect_uris ?? [
+      input.redirectUri,
+    ],
+    grant_types: dynamicRegistrationDefaults.grant_types ?? [
+      "authorization_code",
+      "refresh_token",
+    ],
+    response_types: dynamicRegistrationDefaults.response_types ?? ["code"],
+    token_endpoint_auth_method:
+      dynamicRegistrationDefaults.token_endpoint_auth_method ?? "none",
+  };
+
+  if (input.scope) {
+    clientMetadata.scope = input.scope;
+  }
+
+  return {
+    method: "POST",
+    url: input.registrationEndpoint,
+    headers: mergeHeadersForAuthServer(input.customHeaders, {
+      "Content-Type": "application/json",
+    }),
+    body: clientMetadata,
+  };
+}
+
+function redactValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(redactValue);
+  }
+  if (value && typeof value === "object") {
+    const result: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value)) {
+      result[key] = CREDENTIAL_FIELD_NAMES.has(key.toLowerCase())
+        ? REDACTED_VALUE
+        : redactValue(entry);
+    }
+    return result;
+  }
+  return value;
+}
+
+/**
+ * Clones a registration response and masks every credential-bearing field.
+ * This is the only response shape that may reach diagnostic surfaces
+ * (lastResponse, httpHistory, info logs). Raw credentials travel exclusively
+ * through DynamicClientRegistrationOutcome.credentials / clientInfo.
+ */
+export function redactDynamicClientRegistrationResponse(
+  response: OAuthHttpResponse
+): OAuthHttpResponse {
+  return {
+    status: response.status,
+    statusText: response.statusText,
+    headers: { ...response.headers },
+    body: redactValue(response.body),
+  };
+}
+
+/** Minimal structural constraint so both the OAuth machines' HttpHistoryEntry
+ * and the inspector's XAAHttpHistoryEntry fit; the helper never reads `step`. */
+type BackfillableHistoryEntry = {
+  timestamp: number;
+  duration?: number;
+  response?: OAuthHttpResponse;
+};
+
+export interface DynamicClientRegistrationCredentials {
+  clientId?: string;
+  clientSecret?: string;
+  /** Raw token_endpoint_auth_method from the response. Legacy OAuth machines
+   * normalize it via normalizeRegisteredClientAuthMethod at their call sites;
+   * other callers validate the raw value against their own policy. */
+  tokenEndpointAuthMethod?: string;
+  clientSecretExpiresAt?: number;
+}
+
+export type DynamicClientRegistrationOutcome<
+  THistory extends BackfillableHistoryEntry = BackfillableHistoryEntry
+> =
+  | {
+      status: "registered";
+      /** Redacted; safe for diagnostic surfaces. */
+      response: OAuthHttpResponse;
+      httpHistory: THistory[];
+      /** Raw response body. Operational data — callers must not log it. */
+      clientInfo: Record<string, any>;
+      /** Raw credentials. Operational data — callers must not log them. */
+      credentials: DynamicClientRegistrationCredentials;
+      /** typeof clientInfo.client_id !== "string" — strict callers hard-fail. */
+      missingClientId: boolean;
+      /** 2xx other than 201; RFC 7591 specifies 201 Created. */
+      nonCanonicalSuccessStatus: boolean;
+      /** Credential-free record for info logs. */
+      infoLogData: Record<string, any>;
+    }
+  | {
+      status: "http_error" | "network_error" | "invalid_response";
+      /** Redacted (http_error/invalid_response) or synthesized (network_error). */
+      response: OAuthHttpResponse;
+      httpHistory: THistory[];
+      error: string;
+      fallbackNote: string;
+      errorWithFallbackHint: string;
+    };
+
+export interface ExecuteDynamicClientRegistrationInput<
+  THistory extends BackfillableHistoryEntry
+> {
+  /** The exact pre-built request the caller has already recorded in its
+   * lastRequest/history entry. Executed as-is so the displayed request and
+   * the executed request cannot drift; the executor owns wire serialization. */
+  request: OAuthHttpRequest;
+  requestExecutor: OAuthRequestExecutor;
+  httpHistory?: THistory[];
+}
+
+function backfillHistory<THistory extends BackfillableHistoryEntry>(
+  httpHistory: THistory[] | undefined,
+  response: OAuthHttpResponse
+): THistory[] {
+  const updated = [...(httpHistory || [])];
+  if (updated.length > 0) {
+    const last = updated[updated.length - 1];
+    updated[updated.length - 1] = {
+      ...last,
+      response,
+      duration: Date.now() - (last.timestamp || Date.now()),
+    };
+  }
+  return updated;
+}
+
+const FALLBACK_HINT =
+  "Configure a pre-registered client or enable DCR on the authorization server.";
+
+/**
+ * Executes an RFC 7591 registration POST via the caller's executor, back-fills
+ * a cloned last history entry with the redacted response, and classifies the
+ * result. Never calls updateState — state transitions stay caller-owned.
+ * Never throws: transport failures become a "network_error" outcome.
+ */
+export async function executeDynamicClientRegistration<
+  THistory extends BackfillableHistoryEntry
+>(
+  input: ExecuteDynamicClientRegistrationInput<THistory>
+): Promise<DynamicClientRegistrationOutcome<THistory>> {
+  let response;
+  try {
+    response = await input.requestExecutor(input.request);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const synthesized: OAuthHttpResponse = {
+      status: 0,
+      statusText: "Network Error",
+      headers: {},
+      body: { error: message },
+    };
+    const registrationError = `Client registration failed: ${message}`;
+    return {
+      status: "network_error",
+      response: synthesized,
+      httpHistory: backfillHistory(input.httpHistory, synthesized),
+      error: registrationError,
+      fallbackNote:
+        "Client registration failed; using pre-registered client credentials.",
+      errorWithFallbackHint: `${registrationError}. ${FALLBACK_HINT}`,
+    };
+  }
+
+  const redacted = redactDynamicClientRegistrationResponse({
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+    body: response.body,
+  });
+  const httpHistory = backfillHistory(input.httpHistory, redacted);
+
+  if (!response.ok) {
+    const registrationError = `Dynamic Client Registration failed (${response.status}).`;
+    return {
+      status: "http_error",
+      response: redacted,
+      httpHistory,
+      error: registrationError,
+      fallbackNote: `Dynamic Client Registration failed (${response.status}); using pre-registered client credentials.`,
+      errorWithFallbackHint: `${registrationError} ${FALLBACK_HINT}`,
+    };
+  }
+
+  const clientInfo = response.body;
+  if (
+    !clientInfo ||
+    typeof clientInfo !== "object" ||
+    Array.isArray(clientInfo)
+  ) {
+    const registrationError =
+      "Client registration failed: the registration response body was not a JSON object";
+    return {
+      status: "invalid_response",
+      response: redacted,
+      httpHistory,
+      error: registrationError,
+      fallbackNote:
+        "Client registration failed; using pre-registered client credentials.",
+      errorWithFallbackHint: `${registrationError}. ${FALLBACK_HINT}`,
+    };
+  }
+
+  const infoLogData: Record<string, any> = {
+    "Client ID": clientInfo.client_id,
+    "Client Name": clientInfo.client_name,
+    "Token Auth Method": clientInfo.token_endpoint_auth_method || "none",
+    "Redirect URIs": clientInfo.redirect_uris,
+    "Grant Types": clientInfo.grant_types,
+    "Response Types": clientInfo.response_types,
+  };
+
+  if (clientInfo.client_secret) {
+    infoLogData["Client Secret Issued"] = true;
+    infoLogData["Note"] =
+      "Server issued client_secret - this will be used in token requests";
+  }
+
+  return {
+    status: "registered",
+    response: redacted,
+    httpHistory,
+    clientInfo,
+    credentials: {
+      clientId:
+        typeof clientInfo.client_id === "string"
+          ? clientInfo.client_id
+          : undefined,
+      clientSecret:
+        typeof clientInfo.client_secret === "string"
+          ? clientInfo.client_secret
+          : undefined,
+      tokenEndpointAuthMethod:
+        typeof clientInfo.token_endpoint_auth_method === "string"
+          ? clientInfo.token_endpoint_auth_method
+          : undefined,
+      clientSecretExpiresAt:
+        typeof clientInfo.client_secret_expires_at === "number"
+          ? clientInfo.client_secret_expires_at
+          : undefined,
+    },
+    missingClientId: typeof clientInfo.client_id !== "string",
+    nonCanonicalSuccessStatus: response.status !== 201,
+    infoLogData,
+  };
+}

--- a/sdk/src/oauth/state-machines/types.ts
+++ b/sdk/src/oauth/state-machines/types.ts
@@ -142,6 +142,10 @@ export interface OAuthHttpRequest {
   url: string;
   headers: Record<string, string>;
   body?: any;
+  /** Redirect handling for executors that proxy this request. Hosted
+   * (httpsOnly) proxy execution always uses "manual"; otherwise an explicit
+   * value is honored and omission preserves the historical "follow". */
+  redirect?: "follow" | "manual";
 }
 
 export interface OAuthHttpResponse {

--- a/sdk/tests/oauth-proxy.test.ts
+++ b/sdk/tests/oauth-proxy.test.ts
@@ -1,5 +1,6 @@
 import dns from "node:dns/promises";
 import {
+  executeDebugOAuthProxy,
   executeOAuthProxy,
   fetchOAuthMetadata,
   OAuthProxyError,
@@ -68,6 +69,47 @@ describe("oauth-proxy helpers", () => {
       fetchOAuthMetadata("https://auth.example.com/.well-known/oauth"),
     ).resolves.toEqual({
       metadata: { issuer: "https://auth.example.com" },
+    });
+  });
+
+  describe("redirect option plumbing", () => {
+    const jsonResponse = () =>
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+
+    const lastFetchRedirect = () =>
+      (global.fetch as jest.Mock).mock.calls.at(-1)?.[1]?.redirect;
+
+    it.each([executeOAuthProxy, executeDebugOAuthProxy])(
+      "%o honors an explicit manual redirect without httpsOnly",
+      async (proxyFn) => {
+        (global.fetch as jest.Mock).mockResolvedValueOnce(jsonResponse());
+        await proxyFn({
+          url: "http://localhost:3000/client.json",
+          redirect: "manual",
+        });
+        expect(lastFetchRedirect()).toBe("manual");
+      }
+    );
+
+    it("preserves the historical follow default when redirect is omitted", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce(jsonResponse());
+      await executeDebugOAuthProxy({ url: "http://localhost:3000/metadata" });
+      expect(lastFetchRedirect()).toBe("follow");
+    });
+
+    it("cannot weaken httpsOnly to follow with an explicit redirect", async () => {
+      vi.mocked(dns.resolve4).mockResolvedValueOnce(["93.184.216.34"]);
+      vi.mocked(dns.resolve6).mockResolvedValueOnce([]);
+      (global.fetch as jest.Mock).mockResolvedValueOnce(jsonResponse());
+      await executeDebugOAuthProxy({
+        url: "https://example.com/metadata",
+        httpsOnly: true,
+        redirect: "follow",
+      });
+      expect(lastFetchRedirect()).toBe("manual");
     });
   });
 });

--- a/sdk/tests/oauth/dynamic-client-registration.test.ts
+++ b/sdk/tests/oauth/dynamic-client-registration.test.ts
@@ -389,6 +389,10 @@ describe("validateClientIdMetadataUrl (CIMD draft-02)", () => {
     ["\thttps://example.com/client.json", "literal https"], // leading tab
     ["https://example.com/cli ent.json", "whitespace"], // literal space
     ["https://example.com\\client.json", "backslashes"], // backslash path sep
+    // Extra slashes after the scheme: new URL() promotes the next token to the
+    // host, so the raw identity string wouldn't name the host fetch hits.
+    ["https:///169.254.169.254/latest", "host"],
+    ["https:////example.com/client.json", "host"],
     ["https://example.com/client.json#frag", "fragment"],
     // No path component at all (a bare authority) is rejected; a root "/" is
     // accepted above.

--- a/sdk/tests/oauth/dynamic-client-registration.test.ts
+++ b/sdk/tests/oauth/dynamic-client-registration.test.ts
@@ -393,6 +393,12 @@ describe("validateClientIdMetadataUrl (CIMD draft-02)", () => {
     ["https://example.com/a/../client.json", "dot path segments"],
     ["https://example.com/./client.json", "dot path segments"],
     ["https://example.com/a/..", "dot path segments"],
+    // Percent-encoded dot segments: WHATWG decodes %2e (any case) during
+    // dot-segment detection, so these collapse exactly like literal dots.
+    ["https://example.com/a/%2e%2e/client.json", "dot path segments"],
+    ["https://example.com/a/%2E./client.json", "dot path segments"],
+    ["https://example.com/.%2e/client.json", "dot path segments"],
+    ["https://example.com/%2e/client.json", "dot path segments"],
   ])("rejects %s", (url, messageFragment) => {
     expect(() => validateClientIdMetadataUrl(url)).toThrow(
       new RegExp(messageFragment.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i")

--- a/sdk/tests/oauth/dynamic-client-registration.test.ts
+++ b/sdk/tests/oauth/dynamic-client-registration.test.ts
@@ -382,10 +382,13 @@ describe("validateClientIdMetadataUrl (CIMD draft-02)", () => {
     // Empty userinfo: WHATWG URL normalizes username/password to "" (falsy),
     // so this must be caught on the raw authority, not the parsed fields.
     ["https://@example.com/client.json", "userinfo"],
-    // Non-canonical userinfo spellings WHATWG still parses: single-slash and
-    // backslash forms populate username, so the parsed check must run too.
-    ["https:/user@example.com/client.json", "userinfo"],
-    ["https://@example.com/client.json".replace("//", "/"), "userinfo"],
+    // Transport-normalized spellings new URL() accepts but fetch would request
+    // differently — rejected up front so the returned string is what fetch uses.
+    ["https:/example.com/client.json", "literal https"], // single-slash scheme
+    ["https:/user@example.com/client.json", "literal https"],
+    ["\thttps://example.com/client.json", "literal https"], // leading tab
+    ["https://example.com/cli ent.json", "whitespace"], // literal space
+    ["https://example.com\\client.json", "backslashes"], // backslash path sep
     ["https://example.com/client.json#frag", "fragment"],
     // No path component at all (a bare authority) is rejected; a root "/" is
     // accepted above.

--- a/sdk/tests/oauth/dynamic-client-registration.test.ts
+++ b/sdk/tests/oauth/dynamic-client-registration.test.ts
@@ -1,0 +1,495 @@
+import {
+  buildDynamicClientRegistrationRequest,
+  executeDynamicClientRegistration,
+  redactDynamicClientRegistrationResponse,
+} from "../../src/oauth/state-machines/shared/dynamic-client-registration.js";
+import { createOAuthStateMachine } from "../../src/oauth/state-machines/factory.js";
+import { EMPTY_OAUTH_FLOW_STATE } from "../../src/oauth/state-machines/types.js";
+import type { OAuthProtocolVersion } from "../../src/oauth/state-machines/types.js";
+import { validateClientIdMetadataUrl } from "../../src/oauth/state-machines/shared/client-id-metadata.js";
+import {
+  DEFAULT_MCPJAM_CLIENT_ID_METADATA_URL,
+  XAA_DEBUG_CLIENT_ID_METADATA_URL,
+  evaluateIdJagClientMetadata,
+  getXaaDebugClientMetadata,
+} from "../../src/oauth/client-identity.js";
+import type { OAuthHttpRequest } from "../../src/oauth/state-machines/types.js";
+
+const REGISTRATION_ENDPOINT = "https://auth.example.com/register";
+const REDIRECT_URI = "https://client.example.com/callback";
+const SECRET = "super-secret-client-secret-value";
+
+const okResult = (body: unknown, status = 201) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  statusText: status === 201 ? "Created" : "OK",
+  headers: { "content-type": "application/json" },
+  body,
+});
+
+const buildRequest = (
+  overrides: Partial<
+    Parameters<typeof buildDynamicClientRegistrationRequest>[0]
+  > = {}
+): OAuthHttpRequest =>
+  buildDynamicClientRegistrationRequest({
+    registrationEndpoint: REGISTRATION_ENDPOINT,
+    redirectUri: REDIRECT_URI,
+    dynamicRegistrationDefaults: { client_name: "Test Client" },
+    ...overrides,
+  });
+
+describe("buildDynamicClientRegistrationRequest", () => {
+  it("applies authorization-code fallbacks when defaults omit fields", () => {
+    const request = buildRequest();
+    expect(request.method).toBe("POST");
+    expect(request.url).toBe(REGISTRATION_ENDPOINT);
+    expect(request.headers["Content-Type"]).toBe("application/json");
+    expect(request.body).toEqual({
+      client_name: "Test Client",
+      redirect_uris: [REDIRECT_URI],
+      grant_types: ["authorization_code", "refresh_token"],
+      response_types: ["code"],
+      token_endpoint_auth_method: "none",
+    });
+  });
+
+  it("lets caller-supplied defaults win over fallbacks", () => {
+    const request = buildRequest({
+      dynamicRegistrationDefaults: {
+        client_name: "Test Client",
+        redirect_uris: ["https://other.example.com/cb"],
+        grant_types: ["client_credentials"],
+        response_types: [],
+        token_endpoint_auth_method: "client_secret_post",
+      },
+    });
+    expect(request.body).toEqual({
+      client_name: "Test Client",
+      redirect_uris: ["https://other.example.com/cb"],
+      grant_types: ["client_credentials"],
+      response_types: [],
+      token_endpoint_auth_method: "client_secret_post",
+    });
+  });
+
+  it("adds scope only when truthy", () => {
+    expect(buildRequest({ scope: "read write" }).body.scope).toBe("read write");
+    expect(buildRequest({ scope: "" }).body.scope).toBeUndefined();
+    expect(buildRequest().body.scope).toBeUndefined();
+  });
+
+  it("strips Authorization from custom headers", () => {
+    const request = buildRequest({
+      customHeaders: { Authorization: "Bearer leaked", "X-Custom": "yes" },
+    });
+    expect(request.headers.Authorization).toBeUndefined();
+    expect(request.headers["X-Custom"]).toBe("yes");
+  });
+});
+
+describe("redactDynamicClientRegistrationResponse", () => {
+  it("masks credential fields recursively and leaves metadata inspectable", () => {
+    const redacted = redactDynamicClientRegistrationResponse({
+      status: 201,
+      statusText: "Created",
+      headers: { "content-type": "application/json" },
+      body: {
+        client_id: "abc",
+        client_secret: SECRET,
+        registration_access_token: "reg-token-value-1",
+        nested: {
+          access_token: "access-token-value-2",
+          list: [{ refresh_token: "refresh-token-value-3" }, "plain"],
+        },
+        client_name: "Test Client",
+      },
+    });
+    const serialized = JSON.stringify(redacted);
+    expect(serialized).not.toContain(SECRET);
+    expect(serialized).not.toContain("reg-token-value-1");
+    expect(serialized).not.toContain("access-token-value-2");
+    expect(serialized).not.toContain("refresh-token-value-3");
+    expect(redacted.body.client_id).toBe("abc");
+    expect(redacted.body.client_name).toBe("Test Client");
+    expect(redacted.body.client_secret).toBe("***REDACTED***");
+    expect(redacted.body.nested.list[1]).toBe("plain");
+    expect(redacted.status).toBe(201);
+  });
+});
+
+describe("executeDynamicClientRegistration", () => {
+  const history = () => [
+    {
+      timestamp: Date.now() - 5,
+      request: buildRequest(),
+    },
+  ];
+
+  it("passes the caller's exact request to the executor unchanged", async () => {
+    const request = buildRequest();
+    const executor = jest.fn().mockResolvedValue(okResult({ client_id: "c" }));
+    await executeDynamicClientRegistration({
+      request,
+      requestExecutor: executor,
+      httpHistory: history(),
+    });
+    expect(executor).toHaveBeenCalledTimes(1);
+    expect(executor.mock.calls[0][0]).toBe(request);
+  });
+
+  it("parses a successful registration and keeps raw credentials out of diagnostics", async () => {
+    const outcome = await executeDynamicClientRegistration({
+      request: buildRequest(),
+      requestExecutor: jest.fn().mockResolvedValue(
+        okResult({
+          client_id: "generated-client",
+          client_secret: SECRET,
+          client_secret_expires_at: 1234567890,
+          token_endpoint_auth_method: "client_secret_post",
+          client_name: "Test Client",
+          grant_types: ["authorization_code"],
+        })
+      ),
+      httpHistory: history(),
+    });
+
+    expect(outcome.status).toBe("registered");
+    if (outcome.status !== "registered") return;
+    expect(outcome.credentials).toEqual({
+      clientId: "generated-client",
+      clientSecret: SECRET,
+      tokenEndpointAuthMethod: "client_secret_post",
+      clientSecretExpiresAt: 1234567890,
+    });
+    expect(outcome.missingClientId).toBe(false);
+    expect(outcome.nonCanonicalSuccessStatus).toBe(false);
+
+    const diagnostics = JSON.stringify({
+      response: outcome.response,
+      httpHistory: outcome.httpHistory,
+      infoLogData: outcome.infoLogData,
+    });
+    expect(diagnostics).not.toContain(SECRET);
+    expect(diagnostics).not.toContain(SECRET.substring(0, 8));
+    expect(outcome.infoLogData["Client Secret Issued"]).toBe(true);
+    expect(outcome.infoLogData["Client ID"]).toBe("generated-client");
+  });
+
+  it("back-fills a cloned last history entry without mutating the caller's", async () => {
+    const callerHistory = history();
+    const callerEntry = callerHistory[0];
+    const outcome = await executeDynamicClientRegistration({
+      request: buildRequest(),
+      requestExecutor: jest
+        .fn()
+        .mockResolvedValue(okResult({ client_id: "c" })),
+      httpHistory: callerHistory,
+    });
+    expect(callerEntry.response).toBeUndefined();
+    if (outcome.status !== "registered") throw new Error("expected success");
+    expect(outcome.httpHistory[0].response?.status).toBe(201);
+    expect(typeof outcome.httpHistory[0].duration).toBe("number");
+  });
+
+  it("is a no-op on empty history", async () => {
+    const outcome = await executeDynamicClientRegistration({
+      request: buildRequest(),
+      requestExecutor: jest
+        .fn()
+        .mockResolvedValue(okResult({ client_id: "c" })),
+      httpHistory: [],
+    });
+    expect(outcome.httpHistory).toEqual([]);
+  });
+
+  it("surfaces missingClientId and non-201 success", async () => {
+    const outcome = await executeDynamicClientRegistration({
+      request: buildRequest(),
+      requestExecutor: jest
+        .fn()
+        .mockResolvedValue(okResult({ client_name: "No ID" }, 200)),
+      httpHistory: history(),
+    });
+    if (outcome.status !== "registered") throw new Error("expected success");
+    expect(outcome.missingClientId).toBe(true);
+    expect(outcome.nonCanonicalSuccessStatus).toBe(true);
+    expect(outcome.credentials.clientId).toBeUndefined();
+  });
+
+  it("keeps the historical http_error strings byte-stable", async () => {
+    const outcome = await executeDynamicClientRegistration({
+      request: buildRequest(),
+      requestExecutor: jest.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        statusText: "Bad Request",
+        headers: {},
+        body: { error: "invalid_client_metadata" },
+      }),
+      httpHistory: history(),
+    });
+    expect(outcome.status).toBe("http_error");
+    if (outcome.status === "registered") return;
+    expect(outcome.error).toBe("Dynamic Client Registration failed (400).");
+    expect(outcome.fallbackNote).toBe(
+      "Dynamic Client Registration failed (400); using pre-registered client credentials."
+    );
+    expect(outcome.errorWithFallbackHint).toBe(
+      "Dynamic Client Registration failed (400). Configure a pre-registered client or enable DCR on the authorization server."
+    );
+  });
+
+  it("synthesizes a status-0 network_error on executor rejection", async () => {
+    const outcome = await executeDynamicClientRegistration({
+      request: buildRequest(),
+      requestExecutor: jest.fn().mockRejectedValue(new Error("boom")),
+      httpHistory: history(),
+    });
+    expect(outcome.status).toBe("network_error");
+    if (outcome.status === "registered") return;
+    expect(outcome.response).toEqual({
+      status: 0,
+      statusText: "Network Error",
+      headers: {},
+      body: { error: "boom" },
+    });
+    expect(outcome.error).toBe("Client registration failed: boom");
+    expect(outcome.errorWithFallbackHint).toBe(
+      "Client registration failed: boom. Configure a pre-registered client or enable DCR on the authorization server."
+    );
+  });
+
+  it.each([null, "not an object", [1, 2]])(
+    "classifies a 2xx %p body as invalid_response",
+    async (body) => {
+      const outcome = await executeDynamicClientRegistration({
+        request: buildRequest(),
+        requestExecutor: jest.fn().mockResolvedValue(okResult(body, 200)),
+        httpHistory: history(),
+      });
+      expect(outcome.status).toBe("invalid_response");
+      if (outcome.status === "registered") return;
+      expect(outcome.error).toBe(
+        "Client registration failed: the registration response body was not a JSON object"
+      );
+    }
+  );
+
+  it("redacts credentials in error-response diagnostics too", async () => {
+    const outcome = await executeDynamicClientRegistration({
+      request: buildRequest(),
+      requestExecutor: jest.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        statusText: "Bad Request",
+        headers: {},
+        body: { error: "bad", echoed: { client_secret: SECRET } },
+      }),
+      httpHistory: history(),
+    });
+    expect(JSON.stringify(outcome)).not.toContain(SECRET);
+  });
+});
+
+describe("getXaaDebugClientMetadata + evaluateIdJagClientMetadata", () => {
+  it.each(["client_secret_post", "none"] as const)(
+    "builder output with %s self-evaluates to all-present",
+    (method) => {
+      const metadata = getXaaDebugClientMetadata({
+        tokenEndpointAuthMethod: method,
+      });
+      expect(metadata.redirect_uris).toBeUndefined();
+      expect(metadata.response_types).toBeUndefined();
+      const evaluation = evaluateIdJagClientMetadata(
+        metadata as Record<string, unknown>
+      );
+      expect(evaluation.profile).toBe("present");
+      expect(evaluation.jwtBearerGrant).toBe("present");
+      expect(evaluation.tokenExchangeGrant).toBe("present");
+      expect(evaluation.tokenEndpointAuthMethod).toBe(method);
+    }
+  );
+
+  it("classifies omitted vs contradicted for each field", () => {
+    expect(evaluateIdJagClientMetadata({})).toEqual({
+      profile: "omitted",
+      jwtBearerGrant: "omitted",
+      tokenExchangeGrant: "omitted",
+      tokenEndpointAuthMethod: undefined,
+    });
+
+    const contradicted = evaluateIdJagClientMetadata({
+      authorization_grant_profiles_supported: ["urn:other:profile"],
+      grant_types: ["authorization_code"],
+      token_endpoint_auth_method: "private_key_jwt",
+    });
+    expect(contradicted.profile).toBe("contradicted");
+    expect(contradicted.jwtBearerGrant).toBe("contradicted");
+    expect(contradicted.tokenExchangeGrant).toBe("contradicted");
+    expect(contradicted.tokenEndpointAuthMethod).toBe("private_key_jwt");
+
+    const partial = evaluateIdJagClientMetadata({
+      grant_types: [
+        "urn:ietf:params:oauth:grant-type:jwt-bearer",
+        "authorization_code",
+      ],
+    });
+    expect(partial.jwtBearerGrant).toBe("present");
+    expect(partial.tokenExchangeGrant).toBe("contradicted");
+    expect(partial.profile).toBe("omitted");
+  });
+
+  it("treats a non-array property value as an explicit contradiction", () => {
+    const evaluation = evaluateIdJagClientMetadata({
+      authorization_grant_profiles_supported: "not-a-list",
+      grant_types: 42,
+    });
+    expect(evaluation.profile).toBe("contradicted");
+    expect(evaluation.jwtBearerGrant).toBe("contradicted");
+  });
+});
+
+describe("validateClientIdMetadataUrl (CIMD draft-02)", () => {
+  it("returns the original string unchanged (simple string identity)", () => {
+    const url = "https://example.com:443/client%2Fmetadata.json";
+    expect(validateClientIdMetadataUrl(url)).toBe(url);
+  });
+
+  it("accepts the existing default and XAA URLs", () => {
+    expect(
+      validateClientIdMetadataUrl(DEFAULT_MCPJAM_CLIENT_ID_METADATA_URL)
+    ).toBe(DEFAULT_MCPJAM_CLIENT_ID_METADATA_URL);
+    expect(validateClientIdMetadataUrl(XAA_DEBUG_CLIENT_ID_METADATA_URL)).toBe(
+      XAA_DEBUG_CLIENT_ID_METADATA_URL
+    );
+  });
+
+  it("accepts a query component (SHOULD NOT, not MUST NOT)", () => {
+    const url = "https://example.com/client.json?v=1";
+    expect(validateClientIdMetadataUrl(url)).toBe(url);
+  });
+
+  it.each([
+    ["not-a-url", "valid absolute URL"],
+    ["http://example.com/client.json", "absolute HTTPS URL"],
+    ["https://user:pw@example.com/client.json", "userinfo"],
+    ["https://example.com/client.json#frag", "fragment"],
+    ["https://example.com", "path component"],
+    ["https://example.com/", "path component"],
+    ["https://example.com/a/../client.json", "dot path segments"],
+    ["https://example.com/./client.json", "dot path segments"],
+    ["https://example.com/a/..", "dot path segments"],
+  ])("rejects %s", (url, messageFragment) => {
+    expect(() => validateClientIdMetadataUrl(url)).toThrow(
+      new RegExp(messageFragment.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i")
+    );
+  });
+});
+
+describe("state machine DCR diagnostic surfaces", () => {
+  const SERVER_URL = "https://mcp.example.com/mcp";
+  const REDIRECT = "http://127.0.0.1:3333/callback";
+
+  const runMachineAtRegistration = async (
+    protocolVersion: OAuthProtocolVersion
+  ) => {
+    const registrationRequest = buildRequest();
+    let state = {
+      ...EMPTY_OAUTH_FLOW_STATE,
+      currentStep: "request_client_registration" as const,
+      authorizationServerMetadata: {
+        registration_endpoint: REGISTRATION_ENDPOINT,
+      },
+      lastRequest: registrationRequest,
+      httpHistory: [
+        {
+          step: "request_client_registration" as const,
+          timestamp: Date.now(),
+          request: registrationRequest,
+        },
+      ],
+      infoLogs: [],
+    };
+
+    const machine = createOAuthStateMachine({
+      protocolVersion,
+      registrationStrategy: "dcr",
+      state,
+      getState: () => state,
+      updateState: (updates: any) => {
+        state = { ...state, ...updates };
+      },
+      serverUrl: SERVER_URL,
+      serverName: "Test Server",
+      redirectUrl: REDIRECT,
+      requestExecutor: jest.fn().mockResolvedValue(
+        okResult({
+          client_id: "minted-client",
+          client_secret: SECRET,
+          token_endpoint_auth_method: "client_secret_post",
+          client_name: "Test Client",
+        })
+      ),
+      dynamicRegistration: { client_name: "Test Client" },
+    } as any);
+
+    await machine.proceedToNextStep();
+    return state;
+  };
+
+  it.each(["2025-03-26", "2025-06-18", "2025-11-25"] as const)(
+    "%s keeps the issued secret out of lastResponse/httpHistory/infoLogs",
+    async (version) => {
+      const state = await runMachineAtRegistration(version);
+      expect(state.currentStep).toBe("received_client_credentials");
+      // Operational path: the machine still holds the raw secret for the
+      // token request...
+      expect((state as any).clientSecret).toBe(SECRET);
+      expect((state as any).clientId).toBe("minted-client");
+      // ...but no diagnostic surface may contain even a prefix of it.
+      const diagnostics = JSON.stringify({
+        lastResponse: (state as any).lastResponse,
+        httpHistory: state.httpHistory,
+        infoLogs: state.infoLogs,
+      });
+      expect(diagnostics).not.toContain(SECRET);
+      expect(diagnostics).not.toContain(SECRET.substring(0, 8));
+    }
+  );
+
+  it("2025-11-25 default CIMD URL remains valid through the shared validator", async () => {
+    let state = {
+      ...EMPTY_OAUTH_FLOW_STATE,
+      currentStep: "received_authorization_server_metadata" as const,
+      authorizationServerMetadata: {
+        issuer: "https://auth.example.com",
+        authorization_endpoint: "https://auth.example.com/authorize",
+        token_endpoint: "https://auth.example.com/token",
+        client_id_metadata_document_supported: true,
+      },
+      httpHistory: [],
+      infoLogs: [],
+    };
+
+    const machine = createOAuthStateMachine({
+      protocolVersion: "2025-11-25",
+      registrationStrategy: "cimd",
+      clientIdMetadataUrl: DEFAULT_MCPJAM_CLIENT_ID_METADATA_URL,
+      state,
+      getState: () => state,
+      updateState: (updates: any) => {
+        state = { ...state, ...updates };
+      },
+      serverUrl: SERVER_URL,
+      serverName: "Test Server",
+      redirectUrl: REDIRECT,
+      requestExecutor: jest.fn(),
+    } as any);
+
+    await machine.proceedToNextStep();
+    expect(state.currentStep).toBe("cimd_prepare");
+    // Simple-string identity: the client_id is the exact configured URL.
+    expect((state as any).clientId).toBe(DEFAULT_MCPJAM_CLIENT_ID_METADATA_URL);
+  });
+});

--- a/sdk/tests/oauth/dynamic-client-registration.test.ts
+++ b/sdk/tests/oauth/dynamic-client-registration.test.ts
@@ -374,6 +374,9 @@ describe("validateClientIdMetadataUrl (CIMD draft-02)", () => {
     ["not-a-url", "valid absolute URL"],
     ["http://example.com/client.json", "absolute HTTPS URL"],
     ["https://user:pw@example.com/client.json", "userinfo"],
+    // Empty userinfo: WHATWG URL normalizes username/password to "" (falsy),
+    // so this must be caught on the raw authority, not the parsed fields.
+    ["https://@example.com/client.json", "userinfo"],
     ["https://example.com/client.json#frag", "fragment"],
     ["https://example.com", "path component"],
     ["https://example.com/", "path component"],

--- a/sdk/tests/oauth/dynamic-client-registration.test.ts
+++ b/sdk/tests/oauth/dynamic-client-registration.test.ts
@@ -376,6 +376,15 @@ describe("validateClientIdMetadataUrl (CIMD draft-02)", () => {
   });
 
   it.each([
+    "HTTPS://example.com/client.json",
+    "HtTpS://example.com/client.json",
+  ])("accepts a case-insensitive https scheme %s", (url) => {
+    // RFC 3986 schemes are case-insensitive and the case doesn't change the
+    // host; the string is returned unchanged for byte-exact identity.
+    expect(validateClientIdMetadataUrl(url)).toBe(url);
+  });
+
+  it.each([
     ["not-a-url", "valid absolute URL"],
     ["http://example.com/client.json", "absolute HTTPS URL"],
     ["https://user:pw@example.com/client.json", "userinfo"],
@@ -384,9 +393,9 @@ describe("validateClientIdMetadataUrl (CIMD draft-02)", () => {
     ["https://@example.com/client.json", "userinfo"],
     // Transport-normalized spellings new URL() accepts but fetch would request
     // differently — rejected up front so the returned string is what fetch uses.
-    ["https:/example.com/client.json", "literal https"], // single-slash scheme
-    ["https:/user@example.com/client.json", "literal https"],
-    ["\thttps://example.com/client.json", "literal https"], // leading tab
+    ["https:/example.com/client.json", "scheme"], // single-slash scheme
+    ["https:/user@example.com/client.json", "scheme"],
+    ["\thttps://example.com/client.json", "scheme"], // leading tab
     ["https://example.com/cli ent.json", "whitespace"], // literal space
     ["https://example.com\\client.json", "backslashes"], // backslash path sep
     // Extra slashes after the scheme: new URL() promotes the next token to the

--- a/sdk/tests/oauth/dynamic-client-registration.test.ts
+++ b/sdk/tests/oauth/dynamic-client-registration.test.ts
@@ -370,6 +370,11 @@ describe("validateClientIdMetadataUrl (CIMD draft-02)", () => {
     expect(validateClientIdMetadataUrl(url)).toBe(url);
   });
 
+  it("accepts a root path (NOT RECOMMENDED per draft-02 §3, but valid)", () => {
+    const url = "https://example.com/";
+    expect(validateClientIdMetadataUrl(url)).toBe(url);
+  });
+
   it.each([
     ["not-a-url", "valid absolute URL"],
     ["http://example.com/client.json", "absolute HTTPS URL"],
@@ -377,9 +382,14 @@ describe("validateClientIdMetadataUrl (CIMD draft-02)", () => {
     // Empty userinfo: WHATWG URL normalizes username/password to "" (falsy),
     // so this must be caught on the raw authority, not the parsed fields.
     ["https://@example.com/client.json", "userinfo"],
+    // Non-canonical userinfo spellings WHATWG still parses: single-slash and
+    // backslash forms populate username, so the parsed check must run too.
+    ["https:/user@example.com/client.json", "userinfo"],
+    ["https://@example.com/client.json".replace("//", "/"), "userinfo"],
     ["https://example.com/client.json#frag", "fragment"],
+    // No path component at all (a bare authority) is rejected; a root "/" is
+    // accepted above.
     ["https://example.com", "path component"],
-    ["https://example.com/", "path component"],
     ["https://example.com/a/../client.json", "dot path segments"],
     ["https://example.com/./client.json", "dot path segments"],
     ["https://example.com/a/..", "dot path segments"],

--- a/sdk/tests/oauth/state-machine-regressions.test.ts
+++ b/sdk/tests/oauth/state-machine-regressions.test.ts
@@ -472,4 +472,70 @@ describe("OAuth state machine regressions", () => {
       expect(summary?.data["CIMD Supported"]).toBe(expectedRow);
     },
   );
+
+  // Regression (Codex review, PR #3138): a strict-conformance 2xx registration
+  // response with a non-object body is classified invalid_response by the
+  // shared helper. The old success-path strict missing-client_id branch cleared
+  // isInitiatingAuth for that exact body shape, so the reclassification must
+  // still clear it — otherwise the flow is left "initiating" after failing.
+  it.each(["2025-03-26", "2025-06-18"] as const)(
+    "clears isInitiatingAuth on a strict invalid_response DCR body in %s",
+    async (protocolVersion) => {
+      let state = {
+        ...EMPTY_OAUTH_FLOW_STATE,
+        currentStep: "request_client_registration" as const,
+        authorizationServerMetadata: {
+          registration_endpoint: REGISTRATION_ENDPOINT,
+        },
+        lastRequest: {
+          method: "POST",
+          url: REGISTRATION_ENDPOINT,
+          headers: {},
+          body: { client_name: "Test Client" },
+        },
+        httpHistory: [
+          {
+            step: "request_client_registration" as const,
+            timestamp: Date.now(),
+            request: {
+              method: "POST",
+              url: REGISTRATION_ENDPOINT,
+              headers: {},
+              body: { client_name: "Test Client" },
+            },
+          },
+        ],
+        infoLogs: [],
+        isInitiatingAuth: true,
+      };
+
+      const machine = createOAuthStateMachine({
+        protocolVersion,
+        registrationStrategy: "dcr",
+        strictConformance: true,
+        state,
+        getState: () => state,
+        updateState: (updates) => {
+          state = { ...state, ...updates };
+        },
+        serverUrl: SERVER_URL,
+        serverName: "Test Server",
+        redirectUrl: REDIRECT_URI,
+        // 2xx with a non-object body → invalid_response.
+        requestExecutor: jest.fn().mockResolvedValue({
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          body: "not-json",
+        }),
+        dynamicRegistration: { client_name: "Test Client" },
+      });
+
+      await machine.proceedToNextStep();
+
+      expect(state.error).toBeTruthy();
+      expect(state.isInitiatingAuth).toBe(false);
+    },
+  );
 });


### PR DESCRIPTION
## What & why

Extracts the **byte-duplicated Dynamic Client Registration (RFC 7591)** logic from the three OAuth debug state machines into a single shared, exported helper, and adds the XAA (Cross-App Access / ID-JAG) client-identity building blocks the inspector needs. This is PR1 of 2 — the inspector PR (open DCR + CIMD strategies) builds on these exports.

## Changes

**Shared DCR core** — `sdk/src/oauth/state-machines/shared/dynamic-client-registration.ts`
- `buildDynamicClientRegistrationRequest` + `executeDynamicClientRegistration` (+ `DynamicClientRegistrationOutcome`). All three debug machines (`2025-03-26/06-18/11-25`) now call these; their orchestration, transitions, fallback behavior, and **user-facing error strings are preserved** (including 11-25's `isInitiatingAuth: false` divergence on its two error writes, and each version's scope-sourcing).
- **Intentional behavior changes** (called out so this isn't mis-framed as "no behavior change"):
  - Registration responses are **credential-redacted** (`client_secret`, `registration_access_token`, `access_token`, `refresh_token`) before reaching `lastResponse` / `httpHistory` / info logs. Raw credentials travel only through the returned `credentials`/`clientInfo`.
  - The truncated-secret info log becomes a `Client Secret Issued: true` boolean.
  - A 2xx response with a null/non-object body is classified `invalid_response` and takes the pre-registered-fallback path instead of proceeding with `undefined` credentials.

**XAA client identity** — `sdk/src/oauth/client-identity.ts`
- `getXaaDebugClientMetadata`, `evaluateIdJagClientMetadata`, `ID_JAG_GRANT_PROFILE` / `TOKEN_EXCHANGE_GRANT` / `JWT_BEARER_GRANT`, `XAA_DEBUG_CLIENT_ID_METADATA_URL`. Pinned to `draft-ietf-oauth-identity-assertion-authz-grant-04`.

**CIMD URL validation** — `sdk/src/oauth/state-machines/shared/client-id-metadata.ts`
- `validateClientIdMetadataUrl`, updated to `draft-ietf-oauth-client-id-metadata-document-02`: requires a path component, rejects userinfo/fragment/raw dot segments, accepts a query, and **returns the original string unchanged** (simple-string identity — the old CIMD validator `URL.toString()`-normalized it). The 2025-11-25 machine now imports this.

**Redirect knob** — `OAuthProxyRequest.redirect` / `OAuthHttpRequest.redirect` (`"follow" | "manual"`). `httpsOnly` still always forces `manual` and cannot be weakened; omission preserves the historical `follow`.

## Testing
- New `tests/oauth/dynamic-client-registration.test.ts` (build / execute / redaction / evaluator self-consistency / CIMD URL rules / redirect plumbing) + per-machine no-secret-in-diagnostics regressions.
- Existing OAuth suites pass **unchanged** (behavior-preservation gate). Full SDK: **1723 passed**, build + packaging green.

Minor changeset included → expected release `@mcpjam/sdk@1.31.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth registration, client identity, and CIMD URL validation used by debug flows and upcoming inspector work; credential redaction and invalid-response handling change observable debugger behavior but are tested and scoped.
> 
> **Overview**
> Pulls duplicated **RFC 7591 Dynamic Client Registration** out of the three OAuth debug state machines into shared **`buildDynamicClientRegistrationRequest`** / **`executeDynamicClientRegistration`** exports (browser + Node). Machines still own orchestration and the same user-facing error strings; execution uses the recorded **`lastRequest`** so UI and wire stay aligned.
> 
> **Intentional DCR behavior changes:** registration responses are **credential-redacted** on `lastResponse`, HTTP history, and info logs (raw secrets only via returned `credentials`/`clientInfo`); DCR info logs show **`Client Secret Issued: true`** instead of a truncated secret; **2xx with a null/non-object body** is **`invalid_response`** with pre-registered fallback (strict **2025-03-26/06-18** also clears **`isInitiatingAuth`** for that case).
> 
> Adds **XAA (ID-JAG draft-04)** helpers: **`getXaaDebugClientMetadata`**, **`evaluateIdJagClientMetadata`**, grant/profile constants, and **`XAA_DEBUG_CLIENT_ID_METADATA_URL`**.
> 
> Replaces inline CIMD validation with **`validateClientIdMetadataUrl`** (draft-02): stricter rules and **returns the input string unchanged** (no `URL.toString()` normalization). **2025-11-25** uses this shared validator.
> 
> **OAuth proxy / HTTP request** types gain optional **`redirect: "follow" | "manual"`**; **`httpsOnly`** still forces **`manual`**.
> 
> New tests cover DCR, CIMD URLs, redirect plumbing, and no-secrets-in-diagnostics across all three machines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4a12279132146771f1802b44ad6ebba86edcbb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted RFC 7591 Dynamic Client Registration into a shared core, added XAA (ID‑JAG) client identity helpers, tightened CIMD draft‑02 Client ID URL validation (case‑insensitive https:// with two slashes; rejects empty authority and dot‑segments), and added an OAuth proxy redirect option. Debug OAuth flows keep behavior with safer diagnostics and stricter response checks.

- **New Features**
  - Shared DCR helpers: build/execute (`buildDynamicClientRegistrationRequest`, `executeDynamicClientRegistration`) with typed outcomes and redacted diagnostics.
  - XAA (ID‑JAG draft‑04) client identity: `getXaaDebugClientMetadata`, `evaluateIdJagClientMetadata`, `ID_JAG_GRANT_PROFILE`, `TOKEN_EXCHANGE_GRANT`, `JWT_BEARER_GRANT`, `XAA_DEBUG_CLIENT_ID_METADATA_URL`.
  - CIMD URL validator (draft‑02): `validateClientIdMetadataUrl` returns the original string; requires the https:// scheme with exactly two slashes (scheme is case‑insensitive); rejects controls/space/backslashes and transport‑normalized spellings; rejects userinfo (including empty `https://@host`) and fragments; requires a path (root “/” allowed); rejects dot segments (including percent‑encoded); rejects empty authority after extra slashes (e.g., `https:///host`); accepts a query.
  - OAuth proxy redirect control: `OAuthProxyRequest.redirect` / `OAuthHttpRequest.redirect` ("follow" | "manual"); `httpsOnly` still forces "manual".

- **Refactors**
  - All three debug OAuth machines use the shared DCR core; orchestration and error strings are preserved. 2xx non‑object bodies become `invalid_response`; strict runs on 2025‑03‑26/06‑18 also clear `isInitiatingAuth`.
  - Diagnostics: registration responses redacted before `lastResponse`/`httpHistory`/info logs; secret log becomes `Client Secret Issued: true`. Executed request matches recorded `lastRequest`, and history is backfilled without mutation.

<sup>Written for commit a4a12279132146771f1802b44ad6ebba86edcbb7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

