### PR TITLE
docs(cli): XAA debugger guide page; fix unusable issuer example

### DIFF
--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -36,7 +36,7 @@ npx -y @mcpjam/cli@latest --help
 | Group | Purpose | Key commands |
 |-------|---------|-------------|
 | [`server`](/cli/server-inspection) | Triage connectivity and capabilities | `probe`, `doctor`, `info`, `validate`, `ping`, `capabilities`, `export` |
-| [`xaa`](/cli/reference#xaa-commands) | Run the Cross-App Access (ID-JAG) debugger against an MCP server | `run` |
+| [`xaa`](/cli/xaa) | Run the Cross-App Access (ID-JAG) debugger against an MCP server | `run` |
 | [`oauth`](/cli/oauth-conformance) | Test OAuth flows and conformance | `conformance`, `conformance-suite`, `login`, `metadata`, `proxy` |
 | [`apps`](/cli/apps-conformance) | Validate MCP Apps metadata and resource wiring | `conformance`, `conformance-suite` |
 | [`compat`](/cli/reference#compat-command) | Check whether a server's tools and widgets work on each AI host | `compat` |

--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -236,12 +236,12 @@ Plus shared connection flags.
 
 ### `xaa run`
 
-Run the Cross-App Access (ID-JAG) debugger: self-issue an ID-JAG, redeem it at the target authorization server (RFC 7523), and call the MCP server with the resulting access token.
+Run the Cross-App Access (ID-JAG) debugger: self-issue an ID-JAG, redeem it at the target authorization server (RFC 7523), and call the MCP server with the resulting access token. See the [XAA Debugger guide](/cli/xaa) for the trust setup, registration strategies, and CI usage.
 
 | Flag | Required | Default | Description |
 |------|----------|---------|-------------|
 | `--url <url>` | Yes | | Target MCP server URL (the protected resource) |
-| `--issuer-base-url <url>` | Yes | | Origin the local mock IdP issues from (the AS must be able to fetch its JWKS from here) |
+| `--issuer-base-url <url>` | Yes | | Origin the local mock IdP issues from. It must publish the CLI's local signing key — typically a running [local inspector](/cli/xaa#before-you-run-make-the-issuer-reachable), not your real IdP |
 | `--sub <subject>` | Yes | | Simulated end-user subject identifier |
 | `--client-id <id>` | No | | OAuth client ID. Required for `preregistered`; rejected for `dcr`/`cimd` |
 | `--registration <method>` | No | `preregistered` | `preregistered`, `dcr`, or `cimd` |
@@ -270,13 +270,17 @@ Run the Cross-App Access (ID-JAG) debugger: self-issue an ID-JAG, redeem it at t
 When `--registration cimd --client-auth private-key-jwt` is used, the CLI loads or generates a local EC P-256 key pair (stored in `~/.mcpjam`). The public key is encoded into a reflector URL on `app.mcpjam.com`, which becomes the `client_id`. The CLI signs a `client_assertion` with the private key at token-redemption time; the private key never leaves the machine.
 
 ```bash
+mcpjam inspector start   # serves the issuer at http://localhost:6274/api/mcp/xaa
+
 mcpjam xaa run \
-  --url https://your-mcp-server.com/mcp \
-  --issuer-base-url https://your-idp.example.com \
+  --url http://localhost:8080/mcp \
+  --issuer-base-url http://localhost:6274/api/mcp \
   --sub user@example.com \
   --registration cimd \
   --client-auth private-key-jwt
 ```
+
+For a cloud authorization server, expose the inspector origin through a tunnel and pass the public origin as `--issuer-base-url` — see [making the issuer reachable](/cli/xaa#before-you-run-make-the-issuer-reachable).
 
 **Key rotation:** the key is the identity. Deleting `~/.mcpjam/xaa-client-private.pem` or changing the `XAA_CLIENT_PRIVATE_KEY` environment variable generates a new `client_id`; any RAS-side allowlisting must be updated after rotation.
 

--- a/docs/cli/xaa.mdx
+++ b/docs/cli/xaa.mdx
@@ -1,0 +1,212 @@
+---
+title: "XAA Debugger (CLI)"
+description: "Run the full Cross-App Access (ID-JAG) grant chain against your authorization server and MCP server, headlessly, from one command"
+icon: "id-card"
+---
+
+`mcpjam xaa run` drives a complete Cross-App Access flow — the
+[Identity Assertion Authorization Grant](https://datatracker.ietf.org/doc/draft-ietf-oauth-identity-assertion-authz-grant/)
+(ID-JAG, an active IETF Internet-Draft) — against your authorization server and
+MCP server. MCPJam plays the **enterprise identity provider** (it mints and
+signs the ID-JAG) and the **client/agent** (it redeems the ID-JAG and calls
+your MCP server with the resulting access token). Your authorization server
+and MCP server are the system under test.
+
+```bash
+mcpjam xaa run \
+  --url http://localhost:8788/mcp \
+  --issuer-base-url http://localhost:6274/api/mcp \
+  --sub alice@example.com \
+  --client-id my-registered-client
+```
+
+## The three parties
+
+Cross-App Access separates trust into three relationships that are easy to
+conflate. The CLI covers two of them and simulates the third:
+
+| Relationship | Who configures it | In this test |
+| --- | --- | --- |
+| Client ↔ IdP | Enterprise SSO registration | Simulated — the CLI **is** the IdP, so this leg always succeeds |
+| RAS ↔ IdP | Your authorization server trusts the IdP's issuer + JWKS | **You set this up once** (see below) |
+| Client ↔ RAS | OAuth client registration at your authorization server | Exercised per run via `--registration` |
+
+## Before you run: make the issuer reachable
+
+The CLI signs ID-JAGs with a local key pair (`~/.mcpjam/xaa-idp-private.pem`;
+override the directory with `XAA_IDP_KEY_DIR`). Your authorization server must
+be able to fetch the matching public key, so `--issuer-base-url` must be an
+origin that **publishes that same key** — not your real IdP's URL.
+
+The local MCPJam inspector serves exactly this: it publishes the issuer
+metadata and JWKS from the same key directory at
+`/api/mcp/xaa/.well-known/openid-configuration` and
+`/api/mcp/xaa/.well-known/jwks.json`, no authentication required.
+
+```bash
+mcpjam inspector start    # serves the issuer at http://localhost:6274/api/mcp/xaa
+```
+
+- **Local authorization server:** pass
+  `--issuer-base-url http://localhost:6274/api/mcp`.
+- **Cloud authorization server:** it cannot reach your localhost. Expose the
+  inspector origin through a tunnel and pass the public origin instead.
+
+Then register the issuer in your authorization server: trust
+`<issuer-base-url>/xaa` as an ID-JAG issuer and point it at the JWKS URL above.
+
+The first flow step, `verify_issuer_publication`, fails fast if the issuer
+origin is unreachable or publishes a different key — nothing is sent to your
+servers until it passes.
+
+## What a run checks
+
+Each run walks the grant chain and reports every step:
+
+1. **`verify_issuer_publication`** — the configured issuer publishes the CLI's
+   local signing key
+2. **`discover_resource_metadata`** — protected-resource metadata
+   ([RFC 9728](https://www.rfc-editor.org/rfc/rfc9728)) names the
+   authorization server protecting `--url`
+3. **`discover_authz_metadata`** — authorization-server metadata
+   ([RFC 8414](https://www.rfc-editor.org/rfc/rfc8414)) provides the token
+   endpoint and capability advertisements
+4. **`mint_id_jag`** — the mock IdP exchanges the simulated user's identity
+   assertion for an ID-JAG (`typ: oauth-id-jag+jwt`, audience = your
+   authorization server, `resource` = your MCP server)
+5. **`redeem_id_jag`** — the ID-JAG is presented at your token endpoint via
+   the JWT bearer grant
+   ([RFC 7523](https://www.rfc-editor.org/rfc/rfc7523)); your server
+   validates it and issues its own access token
+6. **`authenticated_mcp_request`** — an MCP `initialize` with the issued
+   token, advertising the
+   [Enterprise-Managed Authorization extension](https://github.com/modelcontextprotocol/ext-auth/blob/main/specification/stable/enterprise-managed-authorization.mdx)
+
+The result also records **capability evidence** separately from operational
+outcomes: whether your authorization server advertises the ID-JAG grant
+profile and the JWT bearer grant, which token-endpoint auth method was
+selected, and whether your MCP server advertises the enterprise-managed
+authorization extension back. Missing advertisements are reported as findings
+but never fail a flow that operationally succeeds — redemption is the verdict,
+advertisement is evidence.
+
+The decoded ID-JAG claims and a local signature-verification verdict are
+included in the result, so you can inspect exactly what your authorization
+server received. Raw tokens, assertions, and secrets are always redacted from
+the output — including when a server reflects them back inside error bodies.
+
+## Registration strategies
+
+`--registration` selects how the CLI identifies itself to your authorization
+server, mirroring the client-registration models MCP clients use:
+
+| Strategy | Credentials needed | Posture notes |
+| --- | --- | --- |
+| `preregistered` (default) | `--client-id` (+ optional `--client-secret`) | Matches the draft's recommended deployment |
+| `dcr` | none | A diagnostic: the CLI performs open [RFC 7591](https://www.rfc-editor.org/rfc/rfc7591) registration and supplies the IdP→RAS client mapping itself. Each run may leave a registration behind. RFC 7591 conformance findings (e.g. missing `Cache-Control: no-store`) are reported as warnings |
+| `cimd` | none | Public client by default — the run completes but is flagged: the draft recommends confidential clients |
+| `cimd` + `--client-auth private-key-jwt` | none | Confidential CIMD: the CLI generates a local EC P-256 key, publishes it through the hosted reflector, and signs a `client_assertion`. The private key never leaves your machine |
+
+For confidential CIMD, **the key is the identity**: the reflector URL derived
+from the public key becomes the `client_id`. Deleting
+`~/.mcpjam/xaa-client-private.pem` (or changing `XAA_CLIENT_PRIVATE_KEY`)
+mints a new identity, and any allowlisting on your authorization server must
+be updated.
+
+## Identity assertion formats
+
+`--assertion-format` selects the identity rail the simulated enterprise uses:
+
+- `oidc` (default) — the mock IdP mints an OIDC ID token as the
+  token-exchange subject token.
+- `saml` — the mock IdP mints a **SAML 2.0 assertion** as the subject token,
+  and the ID-JAG carries a `saml-nameid` `sub_id` claim so a SAML-federated
+  authorization server can resolve the user.
+
+The ID-JAG itself is always a JWT; the format flag changes the SSO leg and the
+subject identifier, not the grant. Either format composes with **any**
+registration strategy.
+
+Use `--sub` (and optionally `--email`) to control the simulated user, and
+`--scopes` for the permissions requested in both the ID-JAG and the token
+request.
+
+## Scenarios
+
+### First run against a local authorization server
+
+```bash
+mcpjam inspector start   # serves the issuer
+
+mcpjam xaa run \
+  --url http://localhost:8788/mcp \
+  --issuer-base-url http://localhost:6274/api/mcp \
+  --sub alice@example.com \
+  --client-id my-registered-client \
+  --scopes "mcp.access"
+```
+
+### Confidential client without pre-registration
+
+```bash
+mcpjam xaa run \
+  --url http://localhost:8788/mcp \
+  --issuer-base-url http://localhost:6274/api/mcp \
+  --sub alice@example.com \
+  --registration cimd \
+  --client-auth private-key-jwt
+```
+
+### SAML-federated enterprise
+
+```bash
+mcpjam xaa run \
+  --url http://localhost:8788/mcp \
+  --issuer-base-url http://localhost:6274/api/mcp \
+  --sub alice@example.com \
+  --client-id my-registered-client \
+  --assertion-format saml
+```
+
+### CI
+
+The JSON result goes to stdout; progress and advisory notes go to stderr. The
+exit code is `0` when the flow completes and `1` otherwise, so a run can gate
+a pipeline directly. Pass `--quiet` to suppress the advisory notes.
+
+```bash
+mcpjam xaa run \
+  --url "$MCP_SERVER_URL" \
+  --issuer-base-url "$ISSUER_ORIGIN" \
+  --sub ci-probe@example.com \
+  --client-id "$XAA_CLIENT_ID" \
+  --quiet > xaa-result.json
+```
+
+## Skipping discovery
+
+- `--authz-server-issuer` pins the authorization server and skips
+  protected-resource discovery (useful while your MCP server's RFC 9728
+  metadata is still in progress).
+- `--token-endpoint` pins the token endpoint and skips authorization-server
+  discovery entirely. Not valid with `dcr` or `cimd`, which need the metadata
+  document for the registration endpoint / CIMD advertisement.
+- `--https-only` rejects non-HTTPS and private targets; by default the CLI
+  allows `http://localhost` for local development.
+
+## What this is not
+
+These are targeted debugging checks for the current ID-JAG draft, not a
+conformance suite. The negative-test scorecard — sending deliberately broken
+ID-JAGs (bad signature, wrong audience, expired, and six more) and verifying
+your authorization server rejects each — lives in the
+[inspector's XAA Debugger](/inspector/xaa-debugger), which also visualizes the
+flow and inspects the ID-JAG interactively before it is sent.
+
+## Related standards
+
+- [Identity Assertion Authorization Grant (ID-JAG)](https://datatracker.ietf.org/doc/draft-ietf-oauth-identity-assertion-authz-grant/)
+- [OAuth 2.0 Token Exchange (RFC 8693)](https://www.rfc-editor.org/rfc/rfc8693)
+- [JWT Bearer Grant (RFC 7523)](https://www.rfc-editor.org/rfc/rfc7523)
+- [Protected Resource Metadata (RFC 9728)](https://www.rfc-editor.org/rfc/rfc9728)
+- [MCP Enterprise-Managed Authorization](https://github.com/modelcontextprotocol/ext-auth/blob/main/specification/stable/enterprise-managed-authorization.mdx)

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -107,6 +107,7 @@
               "cli/server-inspection",
               "cli/oauth-conformance",
               "cli/oauth-login",
+              "cli/xaa",
               "cli/apps-conformance",
               "cli/tools-resources-prompts",
               "cli/ci",


### PR DESCRIPTION
## Summary

The CLI's XAA coverage was a flag table in the reference with an example that cannot work. This adds a proper guide page and fixes the example, so the docs encompass what `mcpjam xaa run` actually does — timed for the XAA CLI launch.

**New: `docs/cli/xaa.mdx`** (added to the CLI nav after OAuth Login)

- The three-party trust map (Client ↔ IdP simulated, RAS ↔ IdP is the one-time setup, Client ↔ RAS exercised per run) — the registration confusion XAA users hit first.
- **"Before you run: make the issuer reachable"** — the CLI signs with a local key; `--issuer-base-url` must be an origin publishing *that* key, i.e. a running local inspector (`mcpjam inspector start`, `/api/mcp/xaa/.well-known/*`), tunneled for cloud authorization servers. Previously documented nowhere.
- The full step-by-step of what a run checks (issuer publication, RFC 9728/8414 discovery, mint, RFC 7523 redemption, authenticated MCP initialize) plus the capability-evidence rows (ID-JAG profile / jwt-bearer advertisement, EMA extension) and the advertise-vs-operational distinction.
- Registration strategies with their posture caveats (DCR diagnostic + leftover registrations, public CIMD interop-only, confidential CIMD key-is-identity) and the OIDC/SAML assertion formats — including that the two axes compose freely (the full 2×4 matrix is verified).
- CI usage: stdout/stderr contract, exit codes, `--quiet`, redaction guarantee.
- "What this is not": targeted draft-04 debugging, not a conformance suite; negative-test scorecard is the inspector's, with a link.

**Fixed: `docs/cli/reference.mdx`**

- The confidential-CIMD example pointed `--issuer-base-url` at `https://your-idp.example.com`. An origin that doesn't publish the CLI's local JWKS always fails `verify_issuer_publication`, so the documented example could never succeed. It now pairs `mcpjam inspector start` with a matching local target and links the reachability section for cloud setups.
- The `--issuer-base-url` flag row now states the requirement instead of implying any IdP URL works.

Also: `docs/cli/overview.mdx` xaa row now links to the guide; `docs.json` nav entry added.

All claims are grounded in live runs from today's XAA CLI audit (every registration strategy × both assertion formats, verified against a real reference RAS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, auth, or data-handling impact.
> 
> **Overview**
> Adds **`docs/cli/xaa.mdx`**, a dedicated guide for `mcpjam xaa run`, and wires it into the CLI nav (`docs/docs.json`) and overview table (link now points to `/cli/xaa` instead of the reference anchor).
> 
> The guide explains the three-party trust model, **issuer reachability** (local inspector JWKS vs a real IdP URL), the step-by-step ID-JAG flow and capability evidence, registration strategies (including confidential CIMD), OIDC/SAML assertion formats, CI stdout/stderr/exit behavior, and how this differs from the inspector’s negative-test scorecard.
> 
> **`docs/cli/reference.mdx`** is updated so `xaa run` links to the guide, clarifies that `--issuer-base-url` must publish the CLI’s signing key, and replaces the broken confidential-CIMD example (`https://your-idp.example.com`) with `mcpjam inspector start` plus matching localhost URLs and a tunnel note for cloud authorization servers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c49f771ab1e61a29f6aaf3f4032b13a469ef0778. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an XAA Debugger guide for the CLI and fixes an unusable issuer example so `mcpjam xaa run` works end to end. Clarifies trust setup, issuer reachability, registration strategies, and CI usage for the XAA launch.

- New Features
  - New guide at `docs/cli/xaa.mdx` covering the three-party trust map, issuer reachability via `mcpjam inspector start`, full flow steps, registration strategies (`preregistered`, `dcr`, `cimd` with `--client-auth private-key-jwt`), OIDC/SAML assertion formats, CI/stdout-stderr contract, and discovery overrides.

- Bug Fixes
  - Fixed `docs/cli/reference.mdx` example: `--issuer-base-url` now points to the local inspector origin and links to the reachability section; flag description now states it must publish the CLI’s key.
  - `docs/cli/overview.mdx` XAA row now links to the new guide.
  - Added nav entry for the guide in `docs/docs.json`.

<sup>Written for commit c49f771ab1e61a29f6aaf3f4032b13a469ef0778. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

