### PR TITLE
polish(oauth): simplify Auto auth select and escalation UI

### DIFF
--- a/mcpjam-inspector/client/src/components/connection/ServerConnectionCard.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerConnectionCard.tsx
@@ -927,16 +927,6 @@ export function ServerConnectionCard({
             </div>
           )}
 
-          {server.connectionStatus === "oauth-flow" && (
-            <div
-              className="mt-3 rounded-md border border-purple-300/40 bg-purple-500/10 p-2 text-xs text-muted-foreground"
-              onClick={(e) => e.stopPropagation()}
-            >
-              Complete sign-in in the browser. Inspector will resume
-              automatically.
-            </div>
-          )}
-
           {showTunnelActions && hasTunnel && showTunnelRequests && (
             <div
               className="mt-2 rounded-md border border-border/70 bg-muted/20 p-2"

--- a/mcpjam-inspector/client/src/components/connection/__tests__/AuthenticationSection.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/AuthenticationSection.test.tsx
@@ -165,24 +165,26 @@ describe("AuthenticationSection", () => {
     clientSecretError: null,
   };
 
-  it("shows only the Auto label in the closed trigger; the description only in the open menu", async () => {
+  it("shows only labels in the menu — no option subtitles", async () => {
     xaaFlagValue = true;
     render(<AuthenticationSection {...autoProps} />);
 
     const trigger = screen.getByRole("combobox");
     expect(trigger).toHaveTextContent("Auto");
+
+    await userEvent.click(trigger);
+    expect(screen.getByRole("option", { name: "Auto" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: "No Authentication" }),
+    ).toBeInTheDocument();
     expect(
       screen.queryByText(
         "Cross-App Access when configured — otherwise connects without credentials, then OAuth if required",
       ),
     ).not.toBeInTheDocument();
-
-    await userEvent.click(trigger);
     expect(
-      screen.getByText(
-        "Cross-App Access when configured — otherwise connects without credentials, then OAuth if required",
-      ),
-    ).toBeInTheDocument();
+      screen.queryByText("Connect without credentials"),
+    ).not.toBeInTheDocument();
   });
 
   it("keeps the Auto option visible for a server saved as auto, even when the flag is off", () => {
@@ -192,17 +194,12 @@ describe("AuthenticationSection", () => {
     expect(screen.getByRole("combobox")).toHaveTextContent("Auto");
   });
 
-  it("offers Auto to everyone with an XAA-free description when the flag is off", async () => {
+  it("offers Auto to everyone without XAA in the menu when the flag is off", async () => {
     xaaFlagValue = false;
     render(<AuthenticationSection {...autoProps} authType="none" />);
 
     await userEvent.click(screen.getByRole("combobox"));
-    expect(screen.getByText("Auto")).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        "Connects without credentials, then OAuth if the server requires it",
-      ),
-    ).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Auto" })).toBeInTheDocument();
     expect(
       screen.queryByText("Cross-App Access (XAA)"),
     ).not.toBeInTheDocument();
@@ -213,9 +210,7 @@ describe("AuthenticationSection", () => {
     render(<AuthenticationSection {...autoProps} autoSelectsXaa={false} />);
 
     expect(
-      screen.getByText(
-        "Connects without credentials first; if the server requires authorization, you'll be prompted to continue with OAuth.",
-      ),
+      screen.getByText("Anonymous first, then OAuth if required."),
     ).toBeInTheDocument();
   });
 
@@ -224,9 +219,7 @@ describe("AuthenticationSection", () => {
     render(<AuthenticationSection {...autoProps} autoSelectsXaa={true} />);
 
     expect(
-      screen.getByText(
-        "Cross-App Access is configured — connecting mints a cross-app token.",
-      ),
+      screen.getByText("Uses Cross-App Access for this server."),
     ).toBeInTheDocument();
   });
 

--- a/mcpjam-inspector/client/src/components/connection/__tests__/ServerConnectionCard.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/ServerConnectionCard.test.tsx
@@ -253,10 +253,8 @@ describe("ServerConnectionCard", () => {
 
       expect(screen.getByText("Authorizing in browser...")).toBeInTheDocument();
       expect(
-        screen.getByText(
-          "Complete sign-in in the browser. Inspector will resume automatically."
-        )
-      ).toBeInTheDocument();
+        screen.queryByText(/Complete sign-in in the browser/),
+      ).not.toBeInTheDocument();
     });
 
     it("shows failed status with retry count", () => {

--- a/mcpjam-inspector/client/src/components/connection/shared/AuthenticationSection.tsx
+++ b/mcpjam-inspector/client/src/components/connection/shared/AuthenticationSection.tsx
@@ -323,43 +323,20 @@ export function AuthenticationSection({
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem
-                value="auto"
-                description={
-                  showXaaOption
-                    ? "Cross-App Access when configured — otherwise connects without credentials, then OAuth if required"
-                    : "Connects without credentials, then OAuth if the server requires it"
-                }
-              >
-                Auto
-              </SelectItem>
-              <SelectItem value="none" description="Connect without credentials">
-                No Authentication
-              </SelectItem>
-              <SelectItem
-                value="bearer"
-                description="Send a static token you provide"
-              >
-                Bearer Token
-              </SelectItem>
-              <SelectItem value="oauth" description="Interactive browser sign-in">
-                OAuth
-              </SelectItem>
+              <SelectItem value="auto">Auto</SelectItem>
+              <SelectItem value="none">No Authentication</SelectItem>
+              <SelectItem value="bearer">Bearer Token</SelectItem>
+              <SelectItem value="oauth">OAuth</SelectItem>
               {showXaaOption && (
-                <SelectItem
-                  value="xaa"
-                  description="Server-side token exchange via your IdP"
-                >
-                  Cross-App Access (XAA)
-                </SelectItem>
+                <SelectItem value="xaa">Cross-App Access (XAA)</SelectItem>
               )}
             </SelectContent>
           </Select>
           {authType === "auto" && (
-            <p className="text-xs text-muted-foreground">
+            <p className="text-xs text-muted-foreground/80">
               {autoSelectsXaa
-                ? "Cross-App Access is configured — connecting mints a cross-app token."
-                : "Connects without credentials first; if the server requires authorization, you'll be prompted to continue with OAuth."}
+                ? "Uses Cross-App Access for this server."
+                : "Anonymous first, then OAuth if required."}
             </p>
           )}
         </div>

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/auto-oauth-escalation.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/auto-oauth-escalation.test.ts
@@ -123,9 +123,16 @@ describe("confirmAutoOAuthEscalation", () => {
 
   it("resolves true when the user continues", async () => {
     const promise = confirmAutoOAuthEscalation("Asana");
-    const options = capturedToastOptions();
-    expect(options.duration).toBe(Infinity);
-    options.action.onClick();
+    expect(toastMock).toHaveBeenCalledWith(
+      'Authorize "Asana"?',
+      expect.objectContaining({
+        duration: Infinity,
+        action: expect.objectContaining({ label: "Continue" }),
+        cancel: expect.objectContaining({ label: "Not now" }),
+      }),
+    );
+    expect(capturedToastOptions()).not.toHaveProperty("description");
+    capturedToastOptions().action.onClick();
     await expect(promise).resolves.toBe(true);
   });
 

--- a/mcpjam-inspector/client/src/lib/oauth/auto-oauth-escalation.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/auto-oauth-escalation.ts
@@ -103,12 +103,10 @@ export function confirmAutoOAuthEscalation(
         resolve(value);
       }
     };
-    toast(`"${serverName}" requires authorization`, {
-      description:
-        "Continue with OAuth? You'll be redirected to the server's sign-in page.",
+    toast(`Authorize "${serverName}"?`, {
       duration: Infinity,
       action: {
-        label: "Continue with OAuth",
+        label: "Continue",
         onClick: () => settle(true),
       },
       cancel: {


### PR DESCRIPTION
## Summary
- Strip option subtitles from the Authentication select; keep a short helper only for Auto
- Simplify the Auto→OAuth confirm toast to a single-line title with Continue / Not now
- Remove the purple “complete sign-in in the browser” banner from the server card during oauth-flow

## Test plan
- [ ] Open Add/Edit server → Authentication dropdown shows clean single-line options
- [ ] With Auto selected, short helper text still appears under the field (XAA vs anonymous)
- [ ] Connect an Auto HTTP server that requires OAuth → confirm toast is title + actions only
- [ ] During browser authorization, server card shows “Authorizing in browser...” without the purple banner
- [ ] `npm run test -- client/src/components/connection/__tests__/AuthenticationSection.test.tsx client/src/components/connection/__tests__/ServerConnectionCard.test.tsx client/src/lib/oauth/__tests__/auto-oauth-escalation.test.ts`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified the Authentication selector and OAuth escalation flow to reduce noise and make Auto connect clearer. Removed option subtitles, shortened the confirm toast, and dropped the in-card banner during browser auth.

- **Refactors**
  - Authentication select: menu shows labels only; keep a short helper under the field for Auto (XAA vs anonymous).
  - Auto→OAuth toast: single-line 'Authorize "<server>"?' with Continue / Not now; no description.
  - oauth-flow UI: removed the in-card banner; server card shows only "Authorizing in browser...".
  - Updated tests to match the new copy and behavior.

<sup>Written for commit d416f8530f335176efd76718306548fd78a2774f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

