### PR TITLE
feat(models): source picker hosted models from backend catalog

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/model/provider-logo.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/model/provider-logo.tsx
@@ -1,7 +1,6 @@
 // Standard React component for Vite
 import { getProviderLogoFromProvider } from "../../shared/chat-helpers";
 import { cn } from "@/lib/chat-utils";
-import { getProviderColorForTheme } from "../../shared/chat-helpers";
 import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
 import { useChatboxHostTheme } from "@/contexts/chatbox-client-style-context";
 
@@ -29,28 +28,21 @@ export function ProviderLogo({
   }
 
   if (!logoSrc) {
-    // Custom providers: first-letter badge matching the Settings tab style
-    if (provider === "custom") {
-      const letter = customProviderName?.[0]?.toUpperCase() || "C";
-      return (
-        <div
-          className={cn(
-            "flex h-3 w-3 items-center justify-center rounded-sm bg-primary/10",
-            className,
-          )}
-        >
-          <span className="text-primary font-bold text-[6px]">{letter}</span>
-        </div>
-      );
-    }
+    // No logo asset — render a first-letter monogram badge (Settings-tab
+    // style). Covers custom providers AND unknown catalog providers (e.g.
+    // "alibaba", "nvidia") that ship no bundled logo, so a brand-new provider
+    // renders a legible badge with no code change.
+    const source = provider === "custom" ? customProviderName : provider;
+    const letter = source?.[0]?.toUpperCase() || "?";
     return (
       <div
         className={cn(
-          "h-3 w-3 rounded-sm",
-          getProviderColorForTheme(provider, resolvedThemeMode),
+          "flex h-3 w-3 items-center justify-center rounded-sm bg-primary/10",
           className,
         )}
-      />
+      >
+        <span className="text-primary font-bold text-[6px]">{letter}</span>
+      </div>
     );
   } else {
     return (

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/__tests__/available-models.test.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/__tests__/available-models.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import type { ModelDefinition } from "@/shared/types";
+import {
+  applyGuestModelLocks,
+  applyOutOfCreditsLocks,
+  GUEST_LOCKED_MODEL_REASON,
+  OUT_OF_CREDITS_MODEL_REASON,
+} from "../available-models";
+
+// Catalog-sourced hosted models carrying the DTO `guestAllowed` flag.
+const HOSTED_GUEST_GATED: ModelDefinition = {
+  id: "newvendor/premium-model",
+  name: "Premium",
+  provider: "newvendor",
+  hosted: true,
+  guestAllowed: false,
+};
+const HOSTED_GUEST_OK: ModelDefinition = {
+  id: "newvendor/free-model",
+  name: "Free",
+  provider: "newvendor",
+  hosted: true,
+  guestAllowed: true,
+};
+const BYOK: ModelDefinition = {
+  id: "some/byok",
+  name: "BYOK",
+  provider: "openrouter",
+};
+
+describe("applyGuestModelLocks", () => {
+  it("no-ops for authenticated users", () => {
+    const models = [HOSTED_GUEST_GATED, HOSTED_GUEST_OK, BYOK];
+    expect(applyGuestModelLocks(models, true)).toEqual(models);
+  });
+
+  it("locks guest-gated hosted models but leaves guest-allowed + BYOK enabled", () => {
+    const [gated, ok, byok] = applyGuestModelLocks(
+      [HOSTED_GUEST_GATED, HOSTED_GUEST_OK, BYOK],
+      false
+    );
+    expect(gated.disabled).toBe(true);
+    expect(gated.disabledReason).toBe(GUEST_LOCKED_MODEL_REASON);
+    expect(ok.disabled).toBeUndefined();
+    expect(byok.disabled).toBeUndefined();
+  });
+
+  it("defaults a hosted model with no guestAllowed flag to guest-gated (locked)", () => {
+    const unknown: ModelDefinition = {
+      id: "newvendor/unknown",
+      name: "Unknown",
+      provider: "newvendor",
+      hosted: true,
+    };
+    const [locked] = applyGuestModelLocks([unknown], false);
+    expect(locked.disabled).toBe(true);
+  });
+});
+
+describe("applyOutOfCreditsLocks", () => {
+  it("locks hosted (free) models but not BYOK when out of credits", () => {
+    const [hosted, byok] = applyOutOfCreditsLocks(
+      [HOSTED_GUEST_OK, BYOK],
+      true
+    );
+    expect(hosted.disabled).toBe(true);
+    expect(hosted.disabledReason).toBe(OUT_OF_CREDITS_MODEL_REASON);
+    expect(byok.disabled).toBeUndefined();
+  });
+
+  it("no-ops when not out of credits", () => {
+    const models = [HOSTED_GUEST_OK, BYOK];
+    expect(applyOutOfCreditsLocks(models, false)).toEqual(models);
+  });
+});

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/__tests__/model-helpers.test.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/__tests__/model-helpers.test.ts
@@ -1,10 +1,33 @@
 import { describe, expect, it } from "vitest";
+import type { ModelDefinition } from "@/shared/types";
 import {
+  buildAvailableModels,
   buildAvailableModelsFromOrgConfig,
   buildModelMenuGroups,
   getDefaultModel,
+  getProviderDisplayName,
+  isMCPJamProvidedModelMenuItem,
   isOrgProviderAvailable,
 } from "../model-helpers";
+
+// A hosted model the backend catalog knows about but the static SUPPORTED_MODELS
+// list does NOT — the whole reason this PR exists.
+const CATALOG_ONLY: ModelDefinition = {
+  id: "newvendor/brand-new-model",
+  name: "Brand New Model",
+  provider: "newvendor",
+  hosted: true,
+  guestAllowed: false,
+};
+
+const NO_KEYS = {
+  hasToken: () => false,
+  getOpenRouterSelectedModels: () => [],
+  isOllamaRunning: false,
+  ollamaModels: [] as ModelDefinition[],
+  getAzureBaseUrl: () => "",
+  customProviders: [],
+};
 
 describe("org model helpers", () => {
   it("prefers Claude Haiku 4.5 as the MCPJam default model", () => {
@@ -96,6 +119,49 @@ describe("org model helpers", () => {
         (m) => m.provider === "bedrock"
       )
     ).toBe(false);
+  });
+
+  it("buildAvailableModels uses the injected hosted catalog as the hosted source", () => {
+    const models = buildAvailableModels({ ...NO_KEYS, hostedCatalog: [CATALOG_ONLY] });
+    // The catalog-only model surfaces even though it's absent from SUPPORTED_MODELS.
+    expect(models).toContainEqual(CATALOG_ONLY);
+    // With no BYOK keys, the hosted catalog is the whole cloud list.
+    expect(models.every((m) => m.hosted === true)).toBe(true);
+  });
+
+  it("buildAvailableModels falls back to the static hosted subset when no catalog is given", () => {
+    const models = buildAvailableModels(NO_KEYS);
+    // Non-empty, and every static hosted entry classifies as MCPJam-provided.
+    expect(models.length).toBeGreaterThan(0);
+    expect(models.some((m) => isMCPJamProvidedModelMenuItem(m))).toBe(true);
+  });
+
+  it("buildAvailableModelsFromOrgConfig uses the injected catalog for the hosted source", () => {
+    const models = buildAvailableModelsFromOrgConfig(
+      { providers: [] },
+      [CATALOG_ONLY]
+    );
+    expect(models).toContainEqual(CATALOG_ONLY);
+  });
+
+  it("isMCPJamProvidedModelMenuItem trusts the hosted flag for catalog-only ids", () => {
+    // Not in the static list, not an own-provider source — the flag decides.
+    expect(isMCPJamProvidedModelMenuItem(CATALOG_ONLY)).toBe(true);
+    // An own-provider (BYOK) model is never MCPJam-provided even if mis-flagged absent.
+    expect(
+      isMCPJamProvidedModelMenuItem({
+        id: "some/model",
+        name: "x",
+        provider: "openrouter",
+      })
+    ).toBe(false);
+  });
+
+  it("getProviderDisplayName title-cases unknown catalog providers", () => {
+    expect(getProviderDisplayName("arcee-ai")).toBe("Arcee Ai");
+    expect(getProviderDisplayName("nvidia")).toBe("Nvidia");
+    // Known providers keep their curated names.
+    expect(getProviderDisplayName("anthropic")).toBe("Anthropic");
   });
 
   it("keeps OpenRouter models with provider-prefixed ids under configured providers", () => {

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/available-models.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/available-models.ts
@@ -31,10 +31,10 @@ export function applyGuestModelLocks(
 
   return models.map((model) => {
     const modelId = String(model.id);
-    if (
-      !isMCPJamProvidedModelMenuItem(model) ||
-      isMCPJamGuestAllowedModel(modelId)
-    ) {
+    // Prefer the catalog-sourced `guestAllowed` flag; fall back to the static
+    // guest allow-list for models without it. Unknown → guest-gated (locked).
+    const guestAllowed = model.guestAllowed ?? isMCPJamGuestAllowedModel(modelId);
+    if (!isMCPJamProvidedModelMenuItem(model) || guestAllowed) {
       return model;
     }
 
@@ -111,6 +111,12 @@ export function composeAvailableModels(params: {
   customProviders: CustomProvider[];
   /** Lock MCPJam-provided ("free") models when the org/guest has 0 credits. */
   outOfCredits?: boolean;
+  /**
+   * The hosted ("free") model source from the backend catalog. When omitted,
+   * composition falls back to the static `SUPPORTED_MODELS` hosted subset —
+   * so this stays a drop-in for any caller that hasn't wired the catalog yet.
+   */
+  hostedCatalog?: ModelDefinition[];
 }): ModelDefinition[] {
   const {
     orgConfig,
@@ -122,10 +128,11 @@ export function composeAvailableModels(params: {
     getAzureBaseUrl,
     customProviders,
     outOfCredits = false,
+    hostedCatalog,
   } = params;
 
   if ((orgConfig?.providers.length ?? 0) > 0) {
-    const orgModels = buildAvailableModelsFromOrgConfig(orgConfig);
+    const orgModels = buildAvailableModelsFromOrgConfig(orgConfig, hostedCatalog);
     const orgModelsWithLocalOllama = appendDetectedLocalOllamaModels(
       orgModels,
       isOllamaRunning,
@@ -144,6 +151,7 @@ export function composeAvailableModels(params: {
     ollamaModels,
     getAzureBaseUrl,
     customProviders,
+    hostedCatalog,
   });
   const guestLockedModels = applyGuestModelLocks(localModels, isAuthenticated);
   const visibleModels = HOSTED_MODE

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/model-helpers.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/model-helpers.ts
@@ -27,6 +27,13 @@ export function buildAvailableModels(params: {
   ollamaModels: ModelDefinition[];
   getAzureBaseUrl: () => string;
   customProviders: CustomProvider[];
+  /**
+   * The hosted ("free") model source. When provided (the backend catalog),
+   * it replaces the static `SUPPORTED_MODELS.filter(isMCPJamProvidedModel)`
+   * subset; BYOK-key-derived models still come from `SUPPORTED_MODELS`. Absent
+   * → the pre-catalog static behavior (keeps un-wired callers + tests working).
+   */
+  hostedCatalog?: ModelDefinition[];
 }): ModelDefinition[] {
   const {
     hasToken,
@@ -35,6 +42,7 @@ export function buildAvailableModels(params: {
     isOllamaRunning,
     ollamaModels,
     customProviders,
+    hostedCatalog,
   } = params;
 
   const providerHasKey: Record<string, boolean> = {
@@ -52,10 +60,16 @@ export function buildAvailableModels(params: {
     meta: false,
   } as const;
 
-  const cloud = SUPPORTED_MODELS.filter((m) => {
-    if (isMCPJamProvidedModel(m.id)) return true;
+  const hosted =
+    hostedCatalog ??
+    SUPPORTED_MODELS.filter((m) => isMCPJamProvidedModel(String(m.id)));
+  // BYOK models the user has a key for — hosted ids handled by `hosted` above,
+  // so exclude them here to avoid duplicates when a static model is both.
+  const byok = SUPPORTED_MODELS.filter((m) => {
+    if (isMCPJamProvidedModel(String(m.id))) return false;
     return providerHasKey[m.provider];
   });
+  const cloud = [...hosted, ...byok];
 
   const openRouterModels: ModelDefinition[] = providerHasKey.openrouter
     ? getOpenRouterSelectedModels().map((id) => ({
@@ -118,11 +132,17 @@ export function isOrgProviderAvailable(
  * so hosted local-runtime Ollama providers appear in the model picker.
  */
 export function buildAvailableModelsFromOrgConfig(
-  orgConfig: OrgVisibleConfig | undefined
+  orgConfig: OrgVisibleConfig | undefined,
+  /** Hosted ("free") source; see `buildAvailableModels`. */
+  hostedCatalog?: ModelDefinition[]
 ): ModelDefinition[] {
+  const hosted =
+    hostedCatalog ??
+    SUPPORTED_MODELS.filter((m) => isMCPJamProvidedModel(String(m.id)));
+
   if (!orgConfig?.providers) {
-    // No org config loaded yet — return only MCPJam-provided models
-    return SUPPORTED_MODELS.filter((m) => isMCPJamProvidedModel(String(m.id)));
+    // No org config loaded yet — return only MCPJam-provided (hosted) models
+    return hosted;
   }
 
   // Determine which provider keys are available. Ollama is skipped — it never
@@ -134,11 +154,13 @@ export function buildAvailableModelsFromOrgConfig(
     if (p.hasSecret) availableProviderKeys.add(p.providerKey);
   }
 
-  // Always include MCPJam-provided models
-  const models: ModelDefinition[] = SUPPORTED_MODELS.filter((m) => {
-    if (isMCPJamProvidedModel(String(m.id))) return true;
+  // Hosted models plus the org-key-derived provider models (hosted ids excluded
+  // from the latter so a static model that is both isn't duplicated).
+  const orgKeyModels = SUPPORTED_MODELS.filter((m) => {
+    if (isMCPJamProvidedModel(String(m.id))) return false;
     return availableProviderKeys.has(m.provider);
   });
+  const models: ModelDefinition[] = [...hosted, ...orgKeyModels];
 
   // OpenRouter: include selectedModels from org config
   const openRouterConfig = orgConfig.providers.find(
@@ -223,6 +245,15 @@ export function compactModelLabel(name: string | undefined | null): string {
   return name.replace(/\s*\(Free\)\s*$/i, "").trim() || name;
 }
 
+/** Title-case an unknown provider key ("arcee-ai" → "Arcee Ai"). */
+function titleCaseProviderKey(groupKey: string): string {
+  return groupKey
+    .split(/[-_]/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
 /** Display name for a provider group key (handles `custom:<slug>`). */
 export function getProviderDisplayName(groupKey: string): string {
   if (groupKey.startsWith("custom:")) {
@@ -261,7 +292,9 @@ export function getProviderDisplayName(groupKey: string): string {
     case "qwen":
       return "Qwen";
     default:
-      return groupKey;
+      // Unknown catalog provider (e.g. "arcee-ai", "nvidia") — render a clean
+      // title-cased name instead of the raw key, so new providers need no code.
+      return titleCaseProviderKey(groupKey);
   }
 }
 
@@ -275,6 +308,8 @@ export interface ModelMenuItem {
   name: string;
   provider: string;
   customProviderName?: string;
+  /** Set by the backend catalog source; see `ModelDefinition.hosted`. */
+  hosted?: boolean;
 }
 
 const OWN_PROVIDER_SOURCES = new Set([
@@ -286,9 +321,15 @@ const OWN_PROVIDER_SOURCES = new Set([
 ]);
 
 export function isMCPJamProvidedModelMenuItem(model: ModelMenuItem): boolean {
+  // The catalog-sourced `hosted` flag is authoritative — a catalog-only model
+  // (not in the static list) still classifies as MCPJam-provided.
+  if (model.hosted === true) {
+    return true;
+  }
   if (OWN_PROVIDER_SOURCES.has(model.provider)) {
     return false;
   }
+  // Back-compat for static-derived items that carry no `hosted` flag.
   return isMCPJamProvidedModel(String(model.id));
 }
 

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-hosted-model-catalog.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-hosted-model-catalog.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+
+const authState = vi.hoisted(() => ({ isAuthenticated: true }));
+const mockGetAccessToken = vi.hoisted(() => vi.fn());
+
+vi.mock("convex/react", () => ({
+  useConvexAuth: () => ({
+    isAuthenticated: authState.isAuthenticated,
+    isLoading: false,
+  }),
+}));
+
+vi.mock("@workos-inc/authkit-react", () => ({
+  useAuth: () => ({ getAccessToken: mockGetAccessToken }),
+}));
+
+import {
+  providerFromCanonicalId,
+  resetHostedModelCatalogForTests,
+  useHostedModelCatalog,
+} from "../use-hosted-model-catalog";
+
+const STORAGE_KEY = "mcpjam.hostedModelCatalog.v1";
+
+function catalogDto(id: string, guestAllowed = true) {
+  return {
+    id,
+    canonical_slug: id,
+    name: id,
+    created: 0,
+    pricing: { prompt: "0", completion: "0", request: "0", image: "0" },
+    context_length: 1000,
+    architecture: {
+      modality: "text->text",
+      input_modalities: ["text"],
+      output_modalities: ["text"],
+      tokenizer: "",
+    },
+    top_provider: {
+      is_moderated: false,
+      context_length: 1000,
+      max_completion_tokens: 1000,
+    },
+    per_request_limits: null,
+    supported_parameters: [],
+    default_parameters: null,
+    description: "",
+    guestAllowed,
+    providerSource: "gateway" as const,
+  };
+}
+
+function stubFetchJson(body: unknown, ok = true, status = 200) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({ ok, status, json: async () => body }))
+  );
+}
+
+beforeEach(() => {
+  resetHostedModelCatalogForTests();
+  authState.isAuthenticated = true;
+  mockGetAccessToken.mockReset();
+  mockGetAccessToken.mockResolvedValue("token-123");
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("providerFromCanonicalId", () => {
+  it("derives the provider from the id prefix, applying aliases", () => {
+    expect(providerFromCanonicalId("anthropic/claude-haiku-4.5")).toBe(
+      "anthropic"
+    );
+    expect(providerFromCanonicalId("meta-llama/llama-4-scout")).toBe("meta");
+    expect(providerFromCanonicalId("x-ai/grok-4-fast")).toBe("xai");
+    expect(providerFromCanonicalId("mistralai/mistral-small-2603")).toBe(
+      "mistral"
+    );
+    // Unknown prefix passes through verbatim (renders with a monogram).
+    expect(providerFromCanonicalId("nvidia/nemotron")).toBe("nvidia");
+  });
+});
+
+describe("useHostedModelCatalog", () => {
+  it("maps the live backend catalog to hosted ModelDefinitions and persists it", async () => {
+    stubFetchJson({ ok: true, data: [catalogDto("newvendor/model-x", false)] });
+
+    const { result } = renderHook(() => useHostedModelCatalog());
+
+    await waitFor(() => expect(result.current.status).toBe("live"));
+    const model = result.current.hostedCatalog.find(
+      (m) => String(m.id) === "newvendor/model-x"
+    );
+    expect(model).toMatchObject({
+      hosted: true,
+      provider: "newvendor",
+      guestAllowed: false,
+      contextLength: 1000,
+    });
+    // Last-good cache is persisted for the next (possibly offline) load.
+    expect(window.localStorage.getItem(STORAGE_KEY)).toContain(
+      "newvendor/model-x"
+    );
+  });
+
+  it("falls back to the last-good localStorage cache on fetch failure", async () => {
+    const cached = [
+      {
+        id: "cached/model",
+        name: "Cached",
+        provider: "cached",
+        hosted: true,
+        guestAllowed: true,
+      },
+    ];
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(cached));
+    stubFetchJson({}, false, 503);
+
+    const { result } = renderHook(() => useHostedModelCatalog());
+
+    await waitFor(() => expect(result.current.status).toBe("fallback"));
+    expect(result.current.hostedCatalog).toEqual(cached);
+  });
+
+  it("falls back to a non-empty static hosted subset when there is no cache", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("offline");
+      })
+    );
+
+    const { result } = renderHook(() => useHostedModelCatalog());
+
+    await waitFor(() => expect(result.current.status).toBe("fallback"));
+    expect(result.current.hostedCatalog.length).toBeGreaterThan(0);
+    expect(result.current.hostedCatalog.every((m) => m.hosted === true)).toBe(
+      true
+    );
+  });
+
+  it("skips the auth-gated fetch for guests and serves the fallback (never empty)", async () => {
+    authState.isAuthenticated = false;
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const { result } = renderHook(() => useHostedModelCatalog());
+
+    await waitFor(() => expect(result.current.status).toBe("fallback"));
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(result.current.hostedCatalog.length).toBeGreaterThan(0);
+  });
+
+  it("refetches the live catalog when a guest signs in (no stale fallback pin)", async () => {
+    // Guest first: resolves to the static fallback and caches it module-wide.
+    authState.isAuthenticated = false;
+    stubFetchJson({ ok: true, data: [catalogDto("newvendor/model-x", false)] });
+
+    const { result, rerender } = renderHook(() => useHostedModelCatalog());
+    await waitFor(() => expect(result.current.status).toBe("fallback"));
+
+    // Sign in: the guest fallback must NOT pin — the hook fetches the now
+    // reachable auth-gated catalog and upgrades to live.
+    authState.isAuthenticated = true;
+    rerender();
+
+    await waitFor(() => expect(result.current.status).toBe("live"));
+    expect(
+      result.current.hostedCatalog.some((m) => String(m.id) === "newvendor/model-x")
+    ).toBe(true);
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/use-available-models.ts
+++ b/mcpjam-inspector/client/src/hooks/use-available-models.ts
@@ -9,6 +9,7 @@ import { useHostedOrgModelConfig } from "@/hooks/use-hosted-org-model-config";
 import { useDetectedOllamaModels } from "@/hooks/use-detected-ollama-models";
 import { composeAvailableModels } from "@/components/chat-v2/shared/available-models";
 import { useOutOfCredits } from "@/hooks/useCreditBalance";
+import { useHostedModelCatalog } from "@/hooks/use-hosted-model-catalog";
 
 /**
  * Models the current user can pick on any model-picker surface (eval suite
@@ -57,6 +58,7 @@ export function useAvailableModels(options?: {
   const { isOllamaRunning, ollamaModels } =
     useDetectedOllamaModels(getOllamaBaseUrl);
   const outOfCredits = useOutOfCredits(organizationId);
+  const { hostedCatalog } = useHostedModelCatalog();
 
   const availableModels = useMemo(
     () =>
@@ -70,6 +72,7 @@ export function useAvailableModels(options?: {
         getAzureBaseUrl,
         customProviders,
         outOfCredits,
+        hostedCatalog,
       }),
     [
       hostedOrgModelConfig,
@@ -81,6 +84,7 @@ export function useAvailableModels(options?: {
       getAzureBaseUrl,
       customProviders,
       outOfCredits,
+      hostedCatalog,
     ]
   );
 

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -68,6 +68,7 @@ import {
   isMCPJamProvidedModel,
 } from "@/shared/types";
 import { useDetectedOllamaModels } from "@/hooks/use-detected-ollama-models";
+import { useHostedModelCatalog } from "@/hooks/use-hosted-model-catalog";
 import { DEFAULT_SYSTEM_PROMPT } from "@/components/chat-v2/shared/chat-helpers";
 import { getToolsMetadata, ToolServerMap } from "@/lib/apis/mcp-tools-api";
 import type { SerializedModelRequestTool } from "@/shared/model-request-payload";
@@ -1399,6 +1400,7 @@ export function useChatSession(
   // uses (see `composeAvailableModels`); only the org-config source is
   // chat-specific (chatbox embeds resolve a host-provided project context).
   const outOfCredits = useOutOfCredits();
+  const { hostedCatalog } = useHostedModelCatalog();
   const availableModels = useMemo(
     () =>
       composeAvailableModels({
@@ -1411,6 +1413,7 @@ export function useChatSession(
         getAzureBaseUrl,
         customProviders,
         outOfCredits,
+        hostedCatalog,
       }),
     [
       hasToken,
@@ -1422,6 +1425,7 @@ export function useChatSession(
       customProviders,
       hostedOrgModelConfig,
       outOfCredits,
+      hostedCatalog,
     ]
   );
 

--- a/mcpjam-inspector/client/src/hooks/use-hosted-model-catalog.ts
+++ b/mcpjam-inspector/client/src/hooks/use-hosted-model-catalog.ts
@@ -1,0 +1,231 @@
+import { useEffect, useState } from "react";
+import { useAuth } from "@workos-inc/authkit-react";
+import { useConvexAuth } from "convex/react";
+import { track } from "@/lib/analytics";
+import {
+  SUPPORTED_MODELS,
+  isMCPJamGuestAllowedModel,
+  isMCPJamProvidedModel,
+  type ModelDefinition,
+} from "@/shared/types";
+import type { OpenRouterModel } from "@/types/model-metadata";
+
+/**
+ * The MCPJam hosted-model catalog for the picker, sourced from the backend
+ * (`GET /api/mcp/models`) instead of the static `SUPPORTED_MODELS` list, so
+ * models the backend adds appear with no inspector release.
+ *
+ * Guarantees the picker is NEVER empty:
+ *   live      → the fresh backend catalog
+ *   fallback  → last-good localStorage cache, else the static hosted subset
+ *
+ * A guest (or offline/Electron) can't reach the auth-gated `/models` route, so
+ * those cases resolve to `fallback` off the cache/static list rather than an
+ * error. The org-config precedence path is unaffected — this only supplies the
+ * hosted ("free") source that composition unions with BYOK/org models.
+ */
+
+const STORAGE_KEY = "mcpjam.hostedModelCatalog.v1";
+
+export type HostedCatalogStatus = "loading" | "live" | "fallback";
+
+export interface HostedModelCatalogState {
+  hostedCatalog: ModelDefinition[];
+  status: HostedCatalogStatus;
+}
+
+// Catalog id prefixes whose logo/display live under a different provider key.
+const PROVIDER_ALIASES: Record<string, string> = {
+  "meta-llama": "meta",
+  "x-ai": "xai",
+  mistralai: "mistral",
+};
+
+/**
+ * Derive the provider key from a canonical (slash-prefixed) catalog id. The
+ * catalog carries no `provider` field; the id prefix is the source of truth
+ * (e.g. "anthropic/claude-haiku-4.5" → "anthropic"). Unknown prefixes are
+ * returned verbatim — the picker renders them with a monogram + title-cased
+ * name, so a brand-new provider needs no code change.
+ */
+export function providerFromCanonicalId(id: string): string {
+  const slash = id.indexOf("/");
+  const prefix = (slash > 0 ? id.slice(0, slash) : id).toLowerCase();
+  return PROVIDER_ALIASES[prefix] ?? prefix;
+}
+
+function catalogDtoToModelDefinition(dto: OpenRouterModel): ModelDefinition {
+  return {
+    id: dto.id,
+    name: dto.name || dto.id,
+    provider: providerFromCanonicalId(dto.id),
+    hosted: true,
+    guestAllowed: dto.guestAllowed,
+    contextLength: dto.context_length ?? undefined,
+  };
+}
+
+/** The pre-catalog behavior: the static hosted subset, tagged `hosted`. */
+function staticHostedFallback(): ModelDefinition[] {
+  return SUPPORTED_MODELS.filter((model) =>
+    isMCPJamProvidedModel(String(model.id))
+  ).map((model) => ({
+    ...model,
+    hosted: true,
+    guestAllowed: isMCPJamGuestAllowedModel(String(model.id)),
+  }));
+}
+
+function loadCachedCatalog(): ModelDefinition[] | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed) && parsed.length > 0) {
+      return parsed as ModelDefinition[];
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function saveCachedCatalog(models: ModelDefinition[]): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(models));
+  } catch {
+    // A full/blocked quota must not break the picker — it just loses the
+    // offline cache for next load.
+  }
+}
+
+/** Last-good hosted models when a live fetch isn't available. */
+function fallbackModels(): ModelDefinition[] {
+  return loadCachedCatalog() ?? staticHostedFallback();
+}
+
+function reportDegradation(reason: string): void {
+  console.warn("[hosted-model-catalog] client catalog degraded", { reason });
+  try {
+    track("hosted_model_catalog_degraded", {
+      location: "hosted_model_catalog",
+      reason,
+    });
+  } catch {
+    // Telemetry must never affect catalog loading.
+  }
+}
+
+// Module-level memo so every picker instance shares a single fetch per load.
+let cached: { status: "live" | "fallback"; models: ModelDefinition[] } | null =
+  null;
+let inflight: Promise<void> | null = null;
+// Bumped on reset so a fetch started before a reset can't write `cached` after
+// it (keeps test cases isolated).
+let generation = 0;
+
+/** Test hook — reset the module-level memo between cases. */
+export function resetHostedModelCatalogForTests(): void {
+  cached = null;
+  inflight = null;
+  generation++;
+}
+
+async function fetchCatalogModels(
+  getAccessToken: () => Promise<string | undefined>
+): Promise<ModelDefinition[] | null> {
+  try {
+    const accessToken = await getAccessToken();
+    const response = await fetch("/api/mcp/models", {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+    if (!response.ok) {
+      reportDegradation(`http_${response.status}`);
+      return null;
+    }
+    const data = (await response.json()) as {
+      ok?: boolean;
+      data?: OpenRouterModel[];
+    };
+    // The catalog always lists every allowed model, so `ok:false` or an empty
+    // array is an implausible/failed fetch, not an authoritative empty catalog.
+    if (!data?.ok || !Array.isArray(data.data) || data.data.length === 0) {
+      reportDegradation("empty_or_error_payload");
+      return null;
+    }
+    return data.data.map(catalogDtoToModelDefinition);
+  } catch (error) {
+    reportDegradation(
+      error instanceof Error ? `threw_${error.name}` : "threw_unknown"
+    );
+    return null;
+  }
+}
+
+export function useHostedModelCatalog(): HostedModelCatalogState {
+  const { isAuthenticated } = useConvexAuth();
+  const { getAccessToken } = useAuth();
+
+  const [state, setState] = useState<HostedModelCatalogState>(() =>
+    cached
+      ? { status: cached.status, hostedCatalog: cached.models }
+      : { status: "loading", hostedCatalog: fallbackModels() }
+  );
+
+  useEffect(() => {
+    // The `/models` route is auth-gated: a guest (or offline/Electron) can't
+    // fetch it, so resolve straight to the cached/static fallback.
+    if (!isAuthenticated) {
+      const models = fallbackModels();
+      cached = { status: "fallback", models };
+      setState({ status: "fallback", hostedCatalog: models });
+      return;
+    }
+
+    // Authenticated: a `live` cache is authoritative and shared across picker
+    // instances. A `fallback` cache is a guest/offline artifact — do NOT reuse
+    // it here, or a guest who signs in stays pinned to the static fallback
+    // forever; fall through and fetch the now-reachable auth-gated catalog.
+    if (cached?.status === "live") {
+      setState({ status: cached.status, hostedCatalog: cached.models });
+      return;
+    }
+
+    let mounted = true;
+    const effectGeneration = generation;
+
+    if (!inflight) {
+      inflight = fetchCatalogModels(getAccessToken)
+        .then((models) => {
+          if (effectGeneration !== generation) return;
+          if (models) {
+            saveCachedCatalog(models);
+            cached = { status: "live", models };
+          } else {
+            cached = { status: "fallback", models: fallbackModels() };
+          }
+        })
+        .finally(() => {
+          inflight = null;
+        });
+    }
+
+    void inflight.then(() => {
+      if (mounted && effectGeneration === generation && cached) {
+        setState({ status: cached.status, hostedCatalog: cached.models });
+      }
+    });
+
+    return () => {
+      mounted = false;
+    };
+  }, [isAuthenticated, getAccessToken]);
+
+  return state;
+}

--- a/mcpjam-inspector/client/src/types/model-metadata.ts
+++ b/mcpjam-inspector/client/src/types/model-metadata.ts
@@ -14,7 +14,9 @@ export interface OpenRouterModel {
     request: string;
     image: string;
   };
-  context_length: number;
+  // Nullable to match the backend `CatalogModelDto`: a model with no known
+  // context length renders "N/A" instead of a misleading 0.
+  context_length: number | null;
   architecture: {
     modality: string;
     input_modalities: string[];
@@ -24,13 +26,20 @@ export interface OpenRouterModel {
   };
   top_provider: {
     is_moderated: boolean;
-    context_length: number;
-    max_completion_tokens: number;
+    context_length: number | null;
+    max_completion_tokens: number | null;
   };
   per_request_limits: any;
   supported_parameters: string[];
   default_parameters: any;
   description: string;
+  // Whether MCPJam serves this model to signed-out guests (from the canonical
+  // model capabilities, not the OpenRouter/Gateway catalog). Consumed by the
+  // picker to gate guest-visible models.
+  guestAllowed: boolean;
+  // Which provider serves this model: 'gateway' when a Gateway price exists,
+  // 'openrouter' for fallback models with no Gateway entry.
+  providerSource: "gateway" | "openrouter";
 }
 
 export interface ModelMetadataResponse {

--- a/mcpjam-inspector/server/app.ts
+++ b/mcpjam-inspector/server/app.ts
@@ -54,9 +54,9 @@ import {
   loadInspectorEnv,
   warnOnConvexDevMisconfiguration,
 } from "./env.js";
+import { startHostedModelCatalogRefresh } from "./services/hosted-model-catalog.js";
 import { startGuestAuthProvisioningInBackground } from "./utils/convex-guest-auth-sync.js";
 import { startLocalBrowserRenderingSetupInBackground } from "./utils/browser-rendering-setup.js";
-import { startHostedModelCatalogRefresh } from "./services/hosted-model-catalog.js";
 import { fetchRemoteGuestJwks } from "./utils/guest-session-source.js";
 import { INSPECTOR_MCP_RETRY_POLICY } from "./utils/mcp-retry-policy.js";
 import { initXAAIdpKeyPair, setXaaIdpLogger } from "@mcpjam/sdk";
@@ -84,11 +84,12 @@ export async function createHonoApp() {
   setXaaIdpLogger(appLogger);
   initXAAIdpKeyPair();
 
-  startGuestAuthProvisioningInBackground();
-  startLocalBrowserRenderingSetupInBackground();
   // Warm the hosted-model catalog (seed ∪ backend /v1/models) so billing
   // dispatch classifies newly-added hosted models correctly. Memoized.
   startHostedModelCatalogRefresh();
+
+  startGuestAuthProvisioningInBackground();
+  startLocalBrowserRenderingSetupInBackground();
   // Mirror of the call in server/index.ts — both production entries must
   // wire this up so the Electron/embedded path also gets a working Computer
   // tab. Memoized, so it's harmless if a process ever ran both. AWAITED (the
@@ -269,9 +270,9 @@ export async function createHonoApp() {
             code: "VALIDATION_ERROR",
             message: "Request body exceeds 1MB limit",
           },
-          400
+          400,
         ),
-    })
+    }),
   );
   app.route("/api/v1", v1Routes);
 
@@ -433,9 +434,8 @@ export async function createHonoApp() {
           })
         ) {
           try {
-            const { session, setCookies } = await mintGuestSessionForDocument(
-              c
-            );
+            const { session, setCookies } =
+              await mintGuestSessionForDocument(c);
             if (session && session.expiresAt > Date.now()) {
               const bootstrapScript = buildGuestBootstrapScript(session);
               html = html.replace("</head>", `${bootstrapScript}</head>`);
@@ -446,7 +446,7 @@ export async function createHonoApp() {
           } catch (error) {
             appLogger.warn(
               "[guest-bootstrap] document mint failed; serving without blob",
-              { error: error instanceof Error ? error.message : String(error) }
+              { error: error instanceof Error ? error.message : String(error) },
             );
           }
         }

--- a/mcpjam-inspector/server/app.ts
+++ b/mcpjam-inspector/server/app.ts
@@ -56,6 +56,7 @@ import {
 } from "./env.js";
 import { startGuestAuthProvisioningInBackground } from "./utils/convex-guest-auth-sync.js";
 import { startLocalBrowserRenderingSetupInBackground } from "./utils/browser-rendering-setup.js";
+import { startHostedModelCatalogRefresh } from "./services/hosted-model-catalog.js";
 import { fetchRemoteGuestJwks } from "./utils/guest-session-source.js";
 import { INSPECTOR_MCP_RETRY_POLICY } from "./utils/mcp-retry-policy.js";
 import { initXAAIdpKeyPair, setXaaIdpLogger } from "@mcpjam/sdk";
@@ -85,6 +86,9 @@ export async function createHonoApp() {
 
   startGuestAuthProvisioningInBackground();
   startLocalBrowserRenderingSetupInBackground();
+  // Warm the hosted-model catalog (seed ∪ backend /v1/models) so billing
+  // dispatch classifies newly-added hosted models correctly. Memoized.
+  startHostedModelCatalogRefresh();
   // Mirror of the call in server/index.ts — both production entries must
   // wire this up so the Electron/embedded path also gets a working Computer
   // tab. Memoized, so it's harmless if a process ever ran both. AWAITED (the
@@ -265,9 +269,9 @@ export async function createHonoApp() {
             code: "VALIDATION_ERROR",
             message: "Request body exceeds 1MB limit",
           },
-          400,
+          400
         ),
-    }),
+    })
   );
   app.route("/api/v1", v1Routes);
 
@@ -429,8 +433,9 @@ export async function createHonoApp() {
           })
         ) {
           try {
-            const { session, setCookies } =
-              await mintGuestSessionForDocument(c);
+            const { session, setCookies } = await mintGuestSessionForDocument(
+              c
+            );
             if (session && session.expiresAt > Date.now()) {
               const bootstrapScript = buildGuestBootstrapScript(session);
               html = html.replace("</head>", `${bootstrapScript}</head>`);
@@ -441,7 +446,7 @@ export async function createHonoApp() {
           } catch (error) {
             appLogger.warn(
               "[guest-bootstrap] document mint failed; serving without blob",
-              { error: error instanceof Error ? error.message : String(error) },
+              { error: error instanceof Error ? error.message : String(error) }
             );
           }
         }

--- a/mcpjam-inspector/server/index.ts
+++ b/mcpjam-inspector/server/index.ts
@@ -42,10 +42,10 @@ import {
 } from "./middleware/session-auth";
 import { originValidationMiddleware } from "./middleware/origin-validation";
 import { securityHeadersMiddleware } from "./middleware/security-headers";
+import { startHostedModelCatalogRefresh } from "./services/hosted-model-catalog";
 import { inAppBrowserMiddleware } from "./middleware/in-app-browser";
 import { startGuestAuthProvisioningInBackground } from "./utils/convex-guest-auth-sync";
 import { startLocalBrowserRenderingSetupInBackground } from "./utils/browser-rendering-setup";
-import { startHostedModelCatalogRefresh } from "./services/hosted-model-catalog";
 
 import { getSystemLogger } from "./utils/request-logger";
 import { requestLogContextMiddleware } from "./middleware/request-log-context";
@@ -242,11 +242,12 @@ generateSessionToken();
 setXaaIdpLogger(appLogger);
 initXAAIdpKeyPair();
 
-startGuestAuthProvisioningInBackground();
-startLocalBrowserRenderingSetupInBackground();
 // Warm the hosted-model catalog (seed ∪ backend /v1/models) so billing
 // dispatch classifies newly-added hosted models correctly. Memoized.
 startHostedModelCatalogRefresh();
+
+startGuestAuthProvisioningInBackground();
+startLocalBrowserRenderingSetupInBackground();
 // Mirror of the call in server/app.ts::createHonoApp — both production
 // entries must wire this up. Memoized, so it's harmless if a process ever
 // ran both. Kicked off here so it overlaps route setup; AWAITED before
@@ -639,7 +640,8 @@ if (process.env.NODE_ENV === "production") {
         })
       ) {
         try {
-          const { session, setCookies } = await mintGuestSessionForDocument(c);
+          const { session, setCookies } =
+            await mintGuestSessionForDocument(c);
           if (session && session.expiresAt > Date.now()) {
             const bootstrapScript = buildGuestBootstrapScript(session);
             htmlContent = htmlContent.replace(

--- a/mcpjam-inspector/server/index.ts
+++ b/mcpjam-inspector/server/index.ts
@@ -45,6 +45,7 @@ import { securityHeadersMiddleware } from "./middleware/security-headers";
 import { inAppBrowserMiddleware } from "./middleware/in-app-browser";
 import { startGuestAuthProvisioningInBackground } from "./utils/convex-guest-auth-sync";
 import { startLocalBrowserRenderingSetupInBackground } from "./utils/browser-rendering-setup";
+import { startHostedModelCatalogRefresh } from "./services/hosted-model-catalog";
 
 import { getSystemLogger } from "./utils/request-logger";
 import { requestLogContextMiddleware } from "./middleware/request-log-context";
@@ -243,6 +244,9 @@ initXAAIdpKeyPair();
 
 startGuestAuthProvisioningInBackground();
 startLocalBrowserRenderingSetupInBackground();
+// Warm the hosted-model catalog (seed ∪ backend /v1/models) so billing
+// dispatch classifies newly-added hosted models correctly. Memoized.
+startHostedModelCatalogRefresh();
 // Mirror of the call in server/app.ts::createHonoApp — both production
 // entries must wire this up. Memoized, so it's harmless if a process ever
 // ran both. Kicked off here so it overlaps route setup; AWAITED before
@@ -635,8 +639,7 @@ if (process.env.NODE_ENV === "production") {
         })
       ) {
         try {
-          const { session, setCookies } =
-            await mintGuestSessionForDocument(c);
+          const { session, setCookies } = await mintGuestSessionForDocument(c);
           if (session && session.expiresAt > Date.now()) {
             const bootstrapScript = buildGuestBootstrapScript(session);
             htmlContent = htmlContent.replace(

--- a/mcpjam-inspector/server/routes/mcp/__tests__/chat-v2.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/chat-v2.test.ts
@@ -184,9 +184,17 @@ vi.mock("@/shared/types", async () => {
   return {
     ...actual,
     isGPT5Model: vi.fn().mockReturnValue(false),
-    isMCPJamProvidedModel: vi.fn().mockReturnValue(false),
   };
 });
+
+// Hosted-model classification moved behind the catalog service; the route keys
+// billing dispatch on isHostedCatalogModel. Default false — tests that exercise
+// the MCPJam path override it explicitly.
+vi.mock("../../../services/hosted-model-catalog.js", () => ({
+  isHostedCatalogModel: vi.fn().mockReturnValue(false),
+  startHostedModelCatalogRefresh: vi.fn(),
+  refreshHostedModelCatalog: vi.fn(),
+}));
 
 vi.mock("../../../utils/guest-auth.js", () => ({
   getProductionGuestAuthHeader: vi
@@ -243,7 +251,9 @@ describe("POST /api/mcp/chat-v2", () => {
 
   describe("MCPJam model classification", () => {
     it("classifies the model PROVIDER-AWARE (bare hosted ids must canonicalize)", async () => {
-      const { isMCPJamProvidedModel } = await import("@/shared/types");
+      const { isHostedCatalogModel } = await import(
+        "../../../services/hosted-model-catalog.js"
+      );
 
       await postAuthenticatedJson({
         messages: [{ role: "user", content: "hi" }],
@@ -254,7 +264,7 @@ describe("POST /api/mcp/chat-v2", () => {
       // here would treat a bare hosted id as non-MCPJam and route it into
       // org/BYOK after it passed preflight (same class of bug as the
       // streamWebChatTurn dispatch).
-      expect(vi.mocked(isMCPJamProvidedModel)).toHaveBeenCalledWith(
+      expect(vi.mocked(isHostedCatalogModel)).toHaveBeenCalledWith(
         "gpt-5-nano",
         "openai"
       );
@@ -1255,8 +1265,10 @@ describe("POST /api/mcp/chat-v2", () => {
 
   describe("MCPJam model persistence", () => {
     beforeEach(async () => {
-      const { isMCPJamProvidedModel } = await import("@/shared/types");
-      vi.mocked(isMCPJamProvidedModel).mockReturnValue(true);
+      const { isHostedCatalogModel } = await import(
+        "../../../services/hosted-model-catalog.js"
+      );
+      vi.mocked(isHostedCatalogModel).mockReturnValue(true);
       process.env.CONVEX_HTTP_URL = "https://test-convex.example.com";
     });
 
@@ -1854,8 +1866,10 @@ describe("POST /api/mcp/chat-v2", () => {
 
   describe("Org BYOK Convex routing", () => {
     beforeEach(async () => {
-      const { isMCPJamProvidedModel } = await import("@/shared/types");
-      vi.mocked(isMCPJamProvidedModel).mockReturnValue(false);
+      const { isHostedCatalogModel } = await import(
+        "../../../services/hosted-model-catalog.js"
+      );
+      vi.mocked(isHostedCatalogModel).mockReturnValue(false);
       process.env.CONVEX_HTTP_URL = "https://test-convex.example.com";
     });
 
@@ -2065,8 +2079,10 @@ describe("POST /api/mcp/chat-v2", () => {
   describe("unresolved tool calls from aborted requests (MCPJam models)", () => {
     beforeEach(async () => {
       // Enable MCPJam model path
-      const { isMCPJamProvidedModel } = await import("@/shared/types");
-      vi.mocked(isMCPJamProvidedModel).mockReturnValue(true);
+      const { isHostedCatalogModel } = await import(
+        "../../../services/hosted-model-catalog.js"
+      );
+      vi.mocked(isHostedCatalogModel).mockReturnValue(true);
 
       // Set required env var
       process.env.CONVEX_HTTP_URL = "https://test-convex.example.com";

--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -6,11 +6,8 @@ import {
 } from "ai";
 import type { ChatV2Request } from "@/shared/chat-v2";
 import { createLlmModel } from "../../utils/chat-helpers";
-import {
-  getCanonicalModelId,
-  isMCPJamGuestAllowedModel,
-  isMCPJamProvidedModel,
-} from "@/shared/types";
+import { getCanonicalModelId, isMCPJamGuestAllowedModel } from "@/shared/types";
+import { isHostedCatalogModel } from "../../services/hosted-model-catalog.js";
 import type { ModelProvider } from "@/shared/types";
 import { getClientIp } from "../../utils/client-ip.js";
 import { getProductionGuestAuthHeader } from "../../utils/guest-auth.js";
@@ -145,7 +142,7 @@ function formatStreamError(error: unknown, provider?: ModelProvider): string {
 }
 
 function toPersistedUsage(
-  usage: LiveChatTraceUsage | undefined,
+  usage: LiveChatTraceUsage | undefined
 ): { inputTokens: number; outputTokens: number } | undefined {
   if (
     typeof usage?.inputTokens !== "number" ||
@@ -251,7 +248,7 @@ function streamDirectChatWithLiveTrace(options: {
           },
         })) {
           writer.write(
-            withMcpToolOriginChunkMetadata(chunk, turnOptions.tools),
+            withMcpToolOriginChunkMetadata(chunk, turnOptions.tools)
           );
         }
       } catch (error) {
@@ -311,7 +308,7 @@ chatV2.post("/", async (c) => {
       ? "chatbox"
       : "playground";
     const chatSessionSurface: "preview" | "share_link" | undefined =
-      isChatboxSession ? (bodySurface ?? "preview") : undefined;
+      isChatboxSession ? bodySurface ?? "preview" : undefined;
 
     // Chatbox-bound turns re-resolve execution config from Convex so the
     // host's hostConfigs row is the source of truth (model / prompt /
@@ -355,7 +352,7 @@ chatV2.post("/", async (c) => {
             error:
               "Couldn't authenticate this chatbox turn to load its settings — sign in (or retry) to continue.",
           },
-          401,
+          401
         );
       }
       {
@@ -378,7 +375,7 @@ chatV2.post("/", async (c) => {
               chatboxId: bodyChatboxId,
               status: runtime.status,
               error: runtime.error,
-            },
+            }
           );
           return c.json(
             {
@@ -406,13 +403,13 @@ chatV2.post("/", async (c) => {
       } else {
         logger.warn(
           "[mcp/chat-v2] host runtime-config fetch failed; failing closed",
-          { hostId: bodyHostId, status: runtime.status, error: runtime.error },
+          { hostId: bodyHostId, status: runtime.status, error: runtime.error }
         );
         return c.json(
           {
             error: `Couldn't load this host's settings, so the turn was stopped to avoid running with the wrong engine. ${runtime.error}`,
           },
-          runtime.status >= 500 ? 502 : (runtime.status as 400 | 401 | 403),
+          runtime.status >= 500 ? 502 : (runtime.status as 400 | 401 | 403)
         );
       }
     }
@@ -444,7 +441,7 @@ chatV2.post("/", async (c) => {
             chatboxId: bodyChatboxId,
             body: entry.overrideValue,
             host: entry.hostValue,
-          },
+          }
         );
       } else if (entry.field === "progressiveToolDiscovery") {
         logger.warn(
@@ -453,7 +450,7 @@ chatV2.post("/", async (c) => {
             chatboxId: bodyChatboxId,
             body: entry.overrideValue,
             host: entry.hostValue,
-          },
+          }
         );
       } else if (entry.field === "respectToolVisibility") {
         logger.warn(
@@ -462,7 +459,7 @@ chatV2.post("/", async (c) => {
             chatboxId: bodyChatboxId,
             body: entry.overrideValue,
             host: entry.hostValue,
-          },
+          }
         );
       } else if (
         entry.field === "modelVisibleMcpToolResults" ||
@@ -474,7 +471,7 @@ chatV2.post("/", async (c) => {
             chatboxId: bodyChatboxId,
             body: entry.overrideValue,
             host: entry.hostValue,
-          },
+          }
         );
       }
     }
@@ -508,7 +505,7 @@ chatV2.post("/", async (c) => {
           body: model.id,
           host: hostModelId,
           provider: hostModel.provider,
-        },
+        }
       );
       resolvedModelOverride = hostModel;
     }
@@ -562,7 +559,7 @@ chatV2.post("/", async (c) => {
     // org/BYOK below even after they passed the harness preflight.
     const isMcpJamProvidedModel = Boolean(
       modelDefinition.id &&
-        isMCPJamProvidedModel(modelDefinition.id, modelDefinition.provider)
+        isHostedCatalogModel(modelDefinition.id, modelDefinition.provider)
     );
     if (
       isMcpJamProvidedModel &&
@@ -575,7 +572,7 @@ chatV2.post("/", async (c) => {
           error:
             "This MCPJam model is not available for guest access. Sign in to continue.",
         },
-        403,
+        403
       );
     }
     let mcpJamAuthHeader = requestAuthHeader;
@@ -606,7 +603,7 @@ chatV2.post("/", async (c) => {
     // independent — this conversion is solely for hydration.
     const priorModelMessages = await convertToMcpjamModelMessages(
       messages,
-      inboundMcpToolResultModelOutputOptions,
+      inboundMcpToolResultModelOutputOptions
     );
 
     // SEP-1865 App-Provided Tools: validate the client snapshot at the
@@ -642,7 +639,7 @@ chatV2.post("/", async (c) => {
     let validatedWidgetModelContext;
     try {
       validatedWidgetModelContext = validateWidgetModelContextEntries(
-        body.widgetModelContext,
+        body.widgetModelContext
       );
     } catch (error) {
       if (error instanceof WidgetModelContextValidationError) {
@@ -661,15 +658,15 @@ chatV2.post("/", async (c) => {
         hasSelectedMcpServers: (selectedServers?.length ?? 0) > 0,
         // Provider-aware: a bare model id (no creator prefix) needs the provider
         // to resolve its canonical id, else a hosted MCPJam model is misjudged.
-        modelEligible: isMCPJamProvidedModel(
+        modelEligible: isHostedCatalogModel(
           String(modelDefinition.id),
-          modelDefinition.provider,
+          modelDefinition.provider
         ),
         // Canonical id so the adapter's supportsModel check sees the prefixed
         // form (bare hosted ids like `gpt-5-nano` → `openai/gpt-5-nano`).
         modelId: getCanonicalModelId(
           String(modelDefinition.id),
-          modelDefinition.provider,
+          modelDefinition.provider
         ),
       });
       if (!availability.ok) {
@@ -677,7 +674,7 @@ chatV2.post("/", async (c) => {
           {
             error: `This host runs the ${resolvedExecution.harness} harness, which isn't available: ${availability.reason}.`,
           },
-          503,
+          503
         );
       }
     }
@@ -715,7 +712,7 @@ chatV2.post("/", async (c) => {
               ? { chatSessionId: body.chatSessionId }
               : {}),
           }
-        : null,
+        : null
     );
 
     let prepared;
@@ -767,7 +764,7 @@ chatV2.post("/", async (c) => {
       discoveryState,
     } = prepared;
     const widgetModelContextSystemPrompt = buildWidgetModelContextSystemPrompt(
-      validatedWidgetModelContext,
+      validatedWidgetModelContext
     );
     const effectiveEnhancedSystemPrompt = [
       enhancedSystemPrompt,
@@ -806,7 +803,7 @@ chatV2.post("/", async (c) => {
       if (!process.env.CONVEX_HTTP_URL) {
         return c.json(
           { error: "Server missing CONVEX_HTTP_URL configuration" },
-          500,
+          500
         );
       }
 
@@ -819,13 +816,13 @@ chatV2.post("/", async (c) => {
             error:
               "Unable to authenticate with MCPJam servers. Please try again or sign in.",
           },
-          503,
+          503
         );
       }
 
       const modelMessages = await convertToMcpjamModelMessages(
         messages,
-        inboundMcpToolResultModelOutputOptions,
+        inboundMcpToolResultModelOutputOptions
       );
       const sessionStartedAt = Date.now();
 
@@ -893,7 +890,7 @@ chatV2.post("/", async (c) => {
                 sessionMessages: stampSenderUserIdsOnSessionMessages(
                   fullHistory,
                   messages,
-                  { authenticatedUserId },
+                  { authenticatedUserId }
                 ),
                 startedAt: sessionStartedAt,
                 lastActivityAt: Date.now(),
@@ -946,8 +943,8 @@ chatV2.post("/", async (c) => {
       const modelMessages = scrubMessages(
         await convertToMcpjamModelMessages(
           messages,
-          inboundMcpToolResultModelOutputOptions,
-        ),
+          inboundMcpToolResultModelOutputOptions
+        )
       );
       const sessionStartedAt = Date.now();
       const chatSessionId = body.chatSessionId;
@@ -979,7 +976,7 @@ chatV2.post("/", async (c) => {
       const onConversationComplete = chatSessionId
         ? async (
             fullHistory: ModelMessage[],
-            turnTrace: PersistedTurnTrace,
+            turnTrace: PersistedTurnTrace
           ) => {
             await persistChatSessionToConvex({
               chatSessionId,
@@ -997,7 +994,7 @@ chatV2.post("/", async (c) => {
               sessionMessages: stampSenderUserIdsOnSessionMessages(
                 fullHistory,
                 messages,
-                { authenticatedUserId },
+                { authenticatedUserId }
               ),
               startedAt: sessionStartedAt,
               lastActivityAt: Date.now(),
@@ -1094,7 +1091,7 @@ chatV2.post("/", async (c) => {
             "Personal provider keys aren't supported. Configure cloud models in your organization's settings (Organization Models).",
           code: "personal_byok_unsupported",
         },
-        401,
+        401
       );
     }
 
@@ -1106,12 +1103,12 @@ chatV2.post("/", async (c) => {
         ollama: body.ollamaBaseUrl,
         azure: body.azureBaseUrl,
       },
-      body.customProviders,
+      body.customProviders
     );
 
     const modelMessages = await convertToMcpjamModelMessages(
       messages,
-      inboundMcpToolResultModelOutputOptions,
+      inboundMcpToolResultModelOutputOptions
     );
 
     const streamStartedAt = Date.now();
@@ -1123,7 +1120,7 @@ chatV2.post("/", async (c) => {
     warnIfChatAbortSignalMissing(inboundAbortSignalDirect, "mcp/chat-v2");
 
     const scrubbedModelMessages = scrubMessages(
-      modelMessages as ModelMessage[],
+      modelMessages as ModelMessage[]
     );
 
     return streamDirectChatWithLiveTrace({
@@ -1162,7 +1159,7 @@ chatV2.post("/", async (c) => {
               messages: stampSenderUserIdsOnSessionMessages(
                 modelMessages as ModelMessage[],
                 messages,
-                { authenticatedUserId },
+                { authenticatedUserId }
               ),
               systemPrompt: enhancedSystemPrompt,
               ...(responseMessages.length > 0 ? { responseMessages } : {}),

--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -6,9 +6,12 @@ import {
 } from "ai";
 import type { ChatV2Request } from "@/shared/chat-v2";
 import { createLlmModel } from "../../utils/chat-helpers";
-import { getCanonicalModelId, isMCPJamGuestAllowedModel } from "@/shared/types";
-import { isHostedCatalogModel } from "../../services/hosted-model-catalog.js";
+import {
+  getCanonicalModelId,
+  isMCPJamGuestAllowedModel,
+} from "@/shared/types";
 import type { ModelProvider } from "@/shared/types";
+import { isHostedCatalogModel } from "../../services/hosted-model-catalog.js";
 import { getClientIp } from "../../utils/client-ip.js";
 import { getProductionGuestAuthHeader } from "../../utils/guest-auth.js";
 import { logger } from "../../utils/logger";
@@ -142,7 +145,7 @@ function formatStreamError(error: unknown, provider?: ModelProvider): string {
 }
 
 function toPersistedUsage(
-  usage: LiveChatTraceUsage | undefined
+  usage: LiveChatTraceUsage | undefined,
 ): { inputTokens: number; outputTokens: number } | undefined {
   if (
     typeof usage?.inputTokens !== "number" ||
@@ -248,7 +251,7 @@ function streamDirectChatWithLiveTrace(options: {
           },
         })) {
           writer.write(
-            withMcpToolOriginChunkMetadata(chunk, turnOptions.tools)
+            withMcpToolOriginChunkMetadata(chunk, turnOptions.tools),
           );
         }
       } catch (error) {
@@ -308,7 +311,7 @@ chatV2.post("/", async (c) => {
       ? "chatbox"
       : "playground";
     const chatSessionSurface: "preview" | "share_link" | undefined =
-      isChatboxSession ? bodySurface ?? "preview" : undefined;
+      isChatboxSession ? (bodySurface ?? "preview") : undefined;
 
     // Chatbox-bound turns re-resolve execution config from Convex so the
     // host's hostConfigs row is the source of truth (model / prompt /
@@ -352,7 +355,7 @@ chatV2.post("/", async (c) => {
             error:
               "Couldn't authenticate this chatbox turn to load its settings — sign in (or retry) to continue.",
           },
-          401
+          401,
         );
       }
       {
@@ -375,7 +378,7 @@ chatV2.post("/", async (c) => {
               chatboxId: bodyChatboxId,
               status: runtime.status,
               error: runtime.error,
-            }
+            },
           );
           return c.json(
             {
@@ -403,13 +406,13 @@ chatV2.post("/", async (c) => {
       } else {
         logger.warn(
           "[mcp/chat-v2] host runtime-config fetch failed; failing closed",
-          { hostId: bodyHostId, status: runtime.status, error: runtime.error }
+          { hostId: bodyHostId, status: runtime.status, error: runtime.error },
         );
         return c.json(
           {
             error: `Couldn't load this host's settings, so the turn was stopped to avoid running with the wrong engine. ${runtime.error}`,
           },
-          runtime.status >= 500 ? 502 : (runtime.status as 400 | 401 | 403)
+          runtime.status >= 500 ? 502 : (runtime.status as 400 | 401 | 403),
         );
       }
     }
@@ -441,7 +444,7 @@ chatV2.post("/", async (c) => {
             chatboxId: bodyChatboxId,
             body: entry.overrideValue,
             host: entry.hostValue,
-          }
+          },
         );
       } else if (entry.field === "progressiveToolDiscovery") {
         logger.warn(
@@ -450,7 +453,7 @@ chatV2.post("/", async (c) => {
             chatboxId: bodyChatboxId,
             body: entry.overrideValue,
             host: entry.hostValue,
-          }
+          },
         );
       } else if (entry.field === "respectToolVisibility") {
         logger.warn(
@@ -459,7 +462,7 @@ chatV2.post("/", async (c) => {
             chatboxId: bodyChatboxId,
             body: entry.overrideValue,
             host: entry.hostValue,
-          }
+          },
         );
       } else if (
         entry.field === "modelVisibleMcpToolResults" ||
@@ -471,7 +474,7 @@ chatV2.post("/", async (c) => {
             chatboxId: bodyChatboxId,
             body: entry.overrideValue,
             host: entry.hostValue,
-          }
+          },
         );
       }
     }
@@ -505,7 +508,7 @@ chatV2.post("/", async (c) => {
           body: model.id,
           host: hostModelId,
           provider: hostModel.provider,
-        }
+        },
       );
       resolvedModelOverride = hostModel;
     }
@@ -572,7 +575,7 @@ chatV2.post("/", async (c) => {
           error:
             "This MCPJam model is not available for guest access. Sign in to continue.",
         },
-        403
+        403,
       );
     }
     let mcpJamAuthHeader = requestAuthHeader;
@@ -603,7 +606,7 @@ chatV2.post("/", async (c) => {
     // independent — this conversion is solely for hydration.
     const priorModelMessages = await convertToMcpjamModelMessages(
       messages,
-      inboundMcpToolResultModelOutputOptions
+      inboundMcpToolResultModelOutputOptions,
     );
 
     // SEP-1865 App-Provided Tools: validate the client snapshot at the
@@ -639,7 +642,7 @@ chatV2.post("/", async (c) => {
     let validatedWidgetModelContext;
     try {
       validatedWidgetModelContext = validateWidgetModelContextEntries(
-        body.widgetModelContext
+        body.widgetModelContext,
       );
     } catch (error) {
       if (error instanceof WidgetModelContextValidationError) {
@@ -660,13 +663,13 @@ chatV2.post("/", async (c) => {
         // to resolve its canonical id, else a hosted MCPJam model is misjudged.
         modelEligible: isHostedCatalogModel(
           String(modelDefinition.id),
-          modelDefinition.provider
+          modelDefinition.provider,
         ),
         // Canonical id so the adapter's supportsModel check sees the prefixed
         // form (bare hosted ids like `gpt-5-nano` → `openai/gpt-5-nano`).
         modelId: getCanonicalModelId(
           String(modelDefinition.id),
-          modelDefinition.provider
+          modelDefinition.provider,
         ),
       });
       if (!availability.ok) {
@@ -674,7 +677,7 @@ chatV2.post("/", async (c) => {
           {
             error: `This host runs the ${resolvedExecution.harness} harness, which isn't available: ${availability.reason}.`,
           },
-          503
+          503,
         );
       }
     }
@@ -712,7 +715,7 @@ chatV2.post("/", async (c) => {
               ? { chatSessionId: body.chatSessionId }
               : {}),
           }
-        : null
+        : null,
     );
 
     let prepared;
@@ -764,7 +767,7 @@ chatV2.post("/", async (c) => {
       discoveryState,
     } = prepared;
     const widgetModelContextSystemPrompt = buildWidgetModelContextSystemPrompt(
-      validatedWidgetModelContext
+      validatedWidgetModelContext,
     );
     const effectiveEnhancedSystemPrompt = [
       enhancedSystemPrompt,
@@ -803,7 +806,7 @@ chatV2.post("/", async (c) => {
       if (!process.env.CONVEX_HTTP_URL) {
         return c.json(
           { error: "Server missing CONVEX_HTTP_URL configuration" },
-          500
+          500,
         );
       }
 
@@ -816,13 +819,13 @@ chatV2.post("/", async (c) => {
             error:
               "Unable to authenticate with MCPJam servers. Please try again or sign in.",
           },
-          503
+          503,
         );
       }
 
       const modelMessages = await convertToMcpjamModelMessages(
         messages,
-        inboundMcpToolResultModelOutputOptions
+        inboundMcpToolResultModelOutputOptions,
       );
       const sessionStartedAt = Date.now();
 
@@ -890,7 +893,7 @@ chatV2.post("/", async (c) => {
                 sessionMessages: stampSenderUserIdsOnSessionMessages(
                   fullHistory,
                   messages,
-                  { authenticatedUserId }
+                  { authenticatedUserId },
                 ),
                 startedAt: sessionStartedAt,
                 lastActivityAt: Date.now(),
@@ -943,8 +946,8 @@ chatV2.post("/", async (c) => {
       const modelMessages = scrubMessages(
         await convertToMcpjamModelMessages(
           messages,
-          inboundMcpToolResultModelOutputOptions
-        )
+          inboundMcpToolResultModelOutputOptions,
+        ),
       );
       const sessionStartedAt = Date.now();
       const chatSessionId = body.chatSessionId;
@@ -976,7 +979,7 @@ chatV2.post("/", async (c) => {
       const onConversationComplete = chatSessionId
         ? async (
             fullHistory: ModelMessage[],
-            turnTrace: PersistedTurnTrace
+            turnTrace: PersistedTurnTrace,
           ) => {
             await persistChatSessionToConvex({
               chatSessionId,
@@ -994,7 +997,7 @@ chatV2.post("/", async (c) => {
               sessionMessages: stampSenderUserIdsOnSessionMessages(
                 fullHistory,
                 messages,
-                { authenticatedUserId }
+                { authenticatedUserId },
               ),
               startedAt: sessionStartedAt,
               lastActivityAt: Date.now(),
@@ -1091,7 +1094,7 @@ chatV2.post("/", async (c) => {
             "Personal provider keys aren't supported. Configure cloud models in your organization's settings (Organization Models).",
           code: "personal_byok_unsupported",
         },
-        401
+        401,
       );
     }
 
@@ -1103,12 +1106,12 @@ chatV2.post("/", async (c) => {
         ollama: body.ollamaBaseUrl,
         azure: body.azureBaseUrl,
       },
-      body.customProviders
+      body.customProviders,
     );
 
     const modelMessages = await convertToMcpjamModelMessages(
       messages,
-      inboundMcpToolResultModelOutputOptions
+      inboundMcpToolResultModelOutputOptions,
     );
 
     const streamStartedAt = Date.now();
@@ -1120,7 +1123,7 @@ chatV2.post("/", async (c) => {
     warnIfChatAbortSignalMissing(inboundAbortSignalDirect, "mcp/chat-v2");
 
     const scrubbedModelMessages = scrubMessages(
-      modelMessages as ModelMessage[]
+      modelMessages as ModelMessage[],
     );
 
     return streamDirectChatWithLiveTrace({
@@ -1159,7 +1162,7 @@ chatV2.post("/", async (c) => {
               messages: stampSenderUserIdsOnSessionMessages(
                 modelMessages as ModelMessage[],
                 messages,
-                { authenticatedUserId }
+                { authenticatedUserId },
               ),
               systemPrompt: enhancedSystemPrompt,
               ...(responseMessages.length > 0 ? { responseMessages } : {}),

--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -1129,7 +1129,10 @@ chatV2.post("/", async (c) => {
     return streamDirectChatWithLiveTrace({
       llmModel,
       modelId: String(modelDefinition.id),
-      provider: modelDefinition.provider,
+      // Server-side model definitions always carry a concrete provider (the
+      // widened `string` branch on ModelDefinition.provider is a client
+      // catalog concern), so narrowing back to ModelProvider here is safe.
+      provider: modelDefinition.provider as ModelProvider,
       messageHistory: [...scrubbedModelMessages],
       systemPrompt: effectiveEnhancedSystemPrompt,
       temperature: resolvedTemperature,

--- a/mcpjam-inspector/server/routes/v1/evals.ts
+++ b/mcpjam-inspector/server/routes/v1/evals.ts
@@ -62,10 +62,10 @@ import { v1Error, v1PageJson, v1Resource } from "./envelope.js";
 import { synthesizeServerBody } from "./adapter.js";
 import {
   getCanonicalModelId,
-  isMCPJamProvidedModel,
   isModelSupported,
   SUPPORTED_MODELS,
 } from "@/shared/types";
+import { isHostedCatalogModel } from "../../services/hosted-model-catalog.js";
 
 const evals = new Hono();
 
@@ -415,14 +415,14 @@ export function assertInlineTestModelsValid(
     const provider = test.provider.trim().toLowerCase();
     if (OPEN_MODEL_PROVIDERS.has(provider)) continue;
     const canonical = getCanonicalModelId(test.model, test.provider);
-    if (isMCPJamProvidedModel(canonical, test.provider)) continue;
+    if (isHostedCatalogModel(canonical, test.provider)) continue;
     if (modelApiKeys?.[test.provider] ?? modelApiKeys?.[provider]) continue;
     if (isModelSupported(canonical)) continue;
 
     const hostedIds = SUPPORTED_MODELS.filter(
       (m) =>
         m.provider.toLowerCase() === provider &&
-        isMCPJamProvidedModel(String(m.id), m.provider)
+        isHostedCatalogModel(String(m.id), m.provider)
     ).map((m) => String(m.id));
     throw new WebRouteError(
       400,

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import type { ChatV2Request } from "@/shared/chat-v2";
-import { getCanonicalModelId, isMCPJamProvidedModel } from "@/shared/types";
+import { getCanonicalModelId } from "@/shared/types";
+import { isHostedCatalogModel } from "../../services/hosted-model-catalog.js";
 import { shouldEnableCloudSkillTools } from "../../utils/computers/cloud-skill-tools.js";
 import { isMCPAuthError } from "@mcpjam/sdk";
 import { resolveHostModelDefinition } from "../../utils/org-model-config.js";
@@ -100,7 +101,7 @@ chatV2.post("/", async (c) => {
       throw new WebRouteError(
         400,
         ErrorCode.VALIDATION_ERROR,
-        "messages are required",
+        "messages are required"
       );
     }
 
@@ -109,7 +110,7 @@ chatV2.post("/", async (c) => {
       throw new WebRouteError(
         400,
         ErrorCode.VALIDATION_ERROR,
-        "model is not supported",
+        "model is not supported"
       );
     }
 
@@ -145,14 +146,11 @@ chatV2.post("/", async (c) => {
         // misrepresenting the runtime — and (b) let client-supplied
         // model/approval/server values govern a share-link-reachable turn,
         // the exact tampered-body window this fetch exists to close.
-        logger.warn(
-          "[chat-v2] runtime-config fetch failed; failing closed",
-          {
-            chatboxId,
-            status: runtime.status,
-            error: runtime.error,
-          },
-        );
+        logger.warn("[chat-v2] runtime-config fetch failed; failing closed", {
+          chatboxId,
+          status: runtime.status,
+          error: runtime.error,
+        });
         throw new WebRouteError(
           runtime.status >= 500 ? 502 : runtime.status,
           ErrorCode.INTERNAL_ERROR,
@@ -183,12 +181,12 @@ chatV2.post("/", async (c) => {
             hostId,
             status: runtime.status,
             error: runtime.error,
-          },
+          }
         );
         throw new WebRouteError(
           runtime.status >= 500 ? 502 : runtime.status,
           ErrorCode.INTERNAL_ERROR,
-          `Couldn't load this host's settings, so the turn was stopped to avoid running with the wrong engine. ${runtime.error}`,
+          `Couldn't load this host's settings, so the turn was stopped to avoid running with the wrong engine. ${runtime.error}`
         );
       }
     }
@@ -219,7 +217,7 @@ chatV2.post("/", async (c) => {
             chatboxId,
             body: entry.overrideValue,
             host: entry.hostValue,
-          },
+          }
         );
       } else if (entry.field === "progressiveToolDiscovery") {
         logger.warn(
@@ -228,7 +226,7 @@ chatV2.post("/", async (c) => {
             chatboxId,
             body: entry.overrideValue,
             host: entry.hostValue,
-          },
+          }
         );
       } else if (entry.field === "respectToolVisibility") {
         logger.warn(
@@ -237,7 +235,7 @@ chatV2.post("/", async (c) => {
             chatboxId,
             body: entry.overrideValue,
             host: entry.hostValue,
-          },
+          }
         );
       } else if (
         entry.field === "modelVisibleMcpToolResults" ||
@@ -279,7 +277,7 @@ chatV2.post("/", async (c) => {
           body: modelDefinition.id,
           host: hostModelId,
           provider: hostModel.provider,
-        },
+        }
       );
       modelDefinition = hostModel;
     }
@@ -311,22 +309,22 @@ chatV2.post("/", async (c) => {
         // "no MCP servers" fail-closed gate.
         hasSelectedMcpServers:
           (resolvedExecution.selectedServerIds ?? selectedServerIds).length > 0,
-        modelEligible: isMCPJamProvidedModel(
+        modelEligible: isHostedCatalogModel(
           String(modelDefinition.id),
-          modelDefinition.provider,
+          modelDefinition.provider
         ),
         // Canonical id so the adapter's supportsModel check sees the prefixed
         // form (bare hosted ids like `gpt-5-nano` → `openai/gpt-5-nano`).
         modelId: getCanonicalModelId(
           String(modelDefinition.id),
-          modelDefinition.provider,
+          modelDefinition.provider
         ),
       });
       if (!availability.ok) {
         throw new WebRouteError(
           503,
           ErrorCode.INTERNAL_ERROR,
-          `This host runs the ${resolvedExecution.harness} harness, which isn't available: ${availability.reason}.`,
+          `This host runs the ${resolvedExecution.harness} harness, which isn't available: ${availability.reason}.`
         );
       }
     }
@@ -360,7 +358,7 @@ chatV2.post("/", async (c) => {
         isChatboxSession,
         requireToolApproval,
         mcpjamPlatformClient: buildMcpjamPlatformClient(c),
-      },
+      }
     );
 
     // Cloud skills are a Convex-backed PROJECT resource (no computer needed), so
@@ -409,7 +407,7 @@ chatV2.post("/", async (c) => {
         serverNames: selectedServerNames,
         initializePins,
         mcpProtocolVersionsByServerId,
-      },
+      }
     );
     oauthServerUrls = urls;
 
@@ -449,7 +447,7 @@ chatV2.post("/", async (c) => {
     let validatedWidgetModelContext;
     try {
       validatedWidgetModelContext = validateWidgetModelContextEntries(
-        body.widgetModelContext,
+        body.widgetModelContext
       );
     } catch (error) {
       if (error instanceof WidgetModelContextValidationError) {
@@ -593,7 +591,7 @@ chatV2.post("/", async (c) => {
           oauthRequired: true,
           serverUrl: firstUrl,
         },
-        rpcCollector?.buildEnvelope() as Record<string, unknown> | undefined,
+        rpcCollector?.buildEnvelope() as Record<string, unknown> | undefined
       );
     }
     const routeError = mapRuntimeError(error);
@@ -603,7 +601,7 @@ chatV2.post("/", async (c) => {
       routeError.code,
       routeError.message,
       routeError.details,
-      rpcCollector?.buildEnvelope() as Record<string, unknown> | undefined,
+      rpcCollector?.buildEnvelope() as Record<string, unknown> | undefined
     );
   }
 });

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -101,7 +101,7 @@ chatV2.post("/", async (c) => {
       throw new WebRouteError(
         400,
         ErrorCode.VALIDATION_ERROR,
-        "messages are required"
+        "messages are required",
       );
     }
 
@@ -110,7 +110,7 @@ chatV2.post("/", async (c) => {
       throw new WebRouteError(
         400,
         ErrorCode.VALIDATION_ERROR,
-        "model is not supported"
+        "model is not supported",
       );
     }
 
@@ -146,11 +146,14 @@ chatV2.post("/", async (c) => {
         // misrepresenting the runtime — and (b) let client-supplied
         // model/approval/server values govern a share-link-reachable turn,
         // the exact tampered-body window this fetch exists to close.
-        logger.warn("[chat-v2] runtime-config fetch failed; failing closed", {
-          chatboxId,
-          status: runtime.status,
-          error: runtime.error,
-        });
+        logger.warn(
+          "[chat-v2] runtime-config fetch failed; failing closed",
+          {
+            chatboxId,
+            status: runtime.status,
+            error: runtime.error,
+          },
+        );
         throw new WebRouteError(
           runtime.status >= 500 ? 502 : runtime.status,
           ErrorCode.INTERNAL_ERROR,
@@ -181,12 +184,12 @@ chatV2.post("/", async (c) => {
             hostId,
             status: runtime.status,
             error: runtime.error,
-          }
+          },
         );
         throw new WebRouteError(
           runtime.status >= 500 ? 502 : runtime.status,
           ErrorCode.INTERNAL_ERROR,
-          `Couldn't load this host's settings, so the turn was stopped to avoid running with the wrong engine. ${runtime.error}`
+          `Couldn't load this host's settings, so the turn was stopped to avoid running with the wrong engine. ${runtime.error}`,
         );
       }
     }
@@ -217,7 +220,7 @@ chatV2.post("/", async (c) => {
             chatboxId,
             body: entry.overrideValue,
             host: entry.hostValue,
-          }
+          },
         );
       } else if (entry.field === "progressiveToolDiscovery") {
         logger.warn(
@@ -226,7 +229,7 @@ chatV2.post("/", async (c) => {
             chatboxId,
             body: entry.overrideValue,
             host: entry.hostValue,
-          }
+          },
         );
       } else if (entry.field === "respectToolVisibility") {
         logger.warn(
@@ -235,7 +238,7 @@ chatV2.post("/", async (c) => {
             chatboxId,
             body: entry.overrideValue,
             host: entry.hostValue,
-          }
+          },
         );
       } else if (
         entry.field === "modelVisibleMcpToolResults" ||
@@ -277,7 +280,7 @@ chatV2.post("/", async (c) => {
           body: modelDefinition.id,
           host: hostModelId,
           provider: hostModel.provider,
-        }
+        },
       );
       modelDefinition = hostModel;
     }
@@ -311,20 +314,20 @@ chatV2.post("/", async (c) => {
           (resolvedExecution.selectedServerIds ?? selectedServerIds).length > 0,
         modelEligible: isHostedCatalogModel(
           String(modelDefinition.id),
-          modelDefinition.provider
+          modelDefinition.provider,
         ),
         // Canonical id so the adapter's supportsModel check sees the prefixed
         // form (bare hosted ids like `gpt-5-nano` → `openai/gpt-5-nano`).
         modelId: getCanonicalModelId(
           String(modelDefinition.id),
-          modelDefinition.provider
+          modelDefinition.provider,
         ),
       });
       if (!availability.ok) {
         throw new WebRouteError(
           503,
           ErrorCode.INTERNAL_ERROR,
-          `This host runs the ${resolvedExecution.harness} harness, which isn't available: ${availability.reason}.`
+          `This host runs the ${resolvedExecution.harness} harness, which isn't available: ${availability.reason}.`,
         );
       }
     }
@@ -358,7 +361,7 @@ chatV2.post("/", async (c) => {
         isChatboxSession,
         requireToolApproval,
         mcpjamPlatformClient: buildMcpjamPlatformClient(c),
-      }
+      },
     );
 
     // Cloud skills are a Convex-backed PROJECT resource (no computer needed), so
@@ -407,7 +410,7 @@ chatV2.post("/", async (c) => {
         serverNames: selectedServerNames,
         initializePins,
         mcpProtocolVersionsByServerId,
-      }
+      },
     );
     oauthServerUrls = urls;
 
@@ -447,7 +450,7 @@ chatV2.post("/", async (c) => {
     let validatedWidgetModelContext;
     try {
       validatedWidgetModelContext = validateWidgetModelContextEntries(
-        body.widgetModelContext
+        body.widgetModelContext,
       );
     } catch (error) {
       if (error instanceof WidgetModelContextValidationError) {
@@ -591,7 +594,7 @@ chatV2.post("/", async (c) => {
           oauthRequired: true,
           serverUrl: firstUrl,
         },
-        rpcCollector?.buildEnvelope() as Record<string, unknown> | undefined
+        rpcCollector?.buildEnvelope() as Record<string, unknown> | undefined,
       );
     }
     const routeError = mapRuntimeError(error);
@@ -601,7 +604,7 @@ chatV2.post("/", async (c) => {
       routeError.code,
       routeError.message,
       routeError.details,
-      rpcCollector?.buildEnvelope() as Record<string, unknown> | undefined
+      rpcCollector?.buildEnvelope() as Record<string, unknown> | undefined,
     );
   }
 });

--- a/mcpjam-inspector/server/services/__tests__/hosted-model-catalog.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/hosted-model-catalog.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __resetHostedModelCatalogForTests,
+  __setHostedCatalogForTests,
+  isHostedCatalogModel,
+  refreshHostedModelCatalog,
+} from "../hosted-model-catalog.js";
+
+// A model id that is in the static seed (MCPJAM_PROVIDED_MODEL_IDS).
+const SEED_MODEL = "anthropic/claude-haiku-4.5";
+// A hosted model the backend catalog knows about but the static seed does NOT
+// (simulates a future backend bulk-add the inspector hasn't shipped a seed for).
+const CATALOG_ONLY_MODEL = "newvendor/brand-new-model";
+// A genuine BYOK/unknown model — never hosted.
+const BYOK_MODEL = "someorg/private-model";
+
+// Billing intent, expressed the way the dispatch reads it: hosted ⇒ MCPJam
+// credits, not hosted ⇒ org/BYOK key derivation.
+function billingSource(modelId: string, provider?: string): "mcpjam" | "byok" {
+  return isHostedCatalogModel(modelId, provider) ? "mcpjam" : "byok";
+}
+
+function mockFetchOnce(body: unknown, ok = true, status = 200) {
+  vi.spyOn(globalThis, "fetch").mockResolvedValue({
+    ok,
+    status,
+    json: async () => body,
+  } as unknown as Response);
+}
+
+beforeEach(() => {
+  __resetHostedModelCatalogForTests();
+  process.env.CONVEX_HTTP_URL = "https://backend.example";
+});
+
+afterEach(() => {
+  __resetHostedModelCatalogForTests();
+  vi.restoreAllMocks();
+});
+
+describe("isHostedCatalogModel — billing classification", () => {
+  it("cold start (no catalog fetched): seed model bills to mcpjam, others to BYOK", () => {
+    // Byte-identical to the legacy isMCPJamProvidedModel behavior.
+    expect(billingSource(SEED_MODEL)).toBe("mcpjam");
+    expect(billingSource(CATALOG_ONLY_MODEL)).toBe("byok");
+    expect(billingSource(BYOK_MODEL)).toBe("byok");
+  });
+
+  it("canonicalizes a bare id with provider the same way the legacy check did", () => {
+    // `gpt-5-nano` is only a seed member in its prefixed form `openai/gpt-5-nano`.
+    expect(billingSource("gpt-5-nano", "openai")).toBe("mcpjam");
+    // Without the provider a bare id can't canonicalize → not hosted.
+    expect(billingSource("brand-new-model")).toBe("byok");
+  });
+
+  it("a catalog-only model bills to mcpjam once the catalog is warm", () => {
+    expect(billingSource(CATALOG_ONLY_MODEL)).toBe("byok"); // cold
+    __setHostedCatalogForTests([CATALOG_ONLY_MODEL]);
+    expect(billingSource(CATALOG_ONLY_MODEL)).toBe("mcpjam"); // warm
+  });
+
+  it("the catalog only ADDS: a warm catalog never demotes a seed model", () => {
+    // Catalog that omits the seed model entirely.
+    __setHostedCatalogForTests([CATALOG_ONLY_MODEL]);
+    expect(billingSource(SEED_MODEL)).toBe("mcpjam");
+    expect(billingSource(CATALOG_ONLY_MODEL)).toBe("mcpjam");
+    expect(billingSource(BYOK_MODEL)).toBe("byok");
+  });
+});
+
+describe("refreshHostedModelCatalog — fetch + fail-soft", () => {
+  it("parses the { items: [...] } envelope and unions catalog ids over the seed", async () => {
+    mockFetchOnce({
+      items: [{ id: SEED_MODEL }, { id: CATALOG_ONLY_MODEL }, { id: 123 }],
+    });
+    await refreshHostedModelCatalog();
+
+    expect(billingSource(CATALOG_ONLY_MODEL)).toBe("mcpjam");
+    expect(billingSource(SEED_MODEL)).toBe("mcpjam");
+    expect(billingSource(BYOK_MODEL)).toBe("byok");
+  });
+
+  it("a non-2xx fetch leaves classification on the seed (catalog-only ⇒ BYOK)", async () => {
+    mockFetchOnce({}, false, 503);
+    await refreshHostedModelCatalog();
+
+    expect(billingSource(SEED_MODEL)).toBe("mcpjam"); // seed unaffected
+    expect(billingSource(CATALOG_ONLY_MODEL)).toBe("byok"); // no catalog
+  });
+
+  it("an empty items array is treated as a failed fetch, not an authoritative empty catalog", async () => {
+    // Seed a good catalog first…
+    __setHostedCatalogForTests([CATALOG_ONLY_MODEL]);
+    // …then a 2xx-but-empty refresh must NOT wipe it.
+    mockFetchOnce({ items: [] });
+    await refreshHostedModelCatalog();
+
+    expect(billingSource(CATALOG_ONLY_MODEL)).toBe("mcpjam"); // preserved
+  });
+
+  it("a thrown fetch is swallowed and preserves prior state", async () => {
+    __setHostedCatalogForTests([CATALOG_ONLY_MODEL]);
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("ECONNREFUSED"));
+    await refreshHostedModelCatalog();
+
+    expect(billingSource(CATALOG_ONLY_MODEL)).toBe("mcpjam"); // preserved
+    expect(billingSource(SEED_MODEL)).toBe("mcpjam");
+  });
+
+  it("missing CONVEX_HTTP_URL degrades to seed-only without throwing", async () => {
+    delete process.env.CONVEX_HTTP_URL;
+    await expect(refreshHostedModelCatalog()).resolves.toBeUndefined();
+    expect(billingSource(SEED_MODEL)).toBe("mcpjam");
+    expect(billingSource(CATALOG_ONLY_MODEL)).toBe("byok");
+  });
+});

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -54,10 +54,10 @@ import {
 import {
   getCanonicalModelId,
   getModelById,
-  isMCPJamProvidedModel,
   type ModelDefinition,
   type ModelProvider,
 } from "@/shared/types";
+import { isHostedCatalogModel } from "./hosted-model-catalog.js";
 import {
   hasSkillTools,
   mergeToolCallsByPromptIndex,
@@ -1566,7 +1566,7 @@ const executeTestCase = async (params: {
     String(modelDefinition.id),
     modelDefinition.provider
   );
-  const isJamModel = isMCPJamProvidedModel(
+  const isJamModel = isHostedCatalogModel(
     resolvedModelId,
     modelDefinition.provider
   );

--- a/mcpjam-inspector/server/services/evals/trace-repair-runner.ts
+++ b/mcpjam-inspector/server/services/evals/trace-repair-runner.ts
@@ -33,7 +33,7 @@ const REFINEMENT_CASE_CONCURRENCY_DEFAULT = 2;
 
 /** @internal Exported for unit tests. */
 export function parseRefinementCaseConcurrency(
-  raw: string | undefined
+  raw: string | undefined,
 ): number {
   if (raw == null || raw === "") {
     return REFINEMENT_CASE_CONCURRENCY_DEFAULT;
@@ -52,7 +52,7 @@ export function parseRefinementCaseConcurrency(
 export async function runWithConcurrencyLimit<T, R>(
   items: readonly T[],
   limit: number,
-  fn: (item: T, index: number) => Promise<R>
+  fn: (item: T, index: number) => Promise<R>,
 ): Promise<R[]> {
   if (items.length === 0) {
     return [];
@@ -82,7 +82,7 @@ function sleep(ms: number) {
 /** Never throws; disconnect failures are logged only (avoids masking real errors / unhandled rejections). */
 async function safeDisconnectReplayManager(
   manager: ReturnType<typeof buildReplayManager>,
-  context: string
+  context: string,
 ): Promise<void> {
   try {
     await manager.disconnectAllServers();
@@ -115,7 +115,7 @@ function normalizeProviderKey(provider: string): string | null {
 function resolveModelApiKeys(
   provider: string,
   model: string,
-  modelApiKeys: Record<string, string> | undefined
+  modelApiKeys: Record<string, string> | undefined,
 ): Record<string, string> | undefined {
   if (isHostedCatalogModel(model, provider)) {
     return undefined;
@@ -131,7 +131,7 @@ function resolveModelApiKeys(
 }
 
 function collectSuiteModels(
-  testCases: Array<{ models?: Array<{ model: string; provider: string }> }>
+  testCases: Array<{ models?: Array<{ model: string; provider: string }> }>,
 ): Array<{ model: string; provider: string }> {
   const map = new Map<string, { model: string; provider: string }>();
   for (const tc of testCases ?? []) {
@@ -175,7 +175,7 @@ export function signatureFromFailedTraceRepairAttempt(
     passed: boolean;
     failureSignature?: string;
   }>,
-  orderedLabels?: string[]
+  orderedLabels?: string[],
 ): string {
   const order =
     orderedLabels && orderedLabels.length > 0
@@ -197,7 +197,7 @@ export function failedQuickIterationId(
     passed: boolean;
     iterationId?: string;
   }>,
-  orderedLabels?: string[]
+  orderedLabels?: string[],
 ): string | undefined {
   const order =
     orderedLabels && orderedLabels.length > 0
@@ -214,7 +214,7 @@ export function failedQuickIterationId(
 
 /** @internal exported for unit tests */
 export function isTraceRepairGenerationFailureSession(
-  session: TraceRepairSessionSnapshot
+  session: TraceRepairSessionSnapshot,
 ): boolean {
   if (!session || session.status !== "failed" || session.candidateRevisionId) {
     return false;
@@ -229,7 +229,7 @@ export function isTraceRepairGenerationFailureSession(
 /** @internal exported for unit tests */
 export function resolveTraceRepairFailureStopReason(
   failedCaseCount: number,
-  caseResults: TraceRepairCaseResult[]
+  caseResults: TraceRepairCaseResult[],
 ):
   | "completed_server_likely"
   | "stopped_generation_error"
@@ -277,7 +277,7 @@ export async function captureTraceRepairJobToolSnapshot(args: {
         args.replayServerIds,
         {
           logPrefix: "trace-repair",
-        }
+        },
       );
 
     await args.convexClient.mutation(
@@ -287,7 +287,7 @@ export async function captureTraceRepairJobToolSnapshot(args: {
         leaseOwner: args.leaseOwner,
         toolSnapshot: sanitizeForConvexTransport(toolSnapshot),
         toolSnapshotDebug: sanitizeForConvexTransport(toolSnapshotDebug),
-      }
+      },
     );
   } catch (error) {
     logger.warn("[trace-repair] Failed to capture tool snapshot", {
@@ -303,7 +303,7 @@ export async function captureTraceRepairJobToolSnapshot(args: {
  * Exits early with a dedicated stop reason when there are no failed cases to repair.
  */
 export async function runTraceRepairJob(
-  params: TraceRepairRunnerParams
+  params: TraceRepairRunnerParams,
 ): Promise<void> {
   const { convexClient, convexAuthToken, jobId } = params;
   const modelApiKeys =
@@ -317,7 +317,7 @@ export async function runTraceRepairJob(
     try {
       const job = await convexClient.query(
         "traceRepair:getTraceRepairJob" as any,
-        { jobId }
+        { jobId },
       );
       const repairProjectId =
         typeof job?.projectId === "string" ? job.projectId : undefined;
@@ -325,9 +325,12 @@ export async function runTraceRepairJob(
         ? { projectId: repairProjectId }
         : undefined;
       if (repairOrgConfigTarget) {
-        const orgConfig = await resolveOrgModelConfig(repairOrgConfigTarget, {
-          bearerToken: convexAuthToken,
-        });
+        const orgConfig = await resolveOrgModelConfig(
+          repairOrgConfigTarget,
+          {
+            bearerToken: convexAuthToken,
+          },
+        );
         orgModelConfig = orgConfig;
       }
     } catch (error) {
@@ -372,7 +375,7 @@ export async function runTraceRepairJob(
       "traceRepair:getTraceRepairJob" as any,
       {
         jobId,
-      }
+      },
     );
 
     const checkCancelled = async () => {
@@ -386,7 +389,7 @@ export async function runTraceRepairJob(
             jobId,
             leaseOwner,
             stopReason: "cancelled_by_user",
-          }
+          },
         );
         return true;
       }
@@ -394,12 +397,12 @@ export async function runTraceRepairJob(
         "testSuites:getTestSuite" as any,
         {
           suiteId: job.testSuiteId,
-        }
+        },
       );
       if (suiteNow.configRevision !== job.expectedConfigRevision) {
         await convexClient.mutation(
           "traceRepair:cancelTraceRepairJobForSuiteChange" as any,
-          { jobId, leaseOwner }
+          { jobId, leaseOwner },
         );
         return true;
       }
@@ -412,7 +415,7 @@ export async function runTraceRepairJob(
     if (suite.configRevision !== job.expectedConfigRevision) {
       await convexClient.mutation(
         "traceRepair:cancelTraceRepairJobForSuiteChange" as any,
-        { jobId, leaseOwner }
+        { jobId, leaseOwner },
       );
       return;
     }
@@ -426,14 +429,14 @@ export async function runTraceRepairJob(
     if (job.scope === "case") {
       if (!job.targetSourceIterationId) {
         throw new Error(
-          "Trace repair case job is missing targetSourceIterationId; restart repair from the inspector."
+          "Trace repair case job is missing targetSourceIterationId; restart repair from the inspector.",
         );
       }
       const iteration = await convexClient.query(
         "testSuites:getTestIteration" as any,
         {
           iterationId: job.targetSourceIterationId,
-        }
+        },
       );
       const itTc = iteration?.testCaseId as string | undefined;
       if (!itTc) {
@@ -441,7 +444,7 @@ export async function runTraceRepairJob(
       }
       if (String(itTc) !== String(job.targetTestCaseId)) {
         throw new Error(
-          "Trace repair job target test case does not match source iteration"
+          "Trace repair job target test case does not match source iteration",
         );
       }
       const caseKey = iteration.testCaseSnapshot?.caseKey ?? `ui:${itTc}`;
@@ -455,7 +458,7 @@ export async function runTraceRepairJob(
     } else {
       const refinement = await convexClient.query(
         "testSuites:getRunRefinementState" as any,
-        { suiteRunId: job.sourceRunId }
+        { suiteRunId: job.sourceRunId },
       );
       failedCases = (refinement?.failedCases ?? []).map((fc: any) => ({
         sourceIterationId: fc.sourceIterationId,
@@ -490,7 +493,7 @@ export async function runTraceRepairJob(
       "testSuites:getTestSuiteRunDetails" as any,
       {
         runId: job.sourceRunId,
-      }
+      },
     );
     const iterationByCaseKey = new Map<
       string,
@@ -509,14 +512,14 @@ export async function runTraceRepairJob(
 
     const replayMetadata = await convexClient.query(
       "testSuites:getRunReplayMetadata" as any,
-      { runId: job.sourceRunId }
+      { runId: job.sourceRunId },
     );
     if (!replayMetadata?.hasServerReplayConfig) {
       throw new Error("This run does not have stored replay config");
     }
     const replayConfig = await fetchReplayConfig(
       job.sourceRunId,
-      convexAuthToken
+      convexAuthToken,
     );
     if (!replayConfig || replayConfig.servers.length === 0) {
       throw new Error("No replay configuration found for this run");
@@ -538,7 +541,7 @@ export async function runTraceRepairJob(
 
     const caseConcurrency = parseRefinementCaseConcurrency(
       process.env.TRACE_REPAIR_CASE_CONCURRENCY ??
-        process.env.REFINEMENT_CASE_CONCURRENCY
+        process.env.REFINEMENT_CASE_CONCURRENCY,
     );
 
     const caseResults = await runWithConcurrencyLimit(
@@ -561,7 +564,7 @@ export async function runTraceRepairJob(
             leaseOwner,
             phase: "repairing",
             currentCaseKey: fc.caseKey,
-          }
+          },
         );
 
         let sourceIterationId = fc.sourceIterationId;
@@ -584,7 +587,7 @@ export async function runTraceRepairJob(
               sourceIterationId,
               traceRepairJobId: jobId,
               attemptNumber: attempt,
-            }
+            },
           );
           const sessionId = req.sessionId as string;
           lastSessionId = sessionId;
@@ -598,7 +601,7 @@ export async function runTraceRepairJob(
               "testSuites:getRefinementSession" as any,
               {
                 sessionId,
-              }
+              },
             );
             if (s?.status === "ready") {
               sessionReady = true;
@@ -626,12 +629,12 @@ export async function runTraceRepairJob(
             "testSuites:beginRefinementVerification" as any,
             {
               sessionId,
-            }
+            },
           );
 
           const pack = await convexClient.query(
             "testSuites:getRefinementSessionForVerification" as any,
-            { sessionId }
+            { sessionId },
           );
           const sess = pack?.session;
           const candSnap = pack?.candidateSnapshot;
@@ -660,7 +663,7 @@ export async function runTraceRepairJob(
           }
           const k = Math.min(
             fullPlan.length,
-            Math.max(1, Math.min(2, Number(job.quickPassesRequired) || 1))
+            Math.max(1, Math.min(2, Number(job.quickPassesRequired) || 1)),
           );
           const plan = fullPlan.slice(0, k);
 
@@ -670,7 +673,7 @@ export async function runTraceRepairJob(
               sessionId,
               quickPassesRequired: plan.length,
               verificationPlan: plan,
-            }
+            },
           );
 
           let quickOutcome: string | undefined;
@@ -684,12 +687,12 @@ export async function runTraceRepairJob(
               const stepKeys = resolveModelApiKeys(
                 step.provider,
                 step.model,
-                modelApiKeys
+                modelApiKeys,
               );
               const mergedApiKeys =
                 stepKeys && modelApiKeys
                   ? { ...modelApiKeys, ...stepKeys }
-                  : stepKeys ?? modelApiKeys;
+                  : (stepKeys ?? modelApiKeys);
               const res = await runEvalTestCaseWithManager(
                 manager,
                 {
@@ -709,7 +712,7 @@ export async function runTraceRepairJob(
                     runs: 1,
                   },
                 },
-                { skipLastMessageRunUpdate: true }
+                { skipLastMessageRunUpdate: true },
               );
               const iterationId = (res.iteration as { _id?: string } | null)
                 ?._id;
@@ -722,18 +725,18 @@ export async function runTraceRepairJob(
                   sessionId,
                   label: step.label,
                   iterationId,
-                }
+                },
               );
             } finally {
               await safeDisconnectReplayManager(
                 manager,
-                `verification step ${step.label}`
+                `verification step ${step.label}`,
               );
             }
 
             const sCheck = await convexClient.query(
               "testSuites:getRefinementSession" as any,
-              { sessionId }
+              { sessionId },
             );
             if (sCheck?.status === "completed") {
               quickOutcome = sCheck.outcome as string | undefined;
@@ -746,11 +749,11 @@ export async function runTraceRepairJob(
               "testSuites:promoteRefinementCandidate" as any,
               {
                 sessionId,
-              }
+              },
             );
             await convexClient.mutation(
               "traceRepair:syncTraceRepairJobConfigAfterPromote" as any,
-              { jobId, leaseOwner }
+              { jobId, leaseOwner },
             );
             promoted = true;
             break;
@@ -760,19 +763,19 @@ export async function runTraceRepairJob(
             "testSuites:getRefinementSession" as any,
             {
               sessionId,
-            }
+            },
           );
           const planLabels = plan.map(
-            (s: RefinementVerificationPlanStep) => s.label
+            (s: RefinementVerificationPlanStep) => s.label,
           );
           const sig = signatureFromFailedTraceRepairAttempt(
             sFinal?.verificationRuns ?? [],
-            planLabels
+            planLabels,
           );
           attemptSigs.push(sig);
           const nextIt = failedQuickIterationId(
             sFinal?.verificationRuns ?? [],
-            planLabels
+            planLabels,
           );
           if (nextIt) {
             sourceIterationId = nextIt;
@@ -792,13 +795,13 @@ export async function runTraceRepairJob(
               attemptSignatures: attemptSigs,
               traceRepairJobId: jobId,
               leaseOwner,
-            }
+            },
           );
           const sDone = await convexClient.query(
             "testSuites:getRefinementSession" as any,
             {
               sessionId: lastSessionId,
-            }
+            },
           );
           if (sDone?.outcome === "server_likely") {
             serverLikely = true;
@@ -813,7 +816,7 @@ export async function runTraceRepairJob(
             !promoted && !serverLikely && generationFailedOnly,
           lastSessionId,
         };
-      }
+      },
     );
 
     if (await checkCancelled()) {
@@ -823,7 +826,7 @@ export async function runTraceRepairJob(
     const anyPromoted = caseResults.some((r) => r.promoted);
     const failedStopReason = resolveTraceRepairFailureStopReason(
       failedCases.length,
-      caseResults
+      caseResults,
     );
     const allServerLikely = failedStopReason === "completed_server_likely";
 
@@ -835,7 +838,7 @@ export async function runTraceRepairJob(
             jobId,
             leaseOwner,
             stopReason: "completed_case",
-          }
+          },
         );
       } else if (allServerLikely) {
         await convexClient.mutation(
@@ -844,7 +847,7 @@ export async function runTraceRepairJob(
             jobId,
             leaseOwner,
             stopReason: "completed_server_likely",
-          }
+          },
         );
       } else {
         await convexClient.mutation(
@@ -853,7 +856,7 @@ export async function runTraceRepairJob(
             jobId,
             leaseOwner,
             stopReason: failedStopReason,
-          }
+          },
         );
       }
       return;
@@ -877,7 +880,7 @@ export async function runTraceRepairJob(
       "testSuites:getTestSuite" as any,
       {
         suiteId: job.testSuiteId,
-      }
+      },
     );
 
     const replay = await executeSuiteReplayFromRun({
@@ -899,17 +902,17 @@ export async function runTraceRepairJob(
       "testSuites:getTestSuiteRun" as any,
       {
         runId: replay.runId,
-      }
+      },
     );
     const sourceRun = await convexClient.query(
       "testSuites:getTestSuiteRun" as any,
       {
         runId: job.sourceRunId,
-      }
+      },
     );
     const replayDetails = await convexClient.query(
       "testSuites:getTestSuiteRunDetails" as any,
-      { runId: replay.runId }
+      { runId: replay.runId },
     );
     const replayFailedCaseKeys = Array.from(
       new Set(
@@ -918,12 +921,12 @@ export async function runTraceRepairJob(
           .map(
             (it: any) =>
               it.testCaseSnapshot?.caseKey ??
-              (it.testCaseId ? `ui:${it.testCaseId}` : undefined)
+              (it.testCaseId ? `ui:${it.testCaseId}` : undefined),
           )
           .filter((caseKey: string | undefined): caseKey is string =>
-            Boolean(caseKey)
-          )
-      )
+            Boolean(caseKey),
+          ),
+      ),
     );
     const promotedCaseKeys = caseResults
       .filter((result) => result.promoted)
@@ -951,7 +954,7 @@ export async function runTraceRepairJob(
               : "durable_fix",
           })),
         },
-      }
+      },
     );
 
     await convexClient.mutation("traceRepair:finalizeTraceRepairJob" as any, {
@@ -969,7 +972,7 @@ export async function runTraceRepairJob(
           leaseOwner,
           stopReason: "worker_error",
           lastError: err instanceof Error ? err.message : String(err),
-        }
+        },
       );
     } catch {
       /* best effort */

--- a/mcpjam-inspector/server/services/evals/trace-repair-runner.ts
+++ b/mcpjam-inspector/server/services/evals/trace-repair-runner.ts
@@ -3,7 +3,7 @@ import {
   buildRefinementVerificationPlan,
   type RefinementVerificationPlanStep,
 } from "../../../shared/refinement-verification-plan.js";
-import { isMCPJamProvidedModel } from "../../../shared/types.js";
+import { isHostedCatalogModel } from "../hosted-model-catalog.js";
 import { runEvalTestCaseWithManager } from "../../routes/shared/evals.js";
 import { logger } from "../../utils/logger.js";
 import {
@@ -33,7 +33,7 @@ const REFINEMENT_CASE_CONCURRENCY_DEFAULT = 2;
 
 /** @internal Exported for unit tests. */
 export function parseRefinementCaseConcurrency(
-  raw: string | undefined,
+  raw: string | undefined
 ): number {
   if (raw == null || raw === "") {
     return REFINEMENT_CASE_CONCURRENCY_DEFAULT;
@@ -52,7 +52,7 @@ export function parseRefinementCaseConcurrency(
 export async function runWithConcurrencyLimit<T, R>(
   items: readonly T[],
   limit: number,
-  fn: (item: T, index: number) => Promise<R>,
+  fn: (item: T, index: number) => Promise<R>
 ): Promise<R[]> {
   if (items.length === 0) {
     return [];
@@ -82,7 +82,7 @@ function sleep(ms: number) {
 /** Never throws; disconnect failures are logged only (avoids masking real errors / unhandled rejections). */
 async function safeDisconnectReplayManager(
   manager: ReturnType<typeof buildReplayManager>,
-  context: string,
+  context: string
 ): Promise<void> {
   try {
     await manager.disconnectAllServers();
@@ -115,9 +115,9 @@ function normalizeProviderKey(provider: string): string | null {
 function resolveModelApiKeys(
   provider: string,
   model: string,
-  modelApiKeys: Record<string, string> | undefined,
+  modelApiKeys: Record<string, string> | undefined
 ): Record<string, string> | undefined {
-  if (isMCPJamProvidedModel(model, provider)) {
+  if (isHostedCatalogModel(model, provider)) {
     return undefined;
   }
   const normalized = normalizeProviderKey(provider);
@@ -131,7 +131,7 @@ function resolveModelApiKeys(
 }
 
 function collectSuiteModels(
-  testCases: Array<{ models?: Array<{ model: string; provider: string }> }>,
+  testCases: Array<{ models?: Array<{ model: string; provider: string }> }>
 ): Array<{ model: string; provider: string }> {
   const map = new Map<string, { model: string; provider: string }>();
   for (const tc of testCases ?? []) {
@@ -175,7 +175,7 @@ export function signatureFromFailedTraceRepairAttempt(
     passed: boolean;
     failureSignature?: string;
   }>,
-  orderedLabels?: string[],
+  orderedLabels?: string[]
 ): string {
   const order =
     orderedLabels && orderedLabels.length > 0
@@ -197,7 +197,7 @@ export function failedQuickIterationId(
     passed: boolean;
     iterationId?: string;
   }>,
-  orderedLabels?: string[],
+  orderedLabels?: string[]
 ): string | undefined {
   const order =
     orderedLabels && orderedLabels.length > 0
@@ -214,7 +214,7 @@ export function failedQuickIterationId(
 
 /** @internal exported for unit tests */
 export function isTraceRepairGenerationFailureSession(
-  session: TraceRepairSessionSnapshot,
+  session: TraceRepairSessionSnapshot
 ): boolean {
   if (!session || session.status !== "failed" || session.candidateRevisionId) {
     return false;
@@ -229,7 +229,7 @@ export function isTraceRepairGenerationFailureSession(
 /** @internal exported for unit tests */
 export function resolveTraceRepairFailureStopReason(
   failedCaseCount: number,
-  caseResults: TraceRepairCaseResult[],
+  caseResults: TraceRepairCaseResult[]
 ):
   | "completed_server_likely"
   | "stopped_generation_error"
@@ -277,7 +277,7 @@ export async function captureTraceRepairJobToolSnapshot(args: {
         args.replayServerIds,
         {
           logPrefix: "trace-repair",
-        },
+        }
       );
 
     await args.convexClient.mutation(
@@ -287,7 +287,7 @@ export async function captureTraceRepairJobToolSnapshot(args: {
         leaseOwner: args.leaseOwner,
         toolSnapshot: sanitizeForConvexTransport(toolSnapshot),
         toolSnapshotDebug: sanitizeForConvexTransport(toolSnapshotDebug),
-      },
+      }
     );
   } catch (error) {
     logger.warn("[trace-repair] Failed to capture tool snapshot", {
@@ -303,7 +303,7 @@ export async function captureTraceRepairJobToolSnapshot(args: {
  * Exits early with a dedicated stop reason when there are no failed cases to repair.
  */
 export async function runTraceRepairJob(
-  params: TraceRepairRunnerParams,
+  params: TraceRepairRunnerParams
 ): Promise<void> {
   const { convexClient, convexAuthToken, jobId } = params;
   const modelApiKeys =
@@ -317,7 +317,7 @@ export async function runTraceRepairJob(
     try {
       const job = await convexClient.query(
         "traceRepair:getTraceRepairJob" as any,
-        { jobId },
+        { jobId }
       );
       const repairProjectId =
         typeof job?.projectId === "string" ? job.projectId : undefined;
@@ -325,12 +325,9 @@ export async function runTraceRepairJob(
         ? { projectId: repairProjectId }
         : undefined;
       if (repairOrgConfigTarget) {
-        const orgConfig = await resolveOrgModelConfig(
-          repairOrgConfigTarget,
-          {
-            bearerToken: convexAuthToken,
-          },
-        );
+        const orgConfig = await resolveOrgModelConfig(repairOrgConfigTarget, {
+          bearerToken: convexAuthToken,
+        });
         orgModelConfig = orgConfig;
       }
     } catch (error) {
@@ -375,7 +372,7 @@ export async function runTraceRepairJob(
       "traceRepair:getTraceRepairJob" as any,
       {
         jobId,
-      },
+      }
     );
 
     const checkCancelled = async () => {
@@ -389,7 +386,7 @@ export async function runTraceRepairJob(
             jobId,
             leaseOwner,
             stopReason: "cancelled_by_user",
-          },
+          }
         );
         return true;
       }
@@ -397,12 +394,12 @@ export async function runTraceRepairJob(
         "testSuites:getTestSuite" as any,
         {
           suiteId: job.testSuiteId,
-        },
+        }
       );
       if (suiteNow.configRevision !== job.expectedConfigRevision) {
         await convexClient.mutation(
           "traceRepair:cancelTraceRepairJobForSuiteChange" as any,
-          { jobId, leaseOwner },
+          { jobId, leaseOwner }
         );
         return true;
       }
@@ -415,7 +412,7 @@ export async function runTraceRepairJob(
     if (suite.configRevision !== job.expectedConfigRevision) {
       await convexClient.mutation(
         "traceRepair:cancelTraceRepairJobForSuiteChange" as any,
-        { jobId, leaseOwner },
+        { jobId, leaseOwner }
       );
       return;
     }
@@ -429,14 +426,14 @@ export async function runTraceRepairJob(
     if (job.scope === "case") {
       if (!job.targetSourceIterationId) {
         throw new Error(
-          "Trace repair case job is missing targetSourceIterationId; restart repair from the inspector.",
+          "Trace repair case job is missing targetSourceIterationId; restart repair from the inspector."
         );
       }
       const iteration = await convexClient.query(
         "testSuites:getTestIteration" as any,
         {
           iterationId: job.targetSourceIterationId,
-        },
+        }
       );
       const itTc = iteration?.testCaseId as string | undefined;
       if (!itTc) {
@@ -444,7 +441,7 @@ export async function runTraceRepairJob(
       }
       if (String(itTc) !== String(job.targetTestCaseId)) {
         throw new Error(
-          "Trace repair job target test case does not match source iteration",
+          "Trace repair job target test case does not match source iteration"
         );
       }
       const caseKey = iteration.testCaseSnapshot?.caseKey ?? `ui:${itTc}`;
@@ -458,7 +455,7 @@ export async function runTraceRepairJob(
     } else {
       const refinement = await convexClient.query(
         "testSuites:getRunRefinementState" as any,
-        { suiteRunId: job.sourceRunId },
+        { suiteRunId: job.sourceRunId }
       );
       failedCases = (refinement?.failedCases ?? []).map((fc: any) => ({
         sourceIterationId: fc.sourceIterationId,
@@ -493,7 +490,7 @@ export async function runTraceRepairJob(
       "testSuites:getTestSuiteRunDetails" as any,
       {
         runId: job.sourceRunId,
-      },
+      }
     );
     const iterationByCaseKey = new Map<
       string,
@@ -512,14 +509,14 @@ export async function runTraceRepairJob(
 
     const replayMetadata = await convexClient.query(
       "testSuites:getRunReplayMetadata" as any,
-      { runId: job.sourceRunId },
+      { runId: job.sourceRunId }
     );
     if (!replayMetadata?.hasServerReplayConfig) {
       throw new Error("This run does not have stored replay config");
     }
     const replayConfig = await fetchReplayConfig(
       job.sourceRunId,
-      convexAuthToken,
+      convexAuthToken
     );
     if (!replayConfig || replayConfig.servers.length === 0) {
       throw new Error("No replay configuration found for this run");
@@ -541,7 +538,7 @@ export async function runTraceRepairJob(
 
     const caseConcurrency = parseRefinementCaseConcurrency(
       process.env.TRACE_REPAIR_CASE_CONCURRENCY ??
-        process.env.REFINEMENT_CASE_CONCURRENCY,
+        process.env.REFINEMENT_CASE_CONCURRENCY
     );
 
     const caseResults = await runWithConcurrencyLimit(
@@ -564,7 +561,7 @@ export async function runTraceRepairJob(
             leaseOwner,
             phase: "repairing",
             currentCaseKey: fc.caseKey,
-          },
+          }
         );
 
         let sourceIterationId = fc.sourceIterationId;
@@ -587,7 +584,7 @@ export async function runTraceRepairJob(
               sourceIterationId,
               traceRepairJobId: jobId,
               attemptNumber: attempt,
-            },
+            }
           );
           const sessionId = req.sessionId as string;
           lastSessionId = sessionId;
@@ -601,7 +598,7 @@ export async function runTraceRepairJob(
               "testSuites:getRefinementSession" as any,
               {
                 sessionId,
-              },
+              }
             );
             if (s?.status === "ready") {
               sessionReady = true;
@@ -629,12 +626,12 @@ export async function runTraceRepairJob(
             "testSuites:beginRefinementVerification" as any,
             {
               sessionId,
-            },
+            }
           );
 
           const pack = await convexClient.query(
             "testSuites:getRefinementSessionForVerification" as any,
-            { sessionId },
+            { sessionId }
           );
           const sess = pack?.session;
           const candSnap = pack?.candidateSnapshot;
@@ -663,7 +660,7 @@ export async function runTraceRepairJob(
           }
           const k = Math.min(
             fullPlan.length,
-            Math.max(1, Math.min(2, Number(job.quickPassesRequired) || 1)),
+            Math.max(1, Math.min(2, Number(job.quickPassesRequired) || 1))
           );
           const plan = fullPlan.slice(0, k);
 
@@ -673,7 +670,7 @@ export async function runTraceRepairJob(
               sessionId,
               quickPassesRequired: plan.length,
               verificationPlan: plan,
-            },
+            }
           );
 
           let quickOutcome: string | undefined;
@@ -687,12 +684,12 @@ export async function runTraceRepairJob(
               const stepKeys = resolveModelApiKeys(
                 step.provider,
                 step.model,
-                modelApiKeys,
+                modelApiKeys
               );
               const mergedApiKeys =
                 stepKeys && modelApiKeys
                   ? { ...modelApiKeys, ...stepKeys }
-                  : (stepKeys ?? modelApiKeys);
+                  : stepKeys ?? modelApiKeys;
               const res = await runEvalTestCaseWithManager(
                 manager,
                 {
@@ -712,7 +709,7 @@ export async function runTraceRepairJob(
                     runs: 1,
                   },
                 },
-                { skipLastMessageRunUpdate: true },
+                { skipLastMessageRunUpdate: true }
               );
               const iterationId = (res.iteration as { _id?: string } | null)
                 ?._id;
@@ -725,18 +722,18 @@ export async function runTraceRepairJob(
                   sessionId,
                   label: step.label,
                   iterationId,
-                },
+                }
               );
             } finally {
               await safeDisconnectReplayManager(
                 manager,
-                `verification step ${step.label}`,
+                `verification step ${step.label}`
               );
             }
 
             const sCheck = await convexClient.query(
               "testSuites:getRefinementSession" as any,
-              { sessionId },
+              { sessionId }
             );
             if (sCheck?.status === "completed") {
               quickOutcome = sCheck.outcome as string | undefined;
@@ -749,11 +746,11 @@ export async function runTraceRepairJob(
               "testSuites:promoteRefinementCandidate" as any,
               {
                 sessionId,
-              },
+              }
             );
             await convexClient.mutation(
               "traceRepair:syncTraceRepairJobConfigAfterPromote" as any,
-              { jobId, leaseOwner },
+              { jobId, leaseOwner }
             );
             promoted = true;
             break;
@@ -763,19 +760,19 @@ export async function runTraceRepairJob(
             "testSuites:getRefinementSession" as any,
             {
               sessionId,
-            },
+            }
           );
           const planLabels = plan.map(
-            (s: RefinementVerificationPlanStep) => s.label,
+            (s: RefinementVerificationPlanStep) => s.label
           );
           const sig = signatureFromFailedTraceRepairAttempt(
             sFinal?.verificationRuns ?? [],
-            planLabels,
+            planLabels
           );
           attemptSigs.push(sig);
           const nextIt = failedQuickIterationId(
             sFinal?.verificationRuns ?? [],
-            planLabels,
+            planLabels
           );
           if (nextIt) {
             sourceIterationId = nextIt;
@@ -795,13 +792,13 @@ export async function runTraceRepairJob(
               attemptSignatures: attemptSigs,
               traceRepairJobId: jobId,
               leaseOwner,
-            },
+            }
           );
           const sDone = await convexClient.query(
             "testSuites:getRefinementSession" as any,
             {
               sessionId: lastSessionId,
-            },
+            }
           );
           if (sDone?.outcome === "server_likely") {
             serverLikely = true;
@@ -816,7 +813,7 @@ export async function runTraceRepairJob(
             !promoted && !serverLikely && generationFailedOnly,
           lastSessionId,
         };
-      },
+      }
     );
 
     if (await checkCancelled()) {
@@ -826,7 +823,7 @@ export async function runTraceRepairJob(
     const anyPromoted = caseResults.some((r) => r.promoted);
     const failedStopReason = resolveTraceRepairFailureStopReason(
       failedCases.length,
-      caseResults,
+      caseResults
     );
     const allServerLikely = failedStopReason === "completed_server_likely";
 
@@ -838,7 +835,7 @@ export async function runTraceRepairJob(
             jobId,
             leaseOwner,
             stopReason: "completed_case",
-          },
+          }
         );
       } else if (allServerLikely) {
         await convexClient.mutation(
@@ -847,7 +844,7 @@ export async function runTraceRepairJob(
             jobId,
             leaseOwner,
             stopReason: "completed_server_likely",
-          },
+          }
         );
       } else {
         await convexClient.mutation(
@@ -856,7 +853,7 @@ export async function runTraceRepairJob(
             jobId,
             leaseOwner,
             stopReason: failedStopReason,
-          },
+          }
         );
       }
       return;
@@ -880,7 +877,7 @@ export async function runTraceRepairJob(
       "testSuites:getTestSuite" as any,
       {
         suiteId: job.testSuiteId,
-      },
+      }
     );
 
     const replay = await executeSuiteReplayFromRun({
@@ -902,17 +899,17 @@ export async function runTraceRepairJob(
       "testSuites:getTestSuiteRun" as any,
       {
         runId: replay.runId,
-      },
+      }
     );
     const sourceRun = await convexClient.query(
       "testSuites:getTestSuiteRun" as any,
       {
         runId: job.sourceRunId,
-      },
+      }
     );
     const replayDetails = await convexClient.query(
       "testSuites:getTestSuiteRunDetails" as any,
-      { runId: replay.runId },
+      { runId: replay.runId }
     );
     const replayFailedCaseKeys = Array.from(
       new Set(
@@ -921,12 +918,12 @@ export async function runTraceRepairJob(
           .map(
             (it: any) =>
               it.testCaseSnapshot?.caseKey ??
-              (it.testCaseId ? `ui:${it.testCaseId}` : undefined),
+              (it.testCaseId ? `ui:${it.testCaseId}` : undefined)
           )
           .filter((caseKey: string | undefined): caseKey is string =>
-            Boolean(caseKey),
-          ),
-      ),
+            Boolean(caseKey)
+          )
+      )
     );
     const promotedCaseKeys = caseResults
       .filter((result) => result.promoted)
@@ -954,7 +951,7 @@ export async function runTraceRepairJob(
               : "durable_fix",
           })),
         },
-      },
+      }
     );
 
     await convexClient.mutation("traceRepair:finalizeTraceRepairJob" as any, {
@@ -972,7 +969,7 @@ export async function runTraceRepairJob(
           leaseOwner,
           stopReason: "worker_error",
           lastError: err instanceof Error ? err.message : String(err),
-        },
+        }
       );
     } catch {
       /* best effort */

--- a/mcpjam-inspector/server/services/hosted-model-catalog.ts
+++ b/mcpjam-inspector/server/services/hosted-model-catalog.ts
@@ -1,0 +1,180 @@
+/**
+ * hosted-model-catalog.ts — the authoritative "is this a MCPJam-hosted model?"
+ * check for server-side billing dispatch.
+ *
+ * Historically this was a pure membership test against the static
+ * `MCPJAM_PROVIDED_MODEL_IDS` array (`isMCPJamProvidedModel`). Billing keys on
+ * it: a hosted model bills to MCPJam credits; anything else falls through to
+ * org/BYOK key derivation. That coupling meant every backend model addition
+ * required a synchronized inspector edit, and a hosted model missing from the
+ * array would silently mis-dispatch to the BYOK path.
+ *
+ * This service absorbs a DYNAMIC catalog (the backend `/v1/models` route)
+ * behind the same synchronous check, without changing behavior:
+ *
+ *   isHostedCatalogModel(id) === (id ∈ static seed) OR (id ∈ backend catalog)
+ *
+ * The union with the static seed is what makes this safe:
+ *   • Deploy order is irrelevant — the inspector can ship before the backend
+ *     bulk-adds models; the seed already covers today's set.
+ *   • A catalog outage is safe — the seed keeps every existing model billing
+ *     correctly; the fetch only ever ADDS ids, never removes seed ids.
+ *
+ * The check is SYNCHRONOUS against a warm in-memory cache so callers
+ * (resolveModelSource, chat dispatch, evals) stay synchronous. Cold start with
+ * the catalog unreachable degrades to seed-only — i.e. the exact pre-service
+ * behavior.
+ */
+
+import { getCanonicalModelId, MCPJAM_PROVIDED_MODEL_IDS } from "@/shared/types";
+import { logger } from "../utils/logger.js";
+
+const REFRESH_INTERVAL_MS = 60 * 60 * 1000; // hourly, matches the backend cron
+const FETCH_TIMEOUT_MS = 10_000;
+
+// Static seed: byte-identical to the legacy isMCPJamProvidedModel membership.
+// Canonical (slash-prefixed) ids. Never mutated — the dynamic catalog only
+// unions on top of it.
+const SEED_IDS: ReadonlySet<string> = new Set(MCPJAM_PROVIDED_MODEL_IDS);
+
+// Dynamic ids fetched from the backend catalog. `null` until the first
+// successful refresh; on refresh failure the previous value is retained (stale
+// but safe) rather than being cleared.
+let catalogIds: Set<string> | null = null;
+let refreshInFlight: Promise<void> | null = null;
+let refreshTimer: ReturnType<typeof setInterval> | null = null;
+let started = false;
+
+function catalogUrl(): string | undefined {
+  const base = process.env.CONVEX_HTTP_URL;
+  return base ? `${base.replace(/\/$/, "")}/v1/models` : undefined;
+}
+
+/**
+ * Fetch the backend hosted-model catalog and return the set of canonical model
+ * ids, or `null` on any failure (non-2xx, timeout, malformed/empty payload).
+ * The catalog route returns the canonical envelope `{ items: [{ id, ... }] }`
+ * and always lists every allowed model, so an empty `items` is treated as a
+ * failed/implausible fetch rather than an authoritative empty catalog.
+ */
+async function fetchCatalogIds(): Promise<Set<string> | null> {
+  const url = catalogUrl();
+  if (!url) {
+    logger.warn(
+      "[hosted-model-catalog] CONVEX_HTTP_URL is not set; hosted-model billing " +
+        "falls back to the static seed only"
+    );
+    return null;
+  }
+
+  try {
+    const res = await fetch(url, {
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      logger.warn("[hosted-model-catalog] catalog fetch returned non-2xx", {
+        status: res.status,
+      });
+      return null;
+    }
+    const body = (await res.json()) as { items?: Array<{ id?: unknown }> };
+    if (!Array.isArray(body.items) || body.items.length === 0) {
+      logger.warn(
+        "[hosted-model-catalog] catalog payload missing/empty items array"
+      );
+      return null;
+    }
+    const ids = new Set<string>();
+    for (const item of body.items) {
+      if (typeof item?.id === "string" && item.id.length > 0) {
+        ids.add(item.id);
+      }
+    }
+    if (ids.size === 0) {
+      logger.warn("[hosted-model-catalog] catalog yielded no usable ids");
+      return null;
+    }
+    return ids;
+  } catch (error) {
+    logger.warn("[hosted-model-catalog] catalog fetch threw", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}
+
+/**
+ * Refresh the dynamic catalog once. On failure the prior cache is retained and
+ * a warn is emitted (which also alerts via Sentry) — billing keeps working off
+ * the seed, so this is a degraded-but-safe condition, not an outage. In-flight
+ * refreshes are deduped so a manual refresh can't race the interval.
+ */
+export function refreshHostedModelCatalog(): Promise<void> {
+  if (refreshInFlight) return refreshInFlight;
+  refreshInFlight = (async () => {
+    const fresh = await fetchCatalogIds();
+    if (fresh) {
+      const added = [...fresh].filter((id) => !SEED_IDS.has(id)).length;
+      catalogIds = fresh;
+      logger.debug("[hosted-model-catalog] refreshed", {
+        catalogSize: fresh.size,
+        beyondSeed: added,
+      });
+    }
+    // On failure keep the prior catalogIds (stale but safe).
+  })().finally(() => {
+    refreshInFlight = null;
+  });
+  return refreshInFlight;
+}
+
+/**
+ * Start the boot-time fetch + hourly interval refresh. Memoized: safe to call
+ * from every production entrypoint (index.ts and app.ts) — only the first call
+ * wires anything up. The initial refresh is fire-and-forget so boot never
+ * blocks on backend availability (cold start = seed-only = legacy behavior).
+ */
+export function startHostedModelCatalogRefresh(): void {
+  if (started) return;
+  started = true;
+
+  void refreshHostedModelCatalog();
+
+  refreshTimer = setInterval(() => {
+    void refreshHostedModelCatalog();
+  }, REFRESH_INTERVAL_MS);
+  // Don't keep the process alive just for the refresh timer.
+  refreshTimer.unref?.();
+}
+
+/**
+ * Whether `modelId` is a MCPJam-hosted model — the classification server-side
+ * billing dispatch keys on. Synchronous (reads the warm cache). Union of the
+ * static seed and the dynamic backend catalog; canonicalizes the id the same
+ * way the legacy `isMCPJamProvidedModel` did, so this is a drop-in replacement.
+ */
+export function isHostedCatalogModel(
+  modelId: string,
+  provider?: string
+): boolean {
+  const canonical = getCanonicalModelId(modelId, provider);
+  if (SEED_IDS.has(canonical)) return true;
+  return catalogIds?.has(canonical) ?? false;
+}
+
+// ── Test hooks ────────────────────────────────────────────────────────────
+
+/** Seed the dynamic catalog directly (bypasses the network). */
+export function __setHostedCatalogForTests(ids: Iterable<string>): void {
+  catalogIds = new Set(ids);
+}
+
+/** Reset all module state to a cold start. */
+export function __resetHostedModelCatalogForTests(): void {
+  catalogIds = null;
+  refreshInFlight = null;
+  if (refreshTimer) clearInterval(refreshTimer);
+  refreshTimer = null;
+  started = false;
+}

--- a/mcpjam-inspector/server/utils/__tests__/resolve-synthetic-model-source.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/resolve-synthetic-model-source.test.ts
@@ -24,9 +24,23 @@ import {
   resolveHostModelDefinition,
   resolveSyntheticModelSource,
 } from "../org-model-config";
+import {
+  __resetHostedModelCatalogForTests,
+  __setHostedCatalogForTests,
+} from "../../services/hosted-model-catalog";
+
+// A hosted model the dynamic backend catalog knows about but the static seed
+// (MCPJAM_PROVIDED_MODEL_IDS) does NOT — i.e. a backend bulk-add the inspector
+// hasn't shipped a seed for. This is the case the whole dynamic-catalog PR
+// exists for; a seed id would classify identically under the legacy check.
+const CATALOG_ONLY_MODEL = "futurevendor/brand-new-model";
 
 describe("resolveSyntheticModelSource", () => {
-  it("returns `mcpjam` source with no orgRuntime for MCPJam-catalog models", async () => {
+  afterEach(() => {
+    __resetHostedModelCatalogForTests();
+  });
+
+  it("returns `mcpjam` source with no orgRuntime for static-seed models", async () => {
     const result = await resolveSyntheticModelSource({
       modelDefinition: {
         id: "openai/gpt-oss-120b",
@@ -37,6 +51,42 @@ describe("resolveSyntheticModelSource", () => {
     });
 
     expect(result).toEqual({ source: "mcpjam" });
+  });
+
+  it("dispatches a catalog-only model (absent from the seed) to `mcpjam` once the catalog is warm", async () => {
+    // Guards the swap at org-model-config.ts (isMCPJamProvidedModel →
+    // isHostedCatalogModel). Reverting it would make this catalog-only id fall
+    // through to BYOK key derivation and throw here — the seed-only test above
+    // would NOT catch that regression.
+    __setHostedCatalogForTests([CATALOG_ONLY_MODEL]);
+
+    const result = await resolveSyntheticModelSource({
+      modelDefinition: {
+        id: CATALOG_ONLY_MODEL,
+        name: "Future JAM model",
+        provider: "openai",
+      } as ModelDefinition,
+      projectId: "proj-1",
+    });
+
+    expect(result).toEqual({ source: "mcpjam" });
+  });
+
+  it("a catalog-only model is NOT mcpjam on a cold catalog (byte-identical to the legacy seed-only check)", async () => {
+    // Cold start / catalog unreachable = pre-service behavior: a non-seed id
+    // must fall through to BYOK. `futurevendor/...` isn't local-runtime
+    // eligible and isn't `custom:`, so it short-circuits to cloud BYOK without
+    // a Convex round-trip (no CONVEX_HTTP_URL needed).
+    const result = await resolveSyntheticModelSource({
+      modelDefinition: {
+        id: CATALOG_ONLY_MODEL,
+        name: "Future JAM model",
+        provider: "openai",
+      } as ModelDefinition,
+      projectId: "proj-1",
+    });
+
+    expect(result.source).toBe("byok");
   });
 
   it("returns `byok` + cloud orgRuntime for non-MCPJam providers that aren't local-runtime-eligible (no Convex round-trip)", async () => {

--- a/mcpjam-inspector/server/utils/assistant-turn.ts
+++ b/mcpjam-inspector/server/utils/assistant-turn.ts
@@ -26,7 +26,8 @@ import type {
 import type { MCPClientManager, Harness } from "@mcpjam/sdk";
 import type { ModelVisibleMcpToolResults } from "@mcpjam/sdk/host-config/internal";
 import type { ModelDefinition } from "@/shared/types";
-import { getCanonicalModelId, isMCPJamProvidedModel } from "@/shared/types";
+import { getCanonicalModelId } from "@/shared/types";
+import { isHostedCatalogModel } from "../services/hosted-model-catalog.js";
 import type { LiveChatTraceUsage } from "@/shared/live-chat-trace";
 import type {
   ProgressiveToolPlan,
@@ -512,15 +513,15 @@ export async function runAssistantTurn(
     ? getHarnessAdapter(opts.harness as string)
     : undefined;
   // supportsModel needs the CANONICAL id (bare hosted ids like `gpt-5-nano` →
-  // `openai/gpt-5-nano`); isMCPJamProvidedModel canonicalizes internally, so a
+  // `openai/gpt-5-nano`); isHostedCatalogModel canonicalizes internally, so a
   // bare id would otherwise pass eligibility but fail supportsModel and wrongly
   // fall back to emulated.
   const canonicalHarnessModelId = getCanonicalModelId(
     harnessModelId,
-    opts.modelDefinition.provider,
+    opts.modelDefinition.provider
   );
   const modelEligible =
-    isMCPJamProvidedModel(harnessModelId, opts.modelDefinition.provider) &&
+    isHostedCatalogModel(harnessModelId, opts.modelDefinition.provider) &&
     (harnessAdapter
       ? harnessAdapter.supportsModel(canonicalHarnessModelId)
       : true);
@@ -535,7 +536,7 @@ export async function runAssistantTurn(
         modelId: harnessModelId,
         provider: opts.modelDefinition.provider,
         sourceType: opts.sourceType,
-      },
+      }
     );
   }
   const engineResult = useHarness

--- a/mcpjam-inspector/server/utils/assistant-turn.ts
+++ b/mcpjam-inspector/server/utils/assistant-turn.ts
@@ -518,7 +518,7 @@ export async function runAssistantTurn(
   // fall back to emulated.
   const canonicalHarnessModelId = getCanonicalModelId(
     harnessModelId,
-    opts.modelDefinition.provider
+    opts.modelDefinition.provider,
   );
   const modelEligible =
     isHostedCatalogModel(harnessModelId, opts.modelDefinition.provider) &&
@@ -536,7 +536,7 @@ export async function runAssistantTurn(
         modelId: harnessModelId,
         provider: opts.modelDefinition.provider,
         sourceType: opts.sourceType,
-      }
+      },
     );
   }
   const engineResult = useHarness

--- a/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
+++ b/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
@@ -9,7 +9,7 @@
  *   5. scrubMessages lambda construction
  *
  * Intentionally NOT shared:
- *   - Model type check (isMCPJamProvidedModel) — web rejects non-MCPJam; mcp supports user-provided
+ *   - Model type check (isHostedCatalogModel) — web rejects non-MCPJam; mcp supports user-provided
  *   - Error shape — web throws WebRouteError; mcp returns c.json()
  *   - Manager lifecycle — web has onStreamComplete cleanup; mcp uses singleton
  *   - streamText path — only in mcp
@@ -632,9 +632,7 @@ export interface PrepareChatV2Options {
    * never set it → the existing precedence is byte-identical. `pinned` tools
    * bypass approval (pure reads of frozen content under an auto-deny eval run).
    */
-  skillsSource?:
-    | { kind: "pinned"; skills: PinnableSkill[] }
-    | { kind: "none" };
+  skillsSource?: { kind: "pinned"; skills: PinnableSkill[] } | { kind: "none" };
 }
 
 /**
@@ -834,7 +832,7 @@ export async function prepareChatV2(
   // this throw is belt-and-suspenders at the single point both paths funnel through.
   if (harness && skillsArePinned) {
     throw new Error(
-      "Pinned skills are not supported on harness runs (they live-fetch skills).",
+      "Pinned skills are not supported on harness runs (they live-fetch skills)."
     );
   }
   const { tools: skillTools, systemPromptSection: skillsPromptSection } =
@@ -843,13 +841,13 @@ export async function prepareChatV2(
         ? getPinnedSkillToolsAndPrompt(skillsSource.skills)
         : { tools: {}, systemPromptSection: "" }
       : cloudSkills
-        ? getCloudSkillToolsAndPrompt({
-            authHeader: cloudSkills.authHeader,
-            projectId: cloudSkills.projectId,
-          })
-        : HOSTED_MODE
-          ? { tools: {}, systemPromptSection: "" }
-          : await getSkillToolsAndPrompt();
+      ? getCloudSkillToolsAndPrompt({
+          authHeader: cloudSkills.authHeader,
+          projectId: cloudSkills.projectId,
+        })
+      : HOSTED_MODE
+      ? { tools: {}, systemPromptSection: "" }
+      : await getSkillToolsAndPrompt();
 
   // Pinned skill tools NEVER require approval (pure reads of frozen content; the
   // eval run is auto-deny). Otherwise the normal approval wrap applies.
@@ -884,7 +882,7 @@ export async function prepareChatV2(
   for (const name of Object.keys(uiToolEntries)) {
     if (Object.prototype.hasOwnProperty.call(mcpTools, name)) {
       logger.warn(
-        `[chat-v2] UI tool '${name}' shadows an MCP tool with the same name; using the UI tool`,
+        `[chat-v2] UI tool '${name}' shadows an MCP tool with the same name; using the UI tool`
       );
       delete mcpTools[name];
     }
@@ -913,7 +911,7 @@ export async function prepareChatV2(
       Object.prototype.hasOwnProperty.call(finalSkillTools, name)
     ) {
       throw new Error(
-        `Built-in tool '${name}' collides with an existing app, UI, or skill tool.`,
+        `Built-in tool '${name}' collides with an existing app, UI, or skill tool.`
       );
     }
   }

--- a/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
+++ b/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
@@ -9,7 +9,7 @@
  *   5. scrubMessages lambda construction
  *
  * Intentionally NOT shared:
- *   - Model type check (isHostedCatalogModel) — web rejects non-MCPJam; mcp supports user-provided
+ *   - Model type check (isMCPJamProvidedModel) — web rejects non-MCPJam; mcp supports user-provided
  *   - Error shape — web throws WebRouteError; mcp returns c.json()
  *   - Manager lifecycle — web has onStreamComplete cleanup; mcp uses singleton
  *   - streamText path — only in mcp
@@ -632,7 +632,9 @@ export interface PrepareChatV2Options {
    * never set it → the existing precedence is byte-identical. `pinned` tools
    * bypass approval (pure reads of frozen content under an auto-deny eval run).
    */
-  skillsSource?: { kind: "pinned"; skills: PinnableSkill[] } | { kind: "none" };
+  skillsSource?:
+    | { kind: "pinned"; skills: PinnableSkill[] }
+    | { kind: "none" };
 }
 
 /**
@@ -832,7 +834,7 @@ export async function prepareChatV2(
   // this throw is belt-and-suspenders at the single point both paths funnel through.
   if (harness && skillsArePinned) {
     throw new Error(
-      "Pinned skills are not supported on harness runs (they live-fetch skills)."
+      "Pinned skills are not supported on harness runs (they live-fetch skills).",
     );
   }
   const { tools: skillTools, systemPromptSection: skillsPromptSection } =
@@ -841,13 +843,13 @@ export async function prepareChatV2(
         ? getPinnedSkillToolsAndPrompt(skillsSource.skills)
         : { tools: {}, systemPromptSection: "" }
       : cloudSkills
-      ? getCloudSkillToolsAndPrompt({
-          authHeader: cloudSkills.authHeader,
-          projectId: cloudSkills.projectId,
-        })
-      : HOSTED_MODE
-      ? { tools: {}, systemPromptSection: "" }
-      : await getSkillToolsAndPrompt();
+        ? getCloudSkillToolsAndPrompt({
+            authHeader: cloudSkills.authHeader,
+            projectId: cloudSkills.projectId,
+          })
+        : HOSTED_MODE
+          ? { tools: {}, systemPromptSection: "" }
+          : await getSkillToolsAndPrompt();
 
   // Pinned skill tools NEVER require approval (pure reads of frozen content; the
   // eval run is auto-deny). Otherwise the normal approval wrap applies.
@@ -882,7 +884,7 @@ export async function prepareChatV2(
   for (const name of Object.keys(uiToolEntries)) {
     if (Object.prototype.hasOwnProperty.call(mcpTools, name)) {
       logger.warn(
-        `[chat-v2] UI tool '${name}' shadows an MCP tool with the same name; using the UI tool`
+        `[chat-v2] UI tool '${name}' shadows an MCP tool with the same name; using the UI tool`,
       );
       delete mcpTools[name];
     }
@@ -911,7 +913,7 @@ export async function prepareChatV2(
       Object.prototype.hasOwnProperty.call(finalSkillTools, name)
     ) {
       throw new Error(
-        `Built-in tool '${name}' collides with an existing app, UI, or skill tool.`
+        `Built-in tool '${name}' collides with an existing app, UI, or skill tool.`,
       );
     }
   }

--- a/mcpjam-inspector/server/utils/computers/__tests__/cloud-skill-tools-gate.test.ts
+++ b/mcpjam-inspector/server/utils/computers/__tests__/cloud-skill-tools-gate.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, vi } from "vitest";
 
-// Gate the engine signal: an MCPJam-provided model id reports true, BYOK false.
+// Gate the engine signal: an MCPJam-hosted model id reports true, BYOK false.
 // Mirrors the real helper's provider-aware canonicalization: a BARE id only
-// counts as MCPJam-provided when the provider is supplied (bare + provider →
-// prefixed hosted id).
-vi.mock("@/shared/types", () => ({
-  isMCPJamProvidedModel: (id: string, provider?: string) =>
+// counts as hosted when the provider is supplied (bare + provider → prefixed
+// hosted id).
+vi.mock("../../../services/hosted-model-catalog.js", () => ({
+  isHostedCatalogModel: (id: string, provider?: string) =>
     id.startsWith("mcpjam/") || (provider === "mcpjam" && !id.includes("/")),
 }));
 

--- a/mcpjam-inspector/server/utils/computers/__tests__/cloud-skill-tools-gate.test.ts
+++ b/mcpjam-inspector/server/utils/computers/__tests__/cloud-skill-tools-gate.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi } from "vitest";
 
-// Gate the engine signal: an MCPJam-hosted model id reports true, BYOK false.
+// Gate the engine signal: an MCPJam-provided model id reports true, BYOK false.
 // Mirrors the real helper's provider-aware canonicalization: a BARE id only
-// counts as hosted when the provider is supplied (bare + provider → prefixed
-// hosted id).
+// counts as MCPJam-provided when the provider is supplied (bare + provider →
+// prefixed hosted id).
 vi.mock("../../../services/hosted-model-catalog.js", () => ({
   isHostedCatalogModel: (id: string, provider?: string) =>
     id.startsWith("mcpjam/") || (provider === "mcpjam" && !id.includes("/")),

--- a/mcpjam-inspector/server/utils/computers/cloud-skill-tools.ts
+++ b/mcpjam-inspector/server/utils/computers/cloud-skill-tools.ts
@@ -10,7 +10,7 @@
  */
 import { tool } from "ai";
 import { z } from "zod";
-import { isMCPJamProvidedModel } from "@/shared/types";
+import { isHostedCatalogModel } from "../../services/hosted-model-catalog.js";
 import type { PinnableSkill } from "../../../shared/skill-types.js";
 import {
   CloudSkillsError,
@@ -53,7 +53,7 @@ export function shouldEnableCloudSkillTools(args: {
 }): boolean {
   const willRunHarness =
     args.harness !== undefined &&
-    isMCPJamProvidedModel(args.modelId, args.provider);
+    isHostedCatalogModel(args.modelId, args.provider);
   return !args.isGuest && !willRunHarness && args.hasProjectId;
 }
 
@@ -148,7 +148,9 @@ export function createCloudSkillTools(ctx: CloudSkillsContext) {
         name: z.string().describe("The skill name."),
         path: z
           .string()
-          .describe("Relative path within the skill (e.g., 'scripts/fill.py')."),
+          .describe(
+            "Relative path within the skill (e.g., 'scripts/fill.py')."
+          ),
       }),
       execute: async ({ name, path }) => {
         if (!NAME_RE.test(name)) {

--- a/mcpjam-inspector/server/utils/computers/cloud-skill-tools.ts
+++ b/mcpjam-inspector/server/utils/computers/cloud-skill-tools.ts
@@ -148,9 +148,7 @@ export function createCloudSkillTools(ctx: CloudSkillsContext) {
         name: z.string().describe("The skill name."),
         path: z
           .string()
-          .describe(
-            "Relative path within the skill (e.g., 'scripts/fill.py')."
-          ),
+          .describe("Relative path within the skill (e.g., 'scripts/fill.py')."),
       }),
       execute: async ({ name, path }) => {
         if (!NAME_RE.test(name)) {

--- a/mcpjam-inspector/server/utils/org-model-config.ts
+++ b/mcpjam-inspector/server/utils/org-model-config.ts
@@ -9,7 +9,9 @@ import {
 import { isHostedCatalogModel } from "../services/hosted-model-catalog.js";
 import type { OrgProviderResolvedConfig } from "@mcpjam/sdk/model-factory";
 import type { BaseUrls, CustomProviderConfig } from "./chat-helpers";
-import { isUnsafeHostedOutboundUrl as isUnsafeHostedOutboundUrlLiteral } from "@/shared/local-only-mcp";
+import {
+  isUnsafeHostedOutboundUrl as isUnsafeHostedOutboundUrlLiteral,
+} from "@/shared/local-only-mcp";
 import { HOSTED_MODE } from "../config.js";
 import { logger } from "./logger";
 
@@ -89,7 +91,7 @@ const resolveCache = new Map<
 >();
 
 function normalizeAuthHeader(
-  auth: ResolveOrgModelConfigAuth | undefined
+  auth: ResolveOrgModelConfigAuth | undefined,
 ): string | undefined {
   const header = auth?.authHeader?.trim();
   if (header) return header;
@@ -106,13 +108,13 @@ function normalizeServerIds(serverIds: string[] | undefined): string[] {
     new Set(
       (serverIds ?? [])
         .map((serverId) => serverId.trim())
-        .filter((serverId) => serverId.length > 0)
-    )
+        .filter((serverId) => serverId.length > 0),
+    ),
   ).sort();
 }
 
 function formatTargetForCache(
-  params: ResolveOrgModelConfigTarget | ResolveOrgProviderRuntimeTarget
+  params: ResolveOrgModelConfigTarget | ResolveOrgProviderRuntimeTarget,
 ): string {
   return "projectId" in params
     ? `project:${params.projectId}`
@@ -121,7 +123,7 @@ function formatTargetForCache(
 
 function buildCacheKey(
   params: ResolveOrgModelConfigTarget,
-  auth: ResolveOrgModelConfigAuth | undefined
+  auth: ResolveOrgModelConfigAuth | undefined,
 ): string {
   const target = formatTargetForCache(params);
   // Cache key hashes (chatboxId, accessVersion) so a link-token rotation
@@ -133,13 +135,12 @@ function buildCacheKey(
         authorization: normalizeAuthHeader(auth) ?? "",
         chatboxId: auth?.chatboxId?.trim() ?? "",
         accessVersion:
-          auth?.chatboxId &&
-          auth.chatboxId.trim() &&
+          auth?.chatboxId && auth.chatboxId.trim() &&
           Number.isFinite(auth?.accessVersion)
             ? auth.accessVersion
             : null,
         serverIds: normalizeServerIds(auth?.serverIds),
-      })
+      }),
     )
     .digest("hex");
   return `${target}:auth:${authHash}`;
@@ -147,7 +148,7 @@ function buildCacheKey(
 
 export async function resolveOrgModelConfig(
   params: ResolveOrgModelConfigTarget,
-  auth?: ResolveOrgModelConfigAuth
+  auth?: ResolveOrgModelConfigAuth,
 ): Promise<ResolvedOrgModelConfig> {
   const convexHttpUrl = process.env.CONVEX_HTTP_URL;
   if (!convexHttpUrl) {
@@ -167,10 +168,7 @@ export async function resolveOrgModelConfig(
     return cached.result;
   }
 
-  const url = `${convexHttpUrl.replace(
-    /\/$/,
-    ""
-  )}/internal/v1/org-model-config/resolve`;
+  const url = `${convexHttpUrl.replace(/\/$/, "")}/internal/v1/org-model-config/resolve`;
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), RESOLVE_TIMEOUT_MS);
 
@@ -240,7 +238,7 @@ export async function resolveOrgModelConfig(
               "[org-model-config] Dropping bedrock provider with blocked baseUrl",
               {
                 error: error instanceof Error ? error.message : String(error),
-              }
+              },
             );
             continue;
           }
@@ -274,7 +272,7 @@ export type DeriveOrgProviderKeyResult =
   | { ok: false; error: string };
 
 export function deriveOrgProviderKey(
-  modelDefinition: ModelDefinition
+  modelDefinition: ModelDefinition,
 ): DeriveOrgProviderKeyResult {
   if (modelDefinition.provider === "custom") {
     if (!modelDefinition.customProviderName) {
@@ -293,7 +291,7 @@ export function deriveOrgProviderKey(
 // ---------------------------------------------------------------------------
 
 export function buildModelApiKeysFromOrgConfig(
-  config: ResolvedOrgModelConfig
+  config: ResolvedOrgModelConfig,
 ): Record<string, string> {
   const keys: Record<string, string> = {};
   for (const p of config.providers) {
@@ -315,7 +313,7 @@ export type OrgLlmRuntimeConfig = {
 };
 
 export function buildLlmRuntimeConfigFromOrgConfig(
-  config: ResolvedOrgModelConfig
+  config: ResolvedOrgModelConfig,
 ): OrgLlmRuntimeConfig {
   const runtime: OrgLlmRuntimeConfig = {
     modelApiKeys: buildModelApiKeysFromOrgConfig(config),
@@ -398,7 +396,7 @@ export function isUnsafeHostedOutboundUrl(rawUrl: string): boolean {
 async function assertSafeHostedOutboundUrl(rawUrl: string): Promise<void> {
   if (isUnsafeHostedOutboundUrl(rawUrl)) {
     throw new Error(
-      `Provider base URL is blocked: points to a private or internal address`
+      `Provider base URL is blocked: points to a private or internal address`,
     );
   }
   // For non-IP-literal hostnames, also validate the DNS-resolved IPs.
@@ -408,17 +406,11 @@ async function assertSafeHostedOutboundUrl(rawUrl: string): Promise<void> {
   if (isIpLiteral) return;
 
   const resolvedIps: string[] = [];
-  try {
-    resolvedIps.push(...(await dns.resolve4(host)));
-  } catch {
-    /* NXDOMAIN etc */
-  }
-  try {
-    resolvedIps.push(...(await dns.resolve6(host)));
-  } catch {}
+  try { resolvedIps.push(...await dns.resolve4(host)); } catch { /* NXDOMAIN etc */ }
+  try { resolvedIps.push(...await dns.resolve6(host)); } catch {}
   if (resolvedIps.length === 0) {
     throw new Error(
-      `Provider base URL is blocked: hostname "${host}" could not be resolved`
+      `Provider base URL is blocked: hostname "${host}" could not be resolved`,
     );
   }
   for (const ip of resolvedIps) {
@@ -426,7 +418,7 @@ async function assertSafeHostedOutboundUrl(rawUrl: string): Promise<void> {
     const testUrl = ip.includes(":") ? `http://[${ip}]` : `http://${ip}`;
     if (isUnsafeHostedOutboundUrl(testUrl)) {
       throw new Error(
-        `Provider base URL is blocked: hostname "${host}" resolves to a private or internal address`
+        `Provider base URL is blocked: hostname "${host}" resolves to a private or internal address`,
       );
     }
   }
@@ -447,9 +439,7 @@ export type OrgProviderRuntimeLocal = {
   provider: OrgProviderResolvedConfig;
 };
 
-export type OrgProviderRuntime =
-  | OrgProviderRuntimeCloud
-  | OrgProviderRuntimeLocal;
+export type OrgProviderRuntime = OrgProviderRuntimeCloud | OrgProviderRuntimeLocal;
 
 const RUNTIME_CACHE_TTL_MS = 60_000;
 const RUNTIME_CACHE_MAX_ENTRIES = 1_000;
@@ -479,7 +469,7 @@ function buildRuntimeCacheKey(
   target: ResolveOrgProviderRuntimeTarget,
   providerKey: string,
   model: string,
-  auth: ResolveOrgModelConfigAuth | undefined
+  auth: ResolveOrgModelConfigAuth | undefined,
 ): string {
   const authHash = createHash("sha256")
     .update(
@@ -487,18 +477,15 @@ function buildRuntimeCacheKey(
         authorization: normalizeAuthHeader(auth) ?? "",
         chatboxId: auth?.chatboxId?.trim() ?? "",
         accessVersion:
-          auth?.chatboxId &&
-          auth.chatboxId.trim() &&
+          auth?.chatboxId && auth.chatboxId.trim() &&
           Number.isFinite(auth?.accessVersion)
             ? auth.accessVersion
             : null,
         serverIds: normalizeServerIds(auth?.serverIds),
-      })
+      }),
     )
     .digest("hex");
-  return `runtime:${formatTargetForCache(
-    target
-  )}:${providerKey}:${model}:auth:${authHash}`;
+  return `runtime:${formatTargetForCache(target)}:${providerKey}:${model}:auth:${authHash}`;
 }
 
 /**
@@ -516,13 +503,13 @@ export async function resolveOrgProviderRuntime(
   projectId: string,
   providerKey: string,
   model: string,
-  auth?: ResolveOrgModelConfigAuth
+  auth?: ResolveOrgModelConfigAuth,
 ): Promise<OrgProviderRuntime> {
   return resolveOrgProviderRuntimeForTarget(
     { projectId },
     providerKey,
     model,
-    auth
+    auth,
   );
 }
 
@@ -530,7 +517,7 @@ export async function resolveOrgProviderRuntimeForTarget(
   target: ResolveOrgProviderRuntimeTarget,
   providerKey: string,
   model: string,
-  auth?: ResolveOrgModelConfigAuth
+  auth?: ResolveOrgModelConfigAuth,
 ): Promise<OrgProviderRuntime> {
   const convexHttpUrl = process.env.CONVEX_HTTP_URL;
   if (!convexHttpUrl) throw new Error("CONVEX_HTTP_URL is not set");
@@ -606,7 +593,7 @@ export async function resolveOrgProviderRuntimeForTarget(
         rawProvider.providerKey.length === 0
       ) {
         throw new Error(
-          "Org runtime resolve returned invalid local provider config"
+          "Org runtime resolve returned invalid local provider config",
         );
       }
       // SSRF guard: in hosted mode reject baseUrls that point to private,
@@ -706,7 +693,7 @@ export async function resolveSyntheticModelSource(args: {
   const keyResult = deriveOrgProviderKey(args.modelDefinition);
   if (!keyResult.ok) {
     throw new Error(
-      `Synthetic dispatch failed to derive org provider key: ${keyResult.error}`
+      `Synthetic dispatch failed to derive org provider key: ${keyResult.error}`,
     );
   }
   const orgRuntime: OrgProviderRuntime = isLocalRuntimeEligible(keyResult.key)
@@ -719,7 +706,7 @@ export async function resolveSyntheticModelSource(args: {
           chatboxId: args.chatboxId,
           accessVersion: args.accessVersion,
           serverIds: args.serverIds,
-        }
+        },
       )
     : { runtimeLocation: "cloud", providerKey: keyResult.key };
   return {
@@ -787,7 +774,7 @@ const ID_PREFIX_TO_PROVIDER: Record<string, ModelProvider> = {
  * id shape, never from the request body's model.
  */
 export function buildSyntheticModelDefinition(
-  modelId: string
+  modelId: string,
 ): ModelDefinition {
   // An unpinned host persists modelId "" — without this guard the bare-id
   // fallback below silently classifies it as an Ollama BYOK model and the
@@ -865,7 +852,7 @@ export function buildSyntheticModelDefinition(
  */
 export function matchOrgProviderForModelId(
   config: ResolvedOrgModelConfig,
-  modelId: string
+  modelId: string,
 ): ModelDefinition | null {
   for (const p of config.providers) {
     if (p.providerKey === "openrouter" || p.providerKey === "bedrock") {
@@ -930,7 +917,7 @@ export async function resolveHostModelDefinition(args: {
           modelId,
           projectId,
           error: error instanceof Error ? error.message : String(error),
-        }
+        },
       );
     }
   }

--- a/mcpjam-inspector/server/utils/org-model-config.ts
+++ b/mcpjam-inspector/server/utils/org-model-config.ts
@@ -3,15 +3,13 @@ import dns from "node:dns/promises";
 import {
   getModelById,
   isBedrockModelId,
-  isMCPJamProvidedModel,
   type ModelDefinition,
   type ModelProvider,
 } from "@/shared/types";
+import { isHostedCatalogModel } from "../services/hosted-model-catalog.js";
 import type { OrgProviderResolvedConfig } from "@mcpjam/sdk/model-factory";
 import type { BaseUrls, CustomProviderConfig } from "./chat-helpers";
-import {
-  isUnsafeHostedOutboundUrl as isUnsafeHostedOutboundUrlLiteral,
-} from "@/shared/local-only-mcp";
+import { isUnsafeHostedOutboundUrl as isUnsafeHostedOutboundUrlLiteral } from "@/shared/local-only-mcp";
 import { HOSTED_MODE } from "../config.js";
 import { logger } from "./logger";
 
@@ -91,7 +89,7 @@ const resolveCache = new Map<
 >();
 
 function normalizeAuthHeader(
-  auth: ResolveOrgModelConfigAuth | undefined,
+  auth: ResolveOrgModelConfigAuth | undefined
 ): string | undefined {
   const header = auth?.authHeader?.trim();
   if (header) return header;
@@ -108,13 +106,13 @@ function normalizeServerIds(serverIds: string[] | undefined): string[] {
     new Set(
       (serverIds ?? [])
         .map((serverId) => serverId.trim())
-        .filter((serverId) => serverId.length > 0),
-    ),
+        .filter((serverId) => serverId.length > 0)
+    )
   ).sort();
 }
 
 function formatTargetForCache(
-  params: ResolveOrgModelConfigTarget | ResolveOrgProviderRuntimeTarget,
+  params: ResolveOrgModelConfigTarget | ResolveOrgProviderRuntimeTarget
 ): string {
   return "projectId" in params
     ? `project:${params.projectId}`
@@ -123,7 +121,7 @@ function formatTargetForCache(
 
 function buildCacheKey(
   params: ResolveOrgModelConfigTarget,
-  auth: ResolveOrgModelConfigAuth | undefined,
+  auth: ResolveOrgModelConfigAuth | undefined
 ): string {
   const target = formatTargetForCache(params);
   // Cache key hashes (chatboxId, accessVersion) so a link-token rotation
@@ -135,12 +133,13 @@ function buildCacheKey(
         authorization: normalizeAuthHeader(auth) ?? "",
         chatboxId: auth?.chatboxId?.trim() ?? "",
         accessVersion:
-          auth?.chatboxId && auth.chatboxId.trim() &&
+          auth?.chatboxId &&
+          auth.chatboxId.trim() &&
           Number.isFinite(auth?.accessVersion)
             ? auth.accessVersion
             : null,
         serverIds: normalizeServerIds(auth?.serverIds),
-      }),
+      })
     )
     .digest("hex");
   return `${target}:auth:${authHash}`;
@@ -148,7 +147,7 @@ function buildCacheKey(
 
 export async function resolveOrgModelConfig(
   params: ResolveOrgModelConfigTarget,
-  auth?: ResolveOrgModelConfigAuth,
+  auth?: ResolveOrgModelConfigAuth
 ): Promise<ResolvedOrgModelConfig> {
   const convexHttpUrl = process.env.CONVEX_HTTP_URL;
   if (!convexHttpUrl) {
@@ -168,7 +167,10 @@ export async function resolveOrgModelConfig(
     return cached.result;
   }
 
-  const url = `${convexHttpUrl.replace(/\/$/, "")}/internal/v1/org-model-config/resolve`;
+  const url = `${convexHttpUrl.replace(
+    /\/$/,
+    ""
+  )}/internal/v1/org-model-config/resolve`;
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), RESOLVE_TIMEOUT_MS);
 
@@ -238,7 +240,7 @@ export async function resolveOrgModelConfig(
               "[org-model-config] Dropping bedrock provider with blocked baseUrl",
               {
                 error: error instanceof Error ? error.message : String(error),
-              },
+              }
             );
             continue;
           }
@@ -272,7 +274,7 @@ export type DeriveOrgProviderKeyResult =
   | { ok: false; error: string };
 
 export function deriveOrgProviderKey(
-  modelDefinition: ModelDefinition,
+  modelDefinition: ModelDefinition
 ): DeriveOrgProviderKeyResult {
   if (modelDefinition.provider === "custom") {
     if (!modelDefinition.customProviderName) {
@@ -291,7 +293,7 @@ export function deriveOrgProviderKey(
 // ---------------------------------------------------------------------------
 
 export function buildModelApiKeysFromOrgConfig(
-  config: ResolvedOrgModelConfig,
+  config: ResolvedOrgModelConfig
 ): Record<string, string> {
   const keys: Record<string, string> = {};
   for (const p of config.providers) {
@@ -313,7 +315,7 @@ export type OrgLlmRuntimeConfig = {
 };
 
 export function buildLlmRuntimeConfigFromOrgConfig(
-  config: ResolvedOrgModelConfig,
+  config: ResolvedOrgModelConfig
 ): OrgLlmRuntimeConfig {
   const runtime: OrgLlmRuntimeConfig = {
     modelApiKeys: buildModelApiKeysFromOrgConfig(config),
@@ -396,7 +398,7 @@ export function isUnsafeHostedOutboundUrl(rawUrl: string): boolean {
 async function assertSafeHostedOutboundUrl(rawUrl: string): Promise<void> {
   if (isUnsafeHostedOutboundUrl(rawUrl)) {
     throw new Error(
-      `Provider base URL is blocked: points to a private or internal address`,
+      `Provider base URL is blocked: points to a private or internal address`
     );
   }
   // For non-IP-literal hostnames, also validate the DNS-resolved IPs.
@@ -406,11 +408,17 @@ async function assertSafeHostedOutboundUrl(rawUrl: string): Promise<void> {
   if (isIpLiteral) return;
 
   const resolvedIps: string[] = [];
-  try { resolvedIps.push(...await dns.resolve4(host)); } catch { /* NXDOMAIN etc */ }
-  try { resolvedIps.push(...await dns.resolve6(host)); } catch {}
+  try {
+    resolvedIps.push(...(await dns.resolve4(host)));
+  } catch {
+    /* NXDOMAIN etc */
+  }
+  try {
+    resolvedIps.push(...(await dns.resolve6(host)));
+  } catch {}
   if (resolvedIps.length === 0) {
     throw new Error(
-      `Provider base URL is blocked: hostname "${host}" could not be resolved`,
+      `Provider base URL is blocked: hostname "${host}" could not be resolved`
     );
   }
   for (const ip of resolvedIps) {
@@ -418,7 +426,7 @@ async function assertSafeHostedOutboundUrl(rawUrl: string): Promise<void> {
     const testUrl = ip.includes(":") ? `http://[${ip}]` : `http://${ip}`;
     if (isUnsafeHostedOutboundUrl(testUrl)) {
       throw new Error(
-        `Provider base URL is blocked: hostname "${host}" resolves to a private or internal address`,
+        `Provider base URL is blocked: hostname "${host}" resolves to a private or internal address`
       );
     }
   }
@@ -439,7 +447,9 @@ export type OrgProviderRuntimeLocal = {
   provider: OrgProviderResolvedConfig;
 };
 
-export type OrgProviderRuntime = OrgProviderRuntimeCloud | OrgProviderRuntimeLocal;
+export type OrgProviderRuntime =
+  | OrgProviderRuntimeCloud
+  | OrgProviderRuntimeLocal;
 
 const RUNTIME_CACHE_TTL_MS = 60_000;
 const RUNTIME_CACHE_MAX_ENTRIES = 1_000;
@@ -469,7 +479,7 @@ function buildRuntimeCacheKey(
   target: ResolveOrgProviderRuntimeTarget,
   providerKey: string,
   model: string,
-  auth: ResolveOrgModelConfigAuth | undefined,
+  auth: ResolveOrgModelConfigAuth | undefined
 ): string {
   const authHash = createHash("sha256")
     .update(
@@ -477,15 +487,18 @@ function buildRuntimeCacheKey(
         authorization: normalizeAuthHeader(auth) ?? "",
         chatboxId: auth?.chatboxId?.trim() ?? "",
         accessVersion:
-          auth?.chatboxId && auth.chatboxId.trim() &&
+          auth?.chatboxId &&
+          auth.chatboxId.trim() &&
           Number.isFinite(auth?.accessVersion)
             ? auth.accessVersion
             : null,
         serverIds: normalizeServerIds(auth?.serverIds),
-      }),
+      })
     )
     .digest("hex");
-  return `runtime:${formatTargetForCache(target)}:${providerKey}:${model}:auth:${authHash}`;
+  return `runtime:${formatTargetForCache(
+    target
+  )}:${providerKey}:${model}:auth:${authHash}`;
 }
 
 /**
@@ -503,13 +516,13 @@ export async function resolveOrgProviderRuntime(
   projectId: string,
   providerKey: string,
   model: string,
-  auth?: ResolveOrgModelConfigAuth,
+  auth?: ResolveOrgModelConfigAuth
 ): Promise<OrgProviderRuntime> {
   return resolveOrgProviderRuntimeForTarget(
     { projectId },
     providerKey,
     model,
-    auth,
+    auth
   );
 }
 
@@ -517,7 +530,7 @@ export async function resolveOrgProviderRuntimeForTarget(
   target: ResolveOrgProviderRuntimeTarget,
   providerKey: string,
   model: string,
-  auth?: ResolveOrgModelConfigAuth,
+  auth?: ResolveOrgModelConfigAuth
 ): Promise<OrgProviderRuntime> {
   const convexHttpUrl = process.env.CONVEX_HTTP_URL;
   if (!convexHttpUrl) throw new Error("CONVEX_HTTP_URL is not set");
@@ -593,7 +606,7 @@ export async function resolveOrgProviderRuntimeForTarget(
         rawProvider.providerKey.length === 0
       ) {
         throw new Error(
-          "Org runtime resolve returned invalid local provider config",
+          "Org runtime resolve returned invalid local provider config"
         );
       }
       // SSRF guard: in hosted mode reject baseUrls that point to private,
@@ -687,13 +700,13 @@ export async function resolveSyntheticModelSource(args: {
   serverIds?: string[];
 }): Promise<SyntheticModelResolution> {
   const modelIdStr = String(args.modelDefinition.id);
-  if (isMCPJamProvidedModel(modelIdStr)) {
+  if (isHostedCatalogModel(modelIdStr)) {
     return { source: "mcpjam" };
   }
   const keyResult = deriveOrgProviderKey(args.modelDefinition);
   if (!keyResult.ok) {
     throw new Error(
-      `Synthetic dispatch failed to derive org provider key: ${keyResult.error}`,
+      `Synthetic dispatch failed to derive org provider key: ${keyResult.error}`
     );
   }
   const orgRuntime: OrgProviderRuntime = isLocalRuntimeEligible(keyResult.key)
@@ -706,7 +719,7 @@ export async function resolveSyntheticModelSource(args: {
           chatboxId: args.chatboxId,
           accessVersion: args.accessVersion,
           serverIds: args.serverIds,
-        },
+        }
       )
     : { runtimeLocation: "cloud", providerKey: keyResult.key };
   return {
@@ -774,7 +787,7 @@ const ID_PREFIX_TO_PROVIDER: Record<string, ModelProvider> = {
  * id shape, never from the request body's model.
  */
 export function buildSyntheticModelDefinition(
-  modelId: string,
+  modelId: string
 ): ModelDefinition {
   // An unpinned host persists modelId "" — without this guard the bare-id
   // fallback below silently classifies it as an Ollama BYOK model and the
@@ -852,7 +865,7 @@ export function buildSyntheticModelDefinition(
  */
 export function matchOrgProviderForModelId(
   config: ResolvedOrgModelConfig,
-  modelId: string,
+  modelId: string
 ): ModelDefinition | null {
   for (const p of config.providers) {
     if (p.providerKey === "openrouter" || p.providerKey === "bedrock") {
@@ -917,7 +930,7 @@ export async function resolveHostModelDefinition(args: {
           modelId,
           projectId,
           error: error instanceof Error ? error.message : String(error),
-        },
+        }
       );
     }
   }

--- a/mcpjam-inspector/server/utils/web-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/web-chat-turn.ts
@@ -219,7 +219,7 @@ function approvalFreeUiToolNamesFrom(
  * path and mapping the error to a `webError(...)` response.
  */
 export async function streamWebChatTurn(
-  args: StreamWebChatTurnArgs
+  args: StreamWebChatTurnArgs,
 ): Promise<Response> {
   const { manager, prepare, persist, runtime } = args;
   const { c } = runtime;
@@ -229,7 +229,7 @@ export async function streamWebChatTurn(
     throw new WebRouteError(
       500,
       ErrorCode.INTERNAL_ERROR,
-      "Server missing CONVEX_HTTP_URL configuration"
+      "Server missing CONVEX_HTTP_URL configuration",
     );
   }
 
@@ -244,7 +244,7 @@ export async function streamWebChatTurn(
       // trigger new linked resource reads. Fresh server-side tool execution
       // resolves resource_link results through trusted tool-origin metadata.
       abortSignal: c.req.raw.signal as AbortSignal | undefined,
-    }
+    },
   );
 
   let prepared;
@@ -287,7 +287,7 @@ export async function streamWebChatTurn(
   } = prepared;
 
   const widgetModelContextSystemPrompt = buildWidgetModelContextSystemPrompt(
-    prepare.widgetModelContext ?? []
+    prepare.widgetModelContext ?? [],
   );
   const effectiveEnhancedSystemPrompt = [
     enhancedSystemPrompt,
@@ -311,7 +311,7 @@ export async function streamWebChatTurn(
     Boolean(prepare.modelDefinition.id) &&
     isHostedCatalogModel(
       String(prepare.modelDefinition.id),
-      prepare.modelDefinition.provider
+      prepare.modelDefinition.provider,
     );
 
   // Resolve the host config now that `resolvedTemperature` is known.
@@ -319,21 +319,21 @@ export async function streamWebChatTurn(
   // callers preserve that by passing a closure here.
   const resolvedHostConfig: DirectHostConfig | null =
     typeof persist.hostConfig === "function"
-      ? persist.hostConfig({ resolvedTemperature }) ?? null
-      : persist.hostConfig ?? null;
+      ? (persist.hostConfig({ resolvedTemperature }) ?? null)
+      : (persist.hostConfig ?? null);
 
   // Build the persist callback once — it's a closure over a lot of context
   // and is identical between MCPJam-free and org-BYOK other than the modelId
   // + modelSource.
   const buildOnConversationComplete = (
     modelId: string,
-    modelSource: "mcpjam" | "byok" | "local_byok"
+    modelSource: "mcpjam" | "byok" | "local_byok",
   ) => {
     if (!hostedChatSessionId) return undefined;
     return async (
       fullHistory: ModelMessage[],
       turnTrace: PersistedTurnTrace,
-      harnessSessionCommit?: HarnessSessionCommitPayload
+      harnessSessionCommit?: HarnessSessionCommitPayload,
     ) => {
       const isDirectChat = !isChatboxSession;
       // Capture the live tool catalog. Failures must never block the persist.
@@ -351,7 +351,7 @@ export async function streamWebChatTurn(
               await exportConnectedServerToolSnapshotForEvalAuthoring(
                 manager,
                 knownIds,
-                { logPrefix: "chat-v2.persist" }
+                { logPrefix: "chat-v2.persist" },
               );
           }
         } catch {
@@ -375,7 +375,7 @@ export async function streamWebChatTurn(
         sessionMessages: stampSenderUserIdsOnSessionMessages(
           fullHistory,
           persist.originalMessages as unknown[],
-          { authenticatedUserId: persist.authenticatedUserId }
+          { authenticatedUserId: persist.authenticatedUserId },
         ),
         startedAt: sessionStartedAt,
         lastActivityAt: Date.now(),
@@ -412,13 +412,13 @@ export async function streamWebChatTurn(
 
   if (!isMCPJam) {
     const providerKeyResult = deriveOrgProviderKeyResult(
-      prepare.modelDefinition
+      prepare.modelDefinition,
     );
     if (!providerKeyResult.ok) {
       throw new WebRouteError(
         400,
         ErrorCode.VALIDATION_ERROR,
-        providerKeyResult.error
+        providerKeyResult.error,
       );
     }
     const providerKey = providerKeyResult.key;
@@ -438,13 +438,13 @@ export async function streamWebChatTurn(
             chatboxId: persist.chatboxId,
             accessVersion: persist.accessVersion,
             serverIds: persist.selectedServerIds,
-          }
+          },
         )
       : { runtimeLocation: "cloud", providerKey };
 
     const onConversationComplete = buildOnConversationComplete(
       modelId,
-      orgRuntime.runtimeLocation === "local" ? "local_byok" : "byok"
+      orgRuntime.runtimeLocation === "local" ? "local_byok" : "byok",
     );
 
     warnIfChatAbortSignalMissing(runtime.abortSignal, "web/chat-v2");
@@ -510,7 +510,7 @@ export async function streamWebChatTurn(
   const mcpjamModelId = String(prepare.modelDefinition.id);
   const onConversationComplete = buildOnConversationComplete(
     mcpjamModelId,
-    "mcpjam"
+    "mcpjam",
   );
   warnIfChatAbortSignalMissing(runtime.abortSignal, "web/chat-v2");
 

--- a/mcpjam-inspector/server/utils/web-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/web-chat-turn.ts
@@ -47,7 +47,8 @@ import {
   resolveOrgProviderRuntime,
   type OrgProviderRuntime,
 } from "./org-model-config.js";
-import { isMCPJamProvidedModel, type ModelDefinition } from "@/shared/types";
+import { type ModelDefinition } from "@/shared/types";
+import { isHostedCatalogModel } from "../services/hosted-model-catalog.js";
 import {
   buildWidgetModelContextSystemPrompt,
   prepareChatV2,
@@ -218,7 +219,7 @@ function approvalFreeUiToolNamesFrom(
  * path and mapping the error to a `webError(...)` response.
  */
 export async function streamWebChatTurn(
-  args: StreamWebChatTurnArgs,
+  args: StreamWebChatTurnArgs
 ): Promise<Response> {
   const { manager, prepare, persist, runtime } = args;
   const { c } = runtime;
@@ -228,7 +229,7 @@ export async function streamWebChatTurn(
     throw new WebRouteError(
       500,
       ErrorCode.INTERNAL_ERROR,
-      "Server missing CONVEX_HTTP_URL configuration",
+      "Server missing CONVEX_HTTP_URL configuration"
     );
   }
 
@@ -243,7 +244,7 @@ export async function streamWebChatTurn(
       // trigger new linked resource reads. Fresh server-side tool execution
       // resolves resource_link results through trusted tool-origin metadata.
       abortSignal: c.req.raw.signal as AbortSignal | undefined,
-    },
+    }
   );
 
   let prepared;
@@ -286,7 +287,7 @@ export async function streamWebChatTurn(
   } = prepared;
 
   const widgetModelContextSystemPrompt = buildWidgetModelContextSystemPrompt(
-    prepare.widgetModelContext ?? [],
+    prepare.widgetModelContext ?? []
   );
   const effectiveEnhancedSystemPrompt = [
     enhancedSystemPrompt,
@@ -308,9 +309,9 @@ export async function streamWebChatTurn(
   // harness preflight (which does pass the provider) approved the turn.
   const isMCPJam =
     Boolean(prepare.modelDefinition.id) &&
-    isMCPJamProvidedModel(
+    isHostedCatalogModel(
       String(prepare.modelDefinition.id),
-      prepare.modelDefinition.provider,
+      prepare.modelDefinition.provider
     );
 
   // Resolve the host config now that `resolvedTemperature` is known.
@@ -318,21 +319,21 @@ export async function streamWebChatTurn(
   // callers preserve that by passing a closure here.
   const resolvedHostConfig: DirectHostConfig | null =
     typeof persist.hostConfig === "function"
-      ? (persist.hostConfig({ resolvedTemperature }) ?? null)
-      : (persist.hostConfig ?? null);
+      ? persist.hostConfig({ resolvedTemperature }) ?? null
+      : persist.hostConfig ?? null;
 
   // Build the persist callback once — it's a closure over a lot of context
   // and is identical between MCPJam-free and org-BYOK other than the modelId
   // + modelSource.
   const buildOnConversationComplete = (
     modelId: string,
-    modelSource: "mcpjam" | "byok" | "local_byok",
+    modelSource: "mcpjam" | "byok" | "local_byok"
   ) => {
     if (!hostedChatSessionId) return undefined;
     return async (
       fullHistory: ModelMessage[],
       turnTrace: PersistedTurnTrace,
-      harnessSessionCommit?: HarnessSessionCommitPayload,
+      harnessSessionCommit?: HarnessSessionCommitPayload
     ) => {
       const isDirectChat = !isChatboxSession;
       // Capture the live tool catalog. Failures must never block the persist.
@@ -350,7 +351,7 @@ export async function streamWebChatTurn(
               await exportConnectedServerToolSnapshotForEvalAuthoring(
                 manager,
                 knownIds,
-                { logPrefix: "chat-v2.persist" },
+                { logPrefix: "chat-v2.persist" }
               );
           }
         } catch {
@@ -374,7 +375,7 @@ export async function streamWebChatTurn(
         sessionMessages: stampSenderUserIdsOnSessionMessages(
           fullHistory,
           persist.originalMessages as unknown[],
-          { authenticatedUserId: persist.authenticatedUserId },
+          { authenticatedUserId: persist.authenticatedUserId }
         ),
         startedAt: sessionStartedAt,
         lastActivityAt: Date.now(),
@@ -411,13 +412,13 @@ export async function streamWebChatTurn(
 
   if (!isMCPJam) {
     const providerKeyResult = deriveOrgProviderKeyResult(
-      prepare.modelDefinition,
+      prepare.modelDefinition
     );
     if (!providerKeyResult.ok) {
       throw new WebRouteError(
         400,
         ErrorCode.VALIDATION_ERROR,
-        providerKeyResult.error,
+        providerKeyResult.error
       );
     }
     const providerKey = providerKeyResult.key;
@@ -437,13 +438,13 @@ export async function streamWebChatTurn(
             chatboxId: persist.chatboxId,
             accessVersion: persist.accessVersion,
             serverIds: persist.selectedServerIds,
-          },
+          }
         )
       : { runtimeLocation: "cloud", providerKey };
 
     const onConversationComplete = buildOnConversationComplete(
       modelId,
-      orgRuntime.runtimeLocation === "local" ? "local_byok" : "byok",
+      orgRuntime.runtimeLocation === "local" ? "local_byok" : "byok"
     );
 
     warnIfChatAbortSignalMissing(runtime.abortSignal, "web/chat-v2");
@@ -509,7 +510,7 @@ export async function streamWebChatTurn(
   const mcpjamModelId = String(prepare.modelDefinition.id);
   const onConversationComplete = buildOnConversationComplete(
     mcpjamModelId,
-    "mcpjam",
+    "mcpjam"
   );
   warnIfChatAbortSignalMissing(runtime.abortSignal, "web/chat-v2");
 

--- a/mcpjam-inspector/shared/__tests__/types.test.ts
+++ b/mcpjam-inspector/shared/__tests__/types.test.ts
@@ -79,6 +79,24 @@ describe("MCPJam-provided model classification", () => {
     expect(isMCPJamProvidedModel("grok-4-fast", "xai")).toBe(true);
   });
 
+  it("canonicalizes against an injected catalog (catalog-only ids)", () => {
+    const catalog = [
+      { id: "newvendor/brand-new-model", provider: "newvendor" },
+    ];
+    // A bare id resolves to the prefixed catalog id when the catalog is injected…
+    expect(
+      getCanonicalModelId("brand-new-model", "newvendor", catalog),
+    ).toBe("newvendor/brand-new-model");
+    // …and an exact catalog id passes through.
+    expect(
+      getCanonicalModelId("newvendor/brand-new-model", undefined, catalog),
+    ).toBe("newvendor/brand-new-model");
+    // Without the injected catalog, the unknown bare id can't be canonicalized.
+    expect(getCanonicalModelId("brand-new-model", "newvendor")).toBe(
+      "brand-new-model",
+    );
+  });
+
   it("resolves exact hosted IDs that are allowlisted in the backend", () => {
     expect(getModelById("google/gemini-3-pro-preview")).toBeUndefined();
     expect(getModelById("openai/gpt-4o-mini")?.provider).toBe("openai");

--- a/mcpjam-inspector/shared/analytics-events.ts
+++ b/mcpjam-inspector/shared/analytics-events.ts
@@ -135,6 +135,7 @@ export const ANALYTICS_EVENTS = {
   guest_refresh_success: { source: "client" },
   host_capabilities_dialog_opened: { source: "client" },
   host_catalog_degraded: { source: "client" },
+  hosted_model_catalog_degraded: { source: "client" },
   host_compat_tab_viewed: { source: "client" },
   host_context_dialog_opened: { source: "client" },
   host_theme_toggled: { source: "client" },

--- a/mcpjam-inspector/shared/types.ts
+++ b/mcpjam-inspector/shared/types.ts
@@ -113,7 +113,6 @@ export type ModelProvider =
 // Exported so the server-side hosted-model catalog can PRE-SEED its dynamic
 // cache from this static list — the union of (seed ∪ backend catalog) keeps
 // billing classification byte-identical when the catalog is empty/unreachable.
-// Canonical (slash-prefixed) ids; keep in sync with the backend allowlist.
 export const MCPJAM_PROVIDED_MODEL_IDS: string[] = [
   "mistralai/mistral-small-2603",
   "mistralai/mistral-medium-3-5",
@@ -549,7 +548,12 @@ export const SUPPORTED_MODELS: ModelDefinition[] = [
     "mistral",
     262144
   ),
-  freeModel("mistralai/devstral-2512", "Devstral 2 2512", "mistral", 262144),
+  freeModel(
+    "mistralai/devstral-2512",
+    "Devstral 2 2512",
+    "mistral",
+    262144
+  ),
   freeModel("openai/gpt-4o-mini", "GPT-4o Mini", "openai", 128000),
   {
     id: "openai/gpt-5-nano",

--- a/mcpjam-inspector/shared/types.ts
+++ b/mcpjam-inspector/shared/types.ts
@@ -110,7 +110,11 @@ export type ModelProvider =
   | "qwen"
   | "custom";
 
-const MCPJAM_PROVIDED_MODEL_IDS: string[] = [
+// Exported so the server-side hosted-model catalog can PRE-SEED its dynamic
+// cache from this static list — the union of (seed ∪ backend catalog) keeps
+// billing classification byte-identical when the catalog is empty/unreachable.
+// Canonical (slash-prefixed) ids; keep in sync with the backend allowlist.
+export const MCPJAM_PROVIDED_MODEL_IDS: string[] = [
   "mistralai/mistral-small-2603",
   "mistralai/mistral-medium-3-5",
   "mistralai/mistral-large-2512",
@@ -545,12 +549,7 @@ export const SUPPORTED_MODELS: ModelDefinition[] = [
     "mistral",
     262144
   ),
-  freeModel(
-    "mistralai/devstral-2512",
-    "Devstral 2 2512",
-    "mistral",
-    262144
-  ),
+  freeModel("mistralai/devstral-2512", "Devstral 2 2512", "mistral", 262144),
   freeModel("openai/gpt-4o-mini", "GPT-4o Mini", "openai", 128000),
   {
     id: "openai/gpt-5-nano",

--- a/mcpjam-inspector/shared/types.ts
+++ b/mcpjam-inspector/shared/types.ts
@@ -200,14 +200,31 @@ const MCPJAM_GUEST_ALLOWED_MODEL_IDS: string[] =
     (modelId) => !gatedGuestModelIds.has(modelId)
   );
 
+/** Minimal shape `getCanonicalModelId` matches against — `SUPPORTED_MODELS`
+ * satisfies it, and so does a `ModelDefinition[]` derived from the backend
+ * catalog. */
+export type CanonicalModelCandidate = { id: string | Model; provider: string };
+
 export const getCanonicalModelId = (
   modelId: string,
-  provider?: string
+  provider?: string,
+  /**
+   * Extra known models to canonicalize against (unioned with the static
+   * `SUPPORTED_MODELS`). The client injects the dynamic backend catalog ∪ BYOK
+   * list here so catalog-only ids canonicalize correctly; defaults to `[]`, so
+   * every server/shared caller keeps the exact prior static behavior.
+   */
+  extraModels: readonly CanonicalModelCandidate[] = []
 ): string => {
   const normalizedModelId = modelId.trim();
   if (!normalizedModelId) {
     return normalizedModelId;
   }
+
+  const knownModels: readonly CanonicalModelCandidate[] =
+    extraModels.length > 0
+      ? [...SUPPORTED_MODELS, ...extraModels]
+      : SUPPORTED_MODELS;
 
   const normalizedProvider = provider?.trim().toLowerCase();
 
@@ -215,7 +232,7 @@ export const getCanonicalModelId = (
   // bare ids (e.g. "gpt-4o-mini" — BYOK) don't shadow their hosted
   // counterparts (e.g. "openai/gpt-4o-mini" — MCPJam-provided).
   if (normalizedProvider) {
-    const providerModels = SUPPORTED_MODELS.filter(
+    const providerModels = knownModels.filter(
       (model) => model.provider.toLowerCase() === normalizedProvider
     );
 
@@ -236,7 +253,7 @@ export const getCanonicalModelId = (
     }
   }
 
-  const exactMatch = SUPPORTED_MODELS.find(
+  const exactMatch = knownModels.find(
     (model) => String(model.id) === normalizedModelId
   );
   if (exactMatch) {
@@ -277,12 +294,28 @@ export const isGPT5Model = (modelId: string | Model): boolean => {
 export interface ModelDefinition {
   id: Model | string;
   name: string;
-  provider: ModelProvider;
+  /**
+   * Known provider keys keep autocomplete; `string` is accepted so a brand-new
+   * backend-catalog provider (e.g. "alibaba", "nvidia") renders on its own with
+   * no code change — the whole point of sourcing the picker from the catalog.
+   */
+  provider: ModelProvider | (string & {});
   /** Set when provider === "custom" to identify which custom provider to use */
   customProviderName?: string;
   contextLength?: number;
   disabled?: boolean;
   disabledReason?: string;
+  /**
+   * True when the model comes from the MCPJam backend hosted catalog (billed to
+   * MCPJam credits). Drives `isMCPJamProvidedModelMenuItem` and the free/paid
+   * locks. Absent on BYOK/org/custom models.
+   */
+  hosted?: boolean;
+  /**
+   * Whether MCPJam serves this hosted model to signed-out guests. Sourced from
+   * the catalog DTO; absent → treated as guest-gated (locked for guests).
+   */
+  guestAllowed?: boolean;
 }
 
 export enum Model {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
The model picker now sources hosted models from the backend catalog so new providers/models show up without a release. It keeps the picker usable offline/for guests and updates guest/credit gating.

- **New Features**
  - Added `useHostedModelCatalog` to fetch `/api/mcp/models`, cache to `localStorage`, and fall back to cache/static when offline or guest; emits `hosted_model_catalog_degraded` on failures.
  - Wired the hosted catalog through `composeAvailableModels`, `buildAvailableModels`, and `buildAvailableModelsFromOrgConfig`; integrated into `useAvailableModels` and `useChatSession`.
  - Gating uses the catalog’s `guestAllowed`; missing flag defaults to guest-gated. Out-of-credits locks hosted models only; BYOK models stay enabled.
  - UI: show a first-letter monogram when no logo exists (covers custom and unknown catalog providers); title-case unknown provider names.
  - Types/tests: extended `ModelDefinition` with `hosted` and `guestAllowed` and widened `provider` to `string`; `ModelMenuItem` now accepts `hosted`; `getCanonicalModelId` accepts extra models for catalog-only IDs; added tests for catalog sourcing, provider display, and locks.

<sup>Written for commit 7a6f8505a9ddd7eab84bfcb9372ab5d229f48dfd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

