### PR TITLE
fix(xaa): mock the xaa-registration flag in the flow-tab suite (main is red)

### DIFF
--- a/mcpjam-inspector/client/src/components/__tests__/XAAFlowTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/XAAFlowTab.test.tsx
@@ -21,6 +21,14 @@ vi.mock("convex/react", () => ({
   useConvexAuth: () => ({ isAuthenticated: true, isLoading: false }),
 }));
 
+// The "Run as" people strip rides the xaa-registration flag (the debugger
+// extras are hidden together until launch). Default it on so the suite
+// exercises the strip; the gate itself is asserted below by flipping it.
+let registrationFlag: boolean | undefined = true;
+vi.mock("posthog-js/react", () => ({
+  useFeatureFlagEnabled: () => registrationFlag,
+}));
+
 // Controllable org list — drives the admin derivation (owner/admin/creator).
 let organizationsState: Array<{
   _id: string;
@@ -351,6 +359,7 @@ describe("XAAFlowTab", () => {
     // authUser to null (guest), and a mid-test failure must not leak that into
     // later tests.
     authUser = { email: "tester@example.com" };
+    registrationFlag = true;
     resourceApps = [];
     localStorage.clear();
     runSettingsState = {
@@ -1269,6 +1278,24 @@ describe("XAAFlowTab", () => {
       expect(capturedPeopleStripProps.disabled).toBe(false);
       capturedPeopleStripProps.onSelectPerson(null);
       expect(setSelectedPersonIdMock).toHaveBeenCalledWith("proj_1", null);
+    });
+
+    // The gate itself: the strip is an unreleased debugger extra, hidden
+    // unless the flag resolves explicitly true. `undefined` (flag still
+    // loading, or PostHog unavailable) must hide it too — the strict
+    // `=== true` check is the point, so an unresolved flag never leaks the
+    // surface.
+    it.each([
+      ["off", false],
+      ["unresolved", undefined],
+    ])("hides the people strip when the flag is %s", (_label, flagValue) => {
+      registrationFlag = flagValue as boolean | undefined;
+      seedRoster();
+      currentTarget = personTarget();
+      renderTab();
+
+      expect(screen.queryByTestId("xaa-people-strip")).not.toBeInTheDocument();
+      expect(capturedPeopleStripProps).toBeNull();
     });
 
     it("a person switch resets a completed flow immediately (no debounce)", async () => {


### PR DESCRIPTION
## main is red — this fixes it

`client/src/components/__tests__/XAAFlowTab.test.tsx` fails **20 tests on `main`** today. Latest main run: [29390222150](https://github.com/MCPJam/inspector/actions/runs/29390222150) (`a9039e1d`) — `Tests  20 failed | 8467 passed`. It is the only failing file in the repo; every other suite is green.

## Cause

#3224 gated the "Run as" people strip behind the `xaa-registration` flag:

```tsx
// XAAFlowTab.tsx:514
const registrationEnabled = useFeatureFlagEnabled("xaa-registration");
// XAAFlowTab.tsx:1838
{registrationEnabled === true && (<XAAPeopleStrip ... />)}
```

…but `XAAFlowTab.test.tsx` has no `posthog-js/react` mock. The hook resolves `undefined`, the strip never renders, `capturedPeopleStripProps` stays `null`, and all 20 tests in the "Run as people" and "managed IdP mode" blocks die on `TypeError: Cannot read properties of null (reading 'selectedPersonId')`.

`XAAIdpCard.test.tsx` received the mock in that same PR — the flow-tab suite was just missed.

## Fix

Mock the flag the same way the IdP card suite already does, defaulted **on** so the 20 tests exercise the strip exactly as they were written to.

Plus two tests pinning the gate itself, which #3224 introduced and never covered: the strip is hidden when the flag is **off** *and* when it is **unresolved** (`undefined`). The strict `=== true` is deliberate — a flag that's still loading, or PostHog being unavailable, must not leak an unreleased surface — so both cases are worth holding down.

I checked these aren't vacuous: forcing the flag on inside them fails exactly those 2 tests.

## Result

| | failed | passed |
|---|---|---|
| `main` today | 20 | 41 |
| this branch | 0 | 63 (61 restored + 2 new) |

`npm run typecheck:client` clean. **Test-only — no production code touched.**

Found while rebasing #3234, which inherits these same 20 failures; that PR goes green once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production or runtime behavior impact.
> 
> **Overview**
> Restores **20 failing** `XAAFlowTab` tests after production gated the **Run as** people strip on `useFeatureFlagEnabled("xaa-registration")` with a strict `=== true` check. The suite had no PostHog mock, so the hook returned `undefined`, the strip never mounted, and tests that read `capturedPeopleStripProps` crashed.
> 
> Adds a controllable `posthog-js/react` mock with **`registrationFlag` default `true`** (reset in `beforeEach`), matching the pattern used in `XAAIdpCard.test.tsx`. Adds **`it.each`** coverage that the strip stays hidden when the flag is **`false`** or **`undefined`** (loading/unavailable must not expose the unreleased UI).
> 
> **Test-only** — no application code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a6cc8720f8e0f24ec4e3cb5de070f089b435876. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 20 failing tests on main by mocking the `xaa-registration` feature flag in `XAAFlowTab.test.tsx`. Restores the "Run as" people strip tests and adds coverage for the flag gate; no production code changed.

- **Bug Fixes**
  - Mock `useFeatureFlagEnabled("xaa-registration")` from `posthog-js/react`, defaulting to `true` so the suite exercises the people strip.
  - Add tests that hide the strip when the flag is `false` or `undefined` to pin the strict `=== true` behavior.
  - Result: 20 failures -> 0; suite green.

<sup>Written for commit 6a6cc8720f8e0f24ec4e3cb5de070f089b435876. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

