### PR TITLE
feat(xaa): open DCR + CIMD registration strategies + hosted client metadata document

### DIFF
--- a/.changeset/xaa-dcr-cimd-strategies.md
+++ b/.changeset/xaa-dcr-cimd-strategies.md
@@ -1,0 +1,11 @@
+---
+"@mcpjam/inspector": minor
+---
+
+XAA debugger: target-scoped **open DCR** and **CIMD** client-registration strategies, plus the hosted XAA Client ID Metadata Document.
+
+- New per-target registration-strategy control (manual public targets only; pre-registered stays the default and default runs are byte-identical to before): **Open dynamic registration (DCR)** performs an unauthenticated RFC 7591 registration at the discovered `registration_endpoint`, validates the response against the ID-JAG draft-04 client profile (explicit substitutions park; RFC 7591 echo omissions warn), and keeps the minted credentials in a browser-session-only in-memory cache — never in flow state, storage, history, logs, or telemetry. Reset/Run all reuse the session registration; a confirmed "Register another client" action (also gating retries after any ambiguous POST) is the only path that registers again. **Client metadata URL (CIMD)** preflights MCPJam's hosted document with manual-redirect handling, requires the AS to advertise `client_id_metadata_document_supported`, and uses the URL as the run's `client_id`; JWT Bearer redemption remains the operational verdict.
+- `/proxy/token` gains `tokenEndpointAuthMethod` (`client_secret_post` | `client_secret_basic` | `none`); `client_secret_basic` builds the RFC 6749 Basic header server-side (form-encoded before Base64) and never echoes it into diagnostics. Legacy callers keep body-post behavior.
+- New public route `GET /.well-known/oauth/xaa-client-metadata.json` on both server entry points: a direct-200 JSON Client ID Metadata Document whose `client_id` is the fixed production URL (`https://app.mcpjam.com/...`), declaring the ID-JAG grant profile with both required grants and `token_endpoint_auth_method: "none"`. The login CIMD document on www.mcpjam.com is untouched.
+- The OAuth debug proxy routes and executors thread an optional `redirect: "follow" | "manual"` through to the SDK proxy (hosted `httpsOnly` still forces manual and cannot be weakened).
+- AS-compatibility preflight now reports the draft-04 ID-JAG grant-profile advertisement (absent = warning, explicit contradiction = fail) and CIMD support (informational; never degrades the overall verdict).

--- a/mcpjam-inspector/client/src/components/__tests__/XAAFlowTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/XAAFlowTab.test.tsx
@@ -480,4 +480,89 @@ describe("XAAFlowTab", () => {
       ),
     );
   });
+
+  describe("registration strategy control", () => {
+    it("shows the selector for an eligible manual public target and threads the choice to the machine", async () => {
+      const user = userEvent.setup();
+      render(
+        <XAAFlowTab
+          serverConfigs={{}}
+          selectedServerName="staging"
+        />,
+      );
+
+      // All three options render; default is pre-registered.
+      expect(screen.getByText(/client registration/i)).toBeInTheDocument();
+      const dcrOption = screen.getByRole("radio", {
+        name: /open dynamic registration/i,
+      });
+      expect(dcrOption).toHaveAttribute("aria-checked", "false");
+      expect(capturedMachineConfig.registrationStrategy).toBe(
+        "pre_registered",
+      );
+
+      await user.click(dcrOption);
+      await waitFor(() =>
+        expect(capturedMachineConfig.registrationStrategy).toBe("dcr"),
+      );
+      expect(dcrOption).toHaveAttribute("aria-checked", "true");
+      // A session credential cache rides along, keyed by the target.
+      expect(capturedMachineConfig.dcrCredentialCache).toBeDefined();
+      expect(capturedMachineConfig.dcrCacheTargetKey).toBe(
+        currentTarget.targetKey,
+      );
+
+      await user.click(
+        screen.getByRole("radio", { name: /client metadata url/i }),
+      );
+      await waitFor(() =>
+        expect(capturedMachineConfig.registrationStrategy).toBe("cimd"),
+      );
+    });
+
+    it("hides the selector for confidential server-side-secret targets", () => {
+      currentTarget = makeTarget({
+        usesServerSideSecret: true,
+        serverId: "srv_1",
+        projectId: "proj_1",
+      } as Partial<XaaTestTarget>);
+      render(
+        <XAAFlowTab
+          serverConfigs={{}}
+          selectedServerName="staging"
+          projectId="proj_1"
+        />,
+      );
+      expect(screen.queryByText(/client registration/i)).not.toBeInTheDocument();
+      expect(capturedMachineConfig.registrationStrategy).toBe(
+        "pre_registered",
+      );
+    });
+
+    it("hides the selector for registration-backed targets", () => {
+      currentTarget = makeTarget({
+        targetSource: "registration",
+        runInput: {
+          ...makeTarget().runInput,
+          registrationId: "app_1",
+        },
+      } as Partial<XaaTestTarget>);
+      render(
+        <XAAFlowTab serverConfigs={{}} selectedServerName="staging" />,
+      );
+      expect(screen.queryByText(/client registration/i)).not.toBeInTheDocument();
+      expect(capturedMachineConfig.registrationStrategy).toBe(
+        "pre_registered",
+      );
+    });
+
+    it("hides the selector for unconfigured (not testable) targets", () => {
+      currentTarget = makeTarget({ isTestable: false });
+      render(
+        <XAAFlowTab serverConfigs={{}} selectedServerName="staging" />,
+      );
+      expect(screen.queryByText(/client registration/i)).not.toBeInTheDocument();
+    });
+  });
 });
+

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowLogger.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowLogger.tsx
@@ -662,6 +662,26 @@ export function XAAFlowLogger({
           />
         )}
 
+        {/* Non-blocking readiness/conformance findings from DCR or CIMD
+            setup. Warnings, not errors — the flow continued past them. */}
+        {(flowState.registrationWarnings?.length ?? 0) > 0 && (
+          <Alert>
+            <AlertTriangle className="h-4 w-4" />
+            <AlertDescription>
+              <div className="space-y-1">
+                <p className="text-xs font-medium">
+                  Client registration warnings
+                </p>
+                <ul className="list-disc space-y-1 pl-4 text-xs">
+                  {flowState.registrationWarnings!.map((warning) => (
+                    <li key={warning.code}>{warning.message}</li>
+                  ))}
+                </ul>
+              </div>
+            </AlertDescription>
+          </Alert>
+        )}
+
         {(() => {
           const currentStepHttpEntries = (flowState.httpHistory || []).filter(
             (entry) => entry.step === flowState.currentStep

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -594,8 +594,11 @@ export function XAAFlowTab({
   // and reset, so the next run performs a fresh registration POST. This is
   // also the only path that clears dcrRetryMayCreateDuplicate.
   const registerAnotherClient = useCallback(() => {
+    // The cache key's first component is the encoded target key (see
+    // dcrCacheKeyFor); match on that encoded prefix.
+    const targetPrefix = `${encodeURIComponent(targetKey)}::`;
     for (const key of Array.from(dcrCredentialCacheRef.current.keys())) {
-      if (key.startsWith(`${targetKey}::`)) {
+      if (key.startsWith(targetPrefix)) {
         dcrCredentialCacheRef.current.delete(key);
       }
     }
@@ -608,7 +611,7 @@ export function XAAFlowTab({
   const dcrHasSessionRegistration =
     effectiveStrategy === "dcr" &&
     Array.from(dcrCredentialCacheRef.current.keys()).some((key) =>
-      key.startsWith(`${targetKey}::`)
+      key.startsWith(`${encodeURIComponent(targetKey)}::`)
     );
 
   // Resolve the real IdP issuer from the server's OpenID config so the ID-JAG

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -322,6 +322,22 @@ export function XAAFlowTab({
     const resource =
       flowState.resourceMetadata?.resource || runInput.serverUrl || "";
 
+    // The scorecard fires broken tokens using the run's CONFIGURED client
+    // (runInput.clientId), not the identity a dcr/cimd run established. For a
+    // dynamic run those don't match — often the config client_id is empty —
+    // so results would be about the wrong (or no) client and could read as an
+    // all-green pass that proves nothing. Disable it rather than mislead.
+    if (
+      flowState.registrationStrategy === "dcr" ||
+      flowState.registrationStrategy === "cimd"
+    ) {
+      return {
+        input: null,
+        unavailableReason:
+          "Negative tests run against the pre-registered client credentials, not the client this DCR/CIMD run established — so they can't be trusted here. Switch to the pre-registered strategy to exercise the scorecard.",
+      };
+    }
+
     if (selectedRegistration) {
       if (selectedRegistration.authServerMode === "mcpjam") {
         return {
@@ -893,22 +909,34 @@ export function XAAFlowTab({
           if (!open) {
             // Cancel: acknowledge the switch without resetting, so the effect
             // doesn't immediately re-prompt; the current run stays visible.
-            // A strategy change is the exception: revert the selector to the
-            // strategy the still-running flow actually uses, so UI config and
-            // the state-authoritative strategy can't diverge.
             if (pendingReset) {
+              // Capture BEFORE overwriting: was this dialog a pure strategy
+              // toggle on the still-selected target, or a target switch?
+              const wasSameTarget =
+                pendingReset.targetKey === lastAppliedTargetKey.current;
               lastAppliedTargetKey.current = pendingReset.targetKey;
               lastNegativeTestMode.current = pendingReset.negativeTestMode;
               if (
+                wasSameTarget &&
                 pendingReset.registrationStrategy !==
-                lastRegistrationStrategy.current
+                  lastRegistrationStrategy.current
               ) {
+                // Same-target strategy toggle, cancelled: revert the selector
+                // to the strategy the still-running flow uses so UI config and
+                // the state-authoritative strategy can't diverge. Keep
+                // lastRegistrationStrategy.current (= prior) so no re-prompt.
                 const prior = lastRegistrationStrategy.current;
                 const revertKey = pendingReset.targetKey;
                 setStrategyByTarget((current) => ({
                   ...current,
                   [revertKey]: prior,
                 }));
+              } else {
+                // Target switch (or no strategy change) cancelled: acknowledge
+                // the new target's strategy so the effect doesn't re-prompt.
+                // Never write one target's strategy onto another's key.
+                lastRegistrationStrategy.current =
+                  pendingReset.registrationStrategy;
               }
             }
             setPendingReset(null);

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -56,7 +56,11 @@ const INITIAL_RESOURCE_PARAM =
 
 function buildFlowStateFromInput(
   input: XAAFlowInput,
-  registrationStrategy: XaaRegistrationStrategy = "pre_registered"
+  registrationStrategy: XaaRegistrationStrategy = "pre_registered",
+  // A prior ambiguous DCR POST may have created a remote client. This risk is
+  // tracked per-target OUTSIDE flow state so an ordinary reset re-seeds it —
+  // clearing it only through the confirmed "Register another client" path.
+  dcrRetryMayCreateDuplicate = false
 ): XAAFlowState {
   return createInitialXAAFlowState({
     serverUrl: input.serverUrl || undefined,
@@ -71,6 +75,9 @@ function buildFlowStateFromInput(
     // every rebuild path must seed the currently-effective strategy — a
     // clean rebuild must not silently reset a selected DCR run.
     registrationStrategy,
+    ...(dcrRetryMayCreateDuplicate
+      ? { dcrRetryMayCreateDuplicate: true }
+      : {}),
   });
 }
 
@@ -216,6 +223,10 @@ export function XAAFlowTab({
   const dcrCredentialCacheRef = useRef(
     new Map<string, XaaEphemeralDcrCredentials>()
   );
+  // Per-target "a prior POST may have created a remote client" risk. Lives
+  // outside flow state so it survives ordinary resets/Run all; cleared only by
+  // the confirmed "Register another client" action. Page refresh clears it.
+  const dcrDuplicateRiskRef = useRef(new Set<string>());
   const dcrCredentialCache = useMemo(
     () => ({
       get: (key: string) => dcrCredentialCacheRef.current.get(key),
@@ -230,7 +241,11 @@ export function XAAFlowTab({
   );
 
   const [flowState, setFlowState] = useState<XAAFlowState>(() =>
-    buildFlowStateFromInput(target.runInput, effectiveStrategy)
+    buildFlowStateFromInput(
+      target.runInput,
+      effectiveStrategy,
+      dcrDuplicateRiskRef.current.has(targetKey)
+    )
   );
 
   // The machine reads state through this ref (lazy getState). Keep it in
@@ -299,13 +314,19 @@ export function XAAFlowTab({
         registration_strategy: flowStateRef.current.registrationStrategy,
       });
       // A green run proves the user holds valid client credentials the AS
-      // issued — that authorizes broken-token testing against it.
-      setPositiveRunTargets((current) => {
-        if (current.has(runGateKey)) return current;
-        const next = new Set(current);
-        next.add(runGateKey);
-        return next;
-      });
+      // issued — that authorizes broken-token testing against it. Only unlock
+      // for pre-registered runs though: a dcr/cimd run's negative tests would
+      // fire with the configured (often absent) client, not the identity the
+      // run established, so the scorecard stays disabled for those (see the
+      // scorecard memo) and must not be unlocked here either.
+      if (flowStateRef.current.registrationStrategy === "pre_registered") {
+        setPositiveRunTargets((current) => {
+          if (current.has(runGateKey)) return current;
+          const next = new Set(current);
+          next.add(runGateKey);
+          return next;
+        });
+      }
     }
   }, [flowState.currentStep, authServerModeForTelemetry, runGateKey]);
 
@@ -450,11 +471,26 @@ export function XAAFlowTab({
         email: runInput.email,
       };
       applyFlowState(
-        buildFlowStateFromInput(runInput, strategyOverride ?? effectiveStrategy)
+        buildFlowStateFromInput(
+          runInput,
+          strategyOverride ?? effectiveStrategy,
+          // Re-seed the per-target duplicate-registration risk so an ordinary
+          // reset can't drop the confirmation gate.
+          dcrDuplicateRiskRef.current.has(targetKey)
+        )
       );
     },
-    [applyFlowState, runInput, effectiveStrategy]
+    [applyFlowState, runInput, effectiveStrategy, targetKey]
   );
+
+  // Mirror the machine's duplicate-registration risk into the target-scoped
+  // ref so it outlives flow-state rebuilds. (One-way: the machine only ever
+  // sets it true; the ref is cleared solely by "Register another client".)
+  useEffect(() => {
+    if (flowState.dcrRetryMayCreateDuplicate) {
+      dcrDuplicateRiskRef.current.add(targetKey);
+    }
+  }, [flowState.dcrRetryMayCreateDuplicate, targetKey]);
 
   const applyTargetReset = useCallback(
     (
@@ -556,6 +592,9 @@ export function XAAFlowTab({
         dcrCredentialCacheRef.current.delete(key);
       }
     }
+    // The confirmed action is the ONLY thing that clears the duplicate-risk
+    // gate — the user has acknowledged a second remote client may be created.
+    dcrDuplicateRiskRef.current.delete(targetKey);
     rebuildFlow();
   }, [targetKey, rebuildFlow]);
 

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -486,8 +486,15 @@ export function XAAFlowTab({
   // Mirror the machine's duplicate-registration risk into the target-scoped
   // ref so it outlives flow-state rebuilds. (One-way: the machine only ever
   // sets it true; the ref is cleared solely by "Register another client".)
+  // Guard on lastAppliedTargetKey: on a target switch this effect re-runs
+  // with the NEW targetKey while flowState still holds the OLD target's flow
+  // (the reset-owner effect rebuilds afterwards) — without the guard the old
+  // run's risk would wrongly block registration on the new target.
   useEffect(() => {
-    if (flowState.dcrRetryMayCreateDuplicate) {
+    if (
+      flowState.dcrRetryMayCreateDuplicate &&
+      lastAppliedTargetKey.current === targetKey
+    ) {
       dcrDuplicateRiskRef.current.add(targetKey);
     }
   }, [flowState.dcrRetryMayCreateDuplicate, targetKey]);

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -36,8 +36,11 @@ import type { NegativeTestsInput } from "@/lib/xaa/discovery-client";
 import type { NegativeTestMode } from "@/shared/xaa.js";
 import {
   createInitialXAAFlowState,
+  type XaaEphemeralDcrCredentials,
+  type XaaRegistrationStrategy,
   type XAAFlowState,
 } from "@/lib/xaa/types";
+import { XAARegistrationStrategyControl } from "./XAARegistrationStrategyControl";
 import { createInspectorXAAStateMachine } from "@/lib/xaa/debug-state-machine-adapter";
 import { fetchXaaIdpUrls } from "@/lib/xaa/idp-endpoints";
 import { HOSTED_MODE } from "@/lib/config";
@@ -51,7 +54,10 @@ const INITIAL_RESOURCE_PARAM =
     ? null
     : new URLSearchParams(window.location.search).get("resource");
 
-function buildFlowStateFromInput(input: XAAFlowInput): XAAFlowState {
+function buildFlowStateFromInput(
+  input: XAAFlowInput,
+  registrationStrategy: XaaRegistrationStrategy = "pre_registered"
+): XAAFlowState {
   return createInitialXAAFlowState({
     serverUrl: input.serverUrl || undefined,
     authzServerIssuer: input.authzServerIssuer || undefined,
@@ -61,6 +67,10 @@ function buildFlowStateFromInput(input: XAAFlowInput): XAAFlowState {
     clientId: input.clientId || undefined,
     clientSecret: input.clientSecret || undefined,
     scope: input.scope || undefined,
+    // The machine treats its state value as authoritative after init, so
+    // every rebuild path must seed the currently-effective strategy — a
+    // clean rebuild must not silently reset a selected DCR run.
+    registrationStrategy,
   });
 }
 
@@ -178,8 +188,49 @@ export function XAAFlowTab({
     hostedIssuerOptIn ? "hosted" : "local"
   }|${organizationId ?? ""}`;
 
+  // ── Registration strategy (target-scoped, session-only) ─────────────
+  // Deliberately NOT persisted to run settings / localStorage: DCR creates
+  // remote state at the target AS, so a globally saved preference must not
+  // silently apply to a different AS after navigation or reload.
+  const [strategyByTarget, setStrategyByTarget] = useState<
+    Record<string, XaaRegistrationStrategy>
+  >({});
+  // Dynamic strategies need AS discovery (registration_endpoint / the CIMD
+  // advertisement): manual public bar-server targets only. The CIMD
+  // support gate is deliberately NOT part of eligibility — it's discovered
+  // mid-run and parking on it IS the finding.
+  const dynamicStrategyEligible =
+    target.targetSource === "bar_server" &&
+    isTestable &&
+    !target.usesServerSideSecret &&
+    !runInput.registrationId;
+  const selectedStrategy = strategyByTarget[targetKey] ?? "pre_registered";
+  const effectiveStrategy: XaaRegistrationStrategy = dynamicStrategyEligible
+    ? selectedStrategy
+    : "pre_registered";
+
+  // DCR-minted credentials, keyed by target + registration endpoint. A
+  // useRef-backed Map so machine recreation neither loses nor re-exposes the
+  // secret mid-run; never copied into React state, storage, telemetry, or a
+  // debug export. Page refresh clears it — the remote registration persists.
+  const dcrCredentialCacheRef = useRef(
+    new Map<string, XaaEphemeralDcrCredentials>()
+  );
+  const dcrCredentialCache = useMemo(
+    () => ({
+      get: (key: string) => dcrCredentialCacheRef.current.get(key),
+      set: (key: string, value: XaaEphemeralDcrCredentials) => {
+        dcrCredentialCacheRef.current.set(key, value);
+      },
+      delete: (key: string) => {
+        dcrCredentialCacheRef.current.delete(key);
+      },
+    }),
+    []
+  );
+
   const [flowState, setFlowState] = useState<XAAFlowState>(() =>
-    buildFlowStateFromInput(target.runInput)
+    buildFlowStateFromInput(target.runInput, effectiveStrategy)
   );
 
   // The machine reads state through this ref (lazy getState). Keep it in
@@ -225,8 +276,16 @@ export function XAAFlowTab({
       // Salted one-way bucket id — never a server name/URL/hostname.
       target_id: hashXaaTargetId(targetKey),
       auth_server_mode: authServerModeForTelemetry,
+      // Enum only — never an endpoint, client id, or credential.
+      registration_strategy: effectiveStrategy,
     });
-  }, [runInput.mode, target.targetSource, targetKey, authServerModeForTelemetry]);
+  }, [
+    runInput.mode,
+    target.targetSource,
+    targetKey,
+    authServerModeForTelemetry,
+    effectiveStrategy,
+  ]);
 
   useEffect(() => {
     if (flowState.currentStep === "complete" && !completedFired.current) {
@@ -236,6 +295,8 @@ export function XAAFlowTab({
         success: true,
         target_source: targetSourceRef.current,
         auth_server_mode: authServerModeForTelemetry,
+        // The strategy the completed run actually used (state-authoritative).
+        registration_strategy: flowStateRef.current.registrationStrategy,
       });
       // A green run proves the user holds valid client credentials the AS
       // issued — that authorizes broken-token testing against it.
@@ -343,6 +404,9 @@ export function XAAFlowTab({
   // refs; confirms via AlertDialog before discarding a busy or completed run.
   const lastAppliedTargetKey = useRef<string | null>(null);
   const lastNegativeTestMode = useRef(runSettings.negativeTestMode);
+  const lastRegistrationStrategy = useRef<XaaRegistrationStrategy>(
+    effectiveStrategy
+  );
   // The simulated identity the flow was last (re)built with. Tracked so an
   // identity edit rebuilds the flow (clearing the already-minted ID token /
   // ID-JAG that carry the old sub) — without that, advancing step-by-step
@@ -355,6 +419,7 @@ export function XAAFlowTab({
   const [pendingReset, setPendingReset] = useState<{
     targetKey: string;
     negativeTestMode: NegativeTestMode;
+    registrationStrategy: XaaRegistrationStrategy;
   } | null>(null);
 
   // Rebuild the flow from the current input and record the identity it was
@@ -362,28 +427,40 @@ export function XAAFlowTab({
   // reset can tell whether another path (Run all, Reset, target switch) already
   // applied the current identity — and skip a stale timer that would otherwise
   // wipe a freshly-started run.
-  const rebuildFlow = useCallback(() => {
-    lastAppliedIdentity.current = {
-      userId: runInput.userId,
-      email: runInput.email,
-    };
-    applyFlowState(buildFlowStateFromInput(runInput));
-  }, [applyFlowState, runInput]);
+  const rebuildFlow = useCallback(
+    (strategyOverride?: XaaRegistrationStrategy) => {
+      lastAppliedIdentity.current = {
+        userId: runInput.userId,
+        email: runInput.email,
+      };
+      applyFlowState(
+        buildFlowStateFromInput(runInput, strategyOverride ?? effectiveStrategy)
+      );
+    },
+    [applyFlowState, runInput, effectiveStrategy]
+  );
 
   const applyTargetReset = useCallback(
-    (nextTargetKey: string, nextMode: NegativeTestMode) => {
+    (
+      nextTargetKey: string,
+      nextMode: NegativeTestMode,
+      nextStrategy: XaaRegistrationStrategy
+    ) => {
       lastAppliedTargetKey.current = nextTargetKey;
       lastNegativeTestMode.current = nextMode;
-      rebuildFlow();
+      lastRegistrationStrategy.current = nextStrategy;
+      rebuildFlow(nextStrategy);
     },
     [rebuildFlow]
   );
 
   useEffect(() => {
     const nextMode = runSettings.negativeTestMode;
+    const nextStrategy = effectiveStrategy;
     if (
       lastAppliedTargetKey.current === targetKey &&
-      lastNegativeTestMode.current === nextMode
+      lastNegativeTestMode.current === nextMode &&
+      lastRegistrationStrategy.current === nextStrategy
     ) {
       return;
     }
@@ -393,11 +470,20 @@ export function XAAFlowTab({
       lastAppliedTargetKey.current !== null &&
       (current.isBusy || current.currentStep === "complete");
     if (needsConfirm) {
-      setPendingReset({ targetKey, negativeTestMode: nextMode });
+      setPendingReset({
+        targetKey,
+        negativeTestMode: nextMode,
+        registrationStrategy: nextStrategy,
+      });
       return;
     }
-    applyTargetReset(targetKey, nextMode);
-  }, [targetKey, runSettings.negativeTestMode, applyTargetReset]);
+    applyTargetReset(targetKey, nextMode, nextStrategy);
+  }, [
+    targetKey,
+    runSettings.negativeTestMode,
+    effectiveStrategy,
+    applyTargetReset,
+  ]);
 
   // Identity edits rebuild the flow so the next run mints tokens for the new
   // sub/email. Unlike target/mode (which change discretely), the identity
@@ -440,8 +526,28 @@ export function XAAFlowTab({
   }, []);
 
   const resetFlow = useCallback(() => {
+    // Ordinary reset retains the session credential cache, so a DCR run
+    // reuses its registration instead of minting another remote client.
     rebuildFlow();
   }, [rebuildFlow]);
+
+  // Explicit, confirmed action: drop this target's cached registration(s)
+  // and reset, so the next run performs a fresh registration POST. This is
+  // also the only path that clears dcrRetryMayCreateDuplicate.
+  const registerAnotherClient = useCallback(() => {
+    for (const key of Array.from(dcrCredentialCacheRef.current.keys())) {
+      if (key.startsWith(`${targetKey}::`)) {
+        dcrCredentialCacheRef.current.delete(key);
+      }
+    }
+    rebuildFlow();
+  }, [targetKey, rebuildFlow]);
+
+  const dcrHasSessionRegistration =
+    effectiveStrategy === "dcr" &&
+    Array.from(dcrCredentialCacheRef.current.keys()).some((key) =>
+      key.startsWith(`${targetKey}::`)
+    );
 
   // Resolve the real IdP issuer from the server's OpenID config so the ID-JAG
   // inspection step lints against the issuer actually stamped into `iss`, not
@@ -478,6 +584,12 @@ export function XAAFlowTab({
       scope: runInput.scope,
       authzServerIssuer: runInput.authzServerIssuer,
       registrationId: runInput.registrationId,
+      // Client-identity strategy (forced to pre_registered inside the machine
+      // for registrationId/serverId runs) plus the session credential cache
+      // DCR runs mint into and redeem from.
+      registrationStrategy: effectiveStrategy,
+      dcrCredentialCache,
+      dcrCacheTargetKey: targetKey,
       // Confidential bar-server runs send only serverId/projectId; the server
       // resolves the secret and discovers the token endpoint.
       ...(target.usesServerSideSecret && target.serverId
@@ -496,6 +608,9 @@ export function XAAFlowTab({
     resolvedIssuerBaseUrl,
     organizationId,
     hostedIssuerOptIn,
+    effectiveStrategy,
+    dcrCredentialCache,
+    targetKey,
   ]);
 
   const handleAdvance = useCallback(async () => {
@@ -604,6 +719,23 @@ export function XAAFlowTab({
           )
         }
       />
+      {dynamicStrategyEligible ? (
+        <XAARegistrationStrategyControl
+          value={selectedStrategy}
+          onChange={(next) =>
+            setStrategyByTarget((current) => ({
+              ...current,
+              [targetKey]: next,
+            }))
+          }
+          disabled={flowState.isBusy || isRunningAll}
+          showRegisterAnotherClient={
+            dcrHasSessionRegistration ||
+            Boolean(flowState.dcrRetryMayCreateDuplicate)
+          }
+          onRegisterAnotherClient={registerAnotherClient}
+        />
+      ) : null}
       {selectedRegistration ? (
         <div className="flex items-center justify-between gap-2 border-b border-border bg-muted/30 px-4 py-1.5 text-xs text-muted-foreground">
           <span>Using registered app — overrides the bar selection</span>
@@ -699,7 +831,11 @@ export function XAAFlowTab({
                 summary={{
                   serverUrl: runInput.serverUrl,
                   authzServerIssuer: runInput.authzServerIssuer || undefined,
-                  clientId: runInput.clientId || undefined,
+                  // Prefer the flow's clientId so a DCR-minted or CIMD URL
+                  // identity is shown accurately; pre-registered runs fall
+                  // back to the configured value unchanged.
+                  clientId:
+                    flowState.clientId || runInput.clientId || undefined,
                   scope: runInput.scope || undefined,
                 }}
               />
@@ -757,9 +893,23 @@ export function XAAFlowTab({
           if (!open) {
             // Cancel: acknowledge the switch without resetting, so the effect
             // doesn't immediately re-prompt; the current run stays visible.
+            // A strategy change is the exception: revert the selector to the
+            // strategy the still-running flow actually uses, so UI config and
+            // the state-authoritative strategy can't diverge.
             if (pendingReset) {
               lastAppliedTargetKey.current = pendingReset.targetKey;
               lastNegativeTestMode.current = pendingReset.negativeTestMode;
+              if (
+                pendingReset.registrationStrategy !==
+                lastRegistrationStrategy.current
+              ) {
+                const prior = lastRegistrationStrategy.current;
+                const revertKey = pendingReset.targetKey;
+                setStrategyByTarget((current) => ({
+                  ...current,
+                  [revertKey]: prior,
+                }));
+              }
             }
             setPendingReset(null);
           }
@@ -780,7 +930,8 @@ export function XAAFlowTab({
                 if (pendingReset) {
                   applyTargetReset(
                     pendingReset.targetKey,
-                    pendingReset.negativeTestMode
+                    pendingReset.negativeTestMode,
+                    pendingReset.registrationStrategy
                   );
                 }
                 setPendingReset(null);

--- a/mcpjam-inspector/client/src/components/xaa/XAARegistrationStrategyControl.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAARegistrationStrategyControl.tsx
@@ -1,0 +1,127 @@
+import { useState } from "react";
+import { Button } from "@mcpjam/design-system/button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@mcpjam/design-system/alert-dialog";
+import type { XaaRegistrationStrategy } from "@/lib/xaa/types";
+
+const STRATEGY_OPTIONS: Array<{
+  value: XaaRegistrationStrategy;
+  label: string;
+}> = [
+  { value: "pre_registered", label: "Pre-registered client" },
+  { value: "dcr", label: "Open dynamic registration (DCR)" },
+  { value: "cimd", label: "Client metadata URL (CIMD)" },
+];
+
+const STRATEGY_HINTS: Record<XaaRegistrationStrategy, string> = {
+  pre_registered:
+    "Uses the client ID and secret you registered at the authorization server yourself.",
+  dcr: "Creates a real client at this authorization server. MCPJam keeps its credentials only for this browser session; the remote registration may remain after the session ends. Protected DCR requiring an initial access token is not tested.",
+  cimd: "Uses MCPJam's hosted metadata URL as the client_id. It does not request a DCR-created client, though the authorization server may fetch/cache the document. This mode is public (no client authentication) and requires advertised CIMD support.",
+};
+
+interface XAARegistrationStrategyControlProps {
+  value: XaaRegistrationStrategy;
+  onChange: (next: XaaRegistrationStrategy) => void;
+  disabled?: boolean;
+  /** Show the confirmed "Register another client" action (a session
+   * registration exists, or a prior attempt may have created one). */
+  showRegisterAnotherClient?: boolean;
+  onRegisterAnotherClient?: () => void;
+}
+
+/**
+ * How this run establishes its client identity at the target authorization
+ * server (the Client<->RAS relationship). Deliberately rendered with the
+ * target configuration, NOT in the IdP card — the IdP card is MCPJam's
+ * Client<->IdP side of the triangle.
+ */
+export function XAARegistrationStrategyControl({
+  value,
+  onChange,
+  disabled,
+  showRegisterAnotherClient,
+  onRegisterAnotherClient,
+}: XAARegistrationStrategyControlProps) {
+  const [confirmReregister, setConfirmReregister] = useState(false);
+
+  return (
+    <div className="border-b border-border bg-muted/30 px-4 py-1.5">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-xs font-medium text-muted-foreground">
+          Client registration
+        </span>
+        <div className="flex items-center gap-1" role="radiogroup">
+          {STRATEGY_OPTIONS.map((option) => (
+            <Button
+              key={option.value}
+              type="button"
+              size="sm"
+              variant={value === option.value ? "secondary" : "ghost"}
+              className="h-6 text-xs"
+              disabled={disabled}
+              role="radio"
+              aria-checked={value === option.value}
+              onClick={() => {
+                if (option.value !== value) onChange(option.value);
+              }}
+            >
+              {option.label}
+            </Button>
+          ))}
+        </div>
+        {value === "dcr" && showRegisterAnotherClient ? (
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            className="h-6 text-xs text-muted-foreground"
+            disabled={disabled}
+            onClick={() => setConfirmReregister(true)}
+          >
+            Register another client
+          </Button>
+        ) : null}
+      </div>
+      <p className="mt-0.5 text-xs text-muted-foreground">
+        {STRATEGY_HINTS[value]}
+      </p>
+
+      <AlertDialog
+        open={confirmReregister}
+        onOpenChange={setConfirmReregister}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Register another client?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This performs a new registration at the authorization server. A
+              second remote client may be created there — registrations are
+              not automatically deleted. This session&apos;s cached credentials
+              are discarded and the flow resets.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Keep current registration</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                onRegisterAnotherClient?.();
+                setConfirmReregister(false);
+              }}
+            >
+              Register another client
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/xaa/XAARegistrationStrategyControl.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAARegistrationStrategyControl.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, type KeyboardEvent } from "react";
 import { Button } from "@mcpjam/design-system/button";
 import {
   AlertDialog,
@@ -53,14 +53,39 @@ export function XAARegistrationStrategyControl({
 }: XAARegistrationStrategyControlProps) {
   const [confirmReregister, setConfirmReregister] = useState(false);
 
+  // Native radio-group keyboard semantics: arrows move and select, wrapping.
+  // Focus follows via DOM sibling navigation so we don't depend on Button ref
+  // forwarding.
+  const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>, index: number) => {
+    let nextIndex = index;
+    if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+      nextIndex = (index + 1) % STRATEGY_OPTIONS.length;
+    } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+      nextIndex = (index - 1 + STRATEGY_OPTIONS.length) % STRATEGY_OPTIONS.length;
+    } else {
+      return;
+    }
+    event.preventDefault();
+    const nextValue = STRATEGY_OPTIONS[nextIndex].value;
+    if (nextValue !== value) onChange(nextValue);
+    const sibling = event.currentTarget.parentElement?.children[
+      nextIndex
+    ] as HTMLElement | undefined;
+    sibling?.focus();
+  };
+
   return (
     <div className="border-b border-border bg-muted/30 px-4 py-1.5">
       <div className="flex flex-wrap items-center gap-2">
         <span className="text-xs font-medium text-muted-foreground">
           Client registration
         </span>
-        <div className="flex items-center gap-1" role="radiogroup">
-          {STRATEGY_OPTIONS.map((option) => (
+        <div
+          className="flex items-center gap-1"
+          role="radiogroup"
+          aria-label="Client registration strategy"
+        >
+          {STRATEGY_OPTIONS.map((option, index) => (
             <Button
               key={option.value}
               type="button"
@@ -70,6 +95,10 @@ export function XAARegistrationStrategyControl({
               disabled={disabled}
               role="radio"
               aria-checked={value === option.value}
+              // Roving tabindex: only the selected radio is in the tab order;
+              // arrows move within the group.
+              tabIndex={value === option.value ? 0 : -1}
+              onKeyDown={(event) => handleKeyDown(event, index)}
               onClick={() => {
                 if (option.value !== value) onChange(option.value);
               }}

--- a/mcpjam-inspector/client/src/lib/oauth/debug-state-machine-adapter.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/debug-state-machine-adapter.ts
@@ -106,6 +106,7 @@ export function createDebugRequestExecutor(): OAuthRequestExecutor {
           ...request.headers,
         },
         body: serializeProxyBody(request.body, request.headers),
+        ...(request.redirect ? { redirect: request.redirect } : {}),
       }),
     });
 

--- a/mcpjam-inspector/client/src/lib/xaa/__tests__/capability-preflight.test.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/__tests__/capability-preflight.test.ts
@@ -133,3 +133,62 @@ describe("analyzeAsCompatibility", () => {
     expect(report?.overall).toBe("fail");
   });
 });
+
+describe("draft-04 profile + CIMD advertisement checks", () => {
+  const base = {
+    issuer: "https://auth.example.com",
+    token_endpoint: "https://auth.example.com/oauth/token",
+    grant_types_supported: ["urn:ietf:params:oauth:grant-type:jwt-bearer"],
+  };
+  const check = (metadata: any, id: string) =>
+    analyzeAsCompatibility(metadata)?.checks.find((c) => c.id === id);
+
+  it("passes when the ID-JAG profile is advertised", () => {
+    const result = check(
+      {
+        ...base,
+        authorization_grant_profiles_supported: [
+          "urn:ietf:params:oauth:grant-profile:id-jag",
+        ],
+      },
+      "id_jag_profile"
+    );
+    expect(result?.status).toBe("pass");
+  });
+
+  it("fails only on an explicit profile list without ID-JAG", () => {
+    const contradicted = analyzeAsCompatibility({
+      ...base,
+      authorization_grant_profiles_supported: ["urn:other:profile"],
+    });
+    expect(
+      contradicted?.checks.find((c) => c.id === "id_jag_profile")?.status
+    ).toBe("fail");
+    // An explicit contradiction degrades the overall verdict...
+    expect(contradicted?.overall).toBe("fail");
+
+    // ...but an absent advertisement is a SHOULD-level warning that does NOT
+    // degrade an otherwise-passing server.
+    const absent = analyzeAsCompatibility(base);
+    expect(absent?.checks.find((c) => c.id === "id_jag_profile")?.status).toBe(
+      "warn"
+    );
+    expect(absent?.overall).toBe("pass");
+  });
+
+  it("classifies cimd_supported without affecting the overall verdict", () => {
+    expect(
+      check({ ...base, client_id_metadata_document_supported: true }, "cimd_supported")
+        ?.status
+    ).toBe("pass");
+    const explicitFalse = analyzeAsCompatibility({
+      ...base,
+      client_id_metadata_document_supported: false,
+    });
+    expect(
+      explicitFalse?.checks.find((c) => c.id === "cimd_supported")?.status
+    ).toBe("fail");
+    expect(explicitFalse?.overall).toBe("pass");
+    expect(check(base, "cimd_supported")?.status).toBe("unknown");
+  });
+});

--- a/mcpjam-inspector/client/src/lib/xaa/__tests__/state-machine.test.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/__tests__/state-machine.test.ts
@@ -1353,6 +1353,48 @@ describe("open dcr registration strategy", () => {
     ).toBe(true);
   });
 
+  it("parks the token request when the cached secret has expired mid-run", async () => {
+    // Register with a secret that is valid at registration but expires before
+    // redemption. runAll registers/authenticates/exchanges, then we expire the
+    // cached secret in place before the jwt-bearer step redeems it.
+    const cache = new Map<string, XaaEphemeralDcrCredentials>();
+    const harness = createDynamicHarness({
+      strategy: "dcr",
+      registerResponse: {
+        status: 201,
+        headers: {
+          "content-type": "application/json",
+          "cache-control": "no-store",
+        },
+        body: {
+          client_id: "minted-client",
+          client_secret: DCR_SECRET,
+          client_secret_expires_at: Math.floor(Date.now() / 1000) + 300,
+          token_endpoint_auth_method: "client_secret_post",
+        },
+      },
+      cache,
+    });
+    for (let index = 0; index < 5; index += 1) {
+      await harness.machine.proceedToNextStep();
+    }
+    // Expire the cached secret in place, then let redemption run.
+    const key = `target-1::${REGISTRATION_ENDPOINT}`;
+    cache.set(key, {
+      ...cache.get(key)!,
+      clientSecretExpiresAt: Math.floor(Date.now() / 1000) - 1,
+    });
+    await harness.machine.runAll();
+    const state = harness.getState();
+
+    expect(state.currentStep).toBe("jwt_bearer_request");
+    expect(state.error).toContain("expired");
+    expect(cache.has(key)).toBe(false);
+    expect(
+      harness.internalCalls.some((c) => c.path === "/proxy/token")
+    ).toBe(false);
+  });
+
   it("parks the token request when the session credentials are gone", async () => {
     const cache = new Map<string, XaaEphemeralDcrCredentials>();
     const harness = createDynamicHarness({ strategy: "dcr", cache });

--- a/mcpjam-inspector/client/src/lib/xaa/__tests__/state-machine.test.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/__tests__/state-machine.test.ts
@@ -1427,6 +1427,9 @@ describe("open dcr registration strategy", () => {
     expect(state.currentStep).toBe("jwt_bearer_request");
     expect(state.error).toContain("expired");
     expect(cache.has(key)).toBe(false);
+    // The recovery action ("Register another client") is gated on this flag —
+    // it must be set so the error's instruction is actually actionable.
+    expect(state.dcrRetryMayCreateDuplicate).toBe(true);
     expect(
       harness.internalCalls.some((c) => c.path === "/proxy/token")
     ).toBe(false);
@@ -1574,6 +1577,50 @@ describe("cimd registration strategy", () => {
     });
     await harness.machine.runAll();
     expect(harness.getState().error).toContain("malformed");
+  });
+
+  const cimdDoc = {
+    client_id: XAA_DEBUG_CLIENT_ID_METADATA_URL,
+    grant_types: [
+      "urn:ietf:params:oauth:grant-type:token-exchange",
+      "urn:ietf:params:oauth:grant-type:jwt-bearer",
+    ],
+    authorization_grant_profiles_supported: [
+      "urn:ietf:params:oauth:grant-profile:id-jag",
+    ],
+    token_endpoint_auth_method: "none",
+  };
+
+  it.each([
+    "application/json",
+    "application/json; charset=utf-8",
+    "APPLICATION/JSON",
+    "application/ld+json",
+  ])("accepts the JSON media type %s", async (contentType) => {
+    const harness = createDynamicHarness({
+      strategy: "cimd",
+      authzMetadataExtras: CIMD_SUPPORTED,
+      cimdResponse: { status: 200, headers: { "content-type": contentType }, body: cimdDoc },
+    });
+    await harness.machine.runAll();
+    expect(harness.getState().currentStep).toBe("complete");
+  });
+
+  it.each([
+    "application/jsonp",
+    "text/application/json",
+    "application/+json",
+    "text/html",
+  ])("parks on the non-JSON media type %s", async (contentType) => {
+    const harness = createDynamicHarness({
+      strategy: "cimd",
+      authzMetadataExtras: CIMD_SUPPORTED,
+      cimdResponse: { status: 200, headers: { "content-type": contentType }, body: cimdDoc },
+    });
+    await harness.machine.runAll();
+    const state = harness.getState();
+    expect(state.currentStep).toBe("fetch_client_metadata_document");
+    expect(state.error).toContain("not a JSON media type");
   });
 
   it("parks when the document omits the required grants (no echo tolerance)", async () => {

--- a/mcpjam-inspector/client/src/lib/xaa/__tests__/state-machine.test.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/__tests__/state-machine.test.ts
@@ -895,6 +895,11 @@ describe("createXAAStateMachine", () => {
 const DCR_SECRET = "dcr-minted-secret-value-123";
 const REGISTRATION_ENDPOINT = "https://auth.example.com/oauth/register";
 
+// Mirrors dcrCacheKeyFor: encodeURIComponent each component, join with "::".
+// Harness target key is "target-1".
+const dcrCacheKey = (endpoint: string, scope: string) =>
+  ["target-1", endpoint, scope].map(encodeURIComponent).join("::");
+
 interface DynamicHarnessOptions {
   strategy: "dcr" | "cimd";
   authzMetadataExtras?: Record<string, any>;
@@ -1435,7 +1440,7 @@ describe("open dcr registration strategy", () => {
 
   it("gates re-registration behind confirmation when the cached secret has expired", async () => {
     const cache = new Map<string, XaaEphemeralDcrCredentials>();
-    const key = `target-1::${REGISTRATION_ENDPOINT}::read:tools`;
+    const key = dcrCacheKey(REGISTRATION_ENDPOINT, "read:tools");
     cache.set(key, {
       clientId: "expired-client",
       clientSecret: "expired-secret",
@@ -1469,7 +1474,7 @@ describe("open dcr registration strategy", () => {
   it("does not reuse a registration cached under a different scope", async () => {
     const cache = new Map<string, XaaEphemeralDcrCredentials>();
     // Cached under a scope other than the run's "read:tools".
-    cache.set(`target-1::${REGISTRATION_ENDPOINT}::other:scope`, {
+    cache.set(dcrCacheKey(REGISTRATION_ENDPOINT, "other:scope"), {
       clientId: "other-scope-client",
       clientSecret: "s",
       tokenEndpointAuthMethod: "client_secret_post",
@@ -1528,7 +1533,7 @@ describe("open dcr registration strategy", () => {
     }
     // Expire the cached secret in place, then let redemption run. (Cache key
     // includes the run's scope.)
-    const key = `target-1::${REGISTRATION_ENDPOINT}::read:tools`;
+    const key = dcrCacheKey(REGISTRATION_ENDPOINT, "read:tools");
     cache.set(key, {
       ...cache.get(key)!,
       clientSecretExpiresAt: Math.floor(Date.now() / 1000) - 1,

--- a/mcpjam-inspector/client/src/lib/xaa/__tests__/state-machine.test.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/__tests__/state-machine.test.ts
@@ -910,6 +910,7 @@ interface DynamicHarnessOptions {
   };
   cache?: Map<string, XaaEphemeralDcrCredentials>;
   registrationId?: string;
+  seedDuplicateRisk?: boolean;
 }
 
 function createDynamicHarness(options: DynamicHarnessOptions) {
@@ -924,6 +925,11 @@ function createDynamicHarness(options: DynamicHarnessOptions) {
     email: "demo.user@example.com",
     scope: "read:tools",
     registrationStrategy: options.strategy,
+    // Simulates the per-target duplicate-risk flag re-seeded into a fresh
+    // (from-idle) run after an ordinary reset.
+    ...(options.seedDuplicateRisk
+      ? { dcrRetryMayCreateDuplicate: true }
+      : {}),
   });
 
   const externalCalls: Array<{ url: string; init?: any }> = [];
@@ -1290,6 +1296,37 @@ describe("open dcr registration strategy", () => {
     });
     await harness.machine.proceedToNextStep();
     expect(harness.registerCalls()).toHaveLength(2);
+  });
+
+  it("gates a from-idle run behind confirmation when a prior POST may have created a client", async () => {
+    // The duplicate-risk flag is re-seeded into a fresh run (as the component
+    // does after an ordinary reset). With no reusable cache entry, the machine
+    // must park for confirmation rather than silently POSTing a second client.
+    const harness = createDynamicHarness({
+      strategy: "dcr",
+      seedDuplicateRisk: true,
+    });
+    await harness.machine.runAll();
+    let state = harness.getState();
+
+    expect(state.currentStep).toBe("request_client_registration");
+    expect(state.error).toContain("Register another client");
+    expect(harness.registerCalls()).toHaveLength(0);
+    expect(
+      harness.internalCalls.some((c) => c.path === "/authenticate")
+    ).toBe(false);
+
+    // Clearing the flag (the confirmed "Register another client" path — which
+    // also rebuilds the flow, clearing the parked error) lets exactly one
+    // registration POST through.
+    harness.machine.updateState({
+      dcrRetryMayCreateDuplicate: false,
+      error: undefined,
+    });
+    await harness.machine.runAll();
+    state = harness.getState();
+    expect(harness.registerCalls()).toHaveLength(1);
+    expect(state.currentStep).toBe("complete");
   });
 
   it("parks cleanly when no registration_endpoint is advertised", async () => {

--- a/mcpjam-inspector/client/src/lib/xaa/__tests__/state-machine.test.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/__tests__/state-machine.test.ts
@@ -1433,9 +1433,10 @@ describe("open dcr registration strategy", () => {
     expect(second.proxyTokenBody().clientSecret).toBe(DCR_SECRET);
   });
 
-  it("discards an expired cached registration and registers again", async () => {
+  it("gates re-registration behind confirmation when the cached secret has expired", async () => {
     const cache = new Map<string, XaaEphemeralDcrCredentials>();
-    cache.set(`target-1::${REGISTRATION_ENDPOINT}`, {
+    const key = `target-1::${REGISTRATION_ENDPOINT}::read:tools`;
+    cache.set(key, {
       clientId: "expired-client",
       clientSecret: "expired-secret",
       tokenEndpointAuthMethod: "client_secret_post",
@@ -1444,7 +1445,42 @@ describe("open dcr registration strategy", () => {
     });
     const harness = createDynamicHarness({ strategy: "dcr", cache });
     await harness.machine.runAll();
+    let state = harness.getState();
 
+    // Replacing an expired client mints another remote client — gate it behind
+    // confirmation rather than silently re-registering.
+    expect(state.currentStep).toBe("request_client_registration");
+    expect(state.error).toContain("expired");
+    expect(state.dcrRetryMayCreateDuplicate).toBe(true);
+    expect(harness.registerCalls()).toHaveLength(0);
+    expect(cache.has(key)).toBe(false); // the dead entry is discarded
+
+    // After the confirmed "Register another client" (flag cleared), exactly one
+    // fresh registration goes through.
+    harness.machine.updateState({
+      dcrRetryMayCreateDuplicate: false,
+      error: undefined,
+    });
+    await harness.machine.runAll();
+    expect(harness.registerCalls()).toHaveLength(1);
+    expect(harness.getState().clientId).toBe("minted-client");
+  });
+
+  it("does not reuse a registration cached under a different scope", async () => {
+    const cache = new Map<string, XaaEphemeralDcrCredentials>();
+    // Cached under a scope other than the run's "read:tools".
+    cache.set(`target-1::${REGISTRATION_ENDPOINT}::other:scope`, {
+      clientId: "other-scope-client",
+      clientSecret: "s",
+      tokenEndpointAuthMethod: "client_secret_post",
+      clientSecretExpiresAt: 0,
+      registrationEndpoint: REGISTRATION_ENDPOINT,
+    });
+    const harness = createDynamicHarness({ strategy: "dcr", cache });
+    await harness.machine.runAll();
+
+    // Scope is part of the client's metadata, so the different-scope entry is
+    // not reused — the run registers a fresh client.
     expect(harness.registerCalls()).toHaveLength(1);
     expect(harness.getState().clientId).toBe("minted-client");
   });
@@ -1490,8 +1526,9 @@ describe("open dcr registration strategy", () => {
     for (let index = 0; index < 5; index += 1) {
       await harness.machine.proceedToNextStep();
     }
-    // Expire the cached secret in place, then let redemption run.
-    const key = `target-1::${REGISTRATION_ENDPOINT}`;
+    // Expire the cached secret in place, then let redemption run. (Cache key
+    // includes the run's scope.)
+    const key = `target-1::${REGISTRATION_ENDPOINT}::read:tools`;
     cache.set(key, {
       ...cache.get(key)!,
       clientSecretExpiresAt: Math.floor(Date.now() / 1000) - 1,

--- a/mcpjam-inspector/client/src/lib/xaa/__tests__/state-machine.test.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/__tests__/state-machine.test.ts
@@ -1264,6 +1264,56 @@ describe("open dcr registration strategy", () => {
     expect(state.error).toContain("debugger limitation");
   });
 
+  it("falls back to the requested method (with a warning) when DCR omits token_endpoint_auth_method", async () => {
+    // Secret issued but no method echoed → assume the requested
+    // client_secret_post and continue to redemption, don't park.
+    const harness = createDynamicHarness({
+      strategy: "dcr",
+      registerResponse: {
+        status: 201,
+        headers: {
+          "content-type": "application/json",
+          "cache-control": "no-store",
+        },
+        body: {
+          client_id: "no-method-client",
+          client_secret: DCR_SECRET,
+          client_secret_expires_at: 0,
+          // token_endpoint_auth_method deliberately omitted.
+        },
+      },
+    });
+    await harness.machine.runAll();
+    const state = harness.getState();
+
+    expect(state.currentStep).toBe("complete");
+    expect(
+      state.registrationWarnings?.some((w) => w.code === "auth_method_not_echoed")
+    ).toBe(true);
+    const proxyBody = harness.proxyTokenBody();
+    expect(proxyBody.clientId).toBe("no-method-client");
+    expect(proxyBody.tokenEndpointAuthMethod).toBe("client_secret_post");
+  });
+
+  it("treats an omitted method with no secret as a public client", async () => {
+    const harness = createDynamicHarness({
+      strategy: "dcr",
+      registerResponse: {
+        status: 201,
+        headers: { "content-type": "application/json" },
+        body: { client_id: "public-no-method" }, // no secret, no method
+      },
+    });
+    await harness.machine.runAll();
+    const state = harness.getState();
+
+    expect(state.currentStep).toBe("complete");
+    const codes = (state.registrationWarnings || []).map((w) => w.code);
+    expect(codes).toContain("auth_method_not_echoed");
+    expect(codes).toContain("public_client");
+    expect(harness.proxyTokenBody().tokenEndpointAuthMethod).toBe("none");
+  });
+
   it("parks on refusal and gates the retry behind duplicate-client confirmation", async () => {
     const harness = createDynamicHarness({
       strategy: "dcr",

--- a/mcpjam-inspector/client/src/lib/xaa/__tests__/state-machine.test.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/__tests__/state-machine.test.ts
@@ -1295,6 +1295,31 @@ describe("open dcr registration strategy", () => {
     expect(proxyBody.tokenEndpointAuthMethod).toBe("client_secret_post");
   });
 
+  it("parks on a non-string token_endpoint_auth_method (malformed, not omitted)", async () => {
+    const harness = createDynamicHarness({
+      strategy: "dcr",
+      registerResponse: {
+        status: 201,
+        headers: { "content-type": "application/json" },
+        body: {
+          client_id: "malformed-method-client",
+          client_secret: DCR_SECRET,
+          token_endpoint_auth_method: 123, // present but not a string
+        },
+      },
+    });
+    await harness.machine.runAll();
+    const state = harness.getState();
+
+    // Must NOT be treated as omitted-and-fall-back; a present malformed member
+    // is a malformed registration.
+    expect(state.currentStep).toBe("request_client_registration");
+    expect(state.error).toContain("malformed");
+    expect(
+      harness.internalCalls.some((c) => c.path === "/authenticate")
+    ).toBe(false);
+  });
+
   it("treats an omitted method with no secret as a public client", async () => {
     const harness = createDynamicHarness({
       strategy: "dcr",

--- a/mcpjam-inspector/client/src/lib/xaa/__tests__/state-machine.test.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/__tests__/state-machine.test.ts
@@ -1449,6 +1449,9 @@ describe("open dcr registration strategy", () => {
 
     expect(state.currentStep).toBe("jwt_bearer_request");
     expect(state.error).toContain("no longer available");
+    // The error tells the user to "Register another client" — the gate flag
+    // must be set so that action is actually visible.
+    expect(state.dcrRetryMayCreateDuplicate).toBe(true);
     expect(
       harness.internalCalls.some((c) => c.path === "/proxy/token")
     ).toBe(false);
@@ -1596,6 +1599,7 @@ describe("cimd registration strategy", () => {
     "application/json; charset=utf-8",
     "APPLICATION/JSON",
     "application/ld+json",
+    "application/vnd_acme+json",
   ])("accepts the JSON media type %s", async (contentType) => {
     const harness = createDynamicHarness({
       strategy: "cimd",
@@ -1610,6 +1614,7 @@ describe("cimd registration strategy", () => {
     "application/jsonp",
     "text/application/json",
     "application/+json",
+    "application/-+json",
     "text/html",
   ])("parks on the non-JSON media type %s", async (contentType) => {
     const harness = createDynamicHarness({

--- a/mcpjam-inspector/client/src/lib/xaa/__tests__/state-machine.test.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/__tests__/state-machine.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
+import { XAA_DEBUG_CLIENT_ID_METADATA_URL } from "@mcpjam/sdk/browser";
 import { CLIENT_SECRET_MASK, createXAAStateMachine } from "../state-machine";
-import { createInitialXAAFlowState, type XAAFlowState } from "../types";
+import {
+  createInitialXAAFlowState,
+  type XaaEphemeralDcrCredentials,
+  type XAAFlowState,
+} from "../types";
 
 function encodePart(value: Record<string, any>): string {
   return Buffer.from(JSON.stringify(value)).toString("base64url");
@@ -880,5 +885,632 @@ describe("createXAAStateMachine", () => {
         "https://mcp.example.com/.well-known/oauth-protected-resource",
       ]);
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dynamic client-identity strategies
+// ---------------------------------------------------------------------------
+
+const DCR_SECRET = "dcr-minted-secret-value-123";
+const REGISTRATION_ENDPOINT = "https://auth.example.com/oauth/register";
+
+interface DynamicHarnessOptions {
+  strategy: "dcr" | "cimd";
+  authzMetadataExtras?: Record<string, any>;
+  registerResponse?: {
+    status: number;
+    body: any;
+    headers?: Record<string, string>;
+  };
+  cimdResponse?: {
+    status: number;
+    body: any;
+    headers?: Record<string, string>;
+  };
+  cache?: Map<string, XaaEphemeralDcrCredentials>;
+  registrationId?: string;
+}
+
+function createDynamicHarness(options: DynamicHarnessOptions) {
+  const cache = options.cache ?? new Map<string, XaaEphemeralDcrCredentials>();
+  const cacheSet = vi.fn((key: string, value: XaaEphemeralDcrCredentials) => {
+    cache.set(key, value);
+  });
+
+  let state: XAAFlowState = createInitialXAAFlowState({
+    serverUrl: "https://mcp.example.com",
+    userId: "user-12345",
+    email: "demo.user@example.com",
+    scope: "read:tools",
+    registrationStrategy: options.strategy,
+  });
+
+  const externalCalls: Array<{ url: string; init?: any }> = [];
+  const internalCalls: Array<{ path: string; init?: any }> = [];
+
+  const registerResponse = options.registerResponse ?? {
+    status: 201,
+    headers: {
+      "content-type": "application/json",
+      "cache-control": "no-store",
+    },
+    body: {
+      client_id: "minted-client",
+      client_secret: DCR_SECRET,
+      client_secret_expires_at: 0,
+      token_endpoint_auth_method: "client_secret_post",
+      client_name: "MCPJam XAA Debugger",
+      grant_types: [
+        "urn:ietf:params:oauth:grant-type:token-exchange",
+        "urn:ietf:params:oauth:grant-type:jwt-bearer",
+      ],
+      authorization_grant_profiles_supported: [
+        "urn:ietf:params:oauth:grant-profile:id-jag",
+      ],
+    },
+  };
+
+  const cimdResponse = options.cimdResponse ?? {
+    status: 200,
+    headers: { "content-type": "application/json" },
+    body: {
+      client_id: XAA_DEBUG_CLIENT_ID_METADATA_URL,
+      client_name: "MCPJam XAA Debugger",
+      grant_types: [
+        "urn:ietf:params:oauth:grant-type:token-exchange",
+        "urn:ietf:params:oauth:grant-type:jwt-bearer",
+      ],
+      authorization_grant_profiles_supported: [
+        "urn:ietf:params:oauth:grant-profile:id-jag",
+      ],
+      token_endpoint_auth_method: "none",
+    },
+  };
+
+  const executor = {
+    externalRequest: vi.fn(async (url: string, init?: any) => {
+      externalCalls.push({ url, init });
+      if (url.includes(".well-known/oauth-protected-resource")) {
+        return {
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          body: {
+            resource: "https://mcp.example.com",
+            authorization_servers: ["https://auth.example.com"],
+          },
+          ok: true,
+        };
+      }
+      if (url.includes(".well-known/oauth-authorization-server")) {
+        return {
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          body: {
+            issuer: "https://auth.example.com",
+            token_endpoint: "https://auth.example.com/oauth/token",
+            registration_endpoint: REGISTRATION_ENDPOINT,
+            ...(options.authzMetadataExtras ?? {}),
+          },
+          ok: true,
+        };
+      }
+      if (url === REGISTRATION_ENDPOINT) {
+        return {
+          status: registerResponse.status,
+          statusText: "",
+          headers: registerResponse.headers ?? {},
+          body: registerResponse.body,
+          ok: registerResponse.status >= 200 && registerResponse.status < 300,
+        };
+      }
+      if (url === XAA_DEBUG_CLIENT_ID_METADATA_URL) {
+        return {
+          status: cimdResponse.status,
+          statusText: "",
+          headers: cimdResponse.headers ?? {},
+          body: cimdResponse.body,
+          ok: cimdResponse.status >= 200 && cimdResponse.status < 300,
+        };
+      }
+      return {
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        body: { result: { serverInfo: { name: "demo" } } },
+        ok: true,
+      };
+    }),
+    internalRequest: vi.fn(async (path: string, init?: any) => {
+      internalCalls.push({ path, init });
+      if (path === "/authenticate") {
+        return {
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          body: {
+            id_token: makeJwt(
+              { iss: "https://issuer.example/api/web/xaa", sub: "user-12345" },
+              { alg: "RS256", typ: "JWT", kid: "xaa-idp-1" }
+            ),
+          },
+          ok: true,
+        };
+      }
+      if (path === "/token-exchange") {
+        const body = JSON.parse(init.body);
+        return {
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          body: {
+            id_jag: makeJwt({
+              iss: "https://issuer.example/api/web/xaa",
+              sub: "user-12345",
+              aud: "https://auth.example.com",
+              resource: "https://mcp.example.com",
+              client_id: body.clientId,
+              exp: Math.floor(Date.now() / 1000) + 300,
+              scope: "read:tools",
+            }),
+          },
+          ok: true,
+        };
+      }
+      return {
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        body: {
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          body: {
+            access_token: "access-token",
+            token_type: "Bearer",
+            expires_in: 300,
+          },
+        },
+        ok: true,
+      };
+    }),
+  };
+
+  const machine = createXAAStateMachine({
+    state,
+    getState: () => state,
+    updateState: (updates) => {
+      state = { ...state, ...updates };
+    },
+    serverUrl: "https://mcp.example.com",
+    issuerBaseUrl: "https://issuer.example/api/web/xaa",
+    requestExecutor: executor,
+    userId: "user-12345",
+    email: "demo.user@example.com",
+    scope: "read:tools",
+    registrationStrategy: options.strategy,
+    registrationId: options.registrationId,
+    dcrCredentialCache: {
+      get: (key) => cache.get(key),
+      set: cacheSet,
+      delete: (key) => {
+        cache.delete(key);
+      },
+    },
+    dcrCacheTargetKey: "target-1",
+  });
+
+  return {
+    machine,
+    getState: () => state,
+    executor,
+    externalCalls,
+    internalCalls,
+    cache,
+    cacheSet,
+    registerCalls: () =>
+      externalCalls.filter((call) => call.url === REGISTRATION_ENDPOINT),
+    cimdFetches: () =>
+      externalCalls.filter(
+        (call) => call.url === XAA_DEBUG_CLIENT_ID_METADATA_URL
+      ),
+    proxyTokenBody: () => {
+      const call = internalCalls.find((entry) => entry.path === "/proxy/token");
+      return call ? JSON.parse(call.init.body) : undefined;
+    },
+    tokenExchangeBody: () => {
+      const call = internalCalls.find(
+        (entry) => entry.path === "/token-exchange"
+      );
+      return call ? JSON.parse(call.init.body) : undefined;
+    },
+  };
+}
+
+describe("open dcr registration strategy", () => {
+  it("registers, then completes the flow with the minted client", async () => {
+    const harness = createDynamicHarness({ strategy: "dcr" });
+    await harness.machine.runAll();
+    const state = harness.getState();
+
+    expect(state.currentStep).toBe("complete");
+    expect(state.clientId).toBe("minted-client");
+    expect(state.tokenEndpointAuthMethod).toBe("client_secret_post");
+    expect(harness.registerCalls()).toHaveLength(1);
+
+    // The ID-JAG mint and the redemption both carry the minted identity.
+    expect(harness.tokenExchangeBody().clientId).toBe("minted-client");
+    const proxyBody = harness.proxyTokenBody();
+    expect(proxyBody.clientId).toBe("minted-client");
+    expect(proxyBody.clientSecret).toBe(DCR_SECRET);
+    expect(proxyBody.tokenEndpointAuthMethod).toBe("client_secret_post");
+
+    // The raw secret lives ONLY in the session cache and the outbound
+    // internal request — never in any serialized flow state surface.
+    const serialized = JSON.stringify(state);
+    expect(serialized).not.toContain(DCR_SECRET);
+    expect(serialized).not.toContain(DCR_SECRET.substring(0, 10));
+    const registrationEntry = (state.httpHistory || []).find(
+      (entry) => entry.step === "request_client_registration"
+    );
+    expect(registrationEntry?.response?.status).toBe(201);
+    expect(registrationEntry?.response?.body.client_secret).toBe(
+      "***REDACTED***"
+    );
+    // The logged /proxy/token request masks the secret.
+    const proxyEntry = (state.httpHistory || []).find(
+      (entry) => entry.step === "jwt_bearer_request"
+    );
+    expect(proxyEntry?.request.body.clientSecret).toBe(CLIENT_SECRET_MASK);
+  });
+
+  it("continues as a public client with a posture warning when the method is none", async () => {
+    const harness = createDynamicHarness({
+      strategy: "dcr",
+      registerResponse: {
+        status: 201,
+        headers: { "content-type": "application/json" },
+        body: {
+          client_id: "public-client",
+          token_endpoint_auth_method: "none",
+        },
+      },
+    });
+    await harness.machine.runAll();
+    const state = harness.getState();
+
+    expect(state.currentStep).toBe("complete");
+    expect(
+      state.registrationWarnings?.some((w) => w.code === "public_client")
+    ).toBe(true);
+    const proxyBody = harness.proxyTokenBody();
+    expect(proxyBody.clientSecret).toBeUndefined();
+    expect(proxyBody.tokenEndpointAuthMethod).toBe("none");
+  });
+
+  it("records echo warnings but continues when metadata is omitted", async () => {
+    const harness = createDynamicHarness({
+      strategy: "dcr",
+      registerResponse: {
+        status: 200,
+        headers: {},
+        body: {
+          client_id: "echoless-client",
+          client_secret: DCR_SECRET,
+          token_endpoint_auth_method: "client_secret_post",
+        },
+      },
+    });
+    await harness.machine.runAll();
+    const state = harness.getState();
+
+    expect(state.currentStep).toBe("complete");
+    const codes = (state.registrationWarnings || []).map((w) => w.code);
+    expect(codes).toContain("profile_metadata_not_echoed");
+    expect(codes).toContain("grant_types_not_echoed");
+    expect(codes).toContain("missing_secret_expiry");
+    expect(codes).toContain("non_201_success");
+  });
+
+  it("parks when grant_types explicitly omits the JWT Bearer grant", async () => {
+    const harness = createDynamicHarness({
+      strategy: "dcr",
+      registerResponse: {
+        status: 201,
+        headers: { "content-type": "application/json" },
+        body: {
+          client_id: "no-bearer-client",
+          client_secret: DCR_SECRET,
+          token_endpoint_auth_method: "client_secret_post",
+          grant_types: ["authorization_code"],
+        },
+      },
+    });
+    await harness.machine.runAll();
+    const state = harness.getState();
+
+    expect(state.currentStep).toBe("request_client_registration");
+    expect(state.error).toContain("JWT Bearer");
+    expect(state.dcrRetryMayCreateDuplicate).toBe(true);
+    expect(
+      harness.internalCalls.some((c) => c.path === "/authenticate")
+    ).toBe(false);
+  });
+
+  it("parks on an unusable client-auth method as a debugger limitation", async () => {
+    const harness = createDynamicHarness({
+      strategy: "dcr",
+      registerResponse: {
+        status: 201,
+        headers: { "content-type": "application/json" },
+        body: {
+          client_id: "pkjwt-client",
+          token_endpoint_auth_method: "private_key_jwt",
+        },
+      },
+    });
+    await harness.machine.runAll();
+    const state = harness.getState();
+
+    expect(state.currentStep).toBe("request_client_registration");
+    expect(state.error).toContain("debugger limitation");
+  });
+
+  it("parks on refusal and gates the retry behind duplicate-client confirmation", async () => {
+    const harness = createDynamicHarness({
+      strategy: "dcr",
+      registerResponse: {
+        status: 403,
+        headers: {},
+        body: { error: "access_denied" },
+      },
+    });
+    await harness.machine.runAll();
+    const state = harness.getState();
+
+    expect(state.currentStep).toBe("request_client_registration");
+    expect(state.error).toContain("open Dynamic Client Registration");
+    expect(state.dcrRetryMayCreateDuplicate).toBe(true);
+    expect(harness.registerCalls()).toHaveLength(1);
+    expect(
+      harness.internalCalls.some((c) => c.path === "/authenticate")
+    ).toBe(false);
+
+    // Ordinary Continue must NOT POST again while the flag is set...
+    await harness.machine.proceedToNextStep();
+    expect(harness.registerCalls()).toHaveLength(1);
+
+    // ...but clearing it (the confirmed "Register another client" path)
+    // allows exactly one new POST.
+    harness.machine.updateState({
+      dcrRetryMayCreateDuplicate: false,
+      error: undefined,
+    });
+    await harness.machine.proceedToNextStep();
+    expect(harness.registerCalls()).toHaveLength(2);
+  });
+
+  it("parks cleanly when no registration_endpoint is advertised", async () => {
+    const harness = createDynamicHarness({
+      strategy: "dcr",
+      authzMetadataExtras: { registration_endpoint: undefined },
+    });
+    await harness.machine.runAll();
+    const state = harness.getState();
+
+    expect(state.currentStep).toBe("request_client_registration");
+    expect(state.error).toContain("registration_endpoint");
+    expect(harness.registerCalls()).toHaveLength(0);
+  });
+
+  it("reuses the session registration instead of POSTing again", async () => {
+    const cache = new Map<string, XaaEphemeralDcrCredentials>();
+    const first = createDynamicHarness({ strategy: "dcr", cache });
+    await first.machine.runAll();
+    expect(first.registerCalls()).toHaveLength(1);
+
+    const second = createDynamicHarness({ strategy: "dcr", cache });
+    await second.machine.runAll();
+    const state = second.getState();
+
+    expect(state.currentStep).toBe("complete");
+    expect(state.dcrRegistrationReused).toBe(true);
+    expect(second.registerCalls()).toHaveLength(0);
+    expect(second.proxyTokenBody().clientSecret).toBe(DCR_SECRET);
+  });
+
+  it("discards an expired cached registration and registers again", async () => {
+    const cache = new Map<string, XaaEphemeralDcrCredentials>();
+    cache.set(`target-1::${REGISTRATION_ENDPOINT}`, {
+      clientId: "expired-client",
+      clientSecret: "expired-secret",
+      tokenEndpointAuthMethod: "client_secret_post",
+      clientSecretExpiresAt: Math.floor(Date.now() / 1000) - 60,
+      registrationEndpoint: REGISTRATION_ENDPOINT,
+    });
+    const harness = createDynamicHarness({ strategy: "dcr", cache });
+    await harness.machine.runAll();
+
+    expect(harness.registerCalls()).toHaveLength(1);
+    expect(harness.getState().clientId).toBe("minted-client");
+  });
+
+  it("is forced to pre_registered when a registrationId is present", async () => {
+    const harness = createDynamicHarness({
+      strategy: "dcr",
+      registrationId: "reg-1",
+    });
+    // Behavior, not just the flag: at received_authz_metadata the machine
+    // goes straight to IdP authentication — no registration POST is issued.
+    for (let index = 0; index < 3; index += 1) {
+      await harness.machine.proceedToNextStep();
+    }
+    expect(harness.registerCalls()).toHaveLength(0);
+    expect(
+      harness.internalCalls.some((call) => call.path === "/authenticate")
+    ).toBe(true);
+  });
+
+  it("parks the token request when the session credentials are gone", async () => {
+    const cache = new Map<string, XaaEphemeralDcrCredentials>();
+    const harness = createDynamicHarness({ strategy: "dcr", cache });
+    // Register, authenticate, exchange, inspect — then wipe the cache before
+    // redemption (simulates a lost session cache mid-run).
+    for (let index = 0; index < 5; index += 1) {
+      await harness.machine.proceedToNextStep();
+    }
+    cache.clear();
+    await harness.machine.runAll();
+    const state = harness.getState();
+
+    expect(state.currentStep).toBe("jwt_bearer_request");
+    expect(state.error).toContain("no longer available");
+    expect(
+      harness.internalCalls.some((c) => c.path === "/proxy/token")
+    ).toBe(false);
+  });
+});
+
+describe("cimd registration strategy", () => {
+  const CIMD_SUPPORTED = { client_id_metadata_document_supported: true };
+
+  it("preflights the hosted document and completes with the URL identity", async () => {
+    const harness = createDynamicHarness({
+      strategy: "cimd",
+      authzMetadataExtras: CIMD_SUPPORTED,
+    });
+    await harness.machine.runAll();
+    const state = harness.getState();
+
+    expect(state.currentStep).toBe("complete");
+    expect(state.clientId).toBe(XAA_DEBUG_CLIENT_ID_METADATA_URL);
+    expect(state.tokenEndpointAuthMethod).toBe("none");
+    expect(
+      state.registrationWarnings?.some((w) => w.code === "public_client")
+    ).toBe(true);
+
+    // Exactly one preflight GET, with manual redirect handling.
+    const fetches = harness.cimdFetches();
+    expect(fetches).toHaveLength(1);
+    expect(fetches[0].init.redirect).toBe("manual");
+
+    // The ID-JAG claim and redemption both carry the exact URL, no secret.
+    expect(harness.tokenExchangeBody().clientId).toBe(
+      XAA_DEBUG_CLIENT_ID_METADATA_URL
+    );
+    const proxyBody = harness.proxyTokenBody();
+    expect(proxyBody.clientId).toBe(XAA_DEBUG_CLIENT_ID_METADATA_URL);
+    expect(proxyBody.clientSecret).toBeUndefined();
+    expect(proxyBody.tokenEndpointAuthMethod).toBe("none");
+
+    // CIMD never touches the DCR credential cache.
+    expect(harness.cacheSet).not.toHaveBeenCalled();
+    expect(harness.getState().dcrRetryMayCreateDuplicate).toBeUndefined();
+  });
+
+  it("parks before any fetch when the AS does not advertise CIMD support", async () => {
+    const absent = createDynamicHarness({ strategy: "cimd" });
+    await absent.machine.runAll();
+    expect(absent.getState().currentStep).toBe(
+      "fetch_client_metadata_document"
+    );
+    expect(absent.getState().error).toContain("does not advertise");
+    expect(absent.cimdFetches()).toHaveLength(0);
+
+    const explicit = createDynamicHarness({
+      strategy: "cimd",
+      authzMetadataExtras: { client_id_metadata_document_supported: false },
+    });
+    await explicit.machine.runAll();
+    expect(explicit.getState().error).toContain("explicitly");
+    expect(explicit.cimdFetches()).toHaveLength(0);
+  });
+
+  it("parks on a redirect and retries freely without a confirmation gate", async () => {
+    const harness = createDynamicHarness({
+      strategy: "cimd",
+      authzMetadataExtras: CIMD_SUPPORTED,
+      cimdResponse: {
+        status: 302,
+        headers: { location: "https://elsewhere.example/doc.json" },
+        body: null,
+      },
+    });
+    await harness.machine.runAll();
+    const state = harness.getState();
+
+    expect(state.currentStep).toBe("fetch_client_metadata_document");
+    expect(state.error).toContain("redirect");
+    expect(state.dcrRetryMayCreateDuplicate).toBeUndefined();
+
+    await harness.machine.proceedToNextStep();
+    expect(harness.cimdFetches()).toHaveLength(2);
+  });
+
+  it("parks when the document's client_id is not exactly the URL", async () => {
+    const harness = createDynamicHarness({
+      strategy: "cimd",
+      authzMetadataExtras: CIMD_SUPPORTED,
+      cimdResponse: {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: {
+          client_id: `${XAA_DEBUG_CLIENT_ID_METADATA_URL}?v=2`,
+          grant_types: [
+            "urn:ietf:params:oauth:grant-type:token-exchange",
+            "urn:ietf:params:oauth:grant-type:jwt-bearer",
+          ],
+          authorization_grant_profiles_supported: [
+            "urn:ietf:params:oauth:grant-profile:id-jag",
+          ],
+          token_endpoint_auth_method: "none",
+        },
+      },
+    });
+    await harness.machine.runAll();
+    expect(harness.getState().error).toContain("exactly equal");
+  });
+
+  it("parks on a shared-secret auth method as a malformed document", async () => {
+    const harness = createDynamicHarness({
+      strategy: "cimd",
+      authzMetadataExtras: CIMD_SUPPORTED,
+      cimdResponse: {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: {
+          client_id: XAA_DEBUG_CLIENT_ID_METADATA_URL,
+          grant_types: [
+            "urn:ietf:params:oauth:grant-type:token-exchange",
+            "urn:ietf:params:oauth:grant-type:jwt-bearer",
+          ],
+          authorization_grant_profiles_supported: [
+            "urn:ietf:params:oauth:grant-profile:id-jag",
+          ],
+          token_endpoint_auth_method: "client_secret_post",
+        },
+      },
+    });
+    await harness.machine.runAll();
+    expect(harness.getState().error).toContain("malformed");
+  });
+
+  it("parks when the document omits the required grants (no echo tolerance)", async () => {
+    const harness = createDynamicHarness({
+      strategy: "cimd",
+      authzMetadataExtras: CIMD_SUPPORTED,
+      cimdResponse: {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: {
+          client_id: XAA_DEBUG_CLIENT_ID_METADATA_URL,
+          token_endpoint_auth_method: "none",
+        },
+      },
+    });
+    await harness.machine.runAll();
+    expect(harness.getState().error).toContain("insufficient");
   });
 });

--- a/mcpjam-inspector/client/src/lib/xaa/__tests__/step-metadata.test.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/__tests__/step-metadata.test.ts
@@ -60,3 +60,17 @@ describe("XAA phase metadata", () => {
     ).toBe(true);
   });
 });
+
+describe("dynamic registration steps", () => {
+  it("keeps all four strategy-specific steps in the bootstrap phase", () => {
+    for (const step of [
+      "request_client_registration",
+      "received_client_credentials",
+      "fetch_client_metadata_document",
+      "received_client_metadata",
+    ] as const) {
+      expect(XAA_STEP_ORDER).toContain(step);
+      expect(XAA_STEP_METADATA[step].phase).toBe("bootstrap");
+    }
+  });
+});

--- a/mcpjam-inspector/client/src/lib/xaa/capability-preflight.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/capability-preflight.ts
@@ -1,7 +1,9 @@
+import { ID_JAG_GRANT_PROFILE, JWT_BEARER_GRANT } from "@mcpjam/sdk/browser";
 import type { XAAFlowState } from "./types";
 
-export const JWT_BEARER_GRANT =
-  "urn:ietf:params:oauth:grant-type:jwt-bearer";
+// Re-exported for existing consumers; the URN itself now has a single source
+// of truth in the SDK.
+export { JWT_BEARER_GRANT };
 
 export type XAAVendor =
   | "okta"
@@ -22,7 +24,11 @@ export interface XAAVendorHint {
 export type XAACheckStatus = "pass" | "fail" | "warn" | "unknown";
 
 export interface XAACompatibilityCheck {
-  id: "jwt_bearer_grant" | "token_endpoint";
+  id:
+    | "jwt_bearer_grant"
+    | "token_endpoint"
+    | "id_jag_profile"
+    | "cimd_supported";
   label: string;
   status: XAACheckStatus;
   detail: string;
@@ -149,15 +155,84 @@ export function analyzeAsCompatibility(
         detail: "Missing from discovery metadata.",
       };
 
-  const checks = [jwtBearerCheck, tokenEndpointCheck];
+  // Draft-04 ID-JAG grant profile advertisement. SHOULD, not MUST — so an
+  // absent property is a warning; only an explicitly-present list WITHOUT the
+  // profile is an explicit statement of non-support.
+  const profilesValue = authzMetadata.authorization_grant_profiles_supported;
+  const idJagProfileCheck: XAACompatibilityCheck = Array.isArray(profilesValue)
+    ? profilesValue.includes(ID_JAG_GRANT_PROFILE)
+      ? {
+          id: "id_jag_profile",
+          label: "ID-JAG grant profile (draft -04)",
+          status: "pass",
+          detail: "Advertised in authorization_grant_profiles_supported.",
+        }
+      : {
+          id: "id_jag_profile",
+          label: "ID-JAG grant profile (draft -04)",
+          status: "fail",
+          detail: `authorization_grant_profiles_supported is advertised but does not include ${ID_JAG_GRANT_PROFILE} — an explicit statement that the ID-JAG profile is unsupported.`,
+        }
+    : {
+        id: "id_jag_profile",
+        label: "ID-JAG grant profile (draft -04)",
+        status: "warn",
+        detail:
+          "authorization_grant_profiles_supported is not advertised. Draft -04 says SHOULD, so this is a conformance warning, not a failure.",
+      };
+
+  // CIMD advertisement. Informational unless the cimd strategy is selected —
+  // the flow itself parks on false/absent when it is (that park IS the
+  // finding), so this check never degrades the overall verdict.
+  const cimdValue = authzMetadata.client_id_metadata_document_supported;
+  const cimdCheck: XAACompatibilityCheck =
+    cimdValue === true
+      ? {
+          id: "cimd_supported",
+          label: "Client ID Metadata Documents",
+          status: "pass",
+          detail: "client_id_metadata_document_supported: true.",
+        }
+      : cimdValue === false
+        ? {
+            id: "cimd_supported",
+            label: "Client ID Metadata Documents",
+            status: "fail",
+            detail:
+              "client_id_metadata_document_supported is explicitly false — URL-formatted client_ids are not accepted.",
+          }
+        : {
+            id: "cimd_supported",
+            label: "Client ID Metadata Documents",
+            status: "unknown",
+            detail:
+              "client_id_metadata_document_supported is not advertised; the CIMD draft directs clients not to attempt the flow.",
+          };
+
+  const checks = [
+    jwtBearerCheck,
+    tokenEndpointCheck,
+    idJagProfileCheck,
+    cimdCheck,
+  ];
 
   const vendor = detectVendor(authzMetadata.issuer);
   const vendorHint = VENDOR_NOTES[vendor];
 
+  // Overall verdict: the core operational checks plus an EXPLICIT ID-JAG
+  // profile contradiction. An absent profile advertisement (warn) and the
+  // CIMD check are strategy/conformance signals and deliberately don't
+  // degrade the overall readiness verdict.
+  const coreChecks = [jwtBearerCheck, tokenEndpointCheck];
   let overall: XAACompatibilityVerdict = "pass";
-  if (checks.some((c) => c.status === "fail")) {
+  if (
+    coreChecks.some((c) => c.status === "fail") ||
+    idJagProfileCheck.status === "fail"
+  ) {
     overall = "fail";
-  } else if (checks.some((c) => c.status === "warn" || c.status === "unknown")) {
+  } else if (
+    coreChecks.some((c) => c.status === "warn" || c.status === "unknown")
+  ) {
     overall = "warn";
   }
 

--- a/mcpjam-inspector/client/src/lib/xaa/debug-state-machine-adapter.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/debug-state-machine-adapter.ts
@@ -84,6 +84,12 @@ export function createXAADebugRequestExecutor(): XAARequestExecutor {
         method: init?.method || "GET",
         headers: normalizeHeaders(init?.headers),
         body: init?.body,
+        // CIMD document preflights use "manual" so a 3xx is observable (the
+        // draft forbids the AS from following redirects) instead of silently
+        // followed. Hosted httpsOnly forces manual regardless.
+        ...(init?.redirect === "manual" || init?.redirect === "follow"
+          ? { redirect: init.redirect }
+          : {}),
       });
     },
   };

--- a/mcpjam-inspector/client/src/lib/xaa/error-guidance.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/error-guidance.ts
@@ -253,7 +253,6 @@ export function getXAAErrorGuidance(
     if (
       messageIncludes(stateError, "inconsistent registration response") ||
       messageIncludes(stateError, "missing a client_id") ||
-      messageIncludes(stateError, "did not include token_endpoint_auth_method") ||
       messageIncludes(stateError, "already expired") ||
       messageIncludes(stateError, "could not be parsed")
     ) {

--- a/mcpjam-inspector/client/src/lib/xaa/error-guidance.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/error-guidance.ts
@@ -217,6 +217,110 @@ export function getXAAErrorGuidance(
     }
   }
 
+  if (step === "request_client_registration") {
+    // Pre-validation: no registration endpoint was advertised — no request
+    // was made, so don't frame this as a server refusal.
+    if (!httpEntry && messageIncludes(stateError, "registration_endpoint")) {
+      return {
+        title: "No open registration endpoint advertised",
+        explanation:
+          "The authorization server's metadata has no `registration_endpoint`, so open Dynamic Client Registration isn't available. That's a readiness finding, not a flow bug — the server may still support protected DCR (initial access token), which this debugger doesn't send. Switch the registration strategy to pre-registered credentials to continue.",
+        actions: [CONFIGURE],
+        severity: "error",
+      };
+    }
+    if (messageIncludes(stateError, "cannot use the returned client-auth method")) {
+      return {
+        title: "Registered, but with an auth method this debugger can't use",
+        explanation:
+          "Registration succeeded, but the server assigned a client-authentication method (for example `private_key_jwt`) that this debugger doesn't exercise yet. That's a debugger limitation, not authorization-server unreadiness. Use pre-registered credentials with a supported method to continue.",
+        actions: [CONFIGURE],
+        severity: "error",
+      };
+    }
+    if (
+      messageIncludes(stateError, "explicitly substituted") ||
+      messageIncludes(stateError, "without the JWT Bearer grant")
+    ) {
+      return {
+        title: "The server substituted the requested XAA client metadata",
+        explanation:
+          "The registration response explicitly returned metadata without the ID-JAG profile or the JWT Bearer grant. Unlike an omitted echo (which RFC 7591 permits), an explicit substitution means the registered client can't run this flow. Check whether the server can enable the jwt-bearer grant for dynamically registered clients.",
+        actions: [],
+        severity: "error",
+      };
+    }
+    if (
+      messageIncludes(stateError, "inconsistent registration response") ||
+      messageIncludes(stateError, "missing a client_id") ||
+      messageIncludes(stateError, "already expired") ||
+      messageIncludes(stateError, "could not be parsed")
+    ) {
+      return {
+        title: "Registration response was malformed or unusable",
+        explanation:
+          "The server answered 2xx but the registration isn't usable (missing client_id, inconsistent secret/auth-method combination, or an already-expired secret). Expand the HTTP entry for the raw (redacted) response. A remote client may still have been created — retrying asks for confirmation first.",
+        actions: [CONFIGURE],
+        severity: "error",
+      };
+    }
+    if (stateError || hasFailedResponse || httpEntry?.error) {
+      return {
+        title: "Open dynamic registration was not accepted",
+        explanation:
+          "The authorization server refused the unauthenticated registration POST (this debugger sends no initial access token or software statement). RFC 7591 permits protected registration endpoints, so this does not prove the server lacks DCR — it proves open DCR isn't offered. Expand the HTTP entry for the server's RFC error body, then switch to pre-registered credentials.",
+        actions: [CONFIGURE],
+        severity: "error",
+      };
+    }
+  }
+
+  if (step === "fetch_client_metadata_document") {
+    if (
+      messageIncludes(stateError, "client_id_metadata_document_supported")
+    ) {
+      return {
+        title: "The authorization server doesn't advertise CIMD support",
+        explanation:
+          "Client ID Metadata Documents require the server to advertise `client_id_metadata_document_supported: true`; the draft directs clients not to attempt the flow otherwise. This parked run is itself the readiness answer. Switch to pre-registered credentials (or DCR) to continue testing.",
+        actions: [CONFIGURE],
+        severity: "error",
+      };
+    }
+    if (messageIncludes(stateError, "key-based auth method")) {
+      return {
+        title: "Confidential CIMD isn't supported by this debugger yet",
+        explanation:
+          "The hosted metadata document declares a key-based client-auth method, which this debugger cannot exercise yet. This is a debugger limitation, not a server finding.",
+        actions: [],
+        severity: "error",
+      };
+    }
+    if (
+      messageIncludes(stateError, "does not exactly equal") ||
+      messageIncludes(stateError, "insufficient for XAA") ||
+      messageIncludes(stateError, "shared-secret auth method") ||
+      messageIncludes(stateError, "not a JSON")
+    ) {
+      return {
+        title: "The hosted client metadata document failed validation",
+        explanation:
+          "The debugger's preflight found the hosted document itself invalid (wrong client_id, missing XAA grants, or a forbidden auth method). This points at MCPJam's hosted document, not your authorization server. Retry freely — no remote state was created.",
+        actions: [],
+        severity: "error",
+      };
+    }
+    if (stateError || hasFailedResponse || httpEntry?.error) {
+      return {
+        title: "Client metadata document preflight failed",
+        explanation:
+          "The debugger could not fetch the hosted document as draft-02 requires (a direct 200 JSON response; redirects are forbidden because the authorization server must not follow them). Retry freely — this GET creates no remote state. If it keeps failing, the hosted route may be down.",
+        actions: [],
+        severity: "error",
+      };
+    }
+  }
+
   if (step === "jwt_bearer_request") {
     // Pre-request validation: no HTTP call was made. Don't claim the AS
     // rejected anything — the state machine set an error before contact.

--- a/mcpjam-inspector/client/src/lib/xaa/error-guidance.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/error-guidance.ts
@@ -253,6 +253,7 @@ export function getXAAErrorGuidance(
     if (
       messageIncludes(stateError, "inconsistent registration response") ||
       messageIncludes(stateError, "missing a client_id") ||
+      messageIncludes(stateError, "did not include token_endpoint_auth_method") ||
       messageIncludes(stateError, "already expired") ||
       messageIncludes(stateError, "could not be parsed")
     ) {

--- a/mcpjam-inspector/client/src/lib/xaa/sequence-actions.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/sequence-actions.ts
@@ -16,6 +16,80 @@ function safePath(url?: string): string | undefined {
 }
 
 export function buildXAAActions(flowState: XAAFlowState): Action[] {
+  // Strategy-specific bootstrap exchanges. Included only for the selected
+  // strategy so default (pre-registered) diagrams are unchanged.
+  const registrationActions: Action[] =
+    flowState.registrationStrategy === "dcr"
+      ? flowState.dcrRegistrationReused
+        ? [
+            {
+              id: "received_client_credentials",
+              label: "Reuse session registration",
+              description:
+                "No network exchange: the Agent reuses the client it registered earlier this browser session.",
+              from: "client",
+              to: "client",
+              details: flowState.clientId
+                ? [{ label: "client_id", value: flowState.clientId }]
+                : undefined,
+            },
+          ]
+        : [
+            {
+              id: "request_client_registration",
+              label: "Register client (open DCR)",
+              description:
+                "The Agent registers a client at the Authorization Server without an initial access token. (RFC 7591.)",
+              from: "client",
+              to: "authServer",
+              details: flowState.authzMetadata?.registration_endpoint
+                ? [
+                    {
+                      label: "Endpoint",
+                      value: safePath(
+                        flowState.authzMetadata.registration_endpoint
+                      ),
+                    },
+                  ]
+                : undefined,
+            },
+            {
+              id: "received_client_credentials",
+              label: "Client credentials issued",
+              description:
+                "The Authorization Server created the client; MCPJam holds its credentials for this session only.",
+              from: "authServer",
+              to: "client",
+              details: flowState.clientId
+                ? [{ label: "client_id", value: flowState.clientId }]
+                : undefined,
+            },
+          ]
+      : flowState.registrationStrategy === "cimd"
+        ? [
+            {
+              id: "fetch_client_metadata_document",
+              label: "Preflight hosted client metadata document",
+              description:
+                "Debugger preflight of MCPJam's hosted document — the Authorization Server performs its own fetch; only the later JWT bearer grant tests its acceptance.",
+              from: "client",
+              to: "client",
+              details: flowState.clientId
+                ? [{ label: "client_id (URL)", value: flowState.clientId }]
+                : undefined,
+            },
+            {
+              id: "received_client_metadata",
+              label: "Client metadata ready",
+              description:
+                "The document's client_id equals its URL and declares the XAA grants; the URL is this run's client identity.",
+              from: "client",
+              to: "client",
+              details: [{ label: "Auth method", value: "none (public)" }],
+            },
+          ]
+        : [];
+
   return [
     {
       id: "discover_resource_metadata",
@@ -57,6 +131,7 @@ export function buildXAAActions(flowState: XAAFlowState): Action[] {
         ? [{ label: "Token", value: safePath(flowState.tokenEndpoint) }]
         : undefined,
     },
+    ...registrationActions,
     {
       id: "user_authentication",
       label: "Mock OIDC login",

--- a/mcpjam-inspector/client/src/lib/xaa/state-machine.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/state-machine.ts
@@ -783,22 +783,6 @@ export function createXAAStateMachine(
   const registerClientDynamically = async () => {
     const state = currentState();
 
-    if (
-      state.dcrRetryMayCreateDuplicate &&
-      state.currentStep === "request_client_registration"
-    ) {
-      // A previous POST may already have created a remote client (timeout,
-      // 5xx, refusal, or an unusable 2xx). Ordinary Continue/Run all must not
-      // silently POST again; the UI clears this flag through the explicit
-      // "Register another client" confirmation.
-      machine.updateState({
-        error:
-          state.error ||
-          'The previous registration attempt may have created a client at the authorization server. Confirm "Register another client" to retry.',
-      });
-      return;
-    }
-
     const registrationEndpoint = state.authzMetadata?.registration_endpoint;
     if (!registrationEndpoint) {
       machine.updateState({
@@ -833,6 +817,23 @@ export function createXAAStateMachine(
           "Token Auth Method": cached.tokenEndpointAuthMethod,
         }
       );
+      return;
+    }
+
+    // No reusable session registration, but a prior POST may already have
+    // created a remote client (timeout, 5xx, refusal, or an unusable 2xx set
+    // dcrRetryMayCreateDuplicate). Gate on that here — regardless of how we
+    // arrived (parked retry OR a from-idle run after an ordinary reset that
+    // re-seeded the flag) — so we never silently mint a second remote client.
+    // The UI clears the flag only through the confirmed "Register another
+    // client" action.
+    if (state.dcrRetryMayCreateDuplicate) {
+      machine.updateState({
+        currentStep: "request_client_registration",
+        isBusy: false,
+        error:
+          'The previous registration attempt may have created a client at the authorization server. Confirm "Register another client" to register again.',
+      });
       return;
     }
 

--- a/mcpjam-inspector/client/src/lib/xaa/state-machine.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/state-machine.ts
@@ -1,3 +1,10 @@
+import {
+  evaluateIdJagClientMetadata,
+  executeDynamicClientRegistration,
+  getXaaDebugClientMetadata,
+  validateClientIdMetadataUrl,
+  XAA_DEBUG_CLIENT_ID_METADATA_URL,
+} from "@mcpjam/sdk/browser";
 import type { InfoLogLevel, LogErrorDetails } from "@mcpjam/sdk/browser";
 import { decodeJWTParts, formatJWTTimestamp } from "@/lib/oauth/jwt-decoder";
 import {
@@ -7,6 +14,8 @@ import {
 } from "@/shared/xaa.js";
 import type {
   BaseXAAStateMachineConfig,
+  XaaRegistrationStrategy,
+  XaaRegistrationWarning,
   XAADecodedJwt,
   XAAFlowState,
   XAAFlowStep,
@@ -388,7 +397,18 @@ export function createXAAStateMachine(
     registrationId,
     serverId,
     projectId,
+    registrationStrategy: requestedRegistrationStrategy = "pre_registered",
+    dcrCredentialCache,
+    dcrCacheTargetKey,
   } = config;
+
+  // registrationId / serverId runs skip AS discovery entirely, so the dynamic
+  // strategies (which need the discovered registration_endpoint / CIMD
+  // advertisement) are forced back to pre-registered.
+  const registrationStrategy: XaaRegistrationStrategy =
+    registrationId || serverId
+      ? "pre_registered"
+      : requestedRegistrationStrategy;
 
   // Body fields the LOCAL server uses to forward the mint to the hosted
   // issuer (server-to-server); stripped before the upstream call. Hosted
@@ -412,6 +432,9 @@ export function createXAAStateMachine(
       clientSecret: state.clientSecret || clientSecret,
       scope: state.scope || scope,
       authzServerIssuer: state.authzServerIssuer || authzServerIssuer,
+      // Config-resolved, not snapshot-carried: after initialization the
+      // state value is authoritative and only a rebuild can change it.
+      registrationStrategy,
     }),
     updateState: (updates) => {
       machine.state = { ...machine.state, ...updates };
@@ -716,6 +739,11 @@ export function createXAAStateMachine(
             issuer: resolvedIssuer,
             token_endpoint: metadata.token_endpoint,
             grant_types_supported: metadata.grant_types_supported,
+            registration_endpoint: metadata.registration_endpoint,
+            client_id_metadata_document_supported:
+              metadata.client_id_metadata_document_supported,
+            authorization_grant_profiles_supported:
+              metadata.authorization_grant_profiles_supported,
             compatibility: compatibilityReport
               ? {
                   overall: compatibilityReport.overall,
@@ -736,6 +764,470 @@ export function createXAAStateMachine(
       currentStep: "discover_authz_metadata",
       error: lastError,
     });
+  };
+
+  // --- Dynamic client-identity strategies (dcr / cimd) ----------------------
+
+  const dcrCacheKeyFor = (registrationEndpoint: string) =>
+    `${dcrCacheTargetKey ?? serverUrl}::${registrationEndpoint}`;
+
+  const dcrSecretExpired = (creds: {
+    clientSecret?: string;
+    clientSecretExpiresAt?: number;
+  }) =>
+    Boolean(creds.clientSecret) &&
+    typeof creds.clientSecretExpiresAt === "number" &&
+    creds.clientSecretExpiresAt !== 0 &&
+    creds.clientSecretExpiresAt <= Math.floor(Date.now() / 1000);
+
+  const registerClientDynamically = async () => {
+    const state = currentState();
+
+    if (
+      state.dcrRetryMayCreateDuplicate &&
+      state.currentStep === "request_client_registration"
+    ) {
+      // A previous POST may already have created a remote client (timeout,
+      // 5xx, refusal, or an unusable 2xx). Ordinary Continue/Run all must not
+      // silently POST again; the UI clears this flag through the explicit
+      // "Register another client" confirmation.
+      machine.updateState({
+        error:
+          state.error ||
+          'The previous registration attempt may have created a client at the authorization server. Confirm "Register another client" to retry.',
+      });
+      return;
+    }
+
+    const registrationEndpoint = state.authzMetadata?.registration_endpoint;
+    if (!registrationEndpoint) {
+      machine.updateState({
+        currentStep: "request_client_registration",
+        isBusy: false,
+        error:
+          "The authorization server metadata does not advertise a registration_endpoint, so open Dynamic Client Registration is not available. That is a readiness finding in itself — switch to pre-registered credentials to continue.",
+      });
+      return;
+    }
+
+    const cacheKey = dcrCacheKeyFor(registrationEndpoint);
+    const cached = dcrCredentialCache?.get(cacheKey);
+    if (cached && dcrSecretExpired(cached)) {
+      dcrCredentialCache?.delete(cacheKey);
+    } else if (cached) {
+      // Reuse this browser session's registration instead of minting another
+      // remote client on every Run all / Reset.
+      machine.updateState({
+        currentStep: "received_client_credentials",
+        clientId: cached.clientId,
+        tokenEndpointAuthMethod: cached.tokenEndpointAuthMethod,
+        dcrRegistrationReused: true,
+        error: undefined,
+      });
+      pushInfo(
+        "received_client_credentials",
+        "xaa-dcr-reused",
+        "Reusing this session's dynamic registration",
+        {
+          "Client ID": cached.clientId,
+          "Token Auth Method": cached.tokenEndpointAuthMethod,
+        }
+      );
+      return;
+    }
+
+    const clientMetadata = {
+      ...getXaaDebugClientMetadata({
+        tokenEndpointAuthMethod: "client_secret_post",
+      }),
+      ...(state.scope ? { scope: state.scope } : {}),
+    };
+
+    // One immutable request object: the displayed request (lastRequest /
+    // history) and the executed request are the same value, so they cannot
+    // drift. The executor owns wire serialization.
+    const request = {
+      method: "POST",
+      url: registrationEndpoint,
+      headers: mergeHeadersForAuthServer(undefined, {
+        "Content-Type": "application/json",
+      }),
+      body: clientMetadata,
+    };
+
+    machine.updateState({
+      currentStep: "request_client_registration",
+      isBusy: true,
+      error: undefined,
+      negativeProbe: undefined,
+      dcrRegistrationReused: false,
+      lastRequest: request,
+      lastResponse: undefined,
+      httpHistory: [
+        ...(currentState().httpHistory || []),
+        {
+          step: "request_client_registration",
+          timestamp: Date.now(),
+          request,
+        },
+      ],
+    });
+
+    // The SDK helper owns execution, history back-fill, and credential
+    // redaction; it never throws (transport failures become outcomes).
+    const outcome = await executeDynamicClientRegistration({
+      request,
+      requestExecutor: (req) =>
+        requestExecutor.externalRequest(req.url, {
+          method: req.method,
+          headers: req.headers,
+          body: req.body as BodyInit,
+        }),
+      httpHistory: currentState().httpHistory,
+    });
+
+    const parkRegistration = (error: string) => {
+      machine.updateState({
+        currentStep: "request_client_registration",
+        isBusy: false,
+        lastResponse: outcome.response,
+        httpHistory: outcome.httpHistory,
+        error,
+        // Any POST that did not yield a reusable registration may still have
+        // created a remote client. Retry needs explicit confirmation.
+        dcrRetryMayCreateDuplicate: true,
+      });
+    };
+
+    if (outcome.status !== "registered") {
+      const framing =
+        outcome.status === "http_error"
+          ? "The authorization server did not accept open Dynamic Client Registration (no initial access token was sent). A protected registration endpoint is a valid deployment choice — this does not prove the server lacks DCR."
+          : outcome.status === "invalid_response"
+            ? "The registration response could not be parsed as a client registration."
+            : "The registration request did not reach the authorization server.";
+      parkRegistration(
+        `${outcome.error} ${framing} Switch to pre-registered credentials to continue.`
+      );
+      return;
+    }
+
+    // A 2xx with a client id is not automatically usable for the pinned
+    // ID-JAG profile: validate before caching or advancing. Evidence comes
+    // from the SDK evaluator; only the park/warn policy lives here.
+    const clientId = outcome.credentials.clientId;
+    if (outcome.missingClientId || !clientId) {
+      parkRegistration(
+        "The registration response is missing a client_id, so the registration is unusable. Switch to pre-registered credentials to continue."
+      );
+      return;
+    }
+
+    const warnings: XaaRegistrationWarning[] = [];
+    const evaluation = evaluateIdJagClientMetadata(outcome.clientInfo);
+
+    if (evaluation.profile === "contradicted") {
+      parkRegistration(
+        "The authorization server returned authorization_grant_profiles_supported without the ID-JAG profile — it explicitly substituted the requested draft-04 client profile. Switch to pre-registered credentials to continue."
+      );
+      return;
+    }
+    if (evaluation.profile === "omitted") {
+      warnings.push({
+        code: "profile_metadata_not_echoed",
+        message:
+          "The registration response did not echo authorization_grant_profiles_supported. RFC 7591 lets a server ignore unknown metadata, so this is a conformance warning, not a rejection — JWT Bearer redemption is the operational verdict.",
+      });
+    }
+
+    if (evaluation.jwtBearerGrant === "contradicted") {
+      parkRegistration(
+        "The authorization server returned grant_types without the JWT Bearer grant — the registered client cannot redeem an ID-JAG at this server. Switch to pre-registered credentials to continue."
+      );
+      return;
+    }
+    if (
+      evaluation.jwtBearerGrant === "omitted" &&
+      evaluation.tokenExchangeGrant === "omitted"
+    ) {
+      warnings.push({
+        code: "grant_types_not_echoed",
+        message:
+          "The registration response did not echo grant_types. Continuing — JWT Bearer redemption will show whether the grant is actually enabled.",
+      });
+    } else if (
+      evaluation.jwtBearerGrant === "present" &&
+      evaluation.tokenExchangeGrant !== "present"
+    ) {
+      warnings.push({
+        code: "token_exchange_grant_not_echoed",
+        message:
+          "The registration echoed the JWT Bearer grant but not the Token Exchange grant. Token Exchange is the Client-to-IdP leg, so redemption at this server can still proceed; draft-04 expects both to be registered together.",
+      });
+    }
+
+    const method = outcome.credentials.tokenEndpointAuthMethod;
+    if (method === undefined) {
+      parkRegistration(
+        "The registration response did not include token_endpoint_auth_method, so the debugger cannot tell how to authenticate at the token endpoint. Switch to pre-registered credentials to continue."
+      );
+      return;
+    }
+    if (
+      method !== "client_secret_post" &&
+      method !== "client_secret_basic" &&
+      method !== "none"
+    ) {
+      parkRegistration(
+        `Registration succeeded, but this debugger cannot use the returned client-auth method ("${method}"). This is a debugger limitation, not authorization-server unreadiness.`
+      );
+      return;
+    }
+
+    const secret = outcome.credentials.clientSecret;
+    if (
+      (method === "client_secret_post" || method === "client_secret_basic") &&
+      !secret
+    ) {
+      parkRegistration(
+        `The registration returned token_endpoint_auth_method "${method}" without a client_secret — an inconsistent registration response. Switch to pre-registered credentials to continue.`
+      );
+      return;
+    }
+    if (method === "none" && secret) {
+      parkRegistration(
+        'The registration returned a client_secret together with token_endpoint_auth_method "none" — an inconsistent registration response. Switch to pre-registered credentials to continue.'
+      );
+      return;
+    }
+    if (method === "none") {
+      warnings.push({
+        code: "public_client",
+        message:
+          "The registered client is public (no client authentication). Draft-04 recommends Cross-App Access for confidential clients; the flow can continue, but this does not match the recommended deployment posture.",
+      });
+    }
+
+    if (secret) {
+      const expiresAt = outcome.credentials.clientSecretExpiresAt;
+      if (
+        typeof expiresAt === "number" &&
+        expiresAt !== 0 &&
+        expiresAt <= Math.floor(Date.now() / 1000)
+      ) {
+        parkRegistration(
+          "The issued client_secret is already expired. Switch to pre-registered credentials to continue."
+        );
+        return;
+      }
+      if (typeof expiresAt !== "number") {
+        warnings.push({
+          code: "missing_secret_expiry",
+          message:
+            "The registration response omitted client_secret_expires_at, which RFC 7591 requires whenever a secret is issued.",
+        });
+      }
+    }
+
+    if (outcome.nonCanonicalSuccessStatus) {
+      warnings.push({
+        code: "non_201_success",
+        message: `The registration returned ${outcome.response.status} instead of the RFC 7591 201 Created.`,
+      });
+    }
+    const responseContentType = outcome.response.headers["content-type"] || "";
+    if (!responseContentType.includes("json")) {
+      warnings.push({
+        code: "non_json_content_type",
+        message: `The registration response parsed as JSON but was served as "${responseContentType || "(none)"}".`,
+      });
+    }
+    const cacheControl = outcome.response.headers["cache-control"] || "";
+    if (!cacheControl.includes("no-store")) {
+      warnings.push({
+        code: "missing_no_store",
+        message:
+          "The registration response is missing Cache-Control: no-store, which RFC 7591 requires for responses carrying credentials.",
+      });
+    }
+
+    // The raw credential goes ONLY to the target-scoped session cache — never
+    // into XAAFlowState, history, or logs.
+    dcrCredentialCache?.set(cacheKey, {
+      clientId,
+      clientSecret: secret,
+      tokenEndpointAuthMethod: method,
+      clientSecretExpiresAt: outcome.credentials.clientSecretExpiresAt,
+      registrationEndpoint,
+    });
+
+    machine.updateState({
+      currentStep: "received_client_credentials",
+      clientId,
+      tokenEndpointAuthMethod: method,
+      registrationWarnings: warnings,
+      dcrRegistrationReused: false,
+      dcrRetryMayCreateDuplicate: false,
+      lastResponse: outcome.response,
+      httpHistory: outcome.httpHistory,
+      isBusy: false,
+      error: undefined,
+    });
+
+    pushInfo(
+      "received_client_credentials",
+      "xaa-dcr",
+      "Dynamic Client Registration",
+      outcome.infoLogData
+    );
+  };
+
+  const adoptClientMetadataDocument = async () => {
+    const state = currentState();
+    const supported =
+      state.authzMetadata?.client_id_metadata_document_supported;
+
+    // Gate before any fetch, like the 2025-11-25 OAuth machine: the CIMD
+    // draft defines this advertisement specifically so clients don't enter
+    // an unsupported flow. Parking here IS the readiness finding.
+    if (supported !== true) {
+      machine.updateState({
+        currentStep: "fetch_client_metadata_document",
+        isBusy: false,
+        error:
+          supported === false
+            ? "The authorization server explicitly advertises client_id_metadata_document_supported: false — it does not accept Client ID Metadata Document client_ids. That is the readiness finding; switch to pre-registered credentials to continue."
+            : "The authorization server metadata does not advertise client_id_metadata_document_supported, so the CIMD draft directs clients not to attempt the flow. That is the readiness finding; switch to pre-registered credentials to continue.",
+      });
+      return;
+    }
+
+    let documentUrl: string;
+    try {
+      documentUrl = validateClientIdMetadataUrl(
+        XAA_DEBUG_CLIENT_ID_METADATA_URL
+      );
+    } catch (error) {
+      machine.updateState({
+        currentStep: "fetch_client_metadata_document",
+        isBusy: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Invalid client metadata URL",
+      });
+      return;
+    }
+
+    // Debugger preflight only — the RAS performs its own fetch or metadata
+    // association. redirect:"manual" keeps a 3xx observable, since draft-02
+    // forbids the authorization server from following redirects.
+    const request = {
+      method: "GET",
+      url: documentUrl,
+      headers: mergeHeadersForAuthServer(undefined, {
+        Accept: "application/json",
+      }),
+    };
+
+    let result: XAARequestResult;
+    try {
+      result = await runRequest(
+        "fetch_client_metadata_document",
+        request,
+        () =>
+          requestExecutor.externalRequest(documentUrl, {
+            method: "GET",
+            headers: request.headers,
+            redirect: "manual",
+          })
+      );
+    } catch {
+      // runRequest already recorded the failure and set the error; the step
+      // stays at fetch_client_metadata_document and retries freely.
+      return;
+    }
+
+    const park = (error: string) => {
+      machine.updateState({
+        currentStep: "fetch_client_metadata_document",
+        error: `${error} This is a document preflight/validation failure; retry freely or switch strategy.`,
+      });
+    };
+
+    if (result.status !== 200) {
+      park(
+        result.status >= 300 && result.status < 400
+          ? `The client metadata URL answered with a ${result.status} redirect; draft-02 requires a direct 200 and forbids the authorization server from following redirects.`
+          : `The client metadata URL answered ${result.status}; draft-02 requires a direct 200 OK.`
+      );
+      return;
+    }
+    const contentType = result.headers["content-type"] || "";
+    if (!/application\/([a-z0-9.+-]*\+)?json/i.test(contentType)) {
+      park(
+        `The client metadata document was served as "${contentType || "(none)"}", not a JSON media type.`
+      );
+      return;
+    }
+    const doc = result.body;
+    if (!doc || typeof doc !== "object" || Array.isArray(doc)) {
+      park("The client metadata document body is not a JSON object.");
+      return;
+    }
+    if (doc.client_id !== documentUrl) {
+      park(
+        "The document's client_id does not exactly equal the fetched URL — draft-02 compares Client Identifier URLs with simple string comparison, no normalization."
+      );
+      return;
+    }
+
+    // The document IS the registration: no RFC 7591 echo-tolerance applies.
+    const evaluation = evaluateIdJagClientMetadata(doc);
+    if (
+      evaluation.profile !== "present" ||
+      evaluation.jwtBearerGrant !== "present" ||
+      evaluation.tokenExchangeGrant !== "present"
+    ) {
+      park(
+        "The hosted client metadata document does not declare the ID-JAG grant profile plus both required grants — the document is insufficient for XAA. This points at the hosted document, not the authorization server."
+      );
+      return;
+    }
+    if (evaluation.tokenEndpointAuthMethod !== "none") {
+      const authMethod = evaluation.tokenEndpointAuthMethod ?? "";
+      park(
+        authMethod.startsWith("client_secret")
+          ? "The client metadata document declares a shared-secret auth method, which CIMD draft-02 forbids — the document is malformed."
+          : "The client metadata document declares a key-based auth method this debugger cannot exercise yet (confidential CIMD is a follow-up)."
+      );
+      return;
+    }
+
+    machine.updateState({
+      currentStep: "received_client_metadata",
+      clientId: documentUrl,
+      tokenEndpointAuthMethod: "none",
+      registrationWarnings: [
+        {
+          code: "public_client",
+          message:
+            "CIMD without a key-based auth method is inherently a public client: anyone can present this URL as their client_id. Findings show the RAS accepted the URL identity, not that client authentication was exercised.",
+        },
+      ],
+      error: undefined,
+    });
+
+    pushInfo(
+      "received_client_metadata",
+      "xaa-cimd",
+      "Client ID Metadata Document ready",
+      {
+        "Client ID": documentUrl,
+        "Client Name": (doc as Record<string, any>).client_name,
+        Note: "Debugger preflight only — the RAS performs its own fetch or metadata association; JWT Bearer redemption is the operational verdict.",
+      }
+    );
   };
 
   const authenticateUser = async () => {
@@ -944,6 +1436,34 @@ export function createXAAStateMachine(
       return;
     }
 
+    // Dynamic strategies resolve their credentials outside the flow snapshot:
+    // DCR reads the target-scoped session cache (the secret never enters
+    // XAAFlowState), CIMD is public by construction.
+    let manualClientSecret = state.clientSecret;
+    let manualAuthMethod = state.tokenEndpointAuthMethod;
+    if (!registrationId && !serverId) {
+      if (registrationStrategy === "dcr") {
+        const registrationEndpoint =
+          state.authzMetadata?.registration_endpoint;
+        const cached = registrationEndpoint
+          ? dcrCredentialCache?.get(dcrCacheKeyFor(registrationEndpoint))
+          : undefined;
+        if (!cached || cached.clientId !== state.clientId) {
+          machine.updateState({
+            currentStep: "jwt_bearer_request",
+            error:
+              "This session's dynamic registration credentials are no longer available (the page may have reloaded). Register another client to continue.",
+          });
+          return;
+        }
+        manualClientSecret = cached.clientSecret;
+        manualAuthMethod = cached.tokenEndpointAuthMethod;
+      } else if (registrationStrategy === "cimd") {
+        manualClientSecret = undefined;
+        manualAuthMethod = "none";
+      }
+    }
+
     // Registration- and server-target runs send only an opaque id: the server
     // resolves the stored secret and forces the outbound URL server-side, so
     // neither the secret nor the destination ever rides in from the browser.
@@ -968,7 +1488,10 @@ export function createXAAStateMachine(
           tokenEndpoint: state.tokenEndpoint,
           assertion: state.idJag,
           clientId: state.clientId,
-          ...(state.clientSecret ? { clientSecret: state.clientSecret } : {}),
+          ...(manualClientSecret ? { clientSecret: manualClientSecret } : {}),
+          ...(manualAuthMethod
+            ? { tokenEndpointAuthMethod: manualAuthMethod }
+            : {}),
           scope: state.scope,
           resource: state.resourceUrl || state.serverUrl,
         };
@@ -1225,6 +1748,30 @@ export function createXAAStateMachine(
         await discoverAuthzMetadata();
         return;
       case "received_authz_metadata":
+        // The config-resolved strategy (which already forces pre_registered
+        // for registrationId/serverId runs) is authoritative; the state copy
+        // exists for display surfaces.
+        if (registrationStrategy === "dcr") {
+          await registerClientDynamically();
+          return;
+        }
+        if (registrationStrategy === "cimd") {
+          await adoptClientMetadataDocument();
+          return;
+        }
+        await authenticateUser();
+        return;
+      case "request_client_registration":
+        // First attempt or retry (retry is gated on the duplicate-client
+        // confirmation inside registerClientDynamically).
+        await registerClientDynamically();
+        return;
+      case "fetch_client_metadata_document":
+        // First attempt or freely-retryable CIMD preflight.
+        await adoptClientMetadataDocument();
+        return;
+      case "received_client_credentials":
+      case "received_client_metadata":
       case "user_authentication":
         await authenticateUser();
         return;
@@ -1302,6 +1849,10 @@ export function createXAAStateMachine(
         scope: currentState().scope || scope,
         authzServerIssuer:
           currentState().authzServerIssuer || authzServerIssuer,
+        // Config-resolved strategy survives reset; the target-scoped DCR
+        // credential cache lives outside flow state, so Run all after a reset
+        // reuses this session's registration instead of minting another.
+        registrationStrategy,
       })
     );
   };

--- a/mcpjam-inspector/client/src/lib/xaa/state-machine.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/state-machine.ts
@@ -968,9 +968,13 @@ export function createXAAStateMachine(
       });
     }
 
-    const rawMethod = outcome.credentials.tokenEndpointAuthMethod;
+    // Read the RAW response member, not credentials.tokenEndpointAuthMethod
+    // (the SDK collapses a non-string value to undefined) — so a genuinely
+    // ABSENT member gets the RFC 7591 fallback while a malformed present-but-
+    // non-string member stays parked.
+    const rawMethodMember = outcome.clientInfo.token_endpoint_auth_method;
     let method: XaaTokenEndpointAuthMethod;
-    if (rawMethod === undefined) {
+    if (rawMethodMember === undefined) {
       // RFC 7591 SHOULD echo token_endpoint_auth_method, but some servers omit
       // it. We requested client_secret_post and the token proxy treats an
       // absent method as body-post, so default to that when a secret was
@@ -984,14 +988,19 @@ export function createXAAStateMachine(
           : "The registration response omitted token_endpoint_auth_method and issued no secret; treating the client as public (none).",
       });
     } else if (
-      rawMethod === "client_secret_post" ||
-      rawMethod === "client_secret_basic" ||
-      rawMethod === "none"
+      rawMethodMember === "client_secret_post" ||
+      rawMethodMember === "client_secret_basic" ||
+      rawMethodMember === "none"
     ) {
-      method = rawMethod;
+      method = rawMethodMember;
+    } else if (typeof rawMethodMember === "string") {
+      parkRegistration(
+        `Registration succeeded, but this debugger cannot use the returned client-auth method ("${rawMethodMember}"). This is a debugger limitation, not authorization-server unreadiness.`
+      );
+      return;
     } else {
       parkRegistration(
-        `Registration succeeded, but this debugger cannot use the returned client-auth method ("${rawMethod}"). This is a debugger limitation, not authorization-server unreadiness.`
+        "The registration returned a non-string token_endpoint_auth_method — a malformed registration response. Switch to pre-registered credentials to continue."
       );
       return;
     }

--- a/mcpjam-inspector/client/src/lib/xaa/state-machine.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/state-machine.ts
@@ -771,11 +771,17 @@ export function createXAAStateMachine(
 
   // Scope is part of the registered client's metadata, so a client registered
   // under one scope must NOT be reused when the run's scope changes — key the
-  // cache on it too (a scope change then forces a fresh registration).
+  // cache on it too (a scope change then forces a fresh registration). Each
+  // component is encodeURIComponent-escaped (which escapes ":") so a "::" inside
+  // any component can't collide with the "::" delimiter between components.
   const dcrCacheKeyFor = (registrationEndpoint: string) =>
-    `${dcrCacheTargetKey ?? serverUrl}::${registrationEndpoint}::${
-      currentState().scope ?? ""
-    }`;
+    [
+      dcrCacheTargetKey ?? serverUrl,
+      registrationEndpoint,
+      currentState().scope ?? "",
+    ]
+      .map(encodeURIComponent)
+      .join("::");
 
   const dcrSecretExpired = (creds: {
     clientSecret?: string;

--- a/mcpjam-inspector/client/src/lib/xaa/state-machine.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/state-machine.ts
@@ -16,6 +16,7 @@ import type {
   BaseXAAStateMachineConfig,
   XaaRegistrationStrategy,
   XaaRegistrationWarning,
+  XaaTokenEndpointAuthMethod,
   XAADecodedJwt,
   XAAFlowState,
   XAAFlowStep,
@@ -967,20 +968,30 @@ export function createXAAStateMachine(
       });
     }
 
-    const method = outcome.credentials.tokenEndpointAuthMethod;
-    if (method === undefined) {
-      parkRegistration(
-        "The registration response did not include token_endpoint_auth_method, so the debugger cannot tell how to authenticate at the token endpoint. Switch to pre-registered credentials to continue."
-      );
-      return;
-    }
-    if (
-      method !== "client_secret_post" &&
-      method !== "client_secret_basic" &&
-      method !== "none"
+    const rawMethod = outcome.credentials.tokenEndpointAuthMethod;
+    let method: XaaTokenEndpointAuthMethod;
+    if (rawMethod === undefined) {
+      // RFC 7591 SHOULD echo token_endpoint_auth_method, but some servers omit
+      // it. We requested client_secret_post and the token proxy treats an
+      // absent method as body-post, so default to that when a secret was
+      // issued (or a public client when not) rather than blocking usable
+      // credentials — and warn so the conformance gap stays visible.
+      method = outcome.credentials.clientSecret ? "client_secret_post" : "none";
+      warnings.push({
+        code: "auth_method_not_echoed",
+        message: outcome.credentials.clientSecret
+          ? "The registration response omitted token_endpoint_auth_method (RFC 7591 SHOULD echo it); assuming the requested client_secret_post."
+          : "The registration response omitted token_endpoint_auth_method and issued no secret; treating the client as public (none).",
+      });
+    } else if (
+      rawMethod === "client_secret_post" ||
+      rawMethod === "client_secret_basic" ||
+      rawMethod === "none"
     ) {
+      method = rawMethod;
+    } else {
       parkRegistration(
-        `Registration succeeded, but this debugger cannot use the returned client-auth method ("${method}"). This is a debugger limitation, not authorization-server unreadiness.`
+        `Registration succeeded, but this debugger cannot use the returned client-auth method ("${rawMethod}"). This is a debugger limitation, not authorization-server unreadiness.`
       );
       return;
     }

--- a/mcpjam-inspector/client/src/lib/xaa/state-machine.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/state-machine.ts
@@ -769,8 +769,13 @@ export function createXAAStateMachine(
 
   // --- Dynamic client-identity strategies (dcr / cimd) ----------------------
 
+  // Scope is part of the registered client's metadata, so a client registered
+  // under one scope must NOT be reused when the run's scope changes — key the
+  // cache on it too (a scope change then forces a fresh registration).
   const dcrCacheKeyFor = (registrationEndpoint: string) =>
-    `${dcrCacheTargetKey ?? serverUrl}::${registrationEndpoint}`;
+    `${dcrCacheTargetKey ?? serverUrl}::${registrationEndpoint}::${
+      currentState().scope ?? ""
+    }`;
 
   const dcrSecretExpired = (creds: {
     clientSecret?: string;
@@ -798,7 +803,19 @@ export function createXAAStateMachine(
     const cacheKey = dcrCacheKeyFor(registrationEndpoint);
     const cached = dcrCredentialCache?.get(cacheKey);
     if (cached && dcrSecretExpired(cached)) {
+      // The registered remote client still exists; only its secret died.
+      // Replacing it means minting ANOTHER remote client, so gate that behind
+      // the same "Register another client" confirmation as every other
+      // duplicate-creating path rather than silently re-registering.
       dcrCredentialCache?.delete(cacheKey);
+      machine.updateState({
+        currentStep: "request_client_registration",
+        isBusy: false,
+        error:
+          'This session\'s dynamic client secret has expired. Confirm "Register another client" to register a replacement.',
+        dcrRetryMayCreateDuplicate: true,
+      });
+      return;
     } else if (cached) {
       // Reuse this browser session's registration instead of minting another
       // remote client on every Run all / Reset.

--- a/mcpjam-inspector/client/src/lib/xaa/state-machine.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/state-machine.ts
@@ -1445,14 +1445,29 @@ export function createXAAStateMachine(
       if (registrationStrategy === "dcr") {
         const registrationEndpoint =
           state.authzMetadata?.registration_endpoint;
-        const cached = registrationEndpoint
-          ? dcrCredentialCache?.get(dcrCacheKeyFor(registrationEndpoint))
+        const cacheKey = registrationEndpoint
+          ? dcrCacheKeyFor(registrationEndpoint)
+          : undefined;
+        const cached = cacheKey
+          ? dcrCredentialCache?.get(cacheKey)
           : undefined;
         if (!cached || cached.clientId !== state.clientId) {
           machine.updateState({
             currentStep: "jwt_bearer_request",
             error:
               "This session's dynamic registration credentials are no longer available (the page may have reloaded). Register another client to continue.",
+          });
+          return;
+        }
+        // The secret can expire between registration and redemption. Redeeming
+        // with an expired secret surfaces as a confusing token-endpoint
+        // failure, so discard it and ask to register again instead.
+        if (dcrSecretExpired(cached)) {
+          if (cacheKey) dcrCredentialCache?.delete(cacheKey);
+          machine.updateState({
+            currentStep: "jwt_bearer_request",
+            error:
+              "This session's dynamic client secret has expired. Register another client to continue.",
           });
           return;
         }

--- a/mcpjam-inspector/client/src/lib/xaa/state-machine.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/state-machine.ts
@@ -1167,13 +1167,15 @@ export function createXAAStateMachine(
     // Compare the media-type ESSENCE (type/subtype before any ";" parameters,
     // trimmed + lowercased), anchored — an unanchored substring test wrongly
     // accepts "application/jsonp", "text/application/json", "application/+json".
-    // Allow exactly application/json, or a structured suffix with a NON-empty
-    // subtype tree (application/<x>+json), which the SDK proxy parses correctly.
+    // Allow exactly application/json, or a structured suffix application/<x>+json
+    // where <x> is a valid RFC 6838 subtype tree: it must START with an
+    // alphanumeric (rejects "-+json"/"+json") and may use restricted-name chars
+    // including "_" (accepts "vnd_acme+json"). The SDK proxy parses valid +json.
     const contentType = result.headers["content-type"] || "";
     const mediaTypeEssence = contentType.split(";", 1)[0].trim().toLowerCase();
     const isJsonMediaType =
       mediaTypeEssence === "application/json" ||
-      /^application\/[a-z0-9.+-]+\+json$/.test(mediaTypeEssence);
+      /^application\/[a-z0-9][a-z0-9!#$&^_.+-]*\+json$/.test(mediaTypeEssence);
     if (!isJsonMediaType) {
       park(
         `The client metadata document was served as "${contentType || "(none)"}", not a JSON media type.`
@@ -1466,6 +1468,10 @@ export function createXAAStateMachine(
             currentStep: "jwt_bearer_request",
             error:
               "This session's dynamic registration credentials are no longer available (the page may have reloaded). Register another client to continue.",
+            // A remote client was already registered this session; its secret
+            // is just gone. Set the gate so the "Register another client"
+            // action this error points at is actually visible.
+            dcrRetryMayCreateDuplicate: true,
           });
           return;
         }

--- a/mcpjam-inspector/client/src/lib/xaa/state-machine.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/state-machine.ts
@@ -1164,8 +1164,17 @@ export function createXAAStateMachine(
       );
       return;
     }
+    // Compare the media-type ESSENCE (type/subtype before any ";" parameters,
+    // trimmed + lowercased), anchored — an unanchored substring test wrongly
+    // accepts "application/jsonp", "text/application/json", "application/+json".
+    // Allow exactly application/json, or a structured suffix with a NON-empty
+    // subtype tree (application/<x>+json), which the SDK proxy parses correctly.
     const contentType = result.headers["content-type"] || "";
-    if (!/application\/([a-z0-9.+-]*\+)?json/i.test(contentType)) {
+    const mediaTypeEssence = contentType.split(";", 1)[0].trim().toLowerCase();
+    const isJsonMediaType =
+      mediaTypeEssence === "application/json" ||
+      /^application\/[a-z0-9.+-]+\+json$/.test(mediaTypeEssence);
+    if (!isJsonMediaType) {
       park(
         `The client metadata document was served as "${contentType || "(none)"}", not a JSON media type.`
       );
@@ -1462,13 +1471,18 @@ export function createXAAStateMachine(
         }
         // The secret can expire between registration and redemption. Redeeming
         // with an expired secret surfaces as a confusing token-endpoint
-        // failure, so discard it and ask to register again instead.
+        // failure, so discard it and ask to register again instead. Set the
+        // duplicate-risk flag too: a remote client already exists (with a dead
+        // secret), so registering another is what recovery requires — and the
+        // flag is what keeps the "Register another client" action visible, which
+        // this error tells the user to use.
         if (dcrSecretExpired(cached)) {
           if (cacheKey) dcrCredentialCache?.delete(cacheKey);
           machine.updateState({
             currentStep: "jwt_bearer_request",
             error:
               "This session's dynamic client secret has expired. Register another client to continue.",
+            dcrRetryMayCreateDuplicate: true,
           });
           return;
         }

--- a/mcpjam-inspector/client/src/lib/xaa/step-metadata.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/step-metadata.ts
@@ -85,6 +85,10 @@ export const XAA_STEP_ORDER: XAAFlowStep[] = [
   "received_resource_metadata",
   "discover_authz_metadata",
   "received_authz_metadata",
+  "request_client_registration",
+  "received_client_credentials",
+  "fetch_client_metadata_document",
+  "received_client_metadata",
   "user_authentication",
   "received_identity_assertion",
   "token_exchange_request",
@@ -139,6 +143,47 @@ export const XAA_STEP_METADATA: Record<XAAFlowStep, XAAStepInfo> = {
     phase: "bootstrap",
     teachableMoments: [
       "If discovery fails, the Authorization Server's issuer or its metadata URL is usually misconfigured.",
+    ],
+  },
+  request_client_registration: {
+    title: "Register a Client at the Authorization Server",
+    summary:
+      "Open Dynamic Client Registration: the Agent asks the Authorization Server to create a client for the XAA grant types, without an initial access token. (RFC 7591.)",
+    phase: "bootstrap",
+    teachableMoments: [
+      "The XAA spec assumes the client is already registered — registration is setup, not part of the grant. This step automates that setup when the server allows open registration.",
+      "A 401/403 here means open registration wasn't accepted; the server may still support DCR behind an initial access token.",
+      "The registration created here is real and may persist at the Authorization Server after this session ends.",
+    ],
+  },
+  received_client_credentials: {
+    title: "Client Registered",
+    summary:
+      "The Authorization Server created the client. MCPJam keeps its credentials in memory for this browser session only.",
+    phase: "bootstrap",
+    teachableMoments: [
+      "The minted client_id now flows into the ID-JAG and the token request — the whole rest of the flow runs as this client.",
+      "Whether the server actually enabled the JWT Bearer grant for this client is proven later, at redemption.",
+    ],
+  },
+  fetch_client_metadata_document: {
+    title: "Preflight the Client Metadata Document",
+    summary:
+      "CIMD: the client_id is a URL to MCPJam's hosted metadata document. The debugger fetches and validates it — the Authorization Server does its own fetch later.",
+    phase: "bootstrap",
+    teachableMoments: [
+      "With CIMD there's nothing to register: the Authorization Server learns about the client by fetching the URL the client_id points at.",
+      "This fetch is only the debugger's preflight. Whether the Authorization Server accepts the URL identity is proven at JWT Bearer redemption.",
+      "The Authorization Server must advertise client_id_metadata_document_supported before a client may attempt this flow.",
+    ],
+  },
+  received_client_metadata: {
+    title: "Client Metadata Document Ready",
+    summary:
+      "The hosted document validated: its client_id equals its URL and it declares the XAA grants. The URL is now this run's client_id.",
+    phase: "bootstrap",
+    teachableMoments: [
+      "CIMD without a key-based auth method is a public client — anyone can present this URL. The Authorization Server accepts the identity, it doesn't authenticate it.",
     ],
   },
   user_authentication: {

--- a/mcpjam-inspector/client/src/lib/xaa/types.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/types.ts
@@ -42,6 +42,7 @@ export type XaaRegistrationWarningCode =
   | "profile_metadata_not_echoed"
   | "grant_types_not_echoed"
   | "token_exchange_grant_not_echoed"
+  | "auth_method_not_echoed"
   | "missing_secret_expiry"
   | "non_201_success"
   | "non_json_content_type"

--- a/mcpjam-inspector/client/src/lib/xaa/types.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/types.ts
@@ -11,6 +11,10 @@ export type XAAFlowStep =
   | "received_resource_metadata"
   | "discover_authz_metadata"
   | "received_authz_metadata"
+  | "request_client_registration"
+  | "received_client_credentials"
+  | "fetch_client_metadata_document"
+  | "received_client_metadata"
   | "user_authentication"
   | "received_identity_assertion"
   | "token_exchange_request"
@@ -20,6 +24,52 @@ export type XAAFlowStep =
   | "received_access_token"
   | "authenticated_mcp_request"
   | "complete";
+
+/** How the flow's client identity at the target AS is established.
+ * `pre_registered` (default) = user-supplied credentials, today's behavior.
+ * `dcr` = open RFC 7591 registration (no initial access token).
+ * `cimd` = MCPJam's hosted Client ID Metadata Document URL as the client_id. */
+export type XaaRegistrationStrategy = "pre_registered" | "dcr" | "cimd";
+
+/** Token-endpoint client-auth methods the debugger can actually redeem. */
+export type XaaTokenEndpointAuthMethod =
+  | "client_secret_post"
+  | "client_secret_basic"
+  | "none";
+
+export type XaaRegistrationWarningCode =
+  | "public_client"
+  | "profile_metadata_not_echoed"
+  | "grant_types_not_echoed"
+  | "token_exchange_grant_not_echoed"
+  | "missing_secret_expiry"
+  | "non_201_success"
+  | "non_json_content_type"
+  | "missing_no_store";
+
+/** Non-blocking readiness/conformance finding from DCR or CIMD setup.
+ * Never carries credential material. */
+export interface XaaRegistrationWarning {
+  code: XaaRegistrationWarningCode;
+  message: string;
+}
+
+/** DCR-minted credentials. Live only in the target-scoped in-memory session
+ * cache — never in XAAFlowState, storage, history, or logs. */
+export interface XaaEphemeralDcrCredentials {
+  clientId: string;
+  clientSecret?: string;
+  tokenEndpointAuthMethod: XaaTokenEndpointAuthMethod;
+  /** RFC 7591 client_secret_expires_at (seconds since epoch; 0 = never). */
+  clientSecretExpiresAt?: number;
+  registrationEndpoint: string;
+}
+
+export interface XaaDcrCredentialCache {
+  get(key: string): XaaEphemeralDcrCredentials | undefined;
+  set(key: string, value: XaaEphemeralDcrCredentials): void;
+  delete(key: string): void;
+}
 
 export interface XAAJWTInspectionIssue {
   section: "header" | "payload" | "signature";
@@ -81,10 +131,13 @@ export interface XAAFlowState {
   authzMetadata?: {
     issuer: string;
     token_endpoint?: string;
+    registration_endpoint?: string;
     grant_types_supported?: string[];
     response_types_supported?: string[];
     scopes_supported?: string[];
     token_endpoint_auth_methods_supported?: string[];
+    authorization_grant_profiles_supported?: string[];
+    client_id_metadata_document_supported?: boolean;
   };
   tokenEndpoint?: string;
   negativeTestMode: NegativeTestMode;
@@ -122,6 +175,20 @@ export interface XAAFlowState {
    * anyway. Unset for the happy-path (valid) flow. */
   negativeProbe?: { outcome: "rejected" | "accepted"; status?: number };
   compatibilityReport?: XAACompatibilityReport;
+  /** How this run's client identity is established. Authoritative once the
+   * machine is initialized — the UI must reset the flow to change it. */
+  registrationStrategy: XaaRegistrationStrategy;
+  /** How the jwt-bearer redemption authenticates at the token endpoint.
+   * Unset = legacy body-post behavior. */
+  tokenEndpointAuthMethod?: XaaTokenEndpointAuthMethod;
+  /** True when a DCR run reused this browser session's earlier registration
+   * instead of POSTing again. */
+  dcrRegistrationReused?: boolean;
+  /** Non-blocking readiness/conformance findings from DCR/CIMD setup. */
+  registrationWarnings?: XaaRegistrationWarning[];
+  /** Set after a DCR POST whose outcome left no reusable registration: a
+   * retry may create a second remote client and needs explicit confirmation. */
+  dcrRetryMayCreateDuplicate?: boolean;
 }
 
 export interface XAARequestResult {
@@ -178,6 +245,16 @@ export interface BaseXAAStateMachineConfig {
    * neither the secret nor the destination rides in from the browser. */
   serverId?: string;
   projectId?: string;
+  /** Client-identity strategy. Forced to "pre_registered" whenever
+   * registrationId or serverId is set (those paths skip AS discovery). */
+  registrationStrategy?: XaaRegistrationStrategy;
+  /** Target-scoped in-memory session cache for DCR-minted credentials. The
+   * UI passes a useRef-backed cache so machine recreation neither loses nor
+   * re-exposes the secret; unit tests may pass a Map-backed one. */
+  dcrCredentialCache?: XaaDcrCredentialCache;
+  /** Stable key for the current target; combined with the discovered
+   * registration endpoint to key the credential cache. */
+  dcrCacheTargetKey?: string;
 }
 
 export interface XAAStateMachine {
@@ -233,6 +310,7 @@ export interface XaaResourceAppInput {
 export const EMPTY_XAA_FLOW_STATE: XAAFlowState = {
   isBusy: false,
   currentStep: "idle",
+  registrationStrategy: "pre_registered",
   serverUrl: undefined,
   resourceUrl: undefined,
   resourceMetadataUrl: undefined,

--- a/mcpjam-inspector/server/app.ts
+++ b/mcpjam-inspector/server/app.ts
@@ -17,6 +17,7 @@ import webRoutes from "./routes/web/index.js";
 import v1Routes from "./routes/v1/index.js";
 import cliAuthRoutes from "./routes/cli-auth/index.js";
 import relayRoutes, { relayBodyLimit } from "./routes/relay.js";
+import { registerXaaClientMetadataRoute } from "./routes/xaa-client-metadata.js";
 import workosAuthkitRoutes from "./routes/workos-authkit.js";
 import { MCPClientManager } from "@mcpjam/sdk";
 import { initElicitationCallback } from "./routes/mcp/elicitation.js";
@@ -288,6 +289,12 @@ export async function createHonoApp() {
   // production entries must wire this up.
   app.use("/relay/*", relayBodyLimit());
   app.route("/relay", relayRoutes);
+
+  // XAA Client ID Metadata Document. Also deliberately OUTSIDE /api (the
+  // target authorization server fetches it anonymously) and mounted before
+  // the static/SPA fallback. Mirror of the mount in server/index.ts — both
+  // production entries must wire this up.
+  registerXaaClientMetadataRoute(app);
 
   // Health check
   app.get("/health", (c) => {

--- a/mcpjam-inspector/server/index.ts
+++ b/mcpjam-inspector/server/index.ts
@@ -120,6 +120,7 @@ import webRoutes from "./routes/web/index";
 import v1Routes from "./routes/v1/index";
 import cliAuthRoutes from "./routes/cli-auth/index";
 import relayRoutes, { relayBodyLimit } from "./routes/relay";
+import { registerXaaClientMetadataRoute } from "./routes/xaa-client-metadata";
 import workosAuthkitRoutes from "./routes/workos-authkit";
 import { rpcLogBus } from "./services/rpc-log-bus";
 import { tunnelManager } from "./services/tunnel-manager";
@@ -446,6 +447,12 @@ app.route("/api/cli/auth", cliAuthRoutes);
 // both production entries must wire this up.
 app.use("/relay/*", relayBodyLimit());
 app.route("/relay", relayRoutes);
+
+// XAA Client ID Metadata Document. Also deliberately OUTSIDE /api (the
+// target authorization server fetches it anonymously) and mounted before
+// the production static/SPA fallback. Mirror of the mount in
+// server/app.ts::createHonoApp — both production entries must wire this up.
+registerXaaClientMetadataRoute(app);
 
 // Fallback for clients that post to "/sse/message" instead of the rewritten proxy messages URL.
 // We resolve the upstream messages endpoint via sessionId and forward with any injected auth.

--- a/mcpjam-inspector/server/routes/__tests__/xaa-client-metadata.test.ts
+++ b/mcpjam-inspector/server/routes/__tests__/xaa-client-metadata.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { Hono } from "hono";
+import {
+  evaluateIdJagClientMetadata,
+  XAA_DEBUG_CLIENT_ID_METADATA_URL,
+} from "@mcpjam/sdk";
+import {
+  registerXaaClientMetadataRoute,
+  XAA_CLIENT_METADATA_PATH,
+} from "../xaa-client-metadata";
+
+// Contract tests for the hosted Client ID Metadata Document
+// (draft-ietf-oauth-client-id-metadata-document-02). A regression here
+// degrades the debugger's cimd strategy to an accurate preflight failure —
+// these pins are what keep the fixed production URL redeemable.
+
+function buildApp() {
+  const app = new Hono();
+  registerXaaClientMetadataRoute(app);
+  return app;
+}
+
+describe("XAA client metadata document route", () => {
+  it("serves a DIRECT 200 JSON document (no redirect) with cache and CORS headers", async () => {
+    const response = await buildApp().request(XAA_CLIENT_METADATA_PATH);
+
+    // Exactly 200, not merely 2xx/3xx — draft-02 forbids the AS from
+    // following redirects, so a Location here would break every RAS fetch.
+    expect(response.status).toBe(200);
+    expect(response.headers.get("location")).toBeNull();
+    expect(response.headers.get("content-type")).toContain("application/json");
+    expect(response.headers.get("access-control-allow-origin")).toBe("*");
+    expect(response.headers.get("cache-control")).toContain("max-age=3600");
+  });
+
+  it("publishes the exact production URL as client_id with the full ID-JAG profile", async () => {
+    const response = await buildApp().request(XAA_CLIENT_METADATA_PATH);
+    const document = await response.json();
+
+    // Simple string identity: exactly the fixed production URL, even though
+    // this request hit a local test app.
+    expect(document.client_id).toBe(XAA_DEBUG_CLIENT_ID_METADATA_URL);
+
+    const evaluation = evaluateIdJagClientMetadata(document);
+    expect(evaluation.profile).toBe("present");
+    expect(evaluation.jwtBearerGrant).toBe("present");
+    expect(evaluation.tokenExchangeGrant).toBe("present");
+    // A published document can never hold a shared secret.
+    expect(evaluation.tokenEndpointAuthMethod).toBe("none");
+
+    // No authorization-code shape leaks into the jwt-bearer client identity.
+    expect(document.redirect_uris).toBeUndefined();
+    expect(document.response_types).toBeUndefined();
+    expect(JSON.stringify(document)).not.toContain("client_secret");
+  });
+
+  it("answers OPTIONS with 204 and CORS headers only", async () => {
+    const response = await buildApp().request(XAA_CLIENT_METADATA_PATH, {
+      method: "OPTIONS",
+    });
+    expect(response.status).toBe(204);
+    expect(response.headers.get("access-control-allow-origin")).toBe("*");
+  });
+
+  it("is mounted in both production entry points", () => {
+    // The route must exist on BOTH server/index.ts and server/app.ts — a
+    // missing mount in either deployment shape silently breaks cimd runs.
+    // Reading the sources keeps this honest without booting the full servers.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { readFileSync } = require("node:fs");
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { join } = require("node:path");
+    for (const entry of ["index.ts", "app.ts"]) {
+      const source = readFileSync(
+        join(__dirname, "..", "..", entry),
+        "utf-8",
+      );
+      expect(
+        source.includes("registerXaaClientMetadataRoute(app)"),
+        `${entry} must mount the XAA client metadata route`,
+      ).toBe(true);
+    }
+  });
+});

--- a/mcpjam-inspector/server/routes/__tests__/xaa-client-metadata.test.ts
+++ b/mcpjam-inspector/server/routes/__tests__/xaa-client-metadata.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { Hono } from "hono";
 import {
@@ -66,13 +68,10 @@ describe("XAA client metadata document route", () => {
     // The route must exist on BOTH server/index.ts and server/app.ts — a
     // missing mount in either deployment shape silently breaks cimd runs.
     // Reading the sources keeps this honest without booting the full servers.
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { readFileSync } = require("node:fs");
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { join } = require("node:path");
+    // ESM has no __dirname — resolve relative to this module's URL instead.
     for (const entry of ["index.ts", "app.ts"]) {
       const source = readFileSync(
-        join(__dirname, "..", "..", entry),
+        fileURLToPath(new URL(`../../${entry}`, import.meta.url)),
         "utf-8",
       );
       expect(

--- a/mcpjam-inspector/server/routes/mcp/oauth.ts
+++ b/mcpjam-inspector/server/routes/mcp/oauth.ts
@@ -33,9 +33,17 @@ function safeHostname(url: string | undefined): string {
 oauth.post("/debug/proxy", async (c) => {
   let proxyUrl: string | undefined;
   try {
-    const { url, method, body, headers } = await c.req.json();
+    const { url, method, body, headers, redirect } = await c.req.json();
     proxyUrl = url;
-    const result = await executeDebugOAuthProxy({ url, method, body, headers });
+    const result = await executeDebugOAuthProxy({
+      url,
+      method,
+      body,
+      headers,
+      // Only the two fetch redirect modes we support; anything else is ignored
+      // so a crafted value cannot reach fetch().
+      ...(redirect === "manual" || redirect === "follow" ? { redirect } : {}),
+    });
     return c.json(result);
   } catch (error) {
     const targetUrlHost = safeHostname(proxyUrl);

--- a/mcpjam-inspector/server/routes/mcp/xaa.ts
+++ b/mcpjam-inspector/server/routes/mcp/xaa.ts
@@ -26,7 +26,7 @@ import {
 } from "../../services/xaa-idjag-signer.js";
 import { createHash } from "crypto";
 import {
-  buildJwtBearerBody,
+  buildJwtBearerRequest,
   getIssuerForRequest,
   resolveServerTarget,
 } from "../../services/xaa-mint.js";
@@ -502,6 +502,11 @@ const proxyTokenSchema = z
     assertion: z.string().trim().min(1),
     clientId: z.string().trim().min(1).optional(),
     clientSecret: z.string().trim().min(1).optional(),
+    // How to authenticate at the token endpoint. Absent = legacy body-post
+    // behavior; only the methods the debugger can actually redeem.
+    tokenEndpointAuthMethod: z
+      .enum(["client_secret_post", "client_secret_basic", "none"])
+      .optional(),
     scope: z.string().trim().min(1).optional(),
     resource: z.string().trim().min(1).optional(),
     headers: z.record(z.string(), z.string()).optional(),
@@ -1060,19 +1065,45 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
         url = parsed.tokenEndpoint as string;
       }
 
+      const authMethod = parsed.tokenEndpointAuthMethod;
+      if (
+        (authMethod === "client_secret_post" ||
+          authMethod === "client_secret_basic") &&
+        !clientSecret
+      ) {
+        return toJsonError(`${authMethod} requires a client secret`, {
+          status: 400,
+          code: "VALIDATION_ERROR",
+        });
+      }
+      if (authMethod === "client_secret_basic" && !clientId) {
+        return toJsonError("client_secret_basic requires a client id", {
+          status: 400,
+          code: "VALIDATION_ERROR",
+        });
+      }
+
+      // Method-aware client auth. The generated Authorization value carries
+      // the secret — it is passed only to the outbound proxy call and must
+      // never be copied into logs, history, or error payloads. It is merged
+      // AFTER extraHeaders so a caller-supplied header can't replace it.
+      const jwtBearerRequest = buildJwtBearerRequest({
+        assertion: parsed.assertion,
+        clientId,
+        clientSecret,
+        scope: parsed.scope,
+        resource: parsed.resource,
+        tokenEndpointAuthMethod: authMethod,
+      });
+
       const result = await executeOAuthProxy({
         url,
         method: "POST",
-        body: buildJwtBearerBody({
-          assertion: parsed.assertion,
-          clientId,
-          clientSecret,
-          scope: parsed.scope,
-          resource: parsed.resource,
-        }),
+        body: jwtBearerRequest.body,
         headers: {
           "Content-Type": "application/x-www-form-urlencoded",
           ...(extraHeaders || {}),
+          ...jwtBearerRequest.headers,
         },
         httpsOnly: options.httpsOnlyProxy,
       });

--- a/mcpjam-inspector/server/routes/mcp/xaa.ts
+++ b/mcpjam-inspector/server/routes/mcp/xaa.ts
@@ -1076,8 +1076,16 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
           code: "VALIDATION_ERROR",
         });
       }
-      if (authMethod === "client_secret_basic" && !clientId) {
-        return toJsonError("client_secret_basic requires a client id", {
+      // RFC 6749 §2.3.1: client_id is REQUIRED for post/basic; a public (none)
+      // client still needs a client_id to identify itself. Reject locally with
+      // a 400 rather than letting buildJwtBearerRequest throw into a 500.
+      if (
+        (authMethod === "client_secret_basic" ||
+          authMethod === "client_secret_post" ||
+          authMethod === "none") &&
+        !clientId
+      ) {
+        return toJsonError(`${authMethod} requires a client id`, {
           status: 400,
           code: "VALIDATION_ERROR",
         });

--- a/mcpjam-inspector/server/routes/web/oauth.ts
+++ b/mcpjam-inspector/server/routes/web/oauth.ts
@@ -214,13 +214,16 @@ oauthWeb.post("/import-tokens", async (c) => {
 oauthWeb.post("/debug/proxy", async (c) => {
   let proxyUrl: string | undefined;
   try {
-    const { url, method, body, headers } = await c.req.json();
+    const { url, method, body, headers, redirect } = await c.req.json();
     proxyUrl = url;
     const result = await executeDebugOAuthProxy({
       url,
       method,
       body,
       headers,
+      // httpsOnly already forces manual redirects in the SDK proxy; accepting
+      // the explicit value here cannot weaken that.
+      ...(redirect === "manual" || redirect === "follow" ? { redirect } : {}),
       httpsOnly: true,
     });
     return c.json(result);

--- a/mcpjam-inspector/server/routes/web/oauth.ts
+++ b/mcpjam-inspector/server/routes/web/oauth.ts
@@ -214,16 +214,16 @@ oauthWeb.post("/import-tokens", async (c) => {
 oauthWeb.post("/debug/proxy", async (c) => {
   let proxyUrl: string | undefined;
   try {
-    const { url, method, body, headers, redirect } = await c.req.json();
+    const { url, method, body, headers } = await c.req.json();
     proxyUrl = url;
+    // Note: no `redirect` option here — this route is always httpsOnly, and the
+    // SDK proxy forces `redirect: "manual"` under httpsOnly, so passing one
+    // would be dead code. The mcp route (not httpsOnly) is where it applies.
     const result = await executeDebugOAuthProxy({
       url,
       method,
       body,
       headers,
-      // httpsOnly already forces manual redirects in the SDK proxy; accepting
-      // the explicit value here cannot weaken that.
-      ...(redirect === "manual" || redirect === "follow" ? { redirect } : {}),
       httpsOnly: true,
     });
     return c.json(result);

--- a/mcpjam-inspector/server/routes/xaa-client-metadata.ts
+++ b/mcpjam-inspector/server/routes/xaa-client-metadata.ts
@@ -1,0 +1,48 @@
+import type { Hono } from "hono";
+import {
+  getXaaDebugClientMetadata,
+  XAA_DEBUG_CLIENT_ID_METADATA_URL,
+} from "@mcpjam/sdk";
+
+/** Exact public path of the XAA debugger's Client ID Metadata Document.
+ * Outside /api on purpose: sessionAuthMiddleware only guards /api/* paths,
+ * and the target authorization server must fetch this anonymously. */
+export const XAA_CLIENT_METADATA_PATH =
+  "/.well-known/oauth/xaa-client-metadata.json";
+
+const CORS_HEADERS: Record<string, string> = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, OPTIONS",
+};
+
+/**
+ * Registers GET + OPTIONS for the XAA Client ID Metadata Document
+ * (draft-ietf-oauth-client-id-metadata-document-02). Requirements the
+ * contract tests pin:
+ *  - a DIRECT 200 (never a redirect — the AS must not follow one),
+ *  - Content-Type application/json,
+ *  - client_id exactly equal to the FIXED production URL, even when a local
+ *    dev server serves the handler — the URL IS the client identity, and a
+ *    localhost variant would be a different (unreachable) client.
+ *
+ * This is a separate client identity from the login document served by
+ * mcpjam-webapp at www.mcpjam.com — changing that one's grants would change
+ * the authorization-code login client.
+ */
+export function registerXaaClientMetadataRoute(app: Hono) {
+  app.get(XAA_CLIENT_METADATA_PATH, (c) =>
+    c.json(
+      {
+        client_id: XAA_DEBUG_CLIENT_ID_METADATA_URL,
+        ...getXaaDebugClientMetadata({ tokenEndpointAuthMethod: "none" }),
+      },
+      200,
+      {
+        ...CORS_HEADERS,
+        "Cache-Control": "public, max-age=3600",
+      },
+    ),
+  );
+
+  app.options(XAA_CLIENT_METADATA_PATH, (c) => c.body(null, 204, CORS_HEADERS));
+}

--- a/mcpjam-inspector/server/services/__tests__/xaa-mint.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/xaa-mint.test.ts
@@ -156,17 +156,29 @@ describe("buildJwtBearerRequest", () => {
     }
   });
 
-  it("builds an RFC 6749 Basic header (form-encode before Base64) and strips the secret from the body", () => {
-    const request = buildJwtBearerRequest({
+  it("builds an RFC 6749 Basic header (application/x-www-form-urlencoded before Base64) and strips the secret from the body", () => {
+    // Mirror the production form-urlencoder: space→"+", "!'()~" percent-encoded.
+    const formUrlEncode = (v: string) =>
+      encodeURIComponent(v)
+        .replace(/[!'()~]/g, (c) => "%" + c.charCodeAt(0).toString(16).toUpperCase())
+        .replace(/%20/g, "+");
+    const withSpaces = {
       ...args,
+      clientId: "client id!",
+      clientSecret: "secret (with)~chars",
+    };
+    const request = buildJwtBearerRequest({
+      ...withSpaces,
       tokenEndpointAuthMethod: "client_secret_basic",
     });
     const expected = Buffer.from(
-      `${encodeURIComponent(args.clientId)}:${encodeURIComponent(args.clientSecret)}`
+      `${formUrlEncode(withSpaces.clientId)}:${formUrlEncode(withSpaces.clientSecret)}`
     ).toString("base64");
     expect(request.headers).toEqual({ Authorization: `Basic ${expected}` });
+    // Space must NOT be %20 (that would be encodeURIComponent, not form-encoding).
+    expect(Buffer.from(expected, "base64").toString()).toContain("client+id");
     expect(request.body.client_secret).toBeUndefined();
-    expect(request.body.client_id).toBe(args.clientId);
+    expect(request.body.client_id).toBe(withSpaces.clientId);
     expect(request.body.assertion).toBe(args.assertion);
   });
 
@@ -185,6 +197,22 @@ describe("buildJwtBearerRequest", () => {
         tokenEndpointAuthMethod: "client_secret_basic",
       })
     ).toThrow(/client_secret_basic/);
+  });
+
+  it("requires a client_id for public (none) and client_secret_post clients", () => {
+    expect(() =>
+      buildJwtBearerRequest({
+        assertion: "a",
+        tokenEndpointAuthMethod: "none",
+      })
+    ).toThrow(/client_id/);
+    expect(() =>
+      buildJwtBearerRequest({
+        assertion: "a",
+        clientSecret: "s",
+        tokenEndpointAuthMethod: "client_secret_post",
+      })
+    ).toThrow(/client_id/);
   });
 
   it("sends no secret anywhere for a public (none) client", () => {

--- a/mcpjam-inspector/server/services/__tests__/xaa-mint.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/xaa-mint.test.ts
@@ -177,8 +177,10 @@ describe("buildJwtBearerRequest", () => {
     expect(request.headers).toEqual({ Authorization: `Basic ${expected}` });
     // Space must NOT be %20 (that would be encodeURIComponent, not form-encoding).
     expect(Buffer.from(expected, "base64").toString()).toContain("client+id");
+    // With Basic, BOTH client_id and secret live in the header only — the body
+    // must not repeat client_id (some endpoints reject dual-carried client_id).
     expect(request.body.client_secret).toBeUndefined();
-    expect(request.body.client_id).toBe(withSpaces.clientId);
+    expect(request.body.client_id).toBeUndefined();
     expect(request.body.assertion).toBe(args.assertion);
   });
 

--- a/mcpjam-inspector/server/services/__tests__/xaa-mint.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/xaa-mint.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect } from "vitest";
 import type { Context } from "hono";
 import {
   buildJwtBearerBody,
+  buildJwtBearerRequest,
   buildXaaMintArgs,
   resolveXaaIssuer,
 } from "../xaa-mint.js";
@@ -129,5 +130,70 @@ describe("buildXaaMintArgs", () => {
     });
     expect(args.subject).toBe("alice@corp.com");
     expect(args.email).toBe("alice@corp.com");
+  });
+});
+
+describe("buildJwtBearerRequest", () => {
+  const args = {
+    assertion: "the-id-jag",
+    clientId: "client:with/reserved chars",
+    clientSecret: "secret+with/reserved=chars",
+    scope: "read",
+    resource: "https://mcp.example.com",
+  };
+
+  it("keeps credentials in the form body for client_secret_post and the legacy default", () => {
+    for (const method of ["client_secret_post", undefined] as const) {
+      const request = buildJwtBearerRequest({
+        ...args,
+        tokenEndpointAuthMethod: method,
+      });
+      expect(request.headers).toEqual({});
+      expect(request.body).toEqual(
+        buildJwtBearerBody(args)
+      );
+      expect(request.body.client_secret).toBe(args.clientSecret);
+    }
+  });
+
+  it("builds an RFC 6749 Basic header (form-encode before Base64) and strips the secret from the body", () => {
+    const request = buildJwtBearerRequest({
+      ...args,
+      tokenEndpointAuthMethod: "client_secret_basic",
+    });
+    const expected = Buffer.from(
+      `${encodeURIComponent(args.clientId)}:${encodeURIComponent(args.clientSecret)}`
+    ).toString("base64");
+    expect(request.headers).toEqual({ Authorization: `Basic ${expected}` });
+    expect(request.body.client_secret).toBeUndefined();
+    expect(request.body.client_id).toBe(args.clientId);
+    expect(request.body.assertion).toBe(args.assertion);
+  });
+
+  it("throws when client_secret_basic lacks a credential", () => {
+    expect(() =>
+      buildJwtBearerRequest({
+        assertion: "a",
+        clientId: "c",
+        tokenEndpointAuthMethod: "client_secret_basic",
+      })
+    ).toThrow(/client_secret_basic/);
+    expect(() =>
+      buildJwtBearerRequest({
+        assertion: "a",
+        clientSecret: "s",
+        tokenEndpointAuthMethod: "client_secret_basic",
+      })
+    ).toThrow(/client_secret_basic/);
+  });
+
+  it("sends no secret anywhere for a public (none) client", () => {
+    const request = buildJwtBearerRequest({
+      ...args,
+      tokenEndpointAuthMethod: "none",
+    });
+    expect(request.headers).toEqual({});
+    expect(request.body.client_id).toBe(args.clientId);
+    expect(JSON.stringify(request.body)).not.toContain(args.clientSecret);
   });
 });

--- a/mcpjam-inspector/server/services/xaa-mint.ts
+++ b/mcpjam-inspector/server/services/xaa-mint.ts
@@ -296,11 +296,22 @@ export type XaaTokenEndpointAuthMethod =
   | "client_secret_basic"
   | "none";
 
+// application/x-www-form-urlencoded encoding (WHATWG URLSearchParams rules:
+// space→"+", and "*-._"/alphanumerics kept literal, everything else percent-
+// encoded). encodeURIComponent alone leaves "!'()~" literal and encodes space
+// as %20, so it is NOT form-urlencoding and would corrupt credentials that
+// contain those characters.
+function formUrlEncode(value: string): string {
+  return encodeURIComponent(value)
+    .replace(/[!'()~]/g, (c) => "%" + c.charCodeAt(0).toString(16).toUpperCase())
+    .replace(/%20/g, "+");
+}
+
 // RFC 6749 section 2.3.1: client_id and client_secret are each
-// form-urlencoded BEFORE the id:secret pair is Base64-encoded.
+// application/x-www-form-urlencoded BEFORE the id:secret pair is Base64-encoded.
 function encodeBasicClientAuth(clientId: string, clientSecret: string): string {
   return Buffer.from(
-    `${encodeURIComponent(clientId)}:${encodeURIComponent(clientSecret)}`
+    `${formUrlEncode(clientId)}:${formUrlEncode(clientSecret)}`
   ).toString("base64");
 }
 
@@ -337,8 +348,23 @@ export function buildJwtBearerRequest(args: {
   }
 
   if (method === "none") {
-    // Public client: client_id only, no secret anywhere.
+    // Public client: client_id identifies the client and is required; no
+    // secret travels anywhere. Reject a missing client_id locally rather than
+    // forwarding an invalid request the AS will just bounce.
+    if (!args.clientId) {
+      throw new Error("A public (none) client request requires a client_id");
+    }
     return { headers: {}, body: buildJwtBearerBody({ ...args, clientSecret: null }) };
+  }
+
+  if (method === "client_secret_post") {
+    // RFC 6749 section 2.3.1: client_id is REQUIRED alongside the secret.
+    if (!args.clientId || !args.clientSecret) {
+      throw new Error(
+        "client_secret_post requires both a client_id and a client_secret"
+      );
+    }
+    return { headers: {}, body: buildJwtBearerBody(args) };
   }
 
   // client_secret_post and the legacy no-method default: credentials in the

--- a/mcpjam-inspector/server/services/xaa-mint.ts
+++ b/mcpjam-inspector/server/services/xaa-mint.ts
@@ -291,6 +291,61 @@ export function buildJwtBearerBody(args: {
   };
 }
 
+export type XaaTokenEndpointAuthMethod =
+  | "client_secret_post"
+  | "client_secret_basic"
+  | "none";
+
+// RFC 6749 section 2.3.1: client_id and client_secret are each
+// form-urlencoded BEFORE the id:secret pair is Base64-encoded.
+function encodeBasicClientAuth(clientId: string, clientSecret: string): string {
+  return Buffer.from(
+    `${encodeURIComponent(clientId)}:${encodeURIComponent(clientSecret)}`
+  ).toString("base64");
+}
+
+// Method-aware variant of buildJwtBearerBody: same single-source body, plus
+// the client-auth headers the chosen token_endpoint_auth_method requires.
+// The generated Authorization value carries the secret — callers must never
+// copy `headers` into history, logs, telemetry, or error objects.
+export function buildJwtBearerRequest(args: {
+  assertion: string;
+  clientId?: string | null;
+  clientSecret?: string | null;
+  scope?: string | null;
+  resource?: string | null;
+  tokenEndpointAuthMethod?: XaaTokenEndpointAuthMethod | null;
+}): { headers: Record<string, string>; body: Record<string, string> } {
+  const method = args.tokenEndpointAuthMethod;
+
+  if (method === "client_secret_basic") {
+    if (!args.clientId || !args.clientSecret) {
+      throw new Error(
+        "client_secret_basic requires both a client_id and a client_secret"
+      );
+    }
+    return {
+      headers: {
+        Authorization: `Basic ${encodeBasicClientAuth(
+          args.clientId,
+          args.clientSecret
+        )}`,
+      },
+      // Secret travels only in the Authorization header, never the body.
+      body: buildJwtBearerBody({ ...args, clientSecret: null }),
+    };
+  }
+
+  if (method === "none") {
+    // Public client: client_id only, no secret anywhere.
+    return { headers: {}, body: buildJwtBearerBody({ ...args, clientSecret: null }) };
+  }
+
+  // client_secret_post and the legacy no-method default: credentials in the
+  // form body, exactly as buildJwtBearerBody always produced.
+  return { headers: {}, body: buildJwtBearerBody(args) };
+}
+
 // Derive the MCPJam test-IdP issuer from the inbound request. Shared by the XAA
 // router endpoints and the connect-page mint so the signed ID-JAG `iss` matches
 // the published JWKS regardless of which surface mints it.

--- a/mcpjam-inspector/server/services/xaa-mint.ts
+++ b/mcpjam-inspector/server/services/xaa-mint.ts
@@ -342,8 +342,12 @@ export function buildJwtBearerRequest(args: {
           args.clientSecret
         )}`,
       },
-      // Secret travels only in the Authorization header, never the body.
-      body: buildJwtBearerBody({ ...args, clientSecret: null }),
+      // With Basic auth the client_id AND secret are carried in the
+      // Authorization header only — omit both from the body. Some token
+      // endpoints reject a request that also repeats client_id in the body
+      // (one client-auth method per request), and the repo's shared OAuth
+      // helper likewise keeps client-auth params out of the body for Basic.
+      body: buildJwtBearerBody({ ...args, clientId: null, clientSecret: null }),
     };
   }
 


### PR DESCRIPTION
## What & why

Adds two **target-scoped client-identity strategies** to the XAA debugger so users can test how their authorization server handles automated client onboarding for Cross-App Access, not just pre-registered clients. Manual public targets only; **pre-registered stays the default and default runs are byte-identical to before**.

> **Stacked on #3138** (base = `feat/xaa-dcr-sdk-core`). Consumes the SDK's shared DCR core / ID-JAG metadata / CIMD validator. **Before merge:** after #3138's changeset release lands, bump `@mcpjam/sdk` to `^1.31.0` and refresh the root lockfile (left at `^1.30.0` so the workspace resolves locally).

## Changes

**Open DCR** — unauthenticated RFC 7591 registration at the discovered `registration_endpoint` via the SDK core.
- Response validated against the ID-JAG draft-04 client profile: explicit metadata substitutions **park** as precise readiness findings; RFC 7591 echo omissions **warn and continue** (JWT Bearer redemption is the operational verdict).
- Minted credentials live **only** in a browser-session in-memory cache keyed by `target + endpoint` — never in flow state, storage, HTTP history, logs, or telemetry (pinned by tests). Reset / Run all reuse the session registration; a confirmed **"Register another client"** action is the only path that re-POSTs (and it also gates retries after any ambiguous outcome that may have created a remote client).
- "Open DCR" is explicit: no initial access token / software statement. A 401/403 means *open* DCR wasn't accepted, **not** "the AS lacks DCR".

**CIMD** — MCPJam's hosted Client ID Metadata Document as the `client_id`.
- Preflights the document with `redirect: "manual"` (draft-02 forbids the AS from following redirects), gates on `client_id_metadata_document_supported`, requires `client_id` === the exact URL, `token_endpoint_auth_method: none`.
- New public route `GET /.well-known/oauth/xaa-client-metadata.json` on **both** server entry points — a direct-200 JSON document whose `client_id` is the fixed production URL. The login CIMD document on www.mcpjam.com is untouched.

**Supporting**
- `/proxy/token` gains `tokenEndpointAuthMethod` (`client_secret_post` | `client_secret_basic` | `none`); `client_secret_basic` builds the RFC 6749 Basic header server-side (form-encode before Base64) and never echoes it into diagnostics.
- OAuth debug proxy routes/executors thread `redirect` through to the SDK proxy (hosted `httpsOnly` still forces manual).
- AS-compat preflight reports the draft-04 profile advertisement (absent = warn, contradiction = fail) and CIMD support (informational, never degrades the verdict).
- New `XAARegistrationStrategyControl` rendered with target config (the Client↔RAS relationship), **not** the IdP card.

## Testing
- New DCR + CIMD state-machine suites (happy path, public-client, echo-warnings, all park cases, session reuse, expired-cache, precedence, lost-session redemption), `buildJwtBearerRequest` wire-shape tests, hosted-route contract tests (direct 200, exact `client_id`, mounted in both entries), strategy-control visibility tests.
- Full inspector suite: **8158 passed**, production build green, zero lint errors on touched files.

## Not yet done
Manual E2E (plan §8) — needs a DCR-capable mock AS (Okta is a refusal fixture only); CIMD works end-to-end only once this deploys and serves the hosted document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth client registration, token-endpoint auth, and a new public metadata route—security-sensitive paths—but default behavior is unchanged and DCR secrets are kept out of persisted state with extensive test coverage.
> 
> **Overview**
> Adds **per-target client registration strategies** to the XAA debugger for eligible manual public bar-server targets: **open DCR** (RFC 7591 at `registration_endpoint` via SDK helpers, ID-JAG profile validation, secrets only in a session `useRef` cache with duplicate-registration gating) and **CIMD** (hosted metadata URL as `client_id`, manual-redirect preflight, AS `client_id_metadata_document_supported` gate). **Pre-registered remains default**; the new UI control, flow steps, sequence diagram actions, error guidance, and registration warnings apply only when DCR/CIMD is selected.
> 
> **Server & token path:** New anonymous `GET /.well-known/oauth/xaa-client-metadata.json` on both server entry points; `/proxy/token` accepts `tokenEndpointAuthMethod` and uses `buildJwtBearerRequest` for Basic/post/none; OAuth debug proxy can pass `redirect`. AS compatibility preflight adds ID-JAG profile (warn/fail) and informational CIMD checks.
> 
> **Product guardrails:** Negative-test scorecard and positive-run unlock stay disabled for DCR/CIMD so broken-token probes don’t run against the wrong client identity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ae6297be4d7b005738f98e733e9f920a73572cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds open Dynamic Client Registration (DCR) and Client ID Metadata Document (CIMD) strategies to the XAA debugger, plus a hosted client metadata document, to test automated client onboarding. Pre-registered stays the default and default runs are unchanged.

- **New Features**
  - Open DCR: unauthenticated RFC 7591 at the discovered registration_endpoint with ID‑JAG draft‑04 validation; credentials live only in session memory and are reused until “Register another client”.
  - CIMD: uses MCPJam’s hosted Client ID Metadata Document URL as the client_id (redirect: manual, token_endpoint_auth_method: none; gated on server support).
  - Hosted doc: public GET /.well-known/oauth/xaa-client-metadata.json on both server entries; serves a direct 200 JSON with the fixed production client_id.
  - Proxy/Preflight/UI: /proxy/token accepts tokenEndpointAuthMethod (client_secret_post | client_secret_basic | none) with Basic built server‑side; AS preflight checks ID‑JAG profile + CIMD support; per‑target registration selector, flow‑logger registration warnings, and sequence-diagram registration steps; debug proxy threads redirect.
  - Dependency: requires `@mcpjam/sdk` ^1.31.0.

- **Bug Fixes**
  - Duplicate‑registration gate persists across Reset/Run all and is scoped to the same target; only “Register another client” clears it.
  - DCR cache: key includes scope; components URL‑encoded to avoid delimiter collisions; missing/expired secrets set the retry gate; replacing an expired client requires confirmation.
  - Token auth: client_secret_basic form‑urlencodes before Base64, uses Authorization header, and omits client_id from the form; require client_id for client_secret_post and none (invalid requests are 400’d locally).
  - DCR auth method: if omitted, default to the requested method (client_secret_post if a secret was issued, otherwise none) and warn; present but non‑string is treated as malformed and parked; unsupported is surfaced as a debugger limitation.
  - CIMD media type: strict RFC 6838 check — accept application/json and application/<x>+json; reject invalid patterns.
  - Scorecard: disabled for DCR/CIMD runs; positive‑run unlock skipped on dynamic completions.
  - A11y/UX: registration strategy radio group has a name with arrow‑key navigation; cancel‑revert is scoped to the same target only.

<sup>Written for commit 6ae6297be4d7b005738f98e733e9f920a73572cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

