### PR TITLE
feat(xaa): headless XAA (ID-JAG) debugger in the CLI — mcpjam xaa run

### DIFF
--- a/.changeset/xaa-cli-command.md
+++ b/.changeset/xaa-cli-command.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/cli": minor
+---
+
+Add `mcpjam xaa run`, a headless Cross-App Access (ID-JAG) debugger that mirrors `mcpjam oauth login`. It discovers the target authorization server, self-issues an ID-JAG, redeems it at the AS (RFC 7523 jwt-bearer), and calls the MCP server with the resulting access token — streaming progress to stderr and printing a structured per-step report. Exits non-zero when the flow does not complete (e.g. the AS could not validate a self-issued ID-JAG whose issuer it cannot reach).

--- a/.changeset/xaa-mint-to-sdk.md
+++ b/.changeset/xaa-mint-to-sdk.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/sdk": minor
+---
+
+Extract the XAA (Cross-App Access / ID-JAG) mock-IdP mint into `@mcpjam/sdk` (node entry only). New exports: the ID-JAG/id-token/access-token/code signer (`issueIdJag`, `issueNegativeIdJag`, `issueMockIdToken`, `issueAuthorizationCode`, `issueAccessToken`, `verifyXaaJwt`), the RS256 keypair/JWKS manager (`initXAAIdpKeyPair`, `getXAAIdpJwks`, `getXAAIssuerUrl`, `setXaaIdpLogger`, …), `buildJwtBearerBody`, and the negative-test constants. Pure `crypto`/`fs`; the inspector server now consumes the mint from the SDK. Enables a headless XAA flow for the CLI.

--- a/.changeset/xaa-run-flow-driver.md
+++ b/.changeset/xaa-run-flow-driver.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/sdk": minor
+---
+
+Add `runXaaFlow`, a headless Cross-App Access (ID-JAG) flow driver: discovers the target authorization server (RFC 9728/8414), self-issues an ID-JAG with the in-process mock IdP mint, verifies it locally, redeems it at the AS (RFC 7523 jwt-bearer), and calls the MCP server with the resulting access token — reporting each step. Powers the forthcoming `mcpjam xaa` CLI command.

--- a/cli/src/commands/xaa.ts
+++ b/cli/src/commands/xaa.ts
@@ -1,0 +1,135 @@
+import { runXaaFlow, type XaaFlowConfig, type XaaFlowResult } from "@mcpjam/sdk";
+import { Command } from "commander";
+import { getGlobalOptions } from "../lib/server-config.js";
+import { cliError, setProcessExitCode, usageError, writeResult } from "../lib/output.js";
+
+export interface XaaCommandOptions {
+  url: string;
+  issuerBaseUrl: string;
+  sub: string;
+  clientId: string;
+  authzServerIssuer?: string;
+  tokenEndpoint?: string;
+  email?: string;
+  clientSecret?: string;
+  scopes?: string;
+  httpsOnly?: boolean;
+}
+
+export function registerXaaCommands(program: Command): void {
+  const xaa = program
+    .command("xaa")
+    .description(
+      "Run the Cross-App Access (ID-JAG) debugger against an MCP server",
+    );
+
+  xaa
+    .command("run")
+    .description(
+      "Self-issue an ID-JAG, redeem it at the target authorization server (RFC 7523), and call the MCP server with the resulting access token",
+    )
+    .requiredOption("--url <url>", "Target MCP server URL (the protected resource)")
+    .requiredOption(
+      "--issuer-base-url <url>",
+      "Origin the local mock IdP issues from (the AS must be able to fetch its JWKS from here to validate the ID-JAG)",
+    )
+    .requiredOption("--sub <subject>", "Simulated end-user subject identifier")
+    .requiredOption(
+      "--client-id <id>",
+      "OAuth client the ID-JAG is issued for; also presented at redemption",
+    )
+    .option(
+      "--authz-server-issuer <issuer>",
+      "Target authorization-server issuer. When set, protected-resource metadata discovery is skipped",
+    )
+    .option(
+      "--token-endpoint <url>",
+      "Authorization-server token endpoint. When set, AS-metadata discovery is skipped",
+    )
+    .option("--email <email>", "Simulated end-user email claim")
+    .option("--client-secret <secret>", "OAuth client secret presented at redemption")
+    .option("--scopes <scopes>", "Space-separated scope string")
+    .option(
+      "--https-only",
+      "Reject non-HTTPS / private targets (default: allow http/localhost for local dev)",
+    )
+    .action(async (options, command) => {
+      const globalOptions = getGlobalOptions(command);
+      const format = globalOptions.format;
+      const config = buildXaaConfig(options as XaaCommandOptions);
+
+      const isTTY = process.stderr.isTTY && !globalOptions.quiet;
+      if (isTTY) {
+        config.onProgress = (message: string) => {
+          process.stderr.write(`\r\x1b[K${message}`);
+        };
+      }
+
+      let result: XaaFlowResult | undefined;
+      try {
+        result = await runXaaFlow(config);
+      } finally {
+        if (isTTY) {
+          process.stderr.write("\r\x1b[K");
+        }
+      }
+
+      if (!result) {
+        throw cliError("INTERNAL_ERROR", "XAA flow did not return a result.");
+      }
+
+      writeResult(result, format);
+      if (!result.completed) {
+        setProcessExitCode(1);
+      }
+    });
+}
+
+export function buildXaaConfig(options: XaaCommandOptions): XaaFlowConfig {
+  const serverUrl = options.url.trim();
+  assertValidUrl(serverUrl, "server URL");
+
+  const issuerBaseUrl = options.issuerBaseUrl.trim();
+  assertValidUrl(issuerBaseUrl, "issuer base URL");
+
+  const subject = options.sub.trim();
+  if (!subject) {
+    throw usageError("--sub must not be empty.");
+  }
+
+  const clientId = options.clientId.trim();
+  if (!clientId) {
+    throw usageError("--client-id must not be empty.");
+  }
+
+  const authzServerIssuer = options.authzServerIssuer?.trim() || undefined;
+  if (authzServerIssuer) {
+    assertValidUrl(authzServerIssuer, "authorization server issuer");
+  }
+
+  const tokenEndpoint = options.tokenEndpoint?.trim() || undefined;
+  if (tokenEndpoint) {
+    assertValidUrl(tokenEndpoint, "token endpoint");
+  }
+
+  return {
+    serverUrl,
+    issuerBaseUrl,
+    subject,
+    clientId,
+    ...(authzServerIssuer ? { authzServerIssuer } : {}),
+    ...(tokenEndpoint ? { tokenEndpoint } : {}),
+    ...(options.email?.trim() ? { email: options.email.trim() } : {}),
+    ...(options.clientSecret ? { clientSecret: options.clientSecret } : {}),
+    ...(options.scopes?.trim() ? { scope: options.scopes.trim() } : {}),
+    httpsOnly: options.httpsOnly ?? false,
+  };
+}
+
+function assertValidUrl(value: string, label: string): void {
+  try {
+    new URL(value);
+  } catch {
+    throw usageError(`Invalid ${label}: ${value}`);
+  }
+}

--- a/cli/src/commands/xaa.ts
+++ b/cli/src/commands/xaa.ts
@@ -78,11 +78,44 @@ export function registerXaaCommands(program: Command): void {
         throw cliError("INTERNAL_ERROR", "XAA flow did not return a result.");
       }
 
-      writeResult(result, format);
+      writeResult(redactXaaResult(result), format);
       if (!result.completed) {
         setProcessExitCode(1);
       }
     });
+}
+
+const REDACTED = "[REDACTED]";
+const SECRET_BODY_KEYS = new Set(["access_token", "refresh_token", "id_token"]);
+
+// Never emit raw bearer credentials. The decoded `idJag.claims`, the verify
+// verdict, and the per-step report carry the debug value; the raw ID-JAG and the
+// token-endpoint's issued tokens are redacted from the printed result.
+export function redactXaaResult(result: XaaFlowResult): XaaFlowResult {
+  const redacted: XaaFlowResult = { ...result };
+  if (result.idJag) {
+    redacted.idJag = { ...result.idJag, token: REDACTED };
+  }
+  if (result.redemption) {
+    redacted.redemption = {
+      ...result.redemption,
+      body: redactSecretBodyFields(result.redemption.body),
+    };
+  }
+  return redacted;
+}
+
+function redactSecretBodyFields(body: unknown): unknown {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return body;
+  }
+  const out: Record<string, unknown> = { ...(body as Record<string, unknown>) };
+  for (const key of Object.keys(out)) {
+    if (SECRET_BODY_KEYS.has(key) && typeof out[key] === "string") {
+      out[key] = REDACTED;
+    }
+  }
+  return out;
 }
 
 export function buildXaaConfig(options: XaaCommandOptions): XaaFlowConfig {

--- a/cli/src/commands/xaa.ts
+++ b/cli/src/commands/xaa.ts
@@ -4,6 +4,15 @@ import { getGlobalOptions } from "../lib/server-config.js";
 import { cliError, setProcessExitCode, usageError, writeResult } from "../lib/output.js";
 import { redactSensitiveValue } from "../lib/redaction.js";
 
+type XaaTokenEndpointAuthMethod =
+  | "client_secret_post"
+  | "client_secret_basic"
+  | "none";
+type XaaCliFlowConfig = XaaFlowConfig & {
+  tokenEndpointAuthMethod?: XaaTokenEndpointAuthMethod;
+  timeoutMs?: number;
+};
+
 export interface XaaCommandOptions {
   url: string;
   issuerBaseUrl: string;
@@ -13,6 +22,7 @@ export interface XaaCommandOptions {
   tokenEndpoint?: string;
   email?: string;
   clientSecret?: string;
+  tokenEndpointAuthMethod?: XaaTokenEndpointAuthMethod;
   scopes?: string;
   httpsOnly?: boolean;
 }
@@ -49,6 +59,11 @@ export function registerXaaCommands(program: Command): void {
     )
     .option("--email <email>", "Simulated end-user email claim")
     .option("--client-secret <secret>", "OAuth client secret presented at redemption")
+    .option(
+      "--token-endpoint-auth-method <method>",
+      "Token endpoint client authentication: client_secret_basic, client_secret_post, or none (default: infer from metadata)",
+      parseTokenEndpointAuthMethod,
+    )
     .option("--scopes <scopes>", "Space-separated scope string")
     .option(
       "--https-only",
@@ -57,7 +72,10 @@ export function registerXaaCommands(program: Command): void {
     .action(async (options, command) => {
       const globalOptions = getGlobalOptions(command);
       const format = globalOptions.format;
-      const config = buildXaaConfig(options as XaaCommandOptions);
+      const config = buildXaaConfig(
+        options as XaaCommandOptions,
+        globalOptions.timeout,
+      );
 
       const isTTY = process.stderr.isTTY && !globalOptions.quiet;
       if (isTTY) {
@@ -127,7 +145,10 @@ function replaceRawValue(value: unknown, secret: string): unknown {
   return value;
 }
 
-export function buildXaaConfig(options: XaaCommandOptions): XaaFlowConfig {
+export function buildXaaConfig(
+  options: XaaCommandOptions,
+  timeoutMs?: number,
+): XaaCliFlowConfig {
   const serverUrl = options.url.trim();
   assertValidUrl(serverUrl, "server URL");
 
@@ -154,6 +175,19 @@ export function buildXaaConfig(options: XaaCommandOptions): XaaFlowConfig {
     assertValidUrl(tokenEndpoint, "token endpoint");
   }
 
+  if (timeoutMs !== undefined && (!Number.isFinite(timeoutMs) || timeoutMs <= 0)) {
+    throw usageError("--timeout must be a positive number.");
+  }
+  if (
+    options.tokenEndpointAuthMethod !== "none" &&
+    options.tokenEndpointAuthMethod !== undefined &&
+    !options.clientSecret
+  ) {
+    throw usageError(
+      `--token-endpoint-auth-method ${options.tokenEndpointAuthMethod} requires --client-secret.`,
+    );
+  }
+
   return {
     serverUrl,
     issuerBaseUrl,
@@ -163,9 +197,28 @@ export function buildXaaConfig(options: XaaCommandOptions): XaaFlowConfig {
     ...(tokenEndpoint ? { tokenEndpoint } : {}),
     ...(options.email?.trim() ? { email: options.email.trim() } : {}),
     ...(options.clientSecret ? { clientSecret: options.clientSecret } : {}),
+    ...(options.tokenEndpointAuthMethod
+      ? { tokenEndpointAuthMethod: options.tokenEndpointAuthMethod }
+      : {}),
     ...(options.scopes?.trim() ? { scope: options.scopes.trim() } : {}),
+    ...(timeoutMs !== undefined ? { timeoutMs } : {}),
     httpsOnly: options.httpsOnly ?? false,
   };
+}
+
+function parseTokenEndpointAuthMethod(
+  value: string,
+): XaaTokenEndpointAuthMethod {
+  if (
+    value === "client_secret_basic" ||
+    value === "client_secret_post" ||
+    value === "none"
+  ) {
+    return value;
+  }
+  throw usageError(
+    "--token-endpoint-auth-method must be client_secret_basic, client_secret_post, or none.",
+  );
 }
 
 function assertValidUrl(value: string, label: string): void {

--- a/cli/src/commands/xaa.ts
+++ b/cli/src/commands/xaa.ts
@@ -2,6 +2,7 @@ import { runXaaFlow, type XaaFlowConfig, type XaaFlowResult } from "@mcpjam/sdk"
 import { Command } from "commander";
 import { getGlobalOptions } from "../lib/server-config.js";
 import { cliError, setProcessExitCode, usageError, writeResult } from "../lib/output.js";
+import { redactSensitiveValue } from "../lib/redaction.js";
 
 export interface XaaCommandOptions {
   url: string;
@@ -85,37 +86,17 @@ export function registerXaaCommands(program: Command): void {
     });
 }
 
-const REDACTED = "[REDACTED]";
-const SECRET_BODY_KEYS = new Set(["access_token", "refresh_token", "id_token"]);
-
-// Never emit raw bearer credentials. The decoded `idJag.claims`, the verify
-// verdict, and the per-step report carry the debug value; the raw ID-JAG and the
-// token-endpoint's issued tokens are redacted from the printed result.
+// Never emit raw bearer credentials. First mask the ID-JAG itself — the SDK's
+// recursive redactor keys on token-ish field names and won't catch a bare
+// `token` field — then run redactSensitiveValue over the whole result to scrub
+// reflected or nested secrets (the AS's access_token/refresh_token/id_token,
+// Bearer strings, etc.) anywhere in the output. The decoded `idJag.claims`, the
+// verify verdict, and the per-step report keep the debug value.
 export function redactXaaResult(result: XaaFlowResult): XaaFlowResult {
-  const redacted: XaaFlowResult = { ...result };
-  if (result.idJag) {
-    redacted.idJag = { ...result.idJag, token: REDACTED };
-  }
-  if (result.redemption) {
-    redacted.redemption = {
-      ...result.redemption,
-      body: redactSecretBodyFields(result.redemption.body),
-    };
-  }
-  return redacted;
-}
-
-function redactSecretBodyFields(body: unknown): unknown {
-  if (!body || typeof body !== "object" || Array.isArray(body)) {
-    return body;
-  }
-  const out: Record<string, unknown> = { ...(body as Record<string, unknown>) };
-  for (const key of Object.keys(out)) {
-    if (SECRET_BODY_KEYS.has(key) && typeof out[key] === "string") {
-      out[key] = REDACTED;
-    }
-  }
-  return out;
+  const masked: XaaFlowResult = result.idJag
+    ? { ...result, idJag: { ...result.idJag, token: "[REDACTED]" } }
+    : result;
+  return redactSensitiveValue(masked) as XaaFlowResult;
 }
 
 export function buildXaaConfig(options: XaaCommandOptions): XaaFlowConfig {

--- a/cli/src/commands/xaa.ts
+++ b/cli/src/commands/xaa.ts
@@ -93,10 +93,38 @@ export function registerXaaCommands(program: Command): void {
 // Bearer strings, etc.) anywhere in the output. The decoded `idJag.claims`, the
 // verify verdict, and the per-step report keep the debug value.
 export function redactXaaResult(result: XaaFlowResult): XaaFlowResult {
+  const rawIdJag = result.idJag?.token;
   const masked: XaaFlowResult = result.idJag
     ? { ...result, idJag: { ...result.idJag, token: "[REDACTED]" } }
     : result;
-  return redactSensitiveValue(masked) as XaaFlowResult;
+  const scrubbed = redactSensitiveValue(masked) as XaaFlowResult;
+  // A token endpoint may reflect the submitted `assertion` (the raw ID-JAG) in
+  // an error body under a non-secret field name (e.g. `assertion`,
+  // `error_description`), which the key-based redactor and the Bearer-string
+  // pattern won't catch. Scrub any remaining occurrence of the raw ID-JAG.
+  return rawIdJag
+    ? (replaceRawValue(scrubbed, rawIdJag) as XaaFlowResult)
+    : scrubbed;
+}
+
+function replaceRawValue(value: unknown, secret: string): unknown {
+  if (typeof value === "string") {
+    return value.includes(secret)
+      ? value.split(secret).join("[REDACTED]")
+      : value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => replaceRawValue(entry, secret));
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entryValue]) => [
+        key,
+        replaceRawValue(entryValue, secret),
+      ]),
+    );
+  }
+  return value;
 }
 
 export function buildXaaConfig(options: XaaCommandOptions): XaaFlowConfig {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -12,6 +12,7 @@ import { registerMcpCommands } from "./commands/mcp.js";
 import { registerProjectsCommands } from "./commands/projects.js";
 import { registerProtocolCommands } from "./commands/conformance.js";
 import { registerOAuthCommands } from "./commands/oauth.js";
+import { registerXaaCommands } from "./commands/xaa.js";
 import { registerPromptCommands } from "./commands/prompts.js";
 import { registerResourcesCommands } from "./commands/resources.js";
 import { registerServerCommands } from "./commands/server.js";
@@ -77,6 +78,7 @@ export async function main(
   registerPromptCommands(program);
   registerAppsCommands(program);
   registerOAuthCommands(program);
+  registerXaaCommands(program);
   registerProtocolCommands(program);
   registerAuthCommands(program);
   registerProjectsCommands(program);

--- a/cli/tests/xaa.test.ts
+++ b/cli/tests/xaa.test.ts
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildXaaConfig } from "../src/commands/xaa.js";
+import { CliError } from "../src/lib/output.js";
+
+const base = {
+  url: "https://mcp.example.com/mcp",
+  issuerBaseUrl: "https://issuer.example.com/api/mcp",
+  sub: "user-1",
+  clientId: "client-1",
+};
+
+test("buildXaaConfig maps the required fields", () => {
+  const config = buildXaaConfig({ ...base });
+
+  assert.equal(config.serverUrl, "https://mcp.example.com/mcp");
+  assert.equal(config.issuerBaseUrl, "https://issuer.example.com/api/mcp");
+  assert.equal(config.subject, "user-1");
+  assert.equal(config.clientId, "client-1");
+  assert.equal(config.httpsOnly, false);
+});
+
+test("buildXaaConfig maps the optional fields when supplied", () => {
+  const config = buildXaaConfig({
+    ...base,
+    authzServerIssuer: "https://auth.example.com",
+    tokenEndpoint: "https://auth.example.com/oauth/token",
+    email: "u@example.com",
+    clientSecret: "secret-1",
+    scopes: "read:tools write:tools",
+    httpsOnly: true,
+  });
+
+  assert.equal(config.authzServerIssuer, "https://auth.example.com");
+  assert.equal(config.tokenEndpoint, "https://auth.example.com/oauth/token");
+  assert.equal(config.email, "u@example.com");
+  assert.equal(config.clientSecret, "secret-1");
+  assert.equal(config.scope, "read:tools write:tools");
+  assert.equal(config.httpsOnly, true);
+});
+
+test("buildXaaConfig omits optional fields left unset", () => {
+  const config = buildXaaConfig({ ...base });
+
+  assert.equal(config.authzServerIssuer, undefined);
+  assert.equal(config.tokenEndpoint, undefined);
+  assert.equal(config.email, undefined);
+  assert.equal(config.clientSecret, undefined);
+  assert.equal(config.scope, undefined);
+});
+
+test("buildXaaConfig trims whitespace and treats blank optionals as unset", () => {
+  const config = buildXaaConfig({
+    ...base,
+    url: "  https://mcp.example.com/mcp  ",
+    sub: "  user-1  ",
+    email: "   ",
+    scopes: "   ",
+  });
+
+  assert.equal(config.serverUrl, "https://mcp.example.com/mcp");
+  assert.equal(config.subject, "user-1");
+  assert.equal(config.email, undefined);
+  assert.equal(config.scope, undefined);
+});
+
+test("buildXaaConfig rejects an invalid server URL", () => {
+  assert.throws(
+    () => buildXaaConfig({ ...base, url: "not-a-url" }),
+    (error: unknown) =>
+      error instanceof CliError && /Invalid server URL/.test(error.message),
+  );
+});
+
+test("buildXaaConfig rejects an invalid issuer base URL", () => {
+  assert.throws(
+    () => buildXaaConfig({ ...base, issuerBaseUrl: "nope" }),
+    (error: unknown) =>
+      error instanceof CliError && /Invalid issuer base URL/.test(error.message),
+  );
+});
+
+test("buildXaaConfig rejects an invalid authorization server issuer", () => {
+  assert.throws(
+    () => buildXaaConfig({ ...base, authzServerIssuer: "bad" }),
+    (error: unknown) =>
+      error instanceof CliError &&
+      /Invalid authorization server issuer/.test(error.message),
+  );
+});
+
+test("buildXaaConfig rejects an invalid token endpoint", () => {
+  assert.throws(
+    () => buildXaaConfig({ ...base, tokenEndpoint: "bad" }),
+    (error: unknown) =>
+      error instanceof CliError && /Invalid token endpoint/.test(error.message),
+  );
+});
+
+test("buildXaaConfig rejects a blank subject", () => {
+  assert.throws(
+    () => buildXaaConfig({ ...base, sub: "   " }),
+    (error: unknown) =>
+      error instanceof CliError && /--sub must not be empty/.test(error.message),
+  );
+});
+
+test("buildXaaConfig rejects a blank client id", () => {
+  assert.throws(
+    () => buildXaaConfig({ ...base, clientId: "   " }),
+    (error: unknown) =>
+      error instanceof CliError &&
+      /--client-id must not be empty/.test(error.message),
+  );
+});

--- a/cli/tests/xaa.test.ts
+++ b/cli/tests/xaa.test.ts
@@ -121,8 +121,11 @@ test("redactXaaResult masks the ID-JAG token and issued bearer tokens", () => {
       body: {
         access_token: "at-super-secret",
         refresh_token: "rt-super-secret",
+        id_token: "idt-super-secret",
         token_type: "Bearer",
         expires_in: 300,
+        // A nested/reflected secret the recursive redactor must also catch.
+        extra: { access_token: "nested-secret" },
       },
     },
     mcp: { status: 200, ok: true },
@@ -140,10 +143,19 @@ test("redactXaaResult masks the ID-JAG token and issued bearer tokens", () => {
   const body = redacted.redemption?.body as Record<string, unknown>;
   assert.equal(body.access_token, "[REDACTED]");
   assert.equal(body.refresh_token, "[REDACTED]");
+  assert.equal(body.id_token, "[REDACTED]");
+  assert.equal(
+    (body.extra as Record<string, unknown>).access_token,
+    "[REDACTED]",
+  );
   assert.equal(body.token_type, "Bearer");
   assert.equal(body.expires_in, 300);
   // The original result is not mutated.
   assert.equal(result.idJag?.token, "eyJraWQ.secret.signature");
+  assert.equal(
+    (result.redemption?.body as Record<string, unknown>).access_token,
+    "at-super-secret",
+  );
 });
 
 test("buildXaaConfig rejects a blank client id", () => {

--- a/cli/tests/xaa.test.ts
+++ b/cli/tests/xaa.test.ts
@@ -21,22 +21,28 @@ test("buildXaaConfig maps the required fields", () => {
   assert.equal(config.httpsOnly, false);
 });
 
-test("buildXaaConfig maps the optional fields when supplied", () => {
-  const config = buildXaaConfig({
-    ...base,
-    authzServerIssuer: "https://auth.example.com",
-    tokenEndpoint: "https://auth.example.com/oauth/token",
-    email: "u@example.com",
-    clientSecret: "secret-1",
-    scopes: "read:tools write:tools",
-    httpsOnly: true,
-  });
+test("buildXaaConfig maps optional fields and the global timeout", () => {
+  const config = buildXaaConfig(
+    {
+      ...base,
+      authzServerIssuer: "https://auth.example.com",
+      tokenEndpoint: "https://auth.example.com/oauth/token",
+      email: "u@example.com",
+      clientSecret: "secret-1",
+      tokenEndpointAuthMethod: "client_secret_basic",
+      scopes: "read:tools write:tools",
+      httpsOnly: true,
+    },
+    12_345
+  );
 
   assert.equal(config.authzServerIssuer, "https://auth.example.com");
   assert.equal(config.tokenEndpoint, "https://auth.example.com/oauth/token");
   assert.equal(config.email, "u@example.com");
   assert.equal(config.clientSecret, "secret-1");
+  assert.equal(config.tokenEndpointAuthMethod, "client_secret_basic");
   assert.equal(config.scope, "read:tools write:tools");
+  assert.equal(config.timeoutMs, 12_345);
   assert.equal(config.httpsOnly, true);
 });
 
@@ -69,7 +75,7 @@ test("buildXaaConfig rejects an invalid server URL", () => {
   assert.throws(
     () => buildXaaConfig({ ...base, url: "not-a-url" }),
     (error: unknown) =>
-      error instanceof CliError && /Invalid server URL/.test(error.message),
+      error instanceof CliError && /Invalid server URL/.test(error.message)
   );
 });
 
@@ -77,7 +83,7 @@ test("buildXaaConfig rejects an invalid issuer base URL", () => {
   assert.throws(
     () => buildXaaConfig({ ...base, issuerBaseUrl: "nope" }),
     (error: unknown) =>
-      error instanceof CliError && /Invalid issuer base URL/.test(error.message),
+      error instanceof CliError && /Invalid issuer base URL/.test(error.message)
   );
 });
 
@@ -86,7 +92,7 @@ test("buildXaaConfig rejects an invalid authorization server issuer", () => {
     () => buildXaaConfig({ ...base, authzServerIssuer: "bad" }),
     (error: unknown) =>
       error instanceof CliError &&
-      /Invalid authorization server issuer/.test(error.message),
+      /Invalid authorization server issuer/.test(error.message)
   );
 });
 
@@ -94,7 +100,7 @@ test("buildXaaConfig rejects an invalid token endpoint", () => {
   assert.throws(
     () => buildXaaConfig({ ...base, tokenEndpoint: "bad" }),
     (error: unknown) =>
-      error instanceof CliError && /Invalid token endpoint/.test(error.message),
+      error instanceof CliError && /Invalid token endpoint/.test(error.message)
   );
 });
 
@@ -102,7 +108,7 @@ test("buildXaaConfig rejects a blank subject", () => {
   assert.throws(
     () => buildXaaConfig({ ...base, sub: "   " }),
     (error: unknown) =>
-      error instanceof CliError && /--sub must not be empty/.test(error.message),
+      error instanceof CliError && /--sub must not be empty/.test(error.message)
   );
 });
 
@@ -149,7 +155,7 @@ test("redactXaaResult masks the ID-JAG token and issued bearer tokens", () => {
   assert.equal(body.id_token, "[REDACTED]");
   assert.equal(
     (body.extra as Record<string, unknown>).access_token,
-    "[REDACTED]",
+    "[REDACTED]"
   );
   // A reflected raw ID-JAG is scrubbed even under non-secret field names.
   assert.equal(body.assertion, "[REDACTED]");
@@ -160,7 +166,7 @@ test("redactXaaResult masks the ID-JAG token and issued bearer tokens", () => {
   assert.equal(result.idJag?.token, "eyJraWQ.secret.signature");
   assert.equal(
     (result.redemption?.body as Record<string, unknown>).access_token,
-    "at-super-secret",
+    "at-super-secret"
   );
 });
 
@@ -169,6 +175,27 @@ test("buildXaaConfig rejects a blank client id", () => {
     () => buildXaaConfig({ ...base, clientId: "   " }),
     (error: unknown) =>
       error instanceof CliError &&
-      /--client-id must not be empty/.test(error.message),
+      /--client-id must not be empty/.test(error.message)
+  );
+});
+
+test("buildXaaConfig rejects a non-positive timeout", () => {
+  assert.throws(
+    () => buildXaaConfig({ ...base }, 0),
+    (error: unknown) =>
+      error instanceof CliError &&
+      /--timeout must be a positive/.test(error.message)
+  );
+});
+
+test("buildXaaConfig requires a secret for confidential client auth", () => {
+  assert.throws(
+    () =>
+      buildXaaConfig({
+        ...base,
+        tokenEndpointAuthMethod: "client_secret_basic",
+      }),
+    (error: unknown) =>
+      error instanceof CliError && /requires --client-secret/.test(error.message),
   );
 });

--- a/cli/tests/xaa.test.ts
+++ b/cli/tests/xaa.test.ts
@@ -126,6 +126,9 @@ test("redactXaaResult masks the ID-JAG token and issued bearer tokens", () => {
         expires_in: 300,
         // A nested/reflected secret the recursive redactor must also catch.
         extra: { access_token: "nested-secret" },
+        // The AS reflecting the raw ID-JAG back under non-secret field names.
+        assertion: "eyJraWQ.secret.signature",
+        error_description: "invalid assertion eyJraWQ.secret.signature",
       },
     },
     mcp: { status: 200, ok: true },
@@ -148,6 +151,9 @@ test("redactXaaResult masks the ID-JAG token and issued bearer tokens", () => {
     (body.extra as Record<string, unknown>).access_token,
     "[REDACTED]",
   );
+  // A reflected raw ID-JAG is scrubbed even under non-secret field names.
+  assert.equal(body.assertion, "[REDACTED]");
+  assert.equal(body.error_description, "invalid assertion [REDACTED]");
   assert.equal(body.token_type, "Bearer");
   assert.equal(body.expires_in, 300);
   // The original result is not mutated.

--- a/cli/tests/xaa.test.ts
+++ b/cli/tests/xaa.test.ts
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { buildXaaConfig } from "../src/commands/xaa.js";
+import { buildXaaConfig, redactXaaResult } from "../src/commands/xaa.js";
 import { CliError } from "../src/lib/output.js";
+import type { XaaFlowResult } from "@mcpjam/sdk";
 
 const base = {
   url: "https://mcp.example.com/mcp",
@@ -103,6 +104,46 @@ test("buildXaaConfig rejects a blank subject", () => {
     (error: unknown) =>
       error instanceof CliError && /--sub must not be empty/.test(error.message),
   );
+});
+
+test("redactXaaResult masks the ID-JAG token and issued bearer tokens", () => {
+  const result = {
+    completed: true,
+    issuer: "https://issuer.example.com/api/mcp/xaa",
+    idJag: {
+      token: "eyJraWQ.secret.signature",
+      claims: { sub: "user-1", aud: "https://auth.example.com" },
+      verified: true,
+    },
+    redemption: {
+      status: 200,
+      tokenIssued: true,
+      body: {
+        access_token: "at-super-secret",
+        refresh_token: "rt-super-secret",
+        token_type: "Bearer",
+        expires_in: 300,
+      },
+    },
+    mcp: { status: 200, ok: true },
+    steps: [],
+  } as unknown as XaaFlowResult;
+
+  const redacted = redactXaaResult(result);
+
+  assert.equal(redacted.idJag?.token, "[REDACTED]");
+  // Decoded claims stay visible for inspection.
+  assert.deepEqual(redacted.idJag?.claims, {
+    sub: "user-1",
+    aud: "https://auth.example.com",
+  });
+  const body = redacted.redemption?.body as Record<string, unknown>;
+  assert.equal(body.access_token, "[REDACTED]");
+  assert.equal(body.refresh_token, "[REDACTED]");
+  assert.equal(body.token_type, "Bearer");
+  assert.equal(body.expires_in, 300);
+  // The original result is not mutated.
+  assert.equal(result.idJag?.token, "eyJraWQ.secret.signature");
 });
 
 test("buildXaaConfig rejects a blank client id", () => {

--- a/mcpjam-inspector/server/app.ts
+++ b/mcpjam-inspector/server/app.ts
@@ -58,7 +58,7 @@ import { startGuestAuthProvisioningInBackground } from "./utils/convex-guest-aut
 import { startLocalBrowserRenderingSetupInBackground } from "./utils/browser-rendering-setup.js";
 import { fetchRemoteGuestJwks } from "./utils/guest-session-source.js";
 import { INSPECTOR_MCP_RETRY_POLICY } from "./utils/mcp-retry-policy.js";
-import { initXAAIdpKeyPair } from "./services/xaa-idp-keypair.js";
+import { initXAAIdpKeyPair, setXaaIdpLogger } from "@mcpjam/sdk";
 import { requestLogContextMiddleware } from "./middleware/request-log-context.js";
 import { registerSelfFetch } from "./utils/self-app.js";
 import { getInspectorFrontendUrl } from "./utils/inspector-frontend-url.js";
@@ -80,6 +80,7 @@ export async function createHonoApp() {
 
   // Generate session token for API authentication
   generateSessionToken();
+  setXaaIdpLogger(appLogger);
   initXAAIdpKeyPair();
 
   startGuestAuthProvisioningInBackground();

--- a/mcpjam-inspector/server/index.ts
+++ b/mcpjam-inspector/server/index.ts
@@ -139,7 +139,7 @@ import {
   CANIUSE_LANDING_HOSTS,
 } from "./config";
 import "./types/hono"; // Type extensions
-import { initXAAIdpKeyPair } from "./services/xaa-idp-keypair";
+import { initXAAIdpKeyPair, setXaaIdpLogger } from "@mcpjam/sdk";
 
 // Utility function to extract MCP server config from environment variables
 function getMCPConfigFromEnv() {
@@ -238,6 +238,7 @@ warnOnConvexDevMisconfiguration(loadedEnv);
 
 // Generate session token for API authentication
 generateSessionToken();
+setXaaIdpLogger(appLogger);
 initXAAIdpKeyPair();
 
 startGuestAuthProvisioningInBackground();

--- a/mcpjam-inspector/server/routes/mcp/__tests__/xaa-server-target.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/xaa-server-target.test.ts
@@ -3,10 +3,7 @@ import { Hono } from "hono";
 import { mkdtempSync, rmSync } from "fs";
 import os from "os";
 import path from "path";
-import {
-  initXAAIdpKeyPair,
-  resetXAAIdpKeyPairForTests,
-} from "../../../services/xaa-idp-keypair.js";
+import { initXAAIdpKeyPair, resetXAAIdpKeyPairForTests } from "@mcpjam/sdk";
 import { createXaaRouter } from "../xaa.js";
 
 const DISCOVERED_TOKEN_ENDPOINT = "https://discovered-as.example.com/oauth/token";

--- a/mcpjam-inspector/server/routes/mcp/__tests__/xaa.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/xaa.test.ts
@@ -11,10 +11,7 @@ import {
   generateSessionToken,
   getSessionToken,
 } from "../../../services/session-token.js";
-import {
-  initXAAIdpKeyPair,
-  resetXAAIdpKeyPairForTests,
-} from "../../../services/xaa-idp-keypair.js";
+import { initXAAIdpKeyPair, resetXAAIdpKeyPairForTests } from "@mcpjam/sdk";
 import xaa, { createXaaRouter } from "../xaa.js";
 
 function jsonResponse(

--- a/mcpjam-inspector/server/routes/mcp/xaa.ts
+++ b/mcpjam-inspector/server/routes/mcp/xaa.ts
@@ -13,8 +13,6 @@ import {
 import {
   getXAAIdpJwks,
   initXAAIdpKeyPair,
-} from "../../services/xaa-idp-keypair.js";
-import {
   issueAccessToken,
   issueAuthorizationCode,
   issueIdJag,
@@ -23,7 +21,7 @@ import {
   verifyXaaJwt,
   XAA_ACCESS_TOKEN_TYP,
   XAA_CODE_JWT_TYP,
-} from "../../services/xaa-idjag-signer.js";
+} from "@mcpjam/sdk";
 import { createHash } from "crypto";
 import {
   buildJwtBearerRequest,

--- a/mcpjam-inspector/server/routes/web/__tests__/xaa.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/xaa.test.ts
@@ -8,10 +8,7 @@ import { createXaaRouter } from "../../mcp/xaa.js";
 import { bearerAuthMiddleware } from "../../../middleware/bearer-auth.js";
 import { guestRateLimitMiddleware } from "../../../middleware/guest-rate-limit.js";
 import { ErrorCode, WebRouteError } from "../errors.js";
-import {
-  initXAAIdpKeyPair,
-  resetXAAIdpKeyPairForTests,
-} from "../../../services/xaa-idp-keypair.js";
+import { initXAAIdpKeyPair, resetXAAIdpKeyPairForTests } from "@mcpjam/sdk";
 
 function decodeJwtPayload(token: string): Record<string, any> {
   const [, payload] = token.split(".");

--- a/mcpjam-inspector/server/services/xaa-mint.ts
+++ b/mcpjam-inspector/server/services/xaa-mint.ts
@@ -4,8 +4,11 @@
 // assembly here (see `buildJwtBearerBody`) is what prevents the two surfaces
 // from drifting on the wire.
 import type { Context } from "hono";
-import { issueIdJag } from "./xaa-idjag-signer.js";
-import { getXAAIssuerUrl } from "./xaa-idp-keypair.js";
+import {
+  buildJwtBearerBody,
+  getXAAIssuerUrl,
+  issueIdJag,
+} from "@mcpjam/sdk";
 import {
   buildDiscoveryCandidates,
   buildResourceMetadataCandidates,
@@ -270,26 +273,9 @@ export async function resolveServerTarget(deps: {
   };
 }
 
-// The jwt-bearer (RFC 7523) token-request body posted to the resource
-// authorization server. SINGLE SOURCE OF TRUTH — both `/proxy/token` (debugger)
-// and `mintXaaAccessToken` (connect) build their request body here so the two
-// surfaces stay byte-identical on the wire.
-export function buildJwtBearerBody(args: {
-  assertion: string;
-  clientId?: string | null;
-  clientSecret?: string | null;
-  scope?: string | null;
-  resource?: string | null;
-}): Record<string, string> {
-  return {
-    grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
-    assertion: args.assertion,
-    ...(args.clientId ? { client_id: args.clientId } : {}),
-    ...(args.clientSecret ? { client_secret: args.clientSecret } : {}),
-    ...(args.scope ? { scope: args.scope } : {}),
-    ...(args.resource ? { resource: args.resource } : {}),
-  };
-}
+// `buildJwtBearerBody` (the single-source jwt-bearer request body) now lives in
+// @mcpjam/sdk and is re-exported here so existing importers keep their path.
+export { buildJwtBearerBody };
 
 export type XaaTokenEndpointAuthMethod =
   | "client_secret_post"

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -290,6 +290,10 @@ export type {
 } from "./oauth/state-machines/shared/dynamic-client-registration.js";
 export { validateClientIdMetadataUrl } from "./oauth/state-machines/shared/client-id-metadata.js";
 
+// XAA (Cross-App Access / ID-JAG) mock-IdP mint — node-only (crypto/fs).
+// Consumed by the inspector server and the CLI's headless `runXaaFlow`.
+export * from "./xaa/index.js";
+
 // HostExecutor interface (for deterministic testing without concrete HostRunner)
 export type { HostExecutor, PromptOptions } from "./HostExecutor.js";
 

--- a/sdk/src/oauth-proxy.ts
+++ b/sdk/src/oauth-proxy.ts
@@ -19,6 +19,8 @@ export interface OAuthProxyRequest {
    * weakened); otherwise an explicit value is honored and omission preserves
    * the historical "follow". */
   redirect?: "follow" | "manual";
+  /** Bound the fetch and response-body read. */
+  timeoutMs?: number;
 }
 
 export interface OAuthProxyResponse {
@@ -147,6 +149,16 @@ function buildFetchUrl(targetUrl: URL): string {
   return targetUrl.toString();
 }
 
+function requestTimeoutSignal(
+  timeoutMs: number | undefined,
+): AbortSignal | undefined {
+  if (timeoutMs === undefined) return undefined;
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    throw new OAuthProxyError(400, "timeoutMs must be a positive number");
+  }
+  return AbortSignal.timeout(timeoutMs);
+}
+
 async function parseResponseBody(response: Response): Promise<unknown> {
   try {
     return await response.json();
@@ -216,6 +228,7 @@ export async function executeOAuthProxy(
     headers: requestHeaders,
     redirect: req.httpsOnly ? "manual" : req.redirect ?? "follow",
     body: encodeRequestBody(method, req.body, contentType),
+    signal: requestTimeoutSignal(req.timeoutMs),
   });
 
   const headers: Record<string, string> = {};
@@ -251,6 +264,7 @@ export async function executeDebugOAuthProxy(
     headers: requestHeaders,
     redirect: req.httpsOnly ? "manual" : req.redirect ?? "follow",
     body: encodeRequestBody(method, req.body, contentType),
+    signal: requestTimeoutSignal(req.timeoutMs),
   });
 
   const headers: Record<string, string> = {};
@@ -350,6 +364,7 @@ export async function executeDebugOAuthProxy(
 export async function fetchOAuthMetadata(
   url: string,
   httpsOnly = false,
+  timeoutMs?: number,
 ): Promise<
   | { metadata: Record<string, unknown>; status?: undefined }
   | { status: number; statusText: string }
@@ -363,6 +378,7 @@ export async function fetchOAuthMetadata(
       "User-Agent": "MCP-Inspector/1.0",
     },
     redirect: httpsOnly ? "manual" : "follow",
+    signal: requestTimeoutSignal(timeoutMs),
   });
 
   if (!response.ok) {

--- a/sdk/src/xaa/constants.ts
+++ b/sdk/src/xaa/constants.ts
@@ -1,0 +1,34 @@
+// Stable XAA/ID-JAG spec constants used by the mint. Small, byte-identical
+// primitives (a key id + the negative-test enum); the inspector keeps its own
+// copy in `shared/xaa.ts` alongside UI-only description tables, and both must
+// hold the same literal values.
+
+/** JWKS `kid` the mock IdP signs with and publishes. */
+export const XAA_IDP_KID = "xaa-idp-1";
+
+/** The tamper modes the debugger can apply when minting a broken ID-JAG. */
+export const NEGATIVE_TEST_MODES = [
+  "valid",
+  "bad_signature",
+  "wrong_audience",
+  "expired",
+  "missing_claims",
+  "invalid_type_header",
+  "wrong_issuer",
+  "resource_mismatch",
+  "client_id_mismatch",
+  "unknown_kid",
+  "unknown_sub",
+  "scope_denial",
+] as const;
+
+export type NegativeTestMode = (typeof NEGATIVE_TEST_MODES)[number];
+
+export const DEFAULT_NEGATIVE_TEST_MODE: NegativeTestMode = "valid";
+
+export function isNegativeTestMode(value: unknown): value is NegativeTestMode {
+  return (
+    typeof value === "string" &&
+    (NEGATIVE_TEST_MODES as readonly string[]).includes(value)
+  );
+}

--- a/sdk/src/xaa/index.ts
+++ b/sdk/src/xaa/index.ts
@@ -34,10 +34,16 @@ export {
   type IssueAuthorizationCodeParams,
   type IssueAccessTokenParams,
 } from "./mint/signer.js";
-export { buildJwtBearerBody } from "./mint/jwt-bearer.js";
+export {
+  buildJwtBearerBody,
+  buildJwtBearerRequest,
+  type XaaTokenEndpointAuthMethod,
+} from "./mint/jwt-bearer.js";
 export { runXaaFlow } from "./run-xaa-flow.js";
 export type {
+  XaaCapabilityEvidence,
   XaaFlowConfig,
   XaaFlowResult,
   XaaFlowStep,
+  XaaRedemptionResult,
 } from "./run-xaa-flow.js";

--- a/sdk/src/xaa/index.ts
+++ b/sdk/src/xaa/index.ts
@@ -1,0 +1,37 @@
+// XAA (Cross-App Access / ID-JAG) mock-IdP mint. Node-only (crypto/fs); do not
+// re-export from the browser entry. The inspector server and the CLI both
+// consume the mint from here; the XAA *flow* state machine stays in the
+// inspector client.
+export {
+  XAA_IDP_KID,
+  NEGATIVE_TEST_MODES,
+  DEFAULT_NEGATIVE_TEST_MODE,
+  isNegativeTestMode,
+  type NegativeTestMode,
+} from "./constants.js";
+export {
+  initXAAIdpKeyPair,
+  getXAAIssuerUrl,
+  getXAAIdpPrivateKey,
+  getXAAIdpPublicKeyObject,
+  getXAAIdpJwks,
+  resetXAAIdpKeyPairForTests,
+  setXaaIdpLogger,
+  type XAAIdpJwk,
+  type XaaIdpLogger,
+} from "./mint/keypair.js";
+export {
+  issueIdJag,
+  issueNegativeIdJag,
+  issueMockIdToken,
+  issueAuthorizationCode,
+  issueAccessToken,
+  verifyXaaJwt,
+  XAA_CODE_JWT_TYP,
+  XAA_ACCESS_TOKEN_TYP,
+  type IssueIdJagParams,
+  type IssueMockIdTokenParams,
+  type IssueAuthorizationCodeParams,
+  type IssueAccessTokenParams,
+} from "./mint/signer.js";
+export { buildJwtBearerBody } from "./mint/jwt-bearer.js";

--- a/sdk/src/xaa/index.ts
+++ b/sdk/src/xaa/index.ts
@@ -35,3 +35,9 @@ export {
   type IssueAccessTokenParams,
 } from "./mint/signer.js";
 export { buildJwtBearerBody } from "./mint/jwt-bearer.js";
+export { runXaaFlow } from "./run-xaa-flow.js";
+export type {
+  XaaFlowConfig,
+  XaaFlowResult,
+  XaaFlowStep,
+} from "./run-xaa-flow.js";

--- a/sdk/src/xaa/mint/jwt-bearer.ts
+++ b/sdk/src/xaa/mint/jwt-bearer.ts
@@ -1,0 +1,21 @@
+// The jwt-bearer (RFC 7523) token-request body posted to the resource
+// authorization server to redeem an ID-JAG. SINGLE SOURCE OF TRUTH — the
+// inspector's `/proxy/token` debugger route, the connect-page mint, and the
+// CLI's headless redemption all build their request body here so every surface
+// stays byte-identical on the wire.
+export function buildJwtBearerBody(args: {
+  assertion: string;
+  clientId?: string | null;
+  clientSecret?: string | null;
+  scope?: string | null;
+  resource?: string | null;
+}): Record<string, string> {
+  return {
+    grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+    assertion: args.assertion,
+    ...(args.clientId ? { client_id: args.clientId } : {}),
+    ...(args.clientSecret ? { client_secret: args.clientSecret } : {}),
+    ...(args.scope ? { scope: args.scope } : {}),
+    ...(args.resource ? { resource: args.resource } : {}),
+  };
+}

--- a/sdk/src/xaa/mint/jwt-bearer.ts
+++ b/sdk/src/xaa/mint/jwt-bearer.ts
@@ -19,3 +19,80 @@ export function buildJwtBearerBody(args: {
     ...(args.resource ? { resource: args.resource } : {}),
   };
 }
+
+export type XaaTokenEndpointAuthMethod =
+  | "client_secret_post"
+  | "client_secret_basic"
+  | "none";
+
+// RFC 6749 section 2.3.1 requires each credential to be form-urlencoded before
+// the `client_id:client_secret` pair is Base64-encoded.
+function formUrlEncode(value: string): string {
+  return encodeURIComponent(value)
+    .replace(
+      /[!'()~]/g,
+      (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`
+    )
+    .replace(/%20/g, "+");
+}
+
+function encodeBasicClientAuth(clientId: string, clientSecret: string): string {
+  return Buffer.from(
+    `${formUrlEncode(clientId)}:${formUrlEncode(clientSecret)}`
+  ).toString("base64");
+}
+
+/** Build the jwt-bearer body and the selected OAuth client-auth headers. */
+export function buildJwtBearerRequest(args: {
+  assertion: string;
+  clientId?: string | null;
+  clientSecret?: string | null;
+  scope?: string | null;
+  resource?: string | null;
+  tokenEndpointAuthMethod?: XaaTokenEndpointAuthMethod | null;
+}): { headers: Record<string, string>; body: Record<string, string> } {
+  const method = args.tokenEndpointAuthMethod;
+
+  if (method === "client_secret_basic") {
+    if (!args.clientId || !args.clientSecret) {
+      throw new Error(
+        "client_secret_basic requires both a client_id and a client_secret"
+      );
+    }
+    return {
+      headers: {
+        Authorization: `Basic ${encodeBasicClientAuth(
+          args.clientId,
+          args.clientSecret
+        )}`,
+      },
+      body: buildJwtBearerBody({
+        ...args,
+        clientId: null,
+        clientSecret: null,
+      }),
+    };
+  }
+
+  if (method === "none") {
+    if (!args.clientId) {
+      throw new Error("A public (none) client request requires a client_id");
+    }
+    return {
+      headers: {},
+      body: buildJwtBearerBody({ ...args, clientSecret: null }),
+    };
+  }
+
+  if (method === "client_secret_post") {
+    if (!args.clientId || !args.clientSecret) {
+      throw new Error(
+        "client_secret_post requires both a client_id and a client_secret"
+      );
+    }
+  }
+
+  // Preserve the legacy no-method behavior: credentials, when present, stay
+  // in the form body.
+  return { headers: {}, body: buildJwtBearerBody(args) };
+}

--- a/sdk/src/xaa/mint/keypair.ts
+++ b/sdk/src/xaa/mint/keypair.ts
@@ -13,14 +13,25 @@ import {
 } from "fs";
 import os from "os";
 import path from "path";
-import { logger } from "../utils/logger.js";
-import { XAA_IDP_KID } from "../../shared/xaa.js";
+import { XAA_IDP_KID } from "../constants.js";
 
 export type XAAIdpJwk = JsonWebKey & {
   kid: string;
   alg: string;
   use: string;
 };
+
+// The mint emits a few startup diagnostics (which key source it used, where it
+// persisted the pair). It's a library, so those are silent by default; a host
+// (the inspector server) can inject its own logger.
+export interface XaaIdpLogger {
+  info(message: string): void;
+  warn(message: string): void;
+}
+let mintLogger: XaaIdpLogger = { info() {}, warn() {} };
+export function setXaaIdpLogger(logger: XaaIdpLogger): void {
+  mintLogger = logger;
+}
 
 let privateKey: KeyObject | undefined;
 let publicKey: KeyObject | undefined;
@@ -65,12 +76,12 @@ function loadSecretKeyPair(): boolean {
     const nextPrivateKey = createPrivateKey(pem);
     const nextPublicKey = createPublicKey(nextPrivateKey);
     setKeyPair(nextPrivateKey, nextPublicKey);
-    logger.info(
+    mintLogger.info(
       "XAA issuer: using signing key pair from XAA_IDP_PRIVATE_KEY secret.",
     );
     return true;
   } catch (error) {
-    logger.warn(
+    mintLogger.warn(
       `XAA issuer: XAA_IDP_PRIVATE_KEY is set but could not be parsed, falling back (${error instanceof Error ? error.message : String(error)})`,
     );
     return false;
@@ -97,7 +108,7 @@ function createAndPersistLocalKeyPair(): void {
   }
 
   setKeyPair(createPrivateKey(privatePem), createPublicKey(publicPem));
-  logger.info(`XAA issuer: created signing key pair at ${dir}`);
+  mintLogger.info(`XAA issuer: created signing key pair at ${dir}`);
 }
 
 function loadPersistedLocalKeyPair(): boolean {
@@ -110,12 +121,12 @@ function loadPersistedLocalKeyPair(): boolean {
     const privatePem = readFileSync(privatePath, "utf-8");
     const publicPem = readFileSync(publicPath, "utf-8");
     setKeyPair(createPrivateKey(privatePem), createPublicKey(publicPem));
-    logger.info(
+    mintLogger.info(
       `XAA issuer: using signing key pair from ${path.dirname(privatePath)}`,
     );
     return true;
   } catch (error) {
-    logger.warn(
+    mintLogger.warn(
       `XAA issuer: failed to load signing key pair, regenerating (${error instanceof Error ? error.message : String(error)})`,
     );
     return false;
@@ -125,7 +136,7 @@ function loadPersistedLocalKeyPair(): boolean {
 function generateEphemeralKeyPair(): void {
   const pair = generateKeyPairSync("rsa", { modulusLength: 2048 });
   setKeyPair(pair.privateKey, pair.publicKey);
-  logger.warn(
+  mintLogger.warn(
     "XAA issuer: falling back to ephemeral signing keys; assertions will change after restart.",
   );
 }
@@ -156,7 +167,7 @@ export function initXAAIdpKeyPair(): void {
     try {
       createAndPersistLocalKeyPair();
     } catch (error) {
-      logger.warn(
+      mintLogger.warn(
         `XAA issuer: failed to persist signing key pair, using ephemeral keys (${error instanceof Error ? error.message : String(error)})`,
       );
       generateEphemeralKeyPair();

--- a/sdk/src/xaa/mint/signer.ts
+++ b/sdk/src/xaa/mint/signer.ts
@@ -9,12 +9,12 @@ import {
   getXAAIdpPrivateKey,
   getXAAIdpPublicKeyObject,
   initXAAIdpKeyPair,
-} from "./xaa-idp-keypair.js";
+} from "./keypair.js";
 import {
   DEFAULT_NEGATIVE_TEST_MODE,
   type NegativeTestMode,
   XAA_IDP_KID,
-} from "../../shared/xaa.js";
+} from "../constants.js";
 
 const ID_JAG_TTL_S = 5 * 60;
 const ID_TOKEN_TTL_S = 5 * 60;

--- a/sdk/src/xaa/run-xaa-flow.ts
+++ b/sdk/src/xaa/run-xaa-flow.ts
@@ -112,13 +112,15 @@ function wellKnownCandidates(issuer: string, name: string): string[] {
   if (!path) {
     return [`${origin}/.well-known/${name}`];
   }
-  // Path issuer: try the RFC 8414 path-insertion form AND the OIDC
-  // path-appended form (`issuer + /.well-known/...`), which OIDC-only servers
-  // require. Do NOT fall back to the root well-known — on a multi-tenant host
-  // that would fetch a different tenant's metadata.
+  // Path issuer/resource: RFC 8414 path-insertion, the OIDC path-appended form
+  // (`issuer + /.well-known/...`, which OIDC-only servers require), and the
+  // origin-root form (where RFC 9728 PRM is commonly served). Ordering probes
+  // the most specific first; for AS metadata a wrong-tenant root document is
+  // rejected downstream by the `metadata.issuer` match check.
   return [
     `${origin}/.well-known/${name}${path}`,
     `${trimmed}/.well-known/${name}`,
+    `${origin}/.well-known/${name}`,
   ];
 }
 
@@ -385,7 +387,26 @@ function extractJsonRpcError(body: unknown): string | undefined {
   if (!body || typeof body !== "object") {
     return undefined;
   }
-  const error = (body as { error?: unknown }).error;
+  const record = body as Record<string, unknown>;
+  // executeDebugOAuthProxy wraps a text/event-stream reply in an SSE envelope:
+  // the JSON-RPC payload sits under `mcpResponse`, and a stream-parse failure
+  // surfaces as a string `error`. A streamable-HTTP `initialize` usually
+  // answers as SSE, so this branch is the common path.
+  if (record.transport === "sse") {
+    if (typeof record.error === "string" && record.error.length > 0) {
+      return record.error;
+    }
+    return jsonRpcErrorFrom(record.mcpResponse);
+  }
+  // Plain JSON: the body IS the JSON-RPC response.
+  return jsonRpcErrorFrom(body);
+}
+
+function jsonRpcErrorFrom(payload: unknown): string | undefined {
+  if (!payload || typeof payload !== "object") {
+    return undefined;
+  }
+  const error = (payload as { error?: unknown }).error;
   if (!error || typeof error !== "object") {
     return undefined;
   }

--- a/sdk/src/xaa/run-xaa-flow.ts
+++ b/sdk/src/xaa/run-xaa-flow.ts
@@ -80,7 +80,7 @@ export interface XaaFlowResult {
     error?: string;
     body?: unknown;
   };
-  mcp?: { status: number; ok: boolean };
+  mcp?: { status: number; ok: boolean; jsonRpcError?: string };
   steps: XaaFlowStep[];
   error?: string;
 }
@@ -88,7 +88,11 @@ export interface XaaFlowResult {
 function canonicalResource(serverUrl: string): string {
   try {
     const u = new URL(serverUrl);
-    return `${u.origin}${u.pathname.replace(/\/+$/, "")}`;
+    // Preserve the query — some MCP servers use it to identify/scope the
+    // protected resource, and the `resource` we mint/redeem for must match the
+    // URL the access token is ultimately used against. Keep the root "/" too.
+    const path = u.pathname === "/" ? "/" : u.pathname.replace(/\/+$/, "");
+    return `${u.origin}${path}${u.search}`;
   } catch {
     return serverUrl.replace(/\/+$/, "");
   }
@@ -105,13 +109,17 @@ function wellKnownCandidates(issuer: string, name: string): string[] {
   } catch {
     /* keep trimmed as origin */
   }
-  const candidates = new Set<string>([
-    // RFC 8414 path-insertion form.
+  if (!path) {
+    return [`${origin}/.well-known/${name}`];
+  }
+  // Path issuer: try the RFC 8414 path-insertion form AND the OIDC
+  // path-appended form (`issuer + /.well-known/...`), which OIDC-only servers
+  // require. Do NOT fall back to the root well-known — on a multi-tenant host
+  // that would fetch a different tenant's metadata.
+  return [
     `${origin}/.well-known/${name}${path}`,
-    // Root form.
-    `${origin}/.well-known/${name}`,
-  ]);
-  return [...candidates];
+    `${trimmed}/.well-known/${name}`,
+  ];
 }
 
 export async function runXaaFlow(
@@ -171,8 +179,16 @@ export async function runXaaFlow(
         for (const url of wellKnownCandidates(authzServerIssuer, name)) {
           const meta = await fetchOAuthMetadata(url, httpsOnly);
           if (!("status" in meta)) {
+            // RFC 8414 §3.3: the metadata's `issuer` MUST match the one we asked
+            // for. Reject a mismatched document so it can't redirect the signed
+            // assertion (and any client_secret) to another issuer's endpoint.
+            const metaIssuer = meta.metadata.issuer;
+            const issuerMatches =
+              typeof metaIssuer === "string" &&
+              metaIssuer.replace(/\/+$/, "") ===
+                authzServerIssuer.replace(/\/+$/, "");
             const te = meta.metadata.token_endpoint;
-            if (typeof te === "string") {
+            if (issuerMatches && typeof te === "string") {
               tokenEndpoint = te;
               break;
             }
@@ -303,7 +319,9 @@ export async function runXaaFlow(
     record(
       "authenticated_mcp_request",
       mcpResult.ok,
-      `status ${mcpResult.status}`,
+      mcpResult.jsonRpcError
+        ? `status ${mcpResult.status}, JSON-RPC error ${mcpResult.jsonRpcError}`
+        : `status ${mcpResult.status}`,
     );
 
     return {
@@ -330,7 +348,7 @@ async function callAuthenticatedMcp(
   serverUrl: string,
   accessToken: string,
   httpsOnly: boolean,
-): Promise<{ status: number; ok: boolean }> {
+): Promise<{ status: number; ok: boolean; jsonRpcError?: string }> {
   const response = await executeDebugOAuthProxy({
     url: serverUrl,
     method: "POST",
@@ -351,8 +369,33 @@ async function callAuthenticatedMcp(
     },
     httpsOnly,
   });
+  // A streamable-HTTP `initialize` can answer 200 OK while carrying a JSON-RPC
+  // error in the body (e.g. the MCP server rejects the token or the init). Treat
+  // that as a failed call, not a completed flow — transport status alone lies.
+  const transportOk = response.status >= 200 && response.status < 300;
+  const jsonRpcError = extractJsonRpcError(response.body);
   return {
     status: response.status,
-    ok: response.status >= 200 && response.status < 300,
+    ok: transportOk && !jsonRpcError,
+    ...(jsonRpcError ? { jsonRpcError } : {}),
   };
+}
+
+function extractJsonRpcError(body: unknown): string | undefined {
+  if (!body || typeof body !== "object") {
+    return undefined;
+  }
+  const error = (body as { error?: unknown }).error;
+  if (!error || typeof error !== "object") {
+    return undefined;
+  }
+  const { code, message } = error as { code?: unknown; message?: unknown };
+  const parts: string[] = [];
+  if (typeof code === "number") {
+    parts.push(String(code));
+  }
+  if (typeof message === "string" && message.length > 0) {
+    parts.push(message);
+  }
+  return parts.length > 0 ? parts.join(": ") : "JSON-RPC error";
 }

--- a/sdk/src/xaa/run-xaa-flow.ts
+++ b/sdk/src/xaa/run-xaa-flow.ts
@@ -23,6 +23,8 @@ import {
 } from "./constants.js";
 
 const ID_JAG_TYP = "oauth-id-jag+jwt";
+// JSON-RPC id we send on `initialize`; the response must echo it back.
+const MCP_INIT_ID = "mcpjam-xaa-cli";
 
 export interface XaaFlowConfig {
   /** Target MCP server URL (the protected resource). */
@@ -374,7 +376,7 @@ async function callAuthenticatedMcp(
     },
     body: {
       jsonrpc: "2.0",
-      id: "mcpjam-xaa-cli",
+      id: MCP_INIT_ID,
       method: "initialize",
       params: {
         protocolVersion: "2025-11-25",
@@ -414,12 +416,22 @@ function evaluateMcpInitResponse(body: unknown): string | undefined {
   if (rpcError) {
     return rpcError;
   }
-  // Require a positive result — an empty SSE envelope (no `message` event) or a
-  // 2xx non-MCP body has neither error nor result and must not read as success.
+  // Require a genuine JSON-RPC initialize result: right protocol version, the
+  // `id` we sent echoed back, and an object `result`. This rejects an empty SSE
+  // envelope (no `message` event) and a coincidental non-MCP 2xx body that
+  // merely happens to carry a `result` field.
+  const response = payload as {
+    jsonrpc?: unknown;
+    id?: unknown;
+    result?: unknown;
+  };
   if (
     !payload ||
     typeof payload !== "object" ||
-    (payload as { result?: unknown }).result === undefined
+    response.jsonrpc !== "2.0" ||
+    response.id !== MCP_INIT_ID ||
+    response.result === null ||
+    typeof response.result !== "object"
   ) {
     return "MCP server did not return a JSON-RPC initialize result";
   }

--- a/sdk/src/xaa/run-xaa-flow.ts
+++ b/sdk/src/xaa/run-xaa-flow.ts
@@ -105,29 +105,31 @@ function canonicalResource(serverUrl: string): string {
 }
 
 function wellKnownCandidates(issuer: string, name: string): string[] {
-  const trimmed = issuer.replace(/\/+$/, "");
-  let origin = trimmed;
-  let path = "";
+  let origin: string;
+  let path: string; // exact pathname incl. any trailing slash; "" for the root
   try {
-    const u = new URL(trimmed);
+    const u = new URL(issuer);
     origin = u.origin;
-    path = u.pathname.replace(/\/+$/, "");
+    path = u.pathname === "/" ? "" : u.pathname;
   } catch {
-    /* keep trimmed as origin */
+    return [`${issuer.replace(/\/+$/, "")}/.well-known/${name}`];
   }
   if (!path) {
     return [`${origin}/.well-known/${name}`];
   }
-  // Path issuer/resource: RFC 8414 path-insertion, the OIDC path-appended form
-  // (`issuer + /.well-known/...`, which OIDC-only servers require), and the
-  // origin-root form (where RFC 9728 PRM is commonly served). Ordering probes
-  // the most specific first; for AS metadata a wrong-tenant root document is
-  // rejected downstream by the `metadata.issuer` match check.
-  return [
+  const pathNoTrailing = path.replace(/\/+$/, "");
+  // Path issuer/resource: RFC 8414/9728 path-insertion preserving the exact path
+  // (including a trailing slash — some servers publish PRM under it); the OIDC
+  // path-appended form (`issuer + /.well-known/...`, which OIDC-only servers
+  // require); and the origin-root form (where RFC 9728 PRM is commonly served).
+  // Most specific first; for AS metadata a wrong-tenant root document is rejected
+  // downstream by the `metadata.issuer` match check.
+  const candidates = new Set<string>([
     `${origin}/.well-known/${name}${path}`,
-    `${trimmed}/.well-known/${name}`,
+    `${origin}${pathNoTrailing}/.well-known/${name}`,
     `${origin}/.well-known/${name}`,
-  ];
+  ]);
+  return [...candidates];
 }
 
 export async function runXaaFlow(

--- a/sdk/src/xaa/run-xaa-flow.ts
+++ b/sdk/src/xaa/run-xaa-flow.ts
@@ -25,6 +25,10 @@ import {
 const ID_JAG_TYP = "oauth-id-jag+jwt";
 // JSON-RPC id we send on `initialize`; the response must echo it back.
 const MCP_INIT_ID = "mcpjam-xaa-cli";
+// Protocol version advertised on the initialize probe — sent both in the params
+// and as the MCP-Protocol-Version HTTP header (some 2025-11-25 servers enforce
+// the header on streamable-HTTP requests).
+const MCP_PROTOCOL_VERSION = "2025-11-25";
 
 export interface XaaFlowConfig {
   /** Target MCP server URL (the protected resource). */
@@ -372,6 +376,7 @@ async function callAuthenticatedMcp(
     headers: {
       Accept: "application/json, text/event-stream",
       "Content-Type": "application/json",
+      "MCP-Protocol-Version": MCP_PROTOCOL_VERSION,
       Authorization: `Bearer ${accessToken}`,
     },
     body: {
@@ -379,7 +384,7 @@ async function callAuthenticatedMcp(
       id: MCP_INIT_ID,
       method: "initialize",
       params: {
-        protocolVersion: "2025-11-25",
+        protocolVersion: MCP_PROTOCOL_VERSION,
         capabilities: {},
         clientInfo: { name: "MCPJam XAA CLI", version: "1.0.0" },
       },

--- a/sdk/src/xaa/run-xaa-flow.ts
+++ b/sdk/src/xaa/run-xaa-flow.ts
@@ -88,13 +88,13 @@ export interface XaaFlowResult {
 function canonicalResource(serverUrl: string): string {
   try {
     const u = new URL(serverUrl);
-    // Preserve the query — some MCP servers use it to identify/scope the
-    // protected resource, and the `resource` we mint/redeem for must match the
-    // URL the access token is ultimately used against. Keep the root "/" too.
-    const path = u.pathname === "/" ? "/" : u.pathname.replace(/\/+$/, "");
-    return `${u.origin}${path}${u.search}`;
+    // Preserve the path exactly (including a trailing slash) and the query —
+    // both can distinguish resources, and the `resource` we mint/redeem for
+    // must match the URL the access token is ultimately used against. URL()
+    // still normalizes the origin (lowercase host, default port removal).
+    return `${u.origin}${u.pathname}${u.search}`;
   } catch {
-    return serverUrl.replace(/\/+$/, "");
+    return serverUrl;
   }
 }
 
@@ -149,8 +149,21 @@ export async function runXaaFlow(
       )) {
         const meta = await fetchOAuthMetadata(url, httpsOnly);
         if (!("status" in meta)) {
+          // RFC 9728: the metadata's `resource` MUST identify the protected
+          // resource we fetched it for. Reject a mismatched document so a
+          // compromised/misconfigured well-known can't redirect us to another
+          // AS. Skip-and-continue: a later candidate may still be valid, and an
+          // explicit --authz-server-issuer bypasses discovery entirely.
+          const metaResource = meta.metadata.resource;
+          const resourceMatches =
+            typeof metaResource === "string" &&
+            canonicalResource(metaResource) === resource;
           const servers = meta.metadata.authorization_servers;
-          if (Array.isArray(servers) && typeof servers[0] === "string") {
+          if (
+            resourceMatches &&
+            Array.isArray(servers) &&
+            typeof servers[0] === "string"
+          ) {
             found = servers[0];
             break;
           }
@@ -388,14 +401,17 @@ function extractJsonRpcError(body: unknown): string | undefined {
     return undefined;
   }
   const record = body as Record<string, unknown>;
-  // executeDebugOAuthProxy wraps a text/event-stream reply in an SSE envelope:
-  // the JSON-RPC payload sits under `mcpResponse`, and a stream-parse failure
-  // surfaces as a string `error`. A streamable-HTTP `initialize` usually
-  // answers as SSE, so this branch is the common path.
+  // A top-level string `error` is a proxy-level failure — most notably the SSE
+  // parse-failure envelope executeDebugOAuthProxy returns ({ error: "Failed to
+  // parse SSE stream" }, no `transport` field) when the stream times out before
+  // the first event. That's a failed call, not a completed flow.
+  if (typeof record.error === "string" && record.error.length > 0) {
+    return record.error;
+  }
+  // executeDebugOAuthProxy wraps a successful text/event-stream reply in an SSE
+  // envelope: the JSON-RPC payload sits under `mcpResponse`. A streamable-HTTP
+  // `initialize` usually answers as SSE, so this branch is the common path.
   if (record.transport === "sse") {
-    if (typeof record.error === "string" && record.error.length > 0) {
-      return record.error;
-    }
     return jsonRpcErrorFrom(record.mcpResponse);
   }
   // Plain JSON: the body IS the JSON-RPC response.

--- a/sdk/src/xaa/run-xaa-flow.ts
+++ b/sdk/src/xaa/run-xaa-flow.ts
@@ -132,6 +132,34 @@ function wellKnownCandidates(issuer: string, name: string): string[] {
   return [...candidates];
 }
 
+// Discover a candidate authorization server's token endpoint (RFC 8414 / OIDC).
+// Returns the AS's own canonical `issuer` alongside the endpoint, or undefined
+// when no candidate URL yields metadata whose `issuer` matches (RFC 8414 §3.3 —
+// a mismatched document must not redirect the assertion to another issuer).
+async function discoverAsTokenEndpoint(
+  candidateIssuer: string,
+  httpsOnly: boolean,
+): Promise<{ issuer: string; tokenEndpoint: string } | undefined> {
+  for (const name of ["oauth-authorization-server", "openid-configuration"]) {
+    for (const url of wellKnownCandidates(candidateIssuer, name)) {
+      const meta = await fetchOAuthMetadata(url, httpsOnly);
+      if (!("status" in meta)) {
+        const metaIssuer = meta.metadata.issuer;
+        const te = meta.metadata.token_endpoint;
+        if (
+          typeof metaIssuer === "string" &&
+          metaIssuer.replace(/\/+$/, "") ===
+            candidateIssuer.replace(/\/+$/, "") &&
+          typeof te === "string"
+        ) {
+          return { issuer: metaIssuer, tokenEndpoint: te };
+        }
+      }
+    }
+  }
+  return undefined;
+}
+
 export async function runXaaFlow(
   config: XaaFlowConfig,
 ): Promise<XaaFlowResult> {
@@ -146,11 +174,13 @@ export async function runXaaFlow(
   const resource = canonicalResource(config.serverUrl);
 
   try {
-    // 1. Resolve the target authorization server.
-    let authzServerIssuer = config.authzServerIssuer;
-    if (!authzServerIssuer) {
+    // 1. Resolve the candidate authorization server(s).
+    let candidateIssuers: string[];
+    if (config.authzServerIssuer) {
+      candidateIssuers = [config.authzServerIssuer];
+    } else {
       progress("Discovering protected-resource metadata (RFC 9728)…");
-      let found: string | undefined;
+      let servers: string[] = [];
       for (const url of wellKnownCandidates(
         config.serverUrl,
         "oauth-protected-resource",
@@ -166,18 +196,16 @@ export async function runXaaFlow(
           const resourceMatches =
             typeof metaResource === "string" &&
             canonicalResource(metaResource) === resource;
-          const servers = meta.metadata.authorization_servers;
-          if (
-            resourceMatches &&
-            Array.isArray(servers) &&
-            typeof servers[0] === "string"
-          ) {
-            found = servers[0];
-            break;
+          const advertised = meta.metadata.authorization_servers;
+          if (resourceMatches && Array.isArray(advertised)) {
+            servers = advertised.filter(
+              (entry): entry is string => typeof entry === "string",
+            );
+            if (servers.length > 0) break;
           }
         }
       }
-      if (!found) {
+      if (servers.length === 0) {
         record("discover_resource_metadata", false, "no authorization_servers");
         return {
           completed: false,
@@ -187,54 +215,37 @@ export async function runXaaFlow(
             "Could not discover the authorization server from the MCP server's protected-resource metadata. Pass the issuer explicitly.",
         };
       }
-      authzServerIssuer = found;
-      record("discover_resource_metadata", true, authzServerIssuer);
+      candidateIssuers = servers;
+      record("discover_resource_metadata", true, candidateIssuers.join(", "));
     }
 
-    // 2. Resolve the token endpoint.
+    // 2. Resolve the AS issuer + token endpoint. When PRM advertises several
+    // authorization servers, try each until one yields a token endpoint.
+    let authzServerIssuer: string;
     let tokenEndpoint = config.tokenEndpoint;
-    if (!tokenEndpoint) {
+    if (tokenEndpoint) {
+      authzServerIssuer = candidateIssuers[0];
+    } else {
       progress("Discovering authorization-server metadata (RFC 8414)…");
-      for (const name of [
-        "oauth-authorization-server",
-        "openid-configuration",
-      ]) {
-        for (const url of wellKnownCandidates(authzServerIssuer, name)) {
-          const meta = await fetchOAuthMetadata(url, httpsOnly);
-          if (!("status" in meta)) {
-            // RFC 8414 §3.3: the metadata's `issuer` MUST match the one we asked
-            // for. Reject a mismatched document so it can't redirect the signed
-            // assertion (and any client_secret) to another issuer's endpoint.
-            const metaIssuer = meta.metadata.issuer;
-            const te = meta.metadata.token_endpoint;
-            if (
-              typeof metaIssuer === "string" &&
-              metaIssuer.replace(/\/+$/, "") ===
-                authzServerIssuer.replace(/\/+$/, "") &&
-              typeof te === "string"
-            ) {
-              // Adopt the AS's own canonical issuer string as the ID-JAG `aud`,
-              // so a trailing-slash difference between the PRM/arg issuer and the
-              // issuer the AS advertises doesn't mint an audience it rejects.
-              authzServerIssuer = metaIssuer;
-              tokenEndpoint = te;
-              break;
-            }
-          }
-        }
-        if (tokenEndpoint) break;
+      let resolved: { issuer: string; tokenEndpoint: string } | undefined;
+      for (const candidate of candidateIssuers) {
+        resolved = await discoverAsTokenEndpoint(candidate, httpsOnly);
+        if (resolved) break;
       }
-      if (!tokenEndpoint) {
+      if (!resolved) {
         record("discover_authz_metadata", false, "no token_endpoint");
         return {
           completed: false,
           issuer: getXAAIssuerUrl(config.issuerBaseUrl),
-          authzServerIssuer,
+          authzServerIssuer: candidateIssuers[0],
           steps,
           error:
             "Could not discover the authorization server's token endpoint. Pass --token-endpoint explicitly.",
         };
       }
+      // Adopt the AS's own canonical issuer as the ID-JAG `aud`.
+      authzServerIssuer = resolved.issuer;
+      tokenEndpoint = resolved.tokenEndpoint;
       record("discover_authz_metadata", true, tokenEndpoint);
     }
 

--- a/sdk/src/xaa/run-xaa-flow.ts
+++ b/sdk/src/xaa/run-xaa-flow.ts
@@ -204,12 +204,17 @@ export async function runXaaFlow(
             // for. Reject a mismatched document so it can't redirect the signed
             // assertion (and any client_secret) to another issuer's endpoint.
             const metaIssuer = meta.metadata.issuer;
-            const issuerMatches =
+            const te = meta.metadata.token_endpoint;
+            if (
               typeof metaIssuer === "string" &&
               metaIssuer.replace(/\/+$/, "") ===
-                authzServerIssuer.replace(/\/+$/, "");
-            const te = meta.metadata.token_endpoint;
-            if (issuerMatches && typeof te === "string") {
+                authzServerIssuer.replace(/\/+$/, "") &&
+              typeof te === "string"
+            ) {
+              // Adopt the AS's own canonical issuer string as the ID-JAG `aud`,
+              // so a trailing-slash difference between the PRM/arg issuer and the
+              // issuer the AS advertises doesn't mint an audience it rejects.
+              authzServerIssuer = metaIssuer;
               tokenEndpoint = te;
               break;
             }

--- a/sdk/src/xaa/run-xaa-flow.ts
+++ b/sdk/src/xaa/run-xaa-flow.ts
@@ -80,7 +80,7 @@ export interface XaaFlowResult {
     error?: string;
     body?: unknown;
   };
-  mcp?: { status: number; ok: boolean; jsonRpcError?: string };
+  mcp?: { status: number; ok: boolean; error?: string };
   steps: XaaFlowStep[];
   error?: string;
 }
@@ -334,8 +334,8 @@ export async function runXaaFlow(
     record(
       "authenticated_mcp_request",
       mcpResult.ok,
-      mcpResult.jsonRpcError
-        ? `status ${mcpResult.status}, JSON-RPC error ${mcpResult.jsonRpcError}`
+      mcpResult.error
+        ? `status ${mcpResult.status}: ${mcpResult.error}`
         : `status ${mcpResult.status}`,
     );
 
@@ -363,7 +363,7 @@ async function callAuthenticatedMcp(
   serverUrl: string,
   accessToken: string,
   httpsOnly: boolean,
-): Promise<{ status: number; ok: boolean; jsonRpcError?: string }> {
+): Promise<{ status: number; ok: boolean; error?: string }> {
   const response = await executeDebugOAuthProxy({
     url: serverUrl,
     method: "POST",
@@ -384,38 +384,56 @@ async function callAuthenticatedMcp(
     },
     httpsOnly,
   });
-  // A streamable-HTTP `initialize` can answer 200 OK while carrying a JSON-RPC
-  // error in the body (e.g. the MCP server rejects the token or the init). Treat
-  // that as a failed call, not a completed flow — transport status alone lies.
+  // Transport status alone lies: a 2xx can carry a JSON-RPC error, no JSON-RPC
+  // payload at all, or a non-MCP body. The call succeeds only when the server
+  // returns a proper JSON-RPC `initialize` result.
   const transportOk = response.status >= 200 && response.status < 300;
-  const jsonRpcError = extractJsonRpcError(response.body);
+  const error = evaluateMcpInitResponse(response.body);
   return {
     status: response.status,
-    ok: transportOk && !jsonRpcError,
-    ...(jsonRpcError ? { jsonRpcError } : {}),
+    ok: transportOk && !error,
+    ...(error ? { error } : {}),
   };
 }
 
-function extractJsonRpcError(body: unknown): string | undefined {
-  if (!body || typeof body !== "object") {
-    return undefined;
-  }
-  const record = body as Record<string, unknown>;
+// Returns a failure reason, or undefined when `body` is a valid JSON-RPC
+// `initialize` result.
+function evaluateMcpInitResponse(body: unknown): string | undefined {
   // A top-level string `error` is a proxy-level failure — most notably the SSE
   // parse-failure envelope executeDebugOAuthProxy returns ({ error: "Failed to
   // parse SSE stream" }, no `transport` field) when the stream times out before
-  // the first event. That's a failed call, not a completed flow.
-  if (typeof record.error === "string" && record.error.length > 0) {
-    return record.error;
+  // the first event.
+  if (body && typeof body === "object") {
+    const topError = (body as { error?: unknown }).error;
+    if (typeof topError === "string" && topError.length > 0) {
+      return topError;
+    }
   }
-  // executeDebugOAuthProxy wraps a successful text/event-stream reply in an SSE
-  // envelope: the JSON-RPC payload sits under `mcpResponse`. A streamable-HTTP
-  // `initialize` usually answers as SSE, so this branch is the common path.
-  if (record.transport === "sse") {
-    return jsonRpcErrorFrom(record.mcpResponse);
+  const payload = jsonRpcPayload(body);
+  const rpcError = jsonRpcErrorFrom(payload);
+  if (rpcError) {
+    return rpcError;
   }
-  // Plain JSON: the body IS the JSON-RPC response.
-  return jsonRpcErrorFrom(body);
+  // Require a positive result — an empty SSE envelope (no `message` event) or a
+  // 2xx non-MCP body has neither error nor result and must not read as success.
+  if (
+    !payload ||
+    typeof payload !== "object" ||
+    (payload as { result?: unknown }).result === undefined
+  ) {
+    return "MCP server did not return a JSON-RPC initialize result";
+  }
+  return undefined;
+}
+
+// executeDebugOAuthProxy wraps a text/event-stream reply in an SSE envelope with
+// the JSON-RPC payload under `mcpResponse`; a plain JSON body IS the payload.
+function jsonRpcPayload(body: unknown): unknown {
+  if (!body || typeof body !== "object") {
+    return body;
+  }
+  const record = body as Record<string, unknown>;
+  return record.transport === "sse" ? record.mcpResponse : body;
 }
 
 function jsonRpcErrorFrom(payload: unknown): string | undefined {

--- a/sdk/src/xaa/run-xaa-flow.ts
+++ b/sdk/src/xaa/run-xaa-flow.ts
@@ -1,62 +1,57 @@
-// Headless Cross-App Access (ID-JAG) flow driver. Mirrors the inspector's XAA
-// debugger, minus the UI: it self-issues an ID-JAG with the in-process mint,
-// then redeems it at the target authorization server (RFC 7523 jwt-bearer) and
-// calls the MCP server with the resulting access token — reporting whatever
-// happens at each step.
-//
-// Reachability note: the ID-JAG's `iss`/JWKS is served by THIS host, so a cloud
-// authorization server can only validate it when the issuer origin is reachable
-// (an enterprise/self-hosted AS on the network, or a tunnelled origin). Against
-// an unreachable issuer, redemption fails at the AS — which is itself the
-// finding this tool reports.
+// Headless Cross-App Access (ID-JAG) flow driver. It self-issues an ID-JAG,
+// verifies that the configured issuer actually publishes the signing key,
+// redeems the assertion, and probes the protected MCP resource.
 import {
-  executeOAuthProxy,
   executeDebugOAuthProxy,
+  executeOAuthProxy,
   fetchOAuthMetadata,
 } from "../oauth-proxy.js";
-import { initXAAIdpKeyPair, getXAAIssuerUrl } from "./mint/keypair.js";
+import {
+  ID_JAG_GRANT_PROFILE,
+  JWT_BEARER_GRANT,
+} from "../oauth/client-identity.js";
+import {
+  getXAAIdpJwks,
+  getXAAIssuerUrl,
+  initXAAIdpKeyPair,
+} from "./mint/keypair.js";
 import { issueNegativeIdJag, verifyXaaJwt } from "./mint/signer.js";
-import { buildJwtBearerBody } from "./mint/jwt-bearer.js";
+import {
+  buildJwtBearerRequest,
+  type XaaTokenEndpointAuthMethod,
+} from "./mint/jwt-bearer.js";
 import {
   DEFAULT_NEGATIVE_TEST_MODE,
   type NegativeTestMode,
 } from "./constants.js";
 
 const ID_JAG_TYP = "oauth-id-jag+jwt";
-// JSON-RPC id we send on `initialize`; the response must echo it back.
 const MCP_INIT_ID = "mcpjam-xaa-cli";
-// Protocol version advertised on the initialize probe — sent both in the params
-// and as the MCP-Protocol-Version HTTP header (some 2025-11-25 servers enforce
-// the header on streamable-HTTP requests).
 const MCP_PROTOCOL_VERSION = "2025-11-25";
+const XAA_MCP_EXTENSION =
+  "io.modelcontextprotocol/enterprise-managed-authorization";
+
+export type XaaCapabilityEvidence = "advertised" | "not_advertised" | "unknown";
 
 export interface XaaFlowConfig {
   /** Target MCP server URL (the protected resource). */
   serverUrl: string;
-  /**
-   * Target authorization-server issuer. When set, protected-resource metadata
-   * (RFC 9728) discovery is skipped and this is used directly as the ID-JAG
-   * `aud` and the base for token-endpoint discovery.
-   */
+  /** Explicit authorization-server issuer; skips resource discovery. */
   authzServerIssuer?: string;
-  /** Skip AS-metadata discovery and redeem here directly. */
+  /** Explicit token endpoint; skips authorization-server discovery. */
   tokenEndpoint?: string;
-  /**
-   * Origin the local mock IdP issues from (and that the AS must fetch JWKS
-   * from). The signed `iss` is `getXAAIssuerUrl(issuerBaseUrl)` (appends
-   * `/xaa`), reported verbatim.
-   */
+  /** Base URL whose `/xaa` issuer metadata and JWKS are publicly reachable. */
   issuerBaseUrl: string;
-  /** Simulated end-user identity. */
   subject: string;
   email?: string;
-  /** OAuth client the ID-JAG is issued for; also presented at redemption. */
   clientId: string;
   clientSecret?: string;
   scope?: string;
-  /** Deliberately break the ID-JAG to probe the AS's validation. */
+  tokenEndpointAuthMethod?: XaaTokenEndpointAuthMethod;
   negativeTestMode?: NegativeTestMode;
-  /** Reject non-HTTPS / private targets. Default false (local dev targets). */
+  /** Per outbound request timeout in milliseconds. */
+  timeoutMs?: number;
+  /** Reject non-HTTPS / private targets. Default false for local development. */
   httpsOnly?: boolean;
   onProgress?: (message: string) => void;
 }
@@ -67,38 +62,65 @@ export interface XaaFlowStep {
   detail?: string;
 }
 
+export interface XaaRedemptionResult {
+  status: number;
+  tokenIssued: boolean;
+  error?: string;
+  body?: unknown;
+}
+
 export interface XaaFlowResult {
   completed: boolean;
   issuer: string;
   authzServerIssuer?: string;
   tokenEndpoint?: string;
+  authorizationServerCapabilities?: {
+    idJagProfile: XaaCapabilityEvidence;
+    jwtBearerGrant: XaaCapabilityEvidence;
+    tokenEndpointAuthMethods?: string[];
+    selectedTokenEndpointAuthMethod: XaaTokenEndpointAuthMethod;
+  };
   idJag?: {
     token: string;
     claims: Record<string, unknown>;
-    /** Local verification against the just-signed key (false for negative modes
-     * that break the signature/issuer/type). */
     verified: boolean;
     verifyError?: string;
   };
-  redemption?: {
-    status: number;
-    tokenIssued: boolean;
-    error?: string;
-    body?: unknown;
+  redemption?: XaaRedemptionResult;
+  negativeProbe?: {
+    mode: Exclude<NegativeTestMode, "valid">;
+    baselineAccepted: boolean;
+    baselineStatus: number;
+    baselineError?: string;
+    outcome: "rejected" | "accepted" | "inconclusive";
   };
-  mcp?: { status: number; ok: boolean; error?: string };
+  mcp?: {
+    status: number;
+    ok: boolean;
+    error?: string;
+    xaaExtension: XaaCapabilityEvidence;
+  };
   steps: XaaFlowStep[];
   error?: string;
 }
 
+interface DiscoveredAuthorizationServer {
+  issuer: string;
+  tokenEndpoint: string;
+  metadata: Record<string, unknown>;
+}
+
+interface RedeemedAssertion {
+  result: XaaRedemptionResult;
+  accessToken?: string;
+}
+
+type PublishedJwk = JsonWebKey & { kid?: string };
+
 function canonicalResource(serverUrl: string): string {
   try {
-    const u = new URL(serverUrl);
-    // Preserve the path exactly (including a trailing slash) and the query —
-    // both can distinguish resources, and the `resource` we mint/redeem for
-    // must match the URL the access token is ultimately used against. URL()
-    // still normalizes the origin (lowercase host, default port removal).
-    return `${u.origin}${u.pathname}${u.search}`;
+    const url = new URL(serverUrl);
+    return `${url.origin}${url.pathname}${url.search}`;
   } catch {
     return serverUrl;
   }
@@ -106,75 +128,218 @@ function canonicalResource(serverUrl: string): string {
 
 function wellKnownCandidates(issuer: string, name: string): string[] {
   let origin: string;
-  let path: string; // exact pathname incl. any trailing slash; "" for the root
+  let path: string;
   try {
-    const u = new URL(issuer);
-    origin = u.origin;
-    path = u.pathname === "/" ? "" : u.pathname;
+    const url = new URL(issuer);
+    origin = url.origin;
+    path = url.pathname === "/" ? "" : url.pathname;
   } catch {
     return [`${issuer.replace(/\/+$/, "")}/.well-known/${name}`];
   }
-  if (!path) {
-    return [`${origin}/.well-known/${name}`];
-  }
+  if (!path) return [`${origin}/.well-known/${name}`];
+
   const pathNoTrailing = path.replace(/\/+$/, "");
-  // Path issuer/resource: RFC 8414/9728 path-insertion preserving the exact path
-  // (including a trailing slash — some servers publish PRM under it); the OIDC
-  // path-appended form (`issuer + /.well-known/...`, which OIDC-only servers
-  // require); and the origin-root form (where RFC 9728 PRM is commonly served).
-  // Most specific first; for AS metadata a wrong-tenant root document is rejected
-  // downstream by the `metadata.issuer` match check.
-  const candidates = new Set<string>([
-    `${origin}/.well-known/${name}${path}`,
-    `${origin}${pathNoTrailing}/.well-known/${name}`,
-    `${origin}/.well-known/${name}`,
-  ]);
-  return [...candidates];
+  return [
+    ...new Set([
+      `${origin}/.well-known/${name}${path}`,
+      `${origin}${pathNoTrailing}/.well-known/${name}`,
+      `${origin}/.well-known/${name}`,
+    ]),
+  ];
 }
 
-// Discover a candidate authorization server's token endpoint (RFC 8414 / OIDC).
-// Returns the AS's own canonical `issuer` alongside the endpoint, or undefined
-// when no candidate URL yields metadata whose `issuer` matches (RFC 8414 §3.3 —
-// a mismatched document must not redirect the assertion to another issuer).
 async function discoverAsTokenEndpoint(
   candidateIssuer: string,
   httpsOnly: boolean,
-): Promise<{ issuer: string; tokenEndpoint: string } | undefined> {
+  timeoutMs: number | undefined
+): Promise<DiscoveredAuthorizationServer | undefined> {
   for (const name of ["oauth-authorization-server", "openid-configuration"]) {
     for (const url of wellKnownCandidates(candidateIssuer, name)) {
-      const meta = await fetchOAuthMetadata(url, httpsOnly);
-      if (!("status" in meta)) {
-        const metaIssuer = meta.metadata.issuer;
-        const te = meta.metadata.token_endpoint;
-        if (
-          typeof metaIssuer === "string" &&
-          metaIssuer.replace(/\/+$/, "") ===
-            candidateIssuer.replace(/\/+$/, "") &&
-          typeof te === "string"
-        ) {
-          return { issuer: metaIssuer, tokenEndpoint: te };
-        }
+      const response = await fetchOAuthMetadata(url, httpsOnly, timeoutMs);
+      if ("status" in response) continue;
+
+      const issuer = response.metadata.issuer;
+      const tokenEndpoint = response.metadata.token_endpoint;
+      if (
+        typeof issuer === "string" &&
+        issuer.replace(/\/+$/, "") === candidateIssuer.replace(/\/+$/, "") &&
+        typeof tokenEndpoint === "string"
+      ) {
+        return { issuer, tokenEndpoint, metadata: response.metadata };
       }
     }
   }
   return undefined;
 }
 
+function listEvidence(value: unknown, expected: string): XaaCapabilityEvidence {
+  if (value === undefined || value === null) return "unknown";
+  return Array.isArray(value) && value.includes(expected)
+    ? "advertised"
+    : "not_advertised";
+}
+
+function stringList(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  return value.filter((entry): entry is string => typeof entry === "string");
+}
+
+function selectTokenEndpointAuthMethod(
+  explicit: XaaTokenEndpointAuthMethod | undefined,
+  clientSecret: string | undefined,
+  advertised: string[] | undefined
+): XaaTokenEndpointAuthMethod {
+  if (explicit) return explicit;
+  if (!clientSecret) return "none";
+  if (advertised?.includes("client_secret_basic")) {
+    return "client_secret_basic";
+  }
+  if (advertised?.includes("client_secret_post")) {
+    return "client_secret_post";
+  }
+  if (advertised?.includes("none")) return "none";
+  // Metadata is optional; preserve the previous behavior when it is absent.
+  return "client_secret_post";
+}
+
+function publicJwkMatches(local: JsonWebKey, published: JsonWebKey): boolean {
+  if (local.kty !== published.kty) return false;
+  if (local.kty === "RSA") {
+    return local.n === published.n && local.e === published.e;
+  }
+  return (
+    local.crv === published.crv &&
+    local.x === published.x &&
+    local.y === published.y
+  );
+}
+
+async function verifyIssuerPublication(
+  issuer: string,
+  httpsOnly: boolean,
+  timeoutMs: number | undefined
+): Promise<{ ok: boolean; detail: string }> {
+  let metadata: Record<string, unknown> | undefined;
+  for (const url of wellKnownCandidates(issuer, "openid-configuration")) {
+    const response = await fetchOAuthMetadata(url, httpsOnly, timeoutMs);
+    if (!("status" in response) && response.metadata.issuer === issuer) {
+      metadata = response.metadata;
+      break;
+    }
+  }
+
+  if (!metadata) {
+    return {
+      ok: false,
+      detail: `No OpenID configuration with issuer ${issuer} was reachable`,
+    };
+  }
+
+  const jwksUri = metadata.jwks_uri;
+  if (typeof jwksUri !== "string") {
+    return { ok: false, detail: "Issuer metadata does not contain jwks_uri" };
+  }
+
+  const response = await executeOAuthProxy({
+    url: jwksUri,
+    headers: { Accept: "application/json" },
+    httpsOnly,
+    timeoutMs,
+  });
+  const rawKeys =
+    response.status >= 200 &&
+    response.status < 300 &&
+    response.body &&
+    typeof response.body === "object" &&
+    Array.isArray((response.body as { keys?: unknown }).keys)
+      ? (response.body as { keys: PublishedJwk[] }).keys ?? []
+      : [];
+  const keys = rawKeys.filter(
+    (key): key is PublishedJwk => Boolean(key) && typeof key === "object"
+  );
+  const localKey = getXAAIdpJwks().keys[0];
+  const matchingKey = keys.find(
+    (key) => key.kid === localKey.kid && publicJwkMatches(localKey, key)
+  );
+  if (!matchingKey) {
+    return {
+      ok: false,
+      detail: `Published JWKS ${jwksUri} does not contain the local signing key ${localKey.kid}`,
+    };
+  }
+  return { ok: true, detail: `${jwksUri} (${localKey.kid})` };
+}
+
+async function redeemAssertion(args: {
+  assertion: string;
+  tokenEndpoint: string;
+  tokenEndpointAuthMethod: XaaTokenEndpointAuthMethod;
+  clientId: string;
+  clientSecret?: string;
+  scope?: string;
+  resource: string;
+  httpsOnly: boolean;
+  timeoutMs?: number;
+}): Promise<RedeemedAssertion> {
+  const request = buildJwtBearerRequest({
+    assertion: args.assertion,
+    clientId: args.clientId,
+    clientSecret: args.clientSecret,
+    scope: args.scope,
+    resource: args.resource,
+    tokenEndpointAuthMethod: args.tokenEndpointAuthMethod,
+  });
+  const response = await executeOAuthProxy({
+    url: args.tokenEndpoint,
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      ...request.headers,
+    },
+    body: request.body,
+    httpsOnly: args.httpsOnly,
+    timeoutMs: args.timeoutMs,
+  });
+  const body =
+    response.body && typeof response.body === "object"
+      ? (response.body as Record<string, unknown>)
+      : undefined;
+  const accessToken = body?.access_token;
+  const tokenIssued =
+    response.status >= 200 &&
+    response.status < 300 &&
+    typeof accessToken === "string";
+  const errorDescription = body?.error_description;
+  const oauthError = body?.error;
+  const error = !tokenIssued
+    ? (typeof errorDescription === "string" ? errorDescription : undefined) ||
+      (typeof oauthError === "string" ? oauthError : undefined) ||
+      `Authorization server returned ${response.status}`
+    : undefined;
+  return {
+    result: {
+      status: response.status,
+      tokenIssued,
+      ...(error ? { error } : {}),
+      body: response.body,
+    },
+    ...(typeof accessToken === "string" ? { accessToken } : {}),
+  };
+}
+
 export async function runXaaFlow(
-  config: XaaFlowConfig,
+  config: XaaFlowConfig
 ): Promise<XaaFlowResult> {
   const httpsOnly = config.httpsOnly ?? false;
-  const progress = (m: string) => config.onProgress?.(m);
+  const progress = (message: string) => config.onProgress?.(message);
   const steps: XaaFlowStep[] = [];
   const record = (step: string, ok: boolean, detail?: string) => {
     steps.push({ step, ok, detail });
     return ok;
   };
-
   const resource = canonicalResource(config.serverUrl);
 
   try {
-    // 1. Resolve the candidate authorization server(s).
     let candidateIssuers: string[];
     if (config.authzServerIssuer) {
       candidateIssuers = [config.authzServerIssuer];
@@ -183,26 +348,24 @@ export async function runXaaFlow(
       let servers: string[] = [];
       for (const url of wellKnownCandidates(
         config.serverUrl,
-        "oauth-protected-resource",
+        "oauth-protected-resource"
       )) {
-        const meta = await fetchOAuthMetadata(url, httpsOnly);
-        if (!("status" in meta)) {
-          // RFC 9728: the metadata's `resource` MUST identify the protected
-          // resource we fetched it for. Reject a mismatched document so a
-          // compromised/misconfigured well-known can't redirect us to another
-          // AS. Skip-and-continue: a later candidate may still be valid, and an
-          // explicit --authz-server-issuer bypasses discovery entirely.
-          const metaResource = meta.metadata.resource;
-          const resourceMatches =
-            typeof metaResource === "string" &&
-            canonicalResource(metaResource) === resource;
-          const advertised = meta.metadata.authorization_servers;
-          if (resourceMatches && Array.isArray(advertised)) {
-            servers = advertised.filter(
-              (entry): entry is string => typeof entry === "string",
-            );
-            if (servers.length > 0) break;
-          }
+        const response = await fetchOAuthMetadata(
+          url,
+          httpsOnly,
+          config.timeoutMs
+        );
+        if ("status" in response) continue;
+
+        const resourceMatches =
+          typeof response.metadata.resource === "string" &&
+          canonicalResource(response.metadata.resource) === resource;
+        const advertised = response.metadata.authorization_servers;
+        if (resourceMatches && Array.isArray(advertised)) {
+          servers = advertised.filter(
+            (entry): entry is string => typeof entry === "string"
+          );
+          if (servers.length > 0) break;
         }
       }
       if (servers.length === 0) {
@@ -216,20 +379,23 @@ export async function runXaaFlow(
         };
       }
       candidateIssuers = servers;
-      record("discover_resource_metadata", true, candidateIssuers.join(", "));
+      record("discover_resource_metadata", true, servers.join(", "));
     }
 
-    // 2. Resolve the AS issuer + token endpoint. When PRM advertises several
-    // authorization servers, try each until one yields a token endpoint.
     let authzServerIssuer: string;
     let tokenEndpoint = config.tokenEndpoint;
+    let authzMetadata: Record<string, unknown> | undefined;
     if (tokenEndpoint) {
       authzServerIssuer = candidateIssuers[0];
     } else {
       progress("Discovering authorization-server metadata (RFC 8414)…");
-      let resolved: { issuer: string; tokenEndpoint: string } | undefined;
+      let resolved: DiscoveredAuthorizationServer | undefined;
       for (const candidate of candidateIssuers) {
-        resolved = await discoverAsTokenEndpoint(candidate, httpsOnly);
+        resolved = await discoverAsTokenEndpoint(
+          candidate,
+          httpsOnly,
+          config.timeoutMs
+        );
         if (resolved) break;
       }
       if (!resolved) {
@@ -243,34 +409,94 @@ export async function runXaaFlow(
             "Could not discover the authorization server's token endpoint. Pass --token-endpoint explicitly.",
         };
       }
-      // Adopt the AS's own canonical issuer as the ID-JAG `aud`.
       authzServerIssuer = resolved.issuer;
       tokenEndpoint = resolved.tokenEndpoint;
+      authzMetadata = resolved.metadata;
       record("discover_authz_metadata", true, tokenEndpoint);
     }
 
-    // 3. Mint the ID-JAG in-process (self-issued). The driver IS the IdP and
-    // already holds the identity, so it mints the grant directly rather than
-    // round-tripping an id-token through a token-exchange.
-    progress("Minting the ID-JAG…");
+    const advertisedAuthMethods = stringList(
+      authzMetadata?.token_endpoint_auth_methods_supported
+    );
+    const selectedTokenEndpointAuthMethod = selectTokenEndpointAuthMethod(
+      config.tokenEndpointAuthMethod,
+      config.clientSecret,
+      advertisedAuthMethods
+    );
+    const authorizationServerCapabilities = {
+      idJagProfile: listEvidence(
+        authzMetadata?.authorization_grant_profiles_supported,
+        ID_JAG_GRANT_PROFILE
+      ),
+      jwtBearerGrant: listEvidence(
+        authzMetadata?.grant_types_supported,
+        JWT_BEARER_GRANT
+      ),
+      ...(advertisedAuthMethods
+        ? { tokenEndpointAuthMethods: advertisedAuthMethods }
+        : {}),
+      selectedTokenEndpointAuthMethod,
+    };
+    record(
+      "authorization_server_id_jag_profile",
+      authorizationServerCapabilities.idJagProfile !== "not_advertised",
+      authorizationServerCapabilities.idJagProfile
+    );
+    record(
+      "authorization_server_jwt_bearer_grant",
+      authorizationServerCapabilities.jwtBearerGrant !== "not_advertised",
+      authorizationServerCapabilities.jwtBearerGrant
+    );
+    record(
+      "select_token_endpoint_auth_method",
+      true,
+      selectedTokenEndpointAuthMethod
+    );
+
+    progress("Verifying the configured issuer metadata and JWKS…");
     initXAAIdpKeyPair();
     const issuer = getXAAIssuerUrl(config.issuerBaseUrl);
-    const mode = config.negativeTestMode ?? DEFAULT_NEGATIVE_TEST_MODE;
-    const minted = issueNegativeIdJag(
-      {
-        issuer,
-        subject: config.subject,
-        audience: authzServerIssuer,
-        resource,
-        clientId: config.clientId,
-        scope: config.scope,
-        email: config.email,
-      },
-      mode,
+    const issuerPublication = await verifyIssuerPublication(
+      issuer,
+      httpsOnly,
+      config.timeoutMs
     );
-    record("mint_id_jag", true, mode === "valid" ? "valid" : `negative:${mode}`);
+    record(
+      "verify_issuer_publication",
+      issuerPublication.ok,
+      issuerPublication.detail
+    );
+    if (!issuerPublication.ok) {
+      return {
+        completed: false,
+        issuer,
+        authzServerIssuer,
+        tokenEndpoint,
+        authorizationServerCapabilities,
+        steps,
+        error:
+          "The configured issuer does not publish the local signing key; the authorization server cannot validate this ID-JAG.",
+      };
+    }
 
-    // 4. Verify/inspect locally. Negative modes are EXPECTED to fail here.
+    const mode = config.negativeTestMode ?? DEFAULT_NEGATIVE_TEST_MODE;
+    const issueParams = {
+      issuer,
+      subject: config.subject,
+      audience: authzServerIssuer,
+      resource,
+      clientId: config.clientId,
+      scope: config.scope,
+      email: config.email,
+    };
+    progress("Minting the ID-JAG…");
+    const minted = issueNegativeIdJag(issueParams, mode);
+    record(
+      "mint_id_jag",
+      true,
+      mode === "valid" ? "valid" : `negative:${mode}`
+    );
+
     let verified = false;
     let verifyError: string | undefined;
     try {
@@ -282,85 +508,152 @@ export async function runXaaFlow(
     record(
       "inspect_id_jag",
       mode === "valid" ? verified : true,
-      verified ? "verified" : verifyError,
+      verified ? "verified" : verifyError
     );
-
     const idJag = {
       token: minted.token,
       claims: minted.payload,
       verified,
-      verifyError,
+      ...(verifyError ? { verifyError } : {}),
     };
-
-    // 5. Redeem at the target AS (RFC 7523 jwt-bearer).
-    progress("Redeeming the ID-JAG at the authorization server…");
-    const body = buildJwtBearerBody({
-      assertion: minted.token,
+    const redemptionArgs = {
+      tokenEndpoint,
+      tokenEndpointAuthMethod: selectedTokenEndpointAuthMethod,
       clientId: config.clientId,
       clientSecret: config.clientSecret,
       scope: config.scope,
       resource,
-    });
-    const redeemResponse = await executeOAuthProxy({
-      url: tokenEndpoint,
-      method: "POST",
-      headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      body,
       httpsOnly,
-    });
-    const redeemBody = redeemResponse.body as Record<string, unknown> | null;
-    const accessToken =
-      redeemBody && typeof redeemBody === "object"
-        ? (redeemBody as { access_token?: unknown }).access_token
-        : undefined;
-    const tokenIssued =
-      redeemResponse.status >= 200 &&
-      redeemResponse.status < 300 &&
-      typeof accessToken === "string";
-    const redemptionError = !tokenIssued
-      ? (redeemBody as { error_description?: string; error?: string })
-          ?.error_description ||
-        (redeemBody as { error?: string })?.error ||
-        `Authorization server returned ${redeemResponse.status}`
-      : undefined;
-    record(
-      "redeem_id_jag",
-      tokenIssued,
-      tokenIssued ? "access token issued" : redemptionError,
-    );
-    const redemption = {
-      status: redeemResponse.status,
-      tokenIssued,
-      error: redemptionError,
-      body: redeemResponse.body,
+      timeoutMs: config.timeoutMs,
     };
 
-    if (!tokenIssued) {
+    if (mode !== "valid") {
+      progress("Establishing a valid ID-JAG redemption baseline…");
+      const baseline = await redeemAssertion({
+        ...redemptionArgs,
+        assertion: issueNegativeIdJag(issueParams, "valid").token,
+      });
+      record(
+        "redeem_valid_baseline",
+        baseline.result.tokenIssued,
+        baseline.result.tokenIssued
+          ? "access token issued"
+          : baseline.result.error
+      );
+      if (!baseline.result.tokenIssued) {
+        return {
+          completed: false,
+          issuer,
+          authzServerIssuer,
+          tokenEndpoint,
+          authorizationServerCapabilities,
+          idJag,
+          negativeProbe: {
+            mode,
+            baselineAccepted: false,
+            baselineStatus: baseline.result.status,
+            ...(baseline.result.error
+              ? { baselineError: baseline.result.error }
+              : {}),
+            outcome: "inconclusive",
+          },
+          steps,
+          error:
+            "The valid baseline was not accepted, so the negative probe cannot be scored.",
+        };
+      }
+
+      progress("Redeeming the deliberately invalid ID-JAG…");
+      const probe = await redeemAssertion({
+        ...redemptionArgs,
+        assertion: minted.token,
+      });
+      const outcome = probe.result.tokenIssued
+        ? "accepted"
+        : probe.result.status >= 400 && probe.result.status < 500
+        ? "rejected"
+        : "inconclusive";
+      record(
+        "redeem_negative_id_jag",
+        outcome === "rejected",
+        outcome === "rejected"
+          ? `rejected with status ${probe.result.status}`
+          : outcome === "accepted"
+          ? "authorization server issued an access token"
+          : probe.result.error
+      );
+      return {
+        completed: outcome === "rejected",
+        issuer,
+        authzServerIssuer,
+        tokenEndpoint,
+        authorizationServerCapabilities,
+        idJag,
+        redemption: probe.result,
+        negativeProbe: {
+          mode,
+          baselineAccepted: true,
+          baselineStatus: baseline.result.status,
+          outcome,
+        },
+        steps,
+        ...(outcome === "accepted"
+          ? {
+              error:
+                "The authorization server accepted the deliberately invalid ID-JAG.",
+            }
+          : outcome === "inconclusive"
+          ? {
+              error:
+                "The negative probe did not produce a conclusive 4xx rejection.",
+            }
+          : {}),
+      };
+    }
+
+    progress("Redeeming the ID-JAG at the authorization server…");
+    const redeemed = await redeemAssertion({
+      ...redemptionArgs,
+      assertion: minted.token,
+    });
+    record(
+      "redeem_id_jag",
+      redeemed.result.tokenIssued,
+      redeemed.result.tokenIssued
+        ? "access token issued"
+        : redeemed.result.error
+    );
+    if (!redeemed.result.tokenIssued || !redeemed.accessToken) {
       return {
         completed: false,
         issuer,
         authzServerIssuer,
         tokenEndpoint,
+        authorizationServerCapabilities,
         idJag,
-        redemption,
+        redemption: redeemed.result,
         steps,
       };
     }
 
-    // 6. Call the MCP server with the access token (SSE-aware via the debug
-    // proxy, since streamable-HTTP `initialize` may reply as text/event-stream).
     progress("Calling the MCP server with the access token…");
     const mcpResult = await callAuthenticatedMcp(
       config.serverUrl,
-      accessToken as string,
+      redeemed.accessToken,
       httpsOnly,
+      config.timeoutMs
     );
     record(
       "authenticated_mcp_request",
       mcpResult.ok,
       mcpResult.error
         ? `status ${mcpResult.status}: ${mcpResult.error}`
-        : `status ${mcpResult.status}`,
+        : `status ${mcpResult.status}`
+    );
+    record(
+      "mcp_xaa_extension",
+      mcpResult.xaaExtension !== "not_advertised",
+      mcpResult.xaaExtension
     );
 
     return {
@@ -368,8 +661,9 @@ export async function runXaaFlow(
       issuer,
       authzServerIssuer,
       tokenEndpoint,
+      authorizationServerCapabilities,
       idJag,
-      redemption,
+      redemption: redeemed.result,
       mcp: mcpResult,
       steps,
     };
@@ -387,7 +681,13 @@ async function callAuthenticatedMcp(
   serverUrl: string,
   accessToken: string,
   httpsOnly: boolean,
-): Promise<{ status: number; ok: boolean; error?: string }> {
+  timeoutMs: number | undefined
+): Promise<{
+  status: number;
+  ok: boolean;
+  error?: string;
+  xaaExtension: XaaCapabilityEvidence;
+}> {
   const response = await executeDebugOAuthProxy({
     url: serverUrl,
     method: "POST",
@@ -403,46 +703,33 @@ async function callAuthenticatedMcp(
       method: "initialize",
       params: {
         protocolVersion: MCP_PROTOCOL_VERSION,
-        capabilities: {},
+        capabilities: {
+          extensions: { [XAA_MCP_EXTENSION]: {} },
+        },
         clientInfo: { name: "MCPJam XAA CLI", version: "1.0.0" },
       },
     },
     httpsOnly,
+    timeoutMs,
   });
-  // Transport status alone lies: a 2xx can carry a JSON-RPC error, no JSON-RPC
-  // payload at all, or a non-MCP body. The call succeeds only when the server
-  // returns a proper JSON-RPC `initialize` result.
-  const transportOk = response.status >= 200 && response.status < 300;
   const error = evaluateMcpInitResponse(response.body);
   return {
     status: response.status,
-    ok: transportOk && !error,
+    ok: response.status >= 200 && response.status < 300 && !error,
     ...(error ? { error } : {}),
+    xaaExtension: serverExtensionEvidence(response.body),
   };
 }
 
-// Returns a failure reason, or undefined when `body` is a valid JSON-RPC
-// `initialize` result.
 function evaluateMcpInitResponse(body: unknown): string | undefined {
-  // A top-level string `error` is a proxy-level failure — most notably the SSE
-  // parse-failure envelope executeDebugOAuthProxy returns ({ error: "Failed to
-  // parse SSE stream" }, no `transport` field) when the stream times out before
-  // the first event.
   if (body && typeof body === "object") {
     const topError = (body as { error?: unknown }).error;
-    if (typeof topError === "string" && topError.length > 0) {
-      return topError;
-    }
+    if (typeof topError === "string" && topError.length > 0) return topError;
   }
   const payload = jsonRpcPayload(body);
   const rpcError = jsonRpcErrorFrom(payload);
-  if (rpcError) {
-    return rpcError;
-  }
-  // Require a genuine JSON-RPC initialize result: right protocol version, the
-  // `id` we sent echoed back, and an object `result`. This rejects an empty SSE
-  // envelope (no `message` event) and a coincidental non-MCP 2xx body that
-  // merely happens to carry a `result` field.
+  if (rpcError) return rpcError;
+
   const response = payload as {
     jsonrpc?: unknown;
     id?: unknown;
@@ -461,31 +748,33 @@ function evaluateMcpInitResponse(body: unknown): string | undefined {
   return undefined;
 }
 
-// executeDebugOAuthProxy wraps a text/event-stream reply in an SSE envelope with
-// the JSON-RPC payload under `mcpResponse`; a plain JSON body IS the payload.
+function serverExtensionEvidence(body: unknown): XaaCapabilityEvidence {
+  const payload = jsonRpcPayload(body);
+  if (!payload || typeof payload !== "object") return "unknown";
+  const result = (payload as { result?: unknown }).result;
+  if (!result || typeof result !== "object") return "unknown";
+  const capabilities = (result as { capabilities?: unknown }).capabilities;
+  if (!capabilities || typeof capabilities !== "object") return "unknown";
+  const extensions = (capabilities as { extensions?: unknown }).extensions;
+  if (!extensions || typeof extensions !== "object") return "unknown";
+  return Object.prototype.hasOwnProperty.call(extensions, XAA_MCP_EXTENSION)
+    ? "advertised"
+    : "not_advertised";
+}
+
 function jsonRpcPayload(body: unknown): unknown {
-  if (!body || typeof body !== "object") {
-    return body;
-  }
+  if (!body || typeof body !== "object") return body;
   const record = body as Record<string, unknown>;
   return record.transport === "sse" ? record.mcpResponse : body;
 }
 
 function jsonRpcErrorFrom(payload: unknown): string | undefined {
-  if (!payload || typeof payload !== "object") {
-    return undefined;
-  }
+  if (!payload || typeof payload !== "object") return undefined;
   const error = (payload as { error?: unknown }).error;
-  if (!error || typeof error !== "object") {
-    return undefined;
-  }
+  if (!error || typeof error !== "object") return undefined;
   const { code, message } = error as { code?: unknown; message?: unknown };
   const parts: string[] = [];
-  if (typeof code === "number") {
-    parts.push(String(code));
-  }
-  if (typeof message === "string" && message.length > 0) {
-    parts.push(message);
-  }
+  if (typeof code === "number") parts.push(String(code));
+  if (typeof message === "string" && message.length > 0) parts.push(message);
   return parts.length > 0 ? parts.join(": ") : "JSON-RPC error";
 }

--- a/sdk/src/xaa/run-xaa-flow.ts
+++ b/sdk/src/xaa/run-xaa-flow.ts
@@ -1,0 +1,358 @@
+// Headless Cross-App Access (ID-JAG) flow driver. Mirrors the inspector's XAA
+// debugger, minus the UI: it self-issues an ID-JAG with the in-process mint,
+// then redeems it at the target authorization server (RFC 7523 jwt-bearer) and
+// calls the MCP server with the resulting access token — reporting whatever
+// happens at each step.
+//
+// Reachability note: the ID-JAG's `iss`/JWKS is served by THIS host, so a cloud
+// authorization server can only validate it when the issuer origin is reachable
+// (an enterprise/self-hosted AS on the network, or a tunnelled origin). Against
+// an unreachable issuer, redemption fails at the AS — which is itself the
+// finding this tool reports.
+import {
+  executeOAuthProxy,
+  executeDebugOAuthProxy,
+  fetchOAuthMetadata,
+} from "../oauth-proxy.js";
+import { initXAAIdpKeyPair, getXAAIssuerUrl } from "./mint/keypair.js";
+import { issueNegativeIdJag, verifyXaaJwt } from "./mint/signer.js";
+import { buildJwtBearerBody } from "./mint/jwt-bearer.js";
+import {
+  DEFAULT_NEGATIVE_TEST_MODE,
+  type NegativeTestMode,
+} from "./constants.js";
+
+const ID_JAG_TYP = "oauth-id-jag+jwt";
+
+export interface XaaFlowConfig {
+  /** Target MCP server URL (the protected resource). */
+  serverUrl: string;
+  /**
+   * Target authorization-server issuer. When set, protected-resource metadata
+   * (RFC 9728) discovery is skipped and this is used directly as the ID-JAG
+   * `aud` and the base for token-endpoint discovery.
+   */
+  authzServerIssuer?: string;
+  /** Skip AS-metadata discovery and redeem here directly. */
+  tokenEndpoint?: string;
+  /**
+   * Origin the local mock IdP issues from (and that the AS must fetch JWKS
+   * from). The signed `iss` is `getXAAIssuerUrl(issuerBaseUrl)` (appends
+   * `/xaa`), reported verbatim.
+   */
+  issuerBaseUrl: string;
+  /** Simulated end-user identity. */
+  subject: string;
+  email?: string;
+  /** OAuth client the ID-JAG is issued for; also presented at redemption. */
+  clientId: string;
+  clientSecret?: string;
+  scope?: string;
+  /** Deliberately break the ID-JAG to probe the AS's validation. */
+  negativeTestMode?: NegativeTestMode;
+  /** Reject non-HTTPS / private targets. Default false (local dev targets). */
+  httpsOnly?: boolean;
+  onProgress?: (message: string) => void;
+}
+
+export interface XaaFlowStep {
+  step: string;
+  ok: boolean;
+  detail?: string;
+}
+
+export interface XaaFlowResult {
+  completed: boolean;
+  issuer: string;
+  authzServerIssuer?: string;
+  tokenEndpoint?: string;
+  idJag?: {
+    token: string;
+    claims: Record<string, unknown>;
+    /** Local verification against the just-signed key (false for negative modes
+     * that break the signature/issuer/type). */
+    verified: boolean;
+    verifyError?: string;
+  };
+  redemption?: {
+    status: number;
+    tokenIssued: boolean;
+    error?: string;
+    body?: unknown;
+  };
+  mcp?: { status: number; ok: boolean };
+  steps: XaaFlowStep[];
+  error?: string;
+}
+
+function canonicalResource(serverUrl: string): string {
+  try {
+    const u = new URL(serverUrl);
+    return `${u.origin}${u.pathname.replace(/\/+$/, "")}`;
+  } catch {
+    return serverUrl.replace(/\/+$/, "");
+  }
+}
+
+function wellKnownCandidates(issuer: string, name: string): string[] {
+  const trimmed = issuer.replace(/\/+$/, "");
+  let origin = trimmed;
+  let path = "";
+  try {
+    const u = new URL(trimmed);
+    origin = u.origin;
+    path = u.pathname.replace(/\/+$/, "");
+  } catch {
+    /* keep trimmed as origin */
+  }
+  const candidates = new Set<string>([
+    // RFC 8414 path-insertion form.
+    `${origin}/.well-known/${name}${path}`,
+    // Root form.
+    `${origin}/.well-known/${name}`,
+  ]);
+  return [...candidates];
+}
+
+export async function runXaaFlow(
+  config: XaaFlowConfig,
+): Promise<XaaFlowResult> {
+  const httpsOnly = config.httpsOnly ?? false;
+  const progress = (m: string) => config.onProgress?.(m);
+  const steps: XaaFlowStep[] = [];
+  const record = (step: string, ok: boolean, detail?: string) => {
+    steps.push({ step, ok, detail });
+    return ok;
+  };
+
+  const resource = canonicalResource(config.serverUrl);
+
+  try {
+    // 1. Resolve the target authorization server.
+    let authzServerIssuer = config.authzServerIssuer;
+    if (!authzServerIssuer) {
+      progress("Discovering protected-resource metadata (RFC 9728)…");
+      let found: string | undefined;
+      for (const url of wellKnownCandidates(
+        config.serverUrl,
+        "oauth-protected-resource",
+      )) {
+        const meta = await fetchOAuthMetadata(url, httpsOnly);
+        if (!("status" in meta)) {
+          const servers = meta.metadata.authorization_servers;
+          if (Array.isArray(servers) && typeof servers[0] === "string") {
+            found = servers[0];
+            break;
+          }
+        }
+      }
+      if (!found) {
+        record("discover_resource_metadata", false, "no authorization_servers");
+        return {
+          completed: false,
+          issuer: getXAAIssuerUrl(config.issuerBaseUrl),
+          steps,
+          error:
+            "Could not discover the authorization server from the MCP server's protected-resource metadata. Pass the issuer explicitly.",
+        };
+      }
+      authzServerIssuer = found;
+      record("discover_resource_metadata", true, authzServerIssuer);
+    }
+
+    // 2. Resolve the token endpoint.
+    let tokenEndpoint = config.tokenEndpoint;
+    if (!tokenEndpoint) {
+      progress("Discovering authorization-server metadata (RFC 8414)…");
+      for (const name of [
+        "oauth-authorization-server",
+        "openid-configuration",
+      ]) {
+        for (const url of wellKnownCandidates(authzServerIssuer, name)) {
+          const meta = await fetchOAuthMetadata(url, httpsOnly);
+          if (!("status" in meta)) {
+            const te = meta.metadata.token_endpoint;
+            if (typeof te === "string") {
+              tokenEndpoint = te;
+              break;
+            }
+          }
+        }
+        if (tokenEndpoint) break;
+      }
+      if (!tokenEndpoint) {
+        record("discover_authz_metadata", false, "no token_endpoint");
+        return {
+          completed: false,
+          issuer: getXAAIssuerUrl(config.issuerBaseUrl),
+          authzServerIssuer,
+          steps,
+          error:
+            "Could not discover the authorization server's token endpoint. Pass --token-endpoint explicitly.",
+        };
+      }
+      record("discover_authz_metadata", true, tokenEndpoint);
+    }
+
+    // 3. Mint the ID-JAG in-process (self-issued). The driver IS the IdP and
+    // already holds the identity, so it mints the grant directly rather than
+    // round-tripping an id-token through a token-exchange.
+    progress("Minting the ID-JAG…");
+    initXAAIdpKeyPair();
+    const issuer = getXAAIssuerUrl(config.issuerBaseUrl);
+    const mode = config.negativeTestMode ?? DEFAULT_NEGATIVE_TEST_MODE;
+    const minted = issueNegativeIdJag(
+      {
+        issuer,
+        subject: config.subject,
+        audience: authzServerIssuer,
+        resource,
+        clientId: config.clientId,
+        scope: config.scope,
+        email: config.email,
+      },
+      mode,
+    );
+    record("mint_id_jag", true, mode === "valid" ? "valid" : `negative:${mode}`);
+
+    // 4. Verify/inspect locally. Negative modes are EXPECTED to fail here.
+    let verified = false;
+    let verifyError: string | undefined;
+    try {
+      verifyXaaJwt(minted.token, { issuer, typ: ID_JAG_TYP });
+      verified = true;
+    } catch (error) {
+      verifyError = error instanceof Error ? error.message : String(error);
+    }
+    record(
+      "inspect_id_jag",
+      mode === "valid" ? verified : true,
+      verified ? "verified" : verifyError,
+    );
+
+    const idJag = {
+      token: minted.token,
+      claims: minted.payload,
+      verified,
+      verifyError,
+    };
+
+    // 5. Redeem at the target AS (RFC 7523 jwt-bearer).
+    progress("Redeeming the ID-JAG at the authorization server…");
+    const body = buildJwtBearerBody({
+      assertion: minted.token,
+      clientId: config.clientId,
+      clientSecret: config.clientSecret,
+      scope: config.scope,
+      resource,
+    });
+    const redeemResponse = await executeOAuthProxy({
+      url: tokenEndpoint,
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body,
+      httpsOnly,
+    });
+    const redeemBody = redeemResponse.body as Record<string, unknown> | null;
+    const accessToken =
+      redeemBody && typeof redeemBody === "object"
+        ? (redeemBody as { access_token?: unknown }).access_token
+        : undefined;
+    const tokenIssued =
+      redeemResponse.status >= 200 &&
+      redeemResponse.status < 300 &&
+      typeof accessToken === "string";
+    const redemptionError = !tokenIssued
+      ? (redeemBody as { error_description?: string; error?: string })
+          ?.error_description ||
+        (redeemBody as { error?: string })?.error ||
+        `Authorization server returned ${redeemResponse.status}`
+      : undefined;
+    record(
+      "redeem_id_jag",
+      tokenIssued,
+      tokenIssued ? "access token issued" : redemptionError,
+    );
+    const redemption = {
+      status: redeemResponse.status,
+      tokenIssued,
+      error: redemptionError,
+      body: redeemResponse.body,
+    };
+
+    if (!tokenIssued) {
+      return {
+        completed: false,
+        issuer,
+        authzServerIssuer,
+        tokenEndpoint,
+        idJag,
+        redemption,
+        steps,
+      };
+    }
+
+    // 6. Call the MCP server with the access token (SSE-aware via the debug
+    // proxy, since streamable-HTTP `initialize` may reply as text/event-stream).
+    progress("Calling the MCP server with the access token…");
+    const mcpResult = await callAuthenticatedMcp(
+      config.serverUrl,
+      accessToken as string,
+      httpsOnly,
+    );
+    record(
+      "authenticated_mcp_request",
+      mcpResult.ok,
+      `status ${mcpResult.status}`,
+    );
+
+    return {
+      completed: mcpResult.ok,
+      issuer,
+      authzServerIssuer,
+      tokenEndpoint,
+      idJag,
+      redemption,
+      mcp: mcpResult,
+      steps,
+    };
+  } catch (error) {
+    return {
+      completed: false,
+      issuer: getXAAIssuerUrl(config.issuerBaseUrl),
+      steps,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+async function callAuthenticatedMcp(
+  serverUrl: string,
+  accessToken: string,
+  httpsOnly: boolean,
+): Promise<{ status: number; ok: boolean }> {
+  const response = await executeDebugOAuthProxy({
+    url: serverUrl,
+    method: "POST",
+    headers: {
+      Accept: "application/json, text/event-stream",
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: {
+      jsonrpc: "2.0",
+      id: "mcpjam-xaa-cli",
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-11-25",
+        capabilities: {},
+        clientInfo: { name: "MCPJam XAA CLI", version: "1.0.0" },
+      },
+    },
+    httpsOnly,
+  });
+  return {
+    status: response.status,
+    ok: response.status >= 200 && response.status < 300,
+  };
+}

--- a/sdk/tests/oauth-proxy.test.ts
+++ b/sdk/tests/oauth-proxy.test.ts
@@ -24,14 +24,14 @@ describe("oauth-proxy helpers", () => {
       executeOAuthProxy({
         url: "https://127.0.0.1/foo",
         httpsOnly: true,
-      }),
+      })
     ).rejects.toBeInstanceOf(OAuthProxyError);
 
     await expect(
       executeOAuthProxy({
         url: "https://127.0.0.1/foo",
         httpsOnly: true,
-      }),
+      })
     ).rejects.toMatchObject({ status: 400 });
   });
 
@@ -43,7 +43,7 @@ describe("oauth-proxy helpers", () => {
       new Response(JSON.stringify({ ok: true }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
-      }),
+      })
     );
 
     await executeOAuthProxy({
@@ -53,7 +53,7 @@ describe("oauth-proxy helpers", () => {
 
     expect(global.fetch).toHaveBeenCalledWith(
       expect.stringContaining("https://example.com/path"),
-      expect.any(Object),
+      expect.any(Object)
     );
   });
 
@@ -62,14 +62,34 @@ describe("oauth-proxy helpers", () => {
       new Response(JSON.stringify({ issuer: "https://auth.example.com" }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
-      }),
+      })
     );
 
     await expect(
-      fetchOAuthMetadata("https://auth.example.com/.well-known/oauth"),
+      fetchOAuthMetadata("https://auth.example.com/.well-known/oauth")
     ).resolves.toEqual({
       metadata: { issuer: "https://auth.example.com" },
     });
+  });
+
+  it("bounds regular, debug, and metadata requests with timeoutMs", async () => {
+    global.fetch = vi.fn(async (_input, init?: RequestInit) => {
+      return await new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          reject(init.signal?.reason);
+        });
+      });
+    }) as unknown as typeof fetch;
+
+    await expect(
+      executeOAuthProxy({ url: "https://example.com", timeoutMs: 10 })
+    ).rejects.toThrow(/timeout/i);
+    await expect(
+      executeDebugOAuthProxy({ url: "https://example.com", timeoutMs: 10 })
+    ).rejects.toThrow(/timeout/i);
+    await expect(
+      fetchOAuthMetadata("https://example.com/.well-known/oauth", false, 10)
+    ).rejects.toThrow(/timeout/i);
   });
 
   describe("redirect option plumbing", () => {

--- a/sdk/tests/xaa/jwt-bearer.test.ts
+++ b/sdk/tests/xaa/jwt-bearer.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildJwtBearerBody,
+  buildJwtBearerRequest,
+} from "../../src/xaa/mint/jwt-bearer.js";
+
+describe("buildJwtBearerRequest", () => {
+  const args = {
+    assertion: "the-id-jag",
+    clientId: "client id!",
+    clientSecret: "secret (with)~chars",
+    scope: "read",
+    resource: "https://mcp.example.com/mcp",
+  };
+
+  it("keeps credentials in the body for client_secret_post", () => {
+    const request = buildJwtBearerRequest({
+      ...args,
+      tokenEndpointAuthMethod: "client_secret_post",
+    });
+
+    expect(request.headers).toEqual({});
+    expect(request.body).toEqual(buildJwtBearerBody(args));
+  });
+
+  it("uses RFC 6749 Basic encoding and removes credentials from the body", () => {
+    const request = buildJwtBearerRequest({
+      ...args,
+      tokenEndpointAuthMethod: "client_secret_basic",
+    });
+    const encoded = request.headers.Authorization.replace(/^Basic /, "");
+
+    expect(Buffer.from(encoded, "base64").toString()).toBe(
+      "client+id%21:secret+%28with%29%7Echars"
+    );
+    expect(request.body.client_id).toBeUndefined();
+    expect(request.body.client_secret).toBeUndefined();
+    expect(request.body.assertion).toBe(args.assertion);
+  });
+
+  it("never sends a secret for public clients", () => {
+    const request = buildJwtBearerRequest({
+      ...args,
+      tokenEndpointAuthMethod: "none",
+    });
+
+    expect(request.headers).toEqual({});
+    expect(request.body.client_id).toBe(args.clientId);
+    expect(request.body.client_secret).toBeUndefined();
+  });
+});

--- a/sdk/tests/xaa/keypair.test.ts
+++ b/sdk/tests/xaa/keypair.test.ts
@@ -12,8 +12,8 @@ import {
   getXAAIdpJwks,
   initXAAIdpKeyPair,
   resetXAAIdpKeyPairForTests,
-} from "../xaa-idp-keypair.js";
-import { issueIdJag } from "../xaa-idjag-signer.js";
+} from "../../src/xaa/mint/keypair.js";
+import { issueIdJag } from "../../src/xaa/mint/signer.js";
 
 function publishedModulus(): string {
   const jwk = getXAAIdpJwks().keys[0] as JsonWebKey & { n: string };

--- a/sdk/tests/xaa/run-xaa-flow.test.ts
+++ b/sdk/tests/xaa/run-xaa-flow.test.ts
@@ -109,7 +109,10 @@ describe("runXaaFlow", () => {
 
   it("discovers the AS + token endpoint when not supplied", async () => {
     global.fetch = stubFetch({
-      prm: { authorization_servers: [AS_ISSUER] },
+      prm: {
+        resource: "https://mcp.example.com/mcp",
+        authorization_servers: [AS_ISSUER],
+      },
       asMetadata: { issuer: AS_ISSUER, token_endpoint: TOKEN_ENDPOINT },
       token: {
         status: 200,
@@ -168,7 +171,10 @@ describe("runXaaFlow", () => {
       // PRM is published ONLY at the origin root, not the path-insertion form.
       if (url.includes(".well-known/oauth-protected-resource")) {
         return url === rootPrm
-          ? json({ authorization_servers: [AS_ISSUER] })
+          ? json({
+              resource: "https://mcp.example.com/mcp",
+              authorization_servers: [AS_ISSUER],
+            })
           : json({}, 404);
       }
       if (
@@ -197,9 +203,90 @@ describe("runXaaFlow", () => {
     expect(result.completed).toBe(true);
   });
 
+  it("rejects PRM whose resource does not identify the requested server", async () => {
+    global.fetch = stubFetch({
+      prm: {
+        // Wrong resource — must not be trusted to source the AS (RFC 9728).
+        resource: "https://other.example.com/mcp",
+        authorization_servers: [AS_ISSUER],
+      },
+      asMetadata: { issuer: AS_ISSUER, token_endpoint: TOKEN_ENDPOINT },
+    }) as unknown as typeof fetch;
+
+    const result = await runXaaFlow({
+      serverUrl: SERVER_URL,
+      issuerBaseUrl: ISSUER_BASE,
+      subject: "user-1",
+      clientId: "client-1",
+    });
+
+    expect(result.completed).toBe(false);
+    expect(result.authzServerIssuer).toBeUndefined();
+    expect(result.error).toMatch(/protected-resource metadata/i);
+  });
+
+  it("preserves a meaningful trailing slash in the canonical resource", async () => {
+    const serverWithSlash = "https://mcp.example.com/mcp/";
+    global.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const method = (init?.method || "GET").toUpperCase();
+      if (url === TOKEN_ENDPOINT && method === "POST") {
+        return json({ access_token: "at-1", token_type: "Bearer" });
+      }
+      if (url === serverWithSlash && method === "POST") {
+        return json({ jsonrpc: "2.0", id: "mcpjam-xaa-cli", result: {} });
+      }
+      return json({}, 404);
+    }) as unknown as typeof fetch;
+
+    const result = await runXaaFlow({
+      serverUrl: serverWithSlash,
+      authzServerIssuer: AS_ISSUER,
+      tokenEndpoint: TOKEN_ENDPOINT,
+      issuerBaseUrl: ISSUER_BASE,
+      subject: "user-1",
+      clientId: "client-1",
+    });
+
+    expect(result.idJag?.claims.resource).toBe("https://mcp.example.com/mcp/");
+    expect(result.completed).toBe(true);
+  });
+
+  it("treats a top-level error string (SSE parse failure) as a failed call", async () => {
+    global.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const method = (init?.method || "GET").toUpperCase();
+      if (url === TOKEN_ENDPOINT && method === "POST") {
+        return json({ access_token: "at-1", token_type: "Bearer" });
+      }
+      if (url === SERVER_URL && method === "POST") {
+        // The shape executeDebugOAuthProxy returns when it can't parse the SSE
+        // stream: a top-level string `error`, no `transport` field.
+        return json({ error: "Failed to parse SSE stream" });
+      }
+      return json({}, 404);
+    }) as unknown as typeof fetch;
+
+    const result = await runXaaFlow({
+      serverUrl: SERVER_URL,
+      authzServerIssuer: AS_ISSUER,
+      tokenEndpoint: TOKEN_ENDPOINT,
+      issuerBaseUrl: ISSUER_BASE,
+      subject: "user-1",
+      clientId: "client-1",
+    });
+
+    expect(result.mcp?.ok).toBe(false);
+    expect(result.mcp?.jsonRpcError).toBe("Failed to parse SSE stream");
+    expect(result.completed).toBe(false);
+  });
+
   it("rejects AS metadata whose issuer does not match the requested issuer", async () => {
     global.fetch = stubFetch({
-      prm: { authorization_servers: [AS_ISSUER] },
+      prm: {
+        resource: "https://mcp.example.com/mcp",
+        authorization_servers: [AS_ISSUER],
+      },
       // Mismatched issuer — must not be trusted to source the token endpoint.
       asMetadata: {
         issuer: "https://evil.example.com",

--- a/sdk/tests/xaa/run-xaa-flow.test.ts
+++ b/sdk/tests/xaa/run-xaa-flow.test.ts
@@ -187,6 +187,30 @@ describe("runXaaFlow", () => {
     expect(result.completed).toBe(false);
   });
 
+  it("does not report success on a non-MCP 2xx body that merely has a result field", async () => {
+    global.fetch = stubFetch({
+      token: {
+        status: 200,
+        body: { access_token: "at-123", token_type: "Bearer" },
+      },
+      // A `result` field but no JSON-RPC envelope (wrong/absent jsonrpc + id).
+      mcpBody: { result: { anything: true } },
+    }) as unknown as typeof fetch;
+
+    const result = await runXaaFlow({
+      serverUrl: SERVER_URL,
+      authzServerIssuer: AS_ISSUER,
+      tokenEndpoint: TOKEN_ENDPOINT,
+      issuerBaseUrl: ISSUER_BASE,
+      subject: "user-1",
+      clientId: "client-1",
+    });
+
+    expect(result.mcp?.ok).toBe(false);
+    expect(result.mcp?.error).toMatch(/initialize result/i);
+    expect(result.completed).toBe(false);
+  });
+
   it("discovers PRM served at the origin root for a path resource", async () => {
     const rootPrm =
       "https://mcp.example.com/.well-known/oauth-protected-resource";

--- a/sdk/tests/xaa/run-xaa-flow.test.ts
+++ b/sdk/tests/xaa/run-xaa-flow.test.ts
@@ -187,6 +187,34 @@ describe("runXaaFlow", () => {
     expect(result.completed).toBe(false);
   });
 
+  it("sends the MCP-Protocol-Version header on the initialize probe", async () => {
+    let mcpHeaders: Record<string, string> = {};
+    global.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const method = (init?.method || "GET").toUpperCase();
+      if (url === TOKEN_ENDPOINT && method === "POST") {
+        return json({ access_token: "at-1", token_type: "Bearer" });
+      }
+      if (url === SERVER_URL && method === "POST") {
+        mcpHeaders = (init?.headers as Record<string, string>) ?? {};
+        return json({ jsonrpc: "2.0", id: "mcpjam-xaa-cli", result: {} });
+      }
+      return json({}, 404);
+    }) as unknown as typeof fetch;
+
+    const result = await runXaaFlow({
+      serverUrl: SERVER_URL,
+      authzServerIssuer: AS_ISSUER,
+      tokenEndpoint: TOKEN_ENDPOINT,
+      issuerBaseUrl: ISSUER_BASE,
+      subject: "user-1",
+      clientId: "client-1",
+    });
+
+    expect(result.completed).toBe(true);
+    expect(mcpHeaders["MCP-Protocol-Version"]).toBe("2025-11-25");
+  });
+
   it("does not report success on a non-MCP 2xx body that merely has a result field", async () => {
     global.fetch = stubFetch({
       token: {

--- a/sdk/tests/xaa/run-xaa-flow.test.ts
+++ b/sdk/tests/xaa/run-xaa-flow.test.ts
@@ -3,12 +3,18 @@ import { mkdtempSync, rmSync } from "fs";
 import os from "os";
 import path from "path";
 import { runXaaFlow } from "../../src/xaa/run-xaa-flow.js";
-import { resetXAAIdpKeyPairForTests } from "../../src/xaa/mint/keypair.js";
+import {
+  getXAAIdpJwks,
+  resetXAAIdpKeyPairForTests,
+} from "../../src/xaa/mint/keypair.js";
 
 const SERVER_URL = "https://mcp.example.com/mcp";
 const AS_ISSUER = "https://auth.example.com";
 const TOKEN_ENDPOINT = "https://auth.example.com/oauth/token";
 const ISSUER_BASE = "https://issuer.example.com/api/mcp";
+const ISSUER = `${ISSUER_BASE}/xaa`;
+const ISSUER_METADATA = `${ISSUER}/.well-known/openid-configuration`;
+const ISSUER_JWKS = `${ISSUER}/.well-known/jwks.json`;
 
 const json = (body: unknown, status = 200) =>
   new Response(JSON.stringify(body), {
@@ -20,39 +26,77 @@ interface StubOptions {
   prm?: unknown;
   asMetadata?: unknown;
   token?: { status: number; body: unknown };
+  tokenResponses?: Array<{ status: number; body: unknown }>;
   mcpStatus?: number;
   mcpBody?: unknown;
+  issuerMetadata?: unknown;
+  issuerJwks?: unknown;
+}
+
+type FetchImplementation = (
+  input: RequestInfo | URL,
+  init?: RequestInit
+) => Promise<Response>;
+
+function publishedIssuerResponse(
+  url: string,
+  options: Pick<StubOptions, "issuerMetadata" | "issuerJwks"> = {}
+): Response | undefined {
+  if (url === ISSUER_METADATA) {
+    return json(
+      options.issuerMetadata ?? { issuer: ISSUER, jwks_uri: ISSUER_JWKS }
+    );
+  }
+  if (url === ISSUER_JWKS) {
+    return json(options.issuerJwks ?? getXAAIdpJwks());
+  }
+  return undefined;
+}
+
+function withPublishedIssuer(
+  implementation: FetchImplementation,
+  options: Pick<StubOptions, "issuerMetadata" | "issuerJwks"> = {}
+) {
+  return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    return publishedIssuerResponse(url, options) ?? implementation(input, init);
+  });
 }
 
 function stubFetch(opts: StubOptions) {
-  return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-    const url = typeof input === "string" ? input : input.toString();
-    const method = (init?.method || "GET").toUpperCase();
-    if (url.includes(".well-known/oauth-protected-resource")) {
-      return opts.prm ? json(opts.prm) : json({}, 404);
-    }
-    if (
-      url.includes(".well-known/oauth-authorization-server") ||
-      url.includes(".well-known/openid-configuration")
-    ) {
-      return opts.asMetadata ? json(opts.asMetadata) : json({}, 404);
-    }
-    if (url === TOKEN_ENDPOINT && method === "POST") {
-      const t = opts.token ?? { status: 200, body: {} };
-      return json(t.body, t.status);
-    }
-    if (url === SERVER_URL && method === "POST") {
-      return json(
-        opts.mcpBody ?? {
-          jsonrpc: "2.0",
-          id: "mcpjam-xaa-cli",
-          result: { serverInfo: {} },
-        },
-        opts.mcpStatus ?? 200,
-      );
-    }
-    return json({}, 404);
-  });
+  let tokenResponseIndex = 0;
+  return withPublishedIssuer(
+    async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const method = (init?.method || "GET").toUpperCase();
+      if (url.includes(".well-known/oauth-protected-resource")) {
+        return opts.prm ? json(opts.prm) : json({}, 404);
+      }
+      if (
+        url.includes(".well-known/oauth-authorization-server") ||
+        url.includes(".well-known/openid-configuration")
+      ) {
+        return opts.asMetadata ? json(opts.asMetadata) : json({}, 404);
+      }
+      if (url === TOKEN_ENDPOINT && method === "POST") {
+        const queued = opts.tokenResponses?.[tokenResponseIndex++];
+        const t = queued ?? opts.token ?? { status: 200, body: {} };
+        return json(t.body, t.status);
+      }
+      if (url === SERVER_URL && method === "POST") {
+        return json(
+          opts.mcpBody ?? {
+            jsonrpc: "2.0",
+            id: "mcpjam-xaa-cli",
+            result: { serverInfo: {} },
+          },
+          opts.mcpStatus ?? 200
+        );
+      }
+      return json({}, 404);
+    },
+    opts
+  );
 }
 
 describe("runXaaFlow", () => {
@@ -187,20 +231,38 @@ describe("runXaaFlow", () => {
     expect(result.completed).toBe(false);
   });
 
-  it("sends the MCP-Protocol-Version header on the initialize probe", async () => {
+  it("advertises the XAA extension on the MCP initialize probe", async () => {
     let mcpHeaders: Record<string, string> = {};
-    global.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = typeof input === "string" ? input : input.toString();
-      const method = (init?.method || "GET").toUpperCase();
-      if (url === TOKEN_ENDPOINT && method === "POST") {
-        return json({ access_token: "at-1", token_type: "Bearer" });
+    let mcpRequest: Record<string, unknown> | undefined;
+    global.fetch = withPublishedIssuer(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        const method = (init?.method || "GET").toUpperCase();
+        if (url === TOKEN_ENDPOINT && method === "POST") {
+          return json({ access_token: "at-1", token_type: "Bearer" });
+        }
+        if (url === SERVER_URL && method === "POST") {
+          mcpHeaders = (init?.headers as Record<string, string>) ?? {};
+          mcpRequest = JSON.parse(String(init?.body)) as Record<
+            string,
+            unknown
+          >;
+          return json({
+            jsonrpc: "2.0",
+            id: "mcpjam-xaa-cli",
+            result: {
+              capabilities: {
+                extensions: {
+                  "io.modelcontextprotocol/enterprise-managed-authorization":
+                    {},
+                },
+              },
+            },
+          });
+        }
+        return json({}, 404);
       }
-      if (url === SERVER_URL && method === "POST") {
-        mcpHeaders = (init?.headers as Record<string, string>) ?? {};
-        return json({ jsonrpc: "2.0", id: "mcpjam-xaa-cli", result: {} });
-      }
-      return json({}, 404);
-    }) as unknown as typeof fetch;
+    ) as unknown as typeof fetch;
 
     const result = await runXaaFlow({
       serverUrl: SERVER_URL,
@@ -213,6 +275,16 @@ describe("runXaaFlow", () => {
 
     expect(result.completed).toBe(true);
     expect(mcpHeaders["MCP-Protocol-Version"]).toBe("2025-11-25");
+    expect(mcpRequest).toMatchObject({
+      params: {
+        capabilities: {
+          extensions: {
+            "io.modelcontextprotocol/enterprise-managed-authorization": {},
+          },
+        },
+      },
+    });
+    expect(result.mcp?.xaaExtension).toBe("advertised");
   });
 
   it("does not report success on a non-MCP 2xx body that merely has a result field", async () => {
@@ -243,32 +315,34 @@ describe("runXaaFlow", () => {
     const serverWithSlash = "https://mcp.example.com/mcp/";
     const insertionPrm =
       "https://mcp.example.com/.well-known/oauth-protected-resource/mcp/";
-    global.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = typeof input === "string" ? input : input.toString();
-      const method = (init?.method || "GET").toUpperCase();
-      // PRM is published ONLY at the slash-preserving path-insertion URL.
-      if (url.includes(".well-known/oauth-protected-resource")) {
-        return url === insertionPrm
-          ? json({
-              resource: "https://mcp.example.com/mcp/",
-              authorization_servers: [AS_ISSUER],
-            })
-          : json({}, 404);
+    global.fetch = withPublishedIssuer(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        const method = (init?.method || "GET").toUpperCase();
+        // PRM is published ONLY at the slash-preserving path-insertion URL.
+        if (url.includes(".well-known/oauth-protected-resource")) {
+          return url === insertionPrm
+            ? json({
+                resource: "https://mcp.example.com/mcp/",
+                authorization_servers: [AS_ISSUER],
+              })
+            : json({}, 404);
+        }
+        if (
+          url.includes(".well-known/oauth-authorization-server") ||
+          url.includes(".well-known/openid-configuration")
+        ) {
+          return json({ issuer: AS_ISSUER, token_endpoint: TOKEN_ENDPOINT });
+        }
+        if (url === TOKEN_ENDPOINT && method === "POST") {
+          return json({ access_token: "at-1", token_type: "Bearer" });
+        }
+        if (url === serverWithSlash && method === "POST") {
+          return json({ jsonrpc: "2.0", id: "mcpjam-xaa-cli", result: {} });
+        }
+        return json({}, 404);
       }
-      if (
-        url.includes(".well-known/oauth-authorization-server") ||
-        url.includes(".well-known/openid-configuration")
-      ) {
-        return json({ issuer: AS_ISSUER, token_endpoint: TOKEN_ENDPOINT });
-      }
-      if (url === TOKEN_ENDPOINT && method === "POST") {
-        return json({ access_token: "at-1", token_type: "Bearer" });
-      }
-      if (url === serverWithSlash && method === "POST") {
-        return json({ jsonrpc: "2.0", id: "mcpjam-xaa-cli", result: {} });
-      }
-      return json({}, 404);
-    }) as unknown as typeof fetch;
+    ) as unknown as typeof fetch;
 
     const result = await runXaaFlow({
       serverUrl: serverWithSlash,
@@ -284,32 +358,34 @@ describe("runXaaFlow", () => {
   it("discovers PRM served at the origin root for a path resource", async () => {
     const rootPrm =
       "https://mcp.example.com/.well-known/oauth-protected-resource";
-    global.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = typeof input === "string" ? input : input.toString();
-      const method = (init?.method || "GET").toUpperCase();
-      // PRM is published ONLY at the origin root, not the path-insertion form.
-      if (url.includes(".well-known/oauth-protected-resource")) {
-        return url === rootPrm
-          ? json({
-              resource: "https://mcp.example.com/mcp",
-              authorization_servers: [AS_ISSUER],
-            })
-          : json({}, 404);
+    global.fetch = withPublishedIssuer(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        const method = (init?.method || "GET").toUpperCase();
+        // PRM is published ONLY at the origin root, not the path-insertion form.
+        if (url.includes(".well-known/oauth-protected-resource")) {
+          return url === rootPrm
+            ? json({
+                resource: "https://mcp.example.com/mcp",
+                authorization_servers: [AS_ISSUER],
+              })
+            : json({}, 404);
+        }
+        if (
+          url.includes(".well-known/oauth-authorization-server") ||
+          url.includes(".well-known/openid-configuration")
+        ) {
+          return json({ issuer: AS_ISSUER, token_endpoint: TOKEN_ENDPOINT });
+        }
+        if (url === TOKEN_ENDPOINT && method === "POST") {
+          return json({ access_token: "at-1", token_type: "Bearer" });
+        }
+        if (url === SERVER_URL && method === "POST") {
+          return json({ jsonrpc: "2.0", id: "mcpjam-xaa-cli", result: {} });
+        }
+        return json({}, 404);
       }
-      if (
-        url.includes(".well-known/oauth-authorization-server") ||
-        url.includes(".well-known/openid-configuration")
-      ) {
-        return json({ issuer: AS_ISSUER, token_endpoint: TOKEN_ENDPOINT });
-      }
-      if (url === TOKEN_ENDPOINT && method === "POST") {
-        return json({ access_token: "at-1", token_type: "Bearer" });
-      }
-      if (url === SERVER_URL && method === "POST") {
-        return json({ jsonrpc: "2.0", id: "mcpjam-xaa-cli", result: {} });
-      }
-      return json({}, 404);
-    }) as unknown as typeof fetch;
+    ) as unknown as typeof fetch;
 
     const result = await runXaaFlow({
       serverUrl: SERVER_URL,
@@ -325,7 +401,10 @@ describe("runXaaFlow", () => {
   it("mints the aud from the AS's canonical issuer, not a trailing-slash arg", async () => {
     global.fetch = stubFetch({
       asMetadata: { issuer: AS_ISSUER, token_endpoint: TOKEN_ENDPOINT },
-      token: { status: 200, body: { access_token: "at-1", token_type: "Bearer" } },
+      token: {
+        status: 200,
+        body: { access_token: "at-1", token_type: "Bearer" },
+      },
     }) as unknown as typeof fetch;
 
     const result = await runXaaFlow({
@@ -344,33 +423,35 @@ describe("runXaaFlow", () => {
 
   it("tries every advertised authorization server until one resolves", async () => {
     const deadAs = "https://dead-as.example.com";
-    global.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = typeof input === "string" ? input : input.toString();
-      const method = (init?.method || "GET").toUpperCase();
-      if (url.includes(".well-known/oauth-protected-resource")) {
-        return json({
-          resource: "https://mcp.example.com/mcp",
-          authorization_servers: [deadAs, AS_ISSUER],
-        });
-      }
-      // The first advertised AS has no discoverable metadata.
-      if (url.startsWith(deadAs)) {
+    global.fetch = withPublishedIssuer(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        const method = (init?.method || "GET").toUpperCase();
+        if (url.includes(".well-known/oauth-protected-resource")) {
+          return json({
+            resource: "https://mcp.example.com/mcp",
+            authorization_servers: [deadAs, AS_ISSUER],
+          });
+        }
+        // The first advertised AS has no discoverable metadata.
+        if (url.startsWith(deadAs)) {
+          return json({}, 404);
+        }
+        if (
+          url.includes(".well-known/oauth-authorization-server") ||
+          url.includes(".well-known/openid-configuration")
+        ) {
+          return json({ issuer: AS_ISSUER, token_endpoint: TOKEN_ENDPOINT });
+        }
+        if (url === TOKEN_ENDPOINT && method === "POST") {
+          return json({ access_token: "at-1", token_type: "Bearer" });
+        }
+        if (url === SERVER_URL && method === "POST") {
+          return json({ jsonrpc: "2.0", id: "mcpjam-xaa-cli", result: {} });
+        }
         return json({}, 404);
       }
-      if (
-        url.includes(".well-known/oauth-authorization-server") ||
-        url.includes(".well-known/openid-configuration")
-      ) {
-        return json({ issuer: AS_ISSUER, token_endpoint: TOKEN_ENDPOINT });
-      }
-      if (url === TOKEN_ENDPOINT && method === "POST") {
-        return json({ access_token: "at-1", token_type: "Bearer" });
-      }
-      if (url === SERVER_URL && method === "POST") {
-        return json({ jsonrpc: "2.0", id: "mcpjam-xaa-cli", result: {} });
-      }
-      return json({}, 404);
-    }) as unknown as typeof fetch;
+    ) as unknown as typeof fetch;
 
     const result = await runXaaFlow({
       serverUrl: SERVER_URL,
@@ -407,17 +488,19 @@ describe("runXaaFlow", () => {
 
   it("preserves a meaningful trailing slash in the canonical resource", async () => {
     const serverWithSlash = "https://mcp.example.com/mcp/";
-    global.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = typeof input === "string" ? input : input.toString();
-      const method = (init?.method || "GET").toUpperCase();
-      if (url === TOKEN_ENDPOINT && method === "POST") {
-        return json({ access_token: "at-1", token_type: "Bearer" });
+    global.fetch = withPublishedIssuer(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        const method = (init?.method || "GET").toUpperCase();
+        if (url === TOKEN_ENDPOINT && method === "POST") {
+          return json({ access_token: "at-1", token_type: "Bearer" });
+        }
+        if (url === serverWithSlash && method === "POST") {
+          return json({ jsonrpc: "2.0", id: "mcpjam-xaa-cli", result: {} });
+        }
+        return json({}, 404);
       }
-      if (url === serverWithSlash && method === "POST") {
-        return json({ jsonrpc: "2.0", id: "mcpjam-xaa-cli", result: {} });
-      }
-      return json({}, 404);
-    }) as unknown as typeof fetch;
+    ) as unknown as typeof fetch;
 
     const result = await runXaaFlow({
       serverUrl: serverWithSlash,
@@ -433,19 +516,21 @@ describe("runXaaFlow", () => {
   });
 
   it("treats a top-level error string (SSE parse failure) as a failed call", async () => {
-    global.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = typeof input === "string" ? input : input.toString();
-      const method = (init?.method || "GET").toUpperCase();
-      if (url === TOKEN_ENDPOINT && method === "POST") {
-        return json({ access_token: "at-1", token_type: "Bearer" });
+    global.fetch = withPublishedIssuer(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        const method = (init?.method || "GET").toUpperCase();
+        if (url === TOKEN_ENDPOINT && method === "POST") {
+          return json({ access_token: "at-1", token_type: "Bearer" });
+        }
+        if (url === SERVER_URL && method === "POST") {
+          // The shape executeDebugOAuthProxy returns when it can't parse the SSE
+          // stream: a top-level string `error`, no `transport` field.
+          return json({ error: "Failed to parse SSE stream" });
+        }
+        return json({}, 404);
       }
-      if (url === SERVER_URL && method === "POST") {
-        // The shape executeDebugOAuthProxy returns when it can't parse the SSE
-        // stream: a top-level string `error`, no `transport` field.
-        return json({ error: "Failed to parse SSE stream" });
-      }
-      return json({}, 404);
-    }) as unknown as typeof fetch;
+    ) as unknown as typeof fetch;
 
     const result = await runXaaFlow({
       serverUrl: SERVER_URL,
@@ -488,17 +573,19 @@ describe("runXaaFlow", () => {
 
   it("preserves the query string in the canonical resource", async () => {
     const serverWithQuery = "https://mcp.example.com/mcp?tenant=acme";
-    global.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = typeof input === "string" ? input : input.toString();
-      const method = (init?.method || "GET").toUpperCase();
-      if (url === TOKEN_ENDPOINT && method === "POST") {
-        return json({ access_token: "at-1", token_type: "Bearer" });
+    global.fetch = withPublishedIssuer(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        const method = (init?.method || "GET").toUpperCase();
+        if (url === TOKEN_ENDPOINT && method === "POST") {
+          return json({ access_token: "at-1", token_type: "Bearer" });
+        }
+        if (url === serverWithQuery && method === "POST") {
+          return json({ jsonrpc: "2.0", id: "mcpjam-xaa-cli", result: {} });
+        }
+        return json({}, 404);
       }
-      if (url === serverWithQuery && method === "POST") {
-        return json({ jsonrpc: "2.0", id: "mcpjam-xaa-cli", result: {} });
-      }
-      return json({}, 404);
-    }) as unknown as typeof fetch;
+    ) as unknown as typeof fetch;
 
     const result = await runXaaFlow({
       serverUrl: serverWithQuery,
@@ -510,7 +597,7 @@ describe("runXaaFlow", () => {
     });
 
     expect(result.idJag?.claims.resource).toBe(
-      "https://mcp.example.com/mcp?tenant=acme",
+      "https://mcp.example.com/mcp?tenant=acme"
     );
     expect(result.completed).toBe(true);
   });
@@ -525,20 +612,22 @@ describe("runXaaFlow", () => {
         error: { code: -32002, message: "Server error" },
       }) +
       "\n\n";
-    global.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = typeof input === "string" ? input : input.toString();
-      const method = (init?.method || "GET").toUpperCase();
-      if (url === TOKEN_ENDPOINT && method === "POST") {
-        return json({ access_token: "at-1", token_type: "Bearer" });
+    global.fetch = withPublishedIssuer(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        const method = (init?.method || "GET").toUpperCase();
+        if (url === TOKEN_ENDPOINT && method === "POST") {
+          return json({ access_token: "at-1", token_type: "Bearer" });
+        }
+        if (url === SERVER_URL && method === "POST") {
+          return new Response(sse, {
+            status: 200,
+            headers: { "Content-Type": "text/event-stream" },
+          });
+        }
+        return json({}, 404);
       }
-      if (url === SERVER_URL && method === "POST") {
-        return new Response(sse, {
-          status: 200,
-          headers: { "Content-Type": "text/event-stream" },
-        });
-      }
-      return json({}, 404);
-    }) as unknown as typeof fetch;
+    ) as unknown as typeof fetch;
 
     const result = await runXaaFlow({
       serverUrl: SERVER_URL,
@@ -583,9 +672,131 @@ describe("runXaaFlow", () => {
     expect(result.mcp).toBeUndefined();
   });
 
-  it("a negative-test ID-JAG fails local inspection but is still sent", async () => {
+  it("fails before redemption when the issuer publishes a different key", async () => {
+    const fetchMock = stubFetch({
+      issuerJwks: {
+        keys: [{ kid: "xaa-idp-1", kty: "RSA", n: "different", e: "AQAB" }],
+      },
+      token: {
+        status: 200,
+        body: { access_token: "must-not-be-issued", token_type: "Bearer" },
+      },
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await runXaaFlow({
+      serverUrl: SERVER_URL,
+      authzServerIssuer: AS_ISSUER,
+      tokenEndpoint: TOKEN_ENDPOINT,
+      issuerBaseUrl: ISSUER_BASE,
+      subject: "user-1",
+      clientId: "client-1",
+    });
+
+    expect(result.completed).toBe(false);
+    expect(result.error).toMatch(/does not publish the local signing key/i);
+    expect(
+      fetchMock.mock.calls.some(
+        ([input, init]) =>
+          input.toString() === TOKEN_ENDPOINT && init?.method === "POST"
+      )
+    ).toBe(false);
+  });
+
+  it("infers client_secret_basic and surfaces advertised RAS support", async () => {
+    let tokenHeaders: Record<string, string> = {};
+    let tokenBody = "";
+    global.fetch = withPublishedIssuer(async (input, init) => {
+      const url = input.toString();
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (url.includes(".well-known/oauth-protected-resource")) {
+        return json({
+          resource: SERVER_URL,
+          authorization_servers: [AS_ISSUER],
+        });
+      }
+      if (
+        url.startsWith(AS_ISSUER) &&
+        (url.includes(".well-known/oauth-authorization-server") ||
+          url.includes(".well-known/openid-configuration"))
+      ) {
+        return json({
+          issuer: AS_ISSUER,
+          token_endpoint: TOKEN_ENDPOINT,
+          grant_types_supported: [
+            "urn:ietf:params:oauth:grant-type:jwt-bearer",
+          ],
+          authorization_grant_profiles_supported: [
+            "urn:ietf:params:oauth:grant-profile:id-jag",
+          ],
+          token_endpoint_auth_methods_supported: ["client_secret_basic"],
+        });
+      }
+      if (url === TOKEN_ENDPOINT && method === "POST") {
+        tokenHeaders = (init?.headers as Record<string, string>) ?? {};
+        tokenBody = String(init?.body);
+        return json({ access_token: "at-basic", token_type: "Bearer" });
+      }
+      if (url === SERVER_URL && method === "POST") {
+        return json({ jsonrpc: "2.0", id: "mcpjam-xaa-cli", result: {} });
+      }
+      return json({}, 404);
+    }) as unknown as typeof fetch;
+
+    const result = await runXaaFlow({
+      serverUrl: SERVER_URL,
+      issuerBaseUrl: ISSUER_BASE,
+      subject: "user-1",
+      clientId: "client id!",
+      clientSecret: "secret (value)",
+    });
+
+    expect(result.completed).toBe(true);
+    expect(tokenHeaders.Authorization).toMatch(/^Basic /);
+    expect(tokenBody).not.toContain("client_secret");
+    expect(tokenBody).not.toContain("client_id");
+    expect(result.authorizationServerCapabilities).toMatchObject({
+      idJagProfile: "advertised",
+      jwtBearerGrant: "advertised",
+      selectedTokenEndpointAuthMethod: "client_secret_basic",
+    });
+  });
+
+  it("honors the per-request timeout", async () => {
+    global.fetch = withPublishedIssuer(async (input, init) => {
+      if (input.toString() === TOKEN_ENDPOINT) {
+        return await new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(init.signal?.reason);
+          });
+        });
+      }
+      return json({}, 404);
+    }) as unknown as typeof fetch;
+
+    const result = await runXaaFlow({
+      serverUrl: SERVER_URL,
+      authzServerIssuer: AS_ISSUER,
+      tokenEndpoint: TOKEN_ENDPOINT,
+      issuerBaseUrl: ISSUER_BASE,
+      subject: "user-1",
+      clientId: "client-1",
+      timeoutMs: 10,
+    });
+
+    expect(result.completed).toBe(false);
+    expect(result.error).toMatch(/timeout/i);
+  });
+
+  it("scores a negative-test rejection only after a valid baseline", async () => {
     global.fetch = stubFetch({
-      token: { status: 401, body: { error: "invalid_grant" } },
+      tokenResponses: [
+        {
+          status: 200,
+          body: { access_token: "baseline-token", token_type: "Bearer" },
+        },
+        { status: 401, body: { error: "invalid_grant" } },
+      ],
     }) as unknown as typeof fetch;
 
     const result = await runXaaFlow({
@@ -601,6 +812,47 @@ describe("runXaaFlow", () => {
     // bad_signature can't verify locally, and the AS rejects it.
     expect(result.idJag?.verified).toBe(false);
     expect(result.redemption?.tokenIssued).toBe(false);
+    expect(result.negativeProbe).toMatchObject({
+      baselineAccepted: true,
+      outcome: "rejected",
+    });
+    expect(result.completed).toBe(true);
+    expect(result.mcp).toBeUndefined();
+  });
+
+  it("fails a negative probe when the AS accepts the broken assertion", async () => {
+    const fetchMock = stubFetch({
+      tokenResponses: [
+        {
+          status: 200,
+          body: { access_token: "baseline-token", token_type: "Bearer" },
+        },
+        {
+          status: 200,
+          body: { access_token: "invalid-token", token_type: "Bearer" },
+        },
+      ],
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await runXaaFlow({
+      serverUrl: SERVER_URL,
+      authzServerIssuer: AS_ISSUER,
+      tokenEndpoint: TOKEN_ENDPOINT,
+      issuerBaseUrl: ISSUER_BASE,
+      subject: "user-1",
+      clientId: "client-1",
+      negativeTestMode: "bad_signature",
+    });
+
     expect(result.completed).toBe(false);
+    expect(result.negativeProbe?.outcome).toBe("accepted");
+    expect(result.error).toMatch(/accepted the deliberately invalid/i);
+    expect(
+      fetchMock.mock.calls.some(
+        ([input, init]) =>
+          input.toString() === SERVER_URL && init?.method === "POST"
+      )
+    ).toBe(false);
   });
 });

--- a/sdk/tests/xaa/run-xaa-flow.test.ts
+++ b/sdk/tests/xaa/run-xaa-flow.test.ts
@@ -280,6 +280,26 @@ describe("runXaaFlow", () => {
     expect(result.completed).toBe(true);
   });
 
+  it("mints the aud from the AS's canonical issuer, not a trailing-slash arg", async () => {
+    global.fetch = stubFetch({
+      asMetadata: { issuer: AS_ISSUER, token_endpoint: TOKEN_ENDPOINT },
+      token: { status: 200, body: { access_token: "at-1", token_type: "Bearer" } },
+    }) as unknown as typeof fetch;
+
+    const result = await runXaaFlow({
+      serverUrl: SERVER_URL,
+      // Trailing slash — the AS advertises the canonical form without it.
+      authzServerIssuer: `${AS_ISSUER}/`,
+      issuerBaseUrl: ISSUER_BASE,
+      subject: "user-1",
+      clientId: "client-1",
+    });
+
+    expect(result.authzServerIssuer).toBe(AS_ISSUER);
+    expect(result.idJag?.claims.aud).toBe(AS_ISSUER);
+    expect(result.completed).toBe(true);
+  });
+
   it("rejects PRM whose resource does not identify the requested server", async () => {
     global.fetch = stubFetch({
       prm: {

--- a/sdk/tests/xaa/run-xaa-flow.test.ts
+++ b/sdk/tests/xaa/run-xaa-flow.test.ts
@@ -158,7 +158,32 @@ describe("runXaaFlow", () => {
     expect(result.redemption?.tokenIssued).toBe(true); // token was still issued
     expect(result.mcp?.status).toBe(200);
     expect(result.mcp?.ok).toBe(false);
-    expect(result.mcp?.jsonRpcError).toBe("-32001: Unauthorized");
+    expect(result.mcp?.error).toBe("-32001: Unauthorized");
+    expect(result.completed).toBe(false);
+  });
+
+  it("does not report success on a 2xx body with no JSON-RPC result", async () => {
+    global.fetch = stubFetch({
+      token: {
+        status: 200,
+        body: { access_token: "at-123", token_type: "Bearer" },
+      },
+      // A 2xx non-MCP body: neither error nor a JSON-RPC `result`.
+      mcpBody: { status: "ok" },
+    }) as unknown as typeof fetch;
+
+    const result = await runXaaFlow({
+      serverUrl: SERVER_URL,
+      authzServerIssuer: AS_ISSUER,
+      tokenEndpoint: TOKEN_ENDPOINT,
+      issuerBaseUrl: ISSUER_BASE,
+      subject: "user-1",
+      clientId: "client-1",
+    });
+
+    expect(result.redemption?.tokenIssued).toBe(true);
+    expect(result.mcp?.ok).toBe(false);
+    expect(result.mcp?.error).toMatch(/initialize result/i);
     expect(result.completed).toBe(false);
   });
 
@@ -277,7 +302,7 @@ describe("runXaaFlow", () => {
     });
 
     expect(result.mcp?.ok).toBe(false);
-    expect(result.mcp?.jsonRpcError).toBe("Failed to parse SSE stream");
+    expect(result.mcp?.error).toBe("Failed to parse SSE stream");
     expect(result.completed).toBe(false);
   });
 
@@ -371,7 +396,7 @@ describe("runXaaFlow", () => {
 
     expect(result.redemption?.tokenIssued).toBe(true);
     expect(result.mcp?.ok).toBe(false);
-    expect(result.mcp?.jsonRpcError).toBe("-32002: Server error");
+    expect(result.mcp?.error).toBe("-32002: Server error");
     expect(result.completed).toBe(false);
   });
 

--- a/sdk/tests/xaa/run-xaa-flow.test.ts
+++ b/sdk/tests/xaa/run-xaa-flow.test.ts
@@ -21,6 +21,7 @@ interface StubOptions {
   asMetadata?: unknown;
   token?: { status: number; body: unknown };
   mcpStatus?: number;
+  mcpBody?: unknown;
 }
 
 function stubFetch(opts: StubOptions) {
@@ -42,7 +43,11 @@ function stubFetch(opts: StubOptions) {
     }
     if (url === SERVER_URL && method === "POST") {
       return json(
-        { jsonrpc: "2.0", id: "mcpjam-xaa-cli", result: { serverInfo: {} } },
+        opts.mcpBody ?? {
+          jsonrpc: "2.0",
+          id: "mcpjam-xaa-cli",
+          result: { serverInfo: {} },
+        },
         opts.mcpStatus ?? 200,
       );
     }
@@ -121,6 +126,87 @@ describe("runXaaFlow", () => {
 
     expect(result.authzServerIssuer).toBe(AS_ISSUER);
     expect(result.tokenEndpoint).toBe(TOKEN_ENDPOINT);
+    expect(result.completed).toBe(true);
+  });
+
+  it("does not report completion when the MCP init returns a 200 JSON-RPC error", async () => {
+    global.fetch = stubFetch({
+      token: {
+        status: 200,
+        body: { access_token: "at-123", token_type: "Bearer" },
+      },
+      mcpStatus: 200,
+      mcpBody: {
+        jsonrpc: "2.0",
+        id: "mcpjam-xaa-cli",
+        error: { code: -32001, message: "Unauthorized" },
+      },
+    }) as unknown as typeof fetch;
+
+    const result = await runXaaFlow({
+      serverUrl: SERVER_URL,
+      authzServerIssuer: AS_ISSUER,
+      tokenEndpoint: TOKEN_ENDPOINT,
+      issuerBaseUrl: ISSUER_BASE,
+      subject: "user-1",
+      clientId: "client-1",
+    });
+
+    expect(result.redemption?.tokenIssued).toBe(true); // token was still issued
+    expect(result.mcp?.status).toBe(200);
+    expect(result.mcp?.ok).toBe(false);
+    expect(result.mcp?.jsonRpcError).toBe("-32001: Unauthorized");
+    expect(result.completed).toBe(false);
+  });
+
+  it("rejects AS metadata whose issuer does not match the requested issuer", async () => {
+    global.fetch = stubFetch({
+      prm: { authorization_servers: [AS_ISSUER] },
+      // Mismatched issuer — must not be trusted to source the token endpoint.
+      asMetadata: {
+        issuer: "https://evil.example.com",
+        token_endpoint: "https://evil.example.com/token",
+      },
+    }) as unknown as typeof fetch;
+
+    const result = await runXaaFlow({
+      serverUrl: SERVER_URL,
+      issuerBaseUrl: ISSUER_BASE,
+      subject: "user-1",
+      clientId: "client-1",
+    });
+
+    expect(result.completed).toBe(false);
+    expect(result.tokenEndpoint).toBeUndefined();
+    expect(result.error).toMatch(/token endpoint/i);
+  });
+
+  it("preserves the query string in the canonical resource", async () => {
+    const serverWithQuery = "https://mcp.example.com/mcp?tenant=acme";
+    global.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const method = (init?.method || "GET").toUpperCase();
+      if (url === TOKEN_ENDPOINT && method === "POST") {
+        return json({ access_token: "at-1", token_type: "Bearer" });
+      }
+      if (url === serverWithQuery && method === "POST") {
+        return json({ jsonrpc: "2.0", id: "mcpjam-xaa-cli", result: {} });
+      }
+      return json({}, 404);
+    }) as unknown as typeof fetch;
+
+    const result = await runXaaFlow({
+      serverUrl: serverWithQuery,
+      authzServerIssuer: AS_ISSUER,
+      tokenEndpoint: TOKEN_ENDPOINT,
+      issuerBaseUrl: ISSUER_BASE,
+      subject: "user-1",
+      clientId: "client-1",
+    });
+
+    expect(result.idJag?.claims.resource).toBe(
+      "https://mcp.example.com/mcp?tenant=acme",
+    );
     expect(result.completed).toBe(true);
   });
 

--- a/sdk/tests/xaa/run-xaa-flow.test.ts
+++ b/sdk/tests/xaa/run-xaa-flow.test.ts
@@ -159,6 +159,44 @@ describe("runXaaFlow", () => {
     expect(result.completed).toBe(false);
   });
 
+  it("discovers PRM served at the origin root for a path resource", async () => {
+    const rootPrm =
+      "https://mcp.example.com/.well-known/oauth-protected-resource";
+    global.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const method = (init?.method || "GET").toUpperCase();
+      // PRM is published ONLY at the origin root, not the path-insertion form.
+      if (url.includes(".well-known/oauth-protected-resource")) {
+        return url === rootPrm
+          ? json({ authorization_servers: [AS_ISSUER] })
+          : json({}, 404);
+      }
+      if (
+        url.includes(".well-known/oauth-authorization-server") ||
+        url.includes(".well-known/openid-configuration")
+      ) {
+        return json({ issuer: AS_ISSUER, token_endpoint: TOKEN_ENDPOINT });
+      }
+      if (url === TOKEN_ENDPOINT && method === "POST") {
+        return json({ access_token: "at-1", token_type: "Bearer" });
+      }
+      if (url === SERVER_URL && method === "POST") {
+        return json({ jsonrpc: "2.0", id: "mcpjam-xaa-cli", result: {} });
+      }
+      return json({}, 404);
+    }) as unknown as typeof fetch;
+
+    const result = await runXaaFlow({
+      serverUrl: SERVER_URL,
+      issuerBaseUrl: ISSUER_BASE,
+      subject: "user-1",
+      clientId: "client-1",
+    });
+
+    expect(result.authzServerIssuer).toBe(AS_ISSUER);
+    expect(result.completed).toBe(true);
+  });
+
   it("rejects AS metadata whose issuer does not match the requested issuer", async () => {
     global.fetch = stubFetch({
       prm: { authorization_servers: [AS_ISSUER] },
@@ -208,6 +246,46 @@ describe("runXaaFlow", () => {
       "https://mcp.example.com/mcp?tenant=acme",
     );
     expect(result.completed).toBe(true);
+  });
+
+  it("detects a JSON-RPC error delivered over SSE from the MCP init", async () => {
+    const sse =
+      "event: message\n" +
+      "data: " +
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: "mcpjam-xaa-cli",
+        error: { code: -32002, message: "Server error" },
+      }) +
+      "\n\n";
+    global.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const method = (init?.method || "GET").toUpperCase();
+      if (url === TOKEN_ENDPOINT && method === "POST") {
+        return json({ access_token: "at-1", token_type: "Bearer" });
+      }
+      if (url === SERVER_URL && method === "POST") {
+        return new Response(sse, {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        });
+      }
+      return json({}, 404);
+    }) as unknown as typeof fetch;
+
+    const result = await runXaaFlow({
+      serverUrl: SERVER_URL,
+      authzServerIssuer: AS_ISSUER,
+      tokenEndpoint: TOKEN_ENDPOINT,
+      issuerBaseUrl: ISSUER_BASE,
+      subject: "user-1",
+      clientId: "client-1",
+    });
+
+    expect(result.redemption?.tokenIssued).toBe(true);
+    expect(result.mcp?.ok).toBe(false);
+    expect(result.mcp?.jsonRpcError).toBe("-32002: Server error");
+    expect(result.completed).toBe(false);
   });
 
   it("reports a redemption failure without crashing", async () => {

--- a/sdk/tests/xaa/run-xaa-flow.test.ts
+++ b/sdk/tests/xaa/run-xaa-flow.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "fs";
+import os from "os";
+import path from "path";
+import { runXaaFlow } from "../../src/xaa/run-xaa-flow.js";
+import { resetXAAIdpKeyPairForTests } from "../../src/xaa/mint/keypair.js";
+
+const SERVER_URL = "https://mcp.example.com/mcp";
+const AS_ISSUER = "https://auth.example.com";
+const TOKEN_ENDPOINT = "https://auth.example.com/oauth/token";
+const ISSUER_BASE = "https://issuer.example.com/api/mcp";
+
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+interface StubOptions {
+  prm?: unknown;
+  asMetadata?: unknown;
+  token?: { status: number; body: unknown };
+  mcpStatus?: number;
+}
+
+function stubFetch(opts: StubOptions) {
+  return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const method = (init?.method || "GET").toUpperCase();
+    if (url.includes(".well-known/oauth-protected-resource")) {
+      return opts.prm ? json(opts.prm) : json({}, 404);
+    }
+    if (
+      url.includes(".well-known/oauth-authorization-server") ||
+      url.includes(".well-known/openid-configuration")
+    ) {
+      return opts.asMetadata ? json(opts.asMetadata) : json({}, 404);
+    }
+    if (url === TOKEN_ENDPOINT && method === "POST") {
+      const t = opts.token ?? { status: 200, body: {} };
+      return json(t.body, t.status);
+    }
+    if (url === SERVER_URL && method === "POST") {
+      return json(
+        { jsonrpc: "2.0", id: "mcpjam-xaa-cli", result: { serverInfo: {} } },
+        opts.mcpStatus ?? 200,
+      );
+    }
+    return json({}, 404);
+  });
+}
+
+describe("runXaaFlow", () => {
+  const originalKeyDir = process.env.XAA_IDP_KEY_DIR;
+  const originalFetch = global.fetch;
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), "xaa-flow-"));
+    process.env.XAA_IDP_KEY_DIR = tempDir;
+    resetXAAIdpKeyPairForTests();
+  });
+
+  afterEach(() => {
+    resetXAAIdpKeyPairForTests();
+    rmSync(tempDir, { recursive: true, force: true });
+    global.fetch = originalFetch;
+    if (originalKeyDir === undefined) delete process.env.XAA_IDP_KEY_DIR;
+    else process.env.XAA_IDP_KEY_DIR = originalKeyDir;
+  });
+
+  it("drives a valid flow to completion against a trusting AS", async () => {
+    global.fetch = stubFetch({
+      token: {
+        status: 200,
+        body: { access_token: "at-123", token_type: "Bearer", expires_in: 300 },
+      },
+    }) as unknown as typeof fetch;
+
+    const result = await runXaaFlow({
+      serverUrl: SERVER_URL,
+      authzServerIssuer: AS_ISSUER,
+      tokenEndpoint: TOKEN_ENDPOINT,
+      issuerBaseUrl: ISSUER_BASE,
+      subject: "user-1",
+      email: "u@example.com",
+      clientId: "client-1",
+      scope: "read:tools",
+    });
+
+    expect(result.completed).toBe(true);
+    expect(result.issuer).toBe("https://issuer.example.com/api/mcp/xaa");
+    expect(result.idJag?.verified).toBe(true);
+    expect(result.idJag?.claims).toMatchObject({
+      iss: "https://issuer.example.com/api/mcp/xaa",
+      sub: "user-1",
+      aud: AS_ISSUER,
+      resource: "https://mcp.example.com/mcp",
+      client_id: "client-1",
+    });
+    expect(result.redemption?.tokenIssued).toBe(true);
+    expect(result.mcp?.ok).toBe(true);
+  });
+
+  it("discovers the AS + token endpoint when not supplied", async () => {
+    global.fetch = stubFetch({
+      prm: { authorization_servers: [AS_ISSUER] },
+      asMetadata: { issuer: AS_ISSUER, token_endpoint: TOKEN_ENDPOINT },
+      token: {
+        status: 200,
+        body: { access_token: "at-xyz", token_type: "Bearer" },
+      },
+    }) as unknown as typeof fetch;
+
+    const result = await runXaaFlow({
+      serverUrl: SERVER_URL,
+      issuerBaseUrl: ISSUER_BASE,
+      subject: "user-1",
+      clientId: "client-1",
+    });
+
+    expect(result.authzServerIssuer).toBe(AS_ISSUER);
+    expect(result.tokenEndpoint).toBe(TOKEN_ENDPOINT);
+    expect(result.completed).toBe(true);
+  });
+
+  it("reports a redemption failure without crashing", async () => {
+    global.fetch = stubFetch({
+      token: {
+        status: 400,
+        body: {
+          error: "unsupported_grant_type",
+          error_description: "jwt-bearer not supported",
+        },
+      },
+    }) as unknown as typeof fetch;
+
+    const result = await runXaaFlow({
+      serverUrl: SERVER_URL,
+      authzServerIssuer: AS_ISSUER,
+      tokenEndpoint: TOKEN_ENDPOINT,
+      issuerBaseUrl: ISSUER_BASE,
+      subject: "user-1",
+      clientId: "client-1",
+    });
+
+    expect(result.completed).toBe(false);
+    expect(result.idJag?.verified).toBe(true); // mint + inspect still succeeded
+    expect(result.redemption?.tokenIssued).toBe(false);
+    expect(result.redemption?.status).toBe(400);
+    expect(result.redemption?.error).toContain("jwt-bearer not supported");
+    expect(result.mcp).toBeUndefined();
+  });
+
+  it("a negative-test ID-JAG fails local inspection but is still sent", async () => {
+    global.fetch = stubFetch({
+      token: { status: 401, body: { error: "invalid_grant" } },
+    }) as unknown as typeof fetch;
+
+    const result = await runXaaFlow({
+      serverUrl: SERVER_URL,
+      authzServerIssuer: AS_ISSUER,
+      tokenEndpoint: TOKEN_ENDPOINT,
+      issuerBaseUrl: ISSUER_BASE,
+      subject: "user-1",
+      clientId: "client-1",
+      negativeTestMode: "bad_signature",
+    });
+
+    // bad_signature can't verify locally, and the AS rejects it.
+    expect(result.idJag?.verified).toBe(false);
+    expect(result.redemption?.tokenIssued).toBe(false);
+    expect(result.completed).toBe(false);
+  });
+});

--- a/sdk/tests/xaa/run-xaa-flow.test.ts
+++ b/sdk/tests/xaa/run-xaa-flow.test.ts
@@ -239,6 +239,48 @@ describe("runXaaFlow", () => {
     expect(result.completed).toBe(false);
   });
 
+  it("preserves the trailing slash when building PRM discovery URLs", async () => {
+    const serverWithSlash = "https://mcp.example.com/mcp/";
+    const insertionPrm =
+      "https://mcp.example.com/.well-known/oauth-protected-resource/mcp/";
+    global.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const method = (init?.method || "GET").toUpperCase();
+      // PRM is published ONLY at the slash-preserving path-insertion URL.
+      if (url.includes(".well-known/oauth-protected-resource")) {
+        return url === insertionPrm
+          ? json({
+              resource: "https://mcp.example.com/mcp/",
+              authorization_servers: [AS_ISSUER],
+            })
+          : json({}, 404);
+      }
+      if (
+        url.includes(".well-known/oauth-authorization-server") ||
+        url.includes(".well-known/openid-configuration")
+      ) {
+        return json({ issuer: AS_ISSUER, token_endpoint: TOKEN_ENDPOINT });
+      }
+      if (url === TOKEN_ENDPOINT && method === "POST") {
+        return json({ access_token: "at-1", token_type: "Bearer" });
+      }
+      if (url === serverWithSlash && method === "POST") {
+        return json({ jsonrpc: "2.0", id: "mcpjam-xaa-cli", result: {} });
+      }
+      return json({}, 404);
+    }) as unknown as typeof fetch;
+
+    const result = await runXaaFlow({
+      serverUrl: serverWithSlash,
+      issuerBaseUrl: ISSUER_BASE,
+      subject: "user-1",
+      clientId: "client-1",
+    });
+
+    expect(result.authzServerIssuer).toBe(AS_ISSUER);
+    expect(result.completed).toBe(true);
+  });
+
   it("discovers PRM served at the origin root for a path resource", async () => {
     const rootPrm =
       "https://mcp.example.com/.well-known/oauth-protected-resource";

--- a/sdk/tests/xaa/run-xaa-flow.test.ts
+++ b/sdk/tests/xaa/run-xaa-flow.test.ts
@@ -342,6 +342,47 @@ describe("runXaaFlow", () => {
     expect(result.completed).toBe(true);
   });
 
+  it("tries every advertised authorization server until one resolves", async () => {
+    const deadAs = "https://dead-as.example.com";
+    global.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const method = (init?.method || "GET").toUpperCase();
+      if (url.includes(".well-known/oauth-protected-resource")) {
+        return json({
+          resource: "https://mcp.example.com/mcp",
+          authorization_servers: [deadAs, AS_ISSUER],
+        });
+      }
+      // The first advertised AS has no discoverable metadata.
+      if (url.startsWith(deadAs)) {
+        return json({}, 404);
+      }
+      if (
+        url.includes(".well-known/oauth-authorization-server") ||
+        url.includes(".well-known/openid-configuration")
+      ) {
+        return json({ issuer: AS_ISSUER, token_endpoint: TOKEN_ENDPOINT });
+      }
+      if (url === TOKEN_ENDPOINT && method === "POST") {
+        return json({ access_token: "at-1", token_type: "Bearer" });
+      }
+      if (url === SERVER_URL && method === "POST") {
+        return json({ jsonrpc: "2.0", id: "mcpjam-xaa-cli", result: {} });
+      }
+      return json({}, 404);
+    }) as unknown as typeof fetch;
+
+    const result = await runXaaFlow({
+      serverUrl: SERVER_URL,
+      issuerBaseUrl: ISSUER_BASE,
+      subject: "user-1",
+      clientId: "client-1",
+    });
+
+    expect(result.authzServerIssuer).toBe(AS_ISSUER);
+    expect(result.completed).toBe(true);
+  });
+
   it("rejects PRM whose resource does not identify the requested server", async () => {
     global.fetch = stubFetch({
       prm: {

--- a/sdk/tests/xaa/signer.test.ts
+++ b/sdk/tests/xaa/signer.test.ts
@@ -7,7 +7,7 @@ import {
   getXAAIdpJwks,
   initXAAIdpKeyPair,
   resetXAAIdpKeyPairForTests,
-} from "../xaa-idp-keypair.js";
+} from "../../src/xaa/mint/keypair.js";
 import {
   issueAccessToken,
   issueAuthorizationCode,
@@ -17,12 +17,12 @@ import {
   verifyXaaJwt,
   XAA_ACCESS_TOKEN_TYP,
   XAA_CODE_JWT_TYP,
-} from "../xaa-idjag-signer.js";
+} from "../../src/xaa/mint/signer.js";
 import {
   NEGATIVE_TEST_MODES,
   XAA_IDP_KID,
   type NegativeTestMode,
-} from "../../../shared/xaa.js";
+} from "../../src/xaa/constants.js";
 
 function decodeJwt(token: string): {
   header: Record<string, any>;


### PR DESCRIPTION
Brings the XAA (Cross-App Access / ID-JAG) debugger to the CLI, the way `mcpjam oauth login` brings the OAuth debugger. Three stacked commits:

## PR1 — Extract the XAA mock-IdP mint to `@mcpjam/sdk` (`0524bf9`)
Moves the security-critical, near-pure mint (signer + keypair + jwt-bearer body builder + shared constants) into `sdk/src/xaa/mint/`, exported from the SDK **node entry only** (crypto/fs). The inspector `logger` dependency is dropped in favour of an injectable no-op logger (`setXaaIdpLogger`), so the SDK carries no inspector coupling. The inspector server now consumes the mint from `@mcpjam/sdk`; the server copies are deleted and their unit tests moved to `sdk/tests/xaa/`. **No inspector client change.** The UI-coupled XAA state machine stays in the inspector.

## PR2 — Lean headless `runXaaFlow` driver in the SDK (`a77524b`)
A ~150-line driver that mirrors the debugger's sequence without its UI state: discover the AS (RFC 9728 → RFC 8414) → self-issue the ID-JAG with the in-process mint → verify locally (`verifyXaaJwt`) → redeem at the AS (RFC 7523 jwt-bearer, via `executeOAuthProxy`) → call the MCP server (SSE-aware). Returns a structured per-step `XaaFlowResult`. The driver **is** the IdP, so it mints the grant directly rather than round-tripping an id-token.

## PR3 — `mcpjam xaa run` (`93d6b25`)
Mirrors `mcpjam oauth login`: a pure `buildXaaConfig` flag→config builder, `onProgress` streamed to stderr on a TTY, a structured JSON/human report via `writeResult`, and exit 1 when the flow does not complete. Builder-only `node:test` coverage.

### Reachability constraint (by design, reported honestly)
Unlike OAuth, in XAA the CLI **is** the IdP and self-signs the ID-JAG, so the target AS must be able to fetch the CLI's JWKS. A self-issued `iss` on localhost is unreachable by a cloud AS, so redemption fails "issuer unreachable" — which is itself the finding the tool reports (it still validated discovery, minted, and inspected the ID-JAG). True end-to-end needs a reachable issuer (enterprise/self-hosted AS, or a follow-up that serves the JWKS via `mcpjam tunnel`).

### Deferred (called out, not built here)
Zero-config reachability via `mcpjam tunnel`; negative-test mode (meaningless until the issuer is reachable); hosted-issuer mint via CLI auth.

## Testing
- SDK XAA suite: 28 passing (incl. new `run-xaa-flow.test.ts` — mocked `fetch`, real local mint: drives a full valid flow to completion, exercises AS discovery, and asserts a token-endpoint 400 is reported as a redemption failure, not a crash).
- Inspector server XAA suite: 106 passing against the SDK imports.
- CLI: 10 builder tests passing; `xaa run --help` and a live unreachable-target smoke run (honest failure report, exit 1) verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth token exchange, JWT minting, and outbound fetches to arbitrary URLs, but behavior is largely extracted/shared with the inspector and the CLI adds explicit credential redaction plus broad unit coverage.
> 
> **Overview**
> Adds **`mcpjam xaa run`**, a terminal Cross-App Access (ID-JAG) debugger parallel to **`mcpjam oauth login`**: it maps flags through **`buildXaaConfig`**, runs **`runXaaFlow`** from **`@mcpjam/sdk`**, streams progress on a TTY, prints a structured step report, exits **1** when the flow does not complete, and **redacts** the raw ID-JAG plus nested/reflected tokens (including echoed assertions in error bodies).
> 
> **`@mcpjam/sdk`** gains a node-only **`xaa`** package: the mock IdP mint (signers, RS256 keypair/JWKS, **`buildJwtBearerBody`** / **`buildJwtBearerRequest`**, negative-test constants) is centralized here; **`runXaaFlow`** drives RFC 9728/8414 discovery, local ID-JAG mint/verify, RFC 7523 jwt-bearer redemption, and an MCP **`initialize`** probe (SSE-aware, strict JSON-RPC success). **`oauth-proxy`** now accepts **`timeoutMs`** on proxy and metadata fetches.
> 
> The **inspector server** stops using local XAA mint modules and imports the SDK instead, wiring **`setXaaIdpLogger`** at startup; **`buildJwtBearerBody`** is re-exported from **`xaa-mint`** for existing importers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3239e5d91fc6e839b96fe5e5c0809a84d25cd82b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a headless Cross-App Access (ID-JAG) debugger in the CLI via `mcpjam xaa run`, powered by `runXaaFlow` in `@mcpjam/sdk`. It discovers the authorization server, self-issues an ID-JAG, supports client auth methods, redeems, and calls the MCP server; output masks the ID-JAG and all bearer tokens (including reflected assertions). The flow only succeeds on a strict JSON-RPC `initialize` result with the `MCP-Protocol-Version` header.

- **New Features**
  - `@mcpjam/cli`: `mcpjam xaa run` with flag→config builder, TTY progress to stderr, JSON/human output, `--https-only`, strict URL/flag validation (incl. requiring `--client-secret` for confidential auth), `--token-endpoint-auth-method` (`client_secret_basic`/`client_secret_post`/`none`, with RFC 6749 Basic when selected), per-request timeout via global `--timeout`, and redaction that masks `idJag.token`, scrubs `access_token`/`refresh_token`/`id_token`, Bearer strings, nested secrets, and any reflected raw ID-JAG (e.g., `assertion`/`error_description`).
  - `@mcpjam/sdk`: `runXaaFlow` with per-step results; verifies the issuer publishes the local JWKS before redemption; discovery hardening (PRM `resource` must match, preserves path/query and trailing slash, tries all advertised ASes; AS metadata `issuer` must match; mint `aud` from the AS’s canonical `issuer`); single-source `buildJwtBearerBody` and new `buildJwtBearerRequest` (handles client auth); OAuth proxy and metadata fetch support `timeoutMs`; MCP `initialize` is SSE-aware, requires a proper JSON-RPC result with the echoed id, and sends `MCP-Protocol-Version`; XAA mock-IdP mint moved here (node only) with `setXaaIdpLogger`.

- **Migration**
  - The CLI is the issuer; the AS must fetch the issuer’s JWKS at `--issuer-base-url`. Use a reachable origin (not localhost) or a tunnel for end-to-end success.

<sup>Written for commit 3239e5d91fc6e839b96fe5e5c0809a84d25cd82b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

