### PR TITLE
ci(mintlify): fail triage when the classifier reaches no outcome

### DIFF
--- a/.github/workflows/mintlify-triage.yml
+++ b/.github/workflows/mintlify-triage.yml
@@ -68,26 +68,53 @@ jobs:
 
             Keep the comment to a single sentence.
 
-      # The main ruleset requires 1 approving review before anything merges.
-      # If (and only if) the classifier queued auto-merge above, satisfy that
-      # requirement here so verified docs PRs can actually land. This is the
-      # second half of the MERGE action, not a general bypass: it runs only in
-      # this workflow (job-gated to mintlify[bot] PRs), only after the
-      # classifier's positive verification, and a CLOSE decision leaves no
-      # auto-merge queued so the step is a no-op. Approval is posted by
-      # github-actions[bot], never the PR author.
-      # Explicitly authorized by the repo owner (2026-07-14) to unblock the
-      # docs-PR pipeline after the July backlog.
-      - name: Approve if classifier queued a merge
+      # Assert the classifier actually reached a decision, and complete the
+      # MERGE half of it.
+      #
+      # The prompt above mandates EXACTLY ONE outcome: auto-merge queued, or
+      # the PR closed. Anything else means the classifier never ran to a
+      # decision — and that failure is silent by default: claude-code-action
+      # exits 0 when it soft-skips (e.g. its workflow-validation guard fires
+      # because this file on the PR's merge ref differs from the default
+      # branch, which happens to every in-flight bot PR whenever this workflow
+      # is edited). Without the else-branch below, that soft-skip reported a
+      # green `triage` check having triaged nothing — strictly worse than a
+      # red X, because neither a human nor the shepherd can tell it apart from
+      # a real decision. A no-outcome run must be loud.
+      #
+      # The approval is the second half of the MERGE action, not a general
+      # bypass: the main ruleset requires 1 approving review, and this runs
+      # only in this workflow (job-gated to mintlify[bot] PRs), only on the
+      # classifier's positive verification. Posted by github-actions[bot],
+      # never the PR author. Explicitly authorized by the repo owner
+      # (2026-07-14) to unblock the docs-PR pipeline after the July backlog.
+      - name: Enforce a triage outcome (and approve on MERGE)
+        # Not success(): a soft-skipped classifier exits 0, and a hard failure
+        # should still say why. Not always(): `cancel-in-progress` above means
+        # superseded runs get cancelled, and a cancelled run has legitimately
+        # reached no outcome — failing it would just add noise.
+        if: ${{ !cancelled() }}
         env:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
         run: |
-          queued=$(gh api "repos/${{ github.repository }}/pulls/$PR" --jq '.auto_merge != null')
+          set -euo pipefail
+          pr=$(gh api "repos/$REPO/pulls/$PR")
+          queued=$(jq -r '.auto_merge != null' <<<"$pr")
+          merged=$(jq -r '.merged' <<<"$pr")
+          state=$(jq -r '.state' <<<"$pr")
+
           if [ "$queued" = "true" ]; then
-            gh api -X POST "repos/${{ github.repository }}/pulls/$PR/reviews" \
+            gh api -X POST "repos/$REPO/pulls/$PR/reviews" \
               -f event=APPROVE \
-              -f body="Auto-approved: the Mintlify triage classifier verified this docs-only PR against the code and queued it for merge."
+              -f body="Auto-approved: the Mintlify triage classifier verified this docs-only PR against the code and queued it for merge." >/dev/null
+            echo "Outcome: MERGE — auto-merge queued and approved."
+          elif [ "$merged" = "true" ]; then
+            echo "Outcome: MERGE — already landed; nothing to approve."
+          elif [ "$state" = "closed" ]; then
+            echo "Outcome: CLOSE — classifier rejected the PR."
           else
-            echo "No auto-merge queued (classifier closed the PR or took no action); skipping approval."
+            echo "::error title=Triage reached no outcome::PR #$PR is still open with no auto-merge queued, so the classifier never decided MERGE or CLOSE. Check the 'Classify and act' step: a soft-skip there exits 0 and would otherwise report this check green. If it logged a workflow-validation skip, this file differs from the default branch — re-run once it matches."
+            exit 1
           fi


### PR DESCRIPTION
## The bug

The triage prompt mandates **exactly one** outcome per docs PR: auto-merge queued, or the PR closed. If neither happened, the classifier never reached a decision — and that failure was **silent**.

`claude-code-action` exits 0 when it soft-skips. Its workflow-validation guard fires whenever this file on the PR's merge ref differs from the default branch, which happens to every in-flight bot PR the moment this workflow is edited:

```
Skipping action due to workflow validation: Workflow validation failed. The workflow
file must exist and have identical content to the version on the repository's
default branch.
Exiting due to workflow validation skip
```

Exit 0 → the `triage` check goes **green having triaged nothing**.

That's strictly worse than a red X. A green no-op is indistinguishable from a real decision, both to a human scanning the checks and to the `mintlify-shepherd` sweep. It's the same shape of silent failure that let 130 docs PRs pile up unnoticed for six weeks (#3239).

Observed live on #3251 earlier today: run [29458348630](https://github.com/MCPJam/inspector/actions/runs/29458348630) — green `triage`, no merge queued, no close, no comment.

## The fix

The old approve step's `else` branch conflated two very different states — *"classifier closed the PR"* (correct) and *"classifier did nothing"* (broken) — and echoed a benign message for both. This replaces it with an explicit outcome gate:

| PR state after the classifier | Result |
|---|---|
| auto-merge queued | **MERGE** — approve (unchanged behavior) |
| already merged | **MERGE** — nothing to approve |
| closed, not merged | **CLOSE** |
| still open, nothing queued | **error, exit 1** ← the bug |

Guarded with `!cancelled()` rather than `always()`: this job sets `concurrency.cancel-in-progress: true`, so a superseded run legitimately reaches no outcome and shouldn't be reported as a failure.

The approval path is unchanged — same job gate (`mintlify[bot]` PRs only), same owner authorization (2026-07-14), still posted by `github-actions[bot]` and never the PR author.

## Verification

- YAML parses; all three steps intact; gate condition and `run` block well-formed.
- Gate logic exercised against all four PR states — the soft-skip case (`open` + no auto-merge) correctly exits 1, the other three pass through as before.
- Not exercised end-to-end against a live bot PR: the trigger is `pull_request: opened` by `mintlify[bot]`, which can't be simulated. The gate is a pure function of the PR's API state, and each branch is verified above.

**Note:** merging this will soft-skip triage on any mintlify PR currently in flight (their merge refs won't match the new default branch). After this lands, that now surfaces as a red X instead of a false green — which is the point. Re-run those once main matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change to post-classifier gating; MERGE/approve paths are preserved and the new failure mode only surfaces previously silent classifier skips.
> 
> **Overview**
> The Mintlify triage workflow used to treat “PR still open with no auto-merge” the same as a successful **CLOSE**, so when `claude-code-action` **soft-skipped** (exit 0, no MERGE/CLOSE) the job could still look **green** with nothing triaged.
> 
> The post-classifier step is renamed to **Enforce a triage outcome (and approve on MERGE)** and runs when the job is **not cancelled** (`!cancelled()`), not only on classifier success. It reads PR state via the API (`auto_merge`, `merged`, `state`) and branches explicitly: queue **MERGE** → approve as before; already merged or closed → log the outcome; **still open with no auto-merge** → `::error` and **exit 1** so silent no-ops fail loudly. Approval behavior and authorization comments are unchanged; shell hardening adds `set -euo pipefail` and a `REPO` env var.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea71da3cadb60860c9b3dda8d2fc329544e4a39a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces a triage outcome in the Mintlify workflow and fails the job when the classifier makes no decision. Keeps auto-merge approvals intact and prevents false green no-ops.

- **Bug Fixes**
  - Add an explicit outcome gate: approve when auto-merge is queued; accept already merged or closed; otherwise emit error and exit 1.
  - Guard with `!cancelled()` so superseded runs (via `concurrency.cancel-in-progress`) don’t report failures.
  - Approval path and scoping unchanged (`mintlify[bot]` PRs only; review posted by `github-actions[bot]`).

- **Migration**
  - In-flight Mintlify PRs may show red after this merges due to a prior soft-skip; re-run once `main` matches.

<sup>Written for commit ea71da3cadb60860c9b3dda8d2fc329544e4a39a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

