### PR TITLE
fix(hosts): surface an always-visible Add client button on the Connect pager

### DIFF
--- a/mcpjam-inspector/client/src/components/hosts/HostOverlayBar.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/HostOverlayBar.tsx
@@ -386,13 +386,34 @@ export function HostOverlayBar({
             disabled={arrowDisabled}
             onClick={() => cycle(1)}
             className={cn(
-              "inline-flex h-8 w-7 items-center justify-center rounded-r-md text-muted-foreground transition-colors",
+              "inline-flex h-8 w-7 items-center justify-center text-muted-foreground transition-colors",
               "hover:bg-muted/60 hover:text-foreground",
               "focus-visible:ring-2 focus-visible:ring-ring/45 focus-visible:outline-none",
               "disabled:cursor-not-allowed disabled:opacity-40"
             )}
           >
             <ChevronRight className="size-4" />
+          </button>
+
+          <button
+            type="button"
+            aria-label="Add client"
+            title="Add client"
+            data-testid="host-overlay-add"
+            onClick={() => {
+              track("connect_host_overlay_add_clicked", {
+                location: "chatbox_overlay",
+                host_count: hosts.length,
+              });
+              openCreateWithTemplate(undefined);
+            }}
+            className={cn(
+              "inline-flex h-8 w-7 items-center justify-center rounded-r-md border-l border-border/40 text-primary transition-colors",
+              "hover:bg-primary/10",
+              "focus-visible:ring-2 focus-visible:ring-ring/45 focus-visible:outline-none"
+            )}
+          >
+            <Plus className="size-4" />
           </button>
         </div>
       )}

--- a/mcpjam-inspector/client/src/components/hosts/__tests__/HostOverlayBar.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/__tests__/HostOverlayBar.test.tsx
@@ -2,9 +2,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import userEvent from "@testing-library/user-event";
 import { render, screen, waitFor } from "@testing-library/react";
 import { HostOverlayBar } from "@/components/hosts/HostOverlayBar";
+import { track } from "@/lib/analytics";
 
 vi.mock("@/components/hosts/CreateHostDialog", () => ({
-  CreateHostDialog: () => null,
+  CreateHostDialog: ({ isOpen }: { isOpen: boolean }) =>
+    isOpen ? <div data-testid="create-host-dialog" /> : null,
 }));
 
 const mockUseHostList = vi.fn();
@@ -106,6 +108,43 @@ describe("HostOverlayBar", () => {
       "MCPJam"
     );
     expect(screen.getByTestId("host-overlay-next")).toBeInTheDocument();
+  });
+
+  it("shows an always-visible add button without opening the dropdown", () => {
+    render(
+      <HostOverlayBar
+        projectId="proj-1"
+        previewedHostId="host-a"
+        onChangePreviewedHostId={vi.fn()}
+        onEditHost={vi.fn()}
+      />
+    );
+
+    const addBtn = screen.getByTestId("host-overlay-add");
+    expect(addBtn).toBeVisible();
+    expect(addBtn).not.toBeDisabled();
+    expect(addBtn).toHaveAccessibleName("Add client");
+  });
+
+  it("opens the create dialog and tracks when the add button is clicked", async () => {
+    const user = userEvent.setup();
+    render(
+      <HostOverlayBar
+        projectId="proj-1"
+        previewedHostId="host-a"
+        onChangePreviewedHostId={vi.fn()}
+        onEditHost={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByTestId("create-host-dialog")).not.toBeInTheDocument();
+    await user.click(screen.getByTestId("host-overlay-add"));
+
+    expect(screen.getByTestId("create-host-dialog")).toBeInTheDocument();
+    expect(track).toHaveBeenCalledWith("connect_host_overlay_add_clicked", {
+      location: "chatbox_overlay",
+      host_count: 1,
+    });
   });
 
   it("renders per-row edit/delete actions and a save-as-new entry inside the dropdown", async () => {

--- a/mcpjam-inspector/shared/analytics-events.ts
+++ b/mcpjam-inspector/shared/analytics-events.ts
@@ -92,6 +92,7 @@ export const ANALYTICS_EVENTS = {
   compat_cta_clicked: { source: "client" },
   computer_start_limit_hit: { source: "client" },
   computer_terminal_opened: { source: "client" },
+  connect_host_overlay_add_clicked: { source: "client" },
   connect_host_overlay_opened: { source: "client" },
   connect_host_overlay_quick_added: { source: "client" },
   connect_host_overlay_saved_as_new: { source: "client" },


### PR DESCRIPTION
## UX Fix: Improve discoverability for the "Add host" option

### Problem
On the Connect page, the only way to add a new host/client was a menu item buried inside the dropdown that opens when you click the host name in the pager. New and infrequent users could not tell how to add a host without that "discovery click" — flagged by Gabriel Olarte in Slack ("not clear to devs how to Add a host on this page").

### Change
Added a persistent **`+` segment** at the right end of the host pager so it now reads `[<] [name] [>] [+]`. One click opens the Create Host dialog directly — no dropdown required.

- The plus uses the brand `primary` color (with a subtle `primary/10` hover tint) so it stands out against the muted chevrons without shouting.
- The existing dropdown "Add client" entry and quick-add template shortcuts are untouched — no regression for users who already learned that path.
- Clicks fire a new `connect_host_overlay_add_clicked` analytics event (registered in `shared/analytics-events.ts`).

### Note on terminology
Every visible label in this bar already says "client" ("Previous client", "Add client"), so the new button is labeled **"Add client"** for consistency, even though the task title says "Add host". Trivial to flip if product wording should be "host".

### Testing
- 2 new tests in `HostOverlayBar.test.tsx` (button visible without opening the dropdown; click opens the dialog and fires the event) — all 10 tests pass.
- `typecheck:client` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a persistent “Add client” (+) button to the Connect pager to make adding a host obvious and one click. Opens the Create Host dialog directly and improves discoverability.

- **Bug Fixes**
  - Always-visible “+” at the end of the pager `[<] [name] [>] [+]`, labeled “Add client” for consistency.
  - Keeps the dropdown path intact and tracks clicks via `connect_host_overlay_add_clicked`.

<sup>Written for commit 50ecce591e18bbffd9ae8499aab70f83be984250. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

