### PR TITLE
skill(mcp-inspector): add Cross-App Access (ID-JAG) coverage

### DIFF
--- a/skills/mcp-inspector/SKILL.md
+++ b/skills/mcp-inspector/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mcp-inspector
-description: Interpret and use `mcpjam` probe, doctor, OAuth, apps conformance, tools, resources, and prompts output conservatively against MCP 2025-11-25. Use when interacting with MCP servers, executing tools, triaging findings, performing security reviews, deciding whether a CLI finding is real or overstated, or turning inspection output into an engineer-facing report with severity and confidence.
+description: Interpret and use `mcpjam` probe, doctor, OAuth, XAA (Cross-App Access / ID-JAG), apps conformance, tools, resources, and prompts output conservatively against MCP 2025-11-25. Use when interacting with MCP servers, executing tools, triaging findings, performing security reviews, debugging enterprise-managed authorization, deciding whether a CLI finding is real or overstated, or turning inspection output into an engineer-facing report with severity and confidence.
 ---
 
 # MCPJam CLI Investigation
@@ -61,8 +61,9 @@ When the user asks to investigate, audit, or triage, use the Investigation workf
   - Use `--require-render` when a skipped render should become a hard error instead of a warning.
 9. If a field may be CLI-added or SDK-normalized, read `references/cli-surface-notes.md` before concluding anything.
 10. If the claim depends on MCP semantics, read `references/mcp-2025-11-25-interpretation.md`.
-11. If the task involves security review, read `references/security-best-practices.md` for the full checklist and follow the security review workflow below.
-12. Write the result using the output contract below.
+11. If the claim involves Cross-App Access, ID-JAG, or enterprise-managed authorization, read `references/xaa-id-jag-interpretation.md` before triaging `xaa run` output.
+12. If the task involves security review, read `references/security-best-practices.md` for the full checklist and follow the security review workflow below.
+13. Write the result using the output contract below.
 
 ## Security review workflow
 
@@ -134,6 +135,7 @@ Use `pending` instead of manufacturing a `medium` or `high` security severity fr
 - `oauth metadata`, `oauth proxy`, `oauth debug-proxy`: exact endpoint and metadata inspection when conformance output looks surprising.
 - `oauth login`: obtain reusable credentials and verify the authenticated MCP path. Use `--credentials-out <path>` to save tokens to disk (mode 0600) so later connected commands can use `--credentials-file <path>` without manual token extraction; check `references/cli-surface-notes.md` for commands that require a non-expired access token. Use this when the goal is to inspect a server that requires OAuth, then follow it with connected commands rather than stopping at the login result.
 - `oauth conformance`, `oauth conformance-suite`: flow-level auth checks. Treat these as targeted probes, not a complete security review. Use `--credentials-out <path>` when a passing flow should hand credentials to later connected commands; use `--credentials-file <path>` after that instead of extracting tokens from JSON output. Raw JSON output redacts OAuth secrets by default. When `--conformance-checks` is enabled, the command can directly probe DCR non-loopback `http://` redirects, invalid client rejection, authorization-endpoint redirect mismatch handling, invalid bearer-token rejection at the MCP server, and token-endpoint redirect mismatch handling.
+- `xaa run`: headless Cross-App Access (ID-JAG) flow against an authorization server and MCP server — mint, redeem via JWT bearer grant, and authenticated MCP initialize. Use when the task involves enterprise-managed authorization or ID-JAG trust debugging. Requires `--issuer-base-url` to point at an origin publishing the CLI's local signing key (typically `mcpjam inspector start`); read `references/xaa-id-jag-interpretation.md` before triaging its output. These are targeted checks for the current ID-JAG draft, not a conformance suite; the negative-test scorecard (tampered ID-JAGs) lives in the Inspector UI, not the CLI.
 - `apps conformance`: server-side MCP Apps checks for `_meta.ui.resourceUri`, `ui://` resources, `resources/read`, HTML MIME and payload shape, and `_meta.ui` metadata. Use this for MCP Apps surface triage.
 - `server info`, `server capabilities`, `server validate`, `server ping`, `server export`: connected behavior after initialization and auth.
 - `tools list` and `tools call`, `resources list/read/templates`, `prompts list/get/list-multi`: direct post-connect capability checks. With `--ui`, `tools call` renders the completed tool result in Inspector and reports `inspectorRender` as UI command/render evidence.
@@ -190,6 +192,12 @@ For each claimed security-review finding, return:
 - Public unauthenticated access is not itself a finding. Check whether behavior matches advertised posture and whether exposed surfaces are safe by design.
 - Anonymous trial or rate-limited access is a posture note, not a separate severity finding.
 - When compounding findings, explain the compound attack path. Do not just list unrelated findings and call the combination worse.
+- Never triage an `xaa run` failure against the target server when `verify_issuer_publication` failed or the error is a bare connection failure with an empty `steps` array. Those are local issuer-setup problems: `--issuer-base-url` must serve the CLI's local signing key.
+- Never treat `not_advertised` capability evidence in `xaa run` output as a failure when redemption succeeded, and never treat advertisement as proof redemption would succeed. Advertisement is evidence; the token-endpoint response is the verdict. `unknown` (metadata key absent) is weaker evidence than `not_advertised` (key present without the value) — do not conflate them.
+- Never treat `idJag.verified: true` as proof the authorization server validated the assertion. It is the CLI verifying its own mint against its own issuer.
+- Never claim ID-JAG conformance or a secure XAA posture from one completed `xaa run`. It proves one happy path for one registration strategy.
+- Never describe `--assertion-format saml` as producing a SAML ID-JAG. It changes the identity-assertion leg and the `sub_id` claim; the ID-JAG is always a JWT. ID-JAG is an active IETF Internet-Draft — anchor MUST/SHOULD claims to the draft revision, not to an RFC.
+- Never report `[REDACTED]` values in `xaa run` output as missing data, and never ask for un-redacted output. Redaction is by design and survives server-reflected secrets.
 
 ## Reference map
 
@@ -197,5 +205,7 @@ For each claimed security-review finding, return:
   Use for command-specific caveats, artifact shapes, local enrichments, merged errors, and normalized empty arrays.
 - `references/mcp-2025-11-25-interpretation.md`
   Use for capability, lifecycle, transport, authorization, tools, resources, and prompts interpretation against the latest MCP spec.
+- `references/xaa-id-jag-interpretation.md`
+  Use for `xaa run` output: the three-party trust model, issuer prerequisites, capability-evidence semantics, registration-warning taxonomy, SAML axes, and severity calibration for Cross-App Access findings.
 - `references/security-best-practices.md`
   Use for security review checks mapped to CLI commands. Covers SSRF, confused deputy, PKCE, token passthrough, scope minimization, auth-posture checks, and session security. Source: https://modelcontextprotocol.io/docs/tutorials/security/security_best_practices

--- a/skills/mcp-inspector/references/cli-surface-notes.md
+++ b/skills/mcp-inspector/references/cli-surface-notes.md
@@ -99,6 +99,46 @@ If a higher-priority surface contradicts a lower-priority summary, trust the hig
   - host display modes, host context changes, or postMessage bridge behavior
 - Treat a pass as evidence that the server advertises an MCP Apps surface with plausible resource wiring. Do not describe it as full SEP-1865 conformance.
 
+### `xaa run`
+
+- Drives the full Cross-App Access (ID-JAG) chain: MCPJam is both the
+  self-issuing IdP (local key pair) and the client; the authorization server
+  and MCP server are under test. See `references/xaa-id-jag-interpretation.md`
+  for the interpretation rules.
+- Result shape (top level): `completed`, `issuer`, `registration`,
+  `authzServerIssuer`, `tokenEndpoint`, `authorizationServerCapabilities`,
+  `idJag`, `redemption`, `mcp`, `steps`, and optional `error`; negative/baseline
+  runs also carry `negativeProbe`.
+- `steps[]` names are CLI projections. `mint_id_jag` = the RFC 8693
+  token-exchange request; `redeem_id_jag` = the RFC 7523 JWT-bearer request;
+  discovery steps keep their RFC 9728 / RFC 8414 names. A step is `ok` only on a
+  2xx with no transport error.
+- `verify_issuer_publication` is a **local prerequisite**, not a target check:
+  it confirms `--issuer-base-url` publishes the CLI's own signing key. A failure
+  here, or a bare connection error with an empty/publication-only `steps` array,
+  is issuer setup, not a server finding.
+- `idJag.verified` is the CLI verifying its own mint against its own issuer. It
+  is not evidence that the authorization server validated the assertion; the
+  AS's behavior is in `redemption`.
+- `authorizationServerCapabilities.*` and `mcp.xaaExtension` are three-valued
+  evidence (`advertised` / `not_advertised` / `unknown`). Advertisement is
+  evidence; the token-endpoint response (`redemption.tokenIssued`) is the
+  verdict. `unknown` (key absent) is weaker than `not_advertised` (key present
+  without the value).
+- `registration` is secret-free by construction — a DCR-minted client secret
+  never enters the result. `registration.warnings[]` codes: `public_client`
+  (posture note), `profile_metadata_not_echoed` / `grant_types_not_echoed`
+  (RFC 7591 MAY-ignore, informational), `missing_no_store` (RFC 7591 MUST for
+  credential responses, real `low` compliance finding).
+- Tokens, assertions, secrets, and the ID-JAG string are always `[REDACTED]`,
+  including secrets a token endpoint reflects into an error body. A `[REDACTED]`
+  value is intentional masking, not missing data.
+- Exit `0` only when `completed` is true; `1` otherwise, including local
+  issuer-setup failures. The JSON result is on stdout; progress and advisory
+  notes are on stderr; `--quiet` suppresses the notes.
+- The CLI does not run the tampered-ID-JAG negative scorecard; that is
+  Inspector-UI only. Do not imply a single `xaa run` tested rejection behavior.
+
 ### `tools list`
 
 - The command returns:

--- a/skills/mcp-inspector/references/security-best-practices.md
+++ b/skills/mcp-inspector/references/security-best-practices.md
@@ -206,6 +206,39 @@ Use this file when performing a security-focused review of an MCP server. Each c
 - **Best proving command**: repeated connected commands with `--rpc`
 - **Phase**: 4, with any abuse proof in 3
 
+## Cross-App Access (ID-JAG)
+
+**Attack**: A resource authorization server that accepts an ID-JAG without fully
+validating it can be tricked into issuing an access token for a forged, replayed,
+wrong-audience, or wrong-client assertion — turning the enterprise-managed trust
+chain into a token-minting oracle. Use `xaa run` to probe redemption behavior;
+read `references/xaa-id-jag-interpretation.md` first. ID-JAG is an active
+Internet-Draft — anchor severity to a specific draft revision.
+
+### Authorization server issues a token for a tampered or wrong-audience ID-JAG
+
+- **Command**: Inspector UI negative-test scorecard (bad signature, wrong audience, expired, missing claims, invalid `typ`, wrong issuer, resource mismatch, client-id mismatch, unknown `kid`). `mcpjam xaa run` establishes the happy-path baseline; the CLI itself does not send the tampered probes
+- **Where to look**: `redemption.tokenIssued` / `redemption.status` for each tampered assertion; a rejected probe is a 4xx `invalid_grant`
+- **Checklist hit**: The authorization server returns an access token for an assertion that fails a `MUST` validation (signature, `aud`, `exp`, `typ`, `iss`, `resource`, `client_id`, or `kid`)
+- **Default compliance impact**: `high`
+- **Default security impact**: `high` when acceptance is demonstrated with the exact tampered assertion; `pending` when only the happy-path run exists
+- **Escalates when**: A minted token is then accepted by the MCP server (`authenticated_mcp_request` succeeds with the forged-grant token)
+- **Do not escalate when**: The server rejected the probe (that is the desired behavior), or only the valid baseline was run — a single happy-path `xaa run` proves nothing about rejection
+- **Best proving command**: Inspector UI negative scorecard, with the decoded `idJag.claims` and `redemption` body as evidence
+- **Phase**: 3
+
+### Public-client posture on the Client ↔ RAS leg
+
+- **Command**: `xaa run --registration cimd` (public) or `--registration dcr`
+- **Where to look**: `registration.warnings[]` for `public_client`
+- **Checklist hit**: The authorization server accepts the jwt-bearer grant from a client with no key or secret
+- **Default compliance impact**: `low`
+- **Default security impact**: `info`
+- **Escalates when**: Combined with a demonstrated grant-validation weakness that a public client can actually reach and exploit — explain the compound path
+- **Do not escalate when**: It is a standalone posture observation. Draft-04 *recommends* confidential clients; a public client is a hardening note, not a vulnerability, and confidential CIMD (`--client-auth private-key-jwt`) satisfies the recommendation
+- **Best proving command**: `xaa run` with the registration warning; pair with a redemption-validation probe before compounding
+- **Phase**: 2
+
 ## What NOT to flag
 
 - Missing `scopes_supported`. This is optional.
@@ -217,3 +250,7 @@ Use this file when performing a security-focused review of an MCP server. Each c
 - A no-auth server exposing read-only public tools by design
 - Missing optional metadata like `outputSchema`. This is not a security issue.
 - A server correctly rejecting a bad request. That is the desired behavior, not a finding.
+- `not_advertised` ID-JAG capability evidence when `xaa run` redemption succeeded. Advertisement is interop evidence, not a security control.
+- A public-client XAA registration (`public_client` warning) by itself as medium or high.
+- A single completed `xaa run` as proof of ID-JAG conformance or secure posture. It is one happy path for one registration strategy.
+- `verify_issuer_publication` failure or a bare `xaa run` connection error as a target finding. That is local issuer setup.

--- a/skills/mcp-inspector/references/xaa-id-jag-interpretation.md
+++ b/skills/mcp-inspector/references/xaa-id-jag-interpretation.md
@@ -1,0 +1,147 @@
+# XAA / ID-JAG Interpretation
+
+Use this file when triaging `mcpjam xaa run` output or any Cross-App Access
+(Identity Assertion Authorization Grant) claim. ID-JAG is an active IETF
+Internet-Draft (`draft-ietf-oauth-identity-assertion-authz-grant`), not an RFC.
+Anchor `MUST`/`SHOULD` claims to a specific draft revision (current work targets
+draft-04) and treat interoperability as version-sensitive.
+
+Source docs for the command itself: `/cli/xaa` (guide) and the `xaa run` table
+in `/cli/reference`.
+
+## What the command is
+
+`xaa run` drives the full three-party grant chain headlessly. MCPJam plays two
+roles at once:
+
+- the **enterprise IdP** — it mints and signs the ID-JAG with a local key pair
+  (`~/.mcpjam/xaa-idp-private.pem`, or `XAA_IDP_KEY_DIR`).
+- the **client/agent** — it redeems the ID-JAG and calls the MCP server.
+
+The system under test is the **authorization server (RAS)** that validates the
+ID-JAG and issues an access token, plus the **MCP server (RS)** that accepts it.
+
+| Party | Role | Under test? |
+| --- | --- | --- |
+| Client ↔ IdP | Enterprise SSO registration | No — the CLI is the IdP; this leg always succeeds |
+| RAS ↔ IdP | The AS trusts the IdP issuer + JWKS | Configured once by the user; a failure here is usually setup, not a server bug |
+| Client ↔ RAS | OAuth client registration at the AS | Yes — exercised per run via `--registration` |
+
+## Issuer prerequisite (the #1 setup failure)
+
+The AS must be able to fetch the CLI's public signing key. `--issuer-base-url`
+must therefore point at an origin that **publishes that local key**, not at the
+user's real IdP. The local Inspector serves it at
+`/api/mcp/xaa/.well-known/openid-configuration` and `.../jwks.json`
+(unauthenticated). For a cloud AS, that origin must be tunneled.
+
+The first flow step, `verify_issuer_publication`, checks this before anything is
+sent to the target servers.
+
+- `verify_issuer_publication` failure → **local setup problem**, not a target
+  finding. Do not triage it against the AS or MCP server.
+- A bare `error: "fetch failed"` (or similar connection error) with an empty or
+  publication-only `steps` array → also local/transport, not a server verdict.
+
+## Step vocabulary
+
+`steps[]` names are CLI projections of protocol operations. Discovery steps keep
+their RFC names; two are renamed for readability:
+
+| Step name | What it is |
+| --- | --- |
+| `verify_issuer_publication` | The AS-side trust prerequisite (see above) |
+| `discover_resource_metadata` | RFC 9728 protected-resource metadata on `--url` |
+| `discover_authz_metadata` | RFC 8414 authorization-server metadata |
+| `mint_id_jag` | RFC 8693 token-exchange request at the IdP (CLI-side) |
+| `redeem_id_jag` | RFC 7523 JWT-bearer request at the AS token endpoint |
+| `authenticated_mcp_request` | MCP `initialize` with the issued access token |
+
+A step is `ok` only on a 2xx with no transport error. In negative/baseline runs,
+steps are prefixed (`baseline:`, `probe:`).
+
+## Capability evidence vs. operational verdict
+
+`authorizationServerCapabilities` and `mcp.xaaExtension` carry three-valued
+evidence: `advertised`, `not_advertised`, `unknown`.
+
+- **Redemption is the verdict; advertisement is evidence.** A run that mints,
+  redeems, and calls the MCP server successfully is a working flow even if
+  `idJagProfile` or `jwtBearerGrant` is `not_advertised`. Report the gap as an
+  interoperability/compliance note, never as a flow failure.
+- `unknown` (the metadata key was absent) is weaker than `not_advertised` (the
+  key was present but did not list the value). Do not conflate them.
+- `mcp.xaaExtension` reflects whether the MCP server echoed
+  `io.modelcontextprotocol/enterprise-managed-authorization` in its
+  `initialize` capabilities. `not_advertised` here is a posture/interop note,
+  not a security finding.
+
+## ID-JAG verification field
+
+`idJag.verified` is the **CLI verifying its own mint** against its own issuer +
+`typ: oauth-id-jag+jwt`. It confirms the assertion was well-formed and correctly
+signed by the CLI. It is **not** evidence that the AS validated anything — the
+AS's behavior is only in `redemption`.
+
+The decoded `idJag.claims` are useful for inspecting exactly what the AS
+received (`iss`, `sub`, `aud` = the AS, `resource` = the MCP server,
+`client_id`, `jti`, `iat`, `exp`, optional `scope`/`email`/`sub_id`).
+
+## Registration strategies and their warnings
+
+`registration` is secret-free by construction (a DCR-minted client secret never
+enters the result). `registration.warnings[]` codes and how to weight them:
+
+| Code | Meaning | Default weight |
+| --- | --- | --- |
+| `public_client` | CIMD or DCR client authenticates with no key/secret | Posture note. Draft-04 recommends confidential clients; this is not itself a vulnerability |
+| `profile_metadata_not_echoed` | DCR response omitted `authorization_grant_profiles_supported` | Informational — RFC 7591 lets a server ignore unknown metadata |
+| `grant_types_not_echoed` | DCR response omitted `grant_types` | Informational — same rationale; redemption is the real signal |
+| `missing_no_store` | DCR credential response lacked `Cache-Control: no-store` | Real compliance finding, `low` — RFC 7591 requires it for credential-bearing responses |
+
+Strategy-specific reading:
+
+- `preregistered`: `--client-id` supplied by the user. The default.
+- `dcr`: a **diagnostic**. The CLI performs open RFC 7591 registration and
+  supplies the IdP→RAS client mapping itself (it is the simulated IdP). It may
+  leave a registration behind each run (no RFC 7592 cleanup). Do not read a DCR
+  run as proof a real enterprise IdP is wired to the AS.
+- `cimd`: public by default (`public_client` warning expected). Confirms the AS
+  accepts a URL-shaped `client_id` document.
+- `cimd` + `--client-auth private-key-jwt`: confidential. The CLI publishes a
+  local EC P-256 public key via the hosted reflector; the reflector URL is the
+  `client_id`; the private key never leaves the machine. **The key is the
+  identity** — rotating the key changes `client_id` and breaks AS allowlisting.
+
+## Identity assertion formats (SAML vs OIDC)
+
+`--assertion-format` selects the **identity-assertion leg**, not the grant:
+
+- `oidc` (default): the subject token is an OIDC ID token.
+- `saml`: the subject token is a SAML 2.0 assertion, and the ID-JAG carries a
+  `saml-nameid` `sub_id` so a SAML-federated AS can resolve the user.
+
+The ID-JAG itself is always a JWT. Do not describe a run as producing a "SAML
+ID-JAG." The two axes (assertion format, registration strategy) compose freely.
+
+## Exit codes and redaction
+
+- Exit `0` only when the flow completed (`completed: true`); `1` otherwise,
+  including local issuer-setup failures. Safe to gate CI on.
+- Raw tokens, assertions, client secrets, and the ID-JAG string are always
+  `[REDACTED]`, including secrets a token endpoint reflects back inside an error
+  body. Never report a `[REDACTED]` field as missing data or request the
+  un-redacted value.
+
+## Severity calibration for XAA findings
+
+- The AS **accepting a deliberately invalid ID-JAG** (the Inspector UI's
+  negative scorecard) is a real security finding. The CLI's single happy-path
+  `xaa run` does not run those probes — do not imply it did.
+- A completed run proves one path for one strategy. It is not ID-JAG
+  conformance and not a secure-posture verdict.
+- Missing capability advertisement, public-client posture, and DCR MAY-ignore
+  warnings are `info`/`low` interop or hardening notes, not `high`.
+- Genuine `high` requires demonstrated attacker benefit — e.g. the AS issuing a
+  token for a tampered or wrong-audience ID-JAG, or token misbinding — with
+  direct evidence, consistent with the security-severity rules in `SKILL.md`.


### PR DESCRIPTION
## Summary

The `mcp-inspector` skill teaches agents to interpret `mcpjam` output conservatively — real issue vs. interop warning vs. artifact, with severity calibration. It had **zero** Cross-App Access coverage: `xaa run` appeared in no workflow, command-choice entry, hard rule, or reference. An agent triaging XAA output would improvise on exactly the calls that are easy to get wrong (issuer-setup failures, advertisement-vs-redemption, self-verification, redaction). This adds that coverage.

Every rule is grounded in verified `xaa run` behavior from the XAA CLI audit, and anchors claims to the ID-JAG Internet-Draft (draft-04), not an RFC.

## Changes

**`SKILL.md`**
- XAA / ID-JAG added to the frontmatter description so the skill fires on Cross-App Access questions.
- `xaa run` command-choice entry: when to reach for it, the `--issuer-base-url` prerequisite, and that it is not a conformance suite (the negative scorecard is Inspector-UI only).
- Investigation-workflow step to read the new reference before triaging XAA output (list renumbered, verified sequential 1–13).
- Six hard rules: issuer-setup/connection failures are local not target findings; advertisement is evidence, redemption is the verdict (and `unknown` ≠ `not_advertised`); `idJag.verified` is the CLI verifying its own mint; one run ≠ conformance/secure posture; `--assertion-format saml` is the identity leg, not a "SAML ID-JAG"; `[REDACTED]` is by design.
- Reference-map entry.

**`references/xaa-id-jag-interpretation.md`** (new) — the three-party trust model, issuer prerequisite, step-name projections, capability-evidence semantics, registration-warning taxonomy (`public_client` / `*_not_echoed` / `missing_no_store` with weights), SAML vs OIDC axes, exit codes/redaction, and XAA severity calibration.

**`references/cli-surface-notes.md`** — an `xaa run` section in the existing per-command format: result shape, `mint_id_jag`/`redeem_id_jag` projections, the secret-free `registration` block, exit codes, redaction.

**`references/security-best-practices.md`** — a Cross-App Access check block (tampered-ID-JAG acceptance → the real `high`; public-client posture → `info`) in the file's testable-check format, plus What-NOT-to-flag entries.

## Sequencing

Merge after the CIMD-fix packages publish, so the skill describes behavior the published CLI actually has — matching the docs-page timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to agent skill files; no runtime or application code.
> 
> **Overview**
> Adds **Cross-App Access / ID-JAG** guidance to the `mcp-inspector` skill so agents triaging `mcpjam xaa run` output follow conservative interpretation instead of improvising.
> 
> **`SKILL.md`** now surfaces XAA in the skill description, documents when to use `xaa run` (including `--issuer-base-url` and that tampered-ID-JAG negatives are Inspector-UI only), adds a workflow step to read the XAA reference first, six hard rules (local issuer failures vs target findings, advertisement vs redemption, `idJag.verified`, one-run limits, SAML assertion leg vs JWT ID-JAG, `[REDACTED]`), and a reference-map entry.
> 
> **New `references/xaa-id-jag-interpretation.md`** covers the three-party model, issuer publication prerequisite, step vocabulary, capability evidence semantics, registration warnings, SAML/OIDC axes, and severity calibration (draft-04, not RFC).
> 
> **`cli-surface-notes.md`** gains an `xaa run` section (result shape, steps, redaction, exit codes). **`security-best-practices.md`** adds ID-JAG checks (tampered assertion acceptance → high; public client → info) and matching “what NOT to flag” entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 368d341f2efa42cbccc4891cc71d85dd6b29c165. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Cross-App Access (ID-JAG) coverage to the `mcp-inspector` skill so agents can interpret `mcpjam xaa run` output correctly and apply calibrated severity. Includes new guidance, command selection, and security checks anchored to the ID-JAG Internet-Draft (draft-04).

- **New Features**
  - `SKILL.md`
    - Adds XAA/ID-JAG to the skill description so it triggers on Cross-App Access tasks.
    - New `xaa run` command-choice entry with `--issuer-base-url` prerequisite and a note that it is not a conformance suite.
    - Investigation workflow adds a step to read the new XAA reference (list renumbered).
    - Six hard rules: issuer-setup failures are local; advertisement is evidence while redemption is the verdict; `idJag.verified` is self-check only; one run ≠ conformance/secure posture; `--assertion-format saml` changes the identity leg only; `[REDACTED]` is by design.
    - Reference map links to the new XAA interpretation guide.
  - `references/xaa-id-jag-interpretation.md` (new)
    - Explains the three-party trust model, issuer prerequisite, step names, capability-evidence semantics, registration warning taxonomy, SAML vs OIDC axes, exit codes/redaction, and severity calibration.
  - `references/cli-surface-notes.md`
    - Adds the `xaa run` result shape, `mint_id_jag`/`redeem_id_jag` projections, secret-free `registration` block, exit codes, and redaction behavior.
  - `references/security-best-practices.md`
    - Adds XAA checks: tampered-ID-JAG acceptance (high), public-client posture (info), and “What NOT to flag” items for XAA.

<sup>Written for commit 368d341f2efa42cbccc4891cc71d85dd6b29c165. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

