### PR TITLE
changesets

### DIFF
--- a/.changeset/bright-hosts-share-images.md
+++ b/.changeset/bright-hosts-share-images.md
@@ -1,0 +1,10 @@
+---
+"@mcpjam/inspector": patch
+"@mcpjam/sdk": patch
+---
+
+Restore backend-backed host catalog flows and shared image-support hydration.
+
+- Use the backend host catalog/templates for project host create, update, delete, and detail routes.
+- Hydrate backend image-support facts into concrete host config image fields for SDK fallback catalogs.
+- Export the shared image-support mapping helper for catalog seeding.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restore backend-backed host catalog flows and hydrate shared image-support into host configs for consistent behavior. Patch releases for `@mcpjam/inspector` and `@mcpjam/sdk`; host create/update/delete/detail routes now use backend catalog/templates, SDK fallbacks map image-support facts to concrete image fields, and the shared mapping helper is exported for catalog seeding.

<sup>Written for commit bbb1ffc90faf05a0753fca77694b89e97bf1f62c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

