### PR TITLE
fix(oauth): honor PRM-advertised resource indicator, warn on strict-validation mismatch

### DIFF
--- a/.changeset/oauth-prm-resource-indicator.md
+++ b/.changeset/oauth-prm-resource-indicator.md
@@ -1,0 +1,9 @@
+---
+"@mcpjam/sdk": patch
+---
+
+OAuth debugger: honor the PRM-advertised `resource` identifier in authorization and token requests (fixes #2119).
+
+- The `resource` indicator sent to `/authorize` and `/token` now uses the identifier from the server's Protected Resource Metadata verbatim (it may be a URN), falling back to the server URL only when no PRM resource was discovered. Both requests are guaranteed to send an identical value.
+- When the advertised identifier fails the strict origin/path-prefix validation that Quick OAuth and the official MCP SDK apply (RFC 9728 §3.3), the debug flow proceeds but logs a warning explaining that spec-strict clients will refuse to connect.
+- Applies to the 2025-06-18 and 2025-11-25 debug state machines (debugger UI, `mcpjam oauth login`, conformance); the 2025-03-26 flow does not fetch PRM and is unchanged.

--- a/sdk/src/oauth/state-machines/debug-oauth-2025-06-18.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-06-18.ts
@@ -437,6 +437,19 @@ export const createDebugOAuthStateMachine = (
   // Helper to get current state (use getState if provided, otherwise use initial state)
   const getCurrentState = () => (getState ? getState() : initialState);
 
+  // Per RFC 8707 and the MCP Authorization spec, the OAuth `resource` indicator
+  // must use the identifier advertised in the server's Protected Resource
+  // Metadata when one was discovered. That identifier may be any URI (including
+  // a URN) and is not required to equal the MCP endpoint URL, so the client must
+  // not overwrite it with the server URL. Only fall back to the server URL when
+  // no PRM `resource` is available. Resolving through a single helper also keeps
+  // the authorization request and the token request resource values identical —
+  // some authorization servers reject a mismatch between the two.
+  const resolveResourceParameter = (): string | undefined => {
+    const current = getCurrentState();
+    return current.resourceMetadata?.resource ?? current.serverUrl;
+  };
+
   const executeRequest = (url: string, options: RequestInit = {}) =>
     requestExecutor({
       url,
@@ -1352,7 +1365,7 @@ export const createDebugOAuthStateMachine = (
               {
                 code_challenge: codeChallenge,
                 method: "S256",
-                resource: state.serverUrl || "Unknown",
+                resource: resolveResourceParameter() || "Unknown",
               },
             );
 
@@ -1388,8 +1401,9 @@ export const createDebugOAuthStateMachine = (
             );
             authUrl.searchParams.set("code_challenge_method", "S256");
             authUrl.searchParams.set("state", state.state || "");
-            if (state.serverUrl) {
-              authUrl.searchParams.set("resource", state.serverUrl);
+            const authResourceParam = resolveResourceParameter();
+            if (authResourceParam) {
+              authUrl.searchParams.set("resource", authResourceParam);
             }
 
             const requestedScopeValue = resolveRequestedScopeValue({
@@ -1474,8 +1488,9 @@ export const createDebugOAuthStateMachine = (
               tokenRequestBodyObj.code_verifier = state.codeVerifier;
             }
 
-            if (state.serverUrl) {
-              tokenRequestBodyObj.resource = state.serverUrl;
+            const tokenBodyResourceParam = resolveResourceParameter();
+            if (tokenBodyResourceParam) {
+              tokenRequestBodyObj.resource = tokenBodyResourceParam;
             }
 
             const tokenRequest = {
@@ -1544,8 +1559,9 @@ export const createDebugOAuthStateMachine = (
               });
 
               // Add resource parameter if available
-              if (state.serverUrl) {
-                tokenRequestBody.set("resource", state.serverUrl);
+              const tokenResourceParam = resolveResourceParameter();
+              if (tokenResourceParam) {
+                tokenRequestBody.set("resource", tokenResourceParam);
               }
 
               // Make the token request via backend proxy. The client-auth

--- a/sdk/src/oauth/state-machines/debug-oauth-2025-06-18.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-06-18.ts
@@ -34,7 +34,10 @@ import {
   generateRandomString,
   generateCodeChallenge,
 } from "./shared/pkce.js";
-import { buildResourceMetadataUrl } from "./shared/urls.js";
+import {
+  buildResourceMetadataUrl,
+  resourceMatchesServerUrl,
+} from "./shared/urls.js";
 import {
   buildInitializeRequestBody,
   resolveInitializeProtocolVersion,
@@ -864,7 +867,7 @@ export const createDebugOAuthStateMachine = (
                 resourceMetadata.authorization_servers?.[0] || serverUrl;
 
               // Add info log for Authorization Servers
-              const infoLogs = addInfoLog(
+              let infoLogs = addInfoLog(
                 state,
                 "received_resource_metadata",
                 "authorization-servers",
@@ -875,6 +878,27 @@ export const createDebugOAuthStateMachine = (
                     resourceMetadata.authorization_servers,
                 },
               );
+
+              if (
+                resourceMetadata.resource &&
+                !resourceMatchesServerUrl(
+                  resourceMetadata.resource,
+                  state.serverUrl,
+                )
+              ) {
+                infoLogs = addInfoLog(
+                  { ...state, infoLogs },
+                  "received_resource_metadata",
+                  "resource-identifier-mismatch",
+                  "Resource identifier mismatch",
+                  {
+                    "Advertised resource": resourceMetadata.resource,
+                    "Server URL": state.serverUrl,
+                    Note: "The debugger will send the advertised resource as-is (RFC 8707), but strict MCP clients — including MCPJam's Quick OAuth and the official MCP SDK — validate it against the server URL (RFC 9728 §3.3) and will refuse to connect.",
+                  },
+                  { level: "warning" },
+                );
+              }
 
               updateState({
                 currentStep: "received_resource_metadata",

--- a/sdk/src/oauth/state-machines/debug-oauth-2025-11-25.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-11-25.ts
@@ -37,6 +37,7 @@ import {
 import {
   buildResourceMetadataUrl,
   canonicalizeResourceUrl,
+  resourceMatchesServerUrl,
 } from "./shared/urls.js";
 import {
   buildInitializeRequestBody,
@@ -967,7 +968,7 @@ export const createDebugOAuthStateMachine = (
                 resourceMetadata.authorization_servers?.[0] || serverUrl;
 
               // Add info log for Authorization Servers
-              const infoLogs = addInfoLog(
+              let infoLogs = addInfoLog(
                 state,
                 "received_resource_metadata",
                 "authorization-servers",
@@ -978,6 +979,27 @@ export const createDebugOAuthStateMachine = (
                     resourceMetadata.authorization_servers,
                 }
               );
+
+              if (
+                resourceMetadata.resource &&
+                !resourceMatchesServerUrl(
+                  resourceMetadata.resource,
+                  state.serverUrl
+                )
+              ) {
+                infoLogs = addInfoLog(
+                  { ...state, infoLogs },
+                  "received_resource_metadata",
+                  "resource-identifier-mismatch",
+                  "Resource identifier mismatch",
+                  {
+                    "Advertised resource": resourceMetadata.resource,
+                    "Server URL": state.serverUrl,
+                    Note: "The debugger will send the advertised resource as-is (RFC 8707), but strict MCP clients — including MCPJam's Quick OAuth and the official MCP SDK — validate it against the server URL (RFC 9728 §3.3) and will refuse to connect.",
+                  },
+                  { level: "warning" }
+                );
+              }
 
               updateState({
                 currentStep: "received_resource_metadata",

--- a/sdk/src/oauth/state-machines/debug-oauth-2025-11-25.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-11-25.ts
@@ -566,6 +566,18 @@ export const createDebugOAuthStateMachine = (
   // Helper to get current state (use getState if provided, otherwise use initial state)
   const getCurrentState = () => (getState ? getState() : initialState);
 
+  // Per RFC 8707 and the MCP Authorization spec, the OAuth `resource` indicator
+  // must use the identifier advertised in the server's Protected Resource
+  // Metadata when one was discovered. That identifier may be any URI (including
+  // a URN) and is not required to equal the MCP endpoint URL, so the client must
+  // not overwrite it with the canonicalized server URL. Only fall back to the
+  // canonical server URL when no PRM `resource` is available. Resolving through a
+  // single helper also guarantees the authorization request and the token
+  // request send an identical resource value — some authorization servers reject
+  // a mismatch between the two.
+  const resolveResourceParameter = (): string =>
+    getCurrentState().resourceMetadata?.resource ?? canonicalServerUrl;
+
   const executeRequest = (url: string, options: RequestInit = {}) =>
     requestExecutor({
       url,
@@ -1636,7 +1648,7 @@ export const createDebugOAuthStateMachine = (
               {
                 code_challenge: codeChallenge,
                 method: "S256",
-                resource: canonicalServerUrl,
+                resource: resolveResourceParameter(),
               }
             );
 
@@ -1672,7 +1684,7 @@ export const createDebugOAuthStateMachine = (
             );
             authUrl.searchParams.set("code_challenge_method", "S256");
             authUrl.searchParams.set("state", state.state || "");
-            authUrl.searchParams.set("resource", canonicalServerUrl);
+            authUrl.searchParams.set("resource", resolveResourceParameter());
 
             const requestedScopeValue = resolveRequestedScopeValue({
               customScopes,
@@ -1756,7 +1768,7 @@ export const createDebugOAuthStateMachine = (
               tokenRequestBodyObj.code_verifier = state.codeVerifier;
             }
 
-            tokenRequestBodyObj.resource = canonicalServerUrl;
+            tokenRequestBodyObj.resource = resolveResourceParameter();
 
             const tokenRequest = {
               method: "POST",
@@ -1823,8 +1835,9 @@ export const createDebugOAuthStateMachine = (
                 ...clientAuth.bodyParams,
               });
 
-              // Add resource parameter (canonicalized per RFC 8707)
-              tokenRequestBody.set("resource", canonicalServerUrl);
+              // Add resource parameter (per RFC 8707; prefers the PRM-advertised
+              // resource identifier, falling back to the canonical server URL)
+              tokenRequestBody.set("resource", resolveResourceParameter());
 
               // Make the token request via backend proxy. The client-auth
               // Authorization header is applied AFTER the merge: the merge

--- a/sdk/src/oauth/state-machines/shared/urls.ts
+++ b/sdk/src/oauth/state-machines/shared/urls.ts
@@ -15,6 +15,37 @@ export function buildResourceMetadataUrl(serverUrl: string): string {
   ).toString();
 }
 
+// Mirrors the strict validation used by the non-debug OAuth paths
+// (checkResourceAllowed in browser-auth.ts, and the official MCP SDK): the
+// PRM-advertised resource must share the server URL's origin and be a path
+// prefix of it. The debug flows honor the advertised value either way and
+// only warn on mismatch, so users can still step through the real behavior
+// while learning that spec-strict clients will refuse to connect.
+export function resourceMatchesServerUrl(
+  resource: string,
+  serverUrl: string,
+): boolean {
+  try {
+    const advertised = new URL(resource);
+    const server = new URL(serverUrl);
+
+    if (advertised.origin !== server.origin) {
+      return false;
+    }
+
+    const serverPath = server.pathname.endsWith("/")
+      ? server.pathname
+      : `${server.pathname}/`;
+    const advertisedPath = advertised.pathname.endsWith("/")
+      ? advertised.pathname
+      : `${advertised.pathname}/`;
+
+    return serverPath.startsWith(advertisedPath);
+  } catch {
+    return false;
+  }
+}
+
 export function canonicalizeResourceUrl(url: string): string {
   try {
     const parsed = new URL(url);

--- a/sdk/tests/oauth/state-machine-regressions.test.ts
+++ b/sdk/tests/oauth/state-machine-regressions.test.ts
@@ -662,4 +662,83 @@ describe("OAuth state machine regressions", () => {
       expect(state.lastRequest?.body?.resource).toBe(SERVER_URL);
     },
   );
+
+  // The debugger honors a PRM resource that strict clients (Quick OAuth, the
+  // official MCP SDK) would reject, so it must surface a warning when the
+  // advertised identifier fails the strict origin/path-prefix validation.
+  const seedResourceMetadataFetch = () => ({
+    ...EMPTY_OAUTH_FLOW_STATE,
+    currentStep: "request_resource_metadata" as const,
+    serverUrl: SERVER_URL,
+    httpHistory: [],
+    infoLogs: [],
+  });
+
+  const prmExecutor = (resource: string) =>
+    jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: { "content-type": "application/json" },
+      body: {
+        resource,
+        authorization_servers: ["https://auth.example.com"],
+      },
+    });
+
+  const runResourceMetadataStep = async (
+    protocolVersion: OAuthProtocolVersion,
+    resource: string,
+  ) => {
+    let state: any = seedResourceMetadataFetch();
+
+    const machine = createOAuthStateMachine({
+      protocolVersion,
+      registrationStrategy: "preregistered" as any,
+      state,
+      getState: () => state,
+      updateState: (updates) => {
+        state = { ...state, ...updates };
+      },
+      serverUrl: SERVER_URL,
+      serverName: "Test Server",
+      redirectUrl: REDIRECT_URI,
+      requestExecutor: prmExecutor(resource),
+    });
+
+    await machine.proceedToNextStep(); // fetch protected resource metadata
+
+    return state;
+  };
+
+  it.each<OAuthProtocolVersion>(["2025-06-18", "2025-11-25"])(
+    "warns when the PRM resource fails strict validation in %s",
+    async (protocolVersion) => {
+      const state = await runResourceMetadataStep(
+        protocolVersion,
+        RESOURCE_URN,
+      );
+
+      expect(state.resourceMetadata?.resource).toBe(RESOURCE_URN);
+      const warning = state.infoLogs?.find(
+        (log: any) => log.id === "resource-identifier-mismatch",
+      );
+      expect(warning).toBeDefined();
+      expect(warning.level).toBe("warning");
+    },
+  );
+
+  it.each<OAuthProtocolVersion>(["2025-06-18", "2025-11-25"])(
+    "does not warn when the PRM resource matches the server URL in %s",
+    async (protocolVersion) => {
+      const state = await runResourceMetadataStep(protocolVersion, SERVER_URL);
+
+      expect(state.resourceMetadata?.resource).toBe(SERVER_URL);
+      expect(
+        state.infoLogs?.find(
+          (log: any) => log.id === "resource-identifier-mismatch",
+        ),
+      ).toBeUndefined();
+    },
+  );
 });

--- a/sdk/tests/oauth/state-machine-regressions.test.ts
+++ b/sdk/tests/oauth/state-machine-regressions.test.ts
@@ -538,4 +538,128 @@ describe("OAuth state machine regressions", () => {
       expect(state.isInitiatingAuth).toBe(false);
     },
   );
+
+  // Regression for #2119: the OAuth `resource` indicator must honour the
+  // identifier advertised in the server's Protected Resource Metadata (which may
+  // be a URN, not the MCP endpoint URL) instead of being overwritten with the
+  // server URL. The authorization request and token request must also agree.
+  const RESOURCE_URN = "urn:example:my-resource";
+
+  const seedAuthorizationStart = (
+    resourceMetadata?: { resource: string },
+  ) => ({
+    ...EMPTY_OAUTH_FLOW_STATE,
+    currentStep: "received_client_credentials" as const,
+    serverUrl: SERVER_URL,
+    clientId: "test-client",
+    authorizationServerMetadata: {
+      authorization_endpoint: "https://auth.example.com/authorize",
+      token_endpoint: "https://auth.example.com/token",
+    } as any,
+    ...(resourceMetadata ? { resourceMetadata } : {}),
+    infoLogs: [],
+  });
+
+  const seedTokenExchange = (resourceMetadata?: { resource: string }) => ({
+    ...EMPTY_OAUTH_FLOW_STATE,
+    currentStep: "received_authorization_code" as const,
+    serverUrl: SERVER_URL,
+    clientId: "test-client",
+    codeVerifier: "test-code-verifier",
+    authorizationCode: "test-auth-code",
+    authorizationServerMetadata: {
+      token_endpoint: "https://auth.example.com/token",
+    } as any,
+    ...(resourceMetadata ? { resourceMetadata } : {}),
+    infoLogs: [],
+  });
+
+  it.each<OAuthProtocolVersion>(["2025-06-18", "2025-11-25"])(
+    "uses the PRM-advertised resource for the authorization request in %s",
+    async (protocolVersion) => {
+      let state: any = seedAuthorizationStart({ resource: RESOURCE_URN });
+
+      const machine = createOAuthStateMachine({
+        protocolVersion,
+        registrationStrategy: "preregistered" as any,
+        state,
+        getState: () => state,
+        updateState: (updates) => {
+          state = { ...state, ...updates };
+        },
+        serverUrl: SERVER_URL,
+        serverName: "Test Server",
+        redirectUrl: REDIRECT_URI,
+        requestExecutor: jest.fn(),
+      });
+
+      await machine.proceedToNextStep(); // generate PKCE parameters
+      await machine.proceedToNextStep(); // build authorization URL
+
+      const authUrl = new URL(state.authorizationUrl);
+      expect(authUrl.searchParams.get("resource")).toBe(RESOURCE_URN);
+    },
+  );
+
+  it.each<OAuthProtocolVersion>(["2025-06-18", "2025-11-25"])(
+    "uses the PRM-advertised resource for the token request in %s",
+    async (protocolVersion) => {
+      let state: any = seedTokenExchange({ resource: RESOURCE_URN });
+
+      const machine = createOAuthStateMachine({
+        protocolVersion,
+        registrationStrategy: "preregistered" as any,
+        state,
+        getState: () => state,
+        updateState: (updates) => {
+          state = { ...state, ...updates };
+        },
+        serverUrl: SERVER_URL,
+        serverName: "Test Server",
+        redirectUrl: REDIRECT_URI,
+        requestExecutor: jest.fn().mockResolvedValue({
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          body: { access_token: "token" },
+        }),
+      });
+
+      await machine.proceedToNextStep(); // prepare token request body
+
+      expect(state.lastRequest?.body?.resource).toBe(RESOURCE_URN);
+    },
+  );
+
+  it.each<OAuthProtocolVersion>(["2025-06-18", "2025-11-25"])(
+    "falls back to the server URL when no PRM resource is advertised in %s",
+    async (protocolVersion) => {
+      let state: any = seedTokenExchange();
+
+      const machine = createOAuthStateMachine({
+        protocolVersion,
+        registrationStrategy: "preregistered" as any,
+        state,
+        getState: () => state,
+        updateState: (updates) => {
+          state = { ...state, ...updates };
+        },
+        serverUrl: SERVER_URL,
+        serverName: "Test Server",
+        redirectUrl: REDIRECT_URI,
+        requestExecutor: jest.fn().mockResolvedValue({
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          body: { access_token: "token" },
+        }),
+      });
+
+      await machine.proceedToNextStep(); // prepare token request body
+
+      expect(state.lastRequest?.body?.resource).toBe(SERVER_URL);
+    },
+  );
 });


### PR DESCRIPTION
## Problem

Fixes #2119. Supersedes #2613 (rebase of @serhiizghama's work onto current main — their commits and authorship are preserved; that PR had gone stale with conflicts).

The OAuth debugger fetches the server's Protected Resource Metadata and displays its `resource` identifier, but then ignores it: the `resource` indicator sent to `/authorize` and `/token` was unconditionally the MCP server URL. Servers advertising a non-URL identifier (e.g. a URN) got the wrong resource, and authorization servers rejected flows over the authorize/token mismatch.

## Solution

Cherry-picked from #2613 (thanks @serhiizghama):
- A single `resolveResourceParameter()` helper in the 2025-06-18 and 2025-11-25 state machines prefers `state.resourceMetadata?.resource` verbatim and falls back to the server URL only when no PRM resource was discovered. All four resource sites (PKCE log, authorization URL, token request body, token POST) resolve through it, so both requests always send an identical value.
- Regression tests covering the URN case and the fallback for both protocol versions.

Added on top:
- **Mismatch warning.** The debugger is now deliberately more lenient than MCPJam's Quick OAuth path and the official MCP SDK, both of which validate the advertised resource against the server URL (RFC 9728 §3.3) and refuse to connect on mismatch. Without a signal, a flow that succeeds in the debugger but fails on a real connect would be baffling. PRM discovery now emits a warning-level info log (`resource-identifier-mismatch`) when the advertised identifier fails the same strict origin/path-prefix check (`resourceMatchesServerUrl` in `shared/urls.ts`, mirroring `checkResourceAllowed`), while still sending it as-is.
- Changeset (`@mcpjam/sdk` patch).

The 2025-03-26 flow does not fetch PRM and is intentionally unchanged.

## Testing

- New regression tests: PRM-advertised URN used in authorization + token requests, server-URL fallback, warning emitted on mismatch, no warning when matching (both protocol versions).
- Full SDK suite: 116 files, 2055 passed / 1 skipped. `tsc --noEmit` and `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OAuth `resource` handling on authorize/token requests (RFC 8707-sensitive), but only in debug/conformance flows with regression tests and no change to production Quick OAuth validation.
> 
> **Overview**
> Fixes **#2119** in the OAuth **debugger** paths (`2025-06-18` and `2025-11-25`): the `resource` parameter on `/authorize` and `/token` now comes from Protected Resource Metadata when present (including URNs), not from always substituting the MCP server URL.
> 
> Both protocol debug state machines route PKCE logging, the authorization URL, and token exchange through a shared **`resolveResourceParameter()`** so authorize and token requests always send the **same** value, with fallback to the server URL (canonicalized on `2025-11-25`) only when PRM has no `resource`.
> 
> After PRM discovery, **`resourceMatchesServerUrl`** (aligned with Quick OAuth / `checkResourceAllowed`) triggers a **warning** info log when the advertised identifier would fail strict RFC 9728 §3.3 checks, while the debugger still sends the advertised value. **`2025-03-26`** is unchanged. Regression tests cover URN usage, fallback, and warning behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d564b95b542656022baabe1ecf97439d4c7d8e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honors the PRM-advertised OAuth `resource` identifier and keeps it consistent across `/authorize` and `/token`, fixing flows that use non-URL IDs (e.g., URNs). Adds a warning when the advertised resource doesn’t strictly match the server URL, to explain differences from strict clients.

- **Bug Fixes**
  - Use PRM `resource` verbatim; fall back to the server URL only if absent (2025-06-18 and 2025-11-25 debug flows).
  - One resolver ensures the same `resource` is sent to both requests; tests cover URN, fallback, and parity.

- **New Features**
  - Warn on strict-validation mismatch (`resource-identifier-mismatch`) at PRM discovery; flow proceeds but flags that strict clients will reject it.
  - The 2025-03-26 flow is unchanged.

<sup>Written for commit 6d564b95b542656022baabe1ecf97439d4c7d8e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

