### PR TITLE
feat(hosts): move the client selector into the Connect canvas

### DIFF
--- a/mcpjam-inspector/client/src/components/hosts/GlobalHostBar.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/GlobalHostBar.tsx
@@ -1,13 +1,33 @@
+import { useLocation } from "react-router";
 import { HostOverlayBar } from "@/components/hosts/HostOverlayBar";
 import type { GlobalHostBarProps } from "@/components/Header";
 import { usePreviewedHostId } from "@/hooks/use-previewed-client-id";
+import { routePaths } from "@/lib/app-navigation";
 
 export function GlobalHostBar({
   projectId,
   onEditHost,
   onCanvasReplaceHost,
 }: GlobalHostBarProps) {
+  const location = useLocation();
   const [previewedHostId, setPreviewedHostId] = usePreviewedHostId(projectId);
+
+  // While the Connect host canvas is open, the client selector lives INSIDE
+  // the canvas (`HostCanvasSelector`) — hide the header instance so the
+  // control isn't duplicated. Mirrors HostsTab's open-canvas condition:
+  // on the hosts route with either a URL host id or a previewed fallback.
+  const onHostsRoute =
+    location.pathname === routePaths.hosts ||
+    location.pathname.startsWith(`${routePaths.hosts}/`);
+  const urlHostId = onHostsRoute
+    ? (location.pathname
+        .slice(`${routePaths.hosts}/`.length)
+        .split("/")[0] || null)
+    : null;
+  if (onHostsRoute && (urlHostId || previewedHostId)) {
+    return null;
+  }
+
   return (
     <HostOverlayBar
       projectId={projectId}

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/HostBuilderViewRedesigned.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/HostBuilderViewRedesigned.tsx
@@ -558,10 +558,12 @@ export function HostBuilderViewRedesigned({
                     shellStyle={canvasShellStyle}
                   />
                 </ReactFlowProvider>
-                {/* Client selector pinned over the canvas (fixed position —
-                    it does not pan/zoom with the flow). The header's
-                    GlobalHostBar hides itself while this canvas is open. */}
-                <div className="pointer-events-none absolute inset-x-0 top-5 z-20 flex justify-center pr-2">
+                {/* Client selector pinned top-left over the canvas (fixed
+                    position — it does not pan/zoom with the flow) so it stays
+                    accessible without blocking the canvas content. The
+                    header's GlobalHostBar hides itself while this canvas is
+                    open. */}
+                <div className="pointer-events-none absolute inset-x-0 top-5 z-20 flex justify-start pl-5 pr-2">
                   <div className="pointer-events-auto">
                     <HostCanvasSelector
                       projectId={projectId}

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/HostBuilderViewRedesigned.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/HostBuilderViewRedesigned.tsx
@@ -36,6 +36,7 @@ import {
 import { getChatboxShellStyle } from "@/lib/chatbox-client-style";
 import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
 import { RedesignedHostCanvas } from "./canvas/RedesignedHostCanvas";
+import { HostCanvasSelector } from "./HostCanvasSelector";
 import { parseHostVerifyTabParam } from "../host-verify-deep-link";
 import { buildRedesignedHostCanvas } from "./canvas/canvasBuilder";
 import { HostFocusPanel } from "./focus/HostFocusPanel";
@@ -544,7 +545,7 @@ export function HostBuilderViewRedesigned({
               defaultSize={focusState.open ? 55 : 100}
               minSize={30}
             >
-              <div className="h-full min-h-0 pr-2">
+              <div className="relative h-full min-h-0 pr-2">
                 <ReactFlowProvider>
                   <RedesignedHostCanvas
                     viewModel={viewModel}
@@ -557,6 +558,17 @@ export function HostBuilderViewRedesigned({
                     shellStyle={canvasShellStyle}
                   />
                 </ReactFlowProvider>
+                {/* Client selector pinned over the canvas (fixed position —
+                    it does not pan/zoom with the flow). The header's
+                    GlobalHostBar hides itself while this canvas is open. */}
+                <div className="pointer-events-none absolute inset-x-0 top-5 z-20 flex justify-center pr-2">
+                  <div className="pointer-events-auto">
+                    <HostCanvasSelector
+                      projectId={projectId}
+                      activeHostId={hostId}
+                    />
+                  </div>
+                </div>
               </div>
             </ResizablePanel>
             {focusState.open ? (

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/HostCanvasSelector.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/HostCanvasSelector.tsx
@@ -1,0 +1,356 @@
+import { useMemo, useState } from "react";
+import { useNavigate } from "react-router";
+import { ChevronsUpDown, Plus, Trash2 } from "lucide-react";
+import { useConvexAuth } from "convex/react";
+import { toast } from "@/lib/toast";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@mcpjam/design-system/dropdown-menu";
+import { cn } from "@/lib/utils";
+import { useHostList, useHostMutations } from "@/hooks/useClients";
+import { usePreviewedHostId } from "@/hooks/use-previewed-client-id";
+import { useHostCatalog } from "@/lib/host-compat/use-host-catalog";
+import { buildHostsPath } from "@/lib/app-navigation";
+import { getHostLogoSrc } from "@/lib/host-ui-metadata";
+import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
+import { track } from "@/lib/analytics";
+import { CreateHostDialog } from "@/components/hosts/CreateHostDialog";
+import { getCatalogHost } from "@mcpjam/sdk/host-compat";
+
+/**
+ * Client selector pinned to the top-center of the Connect host canvas.
+ *
+ * Replaces the header `HostOverlayBar` while the canvas is open (the header
+ * instance hides itself — see `GlobalHostBar`). Design settled in the PR
+ * #3144 review round: one large labeled dropdown trigger for switching plus
+ * an explicit "Add client" action, instead of a small pager with adjacent
+ * icon-only buttons. The menu opens to the LEFT of the card so it floats
+ * over empty canvas rather than covering the client card below.
+ */
+
+const QUICK_ADD_TEMPLATES = ["claude", "chatgpt", "copilot"] as const;
+
+const MCPJAM_HOST_NAME = "MCPJam";
+const LAST_HOST_DELETE_REASON =
+  "A project needs at least one client. Create another client first.";
+const ANALYTICS_LOCATION = "host_canvas";
+
+/**
+ * Hosts don't persist which catalog template they came from, so the logo is
+ * inferred from the display name. Unknown names fall back to the generic MCP
+ * mark — never wrong, just anonymous.
+ */
+const LOGO_NAME_HINTS: Array<[RegExp, string]> = [
+  [/mcpjam/i, "mcpjam"],
+  [/claude[ -]?code/i, "claude-code"],
+  [/claude/i, "claude"],
+  [/chatgpt|openai/i, "chatgpt"],
+  [/copilot/i, "copilot"],
+  [/cursor/i, "cursor"],
+  [/vs ?code/i, "vscode"],
+  [/goose/i, "goose"],
+  [/cline/i, "cline"],
+  [/perplexity/i, "perplexity"],
+  [/notion/i, "notion"],
+  [/slack/i, "slack"],
+  [/mistral/i, "mistral"],
+];
+
+const FALLBACK_LOGO = "/mcp.svg";
+
+function inferLogoId(name: string): string | null {
+  for (const [re, id] of LOGO_NAME_HINTS) {
+    if (re.test(name)) return id;
+  }
+  return null;
+}
+
+interface HostCanvasSelectorProps {
+  projectId: string;
+  activeHostId: string;
+}
+
+export function HostCanvasSelector({
+  projectId,
+  activeHostId,
+}: HostCanvasSelectorProps) {
+  const navigate = useNavigate();
+  const { isAuthenticated } = useConvexAuth();
+  const catalogState = useHostCatalog();
+  const themeMode = usePreferencesStore((s) => s.themeMode);
+  const { hosts, isLoading } = useHostList({ isAuthenticated, projectId });
+  const { deleteHost } = useHostMutations();
+  const [, setPreviewedHostId] = usePreviewedHostId(projectId);
+  const [showCreate, setShowCreate] = useState(false);
+  const [createTemplateId, setCreateTemplateId] = useState<string | undefined>(
+    undefined
+  );
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  // Same ordering the header pager uses: the seeded default first, then
+  // alphabetical — keeps the `n / total` position chip stable across surfaces.
+  const sortedHosts = useMemo(() => {
+    return [...hosts].sort((a, b) => {
+      const aIsDefault = a.name === MCPJAM_HOST_NAME;
+      const bIsDefault = b.name === MCPJAM_HOST_NAME;
+      if (aIsDefault && !bIsDefault) return -1;
+      if (bIsDefault && !aIsDefault) return 1;
+      return a.name.localeCompare(b.name);
+    });
+  }, [hosts]);
+
+  const activeIndex = useMemo(
+    () => sortedHosts.findIndex((h) => h.hostId === activeHostId),
+    [sortedHosts, activeHostId]
+  );
+  const active = activeIndex >= 0 ? sortedHosts[activeIndex] : null;
+
+  const switchTo = (hostId: string) => {
+    if (hostId === activeHostId) return;
+    track("connect_host_overlay_swapped", {
+      location: ANALYTICS_LOCATION,
+      from: activeHostId,
+      to: hostId,
+      host_count: hosts.length,
+    });
+    setPreviewedHostId(hostId);
+    // The URL is the source of truth for which host the canvas renders
+    // (see App's hosts-route sync) — replace so switching doesn't pile
+    // history entries.
+    navigate(buildHostsPath(hostId), { replace: true });
+  };
+
+  const openCreateWithTemplate = (templateId?: string) => {
+    setCreateTemplateId(templateId);
+    setShowCreate(true);
+    setMenuOpen(false);
+    if (templateId) {
+      track("connect_host_overlay_quick_added", {
+        location: ANALYTICS_LOCATION,
+        template_id: templateId,
+      });
+    }
+  };
+
+  const canDelete = sortedHosts.length > 1;
+
+  const handleDelete = async (hostId: string) => {
+    const host = hosts.find((h) => h.hostId === hostId);
+    if (!host) return;
+    setIsDeleting(true);
+    try {
+      await deleteHost({ hostId });
+      toast.success(`Host "${host.name}" deleted`);
+      // Deleting the host the canvas is rendering would leave it pointing
+      // at a dead id until HostsTab's reconcile kicks the user back to the
+      // browse view — jump to a surviving host instead.
+      if (hostId === activeHostId) {
+        const survivor = sortedHosts.find((h) => h.hostId !== hostId);
+        if (survivor) switchTo(survivor.hostId);
+      }
+      // Telemetry is best-effort: a posthog throw must not bubble into the
+      // shared catch and surface a delete-failure toast after the client
+      // has already been removed.
+      try {
+        track("client_deleted", {
+          location: ANALYTICS_LOCATION,
+          client_id: hostId,
+          force: false,
+        });
+      } catch {
+        // swallow — analytics must not block the success path
+      }
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : "Failed to delete host";
+      if (msg.includes("consumer")) {
+        toast.error(
+          `${msg} — use force delete or remove dependent chatboxes/evals first`
+        );
+      } else {
+        toast.error(msg);
+      }
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const logoFor = (name: string) => {
+    const id = inferLogoId(name);
+    return id ? getHostLogoSrc(id, themeMode) : FALLBACK_LOGO;
+  };
+
+  if (isLoading || !active) {
+    return (
+      <div className="h-14 w-72 animate-pulse rounded-2xl border border-border/60 bg-card/80" />
+    );
+  }
+
+  return (
+    <div
+      className="flex items-center rounded-2xl border border-border/60 bg-card/95 p-1.5 shadow-lg shadow-black/[0.06] backdrop-blur-sm"
+      data-testid="host-canvas-selector"
+    >
+      <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            aria-label="Client used for preview"
+            data-testid="host-canvas-current"
+            className={cn(
+              "flex h-11 items-center gap-2.5 rounded-xl pr-2.5 pl-3.5 outline-none transition-colors",
+              "hover:bg-muted/50 data-[state=open]:bg-muted/50",
+              "focus-visible:ring-2 focus-visible:ring-ring/45"
+            )}
+          >
+            <img
+              src={logoFor(active.name)}
+              alt=""
+              className="size-5 shrink-0 object-contain"
+            />
+            <span className="max-w-[16rem] truncate text-[15px] font-semibold">
+              {active.name}
+            </span>
+            <span className="rounded-full border border-border/60 px-2 py-0.5 text-[11px] font-medium tabular-nums text-muted-foreground">
+              {activeIndex + 1} / {sortedHosts.length}
+            </span>
+            <ChevronsUpDown className="size-4 shrink-0 text-muted-foreground" />
+          </button>
+        </DropdownMenuTrigger>
+        {/* Opens to the LEFT of the card, over empty canvas — bottom
+            placement would cover the client card the selector sits above. */}
+        <DropdownMenuContent
+          side="left"
+          align="start"
+          sideOffset={10}
+          className="min-w-[15rem]"
+        >
+          <DropdownMenuRadioGroup value={activeHostId} onValueChange={switchTo}>
+            {sortedHosts.map((host) => (
+              <DropdownMenuRadioItem
+                key={host.hostId}
+                value={host.hostId}
+                className="group gap-2.5 py-2 pr-1.5"
+              >
+                <img
+                  src={logoFor(host.name)}
+                  alt=""
+                  className="size-4 shrink-0 object-contain"
+                />
+                <span className="flex-1 truncate">{host.name}</span>
+                <span className="ml-2 flex shrink-0 items-center opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 group-data-[highlighted]:opacity-100">
+                  <button
+                    type="button"
+                    aria-label={`Delete ${host.name}`}
+                    data-testid={`host-canvas-delete-${host.hostId}`}
+                    disabled={isDeleting || !canDelete}
+                    title={!canDelete ? LAST_HOST_DELETE_REASON : undefined}
+                    className="inline-flex size-6 items-center justify-center rounded-sm text-muted-foreground hover:bg-destructive/10 hover:text-destructive disabled:cursor-not-allowed disabled:opacity-50"
+                    onPointerDown={(e) => e.stopPropagation()}
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      void handleDelete(host.hostId);
+                    }}
+                  >
+                    <Trash2 className="size-3.5" />
+                  </button>
+                </span>
+              </DropdownMenuRadioItem>
+            ))}
+          </DropdownMenuRadioGroup>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            data-testid="host-canvas-menu-add"
+            onSelect={() => openCreateWithTemplate(undefined)}
+            className="group py-2 pr-1.5"
+          >
+            <Plus className="size-3.5" />
+            <span className="flex-1">Add client</span>
+            <span
+              className="ml-2 flex shrink-0 items-center gap-0.5"
+              onPointerDown={(e) => e.stopPropagation()}
+            >
+              {QUICK_ADD_TEMPLATES.map((id) => {
+                const catalogHost =
+                  catalogState.status === "live"
+                    ? getCatalogHost(catalogState.catalog, id)
+                    : undefined;
+                if (!catalogHost) return null;
+                return (
+                  <button
+                    key={id}
+                    type="button"
+                    aria-label={`Add ${catalogHost.label} host`}
+                    title={`Add ${catalogHost.label}`}
+                    data-testid={`host-canvas-quick-add-${id}`}
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      openCreateWithTemplate(id);
+                    }}
+                    className={cn(
+                      "inline-flex size-6 items-center justify-center rounded-sm transition-colors",
+                      "hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
+                    )}
+                  >
+                    <img
+                      src={getHostLogoSrc(id, themeMode)}
+                      alt=""
+                      className="size-4 object-contain"
+                    />
+                  </button>
+                );
+              })}
+            </span>
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <div className="mx-1 h-6 w-px shrink-0 bg-border/60" />
+
+      <button
+        type="button"
+        data-testid="host-canvas-add"
+        onClick={() => {
+          track("connect_host_overlay_add_clicked", {
+            location: ANALYTICS_LOCATION,
+            host_count: hosts.length,
+          });
+          openCreateWithTemplate(undefined);
+        }}
+        className={cn(
+          "inline-flex h-11 items-center gap-1.5 rounded-xl px-3 text-sm font-medium text-primary transition-colors",
+          "hover:bg-primary/10",
+          "focus-visible:ring-2 focus-visible:ring-ring/45 focus-visible:outline-none"
+        )}
+      >
+        <Plus className="size-4" />
+        Add client
+      </button>
+
+      <CreateHostDialog
+        isOpen={showCreate}
+        onClose={() => {
+          setShowCreate(false);
+          setCreateTemplateId(undefined);
+        }}
+        projectId={projectId}
+        initialTemplateId={createTemplateId}
+        onCreated={(hostId) => {
+          track("connect_host_overlay_saved_as_new", {
+            location: ANALYTICS_LOCATION,
+            host_id: hostId,
+          });
+          switchTo(hostId);
+        }}
+      />
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/HostCanvasSelector.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/HostCanvasSelector.tsx
@@ -6,10 +6,8 @@ import { toast } from "@/lib/toast";
 import {
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuItem,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@mcpjam/design-system/dropdown-menu";
 import { cn } from "@/lib/utils";
@@ -24,14 +22,17 @@ import { CreateHostDialog } from "@/components/hosts/CreateHostDialog";
 import { getCatalogHost } from "@mcpjam/sdk/host-compat";
 
 /**
- * Client selector pinned to the top-center of the Connect host canvas.
+ * Client selector pinned to the top-left of the Connect host canvas.
  *
  * Replaces the header `HostOverlayBar` while the canvas is open (the header
- * instance hides itself — see `GlobalHostBar`). Design settled in the PR
- * #3144 review round: one large labeled dropdown trigger for switching plus
- * an explicit "Add client" action, instead of a small pager with adjacent
- * icon-only buttons. The menu opens to the LEFT of the card so it floats
- * over empty canvas rather than covering the client card below.
+ * instance hides itself — see `GlobalHostBar`). Layout settled in the #3269
+ * review round: two pills pinned top-left so they stay accessible without
+ * blocking the canvas —
+ *   1. an "Add client" pill (left-most) carrying the quick-add template
+ *      logos, and
+ *   2. a switcher pill (to its right) that opens the full client list.
+ * The add action lives only in the left pill; the switcher menu no longer
+ * duplicates it. The menu opens downward, over empty canvas below the pills.
  */
 
 const QUICK_ADD_TEMPLATES = ["claude", "chatgpt", "copilot"] as const;
@@ -40,6 +41,9 @@ const MCPJAM_HOST_NAME = "MCPJam";
 const LAST_HOST_DELETE_REASON =
   "A project needs at least one client. Create another client first.";
 const ANALYTICS_LOCATION = "host_canvas";
+
+const PILL_CLASS =
+  "flex items-center rounded-2xl border border-border/60 bg-card/95 p-1.5 shadow-lg shadow-black/[0.06] backdrop-blur-sm";
 
 /**
  * Hosts don't persist which catalog template they came from, so the logo is
@@ -188,152 +192,151 @@ export function HostCanvasSelector({
 
   if (isLoading || !active) {
     return (
-      <div className="h-14 w-72 animate-pulse rounded-2xl border border-border/60 bg-card/80" />
+      <div className="flex items-center gap-2">
+        <div className="h-14 w-40 animate-pulse rounded-2xl border border-border/60 bg-card/80" />
+        <div className="h-14 w-56 animate-pulse rounded-2xl border border-border/60 bg-card/80" />
+      </div>
     );
   }
 
   return (
     <div
-      className="flex items-center rounded-2xl border border-border/60 bg-card/95 p-1.5 shadow-lg shadow-black/[0.06] backdrop-blur-sm"
+      className="flex items-center gap-2"
       data-testid="host-canvas-selector"
     >
-      <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
-        <DropdownMenuTrigger asChild>
-          <button
-            type="button"
-            aria-label="Client used for preview"
-            data-testid="host-canvas-current"
-            className={cn(
-              "flex h-11 items-center gap-2.5 rounded-xl pr-2.5 pl-3.5 outline-none transition-colors",
-              "hover:bg-muted/50 data-[state=open]:bg-muted/50",
-              "focus-visible:ring-2 focus-visible:ring-ring/45"
-            )}
-          >
-            <img
-              src={logoFor(active.name)}
-              alt=""
-              className="size-5 shrink-0 object-contain"
-            />
-            <span className="max-w-[16rem] truncate text-[15px] font-semibold">
-              {active.name}
-            </span>
-            <span className="rounded-full border border-border/60 px-2 py-0.5 text-[11px] font-medium tabular-nums text-muted-foreground">
-              {activeIndex + 1} / {sortedHosts.length}
-            </span>
-            <ChevronsUpDown className="size-4 shrink-0 text-muted-foreground" />
-          </button>
-        </DropdownMenuTrigger>
-        {/* Opens to the LEFT of the card, over empty canvas — bottom
-            placement would cover the client card the selector sits above. */}
-        <DropdownMenuContent
-          side="left"
-          align="start"
-          sideOffset={10}
-          className="min-w-[15rem]"
+      {/* Add client — left-most. Carries the quick-add template logos so the
+          add path stays a single control (the switcher menu no longer has its
+          own add action). */}
+      <div className={PILL_CLASS}>
+        <button
+          type="button"
+          data-testid="host-canvas-add"
+          onClick={() => {
+            track("connect_host_overlay_add_clicked", {
+              location: ANALYTICS_LOCATION,
+              host_count: hosts.length,
+            });
+            openCreateWithTemplate(undefined);
+          }}
+          className={cn(
+            "inline-flex h-11 items-center gap-1.5 rounded-xl px-3 text-sm font-medium text-primary transition-colors",
+            "hover:bg-primary/10",
+            "focus-visible:ring-2 focus-visible:ring-ring/45 focus-visible:outline-none"
+          )}
         >
-          <DropdownMenuRadioGroup value={activeHostId} onValueChange={switchTo}>
-            {sortedHosts.map((host) => (
-              <DropdownMenuRadioItem
-                key={host.hostId}
-                value={host.hostId}
-                className="group gap-2.5 py-2 pr-1.5"
+          <Plus className="size-4" />
+          Add client
+        </button>
+        <span
+          className="ml-0.5 flex shrink-0 items-center gap-0.5 pr-1"
+          data-testid="host-canvas-quick-add"
+        >
+          {QUICK_ADD_TEMPLATES.map((id) => {
+            const catalogHost =
+              catalogState.status === "live"
+                ? getCatalogHost(catalogState.catalog, id)
+                : undefined;
+            const label = catalogHost?.label ?? id;
+            return (
+              <button
+                key={id}
+                type="button"
+                aria-label={`Add ${label} client`}
+                title={`Add ${label}`}
+                data-testid={`host-canvas-quick-add-${id}`}
+                onClick={() => openCreateWithTemplate(id)}
+                className={cn(
+                  "inline-flex size-7 items-center justify-center rounded-md transition-colors",
+                  "hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
+                )}
               >
                 <img
-                  src={logoFor(host.name)}
+                  src={getHostLogoSrc(id, themeMode)}
                   alt=""
-                  className="size-4 shrink-0 object-contain"
+                  className="size-4 object-contain"
                 />
-                <span className="flex-1 truncate">{host.name}</span>
-                <span className="ml-2 flex shrink-0 items-center opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 group-data-[highlighted]:opacity-100">
-                  <button
-                    type="button"
-                    aria-label={`Delete ${host.name}`}
-                    data-testid={`host-canvas-delete-${host.hostId}`}
-                    disabled={isDeleting || !canDelete}
-                    title={!canDelete ? LAST_HOST_DELETE_REASON : undefined}
-                    className="inline-flex size-6 items-center justify-center rounded-sm text-muted-foreground hover:bg-destructive/10 hover:text-destructive disabled:cursor-not-allowed disabled:opacity-50"
-                    onPointerDown={(e) => e.stopPropagation()}
-                    onClick={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      void handleDelete(host.hostId);
-                    }}
-                  >
-                    <Trash2 className="size-3.5" />
-                  </button>
-                </span>
-              </DropdownMenuRadioItem>
-            ))}
-          </DropdownMenuRadioGroup>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem
-            data-testid="host-canvas-menu-add"
-            onSelect={() => openCreateWithTemplate(undefined)}
-            className="group py-2 pr-1.5"
-          >
-            <Plus className="size-3.5" />
-            <span className="flex-1">Add client</span>
-            <span
-              className="ml-2 flex shrink-0 items-center gap-0.5"
-              onPointerDown={(e) => e.stopPropagation()}
+              </button>
+            );
+          })}
+        </span>
+      </div>
+
+      {/* Switcher — to the right of Add client. Click to see all clients and
+          switch between them; per-client delete lives on hover. */}
+      <div className={PILL_CLASS}>
+        <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              aria-label="Client used for preview"
+              data-testid="host-canvas-current"
+              className={cn(
+                "flex h-11 items-center gap-2.5 rounded-xl pr-2.5 pl-3.5 outline-none transition-colors",
+                "hover:bg-muted/50 data-[state=open]:bg-muted/50",
+                "focus-visible:ring-2 focus-visible:ring-ring/45"
+              )}
             >
-              {QUICK_ADD_TEMPLATES.map((id) => {
-                const catalogHost =
-                  catalogState.status === "live"
-                    ? getCatalogHost(catalogState.catalog, id)
-                    : undefined;
-                if (!catalogHost) return null;
-                return (
-                  <button
-                    key={id}
-                    type="button"
-                    aria-label={`Add ${catalogHost.label} host`}
-                    title={`Add ${catalogHost.label}`}
-                    data-testid={`host-canvas-quick-add-${id}`}
-                    onClick={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      openCreateWithTemplate(id);
-                    }}
-                    className={cn(
-                      "inline-flex size-6 items-center justify-center rounded-sm transition-colors",
-                      "hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
-                    )}
-                  >
-                    <img
-                      src={getHostLogoSrc(id, themeMode)}
-                      alt=""
-                      className="size-4 object-contain"
-                    />
-                  </button>
-                );
-              })}
-            </span>
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
-
-      <div className="mx-1 h-6 w-px shrink-0 bg-border/60" />
-
-      <button
-        type="button"
-        data-testid="host-canvas-add"
-        onClick={() => {
-          track("connect_host_overlay_add_clicked", {
-            location: ANALYTICS_LOCATION,
-            host_count: hosts.length,
-          });
-          openCreateWithTemplate(undefined);
-        }}
-        className={cn(
-          "inline-flex h-11 items-center gap-1.5 rounded-xl px-3 text-sm font-medium text-primary transition-colors",
-          "hover:bg-primary/10",
-          "focus-visible:ring-2 focus-visible:ring-ring/45 focus-visible:outline-none"
-        )}
-      >
-        <Plus className="size-4" />
-        Add client
-      </button>
+              <img
+                src={logoFor(active.name)}
+                alt=""
+                className="size-5 shrink-0 object-contain"
+              />
+              <span className="max-w-[16rem] truncate text-[15px] font-semibold">
+                {active.name}
+              </span>
+              <span className="rounded-full border border-border/60 px-2 py-0.5 text-[11px] font-medium tabular-nums text-muted-foreground">
+                {activeIndex + 1} / {sortedHosts.length}
+              </span>
+              <ChevronsUpDown className="size-4 shrink-0 text-muted-foreground" />
+            </button>
+          </DropdownMenuTrigger>
+          {/* Opens downward, over the empty canvas below the top-left pills. */}
+          <DropdownMenuContent
+            side="bottom"
+            align="start"
+            sideOffset={10}
+            className="min-w-[15rem]"
+          >
+            <DropdownMenuRadioGroup
+              value={activeHostId}
+              onValueChange={switchTo}
+            >
+              {sortedHosts.map((host) => (
+                <DropdownMenuRadioItem
+                  key={host.hostId}
+                  value={host.hostId}
+                  className="group gap-2.5 py-2 pr-1.5"
+                >
+                  <img
+                    src={logoFor(host.name)}
+                    alt=""
+                    className="size-4 shrink-0 object-contain"
+                  />
+                  <span className="flex-1 truncate">{host.name}</span>
+                  <span className="ml-2 flex shrink-0 items-center opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 group-data-[highlighted]:opacity-100">
+                    <button
+                      type="button"
+                      aria-label={`Delete ${host.name}`}
+                      data-testid={`host-canvas-delete-${host.hostId}`}
+                      disabled={isDeleting || !canDelete}
+                      title={!canDelete ? LAST_HOST_DELETE_REASON : undefined}
+                      className="inline-flex size-6 items-center justify-center rounded-sm text-muted-foreground hover:bg-destructive/10 hover:text-destructive disabled:cursor-not-allowed disabled:opacity-50"
+                      onPointerDown={(e) => e.stopPropagation()}
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        void handleDelete(host.hostId);
+                      }}
+                    >
+                      <Trash2 className="size-3.5" />
+                    </button>
+                  </span>
+                </DropdownMenuRadioItem>
+              ))}
+            </DropdownMenuRadioGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
 
       <CreateHostDialog
         isOpen={showCreate}

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/__tests__/HostCanvasSelector.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/__tests__/HostCanvasSelector.test.tsx
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { render, screen, waitFor } from "@testing-library/react";
+import { HostCanvasSelector } from "@/components/hosts/redesigned/HostCanvasSelector";
+import { track } from "@/lib/analytics";
+
+vi.mock("@/components/hosts/CreateHostDialog", () => ({
+  CreateHostDialog: ({ isOpen }: { isOpen: boolean }) =>
+    isOpen ? <div data-testid="create-host-dialog" /> : null,
+}));
+
+const mockUseHostList = vi.fn();
+const mockNavigate = vi.fn();
+const mockSetPreviewedHostId = vi.fn();
+
+vi.mock("react-router", () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock("convex/react", () => ({
+  useConvexAuth: () => ({ isAuthenticated: true }),
+}));
+
+vi.mock("@/hooks/useClients", () => ({
+  useHostList: (...args: unknown[]) => mockUseHostList(...args),
+  useHostMutations: () => ({
+    createHost: vi.fn(),
+    updateHost: vi.fn(),
+    deleteHost: vi.fn().mockResolvedValue(undefined),
+    duplicateHost: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/use-previewed-client-id", () => ({
+  usePreviewedHostId: () => [null, mockSetPreviewedHostId],
+}));
+
+vi.mock("@/lib/host-compat/use-host-catalog", () => ({
+  useHostCatalog: () => ({
+    status: "loading",
+    catalog: null,
+    version: null,
+    source: null,
+  }),
+}));
+
+vi.mock("@/stores/preferences/preferences-provider", () => ({
+  usePreferencesStore: (
+    selector: (state: { themeMode: "light" | "dark" }) => unknown
+  ) => selector({ themeMode: "light" }),
+}));
+
+vi.mock("@/lib/analytics", () => ({
+  track: vi.fn(),
+}));
+
+const oneHost = [
+  {
+    hostId: "host-a",
+    name: "MCPJam",
+    hostConfigId: "cfg-1",
+    modelId: "x",
+    serverCount: 0,
+    createdAt: 1,
+    updatedAt: 1,
+  },
+];
+
+const twoHosts = [
+  ...oneHost,
+  {
+    hostId: "host-b",
+    name: "Claude",
+    hostConfigId: "cfg-2",
+    modelId: "y",
+    serverCount: 0,
+    createdAt: 2,
+    updatedAt: 2,
+  },
+];
+
+describe("HostCanvasSelector", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseHostList.mockReturnValue({ hosts: oneHost, isLoading: false });
+  });
+
+  it("shows the active client with its position chip and a labeled Add client button", () => {
+    render(<HostCanvasSelector projectId="proj-1" activeHostId="host-a" />);
+
+    expect(screen.getByTestId("host-canvas-current")).toHaveTextContent(
+      "MCPJam"
+    );
+    expect(screen.getByTestId("host-canvas-current")).toHaveTextContent(
+      "1 / 1"
+    );
+    const addBtn = screen.getByTestId("host-canvas-add");
+    expect(addBtn).toBeVisible();
+    expect(addBtn).toHaveTextContent("Add client");
+  });
+
+  it("opens the create dialog and tracks when Add client is clicked", async () => {
+    const user = userEvent.setup();
+    render(<HostCanvasSelector projectId="proj-1" activeHostId="host-a" />);
+
+    expect(screen.queryByTestId("create-host-dialog")).not.toBeInTheDocument();
+    await user.click(screen.getByTestId("host-canvas-add"));
+
+    expect(screen.getByTestId("create-host-dialog")).toBeInTheDocument();
+    expect(track).toHaveBeenCalledWith("connect_host_overlay_add_clicked", {
+      location: "host_canvas",
+      host_count: 1,
+    });
+  });
+
+  it("opens the client menu to the left so it doesn't cover the canvas card", async () => {
+    const user = userEvent.setup();
+    mockUseHostList.mockReturnValue({ hosts: twoHosts, isLoading: false });
+    render(<HostCanvasSelector projectId="proj-1" activeHostId="host-a" />);
+
+    await user.click(screen.getByTestId("host-canvas-current"));
+
+    const menu = await screen.findByRole("menu");
+    await waitFor(() => {
+      expect(menu).toHaveAttribute("data-side", "left");
+    });
+  });
+
+  it("navigates to the picked host and updates the preview pointer", async () => {
+    const user = userEvent.setup();
+    mockUseHostList.mockReturnValue({ hosts: twoHosts, isLoading: false });
+    render(<HostCanvasSelector projectId="proj-1" activeHostId="host-a" />);
+
+    await user.click(screen.getByTestId("host-canvas-current"));
+    await user.click(
+      await screen.findByRole("menuitemradio", { name: /Claude/ })
+    );
+
+    expect(mockSetPreviewedHostId).toHaveBeenCalledWith("host-b");
+    expect(mockNavigate).toHaveBeenCalledWith("/hosts/host-b", {
+      replace: true,
+    });
+    expect(track).toHaveBeenCalledWith(
+      "connect_host_overlay_swapped",
+      expect.objectContaining({
+        location: "host_canvas",
+        from: "host-a",
+        to: "host-b",
+      })
+    );
+  });
+
+  it("disables delete on the only host and explains why in a tooltip", async () => {
+    const user = userEvent.setup();
+    render(<HostCanvasSelector projectId="proj-1" activeHostId="host-a" />);
+
+    await user.click(screen.getByTestId("host-canvas-current"));
+
+    const deleteBtn = await screen.findByTestId("host-canvas-delete-host-a");
+    expect(deleteBtn).toBeDisabled();
+    expect(deleteBtn).toHaveAttribute(
+      "title",
+      expect.stringContaining("at least one client")
+    );
+  });
+
+  it("enables delete when more than one host exists", async () => {
+    const user = userEvent.setup();
+    mockUseHostList.mockReturnValue({ hosts: twoHosts, isLoading: false });
+    render(<HostCanvasSelector projectId="proj-1" activeHostId="host-a" />);
+
+    await user.click(screen.getByTestId("host-canvas-current"));
+
+    const deleteBtn = await screen.findByTestId("host-canvas-delete-host-a");
+    expect(deleteBtn).not.toBeDisabled();
+    expect(deleteBtn).not.toHaveAttribute("title");
+  });
+});

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/__tests__/HostCanvasSelector.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/__tests__/HostCanvasSelector.test.tsx
@@ -113,7 +113,7 @@ describe("HostCanvasSelector", () => {
     });
   });
 
-  it("opens the client menu to the left so it doesn't cover the canvas card", async () => {
+  it("opens the client menu downward, below the top-left pills", async () => {
     const user = userEvent.setup();
     mockUseHostList.mockReturnValue({ hosts: twoHosts, isLoading: false });
     render(<HostCanvasSelector projectId="proj-1" activeHostId="host-a" />);
@@ -122,8 +122,23 @@ describe("HostCanvasSelector", () => {
 
     const menu = await screen.findByRole("menu");
     await waitFor(() => {
-      expect(menu).toHaveAttribute("data-side", "left");
+      expect(menu).toHaveAttribute("data-side", "bottom");
     });
+  });
+
+  it("keeps the add-client action out of the switcher menu", async () => {
+    const user = userEvent.setup();
+    mockUseHostList.mockReturnValue({ hosts: twoHosts, isLoading: false });
+    render(<HostCanvasSelector projectId="proj-1" activeHostId="host-a" />);
+
+    await user.click(screen.getByTestId("host-canvas-current"));
+    await screen.findByRole("menu");
+
+    // The only add path is the left-most pill; the menu must not carry a
+    // second one (per the #3269 review).
+    expect(
+      screen.queryByTestId("host-canvas-menu-add")
+    ).not.toBeInTheDocument();
   });
 
   it("navigates to the picked host and updates the preview pointer", async () => {

--- a/mcpjam-inspector/shared/analytics-events.ts
+++ b/mcpjam-inspector/shared/analytics-events.ts
@@ -92,6 +92,7 @@ export const ANALYTICS_EVENTS = {
   compat_cta_clicked: { source: "client" },
   computer_start_limit_hit: { source: "client" },
   computer_terminal_opened: { source: "client" },
+  connect_host_overlay_add_clicked: { source: "client" },
   connect_host_overlay_opened: { source: "client" },
   connect_host_overlay_quick_added: { source: "client" },
   connect_host_overlay_saved_as_new: { source: "client" },


### PR DESCRIPTION
## UX: client selector moves into the canvas

Follow-up to the #3144 review round ("this needs to be bigger… not a fan of two buttons next to each other… bringing the selector into the canvas in a fixed position and make it larger is a good call for now"). This supersedes the header `+` approach from #3144 with the design the team picked from the exploration screenshots.

### Change
- **New `HostCanvasSelector`**, pinned top-center over the Connect host canvas in a fixed position (it does not pan/zoom with the flow). One large labeled trigger — client logo + name + `n / total` position chip — plus an explicit **Add client** action behind a divider. No adjacent icon-only buttons, and the add path is fully labeled.
- **The client menu opens to the left** of the card (`side="left"`) so it floats over empty canvas instead of covering the client card underneath.
- **Parity with the header pager's menu**: per-client delete (guarded on the last client, with the reason in a tooltip) and the quick-add template shortcuts (Claude / ChatGPT / Copilot). Deleting the active client jumps the canvas to a surviving one.
- **`GlobalHostBar` hides itself while the canvas is open** so the control isn't duplicated; every other tab keeps the header pager unchanged (including its default-client seeding).
- Analytics: the existing `connect_host_overlay_*` events fire with `location: "host_canvas"`; registers `connect_host_overlay_add_clicked`.

### Screenshots
| Closed | Menu open (opens left) |
|---|---|
| _attached in review thread_ | _attached in review thread_ |

### Testing
- 6 new tests in `HostCanvasSelector.test.tsx` (labeled add button + tracking, menu `data-side="left"`, switch navigates + updates preview pointer, delete guard on last client).
- All 37 hosts-area test files (337 tests) and `typecheck:client` pass.
- Verified live: switching via menu re-targets the canvas and URL, add opens the Create dialog, menu opens over empty canvas.

https://github.com/user-attachments/assets/8cf48e6f-4626-447c-b1e2-96ea8c3a811a




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the client selector into the Connect host canvas with a top‑left overlay, replacing the header pager while the canvas is open. Splits controls into two pills: a labeled Add client pill and a separate switcher pill for a clearer, unobtrusive UI.

- **New Features**
  - Canvas‑pinned selector (top‑left, fixed); shows logo, name, and “n / total”.
  - Split controls: Add client pill carries quick‑add logos (Claude, ChatGPT, Copilot); switcher pill lists clients only with per‑client delete (disabled on last with tooltip).
  - Menu opens downward; switching updates the URL and preview pointer; deleting the active client jumps to a surviving one.
  - `GlobalHostBar` hides on the hosts route when a host is active; unchanged elsewhere.
  - Analytics: existing `connect_host_overlay_*` events include `location: "host_canvas"`; added `connect_host_overlay_add_clicked`.

<sup>Written for commit 909f50b62a9d70f0c1fe75e14f2fc6fc45eb221d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



