### PR TITLE
feat(xaa): extract shared mock-IdP mint handler cores into the SDK (SAML prep)

### DIFF
--- a/.changeset/xaa-shared-mint-handlers.md
+++ b/.changeset/xaa-shared-mint-handlers.md
@@ -1,0 +1,13 @@
+---
+"@mcpjam/sdk": minor
+---
+
+Extract the mock-IdP mint handler logic shared by the inspector server and the CLI's in-process executor into pure handler cores (`handleXaaAuthenticate`, `handleXaaJsonTokenExchange`, `handleXaaTokenExchangeGrant` in `xaa/mint/handlers.ts`, node entry only). The cores return `{ status, body }` and own the mint contract; transport concerns (parsing, negative-test-mode resolution, org gating, hosted-issuer forwarding, headers) stay in the adapters.
+
+The in-process executor now delegates its `/authenticate`, `/token`, and `/token-exchange` routes to the cores, which aligns it with the server's tested behavior (deliberate parity fixes, not a pure refactor):
+
+- `/authenticate` applies the server's demo-identity defaults (`user-12345` / `demo.user@example.com`) instead of minting an empty-subject ID token, and returns the server's rich body (`{ id_token, token_type, expires_in, user }`) instead of a bare `{ id_token }`.
+- `/token-exchange` returns the server's rich body (`{ id_jag, token_type, issued_token_type, expires_in, negative_test_mode }`) instead of a bare `{ id_jag }`, and its malformed-assertion error messages now match the server's.
+- `/token` (RFC 8693) keeps its already-identical success body but adopts the server's more specific OAuth error descriptions and check order.
+
+The shared XAA state machine reads only the stable keys (`id_token`, `id_jag`, `access_token`), so existing flows are unaffected.

--- a/.changeset/xaa-shared-mint-handlers.md
+++ b/.changeset/xaa-shared-mint-handlers.md
@@ -2,9 +2,9 @@
 "@mcpjam/sdk": minor
 ---
 
-Extract the mock-IdP mint handler logic shared by the inspector server and the CLI's in-process executor into pure handler cores (`handleXaaAuthenticate`, `handleXaaJsonTokenExchange`, `handleXaaTokenExchangeGrant` in `xaa/mint/handlers.ts`, node entry only). The cores return `{ status, body }` and own the mint contract; transport concerns (parsing, negative-test-mode resolution, org gating, hosted-issuer forwarding, headers) stay in the adapters.
+Extract the mock-IdP mint handler logic into pure handler cores (`handleXaaAuthenticate`, `handleXaaJsonTokenExchange`, `handleXaaTokenExchangeGrant` in `xaa/mint/handlers.ts`, node entry only). The cores return `{ status, body }` and own the mint contract; transport concerns (parsing, negative-test-mode resolution, org gating, hosted-issuer forwarding, headers) stay in the adapters.
 
-The in-process executor now delegates its `/authenticate`, `/token`, and `/token-exchange` routes to the cores, which aligns it with the server's tested behavior (deliberate parity fixes, not a pure refactor):
+This change wires the CLI's in-process executor to the cores; a follow-up change rewires the inspector server routes to the same cores (until then the server keeps its own equivalent handlers). The executor now delegates its `/authenticate`, `/token`, and `/token-exchange` routes to the cores, which aligns it with the server's tested behavior (deliberate parity fixes, not a pure refactor):
 
 - `/authenticate` applies the server's demo-identity defaults (`user-12345` / `demo.user@example.com`) instead of minting an empty-subject ID token, and returns the server's rich body (`{ id_token, token_type, expires_in, user }`) instead of a bare `{ id_token }`.
 - `/token-exchange` returns the server's rich body (`{ id_jag, token_type, issued_token_type, expires_in, negative_test_mode }`) instead of a bare `{ id_jag }`, and its malformed-assertion error messages now match the server's.

--- a/sdk/src/xaa/in-process-executor.ts
+++ b/sdk/src/xaa/in-process-executor.ts
@@ -1,27 +1,20 @@
 // Node-only in-process XAARequestExecutor — the CLI's "loopback" analog to the
-// inspector's server-backed executor. It services the three MCPJam-owned mint
-// routes (`/authenticate`, `/token-exchange`, `/proxy/token`) in-process using
-// the node mint, and external AS/MCP requests through the hardened OAuth proxy.
+// inspector's server-backed executor. It services the MCPJam-owned mint routes
+// (`/authenticate`, `/token`, `/token-exchange`, `/proxy/token`) in-process as
+// thin adapters over the shared handler cores in `mint/handlers.ts`, and
+// external AS/MCP requests through the hardened OAuth proxy.
 // This is the seam that lets the CLI drive the shared browser-safe state machine
 // without a running inspector server. Imports crypto/fs (mint) + node:dns
 // (proxy) — MUST stay out of the browser entry.
 import { executeDebugOAuthProxy, executeOAuthProxy } from "../oauth-proxy.js";
-import {
-  ID_JAG_TOKEN_TYPE,
-  ID_TOKEN_TOKEN_TYPE,
-  TOKEN_EXCHANGE_GRANT,
-  XAA_DEBUG_IDP_CLIENT_ID,
-} from "../oauth/client-identity.js";
+import { TOKEN_EXCHANGE_GRANT } from "../oauth/client-identity.js";
 import { getXAAIssuerUrl, initXAAIdpKeyPair } from "./mint/keypair.js";
 import {
-  issueIdJag,
-  issueMockIdToken,
-  issueNegativeIdJag,
-  validateXaaTokenExchangeSubject,
-  verifyXaaJwt,
-} from "./mint/signer.js";
+  handleXaaAuthenticate,
+  handleXaaJsonTokenExchange,
+  handleXaaTokenExchangeGrant,
+} from "./mint/handlers.js";
 import { buildJwtBearerRequest } from "./mint/jwt-bearer.js";
-import { decodeJWT } from "../oauth/state-machines/shared/jwt.js";
 import { DEFAULT_NEGATIVE_TEST_MODE, isNegativeTestMode } from "./constants.js";
 import type {
   XAARequestExecutor,
@@ -118,113 +111,51 @@ export function createInProcessXaaExecutor(
   ): Promise<XAARequestResult> => {
     const body = parseInitBody(init);
 
-    // Mock OIDC login → id_token. Mirrors the server /authenticate route.
+    // Mock OIDC login → id_token. Thin adapter over the shared core, which
+    // owns the server's demo-identity defaults and rich response body.
     if (path.endsWith("/authenticate")) {
-      const { token } = issueMockIdToken({
+      const result = handleXaaAuthenticate({
         issuer: resolveIssuer(),
-        subject: str(body.userId),
-        email: str(body.email),
-        audience: str(body.audience) || undefined,
-        resourceClientId: str(body.resourceClientId) || undefined,
+        userId: nonEmptyString(body.userId),
+        email: nonEmptyString(body.email),
+        audience: nonEmptyString(body.audience),
+        resourceClientId: nonEmptyString(body.resourceClientId),
       });
-      return jsonResult(200, { id_token: token });
+      return jsonResult(result.status, result.body);
     }
 
     // Standards-track RFC 8693 token exchange. The valid debugger flow uses
     // this form-encoded endpoint; the JSON route below remains available for
-    // intentionally malformed assertions used by negative tests.
+    // intentionally malformed assertions used by negative tests. Grant-type
+    // dispatch is the adapter's (it mirrors the server's outer /token route);
+    // everything else lives in the shared core.
     if (path.endsWith("/token") && !path.endsWith("/proxy/token")) {
       const form = parseFormBody(init);
       if (form.grant_type !== TOKEN_EXCHANGE_GRANT) {
         return jsonResult(400, { error: "unsupported_grant_type" });
       }
-      if (
-        form.requested_token_type !== ID_JAG_TOKEN_TYPE ||
-        form.subject_token_type !== ID_TOKEN_TOKEN_TYPE
-      ) {
-        return jsonResult(400, { error: "invalid_request" });
-      }
-      if (!form.subject_token || !form.audience || !form.client_id) {
-        return jsonResult(400, {
-          error: "subject_token, audience and client_id are required",
-        });
-      }
-      if (form.client_id !== XAA_DEBUG_IDP_CLIENT_ID) {
-        return jsonResult(401, {
-          error: "invalid_client",
-          error_description: "Unknown mock IdP client_id",
-        });
-      }
-
-      let subjectPayload: Record<string, unknown>;
-      let subject: ReturnType<typeof validateXaaTokenExchangeSubject>;
-      try {
-        subjectPayload = verifyXaaJwt(form.subject_token, {
-          issuer: resolveIssuer(),
-          typ: "JWT",
-        });
-        subject = validateXaaTokenExchangeSubject(
-          subjectPayload,
-          XAA_DEBUG_IDP_CLIENT_ID
-        );
-      } catch (error) {
-        return jsonResult(400, {
-          error: "invalid_grant",
-          error_description:
-            error instanceof Error ? error.message : "Invalid subject_token",
-        });
-      }
-      const issued = issueIdJag({
-        issuer: resolveIssuer(),
-        subject: subject.subject,
-        email: subject.email,
-        audience: form.audience,
-        resource: form.resource || undefined,
-        clientId: subject.resourceClientId,
-        scope: form.scope || undefined,
-      });
-      return jsonResult(200, {
-        issued_token_type: ID_JAG_TOKEN_TYPE,
-        access_token: issued.token,
-        token_type: "N_A",
-        expires_in: Math.max(
-          0,
-          Math.floor((issued.expiresAt - Date.now()) / 1000)
-        ),
-        ...(form.scope ? { scope: form.scope } : {}),
-      });
+      const result = handleXaaTokenExchangeGrant(resolveIssuer(), form);
+      return jsonResult(result.status, result.body);
     }
 
-    // Token exchange → ID-JAG. Decodes the identity assertion for sub/email,
-    // exactly as the server /token-exchange route does, then mints (applying
-    // the negative-test tamper when requested). Like the server route, a
-    // missing/malformed assertion or one without a subject is a 400 — never a
-    // silently minted empty-subject ID-JAG.
+    // Token exchange → ID-JAG. The adapter mirrors the server's zod +
+    // resolveNegativeTestMode validation; the shared core decodes the
+    // assertion for sub/email and mints (applying the negative-test tamper
+    // when requested). Like the server route, a missing/malformed assertion
+    // or one without a subject is a 400 — never a silently minted
+    // empty-subject ID-JAG.
     if (path.endsWith("/token-exchange")) {
-      const assertion = nonEmptyString(body.identityAssertion);
-      if (!assertion) {
+      const identityAssertion = nonEmptyString(body.identityAssertion);
+      if (!identityAssertion) {
         return jsonResult(400, {
           error: "Token exchange requires a non-empty identity assertion.",
         });
       }
-      const decoded = decodeJWT(assertion);
-      if (!decoded) {
-        return jsonResult(400, {
-          error: "The identity assertion is not a decodable JWT.",
-        });
-      }
-      const claims = asRecord(decoded);
-      const subject = nonEmptyString(claims.sub);
-      if (!subject) {
-        return jsonResult(400, {
-          error: "The identity assertion has no subject (`sub`) claim.",
-        });
-      }
-      const requiredClaims = {
+      const requiredFields = {
         audience: nonEmptyString(body.audience),
         clientId: nonEmptyString(body.clientId),
       };
-      const missingField = Object.entries(requiredClaims).find(
+      const missingField = Object.entries(requiredFields).find(
         ([, value]) => value === undefined
       )?.[0];
       if (missingField) {
@@ -242,22 +173,27 @@ export function createInProcessXaaExecutor(
           )}`,
         });
       }
-      const mode = isNegativeTestMode(body.negativeTestMode)
-        ? body.negativeTestMode
-        : DEFAULT_NEGATIVE_TEST_MODE;
-      const { token } = issueNegativeIdJag(
-        {
+      try {
+        const result = handleXaaJsonTokenExchange({
           issuer: resolveIssuer(),
-          subject,
-          audience: requiredClaims.audience!,
+          identityAssertion,
+          audience: requiredFields.audience!,
           resource: nonEmptyString(body.resource),
-          clientId: requiredClaims.clientId!,
+          clientId: requiredFields.clientId!,
           scope: nonEmptyString(body.scope),
-          email: typeof claims.email === "string" ? claims.email : undefined,
-        },
-        mode
-      );
-      return jsonResult(200, { id_jag: token });
+          negativeTestMode: isNegativeTestMode(body.negativeTestMode)
+            ? body.negativeTestMode
+            : DEFAULT_NEGATIVE_TEST_MODE,
+        });
+        return jsonResult(result.status, result.body);
+      } catch (error) {
+        return jsonResult(400, {
+          error:
+            error instanceof Error
+              ? error.message
+              : "Invalid token exchange request",
+        });
+      }
     }
 
     // jwt-bearer redemption proxy → { status, body } (the upstream token

--- a/sdk/src/xaa/index.ts
+++ b/sdk/src/xaa/index.ts
@@ -51,6 +51,14 @@ export {
   type XaaTokenExchangeSubject,
 } from "./mint/signer.js";
 export {
+  handleXaaAuthenticate,
+  handleXaaJsonTokenExchange,
+  handleXaaTokenExchangeGrant,
+  type XaaAuthenticateParams,
+  type XaaJsonTokenExchangeParams,
+  type XaaMintHandlerResult,
+} from "./mint/handlers.js";
+export {
   buildJwtBearerBody,
   buildJwtBearerRequest,
   type XaaTokenEndpointAuthMethod,

--- a/sdk/src/xaa/mint/handlers.ts
+++ b/sdk/src/xaa/mint/handlers.ts
@@ -1,0 +1,255 @@
+// Shared mock-IdP handler cores for the MCPJam-owned XAA mint routes. The
+// inspector server (Hono routes) and the CLI's in-process executor both wrap
+// these; the cores own the mint contract — status codes, error strings, and
+// response-body shapes — while the adapters own everything transport-shaped:
+// JSON/zod parsing, negative-test-mode resolution, org gating, hosted-issuer
+// forwarding, rate limiting, and cache-control headers. Node-only (the signer
+// pulls in crypto/fs); export from the node barrel, never the browser entry.
+import {
+  ID_JAG_TOKEN_TYPE,
+  ID_TOKEN_TOKEN_TYPE,
+  XAA_DEBUG_IDP_CLIENT_ID,
+} from "../../oauth/client-identity.js";
+import type { NegativeTestMode } from "../constants.js";
+import {
+  issueIdJag,
+  issueMockIdToken,
+  issueNegativeIdJag,
+  validateXaaTokenExchangeSubject,
+  verifyXaaJwt,
+} from "./signer.js";
+
+/** Transport-free handler outcome; the adapter serializes it as JSON. */
+export interface XaaMintHandlerResult {
+  status: number;
+  body: Record<string, unknown>;
+}
+
+function expiresInSeconds(expiresAt: number): number {
+  return Math.max(0, Math.floor((expiresAt - Date.now()) / 1000));
+}
+
+function oauthErrorResult(
+  status: number,
+  error: string,
+  description: string
+): XaaMintHandlerResult {
+  return { status, body: { error, error_description: description } };
+}
+
+// ── /authenticate ──────────────────────────────────────────────────────────
+
+export interface XaaAuthenticateParams {
+  issuer: string;
+  userId?: string;
+  email?: string;
+  audience?: string;
+  resourceClientId?: string;
+}
+
+/**
+ * Mock OIDC login → id_token. Subject and email fall back to the demo
+ * identity when absent, so no path can mint an empty-subject ID token.
+ * Mint failures throw; the adapter owns the error-body shape.
+ */
+export function handleXaaAuthenticate(
+  params: XaaAuthenticateParams
+): XaaMintHandlerResult {
+  const subject = params.userId || "user-12345";
+  const email = params.email || "demo.user@example.com";
+  const issued = issueMockIdToken({
+    issuer: params.issuer,
+    subject,
+    email,
+    audience: params.audience,
+    resourceClientId: params.resourceClientId,
+  });
+
+  return {
+    status: 200,
+    body: {
+      id_token: issued.token,
+      token_type: "Bearer",
+      expires_in: expiresInSeconds(issued.expiresAt),
+      user: {
+        sub: subject,
+        email,
+      },
+    },
+  };
+}
+
+// ── /token-exchange (forgiving JSON mint route) ────────────────────────────
+
+export interface XaaJsonTokenExchangeParams {
+  issuer: string;
+  identityAssertion: string;
+  audience: string;
+  resource?: string;
+  clientId: string;
+  scope?: string;
+  /** Pre-validated by the adapter (zod + resolveNegativeTestMode on the
+   * server, isNegativeTestMode in-process). */
+  negativeTestMode: NegativeTestMode;
+}
+
+// Deliberately unsafe (no signature check): this route exists to mint the
+// intentionally malformed assertions negative tests need.
+function decodeJwtPayloadUnsafe(token: string): Record<string, unknown> {
+  const parts = token.split(".");
+  if (parts.length !== 3) {
+    throw new Error("Identity assertion must be a JWT");
+  }
+
+  try {
+    return JSON.parse(
+      Buffer.from(parts[1], "base64url").toString("utf-8")
+    ) as Record<string, unknown>;
+  } catch (error) {
+    throw new Error(
+      `Identity assertion payload is not valid JSON (${
+        error instanceof Error ? error.message : String(error)
+      })`
+    );
+  }
+}
+
+/**
+ * Token exchange → ID-JAG. Decodes the identity assertion (unverified — see
+ * decodeJwtPayloadUnsafe) for sub/email, then mints, applying the
+ * negative-test tamper when requested. A malformed assertion or one without a
+ * subject throws; the adapter maps that to its 400 shape — never a silently
+ * minted empty-subject ID-JAG.
+ */
+export function handleXaaJsonTokenExchange(
+  params: XaaJsonTokenExchangeParams
+): XaaMintHandlerResult {
+  const identityPayload = decodeJwtPayloadUnsafe(params.identityAssertion);
+  const subject =
+    typeof identityPayload.sub === "string" ? identityPayload.sub.trim() : "";
+  if (!subject) {
+    throw new Error(
+      "Identity assertion payload must contain a non-empty `sub` claim"
+    );
+  }
+  // Carry the ID token's email into the ID-JAG (spec RECOMMENDED) so the
+  // Resource AS can use it for subject resolution / JIT provisioning.
+  const email =
+    typeof identityPayload.email === "string"
+      ? identityPayload.email
+      : undefined;
+
+  const mintParams = {
+    issuer: params.issuer,
+    subject,
+    email,
+    audience: params.audience,
+    resource: params.resource,
+    clientId: params.clientId,
+    scope: params.scope,
+  };
+  const issued =
+    params.negativeTestMode === "valid"
+      ? issueIdJag(mintParams)
+      : issueNegativeIdJag(mintParams, params.negativeTestMode);
+
+  return {
+    status: 200,
+    body: {
+      id_jag: issued.token,
+      token_type: "N_A",
+      issued_token_type: ID_JAG_TOKEN_TYPE,
+      expires_in: expiresInSeconds(issued.expiresAt),
+      negative_test_mode: params.negativeTestMode,
+    },
+  };
+}
+
+// ── /token (RFC 8693 token-exchange grant) ─────────────────────────────────
+
+/**
+ * Standards-track RFC 8693 token exchange over raw form params. Grant-type
+ * dispatch, cross-origin checks, IP caps, and org gating are adapter
+ * concerns; this core owns the OAuth-error-shaped failures and the rich
+ * success body. Stricter than the JSON route: the subject token must be an ID
+ * token THIS issuer signed, unexpired.
+ */
+export function handleXaaTokenExchangeGrant(
+  issuer: string,
+  form: Record<string, string>
+): XaaMintHandlerResult {
+  if (form.requested_token_type !== ID_JAG_TOKEN_TYPE) {
+    return oauthErrorResult(
+      400,
+      "invalid_request",
+      `requested_token_type must be ${ID_JAG_TOKEN_TYPE}`
+    );
+  }
+  if (form.subject_token_type !== ID_TOKEN_TOKEN_TYPE) {
+    return oauthErrorResult(
+      400,
+      "invalid_request",
+      `subject_token_type must be ${ID_TOKEN_TOKEN_TYPE}`
+    );
+  }
+  const clientId = form.client_id;
+  if (!clientId) {
+    return oauthErrorResult(400, "invalid_request", "client_id is required");
+  }
+  // This endpoint models the Client-to-IdP exchange. Its client_id is the
+  // public debugger client registered at the mock IdP, not the separate
+  // client identity that the RAS expects in the resulting ID-JAG.
+  if (clientId !== XAA_DEBUG_IDP_CLIENT_ID) {
+    return oauthErrorResult(
+      401,
+      "invalid_client",
+      "Unknown mock IdP client_id"
+    );
+  }
+  if (!form.subject_token || !form.audience) {
+    return oauthErrorResult(
+      400,
+      "invalid_request",
+      "subject_token and audience are required"
+    );
+  }
+
+  let subjectPayload: Record<string, unknown>;
+  let subject: ReturnType<typeof validateXaaTokenExchangeSubject>;
+  try {
+    subjectPayload = verifyXaaJwt(form.subject_token, {
+      issuer,
+      typ: "JWT",
+    });
+    subject = validateXaaTokenExchangeSubject(
+      subjectPayload,
+      XAA_DEBUG_IDP_CLIENT_ID
+    );
+  } catch (error) {
+    return oauthErrorResult(
+      400,
+      "invalid_grant",
+      error instanceof Error ? error.message : "Invalid subject_token"
+    );
+  }
+  const issued = issueIdJag({
+    issuer,
+    subject: subject.subject,
+    email: subject.email,
+    audience: form.audience,
+    resource: form.resource || undefined,
+    clientId: subject.resourceClientId,
+    scope: form.scope || undefined,
+  });
+
+  return {
+    status: 200,
+    body: {
+      issued_token_type: ID_JAG_TOKEN_TYPE,
+      access_token: issued.token,
+      token_type: "N_A",
+      expires_in: expiresInSeconds(issued.expiresAt),
+      ...(form.scope ? { scope: form.scope } : {}),
+    },
+  };
+}

--- a/sdk/tests/xaa/in-process-executor.test.ts
+++ b/sdk/tests/xaa/in-process-executor.test.ts
@@ -59,6 +59,33 @@ describe("createInProcessXaaExecutor internal routes", () => {
     expect(claims.email).toBe("u@example.com");
   });
 
+  it("/authenticate returns the rich server-parity body", async () => {
+    const exec = createInProcessXaaExecutor({ issuerBaseUrl: ISSUER_BASE });
+    const result = await exec.internalRequest(
+      "/authenticate",
+      post({ userId: "user-1", email: "u@example.com" })
+    );
+    expect(result.status).toBe(200);
+    const body = result.body as Record<string, unknown>;
+    expect(body.token_type).toBe("Bearer");
+    expect(body.expires_in).toBeGreaterThan(0);
+    expect(body.user).toEqual({ sub: "user-1", email: "u@example.com" });
+  });
+
+  it("/authenticate applies the server's demo-identity defaults", async () => {
+    const exec = createInProcessXaaExecutor({ issuerBaseUrl: ISSUER_BASE });
+    const result = await exec.internalRequest("/authenticate", post({}));
+    expect(result.status).toBe(200);
+    const body = result.body as Record<string, unknown>;
+    expect(body.user).toEqual({
+      sub: "user-12345",
+      email: "demo.user@example.com",
+    });
+    const claims = decodeJWT(body.id_token as string)!;
+    expect(claims.sub).toBe("user-12345");
+    expect(claims.email).toBe("demo.user@example.com");
+  });
+
   it("/token-exchange decodes the assertion and mints an ID-JAG", async () => {
     const exec = createInProcessXaaExecutor({ issuerBaseUrl: ISSUER_BASE });
     const issuer = getXAAIssuerUrl(ISSUER_BASE);
@@ -87,6 +114,31 @@ describe("createInProcessXaaExecutor internal routes", () => {
     expect(claims.resource).toBe(RESOURCE);
     expect(claims.client_id).toBe("client-1");
     expect(claims.email).toBe("u@example.com");
+  });
+
+  it("/token-exchange returns the rich server-parity body", async () => {
+    const exec = createInProcessXaaExecutor({ issuerBaseUrl: ISSUER_BASE });
+    const issuer = getXAAIssuerUrl(ISSUER_BASE);
+    const { token: idToken } = issueMockIdToken({
+      issuer,
+      subject: "user-1",
+      email: "u@example.com",
+    });
+    const result = await exec.internalRequest(
+      "/token-exchange",
+      post({
+        identityAssertion: idToken,
+        audience: AS_ISSUER,
+        clientId: "client-1",
+        negativeTestMode: "wrong_audience",
+      })
+    );
+    expect(result.status).toBe(200);
+    const body = result.body as Record<string, unknown>;
+    expect(body.token_type).toBe("N_A");
+    expect(body.issued_token_type).toBe(ID_JAG_TOKEN_TYPE);
+    expect(body.expires_in).toBeGreaterThan(0);
+    expect(body.negative_test_mode).toBe("wrong_audience");
   });
 
   it("/token handles the RFC 8693 form grant", async () => {

--- a/sdk/tests/xaa/mint-handlers.test.ts
+++ b/sdk/tests/xaa/mint-handlers.test.ts
@@ -1,0 +1,313 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync } from "fs";
+import os from "os";
+import path from "path";
+import {
+  handleXaaAuthenticate,
+  handleXaaJsonTokenExchange,
+  handleXaaTokenExchangeGrant,
+} from "../../src/xaa/mint/handlers.js";
+import { resetXAAIdpKeyPairForTests } from "../../src/xaa/mint/keypair.js";
+import { issueMockIdToken, verifyXaaJwt } from "../../src/xaa/mint/signer.js";
+import { decodeJWT } from "../../src/oauth/state-machines/shared/jwt.js";
+import {
+  ID_JAG_TOKEN_TYPE,
+  ID_TOKEN_TOKEN_TYPE,
+  TOKEN_EXCHANGE_GRANT,
+  XAA_DEBUG_IDP_CLIENT_ID,
+} from "../../src/oauth/client-identity.js";
+
+const ISSUER = "https://issuer.example.com/api/mcp/xaa";
+const AS_ISSUER = "https://auth.example.com";
+const RESOURCE = "https://mcp.example.com/mcp";
+
+describe("shared XAA mint handler cores", () => {
+  const originalKeyDir = process.env.XAA_IDP_KEY_DIR;
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), "xaa-handlers-"));
+    process.env.XAA_IDP_KEY_DIR = tempDir;
+    resetXAAIdpKeyPairForTests();
+  });
+
+  afterEach(() => {
+    resetXAAIdpKeyPairForTests();
+    rmSync(tempDir, { recursive: true, force: true });
+    if (originalKeyDir === undefined) delete process.env.XAA_IDP_KEY_DIR;
+    else process.env.XAA_IDP_KEY_DIR = originalKeyDir;
+  });
+
+  describe("handleXaaAuthenticate", () => {
+    it("mints a verifiable id_token with the rich response body", () => {
+      const result = handleXaaAuthenticate({
+        issuer: ISSUER,
+        userId: "user-1",
+        email: "u@example.com",
+        audience: "client-1",
+        resourceClientId: "ras-client-1",
+      });
+
+      expect(result.status).toBe(200);
+      expect(result.body.token_type).toBe("Bearer");
+      expect(result.body.expires_in).toBeGreaterThan(0);
+      expect(result.body.user).toEqual({
+        sub: "user-1",
+        email: "u@example.com",
+      });
+      const claims = verifyXaaJwt(result.body.id_token as string, {
+        issuer: ISSUER,
+        typ: "JWT",
+      });
+      expect(claims.sub).toBe("user-1");
+      expect(claims.email).toBe("u@example.com");
+      expect(claims.aud).toBe("client-1");
+    });
+
+    it("falls back to the demo identity when subject/email are absent", () => {
+      const result = handleXaaAuthenticate({ issuer: ISSUER });
+
+      expect(result.status).toBe(200);
+      expect(result.body.user).toEqual({
+        sub: "user-12345",
+        email: "demo.user@example.com",
+      });
+      const claims = decodeJWT(result.body.id_token as string)!;
+      expect(claims.sub).toBe("user-12345");
+      expect(claims.email).toBe("demo.user@example.com");
+    });
+
+    it("falls back to the demo identity on empty strings too", () => {
+      const result = handleXaaAuthenticate({
+        issuer: ISSUER,
+        userId: "",
+        email: "",
+      });
+      expect(result.body.user).toEqual({
+        sub: "user-12345",
+        email: "demo.user@example.com",
+      });
+    });
+  });
+
+  describe("handleXaaJsonTokenExchange", () => {
+    const mintAssertion = (subject: string) =>
+      issueMockIdToken({
+        issuer: ISSUER,
+        subject,
+        email: "u@example.com",
+      }).token;
+
+    it("mints an ID-JAG with the rich response body", () => {
+      const result = handleXaaJsonTokenExchange({
+        issuer: ISSUER,
+        identityAssertion: mintAssertion("user-1"),
+        audience: AS_ISSUER,
+        resource: RESOURCE,
+        clientId: "client-1",
+        scope: "read:tools",
+        negativeTestMode: "valid",
+      });
+
+      expect(result.status).toBe(200);
+      expect(result.body.token_type).toBe("N_A");
+      expect(result.body.issued_token_type).toBe(ID_JAG_TOKEN_TYPE);
+      expect(result.body.expires_in).toBeGreaterThan(0);
+      expect(result.body.negative_test_mode).toBe("valid");
+      const claims = verifyXaaJwt(result.body.id_jag as string, {
+        issuer: ISSUER,
+        typ: "oauth-id-jag+jwt",
+      });
+      expect(claims).toMatchObject({
+        sub: "user-1",
+        aud: AS_ISSUER,
+        resource: RESOURCE,
+        client_id: "client-1",
+        scope: "read:tools",
+        email: "u@example.com",
+      });
+    });
+
+    it("applies the negative-test tamper and echoes the mode", () => {
+      const result = handleXaaJsonTokenExchange({
+        issuer: ISSUER,
+        identityAssertion: mintAssertion("user-1"),
+        audience: AS_ISSUER,
+        clientId: "client-1",
+        negativeTestMode: "wrong_audience",
+      });
+
+      expect(result.status).toBe(200);
+      expect(result.body.negative_test_mode).toBe("wrong_audience");
+      expect(decodeJWT(result.body.id_jag as string)!.aud).toBe(
+        "https://wrong-audience.example.com"
+      );
+    });
+
+    it("throws on a non-JWT assertion (adapter maps to 400)", () => {
+      expect(() =>
+        handleXaaJsonTokenExchange({
+          issuer: ISSUER,
+          identityAssertion: "not-a-jwt",
+          audience: AS_ISSUER,
+          clientId: "client-1",
+          negativeTestMode: "valid",
+        })
+      ).toThrow("Identity assertion must be a JWT");
+    });
+
+    it("throws on an assertion without a subject", () => {
+      expect(() =>
+        handleXaaJsonTokenExchange({
+          issuer: ISSUER,
+          identityAssertion: mintAssertion(""),
+          audience: AS_ISSUER,
+          clientId: "client-1",
+          negativeTestMode: "valid",
+        })
+      ).toThrow(
+        "Identity assertion payload must contain a non-empty `sub` claim"
+      );
+    });
+  });
+
+  describe("handleXaaTokenExchangeGrant", () => {
+    const mintSubjectToken = () =>
+      issueMockIdToken({
+        issuer: ISSUER,
+        subject: "user-1",
+        email: "u@example.com",
+        audience: XAA_DEBUG_IDP_CLIENT_ID,
+        resourceClientId: "client-1",
+      }).token;
+
+    const validForm = () => ({
+      grant_type: TOKEN_EXCHANGE_GRANT,
+      requested_token_type: ID_JAG_TOKEN_TYPE,
+      subject_token: mintSubjectToken(),
+      subject_token_type: ID_TOKEN_TOKEN_TYPE,
+      client_id: XAA_DEBUG_IDP_CLIENT_ID,
+      audience: AS_ISSUER,
+      resource: RESOURCE,
+      scope: "read:tools",
+    });
+
+    it("mints an ID-JAG with the rich RFC 8693 response body", () => {
+      const result = handleXaaTokenExchangeGrant(ISSUER, validForm());
+
+      expect(result.status).toBe(200);
+      expect(result.body.issued_token_type).toBe(ID_JAG_TOKEN_TYPE);
+      expect(result.body.token_type).toBe("N_A");
+      expect(result.body.expires_in).toBeGreaterThan(0);
+      expect(result.body.scope).toBe("read:tools");
+      const claims = verifyXaaJwt(result.body.access_token as string, {
+        issuer: ISSUER,
+        typ: "oauth-id-jag+jwt",
+      });
+      expect(claims).toMatchObject({
+        sub: "user-1",
+        aud: AS_ISSUER,
+        resource: RESOURCE,
+        client_id: "client-1",
+        scope: "read:tools",
+        email: "u@example.com",
+      });
+    });
+
+    it("omits scope from the response when the request had none", () => {
+      const { scope: _scope, ...form } = validForm();
+      const result = handleXaaTokenExchangeGrant(ISSUER, form);
+      expect(result.status).toBe(200);
+      expect("scope" in result.body).toBe(false);
+    });
+
+    it("rejects a wrong requested_token_type with 400 invalid_request", () => {
+      const result = handleXaaTokenExchangeGrant(ISSUER, {
+        ...validForm(),
+        requested_token_type: "urn:example:wrong",
+      });
+      expect(result.status).toBe(400);
+      expect(result.body.error).toBe("invalid_request");
+      expect(result.body.error_description).toBe(
+        `requested_token_type must be ${ID_JAG_TOKEN_TYPE}`
+      );
+    });
+
+    it("rejects a wrong subject_token_type with 400 invalid_request", () => {
+      const result = handleXaaTokenExchangeGrant(ISSUER, {
+        ...validForm(),
+        subject_token_type: "urn:example:wrong",
+      });
+      expect(result.status).toBe(400);
+      expect(result.body.error).toBe("invalid_request");
+      expect(result.body.error_description).toBe(
+        `subject_token_type must be ${ID_TOKEN_TOKEN_TYPE}`
+      );
+    });
+
+    it("rejects a missing client_id with 400 invalid_request", () => {
+      const { client_id: _clientId, ...form } = validForm();
+      const result = handleXaaTokenExchangeGrant(ISSUER, form);
+      expect(result.status).toBe(400);
+      expect(result.body.error).toBe("invalid_request");
+      expect(result.body.error_description).toBe("client_id is required");
+    });
+
+    it("rejects an unknown client_id with 401 invalid_client", () => {
+      const result = handleXaaTokenExchangeGrant(ISSUER, {
+        ...validForm(),
+        client_id: "someone-else",
+      });
+      expect(result.status).toBe(401);
+      expect(result.body.error).toBe("invalid_client");
+      expect(result.body.error_description).toBe("Unknown mock IdP client_id");
+    });
+
+    it("rejects a missing subject_token/audience with 400 invalid_request", () => {
+      for (const field of ["subject_token", "audience"] as const) {
+        const form = validForm();
+        delete (form as Record<string, string>)[field];
+        const result = handleXaaTokenExchangeGrant(ISSUER, form);
+        expect(result.status, field).toBe(400);
+        expect(result.body.error, field).toBe("invalid_request");
+        expect(result.body.error_description, field).toBe(
+          "subject_token and audience are required"
+        );
+      }
+    });
+
+    it("rejects a subject token from another issuer with 400 invalid_grant", () => {
+      const foreign = issueMockIdToken({
+        issuer: "https://other-issuer.example.com/xaa",
+        subject: "user-1",
+        email: "u@example.com",
+        audience: XAA_DEBUG_IDP_CLIENT_ID,
+        resourceClientId: "client-1",
+      }).token;
+      const result = handleXaaTokenExchangeGrant(ISSUER, {
+        ...validForm(),
+        subject_token: foreign,
+      });
+      expect(result.status).toBe(400);
+      expect(result.body.error).toBe("invalid_grant");
+    });
+
+    it("rejects a subject token without the RAS client mapping with 400 invalid_grant", () => {
+      const unmapped = issueMockIdToken({
+        issuer: ISSUER,
+        subject: "user-1",
+        email: "u@example.com",
+        audience: XAA_DEBUG_IDP_CLIENT_ID,
+      }).token;
+      const result = handleXaaTokenExchangeGrant(ISSUER, {
+        ...validForm(),
+        subject_token: unmapped,
+      });
+      expect(result.status).toBe(400);
+      expect(result.body.error).toBe("invalid_grant");
+      expect(result.body.error_description).toBe(
+        "The subject token is missing the IdP's RAS client mapping"
+      );
+    });
+  });
+});


### PR DESCRIPTION
## What

Extracts the three duplicated XAA mock-IdP handler bodies (`/authenticate`, RFC 8693 `/token`, JSON `/token-exchange`) into pure, transport-agnostic cores in the SDK (`sdk/src/xaa/mint/handlers.ts`), returning `{ status, body }`. The CLI's in-process executor now delegates to these cores instead of re-implementing them. **No SAML yet** — this is the shared foundation so the SAML branch (next PR) is written once and both the inspector server and the CLI get it.

## Why

The inspector server routes and the CLI's in-process executor carried parallel copies of the same mint/validation logic. This is the "extract shared before forking" step: the SAML work adds one branch to each core rather than two divergent implementations.

## Parity fixes (these are behavior changes, not a pure refactor)

The two implementations had drifted; the cores adopt the server's behavior as canonical:
- `/authenticate` in-process now applies the server's subject/email defaults (`user-12345` / `demo.user@example.com`) instead of passing raw input (an empty-string `sub` was mintable).
- The bare `{id_token}` / `{id_jag}` in-process responses are enriched to the server's rich bodies. The RFC 8693 `/token` route was already identical on both sides and is preserved byte-for-byte.

## Tests

Full SDK suite green (`1935 passed`), including a new `mint-handlers.test.ts` (16 cases: happy paths, defaults, all 400/401 grant errors, negative modes). Existing executor tests read keys via cast, so the enrichment did not disturb them. Changeset included (`@mcpjam/sdk` minor, additive exports only).

## Stack

Bottom of the XAA-SAML stack. **Merge order: this → SAML SDK → server → client.** Review this PR's single commit on its own; the SAML PRs build on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted the mock-IdP mint logic into shared, transport-agnostic handlers in `@mcpjam/sdk`. The CLI in-process executor now delegates to these cores; the inspector server keeps its own handlers for now and will adopt the cores in a follow-up.

- **Refactors**
  - Added `handleXaaAuthenticate`, `handleXaaJsonTokenExchange`, `handleXaaTokenExchangeGrant` in `sdk/src/xaa/mint/handlers.ts` that return `{ status, body }` (exported from the `@mcpjam/sdk` node entry only).
  - Wired the CLI executor to these cores for `/authenticate`, `/token`, and `/token-exchange`; behavior now matches the server (demo defaults and rich bodies for `/authenticate` and `/token-exchange`; clearer OAuth errors/order for `/token`).
  - Added tests for the new handlers and updated executor tests; minor changeset (additive).

<sup>Written for commit b50737e081b385f07c69ed6dc2c350ee518ff7d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth/token minting and changes CLI mock-IdP response shapes and validation messages, though the shared state machine still uses stable token keys and the server path is unchanged until a follow-up.
> 
> **Overview**
> Adds **shared mock-IdP handler cores** in `sdk/src/xaa/mint/handlers.ts` (`handleXaaAuthenticate`, `handleXaaJsonTokenExchange`, `handleXaaTokenExchangeGrant`) that return `{ status, body }` and centralize mint contracts (status codes, errors, response shapes). Transport stays in adapters.
> 
> The **CLI in-process executor** now delegates `/authenticate`, `/token`, and `/token-exchange` to those cores instead of inline mint logic, and **exports** the handlers from the `@mcpjam/sdk` node barrel. Inspector server routes are unchanged in this PR (planned follow-up).
> 
> **Parity with the inspector server** (behavior changes for the CLI path): `/authenticate` uses demo defaults (`user-12345` / `demo.user@example.com`) and a rich body; `/token-exchange` returns the full ID-JAG payload and aligned assertion error text; RFC 8693 `/token` keeps the same success shape with server-style OAuth error descriptions and validation order.
> 
> New **`mint-handlers.test.ts`** and expanded executor tests cover the cores and server-parity responses; changeset marks `@mcpjam/sdk` minor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b50737e081b385f07c69ed6dc2c350ee518ff7d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->