### PR TITLE
feat(auth): authMethod "auto" — select XAA when configured, else OAuth

### DIFF
--- a/mcpjam-inspector/client/src/components/connection/hooks/__tests__/use-server-form.test.ts
+++ b/mcpjam-inspector/client/src/components/connection/hooks/__tests__/use-server-form.test.ts
@@ -826,6 +826,91 @@ describe("useServerForm", () => {
     });
   });
 
+  it("emits authMethod 'auto' with backend-mirrored derived booleans", async () => {
+    // Auto on a server WITH sticky XAA config + a client id → selects XAA.
+    const xaaConfigured = {
+      name: "auto-xaa",
+      config: { url: "https://example.com/mcp" },
+      authMethod: "auto",
+      authServerMode: "mcpjam",
+      lastConnectionTime: new Date(),
+      connectionStatus: "disconnected",
+      retryCount: 0,
+      enabled: true,
+    } as any;
+    const { result } = renderHook(() => useServerForm(xaaConfigured));
+    await waitFor(() => {
+      expect(result.current.authType).toBe("auto");
+    });
+    act(() => {
+      result.current.setClientId("client-1");
+    });
+    expect(result.current.buildFormData()).toMatchObject({
+      authMethod: "auto",
+      useXaa: true,
+      useOAuth: false,
+    });
+
+    // Auto WITHOUT XAA config → selects OAuth.
+    const { result: plain } = renderHook(() => useServerForm());
+    act(() => {
+      plain.current.setName("auto-oauth");
+      plain.current.setUrl("https://example.com/mcp");
+      plain.current.setAuthType("auto");
+    });
+    expect(plain.current.buildFormData()).toMatchObject({
+      authMethod: "auto",
+      useOAuth: true,
+      useXaa: false,
+    });
+  });
+
+  it("sends clearXaaConfig only when explicitly moving off XAA", async () => {
+    const xaaServer = {
+      name: "was-xaa",
+      config: { url: "https://example.com/mcp" },
+      useXaa: true,
+      authServerMode: "mcpjam",
+      lastConnectionTime: new Date(),
+      connectionStatus: "disconnected",
+      retryCount: 0,
+      enabled: true,
+    } as any;
+
+    // Switching to OAuth clears the sticky XAA identity config.
+    const { result } = renderHook(() => useServerForm(xaaServer));
+    await waitFor(() => {
+      expect(result.current.authType).toBe("xaa");
+    });
+    act(() => {
+      result.current.setAuthType("oauth");
+    });
+    expect(result.current.buildFormData()).toMatchObject({
+      authMethod: "oauth",
+      clearXaaConfig: true,
+    });
+
+    // Switching to "auto" preserves it — auto selects ON that config.
+    const { result: toAuto } = renderHook(() => useServerForm(xaaServer));
+    await waitFor(() => {
+      expect(toAuto.current.authType).toBe("xaa");
+    });
+    act(() => {
+      toAuto.current.setAuthType("auto");
+    });
+    const autoData = toAuto.current.buildFormData();
+    expect(autoData.authMethod).toBe("auto");
+    expect(autoData.clearXaaConfig).toBeUndefined();
+
+    // Staying on XAA never sends the reset.
+    const { result: stays } = renderHook(() => useServerForm(xaaServer));
+    await waitFor(() => {
+      expect(stays.current.authType).toBe("xaa");
+    });
+    const xaaData = stays.current.buildFormData();
+    expect(xaaData.clearXaaConfig).toBeUndefined();
+  });
+
   it("blocks submit for preregistered OAuth until client ID passes validation", () => {
     const { result } = renderHook(() => useServerForm());
 

--- a/mcpjam-inspector/client/src/components/connection/hooks/use-server-form.ts
+++ b/mcpjam-inspector/client/src/components/connection/hooks/use-server-form.ts
@@ -334,11 +334,23 @@ export function useServerForm(
         !hasBearer &&
         (server.hasBearerToken === true ||
           getRedactedConfigFlag(config, "hasBearerToken"));
-      // XAA is checked FIRST: an XAA server keeps `useOAuth === false`, so
-      // without this branch it would fall through to the "oauth" catch-all and
-      // a save would silently rewrite it to OAuth. See CLAUDE.local.md guard.
+      // The CANONICAL authMethod wins over the derived booleans (see
+      // feedback: canonical-wins-every-read-site) — a persisted "auto" must
+      // display as Automatic, not as whichever flow it currently derives to.
+      // On legacy rows XAA is checked FIRST: an XAA server keeps
+      // `useOAuth === false`, so without this branch it would fall through to
+      // the "oauth" catch-all and a save would silently rewrite it to OAuth.
+      const canonicalAuthType =
+        server.authMethod === "auto" ||
+        server.authMethod === "oauth" ||
+        server.authMethod === "xaa" ||
+        server.authMethod === "bearer" ||
+        server.authMethod === "none"
+          ? server.authMethod
+          : undefined;
       const resolvedAuthType: ServerFormAuthType =
-        server.useXaa === true
+        canonicalAuthType ??
+        (server.useXaa === true
           ? "xaa"
           : hasServerOAuth
           ? "oauth"
@@ -346,7 +358,7 @@ export function useServerForm(
           ? "bearer"
           : hasOAuth
           ? "oauth"
-          : "none";
+          : "none");
       const timeoutValue =
         typeof config.timeout === "number" && Number.isFinite(config.timeout)
           ? String(config.timeout)
@@ -390,6 +402,9 @@ export function useServerForm(
       // Set auth type based on multiple OAuth detection sources
       if (resolvedAuthType === "xaa") {
         setAuthType("xaa");
+        setShowAuthSettings(true);
+      } else if (resolvedAuthType === "auto") {
+        setAuthType("auto");
         setShowAuthSettings(true);
       } else if (resolvedAuthType === "oauth") {
         setAuthType("oauth");
@@ -779,7 +794,8 @@ export function useServerForm(
       .split(/\s+/)
       .filter((s) => s.length > 0);
     const shouldUsePreregisteredCredentials =
-      authType === "oauth" && registrationMode === "preregistered";
+      (authType === "oauth" || authType === "auto") &&
+      registrationMode === "preregistered";
     const isXaa = authType === "xaa";
     // XAA also collects resource-authorization-server client id / secret, so it
     // shares the preregistered-credential emission path.
@@ -798,7 +814,11 @@ export function useServerForm(
       (hasStoredClientSecret || hasReplacementClientSecret);
 
     // Handle authentication. useOAuth and useXaa are mutually exclusive by
-    // construction — this else-if chain sets at most one.
+    // construction — this else-if chain sets at most one. For "auto" the
+    // booleans mirror the backend's derivation (deriveAuthBooleans: XAA iff
+    // an IdP mode is configured AND a client id is stored) so localStorage-
+    // only mode matches hosted behavior; the backend re-derives on write
+    // regardless.
     let useOAuth = false;
     let useXaa = false;
     if (authType === "bearer" && bearerToken.trim()) {
@@ -807,7 +827,21 @@ export function useServerForm(
       useOAuth = true;
     } else if (authType === "xaa") {
       useXaa = true;
+    } else if (authType === "auto") {
+      const autoSelectsXaa =
+        server?.authServerMode != null && Boolean(clientId.trim());
+      useXaa = autoSelectsXaa;
+      useOAuth = !autoSelectsXaa;
     }
+    // Reset boundary: an explicit modal move OFF XAA clears the sticky XAA
+    // identity config server-side ("auto" keeps it — that's what auto
+    // selects on). Plain non-modal saves never reach this builder with a
+    // changed authType, so they keep preserving.
+    const wasXaa =
+      server?.authMethod === "xaa" ||
+      (server?.authMethod == null && server?.useXaa === true);
+    const clearXaaConfig =
+      wasXaa && authType !== "xaa" && authType !== "auto" ? true : undefined;
     const explicitHeaders =
       Object.keys(headers).length > 0 ? headers : undefined;
     const canPatchHeaders =
@@ -824,11 +858,17 @@ export function useServerForm(
       clientCapabilities,
       useOAuth,
       useXaa,
-      authServerMode: useXaa ? "mcpjam" : undefined,
+      // Canonical method — the booleans above are its derived compat mirrors
+      // (the backend re-derives them through deriveAuthBooleans on write).
+      authMethod: authType,
+      ...(clearXaaConfig ? { clearXaaConfig } : {}),
+      authServerMode:
+        authType === "xaa" ? "mcpjam" : useXaa ? server?.authServerMode : undefined,
       oauthProtocolMode: useOAuth ? oauthProtocolMode : undefined,
-      // The unified registration mode rides with BOTH auth flows — the XAA
-      // debugger reads the same per-server field the OAuth flow does.
-      registrationMode: useOAuth || useXaa ? registrationMode : undefined,
+      // The unified registration mode rides with every authorization flow —
+      // the XAA debugger reads the same per-server field the OAuth flow does.
+      registrationMode:
+        useOAuth || useXaa || authType === "auto" ? registrationMode : undefined,
       oauthScopes: scopes.length > 0 ? scopes : undefined,
       clientId: usesClientCredentials
         ? clientId.trim() || undefined

--- a/mcpjam-inspector/client/src/components/connection/shared/AuthenticationSection.tsx
+++ b/mcpjam-inspector/client/src/components/connection/shared/AuthenticationSection.tsx
@@ -265,7 +265,7 @@ export function AuthenticationSection({
   const effectiveOauthProtocolMode =
     oauthProtocolMode === "auto" ? "2025-11-25" : oauthProtocolMode;
   const oauthPlan =
-    authType === "oauth"
+    authType === "oauth" || authType === "auto"
       ? resolveAuthorizationPlan({
           serverUrl,
           protocolMode: effectiveOauthProtocolMode,
@@ -304,7 +304,7 @@ export function AuthenticationSection({
           <Select
             value={authType}
             onValueChange={(value: ServerFormAuthType) => {
-              if (value !== "oauth") {
+              if (value !== "oauth" && value !== "auto") {
                 setShowAdvancedOAuth(false);
               }
               onAuthTypeChange(value);
@@ -320,8 +320,21 @@ export function AuthenticationSection({
               {showXaaOption && (
                 <SelectItem value="xaa">Cross-App Access (XAA)</SelectItem>
               )}
+              {showXaaOption && (
+                <SelectItem value="auto">
+                  Automatic (XAA when configured, else OAuth)
+                </SelectItem>
+              )}
             </SelectContent>
           </Select>
+          {authType === "auto" && (
+            <p className="text-xs text-muted-foreground">
+              Selects Cross-App Access when this server has an IdP mode and a
+              stored client ID, and OAuth otherwise. The selection happens
+              before connecting — a failed XAA mint surfaces the error rather
+              than retrying as OAuth.
+            </p>
+          )}
         </div>
 
         {/* Bearer Token Settings */}
@@ -391,7 +404,7 @@ export function AuthenticationSection({
         )}
 
         {/* OAuth Settings */}
-        {showAuthSettings && authType === "oauth" && (
+        {showAuthSettings && (authType === "oauth" || authType === "auto") && (
           <div className="border-t border-border bg-muted/30">
             {oauthPlan && showOauthPlanBanner && (
               <div className="px-3 py-3 space-y-2 border-b border-border bg-background/60">

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -1415,6 +1415,10 @@ export function useServerState({
       secretOptions?: {
         clientSecret?: string;
         clearClientSecret?: boolean;
+        // One-shot command (like clearClientSecret): resets the sticky XAA
+        // identity config server-side. Rides the call, never app state — a
+        // persisted flag would re-fire on every future sync.
+        clearXaaConfig?: boolean;
         env?: Record<string, string>;
         headers?: Record<string, string>;
       },
@@ -1465,6 +1469,7 @@ export function useServerState({
 
       const clientSecret = secretOptions?.clientSecret?.trim();
       const clearClientSecret = secretOptions?.clearClientSecret === true;
+      const clearXaaConfig = secretOptions?.clearXaaConfig === true;
       const config = serverEntry.config as any;
       const headers = extractRequestHeaders(config?.requestInit);
       const hasEnvSecretPatch = Object.prototype.hasOwnProperty.call(
@@ -1606,6 +1611,9 @@ export function useServerState({
         ...(serverEntry.registrationMode !== undefined
           ? { registrationMode: serverEntry.registrationMode }
           : {}),
+        ...(serverEntry.authMethod !== undefined
+          ? { authMethod: serverEntry.authMethod }
+          : {}),
       } as const;
 
       try {
@@ -1615,6 +1623,7 @@ export function useServerState({
             ...payload,
             ...(clientSecret ? { clientSecret } : {}),
             ...(clearClientSecret ? { clearClientSecret: true } : {}),
+            ...(clearXaaConfig ? { clearXaaConfig: true } : {}),
           };
           if (hasSecretOperation) {
             await convexUpdateServerWithClientSecret(updatePayload);
@@ -1663,6 +1672,7 @@ export function useServerState({
               ...payload,
               ...(clientSecret ? { clientSecret } : {}),
               ...(clearClientSecret ? { clearClientSecret: true } : {}),
+              ...(clearXaaConfig ? { clearXaaConfig: true } : {}),
             };
             if (hasSecretOperation) {
               await convexUpdateServerWithClientSecret(updatePayload);
@@ -2747,6 +2757,8 @@ export function useServerState({
           ? { clientSecret: formData.clientSecret }
           : {}),
         ...(formData.clearClientSecret ? { clearClientSecret: true } : {}),
+        // One-shot XAA-config reset (modal moved the server off XAA).
+        ...(formData.clearXaaConfig ? { clearXaaConfig: true } : {}),
         ...(formData.secretPatch?.env !== undefined
           ? { env: formData.secretPatch.env }
           : {}),
@@ -2792,11 +2804,12 @@ export function useServerState({
         xaaEmail: formData.useXaa
           ? formData.xaaEmail
           : existingServerForSave?.xaaEmail,
-        // Debugger-only field: preserve any saved value when a non-debugger
-        // save (which omits it) comes through, rather than erasing it.
+        // Unified fields: preserve any saved value when a save that omits
+        // them comes through, rather than erasing it.
         registrationMode:
           formData.registrationMode ??
           existingServerForSave?.registrationMode,
+        authMethod: formData.authMethod ?? existingServerForSave?.authMethod,
       };
       // Both modes: await Convex sync so the returned serverId is available
       // for OAuth binding (hosted) and for the new {projectId, serverId}
@@ -3211,11 +3224,12 @@ export function useServerState({
         xaaEmail: formData.useXaa
           ? formData.xaaEmail
           : existingServer?.xaaEmail,
-        // Debugger-only field: preserve any saved value when a non-debugger
-        // save (which omits it) comes through, rather than erasing it.
+        // Unified fields: preserve any saved value when a save that omits
+        // them comes through, rather than erasing it.
         registrationMode:
           formData.registrationMode ??
           existingServer?.registrationMode,
+        authMethod: formData.authMethod ?? existingServer?.authMethod,
       } as ServerWithName;
 
       const hasPendingOAuthCallback = new URLSearchParams(
@@ -3240,6 +3254,8 @@ export function useServerState({
                 ? { clientSecret: formData.clientSecret }
                 : {}),
               ...(formData.clearClientSecret ? { clearClientSecret: true } : {}),
+              // One-shot XAA-config reset (modal moved the server off XAA).
+              ...(formData.clearXaaConfig ? { clearXaaConfig: true } : {}),
               ...(formData.secretPatch?.env !== undefined
                 ? { env: formData.secretPatch.env }
                 : {}),
@@ -4751,11 +4767,12 @@ export function useServerState({
           xaaEmail: formData.useXaa
             ? formData.xaaEmail
             : originalServer?.xaaEmail,
-          // Debugger-only field: preserve any saved value when a non-debugger
-          // save (which omits it) comes through, rather than erasing it.
+          // Unified fields: preserve any saved value when a save that omits
+          // them comes through, rather than erasing it.
           registrationMode:
             formData.registrationMode ??
             originalServer?.registrationMode,
+          authMethod: formData.authMethod ?? originalServer?.authMethod,
         } as ServerWithName;
 
         if (!formData.useOAuth && !formData.useXaa) {

--- a/mcpjam-inspector/client/src/hooks/useProjects.ts
+++ b/mcpjam-inspector/client/src/hooks/useProjects.ts
@@ -58,6 +58,7 @@ export interface RemoteServer {
   xaaSubject?: string;
   xaaEmail?: string;
   registrationMode?: string;
+  authMethod?: string;
   createdAt: number;
   updatedAt: number;
 }

--- a/mcpjam-inspector/client/src/lib/project-serialization.ts
+++ b/mcpjam-inspector/client/src/lib/project-serialization.ts
@@ -3,7 +3,7 @@ import {
   normalizeOAuthProtocolVersion,
   normalizeOAuthRegistrationStrategy,
 } from "@/lib/oauth/profile";
-import { normalizeRegistrationMode } from "@/shared/xaa.js";
+import { normalizeAuthMethod, normalizeRegistrationMode } from "@/shared/xaa.js";
 
 type SerializeOptions = {
   /**
@@ -78,6 +78,9 @@ function serializeServersInternal(
     }
     if (server.registrationMode !== undefined) {
       serializedServer.registrationMode = server.registrationMode;
+    }
+    if (server.authMethod !== undefined) {
+      serializedServer.authMethod = server.authMethod;
     }
 
     if (server.config) {
@@ -282,6 +285,10 @@ export function deserializeServersFromConvex(
     );
     if (registrationMode !== undefined) {
       server.registrationMode = registrationMode;
+    }
+    const authMethod = normalizeAuthMethod(serverData.authMethod);
+    if (authMethod !== undefined) {
+      server.authMethod = authMethod;
     }
 
     // Handle oauthFlowProfile from legacy nested structure

--- a/mcpjam-inspector/client/src/state/app-reducer.ts
+++ b/mcpjam-inspector/client/src/state/app-reducer.ts
@@ -72,6 +72,9 @@ const buildProjectServerProjection = (
   ...(server.registrationMode === undefined
     ? {}
     : { registrationMode: server.registrationMode }),
+  ...(server.authMethod === undefined
+    ? {}
+    : { authMethod: server.authMethod }),
   ...(server.hasClientSecret === undefined
     ? {}
     : { hasClientSecret: server.hasClientSecret }),

--- a/mcpjam-inspector/client/src/state/app-types.ts
+++ b/mcpjam-inspector/client/src/state/app-types.ts
@@ -1,6 +1,6 @@
 import type { MCPServerConfig, NormalizedError } from "@mcpjam/sdk/browser";
 import { OauthTokens } from "@/shared/types.js";
-import type { RegistrationMode } from "@/shared/xaa.js";
+import type { AuthMethod, RegistrationMode } from "@/shared/xaa.js";
 import type { OAuthTestProfile } from "@/lib/oauth/profile";
 import type {
   ProjectClientConfig,
@@ -91,6 +91,11 @@ export interface ServerWithName {
    * flows and the XAA debugger. Persisted per-server; may be "auto".
    */
   registrationMode?: RegistrationMode;
+  /**
+   * Canonical auth method (useOAuth/useXaa are its derived compat mirrors).
+   * "auto" selects XAA when the server is XAA-configured, OAuth otherwise.
+   */
+  authMethod?: AuthMethod;
 }
 
 export interface Project {

--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -19,6 +19,10 @@ import {
 import { INSPECTOR_MCP_RETRY_POLICY } from "../../utils/mcp-retry-policy.js";
 import { setRequestLogContext } from "../../utils/request-logger.js";
 import { logger } from "../../utils/logger.js";
+import {
+  resolveEffectiveAuthMethod,
+  withXaaExtensionCapability,
+} from "../../utils/effective-auth.js";
 import type { RequestLogContext } from "../../utils/log-events.js";
 import {
   type InternalLogContext,
@@ -868,8 +872,14 @@ export async function createAuthorizedManager(
 
       const oauthToken = auth.oauthAccessToken ?? oauthTokens?.[serverId];
       const displayServerName = serverNamesById?.[serverId] ?? serverId;
+      // One resolver decides the flow for every dispatch below: canonical
+      // authMethod wins ("auto" selects XAA when configured, OAuth
+      // otherwise); legacy rows fall back to the boolean pair. Must match
+      // the local resolver's dispatch (hosted/local/swarm parity).
+      const effectiveAuth = resolveEffectiveAuthMethod(auth.serverConfig);
+      const usesOAuthFlow = effectiveAuth === "oauth";
       const onUnauthorized =
-        auth.serverConfig.useOAuth && auth.oauthAccessToken
+        usesOAuthFlow && auth.oauthAccessToken
           ? buildHostedOAuthUnauthorizedHandler({
               bearerToken,
               projectId,
@@ -882,7 +892,7 @@ export async function createAuthorizedManager(
             })
           : undefined;
 
-      if (auth.serverConfig.useOAuth) {
+      if (usesOAuthFlow) {
         if (auth.serverConfig.url) {
           oauthServerUrls[serverId] = auth.serverConfig.url;
         }
@@ -903,18 +913,29 @@ export async function createAuthorizedManager(
 
       // Cross-App Access: mint the resource access token server-side (MCPJam as
       // the test IdP) and inject it through the same `oauthAccessToken` channel
-      // that sets the Bearer header. Strictly gated on `useXaa === true &&
-      // useOAuth !== true` so it can never collide with the OAuth branch above.
-      // The XAA token always overrides whatever the authorize batch returned: a
-      // server converted from OAuth still has a stored OAuth token, and reusing
-      // it would inject the wrong credential.
+      // that sets the Bearer header. The effective method is a hard selection
+      // (auto picked XAA because the server is XAA-configured, or the row says
+      // xaa) — it can never collide with the OAuth branch above. The XAA token
+      // always overrides whatever the authorize batch returned: a server
+      // converted from OAuth still has a stored OAuth token, and reusing it
+      // would inject the wrong credential.
       let connectToken = oauthToken;
       let connectOnUnauthorized = onUnauthorized;
       const useXaa =
-        auth.serverConfig.transportType === "http" &&
-        auth.serverConfig.useXaa === true &&
-        auth.serverConfig.useOAuth !== true;
+        auth.serverConfig.transportType === "http" && effectiveAuth === "xaa";
       if (useXaa) {
+        // XAA connect runs on stored pre-registered credentials only; a
+        // dynamic registrationMode (dcr/cimd) applies to the debugger and
+        // OAuth flows.
+        if (
+          auth.serverConfig.registrationMode === "dcr" ||
+          auth.serverConfig.registrationMode === "cimd"
+        ) {
+          logger.info(
+            "[XAA connect] registrationMode is dynamic; connect uses stored pre-registered credentials — the mode applies to the debugger and OAuth flows only",
+            { serverId, registrationMode: auth.serverConfig.registrationMode }
+          );
+        }
         if (!options?.xaaIssuer) {
           // Caller-contract violation: a `useXaa` server reached a manager
           // builder that didn't thread the issuer (only callers holding the
@@ -1014,13 +1035,20 @@ export async function createAuthorizedManager(
             }
           : auth;
 
+      // Spec (MCP enterprise-managed authorization): a client whose access is
+      // enterprise-managed MUST advertise the extension in initialize. Merged
+      // — never overwriting — into the caller-configured capabilities.
+      const perServerCapabilities = useXaa
+        ? withXaaExtensionCapability(clientCapabilities)
+        : clientCapabilities;
+
       return [
         serverId,
         toHttpConfig(
           authForConfig,
           effectiveTimeoutMs,
           connectToken,
-          clientCapabilities,
+          perServerCapabilities,
           connectOnUnauthorized,
           effectiveInitializePins
         ),

--- a/mcpjam-inspector/server/utils/__tests__/effective-auth.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/effective-auth.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { XAA_MCP_EXTENSION } from "@mcpjam/sdk";
+import {
+  resolveEffectiveAuthMethod,
+  withXaaExtensionCapability,
+  xaaConfigured,
+} from "../effective-auth";
+
+describe("resolveEffectiveAuthMethod", () => {
+  it("passes explicit canonical methods through", () => {
+    expect(resolveEffectiveAuthMethod({ authMethod: "oauth" })).toBe("oauth");
+    expect(resolveEffectiveAuthMethod({ authMethod: "xaa" })).toBe("xaa");
+    expect(resolveEffectiveAuthMethod({ authMethod: "bearer" })).toBe("bearer");
+    expect(resolveEffectiveAuthMethod({ authMethod: "none" })).toBe("none");
+  });
+
+  it("auto selects XAA only when the server is fully XAA-configured", () => {
+    expect(
+      resolveEffectiveAuthMethod({
+        authMethod: "auto",
+        authServerMode: "mcpjam",
+        clientId: "c1",
+      }),
+    ).toBe("xaa");
+    // Sticky authServerMode WITHOUT a stored client id is not runnable XAA.
+    expect(
+      resolveEffectiveAuthMethod({
+        authMethod: "auto",
+        authServerMode: "mcpjam",
+      }),
+    ).toBe("oauth");
+    expect(
+      resolveEffectiveAuthMethod({ authMethod: "auto", clientId: "c1" }),
+    ).toBe("oauth");
+    expect(resolveEffectiveAuthMethod({ authMethod: "auto" })).toBe("oauth");
+  });
+
+  it("canonical method wins over contradictory legacy booleans", () => {
+    // A stale useOAuth:true must not drag an explicit xaa row into OAuth.
+    expect(
+      resolveEffectiveAuthMethod({ authMethod: "xaa", useOAuth: true }),
+    ).toBe("xaa");
+    expect(
+      resolveEffectiveAuthMethod({ authMethod: "none", useOAuth: true }),
+    ).toBe("none");
+  });
+
+  it("legacy rows fall back to the boolean pair with XAA-first precedence", () => {
+    expect(
+      resolveEffectiveAuthMethod({ useXaa: true, useOAuth: false }),
+    ).toBe("xaa");
+    // Historical gate: useXaa === true && useOAuth !== true → XAA; both set
+    // is contradictory legacy state and resolves to OAuth (matching the old
+    // `useOAuth !== true` guard).
+    expect(resolveEffectiveAuthMethod({ useXaa: true, useOAuth: true })).toBe(
+      "oauth",
+    );
+    expect(resolveEffectiveAuthMethod({ useOAuth: true })).toBe("oauth");
+    expect(resolveEffectiveAuthMethod({})).toBe("none");
+  });
+
+  it("xaaConfigured mirrors the backend derivation rule", () => {
+    expect(xaaConfigured({ authServerMode: "mcpjam", clientId: "c1" })).toBe(
+      true,
+    );
+    expect(xaaConfigured({ authServerMode: "mcpjam" })).toBe(false);
+    expect(xaaConfigured({ clientId: "c1" })).toBe(false);
+  });
+});
+
+describe("withXaaExtensionCapability", () => {
+  it("adds the enterprise-managed authorization extension to empty capabilities", () => {
+    const caps = withXaaExtensionCapability(undefined);
+    expect(caps.extensions).toEqual({ [XAA_MCP_EXTENSION]: {} });
+  });
+
+  it("merges — preserving existing capabilities and extensions", () => {
+    const caps = withXaaExtensionCapability({
+      sampling: {},
+      extensions: { "vendor.example/custom": { pinned: true } },
+    });
+    expect(caps.sampling).toEqual({});
+    expect(caps.extensions).toEqual({
+      "vendor.example/custom": { pinned: true },
+      [XAA_MCP_EXTENSION]: {},
+    });
+  });
+
+  it("keeps an existing extension payload rather than overwriting it", () => {
+    const caps = withXaaExtensionCapability({
+      extensions: { [XAA_MCP_EXTENSION]: { configured: true } },
+    });
+    expect(caps.extensions).toEqual({
+      [XAA_MCP_EXTENSION]: { configured: true },
+    });
+  });
+});

--- a/mcpjam-inspector/server/utils/effective-auth.ts
+++ b/mcpjam-inspector/server/utils/effective-auth.ts
@@ -1,0 +1,87 @@
+/**
+ * Effective auth-method resolution for connect-time dispatch — the single
+ * predicate all three surfaces (local resolver, hosted web/auth routes, swarm
+ * runs) must share so `auto` behaves identically everywhere.
+ *
+ * `auto` SELECTS a flow before it starts (XAA when the server is
+ * XAA-configured, OAuth otherwise); it is never a fallback after a failed
+ * attempt — a failed XAA mint surfaces the error rather than retrying as
+ * OAuth (a silent fallback would mask config errors as confusing OAuth 401s).
+ *
+ * The canonical `authMethod` WINS over the derived/legacy `useOAuth`/`useXaa`
+ * booleans (see feedback: canonical-wins-every-read-site); only rows with no
+ * canonical method fall back to the boolean pair.
+ */
+
+import { XAA_MCP_EXTENSION } from "@mcpjam/sdk";
+
+export type EffectiveAuthMethod = "oauth" | "xaa" | "bearer" | "none";
+
+type AuthConfigFields = {
+  authMethod?: "auto" | "oauth" | "xaa" | "bearer" | "none";
+  useOAuth?: boolean;
+  useXaa?: boolean;
+  authServerMode?: "mcpjam" | "own";
+  clientId?: string;
+};
+
+/**
+ * Whether an `auto` server selects XAA at connect time: an IdP mode is chosen
+ * AND a pre-registered client id is stored (the server-side mint runs on
+ * stored confidential credentials; `authServerMode` alone is sticky — plain
+ * saves preserve it after a server moves off XAA — so it is not enough).
+ * MUST stay in lockstep with the backend's `xaaConfigured` in
+ * mcpjam-backend `convex/lib/serverAuthFields.ts`, which derives the compat
+ * booleans from the same rule.
+ */
+export function xaaConfigured(sc: AuthConfigFields): boolean {
+  return sc.authServerMode != null && !!sc.clientId;
+}
+
+/**
+ * Merge the MCP Enterprise-Managed Authorization extension into a client
+ * capabilities object (spec: a client whose access is enterprise-managed MUST
+ * advertise the extension during initialization). Preserves every existing
+ * capability/extension — merge, never overwrite. Applied by the connect
+ * surfaces whenever the effective auth method is "xaa"; the debugger's
+ * dedicated initialize builder (sdk/src/xaa/mcp-init.ts) advertises the same
+ * key.
+ */
+export function withXaaExtensionCapability(
+  capabilities: Record<string, unknown> | undefined
+): Record<string, unknown> {
+  const existingExtensions =
+    capabilities &&
+    typeof capabilities.extensions === "object" &&
+    capabilities.extensions !== null
+      ? (capabilities.extensions as Record<string, unknown>)
+      : {};
+  return {
+    ...(capabilities ?? {}),
+    extensions: {
+      ...existingExtensions,
+      [XAA_MCP_EXTENSION]: existingExtensions[XAA_MCP_EXTENSION] ?? {},
+    },
+  };
+}
+
+export function resolveEffectiveAuthMethod(
+  sc: AuthConfigFields
+): EffectiveAuthMethod {
+  switch (sc.authMethod) {
+    case "oauth":
+    case "xaa":
+    case "bearer":
+    case "none":
+      return sc.authMethod;
+    case "auto":
+      return xaaConfigured(sc) ? "xaa" : "oauth";
+    default:
+      // Legacy rows: the boolean pair governs. Same precedence the dispatch
+      // gates used before authMethod existed (`useXaa === true && useOAuth
+      // !== true` → XAA never collides with the OAuth branch).
+      if (sc.useXaa === true && sc.useOAuth !== true) return "xaa";
+      if (sc.useOAuth === true) return "oauth";
+      return "none";
+  }
+}

--- a/mcpjam-inspector/server/utils/local-server-resolver.ts
+++ b/mcpjam-inspector/server/utils/local-server-resolver.ts
@@ -15,6 +15,10 @@ import {
   forceRefreshHostedOAuthAccessToken,
 } from "./hosted-oauth-refresh.js";
 import { logger } from "./logger.js";
+import {
+  resolveEffectiveAuthMethod,
+  withXaaExtensionCapability,
+} from "./effective-auth.js";
 import { exportSingleServerForInspection } from "./export-helpers.js";
 import { ConvexHttpClient } from "convex/browser";
 import { getInspectorClientRuntimeConfig } from "../env.js";
@@ -424,9 +428,17 @@ export function toMCPServerConfig(
 ): MCPServerConfig {
   const { serverConfig } = authResult;
   const timeout = options?.timeoutMs ?? serverConfig.timeout;
-  const clientCapabilities =
+  const baseClientCapabilities =
     options?.clientCapabilities ??
     (serverConfig.clientCapabilities as Record<string, unknown> | undefined);
+  // Spec (MCP enterprise-managed authorization): a client whose access is
+  // enterprise-managed MUST advertise the extension in initialize. Merged —
+  // never overwriting — into whatever capabilities the caller configured.
+  const clientCapabilities =
+    serverConfig.transportType === "http" &&
+    resolveEffectiveAuthMethod(serverConfig) === "xaa"
+      ? withXaaExtensionCapability(baseClientCapabilities)
+      : baseClientCapabilities;
 
   if (serverConfig.transportType === "stdio") {
     const stdio: any = {
@@ -510,7 +522,11 @@ export function toMCPServerConfig(
   // server (we have a token from `authorize-batch-local`) AND the caller
   // supplied refresh context. Header-only HTTP servers can't be refreshed
   // server-side, so the hook would be a no-op there.
-  if (oauthToken && serverConfig.useOAuth === true && options?.refreshContext) {
+  if (
+    oauthToken &&
+    resolveEffectiveAuthMethod(serverConfig) === "oauth" &&
+    options?.refreshContext
+  ) {
     http.onUnauthorized = buildHostedOAuthUnauthorizedHandler({
       bearerToken: options.refreshContext.bearerToken,
       projectId: options.refreshContext.projectId,
@@ -519,7 +535,7 @@ export function toMCPServerConfig(
     });
   } else if (
     oauthToken &&
-    serverConfig.useXaa === true &&
+    resolveEffectiveAuthMethod(serverConfig) === "xaa" &&
     options?.xaaUnauthorizedHandler
   ) {
     // XAA re-mint on 401 — mutually exclusive with the OAuth hook above.
@@ -559,9 +575,14 @@ export async function resolveLocalServerForConnect(
 }> {
   let result = await authorizeServerLocal(c, bearerToken, projectId, serverId);
 
-  const useOAuth =
-    result.serverConfig.transportType === "http" &&
-    result.serverConfig.useOAuth === true;
+  // One resolver decides the flow for every dispatch below: canonical
+  // authMethod wins ("auto" selects XAA when configured, OAuth otherwise);
+  // legacy rows fall back to the boolean pair.
+  const effectiveAuth =
+    result.serverConfig.transportType === "http"
+      ? resolveEffectiveAuthMethod(result.serverConfig)
+      : "none";
+  const useOAuth = effectiveAuth === "oauth";
   // Track the access token we'll hand to `toMCPServerConfig`. Starts from
   // whatever `authorize-batch-local` returned, but for hosted-OAuth servers
   // we fall back to a server-side refresh — same `force-refresh` endpoint
@@ -614,18 +635,24 @@ export async function resolveLocalServerForConnect(
 
   // Cross-App Access: mint the resource access token server-side (MCPJam as the
   // test IdP), then hand it to `toMCPServerConfig` through the same
-  // `oauthAccessToken` channel that injects the Bearer header. Gated strictly on
-  // `useXaa === true && useOAuth !== true` so it can never collide with the
+  // `oauthAccessToken` channel that injects the Bearer header. The effective
+  // method is a hard selection (auto picked XAA because the server is
+  // XAA-configured, or the row says xaa) — it can never collide with the
   // OAuth branch above.
-  const useXaa =
-    result.serverConfig.transportType === "http" &&
-    result.serverConfig.useXaa === true &&
-    result.serverConfig.useOAuth !== true;
+  const useXaa = effectiveAuth === "xaa";
   let xaaUnauthorizedHandler:
     | (() => Promise<{ accessToken: string }>)
     | undefined;
   if (useXaa && result.serverConfig.transportType === "http") {
     const sc = result.serverConfig;
+    // XAA connect runs on stored pre-registered credentials only; a dynamic
+    // registrationMode (dcr/cimd) applies to the debugger and OAuth flows.
+    if (sc.registrationMode === "dcr" || sc.registrationMode === "cimd") {
+      logger.info(
+        "[XAA connect] registrationMode is dynamic; connect uses stored pre-registered credentials — the mode applies to the debugger and OAuth flows only",
+        { serverId, registrationMode: sc.registrationMode }
+      );
+    }
     const mintArgs = buildXaaMintArgs({
       issuer: resolveXaaIssuer(c, HOSTED_MODE),
       hostedMode: HOSTED_MODE,

--- a/mcpjam-inspector/shared/types.ts
+++ b/mcpjam-inspector/shared/types.ts
@@ -1,7 +1,7 @@
 // Shared types between client and server
 import { HOSTED_MODEL_IDS } from "./hosted-model-ids.generated";
 
-import type { RegistrationMode } from "./xaa";
+import type { AuthMethod, RegistrationMode } from "./xaa";
 
 // Legacy server config (keeping for compatibility)
 export interface ServerConfig {
@@ -723,8 +723,11 @@ export type ServerFormOAuthRegistrationMode = RegistrationMode;
  * The auth type a server-form row is configured with. "xaa" (Cross-App Access)
  * is a distinct flow from "oauth": the inspector server mints the access token
  * server-side via token-exchange rather than running a browser OAuth flow.
+ * "auto" SELECTS between them at connect time — XAA when the server is
+ * XAA-configured (IdP mode + stored client id), OAuth otherwise. A selection
+ * before the flow starts, never a fallback after a failed attempt.
  */
-export type ServerFormAuthType = "oauth" | "bearer" | "none" | "xaa";
+export type ServerFormAuthType = "auto" | "oauth" | "bearer" | "none" | "xaa";
 
 export interface ServerFormData {
   name: string;
@@ -740,6 +743,19 @@ export interface ServerFormData {
   };
   clientCapabilities?: Record<string, unknown>;
   useOAuth?: boolean;
+  /**
+   * Canonical auth method (Convex `authMethod` column). The useOAuth/useXaa
+   * booleans are its derived compat mirrors — the backend re-derives them on
+   * every write. "auto" selects XAA when the server is XAA-configured,
+   * OAuth otherwise (see server/utils/effective-auth.ts).
+   */
+  authMethod?: AuthMethod;
+  /**
+   * Reset boundary: when true the backend nulls the sticky XAA identity
+   * config (authServerMode, xaaSubject, xaaEmail). Sent when a modal save
+   * explicitly moves the server's auth type off XAA; plain saves preserve.
+   */
+  clearXaaConfig?: boolean;
   oauthProtocolMode?: ServerFormOAuthProtocolMode;
   /**
    * Unified client-registration mode (Client↔AS leg) shared by the OAuth

--- a/mcpjam-inspector/shared/xaa.ts
+++ b/mcpjam-inspector/shared/xaa.ts
@@ -12,11 +12,13 @@ export {
   DEFAULT_REGISTRATION_STRATEGY,
   normalizeRegistrationStrategy,
   normalizeRegistrationMode,
+  normalizeAuthMethod,
 } from "@mcpjam/sdk/browser";
 export type {
   NegativeTestMode,
   RegistrationStrategy,
   RegistrationMode,
+  AuthMethod,
 } from "@mcpjam/sdk/browser";
 
 /**


### PR DESCRIPTION
C2 — the final leg of the unified-registration plan (after #3167 vocabulary, backend MCPJam/mcpjam-backend#710 columns, and #3172 field unification). Delivers the headline behavior: **`auto` selects XAA when the server is XAA-configured, OAuth otherwise** — a selection made before the flow starts, never a fallback after a failed attempt (a failed XAA mint surfaces the error rather than retrying as OAuth).

## What changed
- **One resolver, three surfaces**: new `server/utils/effective-auth.ts` — `resolveEffectiveAuthMethod` replaces the boolean gates in the local resolver (401-hook attach, refresh gate, XAA mint gate) and the hosted `web/auth.ts` manager builder (which swarm runs also flow through). Canonical `authMethod` wins over the derived booleans (a stale `useOAuth: true` can't drag an explicit `xaa` row into OAuth); `auto` selects XAA iff `authServerMode != null && clientId` present — **lockstep with the backend's `deriveAuthBooleans`**, cross-referenced comments both sides; legacy rows keep the historical boolean gates bit-for-bit.
- **Spec compliance (ext-auth)**: whenever the effective method is XAA, the Connect path's `initialize` now advertises the MCP enterprise-managed authorization extension — `withXaaExtensionCapability` merges (never overwrites) the fragment into the configured `clientCapabilities` on both local and hosted surfaces; the extension key comes from the SDK's `mcp-init` (single-sourced with the debugger).
- **Trace note**: a dynamic `registrationMode` (dcr/cimd) on an XAA connect logs that connect runs on stored pre-registered credentials — the mode applies to the debugger and OAuth flows.
- **UI**: the Authentication dropdown gains "Automatic (XAA when configured, else OAuth)" (behind the same `xaa` flag), showing the standard OAuth/registration settings; the auth plan banner runs for auto too. Default for new servers stays "none".
- **Form**: emits canonical `authMethod` for every auth type with backend-mirrored derived booleans; initialization prefers `server.authMethod` (canonical-wins-at-read-sites, per the C1 review lesson).
- **Reset boundary**: an explicit modal move OFF XAA (to oauth/bearer/none — NOT to auto, which selects on that config) sends the one-shot `clearXaaConfig`, riding the sync `secretOptions` channel like `clearClientSecret` — never app state, so it can't re-fire on later syncs.
- **Persistence**: `authMethod` flows through app-types/reducer/useProjects/serialization and the Convex save merges (`?? existing` preservation).

## Tests
- New `effective-auth.test.ts` (8): explicit methods, the auto × {authServerMode, clientId} matrix, contradictory-row canonical-wins, legacy boolean precedence, and extension-merge behavior (empty caps, preserving vendor extensions, not overwriting an existing payload).
- Form (34 total): `auto` emission both ways (XAA-configured → `useXaa: true`; plain → `useOAuth: true`), and the clearXaaConfig matrix (off-XAA sends it; XAA→auto preserves; staying on XAA never sends).
- 392 tests green across the 28 affected suites; client + server typecheck at parity with main.

## Notes for review
- XAA connect remains pre-registered-only by design (the mint uses stored confidential creds); `auto`'s XAA arm therefore requires a stored client id, which is exactly the `xaaConfigured` predicate.
- Backend #710 (already deployed for C1) accepts `authMethod`/`clearXaaConfig` and re-derives the compat booleans server-side on every write, so the form's mirrored derivation is a UX consistency measure, not the source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hosted and local MCP connect/auth dispatch (OAuth tokens, XAA mint, initialize capabilities); behavior is intentionally aligned with backend derivation and covered by new resolver/form tests, but regressions in flow selection would affect connection and credentials.
> 
> **Overview**
> Adds canonical **`authMethod: "auto"`** so connect picks **Cross-App Access (XAA)** when the server has IdP mode plus a stored client ID, otherwise **OAuth** — decided **before** connect, not as a fallback after a failed XAA mint.
> 
> **Server:** New `effective-auth.ts` centralizes `resolveEffectiveAuthMethod` (canonical `authMethod` beats legacy `useOAuth`/`useXaa`; `auto` uses the same `xaaConfigured` rule as the backend). Hosted `web/auth.ts` and `local-server-resolver.ts` route OAuth vs XAA mint/refresh/401 hooks through that resolver. XAA connects merge the enterprise-managed authorization **MCP extension** into `clientCapabilities` via `withXaaExtensionCapability`.
> 
> **Client:** Authentication dropdown adds **Automatic** (behind the XAA flag) with OAuth-style settings and plan banner. `useServerForm` loads/saves `authMethod`, mirrors derived booleans for `auto`, and sends one-shot **`clearXaaConfig`** when explicitly leaving XAA (not when switching to `auto`). `authMethod` and `clearXaaConfig` flow through app state, project serialization, and Convex sync.
> 
> **Tests:** `effective-auth.test.ts` plus expanded `use-server-form` coverage for `auto` emission and `clearXaaConfig` matrix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4ab55fbeef7823bbb120cbf5be1b43b88917518. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `authMethod: "auto"` to choose Cross‑App Access (XAA) when the server is XAA‑configured (IdP mode + stored client ID), otherwise OAuth. The choice is made before connecting and is consistent across local and hosted flows with no silent fallback.

- **New Features**
  - Central resolver `resolveEffectiveAuthMethod` used by all connect paths; canonical `authMethod` wins over legacy booleans; `auto` selects XAA iff `authServerMode` and `clientId` are present.
  - When XAA is effective, initialize advertises the MCP enterprise‑managed authorization extension via `withXaaExtensionCapability` (merges without overwriting existing capabilities).
  - UI/Form: adds “Automatic (XAA when configured, else OAuth)”; shows OAuth settings for auto; form emits canonical `authMethod` and mirrors `useOAuth`/`useXaa` for auto; `registrationMode` applies to both flows.
  - Reset/persistence: moving off XAA to oauth/bearer/none sends one‑shot `clearXaaConfig`; `authMethod` is persisted through state and serialization; local/hosted unauthorized hooks and connect logging now use the resolver.

<sup>Written for commit d4ab55fbeef7823bbb120cbf5be1b43b88917518. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

