### PR TITLE
feat(xaa): capability-ranked authorization-server selection during discovery

### DIFF
--- a/.changeset/xaa-capability-ranked-ras.md
+++ b/.changeset/xaa-capability-ranked-ras.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/sdk": patch
+---
+
+XAA: rank authorization-server candidates by advertised ID-JAG capability during discovery. When a protected resource advertises several authorization servers, the shared engine now prefers, among issuer-matching candidates: (1) one advertising both the RFC 7523 jwt-bearer grant and the ID-JAG grant profile; then (2) one advertising jwt-bearer with the ID-JAG profile omitted (draft-04 SHOULD); otherwise (3) the first issuer-matching candidate, exactly as before. Ranking uses the two specific compatibility checks — never the vendor-influenced `overall` verdict — and is a preference heuristic, never a hard filter (a server may accept the grant without advertising it). Credential binding is preserved: an explicitly configured issuer stays a hard pin, and a confidential (client-secret) run is pinned to the first issuer-matching candidate so its secret is never redirected to a different RAS. Runtime-behavior change only; no API change.

--- a/sdk/src/xaa/state-machines/state-machine.ts
+++ b/sdk/src/xaa/state-machines/state-machine.ts
@@ -36,6 +36,7 @@ import { createInitialXAAFlowState } from "./types.js";
 import {
   analyzeAsCompatibility,
   selectTokenEndpointAuthMethod,
+  type XAACompatibilityReport,
 } from "./capability-preflight.js";
 import {
   buildMcpInitializeRequest,
@@ -230,6 +231,31 @@ function mergeHeadersForAuthServer(
   }
 
   return merged;
+}
+
+/** Rank an issuer-matching authorization-server candidate by its advertised
+ * ID-JAG capability, using the two SPECIFIC compatibility checks — never the
+ * vendor-influenced `overall` verdict. Draft-04: advertising the ID-JAG grant
+ * profile requires also advertising the jwt-bearer grant, so the only valid
+ * "partial" is jwt-bearer present with the ID-JAG profile omitted.
+ *   1 = jwt-bearer AND ID-JAG profile advertised (best)
+ *   2 = jwt-bearer advertised, ID-JAG profile omitted (draft-04 SHOULD)
+ *   3 = otherwise — jwt-bearer unconfirmed, or ID-JAG explicitly unsupported.
+ * Rank 3 is the historical "first issuer-matching wins" fallback: capability
+ * advertisement is a preference heuristic, never a hard filter, since a server
+ * may accept the grant without advertising it. */
+function rankAuthServerCandidate(
+  report: XAACompatibilityReport | null
+): 1 | 2 | 3 {
+  if (!report) return 3;
+  const jwtBearer = report.checks.find(
+    (c) => c.id === "jwt_bearer_grant"
+  )?.status;
+  if (jwtBearer !== "pass") return 3;
+  const idJag = report.checks.find((c) => c.id === "id_jag_profile")?.status;
+  if (idJag === "pass") return 1;
+  if (idJag === "warn") return 2;
+  return 3;
 }
 
 function extractErrorMessage(body: any, fallback: string): string {
@@ -740,6 +766,71 @@ export function createXAAStateMachine(
         ];
     let lastError = "Authorization server metadata discovery failed.";
 
+    // Adopt a chosen candidate's metadata as the authorization server: record
+    // the token endpoint, the pre-registered client-auth method, and the
+    // compatibility report, and log the discovery.
+    const adoptAuthServer = (
+      metadata: Record<string, unknown>,
+      resolvedIssuer: string,
+      compatibilityReport: XAACompatibilityReport | null
+    ) => {
+      machine.updateState({
+        currentStep: "received_authz_metadata",
+        authzMetadata: metadata as XAAFlowState["authzMetadata"],
+        authzServerIssuer: resolvedIssuer,
+        tokenEndpoint: metadata.token_endpoint as string,
+        ...(registrationStrategy === "preregistered"
+          ? {
+              tokenEndpointAuthMethod: selectTokenEndpointAuthMethod(
+                state.tokenEndpointAuthMethod,
+                state.clientSecret,
+                metadata.token_endpoint_auth_methods_supported
+              ),
+            }
+          : {}),
+        compatibilityReport: compatibilityReport ?? undefined,
+        error: undefined,
+      });
+
+      pushInfo(
+        "received_authz_metadata",
+        "xaa-authz-metadata",
+        "Authorization metadata",
+        {
+          issuer: resolvedIssuer,
+          token_endpoint: metadata.token_endpoint,
+          grant_types_supported: metadata.grant_types_supported,
+          registration_endpoint: metadata.registration_endpoint,
+          client_id_metadata_document_supported:
+            metadata.client_id_metadata_document_supported,
+          authorization_grant_profiles_supported:
+            metadata.authorization_grant_profiles_supported,
+          compatibility: compatibilityReport
+            ? {
+                overall: compatibilityReport.overall,
+                vendor: compatibilityReport.vendor,
+              }
+            : undefined,
+        }
+      );
+    };
+
+    // A confidential client's secret is registered at one specific RAS, so
+    // capability ranking must NOT redirect it to a different advertised issuer
+    // than it would have reached before — pin such runs to the first
+    // issuer-matching candidate (pre-ranking behavior). Public clients (no
+    // secret) may rank freely. An explicitly-configured issuer is already a
+    // hard pin above (issuerCandidates collapses to a single entry).
+    const allowRankSwitch = !state.clientSecret;
+
+    type AsCandidate = {
+      metadata: Record<string, unknown>;
+      issuer: string;
+      report: XAACompatibilityReport | null;
+    };
+    let firstIssuerMatch: AsCandidate | undefined;
+    let jwtBearerOnly: AsCandidate | undefined;
+
     for (const candidateIssuer of issuerCandidates) {
       const urls = buildAuthorizationServerMetadataCandidates(candidateIssuer);
       for (const url of urls) {
@@ -793,52 +884,40 @@ export function createXAAStateMachine(
             issuer: resolvedIssuer,
           });
 
-          machine.updateState({
-            currentStep: "received_authz_metadata",
-            authzMetadata: metadata as XAAFlowState["authzMetadata"],
-            authzServerIssuer: resolvedIssuer,
-            tokenEndpoint: metadata.token_endpoint,
-            ...(registrationStrategy === "preregistered"
-              ? {
-                  tokenEndpointAuthMethod: selectTokenEndpointAuthMethod(
-                    state.tokenEndpointAuthMethod,
-                    state.clientSecret,
-                    metadata.token_endpoint_auth_methods_supported
-                  ),
-                }
-              : {}),
-            compatibilityReport: compatibilityReport ?? undefined,
-            error: undefined,
-          });
+          // Confidential run: pin to the first issuer-matching candidate,
+          // preserving pre-ranking behavior so no secret moves issuers.
+          if (!allowRankSwitch) {
+            adoptAuthServer(metadata, resolvedIssuer, compatibilityReport);
+            return;
+          }
 
-          pushInfo(
-            "received_authz_metadata",
-            "xaa-authz-metadata",
-            "Authorization metadata",
-            {
-              issuer: resolvedIssuer,
-              token_endpoint: metadata.token_endpoint,
-              grant_types_supported: metadata.grant_types_supported,
-              registration_endpoint: metadata.registration_endpoint,
-              client_id_metadata_document_supported:
-                metadata.client_id_metadata_document_supported,
-              authorization_grant_profiles_supported:
-                metadata.authorization_grant_profiles_supported,
-              compatibility: compatibilityReport
-                ? {
-                    overall: compatibilityReport.overall,
-                    vendor: compatibilityReport.vendor,
-                  }
-                : undefined,
-            }
-          );
-
-          return;
+          const candidate: AsCandidate = {
+            metadata,
+            issuer: resolvedIssuer,
+            report: compatibilityReport,
+          };
+          const rank = rankAuthServerCandidate(compatibilityReport);
+          if (rank === 1) {
+            // Both jwt-bearer and ID-JAG advertised — can't do better; adopt.
+            adoptAuthServer(metadata, resolvedIssuer, compatibilityReport);
+            return;
+          }
+          if (rank === 2 && !jwtBearerOnly) jwtBearerOnly = candidate;
+          if (!firstIssuerMatch) firstIssuerMatch = candidate;
+          // keep scanning the remaining candidates for a rank-1 server
         } catch (error) {
           lastError =
             error instanceof Error ? error.message : "Metadata request failed";
         }
       }
+    }
+
+    // No rank-1 candidate: prefer a jwt-bearer-capable one (rank 2), else fall
+    // back to the first issuer-matching candidate (historical behavior).
+    const chosen = jwtBearerOnly ?? firstIssuerMatch;
+    if (chosen) {
+      adoptAuthServer(chosen.metadata, chosen.issuer, chosen.report);
+      return;
     }
 
     machine.updateState({

--- a/sdk/tests/xaa/run-xaa-flow.test.ts
+++ b/sdk/tests/xaa/run-xaa-flow.test.ts
@@ -7,6 +7,10 @@ import {
   getXAAIdpJwks,
   resetXAAIdpKeyPairForTests,
 } from "../../src/xaa/mint/keypair.js";
+import {
+  JWT_BEARER_GRANT,
+  ID_JAG_GRANT_PROFILE,
+} from "../../src/oauth/client-identity.js";
 
 const SERVER_URL = "https://mcp.example.com/mcp";
 const AS_ISSUER = "https://auth.example.com";
@@ -966,5 +970,79 @@ describe("runXaaFlow", () => {
     expect(stepNames).toContain("probe:redeem_id_jag");
     expect(stepNames).not.toContain("baseline:token_exchange_request");
     expect(stepNames).not.toContain("probe:jwt_bearer_request");
+  });
+
+  it("redeems at the jwt-bearer/ID-JAG-capable AS when the resource advertises several", async () => {
+    const PLAIN_AS = "https://as-plain.example.com";
+    const CAPABLE_AS = "https://as-capable.example.com";
+    const PLAIN_TOKEN = `${PLAIN_AS}/oauth/token`;
+    const CAPABLE_TOKEN = `${CAPABLE_AS}/oauth/token`;
+
+    const fetchMock = withPublishedIssuer(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        const method = (init?.method || "GET").toUpperCase();
+        if (url.includes(".well-known/oauth-protected-resource")) {
+          return json({
+            resource: SERVER_URL,
+            authorization_servers: [PLAIN_AS, CAPABLE_AS],
+          });
+        }
+        if (
+          url.includes(".well-known/oauth-authorization-server") ||
+          url.includes(".well-known/openid-configuration")
+        ) {
+          if (url.startsWith(CAPABLE_AS)) {
+            return json({
+              issuer: CAPABLE_AS,
+              token_endpoint: CAPABLE_TOKEN,
+              grant_types_supported: [JWT_BEARER_GRANT],
+              authorization_grant_profiles_supported: [ID_JAG_GRANT_PROFILE],
+            });
+          }
+          if (url.startsWith(PLAIN_AS)) {
+            return json({ issuer: PLAIN_AS, token_endpoint: PLAIN_TOKEN });
+          }
+          return json({}, 404);
+        }
+        if (url === CAPABLE_TOKEN && method === "POST") {
+          return json({
+            access_token: "at-capable",
+            token_type: "Bearer",
+            expires_in: 300,
+          });
+        }
+        if (url === SERVER_URL && method === "POST") {
+          return json({
+            jsonrpc: "2.0",
+            id: "mcpjam-xaa-cli",
+            result: { protocolVersion: "2025-11-25", serverInfo: {} },
+          });
+        }
+        return json({}, 404);
+      }
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await runXaaFlow({
+      serverUrl: SERVER_URL,
+      issuerBaseUrl: ISSUER_BASE,
+      subject: "user-1",
+      clientId: "client-1",
+    });
+
+    expect(result.completed).toBe(true);
+    expect(result.authzServerIssuer).toBe(CAPABLE_AS);
+    expect(result.tokenEndpoint).toBe(CAPABLE_TOKEN);
+    expect(result.redemption?.tokenIssued).toBe(true);
+    // The plain AS is advertised first but must not receive the redemption.
+    const postedTo = (endpoint: string) =>
+      fetchMock.mock.calls.some(
+        ([input, init]) =>
+          input.toString() === endpoint &&
+          (init?.method || "GET").toUpperCase() === "POST"
+      );
+    expect(postedTo(CAPABLE_TOKEN)).toBe(true);
+    expect(postedTo(PLAIN_TOKEN)).toBe(false);
   });
 });

--- a/sdk/tests/xaa/state-machine.test.ts
+++ b/sdk/tests/xaa/state-machine.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it, vi } from "vitest";
 import {
   XAA_DEBUG_CLIENT_ID_METADATA_URL,
   XAA_DEBUG_IDP_CLIENT_ID,
+  JWT_BEARER_GRANT,
+  ID_JAG_GRANT_PROFILE,
 } from "../../src/oauth/client-identity.js";
 import {
   CLIENT_SECRET_MASK,
@@ -1179,6 +1181,160 @@ describe("createXAAStateMachine", () => {
         "https://mcp.example.com/mcp/.well-known/oauth-protected-resource",
         "https://mcp.example.com/.well-known/oauth-protected-resource",
       ]);
+    });
+  });
+
+  describe("capability-ranked RAS selection", () => {
+    const SERVER = "https://mcp.example.com/mcp";
+    const ISSUER_BASE = "https://issuer.example/api/web/xaa";
+    const AS_RANK1 = "https://as-both.example.com";
+    const AS_RANK2 = "https://as-jwtonly.example.com";
+    const AS_PLAIN_A = "https://as-plain-a.example.com";
+    const AS_PLAIN_B = "https://as-plain-b.example.com";
+
+    const asMetadata = (issuer: string, extra: Record<string, unknown> = {}) => ({
+      issuer,
+      token_endpoint: `${issuer}/oauth/token`,
+      ...extra,
+    });
+    const rank1Meta = (issuer: string) =>
+      asMetadata(issuer, {
+        grant_types_supported: [JWT_BEARER_GRANT],
+        authorization_grant_profiles_supported: [ID_JAG_GRANT_PROFILE],
+      });
+    const rank2Meta = (issuer: string) =>
+      asMetadata(issuer, { grant_types_supported: [JWT_BEARER_GRANT] });
+    const plainMeta = (issuer: string) => asMetadata(issuer);
+
+    const ok = (body: unknown) => ({
+      status: 200,
+      statusText: "OK",
+      headers: {},
+      body,
+      ok: true,
+    });
+    const notFound = () => ({
+      status: 404,
+      statusText: "Not Found",
+      headers: {},
+      body: {},
+      ok: false,
+    });
+
+    // Executor serving PRM (listing `authorizationServers`) plus per-issuer AS
+    // metadata from `metaByIssuer`; an issuer absent from the map 404s.
+    function rankingExecutor(
+      authorizationServers: string[],
+      metaByIssuer: Record<string, unknown>
+    ) {
+      return {
+        externalRequest: vi.fn(async (url: string) => {
+          if (url.includes("/.well-known/oauth-protected-resource")) {
+            return ok({
+              resource: SERVER,
+              authorization_servers: authorizationServers,
+            });
+          }
+          if (
+            url.includes("/.well-known/oauth-authorization-server") ||
+            url.includes("/.well-known/openid-configuration")
+          ) {
+            const issuer = Object.keys(metaByIssuer).find((i) =>
+              url.startsWith(i)
+            );
+            return issuer ? ok(metaByIssuer[issuer]) : notFound();
+          }
+          return ok({});
+        }),
+        internalRequest: vi.fn(),
+      };
+    }
+
+    async function discoverAuthzIssuer(
+      executor: ReturnType<typeof rankingExecutor>,
+      overrides: Partial<XAAFlowState> = {}
+    ): Promise<XAAFlowState> {
+      let state: XAAFlowState = createInitialXAAFlowState({
+        serverUrl: SERVER,
+        ...overrides,
+      });
+      const machine = createXAAStateMachine({
+        getState: () => state,
+        updateState: (u) => {
+          state = { ...state, ...u };
+        },
+        serverUrl: SERVER,
+        issuerBaseUrl: ISSUER_BASE,
+        requestExecutor: executor,
+        clientSecret: overrides.clientSecret,
+      });
+      await machine.proceedToNextStep(); // discover_resource_metadata
+      await machine.proceedToNextStep(); // discover_authz_metadata
+      return state;
+    }
+
+    it("prefers a rank-1 (jwt-bearer + ID-JAG) server over an earlier plain one", async () => {
+      const executor = rankingExecutor([AS_PLAIN_A, AS_RANK1], {
+        [AS_PLAIN_A]: plainMeta(AS_PLAIN_A),
+        [AS_RANK1]: rank1Meta(AS_RANK1),
+      });
+      const state = await discoverAuthzIssuer(executor);
+      expect(state.currentStep).toBe("received_authz_metadata");
+      expect(state.authzServerIssuer).toBe(AS_RANK1);
+    });
+
+    it("prefers a rank-1 server even when advertised first (order-independent)", async () => {
+      const executor = rankingExecutor([AS_RANK1, AS_PLAIN_A], {
+        [AS_RANK1]: rank1Meta(AS_RANK1),
+        [AS_PLAIN_A]: plainMeta(AS_PLAIN_A),
+      });
+      const state = await discoverAuthzIssuer(executor);
+      expect(state.authzServerIssuer).toBe(AS_RANK1);
+    });
+
+    it("prefers a rank-2 (jwt-bearer only) server over an earlier plain one when no rank-1 exists", async () => {
+      const executor = rankingExecutor([AS_PLAIN_A, AS_RANK2], {
+        [AS_PLAIN_A]: plainMeta(AS_PLAIN_A),
+        [AS_RANK2]: rank2Meta(AS_RANK2),
+      });
+      const state = await discoverAuthzIssuer(executor);
+      expect(state.authzServerIssuer).toBe(AS_RANK2);
+    });
+
+    it("falls back to the first issuer-matching server when none advertise capability", async () => {
+      const executor = rankingExecutor([AS_PLAIN_A, AS_PLAIN_B], {
+        [AS_PLAIN_A]: plainMeta(AS_PLAIN_A),
+        [AS_PLAIN_B]: plainMeta(AS_PLAIN_B),
+      });
+      const state = await discoverAuthzIssuer(executor);
+      expect(state.authzServerIssuer).toBe(AS_PLAIN_A);
+    });
+
+    it("pins a confidential client to the first issuer-matching server (no secret redirect)", async () => {
+      const executor = rankingExecutor([AS_PLAIN_A, AS_RANK1], {
+        [AS_PLAIN_A]: plainMeta(AS_PLAIN_A),
+        [AS_RANK1]: rank1Meta(AS_RANK1),
+      });
+      // A rank-1 server exists later, but the client secret is registered at
+      // the first advertised RAS — ranking must not move it.
+      const state = await discoverAuthzIssuer(executor, {
+        clientSecret: "s3cret",
+      });
+      expect(state.authzServerIssuer).toBe(AS_PLAIN_A);
+    });
+
+    it("hard-pins an explicitly configured issuer and never fetches PRM", async () => {
+      const executor = rankingExecutor([], {
+        [AS_PLAIN_A]: plainMeta(AS_PLAIN_A),
+      });
+      const state = await discoverAuthzIssuer(executor, {
+        authzServerIssuer: AS_PLAIN_A,
+      });
+      expect(state.authzServerIssuer).toBe(AS_PLAIN_A);
+      const fetchedPrm = executor.externalRequest.mock.calls.some(([url]) =>
+        String(url).includes("/.well-known/oauth-protected-resource")
+      );
+      expect(fetchedPrm).toBe(false);
     });
   });
 });

--- a/sdk/tests/xaa/state-machine.test.ts
+++ b/sdk/tests/xaa/state-machine.test.ts
@@ -1192,7 +1192,10 @@ describe("createXAAStateMachine", () => {
     const AS_PLAIN_A = "https://as-plain-a.example.com";
     const AS_PLAIN_B = "https://as-plain-b.example.com";
 
-    const asMetadata = (issuer: string, extra: Record<string, unknown> = {}) => ({
+    const asMetadata = (
+      issuer: string,
+      extra: Record<string, unknown> = {}
+    ) => ({
       issuer,
       token_endpoint: `${issuer}/oauth/token`,
       ...extra,


### PR DESCRIPTION
## What

Behavioral follow-up to #3173 (stacked on it). When a protected resource advertises **several** authorization servers, the shared XAA engine now **ranks** the issuer-matching candidates by advertised ID-JAG capability instead of always adopting the first one.

Rank (among issuer-matching candidates):
1. jwt-bearer grant **and** ID-JAG grant profile advertised (best)
2. jwt-bearer advertised, ID-JAG profile **omitted** (draft-04 SHOULD — advertising ID-JAG *requires* advertising jwt-bearer, so this is the only valid "partial")
3. otherwise the **first issuer-matching** candidate — exactly today's behavior

## Correctness guardrails

- **Scoring uses the two specific compatibility checks** (jwt-bearer, ID-JAG), never the vendor-influenced `compatibilityReport.overall`.
- **Not a hard filter** — advertisement ≠ acceptance. A single-AS setup that advertises no grants still attempts (rank 3), so nothing that worked before stops working.
- **Explicit issuer stays a hard pin** — `config.authzServerIssuer` collapses discovery to one candidate; ranking never crosses it.
- **Confidential-credential binding** — a run with a client secret is pinned to the first issuer-matching candidate, so a secret registered at one RAS is never redirected to a different advertised RAS. Public clients rank freely.

Pinned to draft-04 (current revision): https://datatracker.ietf.org/doc/draft-ietf-oauth-identity-assertion-authz-grant/

## Not in scope

Engine-only behavior change; no `XaaFlowResult`/API change. The rank helper is intentionally **not exported** (patch changeset, behavior-only).

## Verification

- SDK: full XAA suite 157 passed. **6 new engine ranking tests** (rank-1 preference incl. order-independence, rank-2 over plain, all-plain→first fallback, confidential pin, explicit-issuer hard-pin asserting PRM is never fetched) + **1 public-surface `runXaaFlow` test** proving the flow redeems at the capable AS and never POSTs the plain one.
- Inspector (same engine): client XAA 114, server XAA route 47 — no regression.
- `tsc` clean; browser-purity guard green; formatting reflow isolated to its own commit.

> **Note:** targets the #3173 branch to keep this diff to the ranking change (both edit the same `received_authz_metadata` handler). Retarget to `main` once #3173 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which authorization server and token endpoint are selected in multi-AS discovery, which affects redemption behavior; mitigated by confidential-client and explicit-issuer pins and first-match fallback when nothing advertises capability.
> 
> **Overview**
> When protected-resource metadata lists **multiple** authorization servers, XAA discovery no longer stops at the first issuer-valid metadata document. It scans candidates and **prefers** servers that advertise stronger ID-JAG readiness, using only the `jwt_bearer_grant` and `id_jag_profile` compatibility checks (not `compatibilityReport.overall`).
> 
> **Ranking (public clients):** jwt-bearer + ID-JAG profile → jwt-bearer only (ID-JAG profile omitted) → first successful issuer match (same as before). A rank-1 hit adopts immediately; otherwise the loop finishes and picks the best jwt-bearer-only candidate, then falls back to the first match. Advertised capability is a **heuristic**, not a filter—plain servers are still eligible.
> 
> **Unchanged pins:** configured `authzServerIssuer` still limits candidates to one issuer; runs with a **client secret** still adopt the **first** issuer-matching server so credentials are not sent to a different RAS.
> 
> Refactors adoption into `adoptAuthServer`; adds engine and `runXaaFlow` tests plus a patch changeset (`@mcpjam/sdk`). No public API surface change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93a5d0fe823ba92c2f1cfd0402e341fac42e733e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ranks authorization-server candidates during discovery by advertised ID-JAG capability so the engine picks the most capable issuer when several are listed. Engine-only change; public API and `XaaFlowResult` unchanged.

- **New Features**
  - Preference: jwt-bearer + ID-JAG > jwt-bearer-only > first issuer match (fallback).
  - Uses only jwt-bearer and ID-JAG checks; ignores vendor `overall`.
  - Heuristic only; still attempts if nothing is advertised.
  - Confidential clients and explicit issuer stay pinned (explicit issuer skips PRM fetch); public clients can switch.
  - Adds ranking helper with tests (engine + `runXaaFlow`) confirming selection and that the plain AS is never posted.

<sup>Written for commit 93a5d0fe823ba92c2f1cfd0402e341fac42e733e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

