### PR TITLE
feat(auth): "Auto" dropdown polish — short label, option descriptions, per-server helper

### DIFF
--- a/design-system/src/components/select.tsx
+++ b/design-system/src/components/select.tsx
@@ -99,8 +99,18 @@ function SelectLabel({
 function SelectItem({
   className,
   children,
+  description,
   ...props
-}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+}: React.ComponentProps<typeof SelectPrimitive.Item> & {
+  /**
+   * Optional muted second line rendered in the dropdown only. It lives
+   * outside `ItemText` (wrapped in a div so it isn't a direct span child the
+   * `*:[span]:last:*` utilities would restyle), because the closed trigger's
+   * `SelectValue` mirrors the `ItemText` subtree — only the label may go in
+   * there.
+   */
+  description?: string;
+}) {
   return (
     <SelectPrimitive.Item
       data-slot="select-item"
@@ -115,7 +125,19 @@ function SelectItem({
           <CheckIcon className="size-4" />
         </SelectPrimitive.ItemIndicator>
       </span>
-      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+      {description != null ? (
+        <div className="flex min-w-0 flex-col items-start gap-0.5">
+          <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+          <span
+            data-slot="select-item-description"
+            className="text-muted-foreground text-xs"
+          >
+            {description}
+          </span>
+        </div>
+      ) : (
+        <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+      )}
     </SelectPrimitive.Item>
   );
 }

--- a/design-system/src/components/select.tsx
+++ b/design-system/src/components/select.tsx
@@ -125,7 +125,7 @@ function SelectItem({
           <CheckIcon className="size-4" />
         </SelectPrimitive.ItemIndicator>
       </span>
-      {description != null ? (
+      {description ? (
         <div className="flex min-w-0 flex-col items-start gap-0.5">
           <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
           <span

--- a/mcpjam-inspector/client/src/components/connection/AddServerModal.tsx
+++ b/mcpjam-inspector/client/src/components/connection/AddServerModal.tsx
@@ -450,6 +450,7 @@ export function AddServerModal({
               xaaEmail={formState.xaaEmail}
               onXaaEmailChange={formState.setXaaEmail}
               signedInEmail={user?.email}
+              autoSelectsXaa={formState.autoSelectsXaa}
             />
           )}
 

--- a/mcpjam-inspector/client/src/components/connection/EditServerFormContent.tsx
+++ b/mcpjam-inspector/client/src/components/connection/EditServerFormContent.tsx
@@ -279,6 +279,7 @@ export function EditServerFormContent({
             xaaEmail={formState.xaaEmail}
             onXaaEmailChange={formState.setXaaEmail}
             signedInEmail={signedInUser?.email}
+            autoSelectsXaa={formState.autoSelectsXaa}
           />
         </div>
       )}

--- a/mcpjam-inspector/client/src/components/connection/__tests__/AuthenticationSection.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/AuthenticationSection.test.tsx
@@ -142,6 +142,72 @@ describe("AuthenticationSection", () => {
     expect(screen.getByText("Cross-App Access (XAA)")).toBeInTheDocument();
   });
 
+  const autoProps = {
+    serverUrl: "https://example.com/mcp",
+    authType: "auto" as const,
+    onAuthTypeChange: vi.fn(),
+    showAuthSettings: false,
+    bearerToken: "",
+    onBearerTokenChange: vi.fn(),
+    oauthScopesInput: "",
+    onOauthScopesChange: vi.fn(),
+    oauthProtocolMode: "2025-11-25" as const,
+    onOauthProtocolModeChange: vi.fn(),
+    registrationMode: "auto" as const,
+    onOauthRegistrationModeChange: vi.fn(),
+    useCustomClientId: false,
+    onUseCustomClientIdChange: vi.fn(),
+    clientId: "",
+    onClientIdChange: vi.fn(),
+    clientSecret: "",
+    onClientSecretChange: vi.fn(),
+    clientIdError: null,
+    clientSecretError: null,
+  };
+
+  it("shows only the Auto label in the closed trigger; the description only in the open menu", async () => {
+    xaaFlagValue = true;
+    render(<AuthenticationSection {...autoProps} />);
+
+    const trigger = screen.getByRole("combobox");
+    expect(trigger).toHaveTextContent("Auto");
+    expect(
+      screen.queryByText(
+        "Uses Cross-App Access when configured, otherwise OAuth",
+      ),
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(trigger);
+    expect(
+      screen.getByText("Uses Cross-App Access when configured, otherwise OAuth"),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps the Auto option visible for a server saved as auto, even when the flag is off", () => {
+    xaaFlagValue = false;
+    render(<AuthenticationSection {...autoProps} />);
+
+    expect(screen.getByRole("combobox")).toHaveTextContent("Auto");
+  });
+
+  it("explains Auto per-server: OAuth when XAA is not configured", () => {
+    xaaFlagValue = true;
+    render(<AuthenticationSection {...autoProps} autoSelectsXaa={false} />);
+
+    expect(screen.getByText("Auto will use OAuth.")).toBeInTheDocument();
+  });
+
+  it("explains Auto per-server: XAA when configured", () => {
+    xaaFlagValue = true;
+    render(<AuthenticationSection {...autoProps} autoSelectsXaa={true} />);
+
+    expect(
+      screen.getByText(
+        "Cross-App Access is configured — connecting mints a cross-app token.",
+      ),
+    ).toBeInTheDocument();
+  });
+
   it("does not show the OAuth plan explainer for a typical automatic OAuth setup", () => {
     render(
       <AuthenticationSection

--- a/mcpjam-inspector/client/src/components/connection/hooks/use-server-form.ts
+++ b/mcpjam-inspector/client/src/components/connection/hooks/use-server-form.ts
@@ -715,6 +715,12 @@ export function useServerForm(
     }
   };
 
+  // Whether Auto selects XAA for this server — mirrors the server-side
+  // xaaConfigured rule (an IdP mode is chosen AND a client id is stored).
+  // Add flows have no existing server, so this is always false there.
+  const autoSelectsXaa =
+    server?.authServerMode != null && Boolean(clientId.trim());
+
   const buildFormData = (buildOptions?: {
     /**
      * Stored headers fetched from the secrets API at save time. Supplying
@@ -828,8 +834,6 @@ export function useServerForm(
     } else if (authType === "xaa") {
       useXaa = true;
     } else if (authType === "auto") {
-      const autoSelectsXaa =
-        server?.authServerMode != null && Boolean(clientId.trim());
       useXaa = autoSelectsXaa;
       useOAuth = !autoSelectsXaa;
     }
@@ -1034,6 +1038,7 @@ export function useServerForm(
       setAuthDirty(true);
       setAuthType(value);
     },
+    autoSelectsXaa,
     useCustomClientId,
     setUseCustomClientId,
     // XAA-specific fields (client id / secret / scopes are shared above)

--- a/mcpjam-inspector/client/src/components/connection/shared/AuthenticationSection.tsx
+++ b/mcpjam-inspector/client/src/components/connection/shared/AuthenticationSection.tsx
@@ -76,6 +76,12 @@ interface AuthenticationSectionProps {
   onXaaEmailChange?: (value: string) => void;
   /** Signed-in user's email — shown as the default for the simulated identity. */
   signedInEmail?: string;
+  /**
+   * True when Auto would select XAA for this server (an IdP mode is chosen
+   * and a client id is stored — same rule as the server's xaaConfigured).
+   * Drives the helper copy under the select.
+   */
+  autoSelectsXaa?: boolean;
 }
 
 const PROTOCOL_OPTIONS: Array<{
@@ -131,6 +137,7 @@ export function AuthenticationSection({
   xaaEmail = "",
   onXaaEmailChange,
   signedInEmail,
+  autoSelectsXaa = false,
 }: AuthenticationSectionProps) {
   const [showAdvancedOAuth, setShowAdvancedOAuth] = useState(false);
   const [revealedClientSecret, setRevealedClientSecret] = useState<
@@ -149,9 +156,11 @@ export function AuthenticationSection({
   const [isBearerTokenVisible, setIsBearerTokenVisible] = useState(false);
 
   const xaaFlagEnabled = useFeatureFlagEnabled("xaa");
-  // Keep the option visible if a server is already configured with XAA, even
-  // when the flag is off, so the trigger doesn't render blank for it.
-  const showXaaOption = xaaFlagEnabled === true || authType === "xaa";
+  // Keep the options visible if a server is already configured with XAA or
+  // Auto, even when the flag is off, so the trigger doesn't render blank for
+  // it.
+  const showXaaOption =
+    xaaFlagEnabled === true || authType === "xaa" || authType === "auto";
 
   const canRevealClientSecret =
     hasStoredClientSecret &&
@@ -314,25 +323,41 @@ export function AuthenticationSection({
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="none">No Authentication</SelectItem>
-              <SelectItem value="bearer">Bearer Token</SelectItem>
-              <SelectItem value="oauth">OAuth</SelectItem>
+              <SelectItem value="none" description="Connect without credentials">
+                No Authentication
+              </SelectItem>
+              <SelectItem
+                value="bearer"
+                description="Send a static token you provide"
+              >
+                Bearer Token
+              </SelectItem>
+              <SelectItem value="oauth" description="Interactive browser sign-in">
+                OAuth
+              </SelectItem>
               {showXaaOption && (
-                <SelectItem value="xaa">Cross-App Access (XAA)</SelectItem>
+                <SelectItem
+                  value="xaa"
+                  description="Server-side token exchange via your IdP"
+                >
+                  Cross-App Access (XAA)
+                </SelectItem>
               )}
               {showXaaOption && (
-                <SelectItem value="auto">
-                  Automatic (XAA when configured, else OAuth)
+                <SelectItem
+                  value="auto"
+                  description="Uses Cross-App Access when configured, otherwise OAuth"
+                >
+                  Auto
                 </SelectItem>
               )}
             </SelectContent>
           </Select>
           {authType === "auto" && (
             <p className="text-xs text-muted-foreground">
-              Selects Cross-App Access when this server has an IdP mode and a
-              stored client ID, and OAuth otherwise. The selection happens
-              before connecting — a failed XAA mint surfaces the error rather
-              than retrying as OAuth.
+              {autoSelectsXaa
+                ? "Cross-App Access is configured — connecting mints a cross-app token."
+                : "Auto will use OAuth."}
             </p>
           )}
         </div>


### PR DESCRIPTION
## What

UI-only polish of the Authentication dropdown in Add/Edit MCP Server. No behavior change.

- **"Automatic (XAA when configured, else OAuth)" → "Auto"**, with the explanation moved to a muted description line inside the dropdown item. All auth options get a short description.
- **Design system**: `SelectItem` gains an optional `description` prop. The description renders outside `ItemText` (wrapped in a div), so the closed trigger — which mirrors the `ItemText` subtree via `SelectValue` — shows only the label.
- **Per-server helper**: the static paragraph under the select is replaced by one sentence stating what Auto will do for *this* server, driven by a new `autoSelectsXaa` prop (same rule as the server-side `xaaConfigured`: IdP mode chosen + client id stored), hoisted from `buildFormData`'s existing derivation and threaded through both modals.
- **Bug fix**: a server persisted with `authMethod: "auto"` while the `xaa` flag is off rendered a blank trigger — the visibility escape hatch only covered `authType === "xaa"`.

## Screenshots

Before: the option label was a full sentence (see linked context). After: trigger shows "Auto"; the open menu shows label + muted description per option.

## Tests

- Trigger shows only "Auto"; description appears only in the open menu.
- Persisted-auto + flag-off no longer blank.
- Helper copy switches between the XAA-configured and OAuth variants.
- Existing `use-server-form` derived-boolean tests unchanged and passing (51/51 in the two affected suites).

Part 1 of 3 — behavior change (unauthenticated-first Auto with OAuth escalation on 401) follows in a stacked PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and copy only; save-time Auto/XAA derivation is refactored to a shared boolean without changing the rule. Design-system `SelectItem` API is extended but backward compatible.
> 
> **Overview**
> **Authentication dropdown polish** in Add/Edit MCP Server: shorter labels, muted per-option descriptions in the open menu, and clearer **Auto** copy for the current server.
> 
> `SelectItem` gains an optional **`description`** rendered outside `ItemText`, so the closed trigger (via `SelectValue`) shows only the primary label—e.g. **Auto**, not the full “XAA when configured…” sentence. All auth modes get a one-line description in the list.
> 
> **Auto** is renamed from the long inline label; **`autoSelectsXaa`** is hoisted in `use-server-form` (same rule as before: IdP mode + stored client id) and passed into **`AuthenticationSection`** to replace the generic paragraph with either “Auto will use OAuth.” or the XAA-configured line.
> 
> **Fix:** when the `xaa` flag is off but a server is saved with **`authMethod: "auto"`**, XAA/Auto options stay visible (like persisted XAA) so the combobox no longer renders blank.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d87ee212345cff70dc0a3f0af857088c30b70db2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polishes the Authentication dropdown: short “Auto” label with per-option descriptions and a per‑server helper showing what Auto will choose. Adds a `description` prop to the design-system select so the closed trigger shows only the label.

- **New Features**
  - Renamed “Automatic (XAA when configured, else OAuth)” to “Auto” and moved the explanation to a muted description line; added short descriptions for all auth options.
  - `SelectItem` now supports an optional `description` rendered outside `ItemText`, keeping `SelectValue` limited to the label.
  - Replaced the static helper with a per‑server line driven by `autoSelectsXaa` (derived in `use-server-form` and passed into Add/Edit modals).

- **Bug Fixes**
  - Prevents a blank trigger when a server saved with `authMethod: "auto"` and the `xaa` flag is off by keeping XAA/Auto options visible for persisted selections.
  - Treats an empty-string `description` as absent so no empty second line shows in the dropdown.

<sup>Written for commit d87ee212345cff70dc0a3f0af857088c30b70db2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

