### PR TITLE
feat(agent): make the in-app agent act only through the UI

### DIFF
--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/native-mirror.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/native-mirror.test.ts
@@ -77,6 +77,35 @@ describe("mirrorUiToolToNative", () => {
     expect(opts?.signal).toBeInstanceOf(AbortSignal);
   });
 
+  it("projects the full MCP annotations plus WebMCP's untrustedContentHint", () => {
+    const registerTool = stubModelContext("document");
+    mirrorUiToolToNative(
+      makeTool({
+        readOnly: false,
+        annotations: {
+          readOnlyHint: false,
+          destructiveHint: true,
+          openWorldHint: true,
+        },
+        nativeUntrustedContentHint: true,
+      }),
+    );
+    expect(registerTool.mock.calls[0][0].annotations).toEqual({
+      readOnlyHint: false,
+      destructiveHint: true,
+      openWorldHint: true,
+      untrustedContentHint: true,
+    });
+  });
+
+  it("omits untrustedContentHint when the tool doesn't set it", () => {
+    const registerTool = stubModelContext("document");
+    mirrorUiToolToNative(makeTool());
+    expect(
+      registerTool.mock.calls[0][0].annotations,
+    ).not.toHaveProperty("untrustedContentHint");
+  });
+
   it("disposer aborts the registration signal", () => {
     const registerTool = stubModelContext("document");
     const dispose = mirrorUiToolToNative(makeTool());

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tool-executor.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tool-executor.test.ts
@@ -83,6 +83,54 @@ describe("handleUiToolCall", () => {
     ]);
   });
 
+  it("defers a DESTRUCTIVE tool even when requireToolApproval is off", async () => {
+    // The default mode. The client decides "defer" before the server's
+    // approval-request chunk arrives, so this must match the server's
+    // classification exactly or the turn strands.
+    const def = makeTool({
+      name: "ui_execute_tool",
+      readOnly: false,
+      annotations: { readOnlyHint: false, destructiveHint: true },
+    });
+    useUiToolsRegistry.getState().registerUiTool(def);
+    const addToolOutput = vi.fn();
+
+    const handled = await handleUiToolCall({
+      toolName: "ui_execute_tool",
+      toolCallId: "tc-destructive",
+      input: {},
+      addToolOutput,
+      requireToolApproval: false,
+    });
+
+    expect(handled).toBe(true);
+    expect(def.execute).not.toHaveBeenCalled();
+    expect(addToolOutput).not.toHaveBeenCalled();
+    expect(listDeferredUiToolCalls()).toEqual([
+      { toolCallId: "tc-destructive", toolName: "ui_execute_tool", input: {} },
+    ]);
+  });
+
+  it("executes an ADDITIVE tool immediately when requireToolApproval is off", async () => {
+    const def = makeTool({
+      annotations: { readOnlyHint: false, destructiveHint: false },
+    });
+    useUiToolsRegistry.getState().registerUiTool(def);
+    const addToolOutput = vi.fn();
+
+    await handleUiToolCall({
+      toolName: "ui_navigate",
+      toolCallId: "tc-additive",
+      input: { target: "servers" },
+      addToolOutput,
+      requireToolApproval: false,
+    });
+
+    expect(def.execute).toHaveBeenCalled();
+    expect(addToolOutput).toHaveBeenCalled();
+    expect(listDeferredUiToolCalls()).toEqual([]);
+  });
+
   it("read-only tools execute immediately even with the flag on", async () => {
     const def = makeTool({ name: "ui_snapshot_app", readOnly: true });
     useUiToolsRegistry.getState().registerUiTool(def);

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tools-catalog.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tools-catalog.test.ts
@@ -59,6 +59,39 @@ describe("buildUiToolsCatalog", () => {
     expect(getTool("ui_snapshot_app").readOnly).toBe(true);
   });
 
+  it("every tool annotates readOnly/destructive/openWorld explicitly", () => {
+    // An absent `destructiveHint` reads as DESTRUCTIVE, so an unannotated
+    // tool would gate on every call rather than execute silently — safe, but
+    // wrong. Curated entries state their policy instead of inheriting it.
+    for (const tool of buildUiToolsCatalog()) {
+      const annotations = tool.annotations;
+      expect(annotations, `${tool.name} must annotate`).toBeDefined();
+      expect(typeof annotations?.readOnlyHint).toBe("boolean");
+      expect(typeof annotations?.destructiveHint).toBe("boolean");
+      expect(typeof annotations?.openWorldHint).toBe("boolean");
+      // The wire carries both; the validator 400s if they disagree.
+      expect(annotations?.readOnlyHint).toBe(tool.readOnly);
+    }
+  });
+
+  it("gates exactly ui_execute_tool as destructive", () => {
+    // It runs an arbitrary third-party MCP tool, so it confirms even with the
+    // approval toggle off. Everything else is additive: the user watches it
+    // happen in their own app, and a confirmation buys nothing.
+    const destructive = buildUiToolsCatalog()
+      .filter((t) => t.annotations?.destructiveHint === true)
+      .map((t) => t.name);
+    expect(destructive).toEqual(["ui_execute_tool"]);
+  });
+
+  it("marks only ui_execute_tool as open-world", () => {
+    // The one tool whose effects escape the browser.
+    const openWorld = buildUiToolsCatalog()
+      .filter((t) => t.annotations?.openWorldHint === true)
+      .map((t) => t.name);
+    expect(openWorld).toEqual(["ui_execute_tool"]);
+  });
+
   it("ui_navigate dispatches valid targets and errors on missing/unknown ones", async () => {
     const navigate = getTool("ui_navigate");
 

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tools-catalog.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tools-catalog.test.ts
@@ -92,6 +92,20 @@ describe("buildUiToolsCatalog", () => {
     expect(openWorld).toEqual(["ui_execute_tool"]);
   });
 
+  it("flags only ui_execute_tool's output as untrusted for native agents", () => {
+    // Its result comes from a third-party MCP server. `openWorldHint` (MCP)
+    // doesn't convey that to a WebMCP agent; `nativeUntrustedContentHint`
+    // (projected to WebMCP's untrustedContentHint) does.
+    const untrusted = buildUiToolsCatalog()
+      .filter((t) => t.nativeUntrustedContentHint === true)
+      .map((t) => t.name);
+    expect(untrusted).toEqual(["ui_execute_tool"]);
+  });
+
+  it("does not advertise ui_navigate as idempotent (navigation adds history)", () => {
+    expect(getTool("ui_navigate").annotations?.idempotentHint).toBe(false);
+  });
+
   it("ui_navigate dispatches valid targets and errors on missing/unknown ones", async () => {
     const navigate = getTool("ui_navigate");
 

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tools-registry.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tools-registry.test.ts
@@ -59,6 +59,25 @@ describe("useUiToolsRegistry", () => {
     ).toThrow(/must match ui_/);
   });
 
+  it("rejects a readOnlyHint that contradicts readOnly loudly", () => {
+    // The server 400s a contradictory snapshot on every chat POST; catching
+    // it at registration turns that into an obvious local failure instead.
+    expect(() =>
+      useUiToolsRegistry.getState().registerUiTool(
+        makeTool("ui_navigate", {
+          readOnly: false,
+          annotations: { readOnlyHint: true },
+        }),
+      ),
+    ).toThrow(/must agree/);
+  });
+
+  it("accepts a definition with no annotations (legacy shape)", () => {
+    expect(() =>
+      useUiToolsRegistry.getState().registerUiTool(makeTool("ui_navigate")),
+    ).not.toThrow();
+  });
+
   it("replaces a re-registered name with a warn (HMR/StrictMode)", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const first = makeTool("ui_navigate");
@@ -118,6 +137,34 @@ describe("useUiToolsRegistry", () => {
       inputSchema: { type: "object", properties: {} },
       readOnly: true,
     });
+  });
+
+  it("ships annotations so the server can classify approval", () => {
+    const annotations = {
+      readOnlyHint: false,
+      destructiveHint: true,
+      openWorldHint: true,
+    };
+    useUiToolsRegistry
+      .getState()
+      .registerUiTool(makeTool("ui_execute_tool", { annotations }));
+
+    const [entry] = useUiToolsRegistry.getState().snapshotForChatBody();
+    expect(entry.annotations).toEqual(annotations);
+  });
+
+  it("omits the annotations key entirely when a definition has none", () => {
+    useUiToolsRegistry.getState().registerUiTool(makeTool("ui_navigate"));
+    const [entry] = useUiToolsRegistry.getState().snapshotForChatBody();
+    expect(entry).not.toHaveProperty("annotations");
+  });
+
+  it("never ships mayNavigate (client-only metadata)", () => {
+    useUiToolsRegistry
+      .getState()
+      .registerUiTool(makeTool("ui_navigate", { mayNavigate: true }));
+    const [entry] = useUiToolsRegistry.getState().snapshotForChatBody();
+    expect(entry).not.toHaveProperty("mayNavigate");
   });
 
   it("drops oversize schemas from the snapshot instead of truncating them", () => {

--- a/mcpjam-inspector/client/src/lib/webmcp/native-mirror.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/native-mirror.ts
@@ -85,10 +85,20 @@ export function mirrorUiToolToNative(
           properties: {},
           additionalProperties: false,
         },
-        // MCP `ToolAnnotations`, forwarded as-is. `readOnlyHint` falls back to
-        // the legacy flag for a definition that predates annotations; the
-        // registry rejects a definition where the two disagree.
-        annotations: { readOnlyHint: def.readOnly, ...def.annotations },
+        // MCP `ToolAnnotations`, forwarded as-is, plus WebMCP's own
+        // `untrustedContentHint`. `readOnlyHint` falls back to the legacy
+        // flag for a definition that predates annotations; the registry
+        // rejects a definition where the two disagree. `untrustedContentHint`
+        // is a NATIVE-only signal (not a valid MCP annotation), so it lives
+        // on the client def and is projected only here — it tells a
+        // browser-native agent that a tool's output is externally sourced.
+        annotations: {
+          readOnlyHint: def.readOnly,
+          ...def.annotations,
+          ...(def.nativeUntrustedContentHint
+            ? { untrustedContentHint: true }
+            : {}),
+        },
         execute: async (args: unknown) => {
           const input =
             args && typeof args === "object"

--- a/mcpjam-inspector/client/src/lib/webmcp/native-mirror.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/native-mirror.ts
@@ -85,7 +85,10 @@ export function mirrorUiToolToNative(
           properties: {},
           additionalProperties: false,
         },
-        annotations: { readOnlyHint: def.readOnly },
+        // MCP `ToolAnnotations`, forwarded as-is. `readOnlyHint` falls back to
+        // the legacy flag for a definition that predates annotations; the
+        // registry rejects a definition where the two disagree.
+        annotations: { readOnlyHint: def.readOnly, ...def.annotations },
         execute: async (args: unknown) => {
           const input =
             args && typeof args === "object"

--- a/mcpjam-inspector/client/src/lib/webmcp/ui-tool-executor.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/ui-tool-executor.ts
@@ -170,6 +170,7 @@ export async function handleUiToolCall(
   if (
     uiToolCallNeedsApproval({
       readOnly: def.readOnly,
+      annotations: def.annotations,
       requireToolApproval: opts.requireToolApproval === true,
     })
   ) {

--- a/mcpjam-inspector/client/src/lib/webmcp/ui-tools-catalog.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/ui-tools-catalog.ts
@@ -140,6 +140,12 @@ export function buildUiToolsCatalog(): UiToolDefinition[] {
         additionalProperties: false,
       },
       readOnly: false,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
       mayNavigate: true,
       execute: async (args) => {
         const target = asOptionalString(args.target);
@@ -160,6 +166,12 @@ export function buildUiToolsCatalog(): UiToolDefinition[] {
         additionalProperties: false,
       },
       readOnly: false,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
       execute: async (args) => {
         const serverName = asOptionalString(args.serverName);
         if (!serverName) {
@@ -183,6 +195,12 @@ export function buildUiToolsCatalog(): UiToolDefinition[] {
         additionalProperties: false,
       },
       readOnly: false,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
       mayNavigate: true,
       execute: async (args) =>
         fromActionResult(
@@ -210,6 +228,14 @@ export function buildUiToolsCatalog(): UiToolDefinition[] {
         additionalProperties: false,
       },
       readOnly: false,
+      // Prefills a form the user still has to run: mutates UI state, but
+      // nothing about it is destructive and it never leaves the browser.
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
       // Auto-opens the playground when its handler isn't mounted — from a
       // non-playground route that is a navigation.
       mayNavigate: true,
@@ -254,6 +280,17 @@ export function buildUiToolsCatalog(): UiToolDefinition[] {
         additionalProperties: false,
       },
       readOnly: false,
+      // The only UI tool with effects outside the browser: it runs an
+      // arbitrary third-party MCP tool whose own destructiveness is unknown
+      // here. `destructiveHint: true` is what makes it confirm even in the
+      // default (non-strict) approval mode — the pessimistic read is the
+      // correct one until per-call target-annotation pass-through exists.
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
       // Auto-opens the playground when its handler isn't mounted — from a
       // non-playground route that is a navigation.
       mayNavigate: true,
@@ -304,6 +341,12 @@ export function buildUiToolsCatalog(): UiToolDefinition[] {
         additionalProperties: false,
       },
       readOnly: false,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
       // Auto-opens the playground when its handler isn't mounted — from a
       // non-playground route that is a navigation.
       mayNavigate: true,
@@ -347,6 +390,15 @@ export function buildUiToolsCatalog(): UiToolDefinition[] {
         additionalProperties: false,
       },
       readOnly: true,
+      // The only read-only tool in the catalog: never gates, in either
+      // approval mode. That exemption is only sound because `execute` below
+      // refuses rather than auto-opening the playground.
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
       execute: async () => {
         // Honor readOnly: a snapshot must never navigate or mount the
         // playground. Unlike the mutating tools, it does NOT auto-open via

--- a/mcpjam-inspector/client/src/lib/webmcp/ui-tools-catalog.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/ui-tools-catalog.ts
@@ -143,7 +143,11 @@ export function buildUiToolsCatalog(): UiToolDefinition[] {
       annotations: {
         readOnlyHint: false,
         destructiveHint: false,
-        idempotentHint: true,
+        // NOT idempotent: a normal navigation pushes a browser-history entry
+        // even when the destination is unchanged, so repeated calls DO have
+        // an additional effect. Advertising idempotent would invite a native
+        // agent to retry freely and pile up history.
+        idempotentHint: false,
         openWorldHint: false,
       },
       mayNavigate: true,
@@ -291,6 +295,11 @@ export function buildUiToolsCatalog(): UiToolDefinition[] {
         idempotentHint: false,
         openWorldHint: true,
       },
+      // Its result comes from a third-party MCP server — externally sourced,
+      // so a browser-native agent should treat it as untrusted. `openWorldHint`
+      // (MCP) doesn't convey that to a WebMCP agent; `untrustedContentHint`
+      // (WebMCP) does. Native mirror only.
+      nativeUntrustedContentHint: true,
       // Auto-opens the playground when its handler isn't mounted — from a
       // non-playground route that is a navigation.
       mayNavigate: true,

--- a/mcpjam-inspector/client/src/lib/webmcp/ui-tools-registry.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/ui-tools-registry.ts
@@ -24,6 +24,7 @@
 
 import { create } from "zustand";
 import { isUiToolName } from "@/shared/client-fulfilled-tools.js";
+import type { UiToolAnnotations } from "@/shared/client-fulfilled-tools.js";
 import type { UiToolSnapshotEntry } from "@/shared/chat-v2.js";
 import { mirrorUiToolToNative } from "./native-mirror";
 
@@ -38,8 +39,21 @@ export interface UiToolDefinition {
   description: string;
   /** Plain JSON Schema object (no zod), same as the app-tool pipeline. */
   inputSchema?: Record<string, unknown>;
-  /** Mirrored to native `annotations.readOnlyHint`; metadata, not a gate. */
+  /**
+   * Legacy read-only flag. Kept as the wire-compatible mirror of
+   * `annotations.readOnlyHint`; `registerUiTool` rejects a definition where
+   * the two disagree. Prefer reading `annotations`.
+   */
   readOnly: boolean;
+  /**
+   * MCP `ToolAnnotations` for this tool. Drives approval policy
+   * (`uiToolCallNeedsApproval`) and is projected onto the native WebMCP
+   * descriptor. Every entry in the first-party catalog sets these
+   * explicitly — an absent `destructiveHint` is read as DESTRUCTIVE (the
+   * protocol's pessimistic default), so a tool added without annotations
+   * gates rather than executing silently.
+   */
+  annotations?: UiToolAnnotations;
   /**
    * Executing this tool can change the SPA route (directly, or via the
    * auto-open-playground fallback). Route-bound chat surfaces use this to
@@ -92,6 +106,17 @@ export const useUiToolsRegistry = create<UiToolsRegistryState>((set, get) => ({
       // First-party catalog bug, not user input — fail loudly.
       throw new Error(
         `[webmcp] UI tool name "${def.name}" must match ui_[a-z0-9][a-z0-9_]* (max 64 chars).`,
+      );
+    }
+    if (
+      def.annotations?.readOnlyHint !== undefined &&
+      def.annotations.readOnlyHint !== def.readOnly
+    ) {
+      // The server validator rejects contradictory snapshots; catching it at
+      // registration turns a 400 on every chat POST into an obvious local
+      // failure. Same posture as the name check: first-party bug, fail loud.
+      throw new Error(
+        `[webmcp] UI tool "${def.name}" has readOnly=${def.readOnly} but annotations.readOnlyHint=${def.annotations.readOnlyHint}; they must agree.`,
       );
     }
     if (opts?.signal?.aborted) {
@@ -159,6 +184,7 @@ export const useUiToolsRegistry = create<UiToolsRegistryState>((set, get) => ({
         description: def.description.slice(0, MAX_DESCRIPTION_CHARS),
         inputSchema,
         readOnly: def.readOnly,
+        ...(def.annotations ? { annotations: def.annotations } : {}),
       });
     }
     if (dropped > 0) {

--- a/mcpjam-inspector/client/src/lib/webmcp/ui-tools-registry.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/ui-tools-registry.ts
@@ -55,6 +55,16 @@ export interface UiToolDefinition {
    */
   annotations?: UiToolAnnotations;
   /**
+   * WebMCP's `untrustedContentHint` for the NATIVE mirror only. WebMCP has
+   * its own signal for "this tool's output is externally sourced and should
+   * be treated as untrusted"; MCP's `openWorldHint` is a different thing, so
+   * a native agent won't infer it. Set true for a tool whose result comes
+   * from a third party (e.g. `ui_execute_tool` runs an arbitrary MCP server).
+   * Client-only: it is NOT a valid MCP annotation, so the server validator
+   * would reject it — `snapshotForChatBody` never ships it.
+   */
+  nativeUntrustedContentHint?: boolean;
+  /**
    * Executing this tool can change the SPA route (directly, or via the
    * auto-open-playground fallback). Route-bound chat surfaces use this to
    * hand the conversation off to the always-mounted side panel BEFORE the

--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -51,6 +51,7 @@ import {
   validateWidgetModelContextEntries,
   WidgetModelContextValidationError,
 } from "../../utils/chat-v2-orchestration";
+import { classifyUiToolApprovals } from "@/shared/client-fulfilled-tools";
 import {
   formatProviderOverloadError,
   isProviderOverloadError,
@@ -643,6 +644,16 @@ chatV2.post("/", async (c) => {
       }
     }
 
+    // Per-tool `ui_*` approval policy for this turn. The BYOK `streamText`
+    // path reads it off each tool's `needsApproval` (set by `buildUiTools`);
+    // the MCPJam/org loops re-implement approval on top of a proxied stream,
+    // so they need the classification passed explicitly or destructive UI
+    // tools would execute unconfirmed whenever `requireToolApproval` is off.
+    const uiToolApprovals = classifyUiToolApprovals(
+      validatedUiTools,
+      requireToolApproval === true,
+    );
+
     let validatedWidgetModelContext;
     try {
       validatedWidgetModelContext = validateWidgetModelContextEntries(
@@ -860,6 +871,7 @@ chatV2.post("/", async (c) => {
         mcpClientManager,
         selectedServers,
         requireToolApproval,
+        uiToolApprovals,
         modelVisibleMcpToolResults,
         ...(resolvedExecution.harness
           ? {
@@ -1078,6 +1090,7 @@ chatV2.post("/", async (c) => {
         selectedServers,
         serverIds: hostConfigServerIds,
         requireToolApproval,
+        uiToolApprovals,
         modelVisibleMcpToolResults,
         abortSignal: inboundAbortSignalOrg,
         onConversationComplete,

--- a/mcpjam-inspector/server/routes/web/__tests__/mcpjam-agent-widget-content.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/mcpjam-agent-widget-content.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { afterEach, describe, expect, it, vi, beforeEach } from "vitest";
 import { Hono } from "hono";
 
 // The heavy chat-turn machinery is stubbed: the companion endpoint never
@@ -110,8 +110,8 @@ beforeEach(() => {
   streamWebChatTurn.mockClear();
 });
 
-describe("POST /api/web/mcpjam-agent ambient project context", () => {
-  it("augments the prepare prompt with the chat's project id but persists the original", async () => {
+describe("POST /api/web/mcpjam-agent system prompt", () => {
+  it("prepends the agent identity to prepare but persists the user's own prompt", async () => {
     const app = makeApp();
     const response = await app.request("/api/web/mcpjam-agent", {
       method: "POST",
@@ -134,47 +134,85 @@ describe("POST /api/web/mcpjam-agent ambient project context", () => {
       prepare: { systemPrompt?: string };
       persist: { systemPrompt?: string };
     };
-    // The model is told which project it's looking at, so the platform
-    // worker's tools (whose omitted `project` means "most recently
-    // updated") get the chat's project passed explicitly.
     expect(args.prepare.systemPrompt).toContain("Be terse.");
-    expect(args.prepare.systemPrompt).toContain('project: "proj_ambient"');
+    expect(args.prepare.systemPrompt).toContain("MCPJam in-app assistant");
+    // No ambient project id: the platform tools that needed it are gone, and
+    // a per-request value here would break the cacheable prefix.
+    expect(args.prepare.systemPrompt).not.toContain("proj_ambient");
     // The persisted prompt stays the user's own configuration.
     expect(args.persist.systemPrompt).toBe("Be terse.");
   });
 
-  it("omits the workspace section when the platform server failed preflight", async () => {
-    managerState.listTools.mockImplementation(async (serverId: unknown) => {
-      if (serverId === MCPJAM_PLATFORM_SERVER_ID) {
-        throw new Error("issuer mismatch");
-      }
-      return { tools: [] };
+  describe("with MCPJAM_AGENT_PLATFORM_TOOLS=1", () => {
+    beforeEach(() => {
+      process.env.MCPJAM_AGENT_PLATFORM_TOOLS = "1";
+    });
+    afterEach(() => {
+      delete process.env.MCPJAM_AGENT_PLATFORM_TOOLS;
     });
 
-    const app = makeApp();
-    const response = await app.request("/api/web/mcpjam-agent", {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        authorization: "Bearer user-token",
-      },
-      body: JSON.stringify({
-        messages: [{ role: "user", parts: [{ type: "text", text: "hi" }] }],
-        model: { id: "anthropic/claude-haiku-4.5" },
-        chatSessionId: "session_1",
-        projectId: "proj_ambient",
-        systemPrompt: "Be terse.",
-      }),
+    it("augments the prepare prompt with the chat's project id but persists the original", async () => {
+      const app = makeApp();
+      const response = await app.request("/api/web/mcpjam-agent", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer user-token",
+        },
+        body: JSON.stringify({
+          messages: [{ role: "user", parts: [{ type: "text", text: "hi" }] }],
+          model: { id: "anthropic/claude-haiku-4.5" },
+          chatSessionId: "session_1",
+          projectId: "proj_ambient",
+          systemPrompt: "Be terse.",
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      const args = streamWebChatTurn.mock.calls[0]![0] as unknown as {
+        prepare: { systemPrompt?: string };
+        persist: { systemPrompt?: string };
+      };
+      // The model is told which project it's looking at, so the platform
+      // worker's tools (whose omitted `project` means "most recently
+      // updated") get the chat's project passed explicitly.
+      expect(args.prepare.systemPrompt).toContain('project: "proj_ambient"');
+      expect(args.persist.systemPrompt).toBe("Be terse.");
     });
 
-    expect(response.status).toBe(200);
-    const args = streamWebChatTurn.mock.calls[0]![0] as unknown as {
-      prepare: { systemPrompt?: string; selectedServerIds: string[] };
-    };
-    // Degraded turn: no platform tools advertised, so no instructions
-    // about them either.
-    expect(args.prepare.selectedServerIds).toEqual(["mcpjam-docs"]);
-    expect(args.prepare.systemPrompt).toBe("Be terse.");
+    it("omits the workspace section when the platform server failed preflight", async () => {
+      managerState.listTools.mockImplementation(async (serverId: unknown) => {
+        if (serverId === MCPJAM_PLATFORM_SERVER_ID) {
+          throw new Error("issuer mismatch");
+        }
+        return { tools: [] };
+      });
+
+      const app = makeApp();
+      const response = await app.request("/api/web/mcpjam-agent", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer user-token",
+        },
+        body: JSON.stringify({
+          messages: [{ role: "user", parts: [{ type: "text", text: "hi" }] }],
+          model: { id: "anthropic/claude-haiku-4.5" },
+          chatSessionId: "session_1",
+          projectId: "proj_ambient",
+          systemPrompt: "Be terse.",
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      const args = streamWebChatTurn.mock.calls[0]![0] as unknown as {
+        prepare: { systemPrompt?: string; selectedServerIds: string[] };
+      };
+      // Degraded turn: no platform tools advertised, so no instructions
+      // about them either.
+      expect(args.prepare.selectedServerIds).toEqual(["mcpjam-docs"]);
+      expect(args.prepare.systemPrompt).not.toContain("Workspace context");
+    });
   });
 });
 

--- a/mcpjam-inspector/server/routes/web/__tests__/mcpjam-agent.ui-only.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/mcpjam-agent.ui-only.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+
+const {
+  streamWebChatTurnMock,
+  disconnectAllServersMock,
+  listToolsMock,
+  managerConfigs,
+} = vi.hoisted(() => ({
+  streamWebChatTurnMock: vi.fn(),
+  disconnectAllServersMock: vi.fn(),
+  listToolsMock: vi.fn(async (_serverId?: unknown) => ({ tools: [] })),
+  managerConfigs: [] as Array<Record<string, unknown>>,
+}));
+
+vi.mock("@mcpjam/sdk", async () => {
+  const actual = await vi.importActual<typeof import("@mcpjam/sdk")>(
+    "@mcpjam/sdk"
+  );
+  return {
+    ...actual,
+    isMCPAuthError: vi.fn().mockReturnValue(false),
+    MCPClientManager: vi.fn().mockImplementation((configs: any) => {
+      managerConfigs.push(configs);
+      return {
+        disconnectAllServers: disconnectAllServersMock,
+        listTools: listToolsMock,
+      };
+    }),
+  };
+});
+
+vi.mock("../../../utils/web-chat-turn.js", () => ({
+  streamWebChatTurn: streamWebChatTurnMock,
+}));
+
+vi.mock("../apps.js", () => ({
+  default: new Hono(),
+}));
+
+import { createWebTestApp, postJson } from "./helpers/test-app.js";
+
+const BASE_BODY = {
+  messages: [{ role: "user", content: "show me my servers" }],
+  model: { id: "openai/gpt-5-mini", provider: "openai", name: "GPT-5 Mini" },
+  chatSessionId: "agent-session-1",
+  projectId: "project-1",
+};
+
+async function postAgentTurn() {
+  const { app, token } = createWebTestApp();
+  const response = await postJson(app, "/api/web/mcpjam-agent", BASE_BODY, token);
+  expect(response.status).toBe(200);
+  return streamWebChatTurnMock.mock.calls[0][0];
+}
+
+describe("web routes — mcpjam-agent is UI-only", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    managerConfigs.length = 0;
+    delete process.env.MCPJAM_AGENT_PLATFORM_TOOLS;
+    streamWebChatTurnMock.mockResolvedValue(new Response("ok", { status: 200 }));
+  });
+
+  afterEach(() => {
+    delete process.env.MCPJAM_AGENT_PLATFORM_TOOLS;
+  });
+
+  it("never connects the platform server for a chat turn", async () => {
+    // The platform tools mutate the workspace server-side and invisibly —
+    // exactly what a surface whose premise is "you can watch me work" must
+    // not do.
+    await postAgentTurn();
+    expect(Object.keys(managerConfigs[0])).toEqual(["mcpjam-docs"]);
+  });
+
+  it("selects only the docs server", async () => {
+    const args = await postAgentTurn();
+    expect(args.prepare.selectedServerIds).toEqual(["mcpjam-docs"]);
+  });
+
+  it("keeps web_search — knowledge tools are read-only, not actions", async () => {
+    const args = await postAgentTurn();
+    expect(Object.keys(args.prepare.builtInTools ?? {})).toContain("web_search");
+  });
+
+  it("tells the model it acts by driving the UI", async () => {
+    const args = await postAgentTurn();
+    expect(args.prepare.systemPrompt).toContain("MCPJam in-app assistant");
+    expect(args.prepare.systemPrompt).toContain("`ui_*` tools");
+  });
+
+  it("keeps the system prompt free of per-request values so the prefix stays cacheable", async () => {
+    // Anything volatile here (projectId, route, timestamp) would invalidate
+    // the cached prefix for the WHOLE conversation on every turn. Per-turn UI
+    // state rides append-only on the user message instead (PR D).
+    const args = await postAgentTurn();
+    expect(args.prepare.systemPrompt).not.toContain("project-1");
+    expect(args.prepare.systemPrompt).not.toContain("Workspace context");
+  });
+
+  it("is byte-stable across turns", async () => {
+    const first = await postAgentTurn();
+    vi.clearAllMocks();
+    streamWebChatTurnMock.mockResolvedValue(new Response("ok", { status: 200 }));
+    const second = await postAgentTurn();
+    expect(second.prepare.systemPrompt).toBe(first.prepare.systemPrompt);
+  });
+
+  describe("MCPJAM_AGENT_PLATFORM_TOOLS=1 rollback", () => {
+    beforeEach(() => {
+      process.env.MCPJAM_AGENT_PLATFORM_TOOLS = "1";
+    });
+
+    it("restores the platform server, its selection, AND its workspace prompt", async () => {
+      // A rollback that restored the tools but not their `project` guidance
+      // would leave the worker defaulting to the caller's most-recently-updated
+      // project — a state we never shipped.
+      const args = await postAgentTurn();
+      expect(Object.keys(managerConfigs[0])).toEqual([
+        "mcpjam-docs",
+        "mcpjam-platform",
+      ]);
+      expect(args.prepare.selectedServerIds).toEqual([
+        "mcpjam-docs",
+        "mcpjam-platform",
+      ]);
+      expect(args.prepare.systemPrompt).toContain("Workspace context");
+      expect(args.prepare.systemPrompt).toContain("project-1");
+    });
+  });
+});

--- a/mcpjam-inspector/server/routes/web/__tests__/mcpjam-agent.ui-only.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/mcpjam-agent.ui-only.test.ts
@@ -112,6 +112,17 @@ describe("web routes — mcpjam-agent is UI-only", () => {
       process.env.MCPJAM_AGENT_PLATFORM_TOOLS = "1";
     });
 
+    it("drops the UI-only identity prompt so the rollback isn't self-contradictory", async () => {
+      // "The ui_* tools are your only way to act" is false once the platform
+      // tools are back. Shipping both would leave the model with opposite
+      // instructions in the one configuration meant to behave exactly like
+      // the old one.
+      const args = await postAgentTurn();
+      expect(args.prepare.systemPrompt).not.toContain("MCPJam in-app assistant");
+      expect(args.prepare.systemPrompt).not.toContain("no other way to act");
+      expect(args.prepare.systemPrompt).toContain("Workspace context");
+    });
+
     it("restores the platform server, its selection, AND its workspace prompt", async () => {
       // A rollback that restored the tools but not their `project` guidance
       // would leave the worker defaulting to the caller's most-recently-updated

--- a/mcpjam-inspector/server/routes/web/__tests__/mcpjam-agent.uitools.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/mcpjam-agent.uitools.test.ts
@@ -118,11 +118,8 @@ describe("web routes — mcpjam-agent uiTools boundary", () => {
     expect(response.status).toBe(200);
     const args = streamWebChatTurnMock.mock.calls[0][0];
     expect(args.prepare.appTools).toBeUndefined();
-    // Both first-party servers pass the preflight under the mock; the
+    // The docs server passes the preflight under the mock; the
     // client-supplied ids are still ignored.
-    expect(args.prepare.selectedServerIds).toEqual([
-      "mcpjam-docs",
-      "mcpjam-platform",
-    ]);
+    expect(args.prepare.selectedServerIds).toEqual(["mcpjam-docs"]);
   });
 });

--- a/mcpjam-inspector/server/routes/web/mcpjam-agent.ts
+++ b/mcpjam-inspector/server/routes/web/mcpjam-agent.ts
@@ -287,9 +287,15 @@ mcpjamAgent.post("/", async (c) => {
               "explicitly asks about a different project.",
           ].join("\n")
         : undefined;
+      // The identity prompt says the `ui_*` tools are the only way to act.
+      // Under the kill-switch that becomes false — the platform tools are
+      // back — and shipping both sections would hand the model directly
+      // contradictory instructions, in the one configuration whose entire
+      // job is to behave exactly like the old one. A rollback that leaves
+      // the new prompt in place is not a rollback.
       const effectiveSystemPrompt = [
         body.systemPrompt,
-        AGENT_IDENTITY_PROMPT,
+        platformToolsEnabled ? undefined : AGENT_IDENTITY_PROMPT,
         ambientContextPrompt,
       ]
         .filter((section): section is string => Boolean(section?.trim()))

--- a/mcpjam-inspector/server/routes/web/mcpjam-agent.ts
+++ b/mcpjam-inspector/server/routes/web/mcpjam-agent.ts
@@ -1,16 +1,23 @@
 /**
  * MCPJam Agent — POST /api/web/mcpjam-agent
  *
- * Chat surface connected to two MCPJam-owned MCP servers:
+ * UI-ONLY chat surface: the agent ACTS exclusively by driving the inspector
+ * UI through the client-fulfilled `ui_*` tools, so every action is visible
+ * to the user in their own app. It KNOWS things via read-only sources:
  *   - the hosted docs server (`https://docs.mcpjam.com/mcp`, Mintlify) for
  *     documentation search, and
- *   - the MCPJam platform MCP worker (`https://mcp.mcpjam.com/mcp`,
- *     Cloudflare — `mcp/` in this monorepo) for the workspace catalog
- *     (projects, servers, evals, chatboxes) INCLUDING its MCP Apps widget
- *     tools (`show_servers` & co). The platform server is the single owner
- *     of those tools; the agent is a plain MCP client of it, so widget
- *     metadata, `ui://` resources, and payload tagging all flow through the
- *     standard protocol pipeline.
+ *   - the `web_search` built-in.
+ *
+ * It deliberately does NOT connect the MCPJam platform MCP worker for chat
+ * turns any more: those tools mutate the user's workspace (projects,
+ * servers, evals, chatboxes) server-side and invisibly, which is exactly
+ * what this surface is meant not to do. `MCPJAM_AGENT_PLATFORM_TOOLS=1`
+ * restores the old behavior wholesale (see `agentPlatformToolsEnabled`).
+ *
+ * The platform CONFIG and the `/widget-content` sub-route below stay: chat
+ * sessions from before the cutover still contain platform widget parts, and
+ * reloading one re-reads its `ui://` resource through that route. Removing
+ * it would break history rendering, not just new turns.
  *
  * The Home page is its first consumer; the side-panel bubble across the
  * rest of the UI hits the same endpoint.
@@ -84,6 +91,35 @@ import { getClientIp } from "../../utils/client-ip.js";
 const DOCS_SERVER_ID = "mcpjam-docs";
 const DEFAULT_DOCS_URL = "https://docs.mcpjam.com/mcp";
 const PLATFORM_SERVER_ID = MCPJAM_PLATFORM_SERVER_ID;
+
+/**
+ * Rollback switch for the UI-only agent. Restores the COMPLETE prior
+ * contract — the platform server in the manager, its preflight/selection,
+ * and its workspace-context prompt — because a half-rollback (platform tools
+ * advertised, but told to drive the UI) is a state we never shipped and
+ * never tested.
+ */
+function agentPlatformToolsEnabled(): boolean {
+  return process.env.MCPJAM_AGENT_PLATFORM_TOOLS === "1";
+}
+
+/**
+ * Who the agent is and how it acts. Static per build ON PURPOSE: this sits
+ * at the front of every turn's prompt, and anything volatile here (a
+ * projectId, a route, a timestamp) would invalidate the cacheable prefix for
+ * the whole conversation on every request. Per-turn UI state travels
+ * append-only on the user message instead.
+ *
+ * Deliberately says nothing tool-specific — `buildUiToolsSystemPrompt`
+ * (chat-v2-orchestration) owns the `ui_*` mechanics and is emitted from the
+ * validated snapshot, so the two can't drift apart.
+ */
+const AGENT_IDENTITY_PROMPT = [
+  "## You are the MCPJam in-app assistant",
+  "You are embedded in the MCPJam inspector, sitting next to the user's own screen. You act by DRIVING THAT UI with the `ui_*` tools: every action you take lands in the app the user is looking at, and they watch it happen.",
+  "Prefer navigating and showing over describing. If the user asks where something is or how to do it, take them there instead of narrating the click path.",
+  "Use the documentation and web search tools to answer knowledge questions; use the `ui_*` tools to actually do things. You have no other way to act — when something isn't reachable through a `ui_*` tool, say so plainly rather than inventing a tool or claiming you did it.",
+].join("\n");
 
 // Advertise the MCP UI extension so the platform worker registers its
 // widget-backed tools (the worker's session registrar swaps widget vs
@@ -173,10 +209,14 @@ mcpjamAgent.post("/", async (c) => {
       throw error;
     }
 
+    const platformToolsEnabled = agentPlatformToolsEnabled();
+
     manager = new MCPClientManager(
       {
         [DOCS_SERVER_ID]: buildDocsConfig(),
-        [PLATFORM_SERVER_ID]: buildPlatformConfig(bearerToken),
+        ...(platformToolsEnabled
+          ? { [PLATFORM_SERVER_ID]: buildPlatformConfig(bearerToken) }
+          : {}),
       },
       {
         defaultTimeout: WEB_STREAM_TIMEOUT_MS,
@@ -195,7 +235,9 @@ mcpjamAgent.post("/", async (c) => {
       // so the later prepare doesn't repeat the round trips. With both
       // down, the turn still runs on web_search + the bare model.
       const mcp = manager;
-      const candidateServerIds = [DOCS_SERVER_ID, PLATFORM_SERVER_ID];
+      const candidateServerIds = platformToolsEnabled
+        ? [DOCS_SERVER_ID, PLATFORM_SERVER_ID]
+        : [DOCS_SERVER_ID];
       const preflights = await Promise.allSettled(
         candidateServerIds.map((serverId) => mcp.listTools(serverId))
       );
@@ -230,7 +272,10 @@ mcpjamAgent.post("/", async (c) => {
       // this route's body, so the bridge is the system prompt: tell the
       // model what it's looking at and to pass the id explicitly. Appended
       // only while the platform server survived preflight — instructions
-      // must not reference tools the degraded turn doesn't advertise.
+      // must not reference tools the degraded turn doesn't advertise. Only
+      // reachable under the kill-switch; it embeds `projectId`, so it is
+      // per-request-volatile and would sit in front of the whole
+      // conversation in the cacheable prefix.
       const platformToolsAvailable =
         selectedServerIds.includes(PLATFORM_SERVER_ID);
       const ambientContextPrompt = platformToolsAvailable
@@ -242,7 +287,11 @@ mcpjamAgent.post("/", async (c) => {
               "explicitly asks about a different project.",
           ].join("\n")
         : undefined;
-      const effectiveSystemPrompt = [body.systemPrompt, ambientContextPrompt]
+      const effectiveSystemPrompt = [
+        body.systemPrompt,
+        AGENT_IDENTITY_PROMPT,
+        ambientContextPrompt,
+      ]
         .filter((section): section is string => Boolean(section?.trim()))
         .join("\n\n");
 

--- a/mcpjam-inspector/server/utils/__tests__/chat-v2-orchestration.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/chat-v2-orchestration.test.ts
@@ -877,10 +877,21 @@ describe("validateUiToolEntries (WebMCP UI tools)", () => {
       ).toThrow(/readOnlyHint must equal readOnly/);
     });
 
-    it("accepts an agreeing readOnlyHint", () => {
+    it("accepts an agreeing readOnlyHint (both directions)", () => {
       expect(() =>
         validateUiToolEntries([
           { ...validTool, readOnly: false, annotations: { readOnlyHint: false } },
+        ]),
+      ).not.toThrow();
+      // Symmetric case: a read-only tool agreeing it's read-only.
+      expect(() =>
+        validateUiToolEntries([
+          {
+            ...validTool,
+            name: "ui_snapshot_app",
+            readOnly: true,
+            annotations: { readOnlyHint: true },
+          },
         ]),
       ).not.toThrow();
     });
@@ -1145,19 +1156,38 @@ describe("prepareChatV2 — WebMCP UI tools", () => {
     ).toBeFalsy();
   });
 
-  it("describes the approval policy that actually applies in each mode", () => {
-    // Both modes gate something, so both get a sentence — the prompt must not
-    // promise "every mutating action pauses" in the default mode, where only
-    // destructive ones do.
-    const withFlag = buildUiToolsSystemPrompt(uiTools, {
-      requireToolApproval: true,
-    });
-    expect(withFlag).toContain("Every mutating `ui_*` action pauses");
-    expect(withFlag).toContain("denial is final");
+  it("promises a destructive gate in default mode ONLY when the snapshot is annotation-aware", () => {
+    const annotated: UiToolEntry[] = [
+      {
+        name: "ui_navigate",
+        description: "Navigate",
+        readOnly: false,
+        annotations: { readOnlyHint: false, destructiveHint: false },
+      },
+      {
+        name: "ui_execute_tool",
+        description: "Run a tool",
+        readOnly: false,
+        annotations: { readOnlyHint: false, destructiveHint: true },
+      },
+    ];
 
-    const withoutFlag = buildUiToolsSystemPrompt(uiTools);
-    expect(withoutFlag).toContain("Destructive `ui_*` actions pause");
-    expect(withoutFlag).toContain("other actions apply immediately");
-    expect(withoutFlag).not.toContain("Every mutating `ui_*` action pauses");
+    // Strict mode: every mutating tool pauses, regardless of annotations.
+    expect(
+      buildUiToolsSystemPrompt(annotated, { requireToolApproval: true }),
+    ).toContain("Every mutating `ui_*` action pauses");
+
+    // Default mode, annotation-aware: the destructive-gate promise holds.
+    const annotatedDefault = buildUiToolsSystemPrompt(annotated);
+    expect(annotatedDefault).toContain("Destructive `ui_*` actions pause");
+    expect(annotatedDefault).toContain("other actions apply immediately");
+
+    // Default mode, LEGACY snapshot (the fixture has no annotations): the
+    // predicate is `requireToolApproval && !readOnly`, so with the flag off
+    // NOTHING pauses. The prompt must not promise a destructive gate that
+    // isn't enforced.
+    const legacyDefault = buildUiToolsSystemPrompt(uiTools);
+    expect(legacyDefault).not.toContain("Destructive `ui_*` actions pause");
+    expect(legacyDefault).toContain("applies immediately");
   });
 });

--- a/mcpjam-inspector/server/utils/__tests__/chat-v2-orchestration.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/chat-v2-orchestration.test.ts
@@ -819,6 +819,73 @@ describe("validateUiToolEntries (WebMCP UI tools)", () => {
     );
   });
 
+  describe("annotations", () => {
+    it("passes a valid annotations object through", () => {
+      const annotations = {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: false,
+        openWorldHint: true,
+      };
+      const [entry] = validateUiToolEntries([
+        { ...validTool, name: "ui_execute_tool", annotations },
+      ]);
+      expect(entry.annotations).toEqual(annotations);
+    });
+
+    it("omits annotations when the client sent none (legacy client)", () => {
+      const [entry] = validateUiToolEntries([validTool]);
+      expect(entry.annotations).toBeUndefined();
+    });
+
+    it("rejects a non-object annotations value", () => {
+      for (const annotations of [null, "readOnly", 1, []]) {
+        expect(() =>
+          validateUiToolEntries([{ ...validTool, annotations }]),
+        ).toThrow(/annotations must be an object/);
+      }
+    });
+
+    it("rejects non-boolean hint values", () => {
+      expect(() =>
+        validateUiToolEntries([
+          { ...validTool, annotations: { destructiveHint: "yes" } },
+        ]),
+      ).toThrow(/annotations.destructiveHint must be a boolean/);
+    });
+
+    it("rejects unknown hint keys rather than silently dropping them", () => {
+      // A typo'd hint must not pass as "absent" — for destructiveHint that
+      // would flip the entry from destructive to additive.
+      expect(() =>
+        validateUiToolEntries([
+          { ...validTool, annotations: { destructiveHnit: true } },
+        ]),
+      ).toThrow(/unknown key 'destructiveHnit'/);
+    });
+
+    it("rejects a readOnlyHint that contradicts readOnly", () => {
+      expect(() =>
+        validateUiToolEntries([
+          { ...validTool, readOnly: true, annotations: { readOnlyHint: false } },
+        ]),
+      ).toThrow(/readOnlyHint must equal readOnly/);
+      expect(() =>
+        validateUiToolEntries([
+          { ...validTool, readOnly: false, annotations: { readOnlyHint: true } },
+        ]),
+      ).toThrow(/readOnlyHint must equal readOnly/);
+    });
+
+    it("accepts an agreeing readOnlyHint", () => {
+      expect(() =>
+        validateUiToolEntries([
+          { ...validTool, readOnly: false, annotations: { readOnlyHint: false } },
+        ]),
+      ).not.toThrow();
+    });
+  });
+
   it("rejects names outside the reserved ui_ shape", () => {
     for (const name of [
       "navigate",
@@ -1078,13 +1145,19 @@ describe("prepareChatV2 — WebMCP UI tools", () => {
     ).toBeFalsy();
   });
 
-  it("adds the approval sentence to the UI prompt section iff the flag is on", () => {
+  it("describes the approval policy that actually applies in each mode", () => {
+    // Both modes gate something, so both get a sentence — the prompt must not
+    // promise "every mutating action pauses" in the default mode, where only
+    // destructive ones do.
     const withFlag = buildUiToolsSystemPrompt(uiTools, {
       requireToolApproval: true,
     });
-    expect(withFlag).toContain("approval");
+    expect(withFlag).toContain("Every mutating `ui_*` action pauses");
     expect(withFlag).toContain("denial is final");
+
     const withoutFlag = buildUiToolsSystemPrompt(uiTools);
-    expect(withoutFlag).not.toContain("denial is final");
+    expect(withoutFlag).toContain("Destructive `ui_*` actions pause");
+    expect(withoutFlag).toContain("other actions apply immediately");
+    expect(withoutFlag).not.toContain("Every mutating `ui_*` action pauses");
   });
 });

--- a/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
@@ -1846,6 +1846,73 @@ describe("mcpjam-stream-handler", () => {
       expect(onConversationComplete).toHaveBeenCalledTimes(1);
     });
 
+    it("processes a DENIAL of a destructive ui_* tool when the approval flag is OFF", async () => {
+      // The stranding case. Approving a ui_* call is resolved by the browser
+      // shipping a tool-result, but DENYING it sends an approval response
+      // back here. If pending-approval handling stayed gated on
+      // `requireToolApproval`, that denial would never be processed with the
+      // flag off — the tool call stays unresolved and the turn hangs forever.
+      vi.mocked(executeToolCallsFromMessages).mockResolvedValue([]);
+
+      await handleMCPJamFreeChatModel({
+        messages: [
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "tool-call",
+                toolCallId: "call-ui-exec",
+                toolName: "ui_execute_tool",
+                input: {},
+              },
+              {
+                type: "tool-approval-request",
+                approvalId: "approval-ui-exec",
+                toolCallId: "call-ui-exec",
+              },
+            ],
+          },
+          {
+            role: "tool",
+            content: [
+              {
+                type: "tool-approval-response",
+                approvalId: "approval-ui-exec",
+                approved: false,
+              },
+            ],
+          },
+        ] as any,
+        modelId: "gpt-4.1-mini",
+        systemPrompt: "You are helpful",
+        tools: { ui_execute_tool: {} } as any,
+        mcpClientManager: {
+          getAllToolsMetadata: vi.fn().mockReturnValue({}),
+        } as any,
+        requireToolApproval: false,
+        uiToolApprovals: classifyUiToolApprovals(
+          [
+            {
+              name: "ui_execute_tool",
+              readOnly: false,
+              annotations: { readOnlyHint: false, destructiveHint: true },
+            },
+          ],
+          false
+        ),
+      });
+
+      await lastExecution;
+
+      // The denial was processed and reached the client, so the tool call is
+      // resolved and the turn can finish instead of hanging.
+      expect(
+        writtenChunks.filter(
+          (chunk: any) => chunk.type === "tool-output-denied"
+        )
+      ).toMatchObject([{ toolCallId: "call-ui-exec" }]);
+    });
+
     it("handlePendingApprovals skips no-execute tools instead of throwing (stale-client defense)", async () => {
       // The new client resolves an APPROVED ui_* call by executing it and
       // shipping the tool-result, never a bare approval response. If a

--- a/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
@@ -3,6 +3,7 @@ import {
   executeToolCallsFromMessages,
   hasUnresolvedToolCalls,
 } from "@/shared/http-tool-calls";
+import { classifyUiToolApprovals } from "@/shared/client-fulfilled-tools";
 import { handleMCPJamFreeChatModel } from "../mcpjam-stream-handler";
 import { serializeToolsForConvex } from "../mcpjam-tool-helpers";
 import { createHostedRpcLogCollector } from "../../routes/web/hosted-rpc-logs.js";
@@ -1594,7 +1595,21 @@ describe("mcpjam-stream-handler", () => {
           getAllToolsMetadata: vi.fn().mockReturnValue({}),
         } as any,
         requireToolApproval: true,
-        approvalFreeUiToolNames: new Set(["ui_snapshot_app"]),
+        uiToolApprovals: classifyUiToolApprovals(
+          [
+            {
+              name: "ui_snapshot_app",
+              readOnly: true,
+              annotations: { readOnlyHint: true, destructiveHint: false },
+            },
+            {
+              name: "ui_navigate",
+              readOnly: false,
+              annotations: { readOnlyHint: false, destructiveHint: false },
+            },
+          ],
+          true
+        ),
       });
 
       await lastExecution;
@@ -1606,6 +1621,110 @@ describe("mcpjam-stream-handler", () => {
       // flows straight through to client fulfillment with no pill.
       expect(approvalRequests).toHaveLength(1);
       expect(approvalRequests[0]).toMatchObject({ toolCallId: "call-ui-2" });
+    });
+
+    it("emits an approval request for a DESTRUCTIVE ui_* tool when the approval flag is OFF", async () => {
+      // The regression this classification exists to prevent: the gate used to
+      // read `requireToolApproval && !isApprovalFree(name)`, so with the flag
+      // off — the default on every agent surface — a destructive
+      // client-fulfilled call got no pill, and the client's orphaned-defer
+      // fallback then executed it unconfirmed.
+      global.fetch = vi.fn().mockResolvedValue(
+        createSseResponse([
+          {
+            type: "tool-input-available",
+            toolCallId: "call-ui-exec",
+            toolName: "ui_execute_tool",
+            input: { toolName: "delete_everything" },
+          },
+          {
+            type: "tool-input-available",
+            toolCallId: "call-ui-nav",
+            toolName: "ui_navigate",
+            input: { target: "servers" },
+          },
+          { type: "finish", finishReason: "stop" },
+        ])
+      );
+
+      await handleMCPJamFreeChatModel({
+        messages: [{ role: "user", content: "run it" }] as any,
+        modelId: "gpt-4.1-mini",
+        systemPrompt: "You are helpful",
+        tools: { ui_execute_tool: {}, ui_navigate: {} } as any,
+        mcpClientManager: {
+          getAllToolsMetadata: vi.fn().mockReturnValue({}),
+        } as any,
+        requireToolApproval: false,
+        uiToolApprovals: classifyUiToolApprovals(
+          [
+            {
+              name: "ui_execute_tool",
+              readOnly: false,
+              annotations: { readOnlyHint: false, destructiveHint: true },
+            },
+            {
+              name: "ui_navigate",
+              readOnly: false,
+              annotations: { readOnlyHint: false, destructiveHint: false },
+            },
+          ],
+          false
+        ),
+      });
+
+      await lastExecution;
+
+      const approvalRequests = writtenChunks.filter(
+        (chunk: any) => chunk.type === "tool-approval-request"
+      );
+      expect(approvalRequests).toHaveLength(1);
+      expect(approvalRequests[0]).toMatchObject({ toolCallId: "call-ui-exec" });
+    });
+
+    it("does not emit approval requests for real MCP tools when the flag is OFF", async () => {
+      // The UI classification must not leak into real-tool policy: unknown
+      // names still follow `requireToolApproval`.
+      global.fetch = vi.fn().mockResolvedValue(
+        createSseResponse([
+          {
+            type: "tool-input-available",
+            toolCallId: "call-real",
+            toolName: "some_mcp_tool",
+            input: {},
+          },
+          { type: "finish", finishReason: "stop" },
+        ])
+      );
+
+      await handleMCPJamFreeChatModel({
+        messages: [{ role: "user", content: "go" }] as any,
+        modelId: "gpt-4.1-mini",
+        systemPrompt: "You are helpful",
+        tools: { some_mcp_tool: {} } as any,
+        mcpClientManager: {
+          getAllToolsMetadata: vi.fn().mockReturnValue({}),
+        } as any,
+        requireToolApproval: false,
+        uiToolApprovals: classifyUiToolApprovals(
+          [
+            {
+              name: "ui_execute_tool",
+              readOnly: false,
+              annotations: { readOnlyHint: false, destructiveHint: true },
+            },
+          ],
+          false
+        ),
+      });
+
+      await lastExecution;
+
+      expect(
+        writtenChunks.filter(
+          (chunk: any) => chunk.type === "tool-approval-request"
+        )
+      ).toHaveLength(0);
     });
 
     it("read-only ui_* calls skip the approval pause classifier (no drain filter)", async () => {
@@ -1634,14 +1753,24 @@ describe("mcpjam-stream-handler", () => {
           getAllToolsMetadata: vi.fn().mockReturnValue({}),
         } as any,
         requireToolApproval: true,
-        approvalFreeUiToolNames: new Set(["ui_snapshot_app"]),
+        uiToolApprovals: classifyUiToolApprovals(
+          [
+            {
+              name: "ui_snapshot_app",
+              readOnly: true,
+              annotations: { readOnlyHint: true, destructiveHint: false },
+            },
+          ],
+          true
+        ),
       });
 
       await lastExecution;
 
-      // With the exemption, the step has no unresolved REAL tool call, so
-      // the approval branch (whose executor call carries `filterToolName`)
-      // is skipped — the normal client-fulfilled execution path runs.
+      // With the exemption, the step has no unresolved approval-required tool
+      // call, so the approval branch (whose executor call carries
+      // `filterToolName`) is skipped — the normal client-fulfilled execution
+      // path runs.
       const calls = vi.mocked(executeToolCallsFromMessages).mock.calls;
       expect(calls.length).toBeGreaterThan(0);
       for (const call of calls) {

--- a/mcpjam-inspector/server/utils/__tests__/org-model-stream-handler-headless.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/org-model-stream-handler-headless.test.ts
@@ -201,6 +201,37 @@ describe("runLocalOrgChatTurnHeadless", () => {
     expect(runDirectChatTurnMock).not.toHaveBeenCalled();
   });
 
+  it("allows a turn whose only tools are client-fulfilled (no execute)", async () => {
+    // Approving one of these is resolved by the BROWSER shipping a result —
+    // it never needs the server-side resume this guard exists to demand.
+    stubEngineTurn({ responseMessages: [] });
+    await runLocalOrgChatTurnHeadless(
+      baseOptions({
+        requireToolApproval: true,
+        tools: { ui_execute_tool: { description: "no execute here" } },
+      }),
+    );
+    expect(runDirectChatTurnMock).toHaveBeenCalled();
+  });
+
+  it("still guards a server-executed tool that merely LOOKS client-fulfilled", async () => {
+    // A real MCP server tool named `ui_foo` matches the namespace regex while
+    // still having an `execute`. Exempting on the name alone would run it here
+    // without the approval support the guard demands — the same reason the
+    // client dispatches on registry membership, not the `ui_` prefix.
+    await expect(
+      runLocalOrgChatTurnHeadless(
+        baseOptions({
+          requireToolApproval: true,
+          tools: {
+            ui_foo: { description: "impostor", execute: async () => ({}) },
+          },
+        }),
+      ),
+    ).rejects.toThrow(/Tool approval is not supported/i);
+    expect(runDirectChatTurnMock).not.toHaveBeenCalled();
+  });
+
   it("throws config/allowlist failures instead of returning an error stream", async () => {
     assertOrgModelAllowedMock.mockImplementation(() => {
       throw new Error("model not allowed for this org");

--- a/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
+++ b/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
@@ -41,6 +41,7 @@ import { isGPT5Model, type ModelDefinition } from "@/shared/types";
 import {
   UI_TOOL_NAME_REGEX,
   uiToolCallNeedsApproval,
+  type UiToolAnnotations,
 } from "@/shared/client-fulfilled-tools";
 import { HOSTED_MODE } from "../config.js";
 import {
@@ -273,6 +274,49 @@ export function validateAppToolEntries(input: unknown): AppToolEntry[] {
   return out;
 }
 
+/** MCP `ToolAnnotations` hints accepted on a UI tool snapshot entry. */
+const UI_TOOL_ANNOTATION_KEYS = [
+  "readOnlyHint",
+  "destructiveHint",
+  "idempotentHint",
+  "openWorldHint",
+] as const;
+
+/**
+ * Validate the optional `annotations` object on a UI tool snapshot entry.
+ *
+ * Boolean-only, known keys only. Unknown keys are rejected rather than
+ * dropped: this snapshot drives approval policy, so a typo'd hint must not
+ * pass silently as "absent" (which, for `destructiveHint`, flips the meaning
+ * from additive to destructive).
+ */
+function validateUiToolAnnotations(
+  raw: unknown,
+  index: number
+): UiToolAnnotations | undefined {
+  if (raw === undefined) return undefined;
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new UiToolValidationError(
+      `uiTools[${index}].annotations must be an object`
+    );
+  }
+  const out: UiToolAnnotations = {};
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (!(UI_TOOL_ANNOTATION_KEYS as readonly string[]).includes(key)) {
+      throw new UiToolValidationError(
+        `uiTools[${index}].annotations has unknown key '${key}'`
+      );
+    }
+    if (typeof value !== "boolean") {
+      throw new UiToolValidationError(
+        `uiTools[${index}].annotations.${key} must be a boolean`
+      );
+    }
+    out[key as (typeof UI_TOOL_ANNOTATION_KEYS)[number]] = value;
+  }
+  return out;
+}
+
 /**
  * Validate and normalize the client-supplied `uiTools` snapshot.
  *
@@ -357,11 +401,24 @@ export function validateUiToolEntries(input: unknown): UiToolEntry[] {
         `uiTools[${i}].readOnly must be a boolean`
       );
     }
+    const annotations = validateUiToolAnnotations(raw.annotations, i);
+    if (
+      annotations?.readOnlyHint !== undefined &&
+      annotations.readOnlyHint !== raw.readOnly
+    ) {
+      // A snapshot that says both "read-only" and "not read-only" has no safe
+      // reading: trusting `readOnlyHint` would let a contradictory entry skip
+      // approval. Reject rather than pick a winner.
+      throw new UiToolValidationError(
+        `uiTools[${i}].annotations.readOnlyHint must equal readOnly`
+      );
+    }
     out.push({
       name,
       description: raw.description,
       inputSchema,
       readOnly: raw.readOnly,
+      ...(annotations ? { annotations } : {}),
     });
   }
   return out;
@@ -708,6 +765,7 @@ export function buildUiTools(
       inputSchema: t.inputSchema,
       needsApproval: uiToolCallNeedsApproval({
         readOnly: t.readOnly,
+        annotations: t.annotations,
         requireToolApproval: opts?.requireToolApproval === true,
       }),
     });
@@ -730,11 +788,9 @@ export function buildUiToolsSystemPrompt(
     "Prefer `ui_open_playground` before `ui_select_tool` / `ui_execute_tool` / `ui_snapshot_app`. `ui_execute_tool` REALLY runs a tool against the user's connected MCP server — treat it as side-effectful; when the user hasn't clearly asked to run a tool, prefill it with `ui_select_tool` instead.",
     "`ui_snapshot_app` is read-only and needs the playground open — use it to observe state before mutating it.",
     "When a `ui_*` tool returns an error, relay the reason instead of retrying blindly.",
-    ...(opts?.requireToolApproval
-      ? [
-          "Mutating `ui_*` actions pause for the user's explicit approval before they run. A denial is final — explain what you wanted to do instead of retrying the call.",
-        ]
-      : []),
+    opts?.requireToolApproval
+      ? "Every mutating `ui_*` action pauses for the user's explicit approval before it runs. A denial is final — explain what you wanted to do instead of retrying the call."
+      : "Destructive `ui_*` actions pause for the user's explicit approval before they run; other actions apply immediately. A denial is final — explain what you wanted to do instead of retrying the call.",
   ].join("\n");
 }
 

--- a/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
+++ b/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
@@ -788,10 +788,29 @@ export function buildUiToolsSystemPrompt(
     "Prefer `ui_open_playground` before `ui_select_tool` / `ui_execute_tool` / `ui_snapshot_app`. `ui_execute_tool` REALLY runs a tool against the user's connected MCP server — treat it as side-effectful; when the user hasn't clearly asked to run a tool, prefill it with `ui_select_tool` instead.",
     "`ui_snapshot_app` is read-only and needs the playground open — use it to observe state before mutating it.",
     "When a `ui_*` tool returns an error, relay the reason instead of retrying blindly.",
-    opts?.requireToolApproval
-      ? "Every mutating `ui_*` action pauses for the user's explicit approval before it runs. A denial is final — explain what you wanted to do instead of retrying the call."
-      : "Destructive `ui_*` actions pause for the user's explicit approval before they run; other actions apply immediately. A denial is final — explain what you wanted to do instead of retrying the call.",
+    approvalGuidance(uiTools, opts?.requireToolApproval === true),
   ].join("\n");
+}
+
+/**
+ * The approval sentence, told honestly for the snapshot that was actually
+ * sent. The destructive-pauses promise only holds when EVERY entry is
+ * annotation-aware — a legacy client sends bare `readOnly`, whose predicate
+ * with the flag off is `requireToolApproval && !readOnly`, i.e. nothing
+ * pauses. Promising a destructive gate there advertises a safety net that
+ * isn't there.
+ */
+function approvalGuidance(
+  uiTools: UiToolEntry[],
+  requireToolApproval: boolean
+): string {
+  if (requireToolApproval) {
+    return "Every mutating `ui_*` action pauses for the user's explicit approval before it runs. A denial is final — explain what you wanted to do instead of retrying the call.";
+  }
+  const annotationAware = uiTools.every((t) => t.annotations !== undefined);
+  return annotationAware
+    ? "Destructive `ui_*` actions pause for the user's explicit approval before they run; other actions apply immediately. A denial is final — explain what you wanted to do instead of retrying the call."
+    : "Every `ui_*` action applies immediately, so be deliberate about mutating ones — describe what you're about to do when it isn't obviously what the user asked for.";
 }
 
 export interface PrepareChatV2Result {

--- a/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
@@ -2933,8 +2933,16 @@ export async function runChatEngineLoop(
 
       startHeartbeat();
 
-      // Process any pending approval responses from a previous request
-      if (requireToolApproval) {
+      // Process any pending approval responses from a previous request.
+      //
+      // The UI classification has to be honored here too, not just at the
+      // emit gate. With the flag off, a destructive `ui_*` call now pauses
+      // for approval — and DENYING it sends an approval response back (the
+      // approve path ships a tool-result instead). Gating this on
+      // `requireToolApproval` alone would leave that denial unprocessed and
+      // the tool call unresolved: the turn would hang forever, which is the
+      // exact failure the two-sided predicate exists to prevent.
+      if (requireToolApproval || (uiToolApprovals?.requiredNames.size ?? 0) > 0) {
         const handled = await handlePendingApprovals(
           safeWriter,
           messageHistory,

--- a/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
@@ -161,12 +161,17 @@ function toolCallNeedsApproval(
   name: string,
   progressivePlan: ProgressiveToolPlan | undefined,
   uiToolApprovals: UiToolApprovalClassification | undefined,
-  requireToolApproval: boolean
+  // `boolean | undefined`, not `boolean`: the callers thread through an
+  // optional `requireToolApproval`, and this file is server-side (not covered
+  // by the client typecheck), so a bare `boolean` param let `undefined` flow
+  // in and `return requireToolApproval` hand back `undefined` for a real
+  // tool. Coerce so the return is always a real boolean.
+  requireToolApproval: boolean | undefined
 ): boolean {
   if (uiToolApprovals?.requiredNames.has(name)) return true;
   if (uiToolApprovals?.freeNames.has(name)) return false;
   if (isApprovalFreeMetaToolName(name, progressivePlan)) return false;
-  return requireToolApproval;
+  return requireToolApproval === true;
 }
 import { logger } from "./logger";
 import {

--- a/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
@@ -44,7 +44,10 @@ import {
   hasUnresolvedToolCalls,
   executeToolCallsFromMessages,
 } from "@/shared/http-tool-calls";
-import { isClientFulfilledToolName } from "@/shared/client-fulfilled-tools";
+import {
+  isClientFulfilledToolName,
+  type UiToolApprovalClassification,
+} from "@/shared/client-fulfilled-tools";
 import {
   scrubUnavailableToolHistoryForBackend,
   scrubMcpAppsToolResultsForBackend,
@@ -139,20 +142,31 @@ function isApprovalFreeMetaToolName(
 }
 
 /**
- * Union of the approval exemptions this loop honors: progressive-discovery
- * meta-tools, plus the read-only WebMCP UI tools this turn advertised
- * (`approvalFreeUiToolNames`, computed by the caller from the validated
- * `uiTools` snapshot — never from the raw name, which a third-party server
- * could spoof). Read-only UI tools observe rather than mutate, so they flow
- * through the normal client-fulfilled pause with no approval pill.
+ * Whether THIS tool call must pause for the user's approval.
+ *
+ * The turn's `requireToolApproval` flag is the rule for real MCP tools only.
+ * WebMCP `ui_*` tools carry their own per-tool policy, pre-computed by the
+ * caller into `uiToolApprovals` (from the VALIDATED snapshot's MCP
+ * annotations — never from the raw name, which a third-party server could
+ * spoof). A destructive UI tool must gate even when the flag is OFF, which is
+ * the default: writing this as `requireToolApproval && !isApprovalFree(...)`
+ * is what silently let destructive client-fulfilled calls through.
+ *
+ * Order matters. UI classification wins over the flag in both directions:
+ *   - in `requiredNames` → approval, flag or no flag;
+ *   - in `freeNames` → never (a read-only snapshot buys nothing by pausing);
+ *   - unknown name → a real tool: follow the flag, exempting meta-tools.
  */
-function isApprovalFreeToolCallName(
+function toolCallNeedsApproval(
   name: string,
   progressivePlan: ProgressiveToolPlan | undefined,
-  approvalFreeUiToolNames: ReadonlySet<string> | undefined
+  uiToolApprovals: UiToolApprovalClassification | undefined,
+  requireToolApproval: boolean
 ): boolean {
-  if (isApprovalFreeMetaToolName(name, progressivePlan)) return true;
-  return approvalFreeUiToolNames?.has(name) === true;
+  if (uiToolApprovals?.requiredNames.has(name)) return true;
+  if (uiToolApprovals?.freeNames.has(name)) return false;
+  if (isApprovalFreeMetaToolName(name, progressivePlan)) return false;
+  return requireToolApproval;
 }
 import { logger } from "./logger";
 import {
@@ -434,11 +448,13 @@ export interface MCPJamHandlerOptions {
   harnessMcpProxy?: HarnessMcpProxyStrategy;
   requireToolApproval?: boolean;
   /**
-   * Names of read-only `ui_*` tools from this turn's validated snapshot —
-   * exempt from the approval gate even when `requireToolApproval` is on
-   * (see `isApprovalFreeToolCallName`).
+   * Per-tool approval policy for the `ui_*` tools this turn advertised,
+   * classified by the caller from the validated snapshot's MCP annotations
+   * (see `classifyUiToolApprovals`). Overrides `requireToolApproval` in both
+   * directions for those names — destructive UI tools gate even when the flag
+   * is off; read-only ones never gate.
    */
-  approvalFreeUiToolNames?: ReadonlySet<string>;
+  uiToolApprovals?: UiToolApprovalClassification;
   /**
    * Host/client policy for eligible MCP tool-result content/resources.
    * Controls only model-facing tool output; raw results remain available to
@@ -612,7 +628,7 @@ interface StepContext {
   mcpClientManager: MCPClientManager;
   selectedServers?: string[];
   requireToolApproval?: boolean;
-  approvalFreeUiToolNames?: ReadonlySet<string>;
+  uiToolApprovals?: UiToolApprovalClassification;
   modelVisibleMcpToolResults?: ModelVisibleMcpToolResults;
   approvalMode?: "prompt" | "auto-deny";
   stepIndex: number;
@@ -1110,7 +1126,7 @@ async function processStream(
   // supplied. Chat / synthetic omit (handler still writes the UI
   // chunk + trace event unchanged).
   onToolCall?: (event: MCPJamToolCallEvent) => void,
-  approvalFreeUiToolNames?: ReadonlySet<string>
+  uiToolApprovals?: UiToolApprovalClassification
 ): Promise<StreamResult> {
   const contentParts: PersistedAssistantPart[] = [];
   let pendingText = "";
@@ -1337,11 +1353,11 @@ async function processStream(
           }
 
           if (
-            requireToolApproval &&
-            !isApprovalFreeToolCallName(
+            toolCallNeedsApproval(
               chunk.toolName,
               progressivePlan,
-              approvalFreeUiToolNames
+              uiToolApprovals,
+              requireToolApproval
             )
           ) {
             emitToolApprovalRequest(writer, {
@@ -1890,7 +1906,7 @@ async function processOneStep(
     mcpClientManager,
     selectedServers,
     requireToolApproval,
-    approvalFreeUiToolNames,
+    uiToolApprovals,
     modelVisibleMcpToolResults,
     approvalMode,
     stepIndex,
@@ -2166,7 +2182,7 @@ async function processOneStep(
     abortSignal,
     progressivePlan,
     onToolCall,
-    approvalFreeUiToolNames
+    uiToolApprovals
   );
   const llmEndAbs = Date.now();
   traceTurn.turnUsage = mergeLiveChatTraceUsage(
@@ -2206,12 +2222,13 @@ async function processOneStep(
 
   // Check for unresolved tool calls and execute them
   if (hasUnresolvedToolCalls(messageHistory)) {
-    // Meta-tools (search_mcp_tools / load_mcp_tools) are approval-free even
-    // when the user enabled `requireToolApproval` — gating progressive
-    // discovery itself behind N approvals defeats the point. We only pause
-    // when at least one unresolved tool call is a real MCP tool. Pure-meta
+    // We only pause when at least one unresolved tool call actually needs
+    // approval this turn (`toolCallNeedsApproval`): a real MCP tool while the
+    // flag is on, or a destructive `ui_*` tool in any mode. Meta-tools
+    // (search_mcp_tools / load_mcp_tools) never qualify — gating progressive
+    // discovery itself behind N approvals defeats the point — so pure-meta
     // turns fall through to execute and continue the loop.
-    const hasUnresolvedRealToolCall = (() => {
+    const hasUnresolvedApprovalRequiredToolCall = (() => {
       const resultIds = new Set<string>();
       for (const msg of messageHistory) {
         if (msg?.role !== "tool") continue;
@@ -2227,10 +2244,11 @@ async function processOneStep(
           if (
             part.type === "tool-call" &&
             !resultIds.has(part.toolCallId) &&
-            !isApprovalFreeToolCallName(
+            toolCallNeedsApproval(
               part.toolName,
               progressivePlan,
-              approvalFreeUiToolNames
+              uiToolApprovals,
+              requireToolApproval
             )
           ) {
             return true;
@@ -2240,16 +2258,12 @@ async function processOneStep(
       return false;
     })();
 
-    if (
-      requireToolApproval &&
-      hasUnresolvedRealToolCall &&
-      approvalMode === "auto-deny"
-    ) {
+    if (hasUnresolvedApprovalRequiredToolCall && approvalMode === "auto-deny") {
       // Synthetic-session path: instead of pausing the loop for a
       // human approval that will never come, synthesize a denial
-      // tool-result for every approval-required unresolved real
-      // tool call so the model can react and continue. Meta-tool
-      // calls in the same step still execute normally below.
+      // tool-result for every approval-required unresolved tool call
+      // so the model can react and continue. Meta-tool calls in the
+      // same step still execute normally below.
       const resultIds = new Set<string>();
       for (const msg of messageHistory) {
         if (msg?.role !== "tool") continue;
@@ -2267,10 +2281,11 @@ async function processOneStep(
           if (
             part.type !== "tool-call" ||
             resultIds.has(part.toolCallId) ||
-            isApprovalFreeToolCallName(
+            !toolCallNeedsApproval(
               part.toolName,
               progressivePlan,
-              approvalFreeUiToolNames
+              uiToolApprovals,
+              requireToolApproval
             )
           ) {
             continue;
@@ -2317,11 +2332,7 @@ async function processOneStep(
       // denials count as resolved tool-results for the next step.
     }
 
-    if (
-      requireToolApproval &&
-      hasUnresolvedRealToolCall &&
-      approvalMode !== "auto-deny"
-    ) {
+    if (hasUnresolvedApprovalRequiredToolCall && approvalMode !== "auto-deny") {
       // Drain any unresolved meta-tool calls (search/load) before pausing
       // for approval on real tools. Otherwise mixed-step turns (model
       // emits a load_mcp_tools + a real tool in one assistant message)
@@ -2710,7 +2721,7 @@ export async function runChatEngineLoop(
     mcpClientManager,
     selectedServers,
     requireToolApproval,
-    approvalFreeUiToolNames,
+    uiToolApprovals,
     modelVisibleMcpToolResults,
     approvalMode,
     onConversationComplete,
@@ -2966,7 +2977,7 @@ export async function runChatEngineLoop(
           mcpClientManager,
           selectedServers,
           requireToolApproval,
-          approvalFreeUiToolNames,
+          uiToolApprovals,
           modelVisibleMcpToolResults,
           approvalMode,
           stepIndex: effectiveSteps(),

--- a/mcpjam-inspector/server/utils/org-model-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/org-model-stream-handler.ts
@@ -37,6 +37,10 @@ import {
   OrgProviderConfigError,
   type OrgProviderResolvedConfig,
 } from "@mcpjam/sdk/model-factory";
+import {
+  isClientFulfilledToolName,
+  type UiToolApprovalClassification,
+} from "@/shared/client-fulfilled-tools";
 import type { PersistedTurnTrace } from "./chat-ingestion";
 import { handleMCPJamFreeChatModel } from "./mcpjam-stream-handler.js";
 import { logger } from "./logger.js";
@@ -79,8 +83,8 @@ export interface OrgModelHandlerOptions {
   selectedServers?: string[];
   serverIds?: string[];
   requireToolApproval?: boolean;
-  /** Read-only ui_* names exempt from the approval gate (see MCPJam loop). */
-  approvalFreeUiToolNames?: ReadonlySet<string>;
+  /** Per-tool ui_* approval policy (see `classifyUiToolApprovals`). */
+  uiToolApprovals?: UiToolApprovalClassification;
   /** Host/client policy for eligible MCP tool-result content/resources. */
   modelVisibleMcpToolResults?: ModelVisibleMcpToolResults;
   /**
@@ -297,6 +301,31 @@ export interface OrgLocalModelHandlerOptions {
   synthesisRunId?: string;
 }
 
+/**
+ * Whether this local-runtime turn hits the approval gap the handler cannot
+ * serve, and must fail loudly instead.
+ *
+ * The gap is SERVER-EXECUTED tools: approving one resumes the turn by running
+ * it here, and that resume path has never been supported (or tested) on the
+ * local org runtime.
+ *
+ * Client-fulfilled tools (`ui_*`, `app_*`) don't need it. Their approval is
+ * emitted natively by `streamText` from the per-tool `needsApproval` that
+ * `buildUiTools` set, and an approval is resolved by the BROWSER executing the
+ * tool and supplying the result via `addToolOutput` — the engine only has to
+ * accept a history that already contains the output. That is the same path
+ * route 4 (personal BYOK) drives through this very engine today, so refusing
+ * it here would break the UI-only agent surface for local-runtime orgs while
+ * protecting nothing.
+ */
+function hasUnsupportedLocalApprovalGate(
+  tools: ToolSet,
+  requireToolApproval: boolean | undefined
+): boolean {
+  if (!requireToolApproval) return false;
+  return Object.keys(tools).some((name) => !isClientFulfilledToolName(name));
+}
+
 export function handleLocalOrgChatModel(
   options: OrgLocalModelHandlerOptions
 ): Response {
@@ -314,7 +343,7 @@ export function handleLocalOrgChatModel(
     onLiveTextDelta,
   } = options;
 
-  if (requireToolApproval && Object.keys(tools).length > 0) {
+  if (hasUnsupportedLocalApprovalGate(tools, requireToolApproval)) {
     const stream = createUIMessageStream({
       onError: (error) => formatLocalStreamError(error),
       onFinish: async () => {
@@ -606,7 +635,7 @@ export async function runLocalOrgChatTurnHeadless(
   const { provider, modelId, messages, systemPrompt, temperature, tools } =
     options;
 
-  if (options.requireToolApproval && Object.keys(tools).length > 0) {
+  if (hasUnsupportedLocalApprovalGate(tools, options.requireToolApproval)) {
     throw new Error(
       "Tool approval is not supported for local-runtime org providers yet. Disable tool approval or switch this provider to cloud runtime."
     );
@@ -804,7 +833,7 @@ export async function handleHostedOrgChatModel(
     mcpClientManager: options.mcpClientManager,
     selectedServers: options.selectedServers,
     requireToolApproval: options.requireToolApproval,
-    approvalFreeUiToolNames: options.approvalFreeUiToolNames,
+    uiToolApprovals: options.uiToolApprovals,
     modelVisibleMcpToolResults: options.modelVisibleMcpToolResults,
     ...(options.approvalMode !== undefined
       ? { approvalMode: options.approvalMode }

--- a/mcpjam-inspector/server/utils/org-model-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/org-model-stream-handler.ts
@@ -323,7 +323,18 @@ function hasUnsupportedLocalApprovalGate(
   requireToolApproval: boolean | undefined
 ): boolean {
   if (!requireToolApproval) return false;
-  return Object.keys(tools).some((name) => !isClientFulfilledToolName(name));
+  return Object.entries(tools).some(([name, tool]) => {
+    if (!isClientFulfilledToolName(name)) return true;
+    // Name is necessary but NOT sufficient. A real MCP server tool called
+    // `ui_foo` matches the namespace regex while still having an `execute`,
+    // and exempting it on the name alone would let it run here without the
+    // approval support this guard exists to demand. Same reason the client
+    // dispatches on registry membership rather than the `ui_` prefix: the
+    // property that matters is "the browser fulfills this", and only the
+    // missing `execute` actually proves it.
+    return typeof (tool as { execute?: unknown } | undefined)?.execute ===
+      "function";
+  });
 }
 
 export function handleLocalOrgChatModel(

--- a/mcpjam-inspector/server/utils/web-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/web-chat-turn.ts
@@ -68,6 +68,10 @@ import type { HarnessSessionCommitPayload } from "./harness/harness-session-stat
 import { exportConnectedServerToolSnapshotForEvalAuthoring } from "./export-helpers.js";
 import { ErrorCode, WebRouteError } from "./../routes/web/errors.js";
 import { readUrlElicitations } from "@/shared/http-tool-calls";
+import {
+  classifyUiToolApprovals,
+  type UiToolApprovalClassification,
+} from "@/shared/client-fulfilled-tools";
 import type { createHostedRpcLogCollector } from "./../routes/web/hosted-rpc-logs.js";
 import type { HostedElicitationBridge } from "./../routes/web/hosted-elicitation.js";
 import { bridgeHarnessRpcLogsToCollector } from "./../routes/web/hosted-rpc-logs.js";
@@ -208,16 +212,18 @@ export interface StreamWebChatTurnArgs {
 }
 
 /**
- * Read-only `ui_*` names from the validated snapshot — exempt from the
- * MCPJam loop's approval gate (see `isApprovalFreeToolCallName` in
- * mcpjam-stream-handler). Computed from the VALIDATED entries' `readOnly`
- * flag, never from the raw name, which a third-party server could spoof.
+ * Per-tool approval policy for this turn's `ui_*` tools, from the VALIDATED
+ * snapshot's MCP annotations — never from the raw name, which a third-party
+ * server could spoof. Consumed by the MCPJam loop's approval gate (see
+ * `toolCallNeedsApproval` in mcpjam-stream-handler); the BYOK `streamText`
+ * path gets the same policy baked into each tool's `needsApproval` by
+ * `buildUiTools`.
  */
-function approvalFreeUiToolNamesFrom(
-  uiTools: UiToolEntry[] | undefined
-): ReadonlySet<string> | undefined {
-  const names = (uiTools ?? []).filter((t) => t.readOnly).map((t) => t.name);
-  return names.length > 0 ? new Set(names) : undefined;
+function uiToolApprovalsFrom(
+  uiTools: UiToolEntry[] | undefined,
+  requireToolApproval: boolean | undefined
+): UiToolApprovalClassification {
+  return classifyUiToolApprovals(uiTools, requireToolApproval === true);
 }
 
 /**
@@ -558,7 +564,10 @@ export async function streamWebChatTurn(
       selectedServers: persist.selectedServerIds,
       serverIds: persist.selectedServerIds,
       requireToolApproval: persist.requireToolApproval,
-      approvalFreeUiToolNames: approvalFreeUiToolNamesFrom(prepare.uiTools),
+      uiToolApprovals: uiToolApprovalsFrom(
+        prepare.uiTools,
+        persist.requireToolApproval
+      ),
       modelVisibleMcpToolResults: prepare.modelVisibleMcpToolResults,
       onConversationComplete,
       onStreamComplete: cleanupStream,
@@ -620,7 +629,10 @@ export async function streamWebChatTurn(
     mcpClientManager: manager,
     selectedServers: persist.selectedServerIds,
     requireToolApproval: persist.requireToolApproval,
-    approvalFreeUiToolNames: approvalFreeUiToolNamesFrom(prepare.uiTools),
+    uiToolApprovals: uiToolApprovalsFrom(
+        prepare.uiTools,
+        persist.requireToolApproval
+      ),
     modelVisibleMcpToolResults: prepare.modelVisibleMcpToolResults,
     ...(persist.harness ? { harness: persist.harness } : {}),
     ...(harnessMcpProxy ? { harnessMcpProxy } : {}),

--- a/mcpjam-inspector/shared/__tests__/client-fulfilled-tools.test.ts
+++ b/mcpjam-inspector/shared/__tests__/client-fulfilled-tools.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  classifyUiToolApprovals,
   isAppToolAlias,
   isClientFulfilledToolName,
   isUiToolName,
@@ -36,7 +37,7 @@ describe("client-fulfilled tool names", () => {
     expect(isClientFulfilledToolName("ui-navigate")).toBe(false);
   });
 
-  it("uiToolCallNeedsApproval gates mutating tools only when the flag is on", () => {
+  it("uiToolCallNeedsApproval gates mutating tools only when the flag is on (legacy, no annotations)", () => {
     // The truth table both the server gate and the client defer read.
     expect(
       uiToolCallNeedsApproval({ readOnly: false, requireToolApproval: true })
@@ -50,5 +51,167 @@ describe("client-fulfilled tool names", () => {
     expect(
       uiToolCallNeedsApproval({ readOnly: true, requireToolApproval: false })
     ).toBe(false);
+  });
+
+  describe("uiToolCallNeedsApproval with MCP annotations", () => {
+    const additive = { readOnlyHint: false, destructiveHint: false };
+    const destructive = { readOnlyHint: false, destructiveHint: true };
+    const readOnly = { readOnlyHint: true, destructiveHint: false };
+
+    it("gates destructive tools even when the flag is OFF", () => {
+      // The whole point of the annotation work: `requireToolApproval` is off
+      // by default, and a destructive action must still confirm.
+      expect(
+        uiToolCallNeedsApproval({
+          readOnly: false,
+          annotations: destructive,
+          requireToolApproval: false,
+        })
+      ).toBe(true);
+    });
+
+    it("does not gate additive tools when the flag is OFF", () => {
+      expect(
+        uiToolCallNeedsApproval({
+          readOnly: false,
+          annotations: additive,
+          requireToolApproval: false,
+        })
+      ).toBe(false);
+    });
+
+    it("gates every mutating tool when the flag is ON", () => {
+      for (const annotations of [additive, destructive]) {
+        expect(
+          uiToolCallNeedsApproval({
+            readOnly: false,
+            annotations,
+            requireToolApproval: true,
+          })
+        ).toBe(true);
+      }
+    });
+
+    it("never gates read-only tools, in either mode", () => {
+      for (const requireToolApproval of [true, false]) {
+        expect(
+          uiToolCallNeedsApproval({
+            readOnly: true,
+            annotations: readOnly,
+            requireToolApproval,
+          })
+        ).toBe(false);
+      }
+    });
+
+    it("treats an absent destructiveHint as destructive (protocol default)", () => {
+      // A tool added without annotating destructiveHint must fail SAFE.
+      expect(
+        uiToolCallNeedsApproval({
+          readOnly: false,
+          annotations: { readOnlyHint: false },
+          requireToolApproval: false,
+        })
+      ).toBe(true);
+      expect(
+        uiToolCallNeedsApproval({
+          readOnly: false,
+          annotations: {},
+          requireToolApproval: false,
+        })
+      ).toBe(true);
+    });
+
+    it("ignores non-approval hints", () => {
+      expect(
+        uiToolCallNeedsApproval({
+          readOnly: false,
+          annotations: {
+            ...additive,
+            idempotentHint: false,
+            openWorldHint: true,
+          },
+          requireToolApproval: false,
+        })
+      ).toBe(false);
+    });
+  });
+
+  describe("classifyUiToolApprovals", () => {
+    const entries = [
+      {
+        name: "ui_snapshot_app",
+        readOnly: true,
+        annotations: { readOnlyHint: true, destructiveHint: false },
+      },
+      {
+        name: "ui_navigate",
+        readOnly: false,
+        annotations: { readOnlyHint: false, destructiveHint: false },
+      },
+      {
+        name: "ui_execute_tool",
+        readOnly: false,
+        annotations: { readOnlyHint: false, destructiveHint: true },
+      },
+    ];
+
+    it("splits destructive from free in default mode", () => {
+      const { requiredNames, freeNames } = classifyUiToolApprovals(
+        entries,
+        false
+      );
+      expect([...requiredNames]).toEqual(["ui_execute_tool"]);
+      expect([...freeNames].sort()).toEqual(["ui_navigate", "ui_snapshot_app"]);
+    });
+
+    it("moves every mutating tool to required in strict mode, keeping read-only free", () => {
+      const { requiredNames, freeNames } = classifyUiToolApprovals(
+        entries,
+        true
+      );
+      expect([...requiredNames].sort()).toEqual([
+        "ui_execute_tool",
+        "ui_navigate",
+      ]);
+      // Strict mode still must not pause a snapshot — this is why the engine
+      // needs `freeNames` and not just "absent from requiredNames".
+      expect([...freeNames]).toEqual(["ui_snapshot_app"]);
+    });
+
+    it("places every entry in exactly one set", () => {
+      for (const strict of [true, false]) {
+        const { requiredNames, freeNames } = classifyUiToolApprovals(
+          entries,
+          strict
+        );
+        expect(requiredNames.size + freeNames.size).toBe(entries.length);
+        for (const name of requiredNames) {
+          expect(freeNames.has(name)).toBe(false);
+        }
+      }
+    });
+
+    it("handles an absent snapshot", () => {
+      const { requiredNames, freeNames } = classifyUiToolApprovals(
+        undefined,
+        false
+      );
+      expect(requiredNames.size).toBe(0);
+      expect(freeNames.size).toBe(0);
+    });
+
+    it("classifies legacy entries (no annotations) by the flag alone", () => {
+      const legacy = [
+        { name: "ui_navigate", readOnly: false },
+        { name: "ui_snapshot_app", readOnly: true },
+      ];
+      expect([...classifyUiToolApprovals(legacy, false).requiredNames]).toEqual(
+        []
+      );
+      expect([...classifyUiToolApprovals(legacy, true).requiredNames]).toEqual([
+        "ui_navigate",
+      ]);
+    });
   });
 });

--- a/mcpjam-inspector/shared/__tests__/client-fulfilled-tools.test.ts
+++ b/mcpjam-inspector/shared/__tests__/client-fulfilled-tools.test.ts
@@ -122,6 +122,34 @@ describe("client-fulfilled tool names", () => {
       ).toBe(true);
     });
 
+    it("fails CLOSED on a contradictory read-only + destructive entry", () => {
+      // The validator rejects `readOnlyHint` disagreeing with `readOnly`, but
+      // nothing stops "read-only AND destructive". Resolving that in favor of
+      // "don't ask" is the one reading that can silently delete something, so
+      // destructive wins.
+      for (const requireToolApproval of [true, false]) {
+        expect(
+          uiToolCallNeedsApproval({
+            readOnly: true,
+            annotations: { readOnlyHint: true, destructiveHint: true },
+            requireToolApproval,
+          }),
+        ).toBe(true);
+      }
+    });
+
+    it("does not gate a read-only tool whose annotations omit readOnlyHint", () => {
+      // Partial annotations must not lose the legacy signal — otherwise a
+      // snapshot gets gated for no reason in strict mode.
+      expect(
+        uiToolCallNeedsApproval({
+          readOnly: true,
+          annotations: { destructiveHint: false },
+          requireToolApproval: true,
+        }),
+      ).toBe(false);
+    });
+
     it("ignores non-approval hints", () => {
       expect(
         uiToolCallNeedsApproval({

--- a/mcpjam-inspector/shared/chat-v2.ts
+++ b/mcpjam-inspector/shared/chat-v2.ts
@@ -1,5 +1,6 @@
 import { UIMessage } from "ai";
 import type { ModelDefinition } from "./types";
+import type { UiToolAnnotations } from "./client-fulfilled-tools";
 import type {
   McpToolResultImageRenderingPolicy,
   ModelVisibleMcpToolResults,
@@ -154,14 +155,19 @@ export interface AppToolSnapshotEntry {
  *
  * Unlike app tools, UI tools are first-party and curated: `name` is the
  * model-facing tool name directly (reserved `ui_` prefix, validated at the
- * boundary), with no alias indirection. `readOnly` is metadata for policy
- * and native `annotations.readOnlyHint`, not an inclusion gate.
+ * boundary), with no alias indirection.
+ *
+ * `annotations` carries the MCP `ToolAnnotations` hints and is what drives
+ * approval policy (`uiToolCallNeedsApproval`). `readOnly` predates it and is
+ * retained for wire compatibility: an old client ships only `readOnly`, and
+ * the validator rejects a snapshot whose `readOnlyHint` contradicts it.
  */
 export interface UiToolSnapshotEntry {
   name: string;
   description: string;
   inputSchema?: Record<string, unknown>;
   readOnly: boolean;
+  annotations?: UiToolAnnotations;
 }
 
 export interface WidgetModelContextEntry {

--- a/mcpjam-inspector/shared/client-fulfilled-tools.ts
+++ b/mcpjam-inspector/shared/client-fulfilled-tools.ts
@@ -44,21 +44,101 @@ export function isClientFulfilledToolName(name: string): boolean {
 }
 
 /**
+ * MCP tool annotations, as defined by the protocol's `ToolAnnotations`.
+ *
+ * Only the hints MCPJam's first-party `ui_*` catalog sets are modelled. The
+ * protocol's defaults are deliberately pessimistic — an absent
+ * `destructiveHint` means "assume destructive" — which is what makes an
+ * unannotated future tool fail safe rather than execute silently.
+ *
+ * TRUST BOUNDARY: annotations are hints, and the MCP spec requires clients to
+ * treat them as untrusted unless the server is verified. This type — and the
+ * approval policy below — apply ONLY to MCPJam's own curated `ui_*` catalog
+ * and its server-validated snapshot. Never derive approval policy from a
+ * third-party MCP server's annotations.
+ */
+export interface UiToolAnnotations {
+  readOnlyHint?: boolean;
+  destructiveHint?: boolean;
+  idempotentHint?: boolean;
+  openWorldHint?: boolean;
+}
+
+/**
  * Whether a UI tool call must pause for the user's approval this turn.
  *
  * Single source of truth for BOTH sides of the approval handshake: the
- * server (per-tool `needsApproval` in `buildUiTools`, and the free-model
- * loop's approval gate) and the client (the executor's defer-before-execute
- * gate). They must agree because the client decides "defer" when the
- * tool-call chunk arrives — BEFORE the server's approval-request chunk
- * reaches it.
+ * server (per-tool `needsApproval` in `buildUiTools`, and every engine's
+ * approval gate via `classifyUiToolApprovals`) and the client (the
+ * executor's defer-before-execute gate). They must agree because the client
+ * decides "defer" when the tool-call chunk arrives — BEFORE the server's
+ * approval-request chunk reaches it. If they disagree, turns strand.
  *
- * Read-only tools (`ui_snapshot_app`) never gate: they observe, so pausing
- * them buys no safety and costs a click.
+ * Two modes, keyed off the turn's `requireToolApproval` flag:
+ *   - strict (flag on)  — every mutating UI tool gates.
+ *   - default (flag off) — only DESTRUCTIVE UI tools gate. Actions the user
+ *     watches happen in their own app don't need a confirmation click; the
+ *     ones they can't undo by looking at the screen do.
+ *
+ * Read-only tools (`ui_snapshot_app`) never gate in either mode: they
+ * observe, so pausing them buys no safety and costs a click.
+ *
+ * Entries WITHOUT `annotations` keep the legacy `readOnly`-only semantics —
+ * an old client's snapshot must not suddenly start gating differently.
  */
 export function uiToolCallNeedsApproval(opts: {
   readOnly: boolean;
+  annotations?: UiToolAnnotations;
   requireToolApproval: boolean;
 }): boolean {
-  return opts.requireToolApproval && !opts.readOnly;
+  const { annotations, requireToolApproval } = opts;
+  if (!annotations) {
+    return requireToolApproval && !opts.readOnly;
+  }
+  if (annotations.readOnlyHint === true) return false;
+  if (requireToolApproval) return true;
+  // Protocol default: absent destructiveHint means destructive.
+  return annotations.destructiveHint !== false;
+}
+
+/**
+ * Per-turn approval classification for the UI tools a turn advertised.
+ *
+ * Every validated entry lands in exactly one set, so an engine can answer
+ * "does this UI tool call need approval?" without re-deriving policy — and
+ * without the `requireToolApproval && …` shape that silently drops
+ * destructive gating when the flag is off (the flag is off by default).
+ *
+ * `freeNames` is NOT redundant with "not in requiredNames": engines must
+ * distinguish a UI tool that is deliberately approval-free from a name they
+ * don't know about (a real MCP tool), which still follows the flag.
+ */
+export interface UiToolApprovalClassification {
+  requiredNames: ReadonlySet<string>;
+  freeNames: ReadonlySet<string>;
+}
+
+export function classifyUiToolApprovals(
+  entries:
+    | ReadonlyArray<{
+        name: string;
+        readOnly: boolean;
+        annotations?: UiToolAnnotations;
+      }>
+    | undefined,
+  requireToolApproval: boolean,
+): UiToolApprovalClassification {
+  const requiredNames = new Set<string>();
+  const freeNames = new Set<string>();
+  for (const entry of entries ?? []) {
+    const target = uiToolCallNeedsApproval({
+      readOnly: entry.readOnly,
+      annotations: entry.annotations,
+      requireToolApproval,
+    })
+      ? requiredNames
+      : freeNames;
+    target.add(entry.name);
+  }
+  return { requiredNames, freeNames };
 }

--- a/mcpjam-inspector/shared/client-fulfilled-tools.ts
+++ b/mcpjam-inspector/shared/client-fulfilled-tools.ts
@@ -95,7 +95,16 @@ export function uiToolCallNeedsApproval(opts: {
   if (!annotations) {
     return requireToolApproval && !opts.readOnly;
   }
-  if (annotations.readOnlyHint === true) return false;
+  // Destructive wins over everything, including a contradictory
+  // `readOnlyHint: true`. The validator rejects `readOnlyHint` disagreeing
+  // with `readOnly`, but nothing stops "read-only AND destructive" — and
+  // resolving that contradiction in favor of "don't ask" is the one reading
+  // that can silently delete something.
+  if (annotations.destructiveHint === true) return true;
+  // Read-only never gates. Honor BOTH signals: a partial annotation object
+  // (e.g. `{destructiveHint: false}`) leaves `readOnlyHint` undefined, and
+  // ignoring the legacy flag there would gate a snapshot for no reason.
+  if (opts.readOnly || annotations.readOnlyHint === true) return false;
   if (requireToolApproval) return true;
   // Protocol default: absent destructiveHint means destructive.
   return annotations.destructiveHint !== false;


### PR DESCRIPTION
> Stacked on #3262 — review that first; this PR's diff is against it.

Second of six PRs moving the in-app agent chat to a UI-tools-only strategy.

## Why

The Home box and side-panel agent advertised the MCPJam **platform MCP server's** tools alongside the `ui_*` catalog. Those tools mutate the user's workspace (projects, servers, evals, chatboxes) **server-side and invisibly** — the opposite of this surface's premise. The user is sitting in front of the app; the agent should work where they can watch it.

## What changes

Drop the platform server from the chat turn, leaving a clean split between **knowing** and **doing**:

| | source | acts? |
| --- | --- | --- |
| knows | docs MCP server, `web_search` | no — read-only |
| does | `ui_*` tools | yes — every effect lands on the user's screen |

Knowledge tools stay *precisely because* they never act.

## What deliberately does NOT change

`buildPlatformConfig` and the **`/widget-content` sub-route stay.** Chat sessions from before this cutover still contain platform widget parts, and reloading one re-reads its `ui://` resource through that route. Deleting it would break **history rendering**, not just new turns. The removal is scoped to the chat POST only; no client changes are needed.

## System prompt

The workspace-context block goes with the tools it existed for (it only ever told the model to pass `project:` explicitly). In its place: a **static** identity prompt.

Static per build is load-bearing, not incidental — this sits at the front of every turn, so the per-request `projectId` it used to embed would invalidate the cacheable prefix for the **whole conversation, on every request**. Per-turn UI state will ride append-only on the user message instead (PR D). Tool mechanics stay in `buildUiToolsSystemPrompt`, emitted from the validated snapshot, so the prompt and the advertised tools can't drift.

## Rollback

`MCPJAM_AGENT_PLATFORM_TOOLS=1` restores the **complete** prior contract — server, preflight/selection, and workspace prompt together. A half-rollback (platform tools advertised, but told to drive the UI) is a configuration we never shipped, so the switch doesn't offer it.

## Test plan

- New `mcpjam-agent.ui-only.test.ts`: platform server never enters the manager; only docs is selected; `web_search` retained; identity prompt present; **no per-request values in the prompt**; prompt byte-stable across turns.
- Kill-switch tests assert the full contract comes back (server + selection + workspace prompt).
- Existing ambient-context tests moved under the kill-switch, where that behavior now lives; the persist-≠-prepare invariant kept.
- Widget-content route tests untouched and green — history still renders.
- Server suite: 228 files / 2902 tests, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which MCP tools the in-app agent can invoke and how system prompts are built; behavior is reversible via env flag but alters default agent capabilities for all users.
> 
> **Overview**
> The in-app agent chat turn no longer connects the **MCPJam platform MCP worker** by default. New turns only preflight/select **`mcpjam-docs`** plus read-only **`web_search`**; workspace mutations that used to run invisibly via platform tools are removed from the default tool set. **`ui_*` tools** remain the intended way to act in the inspector UI.
> 
> A **static identity system prompt** (`AGENT_IDENTITY_PROMPT`) is prepended on prepare (not persisted) so the model is told to drive the UI and that `ui_*` is the only action path. The old **workspace context** block (explicit `project:` for platform tools) is dropped in the default mode so **`projectId` is not embedded** in the cacheable prompt prefix.
> 
> **`MCPJAM_AGENT_PLATFORM_TOOLS=1`** restores the full prior contract: platform server in the manager, both servers selected, workspace context prompt back, and the UI-only identity prompt omitted to avoid contradictory instructions. **`/widget-content`** and platform config for history are unchanged.
> 
> Tests: new **`mcpjam-agent.ui-only.test.ts`**, ambient-context cases nested under the env flag, and **`selectedServerIds`** expectations updated to docs-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff42c03a55300f6c784529a305b009a6828a63a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the in‑app agent UI-only: it now acts only through `ui_*` tools so every change is visible. The platform MCP server is dropped from chat turns; read‑only knowledge (`mcpjam-docs`, `web_search`) stays, and a static identity system prompt replaces the workspace-context prompt to keep the cached prefix stable.

- **Refactors**
  - Removed the platform MCP worker from chat turns; `selectedServerIds` now includes only `mcpjam-docs`, and `web_search` is retained.
  - Added a static `AGENT_IDENTITY_PROMPT` in UI‑only mode with no per‑request values; under `MCPJAM_AGENT_PLATFORM_TOOLS=1` the identity prompt is omitted and the workspace context prompt is restored.
  - Kept `buildPlatformConfig` and the `/widget-content` route to render existing chats with widget parts.

- **Migration**
  - No client changes; history still renders.
  - Optional rollback: set `MCPJAM_AGENT_PLATFORM_TOOLS=1` to restore the previous behavior (platform server + selection + workspace prompt). The UI‑only identity prompt is not included during rollback to avoid conflicting instructions.

<sup>Written for commit ff42c03a55300f6c784529a305b009a6828a63a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

