### PR TITLE
feat(swarms): goal-completion judge scores in the Swarms UI (PR 2)

### DIFF
--- a/mcpjam-inspector/client/src/components/connection/share-usage/ShareUsageDialog.tsx
+++ b/mcpjam-inspector/client/src/components/connection/share-usage/ShareUsageDialog.tsx
@@ -14,13 +14,12 @@ import {
 } from "@/components/ui/resizable";
 import { ShareUsageThreadList } from "./ShareUsageThreadList";
 import { ShareUsageThreadDetail } from "./ShareUsageThreadDetail";
-import type { SharedChatSourceType } from "@/hooks/useSharedChatThreads";
 
 interface ShareUsageDialogProps {
   isOpen: boolean;
   onClose: () => void;
   onBackToSettings: () => void;
-  sourceType: SharedChatSourceType;
+  sourceType: "chatbox";
   sourceId: string;
   title: string;
 }

--- a/mcpjam-inspector/client/src/components/connection/share-usage/ShareUsageThreadDetail.tsx
+++ b/mcpjam-inspector/client/src/components/connection/share-usage/ShareUsageThreadDetail.tsx
@@ -40,21 +40,22 @@ const EMPTY_SPANS: EvalTraceSpan[] = [];
 /**
  * Goal-completion judge section for SWARM sessions — rendered under the
  * readiness insight bar so the verdict is visible on every tab. States:
- * completed → shared JudgeVerdictCard + a Re-judge affordance; failed →
- * "Judge unavailable" + Retry (a failed judgment must be recoverable, not
- * hidden); running → judging placeholder. Retry/Re-judge call the backend
- * `requestSwarmSessionJudge` (sessionId only — goal/run/project are
- * server-derived) and rely on the reactive thread subscription to refresh.
+ * absent → explicit first-run affordance; completed → shared JudgeVerdictCard
+ * + a Re-judge affordance; failed → "Judge unavailable" + Retry (a failed
+ * judgment must be recoverable, not hidden); running → judging placeholder.
+ * All controls call the backend `requestSwarmSessionJudge` (sessionId only —
+ * goal/run/project are server-derived) and rely on the reactive thread
+ * subscription to refresh.
  */
 export function SwarmJudgeSection({
   threadId,
   goalScore,
 }: {
   threadId: string;
-  goalScore: NonNullable<SharedChatThread["goalScore"]>;
+  goalScore?: SharedChatThread["goalScore"];
 }) {
   const requestJudge = useAction(
-    "swarmJudge:requestSwarmSessionJudge" as never,
+    "swarmJudge:requestSwarmSessionJudge" as never
   ) as unknown as (args: { sessionId: string }) => Promise<unknown>;
   const [requesting, setRequesting] = useState(false);
 
@@ -64,14 +65,14 @@ export function SwarmJudgeSection({
       await requestJudge({ sessionId: threadId });
     } catch (err) {
       toast.error(
-        err instanceof Error ? err.message : "Failed to re-run the judge",
+        err instanceof Error ? err.message : "Failed to run the judge"
       );
     } finally {
       setRequesting(false);
     }
   };
 
-  const judging = requesting || goalScore.status === "running";
+  const judging = requesting || goalScore?.status === "running";
 
   return (
     <div className="shrink-0 space-y-1.5 px-4 pt-2">
@@ -79,6 +80,26 @@ export function SwarmJudgeSection({
         <div className="flex items-center gap-2 rounded-lg border border-border/50 bg-muted/15 px-3 py-2 text-xs text-muted-foreground">
           <Loader2 className="size-3.5 animate-spin" aria-hidden />
           Judging against the journey goal…
+        </div>
+      ) : !goalScore ? (
+        <div className="flex items-center gap-2 rounded-lg border border-border/50 bg-muted/15 px-3 py-2 text-xs">
+          <Gavel
+            className="size-3.5 shrink-0 text-muted-foreground"
+            aria-hidden
+          />
+          <span className="text-muted-foreground">
+            Check this session against the journey goal.
+          </span>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="ml-auto shrink-0 rounded-xl"
+            onClick={() => void rerun()}
+          >
+            <Gavel className="mr-1.5 size-3.5" />
+            Run judge
+          </Button>
         </div>
       ) : goalScore.status === "completed" &&
         typeof goalScore.score === "number" &&
@@ -109,7 +130,10 @@ export function SwarmJudgeSection({
         </div>
       ) : goalScore.status === "failed" ? (
         <div className="flex items-center gap-2 rounded-lg border border-border/50 bg-muted/15 px-3 py-2 text-xs">
-          <Gavel className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
+          <Gavel
+            className="size-3.5 shrink-0 text-muted-foreground"
+            aria-hidden
+          />
           <span className="font-medium uppercase tracking-wide text-muted-foreground">
             Judge unavailable
           </span>
@@ -141,7 +165,7 @@ export function SwarmJudgeSection({
  * named seam so future read-only consumers can reuse it.
  */
 function bridgeToolRenderOverrides(
-  overrides: Record<string, unknown> | undefined,
+  overrides: Record<string, unknown> | undefined
 ): Record<string, ChatUiToolRenderOverride> | undefined {
   return overrides as Record<string, ChatUiToolRenderOverride> | undefined;
 }
@@ -160,7 +184,7 @@ interface ShareUsageThreadDetailProps {
  * Fetch span blobs from turn trace URLs and flatten into a single span array.
  */
 async function hydrateSpans(
-  traces: SharedChatTurnTrace[],
+  traces: SharedChatTurnTrace[]
 ): Promise<EvalTraceSpan[]> {
   const results = await Promise.all(
     traces.map(async (trace) => {
@@ -173,7 +197,7 @@ async function hydrateSpans(
       } catch {
         return [];
       }
-    }),
+    })
   );
   return results.flat();
 }
@@ -226,7 +250,7 @@ export function ShareUsageThreadDetail({
         if (err instanceof DOMException && err.name === "AbortError") return;
         console.error("Failed to load thread messages:", err);
         setError(
-          err instanceof Error ? err.message : "Failed to load messages",
+          err instanceof Error ? err.message : "Failed to load messages"
         );
       } finally {
         if (isActive) {
@@ -297,7 +321,13 @@ export function ShareUsageThreadDetail({
         ? { browserInteractionSteps: interactionSteps }
         : {}),
     };
-  }, [messages, widgetSnapshots, hydratedSpans, renderObservations, interactionSteps]);
+  }, [
+    messages,
+    widgetSnapshots,
+    hydratedSpans,
+    renderObservations,
+    interactionSteps,
+  ]);
 
   // Adapt trace to UI messages for the chat view
   const adaptedTrace = useMemo(() => {
@@ -315,7 +345,7 @@ export function ShareUsageThreadDetail({
       name: thread?.modelId ?? "Unknown",
       provider: "custom" as ModelProvider,
     }),
-    [thread?.modelId],
+    [thread?.modelId]
   );
 
   // Compute trace timing from turn traces
@@ -335,7 +365,7 @@ export function ShareUsageThreadDetail({
     const ok = await copyToClipboard(text);
     if (ok) {
       toast.success(
-        sessionLink ? "Session link copied" : "Session reference copied",
+        sessionLink ? "Session link copied" : "Session reference copied"
       );
     } else {
       toast.error("Failed to copy");
@@ -459,9 +489,9 @@ export function ShareUsageThreadDetail({
         <SessionInsightBar readiness={thread.readiness} />
       ) : null}
 
-      {/* Swarm-only: goalScore exists ONLY on judge-graded swarm sessions
-          (provenance-gated backend-side), so its presence is the render gate. */}
-      {thread.goalScore ? (
+      {/* Swarm-only: render before the first score exists so deployments with
+          automatic judging disabled still expose the on-demand entry point. */}
+      {thread.sourceType === "swarm" ? (
         <SwarmJudgeSection threadId={threadId} goalScore={thread.goalScore} />
       ) : null}
 
@@ -489,7 +519,7 @@ export function ShareUsageThreadDetail({
               messages={adaptedTrace.messages}
               model={resolvedModel}
               toolRenderOverrides={bridgeToolRenderOverrides(
-                adaptedTrace.toolRenderOverrides,
+                adaptedTrace.toolRenderOverrides
               )}
               reasoningDisplayMode={reasoningDisplayMode}
               widgetPolicy="placeholder"

--- a/mcpjam-inspector/client/src/components/connection/share-usage/ShareUsageThreadDetail.tsx
+++ b/mcpjam-inspector/client/src/components/connection/share-usage/ShareUsageThreadDetail.tsx
@@ -81,13 +81,17 @@ export function SwarmJudgeSection({
           Judging against the journey goal…
         </div>
       ) : goalScore.status === "completed" &&
-        typeof goalScore.score === "number" ? (
+        typeof goalScore.score === "number" &&
+        Number.isFinite(goalScore.score) &&
+        typeof goalScore.passed === "boolean" ? (
+        // Both fields validated — a malformed `passed` must not render as
+        // "below threshold" (same guard as the list badge).
         <div className="flex items-start gap-1.5">
           <div className="min-w-0 flex-1">
             <JudgeVerdictCard
               verdict={{
                 score: goalScore.score,
-                passed: goalScore.passed === true,
+                passed: goalScore.passed,
                 reason: goalScore.reason,
               }}
             />

--- a/mcpjam-inspector/client/src/components/connection/share-usage/ShareUsageThreadDetail.tsx
+++ b/mcpjam-inspector/client/src/components/connection/share-usage/ShareUsageThreadDetail.tsx
@@ -30,8 +30,105 @@ import {
   type SharedChatTurnTrace,
 } from "@/hooks/useSharedChatThreads";
 import { SessionInsightBar } from "@/components/chatboxes/session-readiness";
+import { useAction } from "convex/react";
+import { Gavel, RotateCcw } from "lucide-react";
+import { JudgeVerdictCard } from "@/components/shared/session-quality/judge-presentation";
+import type { SharedChatThread } from "@/hooks/useSharedChatThreads";
 
 const EMPTY_SPANS: EvalTraceSpan[] = [];
+
+/**
+ * Goal-completion judge section for SWARM sessions — rendered under the
+ * readiness insight bar so the verdict is visible on every tab. States:
+ * completed → shared JudgeVerdictCard + a Re-judge affordance; failed →
+ * "Judge unavailable" + Retry (a failed judgment must be recoverable, not
+ * hidden); running → judging placeholder. Retry/Re-judge call the backend
+ * `requestSwarmSessionJudge` (sessionId only — goal/run/project are
+ * server-derived) and rely on the reactive thread subscription to refresh.
+ */
+export function SwarmJudgeSection({
+  threadId,
+  goalScore,
+}: {
+  threadId: string;
+  goalScore: NonNullable<SharedChatThread["goalScore"]>;
+}) {
+  const requestJudge = useAction(
+    "swarmJudge:requestSwarmSessionJudge" as never,
+  ) as unknown as (args: { sessionId: string }) => Promise<unknown>;
+  const [requesting, setRequesting] = useState(false);
+
+  const rerun = async () => {
+    setRequesting(true);
+    try {
+      await requestJudge({ sessionId: threadId });
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to re-run the judge",
+      );
+    } finally {
+      setRequesting(false);
+    }
+  };
+
+  const judging = requesting || goalScore.status === "running";
+
+  return (
+    <div className="shrink-0 space-y-1.5 px-4 pt-2">
+      {judging ? (
+        <div className="flex items-center gap-2 rounded-lg border border-border/50 bg-muted/15 px-3 py-2 text-xs text-muted-foreground">
+          <Loader2 className="size-3.5 animate-spin" aria-hidden />
+          Judging against the journey goal…
+        </div>
+      ) : goalScore.status === "completed" &&
+        typeof goalScore.score === "number" ? (
+        <div className="flex items-start gap-1.5">
+          <div className="min-w-0 flex-1">
+            <JudgeVerdictCard
+              verdict={{
+                score: goalScore.score,
+                passed: goalScore.passed === true,
+                reason: goalScore.reason,
+              }}
+            />
+          </div>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="shrink-0 rounded-xl"
+            onClick={() => void rerun()}
+            title="Re-run the judge on this session"
+          >
+            <RotateCcw className="size-3.5" />
+          </Button>
+        </div>
+      ) : goalScore.status === "failed" ? (
+        <div className="flex items-center gap-2 rounded-lg border border-border/50 bg-muted/15 px-3 py-2 text-xs">
+          <Gavel className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
+          <span className="font-medium uppercase tracking-wide text-muted-foreground">
+            Judge unavailable
+          </span>
+          {goalScore.error ? (
+            <span className="min-w-0 flex-1 truncate text-muted-foreground">
+              {goalScore.error}
+            </span>
+          ) : null}
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="ml-auto shrink-0 rounded-xl"
+            onClick={() => void rerun()}
+          >
+            <RotateCcw className="mr-1.5 size-3.5" />
+            Retry
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  );
+}
 
 /**
  * Bridge inspector ToolRenderOverrides — whose widget/CSP fields use the MCP
@@ -356,6 +453,12 @@ export function ShareUsageThreadDetail({
 
       {thread.synthetic === true && thread.readiness ? (
         <SessionInsightBar readiness={thread.readiness} />
+      ) : null}
+
+      {/* Swarm-only: goalScore exists ONLY on judge-graded swarm sessions
+          (provenance-gated backend-side), so its presence is the render gate. */}
+      {thread.goalScore ? (
+        <SwarmJudgeSection threadId={threadId} goalScore={thread.goalScore} />
       ) : null}
 
       {/* Trace / Chat / [Browser] / Raw tabs. The Browser tab appears when the

--- a/mcpjam-inspector/client/src/components/connection/share-usage/__tests__/ShareUsageThreadDetail.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/share-usage/__tests__/ShareUsageThreadDetail.test.tsx
@@ -7,20 +7,27 @@ const {
   mockMessageView,
   mockReadOnlyTranscript,
   mockAdaptTraceToUiMessages,
+  mockRequestJudge,
   mockThreadState,
   mockBrowserArtifactsState,
 } = vi.hoisted(() => ({
   mockMessageView: vi.fn(),
   mockReadOnlyTranscript: vi.fn(),
   mockAdaptTraceToUiMessages: vi.fn(),
+  mockRequestJudge: vi.fn().mockResolvedValue(null),
   mockThreadState: {
     sourceType: "chatbox",
     synthetic: false as boolean,
     readiness: undefined as unknown,
+    goalScore: undefined as unknown,
   },
   mockBrowserArtifactsState: {
     artifacts: undefined as unknown,
   },
+}));
+
+vi.mock("convex/react", () => ({
+  useAction: () => mockRequestJudge,
 }));
 
 vi.mock("@/hooks/useSharedChatThreads", () => ({
@@ -29,6 +36,7 @@ vi.mock("@/hooks/useSharedChatThreads", () => ({
       sourceType: mockThreadState.sourceType,
       synthetic: mockThreadState.synthetic,
       readiness: mockThreadState.readiness,
+      goalScore: mockThreadState.goalScore,
       messagesBlobUrl: "https://storage.example.com/thread.json",
       modelId: "openai/gpt-oss-120b",
       visitorDisplayName: "Marcelo Jimenez",
@@ -80,6 +88,7 @@ describe("ShareUsageThreadDetail", () => {
     mockThreadState.sourceType = "chatbox";
     mockThreadState.synthetic = false;
     mockThreadState.readiness = undefined;
+    mockThreadState.goalScore = undefined;
     mockBrowserArtifactsState.artifacts = undefined;
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
@@ -111,22 +120,18 @@ describe("ShareUsageThreadDetail", () => {
     render(<ShareUsageThreadDetail threadId="thread-1" />);
 
     await waitFor(() => {
-      expect(
-        screen.getByRole("button", { name: "Chat" }),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByRole("button", { name: "Trace" }),
-      ).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Chat" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Trace" })).toBeInTheDocument();
       expect(mockAdaptTraceToUiMessages).toHaveBeenCalledWith(
         expect.objectContaining({
           toolResultDisplay: "attached-to-tool",
-        }),
+        })
       );
       expect(mockReadOnlyTranscript).toHaveBeenCalledWith(
         expect.objectContaining({
           reasoningDisplayMode: "collapsible",
           widgetPolicy: "placeholder",
-        }),
+        })
       );
     });
   });
@@ -138,9 +143,19 @@ describe("ShareUsageThreadDetail", () => {
       expect(mockReadOnlyTranscript).toHaveBeenCalledWith(
         expect.objectContaining({
           reasoningDisplayMode: "collapsible",
-        }),
+        })
       );
     });
+  });
+
+  it("offers an initial judge action for an ungraded swarm session", async () => {
+    mockThreadState.sourceType = "swarm";
+    const user = userEvent.setup();
+
+    render(<ShareUsageThreadDetail threadId="thread-1" />);
+
+    await user.click(await screen.findByRole("button", { name: /run judge/i }));
+    expect(mockRequestJudge).toHaveBeenCalledWith({ sessionId: "thread-1" });
   });
 
   it("hides the App tab when the session has no browser artifacts", async () => {
@@ -150,7 +165,7 @@ describe("ShareUsageThreadDetail", () => {
       expect(screen.getByRole("button", { name: "Chat" })).toBeInTheDocument();
     });
     expect(
-      screen.queryByRole("button", { name: "App" }),
+      screen.queryByRole("button", { name: "App" })
     ).not.toBeInTheDocument();
   });
 
@@ -192,7 +207,7 @@ describe("ShareUsageThreadDetail", () => {
     // eval replay uses). The per-step interaction timeline now lives on the
     // Trace tab (`Interact · …` spans), not in the App tab.
     expect(
-      await screen.findByTestId("browser-artifacts-view"),
+      await screen.findByTestId("browser-artifacts-view")
     ).toBeInTheDocument();
     expect(screen.getByTestId("render-observation-card")).toBeInTheDocument();
     expect(screen.queryByText("Computer Use timeline")).toBeNull();
@@ -215,10 +230,10 @@ describe("ShareUsageThreadDetail", () => {
     render(<ShareUsageThreadDetail threadId="thread-1" />);
 
     expect(
-      await screen.findByText(/Why this needs attention/i),
+      await screen.findByText(/Why this needs attention/i)
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/Only 20% of advertised tools were used/i),
+      screen.getByText(/Only 20% of advertised tools were used/i)
     ).toBeInTheDocument();
   });
 
@@ -243,11 +258,9 @@ describe("ShareUsageThreadDetail", () => {
     };
 
     const { rerender } = render(<ShareUsageThreadDetail threadId="thread-1" />);
-    await userEvent.click(
-      await screen.findByRole("button", { name: "App" }),
-    );
+    await userEvent.click(await screen.findByRole("button", { name: "App" }));
     expect(
-      await screen.findByTestId("browser-artifacts-view"),
+      await screen.findByTestId("browser-artifacts-view")
     ).toBeInTheDocument();
 
     // The next session has no artifacts (same mounted component instance).
@@ -259,15 +272,17 @@ describe("ShareUsageThreadDetail", () => {
 
     await waitFor(() => {
       expect(
-        screen.queryByTestId("browser-artifacts-view"),
+        screen.queryByTestId("browser-artifacts-view")
       ).not.toBeInTheDocument();
     });
     expect(
-      screen.queryByRole("button", { name: "App" }),
+      screen.queryByRole("button", { name: "App" })
     ).not.toBeInTheDocument();
     // Chat content renders instead of a blank panel. findBy: the messages
     // blob re-fetch on thread switch is async — don't depend on the previous
     // thread's messages state being retained (CodeRabbit, PR 2610).
-    expect(await screen.findByTestId("read-only-transcript")).toBeInTheDocument();
+    expect(
+      await screen.findByTestId("read-only-transcript")
+    ).toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/components/connection/share-usage/__tests__/SwarmJudgeSection.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/share-usage/__tests__/SwarmJudgeSection.test.tsx
@@ -89,6 +89,20 @@ describe("SwarmJudgeSection", () => {
     expect(requestJudgeMock).toHaveBeenCalledWith({ sessionId: "session-1" });
   });
 
+  it("a completed record with malformed passed renders nothing (never a bogus verdict)", () => {
+    const { container } = render(
+      <SwarmJudgeSection
+        threadId="session-1"
+        goalScore={{
+          status: "completed",
+          score: 0.9,
+          passed: "yes" as unknown as boolean,
+        }}
+      />,
+    );
+    expect(container.textContent).not.toMatch(/below threshold|meets goal/);
+  });
+
   it("running → judging placeholder, no controls", () => {
     render(
       <SwarmJudgeSection threadId="session-1" goalScore={{ status: "running" }} />,

--- a/mcpjam-inspector/client/src/components/connection/share-usage/__tests__/SwarmJudgeSection.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/share-usage/__tests__/SwarmJudgeSection.test.tsx
@@ -4,10 +4,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 /**
  * The session viewer's judge section (TL must-have: on-demand UX). States:
- * completed → shared verdict card + Re-judge; failed → "Judge unavailable" +
- * Retry (failed judgments are recoverable, never hidden); running → judging
- * placeholder. Retry/Re-judge invoke `swarmJudge:requestSwarmSessionJudge`
- * with ONLY the session id.
+ * absent → Run judge; completed → shared verdict card + Re-judge; failed →
+ * "Judge unavailable" + Retry (failed judgments are recoverable, never
+ * hidden); running → judging placeholder. Controls invoke
+ * `swarmJudge:requestSwarmSessionJudge` with ONLY the session id.
  */
 const { requestJudgeMock, toastMock } = vi.hoisted(() => ({
   requestJudgeMock: vi.fn().mockResolvedValue(null),
@@ -53,6 +53,15 @@ describe("SwarmJudgeSection", () => {
     toastMock.error.mockClear();
   });
 
+  it("absent → first-run affordance invoking the action", async () => {
+    const user = userEvent.setup();
+    render(<SwarmJudgeSection threadId="session-1" />);
+
+    await user.click(screen.getByRole("button", { name: /run judge/i }));
+
+    expect(requestJudgeMock).toHaveBeenCalledWith({ sessionId: "session-1" });
+  });
+
   it("completed → verdict card with score/reason + a Re-judge affordance", async () => {
     const user = userEvent.setup();
     render(
@@ -64,7 +73,7 @@ describe("SwarmJudgeSection", () => {
           passed: true,
           reason: "accomplished the goal",
         }}
-      />,
+      />
     );
     expect(screen.getByText("82%")).toBeInTheDocument();
     expect(screen.getByText(/meets goal/)).toBeInTheDocument();
@@ -80,7 +89,7 @@ describe("SwarmJudgeSection", () => {
       <SwarmJudgeSection
         threadId="session-1"
         goalScore={{ status: "failed", error: "spend_cap_exceeded" }}
-      />,
+      />
     );
     expect(screen.getByText("Judge unavailable")).toBeInTheDocument();
     expect(screen.getByText("spend_cap_exceeded")).toBeInTheDocument();
@@ -98,17 +107,20 @@ describe("SwarmJudgeSection", () => {
           score: 0.9,
           passed: "yes" as unknown as boolean,
         }}
-      />,
+      />
     );
     expect(container.textContent).not.toMatch(/below threshold|meets goal/);
   });
 
   it("running → judging placeholder, no controls", () => {
     render(
-      <SwarmJudgeSection threadId="session-1" goalScore={{ status: "running" }} />,
+      <SwarmJudgeSection
+        threadId="session-1"
+        goalScore={{ status: "running" }}
+      />
     );
     expect(
-      screen.getByText(/Judging against the journey goal/),
+      screen.getByText(/Judging against the journey goal/)
     ).toBeInTheDocument();
     expect(screen.queryByRole("button")).not.toBeInTheDocument();
   });
@@ -120,7 +132,7 @@ describe("SwarmJudgeSection", () => {
       <SwarmJudgeSection
         threadId="session-1"
         goalScore={{ status: "failed", error: "x" }}
-      />,
+      />
     );
     await user.click(screen.getByRole("button", { name: /retry/i }));
     await waitFor(() => {

--- a/mcpjam-inspector/client/src/components/connection/share-usage/__tests__/SwarmJudgeSection.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/share-usage/__tests__/SwarmJudgeSection.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The session viewer's judge section (TL must-have: on-demand UX). States:
+ * completed → shared verdict card + Re-judge; failed → "Judge unavailable" +
+ * Retry (failed judgments are recoverable, never hidden); running → judging
+ * placeholder. Retry/Re-judge invoke `swarmJudge:requestSwarmSessionJudge`
+ * with ONLY the session id.
+ */
+const { requestJudgeMock, toastMock } = vi.hoisted(() => ({
+  requestJudgeMock: vi.fn().mockResolvedValue(null),
+  toastMock: { error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock("convex/react", () => ({
+  useAction: () => requestJudgeMock,
+  useQuery: () => undefined,
+}));
+vi.mock("sonner", () => ({ toast: toastMock }));
+
+// Heavy transitive deps of ShareUsageThreadDetail — stubbed; only
+// SwarmJudgeSection renders in these tests.
+vi.mock("@mcpjam/chat-ui", () => ({ ReadOnlyTranscript: () => null }));
+vi.mock("@/components/evals/trace-viewer-adapter", () => ({
+  adaptTraceToUiMessages: () => [],
+  snapshotsToTraceWidgetSnapshots: () => [],
+}));
+vi.mock("@/components/evals/trace-viewer", () => ({ TraceViewer: () => null }));
+vi.mock("@/components/evals/browser-artifacts-view", () => ({
+  BrowserArtifactsView: () => null,
+}));
+vi.mock("@/components/evals/trace-view-mode-tabs", () => ({
+  ChatTraceViewModeHeaderBar: () => null,
+}));
+vi.mock("@/hooks/useSharedChatThreads", () => ({
+  useSharedChatThread: () => ({ thread: null }),
+  useSharedChatWidgetSnapshots: () => ({ snapshots: [] }),
+  useSharedChatTurnTraces: () => ({ traces: [] }),
+  useSessionBrowserArtifacts: () => ({ artifacts: [] }),
+}));
+vi.mock("@/components/chatboxes/session-readiness", () => ({
+  SessionInsightBar: () => null,
+}));
+
+import { SwarmJudgeSection } from "../ShareUsageThreadDetail";
+
+describe("SwarmJudgeSection", () => {
+  afterEach(() => {
+    requestJudgeMock.mockClear();
+    requestJudgeMock.mockResolvedValue(null);
+    toastMock.error.mockClear();
+  });
+
+  it("completed → verdict card with score/reason + a Re-judge affordance", async () => {
+    const user = userEvent.setup();
+    render(
+      <SwarmJudgeSection
+        threadId="session-1"
+        goalScore={{
+          status: "completed",
+          score: 0.82,
+          passed: true,
+          reason: "accomplished the goal",
+        }}
+      />,
+    );
+    expect(screen.getByText("82%")).toBeInTheDocument();
+    expect(screen.getByText(/meets goal/)).toBeInTheDocument();
+    expect(screen.getByText(/accomplished the goal/)).toBeInTheDocument();
+
+    await user.click(screen.getByTitle("Re-run the judge on this session"));
+    expect(requestJudgeMock).toHaveBeenCalledWith({ sessionId: "session-1" });
+  });
+
+  it("failed → 'Judge unavailable' + error + Retry invoking the action", async () => {
+    const user = userEvent.setup();
+    render(
+      <SwarmJudgeSection
+        threadId="session-1"
+        goalScore={{ status: "failed", error: "spend_cap_exceeded" }}
+      />,
+    );
+    expect(screen.getByText("Judge unavailable")).toBeInTheDocument();
+    expect(screen.getByText("spend_cap_exceeded")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /retry/i }));
+    expect(requestJudgeMock).toHaveBeenCalledWith({ sessionId: "session-1" });
+  });
+
+  it("running → judging placeholder, no controls", () => {
+    render(
+      <SwarmJudgeSection threadId="session-1" goalScore={{ status: "running" }} />,
+    );
+    expect(
+      screen.getByText(/Judging against the journey goal/),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("a rerun failure surfaces a toast instead of throwing", async () => {
+    requestJudgeMock.mockRejectedValueOnce(new Error("nope"));
+    const user = userEvent.setup();
+    render(
+      <SwarmJudgeSection
+        threadId="session-1"
+        goalScore={{ status: "failed", error: "x" }}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: /retry/i }));
+    await waitFor(() => {
+      expect(toastMock.error).toHaveBeenCalled();
+    });
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/goal-completion-presentation.tsx
+++ b/mcpjam-inspector/client/src/components/evals/goal-completion-presentation.tsx
@@ -1,8 +1,22 @@
-import { useState } from "react";
-import { ChevronDown, Gavel, Wrench } from "lucide-react";
+import { Gavel, Wrench } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { EvalSuiteRun } from "./types";
 import type { RunCaseGroup } from "./run-case-groups";
+import {
+  formatScore,
+  parseJudgeReason,
+  JudgeVerdictCard,
+  ScoreBadge,
+} from "@/components/shared/session-quality/judge-presentation";
+
+// Generic judge presentation now lives in the product-neutral module (the
+// Swarms session viewer renders the same backend judge's verdicts). Re-export
+// under the historical names so every eval call site keeps compiling.
+export {
+  formatScore,
+  parseJudgeReason,
+  ScoreBadge,
+} from "@/components/shared/session-quality/judge-presentation";
 
 /** Per-(case×host) server-quality workflow finding, keyed by caseKey on a run. */
 export type WorkflowInsight = NonNullable<
@@ -18,52 +32,6 @@ export type WorkflowInsight = NonNullable<
  */
 
 export type JudgeCase = NonNullable<EvalSuiteRun["goalCompletion"]>["cases"][number];
-
-/**
- * The judge prefixes objective-mode reasons with "no rubric:" — internal
- * jargon for the lower-confidence (≤85%) mode used when a case has neither an
- * Expected Output nor derivable assertions. Parse it out so the UI can show a
- * friendly "no expected output" tag and a clean reason instead of leaking the
- * prefix. (Most cases now derive a rubric from their assertions, so this is
- * rare — but when it appears it shouldn't read as gibberish.)
- */
-const NO_RUBRIC_PREFIX = /^\s*no rubric\s*[:—-]\s*/i;
-export function parseJudgeReason(reason: string | undefined): {
-  noRubric: boolean;
-  text: string;
-} {
-  const raw = reason ?? "";
-  return {
-    noRubric: NO_RUBRIC_PREFIX.test(raw),
-    text: raw.replace(NO_RUBRIC_PREFIX, "").trim(),
-  };
-}
-
-export function formatScore(score: number): string {
-  // Don't route the score through clampThreshold: its NaN→DEFAULT_THRESHOLD
-  // fallback is right for the threshold input but would render a corrupt/NaN
-  // score as "70%" (the pass cutoff). Show a neutral dash instead, and clamp
-  // finite scores into [0,1].
-  if (!Number.isFinite(score)) {
-    return "—";
-  }
-  return `${Math.round(Math.min(1, Math.max(0, score)) * 100)}%`;
-}
-
-export function ScoreBadge({ passed }: { passed: boolean }) {
-  return (
-    <span
-      className={cn(
-        "rounded-sm px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide",
-        passed
-          ? "bg-success/50 text-foreground"
-          : "bg-warning/50 text-foreground",
-      )}
-    >
-      {passed ? "meets goal" : "below threshold"}
-    </span>
-  );
-}
 
 /**
  * Build a `caseKey → judge verdict` map from a run's goal-completion result.
@@ -251,70 +219,16 @@ export function resolveIterationJudge(
  * the per-case home.
  */
 export function JudgeVerdictPanel({ judgeCase }: { judgeCase: JudgeCase }) {
-  const { noRubric, text: reason } = parseJudgeReason(judgeCase.reason);
-  const canExpand = Boolean(reason);
-  const [expanded, setExpanded] = useState(false);
-
-  const header = (
-    <>
-      <Gavel className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
-      <span className="font-medium uppercase tracking-wide text-muted-foreground">
-        Judge · advisory
-      </span>
-      <span className="font-semibold tabular-nums text-foreground">
-        {formatScore(judgeCase.score)}
-      </span>
-      <ScoreBadge passed={judgeCase.passed} />
-      {noRubric ? (
-        <span
-          className="shrink-0 rounded-sm bg-muted/70 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground"
-          title="No expected output or assertions to grade against — graded loosely against the request, score capped at 85%. Add assertions or an Expected Output for stricter grading."
-        >
-          no expected output
-        </span>
-      ) : null}
-      {canExpand && !expanded ? (
-        <span className="min-w-0 flex-1 truncate text-muted-foreground">
-          {reason}
-        </span>
-      ) : null}
-      {canExpand ? (
-        <ChevronDown
-          className={cn(
-            "ml-auto size-3.5 shrink-0 text-muted-foreground transition-transform",
-            expanded && "rotate-180",
-          )}
-          aria-hidden
-        />
-      ) : null}
-    </>
-  );
-
+  // Thin adapter: the panel itself is product-neutral (shared with the Swarms
+  // session viewer); this keeps the historical eval-shaped signature.
   return (
-    <div className="shrink-0 rounded-lg border border-border/50 bg-muted/15 text-xs">
-      {canExpand ? (
-        <button
-          type="button"
-          className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left transition-colors hover:bg-muted/25"
-          onClick={() => setExpanded((value) => !value)}
-          aria-expanded={expanded}
-          aria-label={
-            expanded ? "Collapse judge reason" : "Expand judge reason"
-          }
-        >
-          {header}
-        </button>
-      ) : (
-        <div className="flex items-center gap-2 px-3 py-2">{header}</div>
-      )}
-      {canExpand && expanded ? (
-        <div
-          className="border-t border-border/40 px-3 py-2 text-muted-foreground leading-relaxed whitespace-pre-wrap break-words"
-        >
-          {reason}
-        </div>
-      ) : null}
-    </div>
+    <JudgeVerdictCard
+      verdict={{
+        score: judgeCase.score,
+        passed: judgeCase.passed,
+        reason: judgeCase.reason,
+      }}
+    />
   );
 }
 

--- a/mcpjam-inspector/client/src/components/shared/session-quality/judge-presentation.tsx
+++ b/mcpjam-inspector/client/src/components/shared/session-quality/judge-presentation.tsx
@@ -1,0 +1,140 @@
+import { useState } from "react";
+import { ChevronDown, Gavel } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Product-neutral LLM-judge presentation.
+ *
+ * The generic pieces of "what a goal-completion judge verdict looks like" —
+ * score formatting, the pass/fail badge, the reason parser, and the
+ * expandable verdict panel — extracted from
+ * `components/evals/goal-completion-presentation.tsx` so non-eval surfaces
+ * (the Swarms session viewer grades sessions with the same backend judge)
+ * render identical verdicts without importing eval-shaped types. The evals
+ * module re-exports these and keeps its `JudgeCase`-shaped adapters; Swarms
+ * adapts its denormalized `goalScore` records.
+ */
+
+/**
+ * The judge prefixes objective-mode reasons with "no rubric:" — internal
+ * jargon for the lower-confidence (≤85%) mode used when grading without an
+ * expected output. Parse it out so the UI shows a friendly tag and a clean
+ * reason instead of leaking the prefix.
+ */
+const NO_RUBRIC_PREFIX = /^\s*no rubric\s*[:—-]\s*/i;
+export function parseJudgeReason(reason: string | undefined): {
+  noRubric: boolean;
+  text: string;
+} {
+  const raw = reason ?? "";
+  return {
+    noRubric: NO_RUBRIC_PREFIX.test(raw),
+    text: raw.replace(NO_RUBRIC_PREFIX, "").trim(),
+  };
+}
+
+export function formatScore(score: number): string {
+  // Don't route the score through clampThreshold: its NaN→DEFAULT_THRESHOLD
+  // fallback is right for the threshold input but would render a corrupt/NaN
+  // score as "70%" (the pass cutoff). Show a neutral dash instead, and clamp
+  // finite scores into [0,1].
+  if (!Number.isFinite(score)) {
+    return "—";
+  }
+  return `${Math.round(Math.min(1, Math.max(0, score)) * 100)}%`;
+}
+
+export function ScoreBadge({ passed }: { passed: boolean }) {
+  return (
+    <span
+      className={cn(
+        "rounded-sm px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide",
+        passed
+          ? "bg-success/50 text-foreground"
+          : "bg-warning/50 text-foreground",
+      )}
+    >
+      {passed ? "meets goal" : "below threshold"}
+    </span>
+  );
+}
+
+/** The generic verdict shape every judge surface shares. */
+export type JudgeVerdict = {
+  score: number;
+  passed: boolean;
+  reason?: string;
+};
+
+/**
+ * Compact, always-visible advisory judge verdict panel. One line: gavel +
+ * score + verdict badge + a one-line reason preview; click to expand the full
+ * reason. Product-neutral core of the evals `JudgeVerdictPanel` (which adapts
+ * its `JudgeCase` onto this) — the Swarms session viewer adapts its
+ * denormalized `goalScore` the same way.
+ */
+export function JudgeVerdictCard({ verdict }: { verdict: JudgeVerdict }) {
+  const { noRubric, text: reason } = parseJudgeReason(verdict.reason);
+  const canExpand = Boolean(reason);
+  const [expanded, setExpanded] = useState(false);
+
+  const header = (
+    <>
+      <Gavel className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
+      <span className="font-medium uppercase tracking-wide text-muted-foreground">
+        Judge · advisory
+      </span>
+      <span className="font-semibold tabular-nums text-foreground">
+        {formatScore(verdict.score)}
+      </span>
+      <ScoreBadge passed={verdict.passed} />
+      {noRubric ? (
+        <span
+          className="shrink-0 rounded-sm bg-muted/70 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground"
+          title="No expected output or assertions to grade against — graded loosely against the request, score capped at 85%. Add assertions or an Expected Output for stricter grading."
+        >
+          no expected output
+        </span>
+      ) : null}
+      {canExpand && !expanded ? (
+        <span className="min-w-0 flex-1 truncate text-muted-foreground">
+          {reason}
+        </span>
+      ) : null}
+      {canExpand ? (
+        <ChevronDown
+          className={cn(
+            "ml-auto size-3.5 shrink-0 text-muted-foreground transition-transform",
+            expanded && "rotate-180",
+          )}
+          aria-hidden
+        />
+      ) : null}
+    </>
+  );
+
+  return (
+    <div className="shrink-0 rounded-lg border border-border/50 bg-muted/15 text-xs">
+      {canExpand ? (
+        <button
+          type="button"
+          className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left transition-colors hover:bg-muted/25"
+          onClick={() => setExpanded((value) => !value)}
+          aria-expanded={expanded}
+          aria-label={
+            expanded ? "Collapse judge reason" : "Expand judge reason"
+          }
+        >
+          {header}
+        </button>
+      ) : (
+        <div className="flex items-center gap-2 px-3 py-2">{header}</div>
+      )}
+      {canExpand && expanded ? (
+        <div className="border-t border-border/40 px-3 py-2 text-muted-foreground leading-relaxed whitespace-pre-wrap break-words">
+          {reason}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
@@ -94,7 +94,14 @@ export function toSessionGoalScore(raw: JourneySessionRow["goalScore"]):
     return undefined;
   }
   const status = raw.status as GoalScoreStatus;
-  if (status === "completed" && !Number.isFinite(raw.score)) return undefined;
+  // A completed verdict must carry BOTH a finite score and a boolean passed —
+  // a malformed `passed` must not silently render as "below threshold".
+  if (
+    status === "completed" &&
+    (!Number.isFinite(raw.score) || typeof raw.passed !== "boolean")
+  ) {
+    return undefined;
+  }
   return { ...raw, status };
 }
 

--- a/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
@@ -15,11 +15,14 @@ import {
   launchJourneyRun,
   SWARM_QUERIES,
   DEFAULT_PAGE_SIZE,
+  type GoalScoreRollup,
   type JourneyRun,
   type JourneySessionRow,
   type PersonaTrackRecord,
   type JourneyRollup,
+  type SessionGoalScore,
 } from "@/lib/swarm-api";
+import { formatScore } from "@/components/shared/session-quality/judge-presentation";
 import {
   EMPTY_SESSION_FILTER,
   sessionMatchesFilter,
@@ -75,6 +78,74 @@ function toSessionReadiness(
         ? raw.issueCount
         : 0,
   };
+}
+
+// Judge-verdict guard, same philosophy as `toSessionReadiness`: the backend
+// denormalizes a WIDE `goalScore` subset; validate the status enum + score
+// before rendering so a malformed record degrades to "no badge".
+const GOAL_SCORE_STATUSES = ["running", "completed", "failed"] as const;
+type GoalScoreStatus = (typeof GOAL_SCORE_STATUSES)[number];
+
+export function toSessionGoalScore(raw: JourneySessionRow["goalScore"]):
+  | (SessionGoalScore & { status: GoalScoreStatus })
+  | undefined {
+  if (!raw) return undefined;
+  if (!(GOAL_SCORE_STATUSES as readonly string[]).includes(raw.status ?? "")) {
+    return undefined;
+  }
+  const status = raw.status as GoalScoreStatus;
+  if (status === "completed" && !Number.isFinite(raw.score)) return undefined;
+  return { ...raw, status };
+}
+
+/**
+ * Per-session judge score badge, rendered next to the readiness badge.
+ * completed → "82% · meets goal"; running → "judging…"; failed → "judge
+ * unavailable" (never silently hidden — the viewer offers Retry); absent →
+ * nothing.
+ */
+export function SessionGoalScoreBadge({
+  goalScore,
+}: {
+  goalScore: JourneySessionRow["goalScore"];
+}) {
+  const gs = toSessionGoalScore(goalScore);
+  if (!gs) return null;
+  if (gs.status === "running") {
+    return (
+      <span className="rounded-sm bg-muted/60 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide text-muted-foreground">
+        judging…
+      </span>
+    );
+  }
+  if (gs.status === "failed") {
+    return (
+      <span
+        className="rounded-sm bg-muted/60 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide text-muted-foreground"
+        title={gs.error ?? "Judge run failed — open the session to retry"}
+      >
+        judge unavailable
+      </span>
+    );
+  }
+  return (
+    <span
+      className={`rounded-sm px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide ${
+        gs.passed ? "bg-success/50 text-foreground" : "bg-warning/50 text-foreground"
+      }`}
+      title={gs.reason ?? undefined}
+    >
+      {formatScore(gs.score ?? NaN)} · {gs.passed ? "meets goal" : "below threshold"}
+    </span>
+  );
+}
+
+/** `· goal 78% avg (4 judged)` — shared by the run card + persona strip. */
+export function goalScoreAvgLabel(rollup: GoalScoreRollup | undefined): string | null {
+  if (!rollup || rollup.gradedCount === 0 || rollup.avgScore === null) {
+    return null;
+  }
+  return `goal ${formatScore(rollup.avgScore)} avg (${rollup.gradedCount} judged)`;
 }
 
 type Persona = {
@@ -336,6 +407,9 @@ function PersonaTrackRecordStrip({ personaRefId }: { personaRefId: string }) {
       <span className="text-muted-foreground">
         {record.sessionCount} session{record.sessionCount === 1 ? "" : "s"} ·{" "}
         {record.runCount} run{record.runCount === 1 ? "" : "s"}
+        {goalScoreAvgLabel(record.goalScore)
+          ? ` · ${goalScoreAvgLabel(record.goalScore)}`
+          : ""}
       </span>
     </div>
   );
@@ -481,6 +555,9 @@ function JourneyCard({
                   {r.summary.failed > 0 && ` · ${r.summary.failed} failed`}
                   {r.summary.rateLimited > 0 &&
                     ` · ${r.summary.rateLimited} rate-limited`}
+                  {goalScoreAvgLabel(r.goalScoreSummary)
+                    ? ` · ${goalScoreAvgLabel(r.goalScoreSummary)}`
+                    : ""}
                 </span>
               </div>
               <div className="mt-1 flex flex-wrap items-center gap-2">
@@ -629,6 +706,7 @@ function RunSessionsView({
                   {s.modelId ? ` · ${s.modelId}` : ""}
                 </span>
               </span>
+              <SessionGoalScoreBadge goalScore={s.goalScore} />
               <SessionReadinessBadge readiness={toSessionReadiness(s.readiness)} />
             </button>
           ))}

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.goalScore.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.goalScore.test.tsx
@@ -31,12 +31,24 @@ import {
 } from "../SwarmsTab";
 
 describe("toSessionGoalScore (wide-shape guard)", () => {
-  it("rejects absent, unknown-status, and completed-without-finite-score records", () => {
+  it("rejects absent, unknown-status, and malformed completed records", () => {
     expect(toSessionGoalScore(undefined)).toBeUndefined();
     expect(toSessionGoalScore({ status: "bogus" })).toBeUndefined();
     expect(toSessionGoalScore({ status: "completed" })).toBeUndefined();
     expect(
       toSessionGoalScore({ status: "completed", score: Number.NaN }),
+    ).toBeUndefined();
+    // A completed record with a non-boolean `passed` must NOT degrade to
+    // "below threshold" — it's rejected outright.
+    expect(
+      toSessionGoalScore({ status: "completed", score: 0.9 }),
+    ).toBeUndefined();
+    expect(
+      toSessionGoalScore({
+        status: "completed",
+        score: 0.9,
+        passed: "yes" as unknown as boolean,
+      }),
     ).toBeUndefined();
   });
 

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.goalScore.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.goalScore.test.tsx
@@ -1,0 +1,111 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+/**
+ * Guards the swarm judge presentation helpers: the wide-shape guard, the
+ * per-session badge states (completed / running / failed / absent), and the
+ * rollup average label. Heavy SwarmsTab deps are stubbed — these helpers are
+ * pure of Convex state.
+ */
+vi.mock("convex/react", () => ({
+  useQuery: () => undefined,
+  useMutation: () => vi.fn(),
+  usePaginatedQuery: () => ({
+    results: [],
+    status: "Exhausted",
+    loadMore: vi.fn(),
+  }),
+}));
+vi.mock(
+  "@/components/connection/share-usage/ShareUsageThreadDetail",
+  () => ({ ShareUsageThreadDetail: () => null }),
+);
+vi.mock("@/components/swarms/SwarmHostsPanel", () => ({
+  SwarmHostsPanel: () => null,
+}));
+
+import {
+  goalScoreAvgLabel,
+  SessionGoalScoreBadge,
+  toSessionGoalScore,
+} from "../SwarmsTab";
+
+describe("toSessionGoalScore (wide-shape guard)", () => {
+  it("rejects absent, unknown-status, and completed-without-finite-score records", () => {
+    expect(toSessionGoalScore(undefined)).toBeUndefined();
+    expect(toSessionGoalScore({ status: "bogus" })).toBeUndefined();
+    expect(toSessionGoalScore({ status: "completed" })).toBeUndefined();
+    expect(
+      toSessionGoalScore({ status: "completed", score: Number.NaN }),
+    ).toBeUndefined();
+  });
+
+  it("accepts the three valid statuses", () => {
+    expect(toSessionGoalScore({ status: "running" })?.status).toBe("running");
+    expect(toSessionGoalScore({ status: "failed", error: "x" })?.status).toBe(
+      "failed",
+    );
+    expect(
+      toSessionGoalScore({ status: "completed", score: 0.8, passed: true })
+        ?.score,
+    ).toBe(0.8);
+  });
+});
+
+describe("SessionGoalScoreBadge", () => {
+  it("renders score + verdict for a completed record", () => {
+    render(
+      <SessionGoalScoreBadge
+        goalScore={{ status: "completed", score: 0.82, passed: true }}
+      />,
+    );
+    expect(screen.getByText(/82%/)).toBeInTheDocument();
+    expect(screen.getByText(/meets goal/)).toBeInTheDocument();
+  });
+
+  it("renders 'below threshold' for a completed failing record", () => {
+    render(
+      <SessionGoalScoreBadge
+        goalScore={{ status: "completed", score: 0.4, passed: false }}
+      />,
+    );
+    expect(screen.getByText(/below threshold/)).toBeInTheDocument();
+  });
+
+  it("renders judging… while running and 'judge unavailable' on failure (never hidden)", () => {
+    const { rerender } = render(
+      <SessionGoalScoreBadge goalScore={{ status: "running" }} />,
+    );
+    expect(screen.getByText(/judging…/)).toBeInTheDocument();
+    rerender(
+      <SessionGoalScoreBadge
+        goalScore={{ status: "failed", error: "spend_cap_exceeded" }}
+      />,
+    );
+    expect(screen.getByText(/judge unavailable/)).toBeInTheDocument();
+  });
+
+  it("renders nothing for absent or malformed records", () => {
+    const { container } = render(<SessionGoalScoreBadge goalScore={undefined} />);
+    expect(container).toBeEmptyDOMElement();
+    const { container: c2 } = render(
+      <SessionGoalScoreBadge goalScore={{ status: "??" }} />,
+    );
+    expect(c2).toBeEmptyDOMElement();
+  });
+});
+
+describe("goalScoreAvgLabel", () => {
+  it("returns null until something was graded", () => {
+    expect(goalScoreAvgLabel(undefined)).toBeNull();
+    expect(
+      goalScoreAvgLabel({ gradedCount: 0, passedCount: 0, avgScore: null }),
+    ).toBeNull();
+  });
+
+  it("formats the average + graded count", () => {
+    expect(
+      goalScoreAvgLabel({ gradedCount: 4, passedCount: 3, avgScore: 0.78 }),
+    ).toBe("goal 78% avg (4 judged)");
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/useSharedChatThreads.ts
+++ b/mcpjam-inspector/client/src/hooks/useSharedChatThreads.ts
@@ -5,7 +5,7 @@ import type {
 } from "@/shared/eval-trace";
 import type { SessionReadiness } from "@/components/chatboxes/session-readiness";
 
-export type SharedChatSourceType = "chatbox";
+export type SharedChatSourceType = "chatbox" | "swarm";
 
 export interface SharedChatThread {
   _id: string;

--- a/mcpjam-inspector/client/src/hooks/useSharedChatThreads.ts
+++ b/mcpjam-inspector/client/src/hooks/useSharedChatThreads.ts
@@ -59,6 +59,20 @@ export interface SharedChatThread {
    * (`getSession`) returns the full record with denormalized findings.
    */
   readiness?: SessionReadiness;
+  /**
+   * Goal-completion judge verdict for SWARM sessions — the compact
+   * denormalized `chatSessions.goalScore` subset (see backend
+   * `convex/swarmJudge.ts`). Absent on non-swarm sessions and before the
+   * first grading; `getSession` spreads the whole doc so this flows through.
+   */
+  goalScore?: {
+    status?: string;
+    score?: number;
+    passed?: boolean;
+    threshold?: number;
+    reason?: string;
+    error?: string;
+  };
 }
 
 /**

--- a/mcpjam-inspector/client/src/lib/swarm-api.ts
+++ b/mcpjam-inspector/client/src/lib/swarm-api.ts
@@ -50,11 +50,38 @@ export interface JourneyHostSummary {
   rateLimited: number;
 }
 
+/**
+ * Aggregated goal-completion judge rollup — backend `GoalScoreSummary`
+ * (`convex/lib/swarmJudge.ts`). `avgScore` averages COMPLETED verdicts only.
+ */
+export interface GoalScoreRollup {
+  gradedCount: number;
+  passedCount: number;
+  avgScore: number | null;
+  pendingCount?: number;
+  failedCount?: number;
+}
+
+/**
+ * Compact per-session judge verdict — the denormalized
+ * `chatSessions.goalScore` subset (full verdict lives on the check row).
+ */
+export interface SessionGoalScore {
+  status?: string;
+  score?: number;
+  passed?: boolean;
+  threshold?: number;
+  reason?: string;
+  error?: string;
+}
+
 export interface JourneyRun {
   _id: string;
   status: JourneyRunStatus | string;
   summary: JourneyRunSummary;
   hostSummaries: JourneyHostSummary[];
+  /** Judge rollup for this run's sessions (absent until first grading). */
+  goalScoreSummary?: GoalScoreRollup;
   createdAt: number;
 }
 
@@ -82,6 +109,8 @@ export interface JourneySessionRow {
     verdict?: string;
     issueCount?: number;
   };
+  /** Server-denormalized judge verdict subset (see `swarmJudge.ts` backend). */
+  goalScore?: SessionGoalScore;
 }
 
 /**
@@ -97,6 +126,8 @@ export interface PersonaTrackRecord {
   runCount: number;
   sessionCount: number;
   readiness?: Record<string, unknown>;
+  /** Persona-level judge rollup (absent on older backends). */
+  goalScore?: GoalScoreRollup;
   sessionExamples?: unknown[];
 }
 
@@ -108,6 +139,8 @@ export interface JourneyHostRollup {
   failed: number;
   rateLimited: number;
   readiness?: Record<string, unknown>;
+  /** Per-host judge rollup (absent on older backends). */
+  goalScore?: GoalScoreRollup;
 }
 
 /**


### PR DESCRIPTION
## What & why

Inspector half of **swarm session rating** — pairs with **MCPJam/mcpjam-backend#704** (the judge itself). Surfaces the goal-completion judge's verdicts at every granularity of the Swarms surface, reusing the evals judge presentation.

## Changes

**Product-neutral judge presentation** (TL: shared core + adapters, not a faked `JudgeCase`):
- New `shared/session-quality/judge-presentation.tsx` — `formatScore`, `ScoreBadge`, `parseJudgeReason`, `JudgeVerdictCard` extracted from `evals/goal-completion-presentation.tsx`. The evals module re-exports the generic pieces and keeps `JudgeVerdictPanel` as a thin `JudgeCase` adapter; **all 15 existing presentation tests pass unchanged**.

**Swarms surfaces:**
- Session rows: `SessionGoalScoreBadge` next to the readiness badge — `82% · meets goal` / `judging…` / `judge unavailable` (failed judgments are visible, never hidden). Wide-shape guard (`toSessionGoalScore`) mirrors `toSessionReadiness` — malformed records degrade to no badge.
- Run cards: `· goal 78% avg (4 judged)` from the stored `journeyRuns.goalScoreSummary` (no client aggregation).
- Persona track record: same average chip.
- Session viewer (`ShareUsageThreadDetail`): judge section under the readiness bar — completed → shared verdict card (score + expandable reason) + **Re-judge**; failed → **"Judge unavailable"** + error + **Retry**; running → judging placeholder. Retry/Re-judge invoke `swarmJudge:requestSwarmSessionJudge` with **only the sessionId** (goal/run/project are server-derived — provenance).

**Types:** `SessionGoalScore` + `GoalScoreRollup` on the swarm DTOs; `goalScore` on `SharedChatThread` (the detail query spreads the doc, so it flows with no backend read-path change).

## Tests
27 across three suites: guard rejects malformed shapes; badge states (completed/running/failed/absent); rollup label gating; viewer states + retry invokes the action + toast-on-failure; evals extraction regression. Gates: tsc 0 errors, eslint 0 errors, `build:client` clean, 1079 swarms/evals/connection tests green.

## Dependency order
Depends on **mcpjam-backend#704 merged + deployed** — the new DTO fields read as absent against an old backend (UI renders nothing), so nothing breaks, but no scores appear until the judge ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only UI and type guards over optional backend fields; judge triggers go through a single Convex action and degrade cleanly when DTOs are absent on older backends.
> 
> **Overview**
> Surfaces **goal-completion judge** verdicts across Swarms by reusing eval-style presentation and wiring new backend `goalScore` / rollup fields.
> 
> **Shared judge UI:** Generic score formatting, pass/fail badge, reason parsing, and expandable `JudgeVerdictCard` move to `shared/session-quality/judge-presentation.tsx`. Evals **re-export** those helpers and make `JudgeVerdictPanel` a thin adapter so existing call sites stay unchanged.
> 
> **Swarms tab:** Session rows get `SessionGoalScoreBadge` (with `toSessionGoalScore` validation so bad `passed` values never show a fake verdict). Run cards and persona track record show stored **`goal 78% avg (N judged)`** rollups—no client-side aggregation. DTOs gain `SessionGoalScore` and `GoalScoreRollup`.
> 
> **Session viewer:** For `sourceType === "swarm"`, **`SwarmJudgeSection`** under the readiness bar handles Run judge / verdict + Re-judge / failed Retry / running placeholder, calling `swarmJudge:requestSwarmSessionJudge` with **sessionId only**. `SharedChatThread` adds optional `goalScore` and extends `SharedChatSourceType` with `"swarm"`.
> 
> **Tests:** New coverage for judge section states, badge/rollup helpers, and an integration case for ungraded swarm “Run judge”.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb10baa887cc1a5a20f3426af45662847d12d8a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show goal‑completion judge verdicts across the Swarms UI with badges, run/persona averages, and a session‑level verdict panel. Uses a shared, product‑neutral judge UI from evals, rejects malformed records (incl. non‑boolean `passed`), and exposes an initial “Run judge” action for ungraded sessions.

- **New Features**
  - Session rows: goal score badge — “82% · meets goal”, “judging…”, or “judge unavailable”; malformed records show no badge.
  - Run cards and persona strip: “goal 78% avg (4 judged)” from stored rollups (no client aggregation).
  - Session viewer: swarm‑only judge section under readiness — absent shows “Run judge”; completed shows a verdict card with expandable reason + Re‑judge; failed shows “Judge unavailable” + error + Retry; running shows a judging placeholder. All actions call `swarmJudge:requestSwarmSessionJudge` with the sessionId only.

- **Dependencies**
  - Requires backend mcpjam-backend#704 for new DTO fields. On older backends the UI degrades gracefully (no scores shown).

<sup>Written for commit fb10baa887cc1a5a20f3426af45662847d12d8a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

