### PR TITLE
fix: send attachment data as base64

### DIFF
--- a/mcpjam-inspector/server/utils/__tests__/normalize-model-messages-for-convex.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/normalize-model-messages-for-convex.test.ts
@@ -140,4 +140,39 @@ describe("normalizeModelMessagesForConvex", () => {
     expect(tool.content[0].toolCallId).toBe("c1");
     expect((out[0] as { content: unknown }).content).toBe("hi");
   });
+
+  it("converts base64 data URL file parts to the backend's raw base64 format", () => {
+    const messages = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "Summarize this file." },
+          {
+            type: "file",
+            mediaType: "text/plain",
+            filename: "note.txt",
+            data: "data:text/plain;base64,aGVsbG8=",
+          },
+          {
+            type: "file",
+            mediaType: "application/pdf",
+            filename: "remote.pdf",
+            data: "https://example.test/remote.pdf",
+          },
+        ],
+      },
+    ] as unknown as ModelMessage[];
+
+    const out = normalizeModelMessagesForConvex(messages);
+    const content = (out[0] as { content: Array<Record<string, unknown>> })
+      .content;
+
+    expect(content[1]).toMatchObject({
+      type: "file",
+      mediaType: "text/plain",
+      filename: "note.txt",
+      data: "aGVsbG8=",
+    });
+    expect(content[2].data).toBe("https://example.test/remote.pdf");
+  });
 });

--- a/mcpjam-inspector/server/utils/normalize-model-messages-for-convex.ts
+++ b/mcpjam-inspector/server/utils/normalize-model-messages-for-convex.ts
@@ -15,6 +15,22 @@ export function normalizeModelMessagesForConvex(
 
   const pendingToolCallIds: string[] = [];
 
+  const normalizeFilePart = (part: unknown): unknown => {
+    if (!part || typeof part !== "object" || Array.isArray(part)) {
+      return part;
+    }
+
+    const filePart = part as Record<string, unknown>;
+    if (filePart.type !== "file" || typeof filePart.data !== "string") {
+      return part;
+    }
+
+    // Browser attachments arrive as data URLs, but Convex expects the raw
+    // base64 payload and otherwise attempts to fetch the data: URI.
+    const match = /^data:[^,]*;base64,([\s\S]*)$/i.exec(filePart.data);
+    return match ? { ...filePart, data: match[1] } : part;
+  };
+
   const normalizePart = (
     part: unknown,
     role: "assistant" | "tool",
@@ -70,7 +86,9 @@ export function normalizeModelMessagesForConvex(
       if (!Array.isArray(m.content)) return msg;
       return {
         ...msg,
-        content: m.content.map((part) => normalizePart(part, "assistant")),
+        content: m.content.map((part) =>
+          normalizeFilePart(normalizePart(part, "assistant")),
+        ),
       } as ModelMessage;
     }
     if (msg.role === "tool") {
@@ -78,24 +96,30 @@ export function normalizeModelMessagesForConvex(
       if (!Array.isArray(m.content)) return msg;
       return {
         ...msg,
-        content: m.content.map((part) => normalizePart(part, "tool")),
+        content: m.content.map((part) =>
+          normalizeFilePart(normalizePart(part, "tool")),
+        ),
       } as ModelMessage;
     }
     if (msg.role === "user") {
       const m = msg as { content?: unknown };
       const c = m.content;
+      const content = Array.isArray(c) ? c.map(normalizeFilePart) : c;
       if (
-        Array.isArray(c) &&
-        c.length === 1 &&
-        c[0] &&
-        typeof c[0] === "object" &&
-        (c[0] as { type?: string }).type === "text" &&
-        typeof (c[0] as { text?: string }).text === "string"
+        Array.isArray(content) &&
+        content.length === 1 &&
+        content[0] &&
+        typeof content[0] === "object" &&
+        (content[0] as { type?: string }).type === "text" &&
+        typeof (content[0] as { text?: string }).text === "string"
       ) {
         return {
           ...msg,
-          content: (c[0] as { text: string }).text,
+          content: (content[0] as { text: string }).text,
         } as ModelMessage;
+      }
+      if (content !== c) {
+        return { ...msg, content } as ModelMessage;
       }
     }
     return msg;


### PR DESCRIPTION
Fixes #1692

Browser attachments are converted to base64 data URLs before they reach the server. The Convex request now removes the data URL prefix while keeping the file metadata, so the backend receives raw base64 instead of trying to fetch a `data:` URI.

Tests:

- `npx vitest run server/utils/__tests__/normalize-model-messages-for-convex.test.ts server/utils/__tests__/mcpjam-stream-handler-snapshot.test.ts`
- `npm run build -w @mcpjam/sdk`
- `npm run bundle:sandbox-proxies -w @mcpjam/inspector && npm run bundle:browser-harness -w @mcpjam/inspector && npm run build:server -w @mcpjam/inspector`

The full server TypeScript check was not run after the generated build assets were available.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send browser attachments as raw base64 instead of data URLs. Prevents the backend from trying to fetch data: URIs and restores attachment handling (fixes #1692).

- **Bug Fixes**
  - Strip data URL prefix from file parts and keep `mediaType` and `filename`.
  - Apply normalization to user, assistant, and tool message content.
  - Leave http(s) file URLs unchanged.

<sup>Written for commit b4e76c1dc191a96641820503bd5a9f2fd758b9f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

