### PR TITLE
fix(xaa): CIMD document fetch dies with ERR_INVALID_IP_ADDRESS on Node 20+

### DIFF
--- a/.changeset/xaa-cimd-pinned-lookup-fix.md
+++ b/.changeset/xaa-cimd-pinned-lookup-fix.md
@@ -1,0 +1,8 @@
+---
+"@mcpjam/sdk": patch
+"@mcpjam/cli": patch
+---
+
+Fix `mcpjam xaa run --registration cimd` failing with `Invalid IP address: undefined` on Node 20+.
+
+The SSRF-hardened CIMD document fetch (`fetchPinnedPublicDocument`) pins DNS through a custom `lookup` function, but always answered with a single address string. With `autoSelectFamily` (the Node ≥ 20 default) the socket invokes the lookup with `all: true` and requires an array of `{address, family}` entries, so every CIMD fetch — public and confidential (`--client-auth private-key-jwt`) — died before any request was sent. The lookup now honors `options.all`; every resolved address is still validated against the private/reserved-range blocklist in both callback shapes.

--- a/sdk/src/oauth-proxy.ts
+++ b/sdk/src/oauth-proxy.ts
@@ -316,10 +316,15 @@ export async function fetchPinnedPublicDocument(
   const timeoutMs =
     opts.timeoutMs && opts.timeoutMs > 0 ? opts.timeoutMs : 5000;
 
-  // Resolve once, validate every candidate, and pin the chosen IP into the
-  // connection. The socket uses exactly this address — no re-resolution — which
-  // is what actually closes the DNS-rebinding window.
-  const pinningLookup: LookupFunction = (hostname, _options, callback) => {
+  // Resolve once, validate every candidate, and pin the validated result into
+  // the connection. The socket uses exactly these addresses — no re-resolution —
+  // which is what actually closes the DNS-rebinding window.
+  //
+  // The callback shape must follow `options.all`: with autoSelectFamily (the
+  // Node ≥20 default) the socket passes `all: true` and expects an ARRAY of
+  // {address, family} entries; answering with a bare string there makes Node
+  // throw ERR_INVALID_IP_ADDRESS ("Invalid IP address: undefined").
+  const pinningLookup: LookupFunction = (hostname, options, callback) => {
     dnsLookupCb(hostname, { all: true, verbatim: true }, (err, addresses) => {
       if (err) return callback(err, "", 0);
       const list = Array.isArray(addresses) ? addresses : [];
@@ -341,6 +346,14 @@ export async function fetchPinnedPublicDocument(
             0,
           );
         }
+      }
+      if (typeof options === "object" && options?.all) {
+        return (
+          callback as unknown as (
+            err: NodeJS.ErrnoException | null,
+            addresses: { address: string; family: number }[],
+          ) => void
+        )(null, list);
       }
       callback(null, list[0].address, list[0].family);
     });

--- a/sdk/tests/oauth-proxy-pinned-lookup.test.ts
+++ b/sdk/tests/oauth-proxy-pinned-lookup.test.ts
@@ -1,0 +1,113 @@
+// Regression coverage for the pinning DNS lookup inside
+// fetchPinnedPublicDocument. With autoSelectFamily (the Node ≥20 default) the
+// socket invokes the custom lookup with `all: true` and requires an ARRAY
+// callback; answering with a bare string made every CIMD document fetch die
+// with ERR_INVALID_IP_ADDRESS ("Invalid IP address: undefined").
+import { describe, expect, it, vi } from "vitest";
+
+const requestMock = vi.hoisted(() => vi.fn());
+const lookupMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:https", () => ({
+  __esModule: true,
+  default: { request: requestMock },
+  request: requestMock,
+}));
+vi.mock("node:dns", () => ({
+  __esModule: true,
+  lookup: lookupMock,
+}));
+
+import { fetchPinnedPublicDocument } from "../src/oauth-proxy.js";
+
+type LookupCallbackResult = {
+  err: unknown;
+  addresses: unknown;
+  family: unknown;
+};
+
+/** Capture the `lookup` option handed to https.request, failing the request
+ * immediately so fetchPinnedPublicDocument's promise settles. */
+async function capturePinningLookup(): Promise<
+  (hostname: string, options: unknown, cb: (...args: unknown[]) => void) => void
+> {
+  let captured:
+    | ((hostname: string, options: unknown, cb: (...args: unknown[]) => void) => void)
+    | undefined;
+  requestMock.mockImplementation(
+    (_url: unknown, options: { lookup?: typeof captured }) => {
+      captured = options.lookup;
+      const handlers: Record<string, (err: Error) => void> = {};
+      const req = {
+        on(event: string, handler: (err: Error) => void) {
+          handlers[event] = handler;
+          return req;
+        },
+        end() {
+          queueMicrotask(() => handlers.error?.(new Error("stop after capture")));
+        },
+        destroy() {},
+      };
+      return req;
+    },
+  );
+  await expect(
+    fetchPinnedPublicDocument("https://app.example.com/meta.json"),
+  ).rejects.toThrow("stop after capture");
+  expect(captured).toBeTypeOf("function");
+  return captured!;
+}
+
+function invokeLookup(
+  lookup: (hostname: string, options: unknown, cb: (...args: unknown[]) => void) => void,
+  options: unknown,
+): Promise<LookupCallbackResult> {
+  return new Promise((resolve) => {
+    lookup("app.example.com", options, (err, addresses, family) =>
+      resolve({ err, addresses, family }),
+    );
+  });
+}
+
+const PUBLIC_V4 = { address: "93.184.216.34", family: 4 };
+const PUBLIC_V6 = { address: "2606:2800:220:1:248:1893:25c8:1946", family: 6 };
+
+describe("fetchPinnedPublicDocument pinning lookup", () => {
+  it("answers with the address ARRAY when the socket passes all: true (autoSelectFamily)", async () => {
+    lookupMock.mockImplementation(
+      (_hostname: string, _opts: unknown, cb: (...args: unknown[]) => void) =>
+        cb(null, [PUBLIC_V4, PUBLIC_V6]),
+    );
+    const lookup = await capturePinningLookup();
+
+    const result = await invokeLookup(lookup, { all: true });
+    expect(result.err).toBeNull();
+    expect(result.addresses).toEqual([PUBLIC_V4, PUBLIC_V6]);
+  });
+
+  it("answers with a single address + family when all is not set", async () => {
+    lookupMock.mockImplementation(
+      (_hostname: string, _opts: unknown, cb: (...args: unknown[]) => void) =>
+        cb(null, [PUBLIC_V4, PUBLIC_V6]),
+    );
+    const lookup = await capturePinningLookup();
+
+    const result = await invokeLookup(lookup, { family: 0 });
+    expect(result.err).toBeNull();
+    expect(result.addresses).toBe(PUBLIC_V4.address);
+    expect(result.family).toBe(PUBLIC_V4.family);
+  });
+
+  it("rejects when ANY resolved address is private/reserved, in both callback shapes", async () => {
+    lookupMock.mockImplementation(
+      (_hostname: string, _opts: unknown, cb: (...args: unknown[]) => void) =>
+        cb(null, [PUBLIC_V4, { address: "10.0.0.5", family: 4 }]),
+    );
+    const lookup = await capturePinningLookup();
+
+    for (const options of [{ all: true }, { family: 0 }]) {
+      const result = await invokeLookup(lookup, options);
+      expect(String(result.err)).toMatch(/private or reserved address \(10\.0\.0\.5\)/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`mcpjam xaa run --registration cimd` — both public and confidential (`--client-auth private-key-jwt`) — fails 100% of the time in the published CLI with:

```
fetch_client_metadata_document: Invalid IP address: undefined
```

The flow dies before any request is sent to the target server.

**Root cause:** the SSRF-hardened CIMD document fetch (`fetchPinnedPublicDocument` in `sdk/src/oauth-proxy.ts`) pins DNS through a custom `lookup` function that always answers with a single address string. With `autoSelectFamily` — the default since Node 20, which is also the CLI's minimum supported version — the socket invokes the lookup with `all: true` and requires an **array** of `{address, family}` entries. Node then reads `.address` off the string, gets `undefined`, and throws `ERR_INVALID_IP_ADDRESS`.

**Fix:** honor `options.all` in the lookup callback. Every resolved address is still validated against the private/reserved-range blocklist in both callback shapes, so the SSRF/DNS-rebinding posture is unchanged — same resolve-once-and-pin behavior, same rejections.

## Why tests missed it

The existing `fetchPinnedPublicDocument` tests only cover the pre-connection guards (non-HTTPS, literal private host); nothing exercised the lookup contract on a real socket path. The new regression test captures the `lookup` option handed to `https.request` and pins the callback contract directly:

- `all: true` (autoSelectFamily) → array of validated addresses
- classic shape → single address + family
- private/reserved rejection in **both** shapes

## Verification

- Repro: 15-line script using `node:https` + a string-answering custom lookup reproduces `Invalid IP address: undefined` on Node 26.
- End-to-end against a real RAS (the `xaa-mcp-server` reference Worker, `wrangler dev`, own-AS mode): published `@mcpjam/cli@3.15.0` fails at `fetch_client_metadata_document`; this branch's build completes the full flow — CIMD document fetched, ID-JAG minted/verified, redeemed with `private_key_jwt` at `/token`, `at+jwt` issued, authenticated `/mcp` initialize OK.
- `sdk`: xaa + oauth-proxy suites 328/328; typecheck clean.
- `cli`: 380/380.

Changeset: patch for `@mcpjam/sdk` (the fix) and `@mcpjam/cli` (forces fresh `npx` installs to pick up the fixed SDK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches SSRF-sensitive outbound HTTPS/DNS pinning used for CIMD client metadata; behavior change is narrow but security-relevant if validation were wrong.
> 
> **Overview**
> Fixes **`mcpjam xaa run --registration cimd`** failing on Node 20+ with `Invalid IP address: undefined` before any HTTP request is sent.
> 
> The SSRF-hardened **`fetchPinnedPublicDocument`** custom DNS `lookup` always called back with a single `(address, family)` string. With **`autoSelectFamily`** (Node ≥20 default), the socket passes **`all: true`** and expects an **array** of `{address, family}`; the mismatch triggered **`ERR_INVALID_IP_ADDRESS`**. The lookup now branches on **`options.all`**: array callback when required, classic single-address callback otherwise. **Private/reserved IP validation** on every resolved address is unchanged in both shapes.
> 
> Adds **`oauth-proxy-pinned-lookup.test.ts`** regression tests for the `https.request` lookup contract. Changeset: patch **`@mcpjam/sdk`** and **`@mcpjam/cli`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97912e6988ecd9618a6261c47e316974fd2b51ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CIMD document fetch in `mcpjam xaa run --registration cimd` on Node 20+ failing with `ERR_INVALID_IP_ADDRESS`. The pinned DNS lookup now matches Node’s `autoSelectFamily` contract while keeping SSRF protections.

- **Bug Fixes**
  - Honor `options.all` in the pinned DNS `lookup`. Return an array of `{address, family}` when `all: true`; otherwise return a single address and family.
  - Validate all resolved addresses against private/reserved ranges in both callback shapes.
  - Add regression tests for both shapes and for private/reserved rejection.

- **Dependencies**
  - Patch releases for `@mcpjam/sdk` and `@mcpjam/cli` to ship the fix.

<sup>Written for commit 97912e6988ecd9618a6261c47e316974fd2b51ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

