### PR TITLE
feat(elicitation): hosted-mode elicitation bridge, gating, and -32042 surfacing

### DIFF
--- a/.changeset/elicitation-modes-and-timeouts.md
+++ b/.changeset/elicitation-modes-and-timeouts.md
@@ -1,0 +1,10 @@
+---
+"@mcpjam/sdk": minor
+---
+
+Elicitation mode/serverId passthrough and elicitation-aware tool timeouts. Additive: existing callbacks and call sites are unaffected.
+
+- `ElicitationCallbackRequest` gains optional `serverId`, `mode` (`"form" | "url"`, absent ⇒ form), `url`, and `elicitationId`, so a global elicitation callback can tell which server asked, render URL-mode consent (MCP 2025-11-25), and correlate the server-chosen elicitation id. Form mode keeps reading `requestedSchema ?? schema`.
+- `ElicitationManager.applyToClient` takes an optional third argument carrying the `elicitation` client capability actually advertised on the wire, and rejects elicitations whose mode was not declared with JSON-RPC `-32602` per spec (bare `{}` ≡ form-only; `{form:{},url:{}}` allows both). Mode-vs-declaration semantics come from upstream's own `getSupportedElicitationModes`, so they cannot drift from what the upstream `Client` enforces. New `hasPendingForServer(serverId)` reports whether an elicitation handler is currently in flight.
+- New `MCPClientManagerOptions.elicitationTimeoutExtensionMs` (default 10 minutes, exported as `DEFAULT_ELICITATION_TIMEOUT_EXTENSION_MS`). When a server has an elicitation handler, `executeTool` no longer lets the per-request timeout kill a tool call that is merely blocked on a human: the base timeout is enforced by a watchdog that only accumulates time while no elicitation is pending, while total time spent suspended across all elicitations in the call is capped by the extension. A genuinely hung server still dies at its base timeout. Aborts are timeout-shaped (`SdkError` / `SdkErrorCode.RequestTimeout`) and never classified as retryable. Servers without an elicitation handler are a pure passthrough.
+- New `ElicitationMode` and `DeclaredElicitationCapability` type exports.

--- a/mcpjam-inspector/server/config.ts
+++ b/mcpjam-inspector/server/config.ts
@@ -86,6 +86,30 @@ export const WEB_CONNECT_TIMEOUT_MS = 10_000;
 export const WEB_CALL_TIMEOUT_MS = 30_000;
 export const WEB_STREAM_TIMEOUT_MS = 120_000;
 
+// ── Hosted elicitation (MCP 2025-11-25) ─────────────────────────────────────
+// An elicitation blocks a `tools/call` on a HUMAN, so these are human-scale.
+// They do not extend how long a *server* may take to respond: the SDK's
+// elicitation-aware timeout only stops the clock while an elicitation is
+// pending (see `elicitationTimeoutExtensionMs`), so a hung server still dies
+// at WEB_STREAM_TIMEOUT_MS of its own activity.
+
+/** How long the user has to answer a form before we resolve `{action:"cancel"}`. */
+export const ELICITATION_FORM_TTL_MS = 5 * 60_000;
+/** How long the user has to consent to (or decline) opening a URL. */
+export const ELICITATION_URL_CONSENT_TTL_MS = 2 * 60_000;
+/** Convex rendezvous poll cadence while a tool call is blocked. */
+export const ELICITATION_POLL_INTERVAL_MS = 1_000;
+/** Jitter added per poll so replicas don't synchronize (scheduled-evals idiom). */
+export const ELICITATION_POLL_JITTER_MS = 250;
+/** Consecutive poll transport failures tolerated before resolving `cancel`. */
+export const ELICITATION_POLL_MAX_FAILURES = 5;
+/**
+ * Total suspended-time budget granted to ONE tool call across all of its
+ * sequential elicitations. Slack over the longest single TTL so a form answered
+ * at the last second still lands.
+ */
+export const ELICITATION_TIMEOUT_EXTENSION_MS = ELICITATION_FORM_TTL_MS + 30_000;
+
 // Hosted app origin the LOCAL inspector server forwards XAA hosted-issuer
 // mint requests to (server-to-server; hosted CORS blocks the browser from
 // calling it directly). Override for staging. Never derived from a request.

--- a/mcpjam-inspector/server/config.ts
+++ b/mcpjam-inspector/server/config.ts
@@ -104,6 +104,13 @@ export const ELICITATION_POLL_JITTER_MS = 250;
 /** Consecutive poll transport failures tolerated before resolving `cancel`. */
 export const ELICITATION_POLL_MAX_FAILURES = 5;
 /**
+ * Deadline for a single Convex service-route call (poll/ack/cancel). These are
+ * tiny reads/writes; anything slower is a stall. Unbounded, a hung Convex would
+ * park the poll loop forever — the tool call would outlive its TTL and
+ * end-of-stream cleanup would block behind it.
+ */
+export const ELICITATION_SERVICE_ROUTE_TIMEOUT_MS = 10_000;
+/**
  * Total suspended-time budget granted to ONE tool call across all of its
  * sequential elicitations. Slack over the longest single TTL so a form answered
  * at the last second still lands.

--- a/mcpjam-inspector/server/routes/mcp/__tests__/elicitation-local-modes.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/elicitation-local-modes.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { narrowElicitationToLocalSupport } from "../elicitation.js";
+
+/**
+ * The local SSE bridge is form-only. These lock "advertise = enforce" on that
+ * path: whatever goes on the wire must be something the bridge can complete.
+ */
+describe("narrowElicitationToLocalSupport", () => {
+  it("strips url while keeping form", () => {
+    // The host toggle can write {form,url}. Local must not claim url: the SDK
+    // would accept the request and the bridge would drop the URL, leaving a
+    // form the user cannot complete.
+    expect(
+      narrowElicitationToLocalSupport({
+        roots: {},
+        elicitation: { form: {}, url: {} },
+      }),
+    ).toEqual({ roots: {}, elicitation: { form: {} } });
+  });
+
+  it("drops the capability entirely when only url was declared", () => {
+    // Narrowing {url:{}} to {} would silently mean "form" — a capability the
+    // caller never asked for. Claiming nothing is the honest outcome.
+    expect(
+      narrowElicitationToLocalSupport({ roots: {}, elicitation: { url: {} } }),
+    ).toEqual({ roots: {} });
+  });
+
+  it("leaves bare {} untouched", () => {
+    // Already form-only per the spec's back-compat rule; rewriting it would
+    // churn configs for no behavior change.
+    const caps = { elicitation: {} };
+    expect(narrowElicitationToLocalSupport(caps)).toBe(caps);
+  });
+
+  it("leaves form-only declarations untouched in value", () => {
+    expect(narrowElicitationToLocalSupport({ elicitation: { form: {} } })).toEqual(
+      { elicitation: { form: {} } },
+    );
+  });
+
+  it("preserves unrelated capabilities and unknown elicitation sub-keys are dropped", () => {
+    // Unknown modes are, by definition, modes this bridge cannot complete.
+    expect(
+      narrowElicitationToLocalSupport({
+        sampling: {},
+        elicitation: { form: {}, telepathy: {} },
+      }),
+    ).toEqual({ sampling: {}, elicitation: { form: {} } });
+  });
+
+  it.each([
+    [undefined],
+    [{}],
+    [{ roots: {} }],
+    [{ elicitation: true }],
+    [{ elicitation: "yes" }],
+    [{ elicitation: [] }],
+  ])("passes through non-object / absent elicitation: %p", (caps) => {
+    expect(narrowElicitationToLocalSupport(caps as any)).toBe(caps);
+  });
+
+  it("does not mutate the input", () => {
+    const caps = { elicitation: { form: {}, url: {} } };
+    narrowElicitationToLocalSupport(caps);
+    expect(caps).toEqual({ elicitation: { form: {}, url: {} } });
+  });
+});

--- a/mcpjam-inspector/server/routes/mcp/elicitation.ts
+++ b/mcpjam-inspector/server/routes/mcp/elicitation.ts
@@ -97,7 +97,7 @@ export function initElicitationCallback(manager: MCPClientManager): void {
 
   // Per MCP Tasks spec (2025-11-25), elicitations related to a task include relatedTaskId
   manager.setElicitationCallback(
-    ({ requestId, message, schema, relatedTaskId }) => {
+    ({ requestId, serverId, message, schema, relatedTaskId }) => {
       return new Promise<ElicitResult>((resolve, reject) => {
         try {
           manager.getPendingElicitations().set(requestId, { resolve, reject });
@@ -109,6 +109,12 @@ export function initElicitationCallback(manager: MCPClientManager): void {
         broadcastElicitation({
           type: "elicitation_request",
           requestId,
+          // Spec: the client MUST make it clear which server is asking. This
+          // matters most in local chat, where several servers are connected at
+          // once and the dialog is otherwise anonymous. The SDK supplies the
+          // id; it is the trusted, immutable anchor (there is no display name
+          // on this path, so the dialog shows the id itself).
+          serverId,
           message,
           schema,
           timestamp: new Date().toISOString(),

--- a/mcpjam-inspector/server/routes/mcp/elicitation.ts
+++ b/mcpjam-inspector/server/routes/mcp/elicitation.ts
@@ -34,6 +34,62 @@ const registeredManagers = new WeakSet<MCPClientManager>();
  * Without this, tasks/result calls might fail with "Method not found" if
  * no one has hit the elicitation routes yet.
  */
+/**
+ * Elicitation modes the LOCAL bridge can actually complete.
+ *
+ * This SSE flow is form-only: it broadcasts `{requestId, message, schema}` and
+ * resolves with form content. URL mode needs the URL to reach a consent dialog
+ * and returns no content — neither of which this pipeline carries. (Hosted
+ * chat has its own bridge, `routes/web/hosted-elicitation.ts`, which does both.)
+ */
+const LOCAL_SUPPORTED_ELICITATION_MODES = ["form"] as const;
+
+/**
+ * Drop elicitation modes the local bridge can't complete before they reach the
+ * wire.
+ *
+ * Advertising `url` here would be a lie with teeth: the SDK would accept a
+ * conforming url-mode request, this bridge would drop the `url`, and the user
+ * would get a form with nothing to fill in and no way to finish the
+ * interaction. Not advertising it means the SDK rejects such requests with
+ * `-32602` and the server can fall back — which is the honest outcome until the
+ * local pipeline carries URL mode end to end.
+ *
+ * Only prunes; a config that never mentioned elicitation is returned untouched
+ * so this can sit on the shared local path without inventing capabilities.
+ */
+export function narrowElicitationToLocalSupport(
+  capabilities: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  const elicitation = capabilities?.elicitation;
+  if (
+    !capabilities ||
+    typeof elicitation !== "object" ||
+    elicitation === null ||
+    Array.isArray(elicitation)
+  ) {
+    return capabilities;
+  }
+
+  const declared = elicitation as Record<string, unknown>;
+  // Bare `{}` is form-only per the spec's back-compat rule — already safe, and
+  // rewriting it would churn configs for no behavior change.
+  if (Object.keys(declared).length === 0) return capabilities;
+
+  const narrowed: Record<string, unknown> = {};
+  for (const mode of LOCAL_SUPPORTED_ELICITATION_MODES) {
+    if (declared[mode] !== undefined) narrowed[mode] = declared[mode];
+  }
+  // Everything was unsupported (e.g. `{url:{}}`): declaring `elicitation: {}`
+  // would silently mean "form", which the caller never asked for. Drop the
+  // capability entirely instead.
+  if (Object.keys(narrowed).length === 0) {
+    const { elicitation: _dropped, ...rest } = capabilities;
+    return rest;
+  }
+  return { ...capabilities, elicitation: narrowed };
+}
+
 export function initElicitationCallback(manager: MCPClientManager): void {
   // Use WeakSet to track registration per manager instance
   // This handles hot reload scenarios where a new manager is created

--- a/mcpjam-inspector/server/routes/web/__tests__/hosted-elicitation.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/hosted-elicitation.test.ts
@@ -496,4 +496,39 @@ describe("HostedElicitationBridge", () => {
     // No JSON-RPC response is owed on the error path.
     expect(mutation).not.toHaveBeenCalled();
   });
+
+  it("emitUrlRequired is engine-agnostic: it only needs the writer", async () => {
+    // Guards the BYOK fix. The org branches run `runDirectChatTurn`, where the
+    // AI SDK owns the tool loop and never reaches the shared executor's catch —
+    // so the old engine-level hook compiled and silently never fired for BYOK
+    // users. Emission now hangs off the tool set every engine shares, so the
+    // bridge needs nothing engine-specific to surface a -32042.
+    stubFetch({});
+    const { writer, events } = makeWriter();
+    const bridge = makeBridge();
+    bridge.attachStreamWriter(writer);
+
+    bridge.emitUrlRequired({
+      serverId: "srv-1",
+      toolCallId: "byok-call",
+      elicitations: [
+        { url: "https://example.com/connect", elicitationId: "e1" },
+      ],
+    });
+
+    expect(events()).toContainEqual(
+      expect.objectContaining({ kind: "url_required", toolCallId: "byok-call" }),
+    );
+  });
+
+  it("drops a url_required with no elicitations rather than emit an empty notice", async () => {
+    stubFetch({});
+    const { writer, events } = makeWriter();
+    const bridge = makeBridge();
+    bridge.attachStreamWriter(writer);
+
+    bridge.emitUrlRequired({ serverId: "srv-1", elicitations: [] });
+
+    expect(events()).toHaveLength(0);
+  });
 });

--- a/mcpjam-inspector/server/routes/web/__tests__/hosted-elicitation.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/hosted-elicitation.test.ts
@@ -1,0 +1,446 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { UIMessageChunk } from "ai";
+
+const mutation = vi.fn();
+vi.mock("convex/browser", () => ({
+  ConvexHttpClient: class {
+    setAuth = vi.fn();
+    mutation = (...args: unknown[]) => mutation(...args);
+  },
+}));
+
+import {
+  HostedElicitationBridge,
+  hostDeclaresElicitation,
+  resolveElicitationGate,
+} from "../hosted-elicitation.js";
+
+type Captured = { type: string; data: any; transient?: boolean };
+
+function makeWriter() {
+  const chunks: Captured[] = [];
+  return {
+    writer: { write: (c: UIMessageChunk) => chunks.push(c as unknown as Captured) },
+    chunks,
+    events: () => chunks.map((c) => c.data),
+  };
+}
+
+/** Minimal callback request; the SDK always supplies serverId in practice. */
+function formRequest(overrides: Record<string, unknown> = {}) {
+  return {
+    requestId: "req-1",
+    serverId: "srv-1",
+    message: "Pick a branch",
+    schema: { type: "object", properties: { branch: { type: "string" } } },
+    ...overrides,
+  } as any;
+}
+
+/** Route responses, keyed by path, consumed in order. */
+function stubFetch(routes: Record<string, unknown[]>) {
+  const calls: Array<{ path: string; body: any }> = [];
+  const cursor: Record<string, number> = {};
+  const fetchMock = vi.fn(async (url: string, init: any) => {
+    const path = new URL(url).pathname;
+    calls.push({ path, body: JSON.parse(init.body) });
+    const queue = routes[path];
+    if (!queue) return { ok: true, json: async () => ({ ok: true }) } as any;
+    const idx = Math.min(cursor[path] ?? 0, queue.length - 1);
+    cursor[path] = (cursor[path] ?? 0) + 1;
+    const next = queue[idx];
+    if (next instanceof Error) throw next;
+    return { ok: true, json: async () => next } as any;
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return { calls, fetchMock };
+}
+
+const pollPending = { ok: true, elicitation: { status: "pending" } };
+const pollAnswered = {
+  ok: true,
+  elicitation: {
+    status: "answered",
+    action: "accept",
+    content: { branch: "main" },
+  },
+};
+
+function makeBridge(overrides: Partial<any> = {}) {
+  return new HostedElicitationBridge({
+    convexBearer: "Bearer jwt-token",
+    projectId: "proj-1",
+    chatSessionId: "sess-1",
+    serverNamesById: { "srv-1": "GitHub" },
+    ...overrides,
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  mutation.mockReset().mockResolvedValue({ ok: true });
+  process.env.CONVEX_URL = "https://convex.test";
+  process.env.CONVEX_HTTP_URL = "https://convex-http.test";
+  process.env.INSPECTOR_SERVICE_TOKEN = "svc-token";
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("hostDeclaresElicitation", () => {
+  it("accepts every shape the catalog actually ships", () => {
+    // Bare {} is form-only per the spec's back-compat rule; the catalog uses
+    // both it and the explicit form. Presence of the key is the toggle.
+    expect(hostDeclaresElicitation({ elicitation: {} })).toBe(true);
+    expect(hostDeclaresElicitation({ elicitation: { form: {} } })).toBe(true);
+    expect(
+      hostDeclaresElicitation({ elicitation: { form: {}, url: {} } }),
+    ).toBe(true);
+  });
+
+  it("rejects absence and non-object junk", () => {
+    expect(hostDeclaresElicitation(undefined)).toBe(false);
+    expect(hostDeclaresElicitation({})).toBe(false);
+    expect(hostDeclaresElicitation({ elicitation: true })).toBe(false);
+    expect(hostDeclaresElicitation({ elicitation: "yes" })).toBe(false);
+    expect(hostDeclaresElicitation({ elicitation: [] })).toBe(false);
+    expect(hostDeclaresElicitation({ roots: {} })).toBe(false);
+  });
+});
+
+describe("resolveElicitationGate", () => {
+  const ON = { elicitation: {} };
+  const OFF = { roots: {} };
+
+  it("enables a direct turn from the body when the client speaks v1", () => {
+    const gate = resolveElicitationGate({
+      isChatboxSession: false,
+      hostClientCapabilities: undefined,
+      bodyClientCapabilities: ON,
+      clientVersion: 1,
+    });
+    expect(gate.enabled).toBe(true);
+    expect(gate.effectiveClientCapabilities).toBe(ON);
+  });
+
+  it("ignores the body for a chatbox turn and uses the published host", () => {
+    // THE security property: a share-link visitor controls the body. If the
+    // published host has elicitation off, no body can switch it on.
+    const gate = resolveElicitationGate({
+      isChatboxSession: true,
+      hostClientCapabilities: OFF,
+      bodyClientCapabilities: ON,
+      clientVersion: 1,
+    });
+    expect(gate.enabled).toBe(false);
+    expect(gate.effectiveClientCapabilities).toBe(OFF);
+  });
+
+  it("honors a chatbox host that DOES declare elicitation", () => {
+    const gate = resolveElicitationGate({
+      isChatboxSession: true,
+      hostClientCapabilities: ON,
+      bodyClientCapabilities: undefined,
+      clientVersion: 1,
+    });
+    expect(gate.enabled).toBe(true);
+    expect(gate.effectiveClientCapabilities).toBe(ON);
+  });
+
+  it("fails closed for a chatbox when the backend omits clientCapabilities", () => {
+    // Backend predating the runtime-config field → absent → off, never "trust
+    // the body instead".
+    const gate = resolveElicitationGate({
+      isChatboxSession: true,
+      hostClientCapabilities: undefined,
+      bodyClientCapabilities: ON,
+      clientVersion: 1,
+    });
+    expect(gate.enabled).toBe(false);
+    expect(gate.effectiveClientCapabilities).toBeUndefined();
+  });
+
+  it.each([[undefined], [0], [2], ["1"]])(
+    "stays off when the client handshake is %p",
+    (clientVersion) => {
+      // Catalog hosts already declare elicitation; without the handshake an old
+      // bundle would hang for a TTL on any server that elicits.
+      const gate = resolveElicitationGate({
+        isChatboxSession: false,
+        hostClientCapabilities: undefined,
+        bodyClientCapabilities: ON,
+        clientVersion: clientVersion as number | undefined,
+      });
+      expect(gate.enabled).toBe(false);
+      // The capability still goes on the wire decision unchanged — only the
+      // honoring is gated.
+      expect(gate.effectiveClientCapabilities).toBe(ON);
+    },
+  );
+
+  it("stays off when the host does not declare it, even at v1", () => {
+    expect(
+      resolveElicitationGate({
+        isChatboxSession: false,
+        hostClientCapabilities: undefined,
+        bodyClientCapabilities: OFF,
+        clientVersion: 1,
+      }).enabled,
+    ).toBe(false);
+  });
+});
+
+describe("HostedElicitationBridge", () => {
+  it("cancels immediately when no writer is attached, without touching Convex", async () => {
+    // The pre-writer window is connect/tools-list inside prepareChatV2, which
+    // BLOCKS stream creation — buffering here would deadlock until TTL.
+    stubFetch({});
+    const bridge = makeBridge();
+
+    const result = await bridge.callback(formRequest());
+
+    expect(result).toEqual({ action: "cancel" });
+    expect(mutation).not.toHaveBeenCalled();
+  });
+
+  it("cancels when the rendezvous row cannot be created", async () => {
+    stubFetch({});
+    const { writer } = makeWriter();
+    mutation.mockRejectedValueOnce(new Error("convex down"));
+    const bridge = makeBridge();
+    bridge.attachStreamWriter(writer);
+
+    // A broken rendezvous has nothing to answer it — hanging the tool call
+    // would be strictly worse than a clean cancel.
+    await expect(bridge.callback(formRequest())).resolves.toEqual({
+      action: "cancel",
+    });
+  });
+
+  it("emits the request part, then resolves the answered content", async () => {
+    stubFetch({ "/elicitations/poll": [pollPending, pollAnswered] });
+    const { writer, events } = makeWriter();
+    const bridge = makeBridge();
+    bridge.attachStreamWriter(writer);
+
+    const promise = bridge.callback(formRequest());
+    await vi.advanceTimersByTimeAsync(3000);
+
+    await expect(promise).resolves.toEqual({
+      action: "accept",
+      content: { branch: "main" },
+    });
+
+    const request = events().find((e) => e.kind === "request");
+    expect(request).toMatchObject({
+      serverId: "srv-1",
+      serverName: "GitHub",
+      mode: "form",
+      message: "Pick a branch",
+      chatSessionId: "sess-1",
+    });
+    expect(typeof request.rendezvousId).toBe("string");
+    expect(events()).toContainEqual(
+      expect.objectContaining({ kind: "resolved", outcome: "answered" }),
+    );
+  });
+
+  it("marks request parts transient so they never enter the transcript", async () => {
+    stubFetch({ "/elicitations/poll": [pollAnswered] });
+    const { writer, chunks } = makeWriter();
+    const bridge = makeBridge();
+    bridge.attachStreamWriter(writer);
+
+    const promise = bridge.callback(formRequest());
+    await vi.advanceTimersByTimeAsync(2000);
+    await promise;
+
+    expect(chunks.length).toBeGreaterThan(0);
+    for (const chunk of chunks) {
+      expect(chunk.type).toBe("data-elicitation");
+      expect(chunk.transient).toBe(true);
+    }
+  });
+
+  it("does not ack while the answer is still pending", async () => {
+    // Acking early would scrub a payload we never received. (The complementary
+    // guarantee — that reading via /elicitations/poll has no side effects — is
+    // enforced and tested backend-side; the bridge cannot observe it.)
+    const { calls } = stubFetch({ "/elicitations/poll": [pollPending] });
+    const { writer } = makeWriter();
+    const bridge = makeBridge();
+    bridge.attachStreamWriter(writer);
+
+    void bridge.callback(formRequest());
+    await vi.advanceTimersByTimeAsync(6000);
+
+    expect(calls.filter((c) => c.path === "/elicitations/poll").length)
+      .toBeGreaterThan(1);
+    expect(calls.some((c) => c.path === "/elicitations/ack")).toBe(false);
+  });
+
+  it("acks exactly once, and only for an answered row", async () => {
+    const { calls } = stubFetch({
+      "/elicitations/poll": [pollPending, pollAnswered],
+    });
+    const { writer } = makeWriter();
+    const bridge = makeBridge();
+    bridge.attachStreamWriter(writer);
+
+    const promise = bridge.callback(formRequest());
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+    await vi.advanceTimersByTimeAsync(50);
+
+    const acks = calls.filter((c) => c.path === "/elicitations/ack");
+    expect(acks).toHaveLength(1);
+    expect(acks[0].body.rendezvousId).toEqual(
+      calls.find((c) => c.path === "/elicitations/poll")!.body.rendezvousId,
+    );
+  });
+
+  it("does not ack a terminal row it never consumed an answer from", async () => {
+    // expired/cancelled carry no content; the backend scrubs those inline.
+    const { calls } = stubFetch({
+      "/elicitations/poll": [{ ok: true, elicitation: { status: "expired" } }],
+    });
+    const { writer } = makeWriter();
+    const bridge = makeBridge();
+    bridge.attachStreamWriter(writer);
+
+    const promise = bridge.callback(formRequest());
+    await vi.advanceTimersByTimeAsync(2000);
+    await promise;
+    await vi.advanceTimersByTimeAsync(50);
+
+    expect(calls.some((c) => c.path === "/elicitations/ack")).toBe(false);
+  });
+
+  it("never sends content for a url-mode accept", async () => {
+    // Spec: URL-mode results carry no content. Inventing one would be a lie
+    // about what the user supplied.
+    stubFetch({
+      "/elicitations/poll": [
+        { ok: true, elicitation: { status: "answered", action: "accept" } },
+      ],
+    });
+    const { writer } = makeWriter();
+    const bridge = makeBridge();
+    bridge.attachStreamWriter(writer);
+
+    const promise = bridge.callback(
+      formRequest({
+        mode: "url",
+        url: "https://example.com/connect",
+        elicitationId: "srv-chosen-1",
+        schema: undefined,
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(2000);
+
+    await expect(promise).resolves.toEqual({ action: "accept" });
+  });
+
+  it.each([
+    ["decline", { status: "answered", action: "decline" }, { action: "decline" }],
+    ["expired", { status: "expired" }, { action: "cancel" }],
+    ["cancelled", { status: "cancelled" }, { action: "cancel" }],
+  ])("resolves %s terminal states", async (_label, elicitation, expected) => {
+    stubFetch({ "/elicitations/poll": [{ ok: true, elicitation }] });
+    const { writer } = makeWriter();
+    const bridge = makeBridge();
+    bridge.attachStreamWriter(writer);
+
+    const promise = bridge.callback(formRequest());
+    await vi.advanceTimersByTimeAsync(2000);
+
+    await expect(promise).resolves.toEqual(expected);
+  });
+
+  it("cancels on client abort and withdraws the row without emitting", async () => {
+    const { calls } = stubFetch({ "/elicitations/poll": [pollPending] });
+    const controller = new AbortController();
+    const { writer, events } = makeWriter();
+    const bridge = makeBridge({ abortSignal: controller.signal });
+    bridge.attachStreamWriter(writer);
+
+    const promise = bridge.callback(formRequest());
+    await vi.advanceTimersByTimeAsync(1500);
+    controller.abort();
+    await vi.advanceTimersByTimeAsync(1500);
+
+    await expect(promise).resolves.toEqual({ action: "cancel" });
+    // Nobody is listening once the stream is gone, so no resolved part.
+    expect(events().some((e) => e.kind === "resolved")).toBe(false);
+    expect(calls.some((c) => c.path === "/elicitations/cancel")).toBe(true);
+  });
+
+  it("cancels once the local deadline passes rather than waiting on the cron", async () => {
+    stubFetch({ "/elicitations/poll": [pollPending] });
+    const { writer, events } = makeWriter();
+    const bridge = makeBridge();
+    bridge.attachStreamWriter(writer);
+
+    const promise = bridge.callback(formRequest());
+    // Past ELICITATION_FORM_TTL_MS (5 min).
+    await vi.advanceTimersByTimeAsync(5 * 60_000 + 5_000);
+
+    await expect(promise).resolves.toEqual({ action: "cancel" });
+    expect(events()).toContainEqual(
+      expect.objectContaining({ kind: "resolved", outcome: "expired" }),
+    );
+  });
+
+  it("tolerates transient poll failures, then cancels after the ceiling", async () => {
+    stubFetch({ "/elicitations/poll": [new Error("network")] });
+    const { writer } = makeWriter();
+    const bridge = makeBridge();
+    bridge.attachStreamWriter(writer);
+
+    const promise = bridge.callback(formRequest());
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    await expect(promise).resolves.toEqual({ action: "cancel" });
+  });
+
+  it("withdraws still-pending rows on dispose", async () => {
+    const { calls } = stubFetch({ "/elicitations/poll": [pollPending] });
+    const { writer } = makeWriter();
+    const bridge = makeBridge();
+    bridge.attachStreamWriter(writer);
+
+    void bridge.callback(formRequest());
+    await vi.advanceTimersByTimeAsync(1500);
+    await bridge.dispose();
+
+    expect(calls.some((c) => c.path === "/elicitations/cancel")).toBe(true);
+  });
+
+  it("emits url_required for -32042 without creating a rendezvous row", async () => {
+    stubFetch({});
+    const { writer, events } = makeWriter();
+    const bridge = makeBridge();
+    bridge.attachStreamWriter(writer);
+
+    bridge.emitUrlRequired({
+      serverId: "srv-1",
+      toolCallId: "call-9",
+      elicitations: [
+        { url: "https://example.com/auth", elicitationId: "e1", message: "Connect" },
+      ],
+    });
+
+    expect(events()).toContainEqual(
+      expect.objectContaining({
+        kind: "url_required",
+        serverId: "srv-1",
+        serverName: "GitHub",
+        toolCallId: "call-9",
+      }),
+    );
+    // No JSON-RPC response is owed on the error path.
+    expect(mutation).not.toHaveBeenCalled();
+  });
+});

--- a/mcpjam-inspector/server/routes/web/__tests__/hosted-elicitation.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/hosted-elicitation.test.ts
@@ -405,6 +405,59 @@ describe("HostedElicitationBridge", () => {
     await expect(promise).resolves.toEqual({ action: "cancel" });
   });
 
+  it("bounds a stalled Convex call instead of hanging the tool forever", async () => {
+    // Without a deadline the poll never returns: the TTL check only runs
+    // between polls, so the tool call would outlive its TTL with nothing able
+    // to resolve it. A stall must degrade to a poll failure, not a hang.
+    const hang = vi.fn(
+      (_url: string, init: any) =>
+        new Promise((_resolve, reject) => {
+          init.signal?.addEventListener("abort", () =>
+            reject(new Error("aborted")),
+          );
+        }),
+    );
+    vi.stubGlobal("fetch", hang);
+    const { writer } = makeWriter();
+    const bridge = makeBridge();
+    bridge.attachStreamWriter(writer);
+
+    const promise = bridge.callback(formRequest());
+    // 5 failures × (10s deadline + ~1s backoff) — comfortably covered.
+    await vi.advanceTimersByTimeAsync(90_000);
+
+    await expect(promise).resolves.toEqual({ action: "cancel" });
+  });
+
+  it("does not bind cancel to the turn signal", async () => {
+    // dispose() runs BECAUSE the turn ended. Binding the withdraw request to
+    // the turn's signal would abort the very call meant to retract the prompt,
+    // leaving it answerable for its whole TTL.
+    const seen: Array<boolean> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init: any) => {
+        if (new URL(url).pathname === "/elicitations/cancel") {
+          seen.push(Boolean(init.signal?.aborted));
+        }
+        return { ok: true, json: async () => ({ ok: true }) } as any;
+      }),
+    );
+    const controller = new AbortController();
+    const { writer } = makeWriter();
+    const bridge = makeBridge({ abortSignal: controller.signal });
+    bridge.attachStreamWriter(writer);
+
+    void bridge.callback(formRequest());
+    await vi.advanceTimersByTimeAsync(50);
+    controller.abort();
+    await bridge.dispose();
+    await vi.advanceTimersByTimeAsync(50);
+
+    expect(seen.length).toBeGreaterThan(0);
+    expect(seen.every((aborted) => aborted === false)).toBe(true);
+  });
+
   it("withdraws still-pending rows on dispose", async () => {
     const { calls } = stubFetch({ "/elicitations/poll": [pollPending] });
     const { writer } = makeWriter();

--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -7,6 +7,7 @@ import {
   type McpProtocolVersion,
 } from "@mcpjam/sdk";
 import type {
+  ElicitationCallback,
   HttpServerConfig,
   RpcLogger,
   UnauthorizedRefreshHandler,
@@ -200,6 +201,17 @@ export const hostedChatSchema = z
     selectedServerIds: z.array(z.string().min(1)),
     selectedServerNames: z.array(z.string().min(1)).optional(),
     clientCapabilities: clientCapabilitiesSchema.optional(),
+    /**
+     * Client's hosted-elicitation protocol version. Absent ⇒ the client cannot
+     * render an elicitation prompt, so the server must not register the
+     * callback (and therefore must not advertise the capability).
+     *
+     * This handshake exists because catalog hosts ALREADY declare
+     * `elicitation`: without it, deploying server support would make every
+     * stale browser bundle hang for a full TTL on any server that elicits.
+     * Bump only if the wire contract changes incompatibly.
+     */
+    hostedElicitationVersion: z.literal(1).optional(),
     chatSessionId: z.string().min(1).optional(),
     surface: z.enum(["preview", "share_link"]).optional(),
     oauthTokens: z.record(z.string(), z.string()).optional(),
@@ -216,7 +228,7 @@ export function buildSingleServerOAuthTokens(serverId: string, token?: string) {
   return token ? { [serverId]: token } : undefined;
 }
 
-function buildServerNamesById(
+export function buildServerNamesById(
   serverIds: string[],
   serverNames?: readonly string[]
 ): Record<string, string> | undefined {
@@ -852,6 +864,28 @@ export async function createAuthorizedManager(
      * also pass `xaaIssuer`.
      */
     xaaPolicy?: XaaEnterprisePolicy;
+     * Global elicitation callback for INTERACTIVE, streaming surfaces.
+     *
+     * Registration is what makes elicitation work at all: `buildCapabilities`
+     * strips a host-declared `elicitation` capability unless a handler is
+     * already registered at connect time, so passing this is simultaneously
+     * "advertise it" and "honor it" — they cannot drift apart.
+     *
+     * MUST be registered here, not by the caller: the manager constructor kicks
+     * off connects in a microtask, so a caller registering after
+     * `await createAuthorizedManager(...)` loses the race and the capability is
+     * silently stripped. Registering synchronously below always wins.
+     *
+     * Non-interactive surfaces (swarm, evals, chatbox persona/simulation,
+     * tools/execute) deliberately omit this: they have no human to answer, so
+     * servers should fail fast rather than block on a prompt nobody sees.
+     */
+    elicitationCallback?: ElicitationCallback;
+    /**
+     * Total suspended-time budget per tool call while an elicitation is pending
+     * (SDK-side watchdog). Only meaningful alongside `elicitationCallback`.
+     */
+    elicitationTimeoutExtensionMs?: number;
   }
 ): Promise<AuthorizedManagerResult> {
   const serverNamesById = buildServerNamesById(serverIds, options?.serverNames);
@@ -1199,7 +1233,17 @@ export async function createAuthorizedManager(
     defaultTimeout: timeoutMs,
     rpcLogger: options?.rpcLogger,
     retryPolicy: INSPECTOR_MCP_RETRY_POLICY,
+    ...(options?.elicitationTimeoutExtensionMs !== undefined
+      ? { elicitationTimeoutExtensionMs: options.elicitationTimeoutExtensionMs }
+      : {}),
   });
+  // SYNCHRONOUS, before any `await` — the constructor above queued its connects
+  // as microtasks, and `buildCapabilities` (which decides whether `elicitation`
+  // survives onto the initialize wire) runs inside them. Registering here always
+  // wins that race; registering after an await never does.
+  if (options?.elicitationCallback) {
+    manager.setElicitationCallback(options.elicitationCallback);
+  }
   return {
     manager,
     oauthServerUrls,

--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -210,8 +210,14 @@ export const hostedChatSchema = z
      * `elicitation`: without it, deploying server support would make every
      * stale browser bundle hang for a full TTL on any server that elicits.
      * Bump only if the wire contract changes incompatibly.
+     *
+     * Accepts ANY non-negative integer, not `literal(1)`: a newer client
+     * advertising v2 against this older server must degrade to
+     * elicitation-disabled, not 400 the entire chat request. The exact-version
+     * check lives in `resolveElicitationGate`, which is what actually decides
+     * whether to honor it.
      */
-    hostedElicitationVersion: z.literal(1).optional(),
+    hostedElicitationVersion: z.number().int().nonnegative().optional(),
     chatSessionId: z.string().min(1).optional(),
     surface: z.enum(["preview", "share_link"]).optional(),
     oauthTokens: z.record(z.string(), z.string()).optional(),

--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -870,6 +870,7 @@ export async function createAuthorizedManager(
      * also pass `xaaIssuer`.
      */
     xaaPolicy?: XaaEnterprisePolicy;
+    /**
      * Global elicitation callback for INTERACTIVE, streaming surfaces.
      *
      * Registration is what makes elicitation work at all: `buildCapabilities`

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -5,7 +5,16 @@ import { isHostedCatalogModel } from "../../services/hosted-model-catalog.js";
 import { shouldEnableCloudSkillTools } from "../../utils/computers/cloud-skill-tools.js";
 import { isMCPAuthError } from "@mcpjam/sdk";
 import { resolveHostModelDefinition } from "../../utils/org-model-config.js";
-import { HOSTED_MODE, WEB_STREAM_TIMEOUT_MS } from "../../config.js";
+import {
+  ELICITATION_TIMEOUT_EXTENSION_MS,
+  HOSTED_MODE,
+  WEB_STREAM_TIMEOUT_MS,
+} from "../../config.js";
+import {
+  HostedElicitationBridge,
+  resolveElicitationGate,
+} from "./hosted-elicitation.js";
+import { getConvexBearerForRequest } from "../../utils/v1-convex-token.js";
 import {
   validateAppToolEntries,
   AppToolValidationError,
@@ -20,6 +29,7 @@ import { captureServerEvent } from "../../utils/analytics.js";
 import {
   hostedChatSchema,
   createAuthorizedManager,
+  buildServerNamesById,
   callerContextFromHono,
   assertBearerToken,
   readJsonBody,
@@ -409,6 +419,33 @@ chatV2.post("/", async (c) => {
       hasProjectId: Boolean(hostedBody.projectId),
     });
 
+    // Registering the callback is what makes the SDK advertise `elicitation`,
+    // so "who declares it" and "may we honor it" are one decision — see
+    // `resolveElicitationGate` for why chatbox turns must not read the body.
+    const {
+      effectiveClientCapabilities,
+      enabled: elicitationEnabled,
+    } = resolveElicitationGate({
+      isChatboxSession,
+      hostClientCapabilities: hostRuntimeConfig?.clientCapabilities,
+      bodyClientCapabilities: hostedBody.clientCapabilities,
+      clientVersion: hostedBody.hostedElicitationVersion,
+    });
+
+    const elicitationBridge = elicitationEnabled
+      ? new HostedElicitationBridge({
+          // NOT the raw Authorization header: for WorkOS API-key callers that
+          // is an `sk_…` key Convex cannot verify. This resolves the delegated
+          // JWT for those callers and passes JWTs through untouched.
+          convexBearer: await getConvexBearerForRequest(c),
+          projectId: hostedBody.projectId,
+          chatSessionId: hostedBody.chatSessionId,
+          serverNamesById:
+            buildServerNamesById(selectedServerIds, selectedServerNames) ?? {},
+          abortSignal: c.req.raw.signal as AbortSignal | undefined,
+        })
+      : undefined;
+
     // Membership chat (no share/chatbox token) is the default — the backend
     // authorizes via project ownership for both guest and authed users.
     // accessScope is only set when a token is in play (shared chat / chatbox)
@@ -424,7 +461,9 @@ chatV2.post("/", async (c) => {
       selectedServerIds,
       WEB_STREAM_TIMEOUT_MS,
       hostedBody.oauthTokens,
-      hostedBody.clientCapabilities,
+      // Chatbox: advertise the HOST's capabilities, not the body's, so the
+      // wire matches what we're prepared to honor.
+      effectiveClientCapabilities,
       {
         ...(isChatboxSession ? { accessScope: "chat_v2" } : {}),
         chatboxId,
@@ -438,6 +477,12 @@ chatV2.post("/", async (c) => {
         // per-server configured) — without it the builder 500s rather than
         // connecting tokenless.
         xaaIssuer: resolveXaaIssuer(c, HOSTED_MODE),
+        ...(elicitationBridge
+          ? {
+              elicitationCallback: elicitationBridge.callback,
+              elicitationTimeoutExtensionMs: ELICITATION_TIMEOUT_EXTENSION_MS,
+            }
+          : {}),
       },
     );
     oauthServerUrls = urls;
@@ -601,10 +646,15 @@ chatV2.post("/", async (c) => {
           clientIp: getClientIp(c),
           abortSignal: c.req.raw.signal as AbortSignal | undefined,
           rpcCollector,
+          elicitationBridge,
           c,
         },
       });
     } catch (error) {
+      // The bridge can hold rows created before the throw (e.g. an elicitation
+      // during a tool call that then failed); withdraw them so no answerable
+      // prompt outlives the turn.
+      await elicitationBridge?.dispose();
       await manager.disconnectAllServers();
       throw error;
     }

--- a/mcpjam-inspector/server/routes/web/hosted-elicitation.ts
+++ b/mcpjam-inspector/server/routes/web/hosted-elicitation.ts
@@ -1,0 +1,514 @@
+/**
+ * Hosted-mode MCP elicitation bridge (MCP 2025-11-25, form + URL modes).
+ *
+ * ## Why a bridge at all
+ *
+ * An MCP server can send `elicitation/create` in the middle of a `tools/call`.
+ * Answering it means asking a HUMAN, which takes minutes — and the hosted plane
+ * is horizontally scaled, so the answer arrives as a *separate* HTTP request the
+ * load balancer may route to any replica.
+ *
+ * The split that makes this tractable:
+ *
+ * - **Delivery (server → user) needs no coordination.** Hosted chat builds a
+ *   per-request `MCPClientManager` and tears it down at end of turn, so the MCP
+ *   connection, the blocked tool call, and the browser's stream all live on THIS
+ *   replica for the turn. The request rides the turn's own UI message stream as
+ *   a transient `data-elicitation` part — inherently scoped to the one user who
+ *   asked, with no broadcast surface.
+ * - **The answer (user → blocked replica) is the only cross-replica leg.** It
+ *   rendezvouses through Convex: the browser writes the answer with its own live
+ *   Convex auth; this replica polls until answered/expired/aborted. Node cannot
+ *   subscribe to Convex (HTTP client only), hence polling.
+ *
+ * ## Ordering guarantee (do not "optimize" this)
+ *
+ * poll (read, side-effect-free) → resolve the ElicitResult to the MCP server →
+ * ack (scrub the payload). Scrubbing during the poll read is a CORRECTNESS BUG:
+ * if that response is lost in flight, the retry returns `answered` with the
+ * content already destroyed, and this bridge cannot distinguish that from a
+ * legitimately contentless accept (URL mode carries none; an empty form accept
+ * is valid) — it would fabricate a cancel over a real accept, or an empty accept
+ * over real content. If a replica dies before acking, the payload simply waits
+ * for the backend's 24h cleanup; retention is unchanged.
+ *
+ * ## Fail-fast before the writer exists
+ *
+ * The stream writer only arrives at `onStreamWriterReady`, which fires after MCP
+ * connect + tool discovery (`prepareChatV2`). An elicitation raised during that
+ * window has nowhere to render AND its consumer (the stream) is created by the
+ * very code path it would block — buffering it would deadlock until TTL. Every
+ * legitimate elicitation happens during tool execution, when the writer exists,
+ * so we resolve pre-writer requests as `cancel` immediately.
+ */
+
+import { ConvexHttpClient } from "convex/browser";
+import type { UIMessageChunk } from "ai";
+import type { ElicitResult } from "@modelcontextprotocol/client";
+import type { ElicitationCallback } from "@mcpjam/sdk";
+import {
+  ELICITATION_FORM_TTL_MS,
+  ELICITATION_POLL_INTERVAL_MS,
+  ELICITATION_POLL_JITTER_MS,
+  ELICITATION_POLL_MAX_FAILURES,
+  ELICITATION_URL_CONSENT_TTL_MS,
+} from "../../config.js";
+import { logger } from "../../utils/logger.js";
+import {
+  HOSTED_ELICITATION_DATA_PART_TYPE,
+  type HostedElicitationEvent,
+  type HostedElicitationMode,
+} from "@/shared/hosted-elicitation";
+
+type ElicitationChunkWriter = {
+  write: (chunk: UIMessageChunk) => void;
+};
+
+/** Terminal states the rendezvous row can report. */
+type PollStatus = "pending" | "answered" | "cancelled" | "expired";
+
+type PollResult = {
+  status: PollStatus;
+  action?: "accept" | "decline" | "cancel";
+  content?: Record<string, unknown>;
+};
+
+export interface HostedElicitationBridgeOptions {
+  /**
+   * A CONVEX-VALID bearer, i.e. the output of `getConvexBearerForRequest(c)` —
+   * not the raw Authorization header, which for WorkOS API-key callers is an
+   * `sk_…` key Convex cannot verify.
+   */
+  convexBearer: string;
+  projectId: string;
+  chatSessionId?: string;
+  /** Display labels only; `serverId` stays the trusted anchor. */
+  serverNamesById: Record<string, string>;
+  /** The turn's abort signal — a closed stream must not leave a pending row. */
+  abortSignal?: AbortSignal;
+}
+
+function stripBearer(token: string): string {
+  return token.replace(/^Bearer\s+/i, "").trim();
+}
+
+function requireConvexUrl(): string {
+  const url = process.env.CONVEX_URL;
+  if (!url) throw new Error("CONVEX_URL is not configured");
+  return url;
+}
+
+function requireConvexHttpUrl(): string {
+  const url = process.env.CONVEX_HTTP_URL;
+  if (!url) throw new Error("CONVEX_HTTP_URL is not configured");
+  return url;
+}
+
+function serviceToken(): string {
+  const token = process.env.INSPECTOR_SERVICE_TOKEN;
+  if (!token) throw new Error("INSPECTOR_SERVICE_TOKEN is not configured");
+  return token;
+}
+
+const CANCEL: ElicitResult = { action: "cancel" };
+
+/**
+ * Build the ElicitResult for an answered row.
+ *
+ * `content` rides ONLY on a form-mode accept. The backend already validates the
+ * shape, and the MCP server re-validates against its own schema; we simply must
+ * not invent a `content` key where the spec says there is none (URL accepts,
+ * declines, cancels).
+ */
+function toElicitResult(poll: PollResult, mode: HostedElicitationMode): ElicitResult {
+  const action = poll.action ?? "cancel";
+  if (action === "accept" && mode === "form") {
+    return { action: "accept", content: poll.content ?? {} } as ElicitResult;
+  }
+  return { action } as ElicitResult;
+}
+
+export class HostedElicitationBridge {
+  private writer: ElicitationChunkWriter | null = null;
+  /** Rendezvous ids still awaiting an answer — cancelled on dispose. */
+  private readonly pending = new Set<string>();
+  private disposed = false;
+
+  constructor(private readonly options: HostedElicitationBridgeOptions) {}
+
+  attachStreamWriter(writer: ElicitationChunkWriter): void {
+    this.writer = writer;
+  }
+
+  /**
+   * The SDK global elicitation callback. Registered on the per-turn manager
+   * ONLY when the host declares the capability (see `chat-v2.ts`), because the
+   * SDK gates advertisement on a handler being present — registering is what
+   * makes `elicitation` appear in `initialize`.
+   */
+  readonly callback: ElicitationCallback = async (request) => {
+    const mode: HostedElicitationMode = request.mode === "url" ? "url" : "form";
+    const serverId = request.serverId ?? "unknown";
+
+    // Pre-writer: nothing can render this, and its consumer is the very stream
+    // that hasn't been created yet. Fail fast rather than deadlock to TTL.
+    if (!this.writer || this.disposed) {
+      logger.warn(
+        "[elicitation] request arrived with no live stream; cancelling",
+        { serverId, mode, disposed: this.disposed },
+      );
+      return CANCEL;
+    }
+
+    // URL mode is a consent decision (seconds); form mode is data entry.
+    const ttlMs =
+      mode === "url" ? ELICITATION_URL_CONSENT_TTL_MS : ELICITATION_FORM_TTL_MS;
+    const rendezvousId = crypto.randomUUID();
+    const expiresAt = Date.now() + ttlMs;
+
+    try {
+      await this.createRow({ rendezvousId, request, mode, ttlMs, serverId });
+    } catch (error) {
+      // A broken rendezvous must never hang a tool call: without a row there is
+      // nothing for the browser to answer, so the only honest outcome is cancel.
+      logger.error("[elicitation] failed to create rendezvous row; cancelling", {
+        error,
+        serverId,
+        mode,
+      });
+      return CANCEL;
+    }
+
+    this.pending.add(rendezvousId);
+    this.emit({
+      kind: "request",
+      rendezvousId,
+      serverId,
+      serverName: this.options.serverNamesById[serverId],
+      mode,
+      message: request.message,
+      ...(mode === "form" ? { requestedSchema: request.schema } : {}),
+      ...(mode === "url" && request.url ? { url: request.url } : {}),
+      ...(request.elicitationId
+        ? { serverElicitationId: request.elicitationId }
+        : {}),
+      expiresAt,
+      ...(this.options.chatSessionId
+        ? { chatSessionId: this.options.chatSessionId }
+        : {}),
+    });
+
+    try {
+      return await this.awaitAnswer({ rendezvousId, expiresAt, mode });
+    } finally {
+      this.pending.delete(rendezvousId);
+    }
+  };
+
+  /**
+   * Surface a `-32042 URLElicitationRequiredError` raised by a failed
+   * `tools/call`. Display-only: the call already failed, so no JSON-RPC response
+   * is owed and there is nothing to rendezvous on.
+   */
+  emitUrlRequired(info: {
+    serverId: string;
+    toolCallId?: string;
+    elicitations: Array<{ url: string; elicitationId: string; message?: string }>;
+  }): void {
+    if (info.elicitations.length === 0) return;
+    this.emit({
+      kind: "url_required",
+      serverId: info.serverId,
+      serverName: this.options.serverNamesById[info.serverId],
+      ...(info.toolCallId ? { toolCallId: info.toolCallId } : {}),
+      elicitations: info.elicitations,
+    });
+  }
+
+  /**
+   * End-of-turn cleanup. Withdraws any row still pending so a closed stream
+   * can't leave an answerable prompt behind for its TTL.
+   */
+  async dispose(): Promise<void> {
+    this.disposed = true;
+    this.writer = null;
+    const outstanding = Array.from(this.pending);
+    this.pending.clear();
+    await Promise.all(
+      outstanding.map((rendezvousId) => this.cancelRow(rendezvousId)),
+    );
+  }
+
+  // ── internals ────────────────────────────────────────────────────────────
+
+  private emit(event: HostedElicitationEvent): void {
+    if (!this.writer) return;
+    try {
+      this.writer.write({
+        type: HOSTED_ELICITATION_DATA_PART_TYPE,
+        data: event,
+        transient: true,
+      } as unknown as UIMessageChunk);
+    } catch (error) {
+      // A dead writer means the browser is gone; the poll loop's abort/TTL
+      // paths still resolve the blocked call, so this is not fatal.
+      logger.warn("[elicitation] stream write failed", { error });
+      this.writer = null;
+    }
+  }
+
+  /**
+   * Written with the USER's bearer (not the service token) so the backend
+   * derives ownership from verified identity via `ctx.actor` — the row is never
+   * told who owns it. Works identically for guests.
+   */
+  private async createRow(args: {
+    rendezvousId: string;
+    request: Parameters<ElicitationCallback>[0];
+    mode: HostedElicitationMode;
+    ttlMs: number;
+    serverId: string;
+  }): Promise<void> {
+    const client = new ConvexHttpClient(requireConvexUrl());
+    client.setAuth(stripBearer(this.options.convexBearer));
+    await client.mutation("elicitations:createElicitation" as any, {
+      rendezvousId: args.rendezvousId,
+      projectId: this.options.projectId,
+      ...(this.options.chatSessionId
+        ? { chatSessionId: this.options.chatSessionId }
+        : {}),
+      serverId: args.serverId,
+      ...(this.options.serverNamesById[args.serverId]
+        ? { serverName: this.options.serverNamesById[args.serverId] }
+        : {}),
+      mode: args.mode,
+      message: args.request.message,
+      ...(args.mode === "form"
+        ? { requestedSchema: args.request.schema ?? {} }
+        : {}),
+      ...(args.mode === "url" && args.request.url
+        ? { url: args.request.url }
+        : {}),
+      ...(args.request.elicitationId
+        ? { serverElicitationId: args.request.elicitationId }
+        : {}),
+      ttlMs: args.ttlMs,
+    });
+  }
+
+  /**
+   * Service-token routes: the wait spans human time and can outlive a WorkOS
+   * access token, so the poll leg must not depend on the user's bearer staying
+   * fresh. Safe because `rendezvousId` is a replica-minted UUID and these routes
+   * are read/withdraw-only.
+   */
+  private async serviceRoute<T>(path: string, body: unknown): Promise<T> {
+    const response = await fetch(
+      new URL(path, requireConvexHttpUrl()).toString(),
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-inspector-service-token": serviceToken(),
+        },
+        body: JSON.stringify(body),
+      },
+    );
+    if (!response.ok) {
+      throw new Error(`${path} returned ${response.status}`);
+    }
+    return (await response.json()) as T;
+  }
+
+  private async poll(rendezvousId: string): Promise<PollResult | null> {
+    const payload = await this.serviceRoute<{
+      ok: boolean;
+      elicitation: PollResult | null;
+    }>("/elicitations/poll", { rendezvousId });
+    return payload.elicitation ?? null;
+  }
+
+  /** Fire-and-forget: scrubs the payload once we've resolved to the server. */
+  private ackRow(rendezvousId: string): void {
+    void this.serviceRoute("/elicitations/ack", { rendezvousId }).catch(
+      (error) => {
+        // Harmless: the backend's 24h cleanup is the real retention bound.
+        logger.warn("[elicitation] ack failed; payload waits for cleanup", {
+          error,
+          rendezvousId,
+        });
+      },
+    );
+  }
+
+  private async cancelRow(rendezvousId: string): Promise<void> {
+    try {
+      await this.serviceRoute("/elicitations/cancel", { rendezvousId });
+    } catch (error) {
+      logger.warn("[elicitation] cancel failed; TTL will expire the row", {
+        error,
+        rendezvousId,
+      });
+    }
+  }
+
+  private async awaitAnswer(args: {
+    rendezvousId: string;
+    expiresAt: number;
+    mode: HostedElicitationMode;
+  }): Promise<ElicitResult> {
+    const { rendezvousId, expiresAt, mode } = args;
+    let consecutiveFailures = 0;
+
+    for (;;) {
+      if (this.options.abortSignal?.aborted || this.disposed) {
+        // Client hung up: withdraw the row, and don't emit — nobody is reading.
+        void this.cancelRow(rendezvousId);
+        return CANCEL;
+      }
+
+      if (Date.now() >= expiresAt) {
+        // Enforce the deadline locally rather than waiting on the 1-min cron.
+        void this.cancelRow(rendezvousId);
+        this.emit({ kind: "resolved", rendezvousId, outcome: "expired" });
+        return CANCEL;
+      }
+
+      let result: PollResult | null;
+      try {
+        result = await this.poll(rendezvousId);
+        consecutiveFailures = 0;
+      } catch (error) {
+        consecutiveFailures += 1;
+        if (consecutiveFailures >= ELICITATION_POLL_MAX_FAILURES) {
+          logger.error("[elicitation] poll failed repeatedly; cancelling", {
+            error,
+            rendezvousId,
+          });
+          void this.cancelRow(rendezvousId);
+          this.emit({ kind: "resolved", rendezvousId, outcome: "cancelled" });
+          return CANCEL;
+        }
+        await this.waitOnePollInterval();
+        continue;
+      }
+
+      if (!result || result.status === "pending") {
+        await this.waitOnePollInterval();
+        continue;
+      }
+
+      if (result.status === "answered") {
+        const elicitResult = toElicitResult(result, mode);
+        // Ack only AFTER we hold the answer (see the ordering note up top).
+        this.ackRow(rendezvousId);
+        this.emit({
+          kind: "resolved",
+          rendezvousId,
+          outcome: "answered",
+          action: result.action,
+        });
+        return elicitResult;
+      }
+
+      // expired | cancelled — terminal, no answer to deliver.
+      this.emit({
+        kind: "resolved",
+        rendezvousId,
+        outcome: result.status === "expired" ? "expired" : "cancelled",
+      });
+      return CANCEL;
+    }
+  }
+
+  /**
+   * Jittered so concurrent turns don't lock-step onto Convex (mirrors the
+   * scheduled-evals worker). Wakes early on abort so a closed stream resolves
+   * immediately instead of sleeping out the interval.
+   */
+  private waitOnePollInterval(): Promise<void> {
+    const delay =
+      ELICITATION_POLL_INTERVAL_MS + Math.random() * ELICITATION_POLL_JITTER_MS;
+    return new Promise((resolve) => {
+      const signal = this.options.abortSignal;
+      const timer = setTimeout(() => {
+        signal?.removeEventListener("abort", onAbort);
+        resolve();
+      }, delay);
+      function onAbort() {
+        clearTimeout(timer);
+        resolve();
+      }
+      signal?.addEventListener("abort", onAbort, { once: true });
+    });
+  }
+}
+
+/**
+ * True when a host's declared client capabilities enable elicitation.
+ *
+ * Lenient by design: bare `{}` is form-only per the spec's back-compat rule,
+ * and the catalog ships both `{}` and `{form:{}}`. Presence of the key — in any
+ * object shape — is the toggle.
+ */
+export function hostDeclaresElicitation(
+  clientCapabilities: unknown,
+): boolean {
+  if (!clientCapabilities || typeof clientCapabilities !== "object") {
+    return false;
+  }
+  const elicitation = (clientCapabilities as Record<string, unknown>)
+    .elicitation;
+  return (
+    typeof elicitation === "object" &&
+    elicitation !== null &&
+    !Array.isArray(elicitation)
+  );
+}
+
+/** The hosted-elicitation wire contract this server speaks. */
+export const HOSTED_ELICITATION_VERSION = 1;
+
+/**
+ * Decide (a) whose client capabilities go on the initialize wire and (b) whether
+ * this turn may honor elicitation at all.
+ *
+ * Two independent gates, both required:
+ *
+ * 1. **Capability, from the right authority.** For a chatbox turn the published
+ *    host wins — a share-link visitor controls the request body, so reading
+ *    capabilities from it would let anyone switch elicitation on for a host
+ *    whose owner has it off. (Same host-wins reasoning chat-v2 already applies
+ *    to model/approval.) A backend predating `clientCapabilities` on
+ *    runtime-config omits it → treated as absent → fail closed. For a direct
+ *    turn the body IS the owner's own host config, sent by their own client.
+ *
+ * 2. **Client handshake.** Catalog hosts (claude-code, cursor, vscode, …)
+ *    ALREADY declare `elicitation`, so honoring it for every client would make
+ *    stale browser bundles — which cannot render the prompt — hang for a full
+ *    TTL on any server that elicits. Only clients that announce the version get
+ *    the callback; everyone else keeps today's fail-fast behavior.
+ */
+export function resolveElicitationGate(args: {
+  isChatboxSession: boolean;
+  /** `clientCapabilities` from the chatbox/host runtime-config (authoritative). */
+  hostClientCapabilities: unknown;
+  /** `clientCapabilities` from the request body (owner-supplied on direct turns). */
+  bodyClientCapabilities: unknown;
+  /** `hostedElicitationVersion` from the request body. */
+  clientVersion: number | undefined;
+}): {
+  effectiveClientCapabilities: Record<string, unknown> | undefined;
+  enabled: boolean;
+} {
+  const effectiveClientCapabilities = (
+    args.isChatboxSession ? args.hostClientCapabilities : args.bodyClientCapabilities
+  ) as Record<string, unknown> | undefined;
+
+  return {
+    effectiveClientCapabilities: effectiveClientCapabilities ?? undefined,
+    enabled:
+      hostDeclaresElicitation(effectiveClientCapabilities) &&
+      args.clientVersion === HOSTED_ELICITATION_VERSION,
+  };
+}

--- a/mcpjam-inspector/server/routes/web/hosted-elicitation.ts
+++ b/mcpjam-inspector/server/routes/web/hosted-elicitation.ts
@@ -51,6 +51,7 @@ import {
   ELICITATION_POLL_INTERVAL_MS,
   ELICITATION_POLL_JITTER_MS,
   ELICITATION_POLL_MAX_FAILURES,
+  ELICITATION_SERVICE_ROUTE_TIMEOUT_MS,
   ELICITATION_URL_CONSENT_TTL_MS,
 } from "../../config.js";
 import { logger } from "../../utils/logger.js";
@@ -302,35 +303,79 @@ export class HostedElicitationBridge {
    * fresh. Safe because `rendezvousId` is a replica-minted UUID and these routes
    * are read/withdraw-only.
    */
-  private async serviceRoute<T>(path: string, body: unknown): Promise<T> {
-    const response = await fetch(
-      new URL(path, requireConvexHttpUrl()).toString(),
-      {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "x-inspector-service-token": serviceToken(),
-        },
-        body: JSON.stringify(body),
-      },
+  /**
+   * @param bindToTurn abort this call when the TURN aborts, on top of the
+   *   per-call deadline. True for polling — a closed stream has no use for the
+   *   answer. **False for cancel/ack**: those run *because* the turn is ending,
+   *   so binding them to its signal would abort the very request meant to
+   *   withdraw the row, and the prompt would stay answerable for its whole TTL.
+   */
+  private async serviceRoute<T>(
+    path: string,
+    body: unknown,
+    opts: { bindToTurn: boolean },
+  ): Promise<T> {
+    // Every service call is bounded. Without a deadline a stalled Convex
+    // request would park the poll loop forever: the tool call would outlive its
+    // TTL (nothing else can resolve it — the deadline check only runs between
+    // polls), and `dispose()` would await a cancel that never returns, blocking
+    // end-of-stream cleanup. A timed-out call surfaces as a poll failure, which
+    // the loop already tolerates and eventually resolves as `cancel`.
+    //
+    // setTimeout rather than `AbortSignal.timeout()`: the latter is driven by
+    // the platform's own clock, which fake timers don't control — the deadline
+    // would be untestable.
+    const controller = new AbortController();
+    const deadline = setTimeout(
+      () => controller.abort(new Error("service route deadline exceeded")),
+      ELICITATION_SERVICE_ROUTE_TIMEOUT_MS,
     );
-    if (!response.ok) {
-      throw new Error(`${path} returned ${response.status}`);
+    const onTurnAbort = () => controller.abort();
+    const turnSignal = opts.bindToTurn ? this.options.abortSignal : undefined;
+    if (turnSignal) {
+      if (turnSignal.aborted) controller.abort();
+      else turnSignal.addEventListener("abort", onTurnAbort, { once: true });
     }
-    return (await response.json()) as T;
+
+    try {
+      const response = await fetch(
+        new URL(path, requireConvexHttpUrl()).toString(),
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-inspector-service-token": serviceToken(),
+          },
+          body: JSON.stringify(body),
+          signal: controller.signal,
+        },
+      );
+      if (!response.ok) {
+        throw new Error(`${path} returned ${response.status}`);
+      }
+      return (await response.json()) as T;
+    } finally {
+      clearTimeout(deadline);
+      turnSignal?.removeEventListener("abort", onTurnAbort);
+    }
   }
 
   private async poll(rendezvousId: string): Promise<PollResult | null> {
     const payload = await this.serviceRoute<{
       ok: boolean;
       elicitation: PollResult | null;
-    }>("/elicitations/poll", { rendezvousId });
+    }>("/elicitations/poll", { rendezvousId }, { bindToTurn: true });
     return payload.elicitation ?? null;
   }
 
   /** Fire-and-forget: scrubs the payload once we've resolved to the server. */
   private ackRow(rendezvousId: string): void {
-    void this.serviceRoute("/elicitations/ack", { rendezvousId }).catch(
+    // Not bound to the turn: the ack usually fires as the turn is wrapping up.
+    void this.serviceRoute(
+      "/elicitations/ack",
+      { rendezvousId },
+      { bindToTurn: false },
+    ).catch(
       (error) => {
         // Harmless: the backend's 24h cleanup is the real retention bound.
         logger.warn("[elicitation] ack failed; payload waits for cleanup", {
@@ -343,7 +388,11 @@ export class HostedElicitationBridge {
 
   private async cancelRow(rendezvousId: string): Promise<void> {
     try {
-      await this.serviceRoute("/elicitations/cancel", { rendezvousId });
+      await this.serviceRoute(
+        "/elicitations/cancel",
+        { rendezvousId },
+        { bindToTurn: false },
+      );
     } catch (error) {
       logger.warn("[elicitation] cancel failed; TTL will expire the row", {
         error,

--- a/mcpjam-inspector/server/utils/chatbox-runtime-config.ts
+++ b/mcpjam-inspector/server/utils/chatbox-runtime-config.ts
@@ -31,6 +31,14 @@ export type ChatboxRuntimeConfig = RuntimeExecutionFields & {
   // Optional for compatibility with backends that predate SEP-1865
   // visibility filtering on runtime-config.
   respectToolVisibility?: boolean;
+  // Client capabilities from the chatbox's pinned HostConfigV2 — the
+  // HOST-AUTHORITATIVE copy. The request body also carries clientCapabilities,
+  // but a share-link visitor controls that body; trusting it would let anyone
+  // turn on capabilities (e.g. elicitation) the published host has off. Use
+  // this for any capability decision on a chatbox turn. Optional so a backend
+  // predating the field returns omitted → capability treated as absent
+  // (fail-closed).
+  clientCapabilities?: Record<string, unknown>;
   hostStyle: string;
   // Host-level opt-in for progressive MCP tool discovery, mirrored from
   // the chatbox's pinned HostConfigV2. Optional so a backend older than

--- a/mcpjam-inspector/server/utils/local-server-resolver.ts
+++ b/mcpjam-inspector/server/utils/local-server-resolver.ts
@@ -1,5 +1,6 @@
 import type { Context } from "hono";
 import type { MCPClientManager, MCPServerConfig } from "@mcpjam/sdk";
+import { narrowElicitationToLocalSupport } from "../routes/mcp/elicitation.js";
 import {
   describeError,
   isKnownProtocolVersion,
@@ -464,12 +465,17 @@ export function toMCPServerConfig(
   // never overwriting — into whatever capabilities the caller configured.
   // Advertised when the connection actually uses XAA (the backstop) or
   // whenever the host's enterprise policy is on (host-wide declare-support).
-  const clientCapabilities =
+  const xaaMerged =
     options?.xaaPolicy != null ||
     (serverConfig.transportType === "http" &&
       resolveEffectiveAuthMethod(serverConfig, options?.xaaPolicy) === "xaa")
       ? withXaaExtensionCapability(baseClientCapabilities)
       : baseClientCapabilities;
+  // Advertise = enforce: the local elicitation bridge is form-only, so a config
+  // declaring `elicitation.url` (the host toggle can write it) must not put url
+  // on the wire — the SDK would accept the request and the bridge would drop
+  // the URL, leaving the user a form they cannot complete.
+  const clientCapabilities = narrowElicitationToLocalSupport(xaaMerged);
 
   if (serverConfig.transportType === "stdio") {
     const stdio: any = {

--- a/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
@@ -467,21 +467,6 @@ export interface MCPJamHandlerOptions {
   onStreamWriterReady?: (writer: {
     write: (chunk: UIMessageChunk) => void;
   }) => void;
-  /**
-   * Fires when an MCP tool call fails with `-32042 URLElicitationRequiredError`
-   * (MCP 2025-11-25). Interactive surfaces use it to show the URL for consent;
-   * the tool result already carries a retry hint for the model. Display-only —
-   * nothing is owed back to the server on this path.
-   */
-  onUrlElicitationRequired?: (info: {
-    serverId?: string;
-    toolCallId: string;
-    elicitations: Array<{
-      url: string;
-      elicitationId: string;
-      message?: string;
-    }>;
-  }) => void;
   onLiveTextDelta?: (delta: string) => void;
   /**
    * Engine consolidation PR 5b-pre — fires from the chunk-processing
@@ -651,8 +636,6 @@ interface StepContext {
   onEngineError?: (event: MCPJamEngineErrorEvent) => void;
   // Browser-rendered MCP App eval PR 2: per-step advertised-tool narrowing.
   prepareAdvertisedTools?: MCPJamHandlerOptions["prepareAdvertisedTools"];
-  // -32042 URLElicitationRequiredError surfacing (MCP 2025-11-25).
-  onUrlElicitationRequired?: MCPJamHandlerOptions["onUrlElicitationRequired"];
   abortSignal?: AbortSignal;
 }
 
@@ -1637,10 +1620,6 @@ async function handlePendingApprovals(
   // emits `tool-input-available` UI chunks — `onToolCall` must fire
   // here too so PR 5b's wiring doesn't see orphan `tool_result`.
   onToolCall?: (event: MCPJamToolCallEvent) => void,
-  // An APPROVED tool can hit -32042 just like an unapproved one (approval and
-  // third-party authorization are orthogonal), so this path needs the hook too
-  // or the consent UI would silently not appear for approval-gated hosts.
-  onUrlElicitationRequired?: MCPJamHandlerOptions["onUrlElicitationRequired"],
 ): Promise<boolean> {
   // Build approvalId → toolCallId map, toolCallId → toolName map,
   // and toolCallId → assistant message index map from assistant messages
@@ -1871,7 +1850,6 @@ async function handlePendingApprovals(
       // fulfillment) instead of throwing and 500ing the whole turn.
       skipNonExecutableTools: true,
       ...(abortSignal ? { abortSignal } : {}),
-      ...(onUrlElicitationRequired ? { onUrlElicitationRequired } : {}),
     });
 
     await emitToolResults(
@@ -1928,8 +1906,6 @@ async function processOneStep(
     onEngineError,
     // Browser-rendered MCP App eval PR 2: advertised-tool narrowing hook.
     prepareAdvertisedTools,
-    // -32042 surfacing (MCP 2025-11-25).
-    onUrlElicitationRequired,
   } = ctx;
 
   // Pick the active tool subset for this step. In non-progressive mode
@@ -2477,8 +2453,7 @@ async function processOneStep(
         modelVisibleMcpToolResults,
         readLinkedResource: readLinkedMcpResourceWithManager(mcpClientManager),
         ...(abortSignal ? { abortSignal } : {}),
-        ...(onUrlElicitationRequired ? { onUrlElicitationRequired } : {}),
-      });
+        });
       const toolsEndAbs = Date.now();
 
       const newToolCallIds = new Set<string>();
@@ -2756,8 +2731,6 @@ export async function runChatEngineLoop(
     onEngineError,
     // Browser-rendered MCP App eval PR 2: advertised-tool narrowing hook.
     prepareAdvertisedTools,
-    // -32042 URLElicitationRequiredError surfacing (MCP 2025-11-25).
-    onUrlElicitationRequired,
     abortSignal,
     heartbeatIntervalMs,
     maxSteps,
@@ -2962,7 +2935,6 @@ export async function runChatEngineLoop(
           modelVisibleMcpToolResults,
           onToolResult,
           onToolCall,
-          onUrlElicitationRequired,
         );
         if (handled) {
           // Approvals were processed — if there are still unresolved tool
@@ -3016,8 +2988,6 @@ export async function runChatEngineLoop(
           onEngineError,
           // Browser-rendered MCP App eval PR 2: advertised-tool narrowing.
           prepareAdvertisedTools,
-          // -32042 surfacing (MCP 2025-11-25).
-          onUrlElicitationRequired,
           abortSignal,
         });
 

--- a/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
@@ -467,6 +467,21 @@ export interface MCPJamHandlerOptions {
   onStreamWriterReady?: (writer: {
     write: (chunk: UIMessageChunk) => void;
   }) => void;
+  /**
+   * Fires when an MCP tool call fails with `-32042 URLElicitationRequiredError`
+   * (MCP 2025-11-25). Interactive surfaces use it to show the URL for consent;
+   * the tool result already carries a retry hint for the model. Display-only —
+   * nothing is owed back to the server on this path.
+   */
+  onUrlElicitationRequired?: (info: {
+    serverId?: string;
+    toolCallId: string;
+    elicitations: Array<{
+      url: string;
+      elicitationId: string;
+      message?: string;
+    }>;
+  }) => void;
   onLiveTextDelta?: (delta: string) => void;
   /**
    * Engine consolidation PR 5b-pre — fires from the chunk-processing
@@ -636,6 +651,8 @@ interface StepContext {
   onEngineError?: (event: MCPJamEngineErrorEvent) => void;
   // Browser-rendered MCP App eval PR 2: per-step advertised-tool narrowing.
   prepareAdvertisedTools?: MCPJamHandlerOptions["prepareAdvertisedTools"];
+  // -32042 URLElicitationRequiredError surfacing (MCP 2025-11-25).
+  onUrlElicitationRequired?: MCPJamHandlerOptions["onUrlElicitationRequired"];
   abortSignal?: AbortSignal;
 }
 
@@ -1620,6 +1637,10 @@ async function handlePendingApprovals(
   // emits `tool-input-available` UI chunks — `onToolCall` must fire
   // here too so PR 5b's wiring doesn't see orphan `tool_result`.
   onToolCall?: (event: MCPJamToolCallEvent) => void,
+  // An APPROVED tool can hit -32042 just like an unapproved one (approval and
+  // third-party authorization are orthogonal), so this path needs the hook too
+  // or the consent UI would silently not appear for approval-gated hosts.
+  onUrlElicitationRequired?: MCPJamHandlerOptions["onUrlElicitationRequired"],
 ): Promise<boolean> {
   // Build approvalId → toolCallId map, toolCallId → toolName map,
   // and toolCallId → assistant message index map from assistant messages
@@ -1850,6 +1871,7 @@ async function handlePendingApprovals(
       // fulfillment) instead of throwing and 500ing the whole turn.
       skipNonExecutableTools: true,
       ...(abortSignal ? { abortSignal } : {}),
+      ...(onUrlElicitationRequired ? { onUrlElicitationRequired } : {}),
     });
 
     await emitToolResults(
@@ -1906,6 +1928,8 @@ async function processOneStep(
     onEngineError,
     // Browser-rendered MCP App eval PR 2: advertised-tool narrowing hook.
     prepareAdvertisedTools,
+    // -32042 surfacing (MCP 2025-11-25).
+    onUrlElicitationRequired,
   } = ctx;
 
   // Pick the active tool subset for this step. In non-progressive mode
@@ -2453,6 +2477,7 @@ async function processOneStep(
         modelVisibleMcpToolResults,
         readLinkedResource: readLinkedMcpResourceWithManager(mcpClientManager),
         ...(abortSignal ? { abortSignal } : {}),
+        ...(onUrlElicitationRequired ? { onUrlElicitationRequired } : {}),
       });
       const toolsEndAbs = Date.now();
 
@@ -2731,6 +2756,8 @@ export async function runChatEngineLoop(
     onEngineError,
     // Browser-rendered MCP App eval PR 2: advertised-tool narrowing hook.
     prepareAdvertisedTools,
+    // -32042 URLElicitationRequiredError surfacing (MCP 2025-11-25).
+    onUrlElicitationRequired,
     abortSignal,
     heartbeatIntervalMs,
     maxSteps,
@@ -2935,6 +2962,7 @@ export async function runChatEngineLoop(
           modelVisibleMcpToolResults,
           onToolResult,
           onToolCall,
+          onUrlElicitationRequired,
         );
         if (handled) {
           // Approvals were processed — if there are still unresolved tool
@@ -2988,6 +3016,8 @@ export async function runChatEngineLoop(
           onEngineError,
           // Browser-rendered MCP App eval PR 2: advertised-tool narrowing.
           prepareAdvertisedTools,
+          // -32042 surfacing (MCP 2025-11-25).
+          onUrlElicitationRequired,
           abortSignal,
         });
 

--- a/mcpjam-inspector/server/utils/web-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/web-chat-turn.ts
@@ -68,6 +68,7 @@ import type { HarnessSessionCommitPayload } from "./harness/harness-session-stat
 import { exportConnectedServerToolSnapshotForEvalAuthoring } from "./export-helpers.js";
 import { ErrorCode, WebRouteError } from "./../routes/web/errors.js";
 import type { createHostedRpcLogCollector } from "./../routes/web/hosted-rpc-logs.js";
+import type { HostedElicitationBridge } from "./../routes/web/hosted-elicitation.js";
 import { bridgeHarnessRpcLogsToCollector } from "./../routes/web/hosted-rpc-logs.js";
 import type { CustomProviderConfig } from "./chat-helpers.js";
 import { getClientIp } from "./client-ip.js";
@@ -187,6 +188,13 @@ export interface WebChatTurnRuntime {
   abortSignal: AbortSignal | undefined;
   /** Hosted RPC log collector — attached to the stream writer. Optional. */
   rpcCollector?: RpcCollector;
+  /**
+   * Hosted elicitation bridge — attached to the stream writer alongside the
+   * RPC collector, and disposed on stream completion. Present only for
+   * interactive turns whose host declares the elicitation capability AND whose
+   * client speaks the hosted-elicitation handshake; see `chat-v2.ts`.
+   */
+  elicitationBridge?: HostedElicitationBridge;
   /** Hono context (needed for getClientIp fallback / future hooks). */
   c: Context;
 }
@@ -298,6 +306,11 @@ export async function streamWebChatTurn(
 
   const hostedChatSessionId = persist.chatSessionId;
   const cleanupStream = async () => {
+    // Withdraw pending elicitation rows BEFORE dropping the connections: once
+    // the stream is gone nobody can answer, and an abandoned row would stay
+    // answerable until its TTL. Disposal is best-effort and must never block
+    // the disconnect, so failures are swallowed inside the bridge.
+    await runtime.elicitationBridge?.dispose();
     await manager.disconnectAllServers();
   };
 
@@ -470,8 +483,10 @@ export async function streamWebChatTurn(
         requireToolApproval: persist.requireToolApproval,
         onConversationComplete,
         onStreamComplete: cleanupStream,
-        onStreamWriterReady: (writer) =>
-          runtime.rpcCollector?.attachStreamWriter(writer),
+        onStreamWriterReady: (writer) => {
+          runtime.rpcCollector?.attachStreamWriter(writer);
+          runtime.elicitationBridge?.attachStreamWriter(writer);
+        },
         abortSignal: runtime.abortSignal,
       });
     }
@@ -500,8 +515,10 @@ export async function streamWebChatTurn(
       modelVisibleMcpToolResults: prepare.modelVisibleMcpToolResults,
       onConversationComplete,
       onStreamComplete: cleanupStream,
-      onStreamWriterReady: (writer) =>
-        runtime.rpcCollector?.attachStreamWriter(writer),
+      onStreamWriterReady: (writer) => {
+        runtime.rpcCollector?.attachStreamWriter(writer);
+        runtime.elicitationBridge?.attachStreamWriter(writer);
+      },
       abortSignal: runtime.abortSignal,
     });
   }
@@ -572,8 +589,19 @@ export async function streamWebChatTurn(
       stopHarnessRpcLogBridge = undefined;
       await cleanupStream();
     },
+    onUrlElicitationRequired: (info) =>
+      runtime.elicitationBridge?.emitUrlRequired({
+        serverId: info.serverId ?? "unknown",
+        toolCallId: info.toolCallId,
+        elicitations: info.elicitations,
+      }),
     onStreamWriterReady: (writer) => {
       runtime.rpcCollector?.attachStreamWriter(writer);
+      // NOTE: for HARNESS hosts this writer exists but elicitation still won't
+      // fire — harness MCP traffic goes through separate /api/web/harness-mcp
+      // requests, not this turn's manager, so the callback is never invoked.
+      // Attaching is harmless and keeps the three sites uniform.
+      runtime.elicitationBridge?.attachStreamWriter(writer);
       if (persist.harness && runtime.rpcCollector && !stopHarnessRpcLogBridge) {
         stopHarnessRpcLogBridge = bridgeHarnessRpcLogsToCollector(
           persist.selectedServerIds,

--- a/mcpjam-inspector/server/utils/web-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/web-chat-turn.ts
@@ -67,6 +67,7 @@ import {
 import type { HarnessSessionCommitPayload } from "./harness/harness-session-state.js";
 import { exportConnectedServerToolSnapshotForEvalAuthoring } from "./export-helpers.js";
 import { ErrorCode, WebRouteError } from "./../routes/web/errors.js";
+import { readUrlElicitations } from "@/shared/http-tool-calls";
 import type { createHostedRpcLogCollector } from "./../routes/web/hosted-rpc-logs.js";
 import type { HostedElicitationBridge } from "./../routes/web/hosted-elicitation.js";
 import { bridgeHarnessRpcLogsToCollector } from "./../routes/web/hosted-rpc-logs.js";
@@ -286,13 +287,59 @@ export async function streamWebChatTurn(
   }
 
   const {
-    allTools,
+    allTools: preparedTools,
     enhancedSystemPrompt,
     resolvedTemperature,
     scrubMessages,
     progressivePlan,
     discoveryState,
   } = prepared;
+
+  /**
+   * Surface `-32042 URLElicitationRequiredError` from ANY engine.
+   *
+   * Wrapped here, on the tool set, rather than in the engines: `prepareChatV2`
+   * builds this set once and all three consumers share it (MCPJam-free,
+   * org-BYOK local, org-BYOK hosted). The org branches run `runDirectChatTurn`,
+   * where the AI SDK owns the tool loop and never touches the shared
+   * `executeToolCallsFromMessages` catch — so an engine-level hook compiled
+   * fine and silently never fired for BYOK users, who advertise and handle
+   * elicitation like everyone else.
+   *
+   * Rethrows always: this only observes. The engines' own error handling still
+   * produces the tool result the model sees.
+   */
+  const allTools = runtime.elicitationBridge
+    ? (Object.fromEntries(
+        Object.entries(preparedTools as Record<string, any>).map(
+          ([name, tool]) => {
+            if (typeof tool?.execute !== "function") return [name, tool];
+            const execute = tool.execute.bind(tool);
+            return [
+              name,
+              {
+                ...tool,
+                execute: async (input: unknown, options: any) => {
+                  try {
+                    return await execute(input, options);
+                  } catch (error) {
+                    const elicitations = readUrlElicitations(error);
+                    if (elicitations) {
+                      runtime.elicitationBridge?.emitUrlRequired({
+                        serverId: (tool as any)._serverId ?? "unknown",
+                        toolCallId: options?.toolCallId,
+                        elicitations,
+                      });
+                    }
+                    throw error;
+                  }
+                },
+              },
+            ];
+          }
+        )
+      ) as typeof preparedTools)
+    : preparedTools;
 
   const widgetModelContextSystemPrompt = buildWidgetModelContextSystemPrompt(
     prepare.widgetModelContext ?? [],
@@ -589,12 +636,6 @@ export async function streamWebChatTurn(
       stopHarnessRpcLogBridge = undefined;
       await cleanupStream();
     },
-    onUrlElicitationRequired: (info) =>
-      runtime.elicitationBridge?.emitUrlRequired({
-        serverId: info.serverId ?? "unknown",
-        toolCallId: info.toolCallId,
-        elicitations: info.elicitations,
-      }),
     onStreamWriterReady: (writer) => {
       runtime.rpcCollector?.attachStreamWriter(writer);
       // NOTE: for HARNESS hosts this writer exists but elicitation still won't

--- a/mcpjam-inspector/shared/__tests__/hosted-elicitation.test.ts
+++ b/mcpjam-inspector/shared/__tests__/hosted-elicitation.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from "vitest";
+import {
+  HOSTED_ELICITATION_DATA_PART_TYPE,
+  isHostedElicitationDataPart,
+  isHostedElicitationEvent,
+} from "../hosted-elicitation";
+
+const formRequest = {
+  kind: "request",
+  rendezvousId: "rv-1",
+  serverId: "srv-1",
+  serverName: "GitHub",
+  mode: "form",
+  message: "Pick a branch",
+  requestedSchema: { type: "object" },
+  expiresAt: 1_700_000_000_000,
+};
+
+const urlRequest = {
+  kind: "request",
+  rendezvousId: "rv-2",
+  serverId: "srv-1",
+  mode: "url",
+  message: "Connect your account",
+  url: "https://example.com/connect",
+  serverElicitationId: "srv-chosen",
+  expiresAt: 1_700_000_000_000,
+};
+
+describe("isHostedElicitationEvent — request", () => {
+  it("accepts form and url requests", () => {
+    expect(isHostedElicitationEvent(formRequest)).toBe(true);
+    expect(isHostedElicitationEvent(urlRequest)).toBe(true);
+  });
+
+  it("rejects a url request with no url", () => {
+    // A consent dialog with nothing to consent to is worse than no dialog.
+    const { url: _url, ...noUrl } = urlRequest;
+    expect(isHostedElicitationEvent(noUrl)).toBe(false);
+  });
+
+  it("rejects an unknown or missing mode", () => {
+    expect(isHostedElicitationEvent({ ...formRequest, mode: "voice" })).toBe(
+      false,
+    );
+    const { mode: _mode, ...noMode } = formRequest;
+    expect(isHostedElicitationEvent(noMode)).toBe(false);
+  });
+
+  it.each([
+    ["rendezvousId", 1],
+    ["serverId", null],
+    ["message", { a: 1 }],
+    ["expiresAt", "soon"],
+  ])("rejects a bad required field: %s", (key, bad) => {
+    expect(isHostedElicitationEvent({ ...formRequest, [key]: bad })).toBe(false);
+  });
+
+  it("rejects a non-finite expiry", () => {
+    // NaN would make the deadline comparison silently never fire.
+    expect(isHostedElicitationEvent({ ...formRequest, expiresAt: NaN })).toBe(
+      false,
+    );
+  });
+
+  it.each([["serverName"], ["serverElicitationId"], ["chatSessionId"]])(
+    "rejects a present-but-wrong-typed optional: %s",
+    (key) => {
+      expect(isHostedElicitationEvent({ ...formRequest, [key]: 42 })).toBe(
+        false,
+      );
+    },
+  );
+
+  it("accepts omitted optionals", () => {
+    expect(
+      isHostedElicitationEvent({
+        kind: "request",
+        rendezvousId: "rv",
+        serverId: "s",
+        mode: "form",
+        message: "m",
+        expiresAt: 1,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("isHostedElicitationEvent — resolved", () => {
+  it("accepts each terminal outcome", () => {
+    for (const outcome of ["answered", "expired", "cancelled"]) {
+      expect(
+        isHostedElicitationEvent({ kind: "resolved", rendezvousId: "rv", outcome }),
+      ).toBe(true);
+    }
+  });
+
+  it("accepts a valid action and rejects an invented one", () => {
+    expect(
+      isHostedElicitationEvent({
+        kind: "resolved",
+        rendezvousId: "rv",
+        outcome: "answered",
+        action: "decline",
+      }),
+    ).toBe(true);
+    expect(
+      isHostedElicitationEvent({
+        kind: "resolved",
+        rendezvousId: "rv",
+        outcome: "answered",
+        action: "approve",
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects an unknown outcome", () => {
+    expect(
+      isHostedElicitationEvent({
+        kind: "resolved",
+        rendezvousId: "rv",
+        outcome: "done",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("isHostedElicitationEvent — url_required", () => {
+  const base = {
+    kind: "url_required",
+    serverId: "srv-1",
+    toolCallId: "call-1",
+    elicitations: [{ url: "https://example.com/a", elicitationId: "e1" }],
+  };
+
+  it("accepts a well-formed notice", () => {
+    expect(isHostedElicitationEvent(base)).toBe(true);
+  });
+
+  it("rejects an empty elicitations array", () => {
+    // Nothing to show — rendering an empty notice is just noise.
+    expect(isHostedElicitationEvent({ ...base, elicitations: [] })).toBe(false);
+  });
+
+  it("rejects entries missing url or elicitationId", () => {
+    expect(
+      isHostedElicitationEvent({ ...base, elicitations: [{ url: "https://x" }] }),
+    ).toBe(false);
+    expect(
+      isHostedElicitationEvent({ ...base, elicitations: [{ elicitationId: "e" }] }),
+    ).toBe(false);
+  });
+
+  it("rejects a wrong-typed optional message on an entry", () => {
+    expect(
+      isHostedElicitationEvent({
+        ...base,
+        elicitations: [{ url: "https://x", elicitationId: "e", message: 5 }],
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("isHostedElicitationEvent — shape", () => {
+  it.each([[null], [undefined], ["str"], [42], [[]], [{}], [{ kind: "nope" }]])(
+    "rejects %p",
+    (value) => {
+      expect(isHostedElicitationEvent(value)).toBe(false);
+    },
+  );
+});
+
+describe("isHostedElicitationDataPart", () => {
+  it("accepts the wire literal wrapping a valid event", () => {
+    expect(
+      isHostedElicitationDataPart({
+        type: HOSTED_ELICITATION_DATA_PART_TYPE,
+        data: formRequest,
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects another part type", () => {
+    expect(
+      isHostedElicitationDataPart({ type: "data-rpc-log", data: formRequest }),
+    ).toBe(false);
+  });
+
+  it("rejects a valid wrapper around an invalid event", () => {
+    expect(
+      isHostedElicitationDataPart({
+        type: HOSTED_ELICITATION_DATA_PART_TYPE,
+        data: { kind: "request" },
+      }),
+    ).toBe(false);
+  });
+});

--- a/mcpjam-inspector/shared/hosted-elicitation.ts
+++ b/mcpjam-inspector/shared/hosted-elicitation.ts
@@ -119,19 +119,46 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+/** Optional string: absent is fine, present-but-wrong-type is not. */
+function isOptionalString(value: unknown): boolean {
+  return value === undefined || typeof value === "string";
+}
+
+function isAction(value: unknown): value is HostedElicitationAction {
+  return value === "accept" || value === "decline" || value === "cancel";
+}
+
+/**
+ * Validates a `data-elicitation` payload before consumers treat it as typed.
+ *
+ * Strict about optional fields, not just required ones: this guard is what
+ * stands between a malformed part and UI that dereferences it. A `url`-mode
+ * request without a `url` would render a consent dialog with nothing to
+ * consent to, and an unconstrained `action` would be forwarded to the backend
+ * as an answer it must then reject.
+ */
 export function isHostedElicitationEvent(
   value: unknown,
 ): value is HostedElicitationEvent {
   if (!isRecord(value)) return false;
 
   if (value.kind === "request") {
-    return (
-      typeof value.rendezvousId === "string" &&
-      typeof value.serverId === "string" &&
-      (value.mode === "form" || value.mode === "url") &&
-      typeof value.message === "string" &&
-      typeof value.expiresAt === "number"
-    );
+    if (
+      typeof value.rendezvousId !== "string" ||
+      typeof value.serverId !== "string" ||
+      typeof value.message !== "string" ||
+      typeof value.expiresAt !== "number" ||
+      !Number.isFinite(value.expiresAt) ||
+      !isOptionalString(value.serverName) ||
+      !isOptionalString(value.serverElicitationId) ||
+      !isOptionalString(value.chatSessionId)
+    ) {
+      return false;
+    }
+    // Mode-specific payload: each mode's dialog is useless without its field.
+    if (value.mode === "url") return typeof value.url === "string";
+    if (value.mode === "form") return true;
+    return false;
   }
 
   if (value.kind === "resolved") {
@@ -139,19 +166,24 @@ export function isHostedElicitationEvent(
       typeof value.rendezvousId === "string" &&
       (value.outcome === "answered" ||
         value.outcome === "expired" ||
-        value.outcome === "cancelled")
+        value.outcome === "cancelled") &&
+      (value.action === undefined || isAction(value.action))
     );
   }
 
   if (value.kind === "url_required") {
     return (
       typeof value.serverId === "string" &&
+      isOptionalString(value.serverName) &&
+      isOptionalString(value.toolCallId) &&
       Array.isArray(value.elicitations) &&
+      value.elicitations.length > 0 &&
       value.elicitations.every(
         (entry) =>
           isRecord(entry) &&
           typeof entry.url === "string" &&
-          typeof entry.elicitationId === "string",
+          typeof entry.elicitationId === "string" &&
+          isOptionalString(entry.message),
       )
     );
   }

--- a/mcpjam-inspector/shared/hosted-elicitation.ts
+++ b/mcpjam-inspector/shared/hosted-elicitation.ts
@@ -1,0 +1,170 @@
+/**
+ * Wire types for hosted-mode MCP elicitation.
+ *
+ * Elicitation is a nested server→client request that arrives in the middle of
+ * a `tools/call`. In hosted mode the turn's MCP connection, the blocking tool
+ * call, and the HTTP stream to the browser all live on ONE replica, so the
+ * REQUEST rides this turn's UI message stream as a transient data part (the
+ * same delivery `data-trace-event` / `data-rpc-log` use). Only the user's
+ * ANSWER has to cross replicas — it rendezvouses through Convex, keyed by
+ * `rendezvousId`.
+ *
+ * Delivery is therefore scoped to the requesting turn's own stream by
+ * construction: there is no broadcast surface and no cross-tenant fan-out.
+ *
+ * These parts are `transient: true` at the write site — they reach the AI SDK
+ * `onData` callback but never enter `message.parts`, because an elicitation is
+ * turn-scoped UI, not conversation history.
+ */
+
+/** Elicitation mode per MCP 2025-11-25. Absent on the wire ⇒ `"form"`. */
+export type HostedElicitationMode = "form" | "url";
+
+export type HostedElicitationAction = "accept" | "decline" | "cancel";
+
+/** Terminal outcomes the server reports back to the browser. */
+export type HostedElicitationOutcome = "answered" | "expired" | "cancelled";
+
+/**
+ * A server is asking the user for input, and the tool call is blocked on the
+ * answer.
+ *
+ * `rendezvousId` is minted by the replica (`crypto.randomUUID`) and is the key
+ * the browser answers on. It is deliberately NOT the server-chosen
+ * `elicitationId` (URL mode), which is untrusted and must never be used as an
+ * unguessable key.
+ */
+export interface HostedElicitationRequestEvent {
+  kind: "request";
+  rendezvousId: string;
+  /**
+   * The MCP server that issued the request. `serverId` is the trusted,
+   * immutable anchor; `serverName` is a display label only. Clients MUST make
+   * it clear which server is asking (MCP 2025-11-25 elicitation §Security).
+   */
+  serverId: string;
+  serverName?: string;
+  mode: HostedElicitationMode;
+  message: string;
+  /** Form mode: the MCP `requestedSchema` (flat-object subset). */
+  requestedSchema?: unknown;
+  /** URL mode: the URL the user is asked to open. Never pre-fetched. */
+  url?: string;
+  /** URL mode: server-chosen correlation id. Untrusted; display/correlation only. */
+  serverElicitationId?: string;
+  /** Epoch ms after which the server resolves this as `cancel`. */
+  expiresAt: number;
+  chatSessionId?: string;
+}
+
+/**
+ * The request reached a terminal state server-side. Sent so an open dialog
+ * closes even when the browser was not the thing that resolved it (TTL expiry,
+ * or an answer submitted from elsewhere).
+ */
+export interface HostedElicitationResolvedEvent {
+  kind: "resolved";
+  rendezvousId: string;
+  outcome: HostedElicitationOutcome;
+  action?: HostedElicitationAction;
+}
+
+/**
+ * A `tools/call` failed with `-32042 URLElicitationRequiredError`: the server
+ * needs an out-of-band interaction completed before it can serve the request.
+ *
+ * Display-only — there is NO rendezvous row and no JSON-RPC response owed,
+ * because the call already failed. The user opens the URL out of band and the
+ * tool is retried (by the model, or manually).
+ */
+export interface HostedElicitationUrlRequiredEvent {
+  kind: "url_required";
+  serverId: string;
+  serverName?: string;
+  /** The tool call that failed, so the UI can anchor the notice to it. */
+  toolCallId?: string;
+  elicitations: Array<{
+    url: string;
+    elicitationId: string;
+    message?: string;
+  }>;
+}
+
+export type HostedElicitationEvent =
+  | HostedElicitationRequestEvent
+  | HostedElicitationResolvedEvent
+  | HostedElicitationUrlRequiredEvent;
+
+/** Wire literal for the stream data part carrying a `HostedElicitationEvent`. */
+export const HOSTED_ELICITATION_DATA_PART_TYPE = "data-elicitation" as const;
+
+export interface HostedElicitationDataPart {
+  type: typeof HOSTED_ELICITATION_DATA_PART_TYPE;
+  data: HostedElicitationEvent;
+}
+
+/**
+ * The answer the browser submits to Convex. `rendezvousId` scopes it; the
+ * backend re-derives ownership from the caller's identity and enforces a
+ * one-shot transition, so this payload is not trusted for authorization.
+ */
+export interface HostedElicitationAnswer {
+  rendezvousId: string;
+  action: HostedElicitationAction;
+  /** Form-mode accepts only. Values are constrained to MCP's ElicitResult shape. */
+  content?: Record<string, unknown>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function isHostedElicitationEvent(
+  value: unknown,
+): value is HostedElicitationEvent {
+  if (!isRecord(value)) return false;
+
+  if (value.kind === "request") {
+    return (
+      typeof value.rendezvousId === "string" &&
+      typeof value.serverId === "string" &&
+      (value.mode === "form" || value.mode === "url") &&
+      typeof value.message === "string" &&
+      typeof value.expiresAt === "number"
+    );
+  }
+
+  if (value.kind === "resolved") {
+    return (
+      typeof value.rendezvousId === "string" &&
+      (value.outcome === "answered" ||
+        value.outcome === "expired" ||
+        value.outcome === "cancelled")
+    );
+  }
+
+  if (value.kind === "url_required") {
+    return (
+      typeof value.serverId === "string" &&
+      Array.isArray(value.elicitations) &&
+      value.elicitations.every(
+        (entry) =>
+          isRecord(entry) &&
+          typeof entry.url === "string" &&
+          typeof entry.elicitationId === "string",
+      )
+    );
+  }
+
+  return false;
+}
+
+export function isHostedElicitationDataPart(
+  value: unknown,
+): value is HostedElicitationDataPart {
+  if (!isRecord(value)) return false;
+  return (
+    value.type === HOSTED_ELICITATION_DATA_PART_TYPE &&
+    isHostedElicitationEvent(value.data)
+  );
+}

--- a/mcpjam-inspector/shared/http-tool-calls.ts
+++ b/mcpjam-inspector/shared/http-tool-calls.ts
@@ -171,25 +171,6 @@ type ExecuteToolCallOptionsBase = {
     uri: string;
     options?: { abortSignal?: AbortSignal };
   }) => Promise<unknown>;
-  /**
-   * Called when a tool call fails with `-32042 URLElicitationRequiredError`
-   * (MCP 2025-11-25): the server needs an out-of-band interaction (an OAuth
-   * connect, a payment, …) completed before it can serve this request.
-   *
-   * Display-only — the call already failed, so there is no JSON-RPC response
-   * owed and nothing to wait on. The hook lets an interactive surface show the
-   * URL(s) for consent; the tool is retried afterwards (by the model, from the
-   * hint in the error-text result, or manually by the user).
-   */
-  onUrlElicitationRequired?: (info: {
-    serverId?: string;
-    toolCallId: string;
-    elicitations: Array<{
-      url: string;
-      elicitationId: string;
-      message?: string;
-    }>;
-  }) => void;
 };
 
 /**
@@ -200,9 +181,9 @@ type ExecuteToolCallOptionsBase = {
  * instances), which makes prototype identity unreliable. The shape is the
  * contract.
  */
-const URL_ELICITATION_REQUIRED_CODE = -32042;
+export const URL_ELICITATION_REQUIRED_CODE = -32042;
 
-function readUrlElicitations(
+export function readUrlElicitations(
   error: unknown,
 ): Array<{ url: string; elicitationId: string; message?: string }> | null {
   if (!error || typeof error !== "object") return null;
@@ -543,16 +524,12 @@ export async function executeToolCallsFromMessages(
           // -32042: the server wants an out-of-band interaction first. Surface
           // the URLs structurally to the UI and give the model an actionable
           // retry hint instead of a raw protocol error it can't interpret.
+          // Surfacing the URL to the UI is the tool wrapper's job (see
+          // `web-chat-turn`), which sits on the shared tool set and therefore
+          // fires for every engine. Here we only reshape the model-visible
+          // result so it gets an actionable retry hint instead of a raw
+          // protocol error.
           const urlElicitations = readUrlElicitations(error);
-          if (urlElicitations) {
-            options.onUrlElicitationRequired?.({
-              // Recomputed, not captured: the `serverId` binding lives inside
-              // the try block and isn't in scope here.
-              serverId: extractServerId(content.toolName),
-              toolCallId: content.toolCallId,
-              elicitations: urlElicitations,
-            });
-          }
           const errorOutput: ToolResultPart = {
             type: "error-text",
             value: urlElicitations

--- a/mcpjam-inspector/shared/http-tool-calls.ts
+++ b/mcpjam-inspector/shared/http-tool-calls.ts
@@ -171,7 +171,64 @@ type ExecuteToolCallOptionsBase = {
     uri: string;
     options?: { abortSignal?: AbortSignal };
   }) => Promise<unknown>;
+  /**
+   * Called when a tool call fails with `-32042 URLElicitationRequiredError`
+   * (MCP 2025-11-25): the server needs an out-of-band interaction (an OAuth
+   * connect, a payment, …) completed before it can serve this request.
+   *
+   * Display-only — the call already failed, so there is no JSON-RPC response
+   * owed and nothing to wait on. The hook lets an interactive surface show the
+   * URL(s) for consent; the tool is retried afterwards (by the model, from the
+   * hint in the error-text result, or manually by the user).
+   */
+  onUrlElicitationRequired?: (info: {
+    serverId?: string;
+    toolCallId: string;
+    elicitations: Array<{
+      url: string;
+      elicitationId: string;
+      message?: string;
+    }>;
+  }) => void;
 };
+
+/**
+ * MCP `URLElicitationRequiredError` (-32042).
+ *
+ * Detected STRUCTURALLY, never via `instanceof`: the error may cross package
+ * copies (the inspector and the SDK can resolve different upstream client
+ * instances), which makes prototype identity unreliable. The shape is the
+ * contract.
+ */
+const URL_ELICITATION_REQUIRED_CODE = -32042;
+
+function readUrlElicitations(
+  error: unknown,
+): Array<{ url: string; elicitationId: string; message?: string }> | null {
+  if (!error || typeof error !== "object") return null;
+  const candidate = error as { code?: unknown; data?: unknown };
+  if (candidate.code !== URL_ELICITATION_REQUIRED_CODE) return null;
+
+  const data = candidate.data as { elicitations?: unknown } | undefined;
+  if (!data || !Array.isArray(data.elicitations)) return null;
+
+  const parsed = data.elicitations.flatMap((entry) => {
+    if (!entry || typeof entry !== "object") return [];
+    const item = entry as Record<string, unknown>;
+    if (typeof item.url !== "string" || typeof item.elicitationId !== "string") {
+      return [];
+    }
+    return [
+      {
+        url: item.url,
+        elicitationId: item.elicitationId,
+        ...(typeof item.message === "string" ? { message: item.message } : {}),
+      },
+    ];
+  });
+
+  return parsed.length > 0 ? parsed : null;
+}
 
 type ExecuteToolCallOptions = ExecuteToolCallOptionsBase &
   (
@@ -483,9 +540,26 @@ export async function executeToolCallsFromMessages(
           if (isAbortError(error)) {
             throw error;
           }
+          // -32042: the server wants an out-of-band interaction first. Surface
+          // the URLs structurally to the UI and give the model an actionable
+          // retry hint instead of a raw protocol error it can't interpret.
+          const urlElicitations = readUrlElicitations(error);
+          if (urlElicitations) {
+            options.onUrlElicitationRequired?.({
+              // Recomputed, not captured: the `serverId` binding lives inside
+              // the try block and isn't in scope here.
+              serverId: extractServerId(content.toolName),
+              toolCallId: content.toolCallId,
+              elicitations: urlElicitations,
+            });
+          }
           const errorOutput: ToolResultPart = {
             type: "error-text",
-            value: error instanceof Error ? error.message : String(error),
+            value: urlElicitations
+              ? "This tool needs the user to complete an interaction at a URL first. The user has been shown the link and may complete it out of band. Retry this tool once they confirm they're done."
+              : error instanceof Error
+                ? error.message
+                : String(error),
           } as any;
           const errorToolResultMessage: ModelMessage = {
             role: "tool" as const,

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -2269,7 +2269,17 @@ export class MCPClientManager {
       baseTimeoutMs,
       extensionMs: this.elicitationTimeoutExtensionMs,
       callerSignal: options.signal,
-      hasPending: () => this.elicitationManager.hasPendingForServer(serverId),
+      // Age-bound the check with this call's OWN elicitation budget. Without
+      // it, a handler that never settles (e.g. its `tools/call` was aborted by
+      // this very watchdog, so its `finally` never ran) would pin the server
+      // "pending" for the process lifetime and silently pause the clock of
+      // every later call — unbounded timeouts, with nothing in the logs.
+      // An entry older than this budget would have blown it anyway.
+      hasPending: () =>
+        this.elicitationManager.hasPendingForServer(
+          serverId,
+          this.elicitationTimeoutExtensionMs
+        ),
     });
 
     try {

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -2263,6 +2263,7 @@ export class MCPClientManager {
       options.timeout ??
       this.registeredServers.get(serverId)?.timeout ??
       this.defaultTimeout;
+    const pendingSequenceAtStart = this.elicitationManager.getPendingSequence();
 
     const suspension = createElicitationTimeoutSuspension({
       serverId,
@@ -2278,7 +2279,8 @@ export class MCPClientManager {
       hasPending: () =>
         this.elicitationManager.hasPendingForServer(
           serverId,
-          this.elicitationTimeoutExtensionMs
+          this.elicitationTimeoutExtensionMs,
+          pendingSequenceAtStart,
         ),
     });
 

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -50,6 +50,7 @@ import type { MCPServerReplayConfig } from "../eval-reporting-types.js";
 
 import {
   DEFAULT_CLIENT_VERSION,
+  DEFAULT_ELICITATION_TIMEOUT_EXTENSION_MS,
   DEFAULT_TIMEOUT,
   HTTP_CONNECT_TIMEOUT,
 } from "./constants.js";
@@ -80,6 +81,8 @@ import {
   type NotificationHandler,
 } from "./notification-handlers.js";
 import { ElicitationManager } from "./elicitation.js";
+import type { DeclaredElicitationCapability } from "./elicitation.js";
+import { createElicitationTimeoutSuspension } from "./elicitation-timeout.js";
 import {
   TaskStatusNotificationMethod,
   listTasks as tasksListTasks,
@@ -248,6 +251,7 @@ export class MCPClientManager {
   private readonly defaultProgressHandler?: ProgressHandler;
   private readonly defaultRetryPolicy: RetryPolicy;
   private readonly lazyConnect: boolean;
+  private readonly elicitationTimeoutExtensionMs: number;
 
   // Progress token counter for uniqueness
   private progressTokenCounter = 0;
@@ -278,6 +282,11 @@ export class MCPClientManager {
     this.defaultProgressHandler = options.progressHandler;
     this.defaultRetryPolicy = normalizeRetryPolicy(options.retryPolicy);
     this.lazyConnect = options.lazyConnect ?? false;
+    this.elicitationTimeoutExtensionMs = Math.max(
+      0,
+      options.elicitationTimeoutExtensionMs ??
+        DEFAULT_ELICITATION_TIMEOUT_EXTENSION_MS
+    );
 
     // Start connecting to all configured servers (unless replay/trace-repair use explicit connect)
     if (!this.lazyConnect) {
@@ -760,7 +769,11 @@ export class MCPClientManager {
         };
       }
 
-      return client.callTool(callParams, mergedOptions);
+      return this.withElicitationTimeoutSuspension(
+        serverId,
+        mergedOptions,
+        (callOptions) => client.callTool(callParams, callOptions)
+      );
     };
 
     return this.runRetriedOperation(
@@ -1030,7 +1043,11 @@ export class MCPClientManager {
     const state = this.liveClientStates.get(serverId);
     const client = state?.client;
     if (client && this.hasNegotiatedElicitation(state)) {
-      this.elicitationManager.applyToClient(serverId, client);
+      this.elicitationManager.applyToClient(
+        serverId,
+        client,
+        this.negotiatedElicitationCapability(state)
+      );
     }
   }
 
@@ -1046,7 +1063,11 @@ export class MCPClientManager {
         this.elicitationManager.getGlobalCallback() &&
         this.hasNegotiatedElicitation(state)
       ) {
-        this.elicitationManager.applyToClient(serverId, client);
+        this.elicitationManager.applyToClient(
+          serverId,
+          client,
+          this.negotiatedElicitationCapability(state)
+        );
       } else {
         this.elicitationManager.removeFromClient(client);
       }
@@ -1060,7 +1081,11 @@ export class MCPClientManager {
     this.elicitationManager.setGlobalCallback(callback);
     for (const [serverId, state] of this.liveClientStates.entries()) {
       if (state.client && this.hasNegotiatedElicitation(state)) {
-        this.elicitationManager.applyToClient(serverId, state.client);
+        this.elicitationManager.applyToClient(
+          serverId,
+          state.client,
+          this.negotiatedElicitationCapability(state)
+        );
       }
     }
   }
@@ -1076,7 +1101,11 @@ export class MCPClientManager {
         this.elicitationManager.getHandler(serverId) &&
         this.hasNegotiatedElicitation(state)
       ) {
-        this.elicitationManager.applyToClient(serverId, state.client);
+        this.elicitationManager.applyToClient(
+          serverId,
+          state.client,
+          this.negotiatedElicitationCapability(state)
+        );
       } else {
         this.elicitationManager.removeFromClient(state.client);
       }
@@ -1343,8 +1372,15 @@ export class MCPClientManager {
       if (this.defaultProgressHandler) {
         applyProgressHandler(serverId, client, this.defaultProgressHandler);
       }
-      if ((clientCapabilities as Record<string, unknown>).elicitation != null) {
-        this.elicitationManager.applyToClient(serverId, client);
+      const declaredElicitation = (
+        clientCapabilities as Record<string, unknown>
+      ).elicitation;
+      if (declaredElicitation != null) {
+        this.elicitationManager.applyToClient(
+          serverId,
+          client,
+          declaredElicitation as DeclaredElicitationCapability
+        );
       }
 
       if (config.onError) {
@@ -1737,7 +1773,11 @@ export class MCPClientManager {
         this.buildCapabilities(serverId, config) as Record<string, unknown>
       ).elicitation;
       if (elicitationCaps != null) {
-        this.elicitationManager.applyToClient(serverId, previewClient);
+        this.elicitationManager.applyToClient(
+          serverId,
+          previewClient,
+          elicitationCaps as DeclaredElicitationCapability
+        );
       }
       if (config.onError) {
         previewClient.onerror = (error) => config.onError?.(error);
@@ -2191,6 +2231,58 @@ export class MCPClientManager {
     return mergedOptions;
   }
 
+  /**
+   * Runs a tool call under an elicitation-aware timeout budget.
+   *
+   * The request timeout is a *server* budget. A tool call blocked because the
+   * server asked the user a question is not hung, so its clock stops while an
+   * elicitation is pending — but a genuinely hung server must still die at the
+   * base timeout, and a human who never answers must not block forever.
+   *
+   * Mechanics (see `elicitation-timeout.ts` for the budget accounting):
+   *  - No elicitation handler for this server ⇒ pure passthrough, no watchdog,
+   *    no behavior change whatsoever.
+   *  - Otherwise the upstream hard timeout is **overridden** to
+   *    `base + extension` to move it out of the way (`withTimeout` only
+   *    *injects* a timeout when unset, so a plain merge would not take), and
+   *    the real budget is enforced locally by the watchdog.
+   *  - The watchdog's signal is composed with the caller's — the AI SDK
+   *    forwards its own `abortSignal` into these request options and it must
+   *    keep working.
+   */
+  private async withElicitationTimeoutSuspension<T>(
+    serverId: string,
+    options: RequestOptions,
+    run: (options: RequestOptions) => Promise<T>
+  ): Promise<T> {
+    if (!this.elicitationManager.hasHandler(serverId)) {
+      return run(options);
+    }
+
+    const baseTimeoutMs =
+      options.timeout ??
+      this.registeredServers.get(serverId)?.timeout ??
+      this.defaultTimeout;
+
+    const suspension = createElicitationTimeoutSuspension({
+      serverId,
+      baseTimeoutMs,
+      extensionMs: this.elicitationTimeoutExtensionMs,
+      callerSignal: options.signal,
+      hasPending: () => this.elicitationManager.hasPendingForServer(serverId),
+    });
+
+    try {
+      return await run({
+        ...options,
+        timeout: suspension.timeoutMs,
+        signal: suspension.signal,
+      });
+    } finally {
+      suspension.dispose();
+    }
+  }
+
   private buildCapabilities(
     serverId: string,
     config: MCPServerConfig
@@ -2219,10 +2311,23 @@ export class MCPClientManager {
   }
 
   private hasNegotiatedElicitation(state?: LiveClientState): boolean {
+    return this.negotiatedElicitationCapability(state) != null;
+  }
+
+  /**
+   * The `elicitation` client capability actually advertised to this server on
+   * the wire, for `applyToClient` to enforce declared modes against.
+   */
+  private negotiatedElicitationCapability(
+    state?: LiveClientState
+  ): DeclaredElicitationCapability {
     const capabilities = state?.initializedClientCapabilities as
       | Record<string, unknown>
       | undefined;
-    return capabilities?.elicitation != null;
+    const elicitation = capabilities?.elicitation;
+    return elicitation != null
+      ? (elicitation as DeclaredElicitationCapability)
+      : undefined;
   }
 
   private resolveRpcLogger(config: MCPServerConfig): RpcLogger | undefined {

--- a/sdk/src/mcp-client-manager/constants.ts
+++ b/sdk/src/mcp-client-manager/constants.ts
@@ -12,3 +12,10 @@ export const DEFAULT_TIMEOUT = DEFAULT_REQUEST_TIMEOUT_MSEC;
 
 /** Timeout for initial HTTP transport attempt before falling back to SSE */
 export const HTTP_CONNECT_TIMEOUT = 3000;
+
+/**
+ * Default extra time budget granted to a `tools/call` while elicitations are
+ * pending for that server (see `MCPClientManagerOptions.elicitationTimeoutExtensionMs`).
+ * Human-scale: a person has to read a dialog and answer it.
+ */
+export const DEFAULT_ELICITATION_TIMEOUT_EXTENSION_MS = 10 * 60 * 1000;

--- a/sdk/src/mcp-client-manager/elicitation-timeout.ts
+++ b/sdk/src/mcp-client-manager/elicitation-timeout.ts
@@ -171,16 +171,17 @@ export function createElicitationTimeoutSuspension(
    * itself — 120s budgets still sample at 1s (0.8% slop), while a 100ms budget
    * samples at 100ms and fires on time.
    */
-  const nextDelay = (): number => {
+  const nextDelay = (pending: boolean): number => {
     const remainingActive = Math.max(0, baseTimeoutMs - activeMs);
+    if (!pending) {
+      // The suspended budget is irrelevant until an elicitation actually
+      // starts. Including it here made extension=0 spin a normal tool call at
+      // 1ms, and tiny extensions caused similarly aggressive polling even
+      // while all time belonged to the server.
+      return Math.max(1, Math.min(intervalMs, remainingActive));
+    }
+
     const remainingSuspended = Math.max(0, extensionMs - suspendedMs);
-    // Bound by BOTH budgets, always — including `remainingActive` while an
-    // elicitation is pending. That looks redundant (the active clock is paused)
-    // but it is what bounds how late we notice the elicitation *ending*: a
-    // 100ms budget that samples every 1s during a 5-minute wait would overshoot
-    // by up to 1s the moment the user answers. Sampling at 100ms throughout
-    // costs nothing measurable and keeps the budget honest on both sides of the
-    // transition.
     return Math.max(
       1,
       Math.min(intervalMs, remainingActive, remainingSuspended)
@@ -192,7 +193,8 @@ export function createElicitationTimeoutSuspension(
     const elapsed = Math.max(0, now - lastSampleAt);
     lastSampleAt = now;
 
-    if (hasPending()) {
+    const pending = hasPending();
+    if (pending) {
       suspendedMs += elapsed;
       if (suspendedMs >= extensionMs) {
         abortWith(
@@ -217,16 +219,16 @@ export function createElicitationTimeoutSuspension(
     }
 
     if (disposed) return;
-    schedule();
+    schedule(pending);
   };
 
-  function schedule() {
-    timer = setTimeout(tick, nextDelay());
+  function schedule(pending: boolean) {
+    timer = setTimeout(tick, nextDelay(pending));
     // Never hold the event loop open on this watchdog.
     (timer as unknown as { unref?: () => void }).unref?.();
   }
 
-  schedule();
+  schedule(hasPending());
   const composed = composeAbortSignals(
     callerSignal ? [callerSignal, watchdog.signal] : [watchdog.signal]
   );

--- a/sdk/src/mcp-client-manager/elicitation-timeout.ts
+++ b/sdk/src/mcp-client-manager/elicitation-timeout.ts
@@ -1,0 +1,200 @@
+/**
+ * Elicitation-aware timeout suspension for `tools/call`.
+ *
+ * The per-request MCP timeout is a *server* budget: it exists to kill a hung
+ * server. A tool call that is blocked because the server asked the user a
+ * question is not hung — the clock should stop while a human is thinking.
+ *
+ * Upstream enforces `RequestOptions.timeout` itself and has no notion of
+ * "suspended", so this module raises the upstream hard timeout out of the way
+ * (`base + extension`) and re-implements the budget locally with a watchdog
+ * that tracks two clocks:
+ *
+ *  - **active**: accumulates only while NO elicitation is pending for the
+ *    server. Exhausting it at `base` means the server really is hung.
+ *  - **suspended**: accumulates only while an elicitation IS pending, and is
+ *    cumulative across every elicitation in the call. Exhausting it at
+ *    `extension` means the human never finished. This is the TOTAL elicitation
+ *    budget for one tool call; each individual elicitation is additionally
+ *    bounded by whatever TTL the callback implementation enforces.
+ *
+ * Either exhaustion aborts the call with a timeout-shaped `SdkError`, so
+ * callers see a timeout rather than a bare `AbortError`. The watchdog signal is
+ * COMPOSED with the caller's signal (never clobbers it): the AI SDK forwards
+ * its own `abortSignal` into `executeTool` request options.
+ *
+ * Known conservative edge: pending state is tracked per SERVER, not per call.
+ * A second, unrelated tool call in flight on the same server while an
+ * elicitation is pending also has its active clock paused. It stays bounded by
+ * its own suspended budget, so it still terminates — just later than a strict
+ * per-call accounting would.
+ */
+
+import { SdkError, SdkErrorCode } from "@modelcontextprotocol/client";
+import { markNonRetryableError } from "./error-utils.js";
+
+/** How often the watchdog samples the pending state. */
+export const ELICITATION_WATCHDOG_INTERVAL_MS = 1000;
+
+export interface ElicitationTimeoutSuspensionOptions {
+  /** Server the tool call targets (for error messages). */
+  serverId: string;
+  /** Active-time budget, i.e. the timeout the call would have had. */
+  baseTimeoutMs: number;
+  /** Cumulative suspended-time budget for the whole call. */
+  extensionMs: number;
+  /** Whether an elicitation is currently pending for this server. */
+  hasPending: () => boolean;
+  /** The caller's abort signal, if any. Composed, never replaced. */
+  callerSignal?: AbortSignal;
+  /** Watchdog sampling interval. Defaults to {@link ELICITATION_WATCHDOG_INTERVAL_MS}. */
+  intervalMs?: number;
+}
+
+export interface ElicitationTimeoutSuspension {
+  /** Signal to hand to the MCP request. Composed of caller + watchdog. */
+  signal: AbortSignal;
+  /** The hard timeout to hand to the MCP request (`base + extension`). */
+  timeoutMs: number;
+  /** Clears the interval and removes any listeners. Idempotent. */
+  dispose(): void;
+}
+
+/**
+ * Composes abort signals, preferring the platform `AbortSignal.any`.
+ *
+ * The package's engines floor is `node >= 20.0.0` but `AbortSignal.any` only
+ * landed in Node 20.3.0, so this feature-detects and hand-rolls forwarding on
+ * older runtimes rather than raising the floor (which would be a breaking
+ * change to a published package).
+ */
+function composeAbortSignals(signals: AbortSignal[]): {
+  signal: AbortSignal;
+  dispose: () => void;
+} {
+  if (signals.length === 1) {
+    return { signal: signals[0], dispose: () => {} };
+  }
+
+  const nativeAny = (
+    AbortSignal as unknown as {
+      any?: (signals: Iterable<AbortSignal>) => AbortSignal;
+    }
+  ).any;
+  if (typeof nativeAny === "function") {
+    // `AbortSignal.any` holds its sources weakly and needs no teardown.
+    return { signal: nativeAny.call(AbortSignal, signals), dispose: () => {} };
+  }
+
+  // Node 20.0–20.2 fallback: forward manually.
+  const controller = new AbortController();
+  const teardown: Array<() => void> = [];
+  for (const source of signals) {
+    if (source.aborted) {
+      controller.abort(source.reason);
+      break;
+    }
+    const onAbort = () => controller.abort(source.reason);
+    source.addEventListener("abort", onAbort, { once: true });
+    teardown.push(() => source.removeEventListener("abort", onAbort));
+  }
+  return {
+    signal: controller.signal,
+    dispose: () => {
+      for (const off of teardown) off();
+      teardown.length = 0;
+    },
+  };
+}
+
+/**
+ * Builds the timeout-shaped error the watchdog aborts with.
+ *
+ * Shape matches what upstream raises on its own timeouts
+ * (`SdkError` / `SdkErrorCode.RequestTimeout`), so existing timeout handling
+ * keeps working. Marked non-retryable: the message unavoidably says "timed
+ * out", which `isRetryableTransientError` would otherwise treat as transient.
+ */
+export function createElicitationTimeoutError(
+  message: string,
+  data: Record<string, unknown>
+): SdkError {
+  return markNonRetryableError(
+    new SdkError(SdkErrorCode.RequestTimeout, message, data)
+  );
+}
+
+/**
+ * Creates a watchdog enforcing the active/suspended budgets for one tool call.
+ *
+ * Caller MUST call {@link ElicitationTimeoutSuspension.dispose} in a `finally`.
+ */
+export function createElicitationTimeoutSuspension(
+  options: ElicitationTimeoutSuspensionOptions
+): ElicitationTimeoutSuspension {
+  const {
+    serverId,
+    baseTimeoutMs,
+    extensionMs,
+    hasPending,
+    callerSignal,
+    intervalMs = ELICITATION_WATCHDOG_INTERVAL_MS,
+  } = options;
+
+  const watchdog = new AbortController();
+  let activeMs = 0;
+  let suspendedMs = 0;
+  let lastSampleAt = Date.now();
+  let disposed = false;
+
+  const abortWith = (error: SdkError) => {
+    if (watchdog.signal.aborted) return;
+    watchdog.abort(error);
+  };
+
+  const timer = setInterval(() => {
+    const now = Date.now();
+    const elapsed = Math.max(0, now - lastSampleAt);
+    lastSampleAt = now;
+
+    if (hasPending()) {
+      suspendedMs += elapsed;
+      if (suspendedMs >= extensionMs) {
+        abortWith(
+          createElicitationTimeoutError(
+            `Request timed out: server "${serverId}" spent ${suspendedMs}ms waiting on elicitation responses, exceeding the ${extensionMs}ms elicitation budget for this tool call.`,
+            { serverId, timeout: extensionMs, reason: "elicitation-budget" }
+          )
+        );
+      }
+      return;
+    }
+
+    activeMs += elapsed;
+    if (activeMs >= baseTimeoutMs) {
+      abortWith(
+        createElicitationTimeoutError(
+          `Request timed out after ${activeMs}ms of server time (${baseTimeoutMs}ms budget, excluding time suspended on elicitation).`,
+          { serverId, timeout: baseTimeoutMs, reason: "server-timeout" }
+        )
+      );
+    }
+  }, intervalMs);
+  // Never hold the event loop open on this watchdog.
+  (timer as unknown as { unref?: () => void }).unref?.();
+
+  const composed = composeAbortSignals(
+    callerSignal ? [callerSignal, watchdog.signal] : [watchdog.signal]
+  );
+
+  return {
+    signal: composed.signal,
+    timeoutMs: baseTimeoutMs + extensionMs,
+    dispose: () => {
+      if (disposed) return;
+      disposed = true;
+      clearInterval(timer);
+      composed.dispose();
+    },
+  };
+}

--- a/sdk/src/mcp-client-manager/elicitation-timeout.ts
+++ b/sdk/src/mcp-client-manager/elicitation-timeout.ts
@@ -152,7 +152,42 @@ export function createElicitationTimeoutSuspension(
     watchdog.abort(error);
   };
 
-  const timer = setInterval(() => {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  /**
+   * Sample interval for the NEXT check.
+   *
+   * A fixed 1s cadence silently broke short per-call timeouts: we raise the
+   * upstream timeout to `base + extension` immediately, so a caller asking for
+   * 100ms would not be stopped until our first sample at 1s — a 10x overrun of
+   * a budget the caller explicitly set.
+   *
+   * We cannot schedule a single one-shot at the full remaining budget instead:
+   * `hasPending()` is a poll, so we must keep looking often enough to notice an
+   * elicitation *starting* and stop counting its wait as server time.
+   *
+   * So: sample at the cap, or at whatever budget remains if that is sooner.
+   * Overshoot is bounded by one interval, which is now always ≤ the budget
+   * itself — 120s budgets still sample at 1s (0.8% slop), while a 100ms budget
+   * samples at 100ms and fires on time.
+   */
+  const nextDelay = (): number => {
+    const remainingActive = Math.max(0, baseTimeoutMs - activeMs);
+    const remainingSuspended = Math.max(0, extensionMs - suspendedMs);
+    // Bound by BOTH budgets, always — including `remainingActive` while an
+    // elicitation is pending. That looks redundant (the active clock is paused)
+    // but it is what bounds how late we notice the elicitation *ending*: a
+    // 100ms budget that samples every 1s during a 5-minute wait would overshoot
+    // by up to 1s the moment the user answers. Sampling at 100ms throughout
+    // costs nothing measurable and keeps the budget honest on both sides of the
+    // transition.
+    return Math.max(
+      1,
+      Math.min(intervalMs, remainingActive, remainingSuspended)
+    );
+  };
+
+  const tick = () => {
     const now = Date.now();
     const elapsed = Math.max(0, now - lastSampleAt);
     lastSampleAt = now;
@@ -166,23 +201,32 @@ export function createElicitationTimeoutSuspension(
             { serverId, timeout: extensionMs, reason: "elicitation-budget" }
           )
         );
+        return;
       }
-      return;
+    } else {
+      activeMs += elapsed;
+      if (activeMs >= baseTimeoutMs) {
+        abortWith(
+          createElicitationTimeoutError(
+            `Request timed out after ${activeMs}ms of server time (${baseTimeoutMs}ms budget, excluding time suspended on elicitation).`,
+            { serverId, timeout: baseTimeoutMs, reason: "server-timeout" }
+          )
+        );
+        return;
+      }
     }
 
-    activeMs += elapsed;
-    if (activeMs >= baseTimeoutMs) {
-      abortWith(
-        createElicitationTimeoutError(
-          `Request timed out after ${activeMs}ms of server time (${baseTimeoutMs}ms budget, excluding time suspended on elicitation).`,
-          { serverId, timeout: baseTimeoutMs, reason: "server-timeout" }
-        )
-      );
-    }
-  }, intervalMs);
-  // Never hold the event loop open on this watchdog.
-  (timer as unknown as { unref?: () => void }).unref?.();
+    if (disposed) return;
+    schedule();
+  };
 
+  function schedule() {
+    timer = setTimeout(tick, nextDelay());
+    // Never hold the event loop open on this watchdog.
+    (timer as unknown as { unref?: () => void }).unref?.();
+  }
+
+  schedule();
   const composed = composeAbortSignals(
     callerSignal ? [callerSignal, watchdog.signal] : [watchdog.signal]
   );
@@ -193,7 +237,7 @@ export function createElicitationTimeoutSuspension(
     dispose: () => {
       if (disposed) return;
       disposed = true;
-      clearInterval(timer);
+      if (timer) clearTimeout(timer);
       composed.dispose();
     },
   };

--- a/sdk/src/mcp-client-manager/elicitation.ts
+++ b/sdk/src/mcp-client-manager/elicitation.ts
@@ -3,10 +3,84 @@
  */
 
 import type { ElicitResult } from "@modelcontextprotocol/client";
-import type { ElicitationHandler, ElicitationCallback } from "./types.js";
+import {
+  getSupportedElicitationModes,
+  ProtocolError,
+  ProtocolErrorCode,
+} from "@modelcontextprotocol/client";
+import type {
+  ElicitationHandler,
+  ElicitationCallback,
+  ElicitationMode,
+} from "./types.js";
 import type { ManagedMcpClient } from "./managed-mcp-client.js";
 
 export const ElicitRequestMethod = "elicitation/create" as const;
+
+/**
+ * The `elicitation` client capability actually advertised on the wire for a
+ * server, exactly as it appeared in `initialize`. `undefined` means we have no
+ * record of one (legacy call sites; capability negotiation not tracked).
+ */
+export type DeclaredElicitationCapability = Record<string, unknown> | undefined;
+
+/**
+ * Reads the requested mode off an inbound `elicitation/create`.
+ *
+ * Absent ⇒ `"form"`: `mode` is optional in the form-params schema and every
+ * pre-2025-11-25 elicitation is a form. An unrecognized string is returned
+ * verbatim so the caller can reject it as undeclared.
+ */
+function readElicitationMode(params: unknown): string {
+  const mode = (params as { mode?: unknown } | undefined)?.mode;
+  return typeof mode === "string" ? mode : "form";
+}
+
+/**
+ * Enforces the spec MUST: a client rejects an elicitation whose mode it did
+ * not declare, with JSON-RPC `-32602` (InvalidParams).
+ *
+ * Thrown from inside a request handler, `ProtocolError` surfaces to the server
+ * as a JSON-RPC error response carrying `error.code` verbatim (upstream maps
+ * `error.code` whenever it is a safe integer).
+ *
+ * Mode-vs-declaration semantics come from upstream's own
+ * `getSupportedElicitationModes`, so this cannot drift from the shape the
+ * upstream `Client` enforces: bare `{}` ≡ form-only, `{form:{}}` form-only,
+ * `{form:{},url:{}}` both, `{url:{}}` url-only.
+ *
+ * This duplicates a check the upstream `Client` already performs for real
+ * connections — deliberately. It is the ONLY enforcement on the stateless
+ * preview client (which stores raw handlers), and it keeps the rejection
+ * identical across both client adapters.
+ */
+function assertElicitationModeDeclared(
+  serverId: string,
+  mode: string,
+  declaredCapability: DeclaredElicitationCapability
+): asserts mode is ElicitationMode {
+  if (declaredCapability === undefined) {
+    // No declaration on record. Form is the legacy default and stays allowed
+    // for back-compat; url mode requires an explicit declaration.
+    if (mode === "form") return;
+    throw new ProtocolError(
+      ProtocolErrorCode.InvalidParams,
+      `Client did not declare support for "${mode}"-mode elicitation (server "${serverId}").`
+    );
+  }
+
+  const { supportsFormMode, supportsUrlMode } = getSupportedElicitationModes(
+    declaredCapability as Parameters<typeof getSupportedElicitationModes>[0]
+  );
+
+  if (mode === "form" && supportsFormMode) return;
+  if (mode === "url" && supportsUrlMode) return;
+
+  throw new ProtocolError(
+    ProtocolErrorCode.InvalidParams,
+    `Client did not declare support for "${mode}"-mode elicitation (server "${serverId}").`
+  );
+}
 
 /**
  * Manages elicitation handlers and callbacks for MCP servers.
@@ -22,6 +96,12 @@ export class ElicitationManager {
       reject: (error: unknown) => void;
     }
   >();
+  /**
+   * In-flight elicitation handler invocations per server. Drives
+   * {@link hasPendingForServer}, which the elicitation-aware tool timeout uses
+   * to decide whether the clock is running.
+   */
+  private pendingCountByServer = new Map<string, number>();
 
   /**
    * Sets a server-specific elicitation handler.
@@ -85,6 +165,34 @@ export class ElicitationManager {
   }
 
   /**
+   * Whether an elicitation handler invocation is currently in flight for a
+   * server — i.e. whether we are waiting on a human rather than on the server.
+   *
+   * Per-server, not per-call: see the note in `elicitation-timeout.ts`.
+   *
+   * @param serverId - The server ID
+   */
+  hasPendingForServer(serverId: string): boolean {
+    return (this.pendingCountByServer.get(serverId) ?? 0) > 0;
+  }
+
+  private beginPending(serverId: string): void {
+    this.pendingCountByServer.set(
+      serverId,
+      (this.pendingCountByServer.get(serverId) ?? 0) + 1
+    );
+  }
+
+  private endPending(serverId: string): void {
+    const next = (this.pendingCountByServer.get(serverId) ?? 0) - 1;
+    if (next > 0) {
+      this.pendingCountByServer.set(serverId, next);
+    } else {
+      this.pendingCountByServer.delete(serverId);
+    }
+  }
+
+  /**
    * Gets the pending elicitations map.
    * Useful for external code that needs to add resolvers.
    *
@@ -126,8 +234,16 @@ export class ElicitationManager {
    *
    * @param serverId - The server ID
    * @param client - The MCP client
+   * @param declaredCapability - The `elicitation` client capability actually
+   *   advertised to this server on the wire. Used to reject undeclared modes
+   *   with `-32602`. Omit only when no declaration is on record — form mode is
+   *   then allowed for back-compat and url mode rejected.
    */
-  applyToClient(serverId: string, client: ManagedMcpClient): void {
+  applyToClient(
+    serverId: string,
+    client: ManagedMcpClient,
+    declaredCapability?: DeclaredElicitationCapability
+  ): void {
     const serverSpecific = this.handlers.get(serverId);
 
     if (serverSpecific) {
@@ -140,32 +256,64 @@ export class ElicitationManager {
         const params = (request as { params?: unknown }).params as
           | Parameters<ElicitationHandler>[0]
           | undefined;
-        return serverSpecific(
-          params ?? ({} as Parameters<ElicitationHandler>[0]),
+
+        assertElicitationModeDeclared(
+          serverId,
+          readElicitationMode(params),
+          declaredCapability
         );
+
+        this.beginPending(serverId);
+        try {
+          return await serverSpecific(
+            params ?? ({} as Parameters<ElicitationHandler>[0])
+          );
+        } finally {
+          this.endPending(serverId);
+        }
       });
       return;
     }
 
     if (this.globalCallback) {
       client.setRequestHandler(ElicitRequestMethod, async (request) => {
+        const params = (request as { params?: unknown }).params as
+          | Record<string, any>
+          | undefined;
+
+        const mode = readElicitationMode(params);
+        assertElicitationModeDeclared(serverId, mode, declaredCapability);
+
         const reqId = `elicit_${Date.now()}_${Math.random()
           .toString(36)
           .slice(2, 9)}`;
 
         // Extract related task ID from _meta per MCP Tasks spec (2025-11-25)
-        const meta = (request.params as any)?._meta;
+        const meta = params?._meta;
         const relatedTask = meta?.["io.modelcontextprotocol/related-task"];
         const relatedTaskId = relatedTask?.taskId as string | undefined;
 
-        return await this.globalCallback!({
-          requestId: reqId,
-          message: (request.params as any)?.message,
-          schema:
-            (request.params as any)?.requestedSchema ??
-            (request.params as any)?.schema,
-          relatedTaskId,
-        });
+        this.beginPending(serverId);
+        try {
+          return await this.globalCallback!({
+            requestId: reqId,
+            serverId,
+            mode,
+            message: params?.message,
+            // Form mode only. `schema` is the legacy alias some servers
+            // still send; url-mode params carry neither.
+            schema: params?.requestedSchema ?? params?.schema,
+            // URL mode only — absent for form requests.
+            url: typeof params?.url === "string" ? params.url : undefined,
+            elicitationId:
+              typeof params?.elicitationId === "string"
+                ? params.elicitationId
+                : undefined,
+            relatedTaskId,
+          });
+        } finally {
+          this.endPending(serverId);
+        }
       });
     }
   }
@@ -186,5 +334,9 @@ export class ElicitationManager {
    */
   clearServer(serverId: string): void {
     this.handlers.delete(serverId);
+    // Drop any pending count: the server is gone, so a handler invocation that
+    // never settles must not pin `hasPendingForServer` true forever. A late
+    // `endPending` from an in-flight handler is harmless (floors at delete).
+    this.pendingCountByServer.delete(serverId);
   }
 }

--- a/sdk/src/mcp-client-manager/elicitation.ts
+++ b/sdk/src/mcp-client-manager/elicitation.ts
@@ -116,8 +116,9 @@ export class ElicitationManager {
    */
   private pendingElicitationEntries = new Map<
     symbol,
-    { serverId: string; startedAt: number }
+    { serverId: string; startedAt: number; sequence: number }
   >();
+  private pendingSequence = 0;
 
   /**
    * Sets a server-specific elicitation handler.
@@ -188,18 +189,44 @@ export class ElicitationManager {
    *
    * @param serverId - The server ID
    */
-  hasPendingForServer(serverId: string, maxAgeMs?: number): boolean {
+  hasPendingForServer(
+    serverId: string,
+    maxAgeMs?: number,
+    startedAfterSequence?: number,
+  ): boolean {
     const now = Date.now();
-    for (const entry of this.pendingElicitationEntries.values()) {
+    let pending = false;
+    for (const [token, entry] of this.pendingElicitationEntries) {
       if (entry.serverId !== serverId) continue;
+      // An entry created after this tool call took its snapshot belongs to work
+      // that started during the call. It must be observed at least once even
+      // when maxAgeMs=0; otherwise the first watchdog tick classifies it as
+      // stale and silently grants a base-timeout wait instead of a zero budget.
+      if (
+        startedAfterSequence !== undefined &&
+        entry.sequence > startedAfterSequence
+      ) {
+        pending = true;
+        continue;
+      }
       // Older than the asking call's entire elicitation budget: that call would
       // have aborted on its own budget by now, so this entry cannot honestly
       // keep pausing anyone's clock. Bounds a stuck handler's blast radius to
-      // one budget window instead of the process lifetime.
-      if (maxAgeMs !== undefined && now - entry.startedAt > maxAgeMs) continue;
-      return true;
+      // one budget window instead of the process lifetime. Remove it as well as
+      // ignoring it so repeated never-settling callbacks cannot grow this map
+      // without bound.
+      if (maxAgeMs !== undefined && now - entry.startedAt > maxAgeMs) {
+        this.pendingElicitationEntries.delete(token);
+        continue;
+      }
+      pending = true;
     }
-    return false;
+    return pending;
+  }
+
+  /** Snapshot used to distinguish this call's future elicitations from stale ones. */
+  getPendingSequence(): number {
+    return this.pendingSequence;
   }
 
   private beginPending(serverId: string): symbol {
@@ -207,6 +234,7 @@ export class ElicitationManager {
     this.pendingElicitationEntries.set(token, {
       serverId,
       startedAt: Date.now(),
+      sequence: ++this.pendingSequence,
     });
     return token;
   }

--- a/sdk/src/mcp-client-manager/elicitation.ts
+++ b/sdk/src/mcp-client-manager/elicitation.ts
@@ -97,11 +97,27 @@ export class ElicitationManager {
     }
   >();
   /**
-   * In-flight elicitation handler invocations per server. Drives
+   * In-flight elicitation handler invocations. Drives
    * {@link hasPendingForServer}, which the elicitation-aware tool timeout uses
    * to decide whether the clock is running.
+   *
+   * Entries, not a bare count, for two reasons a counter cannot express:
+   *
+   * - **A handler that never settles must not poison the server forever.** The
+   *   tool watchdog can abort a `tools/call` while its elicitation callback is
+   *   still awaiting; that callback's `finally` never runs, so a count would sit
+   *   at 1 permanently and every LATER call on that server would have its clock
+   *   paused — silently unbounded timeouts. `startedAt` lets us ignore an entry
+   *   older than the asking call's own budget.
+   * - **A late completion must not decrement a NEW connection.** Reconnect
+   *   reuses the serverId, and a counter is anonymous: the old handler's
+   *   decrement landed on the new connection's tally and could zero out a
+   *   genuinely pending elicitation. A token only ever removes its own entry.
    */
-  private pendingCountByServer = new Map<string, number>();
+  private pendingElicitationEntries = new Map<
+    symbol,
+    { serverId: string; startedAt: number }
+  >();
 
   /**
    * Sets a server-specific elicitation handler.
@@ -172,24 +188,31 @@ export class ElicitationManager {
    *
    * @param serverId - The server ID
    */
-  hasPendingForServer(serverId: string): boolean {
-    return (this.pendingCountByServer.get(serverId) ?? 0) > 0;
-  }
-
-  private beginPending(serverId: string): void {
-    this.pendingCountByServer.set(
-      serverId,
-      (this.pendingCountByServer.get(serverId) ?? 0) + 1
-    );
-  }
-
-  private endPending(serverId: string): void {
-    const next = (this.pendingCountByServer.get(serverId) ?? 0) - 1;
-    if (next > 0) {
-      this.pendingCountByServer.set(serverId, next);
-    } else {
-      this.pendingCountByServer.delete(serverId);
+  hasPendingForServer(serverId: string, maxAgeMs?: number): boolean {
+    const now = Date.now();
+    for (const entry of this.pendingElicitationEntries.values()) {
+      if (entry.serverId !== serverId) continue;
+      // Older than the asking call's entire elicitation budget: that call would
+      // have aborted on its own budget by now, so this entry cannot honestly
+      // keep pausing anyone's clock. Bounds a stuck handler's blast radius to
+      // one budget window instead of the process lifetime.
+      if (maxAgeMs !== undefined && now - entry.startedAt > maxAgeMs) continue;
+      return true;
     }
+    return false;
+  }
+
+  private beginPending(serverId: string): symbol {
+    const token = Symbol("elicitation-pending");
+    this.pendingElicitationEntries.set(token, {
+      serverId,
+      startedAt: Date.now(),
+    });
+    return token;
+  }
+
+  private endPending(token: symbol): void {
+    this.pendingElicitationEntries.delete(token);
   }
 
   /**
@@ -263,13 +286,13 @@ export class ElicitationManager {
           declaredCapability
         );
 
-        this.beginPending(serverId);
+        const pendingToken = this.beginPending(serverId);
         try {
           return await serverSpecific(
             params ?? ({} as Parameters<ElicitationHandler>[0])
           );
         } finally {
-          this.endPending(serverId);
+          this.endPending(pendingToken);
         }
       });
       return;
@@ -293,7 +316,7 @@ export class ElicitationManager {
         const relatedTask = meta?.["io.modelcontextprotocol/related-task"];
         const relatedTaskId = relatedTask?.taskId as string | undefined;
 
-        this.beginPending(serverId);
+        const pendingToken = this.beginPending(serverId);
         try {
           return await this.globalCallback!({
             requestId: reqId,
@@ -312,7 +335,7 @@ export class ElicitationManager {
             relatedTaskId,
           });
         } finally {
-          this.endPending(serverId);
+          this.endPending(pendingToken);
         }
       });
     }
@@ -334,9 +357,13 @@ export class ElicitationManager {
    */
   clearServer(serverId: string): void {
     this.handlers.delete(serverId);
-    // Drop any pending count: the server is gone, so a handler invocation that
-    // never settles must not pin `hasPendingForServer` true forever. A late
-    // `endPending` from an in-flight handler is harmless (floors at delete).
-    this.pendingCountByServer.delete(serverId);
+    // Drop this server's in-flight entries: it's gone, so a handler that never
+    // settles must not pin `hasPendingForServer` true forever.
+    for (const [token, entry] of this.pendingElicitationEntries) {
+      if (entry.serverId === serverId) this.pendingElicitationEntries.delete(token);
+    }
+    // A handler still in flight from the OLD connection can't corrupt a
+    // reconnected one carrying the same id: its `endPending` removes only its
+    // own token, which this purge already dropped.
   }
 }

--- a/sdk/src/mcp-client-manager/error-utils.ts
+++ b/sdk/src/mcp-client-manager/error-utils.ts
@@ -58,6 +58,42 @@ export function isMethodUnavailableError(
 }
 
 /**
+ * Marker for errors this SDK raises deliberately as a final verdict — they
+ * must never be retried, however their message reads.
+ *
+ * The elicitation-aware tool timeout raises a timeout-shaped `SdkError`
+ * ("Request timed out ..."), and {@link isRetryableTransientError} classifies
+ * any error whose message mentions "timeout"/"timed out" as a retryable
+ * transient. Retrying a budget we just declared exhausted is exactly wrong,
+ * so the watchdog stamps its error with this marker and the retry classifier
+ * checks it first.
+ */
+const NON_RETRYABLE_MARKER = "__mcpjamNonRetryable";
+
+/**
+ * Stamps an error as never-retryable and returns it.
+ */
+export function markNonRetryableError<T extends object>(error: T): T {
+  Object.defineProperty(error, NON_RETRYABLE_MARKER, {
+    value: true,
+    enumerable: false,
+    configurable: true,
+  });
+  return error;
+}
+
+/**
+ * Whether an error was explicitly stamped as never-retryable.
+ */
+export function isNonRetryableMarkedError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    (error as Record<string, unknown>)[NON_RETRYABLE_MARKER] === true
+  );
+}
+
+/**
  * Formats an error for display in error messages.
  *
  * @param error - The error to format

--- a/sdk/src/mcp-client-manager/error-utils.ts
+++ b/sdk/src/mcp-client-manager/error-utils.ts
@@ -58,39 +58,38 @@ export function isMethodUnavailableError(
 }
 
 /**
- * Marker for errors this SDK raises deliberately as a final verdict — they
- * must never be retried, however their message reads.
+ * Errors this SDK raises deliberately as a final verdict — they must never be
+ * retried, however their message reads.
  *
  * The elicitation-aware tool timeout raises a timeout-shaped `SdkError`
  * ("Request timed out ..."), and {@link isRetryableTransientError} classifies
  * any error whose message mentions "timeout"/"timed out" as a retryable
  * transient. Retrying a budget we just declared exhausted is exactly wrong,
- * so the watchdog stamps its error with this marker and the retry classifier
- * checks it first.
+ * so the watchdog marks its error here and the retry classifier checks first.
+ *
+ * A WeakSet, not a property on the error. A string-keyed marker was readable —
+ * and forgeable — through the prototype chain: any error inheriting a truthy
+ * `__mcpjamNonRetryable` (including via prototype pollution) would have
+ * silently suppressed legitimate retries. Set membership can't be inherited,
+ * and nothing gets stamped onto errors we don't own.
  */
-const NON_RETRYABLE_MARKER = "__mcpjamNonRetryable";
+const nonRetryableErrors = new WeakSet<object>();
 
 /**
- * Stamps an error as never-retryable and returns it.
+ * Marks an error as never-retryable and returns it.
  */
 export function markNonRetryableError<T extends object>(error: T): T {
-  Object.defineProperty(error, NON_RETRYABLE_MARKER, {
-    value: true,
-    enumerable: false,
-    configurable: true,
-  });
+  nonRetryableErrors.add(error);
   return error;
 }
 
 /**
- * Whether an error was explicitly stamped as never-retryable.
+ * Whether an error was explicitly marked as never-retryable.
  */
 export function isNonRetryableMarkedError(error: unknown): boolean {
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    (error as Record<string, unknown>)[NON_RETRYABLE_MARKER] === true
-  );
+  return typeof error === "object" && error !== null
+    ? nonRetryableErrors.has(error)
+    : false;
 }
 
 /**

--- a/sdk/src/mcp-client-manager/index.ts
+++ b/sdk/src/mcp-client-manager/index.ts
@@ -34,12 +34,15 @@ export type {
   ElicitationHandler,
   ElicitationCallback,
   ElicitationCallbackRequest,
+  ElicitationMode,
   ElicitResult,
   ProgressHandler,
   ProgressEvent,
   RpcLogger,
   RpcLogEvent,
 } from "./types.js";
+export type { DeclaredElicitationCapability } from "./elicitation.js";
+export { DEFAULT_ELICITATION_TIMEOUT_EXTENSION_MS } from "./constants.js";
 
 // Types - Tool execution
 export type {

--- a/sdk/src/mcp-client-manager/types.ts
+++ b/sdk/src/mcp-client-manager/types.ts
@@ -334,6 +334,20 @@ export interface MCPClientManagerOptions {
   /** Default retry policy for retryable manager operations */
   retryPolicy?: RetryPolicy;
   /**
+   * Extra time budget (ms) granted to a `tools/call` while an elicitation is
+   * pending for that server. The per-request timeout is a *server* budget: a
+   * tool call blocked on a human must not die at it, but a hung server must.
+   *
+   * When any elicitation handler is installed for a server, `executeTool`
+   * enforces the base timeout with its own watchdog that only accumulates
+   * time while NO elicitation is pending, and separately caps the total time
+   * spent suspended across all elicitations in that call at this value.
+   *
+   * Defaults to {@link DEFAULT_ELICITATION_TIMEOUT_EXTENSION_MS} (10 minutes).
+   * Has no effect on servers without an elicitation handler.
+   */
+  elicitationTimeoutExtensionMs?: number;
+  /**
    * When true, do not connect in the constructor; callers must use connectToServer
    * (e.g. connectReplayManagerServers) to avoid racing eager connects.
    */
@@ -381,6 +395,11 @@ export type ElicitationHandler = (
 ) => Promise<ElicitResult> | ElicitResult;
 
 /**
+ * Elicitation mode (MCP spec 2025-11-25). Absent on the wire ⇒ `"form"`.
+ */
+export type ElicitationMode = "form" | "url";
+
+/**
  * Request passed to global elicitation callback
  */
 export type ElicitationCallbackRequest = {
@@ -389,6 +408,25 @@ export type ElicitationCallbackRequest = {
   schema: unknown;
   /** Task ID if this elicitation is related to a task (MCP Tasks spec 2025-11-25) */
   relatedTaskId?: string;
+  /**
+   * The server that issued this elicitation. Always populated by
+   * `ElicitationManager.applyToClient`; optional so existing callback
+   * implementations keep type-checking.
+   */
+  serverId?: string;
+  /**
+   * Elicitation mode. Absent ⇒ `"form"` (legacy behavior: every
+   * pre-2025-11-25 elicitation is form mode).
+   */
+  mode?: ElicitationMode;
+  /** URL to present to the user. URL mode only. */
+  url?: string;
+  /**
+   * Server-chosen elicitation id, used by the server to correlate a
+   * `notifications/elicitation/complete`. URL mode only. Never treat this
+   * as a trusted key — it is chosen by the server.
+   */
+  elicitationId?: string;
 };
 
 /**

--- a/sdk/src/retry.ts
+++ b/sdk/src/retry.ts
@@ -1,4 +1,7 @@
-import { isMethodUnavailableError } from "./mcp-client-manager/error-utils.js";
+import {
+  isMethodUnavailableError,
+  isNonRetryableMarkedError,
+} from "./mcp-client-manager/error-utils.js";
 import { isAuthError } from "./mcp-client-manager/errors.js";
 import {
   extractNodeErrno,
@@ -116,6 +119,12 @@ export function normalizeRetryPolicy(policy?: RetryPolicy): RetryPolicy {
 }
 
 export function isRetryableTransientError(error: unknown): boolean {
+  // Deliberate, final verdicts from this SDK (e.g. the elicitation-aware tool
+  // timeout) are timeout-shaped by design but must never be retried.
+  if (isNonRetryableMarkedError(error)) {
+    return false;
+  }
+
   if (isAuthError(error).isAuth) {
     return false;
   }

--- a/sdk/tests/MCPClientManager.server-mgmt.test.ts
+++ b/sdk/tests/MCPClientManager.server-mgmt.test.ts
@@ -218,6 +218,52 @@ describe("MCPClientManager", () => {
       await manager.disconnectServer("elicitation-enabled-test");
     }, 30000);
 
+    it("should advertise an explicit {form,url} elicitation shape verbatim when a callback is registered", async () => {
+      manager.setElicitationCallback(() => ({ action: "cancel" } as any));
+
+      await manager.connectToServer("elicitation-url-mode-test", {
+        command: "npx",
+        args: ["-y", "@modelcontextprotocol/server-everything"],
+        clientCapabilities: {
+          elicitation: {
+            form: {},
+            url: {},
+          },
+        } as any,
+      });
+
+      const info = manager.getInitializationInfo("elicitation-url-mode-test");
+      expect(info).toBeDefined();
+      // Verbatim: the host-declared shape is what goes on the wire, since it
+      // is what `applyToClient` enforces declared modes against.
+      expect(
+        (info!.clientCapabilities as Record<string, unknown>).elicitation
+      ).toEqual({ form: {}, url: {} });
+
+      await manager.disconnectServer("elicitation-url-mode-test");
+    }, 30000);
+
+    it("should strip an explicit {form,url} elicitation shape when no callback is registered", async () => {
+      await manager.connectToServer("elicitation-url-mode-stripped-test", {
+        command: "npx",
+        args: ["-y", "@modelcontextprotocol/server-everything"],
+        clientCapabilities: {
+          elicitation: {
+            form: {},
+            url: {},
+          },
+        } as any,
+      });
+
+      const info = manager.getInitializationInfo(
+        "elicitation-url-mode-stripped-test"
+      );
+      expect(info).toBeDefined();
+      expect(info!.clientCapabilities).not.toHaveProperty("elicitation");
+
+      await manager.disconnectServer("elicitation-url-mode-stripped-test");
+    }, 30000);
+
     it("should keep exact clientCapabilities free of elicitation when not explicitly configured", async () => {
       manager.setElicitationCallback(() => ({ action: "cancel" } as any));
 

--- a/sdk/tests/mcp-client-manager.elicitation.test.ts
+++ b/sdk/tests/mcp-client-manager.elicitation.test.ts
@@ -853,6 +853,46 @@ describe("executeTool elicitation-aware timeout", () => {
     await caught;
   });
 
+  it("does not spin the watchdog while a zero-extension call is active", async () => {
+    const hasPending = jest.fn(() => false);
+    const suspension = createElicitationTimeoutSuspension({
+      serverId: SERVER,
+      baseTimeoutMs: 10_000,
+      extensionMs: 0,
+      intervalMs: 1_000,
+      hasPending,
+    });
+
+    // One initial sample chooses the cadence. A zero suspended budget must not
+    // turn the inactive path into a 1ms poll loop.
+    expect(hasPending).toHaveBeenCalledTimes(1);
+    await jest.advanceTimersByTimeAsync(999);
+    expect(hasPending).toHaveBeenCalledTimes(1);
+
+    suspension.dispose();
+  });
+
+  it("aborts when an elicitation starts with a zero extension budget", async () => {
+    let pending = false;
+    const suspension = createElicitationTimeoutSuspension({
+      serverId: SERVER,
+      baseTimeoutMs: 10_000,
+      extensionMs: 0,
+      intervalMs: 1_000,
+      hasPending: () => pending,
+    });
+
+    pending = true;
+    await jest.advanceTimersByTimeAsync(1_000);
+
+    expect(suspension.signal.aborted).toBe(true);
+    expect((suspension.signal.reason as SdkError).data).toMatchObject({
+      reason: "elicitation-budget",
+      timeout: 0,
+    });
+    suspension.dispose();
+  });
+
   it("disposes the watchdog once the call settles", async () => {
     const manager = buildManager({ elicitationTimeoutExtensionMs: 600_000 });
     manager.setElicitationCallback(() => ({ action: "cancel" } as any));
@@ -890,7 +930,7 @@ describe("ElicitationManager pending accounting", () => {
     // elicitation callback is still awaiting, so the callback's `finally` never
     // runs. With a bare counter the server stayed "pending" forever and EVERY
     // later call had its clock paused — unbounded timeouts, silently.
-    vi.useFakeTimers();
+    jest.useFakeTimers();
     try {
       const mgr = new ElicitationManager();
       const begin = (mgr as any).beginPending.bind(mgr);
@@ -898,14 +938,34 @@ describe("ElicitationManager pending accounting", () => {
 
       expect(mgr.hasPendingForServer("srv", 60_000)).toBe(true);
 
-      vi.advanceTimersByTime(60_001);
+      jest.advanceTimersByTime(60_001);
       // Older than the asking call's whole budget — that call would have
       // aborted on its own budget anyway, so it cannot keep pausing others.
       expect(mgr.hasPendingForServer("srv", 60_000)).toBe(false);
-      // Unbounded callers still see it (back-compat for non-timeout callers).
-      expect(mgr.hasPendingForServer("srv")).toBe(true);
+      // Expired entries are reclaimed, not merely ignored.
+      expect((mgr as any).pendingElicitationEntries.size).toBe(0);
     } finally {
-      vi.useRealTimers();
+      jest.useRealTimers();
+    }
+  });
+
+  it("observes a new pending handler even with a zero age budget", () => {
+    jest.useFakeTimers();
+    try {
+      const mgr = new ElicitationManager();
+      const begin = (mgr as any).beginPending.bind(mgr);
+      const sequenceAtCallStart = mgr.getPendingSequence();
+      begin("srv");
+
+      jest.advanceTimersByTime(1);
+      expect(mgr.hasPendingForServer("srv", 0, sequenceAtCallStart)).toBe(true);
+
+      // A later call snapshots after the stuck handler and may reclaim it.
+      const laterSequence = mgr.getPendingSequence();
+      expect(mgr.hasPendingForServer("srv", 0, laterSequence)).toBe(false);
+      expect((mgr as any).pendingElicitationEntries.size).toBe(0);
+    } finally {
+      jest.useRealTimers();
     }
   });
 

--- a/sdk/tests/mcp-client-manager.elicitation.test.ts
+++ b/sdk/tests/mcp-client-manager.elicitation.test.ts
@@ -882,3 +882,76 @@ describe("executeTool elicitation-aware timeout", () => {
     expect(jest.getTimerCount()).toBe(before);
   });
 });
+
+
+describe("ElicitationManager pending accounting", () => {
+  it("stops counting a handler that never settles, past the age bound", () => {
+    // The poison: the tool watchdog can abort a `tools/call` while its
+    // elicitation callback is still awaiting, so the callback's `finally` never
+    // runs. With a bare counter the server stayed "pending" forever and EVERY
+    // later call had its clock paused — unbounded timeouts, silently.
+    vi.useFakeTimers();
+    try {
+      const mgr = new ElicitationManager();
+      const begin = (mgr as any).beginPending.bind(mgr);
+      begin("srv");
+
+      expect(mgr.hasPendingForServer("srv", 60_000)).toBe(true);
+
+      vi.advanceTimersByTime(60_001);
+      // Older than the asking call's whole budget — that call would have
+      // aborted on its own budget anyway, so it cannot keep pausing others.
+      expect(mgr.hasPendingForServer("srv", 60_000)).toBe(false);
+      // Unbounded callers still see it (back-compat for non-timeout callers).
+      expect(mgr.hasPendingForServer("srv")).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("a late completion from an old connection cannot clear a new one", () => {
+    // Reconnect reuses the serverId. With an anonymous counter the old
+    // handler's decrement landed on the NEW connection's tally and could zero
+    // out a genuinely pending elicitation. A token removes only its own entry.
+    const mgr = new ElicitationManager();
+    const begin = (mgr as any).beginPending.bind(mgr);
+    const end = (mgr as any).endPending.bind(mgr);
+
+    const staleToken = begin("srv");
+    mgr.clearServer("srv"); // disconnect
+
+    const freshToken = begin("srv"); // reconnect, same id
+    expect(mgr.hasPendingForServer("srv")).toBe(true);
+
+    end(staleToken); // old handler finally settles
+    expect(mgr.hasPendingForServer("srv")).toBe(true);
+
+    end(freshToken);
+    expect(mgr.hasPendingForServer("srv")).toBe(false);
+  });
+
+  it("clearServer drops in-flight entries for that server only", () => {
+    const mgr = new ElicitationManager();
+    const begin = (mgr as any).beginPending.bind(mgr);
+    begin("srv-a");
+    begin("srv-b");
+
+    mgr.clearServer("srv-a");
+
+    expect(mgr.hasPendingForServer("srv-a")).toBe(false);
+    expect(mgr.hasPendingForServer("srv-b")).toBe(true);
+  });
+
+  it("counts concurrent elicitations independently", () => {
+    const mgr = new ElicitationManager();
+    const begin = (mgr as any).beginPending.bind(mgr);
+    const end = (mgr as any).endPending.bind(mgr);
+
+    const a = begin("srv");
+    const b = begin("srv");
+    end(a);
+    expect(mgr.hasPendingForServer("srv")).toBe(true);
+    end(b);
+    expect(mgr.hasPendingForServer("srv")).toBe(false);
+  });
+});

--- a/sdk/tests/mcp-client-manager.elicitation.test.ts
+++ b/sdk/tests/mcp-client-manager.elicitation.test.ts
@@ -10,6 +10,10 @@ import {
   ELICITATION_WATCHDOG_INTERVAL_MS,
 } from "../src/mcp-client-manager/elicitation-timeout";
 import { isRetryableTransientError } from "../src/retry";
+import {
+  isNonRetryableMarkedError,
+  markNonRetryableError,
+} from "../src/mcp-client-manager/error-utils";
 import type { ManagedMcpClient } from "../src/mcp-client-manager/managed-mcp-client";
 
 const ELICIT_METHOD = "elicitation/create";
@@ -395,6 +399,41 @@ describe("buildCapabilities elicitation shape", () => {
   });
 });
 
+describe("non-retryable marker", () => {
+  it("is not forgeable through the prototype chain", () => {
+    // A string-keyed marker was read with plain property access, so ANY error
+    // inheriting a truthy `__mcpjamNonRetryable` — including via prototype
+    // pollution — silently suppressed legitimate retries. Set membership can't
+    // be inherited.
+    const impostor = Object.create({ __mcpjamNonRetryable: true }) as object;
+    expect(isNonRetryableMarkedError(impostor)).toBe(false);
+
+    const polluted = new Error("transient");
+    (polluted as unknown as Record<string, unknown>).__mcpjamNonRetryable = true;
+    expect(isNonRetryableMarkedError(polluted)).toBe(false);
+  });
+
+  it("marks only the exact error object handed to it", () => {
+    const marked = markNonRetryableError(new Error("verdict"));
+    expect(isNonRetryableMarkedError(marked)).toBe(true);
+    expect(isNonRetryableMarkedError(new Error("verdict"))).toBe(false);
+  });
+
+  it("stamps nothing onto the error it marks", () => {
+    // We don't own these objects; a marker property would leak into anything
+    // that serializes or enumerates them.
+    const error = markNonRetryableError(new Error("verdict"));
+    expect(Object.keys(error)).not.toContain("__mcpjamNonRetryable");
+    expect(
+      Object.getOwnPropertyNames(error).some((k) => k.includes("Retryable")),
+    ).toBe(false);
+  });
+
+  it.each([[null], [undefined], ["str"], [42]])("is false for %p", (v) => {
+    expect(isNonRetryableMarkedError(v)).toBe(false);
+  });
+});
+
 describe("createElicitationTimeoutSuspension", () => {
   beforeEach(() => {
     jest.useFakeTimers();
@@ -414,6 +453,47 @@ describe("createElicitationTimeoutSuspension", () => {
 
     await jest.advanceTimersByTimeAsync(120_000);
     expect(suspension.signal.aborted).toBe(false);
+    suspension.dispose();
+  });
+
+  it("honors a per-call timeout SHORTER than the watchdog sample interval", async () => {
+    // The bug: we raise the upstream timeout to base+extension immediately, so
+    // the watchdog is the only thing enforcing `base`. Sampling at a fixed 1s
+    // meant a caller asking for 100ms wasn't stopped until 1s — a 10x overrun
+    // of a budget they explicitly set.
+    const suspension = createElicitationTimeoutSuspension({
+      serverId: "srv",
+      baseTimeoutMs: 100,
+      extensionMs: 600_000,
+      hasPending: () => false,
+    });
+
+    await jest.advanceTimersByTimeAsync(99);
+    expect(suspension.signal.aborted).toBe(false);
+
+    // Fires on ITS budget, not on the sampler's cadence.
+    await jest.advanceTimersByTimeAsync(2);
+    expect(suspension.signal.aborted).toBe(true);
+    suspension.dispose();
+  });
+
+  it("still pauses a short budget while an elicitation is pending", async () => {
+    // The short-timeout fix must not cost the suspension itself: a 100ms budget
+    // with a human mid-form should not fire at 100ms.
+    let pending = true;
+    const suspension = createElicitationTimeoutSuspension({
+      serverId: "srv",
+      baseTimeoutMs: 100,
+      extensionMs: 600_000,
+      hasPending: () => pending,
+    });
+
+    await jest.advanceTimersByTimeAsync(30_000);
+    expect(suspension.signal.aborted).toBe(false);
+
+    pending = false;
+    await jest.advanceTimersByTimeAsync(101);
+    expect(suspension.signal.aborted).toBe(true);
     suspension.dispose();
   });
 

--- a/sdk/tests/mcp-client-manager.elicitation.test.ts
+++ b/sdk/tests/mcp-client-manager.elicitation.test.ts
@@ -1,0 +1,804 @@
+import {
+  ProtocolErrorCode,
+  SdkError,
+  SdkErrorCode,
+} from "@modelcontextprotocol/client";
+import { MCPClientManager } from "../src/mcp-client-manager";
+import { ElicitationManager } from "../src/mcp-client-manager/elicitation";
+import {
+  createElicitationTimeoutSuspension,
+  ELICITATION_WATCHDOG_INTERVAL_MS,
+} from "../src/mcp-client-manager/elicitation-timeout";
+import { isRetryableTransientError } from "../src/retry";
+import type { ManagedMcpClient } from "../src/mcp-client-manager/managed-mcp-client";
+
+const ELICIT_METHOD = "elicitation/create";
+
+/**
+ * Minimal ManagedMcpClient stand-in that just records request handlers so a
+ * test can drive `elicitation/create` straight at them.
+ */
+function createHandlerCapturingClient() {
+  const handlers = new Map<string, (request: any, ctx?: any) => Promise<any>>();
+  const client = {
+    setRequestHandler: (method: string, handler: any) => {
+      handlers.set(method, handler);
+    },
+    removeRequestHandler: (method: string) => {
+      handlers.delete(method);
+    },
+  } as unknown as ManagedMcpClient;
+
+  return {
+    client,
+    hasElicitHandler: () => handlers.has(ELICIT_METHOD),
+    elicit: (params: unknown) => {
+      const handler = handlers.get(ELICIT_METHOD);
+      if (!handler) throw new Error("no elicitation handler registered");
+      return handler({ method: ELICIT_METHOD, params }, {});
+    },
+  };
+}
+
+function seedRegisteredServer(
+  manager: MCPClientManager,
+  serverId: string,
+  config: Record<string, unknown>,
+  timeout = 1000
+): void {
+  (manager as any).registeredServers.set(serverId, { config, timeout });
+}
+
+function seedLiveState(
+  manager: MCPClientManager,
+  serverId: string,
+  liveState: Record<string, unknown>
+): void {
+  (manager as any).liveClientStates.set(serverId, liveState);
+}
+
+describe("elicitation callback passthrough", () => {
+  it("passes serverId, mode, url and elicitationId through to the global callback", async () => {
+    const manager = new ElicitationManager();
+    const received: any[] = [];
+    manager.setGlobalCallback(async (request) => {
+      received.push(request);
+      return { action: "accept" } as any;
+    });
+
+    const fake = createHandlerCapturingClient();
+    manager.applyToClient("srv", fake.client, { form: {}, url: {} });
+
+    await fake.elicit({
+      mode: "url",
+      message: "Sign in to continue",
+      url: "https://example.com/authorize",
+      elicitationId: "server-chosen-id",
+    });
+
+    expect(received).toHaveLength(1);
+    expect(received[0]).toMatchObject({
+      serverId: "srv",
+      mode: "url",
+      message: "Sign in to continue",
+      url: "https://example.com/authorize",
+      elicitationId: "server-chosen-id",
+    });
+    expect(received[0].requestId).toEqual(expect.any(String));
+  });
+
+  it("treats an absent mode as form and keeps reading requestedSchema", async () => {
+    const manager = new ElicitationManager();
+    const received: any[] = [];
+    manager.setGlobalCallback(async (request) => {
+      received.push(request);
+      return { action: "decline" } as any;
+    });
+
+    const fake = createHandlerCapturingClient();
+    manager.applyToClient("srv", fake.client, {});
+
+    const requestedSchema = { type: "object", properties: { name: {} } };
+    await fake.elicit({ message: "Your name?", requestedSchema });
+
+    expect(received[0]).toMatchObject({
+      serverId: "srv",
+      mode: "form",
+      message: "Your name?",
+      schema: requestedSchema,
+    });
+    expect(received[0].url).toBeUndefined();
+    expect(received[0].elicitationId).toBeUndefined();
+  });
+
+  it("still falls back to the legacy `schema` alias in form mode", async () => {
+    const manager = new ElicitationManager();
+    const received: any[] = [];
+    manager.setGlobalCallback(async (request) => {
+      received.push(request);
+      return { action: "cancel" } as any;
+    });
+
+    const fake = createHandlerCapturingClient();
+    manager.applyToClient("srv", fake.client, { form: {} });
+
+    const schema = { type: "object" };
+    await fake.elicit({ mode: "form", message: "hi", schema });
+
+    expect(received[0].schema).toBe(schema);
+  });
+
+  it("forwards the related task id from _meta", async () => {
+    const manager = new ElicitationManager();
+    const received: any[] = [];
+    manager.setGlobalCallback(async (request) => {
+      received.push(request);
+      return { action: "cancel" } as any;
+    });
+
+    const fake = createHandlerCapturingClient();
+    manager.applyToClient("srv", fake.client, {});
+
+    await fake.elicit({
+      message: "hi",
+      _meta: { "io.modelcontextprotocol/related-task": { taskId: "task-1" } },
+    });
+
+    expect(received[0].relatedTaskId).toBe("task-1");
+  });
+});
+
+describe("elicitation declared-mode enforcement (-32602)", () => {
+  async function expectInvalidParams(promise: Promise<unknown>) {
+    await expect(promise).rejects.toMatchObject({
+      code: ProtocolErrorCode.InvalidParams,
+    });
+    await promise.catch((error) => {
+      // Spec MUST: rejection crosses the wire as JSON-RPC -32602.
+      expect(error.code).toBe(-32602);
+    });
+  }
+
+  function setup(declared: Record<string, unknown> | undefined) {
+    const manager = new ElicitationManager();
+    const callback = jest.fn(async () => ({ action: "accept" } as any));
+    manager.setGlobalCallback(callback);
+    const fake = createHandlerCapturingClient();
+    manager.applyToClient("srv", fake.client, declared);
+    return { manager, callback, fake };
+  }
+
+  it("rejects a url-mode request when the declared capability is bare {} (form-only)", async () => {
+    const { callback, fake } = setup({});
+    await expectInvalidParams(
+      fake.elicit({ mode: "url", message: "go", url: "https://example.com" })
+    );
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it("rejects a url-mode request when only form is declared", async () => {
+    const { callback, fake } = setup({ form: {} });
+    await expectInvalidParams(
+      fake.elicit({ mode: "url", message: "go", url: "https://example.com" })
+    );
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it("allows both modes when {form:{},url:{}} is declared", async () => {
+    const { callback, fake } = setup({ form: {}, url: {} });
+    await expect(
+      fake.elicit({ mode: "url", message: "go", url: "https://example.com" })
+    ).resolves.toEqual({ action: "accept" });
+    await expect(fake.elicit({ message: "go" })).resolves.toEqual({
+      action: "accept",
+    });
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects a form-mode request when only url is declared", async () => {
+    const { callback, fake } = setup({ url: {} });
+    await expectInvalidParams(fake.elicit({ mode: "form", message: "go" }));
+    await expectInvalidParams(fake.elicit({ message: "go" }));
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it("allows form but rejects url when no declaration is on record", async () => {
+    const { callback, fake } = setup(undefined);
+    await expect(fake.elicit({ message: "go" })).resolves.toEqual({
+      action: "accept",
+    });
+    await expectInvalidParams(
+      fake.elicit({ mode: "url", message: "go", url: "https://example.com" })
+    );
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects an unrecognized mode", async () => {
+    const { callback, fake } = setup({ form: {}, url: {} });
+    await expectInvalidParams(fake.elicit({ mode: "carrier-pigeon" }));
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it("enforces declared modes on the server-specific handler branch too", async () => {
+    const manager = new ElicitationManager();
+    const handler = jest.fn(async () => ({ action: "accept" } as any));
+    manager.setHandler("srv", handler);
+    const fake = createHandlerCapturingClient();
+    manager.applyToClient("srv", fake.client, { form: {} });
+
+    await expectInvalidParams(
+      fake.elicit({ mode: "url", message: "go", url: "https://example.com" })
+    );
+    expect(handler).not.toHaveBeenCalled();
+  });
+});
+
+describe("hasPendingForServer", () => {
+  it("is true only while the global callback is in flight", async () => {
+    const manager = new ElicitationManager();
+    let release!: (value: any) => void;
+    manager.setGlobalCallback(
+      () =>
+        new Promise((resolve) => {
+          release = resolve;
+        })
+    );
+
+    const fake = createHandlerCapturingClient();
+    manager.applyToClient("srv", fake.client, {});
+
+    expect(manager.hasPendingForServer("srv")).toBe(false);
+    const inFlight = fake.elicit({ message: "hi" });
+    await Promise.resolve();
+    expect(manager.hasPendingForServer("srv")).toBe(true);
+    expect(manager.hasPendingForServer("other")).toBe(false);
+
+    release({ action: "cancel" });
+    await inFlight;
+    expect(manager.hasPendingForServer("srv")).toBe(false);
+  });
+
+  it("is true only while a server-specific handler is in flight", async () => {
+    const manager = new ElicitationManager();
+    let release!: (value: any) => void;
+    manager.setHandler(
+      "srv",
+      () =>
+        new Promise((resolve) => {
+          release = resolve;
+        }) as any
+    );
+
+    const fake = createHandlerCapturingClient();
+    manager.applyToClient("srv", fake.client, {});
+
+    const inFlight = fake.elicit({ message: "hi" });
+    await Promise.resolve();
+    expect(manager.hasPendingForServer("srv")).toBe(true);
+
+    release({ action: "cancel" });
+    await inFlight;
+    expect(manager.hasPendingForServer("srv")).toBe(false);
+  });
+
+  it("counts concurrent elicitations and clears only when all settle", async () => {
+    const manager = new ElicitationManager();
+    const releases: Array<(value: any) => void> = [];
+    manager.setGlobalCallback(
+      () => new Promise((resolve) => releases.push(resolve))
+    );
+
+    const fake = createHandlerCapturingClient();
+    manager.applyToClient("srv", fake.client, {});
+
+    const first = fake.elicit({ message: "a" });
+    const second = fake.elicit({ message: "b" });
+    await Promise.resolve();
+    expect(manager.hasPendingForServer("srv")).toBe(true);
+
+    releases[0]({ action: "cancel" });
+    await first;
+    expect(manager.hasPendingForServer("srv")).toBe(true);
+
+    releases[1]({ action: "cancel" });
+    await second;
+    expect(manager.hasPendingForServer("srv")).toBe(false);
+  });
+
+  it("clears the pending count when the callback throws", async () => {
+    const manager = new ElicitationManager();
+    manager.setGlobalCallback(async () => {
+      throw new Error("callback exploded");
+    });
+
+    const fake = createHandlerCapturingClient();
+    manager.applyToClient("srv", fake.client, {});
+
+    await expect(fake.elicit({ message: "hi" })).rejects.toThrow(
+      "callback exploded"
+    );
+    expect(manager.hasPendingForServer("srv")).toBe(false);
+  });
+
+  it("does not count a request rejected for an undeclared mode", async () => {
+    const manager = new ElicitationManager();
+    manager.setGlobalCallback(() => new Promise(() => {}));
+
+    const fake = createHandlerCapturingClient();
+    manager.applyToClient("srv", fake.client, {});
+
+    await expect(
+      fake.elicit({ mode: "url", message: "go", url: "https://example.com" })
+    ).rejects.toMatchObject({ code: -32602 });
+    expect(manager.hasPendingForServer("srv")).toBe(false);
+  });
+});
+
+describe("buildCapabilities elicitation shape", () => {
+  function buildCapabilities(
+    manager: MCPClientManager,
+    serverId: string,
+    config: Record<string, unknown>
+  ) {
+    return (manager as any).buildCapabilities(serverId, config) as Record<
+      string,
+      unknown
+    >;
+  }
+
+  it("preserves an explicit {form:{},url:{}} verbatim when a callback is registered", () => {
+    const manager = new MCPClientManager();
+    manager.setElicitationCallback(() => ({ action: "cancel" } as any));
+
+    const capabilities = buildCapabilities(manager, "srv", {
+      url: "https://example.com/mcp",
+      clientCapabilities: { elicitation: { form: {}, url: {} } },
+    });
+
+    expect(capabilities.elicitation).toEqual({ form: {}, url: {} });
+  });
+
+  it("preserves a bare {} elicitation verbatim when a callback is registered", () => {
+    const manager = new MCPClientManager();
+    manager.setElicitationCallback(() => ({ action: "cancel" } as any));
+
+    const capabilities = buildCapabilities(manager, "srv", {
+      url: "https://example.com/mcp",
+      clientCapabilities: { elicitation: {} },
+    });
+
+    expect(capabilities.elicitation).toEqual({});
+  });
+
+  it("strips an explicit {form:{},url:{}} when no callback is registered", () => {
+    const manager = new MCPClientManager();
+
+    const capabilities = buildCapabilities(manager, "srv", {
+      url: "https://example.com/mcp",
+      clientCapabilities: { elicitation: { form: {}, url: {} } },
+    });
+
+    expect(capabilities).not.toHaveProperty("elicitation");
+  });
+
+  it("strips elicitation when only a different server has a handler", () => {
+    const manager = new MCPClientManager();
+    (manager as any).registeredServers.set("other", { config: {}, timeout: 1 });
+    manager.setElicitationHandler("other", () => ({ action: "cancel" } as any));
+
+    const capabilities = buildCapabilities(manager, "srv", {
+      url: "https://example.com/mcp",
+      clientCapabilities: { elicitation: { form: {}, url: {} } },
+    });
+
+    expect(capabilities).not.toHaveProperty("elicitation");
+  });
+});
+
+describe("createElicitationTimeoutSuspension", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("does not abort while an elicitation is pending, even far past the base budget", async () => {
+    const suspension = createElicitationTimeoutSuspension({
+      serverId: "srv",
+      baseTimeoutMs: 1_000,
+      extensionMs: 600_000,
+      hasPending: () => true,
+    });
+
+    await jest.advanceTimersByTimeAsync(120_000);
+    expect(suspension.signal.aborted).toBe(false);
+    suspension.dispose();
+  });
+
+  it("aborts at the base budget when nothing is pending", async () => {
+    const suspension = createElicitationTimeoutSuspension({
+      serverId: "srv",
+      baseTimeoutMs: 5_000,
+      extensionMs: 600_000,
+      hasPending: () => false,
+    });
+
+    await jest.advanceTimersByTimeAsync(4_000);
+    expect(suspension.signal.aborted).toBe(false);
+
+    await jest.advanceTimersByTimeAsync(1_000);
+    expect(suspension.signal.aborted).toBe(true);
+    expect(suspension.signal.reason).toBeInstanceOf(SdkError);
+    expect(suspension.signal.reason.code).toBe(SdkErrorCode.RequestTimeout);
+    expect(suspension.signal.reason.data).toMatchObject({
+      serverId: "srv",
+      reason: "server-timeout",
+    });
+    suspension.dispose();
+  });
+
+  it("resumes the active clock after an elicitation settles", async () => {
+    let pending = true;
+    const suspension = createElicitationTimeoutSuspension({
+      serverId: "srv",
+      baseTimeoutMs: 5_000,
+      extensionMs: 600_000,
+      hasPending: () => pending,
+    });
+
+    // 60s suspended: the active clock must not have moved.
+    await jest.advanceTimersByTimeAsync(60_000);
+    expect(suspension.signal.aborted).toBe(false);
+
+    pending = false;
+    await jest.advanceTimersByTimeAsync(4_000);
+    expect(suspension.signal.aborted).toBe(false);
+
+    await jest.advanceTimersByTimeAsync(2_000);
+    expect(suspension.signal.aborted).toBe(true);
+    suspension.dispose();
+  });
+
+  it("aborts when the cumulative suspended budget is exhausted", async () => {
+    const suspension = createElicitationTimeoutSuspension({
+      serverId: "srv",
+      baseTimeoutMs: 120_000,
+      extensionMs: 10_000,
+      hasPending: () => true,
+    });
+
+    await jest.advanceTimersByTimeAsync(9_000);
+    expect(suspension.signal.aborted).toBe(false);
+
+    await jest.advanceTimersByTimeAsync(2_000);
+    expect(suspension.signal.aborted).toBe(true);
+    expect(suspension.signal.reason.data).toMatchObject({
+      reason: "elicitation-budget",
+      timeout: 10_000,
+    });
+    suspension.dispose();
+  });
+
+  it("accumulates the suspended budget across sequential elicitations", async () => {
+    let pending = true;
+    const suspension = createElicitationTimeoutSuspension({
+      serverId: "srv",
+      baseTimeoutMs: 120_000,
+      extensionMs: 10_000,
+      hasPending: () => pending,
+    });
+
+    // First elicitation: 6s suspended.
+    await jest.advanceTimersByTimeAsync(6_000);
+    pending = false;
+    await jest.advanceTimersByTimeAsync(2_000);
+    expect(suspension.signal.aborted).toBe(false);
+
+    // Second elicitation: 6s more suspended pushes the cumulative total over.
+    pending = true;
+    await jest.advanceTimersByTimeAsync(6_000);
+    expect(suspension.signal.aborted).toBe(true);
+    expect(suspension.signal.reason.data).toMatchObject({
+      reason: "elicitation-budget",
+    });
+    suspension.dispose();
+  });
+
+  it("raises a timeout-shaped error that is never classified retryable", async () => {
+    const suspension = createElicitationTimeoutSuspension({
+      serverId: "srv",
+      baseTimeoutMs: 1_000,
+      extensionMs: 600_000,
+      hasPending: () => false,
+    });
+
+    await jest.advanceTimersByTimeAsync(2_000);
+    const reason = suspension.signal.reason;
+
+    // Timeout-shaped for callers...
+    expect(reason).toBeInstanceOf(SdkError);
+    expect(reason.code).toBe(SdkErrorCode.RequestTimeout);
+    expect(reason.message).toMatch(/timed out/i);
+    // ...but a deliberate verdict, never a transient to retry, despite the
+    // message matching the classifier's "timed out" heuristic.
+    expect(isRetryableTransientError(reason)).toBe(false);
+    suspension.dispose();
+  });
+
+  it("composes the caller's signal without clobbering it", async () => {
+    const caller = new AbortController();
+    const suspension = createElicitationTimeoutSuspension({
+      serverId: "srv",
+      baseTimeoutMs: 600_000,
+      extensionMs: 600_000,
+      hasPending: () => false,
+      callerSignal: caller.signal,
+    });
+
+    expect(suspension.signal.aborted).toBe(false);
+    const reason = new Error("caller went away");
+    caller.abort(reason);
+    await Promise.resolve();
+
+    expect(suspension.signal.aborted).toBe(true);
+    expect(suspension.signal.reason).toBe(reason);
+    suspension.dispose();
+  });
+
+  it("surfaces an already-aborted caller signal immediately", () => {
+    const caller = new AbortController();
+    caller.abort(new Error("already gone"));
+    const suspension = createElicitationTimeoutSuspension({
+      serverId: "srv",
+      baseTimeoutMs: 600_000,
+      extensionMs: 600_000,
+      hasPending: () => false,
+      callerSignal: caller.signal,
+    });
+
+    expect(suspension.signal.aborted).toBe(true);
+    suspension.dispose();
+  });
+
+  it("dispose clears the watchdog interval and stops the clock", async () => {
+    const before = jest.getTimerCount();
+    const suspension = createElicitationTimeoutSuspension({
+      serverId: "srv",
+      baseTimeoutMs: 1_000,
+      extensionMs: 600_000,
+      hasPending: () => false,
+      intervalMs: ELICITATION_WATCHDOG_INTERVAL_MS,
+    });
+    expect(jest.getTimerCount()).toBe(before + 1);
+
+    suspension.dispose();
+    expect(jest.getTimerCount()).toBe(before);
+
+    await jest.advanceTimersByTimeAsync(60_000);
+    expect(suspension.signal.aborted).toBe(false);
+
+    // Idempotent.
+    expect(() => suspension.dispose()).not.toThrow();
+  });
+});
+
+describe("executeTool elicitation-aware timeout", () => {
+  const SERVER = "srv";
+
+  function buildManager(options: Record<string, unknown> = {}) {
+    const manager = new MCPClientManager({}, options as any);
+    seedRegisteredServer(
+      manager,
+      SERVER,
+      { url: "https://example.com/mcp" },
+      1_000
+    );
+    return manager;
+  }
+
+  function attachClient(manager: MCPClientManager, callTool: any) {
+    const client = { callTool };
+    seedLiveState(manager, SERVER, { client });
+    return client;
+  }
+
+  function setPending(manager: MCPClientManager, pending: () => boolean) {
+    jest
+      .spyOn((manager as any).elicitationManager, "hasPendingForServer")
+      .mockImplementation(() => pending());
+  }
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
+  it("is a pure passthrough when the server has no elicitation handler", async () => {
+    const manager = buildManager();
+    const callTool = jest.fn().mockResolvedValue({ content: [] });
+    attachClient(manager, callTool);
+
+    await expect(manager.executeTool(SERVER, "add", { a: 1 })).resolves.toEqual(
+      {
+        content: [],
+      }
+    );
+
+    const options = callTool.mock.calls[0][1];
+    // Untouched: the registered timeout, and no watchdog signal injected.
+    expect(options.timeout).toBe(1_000);
+    expect(options.signal).toBeUndefined();
+  });
+
+  it("overrides the upstream timeout to base + extension once a handler exists", async () => {
+    const manager = buildManager({ elicitationTimeoutExtensionMs: 60_000 });
+    manager.setElicitationCallback(() => ({ action: "cancel" } as any));
+    const callTool = jest.fn().mockResolvedValue({ content: [] });
+    attachClient(manager, callTool);
+
+    await manager.executeTool(SERVER, "add", { a: 1 });
+
+    const options = callTool.mock.calls[0][1];
+    // `withTimeout` only injects when unset, so this has to be an override.
+    expect(options.timeout).toBe(61_000);
+    expect(options.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("survives past the base timeout while an elicitation is pending", async () => {
+    const manager = buildManager({ elicitationTimeoutExtensionMs: 600_000 });
+    manager.setElicitationCallback(() => ({ action: "cancel" } as any));
+
+    let resolveCall!: (value: unknown) => void;
+    let received: AbortSignal | undefined;
+    const callTool = jest.fn((_params: unknown, options: any) => {
+      received = options.signal;
+      return new Promise((resolve) => {
+        resolveCall = resolve;
+      });
+    });
+    attachClient(manager, callTool);
+    setPending(manager, () => true);
+
+    const inFlight = manager.executeTool(SERVER, "add", { a: 1 });
+    const settled = jest.fn();
+    void inFlight.then(settled, settled);
+
+    // 120x the 1s base budget, all of it suspended on a human.
+    await jest.advanceTimersByTimeAsync(120_000);
+    expect(received!.aborted).toBe(false);
+    expect(settled).not.toHaveBeenCalled();
+
+    resolveCall({ content: [{ type: "text", text: "answered" }] });
+    await expect(inFlight).resolves.toEqual({
+      content: [{ type: "text", text: "answered" }],
+    });
+  });
+
+  it("still kills a hung server at the base timeout when nothing is pending", async () => {
+    const manager = buildManager({ elicitationTimeoutExtensionMs: 600_000 });
+    manager.setElicitationCallback(() => ({ action: "cancel" } as any));
+
+    let received: AbortSignal | undefined;
+    // A server that never answers, and never elicits: this is the hang the
+    // base budget exists to catch. Model the upstream contract — reject with
+    // the signal's reason on abort.
+    const callTool = jest.fn(
+      (_params: unknown, options: any) =>
+        new Promise((_resolve, reject) => {
+          received = options.signal;
+          options.signal.addEventListener("abort", () =>
+            reject(options.signal.reason)
+          );
+        })
+    );
+    attachClient(manager, callTool);
+    setPending(manager, () => false);
+
+    const inFlight = manager.executeTool(SERVER, "add", { a: 1 });
+    const caught = inFlight.catch((error) => error);
+
+    await jest.advanceTimersByTimeAsync(2_000);
+    const error = await caught;
+
+    expect(received!.aborted).toBe(true);
+    expect(error).toBeInstanceOf(SdkError);
+    expect(error.code).toBe(SdkErrorCode.RequestTimeout);
+    expect(error.data).toMatchObject({ reason: "server-timeout" });
+  });
+
+  it("aborts when the suspended budget is exhausted", async () => {
+    const manager = buildManager({ elicitationTimeoutExtensionMs: 10_000 });
+    manager.setElicitationCallback(() => ({ action: "cancel" } as any));
+
+    const callTool = jest.fn(
+      (_params: unknown, options: any) =>
+        new Promise((_resolve, reject) => {
+          options.signal.addEventListener("abort", () =>
+            reject(options.signal.reason)
+          );
+        })
+    );
+    attachClient(manager, callTool);
+    setPending(manager, () => true);
+
+    const inFlight = manager.executeTool(SERVER, "add", { a: 1 });
+    const caught = inFlight.catch((error) => error);
+
+    await jest.advanceTimersByTimeAsync(12_000);
+    const error = await caught;
+
+    expect(error).toBeInstanceOf(SdkError);
+    expect(error.data).toMatchObject({ reason: "elicitation-budget" });
+  });
+
+  it("propagates a caller abort through the composed signal", async () => {
+    const manager = buildManager({ elicitationTimeoutExtensionMs: 600_000 });
+    manager.setElicitationCallback(() => ({ action: "cancel" } as any));
+
+    let received: AbortSignal | undefined;
+    const callTool = jest.fn((_params: unknown, options: any) => {
+      received = options.signal;
+      return new Promise(() => {});
+    });
+    attachClient(manager, callTool);
+    setPending(manager, () => true);
+
+    const caller = new AbortController();
+    const inFlight = manager.executeTool(
+      SERVER,
+      "add",
+      { a: 1 },
+      {
+        signal: caller.signal,
+      }
+    );
+    const caught = inFlight.catch((error) => error);
+
+    await jest.advanceTimersByTimeAsync(10);
+    expect(received!.aborted).toBe(false);
+
+    const reason = new Error("caller cancelled the turn");
+    caller.abort(reason);
+    await jest.advanceTimersByTimeAsync(10);
+
+    // The watchdog composed with the caller's signal rather than replacing it.
+    expect(received!.aborted).toBe(true);
+    expect(received!.reason).toBe(reason);
+    await caught;
+  });
+
+  it("disposes the watchdog once the call settles", async () => {
+    const manager = buildManager({ elicitationTimeoutExtensionMs: 600_000 });
+    manager.setElicitationCallback(() => ({ action: "cancel" } as any));
+    attachClient(manager, jest.fn().mockResolvedValue({ content: [] }));
+    setPending(manager, () => false);
+
+    const before = jest.getTimerCount();
+    await manager.executeTool(SERVER, "add", { a: 1 });
+    expect(jest.getTimerCount()).toBe(before);
+  });
+
+  it("disposes the watchdog when the call throws", async () => {
+    const manager = buildManager({ elicitationTimeoutExtensionMs: 600_000 });
+    manager.setElicitationCallback(() => ({ action: "cancel" } as any));
+    attachClient(
+      manager,
+      jest
+        .fn()
+        .mockRejectedValue(Object.assign(new Error("boom"), { code: -1 }))
+    );
+    setPending(manager, () => false);
+
+    const before = jest.getTimerCount();
+    await expect(manager.executeTool(SERVER, "add", { a: 1 })).rejects.toThrow(
+      "boom"
+    );
+    expect(jest.getTimerCount()).toBe(before);
+  });
+});


### PR DESCRIPTION
Part 3 of 6 adding MCP elicitation (form + URL, spec 2025-11-25) to hosted mode.

**Stacked on #3226** (base is `feat/elicitation-sdk`, so this diff is server-only). Merge order: backend ([mcpjam-backend#724](https://github.com/MCPJam/mcpjam-backend/pull/724), **deploy first**) → #3226 → **this** → client. Independent siblings: #3227 (toggle), #3228 (dialog).

## Why

Hosted chat could never honor elicitation: no handler was registered on the per-turn manager, so the SDK stripped the host-declared `elicitation` capability from every `initialize` and eliciting servers got "Method not found". The legacy local design (process-global SSE broadcast + in-memory pending map) can't be reused — it's single-replica and broadcasts to every subscriber with no tenant scoping.

## The shape

The turn's MCP connection, its blocked tool call and the browser's stream all live on **one replica**, so the request rides that turn's own UI message stream as a transient `data-elicitation` part — scoped to the requesting user by construction, no broadcast surface. Only the **answer** crosses replicas, via the Convex rendezvous: the browser writes it, this replica polls.

## Four things that are load-bearing

**1. Registration is synchronous, inside `createAuthorizedManager`.** The manager constructor queues its connects as microtasks and `buildCapabilities` runs inside them — so a caller registering after `await createAuthorizedManager(...)` **loses the race and the capability is silently stripped**. Registering the callback is simultaneously "advertise it" and "honor it": they can't drift.

**2. Pre-writer elicitations fail fast, they are not buffered.** The stream writer only exists at `onStreamWriterReady`, after connect + tool discovery. An elicitation raised during `prepareChatV2` has nowhere to render *and its consumer is the very stream it's blocking* — buffering deadlocks until TTL. Every legitimate elicitation happens during tool execution, when the writer exists.

**3. Ack only after the answer is in hand.** Poll (read) → resolve the `ElicitResult` to the MCP server → ack → scrub. Scrubbing on read means a lost response leaves a retry reading `answered` with content already destroyed — indistinguishable from a legitimately contentless accept (URL mode carries none; an empty form accept is valid).

**4. Chatbox turns gate on the published host, never the request body.** A share-link visitor controls that body; reading capabilities from it would let anyone switch elicitation on for a host whose owner has it off. Same host-wins reasoning this route already applies to model/approval. A backend predating `clientCapabilities` on runtime-config → absent → **fail closed**.

## The rollout handshake

`hostedElicitationVersion: 1` on the request, ANDed with the host capability. Catalog hosts (claude-code, cursor, vscode…) **already declare `elicitation`**, so honoring it for every client would make stale browser bundles — which can't render the prompt — hang for a full TTL on any server that elicits. Old clients keep today's fail-fast behavior. This is what makes server-before-client safe.

## Scope

Non-interactive surfaces (swarm, evals, chatbox persona/sim, `tools/execute`) never register — servers there keep failing fast, which is honest. Two documented gaps: **harness hosts** route MCP through separate `/api/web/harness-mcp` requests, not this turn's manager, so the callback never fires; **org-BYOK** uses `runDirectChatTurn`, which doesn't go through the shared tool executor, so the -32042 hook can't attach there (elicitation itself still works — it's manager-level).

`-32042 URLElicitationRequiredError` is detected **structurally**, not via `instanceof` — the error crosses package copies, so prototype identity is unreliable. The model gets an actionable retry hint instead of a raw protocol error.

## Tests

27 (`hosted-elicitation.test.ts`): the gate matrix incl. the chatbox-body escalation, poll resolution matrix (answered/decline/expired/cancelled/abort/local-deadline/failure-ceiling), ack-only-after-answer, transient parts, url-mode accept carrying no content.

Mutation-tested. **One of these tests was found vacuous that way** — my original ack-ordering assertion passed even with the code inverted (swapping two synchronous statements can't change observable fetch order), so it was replaced with invariants that actually bite. The cross-replica ordering guarantee is enforced backend-side and tested there.

`Test Files 123 passed | Tests 1608 passed`. Server typecheck introduces no new errors.

## Not done

No end-to-end run against a live eliciting server (the `everything` server isn't installed locally). Everything here is unit/integration-level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hosted chat tool-call blocking, cross-replica Convex rendezvous, and capability gating on share-link surfaces; correctness and cleanup paths are heavily tested but depend on backend deploy order and client handshake v1.
> 
> **Overview**
> Adds **hosted-mode MCP elicitation** (form + URL, 2025-11-25): blocked `tools/call` prompts stream as transient `data-elicitation` parts on the turn; user answers rendezvous through Convex while the replica polls, with human-scale TTLs, bounded service-route deadlines, and end-of-turn withdrawal.
> 
> **`HostedElicitationBridge`** registers only when `resolveElicitationGate` passes: host declares elicitation **and** `hostedElicitationVersion === 1`. Chatbox turns use **published host** `clientCapabilities` (not the request body); pre-writer requests cancel immediately; poll → resolve → ack ordering is preserved; cancel/ack are not bound to the turn abort signal.
> 
> **`createAuthorizedManager`** now accepts `elicitationCallback` and `elicitationTimeoutExtensionMs`, registering the callback **synchronously** before connect microtasks so advertisement and handling stay aligned. **`chat-v2`** wires the bridge, effective capabilities, and dispose on errors.
> 
> **Local path:** `narrowElicitationToLocalSupport` advertises form-only elicitation; local SSE broadcasts include **`serverId`**.
> 
> **`-32042`:** structural detection via `readUrlElicitations`; shared tool wrappers emit `url_required` for all engines (incl. org-BYOK); model-facing tool errors get a retry hint. Shared wire types and extensive tests cover gating, bridge behavior, and payload validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6a1ed2235a366e0ca20a783b18cc946417001a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds hosted-mode MCP elicitation (form + URL) with a per-turn bridge that streams transient `data-elicitation` prompts and resolves answers via Convex, with strict gating, deadlines, and cleanup. Also surfaces `-32042` URL flows across all engines (incl. org‑BYOK), narrows local capability ads to form-only, and includes the requesting `serverId` in local dialogs.

- **New Features**
  - Hosted bridge: emits transient request parts; creates a Convex rendezvous with a Convex-valid bearer; polls with jitter and a 10s per-call deadline; pre-writer elicitations cancel; withdraws pending rows on dispose; acks only after the answer; polls bind to the turn abort signal, cancel/ack do not.
  - Gating/handshake: honor elicitation only when the host declares it and the client sends `hostedElicitationVersion: 1`; chatbox turns use the published host’s `clientCapabilities`; schema accepts any non‑negative version but the gate requires v1; registration is synchronous in `createAuthorizedManager`; includes `elicitationTimeoutExtensionMs`.
  - URL flows: detect `-32042` structurally, emit `url_required`, and return a retry hint to the model instead of the raw protocol error; engine‑agnostic emission via a tool wrapper covers MCPJam‑free, org‑BYOK local, and org‑BYOK hosted paths; shared wire types and guards validate payloads.

- **Bug Fixes**
  - Local mode advertises form‑only elicitation: `narrowElicitationToLocalSupport` prunes `url` (or drops `elicitation` when only `url` is set) to avoid unfulfillable requests.
  - Local SSE dialogs now include `serverId` on elicitation requests to clearly identify which server is asking.
  - Fixed a stray JSDoc block in `server/routes/web/auth.ts` that broke the server build; `build:server` now succeeds.

<sup>Written for commit f6a1ed2235a366e0ca20a783b18cc946417001a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

