### PR TITLE
refactor(xaa): single-source auth-method selector + capability evidence + spec step vocab

### DIFF
--- a/.changeset/xaa-shared-selector-and-step-vocab.md
+++ b/.changeset/xaa-shared-selector-and-step-vocab.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/sdk": minor
+---
+
+XAA convergence finishing pass (mechanical): collapse the last duplicated flow logic across the engine/CLI boundary and single-source the CLI result projection. The token-endpoint auth-method selector — previously copied byte-for-byte as `selectPreRegisteredTokenAuthMethod` in the engine and `selectTokenEndpointAuthMethod` in `runXaaFlow` — is now one exported `selectTokenEndpointAuthMethod` in `xaa/state-machines/capability-preflight.ts` (re-exported from `@mcpjam/sdk/browser`). A new `deriveCapabilityEvidence` there is the single source for the flat `{idJagProfile, jwtBearerGrant}` advertisement evidence used by `runXaaFlow`'s `authorizationServerCapabilities` projection. `runXaaFlow` also now surfaces its `steps[]` in ID-JAG spec vocabulary (`mint_id_jag`, `redeem_id_jag`) instead of the engine's internal HTTP-step names; the engine's own `XAAFlowStep` names are unchanged. No behavior change to the flow, discovery, redemption, or the public `XaaFlowResult` shape; the 23 golden contract tests pass unchanged and a new test locks the step vocabulary.

--- a/sdk/src/xaa/run-xaa-flow.ts
+++ b/sdk/src/xaa/run-xaa-flow.ts
@@ -6,10 +6,6 @@ import {
   fetchOAuthMetadata,
 } from "../oauth-proxy.js";
 import {
-  ID_JAG_GRANT_PROFILE,
-  JWT_BEARER_GRANT,
-} from "../oauth/client-identity.js";
-import {
   getXAAIdpJwks,
   getXAAIssuerUrl,
   initXAAIdpKeyPair,
@@ -32,6 +28,10 @@ import {
 import { createInProcessXaaExecutor } from "./in-process-executor.js";
 import { createXAAStateMachine } from "./state-machines/state-machine.js";
 import { runXaaStateMachine } from "./state-machines/runner.js";
+import {
+  deriveCapabilityEvidence,
+  selectTokenEndpointAuthMethod,
+} from "./state-machines/capability-preflight.js";
 import {
   createInitialXAAFlowState,
   type XAAFlowState,
@@ -113,34 +113,9 @@ export interface XaaFlowResult {
 
 type PublishedJwk = JsonWebKey & { kid?: string };
 
-function listEvidence(value: unknown, expected: string): XaaCapabilityEvidence {
-  if (value === undefined || value === null) return "unknown";
-  return Array.isArray(value) && value.includes(expected)
-    ? "advertised"
-    : "not_advertised";
-}
-
 function stringList(value: unknown): string[] | undefined {
   if (!Array.isArray(value)) return undefined;
   return value.filter((entry): entry is string => typeof entry === "string");
-}
-
-function selectTokenEndpointAuthMethod(
-  explicit: XaaTokenEndpointAuthMethod | undefined,
-  clientSecret: string | undefined,
-  advertised: string[] | undefined
-): XaaTokenEndpointAuthMethod {
-  if (explicit) return explicit;
-  if (!clientSecret) return "none";
-  if (advertised?.includes("client_secret_basic")) {
-    return "client_secret_basic";
-  }
-  if (advertised?.includes("client_secret_post")) {
-    return "client_secret_post";
-  }
-  if (advertised?.includes("none")) return "none";
-  // Metadata is optional; preserve the previous behavior when it is absent.
-  return "client_secret_post";
 }
 
 function publicJwkMatches(local: JsonWebKey, published: JsonWebKey): boolean {
@@ -320,14 +295,7 @@ function projectCapabilities(
     );
 
   return {
-    idJagProfile: listEvidence(
-      state.authzMetadata?.authorization_grant_profiles_supported,
-      ID_JAG_GRANT_PROFILE
-    ),
-    jwtBearerGrant: listEvidence(
-      state.authzMetadata?.grant_types_supported,
-      JWT_BEARER_GRANT
-    ),
+    ...deriveCapabilityEvidence(state.authzMetadata),
     ...(advertisedAuthMethods
       ? { tokenEndpointAuthMethods: advertisedAuthMethods }
       : {}),
@@ -335,12 +303,21 @@ function projectCapabilities(
   };
 }
 
+// The engine names HTTP steps by protocol operation; the CLI surfaces them in
+// ID-JAG spec vocabulary. Projection-only — the engine's XAAFlowStep names are
+// unchanged. Steps absent from this map pass through as-is, so the discovery
+// steps keep their RFC 9728 / RFC 8414 names.
+const CLI_STEP_VOCABULARY: Record<string, string> = {
+  token_exchange_request: "mint_id_jag",
+  jwt_bearer_request: "redeem_id_jag",
+};
+
 function projectSteps(
   state: XAAFlowState,
   prefix = ""
 ): XaaFlowStep[] {
   return (state.httpHistory ?? []).map((entry) => ({
-    step: prefix + entry.step,
+    step: prefix + (CLI_STEP_VOCABULARY[entry.step] ?? entry.step),
     ok:
       !entry.error &&
       !!entry.response &&

--- a/sdk/src/xaa/run-xaa-flow.ts
+++ b/sdk/src/xaa/run-xaa-flow.ts
@@ -1,10 +1,7 @@
 // Headless Cross-App Access (ID-JAG) flow driver. It self-issues an ID-JAG,
 // verifies that the configured issuer actually publishes the signing key,
 // redeems the assertion, and probes the protected MCP resource.
-import {
-  executeOAuthProxy,
-  fetchOAuthMetadata,
-} from "../oauth-proxy.js";
+import { executeOAuthProxy, fetchOAuthMetadata } from "../oauth-proxy.js";
 import {
   getXAAIdpJwks,
   getXAAIssuerUrl,
@@ -168,7 +165,7 @@ async function verifyIssuerPublication(
     response.body &&
     typeof response.body === "object" &&
     Array.isArray((response.body as { keys?: unknown }).keys)
-      ? (response.body as { keys: PublishedJwk[] }).keys ?? []
+      ? ((response.body as { keys: PublishedJwk[] }).keys ?? [])
       : [];
   const keys = rawKeys.filter(
     (key): key is PublishedJwk => Boolean(key) && typeof key === "object"
@@ -240,10 +237,7 @@ function projectMcpResult(state: XAAFlowState): XaaFlowResult["mcp"] {
   const error = evaluateMcpInitializeResponse(entry.response.body);
   return {
     status: entry.response.status,
-    ok:
-      entry.response.status >= 200 &&
-      entry.response.status < 300 &&
-      !error,
+    ok: entry.response.status >= 200 && entry.response.status < 300 && !error,
     ...(error ? { error } : {}),
     xaaExtension: mcpInitializeExtensionEvidence(entry.response.body),
   };
@@ -312,10 +306,7 @@ const CLI_STEP_VOCABULARY: Record<string, string> = {
   jwt_bearer_request: "redeem_id_jag",
 };
 
-function projectSteps(
-  state: XAAFlowState,
-  prefix = ""
-): XaaFlowStep[] {
+function projectSteps(state: XAAFlowState, prefix = ""): XaaFlowStep[] {
   return (state.httpHistory ?? []).map((entry) => ({
     step: prefix + (CLI_STEP_VOCABULARY[entry.step] ?? entry.step),
     ok:
@@ -323,7 +314,8 @@ function projectSteps(
       !!entry.response &&
       entry.response.status >= 200 &&
       entry.response.status < 300,
-    detail: entry.error?.message ??
+    detail:
+      entry.error?.message ??
       (entry.response ? "status " + entry.response.status : undefined),
   }));
 }
@@ -381,16 +373,16 @@ async function runSharedAttempt(
       step === "discover_resource_metadata"
         ? "Discovering protected-resource metadata (RFC 9728)…"
         : step === "discover_authz_metadata"
-        ? "Discovering authorization-server metadata (RFC 8414)…"
-        : step === "token_exchange_request"
-        ? "Minting the ID-JAG…"
-        : step === "jwt_bearer_request"
-        ? mode === "valid"
-          ? "Redeeming the ID-JAG at the authorization server…"
-          : "Redeeming the deliberately invalid ID-JAG…"
-        : step === "authenticated_mcp_request"
-        ? "Calling the MCP server with the access token…"
-        : undefined;
+          ? "Discovering authorization-server metadata (RFC 8414)…"
+          : step === "token_exchange_request"
+            ? "Minting the ID-JAG…"
+            : step === "jwt_bearer_request"
+              ? mode === "valid"
+                ? "Redeeming the ID-JAG at the authorization server…"
+                : "Redeeming the deliberately invalid ID-JAG…"
+              : step === "authenticated_mcp_request"
+                ? "Calling the MCP server with the access token…"
+                : undefined;
     if (message) progress?.(message);
   };
   const machine = createXAAStateMachine({
@@ -586,12 +578,12 @@ export async function runXaaFlow(
               "The authorization server accepted the deliberately invalid ID-JAG.",
           }
         : outcome === "inconclusive"
-        ? {
-            error:
-              projectFlowError(probeState) ??
-              "The negative probe did not produce a conclusive 4xx rejection.",
-          }
-        : {}),
+          ? {
+              error:
+                projectFlowError(probeState) ??
+                "The negative probe did not produce a conclusive 4xx rejection.",
+            }
+          : {}),
     };
   } catch (error) {
     return {

--- a/sdk/src/xaa/state-machines/capability-preflight.ts
+++ b/sdk/src/xaa/state-machines/capability-preflight.ts
@@ -107,12 +107,12 @@ const VENDOR_NOTES: Partial<Record<XAAVendor, XAAVendorHint>> = {
 };
 
 export function analyzeAsCompatibility(
-  authzMetadata: XAAFlowState["authzMetadata"],
+  authzMetadata: XAAFlowState["authzMetadata"]
 ): XAACompatibilityReport | null {
   if (!authzMetadata) return null;
 
   const grantTypesAdvertised = Array.isArray(
-    authzMetadata.grant_types_supported,
+    authzMetadata.grant_types_supported
   );
   const grantTypes = grantTypesAdvertised
     ? (authzMetadata.grant_types_supported as string[])
@@ -257,7 +257,7 @@ export function analyzeAsCompatibility(
  * array is `advertised`/`not_advertised` by membership. */
 function capabilityEvidence(
   value: unknown,
-  expected: string,
+  expected: string
 ): XaaCapabilityEvidence {
   if (value === undefined || value === null) return "unknown";
   return Array.isArray(value) && value.includes(expected)
@@ -269,16 +269,19 @@ function capabilityEvidence(
  * authorization-server metadata. Single source shared by the engine and the
  * CLI's result projection so the two never drift. */
 export function deriveCapabilityEvidence(
-  authzMetadata: XAAFlowState["authzMetadata"],
-): { idJagProfile: XaaCapabilityEvidence; jwtBearerGrant: XaaCapabilityEvidence } {
+  authzMetadata: XAAFlowState["authzMetadata"]
+): {
+  idJagProfile: XaaCapabilityEvidence;
+  jwtBearerGrant: XaaCapabilityEvidence;
+} {
   return {
     idJagProfile: capabilityEvidence(
       authzMetadata?.authorization_grant_profiles_supported,
-      ID_JAG_GRANT_PROFILE,
+      ID_JAG_GRANT_PROFILE
     ),
     jwtBearerGrant: capabilityEvidence(
       authzMetadata?.grant_types_supported,
-      JWT_BEARER_GRANT,
+      JWT_BEARER_GRANT
     ),
   };
 }
@@ -292,7 +295,7 @@ export function deriveCapabilityEvidence(
 export function selectTokenEndpointAuthMethod(
   explicit: XaaTokenEndpointAuthMethod | undefined,
   clientSecret: string | undefined,
-  advertised: unknown,
+  advertised: unknown
 ): XaaTokenEndpointAuthMethod {
   if (explicit) return explicit;
   if (!clientSecret) return "none";

--- a/sdk/src/xaa/state-machines/capability-preflight.ts
+++ b/sdk/src/xaa/state-machines/capability-preflight.ts
@@ -2,7 +2,8 @@ import {
   ID_JAG_GRANT_PROFILE,
   JWT_BEARER_GRANT,
 } from "../../oauth/client-identity.js";
-import type { XAAFlowState } from "./types.js";
+import type { XAAFlowState, XaaTokenEndpointAuthMethod } from "./types.js";
+import type { XaaCapabilityEvidence } from "../mcp-init.js";
 
 // Re-exported for existing consumers; the URN itself now has a single source
 // of truth in the SDK.
@@ -249,4 +250,60 @@ export function analyzeAsCompatibility(
     vendor,
     vendorHint,
   };
+}
+
+/** Tri-state advertisement evidence for a single capability URN in AS
+ * metadata: an absent array is `unknown` (the server didn't say), a present
+ * array is `advertised`/`not_advertised` by membership. */
+function capabilityEvidence(
+  value: unknown,
+  expected: string,
+): XaaCapabilityEvidence {
+  if (value === undefined || value === null) return "unknown";
+  return Array.isArray(value) && value.includes(expected)
+    ? "advertised"
+    : "not_advertised";
+}
+
+/** Flat ID-JAG-profile / jwt-bearer-grant advertisement evidence derived from
+ * authorization-server metadata. Single source shared by the engine and the
+ * CLI's result projection so the two never drift. */
+export function deriveCapabilityEvidence(
+  authzMetadata: XAAFlowState["authzMetadata"],
+): { idJagProfile: XaaCapabilityEvidence; jwtBearerGrant: XaaCapabilityEvidence } {
+  return {
+    idJagProfile: capabilityEvidence(
+      authzMetadata?.authorization_grant_profiles_supported,
+      ID_JAG_GRANT_PROFILE,
+    ),
+    jwtBearerGrant: capabilityEvidence(
+      authzMetadata?.grant_types_supported,
+      JWT_BEARER_GRANT,
+    ),
+  };
+}
+
+/** Select the token-endpoint client-auth method for the jwt-bearer redemption.
+ * Precedence: an explicit choice wins; with no client secret the client is
+ * public (`none`); otherwise prefer the advertised method
+ * (basic → post → none); when metadata is absent, default to
+ * `client_secret_post`. Single source shared by the engine (pre-registered
+ * discovery) and the CLI result projection. */
+export function selectTokenEndpointAuthMethod(
+  explicit: XaaTokenEndpointAuthMethod | undefined,
+  clientSecret: string | undefined,
+  advertised: unknown,
+): XaaTokenEndpointAuthMethod {
+  if (explicit) return explicit;
+  if (!clientSecret) return "none";
+  if (Array.isArray(advertised)) {
+    if (advertised.includes("client_secret_basic")) {
+      return "client_secret_basic";
+    }
+    if (advertised.includes("client_secret_post")) {
+      return "client_secret_post";
+    }
+    if (advertised.includes("none")) return "none";
+  }
+  return "client_secret_post";
 }

--- a/sdk/src/xaa/state-machines/index.ts
+++ b/sdk/src/xaa/state-machines/index.ts
@@ -33,7 +33,12 @@ export type {
   XAACompatibilityVerdict,
   XAACompatibilityReport,
 } from "./capability-preflight.js";
-export { detectVendor, analyzeAsCompatibility } from "./capability-preflight.js";
+export {
+  detectVendor,
+  analyzeAsCompatibility,
+  deriveCapabilityEvidence,
+  selectTokenEndpointAuthMethod,
+} from "./capability-preflight.js";
 export {
   createXAAStateMachine,
   CLIENT_SECRET_MASK,

--- a/sdk/src/xaa/state-machines/index.ts
+++ b/sdk/src/xaa/state-machines/index.ts
@@ -20,10 +20,7 @@ export type {
   BaseXAAStateMachineConfig,
   XAAStateMachine,
 } from "./types.js";
-export {
-  EMPTY_XAA_FLOW_STATE,
-  createInitialXAAFlowState,
-} from "./types.js";
+export { EMPTY_XAA_FLOW_STATE, createInitialXAAFlowState } from "./types.js";
 export type {
   XAAVendor,
   XAAVendorVerdict,
@@ -39,10 +36,7 @@ export {
   deriveCapabilityEvidence,
   selectTokenEndpointAuthMethod,
 } from "./capability-preflight.js";
-export {
-  createXAAStateMachine,
-  CLIENT_SECRET_MASK,
-} from "./state-machine.js";
+export { createXAAStateMachine, CLIENT_SECRET_MASK } from "./state-machine.js";
 export { runXaaStateMachine } from "./runner.js";
 export type {
   RunXaaStateMachineOptions,

--- a/sdk/src/xaa/state-machines/state-machine.ts
+++ b/sdk/src/xaa/state-machines/state-machine.ts
@@ -29,7 +29,10 @@ import type {
   XAAStateMachine,
 } from "./types.js";
 import { createInitialXAAFlowState } from "./types.js";
-import { analyzeAsCompatibility } from "./capability-preflight.js";
+import {
+  analyzeAsCompatibility,
+  selectTokenEndpointAuthMethod,
+} from "./capability-preflight.js";
 import {
   buildMcpInitializeRequest,
   evaluateMcpInitializeResponse,
@@ -223,25 +226,6 @@ function mergeHeadersForAuthServer(
   }
 
   return merged;
-}
-
-function selectPreRegisteredTokenAuthMethod(
-  explicit: XaaTokenEndpointAuthMethod | undefined,
-  clientSecret: string | undefined,
-  advertised: unknown
-): XaaTokenEndpointAuthMethod {
-  if (explicit) return explicit;
-  if (!clientSecret) return "none";
-  if (Array.isArray(advertised)) {
-    if (advertised.includes("client_secret_basic")) {
-      return "client_secret_basic";
-    }
-    if (advertised.includes("client_secret_post")) {
-      return "client_secret_post";
-    }
-    if (advertised.includes("none")) return "none";
-  }
-  return "client_secret_post";
 }
 
 function extractErrorMessage(body: any, fallback: string): string {
@@ -812,7 +796,7 @@ export function createXAAStateMachine(
             tokenEndpoint: metadata.token_endpoint,
             ...(registrationStrategy === "preregistered"
               ? {
-                  tokenEndpointAuthMethod: selectPreRegisteredTokenAuthMethod(
+                  tokenEndpointAuthMethod: selectTokenEndpointAuthMethod(
                     state.tokenEndpointAuthMethod,
                     state.clientSecret,
                     metadata.token_endpoint_auth_methods_supported

--- a/sdk/src/xaa/state-machines/state-machine.ts
+++ b/sdk/src/xaa/state-machines/state-machine.ts
@@ -68,7 +68,7 @@ function diagnosticKey(key: string): string {
 
 function redactDiagnosticValue(
   value: unknown,
-  knownSecrets: ReadonlyArray<string> = [],
+  knownSecrets: ReadonlyArray<string> = []
 ): any {
   const redactString = (input: string): string => {
     let redacted = input;
@@ -102,7 +102,7 @@ function redactDiagnosticValue(
       Object.entries(current).map(([childKey, childValue]) => [
         childKey,
         visit(childValue, childKey),
-      ]),
+      ])
     );
   };
 
@@ -111,7 +111,7 @@ function redactDiagnosticValue(
 
 function sanitizeDiagnosticUpdates(
   state: Partial<XAAFlowState>,
-  updates: Partial<XAAFlowState>,
+  updates: Partial<XAAFlowState>
 ): Partial<XAAFlowState> {
   const knownSecrets = [
     state.clientSecret,
@@ -135,7 +135,7 @@ function sanitizeDiagnosticUpdates(
     if (key in sanitized) {
       (sanitized as Record<string, unknown>)[key] = redactDiagnosticValue(
         sanitized[key],
-        knownSecrets,
+        knownSecrets
       );
     }
   }
@@ -469,7 +469,7 @@ export function createXAAStateMachine(
     updateState: (updates) => {
       const sanitizedUpdates = sanitizeDiagnosticUpdates(
         machine.state,
-        updates,
+        updates
       );
       machine.state = { ...machine.state, ...sanitizedUpdates };
       updateState(sanitizedUpdates);
@@ -633,9 +633,7 @@ export function createXAAStateMachine(
           typeof resourceMetadata.resource === "string"
             ? resourceMetadata.resource
             : undefined;
-        if (
-          !metadataResource || metadataResource !== requestedResource
-        ) {
+        if (!metadataResource || metadataResource !== requestedResource) {
           lastError = `Protected-resource metadata at ${resourceMetadataUrl} does not identify ${requestedResource}.`;
           continue;
         }
@@ -769,10 +767,10 @@ export function createXAAStateMachine(
             );
           }
 
-        // RFC 8414 §3.3: the metadata's `issuer` MUST match the one we asked
-        // for. A mismatched (or absent) issuer means its token endpoint can't
-        // be trusted with the signed assertion + any client secret — continue
-        // to the next candidate rather than adopting a foreign issuer.
+          // RFC 8414 §3.3: the metadata's `issuer` MUST match the one we asked
+          // for. A mismatched (or absent) issuer means its token endpoint can't
+          // be trusted with the signed assertion + any client secret — continue
+          // to the next candidate rather than adopting a foreign issuer.
           if (
             typeof metadata.issuer !== "string" ||
             metadata.issuer !== candidateIssuer
@@ -1252,15 +1250,12 @@ export function createXAAStateMachine(
 
     let result: XAARequestResult;
     try {
-      result = await runRequest(
-        "fetch_client_metadata_document",
-        request,
-        () =>
-          requestExecutor.externalRequest(documentUrl, {
-            method: "GET",
-            headers: request.headers,
-            redirect: "manual",
-          })
+      result = await runRequest("fetch_client_metadata_document", request, () =>
+        requestExecutor.externalRequest(documentUrl, {
+          method: "GET",
+          headers: request.headers,
+          redirect: "manual",
+        })
       );
     } catch {
       // runRequest already recorded the failure and set the error; the step
@@ -1577,14 +1572,11 @@ export function createXAAStateMachine(
     let manualAuthMethod = state.tokenEndpointAuthMethod;
     if (!registrationId && !serverId) {
       if (registrationStrategy === "dcr") {
-        const registrationEndpoint =
-          state.authzMetadata?.registration_endpoint;
+        const registrationEndpoint = state.authzMetadata?.registration_endpoint;
         const cacheKey = registrationEndpoint
           ? dcrCacheKeyFor(registrationEndpoint)
           : undefined;
-        const cached = cacheKey
-          ? dcrCredentialCache?.get(cacheKey)
-          : undefined;
+        const cached = cacheKey ? dcrCredentialCache?.get(cacheKey) : undefined;
         if (!cached || cached.clientId !== state.clientId) {
           machine.updateState({
             currentStep: "jwt_bearer_request",
@@ -1635,24 +1627,24 @@ export function createXAAStateMachine(
           resource: state.resourceUrl || state.serverUrl,
         }
       : serverId
-      ? {
-          serverId,
-          ...(projectId ? { projectId } : {}),
-          assertion: state.idJag,
-          scope: state.scope,
-          resource: state.resourceUrl || state.serverUrl,
-        }
-      : {
-          tokenEndpoint: state.tokenEndpoint,
-          assertion: state.idJag,
-          clientId: state.clientId,
-          ...(manualClientSecret ? { clientSecret: manualClientSecret } : {}),
-          ...(manualAuthMethod
-            ? { tokenEndpointAuthMethod: manualAuthMethod }
-            : {}),
-          scope: state.scope,
-          resource: state.resourceUrl || state.serverUrl,
-        };
+        ? {
+            serverId,
+            ...(projectId ? { projectId } : {}),
+            assertion: state.idJag,
+            scope: state.scope,
+            resource: state.resourceUrl || state.serverUrl,
+          }
+        : {
+            tokenEndpoint: state.tokenEndpoint,
+            assertion: state.idJag,
+            clientId: state.clientId,
+            ...(manualClientSecret ? { clientSecret: manualClientSecret } : {}),
+            ...(manualAuthMethod
+              ? { tokenEndpointAuthMethod: manualAuthMethod }
+              : {}),
+            scope: state.scope,
+            resource: state.resourceUrl || state.serverUrl,
+          };
 
     // The request object lands verbatim in the HTTP history panel (and any
     // export of it), so the logged copy masks the secret. Only

--- a/sdk/tests/xaa/run-xaa-flow.test.ts
+++ b/sdk/tests/xaa/run-xaa-flow.test.ts
@@ -887,4 +887,61 @@ describe("runXaaFlow", () => {
       )
     ).toBe(false);
   });
+
+  it("reports steps in ID-JAG spec vocabulary for a valid flow", async () => {
+    global.fetch = stubFetch({
+      token: {
+        status: 200,
+        body: { access_token: "at-123", token_type: "Bearer", expires_in: 300 },
+      },
+    }) as unknown as typeof fetch;
+
+    const result = await runXaaFlow({
+      serverUrl: SERVER_URL,
+      authzServerIssuer: AS_ISSUER,
+      tokenEndpoint: TOKEN_ENDPOINT,
+      issuerBaseUrl: ISSUER_BASE,
+      subject: "user-1",
+      clientId: "client-1",
+    });
+
+    const stepNames = result.steps.map((s) => s.step);
+    expect(stepNames).toContain("verify_issuer_publication");
+    expect(stepNames).toContain("mint_id_jag");
+    expect(stepNames).toContain("redeem_id_jag");
+    expect(stepNames).toContain("authenticated_mcp_request");
+    // The engine's internal HTTP-step names must not leak into CLI output.
+    expect(stepNames).not.toContain("token_exchange_request");
+    expect(stepNames).not.toContain("jwt_bearer_request");
+  });
+
+  it("prefixes and renames baseline/probe steps in a negative flow", async () => {
+    global.fetch = stubFetch({
+      tokenResponses: [
+        {
+          status: 200,
+          body: { access_token: "baseline-token", token_type: "Bearer" },
+        },
+        { status: 401, body: { error: "invalid_grant" } },
+      ],
+    }) as unknown as typeof fetch;
+
+    const result = await runXaaFlow({
+      serverUrl: SERVER_URL,
+      authzServerIssuer: AS_ISSUER,
+      tokenEndpoint: TOKEN_ENDPOINT,
+      issuerBaseUrl: ISSUER_BASE,
+      subject: "user-1",
+      clientId: "client-1",
+      negativeTestMode: "bad_signature",
+    });
+
+    const stepNames = result.steps.map((s) => s.step);
+    expect(stepNames).toContain("baseline:mint_id_jag");
+    expect(stepNames).toContain("baseline:redeem_id_jag");
+    expect(stepNames).toContain("probe:mint_id_jag");
+    expect(stepNames).toContain("probe:redeem_id_jag");
+    expect(stepNames).not.toContain("baseline:token_exchange_request");
+    expect(stepNames).not.toContain("probe:jwt_bearer_request");
+  });
 });

--- a/sdk/tests/xaa/run-xaa-flow.test.ts
+++ b/sdk/tests/xaa/run-xaa-flow.test.ts
@@ -303,8 +303,7 @@ describe("runXaaFlow", () => {
 
     expect(result.completed).toBe(true);
     expect(
-      mcpHeaders["MCP-Protocol-Version"] ??
-        mcpHeaders["mcp-protocol-version"]
+      mcpHeaders["MCP-Protocol-Version"] ?? mcpHeaders["mcp-protocol-version"]
     ).toBe("2025-11-25");
     expect(mcpRequest).toMatchObject({
       params: {
@@ -369,7 +368,11 @@ describe("runXaaFlow", () => {
           return json({ access_token: "at-1", token_type: "Bearer" });
         }
         if (url === serverWithSlash && method === "POST") {
-          return json({ jsonrpc: "2.0", id: "mcpjam-xaa-cli", result: { protocolVersion: "2025-11-25" } });
+          return json({
+            jsonrpc: "2.0",
+            id: "mcpjam-xaa-cli",
+            result: { protocolVersion: "2025-11-25" },
+          });
         }
         return json({}, 404);
       }
@@ -412,7 +415,11 @@ describe("runXaaFlow", () => {
           return json({ access_token: "at-1", token_type: "Bearer" });
         }
         if (url === SERVER_URL && method === "POST") {
-          return json({ jsonrpc: "2.0", id: "mcpjam-xaa-cli", result: { protocolVersion: "2025-11-25" } });
+          return json({
+            jsonrpc: "2.0",
+            id: "mcpjam-xaa-cli",
+            result: { protocolVersion: "2025-11-25" },
+          });
         }
         return json({}, 404);
       }
@@ -479,7 +486,11 @@ describe("runXaaFlow", () => {
           return json({ access_token: "at-1", token_type: "Bearer" });
         }
         if (url === SERVER_URL && method === "POST") {
-          return json({ jsonrpc: "2.0", id: "mcpjam-xaa-cli", result: { protocolVersion: "2025-11-25" } });
+          return json({
+            jsonrpc: "2.0",
+            id: "mcpjam-xaa-cli",
+            result: { protocolVersion: "2025-11-25" },
+          });
         }
         return json({}, 404);
       }
@@ -528,7 +539,11 @@ describe("runXaaFlow", () => {
           return json({ access_token: "at-1", token_type: "Bearer" });
         }
         if (url === serverWithSlash && method === "POST") {
-          return json({ jsonrpc: "2.0", id: "mcpjam-xaa-cli", result: { protocolVersion: "2025-11-25" } });
+          return json({
+            jsonrpc: "2.0",
+            id: "mcpjam-xaa-cli",
+            result: { protocolVersion: "2025-11-25" },
+          });
         }
         return json({}, 404);
       }
@@ -613,7 +628,11 @@ describe("runXaaFlow", () => {
           return json({ access_token: "at-1", token_type: "Bearer" });
         }
         if (url === serverWithQuery && method === "POST") {
-          return json({ jsonrpc: "2.0", id: "mcpjam-xaa-cli", result: { protocolVersion: "2025-11-25" } });
+          return json({
+            jsonrpc: "2.0",
+            id: "mcpjam-xaa-cli",
+            result: { protocolVersion: "2025-11-25" },
+          });
         }
         return json({}, 404);
       }
@@ -770,7 +789,11 @@ describe("runXaaFlow", () => {
         return json({ access_token: "at-basic", token_type: "Bearer" });
       }
       if (url === SERVER_URL && method === "POST") {
-        return json({ jsonrpc: "2.0", id: "mcpjam-xaa-cli", result: { protocolVersion: "2025-11-25" } });
+        return json({
+          jsonrpc: "2.0",
+          id: "mcpjam-xaa-cli",
+          result: { protocolVersion: "2025-11-25" },
+        });
       }
       return json({}, 404);
     }) as unknown as typeof fetch;


### PR DESCRIPTION
## What

Mechanical finishing pass for the XAA convergence initiative — removes the **last literal duplication of flow logic** across the engine/CLI boundary and single-sources the CLI result projection. **No flow behavior change.**

The CLI's `runXaaFlow` already drives the shared engine end-to-end (landed in #3163/#3164); what remained was duplicated helpers on either side of the boundary. This PR collapses them:

- **Auth-method selector** — was copied byte-for-byte as `selectPreRegisteredTokenAuthMethod` (engine) and `selectTokenEndpointAuthMethod` (`runXaaFlow`). Now one exported `selectTokenEndpointAuthMethod` in `xaa/state-machines/capability-preflight.ts` (browser-safe), re-exported from `@mcpjam/sdk/browser`.
- **Capability evidence** — new `deriveCapabilityEvidence` is the single source for the flat `{idJagProfile, jwtBearerGrant}` advertisement evidence used by `runXaaFlow`'s `authorizationServerCapabilities` projection (previously a private `listEvidence` copy).
- **Step vocabulary** — `runXaaFlow` now surfaces `steps[]` in ID-JAG spec vocabulary (`mint_id_jag`, `redeem_id_jag`); the engine's internal `XAAFlowStep` names are unchanged (projection-only).

## Not in scope

The Node composition root stays in Node by design (issuer-publication verify, crypto ID-JAG verify, the two-run negative-baseline orchestration, `XaaFlowResult` projection). Capability-ranked RAS selection is the follow-up behavioral PR.

## Verification

- SDK: full suite green (1901 passed); `sdk/tests/xaa` incl. the **23 golden contract tests unchanged** + **2 new tests** locking the step vocabulary (valid + `baseline:`/`probe:` negative flows); browser-purity guard green; `npm run build -w @mcpjam/sdk` clean.
- Inspector (same engine): client XAA 114 passed, server XAA route 47 passed.
- `tsc` clean; public `XaaFlowConfig`/`XaaFlowResult` shape untouched.
- Formatting reflow isolated to its own commit (these files already failed `prettier --check` on main).

Changeset included (`@mcpjam/sdk` minor — new browser exports).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only deduplication and CLI step projection; OAuth redemption and discovery paths are unchanged and covered by existing contract tests plus new step-vocabulary tests.
> 
> **Overview**
> Mechanical XAA convergence pass: **deduplicates** the last copy-pasted helpers between the shared state machine and `runXaaFlow` without changing flow behavior or the public `XaaFlowResult` shape.
> 
> **`selectTokenEndpointAuthMethod`** and **`deriveCapabilityEvidence`** now live in `capability-preflight.ts` (re-exported from `@mcpjam/sdk/browser`). The engine drops `selectPreRegisteredTokenAuthMethod`; the CLI drops its local selector and `listEvidence` in favor of those shared helpers.
> 
> **CLI-only step labels:** `runXaaFlow` maps internal HTTP history steps `token_exchange_request` → `mint_id_jag` and `jwt_bearer_request` → `redeem_id_jag` (including `baseline:` / `probe:` prefixes in negative runs). Engine step names are unchanged.
> 
> Two tests lock the new step vocabulary; existing golden contract tests are unchanged. Changeset: `@mcpjam/sdk` minor for the new browser exports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0ffae56b67e8247d01265c79aa139ddb69609cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Single-source the XAA token-endpoint auth-method selector and capability evidence, and surface CLI steps in ID‑JAG spec vocabulary. No behavior changes.

- **Refactors**
  - Unified `selectTokenEndpointAuthMethod` in `xaa/state-machines/capability-preflight.ts`; used by engine and CLI; re-exported from `@mcpjam/sdk/browser`.
  - Added `deriveCapabilityEvidence` to produce `{ idJagProfile, jwtBearerGrant }` for the CLI’s `authorizationServerCapabilities`.
  - `runXaaFlow` now reports steps as `mint_id_jag` and `redeem_id_jag` (projection-only; engine step names unchanged).
  - Tests: contract tests unchanged; 2 new tests lock the step vocabulary. Minor release for `@mcpjam/sdk` to expose new browser exports.

<sup>Written for commit b0ffae56b67e8247d01265c79aa139ddb69609cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

