### PR TITLE
fix(xaa): re-gate persona strip + registration surfaces behind xaa-registration flag

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -1370,7 +1370,8 @@ export function XAASetupRoute() {
   const { xaaEnabled, activeOrganizationId } = useAppRouteContext();
   // Same gates as the surfaces that link here: the debugger flag plus the
   // registration flag (the setup center manages registered resource apps).
-  if (xaaEnabled !== true) return null;
+  const registrationEnabled = useFeatureFlagEnabled("xaa-registration");
+  if (xaaEnabled !== true || registrationEnabled !== true) return null;
 
   return (
     <ErrorBoundary

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -10,6 +10,7 @@ import {
 import type { ImperativePanelHandle } from "react-resizable-panels";
 import { useAuth } from "@workos-inc/authkit-react";
 import { useConvexAuth } from "convex/react";
+import { useFeatureFlagEnabled } from "posthog-js/react";
 import { track } from "@/lib/analytics";
 import { Loader2, ShieldAlert } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
@@ -507,6 +508,9 @@ export function XAAFlowTab({
     : undefined;
 
   // ── "Run as" people ──────────────────────────────────────────────────
+  // The people strip rides the same flag as the registration surfaces:
+  // both are unreleased debugger extras, hidden together until launch.
+  const registrationEnabled = useFeatureFlagEnabled("xaa-registration");
   // Managed-capable runs use the ORG roster (the managed test IdP's shared
   // identities, edited in the setup center); everything else keeps the
   // project fixtures — an unregistered/bar-server run is untouched.
@@ -1831,25 +1835,27 @@ export function XAAFlowTab({
         hostedIssuerDisabledReason={hostedIssuerDisabledReason}
         issuerKind={hostedIssuerKind}
       />
-      <XAAPeopleStrip
-        people={people}
-        isLoading={peopleLoading}
-        isAvailable={peopleAvailable}
-        projectId={projectId ?? null}
-        selectedPersonId={selectedPersonId}
-        onSelectPerson={handleSelectPerson}
-        // Disabled while busy AND while a step-through run is paused between
-        // steps — a person change mid-run (switch, edit, delete) would drop
-        // the in-progress state or mutate the running identity.
-        disabled={
-          flowState.isBusy ||
-          isRunningAll ||
-          (flowState.currentStep !== "idle" &&
-            flowState.currentStep !== "complete")
-        }
-        outcomeFor={outcomeForPerson}
-        mode={managedCapable ? "org" : "project"}
-      />
+      {registrationEnabled === true && (
+        <XAAPeopleStrip
+          people={people}
+          isLoading={peopleLoading}
+          isAvailable={peopleAvailable}
+          projectId={projectId ?? null}
+          selectedPersonId={selectedPersonId}
+          onSelectPerson={handleSelectPerson}
+          // Disabled while busy AND while a step-through run is paused between
+          // steps — a person change mid-run (switch, edit, delete) would drop
+          // the in-progress state or mutate the running identity.
+          disabled={
+            flowState.isBusy ||
+            isRunningAll ||
+            (flowState.currentStep !== "idle" &&
+              flowState.currentStep !== "complete")
+          }
+          outcomeFor={outcomeForPerson}
+          mode={managedCapable ? "org" : "project"}
+        />
+      )}
       <XAAResourceAppsSection
         organizationId={organizationId ?? null}
         selectedId={selectedRegistrationId}

--- a/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
@@ -7,6 +7,7 @@ import {
   KeyRound,
   Settings2,
 } from "lucide-react";
+import { useFeatureFlagEnabled } from "posthog-js/react";
 import { Switch } from "@mcpjam/design-system/switch";
 import { useLearnMore } from "@/hooks/use-learn-more";
 import { LearnMoreExpandedPanel } from "@/components/learn-more/LearnMoreExpandedPanel";
@@ -135,9 +136,10 @@ export function XAAIdpCard({
   // Entry point to the setup center (org People / app connections / access
   // policy). Hosted + org + registration flag: exactly the surface the setup
   // routes require, so the gear never links to a blank page.
+  const registrationEnabled = useFeatureFlagEnabled("xaa-registration");
   const navigate = useAppNavigate();
   const showSetupLink =
-    HOSTED_MODE && Boolean(organizationId);
+    HOSTED_MODE && Boolean(organizationId) && registrationEnabled === true;
 
   // Start from the browser-origin guess, then swap in the server-advertised
   // issuer once resolved — see fetchXaaIdpUrls for why the guess can be wrong.

--- a/mcpjam-inspector/client/src/components/xaa/__tests__/XAAIdpCard.test.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/__tests__/XAAIdpCard.test.tsx
@@ -13,6 +13,12 @@ vi.mock("@/lib/config", () => ({
   HOSTED_MODE: true,
 }));
 
+// The setup gear is gated on the xaa-registration flag (plus hosted + org).
+let registrationFlag: boolean | undefined = true;
+vi.mock("posthog-js/react", () => ({
+  useFeatureFlagEnabled: () => registrationFlag,
+}));
+
 const navigateMock = vi.fn();
 vi.mock("@/lib/app-navigation", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/app-navigation")>();
@@ -30,6 +36,7 @@ describe("XAAIdpCard", () => {
   beforeEach(() => {
     copyToClipboard.mockClear();
     navigateMock.mockClear();
+    registrationFlag = true;
   });
 
   // Only unstub globals (e.g. the fetch stub) — NOT restoreAllMocks, which
@@ -200,8 +207,15 @@ describe("XAAIdpCard", () => {
     expect(navigateMock).toHaveBeenCalledWith("/xaa-flow/setup");
   });
 
-  it("hides the setup gear without an org", () => {
-    render(<XAAIdpCard />);
+  it("hides the setup gear without an org or without the registration flag", () => {
+    const { unmount } = render(<XAAIdpCard />);
+    expect(
+      screen.queryByRole("button", { name: /open xaa setup/i })
+    ).toBeNull();
+    unmount();
+
+    registrationFlag = false;
+    render(<XAAIdpCard organizationId="org_a1B2" />);
     expect(
       screen.queryByRole("button", { name: /open xaa setup/i })
     ).toBeNull();

--- a/mcpjam-inspector/client/src/components/xaa/registration/XAARegistrationWizard.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/registration/XAARegistrationWizard.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import { useFeatureFlagEnabled } from "posthog-js/react";
 import { Loader2 } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
 import {
@@ -66,6 +67,9 @@ export function XAARegistrationWizard({
   prefill,
   onSaved,
 }: XAARegistrationWizardProps) {
+  // Hooks run unconditionally — the flag gate returns null at the bottom of
+  // the hook block, never before a hook call.
+  const registrationEnabled = useFeatureFlagEnabled("xaa-registration");
   const { upsert } = useXaaResourceApps(organizationId);
 
   // Project server catalog for the "start from an existing server" picker
@@ -122,6 +126,10 @@ export function XAARegistrationWizard({
       stepHeadingRef.current?.focus();
     }
   }, [step, open]);
+
+  if (registrationEnabled !== true) {
+    return null;
+  }
 
   const updateDraft = (updates: Partial<RegistrationDraft>) => {
     setDraft((current) => ({ ...current, ...updates }));

--- a/mcpjam-inspector/client/src/components/xaa/registration/XAAResourceAppsSection.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/registration/XAAResourceAppsSection.tsx
@@ -1,4 +1,5 @@
 import { useConvexAuth } from "convex/react";
+import { useFeatureFlagEnabled } from "posthog-js/react";
 import { KeyRound, Loader2, Pencil, Plus, Trash2 } from "lucide-react";
 import { Badge } from "@mcpjam/design-system/badge";
 import { Button } from "@mcpjam/design-system/button";
@@ -73,7 +74,8 @@ export function XAAResourceAppsSection({
   selectedId,
   onSelect,
 }: XAAResourceAppsSectionProps) {
-  // Hooks run unconditionally; the auth gate returns null below.
+  // Hooks run unconditionally; the flag/auth gates return null below.
+  const registrationEnabled = useFeatureFlagEnabled("xaa-registration");
   const { isAuthenticated: isConvexAuthenticated } = useConvexAuth();
   const { resourceApps, isLoading, isAuthenticated, error, remove } =
     useXaaResourceApps(organizationId);
@@ -83,7 +85,7 @@ export function XAAResourceAppsSection({
 
   const crud = useRegistrationCrud(remove);
 
-  if (!isAuthenticated) {
+  if (registrationEnabled !== true || !isAuthenticated) {
     return null;
   }
 

--- a/mcpjam-inspector/client/src/components/xaa/registration/__tests__/XAARegistrationWizard.test.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/registration/__tests__/XAARegistrationWizard.test.tsx
@@ -7,6 +7,11 @@ import type { AppState } from "@/state/app-types";
 import type { ServerWithName } from "@/hooks/use-app-state";
 import type { XaaResourceApp } from "@/lib/xaa/types";
 
+let flagValue: boolean | undefined = true;
+vi.mock("posthog-js/react", () => ({
+  useFeatureFlagEnabled: () => flagValue,
+}));
+
 const trackMock = vi.fn();
 vi.mock("@/lib/analytics", () => ({
   track: (...args: unknown[]) => trackMock(...args),
@@ -126,10 +131,25 @@ async function fillBasicInfoAndAdvance(
 
 describe("XAARegistrationWizard", () => {
   beforeEach(() => {
+    flagValue = true;
     upsert.mockClear();
     discoverMock.mockReset();
     healthCheckMock.mockReset();
     trackMock.mockClear();
+  });
+
+  describe("flag gating", () => {
+    it("renders nothing when the flag is false", () => {
+      flagValue = false;
+      renderWizard();
+      expect(screen.queryByText("Register resource app")).toBeNull();
+    });
+
+    it("renders nothing when the flag is undefined (bootstrap)", () => {
+      flagValue = undefined;
+      renderWizard();
+      expect(screen.queryByText("Register resource app")).toBeNull();
+    });
   });
 
   describe("step validation", () => {

--- a/mcpjam-inspector/client/src/components/xaa/registration/__tests__/XAAResourceAppsSection.test.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/registration/__tests__/XAAResourceAppsSection.test.tsx
@@ -4,6 +4,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { XAAResourceAppsSection } from "../XAAResourceAppsSection";
 import type { XaaResourceApp } from "@/lib/xaa/types";
 
+let flagValue: boolean | undefined = true;
+vi.mock("posthog-js/react", () => ({
+  useFeatureFlagEnabled: () => flagValue,
+}));
+
 vi.mock("convex/react", () => ({
   useConvexAuth: () => ({ isAuthenticated: true, isLoading: false }),
 }));
@@ -55,6 +60,7 @@ const APP: XaaResourceApp = {
 
 describe("XAAResourceAppsSection", () => {
   beforeEach(() => {
+    flagValue = true;
     resourceApps = [];
     hookAuthenticated = true;
     myRole = "admin";
@@ -62,6 +68,18 @@ describe("XAAResourceAppsSection", () => {
   });
 
   describe("gating", () => {
+    it("renders nothing when the flag is false", () => {
+      flagValue = false;
+      render(<XAAResourceAppsSection organizationId={ORG_ID} />);
+      expect(screen.queryByText("Registered resource apps")).toBeNull();
+    });
+
+    it("renders nothing when the flag is undefined", () => {
+      flagValue = undefined;
+      render(<XAAResourceAppsSection organizationId={ORG_ID} />);
+      expect(screen.queryByText("Registered resource apps")).toBeNull();
+    });
+
     it("renders nothing when the hook gate is closed (local mode / logged out)", () => {
       hookAuthenticated = false;
       render(<XAAResourceAppsSection organizationId={ORG_ID} />);


### PR DESCRIPTION
## Why

The 2026-07-15 mass-merge shipped the whole XAA debugger stack to prod un-gated: the "Run as…" people strip (#3185) and the registration surfaces after #3197 retired the `xaa-registration` flag. These aren't ready for general exposure.

## What

- Reverts 57062a8b0 — restores the `xaa-registration` gate on the resource-apps section, registration wizard, setup route, and IdP-card gear (and their flag-gating tests).
- Newly gates the "Run as…" people strip in `XAAFlowTab` behind the same flag — both are unreleased debugger extras, hidden together until launch.

The flag does not exist in PostHog, so everything hides for everyone immediately on deploy. Create/enable `xaa-registration` (e.g. for @mcpjam.com) when we want it visible internally.

## Testing

- `vitest run src/components/xaa` — 12 files, 131 tests pass.
- Client typecheck errors are pre-existing on main (unrelated test files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only feature-flag gating with no auth or API behavior changes; surfaces hide by default when the flag is absent.
> 
> **Overview**
> Re-introduces the PostHog **`xaa-registration`** flag so unreleased XAA debugger extras stay hidden in production until the flag is enabled.
> 
> **Setup and registration UI** (`XAASetupRoute`, resource-apps section, registration wizard, IdP setup gear) again require `xaa-registration === true` in addition to existing auth/org gates. The **“Run as…” people strip** in `XAAFlowTab` is newly tied to the same flag so it hides with the other registration surfaces.
> 
> While the flag is off or still bootstrapping (`undefined`), those components render nothing and the setup route does not mount. Tests mock `useFeatureFlagEnabled` and cover false/undefined flag behavior for the wizard, resource-apps section, and IdP gear.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31ebcaf4f996573a46c51a64ed35f13243da35f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-gated XAA registration surfaces and the “Run as” people strip behind the `xaa-registration` flag to prevent premature exposure. These UIs now render only when the flag is enabled.

- **Bug Fixes**
  - Restored `xaa-registration` gating for the resource apps section, registration wizard, setup route, and IdP gear.
  - Gated the “Run as” people strip in `XAAFlowTab` with the same flag.
  - Used `useFeatureFlagEnabled` from `posthog-js/react`; components return null when the flag is false or undefined.
  - Updated tests to cover the gating behavior.

<sup>Written for commit 31ebcaf4f996573a46c51a64ed35f13243da35f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

