### PR TITLE
feat(sdk): elicitation mode/serverId passthrough + elicitation-aware tool timeouts

### DIFF
--- a/.changeset/elicitation-modes-and-timeouts.md
+++ b/.changeset/elicitation-modes-and-timeouts.md
@@ -1,0 +1,10 @@
+---
+"@mcpjam/sdk": minor
+---
+
+Elicitation mode/serverId passthrough and elicitation-aware tool timeouts. Additive: existing callbacks and call sites are unaffected.
+
+- `ElicitationCallbackRequest` gains optional `serverId`, `mode` (`"form" | "url"`, absent ⇒ form), `url`, and `elicitationId`, so a global elicitation callback can tell which server asked, render URL-mode consent (MCP 2025-11-25), and correlate the server-chosen elicitation id. Form mode keeps reading `requestedSchema ?? schema`.
+- `ElicitationManager.applyToClient` takes an optional third argument carrying the `elicitation` client capability actually advertised on the wire, and rejects elicitations whose mode was not declared with JSON-RPC `-32602` per spec (bare `{}` ≡ form-only; `{form:{},url:{}}` allows both). Mode-vs-declaration semantics come from upstream's own `getSupportedElicitationModes`, so they cannot drift from what the upstream `Client` enforces. New `hasPendingForServer(serverId)` reports whether an elicitation handler is currently in flight.
+- New `MCPClientManagerOptions.elicitationTimeoutExtensionMs` (default 10 minutes, exported as `DEFAULT_ELICITATION_TIMEOUT_EXTENSION_MS`). When a server has an elicitation handler, `executeTool` no longer lets the per-request timeout kill a tool call that is merely blocked on a human: the base timeout is enforced by a watchdog that only accumulates time while no elicitation is pending, while total time spent suspended across all elicitations in the call is capped by the extension. A genuinely hung server still dies at its base timeout. Aborts are timeout-shaped (`SdkError` / `SdkErrorCode.RequestTimeout`) and never classified as retryable. Servers without an elicitation handler are a pure passthrough.
+- New `ElicitationMode` and `DeclaredElicitationCapability` type exports.

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -2269,7 +2269,17 @@ export class MCPClientManager {
       baseTimeoutMs,
       extensionMs: this.elicitationTimeoutExtensionMs,
       callerSignal: options.signal,
-      hasPending: () => this.elicitationManager.hasPendingForServer(serverId),
+      // Age-bound the check with this call's OWN elicitation budget. Without
+      // it, a handler that never settles (e.g. its `tools/call` was aborted by
+      // this very watchdog, so its `finally` never ran) would pin the server
+      // "pending" for the process lifetime and silently pause the clock of
+      // every later call — unbounded timeouts, with nothing in the logs.
+      // An entry older than this budget would have blown it anyway.
+      hasPending: () =>
+        this.elicitationManager.hasPendingForServer(
+          serverId,
+          this.elicitationTimeoutExtensionMs
+        ),
     });
 
     try {

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -2263,6 +2263,7 @@ export class MCPClientManager {
       options.timeout ??
       this.registeredServers.get(serverId)?.timeout ??
       this.defaultTimeout;
+    const pendingSequenceAtStart = this.elicitationManager.getPendingSequence();
 
     const suspension = createElicitationTimeoutSuspension({
       serverId,
@@ -2278,7 +2279,8 @@ export class MCPClientManager {
       hasPending: () =>
         this.elicitationManager.hasPendingForServer(
           serverId,
-          this.elicitationTimeoutExtensionMs
+          this.elicitationTimeoutExtensionMs,
+          pendingSequenceAtStart,
         ),
     });
 

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -50,6 +50,7 @@ import type { MCPServerReplayConfig } from "../eval-reporting-types.js";
 
 import {
   DEFAULT_CLIENT_VERSION,
+  DEFAULT_ELICITATION_TIMEOUT_EXTENSION_MS,
   DEFAULT_TIMEOUT,
   HTTP_CONNECT_TIMEOUT,
 } from "./constants.js";
@@ -80,6 +81,8 @@ import {
   type NotificationHandler,
 } from "./notification-handlers.js";
 import { ElicitationManager } from "./elicitation.js";
+import type { DeclaredElicitationCapability } from "./elicitation.js";
+import { createElicitationTimeoutSuspension } from "./elicitation-timeout.js";
 import {
   TaskStatusNotificationMethod,
   listTasks as tasksListTasks,
@@ -248,6 +251,7 @@ export class MCPClientManager {
   private readonly defaultProgressHandler?: ProgressHandler;
   private readonly defaultRetryPolicy: RetryPolicy;
   private readonly lazyConnect: boolean;
+  private readonly elicitationTimeoutExtensionMs: number;
 
   // Progress token counter for uniqueness
   private progressTokenCounter = 0;
@@ -278,6 +282,11 @@ export class MCPClientManager {
     this.defaultProgressHandler = options.progressHandler;
     this.defaultRetryPolicy = normalizeRetryPolicy(options.retryPolicy);
     this.lazyConnect = options.lazyConnect ?? false;
+    this.elicitationTimeoutExtensionMs = Math.max(
+      0,
+      options.elicitationTimeoutExtensionMs ??
+        DEFAULT_ELICITATION_TIMEOUT_EXTENSION_MS
+    );
 
     // Start connecting to all configured servers (unless replay/trace-repair use explicit connect)
     if (!this.lazyConnect) {
@@ -760,7 +769,11 @@ export class MCPClientManager {
         };
       }
 
-      return client.callTool(callParams, mergedOptions);
+      return this.withElicitationTimeoutSuspension(
+        serverId,
+        mergedOptions,
+        (callOptions) => client.callTool(callParams, callOptions)
+      );
     };
 
     return this.runRetriedOperation(
@@ -1030,7 +1043,11 @@ export class MCPClientManager {
     const state = this.liveClientStates.get(serverId);
     const client = state?.client;
     if (client && this.hasNegotiatedElicitation(state)) {
-      this.elicitationManager.applyToClient(serverId, client);
+      this.elicitationManager.applyToClient(
+        serverId,
+        client,
+        this.negotiatedElicitationCapability(state)
+      );
     }
   }
 
@@ -1046,7 +1063,11 @@ export class MCPClientManager {
         this.elicitationManager.getGlobalCallback() &&
         this.hasNegotiatedElicitation(state)
       ) {
-        this.elicitationManager.applyToClient(serverId, client);
+        this.elicitationManager.applyToClient(
+          serverId,
+          client,
+          this.negotiatedElicitationCapability(state)
+        );
       } else {
         this.elicitationManager.removeFromClient(client);
       }
@@ -1060,7 +1081,11 @@ export class MCPClientManager {
     this.elicitationManager.setGlobalCallback(callback);
     for (const [serverId, state] of this.liveClientStates.entries()) {
       if (state.client && this.hasNegotiatedElicitation(state)) {
-        this.elicitationManager.applyToClient(serverId, state.client);
+        this.elicitationManager.applyToClient(
+          serverId,
+          state.client,
+          this.negotiatedElicitationCapability(state)
+        );
       }
     }
   }
@@ -1076,7 +1101,11 @@ export class MCPClientManager {
         this.elicitationManager.getHandler(serverId) &&
         this.hasNegotiatedElicitation(state)
       ) {
-        this.elicitationManager.applyToClient(serverId, state.client);
+        this.elicitationManager.applyToClient(
+          serverId,
+          state.client,
+          this.negotiatedElicitationCapability(state)
+        );
       } else {
         this.elicitationManager.removeFromClient(state.client);
       }
@@ -1343,8 +1372,15 @@ export class MCPClientManager {
       if (this.defaultProgressHandler) {
         applyProgressHandler(serverId, client, this.defaultProgressHandler);
       }
-      if ((clientCapabilities as Record<string, unknown>).elicitation != null) {
-        this.elicitationManager.applyToClient(serverId, client);
+      const declaredElicitation = (
+        clientCapabilities as Record<string, unknown>
+      ).elicitation;
+      if (declaredElicitation != null) {
+        this.elicitationManager.applyToClient(
+          serverId,
+          client,
+          declaredElicitation as DeclaredElicitationCapability
+        );
       }
 
       if (config.onError) {
@@ -1737,7 +1773,11 @@ export class MCPClientManager {
         this.buildCapabilities(serverId, config) as Record<string, unknown>
       ).elicitation;
       if (elicitationCaps != null) {
-        this.elicitationManager.applyToClient(serverId, previewClient);
+        this.elicitationManager.applyToClient(
+          serverId,
+          previewClient,
+          elicitationCaps as DeclaredElicitationCapability
+        );
       }
       if (config.onError) {
         previewClient.onerror = (error) => config.onError?.(error);
@@ -2191,6 +2231,58 @@ export class MCPClientManager {
     return mergedOptions;
   }
 
+  /**
+   * Runs a tool call under an elicitation-aware timeout budget.
+   *
+   * The request timeout is a *server* budget. A tool call blocked because the
+   * server asked the user a question is not hung, so its clock stops while an
+   * elicitation is pending — but a genuinely hung server must still die at the
+   * base timeout, and a human who never answers must not block forever.
+   *
+   * Mechanics (see `elicitation-timeout.ts` for the budget accounting):
+   *  - No elicitation handler for this server ⇒ pure passthrough, no watchdog,
+   *    no behavior change whatsoever.
+   *  - Otherwise the upstream hard timeout is **overridden** to
+   *    `base + extension` to move it out of the way (`withTimeout` only
+   *    *injects* a timeout when unset, so a plain merge would not take), and
+   *    the real budget is enforced locally by the watchdog.
+   *  - The watchdog's signal is composed with the caller's — the AI SDK
+   *    forwards its own `abortSignal` into these request options and it must
+   *    keep working.
+   */
+  private async withElicitationTimeoutSuspension<T>(
+    serverId: string,
+    options: RequestOptions,
+    run: (options: RequestOptions) => Promise<T>
+  ): Promise<T> {
+    if (!this.elicitationManager.hasHandler(serverId)) {
+      return run(options);
+    }
+
+    const baseTimeoutMs =
+      options.timeout ??
+      this.registeredServers.get(serverId)?.timeout ??
+      this.defaultTimeout;
+
+    const suspension = createElicitationTimeoutSuspension({
+      serverId,
+      baseTimeoutMs,
+      extensionMs: this.elicitationTimeoutExtensionMs,
+      callerSignal: options.signal,
+      hasPending: () => this.elicitationManager.hasPendingForServer(serverId),
+    });
+
+    try {
+      return await run({
+        ...options,
+        timeout: suspension.timeoutMs,
+        signal: suspension.signal,
+      });
+    } finally {
+      suspension.dispose();
+    }
+  }
+
   private buildCapabilities(
     serverId: string,
     config: MCPServerConfig
@@ -2219,10 +2311,23 @@ export class MCPClientManager {
   }
 
   private hasNegotiatedElicitation(state?: LiveClientState): boolean {
+    return this.negotiatedElicitationCapability(state) != null;
+  }
+
+  /**
+   * The `elicitation` client capability actually advertised to this server on
+   * the wire, for `applyToClient` to enforce declared modes against.
+   */
+  private negotiatedElicitationCapability(
+    state?: LiveClientState
+  ): DeclaredElicitationCapability {
     const capabilities = state?.initializedClientCapabilities as
       | Record<string, unknown>
       | undefined;
-    return capabilities?.elicitation != null;
+    const elicitation = capabilities?.elicitation;
+    return elicitation != null
+      ? (elicitation as DeclaredElicitationCapability)
+      : undefined;
   }
 
   private resolveRpcLogger(config: MCPServerConfig): RpcLogger | undefined {

--- a/sdk/src/mcp-client-manager/constants.ts
+++ b/sdk/src/mcp-client-manager/constants.ts
@@ -12,3 +12,10 @@ export const DEFAULT_TIMEOUT = DEFAULT_REQUEST_TIMEOUT_MSEC;
 
 /** Timeout for initial HTTP transport attempt before falling back to SSE */
 export const HTTP_CONNECT_TIMEOUT = 3000;
+
+/**
+ * Default extra time budget granted to a `tools/call` while elicitations are
+ * pending for that server (see `MCPClientManagerOptions.elicitationTimeoutExtensionMs`).
+ * Human-scale: a person has to read a dialog and answer it.
+ */
+export const DEFAULT_ELICITATION_TIMEOUT_EXTENSION_MS = 10 * 60 * 1000;

--- a/sdk/src/mcp-client-manager/elicitation-timeout.ts
+++ b/sdk/src/mcp-client-manager/elicitation-timeout.ts
@@ -171,16 +171,17 @@ export function createElicitationTimeoutSuspension(
    * itself — 120s budgets still sample at 1s (0.8% slop), while a 100ms budget
    * samples at 100ms and fires on time.
    */
-  const nextDelay = (): number => {
+  const nextDelay = (pending: boolean): number => {
     const remainingActive = Math.max(0, baseTimeoutMs - activeMs);
+    if (!pending) {
+      // The suspended budget is irrelevant until an elicitation actually
+      // starts. Including it here made extension=0 spin a normal tool call at
+      // 1ms, and tiny extensions caused similarly aggressive polling even
+      // while all time belonged to the server.
+      return Math.max(1, Math.min(intervalMs, remainingActive));
+    }
+
     const remainingSuspended = Math.max(0, extensionMs - suspendedMs);
-    // Bound by BOTH budgets, always — including `remainingActive` while an
-    // elicitation is pending. That looks redundant (the active clock is paused)
-    // but it is what bounds how late we notice the elicitation *ending*: a
-    // 100ms budget that samples every 1s during a 5-minute wait would overshoot
-    // by up to 1s the moment the user answers. Sampling at 100ms throughout
-    // costs nothing measurable and keeps the budget honest on both sides of the
-    // transition.
     return Math.max(
       1,
       Math.min(intervalMs, remainingActive, remainingSuspended)
@@ -192,7 +193,8 @@ export function createElicitationTimeoutSuspension(
     const elapsed = Math.max(0, now - lastSampleAt);
     lastSampleAt = now;
 
-    if (hasPending()) {
+    const pending = hasPending();
+    if (pending) {
       suspendedMs += elapsed;
       if (suspendedMs >= extensionMs) {
         abortWith(
@@ -217,16 +219,16 @@ export function createElicitationTimeoutSuspension(
     }
 
     if (disposed) return;
-    schedule();
+    schedule(pending);
   };
 
-  function schedule() {
-    timer = setTimeout(tick, nextDelay());
+  function schedule(pending: boolean) {
+    timer = setTimeout(tick, nextDelay(pending));
     // Never hold the event loop open on this watchdog.
     (timer as unknown as { unref?: () => void }).unref?.();
   }
 
-  schedule();
+  schedule(hasPending());
   const composed = composeAbortSignals(
     callerSignal ? [callerSignal, watchdog.signal] : [watchdog.signal]
   );

--- a/sdk/src/mcp-client-manager/elicitation-timeout.ts
+++ b/sdk/src/mcp-client-manager/elicitation-timeout.ts
@@ -1,0 +1,200 @@
+/**
+ * Elicitation-aware timeout suspension for `tools/call`.
+ *
+ * The per-request MCP timeout is a *server* budget: it exists to kill a hung
+ * server. A tool call that is blocked because the server asked the user a
+ * question is not hung — the clock should stop while a human is thinking.
+ *
+ * Upstream enforces `RequestOptions.timeout` itself and has no notion of
+ * "suspended", so this module raises the upstream hard timeout out of the way
+ * (`base + extension`) and re-implements the budget locally with a watchdog
+ * that tracks two clocks:
+ *
+ *  - **active**: accumulates only while NO elicitation is pending for the
+ *    server. Exhausting it at `base` means the server really is hung.
+ *  - **suspended**: accumulates only while an elicitation IS pending, and is
+ *    cumulative across every elicitation in the call. Exhausting it at
+ *    `extension` means the human never finished. This is the TOTAL elicitation
+ *    budget for one tool call; each individual elicitation is additionally
+ *    bounded by whatever TTL the callback implementation enforces.
+ *
+ * Either exhaustion aborts the call with a timeout-shaped `SdkError`, so
+ * callers see a timeout rather than a bare `AbortError`. The watchdog signal is
+ * COMPOSED with the caller's signal (never clobbers it): the AI SDK forwards
+ * its own `abortSignal` into `executeTool` request options.
+ *
+ * Known conservative edge: pending state is tracked per SERVER, not per call.
+ * A second, unrelated tool call in flight on the same server while an
+ * elicitation is pending also has its active clock paused. It stays bounded by
+ * its own suspended budget, so it still terminates — just later than a strict
+ * per-call accounting would.
+ */
+
+import { SdkError, SdkErrorCode } from "@modelcontextprotocol/client";
+import { markNonRetryableError } from "./error-utils.js";
+
+/** How often the watchdog samples the pending state. */
+export const ELICITATION_WATCHDOG_INTERVAL_MS = 1000;
+
+export interface ElicitationTimeoutSuspensionOptions {
+  /** Server the tool call targets (for error messages). */
+  serverId: string;
+  /** Active-time budget, i.e. the timeout the call would have had. */
+  baseTimeoutMs: number;
+  /** Cumulative suspended-time budget for the whole call. */
+  extensionMs: number;
+  /** Whether an elicitation is currently pending for this server. */
+  hasPending: () => boolean;
+  /** The caller's abort signal, if any. Composed, never replaced. */
+  callerSignal?: AbortSignal;
+  /** Watchdog sampling interval. Defaults to {@link ELICITATION_WATCHDOG_INTERVAL_MS}. */
+  intervalMs?: number;
+}
+
+export interface ElicitationTimeoutSuspension {
+  /** Signal to hand to the MCP request. Composed of caller + watchdog. */
+  signal: AbortSignal;
+  /** The hard timeout to hand to the MCP request (`base + extension`). */
+  timeoutMs: number;
+  /** Clears the interval and removes any listeners. Idempotent. */
+  dispose(): void;
+}
+
+/**
+ * Composes abort signals, preferring the platform `AbortSignal.any`.
+ *
+ * The package's engines floor is `node >= 20.0.0` but `AbortSignal.any` only
+ * landed in Node 20.3.0, so this feature-detects and hand-rolls forwarding on
+ * older runtimes rather than raising the floor (which would be a breaking
+ * change to a published package).
+ */
+function composeAbortSignals(signals: AbortSignal[]): {
+  signal: AbortSignal;
+  dispose: () => void;
+} {
+  if (signals.length === 1) {
+    return { signal: signals[0], dispose: () => {} };
+  }
+
+  const nativeAny = (
+    AbortSignal as unknown as {
+      any?: (signals: Iterable<AbortSignal>) => AbortSignal;
+    }
+  ).any;
+  if (typeof nativeAny === "function") {
+    // `AbortSignal.any` holds its sources weakly and needs no teardown.
+    return { signal: nativeAny.call(AbortSignal, signals), dispose: () => {} };
+  }
+
+  // Node 20.0–20.2 fallback: forward manually.
+  const controller = new AbortController();
+  const teardown: Array<() => void> = [];
+  for (const source of signals) {
+    if (source.aborted) {
+      controller.abort(source.reason);
+      break;
+    }
+    const onAbort = () => controller.abort(source.reason);
+    source.addEventListener("abort", onAbort, { once: true });
+    teardown.push(() => source.removeEventListener("abort", onAbort));
+  }
+  return {
+    signal: controller.signal,
+    dispose: () => {
+      for (const off of teardown) off();
+      teardown.length = 0;
+    },
+  };
+}
+
+/**
+ * Builds the timeout-shaped error the watchdog aborts with.
+ *
+ * Shape matches what upstream raises on its own timeouts
+ * (`SdkError` / `SdkErrorCode.RequestTimeout`), so existing timeout handling
+ * keeps working. Marked non-retryable: the message unavoidably says "timed
+ * out", which `isRetryableTransientError` would otherwise treat as transient.
+ */
+export function createElicitationTimeoutError(
+  message: string,
+  data: Record<string, unknown>
+): SdkError {
+  return markNonRetryableError(
+    new SdkError(SdkErrorCode.RequestTimeout, message, data)
+  );
+}
+
+/**
+ * Creates a watchdog enforcing the active/suspended budgets for one tool call.
+ *
+ * Caller MUST call {@link ElicitationTimeoutSuspension.dispose} in a `finally`.
+ */
+export function createElicitationTimeoutSuspension(
+  options: ElicitationTimeoutSuspensionOptions
+): ElicitationTimeoutSuspension {
+  const {
+    serverId,
+    baseTimeoutMs,
+    extensionMs,
+    hasPending,
+    callerSignal,
+    intervalMs = ELICITATION_WATCHDOG_INTERVAL_MS,
+  } = options;
+
+  const watchdog = new AbortController();
+  let activeMs = 0;
+  let suspendedMs = 0;
+  let lastSampleAt = Date.now();
+  let disposed = false;
+
+  const abortWith = (error: SdkError) => {
+    if (watchdog.signal.aborted) return;
+    watchdog.abort(error);
+  };
+
+  const timer = setInterval(() => {
+    const now = Date.now();
+    const elapsed = Math.max(0, now - lastSampleAt);
+    lastSampleAt = now;
+
+    if (hasPending()) {
+      suspendedMs += elapsed;
+      if (suspendedMs >= extensionMs) {
+        abortWith(
+          createElicitationTimeoutError(
+            `Request timed out: server "${serverId}" spent ${suspendedMs}ms waiting on elicitation responses, exceeding the ${extensionMs}ms elicitation budget for this tool call.`,
+            { serverId, timeout: extensionMs, reason: "elicitation-budget" }
+          )
+        );
+      }
+      return;
+    }
+
+    activeMs += elapsed;
+    if (activeMs >= baseTimeoutMs) {
+      abortWith(
+        createElicitationTimeoutError(
+          `Request timed out after ${activeMs}ms of server time (${baseTimeoutMs}ms budget, excluding time suspended on elicitation).`,
+          { serverId, timeout: baseTimeoutMs, reason: "server-timeout" }
+        )
+      );
+    }
+  }, intervalMs);
+  // Never hold the event loop open on this watchdog.
+  (timer as unknown as { unref?: () => void }).unref?.();
+
+  const composed = composeAbortSignals(
+    callerSignal ? [callerSignal, watchdog.signal] : [watchdog.signal]
+  );
+
+  return {
+    signal: composed.signal,
+    timeoutMs: baseTimeoutMs + extensionMs,
+    dispose: () => {
+      if (disposed) return;
+      disposed = true;
+      clearInterval(timer);
+      composed.dispose();
+    },
+  };
+}

--- a/sdk/src/mcp-client-manager/elicitation-timeout.ts
+++ b/sdk/src/mcp-client-manager/elicitation-timeout.ts
@@ -152,7 +152,42 @@ export function createElicitationTimeoutSuspension(
     watchdog.abort(error);
   };
 
-  const timer = setInterval(() => {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  /**
+   * Sample interval for the NEXT check.
+   *
+   * A fixed 1s cadence silently broke short per-call timeouts: we raise the
+   * upstream timeout to `base + extension` immediately, so a caller asking for
+   * 100ms would not be stopped until our first sample at 1s — a 10x overrun of
+   * a budget the caller explicitly set.
+   *
+   * We cannot schedule a single one-shot at the full remaining budget instead:
+   * `hasPending()` is a poll, so we must keep looking often enough to notice an
+   * elicitation *starting* and stop counting its wait as server time.
+   *
+   * So: sample at the cap, or at whatever budget remains if that is sooner.
+   * Overshoot is bounded by one interval, which is now always ≤ the budget
+   * itself — 120s budgets still sample at 1s (0.8% slop), while a 100ms budget
+   * samples at 100ms and fires on time.
+   */
+  const nextDelay = (): number => {
+    const remainingActive = Math.max(0, baseTimeoutMs - activeMs);
+    const remainingSuspended = Math.max(0, extensionMs - suspendedMs);
+    // Bound by BOTH budgets, always — including `remainingActive` while an
+    // elicitation is pending. That looks redundant (the active clock is paused)
+    // but it is what bounds how late we notice the elicitation *ending*: a
+    // 100ms budget that samples every 1s during a 5-minute wait would overshoot
+    // by up to 1s the moment the user answers. Sampling at 100ms throughout
+    // costs nothing measurable and keeps the budget honest on both sides of the
+    // transition.
+    return Math.max(
+      1,
+      Math.min(intervalMs, remainingActive, remainingSuspended)
+    );
+  };
+
+  const tick = () => {
     const now = Date.now();
     const elapsed = Math.max(0, now - lastSampleAt);
     lastSampleAt = now;
@@ -166,23 +201,32 @@ export function createElicitationTimeoutSuspension(
             { serverId, timeout: extensionMs, reason: "elicitation-budget" }
           )
         );
+        return;
       }
-      return;
+    } else {
+      activeMs += elapsed;
+      if (activeMs >= baseTimeoutMs) {
+        abortWith(
+          createElicitationTimeoutError(
+            `Request timed out after ${activeMs}ms of server time (${baseTimeoutMs}ms budget, excluding time suspended on elicitation).`,
+            { serverId, timeout: baseTimeoutMs, reason: "server-timeout" }
+          )
+        );
+        return;
+      }
     }
 
-    activeMs += elapsed;
-    if (activeMs >= baseTimeoutMs) {
-      abortWith(
-        createElicitationTimeoutError(
-          `Request timed out after ${activeMs}ms of server time (${baseTimeoutMs}ms budget, excluding time suspended on elicitation).`,
-          { serverId, timeout: baseTimeoutMs, reason: "server-timeout" }
-        )
-      );
-    }
-  }, intervalMs);
-  // Never hold the event loop open on this watchdog.
-  (timer as unknown as { unref?: () => void }).unref?.();
+    if (disposed) return;
+    schedule();
+  };
 
+  function schedule() {
+    timer = setTimeout(tick, nextDelay());
+    // Never hold the event loop open on this watchdog.
+    (timer as unknown as { unref?: () => void }).unref?.();
+  }
+
+  schedule();
   const composed = composeAbortSignals(
     callerSignal ? [callerSignal, watchdog.signal] : [watchdog.signal]
   );
@@ -193,7 +237,7 @@ export function createElicitationTimeoutSuspension(
     dispose: () => {
       if (disposed) return;
       disposed = true;
-      clearInterval(timer);
+      if (timer) clearTimeout(timer);
       composed.dispose();
     },
   };

--- a/sdk/src/mcp-client-manager/elicitation.ts
+++ b/sdk/src/mcp-client-manager/elicitation.ts
@@ -3,10 +3,84 @@
  */
 
 import type { ElicitResult } from "@modelcontextprotocol/client";
-import type { ElicitationHandler, ElicitationCallback } from "./types.js";
+import {
+  getSupportedElicitationModes,
+  ProtocolError,
+  ProtocolErrorCode,
+} from "@modelcontextprotocol/client";
+import type {
+  ElicitationHandler,
+  ElicitationCallback,
+  ElicitationMode,
+} from "./types.js";
 import type { ManagedMcpClient } from "./managed-mcp-client.js";
 
 export const ElicitRequestMethod = "elicitation/create" as const;
+
+/**
+ * The `elicitation` client capability actually advertised on the wire for a
+ * server, exactly as it appeared in `initialize`. `undefined` means we have no
+ * record of one (legacy call sites; capability negotiation not tracked).
+ */
+export type DeclaredElicitationCapability = Record<string, unknown> | undefined;
+
+/**
+ * Reads the requested mode off an inbound `elicitation/create`.
+ *
+ * Absent ⇒ `"form"`: `mode` is optional in the form-params schema and every
+ * pre-2025-11-25 elicitation is a form. An unrecognized string is returned
+ * verbatim so the caller can reject it as undeclared.
+ */
+function readElicitationMode(params: unknown): string {
+  const mode = (params as { mode?: unknown } | undefined)?.mode;
+  return typeof mode === "string" ? mode : "form";
+}
+
+/**
+ * Enforces the spec MUST: a client rejects an elicitation whose mode it did
+ * not declare, with JSON-RPC `-32602` (InvalidParams).
+ *
+ * Thrown from inside a request handler, `ProtocolError` surfaces to the server
+ * as a JSON-RPC error response carrying `error.code` verbatim (upstream maps
+ * `error.code` whenever it is a safe integer).
+ *
+ * Mode-vs-declaration semantics come from upstream's own
+ * `getSupportedElicitationModes`, so this cannot drift from the shape the
+ * upstream `Client` enforces: bare `{}` ≡ form-only, `{form:{}}` form-only,
+ * `{form:{},url:{}}` both, `{url:{}}` url-only.
+ *
+ * This duplicates a check the upstream `Client` already performs for real
+ * connections — deliberately. It is the ONLY enforcement on the stateless
+ * preview client (which stores raw handlers), and it keeps the rejection
+ * identical across both client adapters.
+ */
+function assertElicitationModeDeclared(
+  serverId: string,
+  mode: string,
+  declaredCapability: DeclaredElicitationCapability
+): asserts mode is ElicitationMode {
+  if (declaredCapability === undefined) {
+    // No declaration on record. Form is the legacy default and stays allowed
+    // for back-compat; url mode requires an explicit declaration.
+    if (mode === "form") return;
+    throw new ProtocolError(
+      ProtocolErrorCode.InvalidParams,
+      `Client did not declare support for "${mode}"-mode elicitation (server "${serverId}").`
+    );
+  }
+
+  const { supportsFormMode, supportsUrlMode } = getSupportedElicitationModes(
+    declaredCapability as Parameters<typeof getSupportedElicitationModes>[0]
+  );
+
+  if (mode === "form" && supportsFormMode) return;
+  if (mode === "url" && supportsUrlMode) return;
+
+  throw new ProtocolError(
+    ProtocolErrorCode.InvalidParams,
+    `Client did not declare support for "${mode}"-mode elicitation (server "${serverId}").`
+  );
+}
 
 /**
  * Manages elicitation handlers and callbacks for MCP servers.
@@ -22,6 +96,12 @@ export class ElicitationManager {
       reject: (error: unknown) => void;
     }
   >();
+  /**
+   * In-flight elicitation handler invocations per server. Drives
+   * {@link hasPendingForServer}, which the elicitation-aware tool timeout uses
+   * to decide whether the clock is running.
+   */
+  private pendingCountByServer = new Map<string, number>();
 
   /**
    * Sets a server-specific elicitation handler.
@@ -85,6 +165,34 @@ export class ElicitationManager {
   }
 
   /**
+   * Whether an elicitation handler invocation is currently in flight for a
+   * server — i.e. whether we are waiting on a human rather than on the server.
+   *
+   * Per-server, not per-call: see the note in `elicitation-timeout.ts`.
+   *
+   * @param serverId - The server ID
+   */
+  hasPendingForServer(serverId: string): boolean {
+    return (this.pendingCountByServer.get(serverId) ?? 0) > 0;
+  }
+
+  private beginPending(serverId: string): void {
+    this.pendingCountByServer.set(
+      serverId,
+      (this.pendingCountByServer.get(serverId) ?? 0) + 1
+    );
+  }
+
+  private endPending(serverId: string): void {
+    const next = (this.pendingCountByServer.get(serverId) ?? 0) - 1;
+    if (next > 0) {
+      this.pendingCountByServer.set(serverId, next);
+    } else {
+      this.pendingCountByServer.delete(serverId);
+    }
+  }
+
+  /**
    * Gets the pending elicitations map.
    * Useful for external code that needs to add resolvers.
    *
@@ -126,8 +234,16 @@ export class ElicitationManager {
    *
    * @param serverId - The server ID
    * @param client - The MCP client
+   * @param declaredCapability - The `elicitation` client capability actually
+   *   advertised to this server on the wire. Used to reject undeclared modes
+   *   with `-32602`. Omit only when no declaration is on record — form mode is
+   *   then allowed for back-compat and url mode rejected.
    */
-  applyToClient(serverId: string, client: ManagedMcpClient): void {
+  applyToClient(
+    serverId: string,
+    client: ManagedMcpClient,
+    declaredCapability?: DeclaredElicitationCapability
+  ): void {
     const serverSpecific = this.handlers.get(serverId);
 
     if (serverSpecific) {
@@ -140,32 +256,64 @@ export class ElicitationManager {
         const params = (request as { params?: unknown }).params as
           | Parameters<ElicitationHandler>[0]
           | undefined;
-        return serverSpecific(
-          params ?? ({} as Parameters<ElicitationHandler>[0]),
+
+        assertElicitationModeDeclared(
+          serverId,
+          readElicitationMode(params),
+          declaredCapability
         );
+
+        this.beginPending(serverId);
+        try {
+          return await serverSpecific(
+            params ?? ({} as Parameters<ElicitationHandler>[0])
+          );
+        } finally {
+          this.endPending(serverId);
+        }
       });
       return;
     }
 
     if (this.globalCallback) {
       client.setRequestHandler(ElicitRequestMethod, async (request) => {
+        const params = (request as { params?: unknown }).params as
+          | Record<string, any>
+          | undefined;
+
+        const mode = readElicitationMode(params);
+        assertElicitationModeDeclared(serverId, mode, declaredCapability);
+
         const reqId = `elicit_${Date.now()}_${Math.random()
           .toString(36)
           .slice(2, 9)}`;
 
         // Extract related task ID from _meta per MCP Tasks spec (2025-11-25)
-        const meta = (request.params as any)?._meta;
+        const meta = params?._meta;
         const relatedTask = meta?.["io.modelcontextprotocol/related-task"];
         const relatedTaskId = relatedTask?.taskId as string | undefined;
 
-        return await this.globalCallback!({
-          requestId: reqId,
-          message: (request.params as any)?.message,
-          schema:
-            (request.params as any)?.requestedSchema ??
-            (request.params as any)?.schema,
-          relatedTaskId,
-        });
+        this.beginPending(serverId);
+        try {
+          return await this.globalCallback!({
+            requestId: reqId,
+            serverId,
+            mode,
+            message: params?.message,
+            // Form mode only. `schema` is the legacy alias some servers
+            // still send; url-mode params carry neither.
+            schema: params?.requestedSchema ?? params?.schema,
+            // URL mode only — absent for form requests.
+            url: typeof params?.url === "string" ? params.url : undefined,
+            elicitationId:
+              typeof params?.elicitationId === "string"
+                ? params.elicitationId
+                : undefined,
+            relatedTaskId,
+          });
+        } finally {
+          this.endPending(serverId);
+        }
       });
     }
   }
@@ -186,5 +334,9 @@ export class ElicitationManager {
    */
   clearServer(serverId: string): void {
     this.handlers.delete(serverId);
+    // Drop any pending count: the server is gone, so a handler invocation that
+    // never settles must not pin `hasPendingForServer` true forever. A late
+    // `endPending` from an in-flight handler is harmless (floors at delete).
+    this.pendingCountByServer.delete(serverId);
   }
 }

--- a/sdk/src/mcp-client-manager/elicitation.ts
+++ b/sdk/src/mcp-client-manager/elicitation.ts
@@ -116,8 +116,9 @@ export class ElicitationManager {
    */
   private pendingElicitationEntries = new Map<
     symbol,
-    { serverId: string; startedAt: number }
+    { serverId: string; startedAt: number; sequence: number }
   >();
+  private pendingSequence = 0;
 
   /**
    * Sets a server-specific elicitation handler.
@@ -188,18 +189,44 @@ export class ElicitationManager {
    *
    * @param serverId - The server ID
    */
-  hasPendingForServer(serverId: string, maxAgeMs?: number): boolean {
+  hasPendingForServer(
+    serverId: string,
+    maxAgeMs?: number,
+    startedAfterSequence?: number,
+  ): boolean {
     const now = Date.now();
-    for (const entry of this.pendingElicitationEntries.values()) {
+    let pending = false;
+    for (const [token, entry] of this.pendingElicitationEntries) {
       if (entry.serverId !== serverId) continue;
+      // An entry created after this tool call took its snapshot belongs to work
+      // that started during the call. It must be observed at least once even
+      // when maxAgeMs=0; otherwise the first watchdog tick classifies it as
+      // stale and silently grants a base-timeout wait instead of a zero budget.
+      if (
+        startedAfterSequence !== undefined &&
+        entry.sequence > startedAfterSequence
+      ) {
+        pending = true;
+        continue;
+      }
       // Older than the asking call's entire elicitation budget: that call would
       // have aborted on its own budget by now, so this entry cannot honestly
       // keep pausing anyone's clock. Bounds a stuck handler's blast radius to
-      // one budget window instead of the process lifetime.
-      if (maxAgeMs !== undefined && now - entry.startedAt > maxAgeMs) continue;
-      return true;
+      // one budget window instead of the process lifetime. Remove it as well as
+      // ignoring it so repeated never-settling callbacks cannot grow this map
+      // without bound.
+      if (maxAgeMs !== undefined && now - entry.startedAt > maxAgeMs) {
+        this.pendingElicitationEntries.delete(token);
+        continue;
+      }
+      pending = true;
     }
-    return false;
+    return pending;
+  }
+
+  /** Snapshot used to distinguish this call's future elicitations from stale ones. */
+  getPendingSequence(): number {
+    return this.pendingSequence;
   }
 
   private beginPending(serverId: string): symbol {
@@ -207,6 +234,7 @@ export class ElicitationManager {
     this.pendingElicitationEntries.set(token, {
       serverId,
       startedAt: Date.now(),
+      sequence: ++this.pendingSequence,
     });
     return token;
   }

--- a/sdk/src/mcp-client-manager/elicitation.ts
+++ b/sdk/src/mcp-client-manager/elicitation.ts
@@ -97,11 +97,27 @@ export class ElicitationManager {
     }
   >();
   /**
-   * In-flight elicitation handler invocations per server. Drives
+   * In-flight elicitation handler invocations. Drives
    * {@link hasPendingForServer}, which the elicitation-aware tool timeout uses
    * to decide whether the clock is running.
+   *
+   * Entries, not a bare count, for two reasons a counter cannot express:
+   *
+   * - **A handler that never settles must not poison the server forever.** The
+   *   tool watchdog can abort a `tools/call` while its elicitation callback is
+   *   still awaiting; that callback's `finally` never runs, so a count would sit
+   *   at 1 permanently and every LATER call on that server would have its clock
+   *   paused — silently unbounded timeouts. `startedAt` lets us ignore an entry
+   *   older than the asking call's own budget.
+   * - **A late completion must not decrement a NEW connection.** Reconnect
+   *   reuses the serverId, and a counter is anonymous: the old handler's
+   *   decrement landed on the new connection's tally and could zero out a
+   *   genuinely pending elicitation. A token only ever removes its own entry.
    */
-  private pendingCountByServer = new Map<string, number>();
+  private pendingElicitationEntries = new Map<
+    symbol,
+    { serverId: string; startedAt: number }
+  >();
 
   /**
    * Sets a server-specific elicitation handler.
@@ -172,24 +188,31 @@ export class ElicitationManager {
    *
    * @param serverId - The server ID
    */
-  hasPendingForServer(serverId: string): boolean {
-    return (this.pendingCountByServer.get(serverId) ?? 0) > 0;
-  }
-
-  private beginPending(serverId: string): void {
-    this.pendingCountByServer.set(
-      serverId,
-      (this.pendingCountByServer.get(serverId) ?? 0) + 1
-    );
-  }
-
-  private endPending(serverId: string): void {
-    const next = (this.pendingCountByServer.get(serverId) ?? 0) - 1;
-    if (next > 0) {
-      this.pendingCountByServer.set(serverId, next);
-    } else {
-      this.pendingCountByServer.delete(serverId);
+  hasPendingForServer(serverId: string, maxAgeMs?: number): boolean {
+    const now = Date.now();
+    for (const entry of this.pendingElicitationEntries.values()) {
+      if (entry.serverId !== serverId) continue;
+      // Older than the asking call's entire elicitation budget: that call would
+      // have aborted on its own budget by now, so this entry cannot honestly
+      // keep pausing anyone's clock. Bounds a stuck handler's blast radius to
+      // one budget window instead of the process lifetime.
+      if (maxAgeMs !== undefined && now - entry.startedAt > maxAgeMs) continue;
+      return true;
     }
+    return false;
+  }
+
+  private beginPending(serverId: string): symbol {
+    const token = Symbol("elicitation-pending");
+    this.pendingElicitationEntries.set(token, {
+      serverId,
+      startedAt: Date.now(),
+    });
+    return token;
+  }
+
+  private endPending(token: symbol): void {
+    this.pendingElicitationEntries.delete(token);
   }
 
   /**
@@ -263,13 +286,13 @@ export class ElicitationManager {
           declaredCapability
         );
 
-        this.beginPending(serverId);
+        const pendingToken = this.beginPending(serverId);
         try {
           return await serverSpecific(
             params ?? ({} as Parameters<ElicitationHandler>[0])
           );
         } finally {
-          this.endPending(serverId);
+          this.endPending(pendingToken);
         }
       });
       return;
@@ -293,7 +316,7 @@ export class ElicitationManager {
         const relatedTask = meta?.["io.modelcontextprotocol/related-task"];
         const relatedTaskId = relatedTask?.taskId as string | undefined;
 
-        this.beginPending(serverId);
+        const pendingToken = this.beginPending(serverId);
         try {
           return await this.globalCallback!({
             requestId: reqId,
@@ -312,7 +335,7 @@ export class ElicitationManager {
             relatedTaskId,
           });
         } finally {
-          this.endPending(serverId);
+          this.endPending(pendingToken);
         }
       });
     }
@@ -334,9 +357,13 @@ export class ElicitationManager {
    */
   clearServer(serverId: string): void {
     this.handlers.delete(serverId);
-    // Drop any pending count: the server is gone, so a handler invocation that
-    // never settles must not pin `hasPendingForServer` true forever. A late
-    // `endPending` from an in-flight handler is harmless (floors at delete).
-    this.pendingCountByServer.delete(serverId);
+    // Drop this server's in-flight entries: it's gone, so a handler that never
+    // settles must not pin `hasPendingForServer` true forever.
+    for (const [token, entry] of this.pendingElicitationEntries) {
+      if (entry.serverId === serverId) this.pendingElicitationEntries.delete(token);
+    }
+    // A handler still in flight from the OLD connection can't corrupt a
+    // reconnected one carrying the same id: its `endPending` removes only its
+    // own token, which this purge already dropped.
   }
 }

--- a/sdk/src/mcp-client-manager/error-utils.ts
+++ b/sdk/src/mcp-client-manager/error-utils.ts
@@ -58,6 +58,42 @@ export function isMethodUnavailableError(
 }
 
 /**
+ * Marker for errors this SDK raises deliberately as a final verdict — they
+ * must never be retried, however their message reads.
+ *
+ * The elicitation-aware tool timeout raises a timeout-shaped `SdkError`
+ * ("Request timed out ..."), and {@link isRetryableTransientError} classifies
+ * any error whose message mentions "timeout"/"timed out" as a retryable
+ * transient. Retrying a budget we just declared exhausted is exactly wrong,
+ * so the watchdog stamps its error with this marker and the retry classifier
+ * checks it first.
+ */
+const NON_RETRYABLE_MARKER = "__mcpjamNonRetryable";
+
+/**
+ * Stamps an error as never-retryable and returns it.
+ */
+export function markNonRetryableError<T extends object>(error: T): T {
+  Object.defineProperty(error, NON_RETRYABLE_MARKER, {
+    value: true,
+    enumerable: false,
+    configurable: true,
+  });
+  return error;
+}
+
+/**
+ * Whether an error was explicitly stamped as never-retryable.
+ */
+export function isNonRetryableMarkedError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    (error as Record<string, unknown>)[NON_RETRYABLE_MARKER] === true
+  );
+}
+
+/**
  * Formats an error for display in error messages.
  *
  * @param error - The error to format

--- a/sdk/src/mcp-client-manager/error-utils.ts
+++ b/sdk/src/mcp-client-manager/error-utils.ts
@@ -58,39 +58,38 @@ export function isMethodUnavailableError(
 }
 
 /**
- * Marker for errors this SDK raises deliberately as a final verdict — they
- * must never be retried, however their message reads.
+ * Errors this SDK raises deliberately as a final verdict — they must never be
+ * retried, however their message reads.
  *
  * The elicitation-aware tool timeout raises a timeout-shaped `SdkError`
  * ("Request timed out ..."), and {@link isRetryableTransientError} classifies
  * any error whose message mentions "timeout"/"timed out" as a retryable
  * transient. Retrying a budget we just declared exhausted is exactly wrong,
- * so the watchdog stamps its error with this marker and the retry classifier
- * checks it first.
+ * so the watchdog marks its error here and the retry classifier checks first.
+ *
+ * A WeakSet, not a property on the error. A string-keyed marker was readable —
+ * and forgeable — through the prototype chain: any error inheriting a truthy
+ * `__mcpjamNonRetryable` (including via prototype pollution) would have
+ * silently suppressed legitimate retries. Set membership can't be inherited,
+ * and nothing gets stamped onto errors we don't own.
  */
-const NON_RETRYABLE_MARKER = "__mcpjamNonRetryable";
+const nonRetryableErrors = new WeakSet<object>();
 
 /**
- * Stamps an error as never-retryable and returns it.
+ * Marks an error as never-retryable and returns it.
  */
 export function markNonRetryableError<T extends object>(error: T): T {
-  Object.defineProperty(error, NON_RETRYABLE_MARKER, {
-    value: true,
-    enumerable: false,
-    configurable: true,
-  });
+  nonRetryableErrors.add(error);
   return error;
 }
 
 /**
- * Whether an error was explicitly stamped as never-retryable.
+ * Whether an error was explicitly marked as never-retryable.
  */
 export function isNonRetryableMarkedError(error: unknown): boolean {
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    (error as Record<string, unknown>)[NON_RETRYABLE_MARKER] === true
-  );
+  return typeof error === "object" && error !== null
+    ? nonRetryableErrors.has(error)
+    : false;
 }
 
 /**

--- a/sdk/src/mcp-client-manager/index.ts
+++ b/sdk/src/mcp-client-manager/index.ts
@@ -34,12 +34,15 @@ export type {
   ElicitationHandler,
   ElicitationCallback,
   ElicitationCallbackRequest,
+  ElicitationMode,
   ElicitResult,
   ProgressHandler,
   ProgressEvent,
   RpcLogger,
   RpcLogEvent,
 } from "./types.js";
+export type { DeclaredElicitationCapability } from "./elicitation.js";
+export { DEFAULT_ELICITATION_TIMEOUT_EXTENSION_MS } from "./constants.js";
 
 // Types - Tool execution
 export type {

--- a/sdk/src/mcp-client-manager/types.ts
+++ b/sdk/src/mcp-client-manager/types.ts
@@ -334,6 +334,20 @@ export interface MCPClientManagerOptions {
   /** Default retry policy for retryable manager operations */
   retryPolicy?: RetryPolicy;
   /**
+   * Extra time budget (ms) granted to a `tools/call` while an elicitation is
+   * pending for that server. The per-request timeout is a *server* budget: a
+   * tool call blocked on a human must not die at it, but a hung server must.
+   *
+   * When any elicitation handler is installed for a server, `executeTool`
+   * enforces the base timeout with its own watchdog that only accumulates
+   * time while NO elicitation is pending, and separately caps the total time
+   * spent suspended across all elicitations in that call at this value.
+   *
+   * Defaults to {@link DEFAULT_ELICITATION_TIMEOUT_EXTENSION_MS} (10 minutes).
+   * Has no effect on servers without an elicitation handler.
+   */
+  elicitationTimeoutExtensionMs?: number;
+  /**
    * When true, do not connect in the constructor; callers must use connectToServer
    * (e.g. connectReplayManagerServers) to avoid racing eager connects.
    */
@@ -381,6 +395,11 @@ export type ElicitationHandler = (
 ) => Promise<ElicitResult> | ElicitResult;
 
 /**
+ * Elicitation mode (MCP spec 2025-11-25). Absent on the wire ⇒ `"form"`.
+ */
+export type ElicitationMode = "form" | "url";
+
+/**
  * Request passed to global elicitation callback
  */
 export type ElicitationCallbackRequest = {
@@ -389,6 +408,25 @@ export type ElicitationCallbackRequest = {
   schema: unknown;
   /** Task ID if this elicitation is related to a task (MCP Tasks spec 2025-11-25) */
   relatedTaskId?: string;
+  /**
+   * The server that issued this elicitation. Always populated by
+   * `ElicitationManager.applyToClient`; optional so existing callback
+   * implementations keep type-checking.
+   */
+  serverId?: string;
+  /**
+   * Elicitation mode. Absent ⇒ `"form"` (legacy behavior: every
+   * pre-2025-11-25 elicitation is form mode).
+   */
+  mode?: ElicitationMode;
+  /** URL to present to the user. URL mode only. */
+  url?: string;
+  /**
+   * Server-chosen elicitation id, used by the server to correlate a
+   * `notifications/elicitation/complete`. URL mode only. Never treat this
+   * as a trusted key — it is chosen by the server.
+   */
+  elicitationId?: string;
 };
 
 /**

--- a/sdk/src/retry.ts
+++ b/sdk/src/retry.ts
@@ -1,4 +1,7 @@
-import { isMethodUnavailableError } from "./mcp-client-manager/error-utils.js";
+import {
+  isMethodUnavailableError,
+  isNonRetryableMarkedError,
+} from "./mcp-client-manager/error-utils.js";
 import { isAuthError } from "./mcp-client-manager/errors.js";
 import {
   extractNodeErrno,
@@ -116,6 +119,12 @@ export function normalizeRetryPolicy(policy?: RetryPolicy): RetryPolicy {
 }
 
 export function isRetryableTransientError(error: unknown): boolean {
+  // Deliberate, final verdicts from this SDK (e.g. the elicitation-aware tool
+  // timeout) are timeout-shaped by design but must never be retried.
+  if (isNonRetryableMarkedError(error)) {
+    return false;
+  }
+
   if (isAuthError(error).isAuth) {
     return false;
   }

--- a/sdk/tests/MCPClientManager.server-mgmt.test.ts
+++ b/sdk/tests/MCPClientManager.server-mgmt.test.ts
@@ -218,6 +218,52 @@ describe("MCPClientManager", () => {
       await manager.disconnectServer("elicitation-enabled-test");
     }, 30000);
 
+    it("should advertise an explicit {form,url} elicitation shape verbatim when a callback is registered", async () => {
+      manager.setElicitationCallback(() => ({ action: "cancel" } as any));
+
+      await manager.connectToServer("elicitation-url-mode-test", {
+        command: "npx",
+        args: ["-y", "@modelcontextprotocol/server-everything"],
+        clientCapabilities: {
+          elicitation: {
+            form: {},
+            url: {},
+          },
+        } as any,
+      });
+
+      const info = manager.getInitializationInfo("elicitation-url-mode-test");
+      expect(info).toBeDefined();
+      // Verbatim: the host-declared shape is what goes on the wire, since it
+      // is what `applyToClient` enforces declared modes against.
+      expect(
+        (info!.clientCapabilities as Record<string, unknown>).elicitation
+      ).toEqual({ form: {}, url: {} });
+
+      await manager.disconnectServer("elicitation-url-mode-test");
+    }, 30000);
+
+    it("should strip an explicit {form,url} elicitation shape when no callback is registered", async () => {
+      await manager.connectToServer("elicitation-url-mode-stripped-test", {
+        command: "npx",
+        args: ["-y", "@modelcontextprotocol/server-everything"],
+        clientCapabilities: {
+          elicitation: {
+            form: {},
+            url: {},
+          },
+        } as any,
+      });
+
+      const info = manager.getInitializationInfo(
+        "elicitation-url-mode-stripped-test"
+      );
+      expect(info).toBeDefined();
+      expect(info!.clientCapabilities).not.toHaveProperty("elicitation");
+
+      await manager.disconnectServer("elicitation-url-mode-stripped-test");
+    }, 30000);
+
     it("should keep exact clientCapabilities free of elicitation when not explicitly configured", async () => {
       manager.setElicitationCallback(() => ({ action: "cancel" } as any));
 

--- a/sdk/tests/mcp-client-manager.elicitation.test.ts
+++ b/sdk/tests/mcp-client-manager.elicitation.test.ts
@@ -853,6 +853,46 @@ describe("executeTool elicitation-aware timeout", () => {
     await caught;
   });
 
+  it("does not spin the watchdog while a zero-extension call is active", async () => {
+    const hasPending = jest.fn(() => false);
+    const suspension = createElicitationTimeoutSuspension({
+      serverId: SERVER,
+      baseTimeoutMs: 10_000,
+      extensionMs: 0,
+      intervalMs: 1_000,
+      hasPending,
+    });
+
+    // One initial sample chooses the cadence. A zero suspended budget must not
+    // turn the inactive path into a 1ms poll loop.
+    expect(hasPending).toHaveBeenCalledTimes(1);
+    await jest.advanceTimersByTimeAsync(999);
+    expect(hasPending).toHaveBeenCalledTimes(1);
+
+    suspension.dispose();
+  });
+
+  it("aborts when an elicitation starts with a zero extension budget", async () => {
+    let pending = false;
+    const suspension = createElicitationTimeoutSuspension({
+      serverId: SERVER,
+      baseTimeoutMs: 10_000,
+      extensionMs: 0,
+      intervalMs: 1_000,
+      hasPending: () => pending,
+    });
+
+    pending = true;
+    await jest.advanceTimersByTimeAsync(1_000);
+
+    expect(suspension.signal.aborted).toBe(true);
+    expect((suspension.signal.reason as SdkError).data).toMatchObject({
+      reason: "elicitation-budget",
+      timeout: 0,
+    });
+    suspension.dispose();
+  });
+
   it("disposes the watchdog once the call settles", async () => {
     const manager = buildManager({ elicitationTimeoutExtensionMs: 600_000 });
     manager.setElicitationCallback(() => ({ action: "cancel" } as any));
@@ -890,7 +930,7 @@ describe("ElicitationManager pending accounting", () => {
     // elicitation callback is still awaiting, so the callback's `finally` never
     // runs. With a bare counter the server stayed "pending" forever and EVERY
     // later call had its clock paused — unbounded timeouts, silently.
-    vi.useFakeTimers();
+    jest.useFakeTimers();
     try {
       const mgr = new ElicitationManager();
       const begin = (mgr as any).beginPending.bind(mgr);
@@ -898,14 +938,34 @@ describe("ElicitationManager pending accounting", () => {
 
       expect(mgr.hasPendingForServer("srv", 60_000)).toBe(true);
 
-      vi.advanceTimersByTime(60_001);
+      jest.advanceTimersByTime(60_001);
       // Older than the asking call's whole budget — that call would have
       // aborted on its own budget anyway, so it cannot keep pausing others.
       expect(mgr.hasPendingForServer("srv", 60_000)).toBe(false);
-      // Unbounded callers still see it (back-compat for non-timeout callers).
-      expect(mgr.hasPendingForServer("srv")).toBe(true);
+      // Expired entries are reclaimed, not merely ignored.
+      expect((mgr as any).pendingElicitationEntries.size).toBe(0);
     } finally {
-      vi.useRealTimers();
+      jest.useRealTimers();
+    }
+  });
+
+  it("observes a new pending handler even with a zero age budget", () => {
+    jest.useFakeTimers();
+    try {
+      const mgr = new ElicitationManager();
+      const begin = (mgr as any).beginPending.bind(mgr);
+      const sequenceAtCallStart = mgr.getPendingSequence();
+      begin("srv");
+
+      jest.advanceTimersByTime(1);
+      expect(mgr.hasPendingForServer("srv", 0, sequenceAtCallStart)).toBe(true);
+
+      // A later call snapshots after the stuck handler and may reclaim it.
+      const laterSequence = mgr.getPendingSequence();
+      expect(mgr.hasPendingForServer("srv", 0, laterSequence)).toBe(false);
+      expect((mgr as any).pendingElicitationEntries.size).toBe(0);
+    } finally {
+      jest.useRealTimers();
     }
   });
 

--- a/sdk/tests/mcp-client-manager.elicitation.test.ts
+++ b/sdk/tests/mcp-client-manager.elicitation.test.ts
@@ -882,3 +882,76 @@ describe("executeTool elicitation-aware timeout", () => {
     expect(jest.getTimerCount()).toBe(before);
   });
 });
+
+
+describe("ElicitationManager pending accounting", () => {
+  it("stops counting a handler that never settles, past the age bound", () => {
+    // The poison: the tool watchdog can abort a `tools/call` while its
+    // elicitation callback is still awaiting, so the callback's `finally` never
+    // runs. With a bare counter the server stayed "pending" forever and EVERY
+    // later call had its clock paused — unbounded timeouts, silently.
+    vi.useFakeTimers();
+    try {
+      const mgr = new ElicitationManager();
+      const begin = (mgr as any).beginPending.bind(mgr);
+      begin("srv");
+
+      expect(mgr.hasPendingForServer("srv", 60_000)).toBe(true);
+
+      vi.advanceTimersByTime(60_001);
+      // Older than the asking call's whole budget — that call would have
+      // aborted on its own budget anyway, so it cannot keep pausing others.
+      expect(mgr.hasPendingForServer("srv", 60_000)).toBe(false);
+      // Unbounded callers still see it (back-compat for non-timeout callers).
+      expect(mgr.hasPendingForServer("srv")).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("a late completion from an old connection cannot clear a new one", () => {
+    // Reconnect reuses the serverId. With an anonymous counter the old
+    // handler's decrement landed on the NEW connection's tally and could zero
+    // out a genuinely pending elicitation. A token removes only its own entry.
+    const mgr = new ElicitationManager();
+    const begin = (mgr as any).beginPending.bind(mgr);
+    const end = (mgr as any).endPending.bind(mgr);
+
+    const staleToken = begin("srv");
+    mgr.clearServer("srv"); // disconnect
+
+    const freshToken = begin("srv"); // reconnect, same id
+    expect(mgr.hasPendingForServer("srv")).toBe(true);
+
+    end(staleToken); // old handler finally settles
+    expect(mgr.hasPendingForServer("srv")).toBe(true);
+
+    end(freshToken);
+    expect(mgr.hasPendingForServer("srv")).toBe(false);
+  });
+
+  it("clearServer drops in-flight entries for that server only", () => {
+    const mgr = new ElicitationManager();
+    const begin = (mgr as any).beginPending.bind(mgr);
+    begin("srv-a");
+    begin("srv-b");
+
+    mgr.clearServer("srv-a");
+
+    expect(mgr.hasPendingForServer("srv-a")).toBe(false);
+    expect(mgr.hasPendingForServer("srv-b")).toBe(true);
+  });
+
+  it("counts concurrent elicitations independently", () => {
+    const mgr = new ElicitationManager();
+    const begin = (mgr as any).beginPending.bind(mgr);
+    const end = (mgr as any).endPending.bind(mgr);
+
+    const a = begin("srv");
+    const b = begin("srv");
+    end(a);
+    expect(mgr.hasPendingForServer("srv")).toBe(true);
+    end(b);
+    expect(mgr.hasPendingForServer("srv")).toBe(false);
+  });
+});

--- a/sdk/tests/mcp-client-manager.elicitation.test.ts
+++ b/sdk/tests/mcp-client-manager.elicitation.test.ts
@@ -10,6 +10,10 @@ import {
   ELICITATION_WATCHDOG_INTERVAL_MS,
 } from "../src/mcp-client-manager/elicitation-timeout";
 import { isRetryableTransientError } from "../src/retry";
+import {
+  isNonRetryableMarkedError,
+  markNonRetryableError,
+} from "../src/mcp-client-manager/error-utils";
 import type { ManagedMcpClient } from "../src/mcp-client-manager/managed-mcp-client";
 
 const ELICIT_METHOD = "elicitation/create";
@@ -395,6 +399,41 @@ describe("buildCapabilities elicitation shape", () => {
   });
 });
 
+describe("non-retryable marker", () => {
+  it("is not forgeable through the prototype chain", () => {
+    // A string-keyed marker was read with plain property access, so ANY error
+    // inheriting a truthy `__mcpjamNonRetryable` — including via prototype
+    // pollution — silently suppressed legitimate retries. Set membership can't
+    // be inherited.
+    const impostor = Object.create({ __mcpjamNonRetryable: true }) as object;
+    expect(isNonRetryableMarkedError(impostor)).toBe(false);
+
+    const polluted = new Error("transient");
+    (polluted as unknown as Record<string, unknown>).__mcpjamNonRetryable = true;
+    expect(isNonRetryableMarkedError(polluted)).toBe(false);
+  });
+
+  it("marks only the exact error object handed to it", () => {
+    const marked = markNonRetryableError(new Error("verdict"));
+    expect(isNonRetryableMarkedError(marked)).toBe(true);
+    expect(isNonRetryableMarkedError(new Error("verdict"))).toBe(false);
+  });
+
+  it("stamps nothing onto the error it marks", () => {
+    // We don't own these objects; a marker property would leak into anything
+    // that serializes or enumerates them.
+    const error = markNonRetryableError(new Error("verdict"));
+    expect(Object.keys(error)).not.toContain("__mcpjamNonRetryable");
+    expect(
+      Object.getOwnPropertyNames(error).some((k) => k.includes("Retryable")),
+    ).toBe(false);
+  });
+
+  it.each([[null], [undefined], ["str"], [42]])("is false for %p", (v) => {
+    expect(isNonRetryableMarkedError(v)).toBe(false);
+  });
+});
+
 describe("createElicitationTimeoutSuspension", () => {
   beforeEach(() => {
     jest.useFakeTimers();
@@ -414,6 +453,47 @@ describe("createElicitationTimeoutSuspension", () => {
 
     await jest.advanceTimersByTimeAsync(120_000);
     expect(suspension.signal.aborted).toBe(false);
+    suspension.dispose();
+  });
+
+  it("honors a per-call timeout SHORTER than the watchdog sample interval", async () => {
+    // The bug: we raise the upstream timeout to base+extension immediately, so
+    // the watchdog is the only thing enforcing `base`. Sampling at a fixed 1s
+    // meant a caller asking for 100ms wasn't stopped until 1s — a 10x overrun
+    // of a budget they explicitly set.
+    const suspension = createElicitationTimeoutSuspension({
+      serverId: "srv",
+      baseTimeoutMs: 100,
+      extensionMs: 600_000,
+      hasPending: () => false,
+    });
+
+    await jest.advanceTimersByTimeAsync(99);
+    expect(suspension.signal.aborted).toBe(false);
+
+    // Fires on ITS budget, not on the sampler's cadence.
+    await jest.advanceTimersByTimeAsync(2);
+    expect(suspension.signal.aborted).toBe(true);
+    suspension.dispose();
+  });
+
+  it("still pauses a short budget while an elicitation is pending", async () => {
+    // The short-timeout fix must not cost the suspension itself: a 100ms budget
+    // with a human mid-form should not fire at 100ms.
+    let pending = true;
+    const suspension = createElicitationTimeoutSuspension({
+      serverId: "srv",
+      baseTimeoutMs: 100,
+      extensionMs: 600_000,
+      hasPending: () => pending,
+    });
+
+    await jest.advanceTimersByTimeAsync(30_000);
+    expect(suspension.signal.aborted).toBe(false);
+
+    pending = false;
+    await jest.advanceTimersByTimeAsync(101);
+    expect(suspension.signal.aborted).toBe(true);
     suspension.dispose();
   });
 

--- a/sdk/tests/mcp-client-manager.elicitation.test.ts
+++ b/sdk/tests/mcp-client-manager.elicitation.test.ts
@@ -1,0 +1,804 @@
+import {
+  ProtocolErrorCode,
+  SdkError,
+  SdkErrorCode,
+} from "@modelcontextprotocol/client";
+import { MCPClientManager } from "../src/mcp-client-manager";
+import { ElicitationManager } from "../src/mcp-client-manager/elicitation";
+import {
+  createElicitationTimeoutSuspension,
+  ELICITATION_WATCHDOG_INTERVAL_MS,
+} from "../src/mcp-client-manager/elicitation-timeout";
+import { isRetryableTransientError } from "../src/retry";
+import type { ManagedMcpClient } from "../src/mcp-client-manager/managed-mcp-client";
+
+const ELICIT_METHOD = "elicitation/create";
+
+/**
+ * Minimal ManagedMcpClient stand-in that just records request handlers so a
+ * test can drive `elicitation/create` straight at them.
+ */
+function createHandlerCapturingClient() {
+  const handlers = new Map<string, (request: any, ctx?: any) => Promise<any>>();
+  const client = {
+    setRequestHandler: (method: string, handler: any) => {
+      handlers.set(method, handler);
+    },
+    removeRequestHandler: (method: string) => {
+      handlers.delete(method);
+    },
+  } as unknown as ManagedMcpClient;
+
+  return {
+    client,
+    hasElicitHandler: () => handlers.has(ELICIT_METHOD),
+    elicit: (params: unknown) => {
+      const handler = handlers.get(ELICIT_METHOD);
+      if (!handler) throw new Error("no elicitation handler registered");
+      return handler({ method: ELICIT_METHOD, params }, {});
+    },
+  };
+}
+
+function seedRegisteredServer(
+  manager: MCPClientManager,
+  serverId: string,
+  config: Record<string, unknown>,
+  timeout = 1000
+): void {
+  (manager as any).registeredServers.set(serverId, { config, timeout });
+}
+
+function seedLiveState(
+  manager: MCPClientManager,
+  serverId: string,
+  liveState: Record<string, unknown>
+): void {
+  (manager as any).liveClientStates.set(serverId, liveState);
+}
+
+describe("elicitation callback passthrough", () => {
+  it("passes serverId, mode, url and elicitationId through to the global callback", async () => {
+    const manager = new ElicitationManager();
+    const received: any[] = [];
+    manager.setGlobalCallback(async (request) => {
+      received.push(request);
+      return { action: "accept" } as any;
+    });
+
+    const fake = createHandlerCapturingClient();
+    manager.applyToClient("srv", fake.client, { form: {}, url: {} });
+
+    await fake.elicit({
+      mode: "url",
+      message: "Sign in to continue",
+      url: "https://example.com/authorize",
+      elicitationId: "server-chosen-id",
+    });
+
+    expect(received).toHaveLength(1);
+    expect(received[0]).toMatchObject({
+      serverId: "srv",
+      mode: "url",
+      message: "Sign in to continue",
+      url: "https://example.com/authorize",
+      elicitationId: "server-chosen-id",
+    });
+    expect(received[0].requestId).toEqual(expect.any(String));
+  });
+
+  it("treats an absent mode as form and keeps reading requestedSchema", async () => {
+    const manager = new ElicitationManager();
+    const received: any[] = [];
+    manager.setGlobalCallback(async (request) => {
+      received.push(request);
+      return { action: "decline" } as any;
+    });
+
+    const fake = createHandlerCapturingClient();
+    manager.applyToClient("srv", fake.client, {});
+
+    const requestedSchema = { type: "object", properties: { name: {} } };
+    await fake.elicit({ message: "Your name?", requestedSchema });
+
+    expect(received[0]).toMatchObject({
+      serverId: "srv",
+      mode: "form",
+      message: "Your name?",
+      schema: requestedSchema,
+    });
+    expect(received[0].url).toBeUndefined();
+    expect(received[0].elicitationId).toBeUndefined();
+  });
+
+  it("still falls back to the legacy `schema` alias in form mode", async () => {
+    const manager = new ElicitationManager();
+    const received: any[] = [];
+    manager.setGlobalCallback(async (request) => {
+      received.push(request);
+      return { action: "cancel" } as any;
+    });
+
+    const fake = createHandlerCapturingClient();
+    manager.applyToClient("srv", fake.client, { form: {} });
+
+    const schema = { type: "object" };
+    await fake.elicit({ mode: "form", message: "hi", schema });
+
+    expect(received[0].schema).toBe(schema);
+  });
+
+  it("forwards the related task id from _meta", async () => {
+    const manager = new ElicitationManager();
+    const received: any[] = [];
+    manager.setGlobalCallback(async (request) => {
+      received.push(request);
+      return { action: "cancel" } as any;
+    });
+
+    const fake = createHandlerCapturingClient();
+    manager.applyToClient("srv", fake.client, {});
+
+    await fake.elicit({
+      message: "hi",
+      _meta: { "io.modelcontextprotocol/related-task": { taskId: "task-1" } },
+    });
+
+    expect(received[0].relatedTaskId).toBe("task-1");
+  });
+});
+
+describe("elicitation declared-mode enforcement (-32602)", () => {
+  async function expectInvalidParams(promise: Promise<unknown>) {
+    await expect(promise).rejects.toMatchObject({
+      code: ProtocolErrorCode.InvalidParams,
+    });
+    await promise.catch((error) => {
+      // Spec MUST: rejection crosses the wire as JSON-RPC -32602.
+      expect(error.code).toBe(-32602);
+    });
+  }
+
+  function setup(declared: Record<string, unknown> | undefined) {
+    const manager = new ElicitationManager();
+    const callback = jest.fn(async () => ({ action: "accept" } as any));
+    manager.setGlobalCallback(callback);
+    const fake = createHandlerCapturingClient();
+    manager.applyToClient("srv", fake.client, declared);
+    return { manager, callback, fake };
+  }
+
+  it("rejects a url-mode request when the declared capability is bare {} (form-only)", async () => {
+    const { callback, fake } = setup({});
+    await expectInvalidParams(
+      fake.elicit({ mode: "url", message: "go", url: "https://example.com" })
+    );
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it("rejects a url-mode request when only form is declared", async () => {
+    const { callback, fake } = setup({ form: {} });
+    await expectInvalidParams(
+      fake.elicit({ mode: "url", message: "go", url: "https://example.com" })
+    );
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it("allows both modes when {form:{},url:{}} is declared", async () => {
+    const { callback, fake } = setup({ form: {}, url: {} });
+    await expect(
+      fake.elicit({ mode: "url", message: "go", url: "https://example.com" })
+    ).resolves.toEqual({ action: "accept" });
+    await expect(fake.elicit({ message: "go" })).resolves.toEqual({
+      action: "accept",
+    });
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects a form-mode request when only url is declared", async () => {
+    const { callback, fake } = setup({ url: {} });
+    await expectInvalidParams(fake.elicit({ mode: "form", message: "go" }));
+    await expectInvalidParams(fake.elicit({ message: "go" }));
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it("allows form but rejects url when no declaration is on record", async () => {
+    const { callback, fake } = setup(undefined);
+    await expect(fake.elicit({ message: "go" })).resolves.toEqual({
+      action: "accept",
+    });
+    await expectInvalidParams(
+      fake.elicit({ mode: "url", message: "go", url: "https://example.com" })
+    );
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects an unrecognized mode", async () => {
+    const { callback, fake } = setup({ form: {}, url: {} });
+    await expectInvalidParams(fake.elicit({ mode: "carrier-pigeon" }));
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it("enforces declared modes on the server-specific handler branch too", async () => {
+    const manager = new ElicitationManager();
+    const handler = jest.fn(async () => ({ action: "accept" } as any));
+    manager.setHandler("srv", handler);
+    const fake = createHandlerCapturingClient();
+    manager.applyToClient("srv", fake.client, { form: {} });
+
+    await expectInvalidParams(
+      fake.elicit({ mode: "url", message: "go", url: "https://example.com" })
+    );
+    expect(handler).not.toHaveBeenCalled();
+  });
+});
+
+describe("hasPendingForServer", () => {
+  it("is true only while the global callback is in flight", async () => {
+    const manager = new ElicitationManager();
+    let release!: (value: any) => void;
+    manager.setGlobalCallback(
+      () =>
+        new Promise((resolve) => {
+          release = resolve;
+        })
+    );
+
+    const fake = createHandlerCapturingClient();
+    manager.applyToClient("srv", fake.client, {});
+
+    expect(manager.hasPendingForServer("srv")).toBe(false);
+    const inFlight = fake.elicit({ message: "hi" });
+    await Promise.resolve();
+    expect(manager.hasPendingForServer("srv")).toBe(true);
+    expect(manager.hasPendingForServer("other")).toBe(false);
+
+    release({ action: "cancel" });
+    await inFlight;
+    expect(manager.hasPendingForServer("srv")).toBe(false);
+  });
+
+  it("is true only while a server-specific handler is in flight", async () => {
+    const manager = new ElicitationManager();
+    let release!: (value: any) => void;
+    manager.setHandler(
+      "srv",
+      () =>
+        new Promise((resolve) => {
+          release = resolve;
+        }) as any
+    );
+
+    const fake = createHandlerCapturingClient();
+    manager.applyToClient("srv", fake.client, {});
+
+    const inFlight = fake.elicit({ message: "hi" });
+    await Promise.resolve();
+    expect(manager.hasPendingForServer("srv")).toBe(true);
+
+    release({ action: "cancel" });
+    await inFlight;
+    expect(manager.hasPendingForServer("srv")).toBe(false);
+  });
+
+  it("counts concurrent elicitations and clears only when all settle", async () => {
+    const manager = new ElicitationManager();
+    const releases: Array<(value: any) => void> = [];
+    manager.setGlobalCallback(
+      () => new Promise((resolve) => releases.push(resolve))
+    );
+
+    const fake = createHandlerCapturingClient();
+    manager.applyToClient("srv", fake.client, {});
+
+    const first = fake.elicit({ message: "a" });
+    const second = fake.elicit({ message: "b" });
+    await Promise.resolve();
+    expect(manager.hasPendingForServer("srv")).toBe(true);
+
+    releases[0]({ action: "cancel" });
+    await first;
+    expect(manager.hasPendingForServer("srv")).toBe(true);
+
+    releases[1]({ action: "cancel" });
+    await second;
+    expect(manager.hasPendingForServer("srv")).toBe(false);
+  });
+
+  it("clears the pending count when the callback throws", async () => {
+    const manager = new ElicitationManager();
+    manager.setGlobalCallback(async () => {
+      throw new Error("callback exploded");
+    });
+
+    const fake = createHandlerCapturingClient();
+    manager.applyToClient("srv", fake.client, {});
+
+    await expect(fake.elicit({ message: "hi" })).rejects.toThrow(
+      "callback exploded"
+    );
+    expect(manager.hasPendingForServer("srv")).toBe(false);
+  });
+
+  it("does not count a request rejected for an undeclared mode", async () => {
+    const manager = new ElicitationManager();
+    manager.setGlobalCallback(() => new Promise(() => {}));
+
+    const fake = createHandlerCapturingClient();
+    manager.applyToClient("srv", fake.client, {});
+
+    await expect(
+      fake.elicit({ mode: "url", message: "go", url: "https://example.com" })
+    ).rejects.toMatchObject({ code: -32602 });
+    expect(manager.hasPendingForServer("srv")).toBe(false);
+  });
+});
+
+describe("buildCapabilities elicitation shape", () => {
+  function buildCapabilities(
+    manager: MCPClientManager,
+    serverId: string,
+    config: Record<string, unknown>
+  ) {
+    return (manager as any).buildCapabilities(serverId, config) as Record<
+      string,
+      unknown
+    >;
+  }
+
+  it("preserves an explicit {form:{},url:{}} verbatim when a callback is registered", () => {
+    const manager = new MCPClientManager();
+    manager.setElicitationCallback(() => ({ action: "cancel" } as any));
+
+    const capabilities = buildCapabilities(manager, "srv", {
+      url: "https://example.com/mcp",
+      clientCapabilities: { elicitation: { form: {}, url: {} } },
+    });
+
+    expect(capabilities.elicitation).toEqual({ form: {}, url: {} });
+  });
+
+  it("preserves a bare {} elicitation verbatim when a callback is registered", () => {
+    const manager = new MCPClientManager();
+    manager.setElicitationCallback(() => ({ action: "cancel" } as any));
+
+    const capabilities = buildCapabilities(manager, "srv", {
+      url: "https://example.com/mcp",
+      clientCapabilities: { elicitation: {} },
+    });
+
+    expect(capabilities.elicitation).toEqual({});
+  });
+
+  it("strips an explicit {form:{},url:{}} when no callback is registered", () => {
+    const manager = new MCPClientManager();
+
+    const capabilities = buildCapabilities(manager, "srv", {
+      url: "https://example.com/mcp",
+      clientCapabilities: { elicitation: { form: {}, url: {} } },
+    });
+
+    expect(capabilities).not.toHaveProperty("elicitation");
+  });
+
+  it("strips elicitation when only a different server has a handler", () => {
+    const manager = new MCPClientManager();
+    (manager as any).registeredServers.set("other", { config: {}, timeout: 1 });
+    manager.setElicitationHandler("other", () => ({ action: "cancel" } as any));
+
+    const capabilities = buildCapabilities(manager, "srv", {
+      url: "https://example.com/mcp",
+      clientCapabilities: { elicitation: { form: {}, url: {} } },
+    });
+
+    expect(capabilities).not.toHaveProperty("elicitation");
+  });
+});
+
+describe("createElicitationTimeoutSuspension", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("does not abort while an elicitation is pending, even far past the base budget", async () => {
+    const suspension = createElicitationTimeoutSuspension({
+      serverId: "srv",
+      baseTimeoutMs: 1_000,
+      extensionMs: 600_000,
+      hasPending: () => true,
+    });
+
+    await jest.advanceTimersByTimeAsync(120_000);
+    expect(suspension.signal.aborted).toBe(false);
+    suspension.dispose();
+  });
+
+  it("aborts at the base budget when nothing is pending", async () => {
+    const suspension = createElicitationTimeoutSuspension({
+      serverId: "srv",
+      baseTimeoutMs: 5_000,
+      extensionMs: 600_000,
+      hasPending: () => false,
+    });
+
+    await jest.advanceTimersByTimeAsync(4_000);
+    expect(suspension.signal.aborted).toBe(false);
+
+    await jest.advanceTimersByTimeAsync(1_000);
+    expect(suspension.signal.aborted).toBe(true);
+    expect(suspension.signal.reason).toBeInstanceOf(SdkError);
+    expect(suspension.signal.reason.code).toBe(SdkErrorCode.RequestTimeout);
+    expect(suspension.signal.reason.data).toMatchObject({
+      serverId: "srv",
+      reason: "server-timeout",
+    });
+    suspension.dispose();
+  });
+
+  it("resumes the active clock after an elicitation settles", async () => {
+    let pending = true;
+    const suspension = createElicitationTimeoutSuspension({
+      serverId: "srv",
+      baseTimeoutMs: 5_000,
+      extensionMs: 600_000,
+      hasPending: () => pending,
+    });
+
+    // 60s suspended: the active clock must not have moved.
+    await jest.advanceTimersByTimeAsync(60_000);
+    expect(suspension.signal.aborted).toBe(false);
+
+    pending = false;
+    await jest.advanceTimersByTimeAsync(4_000);
+    expect(suspension.signal.aborted).toBe(false);
+
+    await jest.advanceTimersByTimeAsync(2_000);
+    expect(suspension.signal.aborted).toBe(true);
+    suspension.dispose();
+  });
+
+  it("aborts when the cumulative suspended budget is exhausted", async () => {
+    const suspension = createElicitationTimeoutSuspension({
+      serverId: "srv",
+      baseTimeoutMs: 120_000,
+      extensionMs: 10_000,
+      hasPending: () => true,
+    });
+
+    await jest.advanceTimersByTimeAsync(9_000);
+    expect(suspension.signal.aborted).toBe(false);
+
+    await jest.advanceTimersByTimeAsync(2_000);
+    expect(suspension.signal.aborted).toBe(true);
+    expect(suspension.signal.reason.data).toMatchObject({
+      reason: "elicitation-budget",
+      timeout: 10_000,
+    });
+    suspension.dispose();
+  });
+
+  it("accumulates the suspended budget across sequential elicitations", async () => {
+    let pending = true;
+    const suspension = createElicitationTimeoutSuspension({
+      serverId: "srv",
+      baseTimeoutMs: 120_000,
+      extensionMs: 10_000,
+      hasPending: () => pending,
+    });
+
+    // First elicitation: 6s suspended.
+    await jest.advanceTimersByTimeAsync(6_000);
+    pending = false;
+    await jest.advanceTimersByTimeAsync(2_000);
+    expect(suspension.signal.aborted).toBe(false);
+
+    // Second elicitation: 6s more suspended pushes the cumulative total over.
+    pending = true;
+    await jest.advanceTimersByTimeAsync(6_000);
+    expect(suspension.signal.aborted).toBe(true);
+    expect(suspension.signal.reason.data).toMatchObject({
+      reason: "elicitation-budget",
+    });
+    suspension.dispose();
+  });
+
+  it("raises a timeout-shaped error that is never classified retryable", async () => {
+    const suspension = createElicitationTimeoutSuspension({
+      serverId: "srv",
+      baseTimeoutMs: 1_000,
+      extensionMs: 600_000,
+      hasPending: () => false,
+    });
+
+    await jest.advanceTimersByTimeAsync(2_000);
+    const reason = suspension.signal.reason;
+
+    // Timeout-shaped for callers...
+    expect(reason).toBeInstanceOf(SdkError);
+    expect(reason.code).toBe(SdkErrorCode.RequestTimeout);
+    expect(reason.message).toMatch(/timed out/i);
+    // ...but a deliberate verdict, never a transient to retry, despite the
+    // message matching the classifier's "timed out" heuristic.
+    expect(isRetryableTransientError(reason)).toBe(false);
+    suspension.dispose();
+  });
+
+  it("composes the caller's signal without clobbering it", async () => {
+    const caller = new AbortController();
+    const suspension = createElicitationTimeoutSuspension({
+      serverId: "srv",
+      baseTimeoutMs: 600_000,
+      extensionMs: 600_000,
+      hasPending: () => false,
+      callerSignal: caller.signal,
+    });
+
+    expect(suspension.signal.aborted).toBe(false);
+    const reason = new Error("caller went away");
+    caller.abort(reason);
+    await Promise.resolve();
+
+    expect(suspension.signal.aborted).toBe(true);
+    expect(suspension.signal.reason).toBe(reason);
+    suspension.dispose();
+  });
+
+  it("surfaces an already-aborted caller signal immediately", () => {
+    const caller = new AbortController();
+    caller.abort(new Error("already gone"));
+    const suspension = createElicitationTimeoutSuspension({
+      serverId: "srv",
+      baseTimeoutMs: 600_000,
+      extensionMs: 600_000,
+      hasPending: () => false,
+      callerSignal: caller.signal,
+    });
+
+    expect(suspension.signal.aborted).toBe(true);
+    suspension.dispose();
+  });
+
+  it("dispose clears the watchdog interval and stops the clock", async () => {
+    const before = jest.getTimerCount();
+    const suspension = createElicitationTimeoutSuspension({
+      serverId: "srv",
+      baseTimeoutMs: 1_000,
+      extensionMs: 600_000,
+      hasPending: () => false,
+      intervalMs: ELICITATION_WATCHDOG_INTERVAL_MS,
+    });
+    expect(jest.getTimerCount()).toBe(before + 1);
+
+    suspension.dispose();
+    expect(jest.getTimerCount()).toBe(before);
+
+    await jest.advanceTimersByTimeAsync(60_000);
+    expect(suspension.signal.aborted).toBe(false);
+
+    // Idempotent.
+    expect(() => suspension.dispose()).not.toThrow();
+  });
+});
+
+describe("executeTool elicitation-aware timeout", () => {
+  const SERVER = "srv";
+
+  function buildManager(options: Record<string, unknown> = {}) {
+    const manager = new MCPClientManager({}, options as any);
+    seedRegisteredServer(
+      manager,
+      SERVER,
+      { url: "https://example.com/mcp" },
+      1_000
+    );
+    return manager;
+  }
+
+  function attachClient(manager: MCPClientManager, callTool: any) {
+    const client = { callTool };
+    seedLiveState(manager, SERVER, { client });
+    return client;
+  }
+
+  function setPending(manager: MCPClientManager, pending: () => boolean) {
+    jest
+      .spyOn((manager as any).elicitationManager, "hasPendingForServer")
+      .mockImplementation(() => pending());
+  }
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
+  it("is a pure passthrough when the server has no elicitation handler", async () => {
+    const manager = buildManager();
+    const callTool = jest.fn().mockResolvedValue({ content: [] });
+    attachClient(manager, callTool);
+
+    await expect(manager.executeTool(SERVER, "add", { a: 1 })).resolves.toEqual(
+      {
+        content: [],
+      }
+    );
+
+    const options = callTool.mock.calls[0][1];
+    // Untouched: the registered timeout, and no watchdog signal injected.
+    expect(options.timeout).toBe(1_000);
+    expect(options.signal).toBeUndefined();
+  });
+
+  it("overrides the upstream timeout to base + extension once a handler exists", async () => {
+    const manager = buildManager({ elicitationTimeoutExtensionMs: 60_000 });
+    manager.setElicitationCallback(() => ({ action: "cancel" } as any));
+    const callTool = jest.fn().mockResolvedValue({ content: [] });
+    attachClient(manager, callTool);
+
+    await manager.executeTool(SERVER, "add", { a: 1 });
+
+    const options = callTool.mock.calls[0][1];
+    // `withTimeout` only injects when unset, so this has to be an override.
+    expect(options.timeout).toBe(61_000);
+    expect(options.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("survives past the base timeout while an elicitation is pending", async () => {
+    const manager = buildManager({ elicitationTimeoutExtensionMs: 600_000 });
+    manager.setElicitationCallback(() => ({ action: "cancel" } as any));
+
+    let resolveCall!: (value: unknown) => void;
+    let received: AbortSignal | undefined;
+    const callTool = jest.fn((_params: unknown, options: any) => {
+      received = options.signal;
+      return new Promise((resolve) => {
+        resolveCall = resolve;
+      });
+    });
+    attachClient(manager, callTool);
+    setPending(manager, () => true);
+
+    const inFlight = manager.executeTool(SERVER, "add", { a: 1 });
+    const settled = jest.fn();
+    void inFlight.then(settled, settled);
+
+    // 120x the 1s base budget, all of it suspended on a human.
+    await jest.advanceTimersByTimeAsync(120_000);
+    expect(received!.aborted).toBe(false);
+    expect(settled).not.toHaveBeenCalled();
+
+    resolveCall({ content: [{ type: "text", text: "answered" }] });
+    await expect(inFlight).resolves.toEqual({
+      content: [{ type: "text", text: "answered" }],
+    });
+  });
+
+  it("still kills a hung server at the base timeout when nothing is pending", async () => {
+    const manager = buildManager({ elicitationTimeoutExtensionMs: 600_000 });
+    manager.setElicitationCallback(() => ({ action: "cancel" } as any));
+
+    let received: AbortSignal | undefined;
+    // A server that never answers, and never elicits: this is the hang the
+    // base budget exists to catch. Model the upstream contract — reject with
+    // the signal's reason on abort.
+    const callTool = jest.fn(
+      (_params: unknown, options: any) =>
+        new Promise((_resolve, reject) => {
+          received = options.signal;
+          options.signal.addEventListener("abort", () =>
+            reject(options.signal.reason)
+          );
+        })
+    );
+    attachClient(manager, callTool);
+    setPending(manager, () => false);
+
+    const inFlight = manager.executeTool(SERVER, "add", { a: 1 });
+    const caught = inFlight.catch((error) => error);
+
+    await jest.advanceTimersByTimeAsync(2_000);
+    const error = await caught;
+
+    expect(received!.aborted).toBe(true);
+    expect(error).toBeInstanceOf(SdkError);
+    expect(error.code).toBe(SdkErrorCode.RequestTimeout);
+    expect(error.data).toMatchObject({ reason: "server-timeout" });
+  });
+
+  it("aborts when the suspended budget is exhausted", async () => {
+    const manager = buildManager({ elicitationTimeoutExtensionMs: 10_000 });
+    manager.setElicitationCallback(() => ({ action: "cancel" } as any));
+
+    const callTool = jest.fn(
+      (_params: unknown, options: any) =>
+        new Promise((_resolve, reject) => {
+          options.signal.addEventListener("abort", () =>
+            reject(options.signal.reason)
+          );
+        })
+    );
+    attachClient(manager, callTool);
+    setPending(manager, () => true);
+
+    const inFlight = manager.executeTool(SERVER, "add", { a: 1 });
+    const caught = inFlight.catch((error) => error);
+
+    await jest.advanceTimersByTimeAsync(12_000);
+    const error = await caught;
+
+    expect(error).toBeInstanceOf(SdkError);
+    expect(error.data).toMatchObject({ reason: "elicitation-budget" });
+  });
+
+  it("propagates a caller abort through the composed signal", async () => {
+    const manager = buildManager({ elicitationTimeoutExtensionMs: 600_000 });
+    manager.setElicitationCallback(() => ({ action: "cancel" } as any));
+
+    let received: AbortSignal | undefined;
+    const callTool = jest.fn((_params: unknown, options: any) => {
+      received = options.signal;
+      return new Promise(() => {});
+    });
+    attachClient(manager, callTool);
+    setPending(manager, () => true);
+
+    const caller = new AbortController();
+    const inFlight = manager.executeTool(
+      SERVER,
+      "add",
+      { a: 1 },
+      {
+        signal: caller.signal,
+      }
+    );
+    const caught = inFlight.catch((error) => error);
+
+    await jest.advanceTimersByTimeAsync(10);
+    expect(received!.aborted).toBe(false);
+
+    const reason = new Error("caller cancelled the turn");
+    caller.abort(reason);
+    await jest.advanceTimersByTimeAsync(10);
+
+    // The watchdog composed with the caller's signal rather than replacing it.
+    expect(received!.aborted).toBe(true);
+    expect(received!.reason).toBe(reason);
+    await caught;
+  });
+
+  it("disposes the watchdog once the call settles", async () => {
+    const manager = buildManager({ elicitationTimeoutExtensionMs: 600_000 });
+    manager.setElicitationCallback(() => ({ action: "cancel" } as any));
+    attachClient(manager, jest.fn().mockResolvedValue({ content: [] }));
+    setPending(manager, () => false);
+
+    const before = jest.getTimerCount();
+    await manager.executeTool(SERVER, "add", { a: 1 });
+    expect(jest.getTimerCount()).toBe(before);
+  });
+
+  it("disposes the watchdog when the call throws", async () => {
+    const manager = buildManager({ elicitationTimeoutExtensionMs: 600_000 });
+    manager.setElicitationCallback(() => ({ action: "cancel" } as any));
+    attachClient(
+      manager,
+      jest
+        .fn()
+        .mockRejectedValue(Object.assign(new Error("boom"), { code: -1 }))
+    );
+    setPending(manager, () => false);
+
+    const before = jest.getTimerCount();
+    await expect(manager.executeTool(SERVER, "add", { a: 1 })).rejects.toThrow(
+      "boom"
+    );
+    expect(jest.getTimerCount()).toBe(before);
+  });
+});


### PR DESCRIPTION
Part 2 of 6 adding MCP elicitation (form + URL, spec 2025-11-25) to hosted mode. **Additive only** — dormant until a consumer registers an elicitation callback, so it's safe to ship ahead of the rest.

Stack: backend ([mcpjam-backend#724](https://github.com/MCPJam/mcpjam-backend/pull/724)) → **this** → server → client.

## What's here

**1. Callback passthrough** (`types.ts`, `elicitation.ts`)

`ElicitationCallbackRequest` gains optional `serverId`, `mode`, `url`, `elicitationId`. Absent `mode` ⇒ `"form"`, preserving legacy behavior. Until now the global callback silently dropped every URL-mode field, so url-mode elicitations were undeliverable.

`serverId` matters beyond convenience: the spec requires clients to make it clear **which server** is asking, and the callback previously had no way to know.

**2. Spec-mandated `-32602` for undeclared modes**

`applyToClient` takes the declared capability and rejects a mode the client never advertised. Note this is *duplicate* for real `Client` connections — upstream enforces it too — but it's the **only** enforcement on `StatelessMcpHttpPreviewClient`, which stores raw handlers with no wrapping. Rather than hand-roll the semantics, this delegates to upstream's exported `getSupportedElicitationModes`, so our check can't drift from the `Client`'s.

**3. Elicitation-aware tool timeouts** — the substantive part

An elicitation blocks `tools/call` on a **human**, but `defaultTimeout` (120s hosted) is a per-request timeout, so a user thinking for two minutes killed their own tool call. A blanket bump would be wrong — it converts the hung-server guard into a 7-minute guard for every request on the host.

Instead the watchdog tracks two budgets: **active** time (accumulates only while no elicitation is pending → aborts at `base`) and cumulative **suspended** time (the total elicitation budget for that call, covering sequential elicitations → aborts at `extension`). A hung server with no elicitation still dies at `base`, exactly as before.

## Implementation notes worth reviewing

- **`withTimeout` only injects when unset**, so the wrapper must *override* `mergedOptions.timeout` — a plain merge silently does nothing.
- **Signals compose.** The AI SDK already forwards an `abortSignal` into `executeTool`, so this uses `AbortSignal.any([caller, watchdog])` and never clobbers the caller's. `engines.node` is `>=20.0` but `AbortSignal.any` needs 20.3 — raising the floor would be a breaking change to a published package, so it's feature-detected with hand-rolled forwarding as a fallback. Both paths preserve the caller's abort `reason` identity.
- **`isRetryableTransientError` matches "timed out" in the message** and would have classified the watchdog's own verdict as retryable, restarting the call and dropping the elicitation. The error carries a non-retryable marker.
- **Upstream v2-alpha has no `McpError`** (that's the v1 name). Errors split into `ProtocolError` (numeric, wire-crossing) and `SdkError` (string, local). `-32602` uses `ProtocolError`; the timeout uses `SdkError`/`RequestTimeout` — which is what upstream itself raises on timeout, so callers see a real timeout, not a bare AbortError.
- Known conservative edge (documented): pending counts are per-server, so a concurrent unrelated call on the same server also pauses its clock — bounded by its own suspended budget.

## Tests

37 new. Fake-timer matrix covers: a call with a pending elicitation surviving past `base`; a hung server **without** one still dying at `base`; suspended-budget exhaustion; caller abort propagating through the composed signal; dispose cleanup. Plus wire-level checks that `{form:{},url:{}}` is preserved verbatim when a callback is registered and stripped when not.

Mutation-tested the three load-bearing behaviors (active-budget abort, suspension, -32602) — each mutation failed 4–6 tests, so coverage isn't vacuous.

`Test Files 118 passed | Tests 2146 passed`. Build + `tsc --noEmit` clean. Changeset: minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core `executeTool` timeout and retry behavior for any server with an elicitation handler; logic is well-tested but concurrent calls on the same server share per-server pending state (documented conservative edge).
> 
> **Overview**
> **Additive MCP elicitation support (MCP 2025-11-25)** for `@mcpjam/sdk`: nothing changes until a host registers an elicitation handler or global callback.
> 
> **Global elicitation callbacks** now receive optional `serverId`, `mode` (`form` | `url`, default `form`), `url`, and `elicitationId`, so URL-mode consent and multi-server routing work. Form mode still uses `requestedSchema ?? schema`.
> 
> **`ElicitationManager.applyToClient`** takes the wire `elicitation` capability and rejects undeclared modes with JSON-RPC `-32602` (via upstream `getSupportedElicitationModes`), including on the stateless preview client. **`hasPendingForServer`** tracks in-flight handler work with token-based accounting so stuck callbacks cannot pause timeouts forever.
> 
> **`executeTool`** wraps `tools/call` in an elicitation-aware watchdog when a handler exists: **active** time still caps hung servers at the base timeout; **suspended** time (default 10 minutes via `elicitationTimeoutExtensionMs`) caps total human wait across elicitations. Upstream timeout is overridden to `base + extension`; caller abort signals are composed, not replaced. Timeout aborts use `SdkError` / `RequestTimeout` and are marked **non-retryable** so retry logic does not re-run exhausted budgets.
> 
> Exports: `ElicitationMode`, `DeclaredElicitationCapability`, `DEFAULT_ELICITATION_TIMEOUT_EXTENSION_MS`. Minor changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95582ff34fec74cbc5af2dfb4cfc61f664af69b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds elicitation mode and server identity passthrough to callbacks and pauses tool-call timeouts while a user responds to an elicitation; also fixes short and resume-timeout overshoots and prevents stuck elicitations from pausing later calls. No behavior change unless an elicitation handler or callback is registered.

- New Features
  - Passthrough: `ElicitationCallbackRequest` adds optional `serverId`, `mode` (`"form" | "url"`, default `"form"`), `url`, and `elicitationId`.
  - Spec enforcement: `ElicitationManager.applyToClient(serverId, client, declared)` validates the requested mode against the client’s declared `elicitation` capability and rejects undeclared modes with JSON-RPC `-32602` (via upstream `getSupportedElicitationModes`).
  - Elicitation-aware timeouts: `executeTool` pauses the base timeout while an elicitation is pending and caps total suspended time via `MCPClientManagerOptions.elicitationTimeoutExtensionMs` (default `DEFAULT_ELICITATION_TIMEOUT_EXTENSION_MS` = 10m). Overrides upstream timeout to `base + extension`, composes with caller signals, and throws `SdkError`/`RequestTimeout` marked non-retryable.
  - Capabilities: preserves an explicit `elicitation` shape in `initialize` only when a handler/callback is set; strips it otherwise.
  - API: exports `ElicitationMode`, `DeclaredElicitationCapability`, and `DEFAULT_ELICITATION_TIMEOUT_EXTENSION_MS`; updates `hasPendingForServer(serverId, maxAgeMs?, startedAfterSequence?)`.

- Bug Fixes
  - Short and resume timeouts honored: watchdog sampling is bounded by the remaining budget(s) to avoid overshooting small per-call timeouts or when resuming after elicitation; zero-extension no longer spins.
  - Stuck handler containment: pending tracking uses per-invocation tokens with `startedAt` and a sequence snapshot; `hasPendingForServer` age-bounds and reclaims stale entries so timeouts don’t pause forever; `clearServer` purges in-flight entries so reconnects don’t corrupt counts.
  - Non-retryable marker hardened: timeout errors are marked via a module-local `WeakSet` and checked in retry logic, preventing forged markers and avoiding accidental retries.

<sup>Written for commit 95582ff34fec74cbc5af2dfb4cfc61f664af69b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

