### PR TITLE
feat(xaa): host-level enterprise-managed authorization policy

### DIFF
--- a/.changeset/xaa-enterprise-policy.md
+++ b/.changeset/xaa-enterprise-policy.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/sdk": minor
+---
+
+Add the XAA enterprise-managed authorization policy helpers: `readXaaEnterprisePolicy` (three-state: off / on / invalid), `withXaaEnterprisePolicy`, `withoutXaaEnterprisePolicy`, and the `XAA_ENTERPRISE_POLICY_EXTENSION` / `XAA_ENTERPRISE_POLICY_IDPS` constants. The policy is stored under `hostConfig.mcpProfile.extensions["com.mcpjam/enterprise-managed-auth"]` and marks a host persona as enterprise-managed: every HTTP server connection resolves to XAA by default unless the server's explicit auth method overrides.

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -205,6 +205,7 @@ import { getEffectiveProjectClientCapabilities } from "./lib/client-config";
 import {
   getDefaultClientCapabilities,
   isKnownProtocolVersion,
+  readXaaEnterprisePolicy,
   type McpProtocolVersion,
 } from "@mcpjam/sdk/browser";
 import {
@@ -2509,6 +2510,14 @@ export default function App() {
       mcpProtocolVersionsByServerId[serverId] = effective;
     }
 
+    // Enterprise-managed authorization policy — sent only when validly ON.
+    // An `invalid` stored value is NOT silently dropped to off: host-bound
+    // turns hit the server-authoritative 409, and interactive connects
+    // fail in buildResolverConnectionDefaults with an actionable message.
+    const xaaPolicyState = readXaaEnterprisePolicy(activeMcpProfile);
+    const xaaPolicy =
+      xaaPolicyState.kind === "on" ? xaaPolicyState.policy : undefined;
+
     return {
       clientInfo,
       supportedProtocolVersions,
@@ -2516,6 +2525,7 @@ export default function App() {
         Object.keys(mcpProtocolVersionsByServerId).length > 0
           ? mcpProtocolVersionsByServerId
           : undefined,
+      xaaPolicy,
     };
   }, [
     activeHost?.serverConnectionOverrides,
@@ -2531,6 +2541,7 @@ export default function App() {
     supportedProtocolVersions: hostedMcpProfilePins.supportedProtocolVersions,
     mcpProtocolVersionsByServerId:
       hostedMcpProfilePins.mcpProtocolVersionsByServerId,
+    xaaPolicy: hostedMcpProfilePins.xaaPolicy,
     clientConfigSyncPending:
       isClientConfigSyncPending || isProjectServerConfigLoading,
     getAccessToken,

--- a/mcpjam-inspector/client/src/components/ServersTab.tsx
+++ b/mcpjam-inspector/client/src/components/ServersTab.tsx
@@ -28,6 +28,7 @@ import {
   ServerDetailModal,
   type ServerDetailTab,
 } from "./connection/ServerDetailModal";
+import { ActiveMcpProfileProvider } from "@/contexts/active-mcp-profile-context";
 
 import { JsonImportModal } from "./connection/JsonImportModal";
 import { ServerFormData } from "@/shared/types.js";
@@ -1829,6 +1830,13 @@ export function ServersTab({
   );
 
   return (
+    // The previewed host's mcpProfile scopes this tab so the server
+    // add/edit modals' AuthenticationSection can read the host's
+    // enterprise-managed authorization policy via useActiveMcpProfile().
+    // The ServerDetailModal's protocol chip keeps its explicit
+    // hostDefaultMcpProtocolVersion prop (prop wins; see the modal's
+    // resolution comment) — the provider is additive, not a replacement.
+    <ActiveMcpProfileProvider value={previewedHost?.config?.mcpProfile}>
     <div className="h-full flex flex-col">
       {isAuthHydrating ||
       isBillingContextPending ||
@@ -1906,5 +1914,6 @@ export function ServersTab({
           )
         : null}
     </div>
+    </ActiveMcpProfileProvider>
   );
 }

--- a/mcpjam-inspector/client/src/components/ServersTab.tsx
+++ b/mcpjam-inspector/client/src/components/ServersTab.tsx
@@ -1891,10 +1891,12 @@ export function ServersTab({
           projectClientConfig={selectedProject?.clientConfig}
           projectId={hostedProjectId}
           hostedServerId={detailModalHostedServerId}
-          // Servers tab doesn't mount under ActiveMcpProfileProvider,
-          // so surface the host default explicitly from the
-          // previewedHost's `mcpProfile.mcpProtocolVersion` for the chip's
-          // source attribution.
+          // The tab now mounts under ActiveMcpProfileProvider (see the
+          // root wrapper), which is the source for general host-profile
+          // reads (e.g. the auth section's enterprise-policy guidance).
+          // The protocol chip stays PROP-FIRST: this explicit value wins
+          // over the provider (see the modal's resolution comment), so
+          // its source attribution is unchanged.
           hostDefaultMcpProtocolVersion={
             previewedHost?.config?.mcpProfile?.mcpProtocolVersion
           }

--- a/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
@@ -80,13 +80,12 @@ interface ServerDetailModalProps {
   hostedServerId?: string | null;
   /**
    * Host-default outbound MCP wire mode resolved from the surrounding
-   * client's hostConfig.mcpProfile. Surfaced as a prop because the
-   * Servers tab doesn't render this modal inside an
-   * `ActiveMcpProfileProvider` scope (that provider only wraps chat /
-   * playground), so `useActiveMcpProfile()` would return undefined and
-   * the chip would always read "Legacy · default" regardless of what
-   * the user toggled on the client. Undefined = no host-level pin =
-   * "Legacy · default" attribution on the chip.
+   * client's hostConfig.mcpProfile. Kept as an explicit prop (PROP-FIRST,
+   * falling back to `useActiveMcpProfile()`) even though the Servers tab
+   * now also mounts `ActiveMcpProfileProvider` — the prop is the
+   * authoritative chip-attribution source everywhere this modal renders.
+   * Undefined = no host-level pin = "Legacy · default" attribution on
+   * the chip.
    */
   hostDefaultMcpProtocolVersion?: McpProtocolVersion;
   /** Project default XAA test identity — shown as override placeholders. */

--- a/mcpjam-inspector/client/src/components/connection/shared/AuthenticationSection.tsx
+++ b/mcpjam-inspector/client/src/components/connection/shared/AuthenticationSection.tsx
@@ -18,7 +18,11 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@mcpjam/design-system/select";
-import { resolveAuthorizationPlan } from "@mcpjam/sdk/browser";
+import {
+  readXaaEnterprisePolicy,
+  resolveAuthorizationPlan,
+} from "@mcpjam/sdk/browser";
+import { useActiveMcpProfile } from "@/contexts/active-mcp-profile-context";
 import type { RegistrationMode } from "@/shared/xaa.js";
 import type {
   ServerFormAuthType,
@@ -140,6 +144,14 @@ export function AuthenticationSection({
   projectDefaultIdentity = null,
 }: AuthenticationSectionProps) {
   const [showAdvancedOAuth, setShowAdvancedOAuth] = useState(false);
+  // Active host's enterprise-managed authorization policy (ProtocolTab
+  // Switch → mcpProfile.extensions). When on, Auto routes this server
+  // through XAA regardless of per-server configuration and an explicit
+  // method here overrides — the helper copy under the select says which.
+  // `invalid` renders as off here; the connect path surfaces the config
+  // error, this component only shapes helper text.
+  const hostPolicyEnterpriseManaged =
+    readXaaEnterprisePolicy(useActiveMcpProfile()).kind === "on";
   const [revealedClientSecret, setRevealedClientSecret] = useState<
     string | null
   >(null);
@@ -334,9 +346,19 @@ export function AuthenticationSection({
           </Select>
           {authType === "auto" && (
             <p className="text-xs text-muted-foreground/80">
-              {autoSelectsXaa
-                ? "Uses Cross-App Access for this server."
-                : "Anonymous first, then OAuth if required."}
+              {hostPolicyEnterpriseManaged
+                ? autoSelectsXaa
+                  ? "Host policy: enterprise-managed — uses Cross-App Access for this server."
+                  : "Host policy: enterprise-managed — fails to connect until an XAA client registration is added or an explicit method overrides."
+                : autoSelectsXaa
+                  ? "Uses Cross-App Access for this server."
+                  : "Anonymous first, then OAuth if required."}
+            </p>
+          )}
+          {hostPolicyEnterpriseManaged && authType !== "auto" && (
+            <p className="text-xs text-muted-foreground/80">
+              Overrides the host&apos;s enterprise-managed authorization
+              policy.
             </p>
           )}
         </div>

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ProtocolTab.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ProtocolTab.tsx
@@ -9,7 +9,13 @@ import {
   SelectValue,
 } from "@mcpjam/design-system/select";
 import { Switch } from "@mcpjam/design-system/switch";
-import { isKnownProtocolVersion, XAA_MCP_EXTENSION } from "@mcpjam/sdk/browser";
+import {
+  isKnownProtocolVersion,
+  readXaaEnterprisePolicy,
+  withXaaEnterprisePolicy,
+  withoutXaaEnterprisePolicy,
+  XAA_MCP_EXTENSION,
+} from "@mcpjam/sdk/browser";
 import {
   type HostConfigInputV2,
   type HostConfigMcpProfileV1,
@@ -63,6 +69,15 @@ type ProtocolDoc = {
    */
   mcpProtocolVersion?: McpProtocolVersion;
   capabilities?: Record<string, unknown>;
+  /**
+   * Host-level MCP profile extensions (`mcpProfile.extensions`) — freeform
+   * JSON deep-sorted into the canonical hash. Carries the enterprise-managed
+   * authorization policy under `com.mcpjam/enterprise-managed-auth` (the
+   * Switch above the editor is its structured control). Distinct from
+   * `capabilities.extensions`, which are the wire `initialize` capability
+   * extensions.
+   */
+  extensions?: Record<string, unknown>;
   connectionDefaults: {
     requestTimeout: number;
     headers?: Record<string, string>;
@@ -117,6 +132,12 @@ function protocolToJson(draft: HostConfigInputV2): ProtocolDoc {
     Object.keys(draft.clientCapabilities).length > 0
   ) {
     doc.capabilities = draft.clientCapabilities;
+  }
+
+  // Surface mcpProfile.extensions only when set — absence is semantic (no
+  // extensions key hashes byte-identically to a pre-feature row).
+  if (draft.mcpProfile?.extensions !== undefined) {
+    doc.extensions = draft.mcpProfile.extensions as Record<string, unknown>;
   }
 
   const headers = draft.connectionDefaults.headers ?? {};
@@ -287,6 +308,20 @@ function applyJsonToDraft(
       ? { ...cleanIncoming, [prevAuthKey]: prevHeaders[prevAuthKey] }
       : cleanIncoming;
 
+  // mcpProfile.extensions — PARSED-AUTHORITATIVE now that the editor
+  // surfaces the key: deleting it in the JSON clears the stored extensions
+  // (including the enterprise-auth policy), editing it wins over the
+  // previous value. An explicit `{}` collapses to absent like the other
+  // tri-state fields, so hand-emptying the object doesn't churn the
+  // canonical hash against a pre-feature row.
+  let profileExtensions: Record<string, unknown> | undefined;
+  if (
+    isPlainObject(parsed.extensions) &&
+    Object.keys(parsed.extensions).length > 0
+  ) {
+    profileExtensions = parsed.extensions;
+  }
+
   // Build the new mcpProfile envelope, collapsing to undefined when empty so
   // the canonical hash stays stable with the form-based editor's outputs.
   const nextProfile = patchProfile(prev.mcpProfile, (base) => {
@@ -303,6 +338,7 @@ function applyJsonToDraft(
       ...base,
       initialize: initHasFields ? initialize : undefined,
       mcpProtocolVersion,
+      extensions: profileExtensions,
     };
 
     const allEmpty =
@@ -372,15 +408,29 @@ export function ProtocolTab({
   // Shared with the cross-host comparison matrix via the field schema.
   const fProtocolVersion = hostConfigField("mcpProtocolVersion");
 
-  // Default-advertisement control, not an XAA on/off: the connect surfaces
-  // re-merge the extension whenever a server's effective auth method is
-  // XAA (withXaaExtensionCapability), regardless of this Switch. The copy
-  // below says so — the toggle governs the stored baseline only.
-  const emaAdvertised = hasEmaExtension(draft.clientCapabilities);
-  const setEmaAdvertised = (next: boolean) => {
-    onDraftChange((prev) =>
-      next ? withEmaExtension(prev) : withoutEmaExtension(prev)
-    );
+  // Enterprise-managed authorization POLICY (simulates Claude's org-admin
+  // "authorize once for the whole org"): when on, every HTTP server whose
+  // auth method is Auto resolves to XAA via the host's IdP; explicit
+  // per-server methods override; unregistered servers fail to connect with
+  // a first-class error instead of silently falling back to OAuth. Stored
+  // under mcpProfile.extensions (surfaced in the JSON editor below); the
+  // EMA capability advertisement is DERIVED from the policy at connect
+  // time, no longer independently stored by this Switch.
+  const policyState = readXaaEnterprisePolicy(draft.mcpProfile);
+  const policyOn = policyState.kind === "on";
+  const policyInvalid = policyState.kind === "invalid";
+  const setPolicyOn = (next: boolean) => {
+    onDraftChange((prev) => {
+      const profile = prev.mcpProfile as Record<string, unknown> | undefined;
+      return {
+        ...prev,
+        mcpProfile: (next
+          ? withXaaEnterprisePolicy(profile)
+          : withoutXaaEnterprisePolicy(profile)) as
+          | HostConfigMcpProfileV1
+          | undefined,
+      };
+    });
   };
 
   return (
@@ -415,19 +465,27 @@ export function ProtocolTab({
         <div className="mt-2.5 flex items-center justify-between gap-3 border-t border-border/50 pt-2.5">
           <div className="min-w-0">
             <span className="text-[12px] font-medium">
-              Advertise EMA support by default
+              Enterprise-managed authorization
             </span>
             <p className="text-[11px] leading-snug text-muted-foreground">
-              Adds the enterprise-managed-authorization extension to this
-              host&apos;s initialize capabilities. XAA-configured connections
-              always advertise it regardless of this setting.
+              Route every HTTP server connection through your IdP (XAA) by
+              default. A server&apos;s explicit auth method overrides.
+              Servers without an XAA client registration fail to connect.
+              Applies on the next connect.
             </p>
+            {policyInvalid ? (
+              <p className="text-[11px] leading-snug text-destructive">
+                This host&apos;s stored policy value is unsupported —
+                connections will fail until it is fixed. Toggling on repairs
+                it; toggling off removes it.
+              </p>
+            ) : null}
           </div>
           <Switch
-            checked={emaAdvertised}
-            onCheckedChange={setEmaAdvertised}
+            checked={policyOn}
+            onCheckedChange={setPolicyOn}
             disabled={readOnly}
-            aria-label="Advertise EMA support by default"
+            aria-label="Enterprise-managed authorization"
           />
         </div>
       </div>

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ProtocolTab.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ProtocolTab.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useFeatureFlagEnabled } from "posthog-js/react";
 import { JsonEditor, type JsonEditorMode } from "@/components/ui/json-editor";
 import { hostConfigField } from "@/lib/host-config-field-schema";
 import {
@@ -419,6 +420,16 @@ export function ProtocolTab({
   const policyState = readXaaEnterprisePolicy(draft.mcpProfile);
   const policyOn = policyState.kind === "on";
   const policyInvalid = policyState.kind === "invalid";
+  // Gated on the same `xaa` flag as the per-server XAA auth option
+  // (AuthenticationSection's `showXaaOption`) — without it a flag-off user
+  // could turn the policy on, make every Auto server fail closed, and have
+  // no UI left to add the XAA registration that fixes them. Same escape
+  // hatch as that gate: an already-on (or malformed) stored policy always
+  // renders, so a host is never stranded with an invisible active policy
+  // it can't turn off.
+  const xaaFlagEnabled = useFeatureFlagEnabled("xaa");
+  const showPolicyToggle =
+    xaaFlagEnabled === true || policyState.kind !== "off";
   const setPolicyOn = (next: boolean) => {
     onDraftChange((prev) => {
       const profile = prev.mcpProfile as Record<string, unknown> | undefined;
@@ -462,6 +473,7 @@ export function ProtocolTab({
             </SelectContent>
           </Select>
         </div>
+        {showPolicyToggle && (
         <div className="mt-2.5 flex items-center justify-between gap-3 border-t border-border/50 pt-2.5">
           <div className="min-w-0">
             <span className="text-[12px] font-medium">
@@ -488,6 +500,7 @@ export function ProtocolTab({
             aria-label="Enterprise-managed authorization"
           />
         </div>
+        )}
       </div>
       <div className="flex min-h-0 flex-1 flex-col">
         <JsonEditor

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/ProtocolTab.enterprisePolicy.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/ProtocolTab.enterprisePolicy.test.tsx
@@ -1,5 +1,16 @@
 import { describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
+
+// The policy toggle is gated on the `xaa` feature flag (same gate as the
+// per-server XAA auth option) — without it a flag-off user could enable the
+// policy and lose the UI needed to register the servers it breaks.
+const { featureFlagMock } = vi.hoisted(() => ({
+  featureFlagMock: vi.fn((flag: string) => flag === "xaa"),
+}));
+vi.mock("posthog-js/react", () => ({
+  usePostHog: () => ({ capture: vi.fn() }),
+  useFeatureFlagEnabled: (flag: string) => featureFlagMock(flag),
+}));
 import { emptyHostConfigInputV2 } from "@/lib/client-config-v2";
 import type { HostConfigInputV2 } from "@/lib/client-config-v2";
 import {
@@ -109,5 +120,38 @@ describe("ProtocolTab — enterprise-managed authorization policy switch", () =>
     expect(
       document.body.textContent?.includes(XAA_ENTERPRISE_POLICY_EXTENSION)
     ).toBe(true);
+  });
+
+  it("hides the toggle when the xaa flag is off (no policy on the host)", () => {
+    featureFlagMock.mockImplementation(() => false);
+    try {
+      renderTab(emptyHostConfigInputV2());
+      expect(
+        screen.queryByRole("switch", {
+          name: /enterprise-managed authorization/i,
+        })
+      ).toBeNull();
+    } finally {
+      featureFlagMock.mockImplementation((flag: string) => flag === "xaa");
+    }
+  });
+
+  it("still shows the toggle with the flag off when a policy is already stored (never strand a host)", () => {
+    featureFlagMock.mockImplementation(() => false);
+    try {
+      const draft = emptyHostConfigInputV2();
+      draft.mcpProfile = {
+        profileVersion: 1,
+        extensions: { [XAA_ENTERPRISE_POLICY_EXTENSION]: { idp: "mcpjam" } },
+      };
+      renderTab(draft);
+      expect(
+        screen.getByRole("switch", {
+          name: /enterprise-managed authorization/i,
+        })
+      ).toHaveAttribute("aria-checked", "true");
+    } finally {
+      featureFlagMock.mockImplementation((flag: string) => flag === "xaa");
+    }
   });
 });

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/ProtocolTab.enterprisePolicy.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/ProtocolTab.enterprisePolicy.test.tsx
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { emptyHostConfigInputV2 } from "@/lib/client-config-v2";
+import type { HostConfigInputV2 } from "@/lib/client-config-v2";
+import {
+  readXaaEnterprisePolicy,
+  XAA_ENTERPRISE_POLICY_EXTENSION,
+} from "@mcpjam/sdk/browser";
+import { ProtocolTab } from "../ProtocolTab";
+
+function renderTab(draft: HostConfigInputV2) {
+  let latest = draft;
+  const onDraftChange = vi.fn(
+    (updater: (prev: HostConfigInputV2) => HostConfigInputV2) => {
+      latest = updater(latest);
+    }
+  );
+  const utils = render(
+    <ProtocolTab draft={draft} onDraftChange={onDraftChange} attention={[]} />
+  );
+  return { ...utils, onDraftChange, getDraft: () => latest };
+}
+
+describe("ProtocolTab — enterprise-managed authorization policy switch", () => {
+  it("toggling on writes the policy under mcpProfile.extensions", () => {
+    const { getDraft } = renderTab(emptyHostConfigInputV2());
+    const toggle = screen.getByRole("switch", {
+      name: /enterprise-managed authorization/i,
+    });
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+
+    fireEvent.click(toggle);
+    const state = readXaaEnterprisePolicy(getDraft().mcpProfile);
+    expect(state).toEqual({ kind: "on", policy: { idp: "mcpjam" } });
+  });
+
+  it("toggling off removes the policy and collapses an otherwise-empty profile to undefined", () => {
+    const draft = emptyHostConfigInputV2();
+    draft.mcpProfile = {
+      profileVersion: 1,
+      extensions: { [XAA_ENTERPRISE_POLICY_EXTENSION]: { idp: "mcpjam" } },
+    };
+    const { getDraft } = renderTab(draft);
+    const toggle = screen.getByRole("switch", {
+      name: /enterprise-managed authorization/i,
+    });
+    expect(toggle).toHaveAttribute("aria-checked", "true");
+
+    fireEvent.click(toggle);
+    // Absence is semantic: a pre-feature host must hash byte-identically.
+    expect(getDraft().mcpProfile).toBeUndefined();
+  });
+
+  it("preserves sibling profile fields and extensions across a toggle round-trip", () => {
+    const draft = emptyHostConfigInputV2();
+    draft.mcpProfile = {
+      profileVersion: 1,
+      mcpProtocolVersion: "2026-07-28",
+      extensions: { "other/ext": { keep: true } },
+    };
+    const { getDraft, rerender, onDraftChange } = renderTab(draft);
+    const toggle = () =>
+      screen.getByRole("switch", {
+        name: /enterprise-managed authorization/i,
+      });
+    fireEvent.click(toggle()); // on
+    // Re-render with the updated draft (the parent does this in production)
+    // so the second click reads the post-toggle state.
+    rerender(
+      <ProtocolTab
+        draft={getDraft()}
+        onDraftChange={onDraftChange}
+        attention={[]}
+      />
+    );
+    fireEvent.click(toggle()); // off
+    expect(getDraft().mcpProfile).toEqual({
+      profileVersion: 1,
+      mcpProtocolVersion: "2026-07-28",
+      extensions: { "other/ext": { keep: true } },
+    });
+  });
+
+  it("renders an invalid stored policy as off with a repair warning", () => {
+    const draft = emptyHostConfigInputV2();
+    draft.mcpProfile = {
+      profileVersion: 1,
+      extensions: { [XAA_ENTERPRISE_POLICY_EXTENSION]: { idp: "okta" } },
+    };
+    renderTab(draft);
+    const toggle = screen.getByRole("switch", {
+      name: /enterprise-managed authorization/i,
+    });
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+    expect(
+      screen.getByText(/stored policy value is unsupported/i)
+    ).toBeInTheDocument();
+  });
+
+  it("surfaces mcpProfile.extensions in the JSON doc so the policy is visible", () => {
+    const draft = emptyHostConfigInputV2();
+    draft.mcpProfile = {
+      profileVersion: 1,
+      extensions: { [XAA_ENTERPRISE_POLICY_EXTENSION]: { idp: "mcpjam" } },
+    };
+    renderTab(draft);
+    // The CodeMirror editor renders the serialized doc text; the policy key
+    // must be present in the surfaced JSON.
+    expect(
+      document.body.textContent?.includes(XAA_ENTERPRISE_POLICY_EXTENSION)
+    ).toBe(true);
+  });
+});

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/tabs.readOnly.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/tabs.readOnly.test.tsx
@@ -144,7 +144,7 @@ describe("Client editor tabs — readOnly prop wiring", () => {
     expect(fieldset).not.toBeDisabled();
   });
 
-  it("ProtocolTab readOnly disables the EMA advertise switch", () => {
+  it("ProtocolTab readOnly disables the enterprise-managed authorization switch", () => {
     render(
       <ProtocolTab
         draft={emptyHostConfigInputV2()}
@@ -154,12 +154,12 @@ describe("Client editor tabs — readOnly prop wiring", () => {
       />
     );
     const emaSwitch = screen.getByRole("switch", {
-      name: /advertise ema support by default/i,
+      name: /enterprise-managed authorization/i,
     });
     expect(emaSwitch).toBeDisabled();
   });
 
-  it("ProtocolTab without readOnly leaves the EMA switch enabled", () => {
+  it("ProtocolTab without readOnly leaves the enterprise-managed authorization switch enabled", () => {
     render(
       <ProtocolTab
         draft={emptyHostConfigInputV2()}
@@ -168,7 +168,7 @@ describe("Client editor tabs — readOnly prop wiring", () => {
       />
     );
     const emaSwitch = screen.getByRole("switch", {
-      name: /advertise ema support by default/i,
+      name: /enterprise-managed authorization/i,
     });
     expect(emaSwitch).not.toBeDisabled();
   });

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/tabs.readOnly.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/tabs.readOnly.test.tsx
@@ -25,7 +25,10 @@ vi.mock("@/hooks/use-available-models", () => ({
 }));
 vi.mock("posthog-js/react", () => ({
   usePostHog: () => ({ capture: vi.fn() }),
-  useFeatureFlagEnabled: () => false,
+  // Flag-aware: ProtocolTab's enterprise-managed policy toggle is gated on
+  // `xaa` (same flag as the per-server XAA auth option). Other tabs' flags
+  // stay off, as before.
+  useFeatureFlagEnabled: (flag: string) => flag === "xaa",
 }));
 vi.mock("@/components/chat-v2/chat-input/model/provider-logo", () => ({
   ProviderLogo: ({ provider }: { provider: string }) => (

--- a/mcpjam-inspector/client/src/hooks/hosted/use-hosted-api-context.ts
+++ b/mcpjam-inspector/client/src/hooks/hosted/use-hosted-api-context.ts
@@ -1,6 +1,9 @@
 import { useLayoutEffect } from "react";
 import { setApiContext } from "@/lib/apis/web/context";
-import type { McpProtocolVersion } from "@mcpjam/sdk/browser";
+import type {
+  McpProtocolVersion,
+  XaaEnterprisePolicy,
+} from "@mcpjam/sdk/browser";
 
 interface UseApiContextOptions {
   projectId: string | null;
@@ -9,6 +12,9 @@ interface UseApiContextOptions {
   clientInfo?: { name?: string; version?: string } & Record<string, unknown>;
   supportedProtocolVersions?: string[];
   mcpProtocolVersionsByServerId?: Record<string, McpProtocolVersion>;
+  // Active host's enterprise-managed authorization policy (validated `on`
+  // value only) — rides ad-hoc chat/eval request bodies.
+  xaaPolicy?: XaaEnterprisePolicy;
   clientConfigSyncPending?: boolean;
   getAccessToken: () => Promise<string | undefined | null>;
   oauthTokensByServerId?: Record<string, string>;
@@ -28,6 +34,7 @@ export function useApiContext({
   clientInfo,
   supportedProtocolVersions,
   mcpProtocolVersionsByServerId,
+  xaaPolicy,
   clientConfigSyncPending,
   getAccessToken,
   oauthTokensByServerId,
@@ -54,6 +61,7 @@ export function useApiContext({
       clientInfo,
       supportedProtocolVersions,
       mcpProtocolVersionsByServerId,
+      xaaPolicy,
       clientConfigSyncPending,
       getAccessToken,
       oauthTokensByServerId,
@@ -74,6 +82,7 @@ export function useApiContext({
     clientInfo,
     supportedProtocolVersions,
     mcpProtocolVersionsByServerId,
+    xaaPolicy,
     clientConfigSyncPending,
     getAccessToken,
     oauthTokensByServerId,

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -9,6 +9,7 @@ import type {
 import {
   isKnownProtocolVersion,
   isStatelessProtocolVersion,
+  readXaaEnterprisePolicy,
 } from "@mcpjam/sdk/browser";
 import { normalizeRegistrationMode } from "@/shared/xaa.js";
 import type {
@@ -1255,6 +1256,18 @@ export function useServerState({
       );
       if (effective !== undefined) {
         defaults.mcpProtocolVersion = effective;
+      }
+      // Enterprise-managed authorization policy from the active host's
+      // mcpProfile. Sent only when validly ON; an `invalid` stored policy
+      // fails the connect client-side with an actionable message instead of
+      // silently connecting unenforced (fail-closed — the server re-gates).
+      const policyState = readXaaEnterprisePolicy(mcpProfile);
+      if (policyState.kind === "on") {
+        defaults.xaaPolicy = policyState.policy;
+      } else if (policyState.kind === "invalid") {
+        throw new Error(
+          `This host has an unsupported enterprise-managed authorization policy (${policyState.reason}). Fix it on the host's MCP Protocol tab, or turn the policy off.`
+        );
       }
       return Object.keys(defaults).length > 0 ? defaults : undefined;
     },

--- a/mcpjam-inspector/client/src/lib/apis/web/context.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/context.ts
@@ -399,6 +399,11 @@ export function buildServerRequest(
             apiContext.mcpProtocolVersionsByServerId[serverId],
         }
       : {}),
+    // Single-server flows (tools/resources/prompts, validate) enforce the
+    // same host policy as batch connects — omitting it here would let these
+    // ephemeral connections bypass enterprise-managed auth. Ignored
+    // server-side for chatbox-scoped calls (server-authoritative fetch wins).
+    ...(apiContext.xaaPolicy ? { xaaPolicy: apiContext.xaaPolicy } : {}),
     ...(accessScope ? { accessScope } : {}),
     ...(chatboxId ? { chatboxId } : {}),
     ...(chatboxId && Number.isFinite(accessVersion) ? { accessVersion } : {}),

--- a/mcpjam-inspector/client/src/lib/apis/web/context.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/context.ts
@@ -5,6 +5,7 @@ import { BootstrapNotReadyError } from "@/lib/app-ready";
 import {
   getDefaultClientCapabilities,
   type McpProtocolVersion,
+  type XaaEnterprisePolicy,
 } from "@mcpjam/sdk/browser";
 
 type GetAccessTokenFn = () => Promise<string | undefined | null>;
@@ -20,6 +21,13 @@ export interface ApiContext {
   clientInfo?: { name?: string; version?: string } & Record<string, unknown>;
   supportedProtocolVersions?: string[];
   mcpProtocolVersionsByServerId?: Record<string, McpProtocolVersion>;
+  /**
+   * The active host's enterprise-managed authorization policy (validated
+   * `on` value only). Rides ad-hoc chat/eval bodies; ignored server-side
+   * whenever a backend host config exists (chatbox/host-bound turns read
+   * the policy server-authoritatively instead).
+   */
+  xaaPolicy?: XaaEnterprisePolicy;
   clientConfigSyncPending?: boolean;
   getAccessToken?: GetAccessTokenFn;
   oauthTokensByServerId?: Record<string, string>;
@@ -405,6 +413,7 @@ export function buildServerBatchRequest(serverNamesOrIds: string[]): {
   clientInfo?: { name?: string; version?: string } & Record<string, unknown>;
   supportedProtocolVersions?: string[];
   mcpProtocolVersionsByServerId?: Record<string, McpProtocolVersion>;
+  xaaPolicy?: XaaEnterprisePolicy;
   oauthTokens?: Record<string, string>;
   accessScope?: HostedAccessScope;
   chatboxId?: string;
@@ -434,6 +443,7 @@ export function buildServerBatchRequest(serverNamesOrIds: string[]): {
     ...(protocolVersions
       ? { mcpProtocolVersionsByServerId: protocolVersions }
       : {}),
+    ...(apiContext.xaaPolicy ? { xaaPolicy: apiContext.xaaPolicy } : {}),
     ...(oauthTokens ? { oauthTokens } : {}),
     ...(accessScope ? { accessScope } : {}),
     ...(chatboxId ? { chatboxId } : {}),
@@ -475,6 +485,7 @@ export function buildResolvedServerBatchRequest(input: {
   clientInfo?: { name?: string; version?: string } & Record<string, unknown>;
   supportedProtocolVersions?: string[];
   mcpProtocolVersionsByServerId?: Record<string, McpProtocolVersion>;
+  xaaPolicy?: XaaEnterprisePolicy;
   oauthTokens?: Record<string, string>;
   accessScope?: HostedAccessScope;
   chatboxId?: string;
@@ -496,6 +507,7 @@ export function buildResolvedServerBatchRequest(input: {
     ...(protocolVersions
       ? { mcpProtocolVersionsByServerId: protocolVersions }
       : {}),
+    ...(apiContext.xaaPolicy ? { xaaPolicy: apiContext.xaaPolicy } : {}),
     ...(input.oauthTokens ? { oauthTokens: input.oauthTokens } : {}),
     ...(input.accessScope ? { accessScope: input.accessScope } : {}),
     ...(input.chatboxId ? { chatboxId: input.chatboxId } : {}),
@@ -513,6 +525,7 @@ export function buildHostedEvalServerBatchRequest(serverNamesOrIds: string[]): {
   clientInfo?: { name?: string; version?: string } & Record<string, unknown>;
   supportedProtocolVersions?: string[];
   mcpProtocolVersionsByServerId?: Record<string, McpProtocolVersion>;
+  xaaPolicy?: XaaEnterprisePolicy;
   oauthTokens?: Record<string, string>;
   accessScope?: HostedAccessScope;
   chatboxId?: string;
@@ -543,6 +556,7 @@ export function buildHostedEvalServerBatchRequest(serverNamesOrIds: string[]): {
     ...(protocolVersions
       ? { mcpProtocolVersionsByServerId: protocolVersions }
       : {}),
+    ...(apiContext.xaaPolicy ? { xaaPolicy: apiContext.xaaPolicy } : {}),
     ...(oauthTokens ? { oauthTokens } : {}),
     ...(accessScope ? { accessScope } : {}),
     ...(chatboxId ? { chatboxId } : {}),

--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -55,7 +55,11 @@ import {
   formatProviderOverloadError,
   isProviderOverloadError,
 } from "../../utils/provider-error-normalization";
-import { describeError, describeAsSlug } from "@mcpjam/sdk";
+import {
+  describeError,
+  describeAsSlug,
+  readXaaEnterprisePolicy,
+} from "@mcpjam/sdk";
 import { type LiveChatTraceUsage } from "@/shared/live-chat-trace";
 import { isAbortError } from "@/shared/abort-errors";
 import {
@@ -671,6 +675,14 @@ chatV2.post("/", async (c) => {
           String(modelDefinition.id),
           modelDefinition.provider,
         ),
+        // Fail closed rather than let a harness turn bypass the host's
+        // enterprise-managed policy: the harness proxy token carries no
+        // host, so that route can't enforce it (see the flag's docstring).
+        // Read from the server-resolved host config, never the body.
+        xaaEnterprisePolicyOn:
+          readXaaEnterprisePolicy(
+            (hostRuntimeConfig as { mcpProfile?: unknown } | null)?.mcpProfile,
+          ).kind !== "off",
       });
       if (!availability.ok) {
         return c.json(

--- a/mcpjam-inspector/server/routes/v1/__tests__/write-routes.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/write-routes.test.ts
@@ -272,6 +272,9 @@ describe("v1 write routes", () => {
         ]);
         expect(createAuthorizedManagerMock.mock.calls[0][7]).toEqual({
           serverNames: ["alpha", "beta"],
+          // Threaded so per-server XAA servers mint instead of 500ing —
+          // the v1 eval API has no host-persona input, so no xaaPolicy.
+          xaaIssuer: expect.stringContaining("/xaa"),
         });
         expect(prepareEvalRunMock.mock.calls[0][1]).toMatchObject({
           serverIds: ["s_alpha", "s_beta"],

--- a/mcpjam-inspector/server/routes/v1/evals.ts
+++ b/mcpjam-inspector/server/routes/v1/evals.ts
@@ -21,6 +21,8 @@ import { z } from "zod";
 import { ConvexHttpClient } from "convex/browser";
 import { parseWithSchema, ErrorCode, WebRouteError } from "../web/errors.js";
 import { createAuthorizedManager, callerContextFromHono } from "../web/auth.js";
+import { resolveXaaIssuer } from "../../services/xaa-mint.js";
+import { HOSTED_MODE } from "../../config.js";
 import { WEB_CALL_TIMEOUT_MS } from "../../config.js";
 import {
   RunEvalsRequestSchema,
@@ -1400,7 +1402,13 @@ evals.post("/projects/:projectId/eval-runs", async (c) => {
       WEB_CALL_TIMEOUT_MS,
       undefined,
       undefined,
-      { serverNames }
+      {
+        serverNames,
+        // v1 eval API has no host-persona input — no enterprise policy to
+        // enforce; the issuer makes per-server XAA servers mint instead of
+        // failing with 'Missing XAA issuer'.
+        xaaIssuer: resolveXaaIssuer(c, HOSTED_MODE),
+      }
     );
 
     let prepared: PreparedEvalRun;
@@ -1516,7 +1524,13 @@ evals.post("/projects/:projectId/eval-suites", async (c) => {
     WEB_CALL_TIMEOUT_MS,
     undefined,
     undefined,
-    { serverNames }
+    {
+        serverNames,
+        // v1 eval API has no host-persona input — no enterprise policy to
+        // enforce; the issuer makes per-server XAA servers mint instead of
+        // failing with 'Missing XAA issuer'.
+        xaaIssuer: resolveXaaIssuer(c, HOSTED_MODE),
+      }
   );
 
   // Author-only is fully synchronous: the manager is only needed to resolve
@@ -2417,7 +2431,13 @@ evals.post(
       WEB_CALL_TIMEOUT_MS,
       undefined,
       undefined,
-      { serverNames }
+      {
+        serverNames,
+        // v1 eval API has no host-persona input — no enterprise policy to
+        // enforce; the issuer makes per-server XAA servers mint instead of
+        // failing with 'Missing XAA issuer'.
+        xaaIssuer: resolveXaaIssuer(c, HOSTED_MODE),
+      }
     );
 
     // A caseMix only counts when it requests at least one case (a bucket > 0).

--- a/mcpjam-inspector/server/routes/web/__tests__/auth.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/auth.test.ts
@@ -158,3 +158,34 @@ describe("web routes — auth enforcement", () => {
     expect(data.code).toBe("VALIDATION_ERROR");
   });
 });
+
+// The single-server/multi-server route schemas are stripping z.objects, so
+// the enterprise-auth policy is deliberately read from the PRE-PARSE raw
+// body in createManualHostedConnection — a route schema that forgets to
+// declare xaaPolicy must not silently drop enforcement (fail-open). This
+// pins the raw-body read: a schema that strips the field still 409s on a
+// malformed policy.
+describe("createManualHostedConnection — xaaPolicy survives schema stripping", () => {
+  it("rejects a malformed policy that a stripping schema would have removed", async () => {
+    const { createManualHostedConnection } = await import("../auth.js");
+    const { z } = await import("zod");
+    const strippingSchema = z.object({ projectId: z.string() });
+    const c = {
+      get: () => undefined,
+      req: { header: () => "Bearer test-bearer" },
+    } as any;
+
+    let thrown: any;
+    try {
+      await createManualHostedConnection(
+        c,
+        { projectId: "proj-1", xaaPolicy: { idp: "okta" } },
+        strippingSchema
+      );
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown?.status).toBe(409);
+    expect(thrown?.details?.reason).toBe("xaa_policy_invalid");
+  });
+});

--- a/mcpjam-inspector/server/routes/web/__tests__/chat-v2.hosted.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chat-v2.hosted.test.ts
@@ -421,6 +421,14 @@ describe("web routes — chat-v2 hosted mode", () => {
     );
 
     expect(response.status).toBe(409);
+    const body = (await response.json()) as {
+      code?: string;
+      message?: string;
+      details?: { reason?: string };
+    };
+    expect(body.code).toBe("VALIDATION_ERROR");
+    expect(body.message).toContain("unsupported enterprise-managed");
+    expect(body.details?.reason).toBe("xaa_policy_invalid");
     expect(handleMCPJamFreeChatModelMock).not.toHaveBeenCalled();
   });
 
@@ -442,6 +450,14 @@ describe("web routes — chat-v2 hosted mode", () => {
     );
 
     expect(response.status).toBe(409);
+    const body = (await response.json()) as {
+      code?: string;
+      message?: string;
+      details?: { reason?: string };
+    };
+    expect(body.code).toBe("VALIDATION_ERROR");
+    expect(body.message).toContain("Unsupported enterprise-managed");
+    expect(body.details?.reason).toBe("xaa_policy_invalid");
     expect(handleMCPJamFreeChatModelMock).not.toHaveBeenCalled();
   });
 

--- a/mcpjam-inspector/server/routes/web/__tests__/chat-v2.hosted.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chat-v2.hosted.test.ts
@@ -389,6 +389,62 @@ describe("web routes — chat-v2 hosted mode", () => {
     expect(handleMCPJamFreeChatModelMock).not.toHaveBeenCalled();
   });
 
+  it("host-bound turn reads the enterprise-auth policy server-authoritatively — an invalid stored policy 409s regardless of the body", async () => {
+    const { app, token } = createWebTestApp();
+    fetchHostRuntimeConfigMock.mockResolvedValue({
+      ok: true,
+      config: {
+        selectedServerIds: ["server-1"],
+        mcpProfile: {
+          profileVersion: 1,
+          extensions: {
+            "com.mcpjam/enterprise-managed-auth": { idp: "okta" },
+          },
+        },
+      },
+    });
+
+    const response = await postJson(
+      app,
+      "/api/web/chat-v2",
+      {
+        projectId: "project-1",
+        selectedServerIds: ["server-1"],
+        hostId: "host-1",
+        chatSessionId: "chat-host-policy",
+        messages: [{ role: "user", content: "preview request" }],
+        model: { id: "anthropic/claude-haiku-4.5", provider: "anthropic", name: "Haiku" },
+        // The body says nothing about the policy — the stored host config is
+        // authoritative, so the unsupported idp fails the turn closed.
+      },
+      token
+    );
+
+    expect(response.status).toBe(409);
+    expect(handleMCPJamFreeChatModelMock).not.toHaveBeenCalled();
+  });
+
+  it("ad-hoc turn strictly validates a body-supplied enterprise-auth policy", async () => {
+    const { app, token } = createWebTestApp();
+
+    const response = await postJson(
+      app,
+      "/api/web/chat-v2",
+      {
+        projectId: "project-1",
+        selectedServerIds: ["server-1"],
+        chatSessionId: "chat-adhoc-policy",
+        messages: [{ role: "user", content: "preview request" }],
+        model: { id: "anthropic/claude-haiku-4.5", provider: "anthropic", name: "Haiku" },
+        xaaPolicy: { idp: "okta" },
+      },
+      token
+    );
+
+    expect(response.status).toBe(409);
+    expect(handleMCPJamFreeChatModelMock).not.toHaveBeenCalled();
+  });
+
   it("FAILS CLOSED when the chatbox runtime-config fetch fails — never runs the engine", async () => {
     const { app, token } = createWebTestApp();
     fetchChatboxRuntimeConfigMock.mockResolvedValue({

--- a/mcpjam-inspector/server/routes/web/__tests__/chatbox-sessions.no-required-servers.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chatbox-sessions.no-required-servers.test.ts
@@ -51,6 +51,21 @@ describe("web routes — chatbox-sessions with no required servers", () => {
     generatePersonasMock.mockResolvedValue([
       { id: "p-1", name: "Curious First-Time User", role: "user", notes: "" },
     ]);
+    // generate-personas now reads the chatbox host config for the
+    // enterprise-managed authorization policy before connecting; the
+    // baseline stub has no policy (mcpProfile omitted → policy off).
+    fetchChatboxRuntimeConfigMock.mockResolvedValue({
+      ok: true,
+      config: {
+        chatboxId: "cbx-1",
+        accessVersion: 0,
+        modelId: "openai/gpt-4o-mini",
+        systemPrompt: "",
+        temperature: 0.7,
+        requireToolApproval: false,
+        hostStyle: "default",
+      },
+    });
   });
 
   afterEach(() => {

--- a/mcpjam-inspector/server/routes/web/__tests__/xaa-connect-identity-error.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/xaa-connect-identity-error.test.ts
@@ -16,9 +16,26 @@ vi.mock("@axiomhq/js", () => ({
 
 // Spy on the mint so the test can prove the identity error blocks the mint
 // BEFORE it starts (no ID-JAG issuance, no token-endpoint exchange).
-const { mintXaaAccessTokenMock } = vi.hoisted(() => ({
+const { mintXaaAccessTokenMock, mcpClientManagerMock } = vi.hoisted(() => ({
   mintXaaAccessTokenMock: vi.fn(),
+  mcpClientManagerMock: vi.fn(),
 }));
+
+// Stub the manager (as auth-manager.test.ts does): the real one starts
+// background connects to the fixture URLs, whose rejections land after the
+// test environment tears down — an unhandled rejection that fails the RUN
+// (exit 1) even while every assertion passes.
+vi.mock("@mcpjam/sdk", async () => {
+  const actual = await vi.importActual<typeof import("@mcpjam/sdk")>(
+    "@mcpjam/sdk"
+  );
+  return {
+    ...actual,
+    MCPClientManager: mcpClientManagerMock.mockImplementation(() => ({
+      disconnectAllServers: vi.fn(),
+    })),
+  };
+});
 vi.mock("../../../services/xaa-mint.js", async (importOriginal) => {
   const actual =
     await importOriginal<typeof import("../../../services/xaa-mint.js")>();
@@ -293,6 +310,50 @@ describe("createAuthorizedManager — batch-wide validation before any mint", ()
         { xaaIssuer: "https://app.mcpjam.com/api/web" },
       ),
     ).rejects.toMatchObject({ status: 400, code: "VALIDATION_ERROR" });
+
+    expect(mintXaaAccessTokenMock).not.toHaveBeenCalled();
+  });
+
+  it("does not mint the CONFIGURED sibling when an explicit-OAuth server has no token", async () => {
+    batchOf({
+      "srv-configured": {
+        ...okBase,
+        serverConfig: {
+          transportType: "http",
+          url: "https://configured.example.com/mcp",
+          authMethod: "auto",
+          authServerMode: "mcpjam",
+          clientId: "client-1",
+        },
+      },
+      // Explicit OAuth, no stored token → 401 oauthRequired.
+      "srv-oauth-untokened": {
+        ...okBase,
+        serverConfig: {
+          transportType: "http",
+          url: "https://oauth.example.com/mcp",
+          authMethod: "oauth",
+          useOAuth: true,
+        },
+      },
+    });
+
+    await expect(
+      createAuthorizedManager(
+        callerContextFromHono(makeContext()),
+        "bearer-token",
+        "ws-1",
+        ["srv-configured", "srv-oauth-untokened"],
+        30_000,
+        undefined,
+        undefined,
+        { xaaIssuer: "https://app.mcpjam.com/api/web" },
+      ),
+    ).rejects.toMatchObject({
+      status: 401,
+      code: "UNAUTHORIZED",
+      details: { oauthRequired: true, serverId: "srv-oauth-untokened" },
+    });
 
     expect(mintXaaAccessTokenMock).not.toHaveBeenCalled();
   });

--- a/mcpjam-inspector/server/routes/web/__tests__/xaa-connect-identity-error.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/xaa-connect-identity-error.test.ts
@@ -173,3 +173,158 @@ describe("createAuthorizedManager — backend-resolved XAA identity error", () =
     expect(mintXaaAccessTokenMock).not.toHaveBeenCalled();
   });
 });
+
+describe("createAuthorizedManager — batch-wide validation before any mint", () => {
+  beforeEach(() => {
+    vi.stubEnv("CONVEX_HTTP_URL", "https://convex.test");
+    mintXaaAccessTokenMock.mockReset();
+    mintXaaAccessTokenMock.mockResolvedValue({ accessToken: "minted-token" });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  function batchOf(results: Record<string, unknown>) {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ results }),
+      } as unknown as Response),
+    );
+  }
+
+  const okBase = {
+    ok: true,
+    role: "member",
+    accessLevel: "project_member",
+    permissions: { chatOnly: false },
+  };
+
+  // The mint pass runs concurrently (Promise.all), so a per-server check
+  // inside it fails only its own server — a sibling's XAA mint (a REAL token
+  // issued at the resource AS) would already be in flight. Validation is
+  // hoisted to a batch-wide pass so no server mints when any server in the
+  // batch is misconfigured.
+  it("does not mint the CONFIGURED sibling when another server fails the policy preflight", async () => {
+    batchOf({
+      // Configured XAA server — would mint if the batch weren't validated first.
+      "srv-configured": {
+        ...okBase,
+        serverConfig: {
+          transportType: "http",
+          url: "https://configured.example.com/mcp",
+          authMethod: "auto",
+          authServerMode: "mcpjam",
+          clientId: "client-1",
+        },
+      },
+      // Unconfigured `auto` server — 409s under the host policy.
+      "srv-unconfigured": {
+        ...okBase,
+        serverConfig: {
+          transportType: "http",
+          url: "https://unconfigured.example.com/mcp",
+          authMethod: "auto",
+        },
+      },
+    });
+
+    await expect(
+      createAuthorizedManager(
+        callerContextFromHono(makeContext()),
+        "bearer-token",
+        "ws-1",
+        ["srv-configured", "srv-unconfigured"],
+        30_000,
+        undefined,
+        undefined,
+        {
+          xaaIssuer: "https://app.mcpjam.com/api/web",
+          xaaPolicy: { idp: "mcpjam" },
+        },
+      ),
+    ).rejects.toMatchObject({
+      status: 409,
+      code: "XAA_CONNECTION_NOT_CONFIGURED",
+      details: { serverId: "srv-unconfigured" },
+    });
+
+    // The whole point: no side effects anywhere in the batch.
+    expect(mintXaaAccessTokenMock).not.toHaveBeenCalled();
+  });
+
+  it("does not mint the CONFIGURED sibling when another server has an identity error", async () => {
+    batchOf({
+      "srv-configured": {
+        ...okBase,
+        serverConfig: {
+          transportType: "http",
+          url: "https://configured.example.com/mcp",
+          authMethod: "auto",
+          authServerMode: "mcpjam",
+          clientId: "client-1",
+        },
+      },
+      "srv-identity-broken": {
+        ...okBase,
+        serverConfig: {
+          transportType: "http",
+          url: "https://broken.example.com/mcp",
+          useXaa: true,
+          authServerMode: "mcpjam",
+          xaaIdentityError: "Complete or clear the server identity override",
+        },
+      },
+    });
+
+    await expect(
+      createAuthorizedManager(
+        callerContextFromHono(makeContext()),
+        "bearer-token",
+        "ws-1",
+        ["srv-configured", "srv-identity-broken"],
+        30_000,
+        undefined,
+        undefined,
+        { xaaIssuer: "https://app.mcpjam.com/api/web" },
+      ),
+    ).rejects.toMatchObject({ status: 400, code: "VALIDATION_ERROR" });
+
+    expect(mintXaaAccessTokenMock).not.toHaveBeenCalled();
+  });
+
+  it("still mints when the whole batch is valid", async () => {
+    batchOf({
+      "srv-configured": {
+        ...okBase,
+        serverConfig: {
+          transportType: "http",
+          url: "https://configured.example.com/mcp",
+          authMethod: "auto",
+          authServerMode: "mcpjam",
+          clientId: "client-1",
+        },
+      },
+    });
+
+    await createAuthorizedManager(
+      callerContextFromHono(makeContext()),
+      "bearer-token",
+      "ws-1",
+      ["srv-configured"],
+      30_000,
+      undefined,
+      undefined,
+      {
+        xaaIssuer: "https://app.mcpjam.com/api/web",
+        xaaPolicy: { idp: "mcpjam" },
+      },
+    );
+
+    expect(mintXaaAccessTokenMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -891,6 +891,10 @@ export async function createAuthorizedManager(
   // time this one rejects. Every purely-synchronous configuration verdict
   // therefore belongs here, so "fails before any side effects" holds for the
   // batch, not just per server.
+  // Resolved once here and reused by PASS 2, so the two passes provably agree
+  // on each server's flow (a re-resolution could drift if the predicate ever
+  // gains an input one pass forgets to thread).
+  const effectiveAuthByServerId = new Map<string, EffectiveAuthMethod>();
   for (const serverId of uniqueServerIds) {
     const auth = batch.results[serverId];
     if (!auth) {
@@ -904,13 +908,19 @@ export async function createAuthorizedManager(
       throw new WebRouteError(auth.status, auth.code as ErrorCode, auth.message);
     }
     const displayServerName = serverNamesById?.[serverId] ?? serverId;
+    const effectiveAuth = resolveEffectiveAuthMethod(
+      auth.serverConfig,
+      options?.xaaPolicy
+    );
+    effectiveAuthByServerId.set(serverId, effectiveAuth);
+    const isHttp = auth.serverConfig.transportType === "http";
 
     // Enterprise policy, unconfigured `auto` server: never silently downgrade
     // to the discover ladder. "Not configured" (no stored client registration
     // at the resource authorization server), NOT "not enrolled" — enrollment
     // verdicts belong to the future issuer-policy evaluator.
     if (
-      auth.serverConfig.transportType === "http" &&
+      isHttp &&
       xaaPolicyRequiresConfiguration(auth.serverConfig, options?.xaaPolicy)
     ) {
       throw new WebRouteError(
@@ -931,17 +941,32 @@ export async function createAuthorizedManager(
     // would mask this actionable 400 behind the caller-contract 500. Gated on
     // the same XAA selection the mint pass uses. No silent fallback to the
     // demo identity, no silent XAA→OAuth fallback.
-    if (
-      auth.serverConfig.transportType === "http" &&
-      resolveEffectiveAuthMethod(auth.serverConfig, options?.xaaPolicy) ===
-        "xaa" &&
-      auth.serverConfig.xaaIdentityError
-    ) {
+    if (isHttp && effectiveAuth === "xaa" && auth.serverConfig.xaaIdentityError) {
       throw new WebRouteError(
         400,
         ErrorCode.VALIDATION_ERROR,
         auth.serverConfig.xaaIdentityError,
         { serverId, serverName: displayServerName }
+      );
+    }
+
+    // Explicit-OAuth server with no stored token: also a synchronous verdict,
+    // so it belongs here — leaving it in the concurrent pass let a configured
+    // XAA sibling start minting a real token while this one rejected.
+    if (
+      effectiveAuth === "oauth" &&
+      !(auth.oauthAccessToken ?? oauthTokens?.[serverId])
+    ) {
+      throw new WebRouteError(
+        401,
+        ErrorCode.UNAUTHORIZED,
+        `Server "${displayServerName}" requires OAuth authentication. Please complete the OAuth flow first.`,
+        {
+          oauthRequired: true,
+          serverId,
+          serverName: serverNamesById?.[serverId] ?? null,
+          serverUrl: auth.serverConfig.url,
+        }
       );
     }
   }
@@ -958,16 +983,14 @@ export async function createAuthorizedManager(
 
       const oauthToken = auth.oauthAccessToken ?? oauthTokens?.[serverId];
       const displayServerName = serverNamesById?.[serverId] ?? serverId;
-      // One resolver decides the flow for every dispatch below: canonical
-      // authMethod wins ("auto" selects XAA when configured, "discover"
-      // otherwise); legacy rows fall back to the boolean pair. Must match
-      // the local resolver's dispatch (hosted/local/swarm parity). The
-      // host's enterprise policy forces `auto` servers to XAA; stdio never
-      // reaches this builder (toHttpConfig strips it).
-      const effectiveAuth = resolveEffectiveAuthMethod(
-        auth.serverConfig,
-        options?.xaaPolicy
-      );
+      // Resolved in PASS 1 (canonical authMethod wins; "auto" selects XAA
+      // when configured or when the host policy forces it, "discover"
+      // otherwise; legacy rows fall back to the boolean pair). Reused rather
+      // than re-resolved so both passes agree by construction. Must match the
+      // local resolver's dispatch (hosted/local/swarm parity).
+      const effectiveAuth = effectiveAuthByServerId.get(
+        serverId
+      ) as EffectiveAuthMethod;
       const usesOAuthFlow = effectiveAuth === "oauth";
       // "discover" (non-XAA auto) rides the OAuth rails only when a stored
       // token exists; tokenless discover connects unauthenticated instead of
@@ -993,19 +1016,8 @@ export async function createAuthorizedManager(
       if (usesStoredTokenFlow && auth.serverConfig.url) {
         oauthServerUrls[serverId] = auth.serverConfig.url;
       }
-      if (usesOAuthFlow && !oauthToken) {
-        throw new WebRouteError(
-          401,
-          ErrorCode.UNAUTHORIZED,
-          `Server "${displayServerName}" requires OAuth authentication. Please complete the OAuth flow first.`,
-          {
-            oauthRequired: true,
-            serverId,
-            serverName: serverNamesById?.[serverId] ?? null,
-            serverUrl: auth.serverConfig.url,
-          }
-        );
-      }
+      // (An explicit-OAuth server with no stored token is rejected batch-wide
+      // in PASS 1 — before any sibling can mint.)
 
       // Cross-App Access: mint the resource access token server-side (MCPJam as
       // the test IdP) and inject it through the same `oauthAccessToken` channel

--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -10,6 +10,7 @@ import type {
   HttpServerConfig,
   RpcLogger,
   UnauthorizedRefreshHandler,
+  XaaEnterprisePolicy,
 } from "@mcpjam/sdk";
 import { HOSTED_MODE, WEB_CALL_TIMEOUT_MS } from "../../config.js";
 import {
@@ -20,9 +21,13 @@ import { INSPECTOR_MCP_RETRY_POLICY } from "../../utils/mcp-retry-policy.js";
 import { setRequestLogContext } from "../../utils/request-logger.js";
 import { logger } from "../../utils/logger.js";
 import {
+  parseXaaPolicyValue,
   resolveEffectiveAuthMethod,
   withXaaExtensionCapability,
+  xaaPolicyFromMcpProfile,
+  xaaPolicyRequiresConfiguration,
 } from "../../utils/effective-auth.js";
+import { fetchChatboxRuntimeConfig } from "../../utils/chatbox-runtime-config.js";
 import type { RequestLogContext } from "../../utils/log-events.js";
 import {
   type InternalLogContext,
@@ -825,6 +830,19 @@ export async function createAuthorizedManager(
      * builder throws a 500 rather than connecting tokenless if it's missing.
      */
     xaaIssuer?: string;
+    /**
+     * The host's enterprise-managed authorization policy (validated `on`
+     * value). Read from the BACKEND-PROJECTED host config wherever a
+     * server-side host exists (chatbox turns, host-bound turns, swarm
+     * snapshots, eval host configs) — never trusted from a shareable
+     * request body, because dropping the policy on an unconfigured `auto`
+     * server would downgrade xaa→discover→OAuth. Under the policy every
+     * HTTP `auto` server resolves to XAA (unconfigured ones fail 409
+     * XAA_CONNECTION_NOT_CONFIGURED pre-mint), and the EMA extension is
+     * advertised on every server of the batch. Callers passing this MUST
+     * also pass `xaaIssuer`.
+     */
+    xaaPolicy?: XaaEnterprisePolicy;
   }
 ): Promise<AuthorizedManagerResult> {
   const serverNamesById = buildServerNamesById(serverIds, options?.serverNames);
@@ -881,8 +899,34 @@ export async function createAuthorizedManager(
       // One resolver decides the flow for every dispatch below: canonical
       // authMethod wins ("auto" selects XAA when configured, "discover"
       // otherwise); legacy rows fall back to the boolean pair. Must match
-      // the local resolver's dispatch (hosted/local/swarm parity).
-      const effectiveAuth = resolveEffectiveAuthMethod(auth.serverConfig);
+      // the local resolver's dispatch (hosted/local/swarm parity). The
+      // host's enterprise policy forces `auto` servers to XAA; stdio never
+      // reaches this builder (toHttpConfig strips it).
+      const effectiveAuth = resolveEffectiveAuthMethod(
+        auth.serverConfig,
+        options?.xaaPolicy
+      );
+
+      // Enterprise policy, unconfigured `auto` server: fail first-class
+      // BEFORE any mint/refresh — never silently downgrade to the discover
+      // ladder. "Not configured" (no stored client registration at the
+      // resource authorization server), NOT "not enrolled" — enrollment
+      // verdicts belong to the future issuer-policy evaluator.
+      if (
+        auth.serverConfig.transportType === "http" &&
+        xaaPolicyRequiresConfiguration(auth.serverConfig, options?.xaaPolicy)
+      ) {
+        throw new WebRouteError(
+          409,
+          ErrorCode.XAA_CONNECTION_NOT_CONFIGURED,
+          `Server "${displayServerName}" has no XAA client registration configured. This host requires enterprise-managed authorization — add the server's client registration in its auth settings, or set an explicit auth method to override the host policy.`,
+          {
+            serverId,
+            serverName: serverNamesById?.[serverId] ?? null,
+            reason: "xaa_connection_not_configured",
+          }
+        );
+      }
       const usesOAuthFlow = effectiveAuth === "oauth";
       // "discover" (non-XAA auto) rides the OAuth rails only when a stored
       // token exists; tokenless discover connects unauthenticated instead of
@@ -1087,9 +1131,14 @@ export async function createAuthorizedManager(
       // Spec (MCP enterprise-managed authorization): a client whose access is
       // enterprise-managed MUST advertise the extension in initialize. Merged
       // — never overwriting — into the caller-configured capabilities.
-      const perServerCapabilities = useXaa
-        ? withXaaExtensionCapability(clientCapabilities)
-        : clientCapabilities;
+      // Advertised when the connection actually uses XAA (the backstop) or
+      // whenever the host's enterprise policy is on — declare-support is
+      // host-wide, including on servers whose explicit auth method overrides
+      // the policy.
+      const perServerCapabilities =
+        useXaa || options?.xaaPolicy != null
+          ? withXaaExtensionCapability(clientCapabilities)
+          : clientCapabilities;
 
       return [
         serverId,
@@ -1388,6 +1437,30 @@ export async function createManualHostedConnection<S extends z.ZodTypeAny>(
   const { initializePins, mcpProtocolVersionsByServerId } =
     extractMcpInitializeOptions(raw);
 
+  // Enterprise-managed authorization policy. Chatbox-scoped connections are
+  // share-token-reachable, so the policy is read from the SERVER-side
+  // chatbox host config (fail closed on fetch failure — connecting with an
+  // unknown policy could downgrade an unconfigured auto server onto the
+  // discover/OAuth ladder). All other manual connections are the caller's
+  // own session; the strictly-validated body value is self-tampering only.
+  let xaaPolicy: XaaEnterprisePolicy | undefined;
+  if (chatboxId) {
+    const runtime = await fetchChatboxRuntimeConfig({
+      chatboxId,
+      bearer: bearerToken,
+    });
+    if (!runtime.ok) {
+      throw new WebRouteError(
+        runtime.status >= 500 ? 502 : runtime.status,
+        ErrorCode.INTERNAL_ERROR,
+        `Couldn't load this chatbox's settings, so the connection was stopped to avoid running with the wrong authorization policy. ${runtime.error}`
+      );
+    }
+    xaaPolicy = xaaPolicyFromMcpProfile(runtime.config.mcpProfile);
+  } else {
+    xaaPolicy = parseXaaPolicyValue(raw.xaaPolicy);
+  }
+
   const { manager } = await createAuthorizedManager(
     callerContextFromHono(c),
     bearerToken,
@@ -1405,6 +1478,7 @@ export async function createManualHostedConnection<S extends z.ZodTypeAny>(
       serverNames,
       initializePins,
       mcpProtocolVersionsByServerId,
+      xaaPolicy,
       // Resolve the XAA issuer here (we hold the request `Context`) so the
       // manager builder can mint Cross-App Access tokens for `useXaa` servers.
       xaaIssuer: resolveXaaIssuer(c, HOSTED_MODE),

--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -884,24 +884,77 @@ export async function createAuthorizedManager(
     }
   );
 
+  // PASS 1 — validate the WHOLE batch before any server does side-effecting
+  // work. The mint pass below runs concurrently (Promise.all), so a check
+  // living inside it only fails *its own* server: a sibling's XAA mint (a
+  // real token issued at the resource AS) would already be in flight by the
+  // time this one rejects. Every purely-synchronous configuration verdict
+  // therefore belongs here, so "fails before any side effects" holds for the
+  // batch, not just per server.
+  for (const serverId of uniqueServerIds) {
+    const auth = batch.results[serverId];
+    if (!auth) {
+      throw new WebRouteError(
+        500,
+        ErrorCode.INTERNAL_ERROR,
+        `Authorization response is missing result for server "${serverId}"`
+      );
+    }
+    if (!auth.ok) {
+      throw new WebRouteError(auth.status, auth.code as ErrorCode, auth.message);
+    }
+    const displayServerName = serverNamesById?.[serverId] ?? serverId;
+
+    // Enterprise policy, unconfigured `auto` server: never silently downgrade
+    // to the discover ladder. "Not configured" (no stored client registration
+    // at the resource authorization server), NOT "not enrolled" — enrollment
+    // verdicts belong to the future issuer-policy evaluator.
+    if (
+      auth.serverConfig.transportType === "http" &&
+      xaaPolicyRequiresConfiguration(auth.serverConfig, options?.xaaPolicy)
+    ) {
+      throw new WebRouteError(
+        409,
+        ErrorCode.XAA_CONNECTION_NOT_CONFIGURED,
+        `Server "${displayServerName}" has no XAA client registration configured. This host requires enterprise-managed authorization — add the server's client registration in its auth settings, or set an explicit auth method to override the host policy.`,
+        {
+          serverId,
+          serverName: serverNamesById?.[serverId] ?? null,
+          reason: "xaa_connection_not_configured",
+        }
+      );
+    }
+
+    // Backend-resolved identity failure (legacy partial per-server override):
+    // a distinct configuration error, surfaced before any mint AND before the
+    // issuer guard — eval routes omit `xaaIssuer`, so checking that first
+    // would mask this actionable 400 behind the caller-contract 500. Gated on
+    // the same XAA selection the mint pass uses. No silent fallback to the
+    // demo identity, no silent XAA→OAuth fallback.
+    if (
+      auth.serverConfig.transportType === "http" &&
+      resolveEffectiveAuthMethod(auth.serverConfig, options?.xaaPolicy) ===
+        "xaa" &&
+      auth.serverConfig.xaaIdentityError
+    ) {
+      throw new WebRouteError(
+        400,
+        ErrorCode.VALIDATION_ERROR,
+        auth.serverConfig.xaaIdentityError,
+        { serverId, serverName: displayServerName }
+      );
+    }
+  }
+
+  // PASS 2 — connect/mint concurrently. Every server reaching this point has
+  // already cleared the batch-wide validation above.
   const configEntries = await Promise.all(
     uniqueServerIds.map(async (serverId) => {
-      const auth = batch.results[serverId];
-      if (!auth) {
-        throw new WebRouteError(
-          500,
-          ErrorCode.INTERNAL_ERROR,
-          `Authorization response is missing result for server "${serverId}"`
-        );
-      }
-
-      if (!auth.ok) {
-        throw new WebRouteError(
-          auth.status,
-          auth.code as ErrorCode,
-          auth.message
-        );
-      }
+      // Non-null: PASS 1 threw for a missing or failed authorize result.
+      const auth = batch.results[serverId] as Extract<
+        (typeof batch.results)[string],
+        { ok: true }
+      >;
 
       const oauthToken = auth.oauthAccessToken ?? oauthTokens?.[serverId];
       const displayServerName = serverNamesById?.[serverId] ?? serverId;
@@ -915,27 +968,6 @@ export async function createAuthorizedManager(
         auth.serverConfig,
         options?.xaaPolicy
       );
-
-      // Enterprise policy, unconfigured `auto` server: fail first-class
-      // BEFORE any mint/refresh — never silently downgrade to the discover
-      // ladder. "Not configured" (no stored client registration at the
-      // resource authorization server), NOT "not enrolled" — enrollment
-      // verdicts belong to the future issuer-policy evaluator.
-      if (
-        auth.serverConfig.transportType === "http" &&
-        xaaPolicyRequiresConfiguration(auth.serverConfig, options?.xaaPolicy)
-      ) {
-        throw new WebRouteError(
-          409,
-          ErrorCode.XAA_CONNECTION_NOT_CONFIGURED,
-          `Server "${displayServerName}" has no XAA client registration configured. This host requires enterprise-managed authorization — add the server's client registration in its auth settings, or set an explicit auth method to override the host policy.`,
-          {
-            serverId,
-            serverName: serverNamesById?.[serverId] ?? null,
-            reason: "xaa_connection_not_configured",
-          }
-        );
-      }
       const usesOAuthFlow = effectiveAuth === "oauth";
       // "discover" (non-XAA auto) rides the OAuth rails only when a stored
       // token exists; tokenless discover connects unauthenticated instead of
@@ -1000,20 +1032,8 @@ export async function createAuthorizedManager(
             { serverId, registrationMode: auth.serverConfig.registrationMode }
           );
         }
-        // Backend-resolved identity failure (legacy partial per-server
-        // override): a distinct configuration error, surfaced BEFORE any
-        // mint AND before the issuer guard below — eval routes omit
-        // `xaaIssuer`, so checking it first would mask this actionable 400
-        // behind the caller-contract 500. No silent fallback to the demo
-        // identity, no silent XAA→OAuth fallback.
-        if (auth.serverConfig.xaaIdentityError) {
-          throw new WebRouteError(
-            400,
-            ErrorCode.VALIDATION_ERROR,
-            auth.serverConfig.xaaIdentityError,
-            { serverId, serverName: displayServerName }
-          );
-        }
+        // (`xaaIdentityError` is validated batch-wide in PASS 1 — before any
+        // sibling server can mint.)
         if (!options?.xaaIssuer) {
           // Caller-contract violation: a `useXaa` server reached a manager
           // builder that didn't thread the issuer (only callers holding the

--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -131,6 +131,15 @@ export const projectServerSchema = z.object({
   // and never reach the SDK's open-routing predicate. Absent means
   // "use SDK default (negotiates at request time)".
   mcpProtocolVersion: mcpProtocolVersionEnum.optional(),
+  // Host enterprise-managed authorization policy, resolved client-side from
+  // `hostConfig.mcpProfile.extensions`. Declared here (like the pins above)
+  // so the wire contract documents it, but VALIDATED by
+  // `parseXaaPolicyValue` from the pre-parse raw body in
+  // `createManualHostedConnection` — enforcement must never be silently
+  // stripped by a route schema that forgot to declare it (fail-open), and
+  // the strict gate 409s with the standard xaa_policy_invalid shape rather
+  // than a generic Zod 400.
+  xaaPolicy: z.unknown().optional(),
 });
 
 export const toolsListSchema = projectServerSchema.extend({
@@ -1458,7 +1467,11 @@ export async function createManualHostedConnection<S extends z.ZodTypeAny>(
     }
     xaaPolicy = xaaPolicyFromMcpProfile(runtime.config.mcpProfile);
   } else {
-    xaaPolicy = parseXaaPolicyValue(raw.xaaPolicy);
+    // Read from the PRE-PARSE raw body, not the schema-parsed `raw`: most
+    // route schemas are stripping z.objects, and a schema that forgot to
+    // declare xaaPolicy would silently drop enforcement (fail-open). The
+    // strict gate below still 409s on anything malformed.
+    xaaPolicy = parseXaaPolicyValue(rawBody.xaaPolicy);
   }
 
   const { manager } = await createAuthorizedManager(

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -341,6 +341,10 @@ chatV2.post("/", async (c) => {
           String(modelDefinition.id),
           modelDefinition.provider,
         ),
+        // Fail closed rather than let a harness turn bypass the host's
+        // enterprise-managed policy: the harness proxy token carries no
+        // host, so that route can't enforce it (see the flag's docstring).
+        xaaEnterprisePolicyOn: xaaPolicy != null,
       });
       if (!availability.ok) {
         throw new WebRouteError(

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -5,7 +5,7 @@ import { isHostedCatalogModel } from "../../services/hosted-model-catalog.js";
 import { shouldEnableCloudSkillTools } from "../../utils/computers/cloud-skill-tools.js";
 import { isMCPAuthError } from "@mcpjam/sdk";
 import { resolveHostModelDefinition } from "../../utils/org-model-config.js";
-import { WEB_STREAM_TIMEOUT_MS } from "../../config.js";
+import { HOSTED_MODE, WEB_STREAM_TIMEOUT_MS } from "../../config.js";
 import {
   validateAppToolEntries,
   AppToolValidationError,
@@ -34,6 +34,11 @@ import { createHostedRpcLogCollector } from "./hosted-rpc-logs.js";
 import { getClientIp } from "../../utils/client-ip.js";
 import { fetchChatboxRuntimeConfig } from "../../utils/chatbox-runtime-config.js";
 import { fetchHostRuntimeConfig } from "../../utils/host-runtime-config.js";
+import {
+  parseXaaPolicyValue,
+  xaaPolicyFromMcpProfile,
+} from "../../utils/effective-auth.js";
+import { resolveXaaIssuer } from "../../services/xaa-mint.js";
 import { type ExecutionScope } from "../../utils/execution-scope.js";
 import { checkHarnessRuntimeAvailable } from "../../utils/harness/harness-availability.js";
 import { resolveExecutionContext } from "../../utils/host-execution-context.js";
@@ -193,6 +198,20 @@ chatV2.post("/", async (c) => {
         );
       }
     }
+    // Enterprise-managed authorization policy. Server-authoritative wherever
+    // a backend host config exists (chatbox / host-bound turns above — the
+    // same fail-closed fetch that owns harness/computer): a tampered body
+    // can neither add the policy (409 DoS on auto servers) nor drop it
+    // (downgrading an unconfigured auto server from xaa to the discover/
+    // OAuth ladder). The body value is honored ONLY on ad-hoc turns, where
+    // the caller is tampering with their own session. Both reads fail
+    // closed on a malformed/unsupported policy (409, never silently off).
+    const xaaPolicy = hostRuntimeConfig
+      ? xaaPolicyFromMcpProfile(
+          (hostRuntimeConfig as { mcpProfile?: unknown }).mcpProfile
+        )
+      : parseXaaPolicyValue((body as Record<string, unknown>).xaaPolicy);
+
     const resolvedExecution = resolveExecutionContext({
       hostConfig: hostRuntimeConfig,
       overrides: {
@@ -410,6 +429,11 @@ chatV2.post("/", async (c) => {
         serverNames: selectedServerNames,
         initializePins,
         mcpProtocolVersionsByServerId,
+        xaaPolicy,
+        // Required for any XAA server in the batch (policy-forced or
+        // per-server configured) — without it the builder 500s rather than
+        // connecting tokenless.
+        xaaIssuer: resolveXaaIssuer(c, HOSTED_MODE),
       },
     );
     oauthServerUrls = urls;

--- a/mcpjam-inspector/server/routes/web/chatbox-sessions.ts
+++ b/mcpjam-inspector/server/routes/web/chatbox-sessions.ts
@@ -262,6 +262,15 @@ chatboxSessions.post("/:chatboxId/simulate-sessions/start", async (c) =>
     // use — and the chatbox runtime never produces it, so there's no
     // route-level gate to add here.
 
+    // Enterprise-managed policy from the server-authoritative chatbox host
+    // config (never the body). Resolved BEFORE createRun so an invalid
+    // stored policy 409s while no run row exists yet — validating after
+    // would strand a created run with no runner to mark it failed. Issuer
+    // resolved eagerly too: the setImmediate factory below runs after the
+    // response, when the Context may be finalized.
+    const xaaPolicy = xaaPolicyFromMcpProfile(runtime.config.mcpProfile);
+    const xaaIssuer = resolveXaaIssuer(c, HOSTED_MODE);
+
     const { runId } = await createRun(
       convexHttpUrl,
       bearerToken,
@@ -288,12 +297,6 @@ chatboxSessions.post("/:chatboxId/simulate-sessions/start", async (c) =>
       runtime.config.mcpToolResultImageRendering;
     const computer = runtime.config.computer;
     const harness = runtime.config.harness;
-    // Enterprise-managed policy from the server-authoritative chatbox host
-    // config (never the body); invalid stored policy fails the run closed.
-    // Issuer resolved eagerly — the setImmediate factory below runs after
-    // the response, when the Context may be finalized.
-    const xaaPolicy = xaaPolicyFromMcpProfile(runtime.config.mcpProfile);
-    const xaaIssuer = resolveXaaIssuer(c, HOSTED_MODE);
     // `runtime.config.accessVersion` is the server-resolved value the
     // chatbox redeem produced (vs the client-supplied `body.accessVersion`,
     // which the generate-sessions dialog never sends). Use the runtime

--- a/mcpjam-inspector/server/routes/web/chatbox-sessions.ts
+++ b/mcpjam-inspector/server/routes/web/chatbox-sessions.ts
@@ -11,8 +11,10 @@ import {
   callerContextFromHono,
   withManager,
 } from "./auth.js";
-import { WEB_STREAM_TIMEOUT_MS } from "../../config.js";
+import { HOSTED_MODE, WEB_STREAM_TIMEOUT_MS } from "../../config.js";
 import { fetchChatboxRuntimeConfig } from "../../utils/chatbox-runtime-config.js";
+import { xaaPolicyFromMcpProfile } from "../../utils/effective-auth.js";
+import { resolveXaaIssuer } from "../../services/xaa-mint.js";
 import { captureToolSnapshotForEvalAuthoring } from "../../services/evals/route-helpers.js";
 import {
   createRun,
@@ -116,6 +118,26 @@ chatboxSessions.post("/:chatboxId/generate-personas", async (c) =>
       body.servers
     );
 
+    // Enterprise-managed policy from the server-authoritative chatbox host
+    // config — persona generation connects to the chatbox's servers, so it
+    // enforces the same policy as a real session. Fail closed on fetch
+    // failure: connecting with an unknown policy could downgrade an
+    // unconfigured auto server onto the discover/OAuth ladder.
+    const personaRuntime = await fetchChatboxRuntimeConfig({
+      chatboxId,
+      bearer: bearerToken,
+    });
+    if (!personaRuntime.ok) {
+      throw new WebRouteError(
+        personaRuntime.status >= 500 ? 502 : personaRuntime.status,
+        ErrorCode.INTERNAL_ERROR,
+        `Couldn't load this chatbox's settings, so persona generation was stopped to avoid connecting with the wrong authorization policy. ${personaRuntime.error}`
+      );
+    }
+    const personaXaaPolicy = xaaPolicyFromMcpProfile(
+      personaRuntime.config.mcpProfile
+    );
+
     const result = await withManager(
       createAuthorizedManager(
         callerContextFromHono(c),
@@ -130,6 +152,8 @@ chatboxSessions.post("/:chatboxId/generate-personas", async (c) =>
           chatboxId,
           accessVersion: body.accessVersion,
           serverNames: selectedServerNames,
+          xaaPolicy: personaXaaPolicy,
+          xaaIssuer: resolveXaaIssuer(c, HOSTED_MODE),
         }
       ),
       async (manager) => {
@@ -264,6 +288,12 @@ chatboxSessions.post("/:chatboxId/simulate-sessions/start", async (c) =>
       runtime.config.mcpToolResultImageRendering;
     const computer = runtime.config.computer;
     const harness = runtime.config.harness;
+    // Enterprise-managed policy from the server-authoritative chatbox host
+    // config (never the body); invalid stored policy fails the run closed.
+    // Issuer resolved eagerly — the setImmediate factory below runs after
+    // the response, when the Context may be finalized.
+    const xaaPolicy = xaaPolicyFromMcpProfile(runtime.config.mcpProfile);
+    const xaaIssuer = resolveXaaIssuer(c, HOSTED_MODE);
     // `runtime.config.accessVersion` is the server-resolved value the
     // chatbox redeem produced (vs the client-supplied `body.accessVersion`,
     // which the generate-sessions dialog never sends). Use the runtime
@@ -318,6 +348,8 @@ chatboxSessions.post("/:chatboxId/simulate-sessions/start", async (c) =>
               // access is authorized against the current version.
               accessVersion,
               serverNames: selectedServerNames,
+              xaaPolicy,
+              xaaIssuer,
             }
           );
           return {

--- a/mcpjam-inspector/server/routes/web/errors.ts
+++ b/mcpjam-inspector/server/routes/web/errors.ts
@@ -21,6 +21,17 @@ export const ErrorCode = {
   // `details` so the client can rebuild a ConvexError and render the proper
   // upgrade message instead of a generic failure.
   BILLING_LIMIT_REACHED: "BILLING_LIMIT_REACHED",
+  // A host with the enterprise-managed authorization POLICY connected an
+  // `auto` server that has no stored XAA client registration. 409 (config
+  // conflict), never a silent downgrade to the discover/OAuth ladder.
+  // "Not configured", deliberately NOT "not enrolled": xaaConfigured proves
+  // an IdP mode + client id registered at the resource authorization
+  // server, not IdP enrollment — XAA_NOT_ENROLLED is reserved for the
+  // future issuer-policy evaluator's denied verdicts. NOTE the local route
+  // envelope (respondWithLocalRouteError) spreads `details` top-level and
+  // drops `code`; clients branch on the top-level `reason:
+  // "xaa_connection_not_configured"`, not this code.
+  XAA_CONNECTION_NOT_CONFIGURED: "XAA_CONNECTION_NOT_CONFIGURED",
 } as const;
 
 export type ErrorCode = (typeof ErrorCode)[keyof typeof ErrorCode];

--- a/mcpjam-inspector/server/routes/web/evals.ts
+++ b/mcpjam-inspector/server/routes/web/evals.ts
@@ -18,6 +18,13 @@ import {
 } from "./auth.js";
 import { assertBearerToken, ErrorCode, WebRouteError } from "./errors.js";
 import {
+  parseXaaPolicyValue,
+  xaaPolicyFromMcpProfile,
+} from "../../utils/effective-auth.js";
+import { fetchChatboxRuntimeConfig } from "../../utils/chatbox-runtime-config.js";
+import { resolveXaaIssuer } from "../../services/xaa-mint.js";
+import { HOSTED_MODE } from "../../config.js";
+import {
   GenerateNegativeTestsRequestSchema,
   GenerateTestsRequestSchema,
   RunEvalsRequestSchema,
@@ -183,6 +190,29 @@ evals.post("/stream-test-case", async (c) => {
   const serverIds = body.serverIds;
   const oauthTokens = body.oauthTokens;
 
+  // Enterprise-managed authorization policy: chatbox-scoped eval authoring
+  // is share-token-reachable, so read the SERVER-side chatbox host config
+  // (fail closed); otherwise honor a strictly-validated body value (member
+  // eval calls own their session, same trust class as clientCapabilities).
+  const evalChatboxId = body.chatboxId as string | undefined;
+  let xaaPolicy;
+  if (evalChatboxId) {
+    const runtime = await fetchChatboxRuntimeConfig({
+      chatboxId: evalChatboxId,
+      bearer: bearerToken,
+    });
+    if (!runtime.ok) {
+      throw new WebRouteError(
+        runtime.status >= 500 ? 502 : runtime.status,
+        ErrorCode.INTERNAL_ERROR,
+        `Couldn't load this chatbox's settings, so the test run was stopped to avoid connecting with the wrong authorization policy. ${runtime.error}`,
+      );
+    }
+    xaaPolicy = xaaPolicyFromMcpProfile(runtime.config.mcpProfile);
+  } else {
+    xaaPolicy = parseXaaPolicyValue(rawBody.xaaPolicy);
+  }
+
   const { manager } = await createAuthorizedManager(
     callerContextFromHono(c),
     bearerToken,
@@ -196,9 +226,11 @@ evals.post("/stream-test-case", async (c) => {
         | "project_member"
         | "chat_v2"
         | undefined,
-      chatboxId: body.chatboxId as string | undefined,
+      chatboxId: evalChatboxId,
       accessVersion: body.accessVersion as number | undefined,
       serverNames: body.serverNames,
+      xaaPolicy,
+      xaaIssuer: resolveXaaIssuer(c, HOSTED_MODE),
     },
   );
 

--- a/mcpjam-inspector/server/routes/web/harness-mcp.ts
+++ b/mcpjam-inspector/server/routes/web/harness-mcp.ts
@@ -29,6 +29,8 @@ import {
 import { verifyHarnessProxyToken } from "../../utils/harness/harness-proxy-token";
 import { rpcLogBus } from "../../services/rpc-log-bus";
 import { logger } from "../../utils/logger";
+import { resolveXaaIssuer } from "../../services/xaa-mint.js";
+import { HOSTED_MODE } from "../../config.js";
 
 const harnessMcp = new Hono();
 
@@ -156,6 +158,14 @@ async function handle(c: any) {
         undefined,
         undefined,
         {
+          // Per-server XAA works on the harness proxy (configured servers
+          // mint instead of 500ing). KNOWN LIMITATION: the host's
+          // enterprise-managed POLICY is NOT enforced here — the harness
+          // token's claims carry projectId/serverId but not the host, so an
+          // unconfigured `auto` server on a policy host takes the discover
+          // ladder in a harness turn instead of 409ing. Fix by threading the
+          // host policy (or hostId) into the harness token claims.
+          xaaIssuer: resolveXaaIssuer(c, HOSTED_MODE),
           // Publish the sandbox's MCP traffic into the in-process rpc-log bus
           // so a live harness turn ON THIS INSTANCE can forward it into the
           // Playground Logs panel (see bridgeHarnessRpcLogsToCollector), and

--- a/mcpjam-inspector/server/routes/web/swarm-runs.ts
+++ b/mcpjam-inspector/server/routes/web/swarm-runs.ts
@@ -10,6 +10,7 @@ import {
   createAuthorizedManager,
   callerContextFromHono,
 } from "./auth.js";
+import { xaaPolicyFromMcpProfile } from "../../utils/effective-auth.js";
 import { getConvexBearerForRequest } from "../../utils/v1-convex-token.js";
 import { WEB_STREAM_TIMEOUT_MS, HOSTED_MODE } from "../../config.js";
 import { resolveXaaIssuer } from "../../services/xaa-mint.js";
@@ -315,6 +316,12 @@ swarmRuns.post("/journeys/:journeyId/runs", async (c) =>
                 // XAA servers fail closed without the issuer; resolved above
                 // from the live request Context.
                 xaaIssuer,
+                // Enterprise-managed policy from the PINNED host snapshot
+                // (server-side, mcpProfile copied verbatim at run-create) —
+                // the run reproduces the snapshot's policy, and an invalid
+                // stored policy fails the host's sessions as a config error
+                // rather than silently un-enforcing.
+                xaaPolicy: xaaPolicyFromMcpProfile(host.mcpProfile),
                 ...(connection.initializePins
                   ? { initializePins: connection.initializePins }
                   : {}),

--- a/mcpjam-inspector/server/services/scheduled-evals-worker.ts
+++ b/mcpjam-inspector/server/services/scheduled-evals-worker.ts
@@ -177,6 +177,13 @@ export async function executeClaimedRun(
 
     // Empty caller context = plain-JWT caller (locked by caller-context
     // contract test); the delegated JWT is the principal.
+    //
+    // NO xaaIssuer/xaaPolicy here: the worker has no request Context to
+    // derive the issuer from, and the scheduled-suite selection carries no
+    // host-persona input, so there is no enterprise policy to enforce. A
+    // per-server XAA (`useXaa`) server in a scheduled suite fails closed in
+    // the manager builder ("Missing XAA issuer") — the pre-existing behavior
+    // on this surface. Lifting it needs an env-derived public issuer URL.
     const authorized = await createAuthorizedManager(
       {},
       bearer,

--- a/mcpjam-inspector/server/utils/__tests__/effective-auth.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/effective-auth.test.ts
@@ -4,7 +4,10 @@ import {
   resolveEffectiveAuthMethod,
   withXaaExtensionCapability,
   xaaConfigured,
+  xaaPolicyRequiresConfiguration,
 } from "../effective-auth";
+
+const POLICY = { idp: "mcpjam" } as const;
 
 describe("resolveEffectiveAuthMethod", () => {
   it("passes explicit canonical methods through", () => {
@@ -57,6 +60,68 @@ describe("resolveEffectiveAuthMethod", () => {
     );
     expect(resolveEffectiveAuthMethod({ useOAuth: true })).toBe("oauth");
     expect(resolveEffectiveAuthMethod({})).toBe("none");
+  });
+
+  it("enterprise policy rewrites ONLY the auto branch", () => {
+    // auto + policy → xaa regardless of configuration state.
+    expect(
+      resolveEffectiveAuthMethod({ authMethod: "auto" }, POLICY),
+    ).toBe("xaa");
+    expect(
+      resolveEffectiveAuthMethod(
+        { authMethod: "auto", authServerMode: "mcpjam", clientId: "c1" },
+        POLICY,
+      ),
+    ).toBe("xaa");
+    // Explicit methods are per-server overrides — the policy never touches
+    // them.
+    expect(resolveEffectiveAuthMethod({ authMethod: "oauth" }, POLICY)).toBe(
+      "oauth",
+    );
+    expect(resolveEffectiveAuthMethod({ authMethod: "bearer" }, POLICY)).toBe(
+      "bearer",
+    );
+    expect(resolveEffectiveAuthMethod({ authMethod: "none" }, POLICY)).toBe(
+      "none",
+    );
+    expect(resolveEffectiveAuthMethod({ authMethod: "xaa" }, POLICY)).toBe(
+      "xaa",
+    );
+    // Legacy boolean rows behave as their canonical equivalents (overrides);
+    // pre-`auto` relics resolving "none" by absence stay outside the policy.
+    expect(resolveEffectiveAuthMethod({ useOAuth: true }, POLICY)).toBe(
+      "oauth",
+    );
+    expect(resolveEffectiveAuthMethod({}, POLICY)).toBe("none");
+    // No policy → identical to the one-arg form.
+    expect(resolveEffectiveAuthMethod({ authMethod: "auto" }, undefined)).toBe(
+      "discover",
+    );
+  });
+
+  it("xaaPolicyRequiresConfiguration fires only for policy-forced unconfigured auto servers", () => {
+    expect(
+      xaaPolicyRequiresConfiguration({ authMethod: "auto" }, POLICY),
+    ).toBe(true);
+    // Configured server mints normally.
+    expect(
+      xaaPolicyRequiresConfiguration(
+        { authMethod: "auto", authServerMode: "mcpjam", clientId: "c1" },
+        POLICY,
+      ),
+    ).toBe(false);
+    // No policy → the discover ladder handles it.
+    expect(
+      xaaPolicyRequiresConfiguration({ authMethod: "auto" }, undefined),
+    ).toBe(false);
+    // Explicit xaa keeps its existing mint-failure path.
+    expect(xaaPolicyRequiresConfiguration({ authMethod: "xaa" }, POLICY)).toBe(
+      false,
+    );
+    // Overrides are out of scope for the policy error.
+    expect(
+      xaaPolicyRequiresConfiguration({ authMethod: "oauth" }, POLICY),
+    ).toBe(false);
   });
 
   it("xaaConfigured mirrors the backend derivation rule", () => {

--- a/mcpjam-inspector/server/utils/__tests__/local-server-resolver.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/local-server-resolver.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   executeLocalServerConnect,
+  parseConnectionDefaults,
   resolveLocalServerForConnect,
   toMCPServerConfig,
 } from "../local-server-resolver.js";
@@ -883,5 +884,201 @@ describe("resolveLocalServerForConnect — backend-resolved XAA identity error",
     // surfaced BEFORE any mint work (and there is no silent fallback to the
     // demo identity or to OAuth).
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("enterprise-managed authorization policy (xaaPolicy)", () => {
+  beforeEach(() => {
+    process.env.CONVEX_HTTP_URL = "https://example.convex.site";
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_CONVEX_HTTP_URL === undefined) {
+      delete process.env.CONVEX_HTTP_URL;
+    } else {
+      process.env.CONVEX_HTTP_URL = ORIGINAL_CONVEX_HTTP_URL;
+    }
+    vi.unstubAllGlobals();
+  });
+
+  const fakeContext = { set: () => {}, get: () => undefined } as any;
+  const POLICY = { idp: "mcpjam" } as const;
+
+  describe("parseConnectionDefaults", () => {
+    it("accepts a well-formed policy and omits an absent one", () => {
+      expect(
+        parseConnectionDefaults({ xaaPolicy: { idp: "mcpjam" } })
+      ).toEqual({ xaaPolicy: { idp: "mcpjam" } });
+      expect(parseConnectionDefaults({ timeoutMs: 5 })?.xaaPolicy).toBe(
+        undefined
+      );
+    });
+
+    it("throws 409 on a malformed or unsupported policy — enforcement is never advisory", () => {
+      for (const bad of [
+        { idp: "okta" },
+        { idp: 1 },
+        {},
+        "on",
+        ["mcpjam"],
+        null,
+      ]) {
+        let thrown: any;
+        try {
+          parseConnectionDefaults({ xaaPolicy: bad });
+        } catch (error) {
+          thrown = error;
+        }
+        expect(thrown, JSON.stringify(bad)).toBeDefined();
+        expect(thrown.status).toBe(409);
+        expect(thrown.details?.reason).toBe("xaa_policy_invalid");
+      }
+    });
+  });
+
+  describe("toMCPServerConfig — host-wide EMA advertisement", () => {
+    const EMA = "io.modelcontextprotocol/enterprise-managed-authorization";
+
+    it("advertises EMA on an explicit-oauth HTTP server when the policy is on", () => {
+      const config: any = toMCPServerConfig(
+        {
+          ...httpHostedOAuthAuth,
+          serverConfig: {
+            ...httpHostedOAuthAuth.serverConfig,
+            authMethod: "oauth" as const,
+          },
+        },
+        { xaaPolicy: POLICY }
+      );
+      expect(config.clientCapabilities.extensions[EMA]).toEqual({});
+    });
+
+    it("advertises EMA on stdio servers under the policy (declare-support is host-wide)", () => {
+      const config: any = toMCPServerConfig(stdioAuth, { xaaPolicy: POLICY });
+      expect(config.clientCapabilities.extensions[EMA]).toEqual({});
+    });
+
+    it("does not advertise EMA on non-XAA servers without the policy", () => {
+      const config: any = toMCPServerConfig(httpHeaderOnlyAuth, {});
+      expect(config.clientCapabilities?.extensions?.[EMA]).toBeUndefined();
+    });
+  });
+
+  describe("resolveLocalServerForConnect — not-configured failure", () => {
+    function authorizeResponse(serverConfig: Record<string, unknown>) {
+      return new Response(
+        JSON.stringify({
+          results: {
+            "srv-1": {
+              ok: true,
+              role: "owner",
+              accessLevel: "project_member",
+              permissions: { chatOnly: false },
+              serverConfig,
+              oauthAccessToken: null,
+            },
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    }
+
+    it("throws 409 XAA_CONNECTION_NOT_CONFIGURED for a policy-forced unconfigured auto server, before any mint or refresh", async () => {
+      const fetchMock = vi.fn(async (input: any) => {
+        const url = String(input);
+        if (url.endsWith("/web/authorize-batch-local")) {
+          return authorizeResponse({
+            transportType: "http",
+            url: "https://plain.example.com/mcp",
+            authMethod: "auto",
+          });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      let thrown: any;
+      try {
+        await resolveLocalServerForConnect(fakeContext, "b", "proj-1", "srv-1", {
+          serverDisplayName: "Plain",
+          defaults: { xaaPolicy: POLICY },
+        });
+      } catch (error) {
+        thrown = error;
+      }
+      expect(thrown?.status).toBe(409);
+      expect(thrown?.code).toBe("XAA_CONNECTION_NOT_CONFIGURED");
+      expect(thrown?.details?.reason).toBe("xaa_connection_not_configured");
+      expect(thrown?.details?.serverId).toBe("srv-1");
+      // Fails first-class: only the authorize call went out — no discover
+      // refresh, no mint, no secret reveal.
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("explicit-oauth server under the policy connects on the OAuth rails (override wins)", async () => {
+      const fetchMock = vi.fn(async (input: any) => {
+        const url = String(input);
+        if (url.endsWith("/web/authorize-batch-local")) {
+          return authorizeResponse({
+            transportType: "http",
+            url: "https://oauth.example.com/mcp",
+            authMethod: "oauth",
+            useOAuth: true,
+          });
+        }
+        if (url.endsWith("/web/oauth/force-refresh")) {
+          return new Response(
+            JSON.stringify({ accessToken: "refreshed-token" }),
+            { status: 200, headers: { "Content-Type": "application/json" } }
+          );
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const { config, effectiveAuth }: any = await resolveLocalServerForConnect(
+        fakeContext,
+        "b",
+        "proj-1",
+        "srv-1",
+        { serverDisplayName: "OAuth", defaults: { xaaPolicy: POLICY } }
+      );
+      expect(effectiveAuth).toBe("oauth");
+      expect(config.requestInit.headers.Authorization).toBe(
+        "Bearer refreshed-token"
+      );
+      // Host-wide declare-support rides along even on the override.
+      expect(
+        config.clientCapabilities.extensions[
+          "io.modelcontextprotocol/enterprise-managed-authorization"
+        ]
+      ).toEqual({});
+    });
+
+    it("stdio server under the policy connects unchanged (XAA is HTTP-only)", async () => {
+      const fetchMock = vi.fn(async (input: any) => {
+        const url = String(input);
+        if (url.endsWith("/web/authorize-batch-local")) {
+          return authorizeResponse({
+            transportType: "stdio",
+            command: "node",
+            args: ["server.js"],
+            env: { FOO: "bar" },
+          });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const { config, effectiveAuth }: any = await resolveLocalServerForConnect(
+        fakeContext,
+        "b",
+        "proj-1",
+        "srv-1",
+        { defaults: { xaaPolicy: POLICY } }
+      );
+      expect(effectiveAuth).toBe("none");
+      expect(config.command).toBe("node");
+    });
   });
 });

--- a/mcpjam-inspector/server/utils/chatbox-runtime-config.ts
+++ b/mcpjam-inspector/server/utils/chatbox-runtime-config.ts
@@ -62,6 +62,13 @@ export type ChatboxRuntimeConfig = RuntimeExecutionFields & {
     toolset?: "bash";
     workdir?: string;
   };
+  // Host-level MCP profile envelope from the pinned HostConfigV2 — carries
+  // the enterprise-managed authorization policy under
+  // `extensions["com.mcpjam/enterprise-managed-auth"]`. Server-authoritative
+  // for chatbox turns (a share-link body must not add/drop the policy).
+  // Optional so a backend that predates the projection returns omitted →
+  // policy off (safe: matches pre-feature behavior).
+  mcpProfile?: Record<string, unknown>;
 };
 
 export type ChatboxRuntimeConfigResult =

--- a/mcpjam-inspector/server/utils/effective-auth.ts
+++ b/mcpjam-inspector/server/utils/effective-auth.ts
@@ -23,7 +23,13 @@
  * canonical method fall back to the boolean pair.
  */
 
-import { XAA_MCP_EXTENSION } from "@mcpjam/sdk";
+import {
+  readXaaEnterprisePolicy,
+  XAA_ENTERPRISE_POLICY_IDPS,
+  XAA_MCP_EXTENSION,
+  type XaaEnterprisePolicy,
+} from "@mcpjam/sdk";
+import { ErrorCode, WebRouteError } from "../routes/web/errors.js";
 
 export type EffectiveAuthMethod =
   | "oauth"
@@ -80,8 +86,23 @@ export function withXaaExtensionCapability(
   };
 }
 
+/**
+ * @param xaaPolicy The active host's enterprise-managed authorization policy
+ * (validated `on` value; callers surface `invalid` as a configuration error
+ * BEFORE resolving — never pass an unvalidated value through). The policy
+ * rewrites ONLY the `auto` branch: under an enterprise-managed host, every
+ * `auto` server resolves to XAA regardless of whether it is XAA-configured —
+ * an unconfigured server then fails with XAA_CONNECTION_NOT_CONFIGURED at
+ * the connect surface instead of taking the discover ladder (no silent
+ * downgrade). Explicit methods and legacy boolean rows are per-server
+ * overrides and win over the policy. Connect-time input only: the backend's
+ * `deriveAuthBooleans` (serverAuthFields.ts) is intentionally unaware of
+ * host policy — a server attaches to many hosts, so the persisted compat
+ * booleans cannot encode a per-connection decision.
+ */
 export function resolveEffectiveAuthMethod(
-  sc: AuthConfigFields
+  sc: AuthConfigFields,
+  xaaPolicy?: XaaEnterprisePolicy
 ): EffectiveAuthMethod {
   switch (sc.authMethod) {
     case "oauth":
@@ -90,13 +111,83 @@ export function resolveEffectiveAuthMethod(
     case "none":
       return sc.authMethod;
     case "auto":
+      if (xaaPolicy) return "xaa";
       return xaaConfigured(sc) ? "xaa" : "discover";
     default:
       // Legacy rows: the boolean pair governs. Same precedence the dispatch
       // gates used before authMethod existed (`useXaa === true && useOAuth
-      // !== true` → XAA never collides with the OAuth branch).
+      // !== true` → XAA never collides with the OAuth branch). Pre-`auto`
+      // relics resolving "none" by absence stay outside the policy.
       if (sc.useXaa === true && sc.useOAuth !== true) return "xaa";
       if (sc.useOAuth === true) return "oauth";
       return "none";
   }
+}
+
+/**
+ * Whether a server resolves to XAA *because of the host policy* while
+ * lacking the stored client registration the mint needs. This is the
+ * XAA_CONNECTION_NOT_CONFIGURED trigger: "not configured", deliberately NOT
+ * "not enrolled" — `xaaConfigured` proves an IdP mode + a client id
+ * registered at the resource authorization server, not IdP enrollment
+ * (enrollment verdicts belong to the future issuer-policy evaluator).
+ * Explicit `authMethod: "xaa"` servers missing credentials keep their
+ * existing mint-failure path and are not this predicate's business.
+ */
+export function xaaPolicyRequiresConfiguration(
+  sc: AuthConfigFields,
+  xaaPolicy: XaaEnterprisePolicy | undefined
+): boolean {
+  return xaaPolicy != null && sc.authMethod === "auto" && !xaaConfigured(sc);
+}
+
+/**
+ * Strict trust-boundary gate for a bare wire `xaaPolicy` value (request
+ * bodies / ConnectionDefaults). UNLIKE advisory connect fields, enforcement
+ * is never silently dropped: absent → undefined (off); a well-formed
+ * `{ idp: <supported> }` → the policy; anything else → 409 — fail-open
+ * would un-enforce a policy the host believes is on.
+ */
+export function parseXaaPolicyValue(
+  raw: unknown
+): XaaEnterprisePolicy | undefined {
+  if (raw === undefined) return undefined;
+  const idp =
+    raw && typeof raw === "object" && !Array.isArray(raw)
+      ? (raw as Record<string, unknown>).idp
+      : undefined;
+  if (
+    typeof idp !== "string" ||
+    !(XAA_ENTERPRISE_POLICY_IDPS as readonly string[]).includes(idp)
+  ) {
+    throw new WebRouteError(
+      409,
+      ErrorCode.VALIDATION_ERROR,
+      `Unsupported enterprise-managed authorization policy on this host: expected { idp: ${XAA_ENTERPRISE_POLICY_IDPS.join(
+        " | "
+      )} }. Fix the host's MCP Protocol settings or turn the policy off.`,
+      { reason: "xaa_policy_invalid" }
+    );
+  }
+  return { idp: idp as XaaEnterprisePolicy["idp"] };
+}
+
+/**
+ * Server-authoritative policy read from a BACKEND-PROJECTED host config's
+ * `mcpProfile` (chatbox turns, host-bound turns, swarm snapshots, eval host
+ * configs). Three-state: off → undefined, on → the policy, invalid →
+ * explicit 409 configuration error (never treated as off).
+ */
+export function xaaPolicyFromMcpProfile(
+  mcpProfile: unknown
+): XaaEnterprisePolicy | undefined {
+  const state = readXaaEnterprisePolicy(mcpProfile);
+  if (state.kind === "off") return undefined;
+  if (state.kind === "on") return state.policy;
+  throw new WebRouteError(
+    409,
+    ErrorCode.VALIDATION_ERROR,
+    `This host has an unsupported enterprise-managed authorization policy (${state.reason}). Fix the host's MCP Protocol settings or turn the policy off.`,
+    { reason: "xaa_policy_invalid" }
+  );
 }

--- a/mcpjam-inspector/server/utils/harness/__tests__/harness-availability.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/harness-availability.test.ts
@@ -64,6 +64,31 @@ describe("checkHarnessRuntimeAvailable", () => {
     },
   );
 
+  // The harness reaches MCP servers through the signed-proxy route, whose
+  // Convex-minted token carries {projectId, serverId} but no host — so that
+  // route can't resolve or enforce the host's enterprise-managed policy. An
+  // unregistered `auto` server would silently take the discover/OAuth path,
+  // bypassing enforcement. Fail closed here instead.
+  it("rejects a harness turn on an enterprise-managed host (proxy can't carry the policy)", () => {
+    setFullyAvailable();
+    const result = checkHarnessRuntimeAvailable(
+      args({ xaaEnterprisePolicyOn: true }),
+    );
+    expect(result.ok).toBe(false);
+    expect((result as { reason: string }).reason).toContain(
+      "enterprise-managed host",
+    );
+  });
+
+  it("allows a harness turn when the host has no enterprise policy", () => {
+    setFullyAvailable();
+    expect(
+      checkHarnessRuntimeAvailable(args({ xaaEnterprisePolicyOn: false })),
+    ).toEqual({ ok: true });
+    // Absent flag behaves as off (pre-feature callers unchanged).
+    expect(checkHarnessRuntimeAvailable(args())).toEqual({ ok: true });
+  });
+
   it("rejects a model the runtime can't run (non-gpt-5 on Codex)", () => {
     setFullyAvailable();
     // MCPJam-provided but not Codex-mappable ⇒ rejected, not silently defaulted.

--- a/mcpjam-inspector/server/utils/harness/harness-availability.ts
+++ b/mcpjam-inspector/server/utils/harness/harness-availability.ts
@@ -38,9 +38,33 @@ export function checkHarnessRuntimeAvailable(args: {
    *  model the runtime can't actually run (e.g. a non-gpt-5 model on Codex) is
    *  rejected instead of silently falling back to the runtime's default. */
   modelId: string;
+  /**
+   * Whether the host's enterprise-managed authorization policy is on. The
+   * harness reaches MCP servers through the signed-proxy route
+   * (`routes/web/harness-mcp.ts`), whose Convex-minted token carries only
+   * `{projectId, serverId}` — no host — so that route CANNOT resolve or
+   * enforce the policy, and an unregistered `auto` server would silently
+   * take the discover/OAuth path instead of failing closed. Rather than let
+   * a harness turn bypass enforcement, reject the combination here. Lifting
+   * this requires threading the policy through the harness proxy token
+   * claims (a hand-mirrored Convex↔inspector contract — separate PR).
+   */
+  xaaEnterprisePolicyOn?: boolean;
 }): HarnessAvailability {
   const adapter = getHarnessAdapter(args.harnessId);
   const name = adapter.displayName;
+
+  if (args.xaaEnterprisePolicyOn) {
+    return {
+      ok: false,
+      reason:
+        `the ${name} harness can't run on an enterprise-managed host yet — ` +
+        "the harness reaches MCP servers through a signed proxy that can't " +
+        "carry the host's authorization policy, so a turn could bypass it. " +
+        "Turn off enterprise-managed authorization on this host, or use the " +
+        "emulated engine",
+    };
+  }
 
   if (adapter.requiresComputer && !isComputersDataPlaneConfigured()) {
     return {

--- a/mcpjam-inspector/server/utils/host-runtime-config.ts
+++ b/mcpjam-inspector/server/utils/host-runtime-config.ts
@@ -38,6 +38,12 @@ export type HostRuntimeConfig = RuntimeExecutionFields & {
     toolset?: "bash";
     workdir?: string;
   };
+  // Host-level MCP profile envelope from the HostConfigV2 — carries the
+  // enterprise-managed authorization policy under
+  // `extensions["com.mcpjam/enterprise-managed-auth"]`. Server-authoritative
+  // for host-bound turns. Optional so a backend that predates the projection
+  // returns omitted → policy off (safe: matches pre-feature behavior).
+  mcpProfile?: Record<string, unknown>;
 };
 
 export type HostRuntimeConfigResult =

--- a/mcpjam-inspector/server/utils/local-server-resolver.ts
+++ b/mcpjam-inspector/server/utils/local-server-resolver.ts
@@ -17,10 +17,13 @@ import {
 } from "./hosted-oauth-refresh.js";
 import { logger } from "./logger.js";
 import {
+  parseXaaPolicyValue,
   resolveEffectiveAuthMethod,
   withXaaExtensionCapability,
+  xaaPolicyRequiresConfiguration,
   type EffectiveAuthMethod,
 } from "./effective-auth.js";
+import type { XaaEnterprisePolicy } from "@mcpjam/sdk";
 import { exportSingleServerForInspection } from "./export-helpers.js";
 import { ConvexHttpClient } from "convex/browser";
 import { getInspectorClientRuntimeConfig } from "../env.js";
@@ -368,6 +371,14 @@ export function parseConnectionDefaults(
     out.mcpProtocolVersion = input.mcpProtocolVersion;
   }
 
+  // Enterprise-managed authorization policy. UNLIKE every field above, this
+  // one is enforcement, not advisory: silently dropping a malformed value
+  // would un-enforce a policy the host believes is on (fail-open), so the
+  // shared gate throws 409 instead. Local connects are the user's own
+  // session — body-sourced policy here is self-tampering only.
+  const xaaPolicy = parseXaaPolicyValue(input.xaaPolicy);
+  if (xaaPolicy) out.xaaPolicy = xaaPolicy;
+
   return Object.keys(out).length > 0 ? out : undefined;
 }
 
@@ -432,6 +443,15 @@ export function toMCPServerConfig(
      * host default on for.
      */
     mcpProtocolVersion?: McpProtocolVersion;
+    /**
+     * The host's enterprise-managed authorization policy (validated `on`
+     * value). Present ⇒ the EMA extension is advertised on EVERY server of
+     * this host — including explicit-OAuth overrides and stdio servers: the
+     * client's *support* for enterprise-managed auth is host-wide, even
+     * where a specific connection's auth flow is overridden. Also feeds the
+     * effective-auth resolution for the per-connection merge condition.
+     */
+    xaaPolicy?: XaaEnterprisePolicy;
   }
 ): MCPServerConfig {
   const { serverConfig } = authResult;
@@ -442,9 +462,12 @@ export function toMCPServerConfig(
   // Spec (MCP enterprise-managed authorization): a client whose access is
   // enterprise-managed MUST advertise the extension in initialize. Merged —
   // never overwriting — into whatever capabilities the caller configured.
+  // Advertised when the connection actually uses XAA (the backstop) or
+  // whenever the host's enterprise policy is on (host-wide declare-support).
   const clientCapabilities =
-    serverConfig.transportType === "http" &&
-    resolveEffectiveAuthMethod(serverConfig) === "xaa"
+    options?.xaaPolicy != null ||
+    (serverConfig.transportType === "http" &&
+      resolveEffectiveAuthMethod(serverConfig, options?.xaaPolicy) === "xaa")
       ? withXaaExtensionCapability(baseClientCapabilities)
       : baseClientCapabilities;
 
@@ -533,6 +556,14 @@ export function toMCPServerConfig(
   // (non-XAA auto) that HAS a token is on its stored-OAuth rung and gets the
   // same hook; tokenless discover connects bare and recovers via the tagged
   // 401 instead.
+  //
+  // INVARIANT: deliberately resolved WITHOUT the enterprise policy. The
+  // policy and no-policy resolutions differ only for an UNCONFIGURED `auto`
+  // server (xaa vs discover), and that case throws
+  // XAA_CONNECTION_NOT_CONFIGURED before any config/hook is built — so by
+  // the time hooks attach, both resolutions agree. If policy semantics ever
+  // change an ENROLLED server's resolution, this must start taking the
+  // policy too (covered by a test in local-server-resolver tests).
   const effectiveAuthForHooks = resolveEffectiveAuthMethod(serverConfig);
   if (
     oauthToken &&
@@ -596,11 +627,39 @@ export async function resolveLocalServerForConnect(
 
   // One resolver decides the flow for every dispatch below: canonical
   // authMethod wins ("auto" selects XAA when configured, "discover"
-  // otherwise); legacy rows fall back to the boolean pair.
+  // otherwise); legacy rows fall back to the boolean pair. The host's
+  // enterprise policy (already validated at parseConnectionDefaults) forces
+  // `auto` servers to XAA; stdio servers stay outside the policy — XAA is
+  // HTTP-only, so an enterprise-managed host still runs its stdio servers
+  // as today (the EMA capability is still advertised on them).
+  const xaaPolicy = options?.defaults?.xaaPolicy;
   const effectiveAuth =
     result.serverConfig.transportType === "http"
-      ? resolveEffectiveAuthMethod(result.serverConfig)
+      ? resolveEffectiveAuthMethod(result.serverConfig, xaaPolicy)
       : "none";
+
+  // Enterprise policy, unconfigured `auto` server: fail first-class BEFORE
+  // any mint/connect attempt — never silently downgrade to the discover
+  // ladder (that would mask the exact misconfiguration an admin needs to
+  // see). "Not configured" (no stored client registration at the resource
+  // authorization server), deliberately NOT "not enrolled" — enrollment
+  // verdicts belong to the future issuer-policy evaluator.
+  if (
+    result.serverConfig.transportType === "http" &&
+    xaaPolicyRequiresConfiguration(result.serverConfig, xaaPolicy)
+  ) {
+    const displayName = options?.serverDisplayName ?? serverId;
+    throw new WebRouteError(
+      409,
+      ErrorCode.XAA_CONNECTION_NOT_CONFIGURED,
+      `Server "${displayName}" has no XAA client registration configured. This host requires enterprise-managed authorization — add the server's client registration in its auth settings, or set an explicit auth method to override the host policy.`,
+      {
+        serverId,
+        serverName: options?.serverDisplayName ?? null,
+        reason: "xaa_connection_not_configured",
+      }
+    );
+  }
   const useOAuth = effectiveAuth === "oauth";
   // Track the access token we'll hand to `toMCPServerConfig`. Starts from
   // whatever `authorize-batch-local` returned, but for hosted-OAuth servers
@@ -806,6 +865,7 @@ export async function resolveLocalServerForConnect(
       serverName: options?.serverDisplayName ?? serverId,
     },
     xaaUnauthorizedHandler,
+    xaaPolicy,
   });
   return { config, authorizeResult: result, effectiveAuth };
 }

--- a/mcpjam-inspector/shared/connection-defaults.ts
+++ b/mcpjam-inspector/shared/connection-defaults.ts
@@ -61,4 +61,16 @@ export type ConnectionDefaults = {
    * never has to gate on transport here.
    */
   mcpProtocolVersion?: import("@mcpjam/sdk/browser").McpProtocolVersion;
+  /**
+   * The host's enterprise-managed authorization policy, resolved client-side
+   * via `readXaaEnterprisePolicy(hostConfig.mcpProfile)`. Present only when
+   * the policy is validly ON — the client surfaces an `invalid` policy as a
+   * configuration error before connecting, and the resolver re-validates.
+   * Under the policy every HTTP `auto` server resolves to XAA; explicit
+   * per-server auth methods override. Local connections are the user's own
+   * session, so a body-supplied value here is self-tampering only (hosted
+   * surfaces read the policy from the backend-projected host config
+   * instead).
+   */
+  xaaPolicy?: import("@mcpjam/sdk/browser").XaaEnterprisePolicy;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -867,7 +867,7 @@
       "version": "0.9.31",
       "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
       "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@adobe/css-tools": {
@@ -1686,7 +1686,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
       "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@csstools/css-calc": "^3.0.0",
@@ -1700,7 +1700,7 @@
       "version": "11.3.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
       "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -1710,7 +1710,7 @@
       "version": "6.8.1",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
       "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/nwsapi": "^2.3.9",
@@ -1724,7 +1724,7 @@
       "version": "11.3.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
       "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -1734,7 +1734,7 @@
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@aws-crypto/crc32": {
@@ -2924,7 +2924,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
       "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -2944,7 +2944,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
       "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -2968,7 +2968,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
       "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -2996,7 +2996,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
       "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -3019,7 +3019,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
       "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -3044,7 +3044,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
       "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -5284,7 +5284,7 @@
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
       "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
@@ -6808,7 +6808,7 @@
       "version": "0.3.11",
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
       "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -9021,7 +9021,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
       "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.59.1"
@@ -14344,7 +14344,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -14354,7 +14353,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -16896,7 +16895,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
       "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
@@ -17118,7 +17117,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/bundle-name": {
@@ -18231,7 +18230,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
       "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "mdn-data": "2.27.1",
@@ -18252,7 +18251,7 @@
       "version": "5.3.7",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
       "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/css-color": "^4.1.1",
@@ -18268,7 +18267,7 @@
       "version": "11.3.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
       "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -18839,7 +18838,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
       "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-mimetype": "^5.0.0",
@@ -18853,7 +18852,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
       "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -18950,7 +18949,7 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/decimal.js-light": {
@@ -20327,7 +20326,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -20338,7 +20336,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -23120,7 +23117,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
       "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@exodus/bytes": "^1.6.0"
@@ -23187,7 +23184,7 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.0",
@@ -23201,7 +23198,7 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -24014,7 +24011,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/is-promise": {
@@ -25417,7 +25414,7 @@
       "version": "27.4.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.4.0.tgz",
       "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
@@ -25457,7 +25454,7 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -25467,7 +25464,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -25481,7 +25478,7 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -25876,7 +25873,7 @@
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -25909,7 +25906,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -25930,7 +25926,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -25951,7 +25946,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -25972,7 +25966,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -25993,7 +25986,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -26014,7 +26006,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -26035,7 +26026,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -26056,7 +26046,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -26077,7 +26066,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -26098,7 +26086,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -26119,7 +26106,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -27038,7 +27024,7 @@
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "CC0-1.0"
     },
     "node_modules/media-typer": {
@@ -29789,7 +29775,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
       "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
@@ -30705,7 +30691,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -32119,7 +32105,7 @@
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -32211,7 +32197,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "xmlchars": "^2.2.0"
@@ -32885,7 +32871,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -32904,7 +32890,7 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -33601,7 +33587,7 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/synckit": {
@@ -33748,7 +33734,7 @@
       "version": "5.46.1",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.1.tgz",
       "integrity": "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -33832,7 +33818,7 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/test-exclude": {
@@ -34090,7 +34076,7 @@
       "version": "7.0.28",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
       "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "tldts-core": "^7.0.28"
@@ -34103,7 +34089,7 @@
       "version": "7.0.28",
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
       "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/tmp": {
@@ -34207,7 +34193,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
       "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tldts": "^7.0.5"
@@ -34220,7 +34206,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
       "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
@@ -34568,7 +34554,7 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -34751,7 +34737,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -35764,7 +35750,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
       "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "xml-name-validator": "^5.0.0"
@@ -35840,7 +35826,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
       "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=20"
@@ -35945,7 +35931,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
       "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -35955,7 +35941,7 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
       "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "^6.0.0",
@@ -36826,7 +36812,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
       "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
@@ -36846,7 +36832,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/xpath": {

--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -269,6 +269,18 @@ export type {
   McpInitializeRequest,
   XaaCapabilityEvidence,
 } from "./xaa/mcp-init.js";
+export {
+  readXaaEnterprisePolicy,
+  withXaaEnterprisePolicy,
+  withoutXaaEnterprisePolicy,
+  XAA_ENTERPRISE_POLICY_EXTENSION,
+  XAA_ENTERPRISE_POLICY_IDPS,
+} from "./xaa/enterprise-policy.js";
+export type {
+  XaaEnterprisePolicy,
+  XaaEnterprisePolicyIdp,
+  XaaEnterprisePolicyState,
+} from "./xaa/enterprise-policy.js";
 // XAA flow-core types + capability preflight (browser-safe engine primitives).
 export * from "./xaa/state-machines/index.js";
 export { EMPTY_OAUTH_FLOW_STATE } from "./oauth/state-machines/types.js";

--- a/sdk/src/xaa/enterprise-policy.ts
+++ b/sdk/src/xaa/enterprise-policy.ts
@@ -43,7 +43,12 @@ export type XaaEnterprisePolicyState =
   | { kind: "invalid"; reason: string };
 
 function isPlainObject(v: unknown): v is Record<string, unknown> {
-  return typeof v === "object" && v !== null && !Array.isArray(v);
+  if (v === null || typeof v !== "object" || Array.isArray(v)) return false;
+  // Reject Date, Map, Set, class instances, etc. — matches the host-config
+  // canonicalizer's predicate so a malformed programmatic profile reads as
+  // `invalid` (fail-closed), never silently as `off`.
+  const proto = Object.getPrototypeOf(v);
+  return proto === Object.prototype || proto === null;
 }
 
 /** Read the policy state from a host config's `mcpProfile` value. */
@@ -131,6 +136,11 @@ export function withoutXaaEnterprisePolicy(
     } else {
       delete profile.extensions;
     }
+  } else if (profile.extensions !== undefined) {
+    // A malformed container (null, array, Date, …) reads as `invalid` and
+    // would stay invalid forever if left in place — the toggle is the
+    // documented repair path, so turning off removes it.
+    delete profile.extensions;
   }
   const meaningful = Object.keys(profile).filter(
     (key) => key !== "profileVersion" && profile[key] !== undefined

--- a/sdk/src/xaa/enterprise-policy.ts
+++ b/sdk/src/xaa/enterprise-policy.ts
@@ -1,0 +1,139 @@
+// Host-level Enterprise-Managed Authorization POLICY (MCPJam extension).
+//
+// Distinct from the MCP EMA *capability* (`io.modelcontextprotocol/
+// enterprise-managed-authorization`, see mcp-init.ts): the capability
+// declares that the client SUPPORTS enterprise-managed auth; this policy
+// says the simulated host deployment IS enterprise-managed — every HTTP
+// server connection resolves to XAA by default unless the server's explicit
+// authMethod overrides. Stored under `hostConfig.mcpProfile.extensions`,
+// which the published canonicalizer deep-sorts as freeform JSON, so the
+// policy persists and content-hashes with no SDK/backend release gate.
+//
+// Browser- and node-safe: pure data helpers, no I/O.
+//
+// NOTE: "host policy" naming is taken by sdk/src/host-config/host-policy.ts
+// (tool-visibility execution policy) — everything here stays XAA-prefixed.
+
+/** mcpProfile.extensions key holding the policy object. */
+export const XAA_ENTERPRISE_POLICY_EXTENSION =
+  "com.mcpjam/enterprise-managed-auth";
+
+/** IdPs the policy can mint through. v1: only the MCPJam test IdP. `own`
+ * (bring-your-own, e.g. Okta) joins later, mirroring the reserved
+ * `authServerMode: "own"` slot on server configs. */
+export const XAA_ENTERPRISE_POLICY_IDPS = ["mcpjam"] as const;
+export type XaaEnterprisePolicyIdp =
+  (typeof XAA_ENTERPRISE_POLICY_IDPS)[number];
+
+/** The stored/wire policy object. */
+export interface XaaEnterprisePolicy {
+  idp: XaaEnterprisePolicyIdp;
+}
+
+/**
+ * Three-state read. `invalid` is deliberately NOT `off`: a malformed object
+ * or an unsupported `idp` (e.g. a future `"okta"` read by an older build)
+ * means an admin believes enforcement is on — treating it as off would
+ * silently un-enforce the policy. Connect surfaces turn `invalid` into an
+ * explicit configuration error.
+ */
+export type XaaEnterprisePolicyState =
+  | { kind: "off" }
+  | { kind: "on"; policy: XaaEnterprisePolicy }
+  | { kind: "invalid"; reason: string };
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/** Read the policy state from a host config's `mcpProfile` value. */
+export function readXaaEnterprisePolicy(
+  mcpProfile: unknown
+): XaaEnterprisePolicyState {
+  if (mcpProfile === undefined || mcpProfile === null) return { kind: "off" };
+  if (!isPlainObject(mcpProfile)) {
+    return { kind: "invalid", reason: "mcpProfile is not an object" };
+  }
+  const extensions = mcpProfile.extensions;
+  if (extensions === undefined) return { kind: "off" };
+  if (!isPlainObject(extensions)) {
+    return { kind: "invalid", reason: "mcpProfile.extensions is not an object" };
+  }
+  if (
+    !Object.prototype.hasOwnProperty.call(
+      extensions,
+      XAA_ENTERPRISE_POLICY_EXTENSION
+    )
+  ) {
+    return { kind: "off" };
+  }
+  const raw = extensions[XAA_ENTERPRISE_POLICY_EXTENSION];
+  if (!isPlainObject(raw)) {
+    return {
+      kind: "invalid",
+      reason: `${XAA_ENTERPRISE_POLICY_EXTENSION} must be an object`,
+    };
+  }
+  const idp = raw.idp;
+  if (
+    typeof idp !== "string" ||
+    !(XAA_ENTERPRISE_POLICY_IDPS as readonly string[]).includes(idp)
+  ) {
+    return {
+      kind: "invalid",
+      reason: `unsupported enterprise-auth idp ${JSON.stringify(raw.idp)}; this build supports: ${XAA_ENTERPRISE_POLICY_IDPS.join(", ")}`,
+    };
+  }
+  return { kind: "on", policy: { idp: idp as XaaEnterprisePolicyIdp } };
+}
+
+/**
+ * Turn the policy on. Preserves every sibling profile field and extension;
+ * an existing VALID policy value is kept as-is, an invalid one is repaired
+ * to the default (the toggle is the recovery path for a broken value).
+ * Accepts an absent profile and materializes the minimal envelope.
+ */
+export function withXaaEnterprisePolicy(
+  mcpProfile: Record<string, unknown> | undefined
+): Record<string, unknown> {
+  const profile: Record<string, unknown> = isPlainObject(mcpProfile)
+    ? { ...mcpProfile }
+    : { profileVersion: 1 };
+  const extensions: Record<string, unknown> = isPlainObject(profile.extensions)
+    ? { ...profile.extensions }
+    : {};
+  const existing = readXaaEnterprisePolicy({ extensions });
+  extensions[XAA_ENTERPRISE_POLICY_EXTENSION] =
+    existing.kind === "on"
+      ? (extensions[XAA_ENTERPRISE_POLICY_EXTENSION] as Record<string, unknown>)
+      : { idp: XAA_ENTERPRISE_POLICY_IDPS[0] };
+  profile.extensions = extensions;
+  return profile;
+}
+
+/**
+ * Turn the policy off. Touches ONLY the policy key: sibling extensions
+ * survive, a now-empty `extensions` container is dropped, and a profile
+ * left with nothing meaningful (only `profileVersion`) collapses to
+ * `undefined` so pre-feature configs keep hashing byte-identically —
+ * absence is semantic in the content-addressed hostConfig store.
+ */
+export function withoutXaaEnterprisePolicy(
+  mcpProfile: Record<string, unknown> | undefined
+): Record<string, unknown> | undefined {
+  if (!isPlainObject(mcpProfile)) return undefined;
+  const profile: Record<string, unknown> = { ...mcpProfile };
+  if (isPlainObject(profile.extensions)) {
+    const extensions = { ...profile.extensions };
+    delete extensions[XAA_ENTERPRISE_POLICY_EXTENSION];
+    if (Object.keys(extensions).length > 0) {
+      profile.extensions = extensions;
+    } else {
+      delete profile.extensions;
+    }
+  }
+  const meaningful = Object.keys(profile).filter(
+    (key) => key !== "profileVersion" && profile[key] !== undefined
+  );
+  return meaningful.length > 0 ? profile : undefined;
+}

--- a/sdk/src/xaa/index.ts
+++ b/sdk/src/xaa/index.ts
@@ -117,6 +117,16 @@ export {
   XAA_MCP_EXTENSION,
   type McpInitializeRequest,
 } from "./mcp-init.js";
+export {
+  readXaaEnterprisePolicy,
+  withXaaEnterprisePolicy,
+  withoutXaaEnterprisePolicy,
+  XAA_ENTERPRISE_POLICY_EXTENSION,
+  XAA_ENTERPRISE_POLICY_IDPS,
+  type XaaEnterprisePolicy,
+  type XaaEnterprisePolicyIdp,
+  type XaaEnterprisePolicyState,
+} from "./enterprise-policy.js";
 export { createInProcessXaaExecutor } from "./in-process-executor.js";
 export type { InProcessXaaExecutorOptions } from "./in-process-executor.js";
 export { runXaaFlow } from "./run-xaa-flow.js";

--- a/sdk/tests/host-config-seed-host-template.test.ts
+++ b/sdk/tests/host-config-seed-host-template.test.ts
@@ -6,6 +6,7 @@ import {
   type HostTemplateId,
 } from "../src/host-config/templates/index.js";
 import { XAA_MCP_EXTENSION } from "../src/xaa/mcp-init.js";
+import { readXaaEnterprisePolicy } from "../src/xaa/enterprise-policy.js";
 
 const ALL_IDS: HostTemplateId[] = [
   "mcpjam",
@@ -66,6 +67,19 @@ describe("seedHostTemplate", () => {
     ).extensions;
     expect(mcpjamExts["io.modelcontextprotocol/ui"]).toBeDefined();
     expect(mcpjamExts[XAA_MCP_EXTENSION]).toEqual({});
+  });
+
+  // The enterprise-managed POLICY (com.mcpjam/enterprise-managed-auth under
+  // mcpProfile.extensions) is opt-in per host — OFF for EVERY persona,
+  // mcpjam included (product decision 2026-07-14). Unlike the EMA
+  // *capability* above (mcpjam alone advertises support), no seed may carry
+  // the policy; this guards against a future seed change enabling
+  // enforcement-by-default.
+  it("seeds the enterprise-managed policy on NO persona", () => {
+    for (const id of ALL_IDS) {
+      const state = readXaaEnterprisePolicy(seedHostTemplate(id).mcpProfile);
+      expect(state.kind, `template ${id}`).toBe("off");
+    }
   });
 
   it("matches the documented model + style for the claude template", () => {

--- a/sdk/tests/xaa/enterprise-policy.test.ts
+++ b/sdk/tests/xaa/enterprise-policy.test.ts
@@ -54,6 +54,20 @@ describe("readXaaEnterprisePolicy — three-state contract", () => {
       "invalid"
     );
   });
+
+  it("non-plain objects (Date/Map/class instances) → invalid, never off", () => {
+    // A malformed programmatic profile must fail closed — the loose
+    // typeof-object check would have read these as "no extensions" = off.
+    expect(readXaaEnterprisePolicy(new Date()).kind).toBe("invalid");
+    expect(readXaaEnterprisePolicy(new Map()).kind).toBe("invalid");
+    expect(
+      readXaaEnterprisePolicy({ extensions: new Date() }).kind
+    ).toBe("invalid");
+    // Object.create(null) is still a plain record.
+    expect(readXaaEnterprisePolicy(Object.create(null))).toEqual({
+      kind: "off",
+    });
+  });
 });
 
 describe("withXaaEnterprisePolicy / withoutXaaEnterprisePolicy", () => {
@@ -101,6 +115,25 @@ describe("withXaaEnterprisePolicy / withoutXaaEnterprisePolicy", () => {
     withoutXaaEnterprisePolicy(base);
     withXaaEnterprisePolicy(base);
     expect(base).toEqual(snapshot);
+  });
+
+  it("toggle-off repairs a malformed extensions container", () => {
+    // extensions: null reads as invalid; leaving it in place would make the
+    // host permanently invalid — the toggle is the documented repair path.
+    const off = withoutXaaEnterprisePolicy({
+      profileVersion: 1,
+      extensions: null as unknown as Record<string, unknown>,
+    });
+    expect(off).toBeUndefined();
+    const offKeepingSiblings = withoutXaaEnterprisePolicy({
+      profileVersion: 1,
+      mcpProtocolVersion: "2025-11-25",
+      extensions: ["junk"] as unknown as Record<string, unknown>,
+    });
+    expect(offKeepingSiblings).toEqual({
+      profileVersion: 1,
+      mcpProtocolVersion: "2025-11-25",
+    });
   });
 
   it("keeps a profile with other meaningful fields when the policy is removed", () => {

--- a/sdk/tests/xaa/enterprise-policy.test.ts
+++ b/sdk/tests/xaa/enterprise-policy.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import {
+  readXaaEnterprisePolicy,
+  withXaaEnterprisePolicy,
+  withoutXaaEnterprisePolicy,
+  XAA_ENTERPRISE_POLICY_EXTENSION,
+} from "../../src/xaa/enterprise-policy.js";
+
+const KEY = XAA_ENTERPRISE_POLICY_EXTENSION;
+
+describe("readXaaEnterprisePolicy — three-state contract", () => {
+  it("absent profile / absent extensions / absent key → off", () => {
+    expect(readXaaEnterprisePolicy(undefined)).toEqual({ kind: "off" });
+    expect(readXaaEnterprisePolicy(null)).toEqual({ kind: "off" });
+    expect(readXaaEnterprisePolicy({ profileVersion: 1 })).toEqual({
+      kind: "off",
+    });
+    expect(
+      readXaaEnterprisePolicy({ extensions: { "other/ext": {} } })
+    ).toEqual({ kind: "off" });
+  });
+
+  it("valid policy → on", () => {
+    expect(
+      readXaaEnterprisePolicy({ extensions: { [KEY]: { idp: "mcpjam" } } })
+    ).toEqual({ kind: "on", policy: { idp: "mcpjam" } });
+  });
+
+  it("malformed value → invalid, never off", () => {
+    for (const bad of ["yes", 1, true, null, ["mcpjam"]]) {
+      const state = readXaaEnterprisePolicy({ extensions: { [KEY]: bad } });
+      expect(state.kind, JSON.stringify(bad)).toBe("invalid");
+    }
+  });
+
+  it("unsupported idp → invalid with an actionable reason", () => {
+    const state = readXaaEnterprisePolicy({
+      extensions: { [KEY]: { idp: "okta" } },
+    });
+    expect(state.kind).toBe("invalid");
+    expect((state as { reason: string }).reason).toContain("okta");
+    expect((state as { reason: string }).reason).toContain("mcpjam");
+  });
+
+  it("missing idp field → invalid", () => {
+    expect(readXaaEnterprisePolicy({ extensions: { [KEY]: {} } }).kind).toBe(
+      "invalid"
+    );
+  });
+
+  it("non-object profile/extensions → invalid", () => {
+    expect(readXaaEnterprisePolicy("junk").kind).toBe("invalid");
+    expect(readXaaEnterprisePolicy({ extensions: "junk" }).kind).toBe(
+      "invalid"
+    );
+  });
+});
+
+describe("withXaaEnterprisePolicy / withoutXaaEnterprisePolicy", () => {
+  it("round-trips on/off restoring the original shape byte-for-byte", () => {
+    const base = {
+      profileVersion: 1,
+      mcpProtocolVersion: "2025-11-25",
+      extensions: { "other/ext": { a: 1 } },
+    };
+    const on = withXaaEnterprisePolicy(base);
+    expect(readXaaEnterprisePolicy(on)).toEqual({
+      kind: "on",
+      policy: { idp: "mcpjam" },
+    });
+    expect((on.extensions as Record<string, unknown>)["other/ext"]).toEqual({
+      a: 1,
+    });
+    const off = withoutXaaEnterprisePolicy(on);
+    expect(off).toEqual(base);
+  });
+
+  it("materializes a minimal envelope from an absent profile and collapses back to undefined", () => {
+    const on = withXaaEnterprisePolicy(undefined);
+    expect(readXaaEnterprisePolicy(on).kind).toBe("on");
+    expect(on.profileVersion).toBe(1);
+    expect(withoutXaaEnterprisePolicy(on)).toBeUndefined();
+  });
+
+  it("preserves a pre-existing valid value, repairs an invalid one", () => {
+    const valid = { extensions: { [KEY]: { idp: "mcpjam" } } };
+    const kept = withXaaEnterprisePolicy(valid);
+    expect((kept.extensions as Record<string, unknown>)[KEY]).toEqual({
+      idp: "mcpjam",
+    });
+    const broken = { extensions: { [KEY]: { idp: "okta" } } };
+    const repaired = withXaaEnterprisePolicy(broken);
+    expect((repaired.extensions as Record<string, unknown>)[KEY]).toEqual({
+      idp: "mcpjam",
+    });
+  });
+
+  it("does not mutate its input", () => {
+    const base = { profileVersion: 1, extensions: { [KEY]: { idp: "mcpjam" } } };
+    const snapshot = JSON.parse(JSON.stringify(base));
+    withoutXaaEnterprisePolicy(base);
+    withXaaEnterprisePolicy(base);
+    expect(base).toEqual(snapshot);
+  });
+
+  it("keeps a profile with other meaningful fields when the policy is removed", () => {
+    const on = withXaaEnterprisePolicy({
+      profileVersion: 1,
+      initialize: { clientInfo: { name: "x", version: "1" } },
+    });
+    const off = withoutXaaEnterprisePolicy(on);
+    expect(off).toEqual({
+      profileVersion: 1,
+      initialize: { clientInfo: { name: "x", version: "1" } },
+    });
+  });
+});


### PR DESCRIPTION
## What

The ProtocolTab toggle now simulates the **enterprise policy** — like Claude's org-admin "authorize a connector once, your team gets it automatically" — instead of only editing the stored EMA capability declaration (#3195).

**Policy ON** (per host): every HTTP server on `authMethod: auto` resolves to XAA, minting via the MCPJam IdP. A server's explicit auth method overrides. stdio is exempt (XAA is HTTP-only). Servers without an XAA client registration fail with a first-class error instead of silently falling back to OAuth.

## Semantics (the load-bearing decisions)

- **Storage**: `mcpProfile.extensions["com.mcpjam/enterprise-managed-auth"] = { idp: "mcpjam" }`. mcpProfile.extensions is freeform-hashed by the *published* canonicalizer, so the policy persists and content-hashes with **no SDK publish / backend bump** (a top-level hostConfig field would be silently dropped until a release — the `harness` precedent). `idp` reserves the future `own`/Okta slot, mirroring `authServerMode`.
- **Not-configured failure**: policy-forced `auto` server with no stored client registration → `409 XAA_CONNECTION_NOT_CONFIGURED` pre-mint, `reason: "xaa_connection_not_configured"` in details. Named "not configured" deliberately — `xaaConfigured` proves a client registration at the resource AS, not IdP enrollment; `XAA_NOT_ENROLLED` stays reserved for the managed-IdP issuer-policy evaluator's denied verdicts.
- **Three-state validation**: absent = off; valid = on; malformed/unsupported `idp` = explicit 409 config error — **never silently off** (silently ignoring an unsupported `idp: "okta"` would un-enforce a policy an admin believes is on). The Switch renders invalid values with a repair warning.
- **Backend-authoritative on hosted surfaces**: chatbox and host-bound turns read the policy from the backend-projected host config (MCPJam/mcpjam-backend#723) — a tampered share-link body can neither add the policy (409 DoS) nor drop it (credential downgrade: unconfigured `auto` would slide from XAA onto the discover/OAuth ladder). Body-sourced only for the user's own ad-hoc/local sessions, strictly validated. Two chat-v2 tests pin both authority directions.
- **Advertisement derives from policy**: the EMA capability extension is merged on the wire when the policy is on (host-wide declare-support, including servers overridden to OAuth) or when the connection actually uses XAA (unchanged backstop). Advertise ≡ enforce by construction.
- **Every `createAuthorizedManager` caller wired**: chat-v2 (+ `xaaIssuer` — XAA servers previously 500'd there), swarm (policy from the pinned host snapshot), chatbox-sessions (both sites, fail-closed runtime fetch), manual/ephemeral connections, web evals. v1 evals and harness-mcp gain `xaaIssuer`, fixing the pre-existing "Missing XAA issuer" 500 for per-server XAA servers on those surfaces.
- **Known gaps, documented in code**: the harness MCP proxy enforces per-server XAA but not host policy (the proxy token's claims carry projectId/serverId, not the host — follow-up: thread policy into the token claims); the scheduled-evals worker and v1 eval API have no host-persona input, so there is no policy to enforce there.
- **Seeds unchanged**: policy is OFF for every persona (product decision) — a leak-guard test asserts no seed carries it. The MCPJam persona still advertises the EMA *capability*.

## UI

- ProtocolTab: Switch relabeled "Enterprise-managed authorization" with honest copy ("…applies on the next connect"); `mcpProfile.extensions` is now surfaced in the JSON editor and parsed-authoritatively round-trips.
- Per-server AuthenticationSection: the Auto helper reads "Inherited from host policy: Enterprise-managed (XAA)" (with a not-registered warning when applicable); explicit methods show "Overrides the host's enterprise-managed authorization policy."

## Companion PR + deploy order

Backend: MCPJam/mcpjam-backend#723 (projects `mcpProfile` on the runtime-config queries). **Deploy backend first**; until then hosted host-bound turns see no projected policy and behave exactly as today (safe).

## Tests

- SDK: 118 files / 2108 tests (new: enterprise-policy helpers ×11, seed leak-guard). Changeset included (new public exports).
- Inspector: 785 files / 8319 tests; `typecheck:client` clean. New: effective-auth policy matrix, resolver not-configured/override/stdio/parse tests, ProtocolTab policy-switch tests ×5, chat-v2 authority tests ×2.
- Not verified live: staging click-through (toggle → unregistered `auto` server 409s with ErrorCard; registered one mints; explicit-OAuth still advertises EMA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes default auth resolution and connect/chat/eval enforcement across hosted and local paths; malformed or tampered policy handling is security-sensitive, with documented harness/scheduled-eval gaps.
> 
> **Overview**
> Introduces **enterprise-managed authorization** as a host policy in `@mcpjam/sdk` (`readXaaEnterprisePolicy`, `withXaaEnterprisePolicy`, storage under `mcpProfile.extensions["com.mcpjam/enterprise-managed-auth"]`). When on, HTTP servers on **Auto** resolve to XAA unless a per-server auth method overrides; unregistered servers get **409** instead of falling back to OAuth.
> 
> **ProtocolTab** replaces the EMA advertise switch with this policy toggle (gated on `xaa`), surfaces `mcpProfile.extensions` in JSON, and **AuthenticationSection** reflects host policy in helper copy. **ServersTab** wraps `ActiveMcpProfileProvider` so server modals see the host profile.
> 
> **Server and client** thread validated `xaaPolicy` through API context, connection defaults, and batch/single-server requests. **Hosted routes** (`createAuthorizedManager`, chat-v2, chatbox-sessions, evals, swarm) enforce policy server-authoritatively from projected host/chatbox config where applicable, validate body policy fail-closed (409, raw body when schemas strip fields), run **batch-wide pre-mint validation**, advertise EMA host-wide when policy is on, and add `xaaIssuer` on v1 evals/harness paths. **Harness** turns are rejected on enterprise-managed hosts; harness MCP proxy documents a known policy gap.
> 
> Extensive unit/integration tests cover policy helpers, resolver behavior, ProtocolTab, and chat authority.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2fc6d70bcece43d277ad602334aad81f022a739. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a host‑level enterprise‑managed authorization policy for Cross‑App Access and enforces it across connect, chat, eval, local, and single‑server hosted flows. Uses `@mcpjam/sdk` helpers to read/validate the policy, derives EMA capability from policy, and fails closed on config errors.

- **Bug Fixes**
  - Closed harness bypass: reject harness turns on enterprise‑managed hosts; both chat‑v2 routes pass the server‑resolved flag through preflight.
  - Gated the Protocol tab policy switch on the `xaa` feature flag; an already stored (or malformed) policy still renders so hosts can turn it off.
  - Read `xaaPolicy` from the pre‑parse raw body to prevent schema‑strip fail‑open; single‑server hosted flows and chatbox simulate‑sessions validate before creating runs.
  - Hoisted validation to a batch‑wide PASS 1 before any mint, including explicit‑OAuth “no stored token” checks, so no tokens mint when any server fails preflight.
  - Server‑authoritative enforcement on hosted surfaces: chatbox sessions/persona generation and host‑bound turns read `mcpProfile` from runtime config; unconfigured `auto` under policy → 409 `XAA_CONNECTION_NOT_CONFIGURED`.
  - Threaded `xaaIssuer` to v1 evals and harness‑mcp so per‑server XAA servers mint instead of 500ing; `ServersTab` now scopes `AuthenticationSection` with the active host profile to show inherited‑policy/override guidance.

- **Migration**
  - Deploy the companion backend first so hosted routes can read `mcpProfile` from runtime config.
  - Default is off; enabling applies on next connect. Ensure HTTP servers have an XAA client registration or set an explicit per‑server auth override.
  - Harness: turns are blocked on enterprise‑managed hosts until the proxy token carries host policy; scheduled‑evals still have no host‑persona input.

<sup>Written for commit a2fc6d70bcece43d277ad602334aad81f022a739. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

