### PR TITLE
fix(server-card): Tools tab lists all tools, not just ones with metadata

### DIFF
--- a/mcpjam-inspector/client/src/components/connection/ServerInfoToolsMetadataContent.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerInfoToolsMetadataContent.tsx
@@ -9,26 +9,27 @@ interface ServerInfoToolsMetadataContentProps {
 export function ServerInfoToolsMetadataContent({
   toolsData,
 }: ServerInfoToolsMetadataContentProps) {
-  const hasToolMetadata = (toolsData?.tools ?? []).some(
-    (tool) => (tool as Tool)?._meta || toolsData?.toolsMetadata?.[tool.name],
-  );
+  const tools = toolsData?.tools ?? [];
 
-  if (!hasToolMetadata) {
+  // The tab is labelled "Tools", so always list the server's tools — most MCP
+  // servers ship tools without `_meta`, and gating the whole list on metadata
+  // made a normal server's tools tab read "No tools" (#125K4kNJ). Metadata and
+  // annotations are surfaced per-tool below only when they exist.
+  if (tools.length === 0) {
     return (
       <div className="text-sm text-muted-foreground text-center py-8">
-        No tool metadata available
+        No tools available
       </div>
     );
   }
 
   return (
     <div className="space-y-4">
-      {(toolsData?.tools ?? [])
+      {tools
         .map((tool: Tool) => {
           const metadata = tool._meta ?? toolsData?.toolsMetadata?.[tool.name];
           const annotations = tool.annotations;
 
-          if (!metadata) return null;
           return (
             <div
               key={tool.name}
@@ -96,8 +97,7 @@ export function ServerInfoToolsMetadataContent({
               )}
             </div>
           );
-        })
-        .filter(Boolean)}
+        })}
     </div>
   );
 }

--- a/mcpjam-inspector/client/src/components/connection/__tests__/ServerInfoToolsMetadataContent.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/ServerInfoToolsMetadataContent.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { Tool } from "@modelcontextprotocol/client";
+import { ServerInfoToolsMetadataContent } from "../ServerInfoToolsMetadataContent";
+import type { ListToolsResultWithMetadata } from "@/lib/apis/mcp-tools-api";
+
+function makeToolsData(
+  tools: Tool[],
+  toolsMetadata?: Record<string, Record<string, unknown>>,
+): ListToolsResultWithMetadata {
+  return { tools, ...(toolsMetadata ? { toolsMetadata } : {}) } as unknown as ListToolsResultWithMetadata;
+}
+
+describe("ServerInfoToolsMetadataContent", () => {
+  it("lists tools even when none carry metadata (#125K4kNJ)", () => {
+    // Regression: the "Tools" tab used to short-circuit to "No tool metadata
+    // available" whenever no tool had `_meta`, hiding the entire tool list for
+    // the common case of a server whose tools ship without metadata.
+    const toolsData = makeToolsData([
+      { name: "search", description: "Search the index" } as Tool,
+      { name: "fetch", description: "Fetch a document" } as Tool,
+    ]);
+
+    render(<ServerInfoToolsMetadataContent toolsData={toolsData} />);
+
+    expect(screen.getByText("search")).toBeInTheDocument();
+    expect(screen.getByText("Search the index")).toBeInTheDocument();
+    expect(screen.getByText("fetch")).toBeInTheDocument();
+    expect(
+      screen.queryByText(/no tool metadata available/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the READ/WRITE badge and metadata when a tool has it", () => {
+    const toolsData = makeToolsData(
+      [{ name: "delete_file", description: "Deletes a file" } as Tool],
+      { delete_file: { write: true, category: "fs" } },
+    );
+
+    render(<ServerInfoToolsMetadataContent toolsData={toolsData} />);
+
+    expect(screen.getByText("delete_file")).toBeInTheDocument();
+    expect(screen.getByText("WRITE")).toBeInTheDocument();
+    expect(screen.getByText("METADATA")).toBeInTheDocument();
+  });
+
+  it("shows an empty state only when there are genuinely no tools", () => {
+    render(<ServerInfoToolsMetadataContent toolsData={makeToolsData([])} />);
+
+    expect(screen.getByText(/no tools available/i)).toBeInTheDocument();
+  });
+
+  it("falls back to a placeholder description when a tool has none", () => {
+    const toolsData = makeToolsData([{ name: "ping" } as Tool]);
+
+    render(<ServerInfoToolsMetadataContent toolsData={toolsData} />);
+
+    expect(screen.getByText("ping")).toBeInTheDocument();
+    expect(screen.getByText("No description available")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Problem

The server detail modal's **Tools** tab rendered a metadata-only view that short-circuited to *"No tool metadata available"* whenever no tool carried a `_meta` field. Most MCP servers ship tools without `_meta`, so a normal server's Tools tab appeared empty (reported as "not seeing tools in server card").

## Fix

Always list the server's tools (name + description). The per-tool **READ/WRITE** badge, **METADATA**, and **ANNOTATIONS** sections now render only when that data is present. The empty state now means genuinely zero tools.




https://github.com/user-attachments/assets/e203fb40-e33b-4462-b6f1-e31d8625914a







## Testing

**Automated** — new unit test covers the empty-list render, the plain tool list, and the `_meta`/annotations badge cases:

```
cd client && npx vitest run src/components/connection/__tests__/ServerInfoToolsMetadataContent.test.tsx
# Test Files  1 passed (1) · Tests  4 passed (4)
```

**Manual** — connected a live MCP server exposing one plain tool (`echo`, no `_meta`) and one annotated tool (`regional-echo`):
- Before: Tools tab showed "No tool metadata available".
- After: both tools list with names + descriptions; the annotated tool additionally shows its metadata/annotations.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the server card Tools tab to show all tools, not just ones with metadata (Linear 125K4kNJ).

- **Bug Fixes**
  - Always render the tool list (name + description); show "No tools available" only when there are zero tools.
  - Display READ/WRITE badge, METADATA, and ANNOTATIONS per tool only when that data exists.
  - Added unit tests covering empty list, plain tools, and metadata/annotations cases.

<sup>Written for commit 5531f7a75cb1342f61b8a0de9c11355bce45a45a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

