### PR TITLE
chore: changesets for the pending sdk/cli/inspector release

### DIFF
--- a/.changeset/auth-auto-discover.md
+++ b/.changeset/auth-auto-discover.md
@@ -1,0 +1,10 @@
+---
+"@mcpjam/inspector": minor
+"@mcpjam/sdk": minor
+---
+
+Auth "Auto": unauthenticated-first connection with OAuth escalation.
+
+- New "Auto" auth method: connect with no credentials first, and only escalate to the OAuth flow when the server answers the initialize request with a 401 challenge. Servers that don't require auth connect immediately with zero configuration.
+- Auto is now listed first in the auth-method dropdown and is the default for new servers; the dropdown gets short labels, per-option descriptions, and a per-server helper explaining what Auto will do. The escalation UI was simplified to a single inline prompt.
+- **SDK:** new `isUnauthorized401` export for classifying the 401 challenge that triggers escalation.

--- a/.changeset/ema-capability-hostconfig.md
+++ b/.changeset/ema-capability-hostconfig.md
@@ -1,0 +1,9 @@
+---
+"@mcpjam/inspector": minor
+"@mcpjam/sdk": minor
+---
+
+Store MCP Enterprise-Managed Authorization (EMA) capability support at the host level.
+
+- Whether a host advertises the EMA/XAA MCP extension in its `clientCapabilities` is now part of the persisted hostConfig, with a Protocol-tab toggle in the inspector to declare it per host.
+- **SDK:** the MCPJam persona seed template now advertises the XAA MCP extension by default (the inspector's own client implements the full SSO assertion → ID-JAG → token redemption path); real-host catalog entries stay silent until those hosts ship support. Connect surfaces still merge the extension at connect time for XAA-configured servers regardless of the stored baseline.

--- a/.changeset/terminal-heartbeat-hibernate.md
+++ b/.changeset/terminal-heartbeat-hibernate.md
@@ -1,0 +1,7 @@
+---
+"@mcpjam/inspector": minor
+---
+
+Computers: terminal activity heartbeat and manual hibernate.
+
+Interactive terminal sessions now emit an activity heartbeat so an open terminal keeps its computer awake, and the computer card gains a manual hibernate control for putting a machine to sleep without waiting for the idle timeout.

--- a/.changeset/xaa-managed-idp-console.md
+++ b/.changeset/xaa-managed-idp-console.md
@@ -1,0 +1,10 @@
+---
+"@mcpjam/inspector": minor
+---
+
+XAA managed-IdP console: setup center, managed debugger mode, and per-subject policy testing.
+
+- **Setup center:** manage the org's test people, resource-app connections, and access policy from one place. Resource apps can be registered by picking an existing server from the workspace instead of re-entering its details.
+- **Debugger managed mode:** the XAA debugger can run against the managed issuer with the org roster, showing stage-aware outcomes (granted / downscoped / denied with the issuer's reason) at each step of the flow.
+- **"Run as" people:** pick a test identity and run the full flow as that subject to verify per-person policy decisions. Projects can set a default test identity in settings, with an atomic per-server override; the debugger resolves server override → project default.
+- The separate `xaa-registration` feature flag is retired — registration now rides the main `xaa` flag.


### PR DESCRIPTION
Adds changesets for everything merged to `main` since the last Version Packages release that didn't have one yet:

- **auth-auto-discover** (`inspector` minor, `sdk` minor) — unauthenticated-first "Auto" auth method with OAuth escalation on 401 (#3194, #3198, #3199, #3220); sdk exports `isUnauthorized401`.
- **ema-capability-hostconfig** (`inspector` minor, `sdk` minor) — EMA capability stored in hostConfig + Protocol-tab toggle; MCPJam persona template advertises the XAA extension (#3195).
- **xaa-managed-idp-console** (`inspector` minor) — setup center, debugger managed mode, "Run as" people, project test-identity defaults, register-by-picking-a-server, `xaa-registration` flag retirement.
- **terminal-heartbeat-hibernate** (`inspector` minor) — terminal activity heartbeat + manual hibernate UI (#3205).

The CLI needed no new changeset — its only unreleased change (confidential CIMD) is already covered by the pending `xaa-confidential-cimd` changeset.

With the five changesets already on `main`, `changeset status` resolves to **minor bumps for @mcpjam/sdk (→1.32.0), @mcpjam/cli (→3.15.0), and @mcpjam/inspector (→2.27.0)**. Merging this should let the changesets action open the Version Packages PR for the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-metadata only (changeset markdown); no runtime or build logic changes.
> 
> **Overview**
> Adds **four new changeset entries** so unreleased work already on `main` is included in the next Version Packages run—no application code changes in this PR.
> 
> **`auth-auto-discover`** bumps `@mcpjam/inspector` and `@mcpjam/sdk` (minor): documents the default **Auto** auth path (unauthenticated connect, OAuth only after a 401 on initialize), UI updates for the auth dropdown, and the SDK **`isUnauthorized401`** export.
> 
> **`ema-capability-hostconfig`** bumps inspector and SDK (minor): EMA/XAA capability on persisted **hostConfig**, a Protocol-tab toggle, and default XAA extension advertisement on the MCPJam persona template.
> 
> **`xaa-managed-idp-console`** bumps inspector (minor): managed-IdP setup center, debugger managed mode, “Run as” test identities with project/server defaults, register-by-server, and retiring the **`xaa-registration`** flag in favor of **`xaa`**.
> 
> **`terminal-heartbeat-hibernate`** bumps inspector (minor): terminal activity heartbeat to keep computers awake and manual hibernate on computer cards.
> 
> Together with existing pending changesets, this should drive **minor** releases for `@mcpjam/sdk`, `@mcpjam/cli`, and `@mcpjam/inspector` when Version Packages merges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97a7896a747147b040f8508680d058316567627d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds four changeset entries so recent work on main is included in the next Version Packages run. No runtime or build changes; prepares minor releases for `@mcpjam/sdk`, `@mcpjam/cli`, and `@mcpjam/inspector`.

- **New Features**
  - Auto auth: unauthenticated connect with OAuth escalation on 401; SDK exports `isUnauthorized401`.
  - EMA capability stored on host config with a Protocol tab toggle; persona template advertises XAA by default.
  - XAA managed IdP console: setup center, managed debugger mode, “Run as” test identities; retire `xaa-registration` flag.
  - Computers: terminal activity heartbeat and manual hibernate control.

<sup>Written for commit 97a7896a747147b040f8508680d058316567627d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

