### PR TITLE
feat(xaa): one-click registration review when starting from an existing server

### DIFF
--- a/mcpjam-inspector/client/src/components/xaa/registration/XAARegistrationWizard.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/registration/XAARegistrationWizard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { useFeatureFlagEnabled } from "posthog-js/react";
 import { Loader2 } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
@@ -32,6 +32,7 @@ import {
   draftToInput,
   EMPTY_DRAFT,
   isPickableServer,
+  parseScopes,
   validateAuthServer,
   validateBasicInfo,
   validateScopesConfig,
@@ -90,10 +91,18 @@ export function XAARegistrationWizard({
   const [step, setStep] = useState<StepId>(1);
   const [draft, setDraft] = useState<RegistrationDraft>(EMPTY_DRAFT);
   const [pickedServerName, setPickedServerName] = useState("");
+  // After a pick the wizard collapses to a one-click review; "Edit details"
+  // expands the full step flow again without losing the pick.
+  const [stepsExpanded, setStepsExpanded] = useState(false);
   const [validationError, setValidationError] = useState<string | null>(null);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
   const stepHeadingRef = useRef<HTMLHeadingElement | null>(null);
+
+  // Review mode is keyed STRICTLY on an explicit pick: draft prefills from
+  // any other source (editing today, debugger prefill on other branches)
+  // must land in the step flow, never in the collapsed review.
+  const isReview = Boolean(pickedServerName) && !stepsExpanded;
 
   // Reset to a fresh (or edit-seeded) draft whenever the dialog opens. The
   // secret field is intentionally never pre-filled.
@@ -113,6 +122,7 @@ export function XAARegistrationWizard({
           : { ...EMPTY_DRAFT, ...(prefill ?? {}) },
       );
       setPickedServerName("");
+      setStepsExpanded(false);
       setValidationError(null);
       setSaveError(null);
     }
@@ -144,7 +154,20 @@ export function XAARegistrationWizard({
     const server = serverOptions.find((s) => s.name === name);
     if (!server) return;
     setPickedServerName(name);
+    setStepsExpanded(false);
+    setStep(1);
+    setSaveError(null);
     updateDraft(draftFromServer(server));
+  };
+
+  // Back to the unpicked state: manual wizard with a blank draft.
+  const handleClearPick = () => {
+    setPickedServerName("");
+    setStepsExpanded(false);
+    setStep(1);
+    setDraft(EMPTY_DRAFT);
+    setValidationError(null);
+    setSaveError(null);
   };
 
   const handleNext = () => {
@@ -157,12 +180,9 @@ export function XAARegistrationWizard({
     setStep((current) => (current === 1 ? 2 : 3));
   };
 
-  const handleSave = async () => {
-    const error = validateScopesConfig(draft);
-    if (error) {
-      setValidationError(error);
-      return;
-    }
+  // The single save path — review's "Register app" and step 3's "Save" both
+  // land here with the same payload.
+  const persist = async () => {
     setIsSaving(true);
     setSaveError(null);
     try {
@@ -183,6 +203,62 @@ export function XAARegistrationWizard({
     }
   };
 
+  const handleSave = async () => {
+    const error = validateScopesConfig(draft);
+    if (error) {
+      setValidationError(error);
+      return;
+    }
+    await persist();
+  };
+
+  // One-click register: run every step's validation; on the first failure,
+  // expand the step flow at the offending step with the inline message
+  // instead of dead-ending in the review.
+  const handleRegisterFromReview = async () => {
+    const checks: Array<[StepId, string | null]> = [
+      [1, validateBasicInfo(draft)],
+      [2, validateAuthServer(draft)],
+      [3, validateScopesConfig(draft)],
+    ];
+    const failed = checks.find(([, error]) => error !== null);
+    if (failed) {
+      setValidationError(failed[1]);
+      setStep(failed[0]);
+      setStepsExpanded(true);
+      return;
+    }
+    await persist();
+  };
+
+  // The picker is shown on step 1 AND in review mode (so re-picking works
+  // everywhere). Hidden while editing (the registration already has its
+  // details) and when the project has no HTTP servers to pick from.
+  const showPicker = !editing && serverOptions.length > 0;
+  const serverPicker = showPicker && (
+    <div className="space-y-1.5">
+      <Label htmlFor="xaa-reg-server-picker">
+        Start from an existing server
+      </Label>
+      <Select value={pickedServerName} onValueChange={handlePickServer}>
+        <SelectTrigger id="xaa-reg-server-picker">
+          <SelectValue placeholder="Pick one of your servers" />
+        </SelectTrigger>
+        <SelectContent>
+          {serverOptions.map((server) => (
+            <SelectItem key={server.name} value={server.name}>
+              {server.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <p className="text-xs text-muted-foreground">
+        Copies the server&apos;s saved details into the form as a one-time
+        snapshot — edit anything before saving.
+      </p>
+    </div>
+  );
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-lg">
@@ -196,84 +272,95 @@ export function XAARegistrationWizard({
           </DialogDescription>
         </DialogHeader>
 
-        <ol className="flex items-center gap-2" aria-label="Registration steps">
-          {STEPS.map((s) => {
-            const isCurrent = s.id === step;
-            return (
-              <li
-                key={s.id}
-                aria-current={isCurrent ? "step" : undefined}
-                className={cn(
-                  "flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs",
-                  isCurrent
-                    ? "border-primary/50 bg-primary/10 font-medium text-foreground"
-                    : "border-border text-muted-foreground",
-                )}
-              >
-                <span className="font-mono">{s.id}</span>
-                {s.title}
-              </li>
-            );
-          })}
-        </ol>
+        {isReview ? (
+          <>
+            {serverPicker}
 
-        <h3
-          ref={stepHeadingRef}
-          tabIndex={-1}
-          className="text-sm font-semibold outline-none"
-        >
-          {STEPS.find((s) => s.id === step)?.title}
-        </h3>
-
-        {step === 1 ? (
-          <div className="space-y-4">
-            {/* Registering starts from picking one of the project's servers;
-                manual entry below is the fallback. Hidden while editing (the
-                registration already has its details) and when the project has
-                no HTTP servers to pick from. */}
-            {!editing && serverOptions.length > 0 && (
-              <>
-                <div className="space-y-1.5">
-                  <Label htmlFor="xaa-reg-server-picker">
-                    Start from an existing server
-                  </Label>
-                  <Select
-                    value={pickedServerName}
-                    onValueChange={handlePickServer}
-                  >
-                    <SelectTrigger id="xaa-reg-server-picker">
-                      <SelectValue placeholder="Pick one of your servers" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {serverOptions.map((server) => (
-                        <SelectItem key={server.name} value={server.name}>
-                          {server.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  <p className="text-xs text-muted-foreground">
-                    Copies the server&apos;s saved details into the form as a
-                    one-time snapshot — edit anything before saving.
-                  </p>
-                </div>
-                <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                  <span aria-hidden="true" className="h-px flex-1 bg-border" />
-                  or enter details manually
-                  <span aria-hidden="true" className="h-px flex-1 bg-border" />
-                </div>
-              </>
-            )}
-            <BasicInfoStep draft={draft} onChange={updateDraft} />
-          </div>
-        ) : step === 2 ? (
-          <AuthServerStep
-            draft={draft}
-            onChange={updateDraft}
-            hasStoredSecret={Boolean(editing?.hasSecret)}
-          />
+            <h3
+              ref={stepHeadingRef}
+              tabIndex={-1}
+              className="text-sm font-semibold outline-none"
+            >
+              Review &amp; register
+            </h3>
+            <ReviewSummary draft={draft} />
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={handleClearPick}
+              disabled={isSaving}
+              className="self-start px-0 text-xs text-muted-foreground hover:text-foreground"
+            >
+              Clear selection and start from scratch
+            </Button>
+          </>
         ) : (
-          <ScopesConfigStep draft={draft} onChange={updateDraft} />
+          <>
+            <ol
+              className="flex items-center gap-2"
+              aria-label="Registration steps"
+            >
+              {STEPS.map((s) => {
+                const isCurrent = s.id === step;
+                return (
+                  <li
+                    key={s.id}
+                    aria-current={isCurrent ? "step" : undefined}
+                    className={cn(
+                      "flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs",
+                      isCurrent
+                        ? "border-primary/50 bg-primary/10 font-medium text-foreground"
+                        : "border-border text-muted-foreground",
+                    )}
+                  >
+                    <span className="font-mono">{s.id}</span>
+                    {s.title}
+                  </li>
+                );
+              })}
+            </ol>
+
+            <h3
+              ref={stepHeadingRef}
+              tabIndex={-1}
+              className="text-sm font-semibold outline-none"
+            >
+              {STEPS.find((s) => s.id === step)?.title}
+            </h3>
+
+            {step === 1 ? (
+              <div className="space-y-4">
+                {/* Registering starts from picking one of the project's
+                    servers; manual entry below is the fallback. */}
+                {showPicker && (
+                  <>
+                    {serverPicker}
+                    <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                      <span
+                        aria-hidden="true"
+                        className="h-px flex-1 bg-border"
+                      />
+                      or enter details manually
+                      <span
+                        aria-hidden="true"
+                        className="h-px flex-1 bg-border"
+                      />
+                    </div>
+                  </>
+                )}
+                <BasicInfoStep draft={draft} onChange={updateDraft} />
+              </div>
+            ) : step === 2 ? (
+              <AuthServerStep
+                draft={draft}
+                onChange={updateDraft}
+                hasStoredSecret={Boolean(editing?.hasSecret)}
+              />
+            ) : (
+              <ScopesConfigStep draft={draft} onChange={updateDraft} />
+            )}
+          </>
         )}
 
         {(validationError || saveError) && (
@@ -283,34 +370,136 @@ export function XAARegistrationWizard({
         )}
 
         <DialogFooter>
-          {step > 1 && (
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => setStep((current) => (current === 3 ? 2 : 1))}
-              disabled={isSaving}
-            >
-              Back
-            </Button>
-          )}
-          {step < 3 ? (
-            <Button type="button" onClick={handleNext}>
-              Next
-            </Button>
+          {isReview ? (
+            <>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setStepsExpanded(true)}
+                disabled={isSaving}
+              >
+                Edit details
+              </Button>
+              <Button
+                type="button"
+                onClick={handleRegisterFromReview}
+                disabled={isSaving}
+              >
+                {isSaving ? (
+                  <>
+                    <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />
+                    Registering
+                  </>
+                ) : (
+                  "Register app"
+                )}
+              </Button>
+            </>
           ) : (
-            <Button type="button" onClick={handleSave} disabled={isSaving}>
-              {isSaving ? (
-                <>
-                  <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />
-                  Saving
-                </>
-              ) : (
-                "Save"
+            <>
+              {step > 1 && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => setStep((current) => (current === 3 ? 2 : 1))}
+                  disabled={isSaving}
+                >
+                  Back
+                </Button>
               )}
-            </Button>
+              {step < 3 ? (
+                <Button type="button" onClick={handleNext}>
+                  Next
+                </Button>
+              ) : (
+                <Button type="button" onClick={handleSave} disabled={isSaving}>
+                  {isSaving ? (
+                    <>
+                      <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />
+                      Saving
+                    </>
+                  ) : (
+                    "Save"
+                  )}
+                </Button>
+              )}
+            </>
           )}
         </DialogFooter>
       </DialogContent>
     </Dialog>
+  );
+}
+
+function ReviewRow({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex items-start gap-2">
+      <dt className="w-24 shrink-0 text-muted-foreground">{label}</dt>
+      <dd className="min-w-0 flex-1">{children}</dd>
+    </div>
+  );
+}
+
+/** Read-only summary of exactly what "Register app" will save. Honest about
+ * provenance: the auth-server mode is the wizard's default (a pick never sets
+ * it), while the issuer/client id/scopes are the picked server's snapshot. */
+function ReviewSummary({ draft }: { draft: RegistrationDraft }) {
+  const scopes = parseScopes(draft.scopes);
+  return (
+    <dl
+      data-testid="xaa-reg-review"
+      className="space-y-2 rounded-md border border-border bg-muted/30 px-3 py-2.5 text-xs"
+    >
+      <ReviewRow label="Name">
+        <span className="font-medium">{draft.name}</span>
+      </ReviewRow>
+      <ReviewRow label="Resource URL">
+        <code className="font-mono break-all">{draft.resourceUrl}</code>
+      </ReviewRow>
+      <ReviewRow label="Auth server">
+        {draft.authServerMode === "mcpjam" ? (
+          "MCPJam test auth server"
+        ) : draft.issuer.trim() ? (
+          <>
+            My own auth server —{" "}
+            <code className="font-mono break-all">{draft.issuer.trim()}</code>
+          </>
+        ) : (
+          <>
+            My own auth server{" "}
+            <span className="text-muted-foreground">(no issuer set)</span>
+          </>
+        )}
+      </ReviewRow>
+      {draft.targetClientId.trim() && (
+        <ReviewRow label="Client ID">
+          <code className="font-mono break-all">
+            {draft.targetClientId.trim()}
+          </code>
+        </ReviewRow>
+      )}
+      <ReviewRow label="Scopes">
+        {scopes.length > 0 ? (
+          <span className="flex flex-wrap gap-1">
+            {scopes.map((scope) => (
+              <code
+                key={scope}
+                className="rounded bg-muted px-1.5 py-0.5 font-mono"
+              >
+                {scope}
+              </code>
+            ))}
+          </span>
+        ) : (
+          <span className="text-muted-foreground">none declared</span>
+        )}
+      </ReviewRow>
+    </dl>
   );
 }

--- a/mcpjam-inspector/client/src/components/xaa/registration/__tests__/XAARegistrationWizard.test.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/registration/__tests__/XAARegistrationWizard.test.tsx
@@ -113,6 +113,16 @@ const HTTP_SERVER = makeServer(
   { xaaAuthzIssuer: "https://idp.example.com" },
 );
 
+const MCPJAM_MODE_SERVER = makeServer(
+  "prod-mcp",
+  {
+    url: "https://prod.example.com/mcp",
+    clientId: "client-abc",
+    oauthScopes: ["read", "write"],
+  },
+  { xaaAuthzIssuer: "https://idp.example.com", authServerMode: "mcpjam" },
+);
+
 const STDIO_SERVER = makeServer("local-stdio", {
   command: "npx",
   args: ["my-server"],
@@ -490,6 +500,7 @@ describe("XAARegistrationWizard", () => {
 
       await user.click(screen.getByLabelText(PICKER_LABEL));
       await user.click(screen.getByRole("option", { name: "prod-mcp" }));
+      await user.click(screen.getByRole("button", { name: "Edit details" }));
 
       expect(screen.getByLabelText("Name")).toHaveValue("prod-mcp");
       expect(screen.getByLabelText("Resource URL")).toHaveValue(
@@ -523,6 +534,7 @@ describe("XAARegistrationWizard", () => {
 
       await user.click(screen.getByLabelText(PICKER_LABEL));
       await user.click(screen.getByRole("option", { name: "prod-mcp" }));
+      await user.click(screen.getByRole("button", { name: "Edit details" }));
 
       // Manual edit after the pick sticks.
       await user.clear(screen.getByLabelText("Name"));
@@ -534,6 +546,7 @@ describe("XAARegistrationWizard", () => {
       // draft never mixes two servers' details.
       await user.click(screen.getByLabelText(PICKER_LABEL));
       await user.click(screen.getByRole("option", { name: "staging-mcp" }));
+      await user.click(screen.getByRole("button", { name: "Edit details" }));
       expect(screen.getByLabelText("Name")).toHaveValue("staging-mcp");
       expect(screen.getByLabelText("Resource URL")).toHaveValue(
         "https://staging.example.com/mcp",
@@ -565,6 +578,7 @@ describe("XAARegistrationWizard", () => {
 
       await user.click(screen.getByLabelText(PICKER_LABEL));
       await user.click(screen.getByRole("option", { name: "prod-mcp" }));
+      await user.click(screen.getByRole("button", { name: "Edit details" }));
       expect(screen.getByLabelText("Name")).toHaveValue("prod-mcp");
 
       await user.click(screen.getByRole("button", { name: "Next" }));
@@ -577,6 +591,7 @@ describe("XAARegistrationWizard", () => {
 
       await user.click(screen.getByLabelText(PICKER_LABEL));
       await user.click(screen.getByRole("option", { name: "prod-mcp" }));
+      await user.click(screen.getByRole("button", { name: "Edit details" }));
       await user.click(screen.getByRole("button", { name: "Next" }));
       await user.type(
         screen.getByLabelText("Token endpoint"),
@@ -598,6 +613,204 @@ describe("XAARegistrationWizard", () => {
         targetClientId: "client-abc",
         scopes: ["read", "write"],
       });
+    });
+  });
+
+  describe("one-click review", () => {
+    it("collapses to a review summary of the derived values after a pick", async () => {
+      const user = userEvent.setup();
+      renderWizardWithServers({ "prod-mcp": HTTP_SERVER });
+
+      await user.click(screen.getByLabelText(PICKER_LABEL));
+      await user.click(screen.getByRole("option", { name: "prod-mcp" }));
+
+      const review = screen.getByTestId("xaa-reg-review");
+      expect(review).toHaveTextContent("prod-mcp");
+      expect(review).toHaveTextContent("https://prod.example.com/mcp");
+      // The pick never sets the auth-server mode — the summary presents the
+      // wizard's default honestly, plus the server's issuer snapshot.
+      expect(review).toHaveTextContent("My own auth server");
+      expect(review).toHaveTextContent("https://idp.example.com");
+      expect(review).toHaveTextContent("client-abc");
+      expect(review).toHaveTextContent("read");
+      expect(review).toHaveTextContent("write");
+
+      // The step flow is collapsed: no step chips, no form fields.
+      expect(
+        screen.queryByRole("list", { name: "Registration steps" }),
+      ).toBeNull();
+      expect(screen.queryByLabelText("Name")).toBeNull();
+      expect(
+        screen.getByRole("button", { name: "Register app" }),
+      ).toBeInTheDocument();
+      // Re-picking stays possible from the review.
+      expect(screen.getByLabelText(PICKER_LABEL)).toBeInTheDocument();
+    });
+
+    it("shows 'none declared' scopes and the missing issuer honestly", async () => {
+      const user = userEvent.setup();
+      renderWizardWithServers({
+        "staging-mcp": makeServer("staging-mcp", {
+          url: "https://staging.example.com/mcp",
+        }),
+      });
+
+      await user.click(screen.getByLabelText(PICKER_LABEL));
+      await user.click(screen.getByRole("option", { name: "staging-mcp" }));
+
+      const review = screen.getByTestId("xaa-reg-review");
+      expect(review).toHaveTextContent("no issuer set");
+      expect(review).toHaveTextContent("none declared");
+      expect(review).not.toHaveTextContent("Client ID");
+    });
+
+    it("registers with the exact same payload the step flow sends", async () => {
+      const user = userEvent.setup();
+
+      // Route A: pick, then walk the steps and save (today's flow).
+      const stepFlow = renderWizardWithServers({ "prod-mcp": HTTP_SERVER });
+      await user.click(screen.getByLabelText(PICKER_LABEL));
+      await user.click(screen.getByRole("option", { name: "prod-mcp" }));
+      await user.click(screen.getByRole("button", { name: "Edit details" }));
+      await user.click(screen.getByRole("button", { name: "Next" }));
+      await user.type(
+        screen.getByLabelText("Token endpoint"),
+        "https://idp.example.com/oauth/token",
+      );
+      await user.click(screen.getByRole("button", { name: "Next" }));
+      await user.click(screen.getByRole("button", { name: "Save" }));
+      await waitFor(() => expect(upsert).toHaveBeenCalledTimes(1));
+      stepFlow.unmount();
+
+      // Route B: same draft via one click. The token endpoint is typed
+      // before the pick (a pick never touches it), so validation passes.
+      renderWizardWithServers({ "prod-mcp": HTTP_SERVER });
+      await user.type(screen.getByLabelText("Name"), "placeholder");
+      await user.type(
+        screen.getByLabelText("Resource URL"),
+        "https://placeholder.example.com/mcp",
+      );
+      await user.click(screen.getByRole("button", { name: "Next" }));
+      await user.type(
+        screen.getByLabelText("Token endpoint"),
+        "https://idp.example.com/oauth/token",
+      );
+      await user.click(screen.getByRole("button", { name: "Back" }));
+      await user.click(screen.getByLabelText(PICKER_LABEL));
+      await user.click(screen.getByRole("option", { name: "prod-mcp" }));
+      await user.click(screen.getByRole("button", { name: "Register app" }));
+
+      await waitFor(() => expect(upsert).toHaveBeenCalledTimes(2));
+      expect(upsert.mock.calls[1]![0]).toEqual(upsert.mock.calls[0]![0]);
+      expect(trackMock).toHaveBeenCalledWith(
+        "xaa_resource_app_saved",
+        expect.objectContaining({
+          location: "xaa_registration_wizard",
+          resource_type: "mcp",
+          auth_server_mode: "own",
+        }),
+      );
+    });
+
+    it("drops into edit mode at the failing step instead of dead-ending", async () => {
+      const user = userEvent.setup();
+      renderWizardWithServers({ "prod-mcp": HTTP_SERVER });
+
+      await user.click(screen.getByLabelText(PICKER_LABEL));
+      await user.click(screen.getByRole("option", { name: "prod-mcp" }));
+      // Own-AS mode without a token endpoint: the one-click validation fails
+      // at step 2, so the wizard expands there with the inline message.
+      await user.click(screen.getByRole("button", { name: "Register app" }));
+
+      expect(upsert).not.toHaveBeenCalled();
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "Token endpoint is required",
+      );
+      const steps = screen.getAllByRole("listitem");
+      expect(steps[1]).toHaveAttribute("aria-current", "step");
+      expect(screen.getByLabelText("Token endpoint")).toHaveValue("");
+    });
+
+    it("'Edit details' expands the prefilled step flow with the picker intact", async () => {
+      const user = userEvent.setup();
+      renderWizardWithServers({ "prod-mcp": HTTP_SERVER });
+
+      await user.click(screen.getByLabelText(PICKER_LABEL));
+      await user.click(screen.getByRole("option", { name: "prod-mcp" }));
+      await user.click(screen.getByRole("button", { name: "Edit details" }));
+
+      expect(
+        screen.getByRole("list", { name: "Registration steps" }),
+      ).toBeInTheDocument();
+      expect(screen.getByLabelText("Name")).toHaveValue("prod-mcp");
+      expect(screen.getByLabelText(PICKER_LABEL)).toBeInTheDocument();
+      expect(screen.queryByTestId("xaa-reg-review")).toBeNull();
+    });
+
+    it("re-picking from edit mode returns to the review", async () => {
+      const user = userEvent.setup();
+      renderWizardWithServers({
+        "prod-mcp": HTTP_SERVER,
+        "staging-mcp": makeServer("staging-mcp", {
+          url: "https://staging.example.com/mcp",
+        }),
+      });
+
+      await user.click(screen.getByLabelText(PICKER_LABEL));
+      await user.click(screen.getByRole("option", { name: "prod-mcp" }));
+      await user.click(screen.getByRole("button", { name: "Edit details" }));
+      await user.click(screen.getByLabelText(PICKER_LABEL));
+      await user.click(screen.getByRole("option", { name: "staging-mcp" }));
+
+      expect(screen.getByTestId("xaa-reg-review")).toBeInTheDocument();
+      expect(screen.getByTestId("xaa-reg-review")).toHaveTextContent(
+        "staging-mcp",
+      );
+    });
+
+    it("clearing the pick returns to the blank manual wizard", async () => {
+      const user = userEvent.setup();
+      renderWizardWithServers({ "prod-mcp": HTTP_SERVER });
+
+      await user.click(screen.getByLabelText(PICKER_LABEL));
+      await user.click(screen.getByRole("option", { name: "prod-mcp" }));
+      await user.click(
+        screen.getByRole("button", {
+          name: "Clear selection and start from scratch",
+        }),
+      );
+
+      expect(screen.queryByTestId("xaa-reg-review")).toBeNull();
+      expect(screen.getByLabelText("Name")).toHaveValue("");
+      expect(screen.getByLabelText(PICKER_LABEL)).toBeInTheDocument();
+      expect(
+        screen.getByRole("list", { name: "Registration steps" }),
+      ).toBeInTheDocument();
+    });
+
+    it("surfaces the save error in review mode", async () => {
+      upsert.mockRejectedValueOnce(new Error("backend said no"));
+      const user = userEvent.setup();
+      renderWizardWithServers({ "prod-mcp": MCPJAM_MODE_SERVER });
+
+      // The server row stores authServerMode "mcpjam"; the pick carries it
+      // over, so the one-click path passes auth-server validation with no
+      // token endpoint.
+      await user.click(screen.getByLabelText(PICKER_LABEL));
+      await user.click(screen.getByRole("option", { name: "prod-mcp" }));
+
+      expect(screen.getByTestId("xaa-reg-review")).toHaveTextContent(
+        "MCPJam test auth server",
+      );
+      await user.click(screen.getByRole("button", { name: "Register app" }));
+
+      await waitFor(() =>
+        expect(screen.getByRole("alert")).toHaveTextContent("backend said no"),
+      );
+      // Still in review — the user can retry or edit.
+      expect(
+        screen.getByRole("button", { name: "Register app" }),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/mcpjam-inspector/client/src/components/xaa/registration/wizard-draft.ts
+++ b/mcpjam-inspector/client/src/components/xaa/registration/wizard-draft.ts
@@ -68,7 +68,13 @@ export function draftFromServer(
   server: ServerWithName,
 ): Pick<
   RegistrationDraft,
-  "name" | "resourceType" | "resourceUrl" | "issuer" | "targetClientId" | "scopes"
+  | "name"
+  | "resourceType"
+  | "resourceUrl"
+  | "issuer"
+  | "targetClientId"
+  | "scopes"
+  | "authServerMode"
 > {
   const httpConfig =
     "url" in server.config ? (server.config as HttpServerConfig) : null;
@@ -83,6 +89,10 @@ export function draftFromServer(
     scopes: Array.isArray(oauthScopes)
       ? oauthScopes.filter((s): s is string => typeof s === "string").join(" ")
       : "",
+    // The server row knows which IdP mints for it; carrying it over makes a
+    // pick of an MCPJam-test-IdP server truly one-click (no auth-server step
+    // to fall into). Servers without a stored mode keep the wizard default.
+    authServerMode: server.authServerMode ?? "own",
   };
 }
 


### PR DESCRIPTION
## Summary
Follow-up to the merged setup-center stack (#3197): after picking an existing server in the Register wizard, the three-step form was still shown even though every field was already known. Now a pick collapses to a compact read-only review — name, resource URL, auth server, client ID, scope chips — with a single **Register app** button.

- **One click**: "Register app" runs the same validation and the exact same upsert payload as walking the steps (payload parity asserted in tests). A validation gap (e.g. own-AS mode missing its token endpoint) drops into edit mode at the relevant step with the existing inline message — never a dead end.
- **Edit details** expands the familiar three-step wizard, prefilled; re-picking from edit collapses back to review; clearing the pick returns to the blank manual wizard (unchanged).
- Picks now also carry the server row's stored `authServerMode`, so a server configured for the MCPJam test IdP registers in one click with nothing to fill in.
- Respects #3224's re-gate: all surfaces stay behind the `xaa-registration` flag.

## Test plan
- Wizard suite 28 tests (13 new/updated: review summary, payload parity across both routes, validation drop-in, edit expansion, re-pick, clear, save-error surfaced in review). Full xaa client suites 139 green; client typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OAuth/resource registration UX and upsert payloads (auth server mode from picks); client-only with broad wizard test coverage, but incorrect snapshots could mis-register resources.
> 
> **Overview**
> After an explicit **pick** from the project server catalog, the register wizard **collapses** into a read-only **Review & register** view (name, resource URL, auth server, client ID, scopes) with **Register app** instead of the three-step form. Edit mode, debugger prefill, and editing an existing app still use the step flow.
> 
> **Register app** runs all step validations and calls the same `persist` / `upsert` path as step 3 **Save**; validation failures expand the wizard at the failing step with the existing inline message. **Edit details**, re-pick, and **Clear selection** restore the full wizard or a blank manual flow.
> 
> `draftFromServer` now snapshots **`authServerMode`** from the server row (defaulting to `own`), so MCPJam-test-IdP servers can register in one click without the auth-server step. Tests cover review UI, payload parity, validation drop-in, and save errors in review mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecdce2fd5ae50ee174e5835c76cb5011da0c3c36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Picking an existing server in the XAA registration wizard now collapses to a compact review with a single Register app button, making registration one click when details are already known. Validation runs before saving; if anything’s missing, it opens the correct step with the inline error.

- New Features
  - After a pick, show a read-only summary (name, resource URL, auth server mode + issuer, client ID, scope chips) with one-click Register app using the same upsert payload as the step flow.
  - Run all step validations before saving; on failure, expand the step flow at the failing step with the existing inline message.
  - Edit details expands the prefilled steps; picker stays available for re-picking; Clear selection returns to the blank manual wizard.
  - Carry `authServerMode` from the server row so MCPJam test IdP servers can register in one click; issuer/client ID/scopes are taken from the server snapshot.
  - Review mode only activates on an explicit pick; other prefills keep the step flow.
  - Feature remains gated behind `xaa-registration`.

- Refactors
  - Unified save path (`persist`) for review and step 3 so both routes send identical payloads; parity covered by tests.

<sup>Written for commit ecdce2fd5ae50ee174e5835c76cb5011da0c3c36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

