### PR TITLE
feat(xaa): store EMA capability in hostConfig + Protocol-tab toggle

### DIFF
--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ProtocolTab.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ProtocolTab.tsx
@@ -8,7 +8,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@mcpjam/design-system/select";
-import { isKnownProtocolVersion } from "@mcpjam/sdk/browser";
+import { Switch } from "@mcpjam/design-system/switch";
+import { isKnownProtocolVersion, XAA_MCP_EXTENSION } from "@mcpjam/sdk/browser";
 import {
   type HostConfigInputV2,
   type HostConfigMcpProfileV1,
@@ -127,6 +128,71 @@ function protocolToJson(draft: HostConfigInputV2): ProtocolDoc {
   }
 
   return doc;
+}
+
+/**
+ * Whether the draft's stored clientCapabilities advertise the MCP
+ * Enterprise-Managed Authorization extension. `extensions` is freeform
+ * JSON, so guard for a plain object before the key check — presence of
+ * the key is the signal, whatever its value.
+ */
+export function hasEmaExtension(
+  capabilities: Record<string, unknown> | undefined
+): boolean {
+  const exts = capabilities?.extensions;
+  return (
+    isPlainObject(exts) &&
+    Object.prototype.hasOwnProperty.call(exts, XAA_MCP_EXTENSION)
+  );
+}
+
+/**
+ * Advertise the EMA extension in the stored clientCapabilities. Unlike the
+ * Apps tab's `withMcpUiExtension` (which resets to the default payload),
+ * a pre-existing value object is preserved — same `?? {}` semantics as the
+ * server's connect-time `withXaaExtensionCapability` merge, so toggling
+ * never clobbers a hand-edited payload.
+ */
+export function withEmaExtension(prev: HostConfigInputV2): HostConfigInputV2 {
+  const nextCaps: Record<string, unknown> = {
+    ...(prev.clientCapabilities ?? {}),
+  };
+  const exts: Record<string, unknown> = isPlainObject(nextCaps.extensions)
+    ? { ...nextCaps.extensions }
+    : {};
+  exts[XAA_MCP_EXTENSION] = exts[XAA_MCP_EXTENSION] ?? {};
+  nextCaps.extensions = exts;
+  return { ...prev, clientCapabilities: nextCaps };
+}
+
+/**
+ * Stop advertising the EMA extension. Touches ONLY the extensions map:
+ * sibling extensions are preserved, a now-empty `extensions` container is
+ * dropped (an empty `extensions: {}` on a config that never had the key
+ * reads as a diff to the deep-equal dirty check), and `clientCapabilities`
+ * itself always stays an object — the canonicalizer requires it. Mistral's
+ * inert `extensions: {}` marker is restored the same way
+ * `withoutMcpUiExtension` restores it.
+ */
+export function withoutEmaExtension(
+  prev: HostConfigInputV2
+): HostConfigInputV2 {
+  const nextCaps: Record<string, unknown> = {
+    ...(prev.clientCapabilities ?? {}),
+  };
+  const exts: Record<string, unknown> = isPlainObject(nextCaps.extensions)
+    ? { ...nextCaps.extensions }
+    : {};
+  delete exts[XAA_MCP_EXTENSION];
+  if (Object.keys(exts).length > 0) {
+    nextCaps.extensions = exts;
+  } else {
+    delete nextCaps.extensions;
+  }
+  if (prev.hostStyle === "mistral" && Object.keys(nextCaps).length === 0) {
+    nextCaps.extensions = {};
+  }
+  return { ...prev, clientCapabilities: nextCaps };
 }
 
 function patchProfile(
@@ -306,6 +372,17 @@ export function ProtocolTab({
   // Shared with the cross-host comparison matrix via the field schema.
   const fProtocolVersion = hostConfigField("mcpProtocolVersion");
 
+  // Default-advertisement control, not an XAA on/off: the connect surfaces
+  // re-merge the extension whenever a server's effective auth method is
+  // XAA (withXaaExtensionCapability), regardless of this Switch. The copy
+  // below says so — the toggle governs the stored baseline only.
+  const emaAdvertised = hasEmaExtension(draft.clientCapabilities);
+  const setEmaAdvertised = (next: boolean) => {
+    onDraftChange((prev) =>
+      next ? withEmaExtension(prev) : withoutEmaExtension(prev)
+    );
+  };
+
   return (
     <div className="flex h-full min-h-[480px] flex-col gap-3">
       <div className="rounded-[10px] border border-border bg-background px-3.5 py-2.5">
@@ -334,6 +411,24 @@ export function ProtocolTab({
               ))}
             </SelectContent>
           </Select>
+        </div>
+        <div className="mt-2.5 flex items-center justify-between gap-3 border-t border-border/50 pt-2.5">
+          <div className="min-w-0">
+            <span className="text-[12px] font-medium">
+              Advertise EMA support by default
+            </span>
+            <p className="text-[11px] leading-snug text-muted-foreground">
+              Adds the enterprise-managed-authorization extension to this
+              host&apos;s initialize capabilities. XAA-configured connections
+              always advertise it regardless of this setting.
+            </p>
+          </div>
+          <Switch
+            checked={emaAdvertised}
+            onCheckedChange={setEmaAdvertised}
+            disabled={readOnly}
+            aria-label="Advertise EMA support by default"
+          />
         </div>
       </div>
       <div className="flex min-h-0 flex-1 flex-col">

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/ProtocolTab.emaToggle.test.ts
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/ProtocolTab.emaToggle.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { emptyHostConfigInputV2 } from "@/lib/client-config-v2";
+import { XAA_MCP_EXTENSION } from "@mcpjam/sdk/browser";
+import {
+  hasEmaExtension,
+  withEmaExtension,
+  withoutEmaExtension,
+} from "../ProtocolTab";
+
+const UI_EXTENSION = "io.modelcontextprotocol/ui";
+
+function extensionsOf(caps: Record<string, unknown> | undefined) {
+  return (caps as { extensions?: Record<string, unknown> } | undefined)
+    ?.extensions;
+}
+
+describe("ProtocolTab EMA extension helpers", () => {
+  it("round-trips on/off while preserving sibling extensions", () => {
+    const base = emptyHostConfigInputV2();
+    expect(hasEmaExtension(base.clientCapabilities)).toBe(false);
+
+    const on = withEmaExtension(base);
+    expect(hasEmaExtension(on.clientCapabilities)).toBe(true);
+    expect(extensionsOf(on.clientCapabilities)?.[XAA_MCP_EXTENSION]).toEqual(
+      {}
+    );
+    // The default MCP UI extension rides along untouched.
+    expect(extensionsOf(on.clientCapabilities)?.[UI_EXTENSION]).toBeDefined();
+
+    const off = withoutEmaExtension(on);
+    expect(hasEmaExtension(off.clientCapabilities)).toBe(false);
+    expect(extensionsOf(off.clientCapabilities)?.[UI_EXTENSION]).toBeDefined();
+    // Removing EMA restores the original shape byte-for-byte.
+    expect(off.clientCapabilities).toEqual(base.clientCapabilities);
+  });
+
+  it("does not mutate the previous draft", () => {
+    const base = emptyHostConfigInputV2();
+    const snapshot = JSON.parse(JSON.stringify(base.clientCapabilities));
+    withEmaExtension(base);
+    withoutEmaExtension(base);
+    expect(base.clientCapabilities).toEqual(snapshot);
+  });
+
+  it("preserves a pre-existing EMA value object on toggle-on", () => {
+    const base = emptyHostConfigInputV2({
+      clientCapabilities: {
+        extensions: { [XAA_MCP_EXTENSION]: { configured: true } },
+      },
+    });
+    const on = withEmaExtension(base);
+    expect(extensionsOf(on.clientCapabilities)?.[XAA_MCP_EXTENSION]).toEqual({
+      configured: true,
+    });
+  });
+
+  it("collapses a now-empty extensions container to absent, never dropping clientCapabilities", () => {
+    const base = emptyHostConfigInputV2({
+      clientCapabilities: { extensions: { [XAA_MCP_EXTENSION]: {} } },
+    });
+    const off = withoutEmaExtension(base);
+    expect(off.clientCapabilities).toEqual({});
+    // The canonicalizer throws on undefined clientCapabilities — {} is the floor.
+    expect(off.clientCapabilities).not.toBeUndefined();
+  });
+
+  it("guards non-object extensions values instead of throwing", () => {
+    const base = emptyHostConfigInputV2({
+      clientCapabilities: { extensions: "junk" },
+    });
+    expect(hasEmaExtension(base.clientCapabilities)).toBe(false);
+
+    const on = withEmaExtension(base);
+    expect(hasEmaExtension(on.clientCapabilities)).toBe(true);
+
+    const off = withoutEmaExtension(base);
+    expect(hasEmaExtension(off.clientCapabilities)).toBe(false);
+  });
+
+  it("restores mistral's inert extensions marker on collapse", () => {
+    const base = emptyHostConfigInputV2({
+      hostStyle: "mistral",
+      clientCapabilities: { extensions: { [XAA_MCP_EXTENSION]: {} } },
+    });
+    const off = withoutEmaExtension(base);
+    // Same special case as the Apps tab's withoutMcpUiExtension: mistral's
+    // "off" state is represented by an empty extensions map, not absence.
+    expect(off.clientCapabilities).toEqual({ extensions: {} });
+  });
+});

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/tabs.readOnly.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/tabs.readOnly.test.tsx
@@ -144,6 +144,35 @@ describe("Client editor tabs — readOnly prop wiring", () => {
     expect(fieldset).not.toBeDisabled();
   });
 
+  it("ProtocolTab readOnly disables the EMA advertise switch", () => {
+    render(
+      <ProtocolTab
+        draft={emptyHostConfigInputV2()}
+        onDraftChange={vi.fn()}
+        attention={[]}
+        readOnly
+      />
+    );
+    const emaSwitch = screen.getByRole("switch", {
+      name: /advertise ema support by default/i,
+    });
+    expect(emaSwitch).toBeDisabled();
+  });
+
+  it("ProtocolTab without readOnly leaves the EMA switch enabled", () => {
+    render(
+      <ProtocolTab
+        draft={emptyHostConfigInputV2()}
+        onDraftChange={vi.fn()}
+        attention={[]}
+      />
+    );
+    const emaSwitch = screen.getByRole("switch", {
+      name: /advertise ema support by default/i,
+    });
+    expect(emaSwitch).not.toBeDisabled();
+  });
+
   it("ProtocolTab accepts the readOnly prop without throwing", () => {
     // ProtocolTab gates Select via `disabled` and forces JsonEditor to
     // `mode="view"` + `readOnly={true}`. Direct interaction with the

--- a/sdk/src/host-compat/catalog.generated.ts
+++ b/sdk/src/host-compat/catalog.generated.ts
@@ -68,6 +68,7 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
           "io.modelcontextprotocol/ui": {
             mimeTypes: ["text/html;profile=mcp-app"],
           },
+          "io.modelcontextprotocol/enterprise-managed-authorization": {},
         },
       },
       hostContext: {

--- a/sdk/src/host-config/templates/seed-host-template.ts
+++ b/sdk/src/host-config/templates/seed-host-template.ts
@@ -18,6 +18,7 @@ import {
   MCP_UI_EXTENSION_ID,
   MCP_UI_RESOURCE_MIME_TYPE,
 } from "../../mcp-client-manager/capabilities.js";
+import { XAA_MCP_EXTENSION } from "../../xaa/mcp-init.js";
 import {
   MCPJAM_FONT_CSS,
   MCPJAM_PLATFORM,
@@ -401,6 +402,21 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
         logging: {},
         updateModelContext: { text: {}, image: {} },
         message: { text: {} },
+      };
+      // Advertise MCP Enterprise-Managed Authorization support. The MCPJam
+      // persona is the inspector's own client, which implements the full
+      // XAA path (SSO assertion → ID-JAG → RAS token redemption), so the
+      // declaration is honest here. Real-host templates deliberately stay
+      // silent until those hosts ship support — the connect surfaces still
+      // merge the extension at connect time for XAA-configured servers
+      // regardless of the stored baseline. Spread keeps the SDK-default
+      // MCP UI extension intact.
+      base.clientCapabilities = {
+        ...base.clientCapabilities,
+        extensions: {
+          ...(base.clientCapabilities.extensions as Record<string, unknown>),
+          [XAA_MCP_EXTENSION]: {},
+        },
       };
       // Per-resource hostContext for MCPJam's own house chrome. Style
       // variables come straight from the design-system tokens that

--- a/sdk/tests/__snapshots__/host-config-seed-host-template.test.ts.snap
+++ b/sdk/tests/__snapshots__/host-config-seed-host-template.test.ts.snap
@@ -1995,6 +1995,7 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
     "chatUiOverride": undefined,
     "clientCapabilities": {
       "extensions": {
+        "io.modelcontextprotocol/enterprise-managed-authorization": {},
         "io.modelcontextprotocol/ui": {
           "mimeTypes": [
             "text/html;profile=mcp-app",
@@ -2180,6 +2181,7 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
     "chatUiOverride": undefined,
     "clientCapabilities": {
       "extensions": {
+        "io.modelcontextprotocol/enterprise-managed-authorization": {},
         "io.modelcontextprotocol/ui": {
           "mimeTypes": [
             "text/html;profile=mcp-app",

--- a/sdk/tests/host-config-seed-host-template.test.ts
+++ b/sdk/tests/host-config-seed-host-template.test.ts
@@ -5,6 +5,7 @@ import {
   emptyHostConfigInputV2,
   type HostTemplateId,
 } from "../src/host-config/templates/index.js";
+import { XAA_MCP_EXTENSION } from "../src/xaa/mcp-init.js";
 
 const ALL_IDS: HostTemplateId[] = [
   "mcpjam",
@@ -40,6 +41,31 @@ describe("seedHostTemplate", () => {
         expect(config.clientCapabilities).toBeTypeOf("object");
       }
     }
+  });
+
+  // The MCPJam persona is the inspector's own client and supports the full
+  // XAA path, so it declares the enterprise-managed-authorization extension.
+  // Every real-host persona must NOT — a seed refactor that leaks the key
+  // into inheriting templates (claude/chatgpt/cursor/copilot/vscode all
+  // derive their clientCapabilities from the empty-input base) fails here.
+  it("advertises EMA on the mcpjam template and on no other", () => {
+    for (const id of ALL_IDS) {
+      const config = seedHostTemplate(id, { theme: "dark" });
+      const exts =
+        (config.clientCapabilities as { extensions?: unknown })?.extensions;
+      const hasEma =
+        typeof exts === "object" &&
+        exts !== null &&
+        Object.prototype.hasOwnProperty.call(exts, XAA_MCP_EXTENSION);
+      expect(hasEma, `template ${id}`).toBe(id === "mcpjam");
+    }
+    // The MCP UI default rides along untouched on the mcpjam seed.
+    const mcpjam = seedHostTemplate("mcpjam", { theme: "dark" });
+    const mcpjamExts = (
+      mcpjam.clientCapabilities as { extensions: Record<string, unknown> }
+    ).extensions;
+    expect(mcpjamExts["io.modelcontextprotocol/ui"]).toBeDefined();
+    expect(mcpjamExts[XAA_MCP_EXTENSION]).toEqual({});
   });
 
   it("matches the documented model + style for the claude template", () => {


### PR DESCRIPTION
## What

Advertise the MCP Enterprise-Managed Authorization extension (`io.modelcontextprotocol/enterprise-managed-authorization`, EMA) from a host's **stored** `clientCapabilities` instead of only injecting it at connect time — so it's visible and controllable in the UI like the other client capabilities.

## Why

Reported in-session: the EMA extension never appeared in the Client → MCP Protocol JSON panel or the host-card capability chips, because `withXaaExtensionCapability` merges it into the wire `initialize` at connect time (for XAA-configured servers) and never writes it back to the hostConfig. Per the MCP extension framework + EMA client guide, declaring support is a **host-level** capability (like `io.modelcontextprotocol/ui`), so it belongs in stored config where users can see and set it.

## Changes

- **`ProtocolTab.tsx`** — new **"Advertise EMA support by default"** Switch in the MCP Protocol settings card, backed by exported pure helpers `hasEmaExtension` / `withEmaExtension` / `withoutEmaExtension`:
  - **on** preserves a pre-existing value object (unlike the Apps tab's clobbering helper — same `?? {}` semantics as the connect-time merge).
  - **off** touches only the `extensions` map, collapses an empty container to absent, and never lets `clientCapabilities` go `undefined` (the canonicalizer requires an object).
  - Respects `readOnly`.
  - The JSON editor and host-card chips reflect the toggle automatically (both are freeform passthroughs).
- **SDK mcpjam seed** (`seed-host-template.ts`) advertises EMA; **real-host personas stay silent** — guarded by a new "advertises EMA on mcpjam and on no other" template test (claude/chatgpt/cursor/copilot/vscode inherit the empty-input base, so this is the leak guard). Golden seed snapshot re-blessed (diff = the two mcpjam entries only).
- **`catalog.generated.ts`** regenerated from the backend catalog change (one-line diff).

## Toggle semantics (deliberate)

The Switch governs the **stored baseline only**. The connect-time `withXaaExtensionCapability` merge is unchanged and stays independent — an XAA-configured connection always advertises EMA regardless of the toggle (advertise must track enforcement). The helper text on the Switch says exactly this.

## Companion PR

Backend: MCPJam/mcpjam-backend#715 adds EMA to the `mcpjam` market catalog template (the real create/update-to-latest funnel). **Deploy the backend PR first** so the regenerated `catalog.generated.ts` fallback here matches the live catalog.

## Not touched (by design)

`getDefaultClientCapabilities()` (feeds every SDK connection), `empty-input.ts` (would leak EMA into 5 real-host seeds), backend `DEFAULT_CLIENT_CAPABILITIES_V2` (mints claude-persona configs).

## Tests

- SDK: 114 files / 1993 tests pass (incl. new template guard + re-blessed golden snapshot).
- Inspector: 780 files / 8248 tests pass; `typecheck:client` clean.
- New `ProtocolTab.emaToggle.test.ts` (6 cases) + 2 new readOnly assertions.

Not yet verified in a live browser — worth a click-through after deploy: the toggle on the MCP Protocol tab, and "Update to latest" offering the capability on an existing MCPJam host once backend#715 is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and stored capability metadata only; connect-time XAA enforcement is untouched, scoped to mcpjam seeds with regression tests.
> 
> **Overview**
> **EMA** (`io.modelcontextprotocol/enterprise-managed-authorization`) is now part of the host’s **stored** `clientCapabilities`, so it shows up in the MCP Protocol JSON editor and capability chips instead of only appearing at connect time.
> 
> On **ProtocolTab**, an **“Advertise EMA support by default”** switch updates the draft via `hasEmaExtension` / `withEmaExtension` / `withoutEmaExtension` (preserves sibling extensions and existing EMA payloads; Mistral empty-`extensions` behavior matches the Apps tab). The switch only sets the **stored baseline**—connect-time `withXaaExtensionCapability` for XAA servers is unchanged. **readOnly** disables the switch.
> 
> The **mcpjam** host seed and regenerated **catalog** fallback add the EMA extension; other host personas stay without it, with a template test guarding leaks. New unit/readOnly tests cover the helpers and UI wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5bbc703ecd3879b88590d65f0cc60d0ae50e30b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist and expose EMA support by storing `io.modelcontextprotocol/enterprise-managed-authorization` in `clientCapabilities`, with a Protocol tab toggle so it appears in the JSON view and host chips. The `mcpjam` template now advertises EMA by default; connect-time XAA merging remains unchanged.

- **New Features**
  - Protocol tab: added “Advertise EMA support by default” Switch that updates stored `clientCapabilities` via `hasEmaExtension` / `withEmaExtension` / `withoutEmaExtension`; preserves any existing EMA payload, collapses empty `extensions`, and respects `readOnly`.
  - Seeds: `mcpjam` template now includes the EMA extension; all other personas remain silent (guarded by a new template test). Snapshots updated and `catalog.generated.ts` regenerated to include the extension.

- **Migration**
  - Deploy MCPJam/mcpjam-backend#715 first so the generated catalog matches the live backend.
  - The toggle controls the stored baseline only; XAA-configured connections still advertise EMA regardless of this setting.

<sup>Written for commit d5bbc703ecd3879b88590d65f0cc60d0ae50e30b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

