### PR TITLE
feat(elicitation): spec-complete form dialog + requesting-server identity

### DIFF
--- a/mcpjam-inspector/client/src/components/ElicitationDialog.tsx
+++ b/mcpjam-inspector/client/src/components/ElicitationDialog.tsx
@@ -1,9 +1,10 @@
-import React, { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Button } from "@mcpjam/design-system/button";
 import { Input } from "@mcpjam/design-system/input";
 import { Label } from "@mcpjam/design-system/label";
 import { Textarea } from "@mcpjam/design-system/textarea";
 import { Badge } from "@mcpjam/design-system/badge";
+import { Checkbox } from "@mcpjam/design-system/checkbox";
 import {
   Select,
   SelectContent,
@@ -21,206 +22,232 @@ import {
 } from "@mcpjam/design-system/dialog";
 import { MessageSquare, X, Check, RefreshCw } from "lucide-react";
 import { DialogElicitation } from "./ToolsTab";
-
-interface FormField {
-  name: string;
-  type: string;
-  description?: string;
-  required: boolean;
-  value: any;
-  enum?: string[];
-  minimum?: number;
-  maximum?: number;
-  pattern?: string;
-}
+import {
+  buildElicitationContent,
+  fieldLabel,
+  initialFormValues,
+  parseElicitationSchema,
+  validateField,
+  type ElicitationField,
+} from "./elicitation/schema";
 
 interface ElicitationDialogProps {
   elicitationRequest: DialogElicitation | null;
   onResponse: (
     action: "accept" | "decline" | "cancel",
-    parameters?: Record<string, any>,
+    parameters?: Record<string, any>
   ) => Promise<void>;
   loading?: boolean;
 }
 
+/**
+ * Input `type` per JSON Schema `format`. Purely a keyboard/affordance hint —
+ * validation is still enforced by `validateField`, never by the browser.
+ */
+const FORMAT_INPUT_TYPES: Record<string, string> = {
+  email: "email",
+  uri: "url",
+  date: "date",
+  "date-time": "datetime-local",
+};
+
+/**
+ * MCP spec MUST: elicitation dialogs never render clickable URLs. Every value,
+ * description and message below is rendered as plain text — no anchors, no
+ * linkification, anywhere in this component.
+ */
 export function ElicitationDialog({
   elicitationRequest,
   onResponse,
   loading = false,
 }: ElicitationDialogProps) {
-  const [fields, setFields] = useState<FormField[]>([]);
+  const fields = useMemo(
+    () => parseElicitationSchema(elicitationRequest?.schema),
+    [elicitationRequest]
+  );
+  const [values, setValues] = useState<Record<string, unknown>>({});
+  const [errors, setErrors] = useState<Record<string, string>>({});
 
-  // Generate form fields from schema when request changes
-  React.useEffect(() => {
-    if (elicitationRequest?.schema) {
-      generateFormFields(elicitationRequest.schema);
-    } else {
-      setFields([]);
-    }
-  }, [elicitationRequest]);
+  // Reset form state (and prefill schema defaults) whenever the request changes.
+  useEffect(() => {
+    setValues(initialFormValues(fields));
+    setErrors({});
+  }, [fields]);
 
-  const generateFormFields = (schema: any) => {
-    if (!schema || !schema.properties) {
-      setFields([]);
-      return;
-    }
-
-    const formFields: FormField[] = [];
-    const required = schema.required || [];
-
-    Object.entries(schema.properties).forEach(([key, prop]: [string, any]) => {
-      const fieldType = prop.enum ? "enum" : prop.type || "string";
-      formFields.push({
-        name: key,
-        type: fieldType,
-        description: prop.description,
-        required: required.includes(key),
-        value: getDefaultValue(fieldType, prop.enum),
-        enum: prop.enum,
-        minimum: prop.minimum,
-        maximum: prop.maximum,
-        pattern: prop.pattern,
-      });
+  const updateFieldValue = (name: string, value: unknown) => {
+    setValues((prev) => ({ ...prev, [name]: value }));
+    // Clear a shown error as soon as the user edits the field; it is
+    // re-evaluated on the next Accept.
+    setErrors((prev) => {
+      if (!(name in prev)) return prev;
+      const next = { ...prev };
+      delete next[name];
+      return next;
     });
-
-    setFields(formFields);
   };
 
-  const getDefaultValue = (type: string, enumValues?: string[]) => {
-    switch (type) {
-      case "enum":
-        return enumValues?.[0] || "";
-      case "string":
-        return "";
-      case "number":
-      case "integer":
-        return "";
-      case "boolean":
-        return false;
-      case "array":
-        return [];
-      case "object":
-        return {};
-      default:
-        return "";
-    }
-  };
-
-  const updateFieldValue = (fieldName: string, value: any) => {
-    setFields((prev) =>
-      prev.map((field) =>
-        field.name === fieldName ? { ...field, value } : field,
-      ),
+  const toggleMultiValue = (
+    field: ElicitationField,
+    option: string,
+    checked: boolean
+  ) => {
+    const current = Array.isArray(values[field.name])
+      ? (values[field.name] as string[])
+      : [];
+    updateFieldValue(
+      field.name,
+      checked
+        ? current.includes(option)
+          ? current
+          : [...current, option]
+        : current.filter((v) => v !== option)
     );
   };
 
-  const buildParameters = (): Record<string, any> => {
-    const params: Record<string, any> = {};
-    fields.forEach((field) => {
-      if (
-        field.value !== "" &&
-        field.value !== null &&
-        field.value !== undefined
-      ) {
-        let processedValue = field.value;
-
-        if (field.type === "number" || field.type === "integer") {
-          processedValue = Number(field.value);
-        } else if (field.type === "boolean") {
-          processedValue = Boolean(field.value);
-        } else if (field.type === "array" || field.type === "object") {
-          try {
-            processedValue = JSON.parse(field.value);
-          } catch {
-            processedValue = field.value;
-          }
-        }
-
-        params[field.name] = processedValue;
-      }
-    });
-    return params;
-  };
-
   const handleResponse = async (action: "accept" | "decline" | "cancel") => {
-    if (action === "accept") {
-      // Validate required fields
-      const missingFields = fields.filter(
-        (field) => field.required && (!field.value || field.value === ""),
-      );
-
-      if (missingFields.length > 0) {
-        // You could show validation errors here
-        return;
-      }
-
-      const parameters = buildParameters();
-      await onResponse(action, parameters);
-    } else {
+    if (action !== "accept") {
       await onResponse(action);
+      return;
     }
+
+    const nextErrors: Record<string, string> = {};
+    for (const field of fields) {
+      const error = validateField(field, values[field.name]);
+      if (error) nextErrors[field.name] = error;
+    }
+
+    if (Object.keys(nextErrors).length > 0) {
+      // Block submit and surface the errors inline.
+      setErrors(nextErrors);
+      return;
+    }
+
+    setErrors({});
+    await onResponse(action, buildElicitationContent(fields, values));
   };
 
-  const renderField = (field: FormField) => {
-    if (field.type === "enum") {
-      return (
-        <Select
-          value={field.value}
-          onValueChange={(value) => updateFieldValue(field.name, value)}
-        >
-          <SelectTrigger className="w-full">
-            <SelectValue placeholder="Select an option" />
-          </SelectTrigger>
-          <SelectContent>
-            {field.enum?.map((option) => (
-              <SelectItem key={option} value={option}>
-                {option}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      );
-    } else if (field.type === "boolean") {
-      return (
-        <div className="flex items-center space-x-3 py-2">
-          <input
-            type="checkbox"
-            checked={field.value}
-            onChange={(e) => updateFieldValue(field.name, e.target.checked)}
-            className="w-4 h-4 text-primary bg-background border-border rounded focus:ring-ring focus:ring-2"
+  const renderField = (field: ElicitationField) => {
+    const inputId = `elicitation-field-${field.name}`;
+    const errorId = `${inputId}-error`;
+    const invalid = Boolean(errors[field.name]);
+    const describedBy = invalid ? errorId : undefined;
+
+    switch (field.kind) {
+      case "enum":
+        return (
+          <Select
+            value={(values[field.name] as string) ?? ""}
+            onValueChange={(value) => updateFieldValue(field.name, value)}
+          >
+            <SelectTrigger
+              id={inputId}
+              className="w-full"
+              aria-invalid={invalid}
+              aria-describedby={describedBy}
+            >
+              <SelectValue placeholder="Select an option" />
+            </SelectTrigger>
+            <SelectContent>
+              {field.options?.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        );
+
+      case "multi-enum": {
+        const selected = Array.isArray(values[field.name])
+          ? (values[field.name] as string[])
+          : [];
+        return (
+          <div
+            role="group"
+            aria-label={fieldLabel(field)}
+            aria-describedby={describedBy}
+            className="space-y-2 py-1"
+          >
+            {field.options?.map((option) => {
+              const optionId = `${inputId}-${option.value}`;
+              return (
+                <div key={option.value} className="flex items-center gap-2">
+                  <Checkbox
+                    id={optionId}
+                    checked={selected.includes(option.value)}
+                    onCheckedChange={(checked) =>
+                      toggleMultiValue(field, option.value, checked === true)
+                    }
+                  />
+                  <Label htmlFor={optionId} className="text-sm font-normal">
+                    {option.label}
+                  </Label>
+                </div>
+              );
+            })}
+          </div>
+        );
+      }
+
+      case "boolean":
+        return (
+          <div className="flex items-center space-x-3 py-2">
+            <input
+              id={inputId}
+              type="checkbox"
+              checked={Boolean(values[field.name])}
+              onChange={(e) => updateFieldValue(field.name, e.target.checked)}
+              className="w-4 h-4 text-primary bg-background border-border rounded focus:ring-ring focus:ring-2"
+            />
+            <span className="text-sm">
+              {values[field.name] ? "Enabled" : "Disabled"}
+            </span>
+          </div>
+        );
+
+      case "json":
+        return (
+          <Textarea
+            id={inputId}
+            value={String(values[field.name] ?? "")}
+            onChange={(e) => updateFieldValue(field.name, e.target.value)}
+            placeholder="Enter value as JSON"
+            aria-invalid={invalid}
+            aria-describedby={describedBy}
+            className="font-mono text-sm h-20 resize-none"
           />
-          <span className="text-sm">
-            {field.value ? "Enabled" : "Disabled"}
-          </span>
-        </div>
-      );
-    } else if (field.type === "array" || field.type === "object") {
-      return (
-        <Textarea
-          value={
-            typeof field.value === "string"
-              ? field.value
-              : JSON.stringify(field.value, null, 2)
-          }
-          onChange={(e) => updateFieldValue(field.name, e.target.value)}
-          placeholder={`Enter ${field.type} as JSON`}
-          className="font-mono text-sm h-20 resize-none"
-        />
-      );
-    } else {
-      return (
-        <Input
-          type={
-            field.type === "number" || field.type === "integer"
-              ? "number"
-              : "text"
-          }
-          value={field.value}
-          onChange={(e) => updateFieldValue(field.name, e.target.value)}
-          placeholder={`Enter ${field.name}`}
-          className="text-sm"
-        />
-      );
+        );
+
+      case "number":
+      case "integer":
+        return (
+          <Input
+            id={inputId}
+            type="number"
+            step={field.kind === "integer" ? 1 : "any"}
+            value={String(values[field.name] ?? "")}
+            onChange={(e) => updateFieldValue(field.name, e.target.value)}
+            placeholder={`Enter ${fieldLabel(field)}`}
+            aria-invalid={invalid}
+            aria-describedby={describedBy}
+            className="text-sm"
+          />
+        );
+
+      case "string":
+      default:
+        return (
+          <Input
+            id={inputId}
+            type={(field.format && FORMAT_INPUT_TYPES[field.format]) ?? "text"}
+            value={String(values[field.name] ?? "")}
+            onChange={(e) => updateFieldValue(field.name, e.target.value)}
+            placeholder={`Enter ${fieldLabel(field)}`}
+            aria-invalid={invalid}
+            aria-describedby={describedBy}
+            className="text-sm"
+          />
+        );
     }
   };
 
@@ -230,7 +257,7 @@ export function ElicitationDialog({
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2 text-sm font-medium">
             <MessageSquare className="h-3 w-3" />
-            Elicitation Request
+            <RequestingServer elicitationRequest={elicitationRequest} />
           </DialogTitle>
           <DialogDescription className="text-md font-bold">
             {elicitationRequest?.message}
@@ -238,32 +265,57 @@ export function ElicitationDialog({
         </DialogHeader>
 
         <div className="space-y-6 py-4">
-          {fields.map((field) => (
-            <div key={field.name}>
-              <div className="flex items-start justify-between mb-2">
-                <div className="space-y-1">
-                  <div className="flex items-center gap-2">
-                    <Label className="text-sm font-medium">{field.name}</Label>
-                    {field.required && (
-                      <div
-                        className="w-1.5 h-1.5 bg-red-500 rounded-full"
-                        title="Required field"
-                      />
+          {fields.map((field) => {
+            const label = fieldLabel(field);
+            const showRawKey = Boolean(
+              field.title && field.title !== field.name
+            );
+            const error = errors[field.name];
+            return (
+              <div key={field.name}>
+                <div className="flex items-start justify-between mb-2">
+                  <div className="space-y-1">
+                    <div className="flex items-center gap-2">
+                      <Label
+                        htmlFor={`elicitation-field-${field.name}`}
+                        className="text-sm font-medium"
+                      >
+                        {label}
+                      </Label>
+                      {showRawKey && (
+                        <span className="text-xs font-mono text-muted-foreground">
+                          {field.name}
+                        </span>
+                      )}
+                      {field.required && (
+                        <div
+                          className="w-1.5 h-1.5 bg-red-500 rounded-full"
+                          title="Required field"
+                        />
+                      )}
+                    </div>
+                    {field.description && (
+                      <p className="text-xs text-muted-foreground">
+                        {field.description}
+                      </p>
                     )}
                   </div>
-                  {field.description && (
-                    <p className="text-xs text-muted-foreground">
-                      {field.description}
-                    </p>
-                  )}
+                  <Badge variant="secondary" className="text-xs">
+                    {field.kind}
+                  </Badge>
                 </div>
-                <Badge variant="secondary" className="text-xs">
-                  {field.type}
-                </Badge>
+                {renderField(field)}
+                {error && (
+                  <p
+                    id={`elicitation-field-${field.name}-error`}
+                    className="text-destructive text-xs mt-1"
+                  >
+                    {error}
+                  </p>
+                )}
               </div>
-              {renderField(field)}
-            </div>
-          ))}
+            );
+          })}
         </div>
 
         <DialogFooter className="flex gap-2">
@@ -293,5 +345,37 @@ export function ElicitationDialog({
         </DialogFooter>
       </DialogContent>
     </Dialog>
+  );
+}
+
+/**
+ * Spec MUST: "clients MUST provide UI that makes it clear which server is
+ * requesting information".
+ *
+ * `serverName` is an untrusted, server-supplied display label; `serverId` is
+ * the immutable local identifier and therefore the trusted anchor — it stays
+ * visible whenever we have it, even when a prettier name exists. Callers that
+ * supply neither (today's local-mode surfaces) get the generic header.
+ */
+function RequestingServer({
+  elicitationRequest,
+}: {
+  elicitationRequest: DialogElicitation | null;
+}) {
+  const { serverId, serverName } = elicitationRequest ?? {};
+  const displayName = serverName ?? serverId;
+
+  if (!displayName) return <>Elicitation Request</>;
+
+  return (
+    <span className="flex items-center gap-1.5">
+      <strong className="font-semibold">{displayName}</strong>
+      {serverId && serverId !== displayName && (
+        <span className="text-xs font-mono font-normal text-muted-foreground">
+          {serverId}
+        </span>
+      )}
+      <span className="font-normal">is requesting information</span>
+    </span>
   );
 }

--- a/mcpjam-inspector/client/src/components/ElicitationDialog.tsx
+++ b/mcpjam-inspector/client/src/components/ElicitationDialog.tsx
@@ -57,6 +57,17 @@ const FORMAT_INPUT_TYPES: Record<string, string> = {
  * description and message below is rendered as plain text — no anchors, no
  * linkification, anywhere in this component.
  */
+/**
+ * Every map keyed by a SERVER-chosen field name must start life without a
+ * prototype. `{}` inherits from Object.prototype, so a field legitimately named
+ * `__proto__` makes `errors["__proto__"]` resolve to Object.prototype itself —
+ * truthy, so the dialog marks the field invalid and then hands that object to
+ * React to render, which throws. Same trap for `values`.
+ */
+function emptyFieldMap<T>(): Record<string, T> {
+  return Object.create(null) as Record<string, T>;
+}
+
 export function ElicitationDialog({
   elicitationRequest,
   onResponse,
@@ -75,32 +86,27 @@ export function ElicitationDialog({
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [requestId]
   );
-  const [values, setValues] = useState<Record<string, unknown>>({});
-  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [values, setValues] = useState<Record<string, unknown>>(emptyFieldMap);
+  const [errors, setErrors] = useState<Record<string, string>>(emptyFieldMap);
 
   // Reset form state (and prefill schema defaults) when a DIFFERENT request
   // arrives — `fields` is now stable for the life of one request, so this no
   // longer fires on unrelated rerenders.
   useEffect(() => {
     setValues(initialFormValues(fields));
-    setErrors({});
+    setErrors(emptyFieldMap());
   }, [fields]);
 
   const updateFieldValue = (name: string, value: unknown) => {
     // Object.assign onto a null-prototype base, not a spread literal: field
     // names are server-chosen and a literal `{...prev, __proto__: v}` would
     // mutate the prototype instead of storing the answer.
-    setValues((prev) =>
-      Object.assign(Object.create(null), prev, { [name]: value })
-    );
+    setValues((prev) => Object.assign(emptyFieldMap(), prev, { [name]: value }));
     // Clear a shown error as soon as the user edits the field; it is
     // re-evaluated on the next Accept.
     setErrors((prev) => {
       if (!Object.prototype.hasOwnProperty.call(prev, name)) return prev;
-      const next: Record<string, string> = Object.assign(
-        Object.create(null),
-        prev
-      );
+      const next: Record<string, string> = Object.assign(emptyFieldMap(), prev);
       delete next[name];
       return next;
     });
@@ -133,7 +139,7 @@ export function ElicitationDialog({
     // Null-prototype: a field named `__proto__` would otherwise write to the
     // prototype, leaving Object.keys empty — the error would vanish and the
     // submit would go through unvalidated.
-    const nextErrors: Record<string, string> = Object.create(null);
+    const nextErrors: Record<string, string> = emptyFieldMap();
     for (const field of fields) {
       const error = validateField(field, values[field.name]);
       if (error) nextErrors[field.name] = error;
@@ -145,7 +151,7 @@ export function ElicitationDialog({
       return;
     }
 
-    setErrors({});
+    setErrors(emptyFieldMap());
     await onResponse(action, buildElicitationContent(fields, values));
   };
 

--- a/mcpjam-inspector/client/src/components/ElicitationDialog.tsx
+++ b/mcpjam-inspector/client/src/components/ElicitationDialog.tsx
@@ -399,7 +399,7 @@ function RequestingServer({
   elicitationRequest: DialogElicitation | null;
 }) {
   const { serverId, serverName } = elicitationRequest ?? {};
-  const displayName = serverName ?? serverId;
+  const displayName = serverName?.trim() || serverId;
 
   if (!displayName) return <>Elicitation Request</>;
 

--- a/mcpjam-inspector/client/src/components/ElicitationDialog.tsx
+++ b/mcpjam-inspector/client/src/components/ElicitationDialog.tsx
@@ -27,6 +27,7 @@ import {
   fieldLabel,
   initialFormValues,
   parseElicitationSchema,
+  patternHint,
   validateField,
   type ElicitationField,
 } from "./elicitation/schema";
@@ -319,6 +320,13 @@ export function ElicitationDialog({
                     {field.description && (
                       <p className="text-xs text-muted-foreground">
                         {field.description}
+                      </p>
+                    )}
+                    {/* The pattern is shown, never executed — see the note on
+                        `patternHint`. Plain text: it is server-supplied. */}
+                    {patternHint(field) && (
+                      <p className="font-mono text-[11px] text-muted-foreground">
+                        {patternHint(field)}
                       </p>
                     )}
                   </div>

--- a/mcpjam-inspector/client/src/components/ElicitationDialog.tsx
+++ b/mcpjam-inspector/client/src/components/ElicitationDialog.tsx
@@ -61,26 +61,45 @@ export function ElicitationDialog({
   onResponse,
   loading = false,
 }: ElicitationDialogProps) {
+  const requestId = elicitationRequest?.requestId;
+  const schema = elicitationRequest?.schema;
   const fields = useMemo(
-    () => parseElicitationSchema(elicitationRequest?.schema),
-    [elicitationRequest]
+    () => parseElicitationSchema(schema),
+    // Keyed on requestId, NOT the request object. Callers build that wrapper
+    // inline, so it is a fresh reference on every parent render — and chat
+    // surfaces rerender constantly while a turn streams. Depending on it made
+    // `fields` new each time, which retriggered the reset effect below and
+    // wiped whatever the user had typed. An elicitation is immutable: same id,
+    // same schema.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [requestId]
   );
   const [values, setValues] = useState<Record<string, unknown>>({});
   const [errors, setErrors] = useState<Record<string, string>>({});
 
-  // Reset form state (and prefill schema defaults) whenever the request changes.
+  // Reset form state (and prefill schema defaults) when a DIFFERENT request
+  // arrives — `fields` is now stable for the life of one request, so this no
+  // longer fires on unrelated rerenders.
   useEffect(() => {
     setValues(initialFormValues(fields));
     setErrors({});
   }, [fields]);
 
   const updateFieldValue = (name: string, value: unknown) => {
-    setValues((prev) => ({ ...prev, [name]: value }));
+    // Object.assign onto a null-prototype base, not a spread literal: field
+    // names are server-chosen and a literal `{...prev, __proto__: v}` would
+    // mutate the prototype instead of storing the answer.
+    setValues((prev) =>
+      Object.assign(Object.create(null), prev, { [name]: value })
+    );
     // Clear a shown error as soon as the user edits the field; it is
     // re-evaluated on the next Accept.
     setErrors((prev) => {
-      if (!(name in prev)) return prev;
-      const next = { ...prev };
+      if (!Object.prototype.hasOwnProperty.call(prev, name)) return prev;
+      const next: Record<string, string> = Object.assign(
+        Object.create(null),
+        prev
+      );
       delete next[name];
       return next;
     });
@@ -110,7 +129,10 @@ export function ElicitationDialog({
       return;
     }
 
-    const nextErrors: Record<string, string> = {};
+    // Null-prototype: a field named `__proto__` would otherwise write to the
+    // prototype, leaving Object.keys empty — the error would vanish and the
+    // submit would go through unvalidated.
+    const nextErrors: Record<string, string> = Object.create(null);
     for (const field of fields) {
       const error = validateField(field, values[field.name]);
       if (error) nextErrors[field.name] = error;

--- a/mcpjam-inspector/client/src/components/ToolsTab.tsx
+++ b/mcpjam-inspector/client/src/components/ToolsTab.tsx
@@ -89,6 +89,16 @@ export type DialogElicitation = {
   message: string;
   schema?: Record<string, unknown>;
   timestamp: string;
+  /**
+   * Identity of the server requesting information (MCP spec MUST: the client
+   * must make it clear which server is asking). Optional and additive: local
+   * surfaces that don't yet plumb it through fall back to a generic header.
+   *
+   * `serverId` is the immutable, locally-assigned identifier — the trusted
+   * anchor. `serverName` is a server-supplied display label and is NOT trusted.
+   */
+  serverId?: string;
+  serverName?: string;
 };
 
 function normalizeElicitationContent(

--- a/mcpjam-inspector/client/src/components/__tests__/ElicitationDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ElicitationDialog.test.tsx
@@ -1,0 +1,439 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { ElicitationDialog } from "../ElicitationDialog";
+import type { DialogElicitation } from "../ToolsTab";
+
+const onResponse = vi.fn(async () => {});
+
+const request = (over: Partial<DialogElicitation> = {}): DialogElicitation => ({
+  requestId: "req-1",
+  message: "Please provide your details",
+  timestamp: "2024-01-01T00:00:00.000Z",
+  ...over,
+});
+
+const accept = () =>
+  fireEvent.click(screen.getByRole("button", { name: /accept/i }));
+
+beforeEach(() => {
+  onResponse.mockClear();
+});
+
+describe("ElicitationDialog", () => {
+  it("renders nothing when there is no request", () => {
+    render(
+      <ElicitationDialog elicitationRequest={null} onResponse={onResponse} />
+    );
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("shows the message and the three actions", () => {
+    render(
+      <ElicitationDialog
+        elicitationRequest={request()}
+        onResponse={onResponse}
+      />
+    );
+    expect(screen.getByText("Please provide your details")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /decline/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /accept/i })).toBeTruthy();
+  });
+
+  describe("labels", () => {
+    it("prefers the schema title and shows the raw key as secondary text", () => {
+      render(
+        <ElicitationDialog
+          elicitationRequest={request({
+            schema: {
+              properties: {
+                user_email: { type: "string", title: "Email address" },
+              },
+            },
+          })}
+          onResponse={onResponse}
+        />
+      );
+      expect(screen.getByText("Email address")).toBeTruthy();
+      // The raw key stays visible — it is what the server keys on.
+      expect(screen.getByText("user_email")).toBeTruthy();
+    });
+
+    it("does not duplicate the key when there is no title", () => {
+      render(
+        <ElicitationDialog
+          elicitationRequest={request({
+            schema: { properties: { nickname: { type: "string" } } },
+          })}
+          onResponse={onResponse}
+        />
+      );
+      expect(screen.getAllByText("nickname")).toHaveLength(1);
+    });
+  });
+
+  it("prefills values from schema defaults", () => {
+    render(
+      <ElicitationDialog
+        elicitationRequest={request({
+          schema: {
+            properties: {
+              name: { type: "string", default: "ada" },
+              age: { type: "integer", default: 36 },
+              subscribed: { type: "boolean", default: true },
+            },
+          },
+        })}
+        onResponse={onResponse}
+      />
+    );
+
+    expect((screen.getByLabelText("name") as HTMLInputElement).value).toBe(
+      "ada"
+    );
+    expect((screen.getByLabelText("age") as HTMLInputElement).value).toBe("36");
+    expect(
+      (screen.getByLabelText("subscribed") as HTMLInputElement).checked
+    ).toBe(true);
+  });
+
+  it("maps formats to input types", () => {
+    render(
+      <ElicitationDialog
+        elicitationRequest={request({
+          schema: {
+            properties: {
+              mail: { type: "string", format: "email" },
+              site: { type: "string", format: "uri" },
+              day: { type: "string", format: "date" },
+              moment: { type: "string", format: "date-time" },
+              plain: { type: "string" },
+            },
+          },
+        })}
+        onResponse={onResponse}
+      />
+    );
+    expect(screen.getByLabelText("mail").getAttribute("type")).toBe("email");
+    expect(screen.getByLabelText("site").getAttribute("type")).toBe("url");
+    expect(screen.getByLabelText("day").getAttribute("type")).toBe("date");
+    expect(screen.getByLabelText("moment").getAttribute("type")).toBe(
+      "datetime-local"
+    );
+    expect(screen.getByLabelText("plain").getAttribute("type")).toBe("text");
+  });
+
+  it("renders a multi-select enum as a checkbox list and sends the selection", async () => {
+    render(
+      <ElicitationDialog
+        elicitationRequest={request({
+          schema: {
+            properties: {
+              tags: {
+                type: "array",
+                items: {
+                  anyOf: [
+                    { const: "x", title: "Ex" },
+                    { const: "y", title: "Why" },
+                  ],
+                },
+              },
+            },
+          },
+        })}
+        onResponse={onResponse}
+      />
+    );
+
+    const group = screen.getByRole("group", { name: "tags" });
+    expect(group).toBeTruthy();
+    // A real checkbox list, not a JSON textarea.
+    expect(screen.queryByRole("textbox")).toBeNull();
+    expect(screen.getByRole("checkbox", { name: "Ex" })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "Ex" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "Why" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "Ex" }));
+    accept();
+
+    await waitFor(() =>
+      expect(onResponse).toHaveBeenCalledWith("accept", { tags: ["y"] })
+    );
+  });
+
+  it("honors minItems on a multi-select enum", async () => {
+    render(
+      <ElicitationDialog
+        elicitationRequest={request({
+          schema: {
+            properties: {
+              tags: {
+                type: "array",
+                items: { enum: ["x", "y"] },
+                minItems: 2,
+              },
+            },
+          },
+        })}
+        onResponse={onResponse}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "x" }));
+    accept();
+
+    expect(await screen.findByText("Select at least 2 options")).toBeTruthy();
+    expect(onResponse).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "y" }));
+    accept();
+    await waitFor(() =>
+      expect(onResponse).toHaveBeenCalledWith("accept", { tags: ["x", "y"] })
+    );
+  });
+
+  it("uses a JSON textarea only for the nested (spec-forbidden) fallback", () => {
+    render(
+      <ElicitationDialog
+        elicitationRequest={request({
+          schema: {
+            properties: { blob: { type: "object", title: "Blob" } },
+          },
+        })}
+        onResponse={onResponse}
+      />
+    );
+    expect(screen.getByLabelText("Blob").tagName).toBe("TEXTAREA");
+    expect(screen.getByText("json")).toBeTruthy();
+  });
+
+  describe("inline validation", () => {
+    it("blocks Accept on a missing required field and shows the error", async () => {
+      render(
+        <ElicitationDialog
+          elicitationRequest={request({
+            schema: {
+              required: ["name"],
+              properties: { name: { type: "string", title: "Name" } },
+            },
+          })}
+          onResponse={onResponse}
+        />
+      );
+
+      accept();
+
+      expect(await screen.findByText("Name is required")).toBeTruthy();
+      expect(onResponse).not.toHaveBeenCalled();
+
+      fireEvent.change(screen.getByLabelText("Name"), {
+        target: { value: "ada" },
+      });
+      // The error clears as soon as the user edits the field.
+      expect(screen.queryByText("Name is required")).toBeNull();
+
+      accept();
+      await waitFor(() =>
+        expect(onResponse).toHaveBeenCalledWith("accept", { name: "ada" })
+      );
+    });
+
+    it("blocks Accept on constraint violations", async () => {
+      render(
+        <ElicitationDialog
+          elicitationRequest={request({
+            schema: {
+              properties: {
+                age: { type: "integer", minimum: 18 },
+                mail: { type: "string", format: "email" },
+              },
+            },
+          })}
+          onResponse={onResponse}
+        />
+      );
+
+      fireEvent.change(screen.getByLabelText("age"), {
+        target: { value: "12" },
+      });
+      fireEvent.change(screen.getByLabelText("mail"), {
+        target: { value: "nope" },
+      });
+      accept();
+
+      expect(await screen.findByText("age must be at least 18")).toBeTruthy();
+      expect(
+        screen.getByText("mail must be a valid email address")
+      ).toBeTruthy();
+      expect(onResponse).not.toHaveBeenCalled();
+    });
+
+    it("renders errors with the destructive text style", async () => {
+      render(
+        <ElicitationDialog
+          elicitationRequest={request({
+            schema: {
+              required: ["name"],
+              properties: { name: { type: "string" } },
+            },
+          })}
+          onResponse={onResponse}
+        />
+      );
+      accept();
+      const error = await screen.findByText("name is required");
+      expect(error.className).toContain("text-destructive");
+      expect(error.className).toContain("text-xs");
+    });
+  });
+
+  describe("actions", () => {
+    it("accepts with coerced content", async () => {
+      render(
+        <ElicitationDialog
+          elicitationRequest={request({
+            schema: {
+              properties: {
+                name: { type: "string" },
+                age: { type: "integer" },
+                subscribed: { type: "boolean" },
+                optional: { type: "string" },
+              },
+            },
+          })}
+          onResponse={onResponse}
+        />
+      );
+
+      fireEvent.change(screen.getByLabelText("name"), {
+        target: { value: "ada" },
+      });
+      fireEvent.change(screen.getByLabelText("age"), {
+        target: { value: "36" },
+      });
+      fireEvent.click(screen.getByLabelText("subscribed"));
+      accept();
+
+      await waitFor(() =>
+        expect(onResponse).toHaveBeenCalledWith("accept", {
+          name: "ada",
+          age: 36,
+          subscribed: true,
+        })
+      );
+    });
+
+    it("declines and cancels without parameters", async () => {
+      render(
+        <ElicitationDialog
+          elicitationRequest={request({
+            schema: {
+              required: ["name"],
+              properties: { name: { type: "string" } },
+            },
+          })}
+          onResponse={onResponse}
+        />
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /decline/i }));
+      await waitFor(() => expect(onResponse).toHaveBeenCalledWith("decline"));
+
+      fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+      await waitFor(() => expect(onResponse).toHaveBeenCalledWith("cancel"));
+
+      // Validation never blocks decline/cancel.
+      expect(screen.queryByText("name is required")).toBeNull();
+    });
+
+    it("disables every action while loading", () => {
+      render(
+        <ElicitationDialog
+          elicitationRequest={request()}
+          onResponse={onResponse}
+          loading
+        />
+      );
+      for (const name of [/cancel/i, /decline/i, /accept/i]) {
+        expect(
+          (screen.getByRole("button", { name }) as HTMLButtonElement).disabled
+        ).toBe(true);
+      }
+    });
+  });
+
+  describe("requesting-server identity (spec MUST)", () => {
+    it("shows the server name with the immutable serverId alongside it", () => {
+      // NOTE: the dialog content is portalled, so it lives on `baseElement`,
+      // not on the render `container`.
+      const { baseElement } = render(
+        <ElicitationDialog
+          elicitationRequest={request({
+            serverId: "srv_abc123",
+            serverName: "Acme Weather",
+          })}
+          onResponse={onResponse}
+        />
+      );
+      expect(screen.getByText("Acme Weather")).toBeTruthy();
+      // The trusted anchor stays visible even when a prettier name exists.
+      expect(screen.getByText("srv_abc123")).toBeTruthy();
+      expect(baseElement.textContent).toContain("is requesting information");
+    });
+
+    it("falls back to the serverId alone when there is no name", () => {
+      const { baseElement } = render(
+        <ElicitationDialog
+          elicitationRequest={request({ serverId: "srv_abc123" })}
+          onResponse={onResponse}
+        />
+      );
+      expect(screen.getAllByText("srv_abc123")).toHaveLength(1);
+      expect(baseElement.textContent).toContain("is requesting information");
+    });
+
+    it("uses the generic header when the caller supplies no identity", () => {
+      const { baseElement } = render(
+        <ElicitationDialog
+          elicitationRequest={request()}
+          onResponse={onResponse}
+        />
+      );
+      expect(screen.getByText("Elicitation Request")).toBeTruthy();
+      expect(baseElement.textContent).toContain("Elicitation Request");
+      expect(baseElement.textContent).not.toContain(
+        "is requesting information"
+      );
+    });
+  });
+
+  it("never renders clickable URLs (spec MUST)", () => {
+    const { baseElement } = render(
+      <ElicitationDialog
+        elicitationRequest={request({
+          message: "Visit https://evil.example.com to continue",
+          serverName: "https://evil.example.com",
+          serverId: "srv_1",
+          schema: {
+            properties: {
+              site: {
+                type: "string",
+                title: "https://evil.example.com",
+                description: "See https://evil.example.com/docs",
+                default: "https://evil.example.com/prefilled",
+                format: "uri",
+              },
+            },
+          },
+        })}
+        onResponse={onResponse}
+      />
+    );
+
+    // Guard the assertion itself: the portalled dialog really is in this tree.
+    expect(baseElement.textContent).toContain("is requesting information");
+    expect(baseElement.querySelectorAll("a")).toHaveLength(0);
+    // The URL text is still shown — just never as a link.
+    expect(screen.getByText("See https://evil.example.com/docs")).toBeTruthy();
+  });
+});

--- a/mcpjam-inspector/client/src/components/__tests__/ElicitationDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ElicitationDialog.test.tsx
@@ -505,4 +505,53 @@ describe("ElicitationDialog", () => {
 
     expect(screen.getByLabelText(/Branch/i)).toHaveValue("");
   });
+
+  it("renders a __proto__ field without crashing", () => {
+    // `errors` started as `{}`, so errors["__proto__"] resolved to
+    // Object.prototype — truthy — and the dialog handed that object to React to
+    // render as the error message. JSON.parse is how a real schema arrives and
+    // is the only way to get a genuine own `__proto__` key.
+    const schema = JSON.parse(
+      '{"type":"object","properties":{"__proto__":{"type":"string","title":"Proto"}},"required":["__proto__"]}',
+    );
+
+    expect(() =>
+      render(
+        <ElicitationDialog
+          elicitationRequest={{
+            requestId: "req-proto",
+            message: "Fill it in",
+            timestamp: new Date().toISOString(),
+            schema,
+          }}
+          onResponse={vi.fn()}
+        />,
+      ),
+    ).not.toThrow();
+
+    expect(screen.getByLabelText(/Proto/i)).toBeInTheDocument();
+  });
+
+  it("blocks submit on a __proto__ field's validation error instead of crashing", () => {
+    const schema = JSON.parse(
+      '{"type":"object","properties":{"__proto__":{"type":"string","title":"Proto"}},"required":["__proto__"]}',
+    );
+    const onResponse = vi.fn();
+    render(
+      <ElicitationDialog
+        elicitationRequest={{
+          requestId: "req-proto-2",
+          message: "Fill it in",
+          timestamp: new Date().toISOString(),
+          schema,
+        }}
+        onResponse={onResponse}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /accept/i }));
+    // Required and empty → blocked, and the error renders as a string.
+    expect(onResponse).not.toHaveBeenCalled();
+    expect(screen.getByText(/is required/i)).toBeInTheDocument();
+  });
 });

--- a/mcpjam-inspector/client/src/components/__tests__/ElicitationDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ElicitationDialog.test.tsx
@@ -392,6 +392,20 @@ describe("ElicitationDialog", () => {
       expect(baseElement.textContent).toContain("is requesting information");
     });
 
+    it("falls back to the serverId when the name is blank", () => {
+      const { baseElement } = render(
+        <ElicitationDialog
+          elicitationRequest={request({
+            serverId: "srv_abc123",
+            serverName: "   ",
+          })}
+          onResponse={onResponse}
+        />
+      );
+      expect(screen.getAllByText("srv_abc123")).toHaveLength(1);
+      expect(baseElement.textContent).toContain("is requesting information");
+    });
+
     it("uses the generic header when the caller supplies no identity", () => {
       const { baseElement } = render(
         <ElicitationDialog

--- a/mcpjam-inspector/client/src/components/__tests__/ElicitationDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ElicitationDialog.test.tsx
@@ -436,4 +436,73 @@ describe("ElicitationDialog", () => {
     // The URL text is still shown — just never as a link.
     expect(screen.getByText("See https://evil.example.com/docs")).toBeTruthy();
   });
+
+  it("keeps typed input when the parent rerenders with an equivalent request", () => {
+    // The P1: chat surfaces build the request wrapper inline and rerender on
+    // every streamed token. Keying the schema parse on the object identity made
+    // `fields` new each render, retriggering the reset effect and erasing the
+    // user's answer mid-typing.
+    const makeRequest = () => ({
+      requestId: "req-1",
+      message: "Pick a branch",
+      timestamp: new Date().toISOString(),
+      // Fresh object each call — exactly what the inline wrapper does.
+      schema: {
+        type: "object",
+        properties: { branch: { type: "string", title: "Branch" } },
+      },
+    });
+
+    const { rerender } = render(
+      <ElicitationDialog
+        elicitationRequest={makeRequest()}
+        onResponse={vi.fn()}
+      />,
+    );
+
+    const input = screen.getByLabelText(/Branch/i);
+    fireEvent.change(input, { target: { value: "main" } });
+    expect(input).toHaveValue("main");
+
+    rerender(
+      <ElicitationDialog
+        elicitationRequest={makeRequest()}
+        onResponse={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByLabelText(/Branch/i)).toHaveValue("main");
+  });
+
+  it("still resets when a genuinely different request arrives", () => {
+    // The flip side: the reset must not be so sticky that a new elicitation
+    // inherits the previous answer.
+    const base = {
+      message: "Pick a branch",
+      timestamp: new Date().toISOString(),
+      schema: {
+        type: "object",
+        properties: { branch: { type: "string", title: "Branch" } },
+      },
+    };
+
+    const { rerender } = render(
+      <ElicitationDialog
+        elicitationRequest={{ ...base, requestId: "req-1" }}
+        onResponse={vi.fn()}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText(/Branch/i), {
+      target: { value: "main" },
+    });
+
+    rerender(
+      <ElicitationDialog
+        elicitationRequest={{ ...base, requestId: "req-2" }}
+        onResponse={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByLabelText(/Branch/i)).toHaveValue("");
+  });
 });

--- a/mcpjam-inspector/client/src/components/elicitation/__tests__/schema.test.ts
+++ b/mcpjam-inspector/client/src/components/elicitation/__tests__/schema.test.ts
@@ -345,7 +345,9 @@ describe("initialFormValues", () => {
       blank: "",
       age: "36",
       subscribed: true,
-      off: false,
+      // Optional, no schema default → UNANSWERED, not `false`. `false` would be
+      // an answer the user never gave; see "unanswered vs answered" below.
+      off: undefined,
       color: "g",
       tags: ["y"],
       blob: JSON.stringify({ a: 1 }, null, 2),
@@ -542,5 +544,81 @@ describe("__proto__ field names", () => {
 
   it("initialFormValues returns a null-prototype map", () => {
     expect(Object.getPrototypeOf(initialFormValues([]))).toBeNull();
+  });
+});
+
+
+describe("unanswered vs answered", () => {
+  const boolSchema = (required: boolean) => ({
+    type: "object",
+    properties: { subscribe: { type: "boolean", title: "Subscribe" } },
+    ...(required ? { required: ["subscribe"] } : {}),
+  });
+
+  it("omits an optional boolean the user never touched", () => {
+    // Every boolean used to initialize to `false` and always serialize, so an
+    // untouched optional checkbox told the server "no" — an answer the user
+    // never gave. Absent and false are different claims.
+    const fields = parseElicitationSchema(boolSchema(false));
+    const values = initialFormValues(fields);
+
+    expect(values.subscribe).toBeUndefined();
+    expect(buildElicitationContent(fields, values)).toEqual({});
+  });
+
+  it("sends false once the user actually answers false", () => {
+    // Toggling on then off is a real answer and must reach the server.
+    const fields = parseElicitationSchema(boolSchema(false));
+    const values = { ...initialFormValues(fields), subscribe: false };
+
+    expect(buildElicitationContent(fields, values)).toEqual({ subscribe: false });
+  });
+
+  it("still sends a required boolean, and honors a schema default", () => {
+    // Required means the server wants a value; unchecked is a legitimate one.
+    const requiredFields = parseElicitationSchema(boolSchema(true));
+    expect(
+      buildElicitationContent(requiredFields, initialFormValues(requiredFields)),
+    ).toEqual({ subscribe: false });
+
+    const defaulted = parseElicitationSchema({
+      type: "object",
+      properties: { subscribe: { type: "boolean", default: true } },
+    });
+    expect(
+      buildElicitationContent(defaulted, initialFormValues(defaulted)),
+    ).toEqual({ subscribe: true });
+  });
+
+  const multiSchema = (required: boolean) => ({
+    type: "object",
+    properties: {
+      colors: {
+        type: "array",
+        minItems: 2,
+        items: { type: "string", enum: ["red", "green", "blue"] },
+      },
+    },
+    ...(required ? { required: ["colors"] } : {}),
+  });
+
+  it("lets an optional multi-select stay empty despite minItems", () => {
+    // minItems constrains an ANSWER, not the choice not to answer. Enforcing it
+    // on an empty optional field made submit unreachable for a value we would
+    // never have sent anyway.
+    const [field] = parseElicitationSchema(multiSchema(false));
+    expect(validateField(field, [])).toBeNull();
+    expect(validateField(field, undefined)).toBeNull();
+  });
+
+  it("still enforces minItems once an optional multi-select is answered", () => {
+    const [field] = parseElicitationSchema(multiSchema(false));
+    expect(validateField(field, ["red"])).toBe("Select at least 2 options");
+    expect(validateField(field, ["red", "blue"])).toBeNull();
+  });
+
+  it("still requires a required multi-select", () => {
+    const [field] = parseElicitationSchema(multiSchema(true));
+    expect(validateField(field, [])).toBe("colors is required");
   });
 });

--- a/mcpjam-inspector/client/src/components/elicitation/__tests__/schema.test.ts
+++ b/mcpjam-inspector/client/src/components/elicitation/__tests__/schema.test.ts
@@ -253,14 +253,14 @@ describe("validateField", () => {
     expect(validateField(f, "abc")).toBeNull();
   });
 
-  it("does not enforce pattern client-side at all", () => {
-    // Deliberate: running a server-chosen regex on the UI thread is a hang
-    // vector with no safe subset (see the note on `patternHint`). A mismatched
-    // value round-trips and the MCP server rejects it; the user still sees the
-    // pattern as a hint. An un-compilable pattern is likewise a non-event.
-    expect(validateField(field({ pattern: "^ab" }), "xy")).toBeNull();
+  it("enforces patterns with a non-backtracking engine", () => {
+    expect(validateField(field({ pattern: "^ab" }), "xy")).toBe(
+      "f does not match the required pattern",
+    );
     expect(validateField(field({ pattern: "^ab" }), "abc")).toBeNull();
-    expect(validateField(field({ pattern: "([" }), "anything")).toBeNull();
+    expect(validateField(field({ pattern: "([" }), "anything")).toBe(
+      "f uses a pattern this client cannot safely validate",
+    );
   });
 
   it("enforces formats", () => {
@@ -472,11 +472,11 @@ describe("buildElicitationContent", () => {
 
 
 describe("pattern handling", () => {
-  it("never executes a server-supplied pattern, however catastrophic", () => {
+  it("validates a catastrophic backtracking pattern in bounded time", () => {
     // An earlier cut tried to allow "safe-looking" patterns. It was bypassable:
     // `a?a?a?...aaa` has no nested-quantifier markers and still took ~150ms at
-    // 50 chars, doubling per character. There is no safe subset — so we simply
-    // don't run them. This test is a clock, not a shape assertion.
+    // 50 chars, doubling per character in JavaScript's RegExp engine. RE2's DFA
+    // remains linear. This test is a clock as well as a result assertion.
     const evil = "^" + "a?".repeat(60) + "a".repeat(60) + "$";
     const field = {
       name: "x",
@@ -489,10 +489,9 @@ describe("pattern handling", () => {
     const result = validateField(field, "a".repeat(55) + "X");
     const elapsed = Date.now() - started;
 
-    // Would be seconds if we compiled and ran it.
+    // Would be seconds in a backtracking engine.
     expect(elapsed).toBeLessThan(50);
-    // And it must not fabricate a failure either — the server validates.
-    expect(result).toBeNull();
+    expect(result).toBe("x does not match the required pattern");
   });
 
   it("surfaces the pattern to the user as a hint instead", () => {

--- a/mcpjam-inspector/client/src/components/elicitation/__tests__/schema.test.ts
+++ b/mcpjam-inspector/client/src/components/elicitation/__tests__/schema.test.ts
@@ -1,3 +1,4 @@
+import { isSafeUserFacingPattern } from "../schema";
 import { describe, it, expect } from "vitest";
 import {
   buildElicitationContent,
@@ -463,5 +464,67 @@ describe("buildElicitationContent", () => {
     expect(buildElicitationContent(fields, { tags: ["x", 3, null] })).toEqual({
       tags: ["x"],
     });
+  });
+});
+
+
+describe("isSafeUserFacingPattern", () => {
+  it.each([
+    ["^[a-z]+$"],
+    ["^\\d{4}-\\d{2}$"],
+    ["^(cat|dog)$"],
+    ["[A-Z][a-z]*"],
+  ])("allows an ordinary pattern: %s", (pattern) => {
+    expect(isSafeUserFacingPattern(pattern)).toBe(true);
+  });
+
+  it.each([
+    ["(a+)+$"],
+    ["(a*)*$"],
+    ["(a|aa)+$"],
+    ["^(\\w+\\s?)*$"],
+    ["(x+){10,}"],
+  ])("refuses a catastrophic pattern: %s", (pattern) => {
+    // These backtrack exponentially. Running them on the UI thread lets any
+    // connected server freeze the tab as the user types.
+    expect(isSafeUserFacingPattern(pattern)).toBe(false);
+  });
+
+  it("refuses an absurdly long pattern", () => {
+    expect(isSafeUserFacingPattern("a".repeat(301))).toBe(false);
+  });
+});
+
+describe("__proto__ field names", () => {
+  // Built via JSON.parse, exactly how a schema reaches us: JSON.parse creates a
+  // real own `__proto__` key, whereas an object *literal* would just set the
+  // prototype and the field would silently not exist. (Writing this test the
+  // literal way hid the bug entirely.)
+  const schema = JSON.parse(
+    '{"type":"object","properties":{"__proto__":{"type":"string"},"safe":{"type":"string"}},"required":["__proto__"]}'
+  );
+
+  it("parses a __proto__ property as a real field", () => {
+    const fields = parseElicitationSchema(schema);
+    expect(fields.map((f) => f.name)).toContain("__proto__");
+  });
+
+  it("keeps a __proto__ answer as an own key, not a prototype mutation", () => {
+    // A plain object would swallow this assignment and the server would never
+    // receive the answer to a field it marked required.
+    const fields = parseElicitationSchema(schema);
+    const values = initialFormValues(fields);
+    values["__proto__"] = "hello";
+    const content = buildElicitationContent(fields, values);
+
+    expect(Object.prototype.hasOwnProperty.call(content, "__proto__")).toBe(true);
+    expect(content["__proto__"]).toBe("hello");
+    expect(Object.keys(content)).toContain("__proto__");
+    // And nothing leaked onto Object.prototype.
+    expect(({} as any).__proto__).not.toBe("hello");
+  });
+
+  it("initialFormValues returns a null-prototype map", () => {
+    expect(Object.getPrototypeOf(initialFormValues([]))).toBeNull();
   });
 });

--- a/mcpjam-inspector/client/src/components/elicitation/__tests__/schema.test.ts
+++ b/mcpjam-inspector/client/src/components/elicitation/__tests__/schema.test.ts
@@ -1,4 +1,4 @@
-import { isSafeUserFacingPattern } from "../schema";
+import { patternHint } from "../schema";
 import { describe, it, expect } from "vitest";
 import {
   buildElicitationContent,
@@ -253,12 +253,13 @@ describe("validateField", () => {
     expect(validateField(f, "abc")).toBeNull();
   });
 
-  it("enforces pattern and survives a malformed pattern", () => {
-    expect(validateField(field({ pattern: "^ab" }), "xy")).toBe(
-      "f does not match the required format"
-    );
+  it("does not enforce pattern client-side at all", () => {
+    // Deliberate: running a server-chosen regex on the UI thread is a hang
+    // vector with no safe subset (see the note on `patternHint`). A mismatched
+    // value round-trips and the MCP server rejects it; the user still sees the
+    // pattern as a hint. An un-compilable pattern is likewise a non-event.
+    expect(validateField(field({ pattern: "^ab" }), "xy")).toBeNull();
     expect(validateField(field({ pattern: "^ab" }), "abc")).toBeNull();
-    // An un-compilable server-supplied pattern must not throw; it is skipped.
     expect(validateField(field({ pattern: "([" }), "anything")).toBeNull();
   });
 
@@ -468,30 +469,45 @@ describe("buildElicitationContent", () => {
 });
 
 
-describe("isSafeUserFacingPattern", () => {
-  it.each([
-    ["^[a-z]+$"],
-    ["^\\d{4}-\\d{2}$"],
-    ["^(cat|dog)$"],
-    ["[A-Z][a-z]*"],
-  ])("allows an ordinary pattern: %s", (pattern) => {
-    expect(isSafeUserFacingPattern(pattern)).toBe(true);
+describe("pattern handling", () => {
+  it("never executes a server-supplied pattern, however catastrophic", () => {
+    // An earlier cut tried to allow "safe-looking" patterns. It was bypassable:
+    // `a?a?a?...aaa` has no nested-quantifier markers and still took ~150ms at
+    // 50 chars, doubling per character. There is no safe subset — so we simply
+    // don't run them. This test is a clock, not a shape assertion.
+    const evil = "^" + "a?".repeat(60) + "a".repeat(60) + "$";
+    const field = {
+      name: "x",
+      kind: "string" as const,
+      required: false,
+      pattern: evil,
+    };
+
+    const started = Date.now();
+    const result = validateField(field, "a".repeat(55) + "X");
+    const elapsed = Date.now() - started;
+
+    // Would be seconds if we compiled and ran it.
+    expect(elapsed).toBeLessThan(50);
+    // And it must not fabricate a failure either — the server validates.
+    expect(result).toBeNull();
   });
 
-  it.each([
-    ["(a+)+$"],
-    ["(a*)*$"],
-    ["(a|aa)+$"],
-    ["^(\\w+\\s?)*$"],
-    ["(x+){10,}"],
-  ])("refuses a catastrophic pattern: %s", (pattern) => {
-    // These backtrack exponentially. Running them on the UI thread lets any
-    // connected server freeze the tab as the user types.
-    expect(isSafeUserFacingPattern(pattern)).toBe(false);
+  it("surfaces the pattern to the user as a hint instead", () => {
+    expect(
+      patternHint({
+        name: "x",
+        kind: "string",
+        required: false,
+        pattern: "^[a-z]+$",
+      }),
+    ).toBe("Must match: ^[a-z]+$");
   });
 
-  it("refuses an absurdly long pattern", () => {
-    expect(isSafeUserFacingPattern("a".repeat(301))).toBe(false);
+  it("has no hint when the schema declares no pattern", () => {
+    expect(
+      patternHint({ name: "x", kind: "string", required: false }),
+    ).toBeUndefined();
   });
 });
 

--- a/mcpjam-inspector/client/src/components/elicitation/__tests__/schema.test.ts
+++ b/mcpjam-inspector/client/src/components/elicitation/__tests__/schema.test.ts
@@ -1,0 +1,467 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildElicitationContent,
+  initialFormValues,
+  parseElicitationSchema,
+  validateField,
+  type ElicitationField,
+} from "../schema";
+
+const field = (over: Partial<ElicitationField>): ElicitationField => ({
+  name: "f",
+  kind: "string",
+  required: false,
+  ...over,
+});
+
+describe("parseElicitationSchema", () => {
+  it("returns [] for non-object / property-less schemas", () => {
+    expect(parseElicitationSchema(undefined)).toEqual([]);
+    expect(parseElicitationSchema(null)).toEqual([]);
+    expect(parseElicitationSchema("nope")).toEqual([]);
+    expect(parseElicitationSchema({})).toEqual([]);
+    expect(parseElicitationSchema({ properties: [] })).toEqual([]);
+  });
+
+  it("parses primitives with constraints and required flags", () => {
+    const fields = parseElicitationSchema({
+      type: "object",
+      required: ["name"],
+      properties: {
+        name: {
+          type: "string",
+          title: "Full name",
+          description: "Your name",
+          minLength: 2,
+          maxLength: 10,
+          pattern: "^[A-Z]",
+        },
+        age: { type: "integer", minimum: 0, maximum: 120 },
+        score: { type: "number", minimum: 0.5 },
+        subscribed: { type: "boolean" },
+      },
+    });
+
+    expect(fields.map((f) => [f.name, f.kind])).toEqual([
+      ["name", "string"],
+      ["age", "integer"],
+      ["score", "number"],
+      ["subscribed", "boolean"],
+    ]);
+    expect(fields[0]).toMatchObject({
+      title: "Full name",
+      description: "Your name",
+      required: true,
+      minLength: 2,
+      maxLength: 10,
+      pattern: "^[A-Z]",
+    });
+    expect(fields[1]).toMatchObject({
+      minimum: 0,
+      maximum: 120,
+      required: false,
+    });
+    expect(fields[2]).toMatchObject({ minimum: 0.5 });
+  });
+
+  it("parses string formats, ignoring unknown ones", () => {
+    const fields = parseElicitationSchema({
+      properties: {
+        a: { type: "string", format: "email" },
+        b: { type: "string", format: "uri" },
+        c: { type: "string", format: "date" },
+        d: { type: "string", format: "date-time" },
+        e: { type: "string", format: "hostname" },
+      },
+    });
+    expect(fields.map((f) => f.format)).toEqual([
+      "email",
+      "uri",
+      "date",
+      "date-time",
+      undefined,
+    ]);
+  });
+
+  it("parses a single-select enum from prop.enum with legacy enumNames", () => {
+    const [f] = parseElicitationSchema({
+      properties: {
+        color: {
+          type: "string",
+          enum: ["r", "g", "b"],
+          enumNames: ["Red", "Green"],
+        },
+      },
+    });
+    expect(f.kind).toBe("enum");
+    expect(f.options).toEqual([
+      { value: "r", label: "Red" },
+      { value: "g", label: "Green" },
+      // No name at this index -> falls back to the raw value.
+      { value: "b", label: "b" },
+    ]);
+  });
+
+  it("parses a single-select enum from oneOf {const,title}", () => {
+    const [f] = parseElicitationSchema({
+      properties: {
+        plan: {
+          oneOf: [
+            { const: "free", title: "Free" },
+            { const: "pro", title: "Pro" },
+          ],
+        },
+      },
+    });
+    expect(f.kind).toBe("enum");
+    expect(f.options).toEqual([
+      { value: "free", label: "Free" },
+      { value: "pro", label: "Pro" },
+    ]);
+  });
+
+  it("parses a single-select enum from anyOf {const} without titles", () => {
+    const [f] = parseElicitationSchema({
+      properties: { plan: { anyOf: [{ const: "a" }, { const: "b" }] } },
+    });
+    expect(f.kind).toBe("enum");
+    expect(f.options).toEqual([
+      { value: "a", label: "a" },
+      { value: "b", label: "b" },
+    ]);
+  });
+
+  it("parses a multi-select enum from array items.enum with minItems/maxItems", () => {
+    const [f] = parseElicitationSchema({
+      required: ["tags"],
+      properties: {
+        tags: {
+          type: "array",
+          title: "Tags",
+          items: { type: "string", enum: ["x", "y", "z"] },
+          minItems: 1,
+          maxItems: 2,
+        },
+      },
+    });
+    expect(f).toMatchObject({
+      kind: "multi-enum",
+      title: "Tags",
+      required: true,
+      minItems: 1,
+      maxItems: 2,
+    });
+    expect(f.options?.map((o) => o.value)).toEqual(["x", "y", "z"]);
+  });
+
+  it("parses a multi-select enum from array items.anyOf {const,title}", () => {
+    const [f] = parseElicitationSchema({
+      properties: {
+        tags: {
+          type: "array",
+          items: { anyOf: [{ const: "x", title: "Ex" }, { const: "y" }] },
+        },
+      },
+    });
+    expect(f.kind).toBe("multi-enum");
+    expect(f.options).toEqual([
+      { value: "x", label: "Ex" },
+      { value: "y", label: "y" },
+    ]);
+  });
+
+  it("captures schema defaults", () => {
+    const fields = parseElicitationSchema({
+      properties: {
+        name: { type: "string", default: "ada" },
+        age: { type: "integer", default: 36 },
+        subscribed: { type: "boolean", default: true },
+        color: { type: "string", enum: ["r", "g"], default: "g" },
+        tags: { type: "array", items: { enum: ["x", "y"] }, default: ["y"] },
+      },
+    });
+    expect(fields.map((f) => f.default)).toEqual(["ada", 36, true, "g", ["y"]]);
+  });
+
+  it("falls back to json for nested/unrecognized (spec-forbidden) shapes", () => {
+    const fields = parseElicitationSchema({
+      properties: {
+        nested: { type: "object", properties: { a: { type: "string" } } },
+        objArray: { type: "array", items: { type: "object" } },
+        plainArray: { type: "array", items: { type: "string" } },
+        untyped: { description: "no type at all" },
+        bogus: "not-an-object",
+        mixedEnum: { type: "string", enum: ["a", 2] },
+        constNonString: { oneOf: [{ const: 1 }, { const: 2 }] },
+      },
+    });
+    expect(fields.map((f) => [f.name, f.kind])).toEqual([
+      ["nested", "json"],
+      ["objArray", "json"],
+      ["plainArray", "json"],
+      ["untyped", "json"],
+      ["bogus", "json"],
+      ["mixedEnum", "json"],
+      ["constNonString", "json"],
+    ]);
+    // json fallbacks still carry their display metadata + required flag.
+    expect(fields[3]).toMatchObject({ description: "no type at all" });
+  });
+});
+
+describe("validateField", () => {
+  it("enforces required and allows blank optionals", () => {
+    expect(validateField(field({ required: true }), "")).toBe("f is required");
+    expect(validateField(field({ required: true }), undefined)).toBe(
+      "f is required"
+    );
+    expect(validateField(field({ required: false }), "")).toBeNull();
+  });
+
+  it("uses the title in messages when present", () => {
+    expect(validateField(field({ required: true, title: "Name" }), "")).toBe(
+      "Name is required"
+    );
+  });
+
+  it("treats a false boolean as answered", () => {
+    expect(
+      validateField(field({ kind: "boolean", required: true }), false)
+    ).toBeNull();
+  });
+
+  it("enforces min/max on numbers", () => {
+    const f = field({ kind: "number", minimum: 1, maximum: 10 });
+    expect(validateField(f, "0")).toBe("f must be at least 1");
+    expect(validateField(f, "11")).toBe("f must be at most 10");
+    expect(validateField(f, "5.5")).toBeNull();
+    expect(validateField(f, "abc")).toBe("f must be a number");
+  });
+
+  it("enforces integer integrality", () => {
+    const f = field({ kind: "integer", minimum: 0 });
+    expect(validateField(f, "3.5")).toBe("f must be an integer");
+    expect(validateField(f, "3")).toBeNull();
+    expect(validateField(f, "-1")).toBe("f must be at least 0");
+  });
+
+  it("enforces minLength/maxLength", () => {
+    const f = field({ minLength: 2, maxLength: 4 });
+    expect(validateField(f, "a")).toBe("f must be at least 2 characters");
+    expect(validateField(f, "abcde")).toBe("f must be at most 4 characters");
+    expect(validateField(f, "abc")).toBeNull();
+  });
+
+  it("enforces pattern and survives a malformed pattern", () => {
+    expect(validateField(field({ pattern: "^ab" }), "xy")).toBe(
+      "f does not match the required format"
+    );
+    expect(validateField(field({ pattern: "^ab" }), "abc")).toBeNull();
+    // An un-compilable server-supplied pattern must not throw; it is skipped.
+    expect(validateField(field({ pattern: "([" }), "anything")).toBeNull();
+  });
+
+  it("enforces formats", () => {
+    expect(validateField(field({ format: "email" }), "nope")).toBe(
+      "f must be a valid email address"
+    );
+    expect(validateField(field({ format: "email" }), "a@b.co")).toBeNull();
+    expect(validateField(field({ format: "uri" }), "not a uri")).toBe(
+      "f must be a valid URI"
+    );
+    expect(
+      validateField(field({ format: "uri" }), "https://example.com/x")
+    ).toBeNull();
+    expect(validateField(field({ format: "date" }), "2024-1-1")).toBe(
+      "f must be a valid date"
+    );
+    expect(validateField(field({ format: "date" }), "2024-01-01")).toBeNull();
+    expect(validateField(field({ format: "date-time" }), "2024-01-01")).toBe(
+      "f must be a valid date and time"
+    );
+    // datetime-local (no timezone) and full RFC 3339 both pass.
+    expect(
+      validateField(field({ format: "date-time" }), "2024-01-01T10:30")
+    ).toBeNull();
+    expect(
+      validateField(field({ format: "date-time" }), "2024-01-01T10:30:00Z")
+    ).toBeNull();
+  });
+
+  it("rejects enum values outside the offered options", () => {
+    const f = field({
+      kind: "enum",
+      options: [{ value: "a", label: "A" }],
+    });
+    expect(validateField(f, "b")).toBe("f must be one of the offered options");
+    expect(validateField(f, "a")).toBeNull();
+  });
+
+  it("enforces multi-enum required/minItems/maxItems", () => {
+    expect(
+      validateField(field({ kind: "multi-enum", required: true }), [])
+    ).toBe("f is required");
+    expect(
+      validateField(field({ kind: "multi-enum", minItems: 2 }), ["a"])
+    ).toBe("Select at least 2 options");
+    expect(
+      validateField(field({ kind: "multi-enum", maxItems: 1 }), ["a", "b"])
+    ).toBe("Select at most 1 option");
+    expect(
+      validateField(field({ kind: "multi-enum", minItems: 1, maxItems: 2 }), [
+        "a",
+      ])
+    ).toBeNull();
+    // An optional multi-enum with no minItems accepts an empty selection.
+    expect(validateField(field({ kind: "multi-enum" }), [])).toBeNull();
+  });
+
+  it("requires valid JSON in the json fallback", () => {
+    expect(validateField(field({ kind: "json" }), "{oops")).toBe(
+      "f must be valid JSON"
+    );
+    expect(validateField(field({ kind: "json" }), '{"a":1}')).toBeNull();
+  });
+});
+
+describe("initialFormValues", () => {
+  it("prefills schema defaults and uses empty values otherwise", () => {
+    const fields = parseElicitationSchema({
+      properties: {
+        name: { type: "string", default: "ada" },
+        blank: { type: "string" },
+        age: { type: "integer", default: 36 },
+        subscribed: { type: "boolean", default: true },
+        off: { type: "boolean" },
+        color: { type: "string", enum: ["r", "g"], default: "g" },
+        tags: { type: "array", items: { enum: ["x", "y"] }, default: ["y"] },
+        blob: { type: "object", default: { a: 1 } },
+      },
+    });
+    expect(initialFormValues(fields)).toEqual({
+      name: "ada",
+      blank: "",
+      age: "36",
+      subscribed: true,
+      off: false,
+      color: "g",
+      tags: ["y"],
+      blob: JSON.stringify({ a: 1 }, null, 2),
+    });
+  });
+
+  it("drops defaults that are not offered options", () => {
+    const fields = parseElicitationSchema({
+      properties: {
+        color: { type: "string", enum: ["r", "g"], default: "purple" },
+        tags: { type: "array", items: { enum: ["x"] }, default: ["x", "zz"] },
+      },
+    });
+    expect(initialFormValues(fields)).toEqual({ color: "", tags: ["x"] });
+  });
+});
+
+describe("buildElicitationContent", () => {
+  it("coerces values into the ElicitResult.content shape", () => {
+    const fields = parseElicitationSchema({
+      properties: {
+        name: { type: "string" },
+        age: { type: "integer" },
+        score: { type: "number" },
+        subscribed: { type: "boolean" },
+        color: { type: "string", enum: ["r", "g"] },
+        tags: { type: "array", items: { enum: ["x", "y"] } },
+      },
+    });
+    expect(
+      buildElicitationContent(fields, {
+        name: "ada",
+        age: "36",
+        score: "1.5",
+        subscribed: true,
+        color: "g",
+        tags: ["x", "y"],
+      })
+    ).toEqual({
+      name: "ada",
+      age: 36,
+      score: 1.5,
+      subscribed: true,
+      color: "g",
+      tags: ["x", "y"],
+    });
+  });
+
+  it("omits empty optionals but always reports booleans", () => {
+    const fields = parseElicitationSchema({
+      properties: {
+        name: { type: "string" },
+        age: { type: "integer" },
+        subscribed: { type: "boolean" },
+        color: { type: "string", enum: ["r"] },
+        tags: { type: "array", items: { enum: ["x"] } },
+        blob: { type: "object" },
+      },
+    });
+    expect(
+      buildElicitationContent(fields, {
+        name: "",
+        age: "",
+        subscribed: false,
+        color: "",
+        tags: [],
+        blob: "",
+      })
+    ).toEqual({ subscribed: false });
+  });
+
+  it("ignores values for fields that are not in the schema", () => {
+    const fields = parseElicitationSchema({
+      properties: { name: { type: "string" } },
+    });
+    expect(
+      buildElicitationContent(fields, { name: "ada", injected: "nope" })
+    ).toEqual({ name: "ada" });
+  });
+
+  it("parses json fallbacks, re-serializing shapes the spec cannot carry", () => {
+    const fields = parseElicitationSchema({
+      properties: {
+        nested: { type: "object" },
+        scalar: { type: "object" },
+        list: { type: "object" },
+      },
+    });
+    expect(
+      buildElicitationContent(fields, {
+        nested: '{"a":1}',
+        scalar: "42",
+        list: '["a","b"]',
+      })
+    ).toEqual({
+      // A nested object cannot be an ElicitResult.content value -> JSON string.
+      nested: '{"a":1}',
+      // Parsed values that already fit the shape pass through natively.
+      scalar: 42,
+      list: ["a", "b"],
+    });
+  });
+
+  it("keeps unparseable json-fallback text as a raw string", () => {
+    const fields = parseElicitationSchema({
+      properties: { blob: { type: "object" } },
+    });
+    expect(buildElicitationContent(fields, { blob: "{oops" })).toEqual({
+      blob: "{oops",
+    });
+  });
+
+  it("drops non-string members from a multi-enum selection", () => {
+    const fields = parseElicitationSchema({
+      properties: { tags: { type: "array", items: { enum: ["x"] } } },
+    });
+    expect(buildElicitationContent(fields, { tags: ["x", 3, null] })).toEqual({
+      tags: ["x"],
+    });
+  });
+});

--- a/mcpjam-inspector/client/src/components/elicitation/schema.ts
+++ b/mcpjam-inspector/client/src/components/elicitation/schema.ts
@@ -65,6 +65,30 @@ const FORMATS: readonly ElicitationFieldFormat[] = [
   "date-time",
 ];
 
+/**
+ * `pattern` is chosen by the MCP server, and `RegExp.test` runs unbounded on
+ * the UI thread with a backtracking engine. A hostile (or merely careless)
+ * server can send a catastrophic pattern — `(a+)+$` already costs ~160ms
+ * against 24 characters and doubles per extra char — which would freeze the tab
+ * as the user types.
+ *
+ * Without a safe (RE2-style) engine available, this refuses to run patterns
+ * carrying the shape that makes backtracking explode: a quantifier applied to a
+ * group that itself contains a quantifier or an alternation, e.g. `(a+)+`,
+ * `(a*)*`, `(a|aa)+`. Skipping validation is the safe failure — the MCP server
+ * re-validates its own schema, so the worst case is that a bad value round-trips
+ * instead of being caught early. Freezing the renderer is not a safe failure.
+ *
+ * Bounded input alone wouldn't save us: maxLength is also server-supplied.
+ */
+const NESTED_QUANTIFIER_RE = /\([^()]*[+*{|][^()]*\)\s*[+*]|\([^()]*\)\s*\{\d+,\s*\}/;
+
+export function isSafeUserFacingPattern(pattern: string): boolean {
+  // Long patterns are themselves a smell and cost more to analyze than to skip.
+  if (pattern.length > 300) return false;
+  return !NESTED_QUANTIFIER_RE.test(pattern);
+}
+
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 // Tolerates the `datetime-local` input's timezone-less value as well as full
@@ -360,7 +384,7 @@ function validateString(
       field.maxLength === 1 ? "" : "s"
     }`;
   }
-  if (field.pattern !== undefined) {
+  if (field.pattern !== undefined && isSafeUserFacingPattern(field.pattern)) {
     let re: RegExp | undefined;
     try {
       re = new RegExp(field.pattern);
@@ -420,7 +444,12 @@ export function buildElicitationContent(
   fields: ElicitationField[],
   values: Record<string, unknown>
 ): Record<string, ElicitationContentValue> {
-  const content: Record<string, ElicitationContentValue> = {};
+  // Null-prototype: field names come from the server, and a field literally
+  // named `__proto__` would otherwise mutate this object's prototype instead of
+  // creating a key — the answer would silently never reach the server.
+  const content: Record<string, ElicitationContentValue> = Object.create(
+    null
+  ) as Record<string, ElicitationContentValue>;
 
   for (const field of fields) {
     const value = values[field.name];
@@ -477,7 +506,12 @@ export function buildElicitationContent(
 export function initialFormValues(
   fields: ElicitationField[]
 ): Record<string, unknown> {
-  const values: Record<string, unknown> = {};
+  // Null-prototype for the same reason as buildElicitationContent: a server can
+  // name a field `__proto__`, and a plain object would swallow it.
+  const values: Record<string, unknown> = Object.create(null) as Record<
+    string,
+    unknown
+  >;
   for (const field of fields) {
     values[field.name] = defaultValueFor(field);
   }

--- a/mcpjam-inspector/client/src/components/elicitation/schema.ts
+++ b/mcpjam-inspector/client/src/components/elicitation/schema.ts
@@ -1,0 +1,513 @@
+/**
+ * Pure (React-free) parsing / validation / serialization helpers for MCP
+ * elicitation request schemas.
+ *
+ * Scope: the MCP 2025-11-25 elicitation subset — a FLAT object schema whose
+ * properties are primitives, single-select enums, or arrays of enums. Anything
+ * outside that subset (nested objects, arrays of objects, unrecognized types)
+ * is spec-forbidden; rather than dropping it we surface it as a `json` field so
+ * the user can still answer by hand.
+ *
+ * Everything here is deliberately free of React and DOM APIs so it can be unit
+ * tested directly and reused by other elicitation surfaces (form dialog today,
+ * hosted/chat dialogs later).
+ */
+
+export type ElicitationFieldKind =
+  | "string"
+  | "number"
+  | "integer"
+  | "boolean"
+  | "enum"
+  | "multi-enum"
+  | "json";
+
+export type ElicitationFieldFormat = "email" | "uri" | "date" | "date-time";
+
+export interface ElicitationFieldOption {
+  /** The value sent back to the server. */
+  value: string;
+  /** Human-readable label; falls back to `value` when the schema has no title. */
+  label: string;
+}
+
+export interface ElicitationField {
+  /** Raw property key from the schema — this is what the server keys on. */
+  name: string;
+  kind: ElicitationFieldKind;
+  /** Schema `title`, when present. Display-only; never replaces `name`. */
+  title?: string;
+  description?: string;
+  required: boolean;
+  /** Schema `default`, when present. Used to prefill the form. */
+  default?: unknown;
+  format?: ElicitationFieldFormat;
+  minimum?: number;
+  maximum?: number;
+  minLength?: number;
+  maxLength?: number;
+  pattern?: string;
+  /** Present for `enum` and `multi-enum`. */
+  options?: ElicitationFieldOption[];
+  /** `multi-enum` only. */
+  minItems?: number;
+  /** `multi-enum` only. */
+  maxItems?: number;
+}
+
+/** A value that fits the MCP `ElicitResult.content` shape. */
+export type ElicitationContentValue = string | number | boolean | string[];
+
+const FORMATS: readonly ElicitationFieldFormat[] = [
+  "email",
+  "uri",
+  "date",
+  "date-time",
+];
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+// Tolerates the `datetime-local` input's timezone-less value as well as full
+// RFC 3339 strings.
+const DATE_TIME_RE =
+  /^\d{4}-\d{2}-\d{2}[Tt]\d{2}:\d{2}(:\d{2}(\.\d+)?)?([Zz]|[+-]\d{2}:\d{2})?$/;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function asFormat(value: unknown): ElicitationFieldFormat | undefined {
+  return typeof value === "string" &&
+    (FORMATS as readonly string[]).includes(value)
+    ? (value as ElicitationFieldFormat)
+    : undefined;
+}
+
+/**
+ * Options from a `{ enum: [...] , enumNames?: [...] }` pair.
+ * `enumNames` is the legacy (pre-2025-11-25) label channel; still emitted by
+ * plenty of servers, so we honor it.
+ */
+function optionsFromEnum(prop: Record<string, unknown>) {
+  const values = prop.enum;
+  if (!Array.isArray(values) || values.length === 0) return undefined;
+  if (!values.every((v): v is string => typeof v === "string"))
+    return undefined;
+  const names = Array.isArray(prop.enumNames) ? prop.enumNames : undefined;
+  return values.map((value, i) => ({
+    value,
+    label: asString(names?.[i]) ?? value,
+  }));
+}
+
+/**
+ * Options from `oneOf`/`anyOf: [{ const, title? }, ...]` — the 2025-11-25 way
+ * of attaching labels to enum members.
+ */
+function optionsFromConstBranches(branches: unknown) {
+  if (!Array.isArray(branches) || branches.length === 0) return undefined;
+  const options: ElicitationFieldOption[] = [];
+  for (const branch of branches) {
+    if (!isRecord(branch)) return undefined;
+    const value = asString(branch.const);
+    if (value === undefined) return undefined;
+    options.push({ value, label: asString(branch.title) ?? value });
+  }
+  return options;
+}
+
+/**
+ * True when a property *declares* a choice constraint, however malformed.
+ * We must not silently degrade `{type:"string", enum:["a",2]}` to a free-text
+ * input — that would drop the server's constraint. Declared-but-unparseable
+ * goes to the `json` fallback instead.
+ */
+function declaresChoice(prop: Record<string, unknown>): boolean {
+  return "enum" in prop || "oneOf" in prop || "anyOf" in prop;
+}
+
+function singleSelectOptions(prop: Record<string, unknown>) {
+  return (
+    optionsFromEnum(prop) ??
+    optionsFromConstBranches(prop.oneOf) ??
+    optionsFromConstBranches(prop.anyOf)
+  );
+}
+
+function multiSelectOptions(prop: Record<string, unknown>) {
+  const items = prop.items;
+  if (!isRecord(items)) return undefined;
+  return (
+    optionsFromEnum(items) ??
+    optionsFromConstBranches(items.anyOf) ??
+    optionsFromConstBranches(items.oneOf)
+  );
+}
+
+function jsonField(
+  name: string,
+  prop: Record<string, unknown> | undefined,
+  required: boolean
+): ElicitationField {
+  return {
+    name,
+    kind: "json",
+    title: asString(prop?.title),
+    description: asString(prop?.description),
+    required,
+    ...(prop && "default" in prop ? { default: prop.default } : {}),
+  };
+}
+
+/**
+ * Parse an elicitation `requestedSchema` into a flat field list.
+ * Non-conforming input yields `[]` (nothing to render) or `json` fields.
+ */
+export function parseElicitationSchema(schema: unknown): ElicitationField[] {
+  if (!isRecord(schema)) return [];
+  const properties = schema.properties;
+  if (!isRecord(properties)) return [];
+
+  const required = new Set(
+    Array.isArray(schema.required)
+      ? schema.required.filter((k): k is string => typeof k === "string")
+      : []
+  );
+
+  const fields: ElicitationField[] = [];
+  for (const [name, rawProp] of Object.entries(properties)) {
+    const isRequired = required.has(name);
+    if (!isRecord(rawProp)) {
+      fields.push(jsonField(name, undefined, isRequired));
+      continue;
+    }
+    fields.push(parseProperty(name, rawProp, isRequired));
+  }
+  return fields;
+}
+
+function parseProperty(
+  name: string,
+  prop: Record<string, unknown>,
+  required: boolean
+): ElicitationField {
+  const base = {
+    name,
+    title: asString(prop.title),
+    description: asString(prop.description),
+    required,
+    ...("default" in prop ? { default: prop.default } : {}),
+  };
+
+  const type = asString(prop.type);
+
+  // Arrays are only supported as multi-select enums (spec subset).
+  if (type === "array") {
+    const options = multiSelectOptions(prop);
+    if (!options) return jsonField(name, prop, required);
+    return {
+      ...base,
+      kind: "multi-enum",
+      options,
+      minItems: asNumber(prop.minItems),
+      maxItems: asNumber(prop.maxItems),
+    };
+  }
+
+  // Single-select enum. Checked before primitives because an enum property is
+  // typically also `type: "string"`.
+  if (declaresChoice(prop)) {
+    const options = singleSelectOptions(prop);
+    return options
+      ? { ...base, kind: "enum", options }
+      : jsonField(name, prop, required);
+  }
+
+  switch (type) {
+    case "string":
+      return {
+        ...base,
+        kind: "string",
+        format: asFormat(prop.format),
+        minLength: asNumber(prop.minLength),
+        maxLength: asNumber(prop.maxLength),
+        pattern: asString(prop.pattern),
+      };
+    case "number":
+    case "integer":
+      return {
+        ...base,
+        kind: type,
+        minimum: asNumber(prop.minimum),
+        maximum: asNumber(prop.maximum),
+      };
+    case "boolean":
+      return { ...base, kind: "boolean" };
+    default:
+      // Nested objects, untyped props, anything else the spec forbids here.
+      return jsonField(name, prop, required);
+  }
+}
+
+export function fieldLabel(field: ElicitationField): string {
+  return field.title ?? field.name;
+}
+
+function isBlank(value: unknown): boolean {
+  return value === undefined || value === null || value === "";
+}
+
+function toStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((v): v is string => typeof v === "string")
+    : [];
+}
+
+/**
+ * Validate a single field's current form value.
+ * @returns an error message to render under the field, or `null` when valid.
+ */
+export function validateField(
+  field: ElicitationField,
+  value: unknown
+): string | null {
+  const label = fieldLabel(field);
+
+  if (field.kind === "multi-enum") {
+    const selected = toStringArray(value);
+    if (field.required && selected.length === 0) {
+      return `${label} is required`;
+    }
+    if (field.minItems !== undefined && selected.length < field.minItems) {
+      return `Select at least ${field.minItems} option${
+        field.minItems === 1 ? "" : "s"
+      }`;
+    }
+    if (field.maxItems !== undefined && selected.length > field.maxItems) {
+      return `Select at most ${field.maxItems} option${
+        field.maxItems === 1 ? "" : "s"
+      }`;
+    }
+    return null;
+  }
+
+  // A checkbox always carries a definite answer; `false` satisfies `required`.
+  if (field.kind === "boolean") return null;
+
+  if (isBlank(value)) {
+    return field.required ? `${label} is required` : null;
+  }
+
+  switch (field.kind) {
+    case "number":
+    case "integer": {
+      const n = Number(value);
+      if (!Number.isFinite(n)) return `${label} must be a number`;
+      if (field.kind === "integer" && !Number.isInteger(n)) {
+        return `${label} must be an integer`;
+      }
+      if (field.minimum !== undefined && n < field.minimum) {
+        return `${label} must be at least ${field.minimum}`;
+      }
+      if (field.maximum !== undefined && n > field.maximum) {
+        return `${label} must be at most ${field.maximum}`;
+      }
+      return null;
+    }
+    case "enum": {
+      const str = String(value);
+      if (field.options && !field.options.some((o) => o.value === str)) {
+        return `${label} must be one of the offered options`;
+      }
+      return null;
+    }
+    case "json": {
+      try {
+        JSON.parse(String(value));
+        return null;
+      } catch {
+        return `${label} must be valid JSON`;
+      }
+    }
+    case "string":
+    default:
+      return validateString(field, String(value), label);
+  }
+}
+
+function validateString(
+  field: ElicitationField,
+  str: string,
+  label: string
+): string | null {
+  if (field.minLength !== undefined && str.length < field.minLength) {
+    return `${label} must be at least ${field.minLength} character${
+      field.minLength === 1 ? "" : "s"
+    }`;
+  }
+  if (field.maxLength !== undefined && str.length > field.maxLength) {
+    return `${label} must be at most ${field.maxLength} character${
+      field.maxLength === 1 ? "" : "s"
+    }`;
+  }
+  if (field.pattern !== undefined) {
+    let re: RegExp | undefined;
+    try {
+      re = new RegExp(field.pattern);
+    } catch {
+      // A malformed server-supplied pattern must not break the form; skip it.
+      re = undefined;
+    }
+    if (re && !re.test(str)) {
+      return `${label} does not match the required format`;
+    }
+  }
+  switch (field.format) {
+    case "email":
+      return EMAIL_RE.test(str)
+        ? null
+        : `${label} must be a valid email address`;
+    case "uri":
+      return isValidUri(str) ? null : `${label} must be a valid URI`;
+    case "date":
+      return DATE_RE.test(str) ? null : `${label} must be a valid date`;
+    case "date-time":
+      return DATE_TIME_RE.test(str)
+        ? null
+        : `${label} must be a valid date and time`;
+    default:
+      return null;
+  }
+}
+
+function isValidUri(str: string): boolean {
+  try {
+    // Parsing only — never fetched, never rendered as a link.
+    new URL(str);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function fitsContentShape(value: unknown): value is ElicitationContentValue {
+  return (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    (Array.isArray(value) && value.every((v) => typeof v === "string"))
+  );
+}
+
+/**
+ * Coerce raw form values into an MCP `ElicitResult.content` payload.
+ * Empty optional fields are omitted entirely; values are narrowed to the
+ * `string | number | boolean | string[]` shape the spec allows (a `json`
+ * fallback field that parses to something richer is re-serialized to a
+ * compact JSON string, mirroring how consumers normalize today).
+ */
+export function buildElicitationContent(
+  fields: ElicitationField[],
+  values: Record<string, unknown>
+): Record<string, ElicitationContentValue> {
+  const content: Record<string, ElicitationContentValue> = {};
+
+  for (const field of fields) {
+    const value = values[field.name];
+
+    switch (field.kind) {
+      case "boolean":
+        content[field.name] = Boolean(value);
+        break;
+
+      case "multi-enum": {
+        const selected = toStringArray(value);
+        if (selected.length > 0) content[field.name] = selected;
+        break;
+      }
+
+      case "number":
+      case "integer": {
+        if (isBlank(value)) break;
+        const n = Number(value);
+        if (Number.isFinite(n)) content[field.name] = n;
+        break;
+      }
+
+      case "json": {
+        if (isBlank(value)) break;
+        const raw = String(value);
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(raw);
+        } catch {
+          content[field.name] = raw;
+          break;
+        }
+        content[field.name] = fitsContentShape(parsed)
+          ? parsed
+          : JSON.stringify(parsed);
+        break;
+      }
+
+      case "enum":
+      case "string":
+      default: {
+        if (isBlank(value)) break;
+        content[field.name] = String(value);
+        break;
+      }
+    }
+  }
+
+  return content;
+}
+
+/** Initial form state for a parsed field list, honoring schema `default`s. */
+export function initialFormValues(
+  fields: ElicitationField[]
+): Record<string, unknown> {
+  const values: Record<string, unknown> = {};
+  for (const field of fields) {
+    values[field.name] = defaultValueFor(field);
+  }
+  return values;
+}
+
+function defaultValueFor(field: ElicitationField): unknown {
+  const hasDefault = field.default !== undefined;
+
+  switch (field.kind) {
+    case "boolean":
+      return hasDefault ? Boolean(field.default) : false;
+    case "multi-enum": {
+      const allowed = new Set(field.options?.map((o) => o.value) ?? []);
+      return toStringArray(field.default).filter((v) => allowed.has(v));
+    }
+    case "enum": {
+      const str = hasDefault ? String(field.default) : "";
+      return field.options?.some((o) => o.value === str) ? str : "";
+    }
+    case "json":
+      if (!hasDefault) return "";
+      return typeof field.default === "string"
+        ? field.default
+        : JSON.stringify(field.default, null, 2);
+    case "number":
+    case "integer":
+      return hasDefault ? String(field.default) : "";
+    case "string":
+    default:
+      return hasDefault ? String(field.default) : "";
+  }
+}

--- a/mcpjam-inspector/client/src/components/elicitation/schema.ts
+++ b/mcpjam-inspector/client/src/components/elicitation/schema.ts
@@ -312,6 +312,13 @@ export function validateField(
     if (field.required && selected.length === 0) {
       return `${label} is required`;
     }
+    // Leaving an OPTIONAL multi-select empty is a valid non-answer, and
+    // `buildElicitationContent` omits it. Enforcing minItems here made that
+    // unreachable: the form refused to submit a field it would never send,
+    // with no way to satisfy the rule short of answering.
+    if (!field.required && selected.length === 0) {
+      return null;
+    }
     if (field.minItems !== undefined && selected.length < field.minItems) {
       return `Select at least ${field.minItems} option${
         field.minItems === 1 ? "" : "s"
@@ -447,6 +454,9 @@ export function buildElicitationContent(
 
     switch (field.kind) {
       case "boolean":
+        // Untouched optional checkbox → omit. Sending `false` would answer a
+        // question the user never saw fit to answer.
+        if (value === undefined) break;
         content[field.name] = Boolean(value);
         break;
 
@@ -514,7 +524,13 @@ function defaultValueFor(field: ElicitationField): unknown {
 
   switch (field.kind) {
     case "boolean":
-      return hasDefault ? Boolean(field.default) : false;
+      if (hasDefault) return Boolean(field.default);
+      // `undefined` = UNANSWERED, distinct from an answered `false`. A required
+      // checkbox still starts unchecked-but-answered (false is a real answer to
+      // "do you consent?"); an optional one the user never touched must not
+      // fabricate one. Toggling on then off yields a real `false`, which does
+      // get sent.
+      return field.required ? false : undefined;
     case "multi-enum": {
       const allowed = new Set(field.options?.map((o) => o.value) ?? []);
       return toStringArray(field.default).filter((v) => allowed.has(v));

--- a/mcpjam-inspector/client/src/components/elicitation/schema.ts
+++ b/mcpjam-inspector/client/src/components/elicitation/schema.ts
@@ -66,27 +66,27 @@ const FORMATS: readonly ElicitationFieldFormat[] = [
 ];
 
 /**
- * `pattern` is chosen by the MCP server, and `RegExp.test` runs unbounded on
- * the UI thread with a backtracking engine. A hostile (or merely careless)
- * server can send a catastrophic pattern — `(a+)+$` already costs ~160ms
- * against 24 characters and doubles per extra char — which would freeze the tab
- * as the user types.
+ * We deliberately DO NOT execute a server-supplied `pattern`.
  *
- * Without a safe (RE2-style) engine available, this refuses to run patterns
- * carrying the shape that makes backtracking explode: a quantifier applied to a
- * group that itself contains a quantifier or an alternation, e.g. `(a+)+`,
- * `(a*)*`, `(a|aa)+`. Skipping validation is the safe failure — the MCP server
- * re-validates its own schema, so the worst case is that a bad value round-trips
- * instead of being caught early. Freezing the renderer is not a safe failure.
+ * `pattern` comes from the MCP server and `RegExp.test` runs unbounded on the
+ * UI thread with a backtracking engine, so a hostile (or merely careless)
+ * pattern freezes the tab. There is no safe subset to allow: an earlier cut
+ * tried rejecting "nested quantifier" shapes like `(a+)+`, and it was trivially
+ * bypassed — `a?a?a?…aaa` carries none of those markers and still took ~150ms
+ * at 50 characters, doubling per extra character. Bounding input doesn't help
+ * either, since `maxLength` is server-supplied too.
  *
- * Bounded input alone wouldn't save us: maxLength is also server-supplied.
+ * Heuristics here are a losing game; the real fix is a non-backtracking engine
+ * (RE2/`node-re2`), which is a dependency decision beyond this change.
+ *
+ * Skipping is the safe failure: the MCP server re-validates its own schema, so
+ * an unmatched value round-trips and is rejected there instead of being caught
+ * early. The pattern is still shown to the user as a hint (see `patternHint`),
+ * so they aren't flying blind. Freezing the renderer is NOT a safe failure.
  */
-const NESTED_QUANTIFIER_RE = /\([^()]*[+*{|][^()]*\)\s*[+*]|\([^()]*\)\s*\{\d+,\s*\}/;
-
-export function isSafeUserFacingPattern(pattern: string): boolean {
-  // Long patterns are themselves a smell and cost more to analyze than to skip.
-  if (pattern.length > 300) return false;
-  return !NESTED_QUANTIFIER_RE.test(pattern);
+export function patternHint(field: ElicitationField): string | undefined {
+  // Displayed verbatim as text — never compiled, never executed.
+  return field.pattern ? `Must match: ${field.pattern}` : undefined;
 }
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -384,18 +384,9 @@ function validateString(
       field.maxLength === 1 ? "" : "s"
     }`;
   }
-  if (field.pattern !== undefined && isSafeUserFacingPattern(field.pattern)) {
-    let re: RegExp | undefined;
-    try {
-      re = new RegExp(field.pattern);
-    } catch {
-      // A malformed server-supplied pattern must not break the form; skip it.
-      re = undefined;
-    }
-    if (re && !re.test(str)) {
-      return `${label} does not match the required format`;
-    }
-  }
+  // `pattern` is intentionally NOT enforced here — see the note above
+  // `patternHint`. Running a server-chosen regex on the UI thread lets any
+  // connected server hang the tab; the server rejects a bad value anyway.
   switch (field.format) {
     case "email":
       return EMAIL_RE.test(str)

--- a/mcpjam-inspector/client/src/components/elicitation/schema.ts
+++ b/mcpjam-inspector/client/src/components/elicitation/schema.ts
@@ -13,6 +13,8 @@
  * hosted/chat dialogs later).
  */
 
+import { RE2JS } from "re2js";
+
 export type ElicitationFieldKind =
   | "string"
   | "number"
@@ -65,27 +67,8 @@ const FORMATS: readonly ElicitationFieldFormat[] = [
   "date-time",
 ];
 
-/**
- * We deliberately DO NOT execute a server-supplied `pattern`.
- *
- * `pattern` comes from the MCP server and `RegExp.test` runs unbounded on the
- * UI thread with a backtracking engine, so a hostile (or merely careless)
- * pattern freezes the tab. There is no safe subset to allow: an earlier cut
- * tried rejecting "nested quantifier" shapes like `(a+)+`, and it was trivially
- * bypassed — `a?a?a?…aaa` carries none of those markers and still took ~150ms
- * at 50 characters, doubling per extra character. Bounding input doesn't help
- * either, since `maxLength` is server-supplied too.
- *
- * Heuristics here are a losing game; the real fix is a non-backtracking engine
- * (RE2/`node-re2`), which is a dependency decision beyond this change.
- *
- * Skipping is the safe failure: the MCP server re-validates its own schema, so
- * an unmatched value round-trips and is rejected there instead of being caught
- * early. The pattern is still shown to the user as a hint (see `patternHint`),
- * so they aren't flying blind. Freezing the renderer is NOT a safe failure.
- */
+/** Patterns are shown verbatim and validated with RE2's linear-time engine. */
 export function patternHint(field: ElicitationField): string | undefined {
-  // Displayed verbatim as text — never compiled, never executed.
   return field.pattern ? `Must match: ${field.pattern}` : undefined;
 }
 
@@ -391,9 +374,20 @@ function validateString(
       field.maxLength === 1 ? "" : "s"
     }`;
   }
-  // `pattern` is intentionally NOT enforced here — see the note above
-  // `patternHint`. Running a server-chosen regex on the UI thread lets any
-  // connected server hang the tab; the server rejects a bad value anyway.
+  if (field.pattern) {
+    try {
+      // RE2JS uses a non-backtracking DFA, so server-controlled patterns cannot
+      // freeze the renderer. `test` intentionally mirrors RegExp.test's
+      // unanchored semantics; schemas that need a full match include ^...$.
+      if (!RE2JS.compile(field.pattern).test(str)) {
+        return `${label} does not match the required pattern`;
+      }
+    } catch {
+      // RE2 deliberately rejects backreferences/lookarounds and malformed
+      // syntax. Do not silently accept content we could not validate.
+      return `${label} uses a pattern this client cannot safely validate`;
+    }
+  }
   switch (field.format) {
     case "email":
       return EMAIL_RE.test(str)

--- a/mcpjam-inspector/package.json
+++ b/mcpjam-inspector/package.json
@@ -179,6 +179,7 @@
     "posthog-js": "^1.310.0",
     "posthog-node": "^5.9.2",
     "radix-ui": "^1.4.2",
+    "re2js": "^2.8.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-force-graph-2d": "^1.29.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -408,6 +408,7 @@
         "posthog-js": "^1.310.0",
         "posthog-node": "^5.9.2",
         "radix-ui": "^1.4.2",
+        "re2js": "^2.8.6",
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-force-graph-2d": "^1.29.1",
@@ -30952,6 +30953,15 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/re2js": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/re2js/-/re2js-2.8.6.tgz",
+      "integrity": "sha512-xLgQil4kIUCrAzVk9fRSkxkFNwmygLFjVxXrLc65aE1F0+Zsb8rxumFBy4XKyvgMCTL6kilDq3EZ0piE2dP/Dg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/react": {


### PR DESCRIPTION
Part 4b of 6 adding MCP elicitation to hosted mode. **Independent** — and it improves **local mode immediately**, since ToolsTab/TasksTab/ChatTabV2 all share this dialog today.

Stack: backend ([mcpjam-backend#724](https://github.com/MCPJam/mcpjam-backend/pull/724)) → sdk (#3226) → server → client. This one is orthogonal (toggle: #3227).

## Why

The existing `ElicitationDialog` implements a fraction of MCP's flat-object schema, and the gaps are user-visible:

- **`default` was ignored** — servers pre-fill fields and the user saw them empty.
- **`title` was ignored** — labels showed the raw property key.
- **`minimum`/`maximum`/`pattern` were parsed and then never applied.** Validation only checked required-non-empty, so invalid input was submitted and rejected by the server.
- **Multi-select enums fell back to a raw JSON textarea.**
- **`oneOf`/`anyOf` `{const,title}`** rendered as raw const values.
- No `format` handling (email/uri/date/date-time).

## What's here

**Pure schema module** (`elicitation/schema.ts`) — `parseElicitationSchema` / `validateField` / `buildElicitationContent`, unit-testable without RTL. Handles the spec's primitive subset, single-select enums (incl. legacy `enumNames`), multi-select arrays with `minItems`/`maxItems`, formats, and routes spec-violating nested shapes to a JSON fallback.

**Dialog rework** — titles, default prefill, checkbox lists for multi-select, format→input-type mapping, and **inline validation that blocks Accept** instead of silently returning.

**Requesting-server identity** (spec MUST: *"clients MUST provide UI that makes it clear which server is requesting information"*). `DialogElicitation` gains optional `serverId`/`serverName`; the header renders the name with the **immutable `serverId` always visible** — `serverName` is a server-supplied label and isn't trusted, `serverId` is the anchor. Callers that don't plumb it get the current generic header.

**Never renders clickable URLs** (spec MUST) — field values, descriptions and messages are plain text only, no linkification. A test asserts zero `<a>` elements.

## Constraints honored

Props signature and the `DialogElicitation` shape are **preserved and extended additively** — ToolsTab, TasksTab and ChatTabV2 all consume this. Task payloads feed `schema` (not `requestedSchema`); still accepted.

## A bug the tests caught

A *declared but malformed* enum (`{type:"string", enum:["a", 2]}`) initially fell through to a plain text input, silently dropping the server's constraint. It now routes to the JSON fallback.

## Worth flagging

`ElicitResult.content` only permits `string | number | boolean | string[]`, so `buildElicitationContent` re-serializes richer parsed values from the JSON fallback to a compact string — matching what `ToolsTab.normalizeElicitationContent` already does downstream, so both paths behave the same.

## Tests

48 new (29 pure schema + 19 RTL). Regression: `Test Files 6 passed | Tests 104 passed`. Note that TasksTab/ChatTabV2 suites mock this dialog to `() => null`, so **`ToolsTab.test.tsx` is the only pre-existing suite that exercises the real thing** — it passes unchanged. Client typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches user-submitted MCP elicitation payloads and validation of untrusted server schemas (including regex), but hardening (RE2, no links, prototype-safe maps) and broad tests reduce regression risk; API surface stays backward compatible.
> 
> **Overview**
> **Reworks the shared MCP elicitation form** used by Tools, Tasks, and Chat: inline schema logic moves into a new React-free `elicitation/schema.ts`, and `ElicitationDialog` becomes a richer, spec-aligned UI on top of it.
> 
> The schema layer parses the flat MCP object subset (primitives, single/multi enums with `enumNames` / `oneOf`/`anyOf`, formats, constraints), validates with **re2js** for server `pattern`s (shown as hints), and builds `ElicitResult.content` with correct coercion and omission rules. Forbidden nested shapes use a **JSON textarea** instead of silently dropping constraints.
> 
> The dialog adds **default prefill**, **title** labels (raw key when needed), **multi-select checkboxes**, format→input types, **inline validation that blocks Accept**, and a **`RequestingServer`** header from optional `serverId`/`serverName` on `DialogElicitation`. It memoizes parsing on **`requestId`** so streaming chat rerenders do not wipe in-progress answers, uses **null-prototype** maps for server-chosen keys like `__proto__`, and keeps all server text **non-linkified**.
> 
> Adds **`re2js`** and **~48 new unit/component tests**; `ToolsTab` wiring is unchanged aside from the extended type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 744992e319b5458070ab01e39d969407182ed409. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Spec-complete elicitation form dialog with a pure schema module, inline validation that blocks Accept, and a clear requesting‑server identity header. Adds multi‑select checkboxes, format→input mapping, a JSON fallback for forbidden shapes, and safe `pattern` validation via `re2js` (also shown as hints).

- **New Features**
  - Pure schema helpers (`parseElicitationSchema`, `validateField`, `buildElicitationContent`, `initialFormValues`) for MCP’s flat‑object subset.
  - Titles/defaults; single- and multi-select enums (`enumNames`, `oneOf`/`anyOf` `{const,title}`) with `minItems`/`maxItems`; email/uri/date/date‑time input types; unsupported/nested shapes use a JSON textarea.
  - Requesting‑server identity via `serverId` (always shown) and optional `serverName`; all text is plain (no clickable URLs).

- **Bug Fixes**
  - Memoizes parsed fields on `requestId` so typed input isn’t wiped by parent rerenders.
  - Enforces `minimum`/`maximum`, `minLength`/`maxLength`, and safe `pattern` checks using `re2js`; malformed choice schemas fall back to JSON.
  - Optional booleans start unanswered and are omitted unless set; required booleans still send false. Optional multi‑selects may be empty; `minItems`/`maxItems` apply once answered.
  - Uses null‑prototype maps for values, errors, and content so `__proto__` fields render, validate, and submit correctly.

<sup>Written for commit 744992e319b5458070ab01e39d969407182ed409. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

