### PR TITLE
feat(swarms): promote swarm sessions to eval test cases (PR 2/2)

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/history/__tests__/convert-session-dialog-core.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/history/__tests__/convert-session-dialog-core.test.tsx
@@ -167,4 +167,49 @@ describe("ConvertSessionDialogCore", () => {
         .getAttribute("data-hosts"),
     ).toBe("host-first");
   });
+
+  it("does not seed hosts while detail is loading, so a late defaultHostId still wins", () => {
+    // Project hosts are typically cached before the promote detail resolves;
+    // seeding during load would grab projectHosts[0] and the non-empty
+    // attachment would then block the authoritative reseed.
+    const loading: PromoteSessionDetailState = {
+      loading: true,
+      error: null,
+      usedServerIds: [],
+      selectedServers: [],
+    };
+    const { rerender } = render(
+      <ConvertSessionDialogCore
+        open
+        summary={SUMMARY}
+        detail={loading}
+        isAuthenticated
+        defaultHostId={null}
+        onOpenChange={vi.fn()}
+        onImported={vi.fn()}
+      />,
+    );
+    expect(
+      screen
+        .getByTestId("client-attachments-editor")
+        .getAttribute("data-hosts"),
+    ).toBe("");
+
+    rerender(
+      <ConvertSessionDialogCore
+        open
+        summary={SUMMARY}
+        detail={READY_DETAIL}
+        isAuthenticated
+        defaultHostId="host-swarm"
+        onOpenChange={vi.fn()}
+        onImported={vi.fn()}
+      />,
+    );
+    expect(
+      screen
+        .getByTestId("client-attachments-editor")
+        .getAttribute("data-hosts"),
+    ).toBe("host-swarm");
+  });
 });

--- a/mcpjam-inspector/client/src/components/chat-v2/history/__tests__/convert-session-dialog-core.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/history/__tests__/convert-session-dialog-core.test.tsx
@@ -80,7 +80,8 @@ function renderCore(
   overrides: Partial<{
     detail: PromoteSessionDetailState;
     defaultHostId: string | null;
-  }> = {},
+    hostDefaultResolved: boolean;
+  }> = {}
 ) {
   return render(
     <ConvertSessionDialogCore
@@ -89,9 +90,10 @@ function renderCore(
       detail={overrides.detail ?? READY_DETAIL}
       isAuthenticated
       defaultHostId={overrides.defaultHostId}
+      hostDefaultResolved={overrides.hostDefaultResolved}
       onOpenChange={vi.fn()}
       onImported={vi.fn()}
-    />,
+    />
   );
 }
 
@@ -102,9 +104,14 @@ afterEach(() => {
 describe("ConvertSessionDialogCore", () => {
   it("renders the adapter's loading state", () => {
     renderCore({
-      detail: { loading: true, error: null, usedServerIds: [], selectedServers: [] },
+      detail: {
+        loading: true,
+        error: null,
+        usedServerIds: [],
+        selectedServers: [],
+      },
     });
-    expect(screen.getByText(/Loading chat session details/)).toBeTruthy();
+    expect(screen.getByText(/Loading session details/)).toBeTruthy();
   });
 
   it("renders the adapter's error state and blocks submission", () => {
@@ -153,18 +160,14 @@ describe("ConvertSessionDialogCore", () => {
   it("pre-seeds the client attachment from defaultHostId when it names a project host", () => {
     renderCore({ defaultHostId: "host-swarm" });
     expect(
-      screen
-        .getByTestId("client-attachments-editor")
-        .getAttribute("data-hosts"),
+      screen.getByTestId("client-attachments-editor").getAttribute("data-hosts")
     ).toBe("host-swarm");
   });
 
   it("falls back to the first project host when defaultHostId is unknown", () => {
     renderCore({ defaultHostId: "host-deleted" });
     expect(
-      screen
-        .getByTestId("client-attachments-editor")
-        .getAttribute("data-hosts"),
+      screen.getByTestId("client-attachments-editor").getAttribute("data-hosts")
     ).toBe("host-first");
   });
 
@@ -187,12 +190,10 @@ describe("ConvertSessionDialogCore", () => {
         defaultHostId={null}
         onOpenChange={vi.fn()}
         onImported={vi.fn()}
-      />,
+      />
     );
     expect(
-      screen
-        .getByTestId("client-attachments-editor")
-        .getAttribute("data-hosts"),
+      screen.getByTestId("client-attachments-editor").getAttribute("data-hosts")
     ).toBe("");
 
     rerender(
@@ -204,12 +205,44 @@ describe("ConvertSessionDialogCore", () => {
         defaultHostId="host-swarm"
         onOpenChange={vi.fn()}
         onImported={vi.fn()}
-      />,
+      />
     );
     expect(
-      screen
-        .getByTestId("client-attachments-editor")
-        .getAttribute("data-hosts"),
+      screen.getByTestId("client-attachments-editor").getAttribute("data-hosts")
+    ).toBe("host-swarm");
+  });
+
+  it("does not seed a cached project host before the adapter resolves its host default", () => {
+    const { rerender } = render(
+      <ConvertSessionDialogCore
+        open
+        summary={SUMMARY}
+        detail={READY_DETAIL}
+        isAuthenticated
+        defaultHostId={null}
+        hostDefaultResolved={false}
+        onOpenChange={vi.fn()}
+        onImported={vi.fn()}
+      />
+    );
+    expect(
+      screen.getByTestId("client-attachments-editor").getAttribute("data-hosts")
+    ).toBe("");
+
+    rerender(
+      <ConvertSessionDialogCore
+        open
+        summary={SUMMARY}
+        detail={READY_DETAIL}
+        isAuthenticated
+        defaultHostId="host-swarm"
+        hostDefaultResolved
+        onOpenChange={vi.fn()}
+        onImported={vi.fn()}
+      />
+    );
+    expect(
+      screen.getByTestId("client-attachments-editor").getAttribute("data-hosts")
     ).toBe("host-swarm");
   });
 });

--- a/mcpjam-inspector/client/src/components/chat-v2/history/__tests__/convert-session-dialog-core.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/history/__tests__/convert-session-dialog-core.test.tsx
@@ -1,0 +1,170 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Tests for the source-agnostic promote-dialog core. The per-source adapters
+ * (direct history / swarm) are covered by their own tests; here we assert the
+ * core's contract: it renders the ADAPTER-provided detail states verbatim,
+ * submits `importChatSessionToTestCase` with the summary's sessionId +
+ * projectId and the picker selections, and pre-seeds the host attachment from
+ * `defaultHostId` when it names a live project host.
+ */
+
+const importAction = vi.fn();
+
+vi.mock("convex/react", () => ({
+  useConvexAuth: () => ({ isAuthenticated: true }),
+  useQuery: () => [],
+  useAction: () => importAction,
+}));
+
+vi.mock("@/hooks/useViews", () => ({
+  useProjectServers: () => ({
+    servers: [{ name: "Excalidraw" }],
+    serversById: new Map([["srv-excalidraw", "Excalidraw"]]),
+    isLoading: false,
+  }),
+  useProjectServerAttachments: () => ({
+    serverAttachments: [{ _id: "attachment-1" }],
+  }),
+}));
+
+vi.mock("@/hooks/useClients", () => ({
+  useHostList: () => ({
+    hosts: [{ hostId: "host-first" }, { hostId: "host-swarm" }],
+  }),
+}));
+
+// Surface the picker VALUES the core wires in, without the heavy editors.
+vi.mock("@/components/evals/server-attachment-picker", () => ({
+  ServerAttachmentPicker: ({ value }: { value: string | null }) => (
+    <div data-testid="server-attachment-picker" data-value={value ?? ""} />
+  ),
+}));
+vi.mock("@/components/evals/client-attachments-editor", () => ({
+  ClientAttachmentsEditor: ({
+    value,
+  }: {
+    value: Array<{ namedHostId: string }>;
+  }) => (
+    <div
+      data-testid="client-attachments-editor"
+      data-hosts={value.map((v) => v.namedHostId).join(",")}
+    />
+  ),
+}));
+
+vi.mock("@/lib/toast", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import {
+  ConvertSessionDialogCore,
+  type PromoteSessionDetailState,
+} from "../convert-session-dialog-core";
+
+const SUMMARY = {
+  sessionId: "chat-session-id-1",
+  title: "draw a dog",
+  projectId: "proj-1",
+};
+
+const READY_DETAIL: PromoteSessionDetailState = {
+  loading: false,
+  error: null,
+  usedServerIds: ["srv-excalidraw"],
+  selectedServers: [],
+};
+
+function renderCore(
+  overrides: Partial<{
+    detail: PromoteSessionDetailState;
+    defaultHostId: string | null;
+  }> = {},
+) {
+  return render(
+    <ConvertSessionDialogCore
+      open
+      summary={SUMMARY}
+      detail={overrides.detail ?? READY_DETAIL}
+      isAuthenticated
+      defaultHostId={overrides.defaultHostId}
+      onOpenChange={vi.fn()}
+      onImported={vi.fn()}
+    />,
+  );
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("ConvertSessionDialogCore", () => {
+  it("renders the adapter's loading state", () => {
+    renderCore({
+      detail: { loading: true, error: null, usedServerIds: [], selectedServers: [] },
+    });
+    expect(screen.getByText(/Loading chat session details/)).toBeTruthy();
+  });
+
+  it("renders the adapter's error state and blocks submission", () => {
+    renderCore({
+      detail: {
+        loading: false,
+        error: "Swarm session's run attempt has not completed",
+        usedServerIds: [],
+        selectedServers: [],
+      },
+    });
+    expect(screen.getByText(/has not completed/)).toBeTruthy();
+    const submit = screen.getByRole("button", { name: "Promote to test case" });
+    expect(submit.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("renders server chips resolved from the adapter-provided usedServerIds", () => {
+    renderCore();
+    expect(screen.getByText("Excalidraw")).toBeTruthy();
+  });
+
+  it("submits sessionId + projectId + picker selections on the new-suite branch", async () => {
+    importAction.mockResolvedValue({
+      suiteId: "suite-1",
+      testCaseId: "case-1",
+    });
+    renderCore();
+
+    const submit = screen.getByRole("button", { name: "Promote to test case" });
+    await waitFor(() => expect(submit.hasAttribute("disabled")).toBe(false));
+    fireEvent.click(submit);
+
+    await waitFor(() => expect(importAction).toHaveBeenCalledTimes(1));
+    expect(importAction).toHaveBeenCalledWith({
+      sessionId: "chat-session-id-1",
+      projectId: "proj-1",
+      testCaseTitle: "draw a dog",
+      newSuiteName: expect.stringContaining("Excalidraw"),
+      newSuiteServerAttachmentId: "attachment-1",
+      newSuiteHostAttachments: [
+        { namedHostId: "host-first", enabledOptionalServerIds: [] },
+      ],
+    });
+  });
+
+  it("pre-seeds the client attachment from defaultHostId when it names a project host", () => {
+    renderCore({ defaultHostId: "host-swarm" });
+    expect(
+      screen
+        .getByTestId("client-attachments-editor")
+        .getAttribute("data-hosts"),
+    ).toBe("host-swarm");
+  });
+
+  it("falls back to the first project host when defaultHostId is unknown", () => {
+    renderCore({ defaultHostId: "host-deleted" });
+    expect(
+      screen
+        .getByTestId("client-attachments-editor")
+        .getAttribute("data-hosts"),
+    ).toBe("host-first");
+  });
+});

--- a/mcpjam-inspector/client/src/components/chat-v2/history/convert-chat-session-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/history/convert-chat-session-dialog.tsx
@@ -1,46 +1,14 @@
-import { useAction, useConvexAuth, useQuery } from "convex/react";
-import { useEffect, useMemo, useRef, useState } from "react";
-import { AlertTriangle, Loader2 } from "lucide-react";
-import { toast } from "@/lib/toast";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@mcpjam/design-system/dialog";
-import { Button } from "@mcpjam/design-system/button";
-import { Input } from "@mcpjam/design-system/input";
-import { Label } from "@mcpjam/design-system/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@mcpjam/design-system/select";
-import { Checkbox } from "@mcpjam/design-system/checkbox";
-import { Alert, AlertDescription, AlertTitle } from "@mcpjam/design-system/alert";
+import { useEffect, useMemo, useState } from "react";
 import {
   getChatHistoryDetail,
   type ChatHistorySession,
 } from "@/lib/apis/web/chat-history-api";
-import type { EvalSuiteOverviewEntry } from "@/components/evals/types";
+import { normalizeServerNames } from "@/components/evals/suite-environment-utils";
 import {
-  buildServerBasedSuiteName,
-  normalizeServerNames,
-} from "@/components/evals/suite-environment-utils";
-import { getBillingErrorMessage } from "@/lib/billing-entitlements";
-import { useProjectServerAttachments, useProjectServers } from "@/hooks/useViews";
-import { useHostList } from "@/hooks/useClients";
-import {
-  ClientAttachmentsEditor,
-  type HostAttachmentDraft,
-} from "@/components/evals/client-attachments-editor";
-import { ServerAttachmentPicker } from "@/components/evals/server-attachment-picker";
-import { deriveSessionServerDisplay } from "./session-server-display";
-import { cn } from "@/lib/utils";
+  ConvertSessionDialogCore,
+  type PromoteSessionDetailState,
+  type PromoteSessionSummary,
+} from "./convert-session-dialog-core";
 
 type ConvertChatSessionDialogProps = {
   open: boolean;
@@ -51,8 +19,6 @@ type ConvertChatSessionDialogProps = {
   onOpenChange: (open: boolean) => void;
   onImported: (result: { suiteId: string; testCaseId: string }) => void;
 };
-
-type DestinationMode = "existing" | "new";
 
 function getSessionTitle(session: ChatHistorySession | null): string {
   if (!session) {
@@ -65,6 +31,20 @@ function getSessionTitle(session: ChatHistorySession | null): string {
   );
 }
 
+const IDLE_DETAIL: PromoteSessionDetailState = {
+  loading: false,
+  error: null,
+  usedServerIds: [],
+  selectedServers: [],
+};
+
+/**
+ * Direct-history adapter for {@link ConvertSessionDialogCore}: resolves the
+ * session-servers detail through the existing `/api/web/chat-history/detail`
+ * route (which also serves guest/HOSTED_MODE actors via `requestHeaders`) and
+ * keeps the exact props ChatHistoryRail has always passed. Swarm sessions go
+ * through `ConvertSwarmSessionDialog`, a sibling adapter over the same core.
+ */
 export function ConvertChatSessionDialog({
   open,
   session,
@@ -75,145 +55,20 @@ export function ConvertChatSessionDialog({
   onImported,
 }: ConvertChatSessionDialogProps) {
   const effectiveProjectId = session?.projectId ?? projectId ?? null;
-  // Mirror Create suite's `hostsEnabled` gate: the server/host attachment
-  // pickers (and the new-suite branch's serverAttachmentId/hostAttachments
-  // wiring) only apply in the unified-attachment world. Signed-out or
-  // project-less sessions preserve the legacy path that #395 already covers.
-  const { isAuthenticated: convexAuthed } = useConvexAuth();
-  const attachmentPickersEnabled = convexAuthed && Boolean(effectiveProjectId);
-  const { servers, serversById, isLoading: projectServersLoading } =
-    useProjectServers({
-      isAuthenticated,
-      projectId: effectiveProjectId,
-    });
-  const { serverAttachments: projectServerAttachments } =
-    useProjectServerAttachments({
-      isAuthenticated: attachmentPickersEnabled,
-      projectId: attachmentPickersEnabled ? effectiveProjectId : null,
-    });
-  const { hosts: projectHosts } = useHostList({
-    isAuthenticated: attachmentPickersEnabled,
-    projectId: attachmentPickersEnabled ? effectiveProjectId : null,
-  });
-  const knownServerNames = useMemo(
-    () => (servers ?? []).map((s) => s.name),
-    [servers],
-  );
-  const suitesOverview = useQuery(
-    "testSuites:getTestSuitesOverview" as any,
-    open && effectiveProjectId
-      ? ({ projectId: effectiveProjectId } as any)
-      : "skip",
-  ) as EvalSuiteOverviewEntry[] | undefined;
-  const importChatSession = useAction(
-    "testSuites:importChatSessionToTestCase" as any,
-  );
-
-  const [detailLoading, setDetailLoading] = useState(false);
-  const [detailError, setDetailError] = useState<string | null>(null);
-  const [caseTitle, setCaseTitle] = useState("");
-  const [destinationMode, setDestinationMode] =
-    useState<DestinationMode>("new");
-  const [selectedSuiteId, setSelectedSuiteId] = useState<string>("");
-  const [newSuiteName, setNewSuiteName] = useState("");
-  const [rawSelectedServers, setRawSelectedServers] = useState<string[]>([]);
-  const [usedServerRefs, setUsedServerRefs] = useState<string[]>([]);
-  const [updateSuiteEnvironment, setUpdateSuiteEnvironment] = useState(false);
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const suiteDefaultsAppliedForSessionId = useRef<string | null>(null);
-  // New-suite-branch picker state. Only consulted when
-  // `attachmentPickersEnabled` is true; defaults seeded from the project's
-  // first standalone serverAttachment / first project host, mirroring
-  // CreateSuiteDialog.
-  const [serverAttachmentId, setServerAttachmentId] = useState<string | null>(
-    null,
-  );
-  const [hostAttachments, setHostAttachments] = useState<HostAttachmentDraft[]>(
-    [],
-  );
-
-  const sessionServerDisplay = useMemo(
-    () =>
-      deriveSessionServerDisplay({
-        usedServerRefs,
-        selectedServers: rawSelectedServers,
-        serversById,
-        knownServerNames,
-      }),
-    [knownServerNames, rawSelectedServers, serversById, usedServerRefs],
-  );
-  const sessionServerLabels = useMemo(
-    () => sessionServerDisplay.items.map((item) => item.label),
-    [sessionServerDisplay.items],
-  );
-
-  const availableSuites = useMemo(
-    () =>
-      (suitesOverview ?? []).filter((entry) => entry.suite.source !== "sdk"),
-    [suitesOverview],
-  );
-
-  const selectedSuiteEntry = useMemo(
-    () =>
-      availableSuites.find((entry) => entry.suite._id === selectedSuiteId) ??
-      null,
-    [availableSuites, selectedSuiteId],
-  );
-  const selectedSuiteServerDisplay = useMemo(() => {
-    if (!selectedSuiteEntry) {
-      return null;
-    }
-
-    return deriveSessionServerDisplay({
-      usedServerRefs: normalizeServerNames(
-        selectedSuiteEntry.suite.environment?.servers,
-      ),
-      selectedServers: [],
-      serversById,
-      knownServerNames,
-    });
-  }, [knownServerNames, selectedSuiteEntry, serversById]);
-
-  const missingServers = useMemo(() => {
-    if (!selectedSuiteEntry) {
-      return [];
-    }
-
-    const suiteServerLabels = new Set(
-      (selectedSuiteServerDisplay?.items ?? []).map((item) =>
-        item.label.toLowerCase(),
-      ),
-    );
-
-    return sessionServerDisplay.items
-      .filter((item) => !suiteServerLabels.has(item.label.toLowerCase()))
-      .map((item) => item.label);
-  }, [selectedSuiteEntry, selectedSuiteServerDisplay, sessionServerDisplay.items]);
-  const sessionServersDescription =
-    sessionServerDisplay.source === "used"
-      ? "Derived from stored tool activity in this chat session."
-      : sessionServerDisplay.source === "selected"
-        ? "Falls back to this chat session's stored server selection."
-        : "Uses stored session metadata when server activity is available.";
+  const [detail, setDetail] = useState<PromoteSessionDetailState>(IDLE_DETAIL);
 
   useEffect(() => {
     if (!open || !session) {
       return;
     }
 
-    const title = getSessionTitle(session);
-    setCaseTitle(title);
-    setDestinationMode("new");
-    setSelectedSuiteId("");
-    setUpdateSuiteEnvironment(false);
-    setDetailLoading(true);
-    setDetailError(null);
+    setDetail({ ...IDLE_DETAIL, loading: true });
 
     let cancelled = false;
 
     void (async () => {
       try {
-        const detail = await getChatHistoryDetail(
+        const response = await getChatHistoryDetail(
           {
             sessionId: session._id,
             chatSessionId: session.chatSessionId,
@@ -227,23 +82,21 @@ export function ConvertChatSessionDialog({
           return;
         }
 
-        const selectedServers = normalizeServerNames(
-          detail.session.resumeConfig?.selectedServers,
-        );
-        const usedServerIds = normalizeServerNames(detail.session.usedServerIds);
-        setRawSelectedServers(selectedServers);
-        setUsedServerRefs(usedServerIds);
+        setDetail({
+          loading: false,
+          error: null,
+          usedServerIds: normalizeServerNames(response.session.usedServerIds),
+          selectedServers: normalizeServerNames(
+            response.session.resumeConfig?.selectedServers,
+          ),
+        });
       } catch (error) {
         if (cancelled) {
           return;
         }
         const message =
           error instanceof Error ? error.message : "Failed to load chat session";
-        setDetailError(message);
-      } finally {
-        if (!cancelled) {
-          setDetailLoading(false);
-        }
+        setDetail({ ...IDLE_DETAIL, error: message });
       }
     })();
 
@@ -254,392 +107,30 @@ export function ConvertChatSessionDialog({
 
   useEffect(() => {
     if (!open) {
-      setDetailError(null);
-      setRawSelectedServers([]);
-      setUsedServerRefs([]);
-      setUpdateSuiteEnvironment(false);
-      setIsSubmitting(false);
-      setServerAttachmentId(null);
-      setHostAttachments([]);
+      setDetail(IDLE_DETAIL);
     }
   }, [open]);
 
-  // Seed picker defaults when the dialog opens against a project that has
-  // attachments/hosts available. Mirrors CreateSuiteDialog: pick the first
-  // standalone serverAttachment and the first project host. User can swap
-  // either via the picker (Create new is supported inline by both editors).
-  useEffect(() => {
-    if (!attachmentPickersEnabled) return;
-    if (serverAttachmentId === null && projectServerAttachments.length > 0) {
-      setServerAttachmentId(projectServerAttachments[0]._id);
-    }
-  }, [attachmentPickersEnabled, projectServerAttachments, serverAttachmentId]);
-
-  useEffect(() => {
-    if (!attachmentPickersEnabled) return;
-    if (hostAttachments.length === 0 && projectHosts.length > 0) {
-      setHostAttachments([
-        {
-          namedHostId: projectHosts[0].hostId,
-          enabledOptionalServerIds: [],
-        },
-      ]);
-    }
-  }, [attachmentPickersEnabled, hostAttachments.length, projectHosts]);
-
-  useEffect(() => {
-    if (!open) {
-      suiteDefaultsAppliedForSessionId.current = null;
-      return;
-    }
-    if (!session) {
-      return;
-    }
-    if (detailLoading) {
-      return;
-    }
-    if (suiteDefaultsAppliedForSessionId.current === session._id) {
-      return;
-    }
-
-    const title = getSessionTitle(session);
-    setNewSuiteName(
-      buildServerBasedSuiteName(sessionServerLabels, `${title} suite`),
-    );
-    suiteDefaultsAppliedForSessionId.current = session._id;
-  }, [
-    open,
-    session,
-    detailLoading,
-    sessionServerLabels,
-  ]);
-
-  // New-suite branch + attachment pickers visible: require both a server
-  // attachment and at least one host (parity with CreateSuiteDialog —
-  // otherwise the created suite lands in the same broken state the
-  // pickers were added to prevent).
-  const newSuiteRequirementsMet =
-    !attachmentPickersEnabled ||
-    (serverAttachmentId !== null && hostAttachments.length > 0);
-
-  const canSubmit =
-    Boolean(session) &&
-    Boolean(effectiveProjectId) &&
-    !detailLoading &&
-    !detailError &&
-    caseTitle.trim().length > 0 &&
-    !isSubmitting &&
-    (destinationMode === "new"
-      ? newSuiteName.trim().length > 0 && newSuiteRequirementsMet
-      : Boolean(selectedSuiteId) &&
-        (missingServers.length === 0 || updateSuiteEnvironment));
-
-  const handleSubmit = async () => {
-    if (!session || !effectiveProjectId || !canSubmit) {
-      return;
-    }
-
-    setIsSubmitting(true);
-    try {
-      const result = (await importChatSession({
-        sessionId: session._id,
-        projectId: effectiveProjectId,
-        ...(destinationMode === "existing"
-          ? {
-              destinationSuiteId: selectedSuiteId,
-              updateSuiteEnvironment,
-            }
-          : {
-              newSuiteName: newSuiteName.trim(),
-              // Forward picker selections so the new suite lands fully
-              // configured (matches `createTestSuite`'s wiring). Omitted
-              // when pickers are disabled — backend keeps the legacy path.
-              ...(attachmentPickersEnabled && serverAttachmentId
-                ? { newSuiteServerAttachmentId: serverAttachmentId }
-                : {}),
-              ...(attachmentPickersEnabled && hostAttachments.length > 0
-                ? { newSuiteHostAttachments: hostAttachments }
-                : {}),
-            }),
-        testCaseTitle: caseTitle.trim(),
-      })) as {
-        suiteId: string;
-        testCaseId: string;
-        createdSuite?: boolean;
-        updatedSuiteEnvironment?: boolean;
-        addedServers?: string[];
-      };
-
-      const added = result.addedServers ?? [];
-      if (
-        destinationMode === "existing" &&
-        result.updatedSuiteEnvironment === true &&
-        added.length > 0
-      ) {
-        toast.success(
-          `Chat session promoted to a test case. Added ${added.join(", ")} to the suite.`,
-        );
-      } else {
-        toast.success("Chat session promoted to a test case");
-      }
-      onOpenChange(false);
-      onImported({ suiteId: result.suiteId, testCaseId: result.testCaseId });
-    } catch (error) {
-      toast.error(
-        getBillingErrorMessage(error, "Failed to promote chat session"),
-      );
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  const sessionTitle = getSessionTitle(session);
+  const summary = useMemo<PromoteSessionSummary | null>(
+    () =>
+      session
+        ? {
+            sessionId: session._id,
+            title: getSessionTitle(session),
+            projectId: effectiveProjectId,
+          }
+        : null,
+    [effectiveProjectId, session],
+  );
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="gap-0 sm:max-w-xl border-border/50 p-0 shadow-sm">
-        <div className="px-6 pt-6">
-          <DialogHeader className="space-y-1.5 pr-10">
-            <DialogTitle>Promote to test case</DialogTitle>
-            <DialogDescription className="text-sm text-muted-foreground">
-              Create a suite-backed test case from this chat session. The full
-              session is compiled into multi-turn prompt turns.
-            </DialogDescription>
-          </DialogHeader>
-        </div>
-
-        <div className="space-y-6 px-6 py-5">
-          <div className="space-y-2">
-            <Label htmlFor="chat-import-case-title">Case title</Label>
-            <Input
-              id="chat-import-case-title"
-              value={caseTitle}
-              onChange={(event) => setCaseTitle(event.target.value)}
-              placeholder={sessionTitle}
-            />
-          </div>
-
-          <div className="space-y-2">
-            <div className="space-y-0.5">
-              <p className="text-sm font-medium text-foreground">Session servers</p>
-              <p className="text-xs text-muted-foreground leading-relaxed">
-                {sessionServersDescription}
-              </p>
-            </div>
-            {detailLoading ? (
-              <div className="flex min-h-10 items-center gap-2 text-sm text-muted-foreground">
-                <Loader2 className="h-4 w-4 shrink-0 animate-spin" />
-                Loading chat session details…
-              </div>
-            ) : detailError ? (
-              <Alert variant="destructive">
-                <AlertTriangle className="h-4 w-4" />
-                <AlertTitle>Import unavailable</AlertTitle>
-                <AlertDescription>{detailError}</AlertDescription>
-              </Alert>
-            ) : !effectiveProjectId ? (
-              <Alert variant="destructive">
-                <AlertTriangle className="h-4 w-4" />
-                <AlertTitle>Import unavailable</AlertTitle>
-                <AlertDescription>
-                  This chat session is not linked to a shared project yet, so
-                  it cannot be promoted to a suite-backed test case.
-                </AlertDescription>
-              </Alert>
-            ) : (
-              <div className="space-y-2">
-                <div className="flex min-h-10 flex-wrap content-center gap-1.5">
-                  {sessionServerDisplay.items.length > 0 ? (
-                    sessionServerDisplay.items.map((server) => (
-                      <span
-                        key={`${server.raw}:${server.label}`}
-                        className={cn(
-                          "inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium",
-                          server.unresolved
-                            ? "border-dashed border-border/50 bg-transparent font-mono text-muted-foreground"
-                            : "border-border/50 bg-muted/50 text-foreground",
-                        )}
-                      >
-                        {server.label}
-                      </span>
-                    ))
-                  ) : (
-                    <span className="text-sm text-muted-foreground">
-                      No servers were recorded for this session.
-                    </span>
-                  )}
-                </div>
-                {!projectServersLoading &&
-                sessionServerDisplay.unresolvedCount > 0 ? (
-                  <p className="text-xs text-muted-foreground leading-relaxed">
-                    Some servers could not be resolved to current project
-                    names, so raw ids are shown.
-                  </p>
-                ) : null}
-              </div>
-            )}
-          </div>
-
-          <div className="space-y-3">
-            <div className="space-y-0.5">
-              <p className="text-sm font-medium text-foreground">Destination suite</p>
-              <p className="text-xs text-muted-foreground leading-relaxed">
-                Create a new suite or add the case to an existing one.
-              </p>
-            </div>
-
-            <div
-              className="flex rounded-lg border border-border/50 bg-muted/30 p-1"
-              role="group"
-              aria-label="Destination suite"
-            >
-              <Button
-                type="button"
-                variant="ghost"
-                className={cn(
-                  "h-8 flex-1 rounded-md text-sm font-medium shadow-none",
-                  destinationMode === "new"
-                    ? "bg-background text-foreground shadow-sm"
-                    : "text-muted-foreground hover:bg-transparent hover:text-foreground",
-                )}
-                onClick={() => setDestinationMode("new")}
-              >
-                Create new suite
-              </Button>
-              <Button
-                type="button"
-                variant="ghost"
-                disabled={availableSuites.length === 0}
-                className={cn(
-                  "h-8 flex-1 rounded-md text-sm font-medium shadow-none",
-                  destinationMode === "existing"
-                    ? "bg-background text-foreground shadow-sm"
-                    : "text-muted-foreground hover:bg-transparent hover:text-foreground",
-                )}
-                onClick={() => setDestinationMode("existing")}
-              >
-                Use existing suite
-              </Button>
-            </div>
-
-            {destinationMode === "new" ? (
-              <div className="space-y-3">
-                <div className="space-y-2">
-                  <Label htmlFor="chat-import-suite-name">Suite name</Label>
-                  <Input
-                    id="chat-import-suite-name"
-                    value={newSuiteName}
-                    onChange={(event) => setNewSuiteName(event.target.value)}
-                    placeholder="Imported suite"
-                  />
-                </div>
-
-                {attachmentPickersEnabled && effectiveProjectId ? (
-                  <div className="divide-y rounded-lg border bg-muted/20">
-                    <div className="flex items-start justify-between gap-4 p-3">
-                      <div className="min-w-0 space-y-0.5">
-                        <h3 className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-                          Servers
-                        </h3>
-                        <p className="text-xs text-muted-foreground">
-                          Server set all clients run against.
-                        </p>
-                      </div>
-                      <div className="shrink-0">
-                        <ServerAttachmentPicker
-                          projectId={effectiveProjectId}
-                          value={serverAttachmentId}
-                          onChange={setServerAttachmentId}
-                          onClearSelection={() => setServerAttachmentId(null)}
-                          disabled={isSubmitting}
-                        />
-                      </div>
-                    </div>
-                    <div className="space-y-2 p-3">
-                      <div className="space-y-0.5">
-                        <h3 className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-                          Clients
-                        </h3>
-                        <p className="text-xs text-muted-foreground">
-                          Each attached client fans out into its own run.
-                        </p>
-                      </div>
-                      <ClientAttachmentsEditor
-                        projectId={effectiveProjectId}
-                        value={hostAttachments}
-                        onChange={setHostAttachments}
-                        disabled={isSubmitting}
-                      />
-                    </div>
-                  </div>
-                ) : null}
-              </div>
-            ) : (
-              <div className="space-y-3">
-                <div className="space-y-2">
-                  <Label htmlFor="chat-import-existing-suite">Existing suite</Label>
-                  <Select
-                    value={selectedSuiteId}
-                    onValueChange={setSelectedSuiteId}
-                  >
-                    <SelectTrigger id="chat-import-existing-suite">
-                      <SelectValue placeholder="Choose a suite" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {availableSuites.map((entry) => (
-                        <SelectItem key={entry.suite._id} value={entry.suite._id}>
-                          {entry.suite.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-
-                {selectedSuiteEntry && missingServers.length > 0 ? (
-                  <Alert>
-                    <AlertTriangle className="h-4 w-4" />
-                    <AlertTitle>Suite environment update required</AlertTitle>
-                    <AlertDescription className="space-y-3">
-                      <p>
-                        The selected suite is missing these servers:{" "}
-                        {missingServers.join(", ")}.
-                      </p>
-                      <label className="flex items-start gap-3">
-                        <Checkbox
-                          checked={updateSuiteEnvironment}
-                          onCheckedChange={(checked) =>
-                            setUpdateSuiteEnvironment(checked === true)
-                          }
-                          className="mt-0.5"
-                        />
-                        <span className="text-sm">
-                          Add the missing servers to this suite before importing
-                          the case.
-                        </span>
-                      </label>
-                    </AlertDescription>
-                  </Alert>
-                ) : null}
-              </div>
-            )}
-          </div>
-        </div>
-
-        <DialogFooter className="border-t border-border/50 px-6 py-4">
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => onOpenChange(false)}
-            disabled={isSubmitting}
-          >
-            Cancel
-          </Button>
-          <Button type="button" onClick={() => void handleSubmit()} disabled={!canSubmit}>
-            {isSubmitting ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
-            Promote to test case
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+    <ConvertSessionDialogCore
+      open={open}
+      summary={summary}
+      detail={detail}
+      isAuthenticated={isAuthenticated}
+      onOpenChange={onOpenChange}
+      onImported={onImported}
+    />
   );
 }

--- a/mcpjam-inspector/client/src/components/chat-v2/history/convert-session-dialog-core.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/history/convert-session-dialog-core.tsx
@@ -1,0 +1,622 @@
+import { useAction, useConvexAuth, useQuery } from "convex/react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { AlertTriangle, Loader2 } from "lucide-react";
+import { toast } from "@/lib/toast";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@mcpjam/design-system/dialog";
+import { Button } from "@mcpjam/design-system/button";
+import { Input } from "@mcpjam/design-system/input";
+import { Label } from "@mcpjam/design-system/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@mcpjam/design-system/select";
+import { Checkbox } from "@mcpjam/design-system/checkbox";
+import { Alert, AlertDescription, AlertTitle } from "@mcpjam/design-system/alert";
+import type { EvalSuiteOverviewEntry } from "@/components/evals/types";
+import {
+  buildServerBasedSuiteName,
+  normalizeServerNames,
+} from "@/components/evals/suite-environment-utils";
+import { getBillingErrorMessage } from "@/lib/billing-entitlements";
+import { useProjectServerAttachments, useProjectServers } from "@/hooks/useViews";
+import { useHostList } from "@/hooks/useClients";
+import {
+  ClientAttachmentsEditor,
+  type HostAttachmentDraft,
+} from "@/components/evals/client-attachments-editor";
+import { ServerAttachmentPicker } from "@/components/evals/server-attachment-picker";
+import { deriveSessionServerDisplay } from "./session-server-display";
+import { cn } from "@/lib/utils";
+
+/**
+ * Source-agnostic identity of the session being promoted. `sessionId` is the
+ * Convex `chatSessions` _id — exactly what `importChatSessionToTestCase`
+ * takes; how it was obtained (direct-history DTO, swarm session row, …) is
+ * the adapter's business.
+ */
+export type PromoteSessionSummary = {
+  sessionId: string;
+  /** Seed for the case title and the generated suite name. */
+  title: string;
+  projectId: string | null;
+};
+
+/**
+ * Session-servers detail, resolved by the source adapter. `usedServerIds`
+ * and `selectedServers` are SERVER-derived (direct: `/chat-history/detail`;
+ * swarm: `chatSessionPromote:getChatSessionPromoteDetail`) — the core only
+ * renders them.
+ */
+export type PromoteSessionDetailState = {
+  loading: boolean;
+  error: string | null;
+  usedServerIds: string[];
+  selectedServers: string[];
+};
+
+type ConvertSessionDialogCoreProps = {
+  open: boolean;
+  summary: PromoteSessionSummary | null;
+  detail: PromoteSessionDetailState;
+  isAuthenticated: boolean;
+  /**
+   * Pre-seed for the new-suite client attachment (e.g. the host a swarm
+   * session actually ran on). Attachment selections stay CLIENT-supplied and
+   * are validated by the backend on submit — unlike test-case provenance,
+   * which the backend derives from the session row and never accepts from
+   * the client. Falls back to the project's first host when absent/unknown.
+   */
+  defaultHostId?: string | null;
+  onOpenChange: (open: boolean) => void;
+  onImported: (result: { suiteId: string; testCaseId: string }) => void;
+};
+
+type DestinationMode = "existing" | "new";
+
+/**
+ * Presentational/submit core of "Promote to test case". Owns the suite
+ * pickers and the `importChatSessionToTestCase` call; per-source adapters
+ * (`ConvertChatSessionDialog` for direct history, `ConvertSwarmSessionDialog`
+ * for swarm runs) own fetching the summary/detail inputs.
+ */
+export function ConvertSessionDialogCore({
+  open,
+  summary,
+  detail,
+  isAuthenticated,
+  defaultHostId,
+  onOpenChange,
+  onImported,
+}: ConvertSessionDialogCoreProps) {
+  const effectiveProjectId = summary?.projectId ?? null;
+  // Mirror Create suite's `hostsEnabled` gate: the server/host attachment
+  // pickers (and the new-suite branch's serverAttachmentId/hostAttachments
+  // wiring) only apply in the unified-attachment world. Signed-out or
+  // project-less sessions preserve the legacy path that #395 already covers.
+  const { isAuthenticated: convexAuthed } = useConvexAuth();
+  const attachmentPickersEnabled = convexAuthed && Boolean(effectiveProjectId);
+  const { servers, serversById, isLoading: projectServersLoading } =
+    useProjectServers({
+      isAuthenticated,
+      projectId: effectiveProjectId,
+    });
+  const { serverAttachments: projectServerAttachments } =
+    useProjectServerAttachments({
+      isAuthenticated: attachmentPickersEnabled,
+      projectId: attachmentPickersEnabled ? effectiveProjectId : null,
+    });
+  const { hosts: projectHosts } = useHostList({
+    isAuthenticated: attachmentPickersEnabled,
+    projectId: attachmentPickersEnabled ? effectiveProjectId : null,
+  });
+  const knownServerNames = useMemo(
+    () => (servers ?? []).map((s) => s.name),
+    [servers],
+  );
+  const suitesOverview = useQuery(
+    "testSuites:getTestSuitesOverview" as any,
+    open && effectiveProjectId
+      ? ({ projectId: effectiveProjectId } as any)
+      : "skip",
+  ) as EvalSuiteOverviewEntry[] | undefined;
+  const importChatSession = useAction(
+    "testSuites:importChatSessionToTestCase" as any,
+  );
+
+  const [caseTitle, setCaseTitle] = useState("");
+  const [destinationMode, setDestinationMode] =
+    useState<DestinationMode>("new");
+  const [selectedSuiteId, setSelectedSuiteId] = useState<string>("");
+  const [newSuiteName, setNewSuiteName] = useState("");
+  const [updateSuiteEnvironment, setUpdateSuiteEnvironment] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const suiteDefaultsAppliedForSessionId = useRef<string | null>(null);
+  // New-suite-branch picker state. Only consulted when
+  // `attachmentPickersEnabled` is true; defaults seeded from the project's
+  // first standalone serverAttachment / `defaultHostId` (falling back to the
+  // first project host), mirroring CreateSuiteDialog.
+  const [serverAttachmentId, setServerAttachmentId] = useState<string | null>(
+    null,
+  );
+  const [hostAttachments, setHostAttachments] = useState<HostAttachmentDraft[]>(
+    [],
+  );
+
+  const sessionServerDisplay = useMemo(
+    () =>
+      deriveSessionServerDisplay({
+        usedServerRefs: detail.usedServerIds,
+        selectedServers: detail.selectedServers,
+        serversById,
+        knownServerNames,
+      }),
+    [detail.selectedServers, detail.usedServerIds, knownServerNames, serversById],
+  );
+  const sessionServerLabels = useMemo(
+    () => sessionServerDisplay.items.map((item) => item.label),
+    [sessionServerDisplay.items],
+  );
+
+  const availableSuites = useMemo(
+    () =>
+      (suitesOverview ?? []).filter((entry) => entry.suite.source !== "sdk"),
+    [suitesOverview],
+  );
+
+  const selectedSuiteEntry = useMemo(
+    () =>
+      availableSuites.find((entry) => entry.suite._id === selectedSuiteId) ??
+      null,
+    [availableSuites, selectedSuiteId],
+  );
+  const selectedSuiteServerDisplay = useMemo(() => {
+    if (!selectedSuiteEntry) {
+      return null;
+    }
+
+    return deriveSessionServerDisplay({
+      usedServerRefs: normalizeServerNames(
+        selectedSuiteEntry.suite.environment?.servers,
+      ),
+      selectedServers: [],
+      serversById,
+      knownServerNames,
+    });
+  }, [knownServerNames, selectedSuiteEntry, serversById]);
+
+  const missingServers = useMemo(() => {
+    if (!selectedSuiteEntry) {
+      return [];
+    }
+
+    const suiteServerLabels = new Set(
+      (selectedSuiteServerDisplay?.items ?? []).map((item) =>
+        item.label.toLowerCase(),
+      ),
+    );
+
+    return sessionServerDisplay.items
+      .filter((item) => !suiteServerLabels.has(item.label.toLowerCase()))
+      .map((item) => item.label);
+  }, [selectedSuiteEntry, selectedSuiteServerDisplay, sessionServerDisplay.items]);
+  const sessionServersDescription =
+    sessionServerDisplay.source === "used"
+      ? "Derived from stored tool activity in this chat session."
+      : sessionServerDisplay.source === "selected"
+        ? "Falls back to this chat session's stored server selection."
+        : "Uses stored session metadata when server activity is available.";
+
+  useEffect(() => {
+    if (!open || !summary) {
+      return;
+    }
+
+    setCaseTitle(summary.title);
+    setDestinationMode("new");
+    setSelectedSuiteId("");
+    setUpdateSuiteEnvironment(false);
+  }, [open, summary]);
+
+  useEffect(() => {
+    if (!open) {
+      setUpdateSuiteEnvironment(false);
+      setIsSubmitting(false);
+      setServerAttachmentId(null);
+      setHostAttachments([]);
+    }
+  }, [open]);
+
+  // Seed picker defaults when the dialog opens against a project that has
+  // attachments/hosts available. Mirrors CreateSuiteDialog: pick the first
+  // standalone serverAttachment; hosts prefer `defaultHostId` when it names
+  // a live project host. User can swap either via the picker (Create new is
+  // supported inline by both editors).
+  useEffect(() => {
+    if (!attachmentPickersEnabled) return;
+    if (serverAttachmentId === null && projectServerAttachments.length > 0) {
+      setServerAttachmentId(projectServerAttachments[0]._id);
+    }
+  }, [attachmentPickersEnabled, projectServerAttachments, serverAttachmentId]);
+
+  useEffect(() => {
+    if (!attachmentPickersEnabled) return;
+    if (hostAttachments.length === 0 && projectHosts.length > 0) {
+      const preferredHostId =
+        defaultHostId &&
+        projectHosts.some((host) => host.hostId === defaultHostId)
+          ? defaultHostId
+          : projectHosts[0].hostId;
+      setHostAttachments([
+        {
+          namedHostId: preferredHostId,
+          enabledOptionalServerIds: [],
+        },
+      ]);
+    }
+  }, [
+    attachmentPickersEnabled,
+    defaultHostId,
+    hostAttachments.length,
+    projectHosts,
+  ]);
+
+  useEffect(() => {
+    if (!open) {
+      suiteDefaultsAppliedForSessionId.current = null;
+      return;
+    }
+    if (!summary) {
+      return;
+    }
+    if (detail.loading) {
+      return;
+    }
+    if (suiteDefaultsAppliedForSessionId.current === summary.sessionId) {
+      return;
+    }
+
+    setNewSuiteName(
+      buildServerBasedSuiteName(sessionServerLabels, `${summary.title} suite`),
+    );
+    suiteDefaultsAppliedForSessionId.current = summary.sessionId;
+  }, [open, summary, detail.loading, sessionServerLabels]);
+
+  // New-suite branch + attachment pickers visible: require both a server
+  // attachment and at least one host (parity with CreateSuiteDialog —
+  // otherwise the created suite lands in the same broken state the
+  // pickers were added to prevent).
+  const newSuiteRequirementsMet =
+    !attachmentPickersEnabled ||
+    (serverAttachmentId !== null && hostAttachments.length > 0);
+
+  const canSubmit =
+    Boolean(summary) &&
+    Boolean(effectiveProjectId) &&
+    !detail.loading &&
+    !detail.error &&
+    caseTitle.trim().length > 0 &&
+    !isSubmitting &&
+    (destinationMode === "new"
+      ? newSuiteName.trim().length > 0 && newSuiteRequirementsMet
+      : Boolean(selectedSuiteId) &&
+        (missingServers.length === 0 || updateSuiteEnvironment));
+
+  const handleSubmit = async () => {
+    if (!summary || !effectiveProjectId || !canSubmit) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      const result = (await importChatSession({
+        sessionId: summary.sessionId,
+        projectId: effectiveProjectId,
+        ...(destinationMode === "existing"
+          ? {
+              destinationSuiteId: selectedSuiteId,
+              updateSuiteEnvironment,
+            }
+          : {
+              newSuiteName: newSuiteName.trim(),
+              // Forward picker selections so the new suite lands fully
+              // configured (matches `createTestSuite`'s wiring). Omitted
+              // when pickers are disabled — backend keeps the legacy path.
+              ...(attachmentPickersEnabled && serverAttachmentId
+                ? { newSuiteServerAttachmentId: serverAttachmentId }
+                : {}),
+              ...(attachmentPickersEnabled && hostAttachments.length > 0
+                ? { newSuiteHostAttachments: hostAttachments }
+                : {}),
+            }),
+        testCaseTitle: caseTitle.trim(),
+      })) as {
+        suiteId: string;
+        testCaseId: string;
+        createdSuite?: boolean;
+        updatedSuiteEnvironment?: boolean;
+        addedServers?: string[];
+      };
+
+      const added = result.addedServers ?? [];
+      if (
+        destinationMode === "existing" &&
+        result.updatedSuiteEnvironment === true &&
+        added.length > 0
+      ) {
+        toast.success(
+          `Chat session promoted to a test case. Added ${added.join(", ")} to the suite.`,
+        );
+      } else {
+        toast.success("Chat session promoted to a test case");
+      }
+      onOpenChange(false);
+      onImported({ suiteId: result.suiteId, testCaseId: result.testCaseId });
+    } catch (error) {
+      toast.error(
+        getBillingErrorMessage(error, "Failed to promote chat session"),
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const sessionTitle = summary?.title ?? "Imported chat";
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="gap-0 sm:max-w-xl border-border/50 p-0 shadow-sm">
+        <div className="px-6 pt-6">
+          <DialogHeader className="space-y-1.5 pr-10">
+            <DialogTitle>Promote to test case</DialogTitle>
+            <DialogDescription className="text-sm text-muted-foreground">
+              Create a suite-backed test case from this chat session. The full
+              session is compiled into multi-turn prompt turns.
+            </DialogDescription>
+          </DialogHeader>
+        </div>
+
+        <div className="space-y-6 px-6 py-5">
+          <div className="space-y-2">
+            <Label htmlFor="chat-import-case-title">Case title</Label>
+            <Input
+              id="chat-import-case-title"
+              value={caseTitle}
+              onChange={(event) => setCaseTitle(event.target.value)}
+              placeholder={sessionTitle}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <div className="space-y-0.5">
+              <p className="text-sm font-medium text-foreground">Session servers</p>
+              <p className="text-xs text-muted-foreground leading-relaxed">
+                {sessionServersDescription}
+              </p>
+            </div>
+            {detail.loading ? (
+              <div className="flex min-h-10 items-center gap-2 text-sm text-muted-foreground">
+                <Loader2 className="h-4 w-4 shrink-0 animate-spin" />
+                Loading chat session details…
+              </div>
+            ) : detail.error ? (
+              <Alert variant="destructive">
+                <AlertTriangle className="h-4 w-4" />
+                <AlertTitle>Import unavailable</AlertTitle>
+                <AlertDescription>{detail.error}</AlertDescription>
+              </Alert>
+            ) : !effectiveProjectId ? (
+              <Alert variant="destructive">
+                <AlertTriangle className="h-4 w-4" />
+                <AlertTitle>Import unavailable</AlertTitle>
+                <AlertDescription>
+                  This chat session is not linked to a shared project yet, so
+                  it cannot be promoted to a suite-backed test case.
+                </AlertDescription>
+              </Alert>
+            ) : (
+              <div className="space-y-2">
+                <div className="flex min-h-10 flex-wrap content-center gap-1.5">
+                  {sessionServerDisplay.items.length > 0 ? (
+                    sessionServerDisplay.items.map((server) => (
+                      <span
+                        key={`${server.raw}:${server.label}`}
+                        className={cn(
+                          "inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium",
+                          server.unresolved
+                            ? "border-dashed border-border/50 bg-transparent font-mono text-muted-foreground"
+                            : "border-border/50 bg-muted/50 text-foreground",
+                        )}
+                      >
+                        {server.label}
+                      </span>
+                    ))
+                  ) : (
+                    <span className="text-sm text-muted-foreground">
+                      No servers were recorded for this session.
+                    </span>
+                  )}
+                </div>
+                {!projectServersLoading &&
+                sessionServerDisplay.unresolvedCount > 0 ? (
+                  <p className="text-xs text-muted-foreground leading-relaxed">
+                    Some servers could not be resolved to current project
+                    names, so raw ids are shown.
+                  </p>
+                ) : null}
+              </div>
+            )}
+          </div>
+
+          <div className="space-y-3">
+            <div className="space-y-0.5">
+              <p className="text-sm font-medium text-foreground">Destination suite</p>
+              <p className="text-xs text-muted-foreground leading-relaxed">
+                Create a new suite or add the case to an existing one.
+              </p>
+            </div>
+
+            <div
+              className="flex rounded-lg border border-border/50 bg-muted/30 p-1"
+              role="group"
+              aria-label="Destination suite"
+            >
+              <Button
+                type="button"
+                variant="ghost"
+                className={cn(
+                  "h-8 flex-1 rounded-md text-sm font-medium shadow-none",
+                  destinationMode === "new"
+                    ? "bg-background text-foreground shadow-sm"
+                    : "text-muted-foreground hover:bg-transparent hover:text-foreground",
+                )}
+                onClick={() => setDestinationMode("new")}
+              >
+                Create new suite
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                disabled={availableSuites.length === 0}
+                className={cn(
+                  "h-8 flex-1 rounded-md text-sm font-medium shadow-none",
+                  destinationMode === "existing"
+                    ? "bg-background text-foreground shadow-sm"
+                    : "text-muted-foreground hover:bg-transparent hover:text-foreground",
+                )}
+                onClick={() => setDestinationMode("existing")}
+              >
+                Use existing suite
+              </Button>
+            </div>
+
+            {destinationMode === "new" ? (
+              <div className="space-y-3">
+                <div className="space-y-2">
+                  <Label htmlFor="chat-import-suite-name">Suite name</Label>
+                  <Input
+                    id="chat-import-suite-name"
+                    value={newSuiteName}
+                    onChange={(event) => setNewSuiteName(event.target.value)}
+                    placeholder="Imported suite"
+                  />
+                </div>
+
+                {attachmentPickersEnabled && effectiveProjectId ? (
+                  <div className="divide-y rounded-lg border bg-muted/20">
+                    <div className="flex items-start justify-between gap-4 p-3">
+                      <div className="min-w-0 space-y-0.5">
+                        <h3 className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                          Servers
+                        </h3>
+                        <p className="text-xs text-muted-foreground">
+                          Server set all clients run against.
+                        </p>
+                      </div>
+                      <div className="shrink-0">
+                        <ServerAttachmentPicker
+                          projectId={effectiveProjectId}
+                          value={serverAttachmentId}
+                          onChange={setServerAttachmentId}
+                          onClearSelection={() => setServerAttachmentId(null)}
+                          disabled={isSubmitting}
+                        />
+                      </div>
+                    </div>
+                    <div className="space-y-2 p-3">
+                      <div className="space-y-0.5">
+                        <h3 className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                          Clients
+                        </h3>
+                        <p className="text-xs text-muted-foreground">
+                          Each attached client fans out into its own run.
+                        </p>
+                      </div>
+                      <ClientAttachmentsEditor
+                        projectId={effectiveProjectId}
+                        value={hostAttachments}
+                        onChange={setHostAttachments}
+                        disabled={isSubmitting}
+                      />
+                    </div>
+                  </div>
+                ) : null}
+              </div>
+            ) : (
+              <div className="space-y-3">
+                <div className="space-y-2">
+                  <Label htmlFor="chat-import-existing-suite">Existing suite</Label>
+                  <Select
+                    value={selectedSuiteId}
+                    onValueChange={setSelectedSuiteId}
+                  >
+                    <SelectTrigger id="chat-import-existing-suite">
+                      <SelectValue placeholder="Choose a suite" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {availableSuites.map((entry) => (
+                        <SelectItem key={entry.suite._id} value={entry.suite._id}>
+                          {entry.suite.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                {selectedSuiteEntry && missingServers.length > 0 ? (
+                  <Alert>
+                    <AlertTriangle className="h-4 w-4" />
+                    <AlertTitle>Suite environment update required</AlertTitle>
+                    <AlertDescription className="space-y-3">
+                      <p>
+                        The selected suite is missing these servers:{" "}
+                        {missingServers.join(", ")}.
+                      </p>
+                      <label className="flex items-start gap-3">
+                        <Checkbox
+                          checked={updateSuiteEnvironment}
+                          onCheckedChange={(checked) =>
+                            setUpdateSuiteEnvironment(checked === true)
+                          }
+                          className="mt-0.5"
+                        />
+                        <span className="text-sm">
+                          Add the missing servers to this suite before importing
+                          the case.
+                        </span>
+                      </label>
+                    </AlertDescription>
+                  </Alert>
+                ) : null}
+              </div>
+            )}
+          </div>
+        </div>
+
+        <DialogFooter className="border-t border-border/50 px-6 py-4">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isSubmitting}
+          >
+            Cancel
+          </Button>
+          <Button type="button" onClick={() => void handleSubmit()} disabled={!canSubmit}>
+            {isSubmitting ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+            Promote to test case
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/mcpjam-inspector/client/src/components/chat-v2/history/convert-session-dialog-core.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/history/convert-session-dialog-core.tsx
@@ -21,14 +21,21 @@ import {
   SelectValue,
 } from "@mcpjam/design-system/select";
 import { Checkbox } from "@mcpjam/design-system/checkbox";
-import { Alert, AlertDescription, AlertTitle } from "@mcpjam/design-system/alert";
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+} from "@mcpjam/design-system/alert";
 import type { EvalSuiteOverviewEntry } from "@/components/evals/types";
 import {
   buildServerBasedSuiteName,
   normalizeServerNames,
 } from "@/components/evals/suite-environment-utils";
 import { getBillingErrorMessage } from "@/lib/billing-entitlements";
-import { useProjectServerAttachments, useProjectServers } from "@/hooks/useViews";
+import {
+  useProjectServerAttachments,
+  useProjectServers,
+} from "@/hooks/useViews";
 import { useHostList } from "@/hooks/useClients";
 import {
   ClientAttachmentsEditor,
@@ -77,6 +84,13 @@ type ConvertSessionDialogCoreProps = {
    * the client. Falls back to the project's first host when absent/unknown.
    */
   defaultHostId?: string | null;
+  /**
+   * Whether the source adapter has resolved its authoritative host default.
+   * Direct-history callers use the default (`true`) and fall back immediately;
+   * async adapters pass `false` until their session detail arrives so a cached
+   * project host cannot win the initial-render race.
+   */
+  hostDefaultResolved?: boolean;
   onOpenChange: (open: boolean) => void;
   onImported: (result: { suiteId: string; testCaseId: string }) => void;
 };
@@ -95,6 +109,7 @@ export function ConvertSessionDialogCore({
   detail,
   isAuthenticated,
   defaultHostId,
+  hostDefaultResolved = true,
   onOpenChange,
   onImported,
 }: ConvertSessionDialogCoreProps) {
@@ -105,11 +120,14 @@ export function ConvertSessionDialogCore({
   // project-less sessions preserve the legacy path that #395 already covers.
   const { isAuthenticated: convexAuthed } = useConvexAuth();
   const attachmentPickersEnabled = convexAuthed && Boolean(effectiveProjectId);
-  const { servers, serversById, isLoading: projectServersLoading } =
-    useProjectServers({
-      isAuthenticated,
-      projectId: effectiveProjectId,
-    });
+  const {
+    servers,
+    serversById,
+    isLoading: projectServersLoading,
+  } = useProjectServers({
+    isAuthenticated,
+    projectId: effectiveProjectId,
+  });
   const { serverAttachments: projectServerAttachments } =
     useProjectServerAttachments({
       isAuthenticated: attachmentPickersEnabled,
@@ -121,16 +139,16 @@ export function ConvertSessionDialogCore({
   });
   const knownServerNames = useMemo(
     () => (servers ?? []).map((s) => s.name),
-    [servers],
+    [servers]
   );
   const suitesOverview = useQuery(
     "testSuites:getTestSuitesOverview" as any,
     open && effectiveProjectId
       ? ({ projectId: effectiveProjectId } as any)
-      : "skip",
+      : "skip"
   ) as EvalSuiteOverviewEntry[] | undefined;
   const importChatSession = useAction(
-    "testSuites:importChatSessionToTestCase" as any,
+    "testSuites:importChatSessionToTestCase" as any
   );
 
   const [caseTitle, setCaseTitle] = useState("");
@@ -146,10 +164,10 @@ export function ConvertSessionDialogCore({
   // first standalone serverAttachment / `defaultHostId` (falling back to the
   // first project host), mirroring CreateSuiteDialog.
   const [serverAttachmentId, setServerAttachmentId] = useState<string | null>(
-    null,
+    null
   );
   const [hostAttachments, setHostAttachments] = useState<HostAttachmentDraft[]>(
-    [],
+    []
   );
 
   const sessionServerDisplay = useMemo(
@@ -160,24 +178,29 @@ export function ConvertSessionDialogCore({
         serversById,
         knownServerNames,
       }),
-    [detail.selectedServers, detail.usedServerIds, knownServerNames, serversById],
+    [
+      detail.selectedServers,
+      detail.usedServerIds,
+      knownServerNames,
+      serversById,
+    ]
   );
   const sessionServerLabels = useMemo(
     () => sessionServerDisplay.items.map((item) => item.label),
-    [sessionServerDisplay.items],
+    [sessionServerDisplay.items]
   );
 
   const availableSuites = useMemo(
     () =>
       (suitesOverview ?? []).filter((entry) => entry.suite.source !== "sdk"),
-    [suitesOverview],
+    [suitesOverview]
   );
 
   const selectedSuiteEntry = useMemo(
     () =>
       availableSuites.find((entry) => entry.suite._id === selectedSuiteId) ??
       null,
-    [availableSuites, selectedSuiteId],
+    [availableSuites, selectedSuiteId]
   );
   const selectedSuiteServerDisplay = useMemo(() => {
     if (!selectedSuiteEntry) {
@@ -186,7 +209,7 @@ export function ConvertSessionDialogCore({
 
     return deriveSessionServerDisplay({
       usedServerRefs: normalizeServerNames(
-        selectedSuiteEntry.suite.environment?.servers,
+        selectedSuiteEntry.suite.environment?.servers
       ),
       selectedServers: [],
       serversById,
@@ -201,20 +224,24 @@ export function ConvertSessionDialogCore({
 
     const suiteServerLabels = new Set(
       (selectedSuiteServerDisplay?.items ?? []).map((item) =>
-        item.label.toLowerCase(),
-      ),
+        item.label.toLowerCase()
+      )
     );
 
     return sessionServerDisplay.items
       .filter((item) => !suiteServerLabels.has(item.label.toLowerCase()))
       .map((item) => item.label);
-  }, [selectedSuiteEntry, selectedSuiteServerDisplay, sessionServerDisplay.items]);
+  }, [
+    selectedSuiteEntry,
+    selectedSuiteServerDisplay,
+    sessionServerDisplay.items,
+  ]);
   const sessionServersDescription =
     sessionServerDisplay.source === "used"
-      ? "Derived from stored tool activity in this chat session."
+      ? "Derived from stored tool activity in this session."
       : sessionServerDisplay.source === "selected"
-        ? "Falls back to this chat session's stored server selection."
-        : "Uses stored session metadata when server activity is available.";
+      ? "Falls back to this session's stored server selection."
+      : "Uses stored session metadata when server activity is available.";
 
   useEffect(() => {
     if (!open || !summary) {
@@ -250,6 +277,7 @@ export function ConvertSessionDialogCore({
 
   useEffect(() => {
     if (!attachmentPickersEnabled) return;
+    if (!hostDefaultResolved) return;
     // Don't seed while the adapter is still resolving detail: project hosts
     // are often already cached, so seeding here would grab projectHosts[0]
     // and the non-empty attachment would then block the reseed once the
@@ -274,6 +302,7 @@ export function ConvertSessionDialogCore({
     defaultHostId,
     detail.loading,
     hostAttachments.length,
+    hostDefaultResolved,
     projectHosts,
   ]);
 
@@ -293,7 +322,7 @@ export function ConvertSessionDialogCore({
     }
 
     setNewSuiteName(
-      buildServerBasedSuiteName(sessionServerLabels, `${summary.title} suite`),
+      buildServerBasedSuiteName(sessionServerLabels, `${summary.title} suite`)
     );
     suiteDefaultsAppliedForSessionId.current = summary.sessionId;
   }, [open, summary, detail.loading, sessionServerLabels]);
@@ -361,17 +390,17 @@ export function ConvertSessionDialogCore({
         added.length > 0
       ) {
         toast.success(
-          `Chat session promoted to a test case. Added ${added.join(", ")} to the suite.`,
+          `Session promoted to a test case. Added ${added.join(
+            ", "
+          )} to the suite.`
         );
       } else {
-        toast.success("Chat session promoted to a test case");
+        toast.success("Session promoted to a test case");
       }
       onOpenChange(false);
       onImported({ suiteId: result.suiteId, testCaseId: result.testCaseId });
     } catch (error) {
-      toast.error(
-        getBillingErrorMessage(error, "Failed to promote chat session"),
-      );
+      toast.error(getBillingErrorMessage(error, "Failed to promote session"));
     } finally {
       setIsSubmitting(false);
     }
@@ -386,7 +415,7 @@ export function ConvertSessionDialogCore({
           <DialogHeader className="space-y-1.5 pr-10">
             <DialogTitle>Promote to test case</DialogTitle>
             <DialogDescription className="text-sm text-muted-foreground">
-              Create a suite-backed test case from this chat session. The full
+              Create a suite-backed test case from this session. The full
               session is compiled into multi-turn prompt turns.
             </DialogDescription>
           </DialogHeader>
@@ -405,7 +434,9 @@ export function ConvertSessionDialogCore({
 
           <div className="space-y-2">
             <div className="space-y-0.5">
-              <p className="text-sm font-medium text-foreground">Session servers</p>
+              <p className="text-sm font-medium text-foreground">
+                Session servers
+              </p>
               <p className="text-xs text-muted-foreground leading-relaxed">
                 {sessionServersDescription}
               </p>
@@ -413,7 +444,7 @@ export function ConvertSessionDialogCore({
             {detail.loading ? (
               <div className="flex min-h-10 items-center gap-2 text-sm text-muted-foreground">
                 <Loader2 className="h-4 w-4 shrink-0 animate-spin" />
-                Loading chat session details…
+                Loading session details…
               </div>
             ) : detail.error ? (
               <Alert variant="destructive">
@@ -426,8 +457,8 @@ export function ConvertSessionDialogCore({
                 <AlertTriangle className="h-4 w-4" />
                 <AlertTitle>Import unavailable</AlertTitle>
                 <AlertDescription>
-                  This chat session is not linked to a shared project yet, so
-                  it cannot be promoted to a suite-backed test case.
+                  This session is not linked to a shared project yet, so it
+                  cannot be promoted to a suite-backed test case.
                 </AlertDescription>
               </Alert>
             ) : (
@@ -441,7 +472,7 @@ export function ConvertSessionDialogCore({
                           "inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium",
                           server.unresolved
                             ? "border-dashed border-border/50 bg-transparent font-mono text-muted-foreground"
-                            : "border-border/50 bg-muted/50 text-foreground",
+                            : "border-border/50 bg-muted/50 text-foreground"
                         )}
                       >
                         {server.label}
@@ -456,8 +487,8 @@ export function ConvertSessionDialogCore({
                 {!projectServersLoading &&
                 sessionServerDisplay.unresolvedCount > 0 ? (
                   <p className="text-xs text-muted-foreground leading-relaxed">
-                    Some servers could not be resolved to current project
-                    names, so raw ids are shown.
+                    Some servers could not be resolved to current project names,
+                    so raw ids are shown.
                   </p>
                 ) : null}
               </div>
@@ -466,7 +497,9 @@ export function ConvertSessionDialogCore({
 
           <div className="space-y-3">
             <div className="space-y-0.5">
-              <p className="text-sm font-medium text-foreground">Destination suite</p>
+              <p className="text-sm font-medium text-foreground">
+                Destination suite
+              </p>
               <p className="text-xs text-muted-foreground leading-relaxed">
                 Create a new suite or add the case to an existing one.
               </p>
@@ -484,7 +517,7 @@ export function ConvertSessionDialogCore({
                   "h-8 flex-1 rounded-md text-sm font-medium shadow-none",
                   destinationMode === "new"
                     ? "bg-background text-foreground shadow-sm"
-                    : "text-muted-foreground hover:bg-transparent hover:text-foreground",
+                    : "text-muted-foreground hover:bg-transparent hover:text-foreground"
                 )}
                 onClick={() => setDestinationMode("new")}
               >
@@ -498,7 +531,7 @@ export function ConvertSessionDialogCore({
                   "h-8 flex-1 rounded-md text-sm font-medium shadow-none",
                   destinationMode === "existing"
                     ? "bg-background text-foreground shadow-sm"
-                    : "text-muted-foreground hover:bg-transparent hover:text-foreground",
+                    : "text-muted-foreground hover:bg-transparent hover:text-foreground"
                 )}
                 onClick={() => setDestinationMode("existing")}
               >
@@ -561,7 +594,9 @@ export function ConvertSessionDialogCore({
             ) : (
               <div className="space-y-3">
                 <div className="space-y-2">
-                  <Label htmlFor="chat-import-existing-suite">Existing suite</Label>
+                  <Label htmlFor="chat-import-existing-suite">
+                    Existing suite
+                  </Label>
                   <Select
                     value={selectedSuiteId}
                     onValueChange={setSelectedSuiteId}
@@ -571,7 +606,10 @@ export function ConvertSessionDialogCore({
                     </SelectTrigger>
                     <SelectContent>
                       {availableSuites.map((entry) => (
-                        <SelectItem key={entry.suite._id} value={entry.suite._id}>
+                        <SelectItem
+                          key={entry.suite._id}
+                          value={entry.suite._id}
+                        >
                           {entry.suite.name}
                         </SelectItem>
                       ))}
@@ -618,8 +656,14 @@ export function ConvertSessionDialogCore({
           >
             Cancel
           </Button>
-          <Button type="button" onClick={() => void handleSubmit()} disabled={!canSubmit}>
-            {isSubmitting ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+          <Button
+            type="button"
+            onClick={() => void handleSubmit()}
+            disabled={!canSubmit}
+          >
+            {isSubmitting ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : null}
             Promote to test case
           </Button>
         </DialogFooter>

--- a/mcpjam-inspector/client/src/components/chat-v2/history/convert-session-dialog-core.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/history/convert-session-dialog-core.tsx
@@ -250,6 +250,12 @@ export function ConvertSessionDialogCore({
 
   useEffect(() => {
     if (!attachmentPickersEnabled) return;
+    // Don't seed while the adapter is still resolving detail: project hosts
+    // are often already cached, so seeding here would grab projectHosts[0]
+    // and the non-empty attachment would then block the reseed once the
+    // authoritative `defaultHostId` arrives — silently attaching the wrong
+    // host. A user edit before load completes still wins (non-empty guard).
+    if (detail.loading) return;
     if (hostAttachments.length === 0 && projectHosts.length > 0) {
       const preferredHostId =
         defaultHostId &&
@@ -266,6 +272,7 @@ export function ConvertSessionDialogCore({
   }, [
     attachmentPickersEnabled,
     defaultHostId,
+    detail.loading,
     hostAttachments.length,
     projectHosts,
   ]);

--- a/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
@@ -32,10 +32,13 @@ import {
 } from "@/components/chatboxes/session-readiness";
 import { ShareUsageThreadDetail } from "@/components/connection/share-usage/ShareUsageThreadDetail";
 import {
+  buildEvalsPath,
   buildSwarmSessionPath,
+  navigateApp,
   parseSwarmSessionParams,
 } from "@/lib/app-navigation";
 import { getShareableAppOrigin } from "@/lib/chatbox-session";
+import { ConvertSwarmSessionDialog } from "@/components/swarms/convert-swarm-session-dialog";
 import { SegmentedControl } from "@/components/ui/json-editor/segmented-control";
 import { SwarmHostsPanel } from "@/components/swarms/SwarmHostsPanel";
 import {
@@ -559,6 +562,8 @@ function RunSessionsView({
   );
   const [filter, setFilter] = useState<SessionFilterState>(EMPTY_SESSION_FILTER);
   const [selected, setSelected] = useState<JourneySessionRow | null>(null);
+  const [sessionToPromote, setSessionToPromote] =
+    useState<JourneySessionRow | null>(null);
 
   const hostName = (id: string) =>
     hosts.find((h) => h.hostId === id)?.name ?? id.slice(0, 8);
@@ -648,18 +653,49 @@ function RunSessionsView({
       {/* Reuse the existing project-scoped session viewer — do NOT build a new
           one. `ShareUsageThreadDetail` takes the session row's `id`. */}
       {selected && (
-        <div className="mt-2 h-[420px] overflow-hidden rounded-lg border">
-          <ShareUsageThreadDetail
-            threadId={selected.id}
-            sessionLink={`${getShareableAppOrigin()}${buildSwarmSessionPath({
-              personaRefId,
-              runId,
-              hostId: selected.hostId,
-              threadId: selected.id,
-            })}`}
-          />
+        <div className="mt-2">
+          <div className="mb-1 flex justify-end">
+            <button
+              type="button"
+              className="text-[11px] font-medium text-primary hover:underline"
+              onClick={() => setSessionToPromote(selected)}
+            >
+              Promote to test case
+            </button>
+          </div>
+          <div className="h-[420px] overflow-hidden rounded-lg border">
+            <ShareUsageThreadDetail
+              threadId={selected.id}
+              sessionLink={`${getShareableAppOrigin()}${buildSwarmSessionPath({
+                personaRefId,
+                runId,
+                hostId: selected.hostId,
+                threadId: selected.id,
+              })}`}
+            />
+          </div>
         </div>
       )}
+
+      <ConvertSwarmSessionDialog
+        open={sessionToPromote !== null}
+        session={sessionToPromote}
+        onOpenChange={(open) => {
+          if (!open) {
+            setSessionToPromote(null);
+          }
+        }}
+        onImported={({ suiteId, testCaseId }) => {
+          setSessionToPromote(null);
+          navigateApp(
+            buildEvalsPath({
+              type: "test-edit",
+              suiteId,
+              testId: testCaseId,
+            }),
+          );
+        }}
+      />
     </div>
   );
 }

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.sessions.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.sessions.test.tsx
@@ -121,6 +121,25 @@ vi.mock("@/lib/toast", () => ({
   toast: { success: vi.fn(), error: vi.fn() },
 }));
 
+// Stub the promote dialog (it owns its own Convex action wiring — covered by
+// convert-swarm-session-dialog.test.tsx) but surface open/session so we can
+// assert the promote affordance hands it the SELECTED row.
+vi.mock("@/components/swarms/convert-swarm-session-dialog", () => ({
+  ConvertSwarmSessionDialog: ({
+    open,
+    session,
+  }: {
+    open: boolean;
+    session: { id: string } | null;
+  }) => (
+    <div
+      data-testid="promote-dialog"
+      data-open={String(open)}
+      data-session-id={session?.id ?? ""}
+    />
+  ),
+}));
+
 import { SwarmsTab } from "../SwarmsTab";
 
 beforeEach(() => {
@@ -163,5 +182,27 @@ describe("SwarmsTab — sessions-by-run query contract", () => {
     const viewer = await screen.findByTestId("viewer");
     expect(viewer.getAttribute("data-thread-id")).toBe("thread-xyz");
     expect(viewer.getAttribute("data-link")).toContain("thread-xyz");
+  });
+
+  it("opens the promote dialog with the selected session row", async () => {
+    render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+    fireEvent.click(screen.getByText("Persona One"));
+    fireEvent.click(await screen.findByText("View sessions"));
+
+    // The dialog is mounted closed until a session is selected + promoted.
+    const dialog = await screen.findByTestId("promote-dialog");
+    expect(dialog.getAttribute("data-open")).toBe("false");
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: /anthropic\/claude-haiku-4\.5/i,
+      })
+    );
+    fireEvent.click(await screen.findByText("Promote to test case"));
+
+    await waitFor(() => {
+      expect(dialog.getAttribute("data-open")).toBe("true");
+      expect(dialog.getAttribute("data-session-id")).toBe("thread-xyz");
+    });
   });
 });

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/convert-swarm-session-dialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/convert-swarm-session-dialog.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { SwarmSessionPromoteDetail } from "@/lib/swarm-api";
 
 /**
  * The swarm adapter's contract with the shared dialog core: it resolves the
@@ -20,9 +21,14 @@ vi.mock("convex/react", () => ({
 // Stub the shared core and surface the props the adapter wires in.
 vi.mock("@/components/chat-v2/history/convert-session-dialog-core", () => ({
   ConvertSessionDialogCore: (props: {
-    summary: { sessionId: string; title: string; projectId: string | null } | null;
+    summary: {
+      sessionId: string;
+      title: string;
+      projectId: string | null;
+    } | null;
     detail: { loading: boolean; error: string | null; usedServerIds: string[] };
     defaultHostId?: string | null;
+    hostDefaultResolved?: boolean;
   }) => (
     <div
       data-testid="core"
@@ -33,6 +39,7 @@ vi.mock("@/components/chat-v2/history/convert-session-dialog-core", () => ({
       data-error={props.detail.error ?? ""}
       data-used-servers={props.detail.usedServerIds.join(",")}
       data-default-host={props.defaultHostId ?? ""}
+      data-host-default-resolved={String(props.hostDefaultResolved ?? true)}
     />
   ),
 }));
@@ -72,17 +79,19 @@ describe("ConvertSwarmSessionDialog", () => {
         session={SESSION}
         onOpenChange={vi.fn()}
         onImported={vi.fn()}
-      />,
+      />
     );
 
     await waitFor(() =>
       expect(getDetailAction).toHaveBeenCalledWith({
         sessionId: "chat-session-id-9",
-      }),
+      })
     );
 
     const core = screen.getByTestId("core");
-    await waitFor(() => expect(core.getAttribute("data-loading")).toBe("false"));
+    await waitFor(() =>
+      expect(core.getAttribute("data-loading")).toBe("false")
+    );
     expect(core.getAttribute("data-session-id")).toBe("chat-session-id-9");
     expect(core.getAttribute("data-project-id")).toBe("proj-1");
     // Title seeded from the transcript preview when no custom title exists.
@@ -92,11 +101,13 @@ describe("ConvertSwarmSessionDialog", () => {
     expect(core.getAttribute("data-default-host")).toBe("host-authoritative");
   });
 
-  it("surfaces an action failure as the core's detail error", async () => {
-    getDetailAction.mockRejectedValue(
-      new Error(
-        "Swarm session's run attempt has not completed; only sessions from succeeded attempts can be promoted.",
-      ),
+  it("marks the host default unresolved on the initial render", async () => {
+    let resolveDetail!: (value: SwarmSessionPromoteDetail) => void;
+    getDetailAction.mockImplementationOnce(
+      () =>
+        new Promise<SwarmSessionPromoteDetail>((resolve) => {
+          resolveDetail = resolve;
+        })
     );
 
     render(
@@ -105,12 +116,51 @@ describe("ConvertSwarmSessionDialog", () => {
         session={SESSION}
         onOpenChange={vi.fn()}
         onImported={vi.fn()}
-      />,
+      />
+    );
+
+    const core = screen.getByTestId("core");
+    expect(core.getAttribute("data-host-default-resolved")).toBe("false");
+    expect(core.getAttribute("data-default-host")).toBe("");
+
+    resolveDetail({
+      sessionId: "chat-session-id-9",
+      chatSessionId: "synth_run-1_host-1_0",
+      sourceType: "swarm",
+      projectId: "proj-1",
+      title: null,
+      firstMessagePreview: "draw a dog for me please",
+      messageCount: 2,
+      usedServerIds: [],
+      selectedServers: [],
+      hostId: "host-authoritative",
+    });
+
+    await waitFor(() =>
+      expect(core.getAttribute("data-host-default-resolved")).toBe("true")
+    );
+    expect(core.getAttribute("data-default-host")).toBe("host-authoritative");
+  });
+
+  it("surfaces an action failure as the core's detail error", async () => {
+    getDetailAction.mockRejectedValue(
+      new Error(
+        "Swarm session's run attempt has not completed; only sessions from succeeded attempts can be promoted."
+      )
+    );
+
+    render(
+      <ConvertSwarmSessionDialog
+        open
+        session={SESSION}
+        onOpenChange={vi.fn()}
+        onImported={vi.fn()}
+      />
     );
 
     const core = screen.getByTestId("core");
     await waitFor(() =>
-      expect(core.getAttribute("data-error")).toMatch(/has not completed/),
+      expect(core.getAttribute("data-error")).toMatch(/has not completed/)
     );
     expect(core.getAttribute("data-loading")).toBe("false");
   });

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/convert-swarm-session-dialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/convert-swarm-session-dialog.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The swarm adapter's contract with the shared dialog core: it resolves the
+ * detail through `chatSessionPromote:getChatSessionPromoteDetail` with the
+ * row's `id` (the chatSessions _id), forwards the ACTION's hostId as
+ * `defaultHostId` (authoritative attribution — not the list row's copy), and
+ * surfaces action failures (auth, completion gate, transcript parse) as the
+ * core's detail error instead of crashing.
+ */
+
+const getDetailAction = vi.fn();
+
+vi.mock("convex/react", () => ({
+  useConvexAuth: () => ({ isAuthenticated: true }),
+  useAction: () => getDetailAction,
+}));
+
+// Stub the shared core and surface the props the adapter wires in.
+vi.mock("@/components/chat-v2/history/convert-session-dialog-core", () => ({
+  ConvertSessionDialogCore: (props: {
+    summary: { sessionId: string; title: string; projectId: string | null } | null;
+    detail: { loading: boolean; error: string | null; usedServerIds: string[] };
+    defaultHostId?: string | null;
+  }) => (
+    <div
+      data-testid="core"
+      data-session-id={props.summary?.sessionId ?? ""}
+      data-title={props.summary?.title ?? ""}
+      data-project-id={props.summary?.projectId ?? ""}
+      data-loading={String(props.detail.loading)}
+      data-error={props.detail.error ?? ""}
+      data-used-servers={props.detail.usedServerIds.join(",")}
+      data-default-host={props.defaultHostId ?? ""}
+    />
+  ),
+}));
+
+import { ConvertSwarmSessionDialog } from "../convert-swarm-session-dialog";
+
+const SESSION = {
+  id: "chat-session-id-9",
+  chatSessionId: "synth_run-1_host-1_0",
+  projectId: "proj-1",
+  hostId: "host-from-row",
+  startedAt: 1,
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("ConvertSwarmSessionDialog", () => {
+  it("fetches promote detail with the row's id and forwards the action's hostId", async () => {
+    getDetailAction.mockResolvedValue({
+      sessionId: "chat-session-id-9",
+      chatSessionId: "synth_run-1_host-1_0",
+      sourceType: "swarm",
+      projectId: "proj-1",
+      title: null,
+      firstMessagePreview: "draw a dog for me please",
+      messageCount: 2,
+      usedServerIds: ["srv-excalidraw"],
+      selectedServers: [],
+      hostId: "host-authoritative",
+    });
+
+    render(
+      <ConvertSwarmSessionDialog
+        open
+        session={SESSION}
+        onOpenChange={vi.fn()}
+        onImported={vi.fn()}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(getDetailAction).toHaveBeenCalledWith({
+        sessionId: "chat-session-id-9",
+      }),
+    );
+
+    const core = screen.getByTestId("core");
+    await waitFor(() => expect(core.getAttribute("data-loading")).toBe("false"));
+    expect(core.getAttribute("data-session-id")).toBe("chat-session-id-9");
+    expect(core.getAttribute("data-project-id")).toBe("proj-1");
+    // Title seeded from the transcript preview when no custom title exists.
+    expect(core.getAttribute("data-title")).toBe("draw a dog for me please");
+    expect(core.getAttribute("data-used-servers")).toBe("srv-excalidraw");
+    // The ACTION's hostId wins over the list row's copy.
+    expect(core.getAttribute("data-default-host")).toBe("host-authoritative");
+  });
+
+  it("surfaces an action failure as the core's detail error", async () => {
+    getDetailAction.mockRejectedValue(
+      new Error(
+        "Swarm session's run attempt has not completed; only sessions from succeeded attempts can be promoted.",
+      ),
+    );
+
+    render(
+      <ConvertSwarmSessionDialog
+        open
+        session={SESSION}
+        onOpenChange={vi.fn()}
+        onImported={vi.fn()}
+      />,
+    );
+
+    const core = screen.getByTestId("core");
+    await waitFor(() =>
+      expect(core.getAttribute("data-error")).toMatch(/has not completed/),
+    );
+    expect(core.getAttribute("data-loading")).toBe("false");
+  });
+});

--- a/mcpjam-inspector/client/src/components/swarms/convert-swarm-session-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/convert-swarm-session-dialog.tsx
@@ -57,11 +57,13 @@ export function ConvertSwarmSessionDialog({
 }: ConvertSwarmSessionDialogProps) {
   const { isAuthenticated } = useConvexAuth();
   const getPromoteDetail = useAction(
-    SWARM_ACTIONS.getChatSessionPromoteDetail as any,
+    SWARM_ACTIONS.getChatSessionPromoteDetail as any
   );
   const [detail, setDetail] = useState<PromoteSessionDetailState>(IDLE_DETAIL);
   const [promoteDetail, setPromoteDetail] =
     useState<SwarmSessionPromoteDetail | null>(null);
+  const resolvedPromoteDetail =
+    session && promoteDetail?.sessionId === session.id ? promoteDetail : null;
 
   useEffect(() => {
     if (!open || !session) {
@@ -118,11 +120,11 @@ export function ConvertSwarmSessionDialog({
       session
         ? {
             sessionId: session.id,
-            title: buildTitle(promoteDetail),
+            title: buildTitle(resolvedPromoteDetail),
             projectId: session.projectId,
           }
         : null,
-    [promoteDetail, session],
+    [resolvedPromoteDetail, session]
   );
 
   return (
@@ -131,7 +133,8 @@ export function ConvertSwarmSessionDialog({
       summary={summary}
       detail={detail}
       isAuthenticated={isAuthenticated}
-      defaultHostId={promoteDetail?.hostId ?? null}
+      defaultHostId={resolvedPromoteDetail?.hostId ?? null}
+      hostDefaultResolved={resolvedPromoteDetail !== null}
       onOpenChange={onOpenChange}
       onImported={onImported}
     />

--- a/mcpjam-inspector/client/src/components/swarms/convert-swarm-session-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/convert-swarm-session-dialog.tsx
@@ -1,0 +1,139 @@
+import { useAction, useConvexAuth } from "convex/react";
+import { useEffect, useMemo, useState } from "react";
+import {
+  SWARM_ACTIONS,
+  type JourneySessionRow,
+  type SwarmSessionPromoteDetail,
+} from "@/lib/swarm-api";
+import {
+  ConvertSessionDialogCore,
+  type PromoteSessionDetailState,
+  type PromoteSessionSummary,
+} from "@/components/chat-v2/history/convert-session-dialog-core";
+
+type ConvertSwarmSessionDialogProps = {
+  open: boolean;
+  session: JourneySessionRow | null;
+  onOpenChange: (open: boolean) => void;
+  onImported: (result: { suiteId: string; testCaseId: string }) => void;
+};
+
+const IDLE_DETAIL: PromoteSessionDetailState = {
+  loading: false,
+  error: null,
+  usedServerIds: [],
+  selectedServers: [],
+};
+
+function buildTitle(detail: SwarmSessionPromoteDetail | null): string {
+  if (!detail) {
+    return "Imported swarm session";
+  }
+  return (
+    detail.title ||
+    detail.firstMessagePreview.slice(0, 60) ||
+    "Imported swarm session"
+  );
+}
+
+/**
+ * Swarm adapter for {@link ConvertSessionDialogCore}: resolves the
+ * session-servers detail through the source-agnostic
+ * `chatSessionPromote:getChatSessionPromoteDetail` action (signed-in only —
+ * the swarm surface is already gated at project member). The action enforces
+ * the swarm completion gate server-side, so a mid-run session surfaces its
+ * rejection here as the dialog's detail error rather than failing at submit.
+ *
+ * `defaultHostId` pre-seeds the new-suite client attachment from the
+ * ACTION's hostId (the session row's authoritative attribution) — the list
+ * row's copy is a display convenience. Provenance itself is derived by the
+ * backend at import time; nothing here is sent back.
+ */
+export function ConvertSwarmSessionDialog({
+  open,
+  session,
+  onOpenChange,
+  onImported,
+}: ConvertSwarmSessionDialogProps) {
+  const { isAuthenticated } = useConvexAuth();
+  const getPromoteDetail = useAction(
+    SWARM_ACTIONS.getChatSessionPromoteDetail as any,
+  );
+  const [detail, setDetail] = useState<PromoteSessionDetailState>(IDLE_DETAIL);
+  const [promoteDetail, setPromoteDetail] =
+    useState<SwarmSessionPromoteDetail | null>(null);
+
+  useEffect(() => {
+    if (!open || !session) {
+      return;
+    }
+
+    setDetail({ ...IDLE_DETAIL, loading: true });
+    setPromoteDetail(null);
+
+    let cancelled = false;
+
+    void (async () => {
+      try {
+        const response = (await getPromoteDetail({
+          sessionId: session.id,
+        })) as SwarmSessionPromoteDetail;
+        if (cancelled) {
+          return;
+        }
+
+        setPromoteDetail(response);
+        setDetail({
+          loading: false,
+          error: null,
+          usedServerIds: response.usedServerIds ?? [],
+          selectedServers: response.selectedServers ?? [],
+        });
+      } catch (error) {
+        if (cancelled) {
+          return;
+        }
+        const message =
+          error instanceof Error
+            ? error.message
+            : "Failed to load swarm session";
+        setDetail({ ...IDLE_DETAIL, error: message });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [getPromoteDetail, open, session]);
+
+  useEffect(() => {
+    if (!open) {
+      setDetail(IDLE_DETAIL);
+      setPromoteDetail(null);
+    }
+  }, [open]);
+
+  const summary = useMemo<PromoteSessionSummary | null>(
+    () =>
+      session
+        ? {
+            sessionId: session.id,
+            title: buildTitle(promoteDetail),
+            projectId: session.projectId,
+          }
+        : null,
+    [promoteDetail, session],
+  );
+
+  return (
+    <ConvertSessionDialogCore
+      open={open}
+      summary={summary}
+      detail={detail}
+      isAuthenticated={isAuthenticated}
+      defaultHostId={promoteDetail?.hostId ?? null}
+      onOpenChange={onOpenChange}
+      onImported={onImported}
+    />
+  );
+}

--- a/mcpjam-inspector/client/src/lib/swarm-api.ts
+++ b/mcpjam-inspector/client/src/lib/swarm-api.ts
@@ -24,6 +24,12 @@ export const SWARM_QUERIES = {
   listSessionsByJourneyRun: "journeyRuns:listSessionsByJourneyRun",
 } as const;
 
+// ── Convex action names (string-keyed calls) ────────────────────────────────
+export const SWARM_ACTIONS = {
+  /** Source-agnostic promote-dialog detail read (`convex/chatSessionPromote.ts`). */
+  getChatSessionPromoteDetail: "chatSessionPromote:getChatSessionPromoteDetail",
+} as const;
+
 // ── DTOs ────────────────────────────────────────────────────────────────────
 
 /** Terminal + in-flight states a journey run can surface in the UI. */
@@ -82,6 +88,29 @@ export interface JourneySessionRow {
     verdict?: string;
     issueCount?: number;
   };
+}
+
+/**
+ * `chatSessionPromote:getChatSessionPromoteDetail` result — the promote
+ * dialog's session-servers detail for any promotable sourceType.
+ * `usedServerIds` is derived server-side from the stored transcript;
+ * `hostId` is the session row's authoritative host attribution (used to
+ * pre-seed the new-suite client attachment). The action THROWS on
+ * unauthorized access, non-promotable sourceTypes, incomplete swarm run
+ * attempts, and unreadable transcripts — adapters surface that as the
+ * dialog's detail error.
+ */
+export interface SwarmSessionPromoteDetail {
+  sessionId: string;
+  chatSessionId: string;
+  sourceType?: string;
+  projectId: string | null;
+  title: string | null;
+  firstMessagePreview: string;
+  messageCount: number;
+  usedServerIds: string[];
+  selectedServers: string[];
+  hostId: string | null;
 }
 
 /**


### PR DESCRIPTION
## Why

Swarm sessions are the same `chatSessions` entity as playground sessions, but the "Promote to test case" flow was only reachable from the Playground history rail and only worked for `sourceType: 'direct'`. With MCPJam/mcpjam-backend#705 making the backend pipeline source-agnostic, this PR adds the UI: promote a swarm session straight from the run's sessions view, sharing the existing dialog rather than forking it.

**Depends on MCPJam/mcpjam-backend#705 being deployed first** — the swarm adapter calls `chatSessionPromote:getChatSessionPromoteDetail` by string key.

## What

- **`ConvertSessionDialogCore`** (new, extracted from `convert-chat-session-dialog.tsx`): the presentational/submit core. Takes exactly two source-shaped inputs — a session summary (`sessionId`/`title`/`projectId`) and a server-derived detail state (`usedServerIds`/`selectedServers`/loading/error) — and owns the suite pickers plus the `importChatSessionToTestCase` submit. Accepts `defaultHostId` to pre-seed the new-suite client attachment; falls back to the first project host as before. Attachment selections remain client-supplied and backend-validated; test-case provenance is backend-derived and never sent from the client.
- **`ConvertChatSessionDialog`** is now a thin direct-history adapter with **identical props** — `ChatHistoryRail` and its tests are untouched. It keeps the `/api/web/chat-history/detail` fetch (including the guest/HOSTED_MODE `requestHeaders` path) and the `effectiveProjectId = session.projectId ?? projectId` fallback.
- **`ConvertSwarmSessionDialog`** (new): swarm adapter resolving detail through the source-agnostic action. The action's `hostId` (authoritative row attribution) drives the pre-seed — not the list row's copy — and server-side rejections (member gate, swarm completion gate, unreadable transcript) surface as the dialog's detail error instead of a submit-time failure.
- **`SwarmsTab` → `RunSessionsView`**: a "Promote to test case" affordance on the selected session, navigating to the created case via the same `buildEvalsPath` pattern as the history rail. No client-side status gating — the backend's completion gate is the enforcement, and its error renders in the dialog.
- `swarm-api.ts`: `SWARM_ACTIONS.getChatSessionPromoteDetail` + `SwarmSessionPromoteDetail` DTO (two-repo hand-mirrored contract).

## Tests

23 tests across the affected surfaces (all green, plus the full `chat-v2/history` + `swarms` dirs — 76 total):
- Core: adapter loading/error states render and block submit; server chips resolve from adapter-provided `usedServerIds`; new-suite submit payload carries `sessionId`/`projectId`/picker selections; `defaultHostId` pre-seed wins when it names a live host and falls back when it doesn't.
- Swarm adapter: detail action called with the row's `id`; action `hostId` forwarded as `defaultHostId`; title seeded from the transcript preview; action failure surfaces as detail error.
- `SwarmsTab.sessions`: promote button hands the dialog the **selected** row; dialog stays closed until then.
- Unchanged: `ChatHistoryRail.test.tsx` (10) and `SwarmsTab.launch.test.tsx` (3) pass without modification — the direct adapter kept its name and props.

`tsc -p client/tsconfig.typecheck.json` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches eval import UX and new-suite host/server defaults; wrong host seeding could misconfigure suites, but behavior is gated on async detail resolution and covered by tests. Depends on backend `chatSessionPromote:getChatSessionPromoteDetail` being deployed.
> 
> **Overview**
> Extracts **`ConvertSessionDialogCore`** from the playground “Promote to test case” flow so suite pickers and `importChatSessionToTestCase` live in one place. Adapters supply a session summary plus server-derived detail; the core also accepts **`defaultHostId`** / **`hostDefaultResolved`** so swarm runs can pre-seed the client attachment without racing cached project hosts.
> 
> **`ConvertChatSessionDialog`** is now a thin direct-history adapter (same props for `ChatHistoryRail`); it still loads detail via `/api/web/chat-history/detail` and delegates to the core.
> 
> Adds **`ConvertSwarmSessionDialog`**, which loads promote detail through **`chatSessionPromote:getChatSessionPromoteDetail`** (wired in `swarm-api.ts` as `SWARM_ACTIONS` + `SwarmSessionPromoteDetail`) and forwards the action’s authoritative **`hostId`**. Backend gates (completion, auth, transcript) show as dialog errors instead of failing on submit.
> 
> **`SwarmsTab` / `RunSessionsView`** gets a **Promote to test case** control on the selected session, opens the swarm dialog, and navigates to the new test case with `buildEvalsPath` after import.
> 
> New unit tests cover the core contract, swarm adapter wiring, and the promote affordance in session list tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63ac5e45ee052c9995ae2eb2a5b6e94225c55495. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promote swarm run sessions to eval test cases directly from Run Sessions using the same “Promote to test case” dialog. Requires MCPJam/mcpjam-backend#705 (`chatSessionPromote:getChatSessionPromoteDetail`) to be deployed first.

- **New Features**
  - Added “Promote to test case” in Run Sessions via `ConvertSwarmSessionDialog`, reading detail from `chatSessionPromote:getChatSessionPromoteDetail` and navigating to the new test.
  - Extracted `ConvertSessionDialogCore` shared between swarm and history; `ConvertChatSessionDialog` keeps identical props; added `SWARM_ACTIONS.getChatSessionPromoteDetail` and `SwarmSessionPromoteDetail`.
  - Pre-seeds client attachment from the action’s `hostId`; backend gates (membership, completion, transcript) render as dialog errors.

- **Bug Fixes**
  - Seed the client attachment only after the authoritative promotion host is known (gated on `detail.loading` and `hostDefaultResolved`) to avoid attaching the wrong host.

<sup>Written for commit 63ac5e45ee052c9995ae2eb2a5b6e94225c55495. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

