### PR TITLE
Negative-test scorecard: support CIMD

### DIFF
--- a/mcpjam-inspector/client/src/components/__tests__/XAAFlowTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/XAAFlowTab.test.tsx
@@ -951,7 +951,11 @@ describe("XAAFlowTab", () => {
       );
     });
 
-    it("keeps confidential DCR secrets out of the hosted issuer scorecard", async () => {
+    // Confidential DCR now runs on the hosted issuer: the server mints on
+    // hosted and redeems locally, so the client builds a normal input (secret
+    // supplied at click time via resolveInput) and the secret-never-reaches-
+    // hosted guarantee is enforced server-side, not by blocking here.
+    it("allows confidential DCR on the hosted issuer, supplying the secret at click time", async () => {
       issuerModeState = "hosted";
       const user = userEvent.setup();
       render(
@@ -989,15 +993,17 @@ describe("XAAFlowTab", () => {
 
       await waitFor(() =>
         expect(screen.getByTestId("xaa-scorecard")).toHaveAttribute(
-          "data-unavailable-reason",
-          expect.stringMatching(/confidential DCR/i)
+          "data-unlocked",
+          "true"
         )
       );
-      expect(screen.getByTestId("xaa-scorecard")).toHaveAttribute(
-        "data-has-input",
-        "false"
-      );
-      expect(capturedScorecardProps.resolveInput).toBeUndefined();
+      const scorecard = screen.getByTestId("xaa-scorecard");
+      expect(scorecard).toHaveAttribute("data-has-input", "true");
+      expect(scorecard).toHaveAttribute("data-unavailable-reason", "");
+      // The base input never carries the secret; resolveInput adds it fresh.
+      expect(capturedScorecardInput.clientSecret).toBeUndefined();
+      const resolved = capturedScorecardProps.resolveInput();
+      expect(resolved.clientSecret).toBe("session-only-secret");
     });
 
     // The CIMD client identity is the metadata document URL the run resolved,

--- a/mcpjam-inspector/client/src/components/__tests__/XAAFlowTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/XAAFlowTab.test.tsx
@@ -1000,42 +1000,79 @@ describe("XAAFlowTab", () => {
       expect(capturedScorecardProps.resolveInput).toBeUndefined();
     });
 
-    it("keeps CIMD negative tests unavailable", async () => {
-      const user = userEvent.setup();
+    // The CIMD client identity is the metadata document URL the run resolved,
+    // and the auth method comes from the document it validated — so the
+    // scorecard reads both straight off flow state.
+    it.each([
+      {
+        variant: "public",
+        clientId:
+          "https://app.mcpjam.com/.well-known/oauth/xaa-client-metadata.json",
+        authMethod: "none" as const,
+      },
+      {
+        variant: "confidential",
+        clientId: "https://app.mcpjam.com/.well-known/oauth/xaa-cimd/AbC123",
+        authMethod: "private_key_jwt" as const,
+      },
+    ])(
+      "runs $variant CIMD negative tests against the run's URL client_id",
+      async ({ clientId, authMethod }) => {
+        const user = userEvent.setup();
+        render(
+          <XAAFlowTab
+            serverConfigs={withStrategy("cimd")}
+            selectedServerName="staging"
+          />
+        );
+        machineCompletionUpdates = {
+          registrationStrategy: "cimd",
+          clientId,
+          tokenEndpoint: "https://auth.example.com/token",
+          tokenEndpointAuthMethod: authMethod,
+          authzMetadata: { issuer: "https://auth.example.com" },
+          resourceMetadata: { resource: "https://staging.mcp.example.com" },
+        };
+
+        await user.click(screen.getByRole("button", { name: /run all/i }));
+
+        await waitFor(() =>
+          expect(screen.getByTestId("xaa-scorecard")).toHaveAttribute(
+            "data-unlocked",
+            "true"
+          )
+        );
+        const scorecard = screen.getByTestId("xaa-scorecard");
+        expect(scorecard).toHaveAttribute("data-has-input", "true");
+        expect(scorecard).toHaveAttribute("data-unavailable-reason", "");
+        expect(scorecard).toHaveAttribute("data-client-id", clientId);
+        expect(scorecard).toHaveAttribute("data-auth-method", authMethod);
+        // No secret exists for a CIMD client — the server signs the
+        // client_assertion for private_key_jwt, so there is nothing to re-read
+        // at click time the way a DCR run must.
+        expect(capturedScorecardInput.clientSecret).toBeUndefined();
+        expect(capturedScorecardProps.resolveInput).toBeUndefined();
+      }
+    );
+
+    it("keeps CIMD negative tests unavailable until the flow has run", async () => {
       render(
         <XAAFlowTab
           serverConfigs={withStrategy("cimd")}
           selectedServerName="staging"
         />
       );
-      const clientId =
-        "https://app.mcpjam.com/.well-known/oauth/xaa-client-metadata.json";
-      machineCompletionUpdates = {
-        registrationStrategy: "cimd",
-        clientId,
-        tokenEndpoint: "https://auth.example.com/token",
-        tokenEndpointAuthMethod: "none",
-        authzMetadata: { issuer: "https://auth.example.com" },
-        resourceMetadata: { resource: "https://staging.mcp.example.com" },
-      };
-
-      await user.click(screen.getByRole("button", { name: /run all/i }));
 
       await waitFor(() =>
         expect(screen.getByTestId("xaa-scorecard")).toHaveAttribute(
           "data-unavailable-reason",
-          expect.stringMatching(/not supported yet/i)
+          expect.stringMatching(/run the flow first/i)
         )
-      );
-      expect(screen.getByTestId("xaa-scorecard")).toHaveAttribute(
-        "data-unlocked",
-        "false"
       );
       expect(screen.getByTestId("xaa-scorecard")).toHaveAttribute(
         "data-has-input",
         "false"
       );
-      expect(capturedScorecardProps.resolveInput).toBeUndefined();
     });
 
     it("keeps an expired DCR credential unavailable without registering again", async () => {

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -894,20 +894,9 @@ export function XAAFlowTab({
             "Run the flow first so the client identity and token endpoint are known.",
         };
       }
-      // Mirrors the confidential-DCR rule below: the confidential-CIMD signing
-      // key exists only on the local inspector, so a hosted-issuer run (which
-      // forwards the whole run server-to-server) could never sign the
-      // client_assertion. Say so here rather than letting the forward 400.
-      if (
-        hostedIssuerOptIn &&
-        flowState.tokenEndpointAuthMethod === "private_key_jwt"
-      ) {
-        return {
-          input: null,
-          unavailableReason:
-            "Negative tests for confidential CIMD clients are unavailable when using the hosted issuer.",
-        };
-      }
+      // Confidential CIMD runs on the hosted issuer too: the server mints the
+      // broken assertions on hosted (correct `iss`) and redeems them locally,
+      // so the CIMD signing key never leaves the machine. No local-only guard.
       if (!audience || !resource) return { input: null };
 
       return {
@@ -963,13 +952,8 @@ export function XAAFlowTab({
             "This session's dynamic client secret has expired. Register another client to run negative tests.",
         };
       }
-      if (hostedIssuerOptIn && credentials.clientSecret) {
-        return {
-          input: null,
-          unavailableReason:
-            "Negative tests for confidential DCR clients are unavailable when using the hosted issuer.",
-        };
-      }
+      // Confidential DCR runs on the hosted issuer too: hosted mints, the local
+      // server redeems, so the DCR secret never leaves the machine.
       if (!audience || !resource) return { input: null };
 
       const input: NegativeTestsInput = {
@@ -977,6 +961,10 @@ export function XAAFlowTab({
         audience,
         resource,
         subject: runInput.userId || undefined,
+        // Needed once this can reach the hosted issuer: its evaluator matches
+        // subject AND email exactly, so an absent email denies every case on
+        // identity and the run reads all-green without testing anything.
+        email: runInput.email || undefined,
         clientId: flowState.clientId,
         tokenEndpointAuthMethod: credentials.tokenEndpointAuthMethod,
         scope: runInput.scope || undefined,
@@ -1061,14 +1049,7 @@ export function XAAFlowTab({
         scope: runInput.scope || undefined,
       },
     };
-  }, [
-    flowState,
-    runInput,
-    target,
-    targetKey,
-    runsDynamicRegistration,
-    hostedIssuerOptIn,
-  ]);
+  }, [flowState, runInput, target, targetKey, runsDynamicRegistration]);
 
   // ── Single target-reset owner ──────────────────────────────────────
   // One effect keyed on the target and all run-defining configuration rebuilds

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -761,16 +761,12 @@ export function XAAFlowTab({
         // The strategy the completed run actually used (state-authoritative).
         registration_strategy: flowStateRef.current.registrationStrategy,
       });
-      // This PR enables dynamic scorecards for DCR only. Keep CIMD locked
-      // until its client-auth behavior is implemented and reviewed separately.
-      if (flowStateRef.current.registrationStrategy !== "cimd") {
-        setPositiveRunTargets((current) => {
-          if (current.has(runGateKey)) return current;
-          const next = new Set(current);
-          next.add(runGateKey);
-          return next;
-        });
-      }
+      setPositiveRunTargets((current) => {
+        if (current.has(runGateKey)) return current;
+        const next = new Set(current);
+        next.add(runGateKey);
+        return next;
+      });
     }
   }, [flowState.currentStep, authServerModeForTelemetry, runGateKey]);
 
@@ -877,10 +873,40 @@ export function XAAFlowTab({
     const resource =
       flowState.resourceMetadata?.resource || runInput.serverUrl || "";
 
+    // CIMD: the client_id IS the metadata document URL, and there are no
+    // issued credentials to cache or expire. Both the URL and the auth method
+    // are read from flow state, which the CIMD step sets from the document it
+    // actually fetched and validated (`none` for public, `private_key_jwt` for
+    // confidential). Using the run's own values — rather than re-deriving from
+    // the server config — keeps the scorecard testing the identity the
+    // positive run established, and can't silently drop the client_assertion
+    // a confidential client owes (which would get every case refused for the
+    // wrong reason and scored as a pass).
     if (flowState.registrationStrategy === "cimd") {
+      if (!flowState.tokenEndpoint || !flowState.clientId) {
+        return {
+          input: null,
+          unavailableReason:
+            "Run the flow first so the client identity and token endpoint are known.",
+        };
+      }
+      if (!audience || !resource) return { input: null };
+
       return {
-        input: null,
-        unavailableReason: "CIMD negative tests are not supported yet.",
+        input: {
+          tokenEndpoint: flowState.tokenEndpoint,
+          audience,
+          resource,
+          subject: runInput.userId || undefined,
+          // Sent alongside `subject`: a hosted-issuer run's evaluator matches
+          // both claims exactly, and a managed scorecard missing the email is
+          // denied outright — which would refuse every case and score the run
+          // all-green without testing anything.
+          email: runInput.email || undefined,
+          clientId: flowState.clientId,
+          tokenEndpointAuthMethod: flowState.tokenEndpointAuthMethod,
+          scope: runInput.scope || undefined,
+        },
       };
     }
 

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -565,10 +565,14 @@ export function XAAFlowTab({
     flowState.registrationStrategy === "preregistered"
       ? runInput.clientId
       : flowState.clientId ?? "";
+  // Every dynamic strategy establishes its own auth method (DCR from the
+  // registration response, CIMD from the document it validated), and the
+  // method is part of what a run proved. Pre-registered keeps it out: its
+  // method comes from saved config, already covered by flowConfigurationKey.
   const scorecardTokenEndpointAuthMethod =
-    flowState.registrationStrategy === "dcr"
-      ? flowState.tokenEndpointAuthMethod ?? ""
-      : "";
+    flowState.registrationStrategy === "preregistered"
+      ? ""
+      : flowState.tokenEndpointAuthMethod ?? "";
   // A positive run unlocks only the exact issuer, client identity, auth
   // method, and saved configuration that it exercised.
   const runGateKey = [
@@ -888,6 +892,20 @@ export function XAAFlowTab({
           input: null,
           unavailableReason:
             "Run the flow first so the client identity and token endpoint are known.",
+        };
+      }
+      // Mirrors the confidential-DCR rule below: the confidential-CIMD signing
+      // key exists only on the local inspector, so a hosted-issuer run (which
+      // forwards the whole run server-to-server) could never sign the
+      // client_assertion. Say so here rather than letting the forward 400.
+      if (
+        hostedIssuerOptIn &&
+        flowState.tokenEndpointAuthMethod === "private_key_jwt"
+      ) {
+        return {
+          input: null,
+          unavailableReason:
+            "Negative tests for confidential CIMD clients are unavailable when using the hosted issuer.",
         };
       }
       if (!audience || !resource) return { input: null };

--- a/mcpjam-inspector/server/routes/mcp/__tests__/xaa.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/xaa.test.ts
@@ -648,11 +648,58 @@ describe("POST /negative-tests", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  // A hosted evaluator matches subject AND email exactly. Minting without the
+  // email gets every case denied on identity before its mutation is evaluated —
+  // 11 rejections that would score as 11 passes.
+  it("mints the full identity pair into the assertion", async () => {
+    // Params are typed so mock.calls carries the request tuple the assertions
+    // below read back.
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response(JSON.stringify({ error: "invalid_grant" }), {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await buildApp().request("/api/web/xaa/negative-tests", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        ...INLINE_BODY,
+        subject: "user-42",
+        email: "person@example.com",
+      }),
+    });
+    expect(response.status).toBe(200);
+
+    // Read the claims off the wire rather than trusting the request body.
+    const assertions = fetchMock.mock.calls.map(([, init]) =>
+      decodeJwtPayload(
+        new URLSearchParams(String(init?.body)).get("assertion") as string
+      )
+    );
+    expect(assertions).toHaveLength(11);
+
+    // Most modes leave the email intact; missing_claims drops it and
+    // unknown_sub rewrites it — mutations that can only happen to a real email.
+    expect(
+      assertions.filter((claims) => claims.email === "person@example.com")
+        .length
+    ).toBeGreaterThan(0);
+    expect(
+      assertions.some((claims) =>
+        String(claims.email).endsWith("@unknown.invalid")
+      )
+    ).toBe(true);
+  });
+
   // Public CIMD: the client_id is the metadata document URL and there is no
   // secret to present.
   it("uses a public CIMD URL client_id without sending a secret", async () => {
     const fetchMock = vi.fn(
-      async () =>
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
         new Response(JSON.stringify({ error: "invalid_grant" }), {
           status: 400,
           headers: { "content-type": "application/json" },
@@ -719,7 +766,7 @@ describe("POST /negative-tests", () => {
 
   it("signs a fresh private_key_jwt client_assertion for every confidential CIMD case", async () => {
     const fetchMock = vi.fn(
-      async () =>
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
         new Response(JSON.stringify({ error: "invalid_grant" }), {
           status: 400,
           headers: { "content-type": "application/json" },
@@ -895,6 +942,65 @@ describe("hosted-issuer forwarding on the local router", () => {
     // The opt-in fields are stripped before the upstream call.
     const forwarded = JSON.parse(String(init.body));
     expect(forwarded).toEqual({ userId: "user-12345" });
+  });
+
+  // The confidential-CIMD signing key is local-only, so a forwarded run could
+  // never sign the client_assertion. Refused at the boundary, like confidential
+  // DCR, rather than dead-ending on hosted's "no provider" 400.
+  it("refuses to forward confidential CIMD negative tests to the hosted issuer", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await buildApp().request("/api/mcp/xaa/negative-tests", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer workos-token",
+      },
+      body: JSON.stringify({
+        audience: "https://auth.example.com",
+        resource: "https://mcp.example.com",
+        tokenEndpoint: "https://auth.example.com/oauth/token",
+        clientId: "https://localhost/.well-known/oauth/xaa-cimd/AbC123",
+        tokenEndpointAuthMethod: "private_key_jwt",
+        issuerMode: "hosted",
+        organizationId: "org_123",
+      }),
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      code: "VALIDATION_ERROR",
+      message: expect.stringContaining("Confidential CIMD"),
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("still forwards public CIMD negative tests to the hosted issuer", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({ results: [], failures: 0 })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await buildApp().request("/api/mcp/xaa/negative-tests", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer workos-token",
+      },
+      body: JSON.stringify({
+        audience: "https://auth.example.com",
+        resource: "https://mcp.example.com",
+        tokenEndpoint: "https://auth.example.com/oauth/token",
+        clientId: "https://app.mcpjam.com/.well-known/oauth/client.json",
+        tokenEndpointAuthMethod: "none",
+        issuerMode: "hosted",
+        organizationId: "org_123",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it("forwards issuerKind:anonymous mints to the /g/ hosted endpoint", async () => {

--- a/mcpjam-inspector/server/routes/mcp/__tests__/xaa.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/xaa.test.ts
@@ -648,6 +648,137 @@ describe("POST /negative-tests", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  // Public CIMD: the client_id is the metadata document URL and there is no
+  // secret to present.
+  it("uses a public CIMD URL client_id without sending a secret", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ error: "invalid_grant" }), {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const clientId = "https://app.example.com/.well-known/oauth/client.json";
+    const response = await buildApp().request("/api/web/xaa/negative-tests", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        ...INLINE_BODY,
+        clientId,
+        tokenEndpointAuthMethod: "none",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const responseBody = (await response.json()) as {
+      results: Array<{ mode: string; verdict: string; diff?: unknown }>;
+    };
+    expect(responseBody.results).toHaveLength(11);
+    expect(fetchMock).toHaveBeenCalledTimes(11);
+    for (const [, init] of fetchMock.mock.calls) {
+      const headers = init?.headers as Record<string, string>;
+      const form = new URLSearchParams(String(init?.body));
+      expect(headers.Authorization).toBeUndefined();
+      expect(form.get("client_id")).toBe(clientId);
+      expect(form.has("client_secret")).toBe(false);
+      expect(form.has("client_assertion")).toBe(false);
+    }
+    // The URL client_id is what client_id_mismatch is measured against.
+    const mismatch = responseBody.results.find(
+      (row) => row.mode === "client_id_mismatch"
+    );
+    expect(mismatch?.diff).toMatchObject({
+      field: "client_id",
+      expected: clientId,
+    });
+  });
+
+  it("rejects private_key_jwt when no confidential provider is configured", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await buildApp().request("/api/web/xaa/negative-tests", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        ...INLINE_BODY,
+        clientId: "https://app.example.com/.well-known/oauth/xaa-cimd/AbC123",
+        tokenEndpointAuthMethod: "private_key_jwt",
+      }),
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      code: "VALIDATION_ERROR",
+      message: expect.stringContaining("not available"),
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("signs a fresh private_key_jwt client_assertion for every confidential CIMD case", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ error: "invalid_grant" }), {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const app = new Hono();
+    app.route(
+      "/api/web/xaa",
+      createXaaRouter({
+        issuerBasePath: "/api/web",
+        httpsOnlyProxy: false,
+        confidentialCimdProvider: getLocalConfidentialCimdProvider(),
+      })
+    );
+
+    const clientId =
+      "https://app.example.com/.well-known/oauth/xaa-cimd/AbC123";
+    const response = await app.request("/api/web/xaa/negative-tests", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        ...INLINE_BODY,
+        clientId,
+        tokenEndpointAuthMethod: "private_key_jwt",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const responseBody = (await response.json()) as {
+      results: Array<{ verdict: string }>;
+    };
+    expect(responseBody.results).toHaveLength(11);
+    expect(fetchMock).toHaveBeenCalledTimes(11);
+
+    const assertions = new Set<string>();
+    for (const [, init] of fetchMock.mock.calls) {
+      const form = new URLSearchParams(String(init?.body));
+      expect(form.get("client_assertion_type")).toBe(
+        "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+      );
+      expect(form.get("client_id")).toBe(clientId);
+      expect(form.has("client_secret")).toBe(false);
+      const assertion = form.get("client_assertion") as string;
+      expect(assertion.split(".")).toHaveLength(3);
+      // iss = sub = the CIMD URL; aud = the token endpoint the case posts to.
+      // A mismatched aud would get every case refused on client auth and
+      // scored "pass" without ever testing the broken ID-JAG.
+      const claims = decodeJwtPayload(assertion);
+      expect(claims.iss).toBe(clientId);
+      expect(claims.sub).toBe(clientId);
+      expect(claims.aud).toBe(INLINE_BODY.tokenEndpoint);
+      assertions.add(assertion);
+    }
+    // Each case authenticates on its own assertion (unique jti), not a shared one.
+    expect(assertions.size).toBe(11);
+  });
+
   it("yields partial results when a case times out (one slow case doesn't sink the run)", async () => {
     let call = 0;
     const fetchMock = vi.fn(async () => {

--- a/mcpjam-inspector/server/routes/mcp/__tests__/xaa.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/xaa.test.ts
@@ -697,6 +697,13 @@ describe("POST /negative-tests", () => {
         String(claims.email).endsWith("@unknown.invalid")
       )
     ).toBe(true);
+
+    // The identity is a PAIR — a regression that dropped or mis-set `sub`
+    // would be denied on identity just the same, scoring 11 false passes.
+    const subjects = assertions.map((claims) => claims.sub);
+    expect(subjects.filter((s) => s === "user-42").length).toBeGreaterThan(0);
+    expect(subjects.some((s) => s === "unknown-user-00000")).toBe(true);
+    expect(subjects.some((s) => s === undefined)).toBe(true);
   });
 
   // Public CIMD: the client_id is the metadata document URL and there is no
@@ -975,10 +982,13 @@ describe("hosted-issuer forwarding on the local router", () => {
   }
 
   // Routes the hosted mint call vs the local AS redeems. Captures the mint
-  // request body and every redeem form for assertion.
+  // request body, and each redeem's DESTINATION as well as its form — the
+  // destination matters: an assertion (or the DCR secret) posted to the wrong
+  // endpoint must fail the test, not pass it.
+  type Redeem = { url: string; form: URLSearchParams };
   function splitFetchMock(captured: {
     mintBody?: Record<string, unknown>;
-    redeems: URLSearchParams[];
+    redeems: Redeem[];
   }) {
     return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input.toString();
@@ -986,7 +996,10 @@ describe("hosted-issuer forwarding on the local router", () => {
         captured.mintBody = JSON.parse(String(init?.body));
         return hostedMintResponse();
       }
-      captured.redeems.push(new URLSearchParams(String(init?.body)));
+      captured.redeems.push({
+        url,
+        form: new URLSearchParams(String(init?.body)),
+      });
       return new Response(JSON.stringify({ error: "invalid_grant" }), {
         status: 400,
         headers: { "content-type": "application/json" },
@@ -998,9 +1011,10 @@ describe("hosted-issuer forwarding on the local router", () => {
   // mints (mint-only, no secret in the body); the local server redeems the 11
   // assertions at the user's AS, attaching the secret there.
   it("splits confidential DCR — mints on hosted without the secret, redeems locally with it", async () => {
-    const captured = { redeems: [] as URLSearchParams[] } as {
+    const TOKEN_ENDPOINT = "https://auth.example.com/oauth/token";
+    const captured = { redeems: [] as Redeem[] } as {
       mintBody?: Record<string, unknown>;
-      redeems: URLSearchParams[];
+      redeems: Redeem[];
     };
     vi.stubGlobal("fetch", splitFetchMock(captured));
 
@@ -1013,7 +1027,7 @@ describe("hosted-issuer forwarding on the local router", () => {
       body: JSON.stringify({
         audience: "https://auth.example.com",
         resource: "https://mcp.example.com",
-        tokenEndpoint: "https://auth.example.com/oauth/token",
+        tokenEndpoint: TOKEN_ENDPOINT,
         clientId: "dynamic-client",
         clientSecret: "session-secret",
         tokenEndpointAuthMethod: "client_secret_post",
@@ -1033,9 +1047,11 @@ describe("hosted-issuer forwarding on the local router", () => {
     expect(captured.mintBody?.clientSecret).toBeUndefined();
     expect(captured.mintBody?.tokenEndpoint).toBeUndefined();
 
-    // Redeems: 11, local, each carrying the secret and a hosted-minted token.
+    // Redeems: 11, each to the REQUESTED endpoint (never elsewhere — the
+    // secret rides along), carrying a hosted-minted token.
     expect(captured.redeems).toHaveLength(11);
-    for (const form of captured.redeems) {
+    for (const { url, form } of captured.redeems) {
+      expect(url).toBe(TOKEN_ENDPOINT);
       expect(form.get("client_secret")).toBe("session-secret");
       expect(String(form.get("assertion"))).toMatch(/^hosted\./);
     }
@@ -1044,9 +1060,10 @@ describe("hosted-issuer forwarding on the local router", () => {
   // Confidential CIMD on hosted: same split. Hosted mints; the local provider
   // signs the private_key_jwt client_assertion at redeem time.
   it("splits confidential CIMD — mints on hosted, signs the assertion locally", async () => {
-    const captured = { redeems: [] as URLSearchParams[] } as {
+    const TOKEN_ENDPOINT = "https://auth.example.com/oauth/token";
+    const captured = { redeems: [] as Redeem[] } as {
       mintBody?: Record<string, unknown>;
-      redeems: URLSearchParams[];
+      redeems: Redeem[];
     };
     vi.stubGlobal("fetch", splitFetchMock(captured));
 
@@ -1071,7 +1088,7 @@ describe("hosted-issuer forwarding on the local router", () => {
       body: JSON.stringify({
         audience: "https://auth.example.com",
         resource: "https://mcp.example.com",
-        tokenEndpoint: "https://auth.example.com/oauth/token",
+        tokenEndpoint: TOKEN_ENDPOINT,
         clientId,
         tokenEndpointAuthMethod: "private_key_jwt",
         issuerMode: "hosted",
@@ -1091,14 +1108,30 @@ describe("hosted-issuer forwarding on the local router", () => {
     expect(captured.mintBody?.tokenEndpoint).toBeUndefined();
 
     expect(captured.redeems).toHaveLength(11);
-    for (const form of captured.redeems) {
+    const clientAssertions = new Set<string>();
+    for (const { url, form } of captured.redeems) {
+      expect(url).toBe(TOKEN_ENDPOINT);
       expect(form.get("client_assertion_type")).toBe(
         "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
       );
       expect(form.get("client_id")).toBe(clientId);
       expect(form.has("client_secret")).toBe(false);
+      // The ID-JAG came from hosted...
       expect(String(form.get("assertion"))).toMatch(/^hosted\./);
+
+      // ...but the client_assertion was signed HERE, by the local provider.
+      // Inspect it rather than trusting the type: a missing, malformed, or
+      // reused JWT is exactly the regression this split could introduce.
+      const clientAssertion = form.get("client_assertion") as string;
+      expect(clientAssertion.split(".")).toHaveLength(3);
+      const claims = decodeJwtPayload(clientAssertion);
+      expect(claims.iss).toBe(clientId);
+      expect(claims.sub).toBe(clientId);
+      expect(claims.aud).toBe(TOKEN_ENDPOINT);
+      clientAssertions.add(clientAssertion);
     }
+    // One fresh signature per case, not a single one reused across all 11.
+    expect(clientAssertions.size).toBe(11);
   });
 
   // A malformed / short hosted mint response fails the whole run rather than
@@ -1146,6 +1179,60 @@ describe("hosted-issuer forwarding on the local router", () => {
     expect(response.status).toBe(502);
     await expect(response.json()).resolves.toMatchObject({
       message: expect.stringContaining("every scorecard case"),
+    });
+  });
+
+  // Counting isn't enough: "valid" is a real mode name, so a skewed response
+  // could hit 11 entries while dropping a required negative case. Completeness
+  // is checked by membership, so this must still fail rather than quietly
+  // redeem 10 broken cases plus one valid one.
+  it("fails the run when the hosted issuer swaps a negative case for 'valid'", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url === HOSTED_MINT_URL) {
+          return jsonResponse({
+            issuer: HOSTED_SCOPED_ISSUER,
+            // 11 entries, but "valid" stands in for the dropped "expired".
+            mints: [
+              { mode: "valid", token: "hosted.valid", header: {}, payload: {} },
+              ...SCORECARD_MODES.filter((mode) => mode !== "expired").map(
+                (mode) => ({
+                  mode,
+                  token: `hosted.${mode}`,
+                  header: {},
+                  payload: { exp: 1000 },
+                })
+              ),
+            ],
+          });
+        }
+        throw new Error("redeem should never run when minting is incomplete");
+      })
+    );
+
+    const response = await buildApp().request("/api/mcp/xaa/negative-tests", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer workos-token",
+      },
+      body: JSON.stringify({
+        audience: "https://auth.example.com",
+        resource: "https://mcp.example.com",
+        tokenEndpoint: "https://auth.example.com/oauth/token",
+        clientId: "dynamic-client",
+        clientSecret: "session-secret",
+        tokenEndpointAuthMethod: "client_secret_post",
+        issuerMode: "hosted",
+        organizationId: "org_123",
+      }),
+    });
+
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toMatchObject({
+      message: expect.stringContaining("expired"),
     });
   });
 

--- a/mcpjam-inspector/server/routes/mcp/__tests__/xaa.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/xaa.test.ts
@@ -23,7 +23,11 @@ import {
   XAA_DEBUG_IDP_CLIENT_ID,
 } from "@mcpjam/sdk";
 import { WebRouteError } from "../../web/errors.js";
+import { NEGATIVE_TEST_MODES } from "../../../../shared/xaa.js";
 import xaa, { createXaaRouter } from "../xaa.js";
+
+// The 11 scorecard modes — everything the hosted split must mint and redeem.
+const SCORECARD_MODES = NEGATIVE_TEST_MODES.filter((mode) => mode !== "valid");
 
 function jsonResponse(
   body: unknown,
@@ -944,12 +948,61 @@ describe("hosted-issuer forwarding on the local router", () => {
     expect(forwarded).toEqual({ userId: "user-12345" });
   });
 
-  // The confidential-CIMD signing key is local-only, so a forwarded run could
-  // never sign the client_assertion. Refused at the boundary, like confidential
-  // DCR, rather than dead-ending on hosted's "no provider" 400.
-  it("refuses to forward confidential CIMD negative tests to the hosted issuer", async () => {
-    const fetchMock = vi.fn();
-    vi.stubGlobal("fetch", fetchMock);
+  const HOSTED_MINT_URL = `${HOSTED_ORIGIN}/api/web/xaa/o/org_123/negative-tests`;
+  const HOSTED_SCOPED_ISSUER = `${HOSTED_ORIGIN}/api/web/xaa/o/org_123`;
+
+  // A hosted mint-only response: the 11 broken assertions plus the canonical
+  // hosted issuer. Tokens are opaque here — the redeem forwards them verbatim.
+  function hostedMintResponse() {
+    return jsonResponse({
+      issuer: HOSTED_SCOPED_ISSUER,
+      mints: SCORECARD_MODES.map((mode) => ({
+        mode,
+        token: `hosted.${mode}`,
+        header: { alg: "RS256", typ: "oauth-id-jag+jwt" },
+        // A realistic payload — what the hosted mint actually returns — so the
+        // diff builder reads real claim values rather than undefined.
+        payload: {
+          iss: HOSTED_SCOPED_ISSUER,
+          sub: "user-12345",
+          aud: "https://auth.example.com",
+          resource: "https://mcp.example.com",
+          client_id: "dynamic-client",
+          exp: 1000,
+        },
+      })),
+    });
+  }
+
+  // Routes the hosted mint call vs the local AS redeems. Captures the mint
+  // request body and every redeem form for assertion.
+  function splitFetchMock(captured: {
+    mintBody?: Record<string, unknown>;
+    redeems: URLSearchParams[];
+  }) {
+    return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url === HOSTED_MINT_URL) {
+        captured.mintBody = JSON.parse(String(init?.body));
+        return hostedMintResponse();
+      }
+      captured.redeems.push(new URLSearchParams(String(init?.body)));
+      return new Response(JSON.stringify({ error: "invalid_grant" }), {
+        status: 400,
+        headers: { "content-type": "application/json" },
+      });
+    });
+  }
+
+  // Confidential DCR on hosted: the secret never leaves the machine. Hosted
+  // mints (mint-only, no secret in the body); the local server redeems the 11
+  // assertions at the user's AS, attaching the secret there.
+  it("splits confidential DCR — mints on hosted without the secret, redeems locally with it", async () => {
+    const captured = { redeems: [] as URLSearchParams[] } as {
+      mintBody?: Record<string, unknown>;
+      redeems: URLSearchParams[];
+    };
+    vi.stubGlobal("fetch", splitFetchMock(captured));
 
     const response = await buildApp().request("/api/mcp/xaa/negative-tests", {
       method: "POST",
@@ -961,19 +1014,139 @@ describe("hosted-issuer forwarding on the local router", () => {
         audience: "https://auth.example.com",
         resource: "https://mcp.example.com",
         tokenEndpoint: "https://auth.example.com/oauth/token",
-        clientId: "https://localhost/.well-known/oauth/xaa-cimd/AbC123",
+        clientId: "dynamic-client",
+        clientSecret: "session-secret",
+        tokenEndpointAuthMethod: "client_secret_post",
+        issuerMode: "hosted",
+        organizationId: "org_123",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      results: Array<{ mode: string }>;
+    };
+    expect(body.results).toHaveLength(11);
+
+    // Mint request: hosted, mint-only, and the secret/endpoint are stripped.
+    expect(captured.mintBody?.mintOnly).toBe(true);
+    expect(captured.mintBody?.clientSecret).toBeUndefined();
+    expect(captured.mintBody?.tokenEndpoint).toBeUndefined();
+
+    // Redeems: 11, local, each carrying the secret and a hosted-minted token.
+    expect(captured.redeems).toHaveLength(11);
+    for (const form of captured.redeems) {
+      expect(form.get("client_secret")).toBe("session-secret");
+      expect(String(form.get("assertion"))).toMatch(/^hosted\./);
+    }
+  });
+
+  // Confidential CIMD on hosted: same split. Hosted mints; the local provider
+  // signs the private_key_jwt client_assertion at redeem time.
+  it("splits confidential CIMD — mints on hosted, signs the assertion locally", async () => {
+    const captured = { redeems: [] as URLSearchParams[] } as {
+      mintBody?: Record<string, unknown>;
+      redeems: URLSearchParams[];
+    };
+    vi.stubGlobal("fetch", splitFetchMock(captured));
+
+    const app = new Hono();
+    app.route(
+      "/api/mcp/xaa",
+      createXaaRouter({
+        issuerBasePath: "/api/mcp",
+        httpsOnlyProxy: false,
+        forwardHostedIssuer: { origin: HOSTED_ORIGIN },
+        confidentialCimdProvider: getLocalConfidentialCimdProvider(),
+      })
+    );
+
+    const clientId = "https://localhost/.well-known/oauth/xaa-cimd/AbC123";
+    const response = await app.request("/api/mcp/xaa/negative-tests", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer workos-token",
+      },
+      body: JSON.stringify({
+        audience: "https://auth.example.com",
+        resource: "https://mcp.example.com",
+        tokenEndpoint: "https://auth.example.com/oauth/token",
+        clientId,
         tokenEndpointAuthMethod: "private_key_jwt",
         issuerMode: "hosted",
         organizationId: "org_123",
       }),
     });
 
-    expect(response.status).toBe(400);
-    await expect(response.json()).resolves.toMatchObject({
-      code: "VALIDATION_ERROR",
-      message: expect.stringContaining("Confidential CIMD"),
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      results: Array<{ mode: string }>;
+    };
+    expect(body.results).toHaveLength(11);
+
+    expect(captured.mintBody?.mintOnly).toBe(true);
+    // There's no secret in a CIMD run, but the endpoint is still redemption-
+    // side and must not go to hosted.
+    expect(captured.mintBody?.tokenEndpoint).toBeUndefined();
+
+    expect(captured.redeems).toHaveLength(11);
+    for (const form of captured.redeems) {
+      expect(form.get("client_assertion_type")).toBe(
+        "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+      );
+      expect(form.get("client_id")).toBe(clientId);
+      expect(form.has("client_secret")).toBe(false);
+      expect(String(form.get("assertion"))).toMatch(/^hosted\./);
+    }
+  });
+
+  // A malformed / short hosted mint response fails the whole run rather than
+  // silently redeeming fewer cases (which would read as passes).
+  it("fails the run when the hosted issuer mints fewer than every case", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url === HOSTED_MINT_URL) {
+          return jsonResponse({
+            issuer: HOSTED_SCOPED_ISSUER,
+            mints: [
+              {
+                mode: "expired",
+                token: "hosted.expired",
+                header: {},
+                payload: {},
+              },
+            ],
+          });
+        }
+        throw new Error("redeem should never run when minting is incomplete");
+      })
+    );
+
+    const response = await buildApp().request("/api/mcp/xaa/negative-tests", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer workos-token",
+      },
+      body: JSON.stringify({
+        audience: "https://auth.example.com",
+        resource: "https://mcp.example.com",
+        tokenEndpoint: "https://auth.example.com/oauth/token",
+        clientId: "dynamic-client",
+        clientSecret: "session-secret",
+        tokenEndpointAuthMethod: "client_secret_post",
+        issuerMode: "hosted",
+        organizationId: "org_123",
+      }),
     });
-    expect(fetchMock).not.toHaveBeenCalled();
+
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toMatchObject({
+      message: expect.stringContaining("every scorecard case"),
+    });
   });
 
   it("still forwards public CIMD negative tests to the hosted issuer", async () => {
@@ -1076,12 +1249,39 @@ describe("hosted-issuer forwarding on the local router", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  // Defense in depth over the field-level check above: the secret string must
+  // appear NOWHERE in the request that reaches the hosted origin, only in the
+  // local AS redeems.
   it("does not forward confidential DCR secrets to the hosted issuer", async () => {
-    const fetchMock = vi.fn();
-    vi.stubGlobal("fetch", fetchMock);
+    let hostedRawBody = "";
+    let sawSecretInRedeem = false;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.startsWith(HOSTED_ORIGIN)) {
+          hostedRawBody = String(init?.body);
+          return jsonResponse({
+            issuer: HOSTED_SCOPED_ISSUER,
+            mints: SCORECARD_MODES.map((mode) => ({
+              mode,
+              token: `hosted.${mode}`,
+              header: {},
+              payload: { exp: 1000 },
+            })),
+          });
+        }
+        if (String(init?.body).includes("dynamic-secret")) {
+          sawSecretInRedeem = true;
+        }
+        return new Response(JSON.stringify({ error: "invalid_grant" }), {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        });
+      })
+    );
 
-    const app = buildApp();
-    const response = await app.request("/api/mcp/xaa/negative-tests", {
+    const response = await buildApp().request("/api/mcp/xaa/negative-tests", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -1099,9 +1299,10 @@ describe("hosted-issuer forwarding on the local router", () => {
       }),
     });
 
-    expect(response.status).toBe(400);
-    expect((await response.json()).message).toMatch(/confidential DCR/i);
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(response.status).toBe(200);
+    // Never in the hosted request; always in the local redeems.
+    expect(hostedRawBody).not.toContain("dynamic-secret");
+    expect(sawSecretInRedeem).toBe(true);
   });
 
   it("preserves the upstream status + WWW-Authenticate on a non-JSON hosted error", async () => {
@@ -2378,6 +2579,114 @@ describe("org-scoped /token with SAML subject tokens", () => {
       sub: "alice-123",
       client_id: "client-1",
     });
+  });
+});
+
+describe("negative-tests mint-only (the hosted half of the split)", () => {
+  const BASE = "http://127.0.0.1:6274/api/mcp/xaa";
+  const originalKeyDir = process.env.XAA_IDP_KEY_DIR;
+  let tempDir: string;
+  let app: Hono;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), "xaa-mintonly-"));
+    process.env.XAA_IDP_KEY_DIR = tempDir;
+    resetXAAIdpKeyPairForTests();
+    initXAAIdpKeyPair();
+    app = new Hono();
+    app.route(
+      "/api/mcp/xaa",
+      createXaaRouter({
+        issuerBasePath: "/api/mcp",
+        httpsOnlyProxy: false,
+        authorizeOrgIssuer: async ({ bearerToken }) => {
+          if (bearerToken !== "member-token") {
+            throw new WebRouteError(403, "FORBIDDEN", "Not an org member");
+          }
+        },
+      })
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    resetXAAIdpKeyPairForTests();
+    rmSync(tempDir, { recursive: true, force: true });
+    if (originalKeyDir === undefined) delete process.env.XAA_IDP_KEY_DIR;
+    else process.env.XAA_IDP_KEY_DIR = originalKeyDir;
+  });
+
+  it("mints every case under the scoped issuer and never fires at an AS", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await app.request(`${BASE}/o/org1/negative-tests`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer member-token",
+      },
+      body: JSON.stringify({
+        mintOnly: true,
+        audience: "https://as.example.com",
+        resource: "https://mcp.example.com",
+        subject: "user-42",
+        email: "person@example.com",
+        clientId: "https://app.example.com/client.json",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      issuer: string;
+      mints: Array<{ mode: string; token: string }>;
+    };
+
+    // Never touched an authorization server — mint-only only signs.
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(body.issuer).toBe(`${BASE}/o/org1`);
+    expect(body.mints).toHaveLength(11);
+
+    // Each token is a real JWT. Every case carries the scoped issuer except
+    // wrong_issuer, whose whole point is to mutate `iss`.
+    for (const { mode, token } of body.mints) {
+      expect(token.split(".")).toHaveLength(3);
+      if (mode !== "wrong_issuer") {
+        expect(decodeJwtPayload(token).iss).toBe(`${BASE}/o/org1`);
+      }
+    }
+    expect(
+      decodeJwtPayload(body.mints.find((m) => m.mode === "wrong_issuer")!.token)
+        .iss
+    ).not.toBe(`${BASE}/o/org1`);
+    // The email is minted into the pair: most cases carry it verbatim, and the
+    // two identity-mutating modes prove it was there to mutate — unknown_sub
+    // rewrites it to @unknown.invalid, missing_claims drops it entirely.
+    const emails = body.mints.map((m) => decodeJwtPayload(m.token).email);
+    expect(
+      emails.filter((e) => e === "person@example.com").length
+    ).toBeGreaterThan(0);
+    expect(emails.some((e) => String(e).endsWith("@unknown.invalid"))).toBe(
+      true
+    );
+    expect(emails.some((e) => e === undefined)).toBe(true);
+  });
+
+  it("gates mint-only behind org membership", async () => {
+    const response = await app.request(`${BASE}/o/org1/negative-tests`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer not-a-member",
+      },
+      body: JSON.stringify({
+        mintOnly: true,
+        audience: "https://as.example.com",
+        resource: "https://mcp.example.com",
+      }),
+    });
+
+    expect(response.status).toBe(403);
   });
 });
 

--- a/mcpjam-inspector/server/routes/mcp/xaa.ts
+++ b/mcpjam-inspector/server/routes/mcp/xaa.ts
@@ -454,8 +454,13 @@ const negativeTestsSchema = z
     headers: z.record(z.string(), z.string()).optional(),
     serverId: z.string().trim().min(1).optional(),
     projectId: z.string().trim().min(1).optional(),
+    // Hosted split: a local inspector asks the hosted issuer to MINT the 11
+    // broken assertions only (right `iss`, hosted's key) and return the tokens,
+    // then redeems each locally so a confidential client's secret / CIMD key
+    // never leaves the machine. Mint-only skips target resolution and firing.
+    mintOnly: z.boolean().optional(),
   })
-  .refine((data) => data.serverId || data.tokenEndpoint, {
+  .refine((data) => data.mintOnly || data.serverId || data.tokenEndpoint, {
     message: "tokenEndpoint or serverId is required",
   });
 
@@ -473,6 +478,16 @@ type NegativeCaseOutcome = {
   detail?: string;
   // What the broken assertion changed vs. a valid one, for the scorecard diff.
   diff?: NegativeTestDiff;
+};
+
+// A minted broken assertion plus the header/payload the diff is built from.
+// The transport shape of the hosted mint-only response, and the per-case value
+// of a mintOverride map. header/payload are plain records so a value decoded
+// from the wire and one straight off the local signer are interchangeable.
+type MintedNegativeCase = {
+  token: string;
+  header: Record<string, unknown>;
+  payload: Record<string, unknown>;
 };
 
 // The 11 scorecard modes (everything except the happy-path "valid").
@@ -512,12 +527,16 @@ function buildNegativeDiff(
         sent: show(payload.aud),
         expected: expected.audience,
       };
-    case "expired":
-      return {
-        field: "exp",
-        sent: `${new Date(Number(payload.exp) * 1000).toISOString()} (past)`,
-        expected: "a time in the future",
-      };
+    case "expired": {
+      // `exp` can now arrive over the wire (the hosted mint response), so a
+      // missing/garbage value must degrade to a label rather than throw on
+      // `new Date(NaN)` — a throw would drop this case to an "error" verdict.
+      const expSeconds = Number(payload.exp);
+      const sent = Number.isFinite(expSeconds)
+        ? `${new Date(expSeconds * 1000).toISOString()} (past)`
+        : "a time in the past";
+      return { field: "exp", sent, expected: "a time in the future" };
+    }
     case "missing_claims":
       return {
         field: "sub, jti",
@@ -720,7 +739,8 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
   const forwardToHostedIssuer = async (
     c: Context,
     path: "/authenticate" | "/token-exchange" | "/negative-tests",
-    body: Record<string, unknown>
+    body: Record<string, unknown>,
+    opts?: { mintOnly?: boolean }
   ): Promise<Response> => {
     const origin = options.forwardHostedIssuer!.origin;
     const authHeader = c.req.header("authorization");
@@ -728,28 +748,6 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
       return toJsonError(
         "Minting through the hosted issuer requires signing in",
         { status: 401, code: "UNAUTHORIZED" }
-      );
-    }
-
-    if (path === "/negative-tests" && typeof body.clientSecret === "string") {
-      return toJsonError(
-        "Confidential DCR negative tests are unavailable with the hosted issuer",
-        { status: 400, code: "VALIDATION_ERROR" }
-      );
-    }
-    // Same shape for confidential CIMD: the signing key is local-only (hosted
-    // owns no confidential-CIMD private key), so a forwarded run could not
-    // produce the client_assertion. Refuse at the boundary with the real
-    // reason instead of letting hosted answer "not available on this
-    // deployment", which reads as a broken deployment rather than an
-    // unsupported combination.
-    if (
-      path === "/negative-tests" &&
-      body.tokenEndpointAuthMethod === "private_key_jwt"
-    ) {
-      return toJsonError(
-        "Confidential CIMD negative tests are unavailable with the hosted issuer",
-        { status: 400, code: "VALIDATION_ERROR" }
       );
     }
 
@@ -782,13 +780,31 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
         ? `/g/${organizationId}`
         : `/o/${organizationId}`;
 
+    // Mint-only (the confidential split): hosted signs the broken assertions
+    // and returns them; the redemption stays local. Strip everything the
+    // redemption owns before it leaves the machine — above all the client
+    // secret, which must never reach hosted; the endpoint/headers/serverId are
+    // redemption-side too and hosted has no use for them.
+    let outboundBody: Record<string, unknown> = forwardBody;
+    if (opts?.mintOnly) {
+      const {
+        clientSecret: _clientSecret,
+        tokenEndpoint: _tokenEndpoint,
+        headers: _headers,
+        serverId: _serverId,
+        projectId: _projectId,
+        ...mintBody
+      } = forwardBody;
+      outboundBody = { ...mintBody, mintOnly: true };
+    }
+
     return relayToHostedIssuer(`${origin}/api/web/xaa${scopedSegment}${path}`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
         Authorization: authHeader,
       },
-      body: JSON.stringify(forwardBody),
+      body: JSON.stringify(outboundBody),
     });
   };
 
@@ -888,6 +904,73 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
       return null;
     }
     return forwardToHostedIssuer(c, path, body as Record<string, unknown>);
+  };
+
+  // Confidential hosted split: ask the hosted issuer to MINT the 11 broken
+  // assertions (mint-only, no secret sent) and hand them back as a
+  // mode→assertion map plus the canonical issuer, for local redemption. Any
+  // hosted failure is surfaced verbatim as a Response.
+  const mintNegativeViaHosted = async (
+    c: Context,
+    body: Record<string, unknown>
+  ): Promise<
+    | { mints: Map<NegativeTestMode, MintedNegativeCase>; issuer: string }
+    | Response
+  > => {
+    const relayed = await forwardToHostedIssuer(c, "/negative-tests", body, {
+      mintOnly: true,
+    });
+    if (!relayed.ok) return relayed;
+
+    let payload: unknown;
+    try {
+      payload = await relayed.json();
+    } catch {
+      return toJsonError(
+        "The hosted issuer returned a malformed mint response",
+        { status: 502, code: "SERVER_UNREACHABLE" }
+      );
+    }
+
+    const rawMints = (payload as { mints?: unknown })?.mints;
+    const issuer = (payload as { issuer?: unknown })?.issuer;
+    if (!Array.isArray(rawMints) || typeof issuer !== "string") {
+      return toJsonError("The hosted issuer returned no minted assertions", {
+        status: 502,
+        code: "SERVER_UNREACHABLE",
+      });
+    }
+
+    const mints = new Map<NegativeTestMode, MintedNegativeCase>();
+    for (const entry of rawMints) {
+      if (
+        entry &&
+        typeof entry === "object" &&
+        isNegativeTestMode((entry as { mode?: unknown }).mode) &&
+        typeof (entry as { token?: unknown }).token === "string"
+      ) {
+        const e = entry as {
+          mode: NegativeTestMode;
+          token: string;
+          header?: Record<string, unknown>;
+          payload?: Record<string, unknown>;
+        };
+        mints.set(e.mode, {
+          token: e.token,
+          header: e.header ?? {},
+          payload: e.payload ?? {},
+        });
+      }
+    }
+    // Every case must be present. Failing the whole run here is clearer than
+    // letting a short map surface as scattered per-case errors downstream.
+    if (mints.size !== NEGATIVE_CASE_MODES.length) {
+      return toJsonError(
+        "The hosted issuer did not mint every scorecard case",
+        { status: 502, code: "SERVER_UNREACHABLE" }
+      );
+    }
+    return { mints, issuer };
   };
 
   // Hosted-issuer forward for the standards-track /token endpoint. The RFC
@@ -1436,7 +1519,16 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
   // Negative-test scorecard: fire each deliberately-broken ID-JAG mode at the
   // user's authorization server and report whether the server correctly
   // rejected it (pass) or wrongly issued a token (fail — a real finding).
-  const handleNegativeTests = async (c: Context, issuer: string) => {
+  //
+  // `mintOverride` (the hosted split) supplies each case's assertion from the
+  // hosted issuer instead of minting locally, so the token carries a
+  // discoverable `iss` while the confidential secret / CIMD key stays here for
+  // the redemption. Absent → mint locally, as an ordinary local-issuer run.
+  const handleNegativeTests = async (
+    c: Context,
+    issuer: string,
+    mintOverride?: Map<NegativeTestMode, MintedNegativeCase>
+  ) => {
     let parsed;
     try {
       parsed = parseRequest(negativeTestsSchema, await c.req.json());
@@ -1447,6 +1539,48 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
           : "Invalid negative-tests request",
         { status: 400, code: "VALIDATION_ERROR" }
       );
+    }
+
+    // Mint-only (the hosted half of the split): sign all 11 broken assertions
+    // with this issuer's key and return them, without resolving a target or
+    // firing. Every mode is a deliberate mutation of an otherwise-valid
+    // assertion, so these tokens are not usable credentials — strictly less
+    // than the valid ID-JAGs any authed caller can already mint via
+    // /token-exchange.
+    if (parsed.mintOnly) {
+      const subject = parsed.subject || "user-12345";
+      const resolvedClientId = parsed.clientId || "mcpjam-debugger";
+      const mints: Array<{ mode: NegativeTestMode } & MintedNegativeCase> = [];
+      for (const mode of NEGATIVE_CASE_MODES) {
+        try {
+          const issued = issueNegativeIdJag(
+            {
+              issuer,
+              subject,
+              email: parsed.email,
+              audience: parsed.audience,
+              resource: parsed.resource,
+              clientId: resolvedClientId,
+              scope: parsed.scope,
+            },
+            mode
+          );
+          mints.push({
+            mode,
+            token: issued.token,
+            header: issued.header,
+            payload: issued.payload,
+          });
+        } catch (error) {
+          return toJsonError(
+            error instanceof Error ? error.message : "Failed to mint ID-JAG",
+            { status: 500, code: "MINT_FAILED" }
+          );
+        }
+      }
+      // `issuer` travels back so the local redeemer's diff shows the real
+      // (hosted) expected `iss` for the wrong_issuer case, not its own.
+      return c.json({ mints, issuer });
     }
 
     // Resolve the authorization-server target. Registration-backed runs
@@ -1559,26 +1693,43 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
       let token: string;
       let diff: NegativeTestDiff | undefined;
       try {
-        const issued = issueNegativeIdJag(
-          {
-            issuer,
-            subject,
-            // Minted alongside `subject`: a hosted evaluator matches BOTH
-            // claims exactly, so omitting the email gets every case denied on
-            // identity before the intended mutation is ever evaluated — the
-            // whole scorecard would read green without testing anything. The
-            // mutation modes rely on it too (missing_claims drops it,
-            // unknown_sub rewrites it), which they can't do if it's absent.
-            email: parsed.email,
-            audience: parsed.audience,
-            resource: parsed.resource,
-            clientId: resolvedClientId,
-            scope: effectiveScope,
-          },
-          mode
-        );
-        token = issued.token;
-        diff = buildNegativeDiff(mode, issued.header, issued.payload, {
+        // Hosted split: the assertion was already signed by the hosted issuer;
+        // reuse it (and its header/payload) rather than minting a second one
+        // here under the local `iss`. Local runs mint inline.
+        //
+        // Minted alongside `subject`: a hosted evaluator matches BOTH claims
+        // exactly, so omitting the email gets every case denied on identity
+        // before the intended mutation is ever evaluated — the whole scorecard
+        // would read green without testing anything. The mutation modes rely on
+        // it too (missing_claims drops it, unknown_sub rewrites it).
+        let minted: MintedNegativeCase;
+        if (mintOverride) {
+          const fromHosted = mintOverride.get(mode);
+          // No silent local fallback: a mode the hosted issuer didn't return
+          // would otherwise be minted under the local `iss` and get rejected
+          // for issuer mismatch — a false "pass". Fail the case instead.
+          if (!fromHosted) {
+            throw new Error(
+              "The hosted issuer did not return an assertion for this case"
+            );
+          }
+          minted = fromHosted;
+        } else {
+          minted = issueNegativeIdJag(
+            {
+              issuer,
+              subject,
+              email: parsed.email,
+              audience: parsed.audience,
+              resource: parsed.resource,
+              clientId: resolvedClientId,
+              scope: effectiveScope,
+            },
+            mode
+          );
+        }
+        token = minted.token;
+        diff = buildNegativeDiff(mode, minted.header, minted.payload, {
           audience: parsed.audience,
           resource: parsed.resource,
           clientId: resolvedClientId,
@@ -1712,9 +1863,35 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
   // endpoint, so a local mint would carry the local `iss` and a strict AS
   // would reject every case for issuer mismatch — a scorecard that "passes"
   // without testing anything.
+  //
+  // Three paths on a hosted-issuer run:
+  //   - public / pre-registered: hosted mints AND fires (no local secret
+  //     needed) — full relay, unchanged.
+  //   - confidential (a client secret, or private_key_jwt CIMD): hosted mints
+  //     only, we redeem locally, so the secret / CIMD signing key never leaves
+  //     the machine.
+  //   - not hosted: mint and fire locally.
   router.post("/negative-tests", async (c) => {
-    const forwarded = await maybeForwardHostedIssuer(c, "/negative-tests");
-    if (forwarded) return forwarded;
+    const body = await c.req.json().catch(() => null);
+    const isHosted =
+      Boolean(options.forwardHostedIssuer) &&
+      body &&
+      typeof body === "object" &&
+      (body as Record<string, unknown>).issuerMode === "hosted";
+
+    if (isHosted) {
+      const b = body as Record<string, unknown>;
+      const isConfidential =
+        typeof b.clientSecret === "string" ||
+        b.tokenEndpointAuthMethod === "private_key_jwt";
+      if (isConfidential) {
+        const minted = await mintNegativeViaHosted(c, b);
+        if (minted instanceof Response) return minted;
+        return handleNegativeTests(c, minted.issuer, minted.mints);
+      }
+      return forwardToHostedIssuer(c, "/negative-tests", b);
+    }
+
     return handleNegativeTests(c, unscopedIssuer(c));
   });
 

--- a/mcpjam-inspector/server/routes/mcp/xaa.ts
+++ b/mcpjam-inspector/server/routes/mcp/xaa.ts
@@ -943,10 +943,16 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
 
     const mints = new Map<NegativeTestMode, MintedNegativeCase>();
     for (const entry of rawMints) {
+      // Membership in NEGATIVE_CASE_MODES, not isNegativeTestMode: the latter
+      // also accepts "valid", which would let a skewed response substitute a
+      // valid assertion for a required negative one and still satisfy the
+      // count check below.
       if (
         entry &&
         typeof entry === "object" &&
-        isNegativeTestMode((entry as { mode?: unknown }).mode) &&
+        NEGATIVE_CASE_MODES.includes(
+          (entry as { mode?: unknown }).mode as NegativeTestMode
+        ) &&
         typeof (entry as { token?: unknown }).token === "string"
       ) {
         const e = entry as {
@@ -962,11 +968,16 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
         });
       }
     }
-    // Every case must be present. Failing the whole run here is clearer than
-    // letting a short map surface as scattered per-case errors downstream.
-    if (mints.size !== NEGATIVE_CASE_MODES.length) {
+    // Every required case must be present — checked by membership, not count,
+    // so a response that swaps one negative mode for a duplicate or an
+    // unexpected one can't satisfy the guard. Failing the whole run here is
+    // clearer than letting a short map surface as scattered per-case errors.
+    const missing = NEGATIVE_CASE_MODES.filter((mode) => !mints.has(mode));
+    if (missing.length > 0) {
       return toJsonError(
-        "The hosted issuer did not mint every scorecard case",
+        `The hosted issuer did not mint every scorecard case (missing: ${missing.join(
+          ", "
+        )})`,
         { status: 502, code: "SERVER_UNREACHABLE" }
       );
     }

--- a/mcpjam-inspector/server/routes/mcp/xaa.ts
+++ b/mcpjam-inspector/server/routes/mcp/xaa.ts
@@ -33,7 +33,6 @@ import {
 } from "@mcpjam/sdk";
 import { createHash } from "crypto";
 import {
-  buildJwtBearerRequest,
   getIssuerForRequest,
   resolveServerTarget,
 } from "../../services/xaa-mint.js";
@@ -403,18 +402,12 @@ const healthCheckSchema = z.object({
   url: z.string().trim().min(1),
 });
 
+// `private_key_jwt` is confidential CIMD: an injected provider signs the
+// client_assertion (the reflector publishes its matching key). Both /proxy/token
+// and the negative-test scorecard redeem through buildXaaJwtBearerRequest, which
+// delegates that signing to the provider, so both accept the same methods. Each
+// route still rejects `private_key_jwt` when no provider is configured.
 const tokenEndpointAuthMethodSchema = z.enum([
-  "client_secret_post",
-  "client_secret_basic",
-  "none",
-]);
-
-// /proxy/token additionally supports confidential CIMD (`private_key_jwt`): an
-// injected provider signs the client_assertion (the reflector publishes its
-// matching key). Kept SEPARATE from the shared schema above so the negative-
-// tests path (which redeems via the low-level buildJwtBearerRequest, with no
-// signer) never accepts it.
-const proxyTokenAuthMethodSchema = z.enum([
   "client_secret_post",
   "client_secret_basic",
   "none",
@@ -424,10 +417,9 @@ const proxyTokenAuthMethodSchema = z.enum([
 type TokenEndpointAuthMethod = z.infer<typeof tokenEndpointAuthMethodSchema>;
 
 function tokenEndpointAuthValidationError(input: {
-  // Accepts `private_key_jwt` too (the /proxy/token superset): the checks below
-  // already treat it correctly — it needs a client_id (its iss/sub) and no
-  // secret.
-  tokenEndpointAuthMethod?: TokenEndpointAuthMethod | "private_key_jwt";
+  // `private_key_jwt` is handled correctly by the checks below — it needs a
+  // client_id (its iss/sub) and no secret.
+  tokenEndpointAuthMethod?: TokenEndpointAuthMethod;
   clientId?: string;
   clientSecret?: string;
 }): string | undefined {
@@ -586,9 +578,8 @@ const proxyTokenSchema = z
     clientId: z.string().trim().min(1).optional(),
     clientSecret: z.string().trim().min(1).optional(),
     // How to authenticate at the token endpoint. Absent = legacy body-post
-    // behavior; only the methods the debugger can actually redeem. The proxy
-    // superset adds `private_key_jwt` (confidential CIMD).
-    tokenEndpointAuthMethod: proxyTokenAuthMethodSchema.optional(),
+    // behavior; only the methods the debugger can actually redeem.
+    tokenEndpointAuthMethod: tokenEndpointAuthMethodSchema.optional(),
     scope: z.string().trim().min(1).optional(),
     resource: z.string().trim().min(1).optional(),
     headers: z.record(z.string(), z.string()).optional(),
@@ -1503,6 +1494,15 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
         code: "VALIDATION_ERROR",
       });
     }
+    if (
+      tokenEndpointAuthMethod === "private_key_jwt" &&
+      !confidentialCimdProvider
+    ) {
+      return toJsonError(
+        "private_key_jwt is not available on this inspector deployment",
+        { status: 400, code: "VALIDATION_ERROR" }
+      );
+    }
 
     // Validate the outbound URL once (every case hits the same endpoint) and
     // enforce the per-host daily cap.
@@ -1576,14 +1576,39 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
         };
       }
 
-      const jwtBearerRequest = buildJwtBearerRequest({
-        assertion: token,
-        clientId,
-        clientSecret,
-        scope: effectiveScope,
-        resource: parsed.resource,
-        tokenEndpointAuthMethod,
-      });
+      // Signs a fresh client_assertion per case for confidential CIMD
+      // (private_key_jwt); a no-op for the other methods. `aud` is the
+      // unnormalized endpoint — the same string the positive flow signs over,
+      // so an AS that compares it strictly can't reject a case for the wrong
+      // reason and make a broken assertion look correctly refused.
+      let jwtBearerRequest: ReturnType<typeof buildXaaJwtBearerRequest>;
+      try {
+        jwtBearerRequest = buildXaaJwtBearerRequest(
+          {
+            assertion: token,
+            tokenEndpoint,
+            clientId,
+            clientSecret,
+            scope: effectiveScope,
+            resource: parsed.resource,
+            tokenEndpointAuthMethod,
+          },
+          confidentialCimdProvider
+        );
+      } catch (error) {
+        return {
+          mode,
+          label: details.label,
+          expectedFailure: details.expectedFailure,
+          outcome: "error",
+          verdict: "unknown",
+          diff,
+          detail:
+            error instanceof Error
+              ? error.message
+              : "Failed to build the token request",
+        };
+      }
 
       try {
         const response = await fetch(validated.toString(), {

--- a/mcpjam-inspector/server/routes/mcp/xaa.ts
+++ b/mcpjam-inspector/server/routes/mcp/xaa.ts
@@ -442,9 +442,9 @@ const negativeTestsSchema = z
     audience: z.string().trim().min(1),
     resource: z.string().trim().min(1),
     subject: z.string().trim().min(1).optional(),
-    // The subject's email. Optional and currently unused by the local mint;
-    // kept for forward compatibility with callers that send the full
-    // identity pair.
+    // The subject's email, minted into the ID-JAG next to `subject`. Optional,
+    // but a hosted run needs the full identity pair: its evaluator matches both
+    // claims exactly and denies the rest outright.
     email: z.string().trim().min(1).optional(),
     clientId: z.string().trim().min(1).optional(),
     scope: z.string().trim().min(1).optional(),
@@ -734,6 +734,21 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
     if (path === "/negative-tests" && typeof body.clientSecret === "string") {
       return toJsonError(
         "Confidential DCR negative tests are unavailable with the hosted issuer",
+        { status: 400, code: "VALIDATION_ERROR" }
+      );
+    }
+    // Same shape for confidential CIMD: the signing key is local-only (hosted
+    // owns no confidential-CIMD private key), so a forwarded run could not
+    // produce the client_assertion. Refuse at the boundary with the real
+    // reason instead of letting hosted answer "not available on this
+    // deployment", which reads as a broken deployment rather than an
+    // unsupported combination.
+    if (
+      path === "/negative-tests" &&
+      body.tokenEndpointAuthMethod === "private_key_jwt"
+    ) {
+      return toJsonError(
+        "Confidential CIMD negative tests are unavailable with the hosted issuer",
         { status: 400, code: "VALIDATION_ERROR" }
       );
     }
@@ -1548,6 +1563,13 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
           {
             issuer,
             subject,
+            // Minted alongside `subject`: a hosted evaluator matches BOTH
+            // claims exactly, so omitting the email gets every case denied on
+            // identity before the intended mutation is ever evaluated — the
+            // whole scorecard would read green without testing anything. The
+            // mutation modes rely on it too (missing_claims drops it,
+            // unknown_sub rewrites it), which they can't do if it's absent.
+            email: parsed.email,
             audience: parsed.audience,
             resource: parsed.resource,
             clientId: resolvedClientId,


### PR DESCRIPTION

- CIMD negative scorecards 
- Pre-existing bug: scorecard minted ID-JAGs without the email claim inside them, so the AS rejected all 11 on identity faking passes for everyone on hosted issuer.
- Confidential-on-hosted-issuer works now, DCR and CIMD.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CIMD negative-test scorecards for public and confidential clients, with hosted-issuer support via a mint/redeem split. Tightens gating and identity handling to avoid false greens.

- **New Features**
  - UI: Unlocks CIMD tests only after a positive run; gate key includes issuer, URL `client_id`, and auth method. Reads `client_id` and `tokenEndpointAuthMethod` from run state; never carries a secret for CIMD. Allows confidential DCR on the hosted issuer by resolving the secret at click time. Threads `email` alongside `subject` so hosted evaluation matches the identity pair.
  - Server: Negative-tests accept `private_key_jwt` when a confidential CIMD provider is configured and reject it otherwise. Hosted split for confidential runs: hosted mints all 11 broken assertions (mint-only) and returns them; the local server redeems each, attaching the DCR secret or signing `private_key_jwt`. The mint relay strips secrets/endpoints/headers, checks completeness by membership (not count), and fails the run if any case is missing. Ensures redeems hit the requested token endpoint. Signs a fresh per-case `client_assertion` with `iss/sub` = URL `client_id` and `aud` = posted token endpoint. Tolerates missing/garbage `exp` in diffs and still forwards public CIMD unchanged.
  - Tests: Cover the identity pair in minted assertions, public CIMD without secrets, rejecting `private_key_jwt` without a provider, per-case signing/audience and uniqueness, hosted mint/redeem for confidential DCR and CIMD (secret never forwarded, assertions redeemed at the correct endpoint), mint-only org gating, UI unlock behavior, hosted mint completeness by membership, and no-fallback handling when a hosted case is missing.

<sup>Written for commit c4b5f466ce0510853b9f81b5af2b42aac923bf9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



