### PR TITLE
changesets

### DIFF
--- a/.changeset/xaa-identity-assertion-toggle.md
+++ b/.changeset/xaa-identity-assertion-toggle.md
@@ -1,0 +1,7 @@
+---
+"@mcpjam/inspector": minor
+---
+
+Add an XAA debugger identity-assertion toggle for OIDC and SAML personas.
+
+The debugger header now lets users switch the active identity assertion mode, reuses shared XAA server form parsing, and keeps persona/registration surfaces behind the XAA registration flag.


### PR DESCRIPTION
Adds the missing changeset for the XAA debugger identity-assertion toggle on latest main.\n\nValidated with Changesets status from the clean worktree:\n- @mcpjam/inspector: minor\n- @mcpjam/sdk: patch\n- @mcpjam/cli: patch

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the missing changeset for the XAA debugger identity-assertion toggle (switch OIDC/SAML personas in the debugger) so it ships with proper release notes and versioning.
This bumps `@mcpjam/inspector` (minor), `@mcpjam/sdk` (patch), and `@mcpjam/cli` (patch).

<sup>Written for commit 56b37195862187f6e718c8d2cd168056f04b00c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

