### PR TITLE
docs(cli): recommend the mcp-inspector Agent Skill on the XAA page

### DIFF
--- a/docs/cli/xaa.mdx
+++ b/docs/cli/xaa.mdx
@@ -20,6 +20,21 @@ mcpjam xaa run \
   --client-id my-registered-client
 ```
 
+## Recommended: use with Agent Skills
+
+The easiest way to use the CLI is through the
+[MCPJam skill](https://github.com/MCPJam/inspector/tree/main/skills/mcp-inspector),
+which gives your agent full context on every command and workflow.
+
+```bash
+npx skills add mcpjam/inspector --skill mcp-inspector
+```
+
+Once installed, your agent will know how and when to invoke `mcpjam` commands
+automatically — and how to read `xaa run` output conservatively (advertisement
+is evidence, redemption is the verdict; an issuer it can't reach is your setup,
+not a server bug).
+
 ## The three parties
 
 Cross-App Access separates trust into three relationships that are easy to


### PR DESCRIPTION
## Summary

Adds a **"Recommended: use with Agent Skills"** section near the top of the `/cli/xaa` guide, matching the requested design: a one-line pitch, the install command, and a note on what the skill gives the agent.

```
npx skills add mcpjam/inspector --skill mcp-inspector
```

The XAA CLI guide (#3237) and the `mcp-inspector` skill (#3238) shipped as separate PRs and were never cross-linked — a reader on the docs page had no way to discover that an agent skill exists for driving the CLI. This connects them, and the closing note ties the skill to the honest-interpretation rules it actually encodes (advertisement is evidence, redemption is the verdict; an unreachable issuer is local setup, not a server bug).

Placed right after the opening example so the recommended path is the first thing a reader sees.

## To confirm before / after merge

- **The install command** `npx skills add mcpjam/inspector --skill mcp-inspector` is reproduced from the requested design — please confirm that command is actually live (the `skills` CLI resolves `mcpjam/inspector` and the `mcp-inspector` skill) before this is published, or point me at the real one.
- **The "MCPJam skill" link** currently points at the skill's source dir on GitHub (`skills/mcp-inspector`). Swap it for a dedicated skill/marketplace page if one exists.

If this section is meant to be standard across CLI pages (not just XAA), say so and I'll add the same block to the other `/cli/*` guides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or security impact.
> 
> **Overview**
> Adds a **"Recommended: use with Agent Skills"** section to the XAA CLI guide immediately after the opening `mcpjam xaa run` example, cross-linking the `mcp-inspector` skill with install instructions (`npx skills add mcpjam/inspector --skill mcp-inspector`).
> 
> The section mirrors the pattern on the CLI overview but adds XAA-specific guidance: agents should interpret `xaa run` output conservatively (advertisement vs. redemption, unreachable issuer as local setup).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 109ec690844350177a066a5f9f6ea07d9cd80b2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Recommended: use with Agent Skills” block to the XAA CLI guide, linking to the MCPJam `mcp-inspector` skill and showing the install command: `npx skills add mcpjam/inspector --skill mcp-inspector`.
This helps users run `mcpjam` via an agent and explains how the skill interprets `xaa run` output.

<sup>Written for commit 109ec690844350177a066a5f9f6ea07d9cd80b2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

