### PR TITLE
polish(xaa): tighten IdP bar layout and surface people chip actions

### DIFF
--- a/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
@@ -1,6 +1,11 @@
-import { useEffect, useRef, useState } from "react";
-import { AlertTriangle, Check, Copy, Info, KeyRound } from "lucide-react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { Check, Copy, Info, KeyRound } from "lucide-react";
 import { Switch } from "@mcpjam/design-system/switch";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@mcpjam/design-system/tooltip";
 import { useLearnMore } from "@/hooks/use-learn-more";
 import { LearnMoreExpandedPanel } from "@/components/learn-more/LearnMoreExpandedPanel";
 import { SegmentedControl } from "@/components/ui/json-editor/segmented-control";
@@ -14,6 +19,36 @@ import {
 import type { XaaIssuerMode } from "@/hooks/useXaaRunSettings";
 import type { IdentityAssertionFormat } from "@/shared/xaa.js";
 import { IDENTITY_ASSERTION_FORMAT_HINTS } from "./xaa-server-form";
+
+function IssuerModeHint({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          aria-label={label}
+          className="inline-flex shrink-0 rounded-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <Info className="h-3.5 w-3.5" />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent
+        side="bottom"
+        align="start"
+        variant="muted"
+        className="max-w-sm text-left text-balance"
+      >
+        {children}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
 
 // A compact click-to-copy chip: shows only the label to keep the bar minimal —
 // the long URL stays hidden (revealed on hover via the native title) and the
@@ -232,6 +267,67 @@ export function XAAIdpCard({
                 />
               </div>
             )}
+            {!HOSTED_MODE && (
+              <div className="flex shrink-0 flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                {onIssuerModeChange && (
+                  <label className="flex items-center gap-2">
+                    <Switch
+                      checked={hostedIssuerOn}
+                      disabled={!canUseHostedIssuer}
+                      onCheckedChange={(checked) =>
+                        onIssuerModeChange(checked ? "hosted" : "local")
+                      }
+                      aria-label="Use hosted issuer"
+                    />
+                    <span className="font-medium text-foreground">
+                      Use hosted issuer (app.mcpjam.com)
+                    </span>
+                  </label>
+                )}
+                {hostedIssuerOn ? (
+                  <IssuerModeHint label="About the hosted issuer">
+                    ID tokens and ID-JAGs are minted by{" "}
+                    <code className="font-mono">app.mcpjam.com</code>, so a
+                    cloud authorization server can discover this issuer and
+                    fetch its JWKS. No tunnel is needed. Token requests and MCP
+                    calls still run from this machine; your authorization server
+                    must be reachable over https.
+                    {issuerKind === "anonymous" && (
+                      <>
+                        {" "}
+                        This session mints under the{" "}
+                        <b>anonymous test issuer</b> (
+                        <code className="font-mono">/g/…</code>): its discovery
+                        document is marked{" "}
+                        <code className="font-mono">
+                          mcpjam:issuer_kind: anonymous-test
+                        </code>{" "}
+                        and an authorization server must explicitly allowlist
+                        it. Assertions prove control of an anonymous session —
+                        this is a testing convenience, not enterprise-managed
+                        authorization. Sign in to mint under a membership-gated
+                        organization issuer.
+                      </>
+                    )}
+                  </IssuerModeHint>
+                ) : (
+                  <IssuerModeHint label="About local issuer URLs">
+                    These are local URLs. Your authorization server can only
+                    fetch them if it can reach this machine. A cloud-hosted Okta
+                    or Auth0 tenant cannot reach{" "}
+                    <code className="font-mono">localhost</code>.
+                    {onIssuerModeChange
+                      ? " Flip on the hosted issuer, or expose MCPJam with a public tunnel (e.g. ngrok)."
+                      : " Expose MCPJam with a public tunnel (e.g. ngrok) first."}
+                  </IssuerModeHint>
+                )}
+                {onIssuerModeChange &&
+                  !canUseHostedIssuer &&
+                  hostedIssuerDisabledReason && (
+                    <span>({hostedIssuerDisabledReason})</span>
+                  )}
+              </div>
+            )}
           </div>
         </div>
         <div className="flex shrink-0 items-center gap-2">
@@ -255,79 +351,6 @@ export function XAAIdpCard({
             are unchanged.
           </div>
         )}
-
-      {!HOSTED_MODE && (
-        <div className="mt-3 space-y-2 text-xs text-muted-foreground">
-          {onIssuerModeChange && (
-            <label className="flex items-center gap-2">
-              <Switch
-                checked={hostedIssuerOn}
-                disabled={!canUseHostedIssuer}
-                onCheckedChange={(checked) =>
-                  onIssuerModeChange(checked ? "hosted" : "local")
-                }
-                aria-label="Use hosted issuer"
-              />
-              <span className="font-medium text-foreground">
-                Use hosted issuer (app.mcpjam.com)
-              </span>
-              {issuerKind === "anonymous" && (
-                <span
-                  className="rounded bg-amber-500/15 px-1.5 py-0.5 font-medium text-amber-600 dark:text-amber-400"
-                  data-testid="anonymous-issuer-badge"
-                >
-                  Anonymous test issuer
-                </span>
-              )}
-              {!canUseHostedIssuer && hostedIssuerDisabledReason && (
-                <span>({hostedIssuerDisabledReason})</span>
-              )}
-            </label>
-          )}
-          {hostedIssuerOn ? (
-            <div className="flex items-start gap-2">
-              <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-              <span>
-                ID tokens and ID-JAGs are minted by{" "}
-                <code className="font-mono">app.mcpjam.com</code>, so a cloud
-                authorization server can discover this issuer and fetch its
-                JWKS. No tunnel is needed. Token requests and MCP calls still
-                run from this machine; your authorization server must be
-                reachable over https.
-                {issuerKind === "anonymous" && (
-                  <>
-                    {" "}
-                    This session mints under the <b>anonymous test issuer</b>{" "}
-                    (<code className="font-mono">/g/…</code>): its discovery
-                    document is marked{" "}
-                    <code className="font-mono">
-                      mcpjam:issuer_kind: anonymous-test
-                    </code>{" "}
-                    and an authorization server must explicitly allowlist it.
-                    Assertions prove control of an anonymous session — this is
-                    a testing convenience, not enterprise-managed
-                    authorization. Sign in to mint under a
-                    membership-gated organization issuer.
-                  </>
-                )}
-              </span>
-            </div>
-          ) : (
-            <div className="flex items-start gap-2">
-              <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-500" />
-              <span>
-                These are local URLs. Your authorization server can only fetch
-                them if it can reach this machine. A cloud-hosted Okta or Auth0
-                tenant cannot reach <code className="font-mono">localhost</code>
-                .
-                {onIssuerModeChange
-                  ? " Flip on the hosted issuer above, or expose MCPJam with a public tunnel (e.g. ngrok)."
-                  : " Expose MCPJam with a public tunnel (e.g. ngrok) first."}
-              </span>
-            </div>
-          )}
-        </div>
-      )}
 
       {isOrgScoped &&
         (issuerKind === "anonymous" ? (

--- a/mcpjam-inspector/client/src/components/xaa/XAAPeopleStrip.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAPeopleStrip.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useId, useState } from "react";
-import { Check, Pencil, Plus } from "lucide-react";
+import { Check, Pencil, Plus, Trash2 } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
 import { Input } from "@mcpjam/design-system/input";
 import { Label } from "@mcpjam/design-system/label";
@@ -13,6 +13,7 @@ import {
   useXaaPeopleMutations,
   type RemoteXaaPerson,
 } from "@/hooks/useXaaPeople";
+import { cn } from "@/lib/utils";
 
 /** Per-person result of the last valid run against the current target,
  * as ruled by the resource authorization server (jwt-bearer redemption).
@@ -199,10 +200,11 @@ export function PersonForm({
             type="button"
             variant="ghost"
             size="sm"
-            className="text-destructive hover:text-destructive"
+            className="gap-1.5 text-destructive hover:text-destructive"
             disabled={busy}
             onClick={() => void handleDelete()}
           >
+            <Trash2 className="size-3.5" />
             Delete
           </Button>
         ) : (
@@ -247,8 +249,10 @@ export function XAAPeopleStrip({
   disabled: boolean;
   outcomeFor: (personId: string) => XaaPersonOutcome | undefined;
 }) {
+  const { remove } = useXaaPeopleMutations();
   const [editingId, setEditingId] = useState<string | null>(null);
   const [adding, setAdding] = useState(false);
+  const [removingId, setRemovingId] = useState<string | null>(null);
 
   // If the roster shrinks under an open edit popover, close it.
   useEffect(() => {
@@ -301,67 +305,109 @@ export function XAAPeopleStrip({
       {people.map((person) => {
         const selected = person._id === selectedPersonId;
         const outcome = outcomeFor(person._id);
+        const chipBusy = disabled || removingId === person._id;
         return (
-          <div key={person._id} className="group/chip flex items-center">
+          <div
+            key={person._id}
+            className={cn(
+              "group/chip flex items-center rounded-full border py-1 pl-1 pr-1 transition-colors",
+              selected
+                ? "border-primary/60 bg-primary/5 ring-1 ring-primary/40"
+                : "border-border/60 hover:bg-muted/40",
+              chipBusy && "opacity-60",
+            )}
+          >
             <button
               type="button"
               aria-pressed={selected}
-              aria-disabled={disabled || undefined}
+              aria-disabled={chipBusy || undefined}
               title={`${person.subject} · ${person.email}`}
               onClick={() => {
-                if (disabled) return;
+                if (chipBusy) return;
                 onSelectPerson(selected ? null : person._id);
               }}
-              className={`flex items-center gap-2 rounded-full border py-1 pl-1 pr-3 text-left transition-colors ${
-                selected
-                  ? "border-primary/60 bg-primary/5 ring-1 ring-primary/40"
-                  : "border-border/60 hover:bg-muted/40"
-              } ${disabled ? "cursor-not-allowed opacity-60" : ""}`}
+              className={cn(
+                "flex items-center gap-2 rounded-full py-0 pl-0 pr-2 text-left",
+                chipBusy && "cursor-not-allowed",
+              )}
             >
               <CharacterAvatar name={person.name} seed={person._id} size="sm" />
               <span className="text-xs font-medium">{person.name}</span>
               {outcome ? <OutcomeBadge outcome={outcome} /> : null}
             </button>
-            <Popover
-              // Same run-in-progress guard as chip switching: editing or
-              // deleting a person mid-run would mutate/deselect the running
-              // identity through the back door the disabled chips close.
-              open={!disabled && editingId === person._id}
-              onOpenChange={(open) => {
-                if (disabled) return;
-                setEditingId(open ? person._id : null);
-              }}
-            >
-              <PopoverTrigger asChild>
-                <button
-                  type="button"
-                  aria-label={`Edit ${person.name}`}
-                  aria-disabled={disabled || undefined}
-                  className={`ml-0.5 rounded p-1 text-muted-foreground opacity-0 transition-opacity focus-visible:opacity-100 group-hover/chip:opacity-100 ${
-                    disabled
-                      ? "cursor-not-allowed"
-                      : "hover:text-foreground"
-                  }`}
-                >
-                  <Pencil className="size-3" />
-                </button>
-              </PopoverTrigger>
-              <PopoverContent align="start" className="w-80">
-                <PersonForm
-                  initial={{
-                    name: person.name,
-                    subject: person.subject,
-                    email: person.email,
-                  }}
-                  personId={person._id}
-                  projectId={projectId}
-                  onDone={() => setEditingId(null)}
-                  onDeleted={() => {
-                    if (selected) onSelectPerson(null);
-                  }}
-                />
-              </PopoverContent>
-            </Popover>
+            <div className="flex items-center border-l border-border/60 pl-0.5">
+              <Popover
+                // Same run-in-progress guard as chip switching: editing or
+                // deleting a person mid-run would mutate/deselect the running
+                // identity through the back door the disabled chips close.
+                open={!chipBusy && editingId === person._id}
+                onOpenChange={(open) => {
+                  if (chipBusy) return;
+                  setEditingId(open ? person._id : null);
+                }}
+              >
+                <PopoverTrigger asChild>
+                  <button
+                    type="button"
+                    aria-label={`Edit ${person.name}`}
+                    aria-disabled={chipBusy || undefined}
+                    title={`Edit ${person.name}`}
+                    className={cn(
+                      "rounded-full p-1.5 text-muted-foreground transition-colors",
+                      chipBusy
+                        ? "cursor-not-allowed"
+                        : "hover:bg-muted hover:text-foreground",
+                    )}
+                  >
+                    <Pencil className="size-3.5" />
+                  </button>
+                </PopoverTrigger>
+                <PopoverContent align="start" className="w-80">
+                  <PersonForm
+                    initial={{
+                      name: person.name,
+                      subject: person.subject,
+                      email: person.email,
+                    }}
+                    personId={person._id}
+                    projectId={projectId}
+                    onDone={() => setEditingId(null)}
+                    onDeleted={() => {
+                      if (selected) onSelectPerson(null);
+                    }}
+                  />
+                </PopoverContent>
+              </Popover>
+              <button
+                type="button"
+                aria-label={`Remove ${person.name}`}
+                aria-disabled={chipBusy || undefined}
+                title={`Remove ${person.name}`}
+                disabled={chipBusy}
+                onClick={() => {
+                  if (chipBusy) return;
+                  setRemovingId(person._id);
+                  void remove({ testIdentityId: person._id })
+                    .then(() => {
+                      if (selected) onSelectPerson(null);
+                      if (editingId === person._id) setEditingId(null);
+                    })
+                    .finally(() => {
+                      setRemovingId((current) =>
+                        current === person._id ? null : current,
+                      );
+                    });
+                }}
+                className={cn(
+                  "rounded-full p-1.5 text-muted-foreground transition-colors",
+                  chipBusy
+                    ? "cursor-not-allowed"
+                    : "hover:bg-destructive/10 hover:text-destructive",
+                )}
+              >
+                <Trash2 className="size-3.5" />
+              </button>
+            </div>
           </div>
         );
       })}

--- a/mcpjam-inspector/client/src/components/xaa/__tests__/XAAIdpCard.test.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/__tests__/XAAIdpCard.test.tsx
@@ -265,21 +265,26 @@ describe("XAAIdpCard (non-hosted mode)", () => {
       copyToClipboard: async () => true,
     }));
     const { XAAIdpCard: LocalIdpCard } = await import("../XAAIdpCard");
+    const user = userEvent.setup();
 
     render(<LocalIdpCard />);
 
-    expect(
-      screen.getByText(/Expose\s+MCPJam with a public tunnel/i)
-    ).toBeInTheDocument();
+    await user.hover(
+      screen.getByRole("button", { name: /about local issuer urls/i })
+    );
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      /Expose\s+MCPJam with a public tunnel/i
+    );
   });
 
-  it("badges the hosted-issuer toggle for guest sessions (anonymous kind)", async () => {
+  it("keeps the hosted-issuer toggle usable for guest sessions (anonymous kind)", async () => {
     vi.resetModules();
     vi.doMock("@/lib/config", () => ({ HOSTED_MODE: false }));
     vi.doMock("@/lib/clipboard", () => ({
       copyToClipboard: async () => true,
     }));
     const { XAAIdpCard: LocalIdpCard } = await import("../XAAIdpCard");
+    const user = userEvent.setup();
 
     render(
       <LocalIdpCard
@@ -291,10 +296,12 @@ describe("XAAIdpCard (non-hosted mode)", () => {
       />
     );
 
-    expect(screen.getByTestId("anonymous-issuer-badge")).toHaveTextContent(
-      /anonymous test issuer/i
+    await user.hover(
+      screen.getByRole("button", { name: /about the hosted issuer/i })
     );
-    expect(screen.getByText(/must explicitly allowlist/i)).toBeInTheDocument();
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      /must explicitly allowlist/i
+    );
     // The toggle itself stays usable for guests with an org.
     expect(
       screen.getByRole("switch", { name: /use hosted issuer/i })

--- a/mcpjam-inspector/client/src/components/xaa/__tests__/XAAPeopleStrip.test.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/__tests__/XAAPeopleStrip.test.tsx
@@ -114,13 +114,47 @@ describe("XAAPeopleStrip", () => {
     expect(props.onSelectPerson).not.toHaveBeenCalled();
   });
 
-  it("blocks the edit popover while disabled — no mid-run edit/delete back door", async () => {
+  it("blocks edit and remove while disabled — no mid-run back door", async () => {
     const user = userEvent.setup();
     renderStrip({ disabled: true });
-    // The pencil is still rendered (discoverable) but opening is inert, so
-    // the running identity can't be mutated or deleted through the form.
+    // Actions stay visible (discoverable) but inert while a run is busy.
     await user.click(screen.getByRole("button", { name: /edit bob tables/i }));
     expect(screen.queryByLabelText(/name/i)).not.toBeInTheDocument();
+    await user.click(
+      screen.getByRole("button", { name: /remove bob tables/i }),
+    );
+    expect(removeMock).not.toHaveBeenCalled();
+  });
+
+  it("shows always-visible edit and remove actions on each chip", () => {
+    renderStrip();
+    expect(
+      screen.getByRole("button", { name: /edit bob tables/i }),
+    ).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: /remove bob tables/i }),
+    ).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: /edit jonah kim/i }),
+    ).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: /remove jonah kim/i }),
+    ).toBeVisible();
+  });
+
+  it("removes a person from the chip trash control and clears selection", async () => {
+    const user = userEvent.setup();
+    removeMock.mockResolvedValue({ ok: true });
+    const { props } = renderStrip({ selectedPersonId: bob._id });
+
+    await user.click(
+      screen.getByRole("button", { name: /remove bob tables/i }),
+    );
+
+    await waitFor(() =>
+      expect(removeMock).toHaveBeenCalledWith({ testIdentityId: bob._id }),
+    );
+    expect(props.onSelectPerson).toHaveBeenCalledWith(null);
   });
 
   it("renders outcome badges from outcomeFor", () => {


### PR DESCRIPTION
## Summary
- Collapse long local/hosted issuer guidance into an info-icon tooltip, and drop the anonymous badge from the toggle row
- Keep Identity assertion and the hosted-issuer toggle in the same IdP toolbar row as the title and URL chips
- Make edit (pencil) and remove (trash) always visible on Run-as person chips, with remove available from the chip itself

## Test plan
- [ ] In a local build, open the XAA debugger and confirm the IdP bar fits assertion + hosted-issuer controls without a separate guidance row
- [ ] Hover the info icon for local and hosted issuer modes and confirm the full guidance still appears
- [ ] Confirm guest/anonymous sessions no longer show the "Anonymous test issuer" badge next to the hosted toggle
- [ ] Confirm each Run-as chip shows always-visible edit and remove controls
- [ ] Edit a person via the pencil; remove a person via the chip trash and via the form Delete button
- [ ] Start a run and confirm edit/remove/select stay inert while busy
- [ ] `npm test -- --run client/src/components/xaa/__tests__/XAAIdpCard.test.tsx client/src/components/xaa/__tests__/XAAPeopleStrip.test.tsx`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polishes the XAA IdP toolbar by moving issuer guidance into tooltips and keeping all controls on one row; surfaces always‑visible edit/remove actions on Run‑as people chips. This reduces visual noise and makes actions faster to reach.

- **New Features**
  - Issuer guidance is now shown in info-tooltips for local and hosted modes; the "Anonymous test issuer" badge is removed from the toggle row.
  - Identity assertion and the hosted-issuer switch sit on the same bar with the title and issuer URL chips.
  - Each Run‑as chip shows always-visible edit (pencil) and remove (trash) actions; removal works directly from the chip and actions are inert while a run is busy.

<sup>Written for commit 441ef06788100669ab43e5046c53774ee70795ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

