### PR TITLE
xaa + oauth debugger pollishes

### DIFF
--- a/mcpjam-inspector/client/src/components/OAuthFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/OAuthFlowTab.tsx
@@ -92,7 +92,7 @@ interface OAuthFlowTabProps {
   onSelectServer: (serverName: string) => void;
   onSaveServerConfig?: (
     formData: ServerFormData,
-    options?: { oauthProfile?: OAuthTestProfile },
+    options?: { oauthProfile?: OAuthTestProfile; originalServerName?: string },
   ) => void;
   onConnectWithTokens?: (
     serverName: string,
@@ -124,6 +124,15 @@ export const OAuthFlowTab = ({
   openProfileModalSignal,
 }: OAuthFlowTabProps) => {
   const [isProfileModalOpen, setIsProfileModalOpen] = useState(false);
+  // "edit" opens the modal prefilled with the selected server; "add" opens it
+  // blank so a new target can be saved without touching the current one.
+  const [profileModalMode, setProfileModalMode] = useState<"edit" | "add">(
+    "edit",
+  );
+  const openProfileModal = useCallback((mode: "edit" | "add") => {
+    setProfileModalMode(mode);
+    setIsProfileModalOpen(true);
+  }, []);
 
   // Open the modal when the shell bumps the signal (header "Add Server"). Skip
   // the initial value so it doesn't pop open on mount.
@@ -131,8 +140,10 @@ export const OAuthFlowTab = ({
   useEffect(() => {
     if (openProfileModalSignal === prevOpenSignalRef.current) return;
     prevOpenSignalRef.current = openProfileModalSignal;
-    setIsProfileModalOpen(true);
-  }, [openProfileModalSignal]);
+    // The header button reads "Add Server" — open blank, not prefilled with
+    // the current selection.
+    openProfileModal("add");
+  }, [openProfileModalSignal, openProfileModal]);
   const [pendingServerSelection, setPendingServerSelection] = useState<
     string | null
   >(null);
@@ -581,7 +592,7 @@ export const OAuthFlowTab = ({
                 protocolVersion={protocolVersion}
                 focusedStep={focusedStep}
                 hasProfile={hasProfile}
-                onConfigure={() => setIsProfileModalOpen(true)}
+                onConfigure={() => openProfileModal("edit")}
               />
             </ResizablePanel>
 
@@ -619,7 +630,8 @@ export const OAuthFlowTab = ({
                     : undefined,
                 }}
                 actions={{
-                  onConfigure: () => setIsProfileModalOpen(true),
+                  onConfigure: () => openProfileModal("edit"),
+                  onAddServer: () => openProfileModal("add"),
                   onReset: hasProfile ? () => resetOAuthFlow() : undefined,
                   // Hide Continue button when showing Connect/Refresh buttons
                   onContinue:
@@ -656,7 +668,7 @@ export const OAuthFlowTab = ({
             focusedStep={focusedStep}
             hasProfile={false}
             showConfigurePrompt={areServersHydrated && !hasHeaderServers}
-            onConfigure={() => setIsProfileModalOpen(true)}
+            onConfigure={() => openProfileModal("edit")}
           />
         )}
       </div>
@@ -672,10 +684,14 @@ export const OAuthFlowTab = ({
       <OAuthProfileModal
         open={isProfileModalOpen}
         onOpenChange={setIsProfileModalOpen}
-        server={activeServer}
+        server={profileModalMode === "add" ? undefined : activeServer}
         existingServerNames={Object.keys(serverConfigs)}
         onSave={({ formData, profile: savedProfile }) => {
-          onSaveServerConfig?.(formData, { oauthProfile: savedProfile });
+          onSaveServerConfig?.(formData, {
+            oauthProfile: savedProfile,
+            originalServerName:
+              profileModalMode === "add" ? undefined : activeServer?.name,
+          });
           setPendingServerSelection(formData.name);
           resetOAuthFlow(formData.url);
         }}

--- a/mcpjam-inspector/client/src/components/OAuthFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/OAuthFlowTab.tsx
@@ -90,10 +90,12 @@ interface OAuthFlowTabProps {
   hasHeaderServers?: boolean;
   areServersHydrated?: boolean;
   onSelectServer: (serverName: string) => void;
+  // Resolves false when the save failed (the hook toasts the reason), so
+  // callers can keep the modal open instead of treating every call as saved.
   onSaveServerConfig?: (
     formData: ServerFormData,
     options?: { oauthProfile?: OAuthTestProfile; originalServerName?: string },
-  ) => void;
+  ) => void | boolean | Promise<void | boolean>;
   onConnectWithTokens?: (
     serverName: string,
     tokens: OAuthTokensFromFlow,
@@ -686,12 +688,19 @@ export const OAuthFlowTab = ({
         onOpenChange={setIsProfileModalOpen}
         server={profileModalMode === "add" ? undefined : activeServer}
         existingServerNames={Object.keys(serverConfigs)}
-        onSave={({ formData, profile: savedProfile }) => {
-          onSaveServerConfig?.(formData, {
+        onSave={async ({ formData, profile: savedProfile }) => {
+          // Await and check the result: a failed save must not close the modal,
+          // reset the flow, or move the selection onto a server that was never
+          // written. The hook already toasted the reason, so throw a generic
+          // message for the modal's inline error.
+          const saved = await onSaveServerConfig?.(formData, {
             oauthProfile: savedProfile,
             originalServerName:
               profileModalMode === "add" ? undefined : activeServer?.name,
           });
+          if (saved === false) {
+            throw new Error("Could not save the server. Please try again.");
+          }
           setPendingServerSelection(formData.name);
           resetOAuthFlow(formData.url);
         }}

--- a/mcpjam-inspector/client/src/components/oauth/OAuthFlowLogger.tsx
+++ b/mcpjam-inspector/client/src/components/oauth/OAuthFlowLogger.tsx
@@ -27,6 +27,7 @@ import {
   Copy,
   AlertTriangle,
   Pencil,
+  Plus,
   RotateCcw,
 } from "lucide-react";
 import { generateGuideText, generateRawText } from "@/lib/oauth/log-formatters";
@@ -57,6 +58,8 @@ interface OAuthFlowLoggerProps {
   };
   actions?: {
     onConfigure?: () => void;
+    /** Open the profile modal blank to add a new target. */
+    onAddServer?: () => void;
     onReset?: () => void;
     onContinue?: () => void;
     continueLabel?: string;
@@ -392,6 +395,17 @@ export function OAuthFlowLogger({
                 </span>
               </button>
               <div className="flex items-center gap-1 shrink-0">
+                {actions?.onAddServer && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={actions.onAddServer}
+                    className="h-7"
+                  >
+                    <Plus className="h-3 w-3 mr-1" />
+                    Add
+                  </Button>
+                )}
                 <Button
                   variant="ghost"
                   size="sm"

--- a/mcpjam-inspector/client/src/components/oauth/OAuthProfileModal.tsx
+++ b/mcpjam-inspector/client/src/components/oauth/OAuthProfileModal.tsx
@@ -91,6 +91,7 @@ export function OAuthProfileModal({
       : [createHeaderRow()],
   );
   const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
   const supportedStrategies = useMemo(
     () => getSupportedRegistrationStrategies(draft.protocolVersion),
     [draft.protocolVersion],
@@ -203,8 +204,9 @@ export function OAuthProfileModal({
     };
 
     // Await so a rejected save keeps the modal open with the entered values
-    // instead of closing over a server that was never written. Mirrors
-    // XAAServerModal.
+    // instead of closing over a server that was never written. `saving` blocks
+    // the resubmits that awaiting now makes possible. Mirrors XAAServerModal.
+    setSaving(true);
     try {
       await onSave({
         formData,
@@ -225,6 +227,8 @@ export function OAuthProfileModal({
           ? saveError.message
           : "Could not save the server. Please try again.",
       );
+    } finally {
+      setSaving(false);
     }
   };
 
@@ -543,10 +547,13 @@ export function OAuthProfileModal({
               type="button"
               variant="ghost"
               onClick={() => onOpenChange(false)}
+              disabled={saving}
             >
               Cancel
             </Button>
-            <Button type="submit">Save configuration</Button>
+            <Button type="submit" disabled={saving}>
+              {saving ? "Saving…" : "Save configuration"}
+            </Button>
           </DialogFooter>
         </form>
       </DialogContent>

--- a/mcpjam-inspector/client/src/components/oauth/OAuthProfileModal.tsx
+++ b/mcpjam-inspector/client/src/components/oauth/OAuthProfileModal.tsx
@@ -44,7 +44,7 @@ interface OAuthProfileModalProps {
   onSave: (payload: {
     formData: ServerFormData;
     profile: OAuthTestProfile;
-  }) => void;
+  }) => void | Promise<void>;
 }
 
 interface HeaderRow {
@@ -156,13 +156,25 @@ export function OAuthProfileModal({
     };
   };
 
-  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const validated = getValidatedProfileValues();
     if (!validated) return;
     const trimmedName = serverName.trim();
     if (!trimmedName) {
       setError("Server name is required");
+      return;
+    }
+    // Add mode has no `server`, so every collision is rejected; edit mode
+    // exempts only the row being edited from its own name. Without this the
+    // save handler treats an add-onto-existing-name as a plain save and
+    // overwrites that server (the hook's guard only covers renames).
+    if (
+      existingServerNames.some(
+        (name) => name === trimmedName && name !== server?.name,
+      )
+    ) {
+      setError(`A server named "${trimmedName}" already exists.`);
       return;
     }
 
@@ -190,19 +202,30 @@ export function OAuthProfileModal({
       clientSecret: validated.trimmedClientSecret || undefined,
     };
 
-    onSave({
-      formData,
-      profile: {
-        serverUrl: validated.trimmedUrl,
-        clientId: validated.trimmedClientId,
-        clientSecret: validated.trimmedClientSecret,
-        scopes: draft.scopes.trim(),
-        customHeaders: normalizedHeaders,
-        protocolVersion: draft.protocolVersion,
-        registrationStrategy: draft.registrationStrategy,
-      },
-    });
-    onOpenChange(false);
+    // Await so a rejected save keeps the modal open with the entered values
+    // instead of closing over a server that was never written. Mirrors
+    // XAAServerModal.
+    try {
+      await onSave({
+        formData,
+        profile: {
+          serverUrl: validated.trimmedUrl,
+          clientId: validated.trimmedClientId,
+          clientSecret: validated.trimmedClientSecret,
+          scopes: draft.scopes.trim(),
+          customHeaders: normalizedHeaders,
+          protocolVersion: draft.protocolVersion,
+          registrationStrategy: draft.registrationStrategy,
+        },
+      });
+      onOpenChange(false);
+    } catch (saveError) {
+      setError(
+        saveError instanceof Error
+          ? saveError.message
+          : "Could not save the server. Please try again.",
+      );
+    }
   };
 
   const handleProtocolChange = (value: OAuthProtocolVersion) => {

--- a/mcpjam-inspector/client/src/components/oauth/__tests__/OAuthProfileModal.test.tsx
+++ b/mcpjam-inspector/client/src/components/oauth/__tests__/OAuthProfileModal.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { OAuthProfileModal } from "../OAuthProfileModal";
+import type { ServerWithName } from "@/hooks/use-app-state";
+
+function renderModal(
+  props?: Partial<React.ComponentProps<typeof OAuthProfileModal>>,
+) {
+  const onSave = vi.fn();
+  const onOpenChange = vi.fn();
+  render(
+    <OAuthProfileModal
+      open
+      onOpenChange={onOpenChange}
+      existingServerNames={[]}
+      onSave={onSave}
+      {...props}
+    />,
+  );
+  return { onSave, onOpenChange };
+}
+
+function createServer(name: string): ServerWithName {
+  return {
+    name,
+    connectionStatus: "connected",
+    enabled: true,
+    retryCount: 0,
+    useOAuth: true,
+    lastConnectionTime: new Date("2024-01-01"),
+    config: {
+      transportType: "streamableHttp",
+      url: "https://existing.example.com/mcp",
+    },
+  } as ServerWithName;
+}
+
+describe("OAuthProfileModal", () => {
+  it("rejects a duplicate name when adding a new target", async () => {
+    // Add mode passes no `server`, so the hook's rename guard never fires —
+    // without the modal's own check this save silently overwrote staging-mcp.
+    const user = userEvent.setup();
+    const { onSave } = renderModal({ existingServerNames: ["staging-mcp"] });
+
+    await user.clear(screen.getByLabelText(/Server Name/));
+    await user.type(screen.getByLabelText(/Server Name/), "staging-mcp");
+    await user.type(
+      screen.getByLabelText(/Server URL/),
+      "https://staging.example.com/mcp",
+    );
+    await user.click(screen.getByRole("button", { name: "Save configuration" }));
+
+    expect(onSave).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert")).toHaveTextContent(/already exists/i);
+  });
+
+  it("rejects renaming an existing target onto another target's name", async () => {
+    const user = userEvent.setup();
+    const { onSave } = renderModal({
+      server: createServer("oauth-flow-target"),
+      existingServerNames: ["oauth-flow-target", "staging-mcp"],
+    });
+
+    await user.clear(screen.getByLabelText(/Server Name/));
+    await user.type(screen.getByLabelText(/Server Name/), "staging-mcp");
+    await user.click(screen.getByRole("button", { name: "Save configuration" }));
+
+    expect(onSave).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert")).toHaveTextContent(/already exists/i);
+  });
+
+  it("allows saving an existing target under its own unchanged name", async () => {
+    const user = userEvent.setup();
+    const { onSave } = renderModal({
+      server: createServer("oauth-flow-target"),
+      existingServerNames: ["oauth-flow-target", "staging-mcp"],
+    });
+
+    await user.click(screen.getByRole("button", { name: "Save configuration" }));
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mcpjam-inspector/client/src/components/oauth/__tests__/OAuthProfileModal.test.tsx
+++ b/mcpjam-inspector/client/src/components/oauth/__tests__/OAuthProfileModal.test.tsx
@@ -81,4 +81,37 @@ describe("OAuthProfileModal", () => {
 
     expect(onSave).toHaveBeenCalledTimes(1);
   });
+
+  it("blocks a second submit while the first save is still in flight", async () => {
+    // Awaiting onSave keeps the modal open, which opened a resubmit window the
+    // old fire-and-forget close never had.
+    const user = userEvent.setup();
+    let releaseSave: (() => void) | undefined;
+    const onSave = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseSave = resolve;
+        }),
+    );
+    render(
+      <OAuthProfileModal
+        open
+        onOpenChange={vi.fn()}
+        server={createServer("oauth-flow-target")}
+        existingServerNames={["oauth-flow-target"]}
+        onSave={onSave}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Save configuration" }));
+    expect(onSave).toHaveBeenCalledTimes(1);
+
+    // Still saving: the button is disabled, so a second click is a no-op.
+    const savingButton = screen.getByRole("button", { name: "Saving…" });
+    expect(savingButton).toBeDisabled();
+    await user.click(savingButton);
+    expect(onSave).toHaveBeenCalledTimes(1);
+
+    releaseSave?.();
+  });
 });

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowLogger.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowLogger.tsx
@@ -10,6 +10,7 @@ import {
   Loader2,
   Pencil,
   Play,
+  Plus,
   RotateCcw,
   ShieldAlert,
   ShieldCheck,
@@ -65,6 +66,8 @@ interface XAAFlowLoggerProps {
   activeStep?: XAAFlowStep | null;
   actions: {
     onConfigure: () => void;
+    /** Open the server modal blank to add a new target. */
+    onAddServer?: () => void;
     onReset?: () => void;
     onContinue?: () => void;
     /** Run the whole flow — surfaced in the Continue split-button's menu. */
@@ -660,6 +663,17 @@ export function XAAFlowLogger({
           </button>
           {hasProfile && (
             <div className="flex shrink-0 items-center justify-end gap-1">
+              {actions.onAddServer && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={actions.onAddServer}
+                  className="h-7"
+                >
+                  <Plus className="h-3 w-3 mr-1" />
+                  Add
+                </Button>
+              )}
               <Button
                 variant="ghost"
                 size="sm"

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -259,7 +259,10 @@ interface XAAFlowTabProps {
   } | null;
   // Shared server-bar callbacks (mirror the OAuth Debugger).
   onSelectServer?: (serverName: string) => void;
-  onSaveServerConfig?: (formData: ServerFormData) => void | Promise<void>;
+  onSaveServerConfig?: (
+    formData: ServerFormData,
+    options?: { originalServerName?: string }
+  ) => void | Promise<void>;
   /**
    * Bumped by the shell when the header "Add Server" button is clicked while
    * this tab is active, so the Configure-Server-to-Test modal opens instead of
@@ -363,6 +366,15 @@ export function XAAFlowTab({
   openServerModalSignal,
 }: XAAFlowTabProps) {
   const [isServerModalOpen, setIsServerModalOpen] = useState(false);
+  // "edit" opens the modal prefilled with the selected server; "add" opens it
+  // blank so a new target can be saved without touching the current one.
+  const [serverModalMode, setServerModalMode] = useState<"edit" | "add">(
+    "edit"
+  );
+  const openServerModal = useCallback((mode: "edit" | "add") => {
+    setServerModalMode(mode);
+    setIsServerModalOpen(true);
+  }, []);
   const [isRunningAll, setIsRunningAll] = useState(false);
   const [scorecardHasResults, setScorecardHasResults] = useState(false);
   const [compactScorecardContentHeight, setCompactScorecardContentHeight] =
@@ -400,8 +412,10 @@ export function XAAFlowTab({
   useEffect(() => {
     if (openServerModalSignal === prevOpenSignalRef.current) return;
     prevOpenSignalRef.current = openServerModalSignal;
-    setIsServerModalOpen(true);
-  }, [openServerModalSignal]);
+    // The header button reads "Add Server" — open blank, not prefilled with
+    // the current selection.
+    openServerModal("add");
+  }, [openServerModalSignal, openServerModal]);
 
   const selectedServer =
     selectedServerName !== "none"
@@ -1801,7 +1815,7 @@ export function XAAFlowTab({
               <div className="flex items-center justify-center gap-2">
                 <Button
                   type="button"
-                  onClick={() => setIsServerModalOpen(true)}
+                  onClick={() => openServerModal("edit")}
                 >
                   Configure Server to Test
                 </Button>
@@ -1821,7 +1835,7 @@ export function XAAFlowTab({
               <XAASequenceDiagram
                 flowState={flowState}
                 hasProfile={isTestable}
-                onConfigure={() => setIsServerModalOpen(true)}
+                onConfigure={() => openServerModal("edit")}
               />
             </ResizablePanel>
 
@@ -1838,7 +1852,8 @@ export function XAAFlowTab({
                 hasProfile={isTestable}
                 activeStep={flowState.currentStep}
                 actions={{
-                  onConfigure: () => setIsServerModalOpen(true),
+                  onConfigure: () => openServerModal("edit"),
+                  onAddServer: () => openServerModal("add"),
                   onReset: isTestable ? () => resetFlow() : undefined,
                   onContinue: continueDisabled ? undefined : handleAdvance,
                   onRunAll: isTestable ? handleRunAll : undefined,
@@ -1871,7 +1886,7 @@ export function XAAFlowTab({
             flowState={flowState}
             hasProfile={false}
             showConfigurePrompt={areServersHydrated && !hasHeaderServers}
-            onConfigure={() => setIsServerModalOpen(true)}
+            onConfigure={() => openServerModal("edit")}
           />
         )}
       </XAAWorkspaceLayout>
@@ -1879,7 +1894,7 @@ export function XAAFlowTab({
       <XAAServerModal
         open={isServerModalOpen}
         onOpenChange={setIsServerModalOpen}
-        server={selectedServer}
+        server={serverModalMode === "add" ? undefined : selectedServer}
         existingServerNames={Object.keys(serverConfigs)}
         projectDefaultIdentity={
           projectXaaTestDefaults?.defaultIdentity ?? null
@@ -1890,7 +1905,10 @@ export function XAAFlowTab({
           // Await so the modal can keep itself open (and preserve the entered
           // values) if the save rejects. Selection only follows a save that
           // didn't throw.
-          await onSaveServerConfig?.(formData);
+          await onSaveServerConfig?.(formData, {
+            originalServerName:
+              serverModalMode === "add" ? undefined : selectedServer?.name,
+          });
           setConfigurationSaveVersion((version) => version + 1);
           onSelectServer?.(formData.name);
         }}

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -259,10 +259,12 @@ interface XAAFlowTabProps {
   } | null;
   // Shared server-bar callbacks (mirror the OAuth Debugger).
   onSelectServer?: (serverName: string) => void;
+  // Resolves false when the save failed (the hook toasts the reason), so
+  // callers can keep the modal open instead of treating every call as saved.
   onSaveServerConfig?: (
     formData: ServerFormData,
     options?: { originalServerName?: string }
-  ) => void | Promise<void>;
+  ) => void | boolean | Promise<void | boolean>;
   /**
    * Bumped by the shell when the header "Add Server" button is clicked while
    * this tab is active, so the Configure-Server-to-Test modal opens instead of
@@ -1903,12 +1905,16 @@ export function XAAFlowTab({
         hostedServerId={target.barServerId}
         onSave={async ({ formData }) => {
           // Await so the modal can keep itself open (and preserve the entered
-          // values) if the save rejects. Selection only follows a save that
-          // didn't throw.
-          await onSaveServerConfig?.(formData, {
+          // values) if the save fails. The hook reports failure by resolving
+          // false (it toasts the reason), not by throwing, so rethrow here —
+          // otherwise selection follows a server that was never written.
+          const saved = await onSaveServerConfig?.(formData, {
             originalServerName:
               serverModalMode === "add" ? undefined : selectedServer?.name,
           });
+          if (saved === false) {
+            throw new Error("Could not save the server. Please try again.");
+          }
           setConfigurationSaveVersion((version) => version + 1);
           onSelectServer?.(formData.name);
         }}

--- a/mcpjam-inspector/client/src/components/xaa/XAAServerModal.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAServerModal.tsx
@@ -151,9 +151,13 @@ export function XAAServerModal({
       setError("Server name is required.");
       return;
     }
+    // Renaming has to collide-check too: only the server being edited is exempt
+    // from its own name. Without the second clause a rename onto another
+    // server's name would silently overwrite that server.
     if (
-      !isEditing &&
-      existingServerNames.some((name) => name === trimmedName)
+      existingServerNames.some(
+        (name) => name === trimmedName && name !== server?.name
+      )
     ) {
       setError(`A server named "${trimmedName}" already exists.`);
       return;

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
@@ -2813,6 +2813,80 @@ describe("syncServerToConvex name-collision recovery", () => {
     expect(mockCreateServerIfMissing).not.toHaveBeenCalled();
   });
 
+  it("renames in place instead of forking a duplicate row", async () => {
+    const appState = createAppState();
+    appState.projects.default.sharedProjectId = "project_default";
+    const dispatch = vi.fn();
+
+    mockCreateServerIfMissing.mockResolvedValue("srv_renamed");
+
+    const { result } = renderUseServerState(dispatch, appState, {
+      isAuthenticated: true,
+      hasSignedInUser: true,
+      useLocalFallback: false,
+      effectiveProjects: appState.projects,
+      activeProjectServersFlat: undefined,
+    });
+
+    await act(async () => {
+      await result.current.saveServerConfigWithoutConnecting(
+        {
+          name: "demo-server-renamed",
+          type: "http",
+          url: "https://example.com/mcp",
+        },
+        { originalServerName: "demo-server" }
+      );
+    });
+
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "REMOVE_SERVER", name: "demo-server" })
+    );
+    // enabled carries over from demo-server, so the pre-rename lookup resolved
+    // against the original name rather than building a fresh entry.
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "UPSERT_SERVER",
+        name: "demo-server-renamed",
+        server: expect.objectContaining({ enabled: true }),
+      })
+    );
+  });
+
+  it("rejects a rename onto another server's name", async () => {
+    const appState = createAppState();
+    appState.projects.default.servers["taken-name"] = {
+      ...appState.projects.default.servers["demo-server"],
+      name: "taken-name",
+    } as ServerWithName;
+    const dispatch = vi.fn();
+
+    const { result } = renderUseServerState(dispatch, appState, {
+      isAuthenticated: true,
+      hasSignedInUser: true,
+      useLocalFallback: false,
+      effectiveProjects: appState.projects,
+      activeProjectServersFlat: undefined,
+    });
+
+    await act(async () => {
+      await result.current.saveServerConfigWithoutConnecting(
+        { name: "taken-name", type: "http", url: "https://example.com/mcp" },
+        { originalServerName: "demo-server" }
+      );
+    });
+
+    expect(toastError).toHaveBeenCalledWith(
+      errorToastMessage(
+        'A server named "taken-name" already exists. Choose a different name.'
+      ),
+      { duration: Infinity }
+    );
+    expect(dispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "REMOVE_SERVER" })
+    );
+  });
+
   it("skips the loading-window project servers query until the user row is ready", async () => {
     const appState = createAppState();
     appState.projects.default.sharedProjectId = "project_default";

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
@@ -2853,6 +2853,44 @@ describe("syncServerToConvex name-collision recovery", () => {
     );
   });
 
+  it("keeps the original server when a rename's sync fails", async () => {
+    // The old row used to be removed before the write, so a failed sync left
+    // the rename with neither row and nothing to retry from.
+    const appState = createAppState();
+    appState.projects.default.sharedProjectId = "project_default";
+    const dispatch = vi.fn();
+
+    mockCreateServerIfMissing.mockRejectedValue(new Error("network down"));
+
+    const { result } = renderUseServerState(dispatch, appState, {
+      isAuthenticated: true,
+      hasSignedInUser: true,
+      useLocalFallback: false,
+      effectiveProjects: appState.projects,
+      activeProjectServersFlat: undefined,
+    });
+
+    let saved: boolean | void;
+    await act(async () => {
+      saved = await result.current.saveServerConfigWithoutConnecting(
+        {
+          name: "demo-server-renamed",
+          type: "http",
+          url: "https://example.com/mcp",
+        },
+        { originalServerName: "demo-server" }
+      );
+    });
+
+    expect(saved).toBe(false);
+    expect(dispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "REMOVE_SERVER", name: "demo-server" })
+    );
+    expect(dispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "UPSERT_SERVER" })
+    );
+  });
+
   it("rejects a rename onto another server's name", async () => {
     const appState = createAppState();
     appState.projects.default.servers["taken-name"] = {

--- a/mcpjam-inspector/client/src/hooks/use-app-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-app-state.ts
@@ -784,10 +784,16 @@ export function useAppState({
     // project, OR when there's no queryable project id (sentinel like
     // "none"/"null" — query was skipped, so no data is ever coming).
     // Lets ServersTab distinguish "still loading" from "no real project".
+    // Guarded by auth/projects loading: on a hard reload isAuthenticated is
+    // briefly false and the resolved project id is briefly null (projects not
+    // loaded yet), both of which would otherwise read as "hydrated, empty"
+    // and flash empty-state UI (e.g. the OAuth/XAA debugger Configure modal).
     areServersHydrated:
-      !isAuthenticated ||
-      projectState.activeProjectServersFlat !== undefined ||
-      !shouldQueryProjectId(projectState.activeProjectServersFlatProjectId),
+      !isAuthLoading &&
+      !isLoadingRemoteProjects &&
+      (!isAuthenticated ||
+        projectState.activeProjectServersFlat !== undefined ||
+        !shouldQueryProjectId(projectState.activeProjectServersFlatProjectId)),
     isCloudSyncActive,
     activeOrganizationId,
     setActiveOrganizationId,

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -832,6 +832,12 @@ export function useServerState({
   const activeProjectServersFlatRef = useRef(activeProjectServersFlat);
   activeProjectServersFlatRef.current = activeProjectServersFlat;
   const persistRuntimeDedupeKeysRef = useRef<Set<string>>(new Set());
+  // handleRemoveServer is declared further down the hook, so the rename branch
+  // in saveServerConfigWithoutConnecting reaches it through a ref rather than a
+  // dependency (a dep array entry would evaluate before the const initializes).
+  const handleRemoveServerRef = useRef<
+    ((serverName: string) => Promise<void>) | null
+  >(null);
 
   async function sleep(ms: number): Promise<void> {
     await new Promise((resolve) => setTimeout(resolve, ms));
@@ -3257,7 +3263,15 @@ export function useServerState({
   const saveServerConfigWithoutConnecting = useCallback(
     async (
       formData: ServerFormData,
-      options?: { oauthProfile?: OAuthTestProfile; suppressToast?: boolean }
+      options?: {
+        oauthProfile?: OAuthTestProfile;
+        suppressToast?: boolean;
+        // The name the server was saved under before this edit. Callers editing
+        // an existing server must pass it: every lookup here keys off the name,
+        // so without it a rename reads as a brand-new server and forks a second
+        // row. Mirrors handleUpdate's originalServerName argument.
+        originalServerName?: string;
+      }
     ) => {
       const validationError = validateForm(formData);
       if (validationError) {
@@ -3271,7 +3285,20 @@ export function useServerState({
         return;
       }
 
-      const existingServer = appState.servers[serverName];
+      const originalServerName = options?.originalServerName?.trim();
+      const isRename = Boolean(
+        originalServerName && originalServerName !== serverName
+      );
+      const activeProjectServers =
+        effectiveProjects[effectiveActiveProjectId]?.servers ?? {};
+      if (isRename && activeProjectServers[serverName]) {
+        toast.error(
+          `A server named "${serverName}" already exists. Choose a different name.`
+        );
+        return;
+      }
+
+      const existingServer = appState.servers[originalServerName ?? serverName];
       const mcpConfig = toMCPConfig(formData);
       const nextOAuthProfile =
         formData.useOAuth || formData.useXaa
@@ -3349,6 +3376,13 @@ export function useServerState({
         clearOAuthData(serverName);
       }
 
+      // serverEntry already carries the old row's data, so drop the old row
+      // before writing the new name. Without this the name-keyed lookups below
+      // miss and leave the original behind as a duplicate.
+      if (isRename && originalServerName) {
+        await handleRemoveServerRef.current?.(originalServerName);
+      }
+
       if (
         isAuthenticated &&
         !useLocalFallback &&
@@ -3393,7 +3427,9 @@ export function useServerState({
           return;
         }
       } else {
-        persistServerToLocalProject(serverName, serverEntry);
+        persistServerToLocalProject(serverName, serverEntry, {
+          originalServerName: isRename ? originalServerName : undefined,
+        });
       }
 
       dispatch({
@@ -3420,6 +3456,7 @@ export function useServerState({
       isAuthenticated,
       useLocalFallback,
       effectiveActiveProjectId,
+      effectiveProjects,
       syncServerToConvex,
       persistServerToLocalProject,
     ]
@@ -3962,6 +3999,7 @@ export function useServerState({
     },
     [logger, handleDisconnect, removeServerFromStateAndCloud]
   );
+  handleRemoveServerRef.current = handleRemoveServer;
 
   const waitForServerReconnectOutcome = useCallback(
     async (

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -3276,13 +3276,13 @@ export function useServerState({
       const validationError = validateForm(formData);
       if (validationError) {
         toast.error(validationError);
-        return;
+        return false;
       }
 
       const serverName = formData.name.trim();
       if (!serverName) {
         toast.error("Server name is required");
-        return;
+        return false;
       }
 
       const originalServerName = options?.originalServerName?.trim();
@@ -3295,7 +3295,7 @@ export function useServerState({
         toast.error(
           `A server named "${serverName}" already exists. Choose a different name.`
         );
-        return;
+        return false;
       }
 
       const existingServer = appState.servers[originalServerName ?? serverName];
@@ -3376,13 +3376,6 @@ export function useServerState({
         clearOAuthData(serverName);
       }
 
-      // serverEntry already carries the old row's data, so drop the old row
-      // before writing the new name. Without this the name-keyed lookups below
-      // miss and leave the original behind as a duplicate.
-      if (isRename && originalServerName) {
-        await handleRemoveServerRef.current?.(originalServerName);
-      }
-
       if (
         isAuthenticated &&
         !useLocalFallback &&
@@ -3413,7 +3406,7 @@ export function useServerState({
               error: "Server sync returned no server id",
             });
             toast.error("Could not save the server. Please try again.");
-            return;
+            return false;
           }
         } catch (error) {
           logger.error("Failed to sync server to Convex", {
@@ -3424,12 +3417,22 @@ export function useServerState({
               ? error.message
               : "Could not save the server. Please try again."
           );
-          return;
+          return false;
         }
       } else {
         persistServerToLocalProject(serverName, serverEntry, {
           originalServerName: isRename ? originalServerName : undefined,
         });
+      }
+
+      // Drop the old row only once the new one is stored. Removing first meant
+      // a failed save left the rename with neither row — the server was gone
+      // with nothing to retry from. Safe to run after the write: the sync
+      // resolves its row by the NEW name, so removing the OLD name can't touch
+      // it. (The local branch already dropped it via originalServerName; this
+      // still disconnects the old runtime entry and clears its artifacts.)
+      if (isRename && originalServerName) {
+        await handleRemoveServerRef.current?.(originalServerName);
       }
 
       dispatch({
@@ -3446,6 +3449,7 @@ export function useServerState({
       if (!options?.suppressToast) {
         toast.success(`Saved configuration for ${serverName}`);
       }
+      return true;
     },
     [
       appState.activeProjectId,


### PR DESCRIPTION
- Renaming a server now works properly — before, saving under a new name forked a second row and left the old one behind. Now it removes the old row and writes the new one, and blocks you if the name is already taken. ( using the same logic as connect tab)

- Clicking "Add Server" now opens an empty form. Before, it opened prefilled with whatever server you had selected, so instead of adding a new one you'd quietly edit the existing one. "Configure" still opens prefilled, since there you do want to edit the current server.

- Configure modal no longer flashes on hard reload 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polishes the OAuth and XAA debuggers to make “Add” vs “Configure” explicit, harden save/rename logic, and prevent UI flashes on reload.

- **New Features**
  - “Add” button in OAuth/XAA loggers opens a blank modal; “Configure” opens prefilled edit mode.
  - Header “Add Server” opens the modal in blank add mode.
  - Modals await saves and show a “Saving…” state; save handlers accept `originalServerName` and return a boolean so the modal stays open on failure with inline errors.

- **Bug Fixes**
  - Renaming replaces the old row in place; the old row is removed only after a successful save, and the original is kept on failure.
  - Name collision checks on add and rename (modal and state) prevent overwriting another server with clear errors.
  - Prevented Configure modal flash on hard reload by gating hydration on auth/project loading.

<sup>Written for commit baecb89697c97630c1a17acc3d3a0fff949e0b3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



