### PR TITLE
feat(elicitation): render hosted elicitation prompts and URL consent

### DIFF
--- a/mcpjam-inspector/client/src/components/ChatTabV2.tsx
+++ b/mcpjam-inspector/client/src/components/ChatTabV2.tsx
@@ -1637,6 +1637,13 @@ export function ChatTabV2({
                 message: data.message,
                 schema: data.schema,
                 timestamp: data.timestamp || new Date().toISOString(),
+                // Spec: make it clear WHICH server is asking. Local chat can
+                // have many servers connected at once, so an anonymous dialog
+                // is a real ambiguity. No display name exists on this path —
+                // the id is the trusted anchor and is what the dialog shows.
+                ...(typeof data.serverId === "string"
+                  ? { serverId: data.serverId }
+                  : {}),
               },
             ];
           });

--- a/mcpjam-inspector/client/src/components/ChatTabV2.tsx
+++ b/mcpjam-inspector/client/src/components/ChatTabV2.tsx
@@ -25,6 +25,7 @@ import {
   ResizableHandle,
 } from "./ui/resizable";
 import { ElicitationDialog } from "@/components/ElicitationDialog";
+import { ElicitationRequestDialog } from "@/components/elicitation/ElicitationRequestDialog";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -401,6 +402,9 @@ export function ChatTabV2({
     requireToolApproval,
     setRequireToolApproval,
     addToolApprovalResponse,
+    pendingElicitations,
+    respondToElicitation,
+    elicitationResponding,
   } = useChatSession({
     selectedServers: selectedConnectedServerNames,
     directVisibility: pendingDirectVisibility,
@@ -2746,10 +2750,25 @@ export function ChatTabV2({
               </>
             )}
 
+            {/*
+              Two independent sources, deliberately not merged into one queue:
+              the local SSE channel (`/api/mcp/elicitation/*`, local mode only)
+              and the hosted stream data part. They carry different identities
+              (requestId vs rendezvousId) and answer over different transports,
+              so each keeps its own dialog and respond path. Only one can be
+              active in a given mode — `elicitationQueue` never fills in hosted
+              (the SSE effect early-returns), and `pendingElicitations` never
+              fills locally (no bridge is registered).
+            */}
             <ElicitationDialog
               elicitationRequest={activeElicitation}
               onResponse={handleElicitationResponse}
               loading={elicitationLoading}
+            />
+            <ElicitationRequestDialog
+              request={pendingElicitations[0] ?? null}
+              onRespond={respondToElicitation}
+              loading={elicitationResponding}
             />
           </div>
         </ResizablePanel>

--- a/mcpjam-inspector/client/src/components/ChatTabV2.tsx
+++ b/mcpjam-inspector/client/src/components/ChatTabV2.tsx
@@ -25,7 +25,10 @@ import {
   ResizableHandle,
 } from "./ui/resizable";
 import { ElicitationDialog } from "@/components/ElicitationDialog";
-import { ElicitationRequestDialog } from "@/components/elicitation/ElicitationRequestDialog";
+import {
+  ElicitationRequestDialog,
+  UrlElicitationRequiredDialog,
+} from "@/components/elicitation/ElicitationRequestDialog";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -405,6 +408,8 @@ export function ChatTabV2({
     pendingElicitations,
     respondToElicitation,
     elicitationResponding,
+    urlElicitationRequired,
+    dismissUrlElicitationRequired,
   } = useChatSession({
     selectedServers: selectedConnectedServerNames,
     directVisibility: pendingDirectVisibility,
@@ -2766,9 +2771,18 @@ export function ChatTabV2({
               loading={elicitationLoading}
             />
             <ElicitationRequestDialog
+              // Keyed so a second request can't inherit the first's internal
+              // dialog state (popup-blocked notice, half-filled form).
+              key={pendingElicitations[0]?.rendezvousId ?? "none"}
               request={pendingElicitations[0] ?? null}
               onRespond={respondToElicitation}
               loading={elicitationResponding}
+            />
+            {/* -32042: a tool needs an out-of-band interaction finished first. */}
+            <UrlElicitationRequiredDialog
+              key={urlElicitationRequired[0]?.toolCallId ?? "no-url-required"}
+              event={urlElicitationRequired[0] ?? null}
+              onDismiss={dismissUrlElicitationRequired}
             />
           </div>
         </ResizablePanel>

--- a/mcpjam-inspector/client/src/components/__tests__/ChatTabV2.history-sync.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ChatTabV2.history-sync.test.tsx
@@ -62,6 +62,9 @@ vi.mock("@workos-inc/authkit-react", () => ({
 }));
 
 vi.mock("convex/react", () => ({
+  // useChatSession resolves the Convex client to submit elicitation answers
+  // straight to the rendezvous table (the blocked replica isn't addressable).
+  useConvex: () => ({ mutation: vi.fn().mockResolvedValue({ ok: true }) }),
   useConvexAuth: () => ({
     isAuthenticated: true,
     isLoading: false,
@@ -323,6 +326,13 @@ vi.mock("@/components/evals/live-trace-raw-empty", () => ({
 }));
 
 const mockUseChatSession = {
+  // Elicitation surface (hosted). These suites never elicit, but the shape
+  // must match the hook's contract or the dialog crashes on undefined.
+  pendingElicitations: [],
+  respondToElicitation: vi.fn(),
+  elicitationResponding: false,
+  urlElicitationRequired: [],
+  dismissUrlElicitationRequired: vi.fn(),
   messages: [
     {
       id: "1",

--- a/mcpjam-inspector/client/src/components/__tests__/ChatTabV2.trace-views.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ChatTabV2.trace-views.test.tsx
@@ -17,6 +17,9 @@ vi.mock("@workos-inc/authkit-react", () => ({
 }));
 
 vi.mock("convex/react", () => ({
+  // useChatSession resolves the Convex client to submit elicitation answers
+  // straight to the rendezvous table (the blocked replica isn't addressable).
+  useConvex: () => ({ mutation: vi.fn().mockResolvedValue({ ok: true }) }),
   useConvexAuth: () => ({
     isAuthenticated: true,
     isLoading: false,
@@ -226,6 +229,13 @@ vi.mock("@/components/evals/trace-view-mode-tabs", () => ({
 }));
 
 const mockUseChatSession = {
+  // Elicitation surface (hosted). These suites never elicit, but the shape
+  // must match the hook's contract or the dialog crashes on undefined.
+  pendingElicitations: [],
+  respondToElicitation: vi.fn(),
+  elicitationResponding: false,
+  urlElicitationRequired: [],
+  dismissUrlElicitationRequired: vi.fn(),
   messages: [],
   setMessages: vi.fn(),
   sendMessage: vi.fn(),

--- a/mcpjam-inspector/client/src/components/chat-v2/__tests__/multi-model-chat-card.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/__tests__/multi-model-chat-card.test.tsx
@@ -31,6 +31,13 @@ const mockTraceViewer = vi.fn();
 const mockModelCompareCardHeader = vi.fn();
 
 const mockUseChatSession = {
+  // Elicitation surface (hosted). These suites never elicit, but the shape
+  // must match the hook's contract or the dialog crashes on undefined.
+  pendingElicitations: [],
+  respondToElicitation: vi.fn(),
+  elicitationResponding: false,
+  urlElicitationRequired: [],
+  dismissUrlElicitationRequired: vi.fn(),
   messages: [],
   setMessages: vi.fn(),
   sendMessage: vi.fn(),

--- a/mcpjam-inspector/client/src/components/elicitation/ElicitationRequestDialog.tsx
+++ b/mcpjam-inspector/client/src/components/elicitation/ElicitationRequestDialog.tsx
@@ -1,0 +1,75 @@
+import type {
+  HostedElicitationAction,
+  HostedElicitationRequestEvent,
+} from "@/shared/hosted-elicitation";
+import { ElicitationDialog } from "../ElicitationDialog";
+import { UrlElicitationConsent } from "./UrlElicitationConsent";
+
+/**
+ * Renders whichever elicitation UI the request's mode calls for.
+ *
+ * The two modes are genuinely different interactions, not styling variants:
+ * form mode collects data the client may read, URL mode gets consent to send
+ * the user somewhere the client must NOT observe. Keeping the split here means
+ * neither component has to know the other exists.
+ *
+ * Chat surfaces render this; ToolsTab/TasksTab keep using `ElicitationDialog`
+ * directly, since local payloads carry no mode.
+ */
+export function ElicitationRequestDialog({
+  request,
+  onRespond,
+  loading,
+}: {
+  request: HostedElicitationRequestEvent | null;
+  onRespond: (answer: {
+    rendezvousId: string;
+    action: HostedElicitationAction;
+    content?: Record<string, unknown>;
+  }) => void | Promise<void>;
+  loading?: boolean;
+}) {
+  if (!request) return null;
+
+  if (request.mode === "url") {
+    return (
+      <UrlElicitationConsent
+        request={{
+          rendezvousId: request.rendezvousId,
+          serverId: request.serverId,
+          serverName: request.serverName,
+          message: request.message,
+          url: request.url,
+        }}
+        onResponse={(action) =>
+          onRespond({ rendezvousId: request.rendezvousId, action })
+        }
+        loading={loading}
+      />
+    );
+  }
+
+  return (
+    <ElicitationDialog
+      elicitationRequest={{
+        // The dialog keys off requestId; the rendezvousId is what the answer
+        // travels on, so it's the identity that matters here.
+        requestId: request.rendezvousId,
+        message: request.message,
+        schema: request.requestedSchema as Record<string, unknown> | undefined,
+        timestamp: new Date(request.expiresAt).toISOString(),
+        serverId: request.serverId,
+        serverName: request.serverName,
+      }}
+      onResponse={async (action, parameters) =>
+        onRespond({
+          rendezvousId: request.rendezvousId,
+          action: action as HostedElicitationAction,
+          // Content rides accepts only; the backend rejects it otherwise.
+          ...(action === "accept" && parameters ? { content: parameters } : {}),
+        })
+      }
+      loading={loading}
+    />
+  );
+}

--- a/mcpjam-inspector/client/src/components/elicitation/ElicitationRequestDialog.tsx
+++ b/mcpjam-inspector/client/src/components/elicitation/ElicitationRequestDialog.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import type {
   HostedElicitationAction,
   HostedElicitationRequestEvent,
@@ -25,22 +26,50 @@ export function UrlElicitationRequiredDialog({
   event: HostedElicitationUrlRequiredEvent | null;
   onDismiss: (toolCallId?: string) => void;
 }) {
-  const first = event?.elicitations[0];
-  if (!event || !first) return null;
+  // The spec allows a server to require SEVERAL interactions before a tool can
+  // run, and they are conjunctive — finishing one doesn't unblock the call.
+  // Showing only `elicitations[0]` and discarding the rest on dismiss left the
+  // user stuck with no way to reach the others. Walk them one at a time and
+  // only dismiss the event once every one has been handled.
+  const [index, setIndex] = useState(0);
+  const total = event?.elicitations.length ?? 0;
+
+  // A new failure resets the walk; keyed state alone wouldn't cover an event
+  // swapped in under the same toolCallId.
+  useEffect(() => {
+    setIndex(0);
+  }, [event]);
+
+  const current = event?.elicitations[index];
+  if (!event || !current) return null;
+
+  const advance = () => {
+    if (index + 1 < total) {
+      setIndex(index + 1);
+      return;
+    }
+    onDismiss(event.toolCallId);
+  };
+
+  const counter = total > 1 ? ` (${index + 1} of ${total})` : "";
 
   return (
     <UrlElicitationConsent
+      // Remount per entry so the previous one's popup-blocked / copied state
+      // can't bleed into the next.
+      key={current.elicitationId}
       advisory
       request={{
-        rendezvousId: first.elicitationId,
+        rendezvousId: current.elicitationId,
         serverId: event.serverId,
         serverName: event.serverName,
         message:
-          first.message ??
-          "This tool needs you to finish something at the link below before it can run.",
-        url: first.url,
+          (current.message ??
+            "This tool needs you to finish something at the link below before it can run.") +
+          counter,
+        url: current.url,
       }}
-      onResponse={() => onDismiss(event.toolCallId)}
+      onResponse={advance}
     />
   );
 }

--- a/mcpjam-inspector/client/src/components/elicitation/ElicitationRequestDialog.tsx
+++ b/mcpjam-inspector/client/src/components/elicitation/ElicitationRequestDialog.tsx
@@ -1,9 +1,49 @@
 import type {
   HostedElicitationAction,
   HostedElicitationRequestEvent,
+  HostedElicitationUrlRequiredEvent,
 } from "@/shared/hosted-elicitation";
 import { ElicitationDialog } from "../ElicitationDialog";
 import { UrlElicitationConsent } from "./UrlElicitationConsent";
+
+/**
+ * A tool call failed with `-32042`: the server needs an out-of-band interaction
+ * finished before it can serve the request.
+ *
+ * Advisory — the call already failed, so nothing is waiting on an answer and
+ * there is no rendezvous. The user opens the URL, then retries (the tool result
+ * carries a retry hint for the model, and they can also just ask again).
+ *
+ * Renders the same consent surface as a live URL elicitation so the safety rules
+ * (full URL shown, no prefetch, domain emphasis, punycode warnings) hold on this
+ * path too — a URL is no safer for having arrived via an error.
+ */
+export function UrlElicitationRequiredDialog({
+  event,
+  onDismiss,
+}: {
+  event: HostedElicitationUrlRequiredEvent | null;
+  onDismiss: (toolCallId?: string) => void;
+}) {
+  const first = event?.elicitations[0];
+  if (!event || !first) return null;
+
+  return (
+    <UrlElicitationConsent
+      advisory
+      request={{
+        rendezvousId: first.elicitationId,
+        serverId: event.serverId,
+        serverName: event.serverName,
+        message:
+          first.message ??
+          "This tool needs you to finish something at the link below before it can run.",
+        url: first.url,
+      }}
+      onResponse={() => onDismiss(event.toolCallId)}
+    />
+  );
+}
 
 /**
  * Renders whichever elicitation UI the request's mode calls for.

--- a/mcpjam-inspector/client/src/components/elicitation/UrlElicitationConsent.tsx
+++ b/mcpjam-inspector/client/src/components/elicitation/UrlElicitationConsent.tsx
@@ -46,8 +46,9 @@ export interface UrlElicitationConsentProps {
   loading?: boolean;
   /**
    * Advisory mode: no server call is blocked on the answer (the -32042 path,
-   * where the tool already failed). Opening still works; there's just nothing
-   * to accept, so the footer reads as "open / close".
+   * where the tool already failed). There is nothing to decline, so that button
+   * is hidden — but `onResponse` still fires, and the parent decides what it
+   * means (there, dismissal).
    */
   advisory?: boolean;
 }
@@ -87,7 +88,7 @@ export function UrlElicitationConsent({
     win.opener = null;
     win.location.replace(analysis.parsed.href);
     setPopupBlocked(false);
-    if (!advisory) void onResponse("accept");
+    void onResponse("accept");
   };
 
   const copy = async () => {
@@ -108,8 +109,10 @@ export function UrlElicitationConsent({
       open
       onOpenChange={(next) => {
         // Dismissing without choosing is `cancel`, not `decline` — the spec
-        // distinguishes "no explicit choice" from an explicit refusal.
-        if (!next && !advisory) void onResponse("cancel");
+        // distinguishes "no explicit choice" from an explicit refusal. In
+        // advisory mode the parent reads this as dismissal; either way the
+        // dialog must always be closable.
+        if (!next) void onResponse("cancel");
       }}
     >
       <DialogContent className="sm:max-w-lg">
@@ -157,6 +160,11 @@ export function UrlElicitationConsent({
                 {/* Plain text, never an <a>: the user must read before they go. */}
                 <div className="max-h-24 overflow-auto break-all font-mono text-xs">
                   <span className="text-muted-foreground">{display.origin}</span>
+                  {display.userinfo && (
+                    <span className="text-muted-foreground">
+                      {display.userinfo}
+                    </span>
+                  )}
                   <span className="font-semibold text-foreground">
                     {display.host}
                   </span>

--- a/mcpjam-inspector/client/src/components/elicitation/UrlElicitationConsent.tsx
+++ b/mcpjam-inspector/client/src/components/elicitation/UrlElicitationConsent.tsx
@@ -1,0 +1,219 @@
+import { useMemo, useState } from "react";
+import { Button } from "@mcpjam/design-system/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@mcpjam/design-system/dialog";
+import { AlertTriangle, ExternalLink, Copy, X } from "lucide-react";
+import {
+  URL_WARNING_COPY,
+  analyzeElicitationUrl,
+  splitUrlForDisplay,
+} from "./url-analysis";
+
+/**
+ * URL-mode elicitation consent (MCP 2025-11-25).
+ *
+ * The server wants the user to complete something out of band — an OAuth
+ * connect, a payment, entering a credential — at a URL the SERVER chose. The
+ * client's whole job here is informed consent, so this dialog:
+ *
+ *   - shows the FULL url, always, before any consent (never truncated behind a
+ *     "details" toggle, and never rendered as an anchor the user could click by
+ *     reflex before reading it)
+ *   - emphasizes the host, warns on punycode / http / embedded credentials, and
+ *     refuses non-http(s) schemes outright
+ *   - performs ZERO network activity (no favicon, no preview, no prefetch)
+ *   - opens in a new tab the client cannot inspect, only on an explicit click
+ *
+ * `accept` means "the user consented and we sent them there" — NOT that the
+ * out-of-band interaction succeeded. The server learns that separately.
+ */
+
+export interface UrlElicitationConsentProps {
+  request: {
+    rendezvousId: string;
+    serverId: string;
+    serverName?: string;
+    message: string;
+    url?: string;
+  } | null;
+  onResponse: (action: "accept" | "decline" | "cancel") => void | Promise<void>;
+  loading?: boolean;
+  /**
+   * Advisory mode: no server call is blocked on the answer (the -32042 path,
+   * where the tool already failed). Opening still works; there's just nothing
+   * to accept, so the footer reads as "open / close".
+   */
+  advisory?: boolean;
+}
+
+export function UrlElicitationConsent({
+  request,
+  onResponse,
+  loading,
+  advisory,
+}: UrlElicitationConsentProps) {
+  const [popupBlocked, setPopupBlocked] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const analysis = useMemo(
+    () => (request?.url ? analyzeElicitationUrl(request.url) : null),
+    [request?.url],
+  );
+
+  if (!request) return null;
+
+  const open = () => {
+    if (!analysis?.parsed || analysis.blocked) return;
+
+    // Two-step open, deliberately.
+    //
+    // `window.open(url, "_blank", "noopener")` returns null even on SUCCESS, so
+    // it cannot distinguish "blocked" from "opened" — we'd either swallow a
+    // real failure or withhold consent from a user who did open the page.
+    // Opening about:blank first gives a real handle (null ⇒ genuinely blocked),
+    // and nulling `opener` before navigating preserves the isolation `noopener`
+    // was there for.
+    const win = window.open("about:blank", "_blank");
+    if (!win) {
+      setPopupBlocked(true);
+      return;
+    }
+    win.opener = null;
+    win.location.replace(analysis.parsed.href);
+    setPopupBlocked(false);
+    if (!advisory) void onResponse("accept");
+  };
+
+  const copy = async () => {
+    if (!request.url) return;
+    try {
+      await navigator.clipboard.writeText(request.url);
+      setCopied(true);
+    } catch {
+      // Clipboard can be denied; the URL is on screen and selectable anyway.
+    }
+  };
+
+  const display = analysis?.parsed ? splitUrlForDisplay(analysis.parsed) : null;
+  const serverLabel = request.serverName ?? request.serverId;
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(next) => {
+        // Dismissing without choosing is `cancel`, not `decline` — the spec
+        // distinguishes "no explicit choice" from an explicit refusal.
+        if (!next && !advisory) void onResponse("cancel");
+      }}
+    >
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <ExternalLink className="h-4 w-4" />
+            Open a link to continue?
+          </DialogTitle>
+          <DialogDescription asChild>
+            <div className="space-y-1">
+              <div>
+                <span className="font-medium text-foreground">
+                  {serverLabel}
+                </span>{" "}
+                is asking you to open a page to finish this step.
+              </div>
+              {/* serverId is the trusted anchor; serverName is server-supplied. */}
+              <div className="font-mono text-[11px] text-muted-foreground">
+                {request.serverId}
+              </div>
+            </div>
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <p className="text-sm text-foreground">{request.message}</p>
+
+          {analysis?.blocked ? (
+            <div className="flex items-start gap-2 rounded-md border border-destructive/50 bg-destructive/10 p-3">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-destructive" />
+              <div className="text-xs text-destructive">
+                This server sent a link MCPJam won't open — it isn't a valid
+                web address. Nothing has been sent to it.
+                <div className="mt-1 break-all font-mono text-[11px] opacity-80">
+                  {request.url}
+                </div>
+              </div>
+            </div>
+          ) : (
+            display && (
+              <div className="rounded-md border bg-muted/40 p-3">
+                <div className="mb-1 text-[11px] uppercase tracking-wide text-muted-foreground">
+                  Destination
+                </div>
+                {/* Plain text, never an <a>: the user must read before they go. */}
+                <div className="max-h-24 overflow-auto break-all font-mono text-xs">
+                  <span className="text-muted-foreground">{display.origin}</span>
+                  <span className="font-semibold text-foreground">
+                    {display.host}
+                  </span>
+                  <span className="text-muted-foreground">{display.rest}</span>
+                </div>
+              </div>
+            )
+          )}
+
+          {analysis?.warnings.map((warning) => (
+            <div
+              key={warning}
+              className="flex items-start gap-2 rounded-md border border-amber-500/50 bg-amber-500/10 p-2"
+            >
+              <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-600" />
+              <span className="text-xs text-amber-700 dark:text-amber-500">
+                {URL_WARNING_COPY[warning]}
+              </span>
+            </div>
+          ))}
+
+          {popupBlocked && (
+            <div className="rounded-md border bg-muted/40 p-2 text-xs text-muted-foreground">
+              Your browser blocked the new tab. Allow pop-ups for this site, or
+              copy the link and open it yourself.
+            </div>
+          )}
+        </div>
+
+        <DialogFooter className="gap-2 sm:justify-between">
+          <Button variant="ghost" size="sm" onClick={copy} disabled={!request.url}>
+            <Copy className="mr-1.5 h-3.5 w-3.5" />
+            {copied ? "Copied" : "Copy link"}
+          </Button>
+          <div className="flex gap-2">
+            {!advisory && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => void onResponse("decline")}
+                disabled={loading}
+              >
+                <X className="mr-1.5 h-3.5 w-3.5" />
+                Decline
+              </Button>
+            )}
+            <Button
+              size="sm"
+              onClick={open}
+              disabled={loading || !analysis || analysis.blocked}
+            >
+              <ExternalLink className="mr-1.5 h-3.5 w-3.5" />
+              Open in new tab
+            </Button>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/mcpjam-inspector/client/src/components/elicitation/__tests__/ElicitationRequestDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/elicitation/__tests__/ElicitationRequestDialog.test.tsx
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { UrlElicitationRequiredDialog } from "../ElicitationRequestDialog";
+import type { HostedElicitationUrlRequiredEvent } from "@/shared/hosted-elicitation";
+
+let openSpy: ReturnType<typeof vi.fn>;
+
+function urlRequired(
+  n: number,
+  toolCallId = "call-1",
+): HostedElicitationUrlRequiredEvent {
+  return {
+    kind: "url_required",
+    serverId: "srv-1",
+    serverName: "GitHub",
+    toolCallId,
+    elicitations: Array.from({ length: n }, (_, i) => ({
+      url: `https://example.com/step-${i + 1}`,
+      elicitationId: `e${i + 1}`,
+      message: `Do step ${i + 1}`,
+    })),
+  };
+}
+
+function openIt() {
+  fireEvent.click(screen.getByRole("button", { name: /open in new tab/i }));
+}
+
+beforeEach(() => {
+  openSpy = vi.fn(() => ({ opener: {}, location: { replace: vi.fn() } }));
+  vi.stubGlobal("open", openSpy);
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("UrlElicitationRequiredDialog", () => {
+  it("renders nothing without an event", () => {
+    const { container } = render(
+      <UrlElicitationRequiredDialog event={null} onDismiss={vi.fn()} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("dismisses after the single required interaction", () => {
+    const onDismiss = vi.fn();
+    render(
+      <UrlElicitationRequiredDialog event={urlRequired(1)} onDismiss={onDismiss} />,
+    );
+    expect(screen.getByText(/Do step 1/)).toBeInTheDocument();
+    // One entry — no counter noise.
+    expect(screen.queryByText(/1 of 1/)).not.toBeInTheDocument();
+
+    openIt();
+    expect(onDismiss).toHaveBeenCalledWith("call-1");
+  });
+
+  it("walks every entry before dismissing", () => {
+    // The spec allows several required interactions, and they're conjunctive:
+    // finishing one doesn't unblock the tool. Showing only the first and
+    // discarding the rest left the user permanently stuck.
+    const onDismiss = vi.fn();
+    render(
+      <UrlElicitationRequiredDialog event={urlRequired(3)} onDismiss={onDismiss} />,
+    );
+
+    expect(screen.getByText(/Do step 1 \(1 of 3\)/)).toBeInTheDocument();
+    openIt();
+    expect(onDismiss).not.toHaveBeenCalled();
+
+    expect(screen.getByText(/Do step 2 \(2 of 3\)/)).toBeInTheDocument();
+    openIt();
+    expect(onDismiss).not.toHaveBeenCalled();
+
+    expect(screen.getByText(/Do step 3 \(3 of 3\)/)).toBeInTheDocument();
+    openIt();
+    expect(onDismiss).toHaveBeenCalledWith("call-1");
+  });
+
+  it("opens each entry's own url, not the first one repeatedly", () => {
+    const replace = vi.fn();
+    openSpy.mockReturnValue({ opener: {}, location: { replace } });
+    render(
+      <UrlElicitationRequiredDialog event={urlRequired(2)} onDismiss={vi.fn()} />,
+    );
+
+    openIt();
+    openIt();
+
+    expect(replace).toHaveBeenNthCalledWith(1, "https://example.com/step-1");
+    expect(replace).toHaveBeenNthCalledWith(2, "https://example.com/step-2");
+  });
+
+  it("restarts the walk when a new failure arrives", () => {
+    const { rerender } = render(
+      <UrlElicitationRequiredDialog event={urlRequired(2)} onDismiss={vi.fn()} />,
+    );
+    openIt();
+    expect(screen.getByText(/Do step 2/)).toBeInTheDocument();
+
+    rerender(
+      <UrlElicitationRequiredDialog
+        event={urlRequired(2, "call-2")}
+        onDismiss={vi.fn()}
+      />,
+    );
+
+    // A different tool failed — start from its first requirement, not wherever
+    // the previous walk happened to stop.
+    expect(screen.getByText(/Do step 1 \(1 of 2\)/)).toBeInTheDocument();
+  });
+});

--- a/mcpjam-inspector/client/src/components/elicitation/__tests__/UrlElicitationConsent.test.tsx
+++ b/mcpjam-inspector/client/src/components/elicitation/__tests__/UrlElicitationConsent.test.tsx
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { UrlElicitationConsent } from "../UrlElicitationConsent";
+
+const request = {
+  rendezvousId: "rv-1",
+  serverId: "srv-github",
+  serverName: "GitHub",
+  message: "Connect your account to continue.",
+  url: "https://github.com/login/oauth/authorize?client_id=abc",
+};
+
+let openSpy: ReturnType<typeof vi.fn>;
+let fetchSpy: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  openSpy = vi.fn(() => ({ opener: {}, location: { replace: vi.fn() } }));
+  vi.stubGlobal("open", openSpy);
+  // Any network call from this component would be the pre-fetch the spec bans.
+  fetchSpy = vi.fn();
+  vi.stubGlobal("fetch", fetchSpy);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("UrlElicitationConsent", () => {
+  it("shows the full url and the requesting server before any consent", () => {
+    render(<UrlElicitationConsent request={request} onResponse={vi.fn()} />);
+
+    // Full URL, not a label or a truncation.
+    expect(screen.getByText(/github\.com/)).toBeInTheDocument();
+    expect(
+      screen.getByText("/login/oauth/authorize?client_id=abc"),
+    ).toBeInTheDocument();
+    // Spec: the client MUST make clear which server is asking. serverId is the
+    // trusted anchor, shown alongside the friendly name.
+    expect(screen.getByText("GitHub")).toBeInTheDocument();
+    expect(screen.getByText("srv-github")).toBeInTheDocument();
+  });
+
+  it("never renders the destination as a clickable link", () => {
+    const { container } = render(
+      <UrlElicitationConsent request={request} onResponse={vi.fn()} />,
+    );
+    // A reflex click must be impossible: consent has to be a deliberate act.
+    expect(container.querySelectorAll("a")).toHaveLength(0);
+  });
+
+  it("performs no network activity", () => {
+    render(<UrlElicitationConsent request={request} onResponse={vi.fn()} />);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("opens with opener isolation and only then accepts", () => {
+    const location = { replace: vi.fn() };
+    const win: any = { opener: {}, location };
+    openSpy.mockReturnValue(win);
+    const onResponse = vi.fn();
+
+    render(<UrlElicitationConsent request={request} onResponse={onResponse} />);
+    fireEvent.click(screen.getByRole("button", { name: /open in new tab/i }));
+
+    // about:blank first — `window.open(url, "_blank", "noopener")` returns null
+    // even on success, so it can't distinguish blocked from opened.
+    expect(openSpy).toHaveBeenCalledWith("about:blank", "_blank");
+    expect(win.opener).toBeNull();
+    expect(location.replace).toHaveBeenCalledWith(request.url);
+    expect(onResponse).toHaveBeenCalledWith("accept");
+  });
+
+  it("withholds accept when the popup is blocked", () => {
+    openSpy.mockReturnValue(null);
+    const onResponse = vi.fn();
+
+    render(<UrlElicitationConsent request={request} onResponse={onResponse} />);
+    fireEvent.click(screen.getByRole("button", { name: /open in new tab/i }));
+
+    // The user never reached the page, so claiming they consented would be a lie.
+    expect(onResponse).not.toHaveBeenCalled();
+    expect(screen.getByText(/blocked the new tab/i)).toBeInTheDocument();
+  });
+
+  it("sends decline when declined", () => {
+    const onResponse = vi.fn();
+    render(<UrlElicitationConsent request={request} onResponse={onResponse} />);
+    fireEvent.click(screen.getByRole("button", { name: /decline/i }));
+    expect(onResponse).toHaveBeenCalledWith("decline");
+  });
+
+  it("refuses to open a non-http scheme and explains why", () => {
+    const onResponse = vi.fn();
+    render(
+      <UrlElicitationConsent
+        request={{ ...request, url: "javascript:alert(1)" }}
+        onResponse={onResponse}
+      />,
+    );
+
+    expect(screen.getByText(/won't open/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /open in new tab/i })).toBeDisabled();
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it("warns about a punycode host", () => {
+    render(
+      <UrlElicitationConsent
+        request={{ ...request, url: "https://xn--80ak6aa92e.com/login" }}
+        onResponse={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/look like a different/i)).toBeInTheDocument();
+  });
+
+  it("advisory mode neither accepts nor offers decline", () => {
+    // The -32042 path: the tool already failed, so no server call is waiting.
+    const location = { replace: vi.fn() };
+    openSpy.mockReturnValue({ opener: {}, location });
+    const onResponse = vi.fn();
+
+    render(
+      <UrlElicitationConsent request={request} onResponse={onResponse} advisory />,
+    );
+    expect(
+      screen.queryByRole("button", { name: /decline/i }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /open in new tab/i }));
+    expect(location.replace).toHaveBeenCalled();
+    expect(onResponse).not.toHaveBeenCalled();
+  });
+});

--- a/mcpjam-inspector/client/src/components/elicitation/__tests__/UrlElicitationConsent.test.tsx
+++ b/mcpjam-inspector/client/src/components/elicitation/__tests__/UrlElicitationConsent.test.tsx
@@ -114,8 +114,10 @@ describe("UrlElicitationConsent", () => {
     expect(screen.getByText(/look like a different/i)).toBeInTheDocument();
   });
 
-  it("advisory mode neither accepts nor offers decline", () => {
-    // The -32042 path: the tool already failed, so no server call is waiting.
+  it("advisory mode hides decline but still opens and reports", () => {
+    // The -32042 path: the tool already failed, so there's nothing to decline.
+    // onResponse still fires — the parent reads it as dismissal. An earlier
+    // cut suppressed it entirely, which made the dialog impossible to close.
     const location = { replace: vi.fn() };
     openSpy.mockReturnValue({ opener: {}, location });
     const onResponse = vi.fn();
@@ -128,7 +130,21 @@ describe("UrlElicitationConsent", () => {
     ).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: /open in new tab/i }));
-    expect(location.replace).toHaveBeenCalled();
-    expect(onResponse).not.toHaveBeenCalled();
+    expect(location.replace).toHaveBeenCalledWith(request.url);
+    expect(onResponse).toHaveBeenCalledWith("accept");
+  });
+
+  it("shows embedded credentials rather than hiding them", () => {
+    // The dialog promises the FULL url and warns that userinfo can disguise a
+    // destination — hiding the segment we warn about would be worse than useless.
+    render(
+      <UrlElicitationConsent
+        request={{ ...request, url: "https://example.com@evil.test/x" }}
+        onResponse={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("example.com@")).toBeInTheDocument();
+    expect(screen.getByText("evil.test")).toBeInTheDocument();
+    expect(screen.getByText(/disguise the real destination/i)).toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/components/elicitation/__tests__/UrlElicitationConsent.test.tsx
+++ b/mcpjam-inspector/client/src/components/elicitation/__tests__/UrlElicitationConsent.test.tsx
@@ -147,4 +147,15 @@ describe("UrlElicitationConsent", () => {
     expect(screen.getByText("evil.test")).toBeInTheDocument();
     expect(screen.getByText(/disguise the real destination/i)).toBeInTheDocument();
   });
+
+  it("shows password-only userinfo in the full URL", () => {
+    render(
+      <UrlElicitationConsent
+        request={{ ...request, url: "https://:password@evil.test/x" }}
+        onResponse={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(":password@")).toBeInTheDocument();
+    expect(screen.getByText("evil.test")).toBeInTheDocument();
+  });
 });

--- a/mcpjam-inspector/client/src/components/elicitation/__tests__/url-analysis.test.ts
+++ b/mcpjam-inspector/client/src/components/elicitation/__tests__/url-analysis.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import {
+  analyzeElicitationUrl,
+  splitUrlForDisplay,
+} from "../url-analysis";
+
+describe("analyzeElicitationUrl", () => {
+  it("accepts a plain https url with no warnings", () => {
+    const result = analyzeElicitationUrl("https://example.com/connect?x=1");
+    expect(result.blocked).toBe(false);
+    expect(result.warnings).toEqual([]);
+    expect(result.parsed?.host).toBe("example.com");
+  });
+
+  it("blocks schemes that are not a web page", () => {
+    // Handing any of these to window.open is dangerous, and none is a
+    // legitimate "go here and finish this" target.
+    for (const url of [
+      "javascript:alert(1)",
+      "data:text/html,<h1>hi</h1>",
+      "file:///etc/passwd",
+    ]) {
+      expect(analyzeElicitationUrl(url).blocked).toBe(true);
+    }
+  });
+
+  it("blocks an unparseable url", () => {
+    const result = analyzeElicitationUrl("not a url at all");
+    expect(result.blocked).toBe(true);
+    expect(result.parsed).toBeNull();
+  });
+
+  it("warns on punycode, whether sent as ascii or as unicode glyphs", () => {
+    // Both spellings must trip the warning: a server can send either, and the
+    // URL parser normalizes unicode INTO the xn-- form.
+    for (const url of [
+      "https://xn--80ak6aa92e.com/login",
+      "https://\u0430pple.com/login", // Cyrillic а — looks exactly like "apple.com"
+    ]) {
+      const result = analyzeElicitationUrl(url);
+      expect(result.blocked).toBe(false);
+      expect(result.warnings).toContain("punycode");
+      // We render the ascii form: it's the non-spoofable representation.
+      expect(result.parsed?.hostname.startsWith("xn--")).toBe(true);
+    }
+  });
+
+  it("warns on http", () => {
+    expect(analyzeElicitationUrl("http://example.com").warnings).toContain(
+      "insecure-scheme",
+    );
+  });
+
+  it("warns on embedded credentials", () => {
+    // https://example.com@evil.test reads as "example.com" at a glance.
+    const result = analyzeElicitationUrl("https://example.com@evil.test/x");
+    expect(result.warnings).toContain("embedded-credentials");
+    expect(result.parsed?.host).toBe("evil.test");
+  });
+
+  it("warns on a raw IP host", () => {
+    expect(analyzeElicitationUrl("https://192.168.1.1/x").warnings).toContain(
+      "ip-host",
+    );
+  });
+
+  it("does not flag a hostname that merely contains 'xn--' mid-label", () => {
+    expect(
+      analyzeElicitationUrl("https://myxn--thing.com/x").warnings,
+    ).not.toContain("punycode");
+  });
+});
+
+describe("splitUrlForDisplay", () => {
+  it("isolates the host so it can be emphasized against the rest", () => {
+    const parsed = new URL("https://evil.test/login?next=https://example.com");
+    expect(splitUrlForDisplay(parsed)).toEqual({
+      origin: "https://",
+      host: "evil.test",
+      rest: "/login?next=https://example.com",
+    });
+  });
+});

--- a/mcpjam-inspector/client/src/components/elicitation/__tests__/url-analysis.test.ts
+++ b/mcpjam-inspector/client/src/components/elicitation/__tests__/url-analysis.test.ts
@@ -76,8 +76,25 @@ describe("splitUrlForDisplay", () => {
     const parsed = new URL("https://evil.test/login?next=https://example.com");
     expect(splitUrlForDisplay(parsed)).toEqual({
       origin: "https://",
+      userinfo: "",
       host: "evil.test",
       rest: "/login?next=https://example.com",
     });
+  });
+
+  it("surfaces userinfo instead of hiding it", () => {
+    // Dropping it would contradict both the full-url promise and the
+    // embedded-credentials warning shown right beside it.
+    expect(splitUrlForDisplay(new URL("https://example.com@evil.test/x"))).toEqual(
+      {
+        origin: "https://",
+        userinfo: "example.com@",
+        host: "evil.test",
+        rest: "/x",
+      },
+    );
+    expect(splitUrlForDisplay(new URL("https://u:p@evil.test/x")).userinfo).toBe(
+      "u:p@",
+    );
   });
 });

--- a/mcpjam-inspector/client/src/components/elicitation/__tests__/url-analysis.test.ts
+++ b/mcpjam-inspector/client/src/components/elicitation/__tests__/url-analysis.test.ts
@@ -96,5 +96,8 @@ describe("splitUrlForDisplay", () => {
     expect(splitUrlForDisplay(new URL("https://u:p@evil.test/x")).userinfo).toBe(
       "u:p@",
     );
+    expect(
+      splitUrlForDisplay(new URL("https://:password@evil.test/x")).userinfo,
+    ).toBe(":password@");
   });
 });

--- a/mcpjam-inspector/client/src/components/elicitation/url-analysis.ts
+++ b/mcpjam-inspector/client/src/components/elicitation/url-analysis.ts
@@ -1,0 +1,88 @@
+/**
+ * Safety analysis for URL-mode elicitation targets.
+ *
+ * A server picks this URL and we ask the user to open it, so the client's job
+ * is to let them see exactly where they're going before they consent (MCP
+ * 2025-11-25, elicitation §Safe URL Handling):
+ *
+ *   - show the FULL url before consent (never a shortened/derived label)
+ *   - highlight the host so subdomain spoofing is visible
+ *   - warn on ambiguous/suspicious URIs (punycode)
+ *   - never pre-fetch the URL or any metadata
+ *
+ * Pure and synchronous BY DESIGN: this module must never touch the network.
+ * A favicon peek or a HEAD "just to check" would be exactly the pre-fetch the
+ * spec forbids, and would leak that the user is looking at the prompt.
+ */
+
+export type ElicitationUrlWarning =
+  /** Hostname contains an xn-- label: renders as unicode that can mimic another domain. */
+  | "punycode"
+  /** http:// — credentials/tokens in the flow would cross the wire in clear. */
+  | "insecure-scheme"
+  /** user:pass@host — a classic way to make a hostile host look legitimate. */
+  | "embedded-credentials"
+  /** Bare IP host: no domain identity to evaluate. */
+  | "ip-host";
+
+export interface ElicitationUrlAnalysis {
+  parsed: URL | null;
+  warnings: ElicitationUrlWarning[];
+  /**
+   * True when the URL must not be opened at all: unparseable, or a scheme
+   * outside http/https (javascript:, data:, file: — none of which are a
+   * legitimate "visit this page" target, and all of which are dangerous to
+   * hand to `window.open`).
+   */
+  blocked: boolean;
+}
+
+const IPV4 = /^\d{1,3}(\.\d{1,3}){3}$/;
+
+export function analyzeElicitationUrl(raw: string): ElicitationUrlAnalysis {
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return { parsed: null, warnings: [], blocked: true };
+  }
+
+  const warnings: ElicitationUrlWarning[] = [];
+
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    return { parsed, warnings, blocked: true };
+  }
+  if (parsed.protocol === "http:") warnings.push("insecure-scheme");
+  if (parsed.username || parsed.password) warnings.push("embedded-credentials");
+
+  const hostname = parsed.hostname;
+  if (hostname.split(".").some((label) => label.startsWith("xn--"))) {
+    warnings.push("punycode");
+  }
+  if (IPV4.test(hostname) || hostname.startsWith("[")) warnings.push("ip-host");
+
+  return { parsed, warnings, blocked: false };
+}
+
+export const URL_WARNING_COPY: Record<ElicitationUrlWarning, string> = {
+  punycode:
+    "This address uses characters that can look like a different, well-known site. Check it carefully.",
+  "insecure-scheme":
+    "This link is not encrypted (http). Anything you enter there could be read in transit.",
+  "embedded-credentials":
+    "This link embeds a username or password, which can disguise the real destination.",
+  "ip-host": "This link points at a raw IP address rather than a named domain.",
+};
+
+/** Split for display: the host is emphasized, everything else is muted. */
+export function splitUrlForDisplay(parsed: URL): {
+  origin: string;
+  host: string;
+  rest: string;
+} {
+  return {
+    origin: `${parsed.protocol}//`,
+    host: parsed.host,
+    rest: `${parsed.pathname}${parsed.search}${parsed.hash}`,
+  };
+}

--- a/mcpjam-inspector/client/src/components/elicitation/url-analysis.ts
+++ b/mcpjam-inspector/client/src/components/elicitation/url-analysis.ts
@@ -74,14 +74,27 @@ export const URL_WARNING_COPY: Record<ElicitationUrlWarning, string> = {
   "ip-host": "This link points at a raw IP address rather than a named domain.",
 };
 
-/** Split for display: the host is emphasized, everything else is muted. */
+/**
+ * Split for display: the host is emphasized, everything else is muted.
+ *
+ * `userinfo` is surfaced separately rather than dropped. Hiding it would break
+ * the promise this dialog makes — it shows the FULL url — and would be actively
+ * misleading next to the embedded-credentials warning: we'd be warning about a
+ * `user:pass@` segment the user cannot see. It renders in the muted prefix,
+ * never emphasized, so `https://example.com@evil.test` still reads as evil.test.
+ */
 export function splitUrlForDisplay(parsed: URL): {
   origin: string;
+  userinfo: string;
   host: string;
   rest: string;
 } {
+  const userinfo = parsed.username
+    ? `${parsed.username}${parsed.password ? `:${parsed.password}` : ""}@`
+    : "";
   return {
     origin: `${parsed.protocol}//`,
+    userinfo,
     host: parsed.host,
     rest: `${parsed.pathname}${parsed.search}${parsed.hash}`,
   };

--- a/mcpjam-inspector/client/src/components/elicitation/url-analysis.ts
+++ b/mcpjam-inspector/client/src/components/elicitation/url-analysis.ts
@@ -89,9 +89,10 @@ export function splitUrlForDisplay(parsed: URL): {
   host: string;
   rest: string;
 } {
-  const userinfo = parsed.username
-    ? `${parsed.username}${parsed.password ? `:${parsed.password}` : ""}@`
-    : "";
+  const userinfo =
+    parsed.username || parsed.password
+      ? `${parsed.username}${parsed.password ? `:${parsed.password}` : ""}@`
+      : "";
   return {
     origin: `${parsed.protocol}//`,
     userinfo,

--- a/mcpjam-inspector/client/src/components/hosted/__tests__/ChatboxChatPage.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/__tests__/ChatboxChatPage.test.tsx
@@ -49,6 +49,9 @@ const {
 }));
 
 vi.mock("convex/react", () => ({
+  // useChatSession resolves the Convex client to submit elicitation answers
+  // straight to the rendezvous table (the blocked replica isn't addressable).
+  useConvex: () => ({ mutation: vi.fn().mockResolvedValue({ ok: true }) }),
   useConvexAuth: () => mockConvexAuthState,
 }));
 

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -22,6 +22,7 @@ import {
 } from "react";
 import type { CSSProperties, ReactNode } from "react";
 import { Braces, Loader2, Trash2 } from "lucide-react";
+import { ElicitationRequestDialog } from "@/components/elicitation/ElicitationRequestDialog";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -768,6 +769,9 @@ export function PlaygroundMain({
     restoredToolRenderOverrides,
     status,
     authHeaders,
+    pendingElicitations,
+    respondToElicitation,
+    elicitationResponding,
   } = useChatSession({
     selectedServers,
     directVisibility: pendingDirectVisibility,
@@ -4067,6 +4071,15 @@ export function PlaygroundMain({
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+      {/*
+        Playground had no elicitation UI at all — a server that asked for input
+        here would block until the request timed out with no way to answer.
+      */}
+      <ElicitationRequestDialog
+        request={pendingElicitations[0] ?? null}
+        onRespond={respondToElicitation}
+        loading={elicitationResponding}
+      />
     </WidgetSurfaceProvider>
   );
 }

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -22,7 +22,10 @@ import {
 } from "react";
 import type { CSSProperties, ReactNode } from "react";
 import { Braces, Loader2, Trash2 } from "lucide-react";
-import { ElicitationRequestDialog } from "@/components/elicitation/ElicitationRequestDialog";
+import {
+  ElicitationRequestDialog,
+  UrlElicitationRequiredDialog,
+} from "@/components/elicitation/ElicitationRequestDialog";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -772,6 +775,8 @@ export function PlaygroundMain({
     pendingElicitations,
     respondToElicitation,
     elicitationResponding,
+    urlElicitationRequired,
+    dismissUrlElicitationRequired,
   } = useChatSession({
     selectedServers,
     directVisibility: pendingDirectVisibility,
@@ -4076,9 +4081,15 @@ export function PlaygroundMain({
         here would block until the request timed out with no way to answer.
       */}
       <ElicitationRequestDialog
+        key={pendingElicitations[0]?.rendezvousId ?? "none"}
         request={pendingElicitations[0] ?? null}
         onRespond={respondToElicitation}
         loading={elicitationResponding}
+      />
+      <UrlElicitationRequiredDialog
+        key={urlElicitationRequired[0]?.toolCallId ?? "no-url-required"}
+        event={urlElicitationRequired[0] ?? null}
+        onDismiss={dismissUrlElicitationRequired}
       />
     </WidgetSurfaceProvider>
   );

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.multi-host.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.multi-host.test.tsx
@@ -135,6 +135,9 @@ vi.mock("@workos-inc/authkit-react", () => ({
 }));
 
 vi.mock("convex/react", () => ({
+  // useChatSession resolves the Convex client to submit elicitation answers
+  // straight to the rendezvous table (the blocked replica isn't addressable).
+  useConvex: () => ({ mutation: vi.fn().mockResolvedValue({ ok: true }) }),
   useConvexAuth: () => ({ isAuthenticated: true, isLoading: false }),
   useQuery: (_name: string, args: unknown) =>
     args === "skip" ? undefined : null,
@@ -156,6 +159,13 @@ vi.mock("@/lib/apis/web/chat-history-api", () => ({
 // `useChatSession` is shared with single-host tests; we don't need it
 // to do anything beyond return the standard mock object.
 const mockUseChatSession = {
+  // Elicitation surface (hosted). These suites never elicit, but the shape
+  // must match the hook's contract or the dialog crashes on undefined.
+  pendingElicitations: [],
+  respondToElicitation: vi.fn(),
+  elicitationResponding: false,
+  urlElicitationRequired: [],
+  dismissUrlElicitationRequired: vi.fn(),
   messages: [],
   setMessages: vi.fn(),
   sendMessage: vi.fn(),

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
@@ -157,6 +157,9 @@ vi.mock("@workos-inc/authkit-react", () => ({
 
 // Mock convex/react
 vi.mock("convex/react", () => ({
+  // useChatSession resolves the Convex client to submit elicitation answers
+  // straight to the rendezvous table (the blocked replica isn't addressable).
+  useConvex: () => ({ mutation: vi.fn().mockResolvedValue({ ok: true }) }),
   useConvexAuth: () => ({
     isAuthenticated: false,
     isLoading: false,
@@ -185,6 +188,13 @@ vi.mock("@/lib/apis/web/chat-history-api", () => ({
 
 // Mock useChatSession hook
 const mockUseChatSession = {
+  // Elicitation surface (hosted). These suites never elicit, but the shape
+  // must match the hook's contract or the dialog crashes on undefined.
+  pendingElicitations: [],
+  respondToElicitation: vi.fn(),
+  elicitationResponding: false,
+  urlElicitationRequired: [],
+  dismissUrlElicitationRequired: vi.fn(),
   messages: [],
   setMessages: vi.fn(),
   sendMessage: vi.fn(),

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/multi-model-playground-card.provider-shadow.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/multi-model-playground-card.provider-shadow.test.tsx
@@ -53,6 +53,13 @@ vi.mock("use-stick-to-bottom", () => {
 });
 
 const mockUseChatSession = {
+  // Elicitation surface (hosted). These suites never elicit, but the shape
+  // must match the hook's contract or the dialog crashes on undefined.
+  pendingElicitations: [],
+  respondToElicitation: vi.fn(),
+  elicitationResponding: false,
+  urlElicitationRequired: [],
+  dismissUrlElicitationRequired: vi.fn(),
   messages: [],
   setMessages: vi.fn(),
   sendMessage: vi.fn(),

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/multi-model-playground-card.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/multi-model-playground-card.test.tsx
@@ -26,6 +26,13 @@ vi.mock("use-stick-to-bottom", () => {
 });
 
 const mockUseChatSession = {
+  // Elicitation surface (hosted). These suites never elicit, but the shape
+  // must match the hook's contract or the dialog crashes on undefined.
+  pendingElicitations: [],
+  respondToElicitation: vi.fn(),
+  elicitationResponding: false,
+  urlElicitationRequired: [],
+  dismissUrlElicitationRequired: vi.fn(),
   messages: [],
   setMessages: vi.fn(),
   sendMessage: vi.fn(),

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.elicitation.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.elicitation.test.tsx
@@ -1,0 +1,367 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useChatSession } from "../use-chat-session";
+
+const mockState = vi.hoisted(() => ({
+  chatOnData: null as ((part: unknown) => void) | null,
+  chatStatus: "ready" as string,
+  convexMutation: vi.fn(async () => ({ ok: true })),
+  setMessages: vi.fn(),
+  sendMessage: vi.fn(),
+  stop: vi.fn(),
+  addToolApprovalResponse: vi.fn(),
+  getAccessToken: vi.fn(async () => null),
+  hasToken: vi.fn(() => false),
+  getToken: vi.fn(() => ""),
+  getOpenRouterSelectedModels: vi.fn(() => []),
+  getOllamaBaseUrl: vi.fn(() => "http://127.0.0.1:11434"),
+  getAzureBaseUrl: vi.fn(() => ""),
+  getCustomProviderByName: vi.fn(),
+  setSelectedModelId: vi.fn(),
+  getToolsMetadata: vi.fn(async () => ({
+    metadata: {},
+    toolServerMap: {},
+    tokenCounts: null,
+  })),
+  countTextTokens: vi.fn(async () => null),
+  convexAuth: { isAuthenticated: true, isLoading: false },
+  detectOllamaModels: vi.fn(async () => ({
+    isRunning: false,
+    availableModels: [],
+  })),
+  detectOllamaToolCapableModels: vi.fn(async () => []),
+  idCounter: 0,
+}));
+
+const mcpJamModel = {
+  id: "openai/gpt-5-mini",
+  name: "GPT-5 Mini",
+  provider: "openai" as const,
+};
+
+function nextSessionId() {
+  mockState.idCounter += 1;
+  return `chat-session-${mockState.idCounter}`;
+}
+
+function elicitationPart(data: unknown) {
+  return { type: "data-elicitation" as const, data };
+}
+
+function formRequest(overrides: Record<string, unknown> = {}) {
+  return {
+    kind: "request",
+    rendezvousId: "rv-1",
+    serverId: "srv-1",
+    serverName: "GitHub",
+    mode: "form",
+    message: "Pick a branch",
+    requestedSchema: { type: "object", properties: {} },
+    expiresAt: Date.now() + 300_000,
+    ...overrides,
+  };
+}
+
+vi.mock("@/lib/config", () => ({ HOSTED_MODE: false }));
+
+vi.mock("@/components/chat-v2/shared/model-helpers", () => ({
+  buildAvailableModels: vi.fn(() => [mcpJamModel]),
+  getDefaultModel: vi.fn(() => mcpJamModel),
+}));
+
+vi.mock("@/hooks/use-ai-provider-keys", () => ({
+  useAiProviderKeys: () => ({
+    hasToken: mockState.hasToken,
+    getToken: mockState.getToken,
+    getOpenRouterSelectedModels: mockState.getOpenRouterSelectedModels,
+    getOllamaBaseUrl: mockState.getOllamaBaseUrl,
+    getAzureBaseUrl: mockState.getAzureBaseUrl,
+  }),
+}));
+
+vi.mock("@/hooks/use-custom-providers", () => ({
+  useCustomProviders: () => ({
+    customProviders: [],
+    getCustomProviderByName: mockState.getCustomProviderByName,
+  }),
+}));
+
+vi.mock("@/hooks/use-persisted-model", () => ({
+  usePersistedModel: () => ({
+    selectedModelId: "openai/gpt-5-mini",
+    setSelectedModelId: mockState.setSelectedModelId,
+    selectedModelIds: ["openai/gpt-5-mini"],
+    setSelectedModelIds: vi.fn(),
+    multiModelEnabled: false,
+    setMultiModelEnabled: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/useSharedChatWidgetCapture", () => ({
+  useSharedChatWidgetCapture: vi.fn(),
+}));
+
+vi.mock("@/lib/ollama-utils", () => ({
+  detectOllamaModels: mockState.detectOllamaModels,
+  detectOllamaToolCapableModels: mockState.detectOllamaToolCapableModels,
+}));
+
+vi.mock("@/lib/apis/mcp-tools-api", () => ({
+  getToolsMetadata: mockState.getToolsMetadata,
+}));
+
+vi.mock("@/lib/apis/mcp-tokenizer-api", () => ({
+  countTextTokens: mockState.countTextTokens,
+}));
+
+vi.mock("@/lib/session-token", () => ({
+  authFetch: vi.fn(),
+  getAuthHeaders: vi.fn(() => ({})),
+}));
+
+vi.mock("@workos-inc/authkit-react", () => ({
+  useAuth: () => ({ getAccessToken: mockState.getAccessToken }),
+}));
+
+vi.mock("convex/react", () => ({
+  useConvexAuth: () => mockState.convexAuth,
+  useQuery: () => undefined,
+  useConvex: () => ({ mutation: mockState.convexMutation }),
+}));
+
+vi.mock("@ai-sdk/react", () => ({
+  useChat: vi.fn((options: { onData?: (part: unknown) => void }) => {
+    mockState.chatOnData = options.onData ?? null;
+    return {
+      messages: [],
+      sendMessage: mockState.sendMessage,
+      stop: mockState.stop,
+      status: mockState.chatStatus,
+      error: undefined,
+      setMessages: mockState.setMessages,
+      addToolApprovalResponse: mockState.addToolApprovalResponse,
+    };
+  }),
+}));
+
+vi.mock("ai", () => ({
+  DefaultChatTransport: class MockTransport {
+    constructor(_options: unknown) {}
+  },
+  generateId: vi.fn(() => nextSessionId()),
+  lastAssistantMessageIsCompleteWithApprovalResponses: vi.fn(),
+  convertToModelMessages: vi.fn(async () => []),
+}));
+
+async function renderChatSession() {
+  const rendered = renderHook(() =>
+    useChatSession({ selectedServers: ["server-1"] }),
+  );
+  await waitFor(() => {
+    expect(mockState.chatOnData).not.toBeNull();
+  });
+  return rendered;
+}
+
+describe("useChatSession elicitation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockState.chatOnData = null;
+    mockState.chatStatus = "ready";
+    mockState.idCounter = 0;
+    mockState.convexMutation.mockResolvedValue({ ok: true } as never);
+  });
+
+  it("queues a streamed request", async () => {
+    const { result } = await renderChatSession();
+
+    act(() => {
+      mockState.chatOnData?.(elicitationPart(formRequest()));
+    });
+
+    expect(result.current.pendingElicitations).toHaveLength(1);
+    expect(result.current.pendingElicitations[0]).toMatchObject({
+      rendezvousId: "rv-1",
+      serverId: "srv-1",
+      mode: "form",
+    });
+  });
+
+  it("ignores a re-delivered request for the same rendezvous", async () => {
+    // A duplicate part must not stack a second dialog over one blocked call.
+    const { result } = await renderChatSession();
+
+    act(() => {
+      mockState.chatOnData?.(elicitationPart(formRequest()));
+      mockState.chatOnData?.(elicitationPart(formRequest()));
+    });
+
+    expect(result.current.pendingElicitations).toHaveLength(1);
+  });
+
+  it("queues distinct rendezvous ids independently", async () => {
+    const { result } = await renderChatSession();
+
+    act(() => {
+      mockState.chatOnData?.(elicitationPart(formRequest()));
+      mockState.chatOnData?.(
+        elicitationPart(formRequest({ rendezvousId: "rv-2" })),
+      );
+    });
+
+    expect(result.current.pendingElicitations).toHaveLength(2);
+  });
+
+  it("drops a request the server resolved on its own", async () => {
+    // TTL expiry server-side: the dialog must close, not submit into a dead row.
+    const { result } = await renderChatSession();
+
+    act(() => {
+      mockState.chatOnData?.(elicitationPart(formRequest()));
+    });
+    expect(result.current.pendingElicitations).toHaveLength(1);
+
+    act(() => {
+      mockState.chatOnData?.(
+        elicitationPart({
+          kind: "resolved",
+          rendezvousId: "rv-1",
+          outcome: "expired",
+        }),
+      );
+    });
+    expect(result.current.pendingElicitations).toHaveLength(0);
+  });
+
+  it("collects url_required notices", async () => {
+    const { result } = await renderChatSession();
+
+    act(() => {
+      mockState.chatOnData?.(
+        elicitationPart({
+          kind: "url_required",
+          serverId: "srv-1",
+          toolCallId: "call-1",
+          elicitations: [
+            { url: "https://example.com/auth", elicitationId: "e1" },
+          ],
+        }),
+      );
+    });
+
+    expect(result.current.urlElicitationRequired).toHaveLength(1);
+    expect(result.current.urlElicitationRequired[0]).toMatchObject({
+      toolCallId: "call-1",
+    });
+  });
+
+  it("ignores malformed elicitation parts", async () => {
+    const { result } = await renderChatSession();
+
+    act(() => {
+      mockState.chatOnData?.(elicitationPart({ kind: "request" }));
+      mockState.chatOnData?.(elicitationPart({ kind: "bogus" }));
+      mockState.chatOnData?.({ type: "data-elicitation" });
+    });
+
+    expect(result.current.pendingElicitations).toHaveLength(0);
+    expect(result.current.urlElicitationRequired).toHaveLength(0);
+  });
+
+  it("submits the answer to Convex and clears the queue", async () => {
+    const { result } = await renderChatSession();
+
+    act(() => {
+      mockState.chatOnData?.(elicitationPart(formRequest()));
+    });
+
+    await act(async () => {
+      await result.current.respondToElicitation({
+        rendezvousId: "rv-1",
+        action: "accept",
+        content: { branch: "main" },
+      });
+    });
+
+    expect(mockState.convexMutation).toHaveBeenCalledWith(
+      "elicitations:respondToElicitation",
+      { rendezvousId: "rv-1", action: "accept", content: { branch: "main" } },
+    );
+    expect(result.current.pendingElicitations).toHaveLength(0);
+  });
+
+  it("omits content for a non-form answer", async () => {
+    // The backend rejects content outside a form accept; sending an empty
+    // object would be inventing data the user never supplied.
+    const { result } = await renderChatSession();
+
+    await act(async () => {
+      await result.current.respondToElicitation({
+        rendezvousId: "rv-9",
+        action: "decline",
+      });
+    });
+
+    expect(mockState.convexMutation).toHaveBeenCalledWith(
+      "elicitations:respondToElicitation",
+      { rendezvousId: "rv-9", action: "decline" },
+    );
+  });
+
+  it("closes the dialog when the answer loses a race", async () => {
+    mockState.convexMutation.mockResolvedValue({
+      ok: false,
+      reason: "expired",
+    } as never);
+    const { result } = await renderChatSession();
+
+    act(() => {
+      mockState.chatOnData?.(elicitationPart(formRequest()));
+    });
+    await act(async () => {
+      await result.current.respondToElicitation({
+        rendezvousId: "rv-1",
+        action: "accept",
+      });
+    });
+
+    // The row is terminal either way — keeping it open invites a doomed retry.
+    expect(result.current.pendingElicitations).toHaveLength(0);
+  });
+
+  it("keeps the dialog closed when the mutation throws", async () => {
+    mockState.convexMutation.mockRejectedValue(new Error("offline") as never);
+    const { result } = await renderChatSession();
+
+    act(() => {
+      mockState.chatOnData?.(elicitationPart(formRequest()));
+    });
+    await act(async () => {
+      await result.current.respondToElicitation({
+        rendezvousId: "rv-1",
+        action: "accept",
+      });
+    });
+
+    expect(result.current.elicitationResponding).toBe(false);
+  });
+
+  it("clears pending requests once the stream ends", async () => {
+    // The blocked tool call cannot outlive the stream; the server has already
+    // cancelled everything by this point.
+    mockState.chatStatus = "streaming";
+    const { result, rerender } = await renderChatSession();
+
+    act(() => {
+      mockState.chatOnData?.(elicitationPart(formRequest()));
+    });
+    expect(result.current.pendingElicitations).toHaveLength(1);
+
+    mockState.chatStatus = "ready";
+    rerender();
+
+    await waitFor(() => {
+      expect(result.current.pendingElicitations).toHaveLength(0);
+    });
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.fork.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.fork.test.tsx
@@ -114,6 +114,9 @@ vi.mock("@workos-inc/authkit-react", () => ({
 }));
 
 vi.mock("convex/react", () => ({
+  // useChatSession resolves the Convex client to submit elicitation answers
+  // straight to the rendezvous table (the blocked replica isn't addressable).
+  useConvex: () => ({ mutation: vi.fn().mockResolvedValue({ ok: true }) }),
   useConvexAuth: () => ({
     isAuthenticated: true,
     isLoading: false,

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.hosted.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.hosted.test.tsx
@@ -210,6 +210,9 @@ vi.mock("@workos-inc/authkit-react", () => ({
 }));
 
 vi.mock("convex/react", () => ({
+  // useChatSession resolves the Convex client to submit elicitation answers
+  // straight to the rendezvous table (the blocked replica isn't addressable).
+  useConvex: () => ({ mutation: vi.fn().mockResolvedValue({ ok: true }) }),
   useConvexAuth: () => mockState.convexAuth,
   // useChatSession reads the credit balance (to lock free models at 0
   // credits); no balance in these tests → outOfCredits resolves false.
@@ -323,6 +326,26 @@ describe("useChatSession hosted mode", () => {
     vi.mocked(generateId).mockReset();
     vi.mocked(generateId).mockReturnValue("chat-session-id");
     useTrafficLogStore.getState().clear();
+  });
+
+  it("announces the hosted-elicitation handshake", async () => {
+    // The server registers its elicitation callback (and therefore advertises
+    // the capability) ONLY when it sees this. Catalog hosts already declare
+    // elicitation, so a client that doesn't announce would be left hanging on a
+    // prompt it can't render — this field is the rollout gate.
+    renderHook(() =>
+      useChatSession({
+        selectedServers: ["server-1"],
+        hostedContext: {
+          projectId: "project-1",
+          selectedServerIds: ["server-id-1"],
+        },
+      })
+    );
+
+    expect(lastTransportOptions.body()).toMatchObject({
+      hostedElicitationVersion: 1,
+    });
   });
 
   it("includes chatSessionId in the hosted transport body", async () => {

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.live-trace.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.live-trace.test.tsx
@@ -118,6 +118,9 @@ vi.mock("@workos-inc/authkit-react", () => ({
 }));
 
 vi.mock("convex/react", () => ({
+  // useChatSession resolves the Convex client to submit elicitation answers
+  // straight to the rendezvous table (the blocked replica isn't addressable).
+  useConvex: () => ({ mutation: vi.fn().mockResolvedValue({ ok: true }) }),
   useConvexAuth: () => mockState.convexAuth,
   // useChatSession reads the credit balance (to lock free models at 0
   // credits); no balance in these tests → outOfCredits resolves false.

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.minimal-mode.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.minimal-mode.test.tsx
@@ -188,6 +188,9 @@ vi.mock("@workos-inc/authkit-react", () => ({
 }));
 
 vi.mock("convex/react", () => ({
+  // useChatSession resolves the Convex client to submit elicitation answers
+  // straight to the rendezvous table (the blocked replica isn't addressable).
+  useConvex: () => ({ mutation: vi.fn().mockResolvedValue({ ok: true }) }),
   useConvexAuth: () => mockConvexAuth,
   // useChatSession reads the credit balance (to lock free models at 0
   // credits); no balance in these tests → outOfCredits resolves false.

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -44,7 +44,7 @@ import {
   fulfillOrphanedDeferredUiToolCalls,
 } from "@/lib/webmcp/ui-tool-approval";
 import { useAuth } from "@workos-inc/authkit-react";
-import { useConvexAuth } from "convex/react";
+import { useConvex, useConvexAuth } from "convex/react";
 import { ModelDefinition, type ModelProvider } from "@/shared/types";
 import {
   ProviderTokens,
@@ -119,6 +119,14 @@ import {
   pickTranscriptForLiveTracePreview,
 } from "@/shared/live-chat-trace-preview";
 import { isHostedRpcLogDataPart } from "@/shared/hosted-rpc-log";
+import {
+  HOSTED_ELICITATION_VERSION,
+  isHostedElicitationDataPart,
+  type HostedElicitationAction,
+  type HostedElicitationRequestEvent,
+  type HostedElicitationUrlRequiredEvent,
+} from "@/shared/hosted-elicitation";
+import { respondToChatElicitation } from "@/lib/apis/elicitation-api";
 import {
   isHarnessSessionDataPart,
   isHarnessResetDataPart,
@@ -300,6 +308,24 @@ export interface TokenUsage {
 }
 
 export interface UseChatSessionReturn {
+  /**
+   * Elicitation requests whose tool call is blocked on this user right now.
+   * Turn-scoped: they arrive as transient stream parts and are dropped when the
+   * stream ends, because the server has already resolved them to `cancel` by
+   * then. FIFO — surfaces render `[0]`.
+   */
+  pendingElicitations: HostedElicitationRequestEvent[];
+  /** Submit accept/decline/cancel. Resolves once the answer is durable. */
+  respondToElicitation: (answer: {
+    rendezvousId: string;
+    action: HostedElicitationAction;
+    content?: Record<string, unknown>;
+  }) => Promise<void>;
+  elicitationResponding: boolean;
+  /** -32042 notices — display-only, anchored to the failed tool call. */
+  urlElicitationRequired: HostedElicitationUrlRequiredEvent[];
+  dismissUrlElicitationRequired: (toolCallId?: string) => void;
+
   // Chat state
   messages: UIMessage[];
   setMessages: React.Dispatch<React.SetStateAction<UIMessage[]>>;
@@ -1181,6 +1207,9 @@ export function useChatSession(
     onResetRef.current = onReset;
   }, [onReset]);
   const { isAuthenticated, isLoading: isAuthLoading } = useConvexAuth();
+  // Elicitation answers go straight to Convex — the blocked replica isn't
+  // addressable from here (see `elicitation-api.ts`).
+  const convexClient = useConvex();
   const {
     hasToken,
     getToken,
@@ -1212,6 +1241,19 @@ export function useChatSession(
     useState<Record<string, ToolRenderOverride>>({});
   const [liveTraceState, setLiveTraceState] =
     useState<LiveTraceAccumulatorState>(() => createEmptyLiveTraceState());
+  /**
+   * Elicitations whose tool call is blocked on this user right now. Turn-scoped
+   * by nature — the request arrives as a transient stream part and the blocked
+   * call dies with the stream, so there is nothing to persist or rehydrate.
+   */
+  const [pendingElicitations, setPendingElicitations] = useState<
+    HostedElicitationRequestEvent[]
+  >([]);
+  const [elicitationResponding, setElicitationResponding] = useState(false);
+  /** -32042 notices: display-only, anchored to the tool call that failed. */
+  const [urlElicitationRequired, setUrlElicitationRequired] = useState<
+    HostedElicitationUrlRequiredEvent[]
+  >([]);
   const resumedVersionRef = useRef<number | null>(null);
   const restoredToolRenderOverridesRef = useRef<
     Record<string, ToolRenderOverride>
@@ -1344,7 +1386,27 @@ export function useChatSession(
   const handleStreamDataPart = useCallback(
     (part: unknown) => {
       if (!isTraceEventDataPart(part)) {
-        if (isHostedRpcLogDataPart(part)) {
+        if (isHostedElicitationDataPart(part)) {
+          const event = part.data;
+          if (event.kind === "request") {
+            // Dedupe on rendezvousId: a re-delivered part must not stack a
+            // second dialog for the same blocked tool call.
+            setPendingElicitations((queue) =>
+              queue.some((e) => e.rendezvousId === event.rendezvousId)
+                ? queue
+                : [...queue, event],
+            );
+          } else if (event.kind === "resolved") {
+            // The server reached a terminal state on its own (TTL expiry, or
+            // an answer that landed elsewhere) — close the dialog rather than
+            // leave the user submitting into a dead rendezvous.
+            setPendingElicitations((queue) =>
+              queue.filter((e) => e.rendezvousId !== event.rendezvousId),
+            );
+          } else if (event.kind === "url_required") {
+            setUrlElicitationRequired((current) => [...current, event]);
+          }
+        } else if (isHostedRpcLogDataPart(part)) {
           ingestHostedRpcLogs([part.data]);
         } else if (isHarnessSessionDataPart(part)) {
           // Cache the harness workdir so the Playground Shell can open a
@@ -1656,6 +1718,12 @@ export function useChatSession(
         selectedServerIds: resolvedServerIds,
         selectedServerNames: resolvedServerNames,
         chatSessionId,
+        // Handshake: tells the server this bundle can render an elicitation
+        // prompt. Catalog hosts already declare the capability, so without
+        // this a stale bundle would leave the turn blocked for a full TTL on
+        // any server that elicits. The server only registers its callback —
+        // and therefore only advertises `elicitation` — when it sees this.
+        hostedElicitationVersion: HOSTED_ELICITATION_VERSION,
         ...(isHostedDirectChat ? { directVisibility } : {}),
         // Host-bound direct preview: forward the saved host id so the server
         // re-resolves the host's authoritative runtime config (harness/computer
@@ -2425,6 +2493,8 @@ export function useChatSession(
     setChatSessionId(generateId());
     setMessages([]);
     setPersistedSnapshotToolCallIds([]);
+    setPendingElicitations([]);
+    setUrlElicitationRequired([]);
     syncResumedVersion(null);
     syncRestoredToolRenderOverrides({});
     onResetRef.current?.("reset");
@@ -2893,6 +2963,54 @@ export function useChatSession(
         selectedServers.length > 0 &&
         hostedSelectedServerIds.length !== selectedServers.length));
   const isStreaming = status === "streaming" || status === "submitted";
+
+  // The blocked tool call cannot outlive the stream: when it ends (finished,
+  // stopped, or errored) the server has already resolved every outstanding
+  // elicitation to `cancel`, so any dialog still open is answering into a dead
+  // rendezvous. Drop them instead of letting the user submit into the void.
+  useEffect(() => {
+    if (isStreaming) return;
+    setPendingElicitations((queue) => (queue.length > 0 ? [] : queue));
+  }, [isStreaming]);
+
+  const respondToElicitation = useCallback(
+    async (answer: {
+      rendezvousId: string;
+      action: HostedElicitationAction;
+      content?: Record<string, unknown>;
+    }) => {
+      setElicitationResponding(true);
+      try {
+        const result = await respondToChatElicitation(convexClient, answer);
+        // Close on a losing race too (already expired / answered elsewhere):
+        // the row is terminal either way, so keeping the dialog open would
+        // only invite a second doomed submit.
+        setPendingElicitations((queue) =>
+          queue.filter((e) => e.rendezvousId !== answer.rendezvousId),
+        );
+        if (!result.ok) {
+          toast.info(
+            result.reason === "expired"
+              ? "That request timed out, so it was cancelled."
+              : "That request was already resolved.",
+          );
+        }
+      } catch (error) {
+        console.warn("[elicitation] respond failed", error);
+        toast.error("Couldn't send your response. The request will time out.");
+      } finally {
+        setElicitationResponding(false);
+      }
+    },
+    [convexClient],
+  );
+
+  const dismissUrlElicitationRequired = useCallback((toolCallId?: string) => {
+    setUrlElicitationRequired((current) =>
+      current.filter((e) => e.toolCallId !== toolCallId),
+    );
+  }, []);
+
   const submitBlocked =
     disableForAuthentication ||
     isAuthLoading ||
@@ -2967,6 +3085,13 @@ export function useChatSession(
     hasTraceSnapshot,
     hasLiveTimelineContent,
     traceViewsSupported,
+
+    // Elicitation (hosted): a server is blocking a tool call on this user.
+    pendingElicitations,
+    respondToElicitation,
+    elicitationResponding,
+    urlElicitationRequired,
+    dismissUrlElicitationRequired,
 
     // Computed state
     isStreaming,

--- a/mcpjam-inspector/client/src/lib/apis/elicitation-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/elicitation-api.ts
@@ -1,0 +1,48 @@
+/**
+ * Submitting an answer to a hosted elicitation.
+ *
+ * This goes DIRECTLY to Convex rather than through an inspector `/api/web`
+ * route, because the blocked replica isn't reachable by name: hosted runs
+ * behind a load balancer, so the answer would land on an arbitrary replica and
+ * still have to cross to the one holding the tool call. Writing straight to the
+ * rendezvous table removes that hop entirely — the browser already holds a live
+ * authenticated Convex client (signed-in users, guests, and chatbox visitors
+ * alike, via `unified-convex-auth`).
+ *
+ * Authorization is NOT taken from this payload: the mutation re-derives the
+ * caller's identity server-side, checks it owns the row, and enforces a
+ * one-shot pending→answered transition.
+ *
+ * Kept behind one function so the transport stays swappable — nothing above it
+ * knows which channel carries the answer.
+ */
+
+import type { ConvexReactClient } from "convex/react";
+import type { HostedElicitationAnswer } from "@/shared/hosted-elicitation";
+
+/**
+ * Convex functions are referenced by string name across this client (there is
+ * no generated `api` object mirrored into this repo — see the two-repo layout),
+ * so a new backend function is callable without any codegen sync.
+ */
+const RESPOND_FN = "elicitations:respondToElicitation";
+
+export type RespondToElicitationResult =
+  | { ok: true }
+  | { ok: false; reason: string };
+
+export async function respondToChatElicitation(
+  convex: ConvexReactClient,
+  answer: HostedElicitationAnswer,
+): Promise<RespondToElicitationResult> {
+  const result = (await convex.mutation(RESPOND_FN as any, {
+    rendezvousId: answer.rendezvousId,
+    action: answer.action,
+    // Only form-mode accepts carry content; the backend rejects it otherwise.
+    ...(answer.content ? { content: answer.content } : {}),
+  })) as RespondToElicitationResult | undefined;
+
+  // A backend that predates this feature (or any non-object return) shouldn't
+  // read as success — the caller decides what to show.
+  return result ?? { ok: false, reason: "unknown" };
+}

--- a/mcpjam-inspector/server/routes/web/hosted-elicitation.ts
+++ b/mcpjam-inspector/server/routes/web/hosted-elicitation.ts
@@ -57,6 +57,7 @@ import {
 import { logger } from "../../utils/logger.js";
 import {
   HOSTED_ELICITATION_DATA_PART_TYPE,
+  HOSTED_ELICITATION_VERSION,
   type HostedElicitationEvent,
   type HostedElicitationMode,
 } from "@/shared/hosted-elicitation";
@@ -514,9 +515,6 @@ export function hostDeclaresElicitation(
     !Array.isArray(elicitation)
   );
 }
-
-/** The hosted-elicitation wire contract this server speaks. */
-export const HOSTED_ELICITATION_VERSION = 1;
 
 /**
  * Decide (a) whose client capabilities go on the initialize wire and (b) whether

--- a/mcpjam-inspector/shared/hosted-elicitation.ts
+++ b/mcpjam-inspector/shared/hosted-elicitation.ts
@@ -17,6 +17,19 @@
  * turn-scoped UI, not conversation history.
  */
 
+/**
+ * Version of the hosted-elicitation wire contract the client speaks, sent on
+ * every chat request as `hostedElicitationVersion`.
+ *
+ * The server honors elicitation only when it sees this AND the host declares
+ * the capability. It exists because catalog hosts (claude-code, cursor,
+ * vscode, …) ALREADY declare `elicitation`: without a handshake, shipping
+ * server support would make every stale browser bundle — which cannot render
+ * the prompt — hang for a full TTL on any server that elicits. Bump only on an
+ * incompatible change to the parts below.
+ */
+export const HOSTED_ELICITATION_VERSION = 1;
+
 /** Elicitation mode per MCP 2025-11-25. Absent on the wire ⇒ `"form"`. */
 export type HostedElicitationMode = "form" | "url";
 


### PR DESCRIPTION
Part 5 of 6 — the last slice. Completes the hosted path end to end.

**Stacked on #3229** (base is `feat/elicitation-server`). It also carries #3228's commits until that merges, since it builds on the dialog — the client-only diff is `use-chat-session.ts`, `elicitation-api.ts`, the `elicitation/` components and the surfaces.

Merge order: backend ([mcpjam-backend#724](https://github.com/MCPJam/mcpjam-backend/pull/724), **deploy first**) → #3226 (sdk) → #3229 (server) → **this**. Siblings: #3227, #3228.

## What

The server streams a `data-elicitation` part while a tool call blocks; the browser renders the prompt and answers **Convex directly**. No inspector replica needs to receive the answer — that's what makes this work under horizontal scaling, and it's why this doesn't go through an `/api/web` route.

- **`useChatSession` owns the queue** — dedupes by `rendezvousId` (a re-delivered part must not stack a second dialog over one blocked call), drops on the server's terminal `resolved` event (TTL expiry, or answered elsewhere), clears on stream end. The blocked call can't outlive the stream, so a dialog left open would submit into a dead row.
- **`elicitation-api.ts`** — one channel-agnostic seam. Convex functions are referenced by string name (this repo mirrors no codegen), so a new backend function is callable with no sync step. Nothing here is trusted for authorization: the mutation re-derives identity server-side and enforces the one-shot transition.
- **`hostedElicitationVersion: 1`** on every hosted request — the rollout gate. Catalog hosts already declare `elicitation`, so without it a stale bundle hangs for a full TTL on any server that elicits.
- **Playground had no elicitation UI at all** — a server asking for input there blocked until timeout with no way to answer. Fixed.

## URL-mode consent

Per the spec's Safe URL Handling: the **full URL is always visible** and never an `<a>` (a reflex click must be impossible — consent has to be deliberate), the host is emphasized, non-http(s) schemes are refused outright, punycode / http / embedded-credential warnings, and **zero network activity** — no favicon, no HEAD, no preview. A pre-fetch would be exactly what the spec forbids and would leak that the user is looking at the prompt.

**Two details worth a look:**

1. **Opening is two-step: `about:blank` → `opener = null` → navigate.** `window.open(url, "_blank", "noopener")` returns `null` **even on success**, so it cannot distinguish blocked from opened — the obvious one-liner either swallows a real failure or fabricates consent from a user who never reached the page. The two-step form keeps opener isolation *and* gives a real blocked signal; accept is only sent once the tab actually opened.

2. **We display the ASCII (`xn--`) hostname deliberately.** The unicode rendering *is* the spoof — it's what makes `аpple.com` (Cyrillic а) indistinguishable from the real thing. The ASCII form is the non-spoofable truth, so showing it plus a warning tells the user more than decoding ever would.

## About the test-mock churn

Not incidental, and worth understanding rather than skimming:

- Adding `useConvex` to the hook **broke 166 tests across 9 suites** that mocked `convex/react` without it.
- 7 further suites mocked `useChatSession` with a return shape that no longer matched the hook, crashing on `pendingElicitations[0]`.

Both are fixed by **correcting the mocks to match the real contract**, not by bending the code to fit stale mocks.

## Tests

30 new: queue/dedupe/terminal-drop/malformed-parts/respond/race-loss/stream-end (driven through the real `onData` path), URL analysis, and consent UI incl. popup-blocked withholding accept and scheme refusal. Mutation-checked — removing the handshake or the dedupe each fail a test.

Client suite: `Test Files 551 passed | 2 skipped | Tests 5413 passed`. Typecheck clean.

## Not done

No end-to-end run against a live eliciting server. The verification steps that remain: dialog appears mid-tool-call, capability visible in the initialize RPC log, cross-replica answer, form-only host rejecting a url-mode request with -32602.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches user-consent URL opening and cross-replica elicitation answers via Convex; mistakes could block tool calls or mis-handle phishing URLs, but behavior is heavily tested and gated by version handshake.
> 
> **Overview**
> Completes the **hosted elicitation** path in the browser: when a tool blocks on user input, the client shows a prompt and sends the answer **directly to Convex** via `elicitation-api.ts` (bypassing inspector replicas for load-balanced hosted runs).
> 
> **`useChatSession`** now owns turn-scoped queues from `data-elicitation` stream parts: dedupe by `rendezvousId`, drop on server `resolved`, clear when streaming ends, and submit through `respondToChatElicitation`. Every hosted chat body includes **`hostedElicitationVersion: 1`** as the rollout handshake so stale bundles don’t hang on servers that already advertise elicitation.
> 
> **Chat and Playground** mount **`ElicitationRequestDialog`** (form vs URL) alongside the existing local SSE **`ElicitationDialog`**. New **`UrlElicitationConsent`** / **`url-analysis`** enforce spec-style safe URL handling (full plain-text URL, warnings, no prefetch, two-step `about:blank` open). **`UrlElicitationRequiredDialog`** handles **-32042** by walking multiple required URLs before dismiss. Local SSE elicitation now optionally carries **`serverId`** for clarity.
> 
> Tests add elicitation hook/UI coverage and extend **`useConvex`** / hook return mocks across suites so the expanded contract doesn’t crash unrelated tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ab09e2eac85dd0b454f877da5139a9ddbb12783. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds spec-complete elicitation UI (form + URL) to Chat and Playground, renders hosted prompts, and submits answers directly to Convex for reliable scaling. Every hosted request now includes `hostedElicitationVersion: 1`.

- **New Features**
  - New `ElicitationRequestDialog` and `UrlElicitationConsent` with safe URL consent: full URL shown as plain text, host emphasized, punycode/http/embedded-credential warnings, non‑http(s) blocked, zero prefetch; opens via about:blank → isolate opener → navigate.
  - `UrlElicitationRequiredDialog` renders `-32042` notices and walks multiple required URLs with progress; dialogs keyed by `rendezvousId`/`toolCallId`; local dialogs now show `serverId`.
  - `useChatSession` queues hosted prompts (dedupe by `rendezvousId`, drop on terminal outcomes, clear on stream end) and responds via `respondToChatElicitation` in `elicitation-api.ts` using `convex/react`’s `useConvex`; hosted transport includes `hostedElicitationVersion: 1`.

- **Bug Fixes**
  - Actually render `url_required` notices in Chat and Playground; advisory mode hides Decline but still reports dismiss/accept.
  - Show embedded credentials (including password‑only) in the full URL while keeping the host emphasized.

<sup>Written for commit 3ab09e2eac85dd0b454f877da5139a9ddbb12783. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

