### PR TITLE
feat(hosts): elicitation client-capability toggle in the Client panel

### DIFF
--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ProtocolTab.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ProtocolTab.tsx
@@ -10,6 +10,7 @@ import {
   SelectValue,
 } from "@mcpjam/design-system/select";
 import { Switch } from "@mcpjam/design-system/switch";
+import { Checkbox } from "@mcpjam/design-system/checkbox";
 import {
   isKnownProtocolVersion,
   readXaaEnterprisePolicy,
@@ -95,7 +96,7 @@ function findAuthorizationKey(
   return Object.keys(headers).find((k) => k.toLowerCase() === "authorization");
 }
 
-function protocolToJson(draft: HostConfigInputV2): ProtocolDoc {
+export function protocolToJson(draft: HostConfigInputV2): ProtocolDoc {
   const doc: ProtocolDoc = {
     connectionDefaults: {
       requestTimeout: draft.connectionDefaults.requestTimeout,
@@ -217,6 +218,88 @@ export function withoutEmaExtension(
   return { ...prev, clientCapabilities: nextCaps };
 }
 
+/**
+ * Read the elicitation slice of the stored clientCapabilities.
+ *
+ * Deliberately LENIENT on `enabled`: the wire shape is freeform per MCP, and
+ * the host catalog ships BOTH a bare `elicitation: {}` (claude-code, cursor,
+ * vscode…) and `elicitation: { form: {} }` (goose, codex) — see
+ * `sdk/src/host-compat/catalog.generated.ts`. Any plain object means the host
+ * advertises elicitation, so the switch must read `{}` as ON rather than
+ * demanding our own canonical shape.
+ *
+ * `url` is the narrow mode probe: only a plain `elicitation.url` object counts
+ * (a bare `{}` is form-only). The SDK enforces the same reading when it
+ * rejects undeclared modes.
+ *
+ * Note this is a TOP-LEVEL capability key, unlike the EMA extension above
+ * which lives under `clientCapabilities.extensions` — the SDK reads and strips
+ * `clientCapabilities.elicitation` directly (`buildCapabilities` in
+ * `MCPClientManager.ts`).
+ */
+export function elicitationCapabilityState(
+  capabilities: Record<string, unknown> | undefined
+): { enabled: boolean; url: boolean } {
+  const elicitation = capabilities?.elicitation;
+  if (!isPlainObject(elicitation)) return { enabled: false, url: false };
+  return { enabled: true, url: isPlainObject(elicitation.url) };
+}
+
+/**
+ * Advertise the elicitation capability, with or without URL mode.
+ *
+ * Writes `{ form: {} }` or `{ form: {}, url: {} }`, but merges over any
+ * pre-existing elicitation object rather than replacing it: unknown sibling
+ * sub-keys and a hand-edited `form`/`url` payload survive the toggle, same
+ * `?? {}` preservation semantics as `withEmaExtension`. `url` is re-guarded
+ * with `isPlainObject` so the value we write always reads back as ON through
+ * `elicitationCapabilityState` — a junk `url: "yes"` left in place would make
+ * the checkbox ignore its own click.
+ *
+ * Never mutates `prev`: both the capabilities record and the elicitation
+ * object are copied before assignment.
+ */
+export function withElicitation(
+  prev: HostConfigInputV2,
+  options: { url: boolean }
+): HostConfigInputV2 {
+  const nextCaps: Record<string, unknown> = {
+    ...(prev.clientCapabilities ?? {}),
+  };
+  const existing: Record<string, unknown> = isPlainObject(nextCaps.elicitation)
+    ? nextCaps.elicitation
+    : {};
+  const nextElicitation: Record<string, unknown> = { ...existing };
+  nextElicitation.form = existing.form ?? {};
+  if (options.url) {
+    nextElicitation.url = isPlainObject(existing.url) ? existing.url : {};
+  } else {
+    delete nextElicitation.url;
+  }
+  nextCaps.elicitation = nextElicitation;
+  return { ...prev, clientCapabilities: nextCaps };
+}
+
+/**
+ * Stop advertising elicitation. Touches ONLY the top-level `elicitation` key —
+ * every sibling capability is preserved and `clientCapabilities` itself always
+ * stays an object, because the canonicalizer throws on undefined.
+ *
+ * No mistral inert-marker guard here, unlike `withoutEmaExtension`: that guard
+ * exists to RESTORE the `extensions: {}` marker that the EMA helper itself had
+ * just deleted when the container went empty. This helper never touches
+ * `extensions`, so mistral's marker survives untouched; synthesizing one here
+ * would invent a key the toggle has no business writing and would break the
+ * byte-exact on→off round-trip back to `{}`.
+ */
+export function withoutElicitation(prev: HostConfigInputV2): HostConfigInputV2 {
+  const nextCaps: Record<string, unknown> = {
+    ...(prev.clientCapabilities ?? {}),
+  };
+  delete nextCaps.elicitation;
+  return { ...prev, clientCapabilities: nextCaps };
+}
+
 function patchProfile(
   prev: HostConfigMcpProfileV1 | undefined,
   patch: (base: HostConfigMcpProfileV1) => HostConfigMcpProfileV1 | undefined
@@ -224,7 +307,7 @@ function patchProfile(
   return patch(prev ?? { profileVersion: 1 });
 }
 
-function applyJsonToDraft(
+export function applyJsonToDraft(
   parsed: unknown,
   prev: HostConfigInputV2
 ): HostConfigInputV2 | null {
@@ -444,6 +527,20 @@ export function ProtocolTab({
     });
   };
 
+  // Derived per render from the draft rather than mirrored into state: catalog
+  // rows already ship an elicitation shape, and seeding local state from it
+  // would write our canonical shape back on mount and churn the config hash
+  // before the user ever touched the switch.
+  const elicitation = elicitationCapabilityState(draft.clientCapabilities);
+  const setElicitationEnabled = (next: boolean) => {
+    onDraftChange((prev) =>
+      next ? withElicitation(prev, { url: false }) : withoutElicitation(prev)
+    );
+  };
+  const setElicitationUrlMode = (next: boolean) => {
+    onDraftChange((prev) => withElicitation(prev, { url: next }));
+  };
+
   return (
     <div className="flex h-full min-h-[480px] flex-col gap-3">
       <div className="rounded-[10px] border border-border bg-background px-3.5 py-2.5">
@@ -501,6 +598,43 @@ export function ProtocolTab({
           />
         </div>
         )}
+        <div className="mt-2.5 border-t border-border/50 pt-2.5">
+          <div className="flex items-center justify-between gap-3">
+            <div className="min-w-0">
+              <span className="text-[12px] font-medium">Elicitation</span>
+              <p className="text-[11px] leading-snug text-muted-foreground">
+                Advertises the elicitation client capability. When enabled,
+                hosted chat pauses tool calls to collect your input.
+              </p>
+            </div>
+            <Switch
+              checked={elicitation.enabled}
+              onCheckedChange={setElicitationEnabled}
+              disabled={readOnly}
+              aria-label="Elicitation"
+            />
+          </div>
+          {elicitation.enabled ? (
+            <div className="mt-2.5 flex items-start gap-2 pl-4">
+              <Checkbox
+                id="elicitation-url-mode"
+                className="mt-0.5"
+                checked={elicitation.url}
+                onCheckedChange={(checked) =>
+                  setElicitationUrlMode(checked === true)
+                }
+                disabled={readOnly}
+              />
+              <label
+                htmlFor="elicitation-url-mode"
+                className="text-[11px] leading-snug text-muted-foreground"
+              >
+                URL mode — allow servers to ask you to open a URL (you always
+                review it first).
+              </label>
+            </div>
+          ) : null}
+        </div>
       </div>
       <div className="flex min-h-0 flex-1 flex-col">
         <JsonEditor

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/ProtocolTab.elicitationToggle.test.ts
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/ProtocolTab.elicitationToggle.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from "vitest";
+import { emptyHostConfigInputV2 } from "@/lib/client-config-v2";
+import {
+  applyJsonToDraft,
+  elicitationCapabilityState,
+  protocolToJson,
+  withElicitation,
+  withoutElicitation,
+} from "../ProtocolTab";
+
+const UI_EXTENSION = "io.modelcontextprotocol/ui";
+
+function elicitationOf(caps: Record<string, unknown> | undefined) {
+  return (caps as { elicitation?: unknown } | undefined)?.elicitation;
+}
+
+function extensionsOf(caps: Record<string, unknown> | undefined) {
+  return (caps as { extensions?: Record<string, unknown> } | undefined)
+    ?.extensions;
+}
+
+describe("ProtocolTab elicitation capability helpers", () => {
+  it("round-trips off -> on -> off, restoring the original shape", () => {
+    const base = emptyHostConfigInputV2();
+    expect(elicitationCapabilityState(base.clientCapabilities)).toEqual({
+      enabled: false,
+      url: false,
+    });
+
+    const on = withElicitation(base, { url: false });
+    expect(elicitationCapabilityState(on.clientCapabilities)).toEqual({
+      enabled: true,
+      url: false,
+    });
+    expect(elicitationOf(on.clientCapabilities)).toEqual({ form: {} });
+    // Elicitation is a TOP-LEVEL key: the EMA/Apps `extensions` map rides
+    // along untouched.
+    expect(extensionsOf(on.clientCapabilities)?.[UI_EXTENSION]).toBeDefined();
+
+    const off = withoutElicitation(on);
+    expect(elicitationCapabilityState(off.clientCapabilities)).toEqual({
+      enabled: false,
+      url: false,
+    });
+    expect(off.clientCapabilities).toEqual(base.clientCapabilities);
+  });
+
+  it("writes { form: {}, url: {} } when URL mode is on", () => {
+    const base = emptyHostConfigInputV2();
+    const on = withElicitation(base, { url: true });
+    expect(elicitationOf(on.clientCapabilities)).toEqual({
+      form: {},
+      url: {},
+    });
+    expect(elicitationCapabilityState(on.clientCapabilities)).toEqual({
+      enabled: true,
+      url: true,
+    });
+  });
+
+  it("does not mutate the previous draft", () => {
+    const base = emptyHostConfigInputV2({
+      clientCapabilities: { elicitation: { form: {}, url: {} } },
+    });
+    const snapshot = JSON.parse(JSON.stringify(base.clientCapabilities));
+    withElicitation(base, { url: false });
+    withElicitation(base, { url: true });
+    withoutElicitation(base);
+    expect(base.clientCapabilities).toEqual(snapshot);
+  });
+
+  it("reads a bare {} catalog shape as enabled with URL mode off", () => {
+    // claude-code / cursor / vscode ship `elicitation: {}`; goose / codex ship
+    // `elicitation: { form: {} }`. Both must read as ON.
+    const bare = emptyHostConfigInputV2({
+      clientCapabilities: { elicitation: {} },
+    });
+    expect(elicitationCapabilityState(bare.clientCapabilities)).toEqual({
+      enabled: true,
+      url: false,
+    });
+
+    const formOnly = emptyHostConfigInputV2({
+      clientCapabilities: { elicitation: { form: {} } },
+    });
+    expect(elicitationCapabilityState(formOnly.clientCapabilities)).toEqual({
+      enabled: true,
+      url: false,
+    });
+  });
+
+  it("preserves form payloads and unknown sibling sub-keys when enabling URL mode", () => {
+    const base = emptyHostConfigInputV2({
+      clientCapabilities: {
+        elicitation: {
+          form: { maxFields: 12 },
+          experimentalThing: { keep: true },
+        },
+      },
+    });
+    const on = withElicitation(base, { url: true });
+    expect(elicitationOf(on.clientCapabilities)).toEqual({
+      form: { maxFields: 12 },
+      experimentalThing: { keep: true },
+      url: {},
+    });
+
+    // Turning URL mode back off drops only `url`.
+    const urlOff = withElicitation(on, { url: false });
+    expect(elicitationOf(urlOff.clientCapabilities)).toEqual({
+      form: { maxFields: 12 },
+      experimentalThing: { keep: true },
+    });
+  });
+
+  it("preserves a hand-edited url payload on re-toggle", () => {
+    const base = emptyHostConfigInputV2({
+      clientCapabilities: {
+        elicitation: { form: {}, url: { allowedSchemes: ["https"] } },
+      },
+    });
+    const on = withElicitation(base, { url: true });
+    expect(elicitationOf(on.clientCapabilities)).toEqual({
+      form: {},
+      url: { allowedSchemes: ["https"] },
+    });
+  });
+
+  it("deletes the key on disable, keeping clientCapabilities an object", () => {
+    const base = emptyHostConfigInputV2({
+      clientCapabilities: { elicitation: { form: {}, url: {} } },
+    });
+    const off = withoutElicitation(base);
+    expect(off.clientCapabilities).toEqual({});
+    expect(
+      Object.prototype.hasOwnProperty.call(
+        off.clientCapabilities,
+        "elicitation"
+      )
+    ).toBe(false);
+    // The canonicalizer throws on undefined clientCapabilities — {} is the floor.
+    expect(off.clientCapabilities).not.toBeUndefined();
+  });
+
+  it("preserves sibling capabilities on disable", () => {
+    const base = emptyHostConfigInputV2({
+      clientCapabilities: {
+        elicitation: { form: {} },
+        roots: { listChanged: true },
+        extensions: { [UI_EXTENSION]: { mimeTypes: ["text/html"] } },
+      },
+    });
+    const off = withoutElicitation(base);
+    expect(off.clientCapabilities).toEqual({
+      roots: { listChanged: true },
+      extensions: { [UI_EXTENSION]: { mimeTypes: ["text/html"] } },
+    });
+  });
+
+  it("leaves mistral's inert extensions marker alone (no synthetic restore)", () => {
+    // Unlike withoutEmaExtension, this helper never deletes `extensions`, so
+    // there is nothing to restore — and it must not invent the marker either.
+    const withMarker = emptyHostConfigInputV2({
+      hostStyle: "mistral",
+      clientCapabilities: { extensions: {}, elicitation: { form: {} } },
+    });
+    expect(withoutElicitation(withMarker).clientCapabilities).toEqual({
+      extensions: {},
+    });
+
+    const noMarker = emptyHostConfigInputV2({
+      hostStyle: "mistral",
+      clientCapabilities: { elicitation: { form: {} } },
+    });
+    expect(withoutElicitation(noMarker).clientCapabilities).toEqual({});
+  });
+
+  it("guards non-object elicitation values instead of throwing", () => {
+    const base = emptyHostConfigInputV2({
+      clientCapabilities: { elicitation: "junk" },
+    });
+    expect(elicitationCapabilityState(base.clientCapabilities)).toEqual({
+      enabled: false,
+      url: false,
+    });
+
+    const on = withElicitation(base, { url: true });
+    expect(elicitationOf(on.clientCapabilities)).toEqual({ form: {}, url: {} });
+
+    expect(withoutElicitation(base).clientCapabilities).toEqual({});
+  });
+
+  it("normalizes a junk url value so the checkbox state reads back true", () => {
+    const base = emptyHostConfigInputV2({
+      clientCapabilities: { elicitation: { form: {}, url: "yes" } },
+    });
+    expect(elicitationCapabilityState(base.clientCapabilities).url).toBe(false);
+
+    const on = withElicitation(base, { url: true });
+    expect(elicitationOf(on.clientCapabilities)).toEqual({ form: {}, url: {} });
+    expect(elicitationCapabilityState(on.clientCapabilities).url).toBe(true);
+  });
+
+  it("round-trips through the JSON editor serializer verbatim", () => {
+    const base = emptyHostConfigInputV2();
+    const on = withElicitation(base, { url: true });
+
+    const doc = protocolToJson(on);
+    expect(doc.capabilities).toEqual(on.clientCapabilities);
+
+    const backThrough = applyJsonToDraft(JSON.parse(JSON.stringify(doc)), on);
+    expect(backThrough).not.toBeNull();
+    expect(backThrough?.clientCapabilities).toEqual(on.clientCapabilities);
+    expect(elicitationCapabilityState(backThrough?.clientCapabilities)).toEqual(
+      { enabled: true, url: true }
+    );
+
+    // ...and the off state stays off across the same trip.
+    const off = withoutElicitation(on);
+    const offBack = applyJsonToDraft(
+      JSON.parse(JSON.stringify(protocolToJson(off))),
+      off
+    );
+    expect(elicitationCapabilityState(offBack?.clientCapabilities)).toEqual({
+      enabled: false,
+      url: false,
+    });
+  });
+});


### PR DESCRIPTION
Part 4a of 6 adding MCP elicitation to hosted mode. **Independent** — no dependency on the other PRs, reviewable and shippable on its own.

Stack: backend ([mcpjam-backend#724](https://github.com/MCPJam/mcpjam-backend/pull/724)) → sdk (#3226) → server → client. This one is orthogonal.

## What

Makes `elicitation` a real, user-facing client capability on the Connect page → host → **Client** → MCP Protocol tab, mirroring the EMA switch right above it: a master **Elicitation** switch plus a URL-mode sub-checkbox.

| UI state | `clientCapabilities.elicitation` |
|---|---|
| Off | key deleted |
| On, URL off | `{ form: {} }` |
| On, URL on | `{ form: {}, url: {} }` |

The capability blob is already hashed and content-addressed, and the canvas chip already renders `elicitation` (with `form`/`url` sub-tags) — this just gives it a control instead of requiring a hand-edit of the JSON.

## Design notes

**Lenient read, explicit write.** The catalog ships *both* shapes — `elicitation: {}` (claude-code, goose, codex, agentcore) and `{ form: {} }` (cursor, vscode). Bare `{}` is form-only per the spec's back-compat rule, so the read treats any object as enabled and writes the explicit form only when the user actually interacts. State is derived per render, so **catalog rows don't churn config hashes** just from being viewed.

**Top-level key, not `.extensions`.** EMA writes under `clientCapabilities.extensions[...]`; elicitation is top-level (`MCPClientManager.buildCapabilities` reads/strips it there). The *pattern* is mirrored, not the key path.

**JSON round-trip needs no changes** — verified: `protocolToJson` emits `draft.clientCapabilities` verbatim and `applyJsonToDraft` reads it back. Editing `capabilities.elicitation` in the JSON editor updates the switch and vice versa; a test pins it.

## Two deliberate deviations from the plan

1. **No mistral inert-marker guard.** The spec I was given said to copy `withoutEmaExtension`'s guard. That guard *restores* the `extensions: {}` marker the EMA helper itself deletes when the container empties. `withoutElicitation` never touches `extensions`, so mistral's marker survives on its own — synthesizing one would invent a key this toggle has no business writing and break the byte-exact on→off round-trip. Rationale is in a code comment, pinned by tests in both directions.
2. **`withElicitation` re-guards `url` with `isPlainObject`.** Preserving a junk `url: "yes"` verbatim would make the state read `url: false` right after the user checked the box — the checkbox would appear to ignore its own click. Plain-object payloads are still preserved verbatim.

## Tests

12 new (`ProtocolTab.elicitationToggle.test.ts`, mirroring the EMA suite): on→off→on round-trip, no mutation of `prev`, bare `{}` reads as enabled, URL-add preserves `form` + unknown sibling sub-keys, disable leaves `clientCapabilities` an object (never `undefined` — the canonicalizer throws), JSON round-trip.

`Test Files 17 passed | Tests 134 passed` across the whole focus dir (EMA suite included, no regression). Client typecheck clean.

## Note

The toggle advertises intent; **the runtime honoring it lands in the server PR** (the SDK strips the capability unless a handler is registered). Turning this on before that ships is a no-op, not a break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Inspector-only host config editing with broad unit tests; enabling elicitation before server runtime support is documented as a no-op, not a break.
> 
> **Overview**
> Adds **Elicitation** controls on the host **Client → MCP Protocol** tab so `clientCapabilities.elicitation` can be set without hand-editing JSON, alongside the existing enterprise-auth switch.
> 
> A master switch turns the capability off (key removed) or on with `{ form: {} }`; when on, a **URL mode** checkbox adds or removes `{ url: {} }` while merging over existing `form`/`url` payloads and unknown sub-keys. UI state is **derived from the draft each render** so catalog presets like bare `elicitation: {}` do not rewrite configs or churn content hashes until the user toggles.
> 
> New exported helpers (`elicitationCapabilityState`, `withElicitation`, `withoutElicitation`, plus `protocolToJson` / `applyJsonToDraft` for tests) implement lenient reads (any object = enabled) and explicit writes, with deliberate differences from the EMA helpers (top-level key, no mistral `extensions: {}` restore). A dedicated Vitest file covers round-trips, immutability, mistral behavior, junk values, and JSON editor sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edce8724466ca245fd8fd0b1907ecd312750c430. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Elicitation toggle to Client → MCP Protocol with an optional URL mode, so you can set `clientCapabilities.elicitation` without editing JSON. State is derived from the draft to avoid config-hash churn; enabling is a no-op until server support ships.

- **New Features**
  - Switch + URL checkbox: Off deletes the key; On writes `{ form: {} }`; URL adds `{ url: {} }`. Derived each render.
  - Lenient read, explicit write: any object = enabled; preserves unknown sub-keys and payloads; re-guards non-object `url` so the checkbox reflects user actions.
  - Top-level `clientCapabilities.elicitation` (not under `extensions`); disabling only removes this key; no synthetic `extensions` marker restore.
  - Exported helpers: `elicitationCapabilityState`, `withElicitation`, `withoutElicitation`, plus `protocolToJson`/`applyJsonToDraft` for round-trip tests.

<sup>Written for commit d71a4d180cf7ade14b5dfaf5e4fcc7efbeee910a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

