### PR TITLE
feat(xaa): OIDC/SAML identity-assertion toggle in the debugger header

### DIFF
--- a/mcpjam-inspector/client/src/components/__tests__/XAAFlowTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/XAAFlowTab.test.tsx
@@ -74,8 +74,12 @@ vi.mock("../xaa/registration/XAARegistrationWizard", () => ({
   },
 }));
 
+let capturedIdpCardProps: any = null;
 vi.mock("../xaa/XAAIdpCard", () => ({
-  XAAIdpCard: () => <div data-testid="xaa-idp-card" />,
+  XAAIdpCard: (props: any) => {
+    capturedIdpCardProps = props;
+    return <div data-testid="xaa-idp-card" />;
+  },
 }));
 
 let capturedServerModalProps: any = null;
@@ -343,6 +347,7 @@ describe("XAAFlowTab", () => {
     capturedMachineConfig = null;
     capturedServerModalProps = null;
     capturedScorecardProps = null;
+    capturedIdpCardProps = null;
     machineShouldComplete = true;
     machineCompleteExtras = {};
     machineCompletionUpdates = {};
@@ -1219,6 +1224,139 @@ describe("XAAFlowTab", () => {
         />
       );
       expect(capturedMachineConfig.registrationStrategy).toBe("preregistered");
+    });
+  });
+
+  describe("identity assertion header toggle (write-through)", () => {
+    // A realistic stored XAA server: the toggle's untouched resave derives
+    // url/clientId/scopes from the config and must preserve the rest of the
+    // stored values by omission.
+    const storedServer = () =>
+      ({
+        staging: {
+          name: "staging",
+          config: { url: "https://staging.mcp.example.com" },
+          hasClientSecret: false,
+          xaaAuthzIssuer: "https://as.example.com",
+          // Stored "auto" is shared with the OAuth flow — the resave must
+          // omit registrationMode so the save-path merge preserves it.
+          registrationMode: "auto",
+          xaaSubject: "stored-subject",
+          xaaEmail: "stored@example.com",
+        },
+      } as any);
+
+    it("passes the persisted format and an enabled control for a testable bar server", () => {
+      render(
+        <XAAFlowTab
+          serverConfigs={{
+            staging: {
+              ...storedServer().staging,
+              xaaIdentityAssertionFormat: "saml",
+            },
+          }}
+          selectedServerName="staging"
+          onSaveServerConfig={vi.fn()}
+        />
+      );
+
+      expect(capturedIdpCardProps.identityAssertionFormat).toBe("saml");
+      expect(capturedIdpCardProps.onIdentityAssertionFormatChange).toEqual(
+        expect.any(Function)
+      );
+      expect(
+        capturedIdpCardProps.identityAssertionFormatDisabledReason
+      ).toBeNull();
+    });
+
+    it("persists a flip to SAML through the modal's save path, preserving stored fields by omission", async () => {
+      const onSaveServerConfig = vi.fn();
+      render(
+        <XAAFlowTab
+          serverConfigs={storedServer()}
+          selectedServerName="staging"
+          onSaveServerConfig={onSaveServerConfig}
+        />
+      );
+
+      await act(async () => {
+        await capturedIdpCardProps.onIdentityAssertionFormatChange("saml");
+      });
+
+      expect(onSaveServerConfig).toHaveBeenCalledTimes(1);
+      const formData = onSaveServerConfig.mock.calls[0][0];
+      expect(formData).toMatchObject({
+        name: "staging",
+        type: "http",
+        url: "https://staging.mcp.example.com",
+        useXaa: true,
+        useOAuth: false,
+        authServerMode: "mcpjam",
+        xaaAuthzIssuer: "https://as.example.com",
+        xaaIdentityAssertionFormat: "saml",
+      });
+      // Preserve-by-omission: the format is the ONLY stored value this save
+      // may change. Sending any of these would clobber stored state (identity
+      // pair, shared "auto" registration mode) or the saved secret.
+      expect(formData).not.toHaveProperty("xaaSubject");
+      expect(formData).not.toHaveProperty("xaaEmail");
+      expect(formData).not.toHaveProperty("registrationMode");
+      expect(formData).not.toHaveProperty("clientSecret");
+      expect(formData).not.toHaveProperty("clearClientSecret");
+    });
+
+    it("does not save when the selected format is already active", async () => {
+      const onSaveServerConfig = vi.fn();
+      render(
+        <XAAFlowTab
+          serverConfigs={storedServer()}
+          selectedServerName="staging"
+          onSaveServerConfig={onSaveServerConfig}
+        />
+      );
+
+      await act(async () => {
+        await capturedIdpCardProps.onIdentityAssertionFormatChange("oidc");
+      });
+      expect(onSaveServerConfig).not.toHaveBeenCalled();
+    });
+
+    it("disables the control (OIDC shown) for registration-backed targets", () => {
+      currentTarget = makeTarget({
+        targetSource: "registration",
+        runInput: {
+          ...makeTarget().runInput,
+          registrationId: "app_1",
+        },
+      } as Partial<XaaTestTarget>);
+      render(
+        <XAAFlowTab
+          serverConfigs={{
+            staging: {
+              ...storedServer().staging,
+              xaaIdentityAssertionFormat: "saml",
+            },
+          }}
+          selectedServerName="staging"
+          onSaveServerConfig={vi.fn()}
+        />
+      );
+
+      // The per-server preset must not leak onto a registration run — the
+      // control shows the OIDC default and says why it's disabled.
+      expect(capturedIdpCardProps.identityAssertionFormat).toBe("oidc");
+      expect(
+        capturedIdpCardProps.identityAssertionFormatDisabledReason
+      ).toMatch(/registered app/i);
+    });
+
+    it("hides the control when no save path is wired", () => {
+      render(
+        <XAAFlowTab serverConfigs={storedServer()} selectedServerName="staging" />
+      );
+      expect(
+        capturedIdpCardProps.onIdentityAssertionFormatChange
+      ).toBeUndefined();
     });
   });
 

--- a/mcpjam-inspector/client/src/components/ui/json-editor/segmented-control.tsx
+++ b/mcpjam-inspector/client/src/components/ui/json-editor/segmented-control.tsx
@@ -5,6 +5,8 @@ interface SegmentedControlOption<T extends string> {
   value: T;
   label: string;
   icon?: React.ReactNode;
+  /** Native tooltip describing what selecting this option does. */
+  title?: string;
 }
 
 type SegmentedControlSize = "sm" | "default";
@@ -15,6 +17,7 @@ interface SegmentedControlProps<T extends string> {
   onChange: (value: T) => void;
   className?: string;
   size?: SegmentedControlSize;
+  disabled?: boolean;
 }
 
 export function SegmentedControl<T extends string>({
@@ -23,6 +26,7 @@ export function SegmentedControl<T extends string>({
   onChange,
   className,
   size = "sm",
+  disabled = false,
 }: SegmentedControlProps<T>) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [indicatorStyle, setIndicatorStyle] = useState<React.CSSProperties>({});
@@ -49,6 +53,7 @@ export function SegmentedControl<T extends string>({
       className={cn(
         "relative inline-flex items-center rounded-md bg-muted/50",
         size === "default" ? "p-1" : "p-0.5",
+        disabled && "opacity-50",
         className,
       )}
     >
@@ -69,6 +74,9 @@ export function SegmentedControl<T extends string>({
         <button
           key={option.value}
           type="button"
+          disabled={disabled}
+          title={option.title}
+          aria-pressed={value === option.value}
           onClick={() => onChange(option.value)}
           className={cn(
             "relative z-10 flex items-center rounded-md font-medium transition-colors duration-200",
@@ -78,6 +86,7 @@ export function SegmentedControl<T extends string>({
             value === option.value
               ? "text-foreground"
               : "text-muted-foreground hover:text-foreground/80",
+            disabled && "cursor-not-allowed",
           )}
         >
           {option.icon}

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -70,6 +70,7 @@ import {
 } from "@/lib/xaa/types";
 import type { XAAFlowStep } from "@/lib/xaa/types";
 import { XAADcrReRegisterControl } from "./XAADcrReRegisterControl";
+import { buildXaaAssertionFormatResave } from "./xaa-server-form";
 import { createInspectorXAAStateMachine } from "@/lib/xaa/debug-state-machine-adapter";
 import { fetchXaaIdpUrls } from "@/lib/xaa/idp-endpoints";
 import { HOSTED_MODE } from "@/lib/config";
@@ -1825,6 +1826,55 @@ export function XAAFlowTab({
   // A server is selected but can't be XAA-tested (STDIO / non-OAuth).
   const showNotTestable = target.targetSource === "bar_server" && !isTestable;
 
+  // ── Header OIDC/SAML toggle ──────────────────────────────────────────
+  // Writes the per-server identity-assertion preset through the SAME save
+  // path as the Configure modal (untouched-resave shape: the format is the
+  // only stored value the save can change). The persisted value flows back
+  // via serverConfigs → effectiveAssertionFormat, so the control always
+  // renders stored state — a failed save simply snaps back — and the single
+  // target-reset owner rebuilds the flow (confirming first if a busy or
+  // completed run would be discarded).
+  const [assertionFormatSaving, setAssertionFormatSaving] = useState(false);
+  const formatToggleApplies =
+    target.targetSource === "bar_server" &&
+    isTestable &&
+    Boolean(selectedServer);
+  const assertionFormatDisabledReason = !formatToggleApplies
+    ? target.targetSource === "registration"
+      ? "Runs against a registered app always use the OIDC ID token."
+      : "Configure a server to test first."
+    : flowState.isBusy || isRunningAll
+    ? "Wait for the current run to finish."
+    : assertionFormatSaving
+    ? "Saving…"
+    : null;
+  const handleAssertionFormatChange = useCallback(
+    async (next: IdentityAssertionFormat) => {
+      if (
+        !selectedServer ||
+        !onSaveServerConfig ||
+        next === effectiveAssertionFormat ||
+        assertionFormatSaving
+      ) {
+        return;
+      }
+      setAssertionFormatSaving(true);
+      try {
+        await onSaveServerConfig(
+          buildXaaAssertionFormatResave(selectedServer, next)
+        );
+      } finally {
+        setAssertionFormatSaving(false);
+      }
+    },
+    [
+      selectedServer,
+      onSaveServerConfig,
+      effectiveAssertionFormat,
+      assertionFormatSaving,
+    ]
+  );
+
   return (
     <div className="h-full flex flex-col bg-background">
       <XAAIdpCard
@@ -1834,6 +1884,12 @@ export function XAAFlowTab({
         canUseHostedIssuer={canUseHostedIssuer}
         hostedIssuerDisabledReason={hostedIssuerDisabledReason}
         issuerKind={hostedIssuerKind}
+        identityAssertionFormat={effectiveAssertionFormat}
+        onIdentityAssertionFormatChange={
+          // No persistence path (parent didn't wire saves) → hide the control.
+          onSaveServerConfig ? handleAssertionFormatChange : undefined
+        }
+        identityAssertionFormatDisabledReason={assertionFormatDisabledReason}
       />
       {registrationEnabled === true && (
         <XAAPeopleStrip

--- a/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
@@ -11,6 +11,7 @@ import { useFeatureFlagEnabled } from "posthog-js/react";
 import { Switch } from "@mcpjam/design-system/switch";
 import { useLearnMore } from "@/hooks/use-learn-more";
 import { LearnMoreExpandedPanel } from "@/components/learn-more/LearnMoreExpandedPanel";
+import { SegmentedControl } from "@/components/ui/json-editor/segmented-control";
 import { HOSTED_MODE } from "@/lib/config";
 import { copyToClipboard } from "@/lib/clipboard";
 import { buildXaaSetupPath, useAppNavigate } from "@/lib/app-navigation";
@@ -20,6 +21,8 @@ import {
   getXaaIdpUrls,
 } from "@/lib/xaa/idp-endpoints";
 import type { XaaIssuerMode } from "@/hooks/useXaaRunSettings";
+import type { IdentityAssertionFormat } from "@/shared/xaa.js";
+import { IDENTITY_ASSERTION_FORMAT_HINTS } from "./xaa-server-form";
 
 // A compact click-to-copy chip: shows only the label to keep the bar minimal —
 // the long URL stays hidden (revealed on hover via the native title) and the
@@ -114,6 +117,9 @@ export function XAAIdpCard({
   canUseHostedIssuer = false,
   hostedIssuerDisabledReason,
   issuerKind = "org",
+  identityAssertionFormat,
+  onIdentityAssertionFormatChange,
+  identityAssertionFormatDisabledReason = null,
 }: {
   organizationId?: string | null;
   /** LOCAL builds only: which issuer mints this run's assertions. */
@@ -129,6 +135,15 @@ export function XAAIdpCard({
    * explicitly allowlist; NOT enterprise-managed-authorization
    * conformance). */
   issuerKind?: "org" | "anonymous";
+  /**
+   * The active target's identity-assertion preset (per-server, persisted).
+   * The OIDC/SAML control renders only when the change handler is provided —
+   * surfaces without a persistence path (e.g. the setup center) omit it.
+   */
+  identityAssertionFormat?: IdentityAssertionFormat;
+  onIdentityAssertionFormatChange?: (format: IdentityAssertionFormat) => void;
+  /** Non-null disables the format control and explains why (native title). */
+  identityAssertionFormatDisabledReason?: string | null;
 }) {
   const hostedIssuerOn =
     !HOSTED_MODE && issuerMode === "hosted" && canUseHostedIssuer;
@@ -206,6 +221,34 @@ export function XAAIdpCard({
               <CopyField label="OpenID Config" value={openidConfigUrl} />
               <CopyField label="JWKS URL" value={jwksUrl} />
             </div>
+            {identityAssertionFormat && onIdentityAssertionFormatChange && (
+              <div
+                className="flex shrink-0 items-center gap-1.5"
+                title={identityAssertionFormatDisabledReason ?? undefined}
+                data-testid="identity-assertion-toggle"
+              >
+                <span className="text-xs text-muted-foreground">
+                  Identity assertion
+                </span>
+                <SegmentedControl
+                  options={[
+                    {
+                      value: "oidc",
+                      label: "OIDC",
+                      title: IDENTITY_ASSERTION_FORMAT_HINTS.oidc,
+                    },
+                    {
+                      value: "saml",
+                      label: "SAML",
+                      title: IDENTITY_ASSERTION_FORMAT_HINTS.saml,
+                    },
+                  ]}
+                  value={identityAssertionFormat}
+                  onChange={onIdentityAssertionFormatChange}
+                  disabled={Boolean(identityAssertionFormatDisabledReason)}
+                />
+              </div>
+            )}
           </div>
         </div>
         <div className="flex shrink-0 items-center gap-2">
@@ -223,6 +266,23 @@ export function XAAIdpCard({
           <SetupGuidance />
         </div>
       </div>
+
+      {/* The chips above stay valid in SAML mode — the ID-JAG is a JWT under
+          this issuer either way; only the identity assertion changes shape.
+          Say so, or the "OpenID Config" labels next to a SAML selection read
+          as a contradiction. */}
+      {identityAssertionFormat === "saml" &&
+        onIdentityAssertionFormatChange && (
+          <div
+            className="mt-2 text-xs text-muted-foreground"
+            data-testid="saml-format-note"
+          >
+            This server's identity assertions are SAML 2.0 (the ID-JAG carries
+            a saml-nameid subject identifier). The ID-JAG itself is still a
+            JWT minted under this issuer, so the discovery and JWKS URLs above
+            are unchanged.
+          </div>
+        )}
 
       {!HOSTED_MODE && (
         <div className="mt-3 space-y-2 text-xs text-muted-foreground">

--- a/mcpjam-inspector/client/src/components/xaa/XAAServerModal.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAServerModal.tsx
@@ -23,32 +23,19 @@ import {
   DEFAULT_IDENTITY_ASSERTION_FORMAT,
   DEFAULT_REGISTRATION_STRATEGY,
   IDENTITY_ASSERTION_FORMATS,
-  normalizeIdentityAssertionFormat,
-  normalizeRegistrationStrategy,
   type IdentityAssertionFormat,
   type RegistrationStrategy,
 } from "@/shared/xaa.js";
 import { XAA_STRATEGY_OPTIONS } from "@/lib/registration-strategy";
-import { deriveOAuthProfileFromServer } from "../oauth/utils";
 import { XaaCredentialFields } from "../connection/shared/XaaCredentialFields";
 import { XAA_PARTIAL_OVERRIDE_ERROR } from "@/lib/xaa/identity";
-
-// UI copy for the identity-assertion preset (input axis of the ID-JAG draft).
-// One selector sets both axes at flow time: "saml" mints a SAML assertion AND
-// asks for a saml-nameid `sub_id` on the ID-JAG; "oidc" keeps both defaults.
-const IDENTITY_ASSERTION_FORMAT_LABELS: Record<
-  IdentityAssertionFormat,
-  string
-> = {
-  oidc: "OIDC ID token",
-  saml: "SAML assertion",
-};
-
-const IDENTITY_ASSERTION_FORMAT_HINTS: Record<IdentityAssertionFormat, string> =
-  {
-    oidc: "The MCPJam IdP mints an OIDC ID token as the identity assertion.",
-    saml: "The MCPJam IdP mints a signed SAML 2.0 assertion; the ID-JAG carries a saml-nameid subject identifier.",
-  };
+import {
+  IDENTITY_ASSERTION_FORMAT_HINTS,
+  IDENTITY_ASSERTION_FORMAT_LABELS,
+  buildXaaServerFormData,
+  deriveXaaServerFormSeed,
+  splitXaaScopes,
+} from "./xaa-server-form";
 
 interface XAAServerModalProps {
   open: boolean;
@@ -78,7 +65,9 @@ export function XAAServerModal({
   projectId,
   hostedServerId,
 }: XAAServerModalProps) {
-  const derived = useMemo(() => deriveOAuthProfileFromServer(server), [server]);
+  // One shared derivation with the flow-header format toggle's untouched
+  // resave, so both surfaces read the same unedited field values.
+  const seed = useMemo(() => deriveXaaServerFormSeed(server), [server]);
   const hasSavedSecret = Boolean(server?.hasClientSecret);
   const isEditing = Boolean(server);
 
@@ -122,31 +111,25 @@ export function XAAServerModal({
 
   useEffect(() => {
     if (!open) return;
-    setServerName(server?.name ?? "");
-    setServerUrl(derived.serverUrl ?? "");
-    setRegistrationStrategy(
-      normalizeRegistrationStrategy(server?.registrationMode) ??
-        DEFAULT_REGISTRATION_STRATEGY
-    );
+    setServerName(seed.serverName);
+    setServerUrl(seed.serverUrl);
+    setRegistrationStrategy(seed.registrationStrategy);
     setRegistrationStrategyDirty(false);
-    setIdentityAssertionFormat(
-      normalizeIdentityAssertionFormat(server?.xaaIdentityAssertionFormat) ??
-        DEFAULT_IDENTITY_ASSERTION_FORMAT
-    );
-    setClientId(derived.clientId ?? "");
-    // Scopes can be stored comma- or space-separated upstream; normalize to
-    // the space-separated form this modal edits.
-    setScopes((derived.scopes ?? "").replace(/,/g, " ").trim());
-    setAuthzIssuer(server?.xaaAuthzIssuer ?? "");
-    setAllowPathScopedIssuer(server?.xaaAllowPathScopedIssuer === true);
+    setIdentityAssertionFormat(seed.identityAssertionFormat);
+    setClientId(seed.clientId);
+    // Scopes arrive space-separated from the seed (stored comma- or
+    // space-separated forms normalized there).
+    setScopes(seed.scopes);
+    setAuthzIssuer(seed.authzIssuer);
+    setAllowPathScopedIssuer(seed.allowPathScopedIssuer);
     setClientSecret("");
     setClearClientSecret(false);
-    setXaaSubject(server?.xaaSubject ?? "");
-    setXaaEmail(server?.xaaEmail ?? "");
+    setXaaSubject(seed.xaaSubject);
+    setXaaEmail(seed.xaaEmail);
     setXaaIdentityDirty(false);
     setError(null);
     setSaving(false);
-  }, [open, server, derived]);
+  }, [open, seed]);
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -196,16 +179,6 @@ export function XAAServerModal({
       }
     }
 
-    const scopesArray = scopes
-      .split(/\s+/)
-      .map((scope) => scope.trim())
-      .filter((scope) => scope.length > 0);
-
-    // A typed value replaces the saved secret; the Clear toggle removes it. A
-    // typed replacement always wins over Clear (the save path rejects both).
-    const trimmedSecret = clientSecret.trim();
-    const submittedClearSecret = clearClientSecret && !trimmedSecret;
-
     // The identity override is atomic: block a partial pair rather than
     // saving a mixed identity or silently dropping one member.
     const trimmedXaaSubject = xaaSubject.trim();
@@ -220,41 +193,30 @@ export function XAAServerModal({
 
     setError(null);
 
-    const formData: ServerFormData = {
+    // Field semantics (secret sentinels, preserve-by-omission for the
+    // identity pair and registrationMode) live in the shared builder — the
+    // flow-header format toggle saves through the same one.
+    const formData: ServerFormData = buildXaaServerFormData({
       name: trimmedName,
-      type: "http",
       url: trimmedUrl,
-      // Cross-App Access discriminator — identical to the /servers Connect
-      // page so a server configured in either surface is unambiguously XAA and
-      // editing it in one place never flips it back to plain OAuth.
-      useXaa: true,
-      useOAuth: false,
-      authServerMode: "mcpjam",
       clientId: trimmedClientId,
-      ...(trimmedSecret ? { clientSecret: trimmedSecret } : {}),
-      ...(submittedClearSecret ? { clearClientSecret: true } : {}),
+      clientSecret,
+      clearClientSecret,
       hasClientSecret: server?.hasClientSecret,
-      oauthScopes: scopesArray,
-      // Always send the issuer (possibly empty) so clearing it persists.
-      xaaAuthzIssuer: trimmedIssuer,
-      xaaAllowPathScopedIssuer: allowPathScopedIssuer,
-      // Atomic identity override, identical to the Connect page: untouched →
-      // omit both keys (the save path preserves stored values); edited
-      // complete pair → both trimmed values; explicit clear → both "" (the
-      // backend normalizes the empty pair away).
-      ...(xaaIdentityDirty
-        ? { xaaSubject: trimmedXaaSubject, xaaEmail: trimmedXaaEmail }
-        : {}),
-      // Identity assertion preset — always sent (absent stored value = oidc).
-      xaaIdentityAssertionFormat: identityAssertionFormat,
-      // Unified registration mode — written ONLY on explicit user edit (see
-      // the auto-clobber guard above); an untouched selector omits the field
-      // so the save-path `?? existing` merge preserves the stored value
-      // (which may be "auto", shared with the OAuth flow).
-      ...(registrationStrategyDirty
-        ? { registrationMode: registrationStrategy }
-        : {}),
-    };
+      oauthScopes: splitXaaScopes(scopes),
+      authzIssuer: trimmedIssuer,
+      allowPathScopedIssuer,
+      identity: {
+        dirty: xaaIdentityDirty,
+        subject: trimmedXaaSubject,
+        email: trimmedXaaEmail,
+      },
+      identityAssertionFormat,
+      registration: {
+        dirty: registrationStrategyDirty,
+        strategy: registrationStrategy,
+      },
+    });
 
     // Final gate: the exact validator the save path runs. Any rule added there
     // is enforced here too, so a new rule can never pass this form and then be

--- a/mcpjam-inspector/client/src/components/xaa/__tests__/XAAIdpCard.test.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/__tests__/XAAIdpCard.test.tsx
@@ -199,6 +199,74 @@ describe("XAAIdpCard", () => {
     });
   });
 
+  // ── Identity-assertion (OIDC/SAML) header control ────────────────────
+  // Renders only when the flow tab wires a persistence handler; other card
+  // consumers (setup center) omit it and see no control.
+
+  it("hides the identity-assertion control without a change handler", () => {
+    render(<XAAIdpCard identityAssertionFormat="oidc" />);
+    expect(
+      screen.queryByTestId("identity-assertion-toggle")
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the OIDC/SAML control and fires the change handler", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <XAAIdpCard
+        identityAssertionFormat="oidc"
+        onIdentityAssertionFormatChange={onChange}
+      />
+    );
+
+    const toggle = screen.getByTestId("identity-assertion-toggle");
+    expect(toggle).toHaveTextContent("Identity assertion");
+    // OIDC is the active option; SAML is offered.
+    expect(screen.getByRole("button", { name: "OIDC" })).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    );
+    await user.click(screen.getByRole("button", { name: "SAML" }));
+    expect(onChange).toHaveBeenCalledWith("saml");
+  });
+
+  it("disables the control with the reason as its tooltip", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <XAAIdpCard
+        identityAssertionFormat="oidc"
+        onIdentityAssertionFormatChange={onChange}
+        identityAssertionFormatDisabledReason="Wait for the current run to finish."
+      />
+    );
+
+    expect(screen.getByTestId("identity-assertion-toggle")).toHaveAttribute(
+      "title",
+      "Wait for the current run to finish."
+    );
+    const samlButton = screen.getByRole("button", { name: "SAML" });
+    expect(samlButton).toBeDisabled();
+    await user.click(samlButton);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("explains that the chips stay valid when SAML is active", () => {
+    render(
+      <XAAIdpCard
+        identityAssertionFormat="saml"
+        onIdentityAssertionFormatChange={() => {}}
+      />
+    );
+
+    // The ID-JAG is a JWT under this issuer in both formats — the note keeps
+    // the "OpenID Config"/"JWKS" chips from reading as a contradiction.
+    const note = screen.getByTestId("saml-format-note");
+    expect(note).toHaveTextContent(/SAML 2\.0/);
+    expect(note).toHaveTextContent(/still a\s+JWT/i);
+  });
+
   it("shows the setup gear for org members and navigates to the setup center", async () => {
     const user = userEvent.setup();
     render(<XAAIdpCard organizationId="org_a1B2" />);

--- a/mcpjam-inspector/client/src/components/xaa/xaa-server-form.ts
+++ b/mcpjam-inspector/client/src/components/xaa/xaa-server-form.ts
@@ -1,0 +1,180 @@
+import type { ServerFormData } from "@/shared/types.js";
+import type { ServerWithName } from "@/hooks/use-app-state";
+import {
+  DEFAULT_IDENTITY_ASSERTION_FORMAT,
+  DEFAULT_REGISTRATION_STRATEGY,
+  normalizeIdentityAssertionFormat,
+  normalizeRegistrationStrategy,
+  type IdentityAssertionFormat,
+  type RegistrationStrategy,
+} from "@/shared/xaa.js";
+import { deriveOAuthProfileFromServer } from "../oauth/utils";
+
+// UI copy for the identity-assertion preset (input axis of the ID-JAG draft).
+// One selector sets both axes at flow time: "saml" mints a SAML assertion AND
+// asks for a saml-nameid `sub_id` on the ID-JAG; "oidc" keeps both defaults.
+// Shared by the Configure-Server modal and the flow-header toggle so both
+// surfaces describe the preset with identical words.
+export const IDENTITY_ASSERTION_FORMAT_LABELS: Record<
+  IdentityAssertionFormat,
+  string
+> = {
+  oidc: "OIDC ID token",
+  saml: "SAML assertion",
+};
+
+export const IDENTITY_ASSERTION_FORMAT_HINTS: Record<
+  IdentityAssertionFormat,
+  string
+> = {
+  oidc: "The MCPJam IdP mints an OIDC ID token as the identity assertion.",
+  saml: "The MCPJam IdP mints a signed SAML 2.0 assertion; the ID-JAG carries a saml-nameid subject identifier.",
+};
+
+/**
+ * The stored-server values the "Configure Server to Test" form edits — one
+ * derivation shared by the modal's open-time seeding and the header format
+ * toggle's untouched resave, so the two surfaces can never disagree about
+ * what an unedited field holds.
+ */
+export interface XaaServerFormSeed {
+  serverName: string;
+  serverUrl: string;
+  registrationStrategy: RegistrationStrategy;
+  identityAssertionFormat: IdentityAssertionFormat;
+  clientId: string;
+  /** Space-separated (stored comma- or space-separated forms normalized). */
+  scopes: string;
+  authzIssuer: string;
+  allowPathScopedIssuer: boolean;
+  xaaSubject: string;
+  xaaEmail: string;
+}
+
+export function deriveXaaServerFormSeed(
+  server: ServerWithName | undefined
+): XaaServerFormSeed {
+  const derived = deriveOAuthProfileFromServer(server);
+  return {
+    serverName: server?.name ?? "",
+    serverUrl: derived.serverUrl ?? "",
+    registrationStrategy:
+      normalizeRegistrationStrategy(server?.registrationMode) ??
+      DEFAULT_REGISTRATION_STRATEGY,
+    identityAssertionFormat:
+      normalizeIdentityAssertionFormat(server?.xaaIdentityAssertionFormat) ??
+      DEFAULT_IDENTITY_ASSERTION_FORMAT,
+    clientId: derived.clientId ?? "",
+    scopes: (derived.scopes ?? "").replace(/,/g, " ").trim(),
+    authzIssuer: server?.xaaAuthzIssuer ?? "",
+    allowPathScopedIssuer: server?.xaaAllowPathScopedIssuer === true,
+    xaaSubject: server?.xaaSubject ?? "",
+    xaaEmail: server?.xaaEmail ?? "",
+  };
+}
+
+/** The space-separated scopes string as the save path's array form. */
+export function splitXaaScopes(scopes: string): string[] {
+  return scopes
+    .split(/\s+/)
+    .map((scope) => scope.trim())
+    .filter((scope) => scope.length > 0);
+}
+
+export interface XaaServerFormInput {
+  name: string;
+  url: string;
+  clientId: string;
+  /** Typed replacement secret; "" leaves the saved secret untouched. */
+  clientSecret: string;
+  /** Clear toggle — a typed replacement always wins over Clear. */
+  clearClientSecret: boolean;
+  hasClientSecret: boolean | undefined;
+  oauthScopes: string[];
+  authzIssuer: string;
+  allowPathScopedIssuer: boolean;
+  /**
+   * Atomic identity-override pair: untouched (dirty=false) omits both keys so
+   * the save path preserves the stored values; an edited complete pair sends
+   * both; an explicit clear sends both as "".
+   */
+  identity: { dirty: boolean; subject: string; email: string };
+  identityAssertionFormat: IdentityAssertionFormat;
+  /**
+   * Unified registration mode — written ONLY on explicit user edit
+   * (auto-clobber guard): an untouched selector omits the field so the
+   * save-path `?? existing` merge preserves the stored value (which may be
+   * "auto", shared with the OAuth flow).
+   */
+  registration: { dirty: boolean; strategy: RegistrationStrategy };
+}
+
+/**
+ * The single ServerFormData shape every XAA-debugger save emits — the modal
+ * submit and the header format toggle both build through here, so field
+ * semantics (secret sentinels, preserve-by-omission) can't drift between them.
+ */
+export function buildXaaServerFormData(
+  input: XaaServerFormInput
+): ServerFormData {
+  // A typed value replaces the saved secret; the Clear toggle removes it. A
+  // typed replacement always wins over Clear (the save path rejects both).
+  const trimmedSecret = input.clientSecret.trim();
+  const submittedClearSecret = input.clearClientSecret && !trimmedSecret;
+
+  return {
+    name: input.name,
+    type: "http",
+    url: input.url,
+    // Cross-App Access discriminator — identical to the /servers Connect
+    // page so a server configured in either surface is unambiguously XAA and
+    // editing it in one place never flips it back to plain OAuth.
+    useXaa: true,
+    useOAuth: false,
+    authServerMode: "mcpjam",
+    clientId: input.clientId,
+    ...(trimmedSecret ? { clientSecret: trimmedSecret } : {}),
+    ...(submittedClearSecret ? { clearClientSecret: true } : {}),
+    hasClientSecret: input.hasClientSecret,
+    oauthScopes: input.oauthScopes,
+    // Always send the issuer (possibly empty) so clearing it persists.
+    xaaAuthzIssuer: input.authzIssuer,
+    xaaAllowPathScopedIssuer: input.allowPathScopedIssuer,
+    ...(input.identity.dirty
+      ? { xaaSubject: input.identity.subject, xaaEmail: input.identity.email }
+      : {}),
+    // Identity assertion preset — always sent (absent stored value = oidc).
+    xaaIdentityAssertionFormat: input.identityAssertionFormat,
+    ...(input.registration.dirty
+      ? { registrationMode: input.registration.strategy }
+      : {}),
+  };
+}
+
+/**
+ * The exact ServerFormData an untouched "Configure Server to Test" resave
+ * would emit, with only the identity-assertion format changed — what the
+ * flow-header OIDC/SAML toggle persists. Identity pair and registrationMode
+ * stay omitted (preserve-by-omission), no secret sentinel is sent, so the
+ * only stored value this save can change is the format.
+ */
+export function buildXaaAssertionFormatResave(
+  server: ServerWithName,
+  format: IdentityAssertionFormat
+): ServerFormData {
+  const seed = deriveXaaServerFormSeed(server);
+  return buildXaaServerFormData({
+    name: seed.serverName,
+    url: seed.serverUrl,
+    clientId: seed.clientId.trim(),
+    clientSecret: "",
+    clearClientSecret: false,
+    hasClientSecret: server.hasClientSecret,
+    oauthScopes: splitXaaScopes(seed.scopes),
+    authzIssuer: seed.authzIssuer.trim(),
+    allowPathScopedIssuer: seed.allowPathScopedIssuer,
+    identity: { dirty: false, subject: "", email: "" },
+    identityAssertionFormat: format,
+    registration: { dirty: false, strategy: seed.registrationStrategy },
+  });
+}


### PR DESCRIPTION
## Why

The XAA debugger has supported both identity-assertion formats for a while, but the only way to pick one was a dropdown buried in the **Configure Server to Test** modal. From the flow itself there was no indication SAML existed, or which format a run would use — the header advertises "Issuer URL / OpenID Config / JWKS URL" and nothing else.

## What

Surfaces the preset as a segmented control in the IdP header bar, next to the chips.

- **Write-through, not a session override.** Flipping it saves the per-server `xaaIdentityAssertionFormat` through the same path the modal uses, so the two surfaces can never disagree. The control renders persisted state only — a failed save just snaps back. A change reroutes through the existing single target-reset owner (so it confirms before discarding a busy/completed run), exactly like changing it in the modal.
- **One builder, two surfaces.** Persisting a field means emitting a full `ServerFormData`, and a hand-rolled minimal payload from the header would risk clobbering the stored secret, the identity-pair override, or the shared `"auto"` registration mode. So the modal's field seeding and formData construction move to a new `client/src/components/xaa/xaa-server-form.ts` that both surfaces build through. The toggle emits exactly what an **untouched modal resave** would, with only the format changed: identity pair, `registrationMode`, and secret sentinels stay omitted so the save path preserves them. `XAAFlowTab.test.tsx` asserts that payload shape explicitly.
- **Disabled with a reason** for registration-backed targets (those always run OIDC — the per-server preset must not leak onto them), while a run is in flight, and before a server is configured (which also makes the feature discoverable from the empty state).
- **SAML note.** In SAML mode a line under the header explains the ID-JAG is still a JWT minted under this issuer, so the "OpenID Config" / "JWKS" chips don't read as a contradiction.

`SegmentedControl` gains `disabled` + per-option `title` (additive; its own suite is unchanged and green).

## Testing

- `XAAIdpCard.test.tsx` — control renders/fires/disables/hides, SAML note.
- `XAAFlowTab.test.tsx` — write-through payload preserves stored fields by omission; no-op when the format is already active; disabled for registration targets; hidden with no save path wired.
- `XAAServerModal.test.tsx` — 20/20 still green after the refactor (parity check on the extraction).
- `npm run typecheck:client` clean.

## :warning: Pre-existing CI failure on main (not from this PR)

`XAAFlowTab.test.tsx` currently fails 20 tests **on pristine `main`**, and this branch inherits exactly those 20:

| | passed | failed |
|---|---|---|
| `origin/main` (untouched) | 41 | 20 |
| this branch | 46 (41 + 5 new) | 20 (same) |

Cause: #3224 added `useFeatureFlagEnabled("xaa-registration")` (`XAAFlowTab.tsx:514`) gating the People strip at line 1894, but `XAAFlowTab.test.tsx` has no `posthog-js/react` mock — so the flag resolves `undefined`, the strip never renders, and every "Run as people" test dereferences null. (`XAAIdpCard.test.tsx` already mocks the flag; the flow-tab suite was missed.)

Fix is test-only (add the same mock), and I deliberately kept it out of this PR rather than bundling someone else's breakage into a feature diff. Happy to send it as a one-file PR first if you'd like this one green before review.

## Verification caveat

Verified via the component/unit suites and typecheck, not by driving the hosted app — the debugger needs org auth state I couldn't stand up locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and shared form-builder refactor around an existing persisted field; save semantics are explicitly tested to avoid clobbering secrets or registration mode.
> 
> **Overview**
> Adds an **OIDC/SAML** segmented control to the XAA IdP header so the per-server `xaaIdentityAssertionFormat` preset is visible and editable without opening **Configure Server to Test**. Flipping it **write-through** persists via the same `onSaveServerConfig` path as the modal, using `buildXaaAssertionFormatResave` so only the format changes and identity pair, `registrationMode`, and secrets stay omitted. The control is hidden without a save callback, disabled for registration-backed runs (OIDC only), while a run is active, or until a testable server exists; SAML mode shows a short note that discovery/JWKS chips still apply.
> 
> **`xaa-server-form.ts`** centralizes seed derivation, `buildXaaServerFormData`, and format labels/hints; **`XAAServerModal`** now builds saves through that module instead of inline logic.
> 
> **`SegmentedControl`** gains optional `disabled` and per-option `title` tooltips (`aria-pressed` on buttons). Tests cover IdP card behavior and flow-tab save payload preservation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2f2683d40fd5ba4e999c45854b903ac9da23635. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an OIDC/SAML identity-assertion toggle to the XAA debugger header, saving the per-server preset and making the active format visible in the flow. Extracts shared form seeding/building so the header and Configure Server modal persist through the same path.

- **New Features**
  - Added an identity-assertion segmented toggle (OIDC/SAML) in the IdP header; changes write through to `xaaIdentityAssertionFormat` (no session override).
  - Toggle is disabled with a reason for registration-backed runs, during active runs, and before a server is configured; hidden when no save path is provided.
  - In SAML mode, shows a note clarifying the ID-JAG is still a JWT under the same issuer.
  - `SegmentedControl` now supports `disabled`, per-option `title`, and `aria-pressed`.

- **Refactors**
  - Introduced `xaa-server-form.ts` to unify modal/header behavior: `deriveXaaServerFormSeed`, `buildXaaServerFormData`, `buildXaaAssertionFormatResave`, and scope splitting.
  - `XAAServerModal` now seeds fields and builds `ServerFormData` via the shared module (preserve-by-omission for identity pair, `registrationMode`, and secret sentinels).
  - Added/updated tests for the header toggle behavior and payload shape; existing modal tests remain green.

<sup>Written for commit c2f2683d40fd5ba4e999c45854b903ac9da23635. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

