### PR TITLE
refactor(copy): finish user-facing "hosts" → "clients" rename (M0 follow-up)

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/client-selector.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/client-selector.tsx
@@ -384,7 +384,7 @@ export function ClientSelector({
               <>
                 <div className="flex cursor-default items-center justify-between gap-2 border-b px-2.5 py-2">
                   <span className="text-xs text-muted-foreground">
-                    Multiple hosts
+                    Multiple clients
                   </span>
                   <Switch
                     checked={multiHostEnabled}
@@ -540,7 +540,7 @@ export function ClientSelector({
                       </div>
                     </TooltipTrigger>
                     <TooltipContent side="right">
-                      You can compare up to {maxSelectedHosts} hosts at once
+                      You can compare up to {maxSelectedHosts} clients at once
                     </TooltipContent>
                   </Tooltip>
                 ) : (
@@ -573,7 +573,7 @@ export function ClientSelector({
                         <button
                           key={host.id}
                           type="button"
-                          aria-label={`Add ${catalogHost.label} host`}
+                          aria-label={`Add ${catalogHost.label} client`}
                           title={`Add ${catalogHost.label}`}
                           data-testid={`client-quick-add-${host.id}`}
                           onClick={() => openCreateWithTemplate(host.id)}

--- a/mcpjam-inspector/client/src/components/chatboxes/session-readiness.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/session-readiness.tsx
@@ -187,7 +187,7 @@ function explainReadinessIssues(
     fallbacks.push({
       code: "high_latency",
       severity: "warning",
-      message: `Host response latency was ${formatLatency(latency)} across turns.`,
+      message: `Client response latency was ${formatLatency(latency)} across turns.`,
     });
   }
 

--- a/mcpjam-inspector/client/src/components/client-config/ClientConfigEditor.tsx
+++ b/mcpjam-inspector/client/src/components/client-config/ClientConfigEditor.tsx
@@ -1326,7 +1326,7 @@ function McpProfileSandboxAttrsEditor({
         <Label className="text-xs">sandboxAttrs (inspector-only)</Label>
         <div className="flex items-center gap-2">
           <span className="text-xs text-muted-foreground">
-            Model host sandbox tokens
+            Model client sandbox tokens
           </span>
           <Switch
             checked={isEnabled}
@@ -1543,7 +1543,7 @@ function McpProfileAllowFeaturesEditor({
         <Label className="text-xs">allowFeatures (inspector-only)</Label>
         <div className="flex items-center gap-2">
           <span className="text-xs text-muted-foreground">
-            Model host allow features
+            Model client allow features
           </span>
           <Switch
             checked={isEnabled}

--- a/mcpjam-inspector/client/src/components/compat/HostCompatContent.tsx
+++ b/mcpjam-inspector/client/src/components/compat/HostCompatContent.tsx
@@ -48,7 +48,7 @@ import { filterReportsByFeatureFlags } from "@/lib/host-compat/feature-visibilit
 const PROVENANCE_LABEL: Record<CompatProvenance, string> = {
   observed: "Observed from a live run",
   "vendor-doc": "Verified from vendor docs",
-  probe: "Probe-captured from a real host",
+  probe: "Probe-captured from a real client",
   assumed: "Best-effort preset — unverified",
 };
 
@@ -247,7 +247,7 @@ export function HostCompatContent({
       <ConformanceGate server={server} />
 
       <p className="pb-1 text-[11px] text-muted-foreground">
-        Static checks from connect-time data · best-effort host profiles
+        Static checks from connect-time data · best-effort client profiles
         {requirements.unknownDimensions.length > 0
           ? ` · incomplete (${requirements.unknownDimensions.join(", ")})`
           : ""}

--- a/mcpjam-inspector/client/src/components/compat/HostCompatPage.tsx
+++ b/mcpjam-inspector/client/src/components/compat/HostCompatPage.tsx
@@ -60,8 +60,8 @@ export function HostCompatPage({
           Compatibility
         </h1>
         <p className="text-xs text-muted-foreground">
-          Whether your servers work on each host — spec conformance first, then
-          per-host apps &amp; server gaps.
+          Whether your servers work on each client — spec conformance first, then
+          per-client apps &amp; server gaps.
         </p>
       </div>
 

--- a/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
@@ -727,7 +727,7 @@ export function ServerDetailModal({
                 aria-label="Client compatibility"
                 className={tabTriggerClass}
               >
-                Hosts
+                Clients
               </TabsTrigger>
               {showHistory && (
                 <TabsTrigger value="history" className={tabTriggerClass}>

--- a/mcpjam-inspector/client/src/components/evals/__tests__/suite-insights-cross-host.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/suite-insights-cross-host.test.tsx
@@ -169,7 +169,7 @@ describe("SuiteInsightsCollapsible scope adaptivity", () => {
     );
     const text = copySpy.mock.calls[0][0] as string;
     expect(text).toContain("Model behavior");
-    expect(text).toContain("Affected host(s): Copilot");
+    expect(text).toContain("Affected client(s): Copilot");
     expect(text).toContain("Strengthen the add_to_cart tool description.");
   });
 

--- a/mcpjam-inspector/client/src/components/evals/client-attachments-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/client-attachments-editor.tsx
@@ -71,8 +71,8 @@ export function ClientAttachmentsEditor({
       <div className="space-y-2">
         {value.length === 0 ? (
           <div className="rounded-lg border border-dashed px-4 py-5 text-sm text-muted-foreground">
-            No hosts attached. Attach one or more hosts to fan runs out across
-            them.
+            No clients attached. Attach one or more clients to fan runs out
+            across them.
           </div>
         ) : (
           value.map((attachment, index) => (

--- a/mcpjam-inspector/client/src/components/evals/create-suite-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/evals/create-suite-dialog.tsx
@@ -184,10 +184,10 @@ export function CreateSuiteDialog({
               <div className="space-y-2 p-3">
                 <div className="space-y-0.5">
                   <h3 className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-                    Hosts
+                    Clients
                   </h3>
                   <p className="text-xs text-muted-foreground">
-                    Each attached host fans out into its own run.
+                    Each attached client fans out into its own run.
                   </p>
                 </div>
                 <ClientAttachmentsEditor

--- a/mcpjam-inspector/client/src/components/evals/run-group-diagnosis-presentation.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-group-diagnosis-presentation.tsx
@@ -28,7 +28,7 @@ export const CATEGORY_LABEL: Record<GroupFinding["category"], string> = {
 
 export const ATTRIBUTION_LABEL: Record<GroupFinding["attribution"], string> = {
   server_design: "Server design",
-  host_prompt: "Host prompt",
+  host_prompt: "Client prompt",
   model_behavior: "Model behavior",
   test_design: "Test design",
   environment: "Environment",
@@ -40,7 +40,7 @@ export function buildGroupFixPrompt(
   result: RunGroupQualityResult,
 ): string {
   const lines: string[] = [];
-  lines.push(`# Cross-host eval finding: ${finding.title}`);
+  lines.push(`# Cross-client eval finding: ${finding.title}`);
   lines.push("");
   lines.push(`Overall: ${result.summary}`);
   lines.push("");
@@ -49,7 +49,7 @@ export function buildGroupFixPrompt(
     `Likely cause (attribution): ${ATTRIBUTION_LABEL[finding.attribution]} (confidence: ${finding.confidence})`,
   );
   if (finding.affectedHosts.length > 0) {
-    lines.push(`Affected host(s): ${finding.affectedHosts.join(", ")}`);
+    lines.push(`Affected client(s): ${finding.affectedHosts.join(", ")}`);
   }
   if (finding.baselineHosts.length > 0) {
     lines.push(`Compared against: ${finding.baselineHosts.join(", ")}`);

--- a/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
@@ -640,10 +640,10 @@ export function SuiteIterationsView({
         hostAttachments: attachments,
       });
       toast.success(
-        attachments.length === 0 ? "Hosts cleared" : "Hosts updated"
+        attachments.length === 0 ? "Clients cleared" : "Clients updated"
       );
     } catch (error) {
-      toast.error(getBillingErrorMessage(error, "Failed to update hosts"));
+      toast.error(getBillingErrorMessage(error, "Failed to update clients"));
       console.error("Failed to update host attachments:", error);
       throw error;
     }

--- a/mcpjam-inspector/client/src/components/evals/suite-overview-client-bar.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-overview-client-bar.tsx
@@ -203,7 +203,7 @@ export function SuiteOverviewClientBar({
         <div className="space-y-0.5">
           <div className="flex items-center justify-between gap-2 px-2 pb-1 pt-0.5">
             <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
-              Hosts
+              Clients
             </span>
             <Tooltip>
               <TooltipTrigger asChild>
@@ -217,7 +217,7 @@ export function SuiteOverviewClientBar({
               </TooltipTrigger>
               <TooltipContent side="top" className="max-w-[240px]">
                 <p className="text-xs leading-snug">
-                  Hosts are the configurations this suite evaluates.
+                  Clients are the configurations this suite evaluates.
                   Attach one or more to compare how each handles the
                   same scenarios.
                 </p>
@@ -226,7 +226,7 @@ export function SuiteOverviewClientBar({
           </div>
           {projectHosts.length === 0 ? (
             <p className="px-2 py-1.5 text-xs text-muted-foreground">
-              No hosts in this project yet — add one below.
+              No clients in this project yet — add one below.
             </p>
           ) : null}
           {projectHosts.map((host) => {
@@ -267,7 +267,7 @@ export function SuiteOverviewClientBar({
                   {isLastAttached ? (
                     <TooltipContent side="right">
                       <p className="text-xs">
-                        Attach another host first
+                        Attach another client first
                       </p>
                     </TooltipContent>
                   ) : null}
@@ -376,7 +376,7 @@ export function SuiteOverviewClientBar({
               clientPicker
             ) : attachments.length === 0 ? (
               <span className="shrink-0 text-[13px] font-normal text-muted-foreground">
-                No hosts attached
+                No clients attached
               </span>
             ) : (
               attachments.map((attachment) => {

--- a/mcpjam-inspector/client/src/components/evals/suite-results-split.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-results-split.tsx
@@ -267,7 +267,7 @@ function RunGroupItem({
       <button
         type="button"
         onClick={onSelect}
-        title={`${group.label} · ${rate ?? "—"}% · ${group.hostCount} host${group.hostCount > 1 ? "s" : ""} · ${formatRelativeTime(group.timestamp)}`}
+        title={`${group.label} · ${rate ?? "—"}% · ${group.hostCount} client${group.hostCount > 1 ? "s" : ""} · ${formatRelativeTime(group.timestamp)}`}
         className={cn(
           "flex h-9 w-9 items-center justify-center rounded-md transition-colors",
           active ? "bg-primary/10 ring-1 ring-primary/40" : "hover:bg-muted",
@@ -319,7 +319,7 @@ function RunGroupItem({
           </div>
           <div className="mt-1 flex items-center gap-2">
             <span className="text-[11px] text-muted-foreground">
-              {group.hostCount} host{group.hostCount > 1 ? "s" : ""}
+              {group.hostCount} client{group.hostCount > 1 ? "s" : ""}
             </span>
             {delta != null && delta !== 0 ? (
               <span

--- a/mcpjam-inspector/client/src/components/hosts/HostIndexPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/HostIndexPage.tsx
@@ -28,9 +28,9 @@ export function HostIndexPage({
     setDeletingId(host.hostId);
     try {
       await deleteHost({ hostId: host.hostId });
-      toast.success(`Host "${host.name}" deleted`);
+      toast.success(`Client "${host.name}" deleted`);
     } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : "Failed to delete host";
+      const msg = err instanceof Error ? err.message : "Failed to delete client";
       if (msg.includes("consumer")) {
         toast.error(
           `${msg} — use force delete or remove dependent chatboxes/evals first`,
@@ -47,10 +47,10 @@ export function HostIndexPage({
     setDuplicatingId(host.hostId);
     try {
       const { hostId } = await duplicateHost({ hostId: host.hostId });
-      toast.success(`Host duplicated`);
+      toast.success(`Client duplicated`);
       onSelectHost(hostId);
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Failed to duplicate host");
+      toast.error(err instanceof Error ? err.message : "Failed to duplicate client");
     } finally {
       setDuplicatingId(null);
     }

--- a/mcpjam-inspector/client/src/components/hosts/HostOverlayBar.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/HostOverlayBar.tsx
@@ -197,7 +197,7 @@ export function HostOverlayBar({
     setIsDeleting(true);
     try {
       await deleteHost({ hostId });
-      toast.success(`Host "${host.name}" deleted`);
+      toast.success(`Client "${host.name}" deleted`);
       // Telemetry is best-effort: a posthog throw must not bubble into the
       // shared catch and surface a delete-failure toast after the client
       // has already been removed.
@@ -211,7 +211,7 @@ export function HostOverlayBar({
         // swallow — analytics must not block the success path
       }
     } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : "Failed to delete host";
+      const msg = err instanceof Error ? err.message : "Failed to delete client";
       if (msg.includes("consumer")) {
         toast.error(
           `${msg} — use force delete or remove dependent chatboxes/evals first`
@@ -353,7 +353,7 @@ export function HostOverlayBar({
                       <button
                         key={id}
                         type="button"
-                        aria-label={`Add ${catalogHost.label} host`}
+                        aria-label={`Add ${catalogHost.label} client`}
                         title={`Add ${catalogHost.label}`}
                         data-testid={`host-overlay-quick-add-${id}`}
                         onClick={(e) => {

--- a/mcpjam-inspector/client/src/components/hosts/MultiHostPicker.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/MultiHostPicker.tsx
@@ -294,7 +294,7 @@ export function MultiHostPicker({
             </p>
           ) : (
             <p className="text-xs font-light text-muted-foreground">
-              Run multiple hosts side by side
+              Run multiple clients side by side
             </p>
           )}
         </TooltipContent>
@@ -369,7 +369,7 @@ export function MultiHostPicker({
                 !isSelected && selectedLimitReached;
               const isDisabled = isLimitedOut;
               const disabledReason = isLimitedOut
-                ? `You can compare up to ${maxSelectedHosts} hosts at once`
+                ? `You can compare up to ${maxSelectedHosts} clients at once`
                 : undefined;
 
               const row = (

--- a/mcpjam-inspector/client/src/components/hosts/comparison/HostCompareSelector.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/HostCompareSelector.tsx
@@ -32,17 +32,17 @@ const SUPPORT_FILTERS: ReadonlyArray<{
   {
     value: "missing",
     label: "Missing",
-    title: "Capabilities not supported by at least one host",
+    title: "Capabilities not supported by at least one client",
   },
   {
     value: "partial",
     label: "Partial",
-    title: "Capabilities that are partial / Auto for at least one host",
+    title: "Capabilities that are partial / Auto for at least one client",
   },
   {
     value: "supported",
     label: "Full",
-    title: "Capabilities supported by every host",
+    title: "Capabilities supported by every client",
   },
 ];
 

--- a/mcpjam-inspector/client/src/components/hosts/comparison/host-config-comparison-matrix.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/host-config-comparison-matrix.tsx
@@ -512,7 +512,7 @@ function FieldRow({
           {coverage && (
             <span
               className="text-[10.5px] text-muted-foreground tabular-nums"
-              title={`Supported by ${coverage.supported} of ${coverage.total} hosts`}
+              title={`Supported by ${coverage.supported} of ${coverage.total} clients`}
               data-testid={`coverage-${field.id}`}
             >
               {coverage.supported}/{coverage.total}

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/HostBuilderViewRedesigned.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/HostBuilderViewRedesigned.tsx
@@ -361,7 +361,7 @@ export function HostBuilderViewRedesigned({
       // The freshly persisted config id arrives via the Convex
       // subscription on the next tick; don't include it in this toast
       // because `host?.config?.id` is still the *previous* saved config here.
-      toast.success("Host saved");
+      toast.success("Client saved");
       // Telemetry is best-effort: a posthog throw must not bubble into the
       // shared catch and surface "Failed to save host" after the config
       // has already been persisted.
@@ -377,7 +377,7 @@ export function HostBuilderViewRedesigned({
         // swallow — analytics must not block the success path
       }
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Failed to save host");
+      toast.error(err instanceof Error ? err.message : "Failed to save client");
     } finally {
       setIsSaving(false);
     }
@@ -481,7 +481,7 @@ export function HostBuilderViewRedesigned({
                   ) : (
                     <Save className="size-4" />
                   )}
-                  {isDirty ? "Save host" : "Saved"}
+                  {isDirty ? "Save client" : "Saved"}
                 </Button>
               </span>
             </TooltipTrigger>

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/canvas/HostCapabilityMatrix.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/canvas/HostCapabilityMatrix.tsx
@@ -472,7 +472,7 @@ function ViewIframeInjectedGlobals({
                 mcpAppsBridge.overrideCount
               } sparse ${
                 mcpAppsBridge.overrideCount === 1 ? "override" : "overrides"
-              } on top of the host preset (e.g. Copilot's M365-published subset). Click to view the matrix.`
+              } on top of the client preset (e.g. Copilot's M365-published subset). Click to view the matrix.`
             : "SEP-1865 app.* spec bridge — primary MCP Apps protocol surface, always present. Click to view the per-dimension matrix."
         }
       >

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/HostFocusDialog.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/HostFocusDialog.tsx
@@ -228,7 +228,7 @@ export function HostFocusDialog({
               ) : (
                 <Save className="size-3" />
               )}
-              Save host
+              Save client
             </Button>
             <kbd className="ml-1 hidden rounded border border-border bg-muted px-1 py-0.5 font-mono text-[9.5px] text-muted-foreground sm:inline">
               esc

--- a/mcpjam-inspector/client/src/components/shared/ClientContextHeader.tsx
+++ b/mcpjam-inspector/client/src/components/shared/ClientContextHeader.tsx
@@ -286,7 +286,7 @@ export function ClientContextHeader({
             {...PLAYGROUND_HEADER_TOOLTIP}
             className="max-w-none whitespace-nowrap"
           >
-            These are temporary overrides applied to your current host.
+            These are temporary overrides applied to your current client.
           </TooltipContent>
         </Tooltip>
 

--- a/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
@@ -899,11 +899,11 @@ function NewJourneyButton({
         value={goal}
         onChange={(e) => setGoal(e.target.value)}
       />
-      <p className="mb-1 text-xs font-medium">Hosts</p>
+      <p className="mb-1 text-xs font-medium">Clients</p>
       <div className="mb-3 flex flex-wrap gap-2">
         {hosts.length === 0 ? (
           <span className="text-xs text-muted-foreground">
-            No hosts in this project.
+            No clients in this project.
           </span>
         ) : (
           sortedHosts.map((h) => {


### PR DESCRIPTION
## Follow-up to #3122

#3122 renamed user-facing **hosts → clients**, but merged with a batch of leftover "host" strings that reviewers (cubic + CodeRabbit) flagged. This finishes the sweep.

### Naming mapping (preserved from #3122)
| Layer | Term |
|-------|------|
| User-facing (labels, buttons, empty states, tooltips, aria-labels, toasts) | **client** |
| Code / wire / storage (identifiers, API fields, analytics, Convex tables, SDK) | **host** (unchanged) |

### Reviewer-flagged fixes
- `suite-overview-client-bar` — section header, info tooltip, 3 empty states
- `ServerDetailModal` — compatibility tab label "Hosts" → "Clients"
- `suite-results-split` — collapsed + expanded run-count labels
- `MultiHostPicker` — comparison tooltip + disabled-reason
- `client-selector` — "Multiple hosts", limit tooltip, quick-add aria-label
- `ClientConfigEditor` — "Model host …" span labels (aria-labels were already renamed)
- `client-attachments-editor`, `create-suite-dialog` — empty state / section header + description
- `HostIndexPage`, `HostOverlayBar` — delete/duplicate toasts + quick-add aria-label
- `ClientContextHeader` — overrides tooltip
- `HostCompatContent` / `HostCompatPage` — provenance + description copy
- `run-group-diagnosis` — "Cross-client eval finding", "Affected client(s)" (+ test)
- `HostCapabilityMatrix`, `HostBuilderViewRedesigned`, `HostFocusDialog` — tooltip, save toasts, buttons

### Additional leftovers caught in the same sweep
- `HostCompareSelector` — 3 filter tooltips
- `host-config-comparison-matrix` — coverage tooltip
- `suite-iterations-view` — attachment update toasts
- `SwarmsTab` — clients label + empty state
- `run-group-diagnosis` — attribution label

### Explicitly left unchanged
Internal identifiers (`hostId`, `hostConfig`, `namedHostId`), analytics events, API/Convex fields, SDK exports, routes (`/hosts`), CSS class names (`chatbox-host-*`), and MCP-spec terms — `Host Capabilities`, the N×M "host" educational articles, and enterprise `Host policy`/XAA (a distinct auth concept).

### Verification
- 97 affected component tests pass
- Typecheck clean on all touched files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Finishes the user-facing rename from “hosts” to “clients” by cleaning up leftover copy across the app. Improves consistency in labels, tooltips, empty states, toasts, and aria-labels without changing APIs or storage.

- **Refactors**
  - Standardized UI copy to “clients” in chat selectors, multi-compare tooltips, suite views, compat screens, swarms, and client-config editors.
  - Updated deletion/duplication/save toasts and quick‑add aria‑labels in `HostIndexPage`, `HostOverlayBar`, and redesigned builder/focus views.
  - Aligned comparison and coverage tooltips in selectors and matrices to reference “clients”.
  - Updated a test assertion to the new wording.
  - Kept internal identifiers, analytics, SDK, routes, and MCP-spec terms as “host” (unchanged).

<sup>Written for commit 404c27bec43d12f92e29e216f4128d257956815a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

