### PR TITLE
fix(test): mock the xaa-registration flag in XAAFlowTab tests (main is red)

### DIFF
--- a/mcpjam-inspector/client/src/components/__tests__/XAAFlowTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/XAAFlowTab.test.tsx
@@ -11,6 +11,16 @@ vi.mock("@/lib/analytics", () => ({
   track: (...args: unknown[]) => captureMock(...args),
 }));
 
+// The people strip is gated on the xaa-registration flag (#3224). Unmocked,
+// `useFeatureFlagEnabled` returns undefined, so `registrationEnabled === true`
+// is false, the strip never renders, and every "Run as people" assertion reads
+// props off a null capture. Mirrors the mock XAAIdpCard.test.tsx already uses
+// for the same gate.
+let registrationFlag: boolean | undefined = true;
+vi.mock("posthog-js/react", () => ({
+  useFeatureFlagEnabled: () => registrationFlag,
+}));
+
 // Controllable signed-in state: null simulates a guest session.
 let authUser: { email: string } | null = { email: "tester@example.com" };
 vi.mock("@workos-inc/authkit-react", () => ({
@@ -365,6 +375,9 @@ describe("XAAFlowTab", () => {
     orgPeopleState = { people: [], isLoading: false, isAuthenticated: false };
     peopleState = { people: undefined, isLoading: false, isAvailable: false };
     capturedPeopleStripProps = null;
+    // Reset the gate between tests — the flag-off cases below mutate it, and a
+    // leaked `false` would silently hide the strip from every later assertion.
+    registrationFlag = true;
     capturedTargetParams = null;
     capturedWizardProps = null;
     capturedScorecardInput = null;
@@ -1259,6 +1272,21 @@ describe("XAAFlowTab", () => {
         />,
       );
     }
+
+    // Locks the gate #3224 added. It had no coverage here, which is why
+    // re-gating the strip silently broke every assertion in this block instead
+    // of failing one honest test.
+    it.each([[false], [undefined]])(
+      "hides the strip entirely when the xaa-registration flag is %p",
+      (flag) => {
+        registrationFlag = flag as boolean | undefined;
+        seedRoster();
+        currentTarget = personTarget();
+        renderTab();
+
+        expect(capturedPeopleStripProps).toBeNull();
+      },
+    );
 
     it("passes selection through and toggling calls the per-project setter", () => {
       seedRoster();


### PR DESCRIPTION
## `main` is currently red

`Tests` fails on `main` HEAD (`952102374`) — **20 failures** in `XAAFlowTab.test.tsx`, all in the "Run as people" block, every one `Cannot read properties of null`. Reproduced on a pristine detached checkout of `origin/main`, so this is not PR-specific. **Every open PR inherits it.**

## Cause

#3224 re-gated the people strip behind the `xaa-registration` flag:

```tsx
const registrationEnabled = useFeatureFlagEnabled("xaa-registration");
…
{registrationEnabled === true && <XAAPeopleStrip … />}
```

It updated `XAAIdpCard.test.tsx` and `XAARegistrationWizard.test.tsx` for that gate, but **not** `XAAFlowTab.test.tsx`, which never mocked `posthog-js/react`. Unmocked, `useFeatureFlagEnabled` returns `undefined` → `=== true` is false → the strip never renders → `capturedPeopleStripProps` stays `null` → every assertion in the block dereferences null.

## Why nobody caught it

**#3224's own main-push `Tests` run was cancelled**, not passed:

```
failure   | 95210237 | Document mcpjam xaa run command and new flags   <- red surfaces here
cancelled | 5edbefcb | fix(xaa): re-gate persona strip + registration  <- the breaking commit
success   | cd773196 | Document tool approval toggle in MCPJam Agent
```

`test.yml` sets `concurrency: cancel-in-progress: true`, so the next push killed #3224's run before it reported. The red then surfaced on an unrelated docs commit, which makes it look like the docs PR broke things.

Worth a follow-up conversation: the current concurrency group means **any main push can cancel the run that would have caught the previous one**. That's a systematic hole, not bad luck.

## The fix

Mirrors the mock `XAAIdpCard.test.tsx` already uses for this exact gate — 6 lines.

## Plus the coverage whose absence caused this

The gate had **no test in this file**, which is precisely why re-gating produced 20 null-dereferences instead of one honest failure. Added `it.each([[false], [undefined]])` pinning flag-off/flag-undefined to a hidden strip, with a `beforeEach` reset so a leaked `false` can't silently hide the strip from later tests.

Verified by mutation: un-gating the strip (`{true && …}`) fails the two new tests. 61 -> **63 passing**.

## Notes

- **No formatting changes.** This file was already not prettier-clean on `main`; reformatting would bury a 6-line fix in noise.
- I have 6 elicitation PRs (#3226-#3230 + a backend one) blocked behind this red. Deliberately fixed **here** rather than bundled into any of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes; no production behavior or runtime paths are modified.
> 
> **Overview**
> Restores **`XAAFlowTab.test.tsx`** after #3224 gated **`XAAPeopleStrip`** on `useFeatureFlagEnabled("xaa-registration")` with a strict `=== true` check. The suite had no PostHog mock, so the flag read as `undefined`, the strip never mounted, and the whole **Run as people** block failed on null `capturedPeopleStripProps`.
> 
> Adds a controllable **`posthog-js/react`** mock (default flag **on**), matching the pattern used in **`XAAIdpCard`** tests. **`beforeEach`** resets **`registrationFlag`** so flag-off cases cannot leak into later tests.
> 
> Adds **`it.each`** coverage for flag **`false`** and **`undefined`**, asserting the strip stays hidden so future re-gating fails one targeted test instead of many null dereferences.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adced5d1c919b4228da6111ab4ee45726f7e99d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes failing tests on main by mocking the `xaa-registration` feature flag in `XAAFlowTab.test.tsx` and adding coverage for flag-off states. Restores the “Run as people” assertions and unblocks other PRs.

- **Bug Fixes**
  - Mock `useFeatureFlagEnabled` from `posthog-js/react` so the people strip renders when expected.
  - Add tests that pin `false`/`undefined` to a hidden strip and reset the flag between tests.

<sup>Written for commit adced5d1c919b4228da6111ab4ee45726f7e99d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

