### PR TITLE
feat(webmcp): gate ui_* approval on MCP tool annotations

### DIFF
--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/native-mirror.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/native-mirror.test.ts
@@ -77,6 +77,35 @@ describe("mirrorUiToolToNative", () => {
     expect(opts?.signal).toBeInstanceOf(AbortSignal);
   });
 
+  it("projects the full MCP annotations plus WebMCP's untrustedContentHint", () => {
+    const registerTool = stubModelContext("document");
+    mirrorUiToolToNative(
+      makeTool({
+        readOnly: false,
+        annotations: {
+          readOnlyHint: false,
+          destructiveHint: true,
+          openWorldHint: true,
+        },
+        nativeUntrustedContentHint: true,
+      }),
+    );
+    expect(registerTool.mock.calls[0][0].annotations).toEqual({
+      readOnlyHint: false,
+      destructiveHint: true,
+      openWorldHint: true,
+      untrustedContentHint: true,
+    });
+  });
+
+  it("omits untrustedContentHint when the tool doesn't set it", () => {
+    const registerTool = stubModelContext("document");
+    mirrorUiToolToNative(makeTool());
+    expect(
+      registerTool.mock.calls[0][0].annotations,
+    ).not.toHaveProperty("untrustedContentHint");
+  });
+
   it("disposer aborts the registration signal", () => {
     const registerTool = stubModelContext("document");
     const dispose = mirrorUiToolToNative(makeTool());

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tool-executor.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tool-executor.test.ts
@@ -83,6 +83,54 @@ describe("handleUiToolCall", () => {
     ]);
   });
 
+  it("defers a DESTRUCTIVE tool even when requireToolApproval is off", async () => {
+    // The default mode. The client decides "defer" before the server's
+    // approval-request chunk arrives, so this must match the server's
+    // classification exactly or the turn strands.
+    const def = makeTool({
+      name: "ui_execute_tool",
+      readOnly: false,
+      annotations: { readOnlyHint: false, destructiveHint: true },
+    });
+    useUiToolsRegistry.getState().registerUiTool(def);
+    const addToolOutput = vi.fn();
+
+    const handled = await handleUiToolCall({
+      toolName: "ui_execute_tool",
+      toolCallId: "tc-destructive",
+      input: {},
+      addToolOutput,
+      requireToolApproval: false,
+    });
+
+    expect(handled).toBe(true);
+    expect(def.execute).not.toHaveBeenCalled();
+    expect(addToolOutput).not.toHaveBeenCalled();
+    expect(listDeferredUiToolCalls()).toEqual([
+      { toolCallId: "tc-destructive", toolName: "ui_execute_tool", input: {} },
+    ]);
+  });
+
+  it("executes an ADDITIVE tool immediately when requireToolApproval is off", async () => {
+    const def = makeTool({
+      annotations: { readOnlyHint: false, destructiveHint: false },
+    });
+    useUiToolsRegistry.getState().registerUiTool(def);
+    const addToolOutput = vi.fn();
+
+    await handleUiToolCall({
+      toolName: "ui_navigate",
+      toolCallId: "tc-additive",
+      input: { target: "servers" },
+      addToolOutput,
+      requireToolApproval: false,
+    });
+
+    expect(def.execute).toHaveBeenCalled();
+    expect(addToolOutput).toHaveBeenCalled();
+    expect(listDeferredUiToolCalls()).toEqual([]);
+  });
+
   it("read-only tools execute immediately even with the flag on", async () => {
     const def = makeTool({ name: "ui_snapshot_app", readOnly: true });
     useUiToolsRegistry.getState().registerUiTool(def);

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tools-catalog.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tools-catalog.test.ts
@@ -59,6 +59,39 @@ describe("buildUiToolsCatalog", () => {
     expect(getTool("ui_snapshot_app").readOnly).toBe(true);
   });
 
+  it("every tool annotates readOnly/destructive/openWorld explicitly", () => {
+    // An absent `destructiveHint` reads as DESTRUCTIVE, so an unannotated
+    // tool would gate on every call rather than execute silently — safe, but
+    // wrong. Curated entries state their policy instead of inheriting it.
+    for (const tool of buildUiToolsCatalog()) {
+      const annotations = tool.annotations;
+      expect(annotations, `${tool.name} must annotate`).toBeDefined();
+      expect(typeof annotations?.readOnlyHint).toBe("boolean");
+      expect(typeof annotations?.destructiveHint).toBe("boolean");
+      expect(typeof annotations?.openWorldHint).toBe("boolean");
+      // The wire carries both; the validator 400s if they disagree.
+      expect(annotations?.readOnlyHint).toBe(tool.readOnly);
+    }
+  });
+
+  it("gates exactly ui_execute_tool as destructive", () => {
+    // It runs an arbitrary third-party MCP tool, so it confirms even with the
+    // approval toggle off. Everything else is additive: the user watches it
+    // happen in their own app, and a confirmation buys nothing.
+    const destructive = buildUiToolsCatalog()
+      .filter((t) => t.annotations?.destructiveHint === true)
+      .map((t) => t.name);
+    expect(destructive).toEqual(["ui_execute_tool"]);
+  });
+
+  it("marks only ui_execute_tool as open-world", () => {
+    // The one tool whose effects escape the browser.
+    const openWorld = buildUiToolsCatalog()
+      .filter((t) => t.annotations?.openWorldHint === true)
+      .map((t) => t.name);
+    expect(openWorld).toEqual(["ui_execute_tool"]);
+  });
+
   it("ui_navigate dispatches valid targets and errors on missing/unknown ones", async () => {
     const navigate = getTool("ui_navigate");
 

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tools-catalog.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tools-catalog.test.ts
@@ -92,6 +92,20 @@ describe("buildUiToolsCatalog", () => {
     expect(openWorld).toEqual(["ui_execute_tool"]);
   });
 
+  it("flags only ui_execute_tool's output as untrusted for native agents", () => {
+    // Its result comes from a third-party MCP server. `openWorldHint` (MCP)
+    // doesn't convey that to a WebMCP agent; `nativeUntrustedContentHint`
+    // (projected to WebMCP's untrustedContentHint) does.
+    const untrusted = buildUiToolsCatalog()
+      .filter((t) => t.nativeUntrustedContentHint === true)
+      .map((t) => t.name);
+    expect(untrusted).toEqual(["ui_execute_tool"]);
+  });
+
+  it("does not advertise ui_navigate as idempotent (navigation adds history)", () => {
+    expect(getTool("ui_navigate").annotations?.idempotentHint).toBe(false);
+  });
+
   it("ui_navigate dispatches valid targets and errors on missing/unknown ones", async () => {
     const navigate = getTool("ui_navigate");
 

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tools-registry.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tools-registry.test.ts
@@ -59,6 +59,25 @@ describe("useUiToolsRegistry", () => {
     ).toThrow(/must match ui_/);
   });
 
+  it("rejects a readOnlyHint that contradicts readOnly loudly", () => {
+    // The server 400s a contradictory snapshot on every chat POST; catching
+    // it at registration turns that into an obvious local failure instead.
+    expect(() =>
+      useUiToolsRegistry.getState().registerUiTool(
+        makeTool("ui_navigate", {
+          readOnly: false,
+          annotations: { readOnlyHint: true },
+        }),
+      ),
+    ).toThrow(/must agree/);
+  });
+
+  it("accepts a definition with no annotations (legacy shape)", () => {
+    expect(() =>
+      useUiToolsRegistry.getState().registerUiTool(makeTool("ui_navigate")),
+    ).not.toThrow();
+  });
+
   it("replaces a re-registered name with a warn (HMR/StrictMode)", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const first = makeTool("ui_navigate");
@@ -118,6 +137,34 @@ describe("useUiToolsRegistry", () => {
       inputSchema: { type: "object", properties: {} },
       readOnly: true,
     });
+  });
+
+  it("ships annotations so the server can classify approval", () => {
+    const annotations = {
+      readOnlyHint: false,
+      destructiveHint: true,
+      openWorldHint: true,
+    };
+    useUiToolsRegistry
+      .getState()
+      .registerUiTool(makeTool("ui_execute_tool", { annotations }));
+
+    const [entry] = useUiToolsRegistry.getState().snapshotForChatBody();
+    expect(entry.annotations).toEqual(annotations);
+  });
+
+  it("omits the annotations key entirely when a definition has none", () => {
+    useUiToolsRegistry.getState().registerUiTool(makeTool("ui_navigate"));
+    const [entry] = useUiToolsRegistry.getState().snapshotForChatBody();
+    expect(entry).not.toHaveProperty("annotations");
+  });
+
+  it("never ships mayNavigate (client-only metadata)", () => {
+    useUiToolsRegistry
+      .getState()
+      .registerUiTool(makeTool("ui_navigate", { mayNavigate: true }));
+    const [entry] = useUiToolsRegistry.getState().snapshotForChatBody();
+    expect(entry).not.toHaveProperty("mayNavigate");
   });
 
   it("drops oversize schemas from the snapshot instead of truncating them", () => {

--- a/mcpjam-inspector/client/src/lib/webmcp/native-mirror.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/native-mirror.ts
@@ -85,10 +85,20 @@ export function mirrorUiToolToNative(
           properties: {},
           additionalProperties: false,
         },
-        // MCP `ToolAnnotations`, forwarded as-is. `readOnlyHint` falls back to
-        // the legacy flag for a definition that predates annotations; the
-        // registry rejects a definition where the two disagree.
-        annotations: { readOnlyHint: def.readOnly, ...def.annotations },
+        // MCP `ToolAnnotations`, forwarded as-is, plus WebMCP's own
+        // `untrustedContentHint`. `readOnlyHint` falls back to the legacy
+        // flag for a definition that predates annotations; the registry
+        // rejects a definition where the two disagree. `untrustedContentHint`
+        // is a NATIVE-only signal (not a valid MCP annotation), so it lives
+        // on the client def and is projected only here — it tells a
+        // browser-native agent that a tool's output is externally sourced.
+        annotations: {
+          readOnlyHint: def.readOnly,
+          ...def.annotations,
+          ...(def.nativeUntrustedContentHint
+            ? { untrustedContentHint: true }
+            : {}),
+        },
         execute: async (args: unknown) => {
           const input =
             args && typeof args === "object"

--- a/mcpjam-inspector/client/src/lib/webmcp/native-mirror.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/native-mirror.ts
@@ -85,7 +85,10 @@ export function mirrorUiToolToNative(
           properties: {},
           additionalProperties: false,
         },
-        annotations: { readOnlyHint: def.readOnly },
+        // MCP `ToolAnnotations`, forwarded as-is. `readOnlyHint` falls back to
+        // the legacy flag for a definition that predates annotations; the
+        // registry rejects a definition where the two disagree.
+        annotations: { readOnlyHint: def.readOnly, ...def.annotations },
         execute: async (args: unknown) => {
           const input =
             args && typeof args === "object"

--- a/mcpjam-inspector/client/src/lib/webmcp/ui-tool-executor.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/ui-tool-executor.ts
@@ -170,6 +170,7 @@ export async function handleUiToolCall(
   if (
     uiToolCallNeedsApproval({
       readOnly: def.readOnly,
+      annotations: def.annotations,
       requireToolApproval: opts.requireToolApproval === true,
     })
   ) {

--- a/mcpjam-inspector/client/src/lib/webmcp/ui-tools-catalog.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/ui-tools-catalog.ts
@@ -140,6 +140,12 @@ export function buildUiToolsCatalog(): UiToolDefinition[] {
         additionalProperties: false,
       },
       readOnly: false,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
       mayNavigate: true,
       execute: async (args) => {
         const target = asOptionalString(args.target);
@@ -160,6 +166,12 @@ export function buildUiToolsCatalog(): UiToolDefinition[] {
         additionalProperties: false,
       },
       readOnly: false,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
       execute: async (args) => {
         const serverName = asOptionalString(args.serverName);
         if (!serverName) {
@@ -183,6 +195,12 @@ export function buildUiToolsCatalog(): UiToolDefinition[] {
         additionalProperties: false,
       },
       readOnly: false,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
       mayNavigate: true,
       execute: async (args) =>
         fromActionResult(
@@ -210,6 +228,14 @@ export function buildUiToolsCatalog(): UiToolDefinition[] {
         additionalProperties: false,
       },
       readOnly: false,
+      // Prefills a form the user still has to run: mutates UI state, but
+      // nothing about it is destructive and it never leaves the browser.
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
       // Auto-opens the playground when its handler isn't mounted — from a
       // non-playground route that is a navigation.
       mayNavigate: true,
@@ -254,6 +280,17 @@ export function buildUiToolsCatalog(): UiToolDefinition[] {
         additionalProperties: false,
       },
       readOnly: false,
+      // The only UI tool with effects outside the browser: it runs an
+      // arbitrary third-party MCP tool whose own destructiveness is unknown
+      // here. `destructiveHint: true` is what makes it confirm even in the
+      // default (non-strict) approval mode — the pessimistic read is the
+      // correct one until per-call target-annotation pass-through exists.
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
       // Auto-opens the playground when its handler isn't mounted — from a
       // non-playground route that is a navigation.
       mayNavigate: true,
@@ -304,6 +341,12 @@ export function buildUiToolsCatalog(): UiToolDefinition[] {
         additionalProperties: false,
       },
       readOnly: false,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
       // Auto-opens the playground when its handler isn't mounted — from a
       // non-playground route that is a navigation.
       mayNavigate: true,
@@ -347,6 +390,15 @@ export function buildUiToolsCatalog(): UiToolDefinition[] {
         additionalProperties: false,
       },
       readOnly: true,
+      // The only read-only tool in the catalog: never gates, in either
+      // approval mode. That exemption is only sound because `execute` below
+      // refuses rather than auto-opening the playground.
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
       execute: async () => {
         // Honor readOnly: a snapshot must never navigate or mount the
         // playground. Unlike the mutating tools, it does NOT auto-open via

--- a/mcpjam-inspector/client/src/lib/webmcp/ui-tools-catalog.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/ui-tools-catalog.ts
@@ -143,7 +143,11 @@ export function buildUiToolsCatalog(): UiToolDefinition[] {
       annotations: {
         readOnlyHint: false,
         destructiveHint: false,
-        idempotentHint: true,
+        // NOT idempotent: a normal navigation pushes a browser-history entry
+        // even when the destination is unchanged, so repeated calls DO have
+        // an additional effect. Advertising idempotent would invite a native
+        // agent to retry freely and pile up history.
+        idempotentHint: false,
         openWorldHint: false,
       },
       mayNavigate: true,
@@ -291,6 +295,11 @@ export function buildUiToolsCatalog(): UiToolDefinition[] {
         idempotentHint: false,
         openWorldHint: true,
       },
+      // Its result comes from a third-party MCP server — externally sourced,
+      // so a browser-native agent should treat it as untrusted. `openWorldHint`
+      // (MCP) doesn't convey that to a WebMCP agent; `untrustedContentHint`
+      // (WebMCP) does. Native mirror only.
+      nativeUntrustedContentHint: true,
       // Auto-opens the playground when its handler isn't mounted — from a
       // non-playground route that is a navigation.
       mayNavigate: true,

--- a/mcpjam-inspector/client/src/lib/webmcp/ui-tools-registry.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/ui-tools-registry.ts
@@ -24,6 +24,7 @@
 
 import { create } from "zustand";
 import { isUiToolName } from "@/shared/client-fulfilled-tools.js";
+import type { UiToolAnnotations } from "@/shared/client-fulfilled-tools.js";
 import type { UiToolSnapshotEntry } from "@/shared/chat-v2.js";
 import { mirrorUiToolToNative } from "./native-mirror";
 
@@ -38,8 +39,21 @@ export interface UiToolDefinition {
   description: string;
   /** Plain JSON Schema object (no zod), same as the app-tool pipeline. */
   inputSchema?: Record<string, unknown>;
-  /** Mirrored to native `annotations.readOnlyHint`; metadata, not a gate. */
+  /**
+   * Legacy read-only flag. Kept as the wire-compatible mirror of
+   * `annotations.readOnlyHint`; `registerUiTool` rejects a definition where
+   * the two disagree. Prefer reading `annotations`.
+   */
   readOnly: boolean;
+  /**
+   * MCP `ToolAnnotations` for this tool. Drives approval policy
+   * (`uiToolCallNeedsApproval`) and is projected onto the native WebMCP
+   * descriptor. Every entry in the first-party catalog sets these
+   * explicitly — an absent `destructiveHint` is read as DESTRUCTIVE (the
+   * protocol's pessimistic default), so a tool added without annotations
+   * gates rather than executing silently.
+   */
+  annotations?: UiToolAnnotations;
   /**
    * Executing this tool can change the SPA route (directly, or via the
    * auto-open-playground fallback). Route-bound chat surfaces use this to
@@ -92,6 +106,17 @@ export const useUiToolsRegistry = create<UiToolsRegistryState>((set, get) => ({
       // First-party catalog bug, not user input — fail loudly.
       throw new Error(
         `[webmcp] UI tool name "${def.name}" must match ui_[a-z0-9][a-z0-9_]* (max 64 chars).`,
+      );
+    }
+    if (
+      def.annotations?.readOnlyHint !== undefined &&
+      def.annotations.readOnlyHint !== def.readOnly
+    ) {
+      // The server validator rejects contradictory snapshots; catching it at
+      // registration turns a 400 on every chat POST into an obvious local
+      // failure. Same posture as the name check: first-party bug, fail loud.
+      throw new Error(
+        `[webmcp] UI tool "${def.name}" has readOnly=${def.readOnly} but annotations.readOnlyHint=${def.annotations.readOnlyHint}; they must agree.`,
       );
     }
     if (opts?.signal?.aborted) {
@@ -159,6 +184,7 @@ export const useUiToolsRegistry = create<UiToolsRegistryState>((set, get) => ({
         description: def.description.slice(0, MAX_DESCRIPTION_CHARS),
         inputSchema,
         readOnly: def.readOnly,
+        ...(def.annotations ? { annotations: def.annotations } : {}),
       });
     }
     if (dropped > 0) {

--- a/mcpjam-inspector/client/src/lib/webmcp/ui-tools-registry.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/ui-tools-registry.ts
@@ -55,6 +55,16 @@ export interface UiToolDefinition {
    */
   annotations?: UiToolAnnotations;
   /**
+   * WebMCP's `untrustedContentHint` for the NATIVE mirror only. WebMCP has
+   * its own signal for "this tool's output is externally sourced and should
+   * be treated as untrusted"; MCP's `openWorldHint` is a different thing, so
+   * a native agent won't infer it. Set true for a tool whose result comes
+   * from a third party (e.g. `ui_execute_tool` runs an arbitrary MCP server).
+   * Client-only: it is NOT a valid MCP annotation, so the server validator
+   * would reject it — `snapshotForChatBody` never ships it.
+   */
+  nativeUntrustedContentHint?: boolean;
+  /**
    * Executing this tool can change the SPA route (directly, or via the
    * auto-open-playground fallback). Route-bound chat surfaces use this to
    * hand the conversation off to the always-mounted side panel BEFORE the

--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -51,6 +51,7 @@ import {
   validateWidgetModelContextEntries,
   WidgetModelContextValidationError,
 } from "../../utils/chat-v2-orchestration";
+import { classifyUiToolApprovals } from "@/shared/client-fulfilled-tools";
 import {
   formatProviderOverloadError,
   isProviderOverloadError,
@@ -643,6 +644,16 @@ chatV2.post("/", async (c) => {
       }
     }
 
+    // Per-tool `ui_*` approval policy for this turn. The BYOK `streamText`
+    // path reads it off each tool's `needsApproval` (set by `buildUiTools`);
+    // the MCPJam/org loops re-implement approval on top of a proxied stream,
+    // so they need the classification passed explicitly or destructive UI
+    // tools would execute unconfirmed whenever `requireToolApproval` is off.
+    const uiToolApprovals = classifyUiToolApprovals(
+      validatedUiTools,
+      requireToolApproval === true,
+    );
+
     let validatedWidgetModelContext;
     try {
       validatedWidgetModelContext = validateWidgetModelContextEntries(
@@ -860,6 +871,7 @@ chatV2.post("/", async (c) => {
         mcpClientManager,
         selectedServers,
         requireToolApproval,
+        uiToolApprovals,
         modelVisibleMcpToolResults,
         ...(resolvedExecution.harness
           ? {
@@ -1078,6 +1090,7 @@ chatV2.post("/", async (c) => {
         selectedServers,
         serverIds: hostConfigServerIds,
         requireToolApproval,
+        uiToolApprovals,
         modelVisibleMcpToolResults,
         abortSignal: inboundAbortSignalOrg,
         onConversationComplete,

--- a/mcpjam-inspector/server/utils/__tests__/chat-v2-orchestration.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/chat-v2-orchestration.test.ts
@@ -877,10 +877,21 @@ describe("validateUiToolEntries (WebMCP UI tools)", () => {
       ).toThrow(/readOnlyHint must equal readOnly/);
     });
 
-    it("accepts an agreeing readOnlyHint", () => {
+    it("accepts an agreeing readOnlyHint (both directions)", () => {
       expect(() =>
         validateUiToolEntries([
           { ...validTool, readOnly: false, annotations: { readOnlyHint: false } },
+        ]),
+      ).not.toThrow();
+      // Symmetric case: a read-only tool agreeing it's read-only.
+      expect(() =>
+        validateUiToolEntries([
+          {
+            ...validTool,
+            name: "ui_snapshot_app",
+            readOnly: true,
+            annotations: { readOnlyHint: true },
+          },
         ]),
       ).not.toThrow();
     });
@@ -1145,19 +1156,38 @@ describe("prepareChatV2 — WebMCP UI tools", () => {
     ).toBeFalsy();
   });
 
-  it("describes the approval policy that actually applies in each mode", () => {
-    // Both modes gate something, so both get a sentence — the prompt must not
-    // promise "every mutating action pauses" in the default mode, where only
-    // destructive ones do.
-    const withFlag = buildUiToolsSystemPrompt(uiTools, {
-      requireToolApproval: true,
-    });
-    expect(withFlag).toContain("Every mutating `ui_*` action pauses");
-    expect(withFlag).toContain("denial is final");
+  it("promises a destructive gate in default mode ONLY when the snapshot is annotation-aware", () => {
+    const annotated: UiToolEntry[] = [
+      {
+        name: "ui_navigate",
+        description: "Navigate",
+        readOnly: false,
+        annotations: { readOnlyHint: false, destructiveHint: false },
+      },
+      {
+        name: "ui_execute_tool",
+        description: "Run a tool",
+        readOnly: false,
+        annotations: { readOnlyHint: false, destructiveHint: true },
+      },
+    ];
 
-    const withoutFlag = buildUiToolsSystemPrompt(uiTools);
-    expect(withoutFlag).toContain("Destructive `ui_*` actions pause");
-    expect(withoutFlag).toContain("other actions apply immediately");
-    expect(withoutFlag).not.toContain("Every mutating `ui_*` action pauses");
+    // Strict mode: every mutating tool pauses, regardless of annotations.
+    expect(
+      buildUiToolsSystemPrompt(annotated, { requireToolApproval: true }),
+    ).toContain("Every mutating `ui_*` action pauses");
+
+    // Default mode, annotation-aware: the destructive-gate promise holds.
+    const annotatedDefault = buildUiToolsSystemPrompt(annotated);
+    expect(annotatedDefault).toContain("Destructive `ui_*` actions pause");
+    expect(annotatedDefault).toContain("other actions apply immediately");
+
+    // Default mode, LEGACY snapshot (the fixture has no annotations): the
+    // predicate is `requireToolApproval && !readOnly`, so with the flag off
+    // NOTHING pauses. The prompt must not promise a destructive gate that
+    // isn't enforced.
+    const legacyDefault = buildUiToolsSystemPrompt(uiTools);
+    expect(legacyDefault).not.toContain("Destructive `ui_*` actions pause");
+    expect(legacyDefault).toContain("applies immediately");
   });
 });

--- a/mcpjam-inspector/server/utils/__tests__/chat-v2-orchestration.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/chat-v2-orchestration.test.ts
@@ -819,6 +819,73 @@ describe("validateUiToolEntries (WebMCP UI tools)", () => {
     );
   });
 
+  describe("annotations", () => {
+    it("passes a valid annotations object through", () => {
+      const annotations = {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: false,
+        openWorldHint: true,
+      };
+      const [entry] = validateUiToolEntries([
+        { ...validTool, name: "ui_execute_tool", annotations },
+      ]);
+      expect(entry.annotations).toEqual(annotations);
+    });
+
+    it("omits annotations when the client sent none (legacy client)", () => {
+      const [entry] = validateUiToolEntries([validTool]);
+      expect(entry.annotations).toBeUndefined();
+    });
+
+    it("rejects a non-object annotations value", () => {
+      for (const annotations of [null, "readOnly", 1, []]) {
+        expect(() =>
+          validateUiToolEntries([{ ...validTool, annotations }]),
+        ).toThrow(/annotations must be an object/);
+      }
+    });
+
+    it("rejects non-boolean hint values", () => {
+      expect(() =>
+        validateUiToolEntries([
+          { ...validTool, annotations: { destructiveHint: "yes" } },
+        ]),
+      ).toThrow(/annotations.destructiveHint must be a boolean/);
+    });
+
+    it("rejects unknown hint keys rather than silently dropping them", () => {
+      // A typo'd hint must not pass as "absent" — for destructiveHint that
+      // would flip the entry from destructive to additive.
+      expect(() =>
+        validateUiToolEntries([
+          { ...validTool, annotations: { destructiveHnit: true } },
+        ]),
+      ).toThrow(/unknown key 'destructiveHnit'/);
+    });
+
+    it("rejects a readOnlyHint that contradicts readOnly", () => {
+      expect(() =>
+        validateUiToolEntries([
+          { ...validTool, readOnly: true, annotations: { readOnlyHint: false } },
+        ]),
+      ).toThrow(/readOnlyHint must equal readOnly/);
+      expect(() =>
+        validateUiToolEntries([
+          { ...validTool, readOnly: false, annotations: { readOnlyHint: true } },
+        ]),
+      ).toThrow(/readOnlyHint must equal readOnly/);
+    });
+
+    it("accepts an agreeing readOnlyHint", () => {
+      expect(() =>
+        validateUiToolEntries([
+          { ...validTool, readOnly: false, annotations: { readOnlyHint: false } },
+        ]),
+      ).not.toThrow();
+    });
+  });
+
   it("rejects names outside the reserved ui_ shape", () => {
     for (const name of [
       "navigate",
@@ -1078,13 +1145,19 @@ describe("prepareChatV2 — WebMCP UI tools", () => {
     ).toBeFalsy();
   });
 
-  it("adds the approval sentence to the UI prompt section iff the flag is on", () => {
+  it("describes the approval policy that actually applies in each mode", () => {
+    // Both modes gate something, so both get a sentence — the prompt must not
+    // promise "every mutating action pauses" in the default mode, where only
+    // destructive ones do.
     const withFlag = buildUiToolsSystemPrompt(uiTools, {
       requireToolApproval: true,
     });
-    expect(withFlag).toContain("approval");
+    expect(withFlag).toContain("Every mutating `ui_*` action pauses");
     expect(withFlag).toContain("denial is final");
+
     const withoutFlag = buildUiToolsSystemPrompt(uiTools);
-    expect(withoutFlag).not.toContain("denial is final");
+    expect(withoutFlag).toContain("Destructive `ui_*` actions pause");
+    expect(withoutFlag).toContain("other actions apply immediately");
+    expect(withoutFlag).not.toContain("Every mutating `ui_*` action pauses");
   });
 });

--- a/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
@@ -1846,6 +1846,73 @@ describe("mcpjam-stream-handler", () => {
       expect(onConversationComplete).toHaveBeenCalledTimes(1);
     });
 
+    it("processes a DENIAL of a destructive ui_* tool when the approval flag is OFF", async () => {
+      // The stranding case. Approving a ui_* call is resolved by the browser
+      // shipping a tool-result, but DENYING it sends an approval response
+      // back here. If pending-approval handling stayed gated on
+      // `requireToolApproval`, that denial would never be processed with the
+      // flag off — the tool call stays unresolved and the turn hangs forever.
+      vi.mocked(executeToolCallsFromMessages).mockResolvedValue([]);
+
+      await handleMCPJamFreeChatModel({
+        messages: [
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "tool-call",
+                toolCallId: "call-ui-exec",
+                toolName: "ui_execute_tool",
+                input: {},
+              },
+              {
+                type: "tool-approval-request",
+                approvalId: "approval-ui-exec",
+                toolCallId: "call-ui-exec",
+              },
+            ],
+          },
+          {
+            role: "tool",
+            content: [
+              {
+                type: "tool-approval-response",
+                approvalId: "approval-ui-exec",
+                approved: false,
+              },
+            ],
+          },
+        ] as any,
+        modelId: "gpt-4.1-mini",
+        systemPrompt: "You are helpful",
+        tools: { ui_execute_tool: {} } as any,
+        mcpClientManager: {
+          getAllToolsMetadata: vi.fn().mockReturnValue({}),
+        } as any,
+        requireToolApproval: false,
+        uiToolApprovals: classifyUiToolApprovals(
+          [
+            {
+              name: "ui_execute_tool",
+              readOnly: false,
+              annotations: { readOnlyHint: false, destructiveHint: true },
+            },
+          ],
+          false
+        ),
+      });
+
+      await lastExecution;
+
+      // The denial was processed and reached the client, so the tool call is
+      // resolved and the turn can finish instead of hanging.
+      expect(
+        writtenChunks.filter(
+          (chunk: any) => chunk.type === "tool-output-denied"
+        )
+      ).toMatchObject([{ toolCallId: "call-ui-exec" }]);
+    });
+
     it("handlePendingApprovals skips no-execute tools instead of throwing (stale-client defense)", async () => {
       // The new client resolves an APPROVED ui_* call by executing it and
       // shipping the tool-result, never a bare approval response. If a

--- a/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
@@ -3,6 +3,7 @@ import {
   executeToolCallsFromMessages,
   hasUnresolvedToolCalls,
 } from "@/shared/http-tool-calls";
+import { classifyUiToolApprovals } from "@/shared/client-fulfilled-tools";
 import { handleMCPJamFreeChatModel } from "../mcpjam-stream-handler";
 import { serializeToolsForConvex } from "../mcpjam-tool-helpers";
 import { createHostedRpcLogCollector } from "../../routes/web/hosted-rpc-logs.js";
@@ -1594,7 +1595,21 @@ describe("mcpjam-stream-handler", () => {
           getAllToolsMetadata: vi.fn().mockReturnValue({}),
         } as any,
         requireToolApproval: true,
-        approvalFreeUiToolNames: new Set(["ui_snapshot_app"]),
+        uiToolApprovals: classifyUiToolApprovals(
+          [
+            {
+              name: "ui_snapshot_app",
+              readOnly: true,
+              annotations: { readOnlyHint: true, destructiveHint: false },
+            },
+            {
+              name: "ui_navigate",
+              readOnly: false,
+              annotations: { readOnlyHint: false, destructiveHint: false },
+            },
+          ],
+          true
+        ),
       });
 
       await lastExecution;
@@ -1606,6 +1621,110 @@ describe("mcpjam-stream-handler", () => {
       // flows straight through to client fulfillment with no pill.
       expect(approvalRequests).toHaveLength(1);
       expect(approvalRequests[0]).toMatchObject({ toolCallId: "call-ui-2" });
+    });
+
+    it("emits an approval request for a DESTRUCTIVE ui_* tool when the approval flag is OFF", async () => {
+      // The regression this classification exists to prevent: the gate used to
+      // read `requireToolApproval && !isApprovalFree(name)`, so with the flag
+      // off — the default on every agent surface — a destructive
+      // client-fulfilled call got no pill, and the client's orphaned-defer
+      // fallback then executed it unconfirmed.
+      global.fetch = vi.fn().mockResolvedValue(
+        createSseResponse([
+          {
+            type: "tool-input-available",
+            toolCallId: "call-ui-exec",
+            toolName: "ui_execute_tool",
+            input: { toolName: "delete_everything" },
+          },
+          {
+            type: "tool-input-available",
+            toolCallId: "call-ui-nav",
+            toolName: "ui_navigate",
+            input: { target: "servers" },
+          },
+          { type: "finish", finishReason: "stop" },
+        ])
+      );
+
+      await handleMCPJamFreeChatModel({
+        messages: [{ role: "user", content: "run it" }] as any,
+        modelId: "gpt-4.1-mini",
+        systemPrompt: "You are helpful",
+        tools: { ui_execute_tool: {}, ui_navigate: {} } as any,
+        mcpClientManager: {
+          getAllToolsMetadata: vi.fn().mockReturnValue({}),
+        } as any,
+        requireToolApproval: false,
+        uiToolApprovals: classifyUiToolApprovals(
+          [
+            {
+              name: "ui_execute_tool",
+              readOnly: false,
+              annotations: { readOnlyHint: false, destructiveHint: true },
+            },
+            {
+              name: "ui_navigate",
+              readOnly: false,
+              annotations: { readOnlyHint: false, destructiveHint: false },
+            },
+          ],
+          false
+        ),
+      });
+
+      await lastExecution;
+
+      const approvalRequests = writtenChunks.filter(
+        (chunk: any) => chunk.type === "tool-approval-request"
+      );
+      expect(approvalRequests).toHaveLength(1);
+      expect(approvalRequests[0]).toMatchObject({ toolCallId: "call-ui-exec" });
+    });
+
+    it("does not emit approval requests for real MCP tools when the flag is OFF", async () => {
+      // The UI classification must not leak into real-tool policy: unknown
+      // names still follow `requireToolApproval`.
+      global.fetch = vi.fn().mockResolvedValue(
+        createSseResponse([
+          {
+            type: "tool-input-available",
+            toolCallId: "call-real",
+            toolName: "some_mcp_tool",
+            input: {},
+          },
+          { type: "finish", finishReason: "stop" },
+        ])
+      );
+
+      await handleMCPJamFreeChatModel({
+        messages: [{ role: "user", content: "go" }] as any,
+        modelId: "gpt-4.1-mini",
+        systemPrompt: "You are helpful",
+        tools: { some_mcp_tool: {} } as any,
+        mcpClientManager: {
+          getAllToolsMetadata: vi.fn().mockReturnValue({}),
+        } as any,
+        requireToolApproval: false,
+        uiToolApprovals: classifyUiToolApprovals(
+          [
+            {
+              name: "ui_execute_tool",
+              readOnly: false,
+              annotations: { readOnlyHint: false, destructiveHint: true },
+            },
+          ],
+          false
+        ),
+      });
+
+      await lastExecution;
+
+      expect(
+        writtenChunks.filter(
+          (chunk: any) => chunk.type === "tool-approval-request"
+        )
+      ).toHaveLength(0);
     });
 
     it("read-only ui_* calls skip the approval pause classifier (no drain filter)", async () => {
@@ -1634,14 +1753,24 @@ describe("mcpjam-stream-handler", () => {
           getAllToolsMetadata: vi.fn().mockReturnValue({}),
         } as any,
         requireToolApproval: true,
-        approvalFreeUiToolNames: new Set(["ui_snapshot_app"]),
+        uiToolApprovals: classifyUiToolApprovals(
+          [
+            {
+              name: "ui_snapshot_app",
+              readOnly: true,
+              annotations: { readOnlyHint: true, destructiveHint: false },
+            },
+          ],
+          true
+        ),
       });
 
       await lastExecution;
 
-      // With the exemption, the step has no unresolved REAL tool call, so
-      // the approval branch (whose executor call carries `filterToolName`)
-      // is skipped — the normal client-fulfilled execution path runs.
+      // With the exemption, the step has no unresolved approval-required tool
+      // call, so the approval branch (whose executor call carries
+      // `filterToolName`) is skipped — the normal client-fulfilled execution
+      // path runs.
       const calls = vi.mocked(executeToolCallsFromMessages).mock.calls;
       expect(calls.length).toBeGreaterThan(0);
       for (const call of calls) {

--- a/mcpjam-inspector/server/utils/__tests__/org-model-stream-handler-headless.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/org-model-stream-handler-headless.test.ts
@@ -201,6 +201,37 @@ describe("runLocalOrgChatTurnHeadless", () => {
     expect(runDirectChatTurnMock).not.toHaveBeenCalled();
   });
 
+  it("allows a turn whose only tools are client-fulfilled (no execute)", async () => {
+    // Approving one of these is resolved by the BROWSER shipping a result —
+    // it never needs the server-side resume this guard exists to demand.
+    stubEngineTurn({ responseMessages: [] });
+    await runLocalOrgChatTurnHeadless(
+      baseOptions({
+        requireToolApproval: true,
+        tools: { ui_execute_tool: { description: "no execute here" } },
+      }),
+    );
+    expect(runDirectChatTurnMock).toHaveBeenCalled();
+  });
+
+  it("still guards a server-executed tool that merely LOOKS client-fulfilled", async () => {
+    // A real MCP server tool named `ui_foo` matches the namespace regex while
+    // still having an `execute`. Exempting on the name alone would run it here
+    // without the approval support the guard demands — the same reason the
+    // client dispatches on registry membership, not the `ui_` prefix.
+    await expect(
+      runLocalOrgChatTurnHeadless(
+        baseOptions({
+          requireToolApproval: true,
+          tools: {
+            ui_foo: { description: "impostor", execute: async () => ({}) },
+          },
+        }),
+      ),
+    ).rejects.toThrow(/Tool approval is not supported/i);
+    expect(runDirectChatTurnMock).not.toHaveBeenCalled();
+  });
+
   it("throws config/allowlist failures instead of returning an error stream", async () => {
     assertOrgModelAllowedMock.mockImplementation(() => {
       throw new Error("model not allowed for this org");

--- a/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
+++ b/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
@@ -41,6 +41,7 @@ import { isGPT5Model, type ModelDefinition } from "@/shared/types";
 import {
   UI_TOOL_NAME_REGEX,
   uiToolCallNeedsApproval,
+  type UiToolAnnotations,
 } from "@/shared/client-fulfilled-tools";
 import { HOSTED_MODE } from "../config.js";
 import {
@@ -273,6 +274,49 @@ export function validateAppToolEntries(input: unknown): AppToolEntry[] {
   return out;
 }
 
+/** MCP `ToolAnnotations` hints accepted on a UI tool snapshot entry. */
+const UI_TOOL_ANNOTATION_KEYS = [
+  "readOnlyHint",
+  "destructiveHint",
+  "idempotentHint",
+  "openWorldHint",
+] as const;
+
+/**
+ * Validate the optional `annotations` object on a UI tool snapshot entry.
+ *
+ * Boolean-only, known keys only. Unknown keys are rejected rather than
+ * dropped: this snapshot drives approval policy, so a typo'd hint must not
+ * pass silently as "absent" (which, for `destructiveHint`, flips the meaning
+ * from additive to destructive).
+ */
+function validateUiToolAnnotations(
+  raw: unknown,
+  index: number
+): UiToolAnnotations | undefined {
+  if (raw === undefined) return undefined;
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new UiToolValidationError(
+      `uiTools[${index}].annotations must be an object`
+    );
+  }
+  const out: UiToolAnnotations = {};
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (!(UI_TOOL_ANNOTATION_KEYS as readonly string[]).includes(key)) {
+      throw new UiToolValidationError(
+        `uiTools[${index}].annotations has unknown key '${key}'`
+      );
+    }
+    if (typeof value !== "boolean") {
+      throw new UiToolValidationError(
+        `uiTools[${index}].annotations.${key} must be a boolean`
+      );
+    }
+    out[key as (typeof UI_TOOL_ANNOTATION_KEYS)[number]] = value;
+  }
+  return out;
+}
+
 /**
  * Validate and normalize the client-supplied `uiTools` snapshot.
  *
@@ -357,11 +401,24 @@ export function validateUiToolEntries(input: unknown): UiToolEntry[] {
         `uiTools[${i}].readOnly must be a boolean`
       );
     }
+    const annotations = validateUiToolAnnotations(raw.annotations, i);
+    if (
+      annotations?.readOnlyHint !== undefined &&
+      annotations.readOnlyHint !== raw.readOnly
+    ) {
+      // A snapshot that says both "read-only" and "not read-only" has no safe
+      // reading: trusting `readOnlyHint` would let a contradictory entry skip
+      // approval. Reject rather than pick a winner.
+      throw new UiToolValidationError(
+        `uiTools[${i}].annotations.readOnlyHint must equal readOnly`
+      );
+    }
     out.push({
       name,
       description: raw.description,
       inputSchema,
       readOnly: raw.readOnly,
+      ...(annotations ? { annotations } : {}),
     });
   }
   return out;
@@ -708,6 +765,7 @@ export function buildUiTools(
       inputSchema: t.inputSchema,
       needsApproval: uiToolCallNeedsApproval({
         readOnly: t.readOnly,
+        annotations: t.annotations,
         requireToolApproval: opts?.requireToolApproval === true,
       }),
     });
@@ -730,11 +788,9 @@ export function buildUiToolsSystemPrompt(
     "Prefer `ui_open_playground` before `ui_select_tool` / `ui_execute_tool` / `ui_snapshot_app`. `ui_execute_tool` REALLY runs a tool against the user's connected MCP server — treat it as side-effectful; when the user hasn't clearly asked to run a tool, prefill it with `ui_select_tool` instead.",
     "`ui_snapshot_app` is read-only and needs the playground open — use it to observe state before mutating it.",
     "When a `ui_*` tool returns an error, relay the reason instead of retrying blindly.",
-    ...(opts?.requireToolApproval
-      ? [
-          "Mutating `ui_*` actions pause for the user's explicit approval before they run. A denial is final — explain what you wanted to do instead of retrying the call.",
-        ]
-      : []),
+    opts?.requireToolApproval
+      ? "Every mutating `ui_*` action pauses for the user's explicit approval before it runs. A denial is final — explain what you wanted to do instead of retrying the call."
+      : "Destructive `ui_*` actions pause for the user's explicit approval before they run; other actions apply immediately. A denial is final — explain what you wanted to do instead of retrying the call.",
   ].join("\n");
 }
 

--- a/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
+++ b/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
@@ -788,10 +788,29 @@ export function buildUiToolsSystemPrompt(
     "Prefer `ui_open_playground` before `ui_select_tool` / `ui_execute_tool` / `ui_snapshot_app`. `ui_execute_tool` REALLY runs a tool against the user's connected MCP server — treat it as side-effectful; when the user hasn't clearly asked to run a tool, prefill it with `ui_select_tool` instead.",
     "`ui_snapshot_app` is read-only and needs the playground open — use it to observe state before mutating it.",
     "When a `ui_*` tool returns an error, relay the reason instead of retrying blindly.",
-    opts?.requireToolApproval
-      ? "Every mutating `ui_*` action pauses for the user's explicit approval before it runs. A denial is final — explain what you wanted to do instead of retrying the call."
-      : "Destructive `ui_*` actions pause for the user's explicit approval before they run; other actions apply immediately. A denial is final — explain what you wanted to do instead of retrying the call.",
+    approvalGuidance(uiTools, opts?.requireToolApproval === true),
   ].join("\n");
+}
+
+/**
+ * The approval sentence, told honestly for the snapshot that was actually
+ * sent. The destructive-pauses promise only holds when EVERY entry is
+ * annotation-aware — a legacy client sends bare `readOnly`, whose predicate
+ * with the flag off is `requireToolApproval && !readOnly`, i.e. nothing
+ * pauses. Promising a destructive gate there advertises a safety net that
+ * isn't there.
+ */
+function approvalGuidance(
+  uiTools: UiToolEntry[],
+  requireToolApproval: boolean
+): string {
+  if (requireToolApproval) {
+    return "Every mutating `ui_*` action pauses for the user's explicit approval before it runs. A denial is final — explain what you wanted to do instead of retrying the call.";
+  }
+  const annotationAware = uiTools.every((t) => t.annotations !== undefined);
+  return annotationAware
+    ? "Destructive `ui_*` actions pause for the user's explicit approval before they run; other actions apply immediately. A denial is final — explain what you wanted to do instead of retrying the call."
+    : "Every `ui_*` action applies immediately, so be deliberate about mutating ones — describe what you're about to do when it isn't obviously what the user asked for.";
 }
 
 export interface PrepareChatV2Result {

--- a/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
@@ -2933,8 +2933,16 @@ export async function runChatEngineLoop(
 
       startHeartbeat();
 
-      // Process any pending approval responses from a previous request
-      if (requireToolApproval) {
+      // Process any pending approval responses from a previous request.
+      //
+      // The UI classification has to be honored here too, not just at the
+      // emit gate. With the flag off, a destructive `ui_*` call now pauses
+      // for approval — and DENYING it sends an approval response back (the
+      // approve path ships a tool-result instead). Gating this on
+      // `requireToolApproval` alone would leave that denial unprocessed and
+      // the tool call unresolved: the turn would hang forever, which is the
+      // exact failure the two-sided predicate exists to prevent.
+      if (requireToolApproval || (uiToolApprovals?.requiredNames.size ?? 0) > 0) {
         const handled = await handlePendingApprovals(
           safeWriter,
           messageHistory,

--- a/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
@@ -161,12 +161,17 @@ function toolCallNeedsApproval(
   name: string,
   progressivePlan: ProgressiveToolPlan | undefined,
   uiToolApprovals: UiToolApprovalClassification | undefined,
-  requireToolApproval: boolean
+  // `boolean | undefined`, not `boolean`: the callers thread through an
+  // optional `requireToolApproval`, and this file is server-side (not covered
+  // by the client typecheck), so a bare `boolean` param let `undefined` flow
+  // in and `return requireToolApproval` hand back `undefined` for a real
+  // tool. Coerce so the return is always a real boolean.
+  requireToolApproval: boolean | undefined
 ): boolean {
   if (uiToolApprovals?.requiredNames.has(name)) return true;
   if (uiToolApprovals?.freeNames.has(name)) return false;
   if (isApprovalFreeMetaToolName(name, progressivePlan)) return false;
-  return requireToolApproval;
+  return requireToolApproval === true;
 }
 import { logger } from "./logger";
 import {

--- a/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
@@ -44,7 +44,10 @@ import {
   hasUnresolvedToolCalls,
   executeToolCallsFromMessages,
 } from "@/shared/http-tool-calls";
-import { isClientFulfilledToolName } from "@/shared/client-fulfilled-tools";
+import {
+  isClientFulfilledToolName,
+  type UiToolApprovalClassification,
+} from "@/shared/client-fulfilled-tools";
 import {
   scrubUnavailableToolHistoryForBackend,
   scrubMcpAppsToolResultsForBackend,
@@ -139,20 +142,31 @@ function isApprovalFreeMetaToolName(
 }
 
 /**
- * Union of the approval exemptions this loop honors: progressive-discovery
- * meta-tools, plus the read-only WebMCP UI tools this turn advertised
- * (`approvalFreeUiToolNames`, computed by the caller from the validated
- * `uiTools` snapshot — never from the raw name, which a third-party server
- * could spoof). Read-only UI tools observe rather than mutate, so they flow
- * through the normal client-fulfilled pause with no approval pill.
+ * Whether THIS tool call must pause for the user's approval.
+ *
+ * The turn's `requireToolApproval` flag is the rule for real MCP tools only.
+ * WebMCP `ui_*` tools carry their own per-tool policy, pre-computed by the
+ * caller into `uiToolApprovals` (from the VALIDATED snapshot's MCP
+ * annotations — never from the raw name, which a third-party server could
+ * spoof). A destructive UI tool must gate even when the flag is OFF, which is
+ * the default: writing this as `requireToolApproval && !isApprovalFree(...)`
+ * is what silently let destructive client-fulfilled calls through.
+ *
+ * Order matters. UI classification wins over the flag in both directions:
+ *   - in `requiredNames` → approval, flag or no flag;
+ *   - in `freeNames` → never (a read-only snapshot buys nothing by pausing);
+ *   - unknown name → a real tool: follow the flag, exempting meta-tools.
  */
-function isApprovalFreeToolCallName(
+function toolCallNeedsApproval(
   name: string,
   progressivePlan: ProgressiveToolPlan | undefined,
-  approvalFreeUiToolNames: ReadonlySet<string> | undefined
+  uiToolApprovals: UiToolApprovalClassification | undefined,
+  requireToolApproval: boolean
 ): boolean {
-  if (isApprovalFreeMetaToolName(name, progressivePlan)) return true;
-  return approvalFreeUiToolNames?.has(name) === true;
+  if (uiToolApprovals?.requiredNames.has(name)) return true;
+  if (uiToolApprovals?.freeNames.has(name)) return false;
+  if (isApprovalFreeMetaToolName(name, progressivePlan)) return false;
+  return requireToolApproval;
 }
 import { logger } from "./logger";
 import {
@@ -434,11 +448,13 @@ export interface MCPJamHandlerOptions {
   harnessMcpProxy?: HarnessMcpProxyStrategy;
   requireToolApproval?: boolean;
   /**
-   * Names of read-only `ui_*` tools from this turn's validated snapshot —
-   * exempt from the approval gate even when `requireToolApproval` is on
-   * (see `isApprovalFreeToolCallName`).
+   * Per-tool approval policy for the `ui_*` tools this turn advertised,
+   * classified by the caller from the validated snapshot's MCP annotations
+   * (see `classifyUiToolApprovals`). Overrides `requireToolApproval` in both
+   * directions for those names — destructive UI tools gate even when the flag
+   * is off; read-only ones never gate.
    */
-  approvalFreeUiToolNames?: ReadonlySet<string>;
+  uiToolApprovals?: UiToolApprovalClassification;
   /**
    * Host/client policy for eligible MCP tool-result content/resources.
    * Controls only model-facing tool output; raw results remain available to
@@ -612,7 +628,7 @@ interface StepContext {
   mcpClientManager: MCPClientManager;
   selectedServers?: string[];
   requireToolApproval?: boolean;
-  approvalFreeUiToolNames?: ReadonlySet<string>;
+  uiToolApprovals?: UiToolApprovalClassification;
   modelVisibleMcpToolResults?: ModelVisibleMcpToolResults;
   approvalMode?: "prompt" | "auto-deny";
   stepIndex: number;
@@ -1110,7 +1126,7 @@ async function processStream(
   // supplied. Chat / synthetic omit (handler still writes the UI
   // chunk + trace event unchanged).
   onToolCall?: (event: MCPJamToolCallEvent) => void,
-  approvalFreeUiToolNames?: ReadonlySet<string>
+  uiToolApprovals?: UiToolApprovalClassification
 ): Promise<StreamResult> {
   const contentParts: PersistedAssistantPart[] = [];
   let pendingText = "";
@@ -1337,11 +1353,11 @@ async function processStream(
           }
 
           if (
-            requireToolApproval &&
-            !isApprovalFreeToolCallName(
+            toolCallNeedsApproval(
               chunk.toolName,
               progressivePlan,
-              approvalFreeUiToolNames
+              uiToolApprovals,
+              requireToolApproval
             )
           ) {
             emitToolApprovalRequest(writer, {
@@ -1890,7 +1906,7 @@ async function processOneStep(
     mcpClientManager,
     selectedServers,
     requireToolApproval,
-    approvalFreeUiToolNames,
+    uiToolApprovals,
     modelVisibleMcpToolResults,
     approvalMode,
     stepIndex,
@@ -2166,7 +2182,7 @@ async function processOneStep(
     abortSignal,
     progressivePlan,
     onToolCall,
-    approvalFreeUiToolNames
+    uiToolApprovals
   );
   const llmEndAbs = Date.now();
   traceTurn.turnUsage = mergeLiveChatTraceUsage(
@@ -2206,12 +2222,13 @@ async function processOneStep(
 
   // Check for unresolved tool calls and execute them
   if (hasUnresolvedToolCalls(messageHistory)) {
-    // Meta-tools (search_mcp_tools / load_mcp_tools) are approval-free even
-    // when the user enabled `requireToolApproval` — gating progressive
-    // discovery itself behind N approvals defeats the point. We only pause
-    // when at least one unresolved tool call is a real MCP tool. Pure-meta
+    // We only pause when at least one unresolved tool call actually needs
+    // approval this turn (`toolCallNeedsApproval`): a real MCP tool while the
+    // flag is on, or a destructive `ui_*` tool in any mode. Meta-tools
+    // (search_mcp_tools / load_mcp_tools) never qualify — gating progressive
+    // discovery itself behind N approvals defeats the point — so pure-meta
     // turns fall through to execute and continue the loop.
-    const hasUnresolvedRealToolCall = (() => {
+    const hasUnresolvedApprovalRequiredToolCall = (() => {
       const resultIds = new Set<string>();
       for (const msg of messageHistory) {
         if (msg?.role !== "tool") continue;
@@ -2227,10 +2244,11 @@ async function processOneStep(
           if (
             part.type === "tool-call" &&
             !resultIds.has(part.toolCallId) &&
-            !isApprovalFreeToolCallName(
+            toolCallNeedsApproval(
               part.toolName,
               progressivePlan,
-              approvalFreeUiToolNames
+              uiToolApprovals,
+              requireToolApproval
             )
           ) {
             return true;
@@ -2240,16 +2258,12 @@ async function processOneStep(
       return false;
     })();
 
-    if (
-      requireToolApproval &&
-      hasUnresolvedRealToolCall &&
-      approvalMode === "auto-deny"
-    ) {
+    if (hasUnresolvedApprovalRequiredToolCall && approvalMode === "auto-deny") {
       // Synthetic-session path: instead of pausing the loop for a
       // human approval that will never come, synthesize a denial
-      // tool-result for every approval-required unresolved real
-      // tool call so the model can react and continue. Meta-tool
-      // calls in the same step still execute normally below.
+      // tool-result for every approval-required unresolved tool call
+      // so the model can react and continue. Meta-tool calls in the
+      // same step still execute normally below.
       const resultIds = new Set<string>();
       for (const msg of messageHistory) {
         if (msg?.role !== "tool") continue;
@@ -2267,10 +2281,11 @@ async function processOneStep(
           if (
             part.type !== "tool-call" ||
             resultIds.has(part.toolCallId) ||
-            isApprovalFreeToolCallName(
+            !toolCallNeedsApproval(
               part.toolName,
               progressivePlan,
-              approvalFreeUiToolNames
+              uiToolApprovals,
+              requireToolApproval
             )
           ) {
             continue;
@@ -2317,11 +2332,7 @@ async function processOneStep(
       // denials count as resolved tool-results for the next step.
     }
 
-    if (
-      requireToolApproval &&
-      hasUnresolvedRealToolCall &&
-      approvalMode !== "auto-deny"
-    ) {
+    if (hasUnresolvedApprovalRequiredToolCall && approvalMode !== "auto-deny") {
       // Drain any unresolved meta-tool calls (search/load) before pausing
       // for approval on real tools. Otherwise mixed-step turns (model
       // emits a load_mcp_tools + a real tool in one assistant message)
@@ -2710,7 +2721,7 @@ export async function runChatEngineLoop(
     mcpClientManager,
     selectedServers,
     requireToolApproval,
-    approvalFreeUiToolNames,
+    uiToolApprovals,
     modelVisibleMcpToolResults,
     approvalMode,
     onConversationComplete,
@@ -2966,7 +2977,7 @@ export async function runChatEngineLoop(
           mcpClientManager,
           selectedServers,
           requireToolApproval,
-          approvalFreeUiToolNames,
+          uiToolApprovals,
           modelVisibleMcpToolResults,
           approvalMode,
           stepIndex: effectiveSteps(),

--- a/mcpjam-inspector/server/utils/org-model-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/org-model-stream-handler.ts
@@ -37,6 +37,10 @@ import {
   OrgProviderConfigError,
   type OrgProviderResolvedConfig,
 } from "@mcpjam/sdk/model-factory";
+import {
+  isClientFulfilledToolName,
+  type UiToolApprovalClassification,
+} from "@/shared/client-fulfilled-tools";
 import type { PersistedTurnTrace } from "./chat-ingestion";
 import { handleMCPJamFreeChatModel } from "./mcpjam-stream-handler.js";
 import { logger } from "./logger.js";
@@ -79,8 +83,8 @@ export interface OrgModelHandlerOptions {
   selectedServers?: string[];
   serverIds?: string[];
   requireToolApproval?: boolean;
-  /** Read-only ui_* names exempt from the approval gate (see MCPJam loop). */
-  approvalFreeUiToolNames?: ReadonlySet<string>;
+  /** Per-tool ui_* approval policy (see `classifyUiToolApprovals`). */
+  uiToolApprovals?: UiToolApprovalClassification;
   /** Host/client policy for eligible MCP tool-result content/resources. */
   modelVisibleMcpToolResults?: ModelVisibleMcpToolResults;
   /**
@@ -297,6 +301,31 @@ export interface OrgLocalModelHandlerOptions {
   synthesisRunId?: string;
 }
 
+/**
+ * Whether this local-runtime turn hits the approval gap the handler cannot
+ * serve, and must fail loudly instead.
+ *
+ * The gap is SERVER-EXECUTED tools: approving one resumes the turn by running
+ * it here, and that resume path has never been supported (or tested) on the
+ * local org runtime.
+ *
+ * Client-fulfilled tools (`ui_*`, `app_*`) don't need it. Their approval is
+ * emitted natively by `streamText` from the per-tool `needsApproval` that
+ * `buildUiTools` set, and an approval is resolved by the BROWSER executing the
+ * tool and supplying the result via `addToolOutput` — the engine only has to
+ * accept a history that already contains the output. That is the same path
+ * route 4 (personal BYOK) drives through this very engine today, so refusing
+ * it here would break the UI-only agent surface for local-runtime orgs while
+ * protecting nothing.
+ */
+function hasUnsupportedLocalApprovalGate(
+  tools: ToolSet,
+  requireToolApproval: boolean | undefined
+): boolean {
+  if (!requireToolApproval) return false;
+  return Object.keys(tools).some((name) => !isClientFulfilledToolName(name));
+}
+
 export function handleLocalOrgChatModel(
   options: OrgLocalModelHandlerOptions
 ): Response {
@@ -314,7 +343,7 @@ export function handleLocalOrgChatModel(
     onLiveTextDelta,
   } = options;
 
-  if (requireToolApproval && Object.keys(tools).length > 0) {
+  if (hasUnsupportedLocalApprovalGate(tools, requireToolApproval)) {
     const stream = createUIMessageStream({
       onError: (error) => formatLocalStreamError(error),
       onFinish: async () => {
@@ -606,7 +635,7 @@ export async function runLocalOrgChatTurnHeadless(
   const { provider, modelId, messages, systemPrompt, temperature, tools } =
     options;
 
-  if (options.requireToolApproval && Object.keys(tools).length > 0) {
+  if (hasUnsupportedLocalApprovalGate(tools, options.requireToolApproval)) {
     throw new Error(
       "Tool approval is not supported for local-runtime org providers yet. Disable tool approval or switch this provider to cloud runtime."
     );
@@ -804,7 +833,7 @@ export async function handleHostedOrgChatModel(
     mcpClientManager: options.mcpClientManager,
     selectedServers: options.selectedServers,
     requireToolApproval: options.requireToolApproval,
-    approvalFreeUiToolNames: options.approvalFreeUiToolNames,
+    uiToolApprovals: options.uiToolApprovals,
     modelVisibleMcpToolResults: options.modelVisibleMcpToolResults,
     ...(options.approvalMode !== undefined
       ? { approvalMode: options.approvalMode }

--- a/mcpjam-inspector/server/utils/org-model-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/org-model-stream-handler.ts
@@ -323,7 +323,18 @@ function hasUnsupportedLocalApprovalGate(
   requireToolApproval: boolean | undefined
 ): boolean {
   if (!requireToolApproval) return false;
-  return Object.keys(tools).some((name) => !isClientFulfilledToolName(name));
+  return Object.entries(tools).some(([name, tool]) => {
+    if (!isClientFulfilledToolName(name)) return true;
+    // Name is necessary but NOT sufficient. A real MCP server tool called
+    // `ui_foo` matches the namespace regex while still having an `execute`,
+    // and exempting it on the name alone would let it run here without the
+    // approval support this guard exists to demand. Same reason the client
+    // dispatches on registry membership rather than the `ui_` prefix: the
+    // property that matters is "the browser fulfills this", and only the
+    // missing `execute` actually proves it.
+    return typeof (tool as { execute?: unknown } | undefined)?.execute ===
+      "function";
+  });
 }
 
 export function handleLocalOrgChatModel(

--- a/mcpjam-inspector/server/utils/web-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/web-chat-turn.ts
@@ -68,6 +68,10 @@ import type { HarnessSessionCommitPayload } from "./harness/harness-session-stat
 import { exportConnectedServerToolSnapshotForEvalAuthoring } from "./export-helpers.js";
 import { ErrorCode, WebRouteError } from "./../routes/web/errors.js";
 import { readUrlElicitations } from "@/shared/http-tool-calls";
+import {
+  classifyUiToolApprovals,
+  type UiToolApprovalClassification,
+} from "@/shared/client-fulfilled-tools";
 import type { createHostedRpcLogCollector } from "./../routes/web/hosted-rpc-logs.js";
 import type { HostedElicitationBridge } from "./../routes/web/hosted-elicitation.js";
 import { bridgeHarnessRpcLogsToCollector } from "./../routes/web/hosted-rpc-logs.js";
@@ -208,16 +212,18 @@ export interface StreamWebChatTurnArgs {
 }
 
 /**
- * Read-only `ui_*` names from the validated snapshot — exempt from the
- * MCPJam loop's approval gate (see `isApprovalFreeToolCallName` in
- * mcpjam-stream-handler). Computed from the VALIDATED entries' `readOnly`
- * flag, never from the raw name, which a third-party server could spoof.
+ * Per-tool approval policy for this turn's `ui_*` tools, from the VALIDATED
+ * snapshot's MCP annotations — never from the raw name, which a third-party
+ * server could spoof. Consumed by the MCPJam loop's approval gate (see
+ * `toolCallNeedsApproval` in mcpjam-stream-handler); the BYOK `streamText`
+ * path gets the same policy baked into each tool's `needsApproval` by
+ * `buildUiTools`.
  */
-function approvalFreeUiToolNamesFrom(
-  uiTools: UiToolEntry[] | undefined
-): ReadonlySet<string> | undefined {
-  const names = (uiTools ?? []).filter((t) => t.readOnly).map((t) => t.name);
-  return names.length > 0 ? new Set(names) : undefined;
+function uiToolApprovalsFrom(
+  uiTools: UiToolEntry[] | undefined,
+  requireToolApproval: boolean | undefined
+): UiToolApprovalClassification {
+  return classifyUiToolApprovals(uiTools, requireToolApproval === true);
 }
 
 /**
@@ -558,7 +564,10 @@ export async function streamWebChatTurn(
       selectedServers: persist.selectedServerIds,
       serverIds: persist.selectedServerIds,
       requireToolApproval: persist.requireToolApproval,
-      approvalFreeUiToolNames: approvalFreeUiToolNamesFrom(prepare.uiTools),
+      uiToolApprovals: uiToolApprovalsFrom(
+        prepare.uiTools,
+        persist.requireToolApproval
+      ),
       modelVisibleMcpToolResults: prepare.modelVisibleMcpToolResults,
       onConversationComplete,
       onStreamComplete: cleanupStream,
@@ -620,7 +629,10 @@ export async function streamWebChatTurn(
     mcpClientManager: manager,
     selectedServers: persist.selectedServerIds,
     requireToolApproval: persist.requireToolApproval,
-    approvalFreeUiToolNames: approvalFreeUiToolNamesFrom(prepare.uiTools),
+    uiToolApprovals: uiToolApprovalsFrom(
+        prepare.uiTools,
+        persist.requireToolApproval
+      ),
     modelVisibleMcpToolResults: prepare.modelVisibleMcpToolResults,
     ...(persist.harness ? { harness: persist.harness } : {}),
     ...(harnessMcpProxy ? { harnessMcpProxy } : {}),

--- a/mcpjam-inspector/shared/__tests__/client-fulfilled-tools.test.ts
+++ b/mcpjam-inspector/shared/__tests__/client-fulfilled-tools.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  classifyUiToolApprovals,
   isAppToolAlias,
   isClientFulfilledToolName,
   isUiToolName,
@@ -36,7 +37,7 @@ describe("client-fulfilled tool names", () => {
     expect(isClientFulfilledToolName("ui-navigate")).toBe(false);
   });
 
-  it("uiToolCallNeedsApproval gates mutating tools only when the flag is on", () => {
+  it("uiToolCallNeedsApproval gates mutating tools only when the flag is on (legacy, no annotations)", () => {
     // The truth table both the server gate and the client defer read.
     expect(
       uiToolCallNeedsApproval({ readOnly: false, requireToolApproval: true })
@@ -50,5 +51,167 @@ describe("client-fulfilled tool names", () => {
     expect(
       uiToolCallNeedsApproval({ readOnly: true, requireToolApproval: false })
     ).toBe(false);
+  });
+
+  describe("uiToolCallNeedsApproval with MCP annotations", () => {
+    const additive = { readOnlyHint: false, destructiveHint: false };
+    const destructive = { readOnlyHint: false, destructiveHint: true };
+    const readOnly = { readOnlyHint: true, destructiveHint: false };
+
+    it("gates destructive tools even when the flag is OFF", () => {
+      // The whole point of the annotation work: `requireToolApproval` is off
+      // by default, and a destructive action must still confirm.
+      expect(
+        uiToolCallNeedsApproval({
+          readOnly: false,
+          annotations: destructive,
+          requireToolApproval: false,
+        })
+      ).toBe(true);
+    });
+
+    it("does not gate additive tools when the flag is OFF", () => {
+      expect(
+        uiToolCallNeedsApproval({
+          readOnly: false,
+          annotations: additive,
+          requireToolApproval: false,
+        })
+      ).toBe(false);
+    });
+
+    it("gates every mutating tool when the flag is ON", () => {
+      for (const annotations of [additive, destructive]) {
+        expect(
+          uiToolCallNeedsApproval({
+            readOnly: false,
+            annotations,
+            requireToolApproval: true,
+          })
+        ).toBe(true);
+      }
+    });
+
+    it("never gates read-only tools, in either mode", () => {
+      for (const requireToolApproval of [true, false]) {
+        expect(
+          uiToolCallNeedsApproval({
+            readOnly: true,
+            annotations: readOnly,
+            requireToolApproval,
+          })
+        ).toBe(false);
+      }
+    });
+
+    it("treats an absent destructiveHint as destructive (protocol default)", () => {
+      // A tool added without annotating destructiveHint must fail SAFE.
+      expect(
+        uiToolCallNeedsApproval({
+          readOnly: false,
+          annotations: { readOnlyHint: false },
+          requireToolApproval: false,
+        })
+      ).toBe(true);
+      expect(
+        uiToolCallNeedsApproval({
+          readOnly: false,
+          annotations: {},
+          requireToolApproval: false,
+        })
+      ).toBe(true);
+    });
+
+    it("ignores non-approval hints", () => {
+      expect(
+        uiToolCallNeedsApproval({
+          readOnly: false,
+          annotations: {
+            ...additive,
+            idempotentHint: false,
+            openWorldHint: true,
+          },
+          requireToolApproval: false,
+        })
+      ).toBe(false);
+    });
+  });
+
+  describe("classifyUiToolApprovals", () => {
+    const entries = [
+      {
+        name: "ui_snapshot_app",
+        readOnly: true,
+        annotations: { readOnlyHint: true, destructiveHint: false },
+      },
+      {
+        name: "ui_navigate",
+        readOnly: false,
+        annotations: { readOnlyHint: false, destructiveHint: false },
+      },
+      {
+        name: "ui_execute_tool",
+        readOnly: false,
+        annotations: { readOnlyHint: false, destructiveHint: true },
+      },
+    ];
+
+    it("splits destructive from free in default mode", () => {
+      const { requiredNames, freeNames } = classifyUiToolApprovals(
+        entries,
+        false
+      );
+      expect([...requiredNames]).toEqual(["ui_execute_tool"]);
+      expect([...freeNames].sort()).toEqual(["ui_navigate", "ui_snapshot_app"]);
+    });
+
+    it("moves every mutating tool to required in strict mode, keeping read-only free", () => {
+      const { requiredNames, freeNames } = classifyUiToolApprovals(
+        entries,
+        true
+      );
+      expect([...requiredNames].sort()).toEqual([
+        "ui_execute_tool",
+        "ui_navigate",
+      ]);
+      // Strict mode still must not pause a snapshot — this is why the engine
+      // needs `freeNames` and not just "absent from requiredNames".
+      expect([...freeNames]).toEqual(["ui_snapshot_app"]);
+    });
+
+    it("places every entry in exactly one set", () => {
+      for (const strict of [true, false]) {
+        const { requiredNames, freeNames } = classifyUiToolApprovals(
+          entries,
+          strict
+        );
+        expect(requiredNames.size + freeNames.size).toBe(entries.length);
+        for (const name of requiredNames) {
+          expect(freeNames.has(name)).toBe(false);
+        }
+      }
+    });
+
+    it("handles an absent snapshot", () => {
+      const { requiredNames, freeNames } = classifyUiToolApprovals(
+        undefined,
+        false
+      );
+      expect(requiredNames.size).toBe(0);
+      expect(freeNames.size).toBe(0);
+    });
+
+    it("classifies legacy entries (no annotations) by the flag alone", () => {
+      const legacy = [
+        { name: "ui_navigate", readOnly: false },
+        { name: "ui_snapshot_app", readOnly: true },
+      ];
+      expect([...classifyUiToolApprovals(legacy, false).requiredNames]).toEqual(
+        []
+      );
+      expect([...classifyUiToolApprovals(legacy, true).requiredNames]).toEqual([
+        "ui_navigate",
+      ]);
+    });
   });
 });

--- a/mcpjam-inspector/shared/__tests__/client-fulfilled-tools.test.ts
+++ b/mcpjam-inspector/shared/__tests__/client-fulfilled-tools.test.ts
@@ -122,6 +122,34 @@ describe("client-fulfilled tool names", () => {
       ).toBe(true);
     });
 
+    it("fails CLOSED on a contradictory read-only + destructive entry", () => {
+      // The validator rejects `readOnlyHint` disagreeing with `readOnly`, but
+      // nothing stops "read-only AND destructive". Resolving that in favor of
+      // "don't ask" is the one reading that can silently delete something, so
+      // destructive wins.
+      for (const requireToolApproval of [true, false]) {
+        expect(
+          uiToolCallNeedsApproval({
+            readOnly: true,
+            annotations: { readOnlyHint: true, destructiveHint: true },
+            requireToolApproval,
+          }),
+        ).toBe(true);
+      }
+    });
+
+    it("does not gate a read-only tool whose annotations omit readOnlyHint", () => {
+      // Partial annotations must not lose the legacy signal — otherwise a
+      // snapshot gets gated for no reason in strict mode.
+      expect(
+        uiToolCallNeedsApproval({
+          readOnly: true,
+          annotations: { destructiveHint: false },
+          requireToolApproval: true,
+        }),
+      ).toBe(false);
+    });
+
     it("ignores non-approval hints", () => {
       expect(
         uiToolCallNeedsApproval({

--- a/mcpjam-inspector/shared/chat-v2.ts
+++ b/mcpjam-inspector/shared/chat-v2.ts
@@ -1,5 +1,6 @@
 import { UIMessage } from "ai";
 import type { ModelDefinition } from "./types";
+import type { UiToolAnnotations } from "./client-fulfilled-tools";
 import type {
   McpToolResultImageRenderingPolicy,
   ModelVisibleMcpToolResults,
@@ -154,14 +155,19 @@ export interface AppToolSnapshotEntry {
  *
  * Unlike app tools, UI tools are first-party and curated: `name` is the
  * model-facing tool name directly (reserved `ui_` prefix, validated at the
- * boundary), with no alias indirection. `readOnly` is metadata for policy
- * and native `annotations.readOnlyHint`, not an inclusion gate.
+ * boundary), with no alias indirection.
+ *
+ * `annotations` carries the MCP `ToolAnnotations` hints and is what drives
+ * approval policy (`uiToolCallNeedsApproval`). `readOnly` predates it and is
+ * retained for wire compatibility: an old client ships only `readOnly`, and
+ * the validator rejects a snapshot whose `readOnlyHint` contradicts it.
  */
 export interface UiToolSnapshotEntry {
   name: string;
   description: string;
   inputSchema?: Record<string, unknown>;
   readOnly: boolean;
+  annotations?: UiToolAnnotations;
 }
 
 export interface WidgetModelContextEntry {

--- a/mcpjam-inspector/shared/client-fulfilled-tools.ts
+++ b/mcpjam-inspector/shared/client-fulfilled-tools.ts
@@ -44,21 +44,101 @@ export function isClientFulfilledToolName(name: string): boolean {
 }
 
 /**
+ * MCP tool annotations, as defined by the protocol's `ToolAnnotations`.
+ *
+ * Only the hints MCPJam's first-party `ui_*` catalog sets are modelled. The
+ * protocol's defaults are deliberately pessimistic — an absent
+ * `destructiveHint` means "assume destructive" — which is what makes an
+ * unannotated future tool fail safe rather than execute silently.
+ *
+ * TRUST BOUNDARY: annotations are hints, and the MCP spec requires clients to
+ * treat them as untrusted unless the server is verified. This type — and the
+ * approval policy below — apply ONLY to MCPJam's own curated `ui_*` catalog
+ * and its server-validated snapshot. Never derive approval policy from a
+ * third-party MCP server's annotations.
+ */
+export interface UiToolAnnotations {
+  readOnlyHint?: boolean;
+  destructiveHint?: boolean;
+  idempotentHint?: boolean;
+  openWorldHint?: boolean;
+}
+
+/**
  * Whether a UI tool call must pause for the user's approval this turn.
  *
  * Single source of truth for BOTH sides of the approval handshake: the
- * server (per-tool `needsApproval` in `buildUiTools`, and the free-model
- * loop's approval gate) and the client (the executor's defer-before-execute
- * gate). They must agree because the client decides "defer" when the
- * tool-call chunk arrives — BEFORE the server's approval-request chunk
- * reaches it.
+ * server (per-tool `needsApproval` in `buildUiTools`, and every engine's
+ * approval gate via `classifyUiToolApprovals`) and the client (the
+ * executor's defer-before-execute gate). They must agree because the client
+ * decides "defer" when the tool-call chunk arrives — BEFORE the server's
+ * approval-request chunk reaches it. If they disagree, turns strand.
  *
- * Read-only tools (`ui_snapshot_app`) never gate: they observe, so pausing
- * them buys no safety and costs a click.
+ * Two modes, keyed off the turn's `requireToolApproval` flag:
+ *   - strict (flag on)  — every mutating UI tool gates.
+ *   - default (flag off) — only DESTRUCTIVE UI tools gate. Actions the user
+ *     watches happen in their own app don't need a confirmation click; the
+ *     ones they can't undo by looking at the screen do.
+ *
+ * Read-only tools (`ui_snapshot_app`) never gate in either mode: they
+ * observe, so pausing them buys no safety and costs a click.
+ *
+ * Entries WITHOUT `annotations` keep the legacy `readOnly`-only semantics —
+ * an old client's snapshot must not suddenly start gating differently.
  */
 export function uiToolCallNeedsApproval(opts: {
   readOnly: boolean;
+  annotations?: UiToolAnnotations;
   requireToolApproval: boolean;
 }): boolean {
-  return opts.requireToolApproval && !opts.readOnly;
+  const { annotations, requireToolApproval } = opts;
+  if (!annotations) {
+    return requireToolApproval && !opts.readOnly;
+  }
+  if (annotations.readOnlyHint === true) return false;
+  if (requireToolApproval) return true;
+  // Protocol default: absent destructiveHint means destructive.
+  return annotations.destructiveHint !== false;
+}
+
+/**
+ * Per-turn approval classification for the UI tools a turn advertised.
+ *
+ * Every validated entry lands in exactly one set, so an engine can answer
+ * "does this UI tool call need approval?" without re-deriving policy — and
+ * without the `requireToolApproval && …` shape that silently drops
+ * destructive gating when the flag is off (the flag is off by default).
+ *
+ * `freeNames` is NOT redundant with "not in requiredNames": engines must
+ * distinguish a UI tool that is deliberately approval-free from a name they
+ * don't know about (a real MCP tool), which still follows the flag.
+ */
+export interface UiToolApprovalClassification {
+  requiredNames: ReadonlySet<string>;
+  freeNames: ReadonlySet<string>;
+}
+
+export function classifyUiToolApprovals(
+  entries:
+    | ReadonlyArray<{
+        name: string;
+        readOnly: boolean;
+        annotations?: UiToolAnnotations;
+      }>
+    | undefined,
+  requireToolApproval: boolean,
+): UiToolApprovalClassification {
+  const requiredNames = new Set<string>();
+  const freeNames = new Set<string>();
+  for (const entry of entries ?? []) {
+    const target = uiToolCallNeedsApproval({
+      readOnly: entry.readOnly,
+      annotations: entry.annotations,
+      requireToolApproval,
+    })
+      ? requiredNames
+      : freeNames;
+    target.add(entry.name);
+  }
+  return { requiredNames, freeNames };
 }

--- a/mcpjam-inspector/shared/client-fulfilled-tools.ts
+++ b/mcpjam-inspector/shared/client-fulfilled-tools.ts
@@ -95,7 +95,16 @@ export function uiToolCallNeedsApproval(opts: {
   if (!annotations) {
     return requireToolApproval && !opts.readOnly;
   }
-  if (annotations.readOnlyHint === true) return false;
+  // Destructive wins over everything, including a contradictory
+  // `readOnlyHint: true`. The validator rejects `readOnlyHint` disagreeing
+  // with `readOnly`, but nothing stops "read-only AND destructive" — and
+  // resolving that contradiction in favor of "don't ask" is the one reading
+  // that can silently delete something.
+  if (annotations.destructiveHint === true) return true;
+  // Read-only never gates. Honor BOTH signals: a partial annotation object
+  // (e.g. `{destructiveHint: false}`) leaves `readOnlyHint` undefined, and
+  // ignoring the legacy flag there would gate a snapshot for no reason.
+  if (opts.readOnly || annotations.readOnlyHint === true) return false;
   if (requireToolApproval) return true;
   // Protocol default: absent destructiveHint means destructive.
   return annotations.destructiveHint !== false;


### PR DESCRIPTION
First of six PRs moving the in-app agent chat to a UI-tools-only strategy: the agent acts by driving the app UI, where the user can see every action, instead of calling backend tools invisibly. This PR is the safety layer that has to land before the catalog grows.

## The bug

UI-tool approval was `requireToolApproval && !readOnly`. That flag is **off by default**, so in practice nothing gated — including `ui_execute_tool`, which really runs an arbitrary third-party MCP tool. Worse, the client *deferred* such a call waiting for an approval the server never emitted, and the orphaned-defer fallback then executed it **unconfirmed** once the stream settled.

Every engine gate was shaped `requireToolApproval && !isApprovalFree(name)`, a shape that simply cannot express "gate this even when the flag is off".

## The change

Use the protocol's own vocabulary. `UiToolDefinition` and the chat snapshot now carry MCP [`ToolAnnotations`](https://blog.modelcontextprotocol.io/posts/2026-03-16-tool-annotations/), and `uiToolCallNeedsApproval` reads them:

| mode | behavior |
| --- | --- |
| strict (`requireToolApproval` on) | every mutating UI tool gates (unchanged) |
| **default (flag off)** | **only destructive UI tools gate** |

Read-only tools never gate in either mode.

Engines now consult a per-turn `classifyUiToolApprovals(...)` that **wins over the flag in both directions**; unknown names (real MCP tools) still follow the flag. `/api/mcp/chat-v2` never passed UI approvals to either handler — it does now.

## Fail-safe by construction

- An absent `destructiveHint` counts as **destructive** (the protocol's pessimistic default), so a UI tool added later without annotations gates rather than executing silently.
- The validator **rejects unknown hint keys** instead of dropping them: a typo'd `destructiveHint` must not read as "additive".
- `readOnly` stays on the wire as the legacy mirror; the registry and validator both reject a definition whose `readOnlyHint` contradicts it.

## Local-org runtime

Narrowed its approval refusal to the case it was written for: **server-executed** tools, whose approval resumes by running them there. Client-fulfilled tools never needed that path (`streamText` emits the request natively; the browser supplies the result), and this is the same engine route 4 already drives — so refusing them protected nothing while breaking the UI-only agent surface for local-runtime orgs.

## Scope

Annotations are hints and are unsafe as policy from untrusted servers — this applies **only** to the first-party `ui_*` catalog and its validated snapshot. Target-tool annotation pass-through for `ui_execute_tool` is a deliberate follow-up; until then it is pessimistically destructive and always confirms.

## Rollout

**Deploy servers before clients.** New client + old server strands no turns (the orphan fallback still settles them) but cannot enforce the gate. Old client + new server keeps legacy semantics via the no-annotations branch.

## Test plan

- `classifyUiToolApprovals` / `uiToolCallNeedsApproval` matrix incl. legacy entries, absent-hint defaults, and every-entry-in-exactly-one-set.
- Engine: destructive `ui_*` **emits an approval request with the flag off**; real MCP tools still don't.
- Validator: contradictory `readOnlyHint`, unknown keys, non-boolean hints.
- Catalog invariant: every tool annotates explicitly; exactly `ui_execute_tool` is destructive/open-world.
- Full suites green: server 227 files / 2894 tests, client+shared 573 files / 5816 tests, client typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes approval policy for in-app agent UI tools and fixes a path where destructive `ui_execute_tool` could run without confirmation; touches shared client/server gates across chat engines.
> 
> **Overview**
> Fixes a safety bug where **`ui_execute_tool`** could run unconfirmed: approval was tied to `requireToolApproval && !readOnly` (flag off by default), while the client still deferred destructive calls—stranding turns or executing via orphan fallback.
> 
> **`ui_*` tools now carry MCP `ToolAnnotations` on the wire.** Shared `uiToolCallNeedsApproval` and `classifyUiToolApprovals` drive client deferral, `buildUiTools` `needsApproval`, and MCPJam/org stream gates via `toolCallNeedsApproval` + `uiToolApprovals` (replacing read-only-only exemptions). In **default mode**, only **destructive** UI tools confirm; strict mode still confirms all mutating tools; read-only tools never gate.
> 
> The first-party catalog sets explicit hints (**only `ui_execute_tool`** is destructive/open-world); registry and server validation reject contradictory `readOnlyHint`, unknown keys, and ship annotations in snapshots. System prompts only promise a destructive pause when every entry is annotation-aware.
> 
> **Native mirror** forwards full annotations and optional **`nativeUntrustedContentHint`** for `ui_execute_tool`. **Local-org** approval refusal is narrowed to server-executed tools (client-fulfilled `ui_*` / `app_*` allowed); pending-approval handling runs when destructive UI tools need gating even if the flag is off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b1479fd55ad5656248ef75246d2fe3ed9aba8a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate `ui_*` approvals on MCP `ToolAnnotations` with a per-turn classification: in default mode destructive actions confirm, additive actions run; strict mode still confirms all mutating tools. Engines, prompts, and validators now agree end-to-end; deploy servers before clients.

- **New Features**
  - Added MCP `annotations` to `UiToolDefinition` and the chat snapshot; `classifyUiToolApprovals` + `uiToolCallNeedsApproval` set per-turn policy (absent `destructiveHint` defaults to destructive).
  - `/api/mcp/chat-v2` now passes the UI approval policy to MCPJam/org handlers; BYOK still reads per-tool `needsApproval`. Default-mode prompt promises a destructive pause only when all entries have annotations; legacy snapshots say everything applies immediately.
  - Catalog: every tool sets explicit hints; only `ui_execute_tool` is destructive/open-world; `ui_navigate` is not idempotent.
  - Native mirror forwards MCP annotations and adds WebMCP’s `untrustedContentHint` for `ui_execute_tool`; client-only metadata isn’t shipped, and server validators enforce known boolean keys.

- **Bug Fixes**
  - Destructive `ui_*` calls pause and DENIALS are processed even with the flag off; engines honor the same classification at emit, drain, and pending-approval gates. Real MCP tools still follow the flag; meta-tools stay approval-free.
  - Fail-closed contradictions: when hints say both read-only and destructive, destructive wins; partial annotations retain legacy `readOnly` behavior.
  - Local-org runtime only blocks server-executed tools; client-fulfilled (`ui_*`, `app_*`) are allowed, and server tools spoofing `ui_*` names no longer bypass the guard.
  - Coerced the optional approval flag in the server gate to a real boolean to prevent indeterminate decisions.

<sup>Written for commit 4b1479fd55ad5656248ef75246d2fe3ed9aba8a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

