### PR TITLE
refactor(xaa): server consumes the SDK jwt-bearer request builder (convergence PR1)

### DIFF
--- a/.changeset/xaa-jwt-bearer-dedup.md
+++ b/.changeset/xaa-jwt-bearer-dedup.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Remove the XAA server's duplicated `buildJwtBearerRequest` (and its `formUrlEncode`/`encodeBasicClientAuth` helpers); the server now consumes the single-source implementation from `@mcpjam/sdk`. No behavior change — the debugger's `/proxy/token` endpoint and the connect-page mint use the same builder as the CLI.

--- a/mcpjam-inspector/server/services/xaa-mint.ts
+++ b/mcpjam-inspector/server/services/xaa-mint.ts
@@ -6,8 +6,10 @@
 import type { Context } from "hono";
 import {
   buildJwtBearerBody,
+  buildJwtBearerRequest,
   getXAAIssuerUrl,
   issueIdJag,
+  type XaaTokenEndpointAuthMethod,
 } from "@mcpjam/sdk";
 import {
   buildDiscoveryCandidates,
@@ -273,94 +275,13 @@ export async function resolveServerTarget(deps: {
   };
 }
 
-// `buildJwtBearerBody` (the single-source jwt-bearer request body) now lives in
-// @mcpjam/sdk and is re-exported here so existing importers keep their path.
-export { buildJwtBearerBody };
-
-export type XaaTokenEndpointAuthMethod =
-  | "client_secret_post"
-  | "client_secret_basic"
-  | "none";
-
-// application/x-www-form-urlencoded encoding (WHATWG URLSearchParams rules:
-// space→"+", and "*-._"/alphanumerics kept literal, everything else percent-
-// encoded). encodeURIComponent alone leaves "!'()~" literal and encodes space
-// as %20, so it is NOT form-urlencoding and would corrupt credentials that
-// contain those characters.
-function formUrlEncode(value: string): string {
-  return encodeURIComponent(value)
-    .replace(/[!'()~]/g, (c) => "%" + c.charCodeAt(0).toString(16).toUpperCase())
-    .replace(/%20/g, "+");
-}
-
-// RFC 6749 section 2.3.1: client_id and client_secret are each
-// application/x-www-form-urlencoded BEFORE the id:secret pair is Base64-encoded.
-function encodeBasicClientAuth(clientId: string, clientSecret: string): string {
-  return Buffer.from(
-    `${formUrlEncode(clientId)}:${formUrlEncode(clientSecret)}`
-  ).toString("base64");
-}
-
-// Method-aware variant of buildJwtBearerBody: same single-source body, plus
-// the client-auth headers the chosen token_endpoint_auth_method requires.
-// The generated Authorization value carries the secret — callers must never
-// copy `headers` into history, logs, telemetry, or error objects.
-export function buildJwtBearerRequest(args: {
-  assertion: string;
-  clientId?: string | null;
-  clientSecret?: string | null;
-  scope?: string | null;
-  resource?: string | null;
-  tokenEndpointAuthMethod?: XaaTokenEndpointAuthMethod | null;
-}): { headers: Record<string, string>; body: Record<string, string> } {
-  const method = args.tokenEndpointAuthMethod;
-
-  if (method === "client_secret_basic") {
-    if (!args.clientId || !args.clientSecret) {
-      throw new Error(
-        "client_secret_basic requires both a client_id and a client_secret"
-      );
-    }
-    return {
-      headers: {
-        Authorization: `Basic ${encodeBasicClientAuth(
-          args.clientId,
-          args.clientSecret
-        )}`,
-      },
-      // With Basic auth the client_id AND secret are carried in the
-      // Authorization header only — omit both from the body. Some token
-      // endpoints reject a request that also repeats client_id in the body
-      // (one client-auth method per request), and the repo's shared OAuth
-      // helper likewise keeps client-auth params out of the body for Basic.
-      body: buildJwtBearerBody({ ...args, clientId: null, clientSecret: null }),
-    };
-  }
-
-  if (method === "none") {
-    // Public client: client_id identifies the client and is required; no
-    // secret travels anywhere. Reject a missing client_id locally rather than
-    // forwarding an invalid request the AS will just bounce.
-    if (!args.clientId) {
-      throw new Error("A public (none) client request requires a client_id");
-    }
-    return { headers: {}, body: buildJwtBearerBody({ ...args, clientSecret: null }) };
-  }
-
-  if (method === "client_secret_post") {
-    // RFC 6749 section 2.3.1: client_id is REQUIRED alongside the secret.
-    if (!args.clientId || !args.clientSecret) {
-      throw new Error(
-        "client_secret_post requires both a client_id and a client_secret"
-      );
-    }
-    return { headers: {}, body: buildJwtBearerBody(args) };
-  }
-
-  // client_secret_post and the legacy no-method default: credentials in the
-  // form body, exactly as buildJwtBearerBody always produced.
-  return { headers: {}, body: buildJwtBearerBody(args) };
-}
+// `buildJwtBearerBody`, `buildJwtBearerRequest`, and `XaaTokenEndpointAuthMethod`
+// (the single-source jwt-bearer request body + method-aware client-auth request)
+// now live in @mcpjam/sdk and are re-exported here so existing importers keep
+// their path. This is the ONE implementation shared by the debugger's
+// `/proxy/token` endpoint, the connect-page server-side mint, and the CLI.
+export { buildJwtBearerBody, buildJwtBearerRequest };
+export type { XaaTokenEndpointAuthMethod };
 
 // Derive the MCPJam test-IdP issuer from the inbound request. Shared by the XAA
 // router endpoints and the connect-page mint so the signed ID-JAG `iss` matches

--- a/sdk/tests/xaa/jwt-bearer.test.ts
+++ b/sdk/tests/xaa/jwt-bearer.test.ts
@@ -48,4 +48,57 @@ describe("buildJwtBearerRequest", () => {
     expect(request.body.client_id).toBe(args.clientId);
     expect(request.body.client_secret).toBeUndefined();
   });
+
+  it("carries the grant type, scope, and resource for every method", () => {
+    for (const method of [
+      "client_secret_post",
+      "client_secret_basic",
+      "none",
+    ] as const) {
+      const request = buildJwtBearerRequest({
+        ...args,
+        tokenEndpointAuthMethod: method,
+      });
+      expect(request.body.grant_type).toBe(
+        "urn:ietf:params:oauth:grant-type:jwt-bearer"
+      );
+      expect(request.body.assertion).toBe(args.assertion);
+      expect(request.body.scope).toBe("read");
+      expect(request.body.resource).toBe("https://mcp.example.com/mcp");
+    }
+  });
+
+  it("defaults (no method) to credentials in the body, no headers", () => {
+    const request = buildJwtBearerRequest(args);
+    expect(request.headers).toEqual({});
+    expect(request.body).toEqual(buildJwtBearerBody(args));
+  });
+
+  it("requires both credentials for client_secret_basic and _post", () => {
+    for (const method of ["client_secret_basic", "client_secret_post"] as const) {
+      expect(() =>
+        buildJwtBearerRequest({
+          assertion: "a",
+          clientId: "c",
+          tokenEndpointAuthMethod: method,
+        })
+      ).toThrow(new RegExp(method));
+      expect(() =>
+        buildJwtBearerRequest({
+          assertion: "a",
+          clientSecret: "s",
+          tokenEndpointAuthMethod: method,
+        })
+      ).toThrow(new RegExp(method));
+    }
+  });
+
+  it("requires a client_id for a public (none) client", () => {
+    expect(() =>
+      buildJwtBearerRequest({
+        assertion: "a",
+        tokenEndpointAuthMethod: "none",
+      })
+    ).toThrow(/none.*client_id|client_id/i);
+  });
 });


### PR DESCRIPTION
**Convergence PR 1 of 8** toward one shared XAA engine (plan: dedup the duplicated flow logic between the CLI's `runXaaFlow` and the inspector's XAA state machine).

Removes the server's byte-copy of `buildJwtBearerRequest` (+ `formUrlEncode`/`encodeBasicClientAuth`) in `server/services/xaa-mint.ts`; it now imports + re-exports the single-source implementation from `@mcpjam/sdk`. The debugger's `/proxy/token`, the connect-page mint, and the CLI now share one builder — the smallest proof the server can consume an SDK XAA primitive.

Strengthens the SDK contract test (`sdk/tests/xaa/jwt-bearer.test.ts`) with scope/resource coverage across all three methods, the legacy no-method default, and the required-credential error cases.

No behavior change; independent of the rest of the series (branches off `main`).

## Testing
- `sdk/tests/xaa/jwt-bearer.test.ts` (7 pass)
- `server/services/__tests__/xaa-mint.test.ts` + `server/routes/mcp/__tests__/xaa.test.ts` (59 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only deduplication with re-exports preserving import paths; OAuth client-auth logic is security-sensitive but behavior is asserted unchanged by existing and new tests.
> 
> **Overview**
> Removes the inspector XAA server’s local copy of **`buildJwtBearerRequest`** (plus **`formUrlEncode`** / **`encodeBasicClientAuth`**) from `xaa-mint.ts` and **imports the canonical implementation from `@mcpjam/sdk`**, still **re-exporting** `buildJwtBearerBody`, `buildJwtBearerRequest`, and `XaaTokenEndpointAuthMethod` so existing server import paths stay stable.
> 
> **`sdk/tests/xaa/jwt-bearer.test.ts`** gains coverage for grant/scope/resource across auth methods, the legacy no-method default, and missing-credential errors. Changeset notes a patch bump for `@mcpjam/inspector` with **no intended wire behavior change** for `/proxy/token` and connect-page mint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 451f7e55457da975f7017cd37c99127e7f60ddbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates the XAA jwt-bearer request builder by having the server consume and re-export the `@mcpjam/sdk` implementation. No behavior change.

- **Refactors**
  - Removed server copies of `buildJwtBearerRequest` and helpers; export `buildJwtBearerBody`, `buildJwtBearerRequest`, and `XaaTokenEndpointAuthMethod` from `@mcpjam/sdk`.
  - The debugger `/proxy/token`, connect-page mint, and CLI now share one builder.
  - Strengthened SDK tests for scope/resource coverage and required-credential errors.

<sup>Written for commit 451f7e55457da975f7017cd37c99127e7f60ddbb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

