### PR TITLE
ci: fix Mintlify triage pipeline (allowed_bots, auto-approve, shepherd sweep)

### DIFF
--- a/.github/workflows/mintlify-shepherd.yml
+++ b/.github/workflows/mintlify-shepherd.yml
@@ -1,0 +1,74 @@
+name: Mintlify PR Shepherd
+
+# Deterministic janitor for Mintlify bot PRs. The event-driven triage workflow
+# (mintlify-triage.yml) classifies each PR when it opens; this sweep keeps the
+# queue healthy afterwards and is the backstop that prevents silent pileups
+# (the July 2026 backlog reached 130 open PRs because triage runs were failing
+# and nothing noticed):
+#   - conflicted ("dirty") PRs are closed — the bot regenerates fresh ones
+#   - PRs queued for auto-merge that fell behind main get their branch updated
+#     (the main ruleset requires up-to-date branches, and GitHub auto-merge
+#     does not update branches on its own)
+#   - PRs still untriaged after 7 days (no auto-merge queued) are closed as a
+#     backstop; if the docs are still relevant the bot re-opens them on the
+#     next code change
+# No AI here — every action is a mechanical rule. Scoped strictly to PRs
+# authored by mintlify[bot]; human PRs are never touched.
+
+on:
+  schedule:
+    - cron: "17 */6 * * *" # every 6h, offset to dodge top-of-hour congestion
+  workflow_dispatch:
+
+concurrency:
+  group: mintlify-shepherd
+  cancel-in-progress: false
+
+jobs:
+  shepherd:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # update-branch
+      pull-requests: write # close / comment
+    steps:
+      - name: Sweep open Mintlify PRs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          now=$(date +%s)
+          closed_dirty=0; updated=0; closed_stale=0; waiting=0
+
+          prs=$(gh api --paginate "repos/$REPO/pulls?state=open&per_page=100" \
+            --jq '.[] | select(.user.login=="mintlify[bot]") | .number')
+
+          for N in $prs; do
+            data=$(gh api "repos/$REPO/pulls/$N")
+            state=$(jq -r '.mergeable_state' <<<"$data")
+            queued=$(jq -r '.auto_merge != null' <<<"$data")
+            created=$(jq -r '.created_at' <<<"$data")
+            age_days=$(( (now - $(date -d "$created" +%s)) / 86400 ))
+
+            if [ "$state" = "dirty" ]; then
+              gh api -X POST "repos/$REPO/issues/$N/comments" \
+                -f body="Closing: this docs PR conflicts with main; the Mintlify bot regenerates an up-to-date PR when the docs change again." >/dev/null
+              gh api -X PATCH "repos/$REPO/pulls/$N" -f state=closed >/dev/null
+              echo "closed (conflict) #$N"; closed_dirty=$((closed_dirty+1))
+            elif [ "$queued" = "true" ] && [ "$state" = "behind" ]; then
+              gh api -X PUT "repos/$REPO/pulls/$N/update-branch" >/dev/null \
+                && { echo "updated branch #$N"; updated=$((updated+1)); } \
+                || echo "update-branch failed #$N (will retry next sweep)"
+            elif [ "$queued" != "true" ] && [ "$age_days" -ge 7 ]; then
+              gh api -X POST "repos/$REPO/issues/$N/comments" \
+                -f body="Closing: not triaged to merge within 7 days (triage backstop); the Mintlify bot re-opens this if the docs are still relevant on the next code change." >/dev/null
+              gh api -X PATCH "repos/$REPO/pulls/$N" -f state=closed >/dev/null
+              echo "closed (stale, untriaged ${age_days}d) #$N"; closed_stale=$((closed_stale+1))
+            else
+              waiting=$((waiting+1))
+            fi
+            sleep 2 # stay clear of secondary rate limits
+          done
+
+          echo "---"
+          echo "summary: closed_dirty=$closed_dirty updated=$updated closed_stale=$closed_stale waiting=$waiting"

--- a/.github/workflows/mintlify-triage.yml
+++ b/.github/workflows/mintlify-triage.yml
@@ -39,6 +39,12 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # This workflow only ever fires for mintlify[bot] PRs (see the job
+          # `if` gate above), and claude-code-action refuses bot-initiated runs
+          # unless the bot is allowlisted. Without this line every triage run
+          # fails at startup — which is how the July 2026 backlog of 130
+          # untriaged docs PRs accumulated. Scoped to the one bot; not `*`.
+          allowed_bots: mintlify
           additional_permissions: |
             actions: read
           claude_args: >-
@@ -49,7 +55,7 @@ jobs:
 
             Investigate first (read-only):
             - Diff + metadata: `gh pr diff ${{ github.event.pull_request.number }}` and `gh pr view ${{ github.event.pull_request.number }} --json files,mergeable,mergeStateStatus,title,body`. A non-mergeable / conflicting PR usually means it targets a page that was renamed or deleted (stale).
-            - Confirm any feature the PR documents actually exists in the code: `git grep -i "<symbol or exact UI string>" -- mcpjam-inspector/ sdk/`. If you cannot find it, treat the feature as non-existent.
+            - Confirm any feature the PR documents actually exists in the code: `git grep -i "<symbol or exact UI string>" -- mcpjam-inspector/ sdk/ cli/`. If you cannot find it, treat the feature as non-existent.
             - Check whether the content is already documented: `git grep -i "<phrase>" -- docs/`.
 
             MERGE only if you can confirm ALL of: the PR is mergeable; every target page still exists; the feature is present in the code; the content is user-facing and accurate; and it is not a duplicate or editing anything under `docs/contributing/**`.
@@ -61,3 +67,27 @@ jobs:
             - CLOSE → `gh pr close ${{ github.event.pull_request.number }} --comment "<one concise sentence on why>"`
 
             Keep the comment to a single sentence.
+
+      # The main ruleset requires 1 approving review before anything merges.
+      # If (and only if) the classifier queued auto-merge above, satisfy that
+      # requirement here so verified docs PRs can actually land. This is the
+      # second half of the MERGE action, not a general bypass: it runs only in
+      # this workflow (job-gated to mintlify[bot] PRs), only after the
+      # classifier's positive verification, and a CLOSE decision leaves no
+      # auto-merge queued so the step is a no-op. Approval is posted by
+      # github-actions[bot], never the PR author.
+      # Explicitly authorized by the repo owner (2026-07-14) to unblock the
+      # docs-PR pipeline after the July backlog.
+      - name: Approve if classifier queued a merge
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          queued=$(gh api "repos/${{ github.repository }}/pulls/$PR" --jq '.auto_merge != null')
+          if [ "$queued" = "true" ]; then
+            gh api -X POST "repos/${{ github.repository }}/pulls/$PR/reviews" \
+              -f event=APPROVE \
+              -f body="Auto-approved: the Mintlify triage classifier verified this docs-only PR against the code and queued it for merge."
+          else
+            echo "No auto-merge queued (classifier closed the PR or took no action); skipping approval."
+          fi


### PR DESCRIPTION
## Why

The Mintlify triage workflow has **never successfully triaged a PR** since it landed on June 4 — 777 runs, 0 real triages. That silent failure is how the docs-PR backlog reached ~130 open PRs by mid-July (cleared manually on 2026-07-14).

Root cause (verified from run logs):

```
##[error]Action failed with error: Workflow initiated by non-human actor: mintlify (type: Bot).
Add bot to allowed_bots list or use '*' to allow all bots.
```

`claude-code-action` refuses bot-initiated runs unless the bot is allowlisted — and this workflow *only* fires for `mintlify[bot]` PRs, so every intended run died at startup. (An earlier June-era failure mode was `actions/checkout` crashing on a broken `.worktrees/pr-1962` gitlink, since removed.)

Two latent bugs would have blocked merges even past the gate:
1. Repo `allow_auto_merge` was disabled → the MERGE action `gh pr merge --auto --squash` always errored.
2. Nothing satisfied the main ruleset's 1-approving-review requirement → queued merges would never land.

## What

**`mintlify-triage.yml`**
- `allowed_bots: mintlify` — the root-cause fix (scoped to the one bot, not `*`)
- Add `cli/` to the feature-verification grep paths (the CLI source lives there; omitting it caused false "feature not found" closes)
- New step: approve as `github-actions[bot]` **iff** the classifier queued auto-merge, satisfying the required-review rule for verified docs-only PRs; no-op on CLOSE decisions. Explicitly authorized by the repo owner (2026-07-14).

**`mintlify-shepherd.yml`** (new; deterministic, no AI)
- Every 6h: close conflicted bot PRs, update queued-but-behind branches (GitHub auto-merge doesn't self-update under strict checks), and backstop-close bot PRs untriaged for 7+ days — so a pileup can never accumulate silently again. Scoped strictly to `mintlify[bot]`-authored PRs.

**Settings enabled alongside** (already applied): repo `allow_auto_merge` + `allow_update_branch`; org+repo "Allow GitHub Actions to create and approve pull requests" (the approve step 403s without it).

## Verification

- Both YAMLs parse; shepherd bash body passes `bash -n`
- Run-history evidence: last 100 runs = 24 failures (all Mintlify PRs) / 75 skipped (human PRs, correct gate) / 1 vacuous success (app-token exchange 500'd, took no action)
- End-to-end merge mechanics (approve → auto-merge → strict-update → land) were exercised manually today across 41 docs PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces automated PR close/approve/update-branch actions on a bot-only scope; misconfiguration could close valid docs PRs or approve merges incorrectly, though gates limit blast radius.
> 
> **Overview**
> Repairs the **Mintlify docs PR pipeline** so triage can run and verified PRs can merge, and adds a scheduled janitor so bot PRs do not pile up silently again.
> 
> **`mintlify-triage.yml`** adds `allowed_bots: mintlify` so `claude-code-action` accepts bot-opened PRs (previously every run failed at startup). The classifier prompt now includes **`cli/`** in feature-verification greps. A new step **approves as `github-actions[bot]`** only when the classifier already queued auto-merge, satisfying the repo’s required review without affecting CLOSE outcomes.
> 
> **`mintlify-shepherd.yml`** (new, no AI) runs every 6 hours on **`mintlify[bot]`** PRs only: closes conflicted PRs, **update-branch** for auto-merge PRs that are behind `main`, and closes untriaged PRs older than 7 days with an explanatory comment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce0ae36c319497d712df2e8675380d40b072be0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Mintlify triage workflow so `mintlify[bot]` docs PRs are triaged and can auto-merge when verified. Adds a 6-hour shepherd sweep to keep the queue clean and prevent backlogs.

- **Bug Fixes**
  - Allow `mintlify[bot]` runs by setting `allowed_bots: mintlify` for `anthropics/claude-code-action`.
  - Include `cli/` in the feature verification grep paths to avoid false “feature not found” closes.
  - Auto-approve as `github-actions[bot]` only when auto-merge is queued, satisfying the required review.

- **New Features**
  - Add `mintlify-shepherd.yml`: every 6h it updates behind branches queued for auto-merge, closes conflicted PRs, and backstop-closes untriaged PRs after 7 days; scoped to `mintlify[bot]` only.

<sup>Written for commit ce0ae36c319497d712df2e8675380d40b072be0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

