### PR TITLE
docs: remove em-dashes from documentation pages (UER-50)

### DIFF
--- a/docs/changelog/overview.mdx
+++ b/docs/changelog/overview.mdx
@@ -13,11 +13,11 @@ This changelog tracks all notable changes to MCPJam Inspector. We follow [Semant
 
 #### Added
 
-- **Compatibility destination** — a new Inspector page that evaluates your connected MCP server against a catalog of AI hosts (Claude, ChatGPT, Cursor, Copilot, Codex, and others). Shows conformance gates, per-host findings split into Apps and Server lanes, and live widget rendering. Accessible from the left sidebar when a server is connected.
+- **Compatibility destination**: a new Inspector page that evaluates your connected MCP server against a catalog of AI hosts (Claude, ChatGPT, Cursor, Copilot, Codex, and others). Shows conformance gates, per-host findings split into Apps and Server lanes, and live widget rendering. Accessible from the left sidebar when a server is connected.
 
-- **OTLP/OpenInference trace export** — export eval run traces as OTLP JSON from the run detail page. Compatible with Arize Phoenix, Datadog, and any OTLP-compatible observability backend. Supports exporting a single run or the whole project, with an opt-in to include content and artifacts.
+- **OTLP/OpenInference trace export**: export eval run traces as OTLP JSON from the run detail page. Compatible with Arize Phoenix, Datadog, and any OTLP-compatible observability backend. Supports exporting a single run or the whole project, with an opt-in to include content and artifacts.
 
-- **`@mcpjam/sdk/host-compat` subpackage** — the shared host-compatibility engine is now importable directly. Use `deriveServerRequirements`, `evaluateHostCompat`, `evaluateAllHosts`, `scanWidgetSource`, and `detectHostCompatBridgeFromMeta` to build your own compatibility checks in CI or custom tooling.
+- **`@mcpjam/sdk/host-compat` subpackage**: the shared host-compatibility engine is now importable directly. Use `deriveServerRequirements`, `evaluateHostCompat`, `evaluateAllHosts`, `scanWidgetSource`, and `detectHostCompatBridgeFromMeta` to build your own compatibility checks in CI or custom tooling.
 
 ### Version 1.1.0
 

--- a/docs/cli/mcp-server.mdx
+++ b/docs/cli/mcp-server.mdx
@@ -4,13 +4,13 @@ description: "Run MCPJam as a local stdio MCP server so agents can connect to, e
 icon: "bot"
 ---
 
-`mcpjam mcp` runs MCPJam itself as an MCP server over stdio. Add it to any MCP client — Claude Desktop, Claude Code, Cursor, or your own agent — and the agent gets MCPJam's local testing engine as tools: connect to a server under test, call its tools, read its resources and prompts, watch the notifications it emits, and run diagnostic sweeps.
+`mcpjam mcp` runs MCPJam itself as an MCP server over stdio. Add it to any MCP client (Claude Desktop, Claude Code, Cursor, or your own agent) and the agent gets MCPJam's local testing engine as tools: connect to a server under test, call its tools, read its resources and prompts, watch the notifications it emits, and run diagnostic sweeps.
 
 ```bash
 npx -y @mcpjam/cli@latest mcp
 ```
 
-Everything runs locally in the spawned process. No account, login, or hosted backend is involved, and the server under test can be a local stdio process — something hosted tooling can't reach.
+Everything runs locally in the spawned process. No account, login, or hosted backend is involved, and the server under test can be a local stdio process, something hosted tooling can't reach.
 
 ## Why use this instead of the CLI?
 
@@ -90,7 +90,7 @@ Agents with shell access can already run `mcpjam` commands directly, and for one
 | Tool | Description |
 |------|-------------|
 | `list_tools` | List the target's tools (with pagination cursor) |
-| `call_tool` | Call a tool and return the target's raw `CallToolResult` — check the payload's `isError` for tool-level failures |
+| `call_tool` | Call a tool and return the target's raw `CallToolResult`. Check the payload's `isError` for tool-level failures |
 | `list_resources` | List resources, or resource templates with `templates: true` |
 | `read_resource` | Read a resource by URI |
 | `list_prompts` | List prompts |
@@ -101,25 +101,25 @@ Agents with shell access can already run `mcpjam` commands directly, and for one
 
 | Tool | Description |
 |------|-------------|
-| `server_doctor` | One-shot diagnostic sweep (HTTP or stdio target) — same checks as [`mcpjam server doctor`](/cli/server-inspection) |
-| `probe_server` | HTTP-only probe: transport selection, auth requirements, OAuth metadata discovery — same as `mcpjam server probe` |
+| `server_doctor` | One-shot diagnostic sweep (HTTP or stdio target); same checks as [`mcpjam server doctor`](/cli/server-inspection) |
+| `probe_server` | HTTP-only probe: transport selection, auth requirements, OAuth metadata discovery; same as `mcpjam server probe` |
 
 ## Example session
 
 A typical agent flow while developing a stdio server:
 
 1. `connect_server` with `{ "name": "dev", "command": "node", "args": ["dist/server.js"] }`
-2. `list_tools` with `{ "server": "dev" }` — review names, descriptions, schemas
+2. `list_tools` with `{ "server": "dev" }`: review names, descriptions, schemas
 3. `call_tool` with `{ "server": "dev", "tool": "search", "arguments": { "query": "test" } }`
-4. `get_notifications` with `{ "server": "dev" }` — did the server log what you expected? Did it emit `notifications/tools/list_changed`?
+4. `get_notifications` with `{ "server": "dev" }`: did the server log what you expected? Did it emit `notifications/tools/list_changed`?
 5. Iterate on the server code, then `disconnect_server` / `connect_server` to pick up the rebuild
 6. `server_doctor` with the same `command` for a final health sweep
 
-Tool results are JSON payloads describing the target server. Errors come back as structured `{ "error": { "code", "message" } }` payloads with `isError: true` — for example `USAGE_ERROR` for invalid input or `SERVER_UNREACHABLE` when the target is down.
+Tool results are JSON payloads describing the target server. Errors come back as structured `{ "error": { "code", "message" } }` payloads with `isError: true`, for example `USAGE_ERROR` for invalid input or `SERVER_UNREACHABLE` when the target is down.
 
 ## Relationship to the hosted MCP server
 
-MCPJam also operates a hosted MCP server at `mcp.mcpjam.com/mcp` that exposes your MCPJam **account** — projects, saved servers, eval suites and runs — behind OAuth. The two are complementary:
+MCPJam also operates a hosted MCP server at `mcp.mcpjam.com/mcp` that exposes your MCPJam **account** (projects, saved servers, eval suites and runs) behind OAuth. The two are complementary:
 
 | | `mcpjam mcp` (this page) | `mcp.mcpjam.com` |
 |---|---|---|
@@ -130,6 +130,6 @@ MCPJam also operates a hosted MCP server at `mcp.mcpjam.com/mcp` that exposes yo
 
 ## Troubleshooting
 
-- **Client says the server failed to start** — run `npx -y @mcpjam/cli@latest mcp` in a terminal; you should see `MCPJam MCP server listening on stdio` on stderr. First runs may be slow while `npx` downloads the package; pre-install with `npm i -g @mcpjam/cli` and use `mcpjam mcp` to avoid the download.
-- **`connect_server` fails with `SERVER_UNREACHABLE`** — the target URL or command is wrong, or the target crashed on startup. Try `server_doctor` against the same target for a structured diagnosis.
-- **A connection name is already taken** — `connect_server` refuses to overwrite an existing name; `disconnect_server` it first or pass a different `name`.
+- **Client says the server failed to start**: run `npx -y @mcpjam/cli@latest mcp` in a terminal; you should see `MCPJam MCP server listening on stdio` on stderr. First runs may be slow while `npx` downloads the package; pre-install with `npm i -g @mcpjam/cli` and use `mcpjam mcp` to avoid the download.
+- **`connect_server` fails with `SERVER_UNREACHABLE`**: the target URL or command is wrong, or the target crashed on startup. Try `server_doctor` against the same target for a structured diagnosis.
+- **A connection name is already taken**: `connect_server` refuses to overwrite an existing name; `disconnect_server` it first or pass a different `name`.

--- a/docs/cli/oauth-conformance.mdx
+++ b/docs/cli/oauth-conformance.mdx
@@ -4,7 +4,7 @@ description: "Test your MCP server's OAuth implementation across all registratio
 icon: "shield-check"
 ---
 
-The OAuth conformance module runs real OAuth handshakes against your MCP server — the same flows Claude Desktop, ChatGPT, and Claude Code perform — and tells you exactly where they break.
+The OAuth conformance module runs real OAuth handshakes against your MCP server (the same flows Claude Desktop, ChatGPT, and Claude Code perform) and tells you exactly where they break.
 
 ## Why you need this
 
@@ -23,7 +23,7 @@ mcpjam oauth conformance \
   --verify-tools
 ```
 
-The default `--auth-mode` is `interactive` — a browser opens for consent. Pass `--auth-mode headless` for CI against auto-consenting auth servers, or `--auth-mode client_credentials` for M2M.
+The default `--auth-mode` is `interactive`: a browser opens for consent. Pass `--auth-mode headless` for CI against auto-consenting auth servers, or `--auth-mode client_credentials` for M2M.
 
 **What success looks like:**
 
@@ -43,21 +43,21 @@ listTools: PASS (8 tools)
 
 Each conformance run walks through:
 
-1. **Initial request** — sends an unauthenticated request to trigger a 401
-2. **Discovery** — fetches resource metadata and authorization server metadata
-3. **Registration** — registers the client via CIMD, DCR, or pre-registered credentials
-4. **Authorization** — obtains an authorization code (interactive, headless, or client_credentials)
-5. **Token exchange** — exchanges the code for access/refresh tokens
-6. **Authenticated request** — retries the MCP request with the token
-7. **Post-auth verification** (optional) — connects via MCP and lists tools / calls a tool
+1. **Initial request**: sends an unauthenticated request to trigger a 401
+2. **Discovery**: fetches resource metadata and authorization server metadata
+3. **Registration**: registers the client via CIMD, DCR, or pre-registered credentials
+4. **Authorization**: obtains an authorization code (interactive, headless, or client_credentials)
+5. **Token exchange**: exchanges the code for access/refresh tokens
+6. **Authenticated request**: retries the MCP request with the token
+7. **Post-auth verification** (optional): connects via MCP and lists tools / calls a tool
 
 When `--conformance-checks` is enabled, six additional negative checks run after the flow:
-- **DCR redirect URI policy** — attempts dynamic client registration with a non-loopback `http://` redirect URI and expects rejection under the MCP authorization profile
-- **Invalid client** — confirms the auth server rejects an unknown client ID
-- **Invalid redirect at the authorization endpoint** — sends an authorization request with a mismatched `redirect_uri` and looks for rejection before the server redirects back to it
-- **Invalid token** — confirms the MCP server rejects an obviously invalid bearer token with HTTP 401
-- **Invalid redirect** — attempts a token request with a mismatched redirect URI to look for exact-match enforcement; this check may be skipped if the request is rejected for a different reason first
-- **Token format** — validates the token response has the expected fields
+- **DCR redirect URI policy**: attempts dynamic client registration with a non-loopback `http://` redirect URI and expects rejection under the MCP authorization profile
+- **Invalid client**: confirms the auth server rejects an unknown client ID
+- **Invalid redirect at the authorization endpoint**: sends an authorization request with a mismatched `redirect_uri` and looks for rejection before the server redirects back to it
+- **Invalid token**: confirms the MCP server rejects an obviously invalid bearer token with HTTP 401
+- **Invalid redirect**: attempts a token request with a mismatched redirect URI to look for exact-match enforcement; this check may be skipped if the request is rejected for a different reason first
+- **Token format**: validates the token response has the expected fields
 
 ## Scenarios
 
@@ -166,7 +166,7 @@ mcpjam oauth conformance \
   --verify-tools
 ```
 
-`--print-url` writes the consent URL to stderr (`OAUTH_CONSENT_URL: https://...`) instead of launching a browser. The local callback listener still runs — your Playwright script opens the URL, drives consent, and the CLI catches the redirect.
+`--print-url` writes the consent URL to stderr (`OAUTH_CONSENT_URL: https://...`) instead of launching a browser. The local callback listener still runs. Your Playwright script opens the URL, drives consent, and the CLI catches the redirect.
 
 ### Run the OAuth negative checks
 
@@ -185,13 +185,13 @@ This adds 6 checks after the main flow: DCR redirect URI policy, invalid client 
 
 | Strategy | Description | Protocol versions |
 |----------|-------------|-------------------|
-| `cimd` | Client ID Metadata Document — the client publishes its identity at a URL | 2025-11-25 only |
-| `dcr` | Dynamic Client Registration — the client registers itself at runtime | All |
+| `cimd` | Client ID Metadata Document: the client publishes its identity at a URL | 2025-11-25 only |
+| `dcr` | Dynamic Client Registration: the client registers itself at runtime | All |
 | `preregistered` | Pre-registered client ID and optional secret | All |
 
 **When to choose what:**
-- **CIMD** (2025-11-25): preferred for production when the auth server supports it — avoids mutable DCR state.
-- **DCR**: the default for quick testing — works everywhere, no pre-configuration needed.
+- **CIMD** (2025-11-25): preferred for production when the auth server supports it (avoids mutable DCR state).
+- **DCR**: the default for quick testing. It works everywhere, no pre-configuration needed.
 - **Preregistered**: use when the auth server doesn't support DCR, or for `client_credentials` M2M flows.
 
 When `cimd` is used without `--client-metadata-url`, the runner falls back to mcpjam's public metadata document at `https://www.mcpjam.com/.well-known/oauth/client-metadata.json`.
@@ -200,7 +200,7 @@ When `cimd` is used without `--client-metadata-url`, the runner falls back to mc
 
 | Mode | Use case | User interaction |
 |------|----------|-----------------|
-| `interactive` (default) | Local dev — opens browser for consent | Browser popup |
+| `interactive` (default) | Local dev, opens browser for consent | Browser popup |
 | `headless` | CI with auto-consenting auth servers | None |
 | `client_credentials` | Machine-to-machine service accounts | None |
 
@@ -220,9 +220,9 @@ OAuth conformance proves a token was issued. Verification proves the token is ac
 
 Three silent-failure modes this catches:
 
-1. **Token audience mismatch** — OAuth flow succeeds but `tools/list` returns 401 because `aud` doesn't match the MCP resource URL.
-2. **Scope mismatch** — token issued but the MCP tool handler requires different scopes.
-3. **Session binding** — some servers require a separate session init after auth.
+1. **Token audience mismatch**: OAuth flow succeeds but `tools/list` returns 401 because `aud` doesn't match the MCP resource URL.
+2. **Scope mismatch**: token issued but the MCP tool handler requires different scopes.
+3. **Session binding**: some servers require a separate session init after auth.
 
 | Flag | What it does |
 |------|-------------|
@@ -257,14 +257,14 @@ supported way to persist live tokens.
 |-----------------|-------------|-----|
 | `request_without_token` returned 200 | Server allows anonymous access or missing `WWW-Authenticate` | Return 401 with `WWW-Authenticate: Bearer resource_metadata="..."` |
 | `request_resource_metadata` 404 | `/.well-known/oauth-protected-resource` missing or wrong Content-Type | Ensure the endpoint exists and returns `application/json` |
-| `received_resource_metadata` — resource validation failed | Protected Resource Metadata is missing its required `resource` field, uses a non-HTTPS URL, or advertises a resource on a different origin than the server URL | Ensure your PRM document includes a `resource` field that is an HTTPS URL on the same origin as the MCP server (RFC 9728 §2) |
-| `received_resource_metadata` — AS URL mismatch | `authorization_servers` points to a URL without AS metadata | Verify the AS URL has `/.well-known/oauth-authorization-server` |
+| `received_resource_metadata` (resource validation failed) | Protected Resource Metadata is missing its required `resource` field, uses a non-HTTPS URL, or advertises a resource on a different origin than the server URL | Ensure your PRM document includes a `resource` field that is an HTTPS URL on the same origin as the MCP server (RFC 9728 §2) |
+| `received_resource_metadata` (AS URL mismatch) | `authorization_servers` points to a URL without AS metadata | Verify the AS URL has `/.well-known/oauth-authorization-server` |
 | `request_client_registration` 400 | DCR endpoint rejected the registration metadata | Check required fields; use SDK `dynamicRegistration` overrides for custom metadata |
-| `received_authorization_code` — HTML login page | Auth server requires interactive login but you used `--auth-mode headless` | Switch to `--auth-mode interactive` |
-| `received_authorization_code` — state mismatch | Stale popup or concurrent authorization flows | Close other browser tabs and retry |
+| `received_authorization_code` (HTML login page) | Auth server requires interactive login but you used `--auth-mode headless` | Switch to `--auth-mode interactive` |
+| `received_authorization_code` (state mismatch) | Stale popup or concurrent authorization flows | Close other browser tabs and retry |
 | `token_request` 401 `invalid_client` | Wrong `token_endpoint_auth_method` or client_id mismatch | Check DCR response for `token_endpoint_auth_method`; CIMD uses `none` |
 | `authenticated_mcp_request` 401 | Token `aud` doesn't match MCP resource URL | Ensure your auth server sets `aud` correctly |
-| `verify_list_tools` auth error | Token works for OAuth but MCP layer rejects it — scope issue | Check that the token's scope matches what tool handlers require |
+| `verify_list_tools` auth error | Token works for OAuth but MCP layer rejects it (scope issue) | Check that the token's scope matches what tool handlers require |
 | DCR + `client_credentials`: "Dynamic registration produced a public client" | DCR returned `token_endpoint_auth_method: "none"` | Use `--registration preregistered` with explicit credentials instead |
 
 ## CI/CD integration
@@ -346,6 +346,6 @@ oauth-conformance:
 
 ## Related
 
-- [OAuth Login & Debugging](/cli/oauth-login) — get tokens and debug OAuth flows
-- [Server Inspection](/cli/server-inspection) — probe and diagnose before testing conformance
-- [OAuth Conformance SDK Reference](/sdk/reference/oauth-conformance) — programmatic usage with `OAuthConformanceTest`
+- [OAuth Login & Debugging](/cli/oauth-login): get tokens and debug OAuth flows
+- [Server Inspection](/cli/server-inspection): probe and diagnose before testing conformance
+- [OAuth Conformance SDK Reference](/sdk/reference/oauth-conformance): programmatic usage with `OAuthConformanceTest`

--- a/docs/cli/oauth-login.mdx
+++ b/docs/cli/oauth-login.mdx
@@ -9,7 +9,7 @@ The `oauth` command group handles authentication against MCP servers that requir
 ## Quick start
 
 ```bash
-# Interactive login — opens a browser for consent
+# Interactive login: opens a browser for consent
 mcpjam oauth login --url https://your-server.com/mcp \
   --protocol-version 2025-11-25 \
   --registration dcr
@@ -63,7 +63,7 @@ mcpjam tools list --url https://your-server.com/mcp --credentials-file creds.jso
 mcpjam server doctor --url https://your-server.com/mcp --credentials-file creds.json
 ```
 
-The `--debug-out <path>` flag captures a structured debug artifact with full HTTP traces — useful for filing bug reports or handing off to another engineer.
+The `--debug-out <path>` flag captures a structured debug artifact with full HTTP traces, useful for filing bug reports or handing off to another engineer.
 
 ```bash
 mcpjam oauth login --url https://your-server.com/mcp \
@@ -160,7 +160,7 @@ When you already have a token from an environment variable, a secret store, or a
 mcpjam tools list --url https://your-server.com/mcp --access-token "$TOKEN"
 mcpjam server doctor --url https://your-server.com/mcp --oauth-access-token "$TOKEN"
 
-# M2M: preregistered client_credentials — token comes back on stdout
+# M2M: preregistered client_credentials; token comes back on stdout
 TOKEN=$(mcpjam oauth login --url https://your-server.com/mcp \
   --protocol-version 2025-11-25 --registration preregistered \
   --auth-mode client_credentials \

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -69,9 +69,9 @@ These flags apply to every command.
 
 The CLI auto-detects whether stdout is a terminal:
 
-- **Interactive terminal** — defaults to `--format human`. For most commands this is pretty-printed JSON; `server doctor` and the OAuth conformance commands provide dedicated human-readable summaries.
-- **Piped or redirected** (CI, `| jq`, agent invocation) — defaults to `--format json`, the full structured result.
-- **Conformance in CI** — `protocol conformance`, `protocol conformance-suite`, `oauth conformance`, `oauth conformance-suite`, `apps conformance`, and `apps conformance-suite` support `--reporter junit-xml` and `--reporter json-summary`.
+- **Interactive terminal**: defaults to `--format human`. For most commands this is pretty-printed JSON; `server doctor` and the OAuth conformance commands provide dedicated human-readable summaries.
+- **Piped or redirected** (CI, `| jq`, agent invocation): defaults to `--format json`, the full structured result.
+- **Conformance in CI**: `protocol conformance`, `protocol conformance-suite`, `oauth conformance`, `oauth conformance-suite`, `apps conformance`, and `apps conformance-suite` support `--reporter junit-xml` and `--reporter json-summary`.
 - **Explicit `--format`** always wins over the auto-detected default.
 
 **For agents**: raw JSON is the source of truth. Human format is a lossy presentation layer. If you're parsing output programmatically, pass `--quiet --format json`.
@@ -194,10 +194,10 @@ Connections to servers under test stay open between tool calls, so agents can al
 
 ## What's next
 
-- [MCPJam as an MCP server](/cli/mcp-server) — give MCP clients the testing engine over stdio
-- [Server inspection](/cli/server-inspection) — probe, doctor, and diagnostics
-- [OAuth conformance](/cli/oauth-conformance) — test your OAuth implementation
-- [OAuth login](/cli/oauth-login) — authenticate and debug OAuth flows
-- [MCP Apps conformance](/cli/apps-conformance) — validate `_meta.ui.resourceUri` and `ui://` resource wiring
-- [Tools, resources & prompts](/cli/tools-resources-prompts) — exercise the connected surface
-- [Full command reference](/cli/reference) — every flag for every command
+- [MCPJam as an MCP server](/cli/mcp-server): give MCP clients the testing engine over stdio
+- [Server inspection](/cli/server-inspection): probe, doctor, and diagnostics
+- [OAuth conformance](/cli/oauth-conformance): test your OAuth implementation
+- [OAuth login](/cli/oauth-login): authenticate and debug OAuth flows
+- [MCP Apps conformance](/cli/apps-conformance): validate `_meta.ui.resourceUri` and `ui://` resource wiring
+- [Tools, resources & prompts](/cli/tools-resources-prompts): exercise the connected surface
+- [Full command reference](/cli/reference): every flag for every command

--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -95,7 +95,7 @@ Uses shared connection flags, plus:
 
 | Flag | Description |
 |------|-------------|
-| `--host <id>` | Connect as this host (e.g. `claude`, `chatgpt`, `cursor`) — sends its `clientInfo`, `clientCapabilities`, and protocol version in `initialize`, and hides app-only tools its model can't see. Mutually exclusive with `--client-capabilities`. |
+| `--host <id>` | Connect as this host (e.g. `claude`, `chatgpt`, `cursor`): sends its `clientInfo`, `clientCapabilities`, and protocol version in `initialize`, and hides app-only tools its model can't see. Mutually exclusive with `--client-capabilities`. |
 | `--cursor <cursor>` | Pagination cursor |
 | `--model-id <model>` | Model ID used for token counting |
 
@@ -105,7 +105,7 @@ When `--host` is set, the output includes a `host` field and a `toolsDroppedVisi
 
 | Flag | Description |
 |------|-------------|
-| `--host <id>` | Connect as this host — sends its identity/capabilities/protocol in `initialize`, and rejects app-only tools the host's model can't call. Mutually exclusive with `--client-capabilities`. |
+| `--host <id>` | Connect as this host: sends its identity/capabilities/protocol in `initialize`, and rejects app-only tools the host's model can't call. Mutually exclusive with `--client-capabilities`. |
 | `--tool-name <name>` | Name of the tool to call |
 | `--name <name>` | Legacy alias for `--tool-name` |
 | `--tool-args <json>` | Tool arguments as inline JSON, `@path`, or `-` for stdin |
@@ -184,14 +184,14 @@ Uses shared connection flags, plus:
 
 | Flag | Description |
 |------|-------------|
-| `--host <id>` | Connect as this host — sends its identity/capabilities/protocol in `initialize`. Mutually exclusive with `--client-capabilities`. |
+| `--host <id>` | Connect as this host: sends its identity/capabilities/protocol in `initialize`. Mutually exclusive with `--client-capabilities`. |
 | `--cursor <cursor>` | Pagination cursor |
 
 ### `resources read`
 
 | Flag | Description |
 |------|-------------|
-| `--host <id>` | Connect as this host — sends its identity/capabilities/protocol in `initialize`. Mutually exclusive with `--client-capabilities`. |
+| `--host <id>` | Connect as this host: sends its identity/capabilities/protocol in `initialize`. Mutually exclusive with `--client-capabilities`. |
 | `--resource-uri <uri>` | URI of the resource to read |
 | `--uri <uri>` | Legacy alias for `--resource-uri` |
 
@@ -203,7 +203,7 @@ Uses shared connection flags, plus:
 
 | Flag | Description |
 |------|-------------|
-| `--host <id>` | Connect as this host — sends its identity/capabilities/protocol in `initialize`. Mutually exclusive with `--client-capabilities`. |
+| `--host <id>` | Connect as this host: sends its identity/capabilities/protocol in `initialize`. Mutually exclusive with `--client-capabilities`. |
 | `--cursor <cursor>` | Pagination cursor |
 
 ---
@@ -216,14 +216,14 @@ Uses shared connection flags, plus:
 
 | Flag | Description |
 |------|-------------|
-| `--host <id>` | Connect as this host — sends its identity/capabilities/protocol in `initialize`. Mutually exclusive with `--client-capabilities`. |
+| `--host <id>` | Connect as this host: sends its identity/capabilities/protocol in `initialize`. Mutually exclusive with `--client-capabilities`. |
 | `--cursor <cursor>` | Pagination cursor |
 
 ### `prompts get`
 
 | Flag | Description |
 |------|-------------|
-| `--host <id>` | Connect as this host — sends its identity/capabilities/protocol in `initialize`. Mutually exclusive with `--client-capabilities`. |
+| `--host <id>` | Connect as this host: sends its identity/capabilities/protocol in `initialize`. Mutually exclusive with `--client-capabilities`. |
 | `--prompt-name <name>` | Name of the prompt |
 | `--name <name>` | Legacy alias for `--prompt-name` |
 | `--prompt-args <json>` | Prompt arguments as inline JSON, `@path`, or `-` for stdin |
@@ -241,12 +241,12 @@ Run the Cross-App Access (ID-JAG) debugger: self-issue an ID-JAG, redeem it at t
 | Flag | Required | Default | Description |
 |------|----------|---------|-------------|
 | `--url <url>` | Yes | | Target MCP server URL (the protected resource) |
-| `--issuer-base-url <url>` | Yes | | Origin the local mock IdP issues from. It must publish the CLI's local signing key — typically a running [local inspector](/cli/xaa#before-you-run-make-the-issuer-reachable), not your real IdP |
+| `--issuer-base-url <url>` | Yes | | Origin the local mock IdP issues from. It must publish the CLI's local signing key: typically a running [local inspector](/cli/xaa#before-you-run-make-the-issuer-reachable), not your real IdP |
 | `--sub <subject>` | Yes | | Simulated end-user subject identifier |
 | `--client-id <id>` | No | | OAuth client ID. Required for `preregistered`; rejected for `dcr`/`cimd` |
 | `--registration <method>` | No | `preregistered` | `preregistered`, `dcr`, or `cimd` |
 | `--client-metadata-url <url>` | No | | CIMD only: the Client ID Metadata Document URL to present as the `client_id` |
-| `--client-auth <method>` | No | `none` | CIMD only: `none` (public) or `private-key-jwt` (confidential — generates a local EC P-256 key, publishes it via the hosted reflector, and signs a `client_assertion`) |
+| `--client-auth <method>` | No | `none` | CIMD only: `none` (public) or `private-key-jwt` (confidential: generates a local EC P-256 key, publishes it via the hosted reflector, and signs a `client_assertion`) |
 | `--cimd-metadata-origin <url>` | No | `https://app.mcpjam.com` | Confidential CIMD only: bare origin hosting the metadata-document reflector. An `http://` loopback origin is a dev-only opt-in; rejected when `--https-only` is set |
 | `--authz-server-issuer <issuer>` | No | | Target AS issuer. When set, protected-resource metadata discovery is skipped |
 | `--token-endpoint <url>` | No | | AS token endpoint. When set, AS-metadata discovery is skipped. Not valid with `dcr` or `cimd` |
@@ -262,8 +262,8 @@ Run the Cross-App Access (ID-JAG) debugger: self-issue an ID-JAG, redeem it at t
 | Strategy | Description |
 |----------|-------------|
 | `preregistered` | Supply a pre-registered `--client-id` (and optional `--client-secret`) |
-| `dcr` | Dynamic Client Registration (RFC 7591) — the CLI registers a client at the RAS each run |
-| `cimd` | Client ID Metadata Document — the client publishes its identity at a URL |
+| `dcr` | Dynamic Client Registration (RFC 7591): the CLI registers a client at the RAS each run |
+| `cimd` | Client ID Metadata Document: the client publishes its identity at a URL |
 
 #### Confidential CIMD (`--client-auth private-key-jwt`)
 
@@ -280,7 +280,7 @@ mcpjam xaa run \
   --client-auth private-key-jwt
 ```
 
-For a cloud authorization server, expose the inspector origin through a tunnel and pass the public origin as `--issuer-base-url` — see [making the issuer reachable](/cli/xaa#before-you-run-make-the-issuer-reachable).
+For a cloud authorization server, expose the inspector origin through a tunnel and pass the public origin as `--issuer-base-url`; see [making the issuer reachable](/cli/xaa#before-you-run-make-the-issuer-reachable).
 
 **Key rotation:** the key is the identity. Deleting `~/.mcpjam/xaa-client-private.pem` or changing the `XAA_CLIENT_PRIVATE_KEY` environment variable generates a new `client_id`; any RAS-side allowlisting must be updated after rotation.
 
@@ -568,7 +568,7 @@ Show an environment's builds (newest first) with their log preview.
 
 ### `env use`
 
-Boot your computer from this environment. This rebuilds the computer — installed files are wiped.
+Boot your computer from this environment. This rebuilds the computer: installed files are wiped.
 
 | Flag | Required | Description |
 |------|----------|-------------|
@@ -970,7 +970,7 @@ These commands manage your MCPJam platform session. `login` opens a browser for 
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--api-url <url>` | `https://app.mcpjam.com/api/v1` | MCPJam API base URL. The value is persisted with the session so subsequent cloud commands target the same deployment without needing `--api-url` again. Must be a valid `http(s)` URL — an invalid value exits with code `2` before any network call. |
+| `--api-url <url>` | `https://app.mcpjam.com/api/v1` | MCPJam API base URL. The value is persisted with the session so subsequent cloud commands target the same deployment without needing `--api-url` again. Must be a valid `http(s)` URL; an invalid value exits with code `2` before any network call. |
 | `--no-browser` | | Print the login URL to stderr instead of opening a browser. |
 
 The `MCPJAM_API_URL` environment variable is equivalent to `--api-url`. An invalid value in either source is a hard error (exit 2).

--- a/docs/cli/server-inspection.mdx
+++ b/docs/cli/server-inspection.mdx
@@ -4,7 +4,7 @@ description: "Probe, diagnose, and export MCP server connectivity and capabiliti
 icon: "stethoscope"
 ---
 
-The `server` command group gives you a breadth-first view of any MCP server — connectivity, OAuth discovery, capabilities, tools, resources, and prompts — without writing code.
+The `server` command group gives you a breadth-first view of any MCP server (connectivity, OAuth discovery, capabilities, tools, resources, and prompts) without writing code.
 
 ## Quick start
 
@@ -19,7 +19,7 @@ If the server requires OAuth, doctor reports `oauth_required` with the discovery
 
 ### `server probe`
 
-Stateless HTTP probe — no full client connection. Tests transport selection, OAuth discovery, and `WWW-Authenticate` parsing.
+Stateless HTTP probe, no full client connection. Tests transport selection, OAuth discovery, and `WWW-Authenticate` parsing.
 
 ```bash
 mcpjam server probe --url https://your-server.com/mcp
@@ -36,7 +36,7 @@ Sensitive fields such as `Authorization` headers are automatically redacted to `
 
 ### `server doctor`
 
-Combined triage — runs probe, then attempts a full client connection, then sweeps tools, resources, resource templates, and prompts. Returns a single JSON artifact.
+Combined triage: runs probe, then attempts a full client connection, then sweeps tools, resources, resource templates, and prompts. Returns a single JSON artifact.
 
 ```bash
 # Human-readable summary
@@ -55,7 +55,7 @@ mcpjam server doctor --command node --args server.js --cwd /path/to/project
 - Initialization info and negotiated capabilities
 - Counts: tools, resources, resource templates, prompts
 
-The `--out <path>` flag writes the full JSON artifact to a file — useful for handoff to another engineer or agent.
+The `--out <path>` flag writes the full JSON artifact to a file, useful for handoff to another engineer or agent.
 For stdio targets, those artifacts only record the explicit env keys you passed
 via `-e/--env`; inherited shell variables are not enumerated.
 

--- a/docs/cli/tools-resources-prompts.mdx
+++ b/docs/cli/tools-resources-prompts.mdx
@@ -8,7 +8,7 @@ Once connected (with or without auth), the `tools`, `resources`, and `prompts` c
 
 ## Running commands as a host
 
-Add `--host <id>` to any `tools`, `resources`, or `prompts` command to connect the way a real host would — sending that host's `clientInfo`, advertised `clientCapabilities`, and protocol version in the MCP `initialize` handshake, exactly as the Inspector Playground does.
+Add `--host <id>` to any `tools`, `resources`, or `prompts` command to connect the way a real host would, sending that host's `clientInfo`, advertised `clientCapabilities`, and protocol version in the MCP `initialize` handshake, exactly as the Inspector Playground does.
 
 ```bash
 mcpjam tools list --url https://your-server.com/mcp --host claude
@@ -16,7 +16,7 @@ mcpjam tools list --url https://your-server.com/mcp --host claude
 
 Valid host IDs match the presets in the Inspector: `claude`, `chatgpt`, `cursor`, `copilot`, `codex`, `mcpjam`.
 
-**Tool visibility with `--host`:** `tools list --host` hides tools whose `_meta.ui.visibility` is `["app"]` — those are app-only tools the host's model cannot see. The output includes a `host` field and a `toolsDroppedVisibility` count. Hosts that opt out of visibility filtering (such as `cursor`) keep all tools. `tools call --host` rejects app-only tools with a usage error; omit `--host` to call them as an operator.
+**Tool visibility with `--host`:** `tools list --host` hides tools whose `_meta.ui.visibility` is `["app"]`. Those are app-only tools the host's model cannot see. The output includes a `host` field and a `toolsDroppedVisibility` count. Hosts that opt out of visibility filtering (such as `cursor`) keep all tools. `tools call --host` rejects app-only tools with a usage error; omit `--host` to call them as an operator.
 
 **Conflict with `--client-capabilities`:** `--host` and `--client-capabilities` both set the exact advertised capabilities and cannot be combined. The CLI exits with a usage error if both are passed.
 

--- a/docs/cli/xaa.mdx
+++ b/docs/cli/xaa.mdx
@@ -4,9 +4,9 @@ description: "Run the full Cross-App Access (ID-JAG) grant chain against your au
 icon: "id-card"
 ---
 
-`mcpjam xaa run` drives a complete Cross-App Access flow — the
+`mcpjam xaa run` drives a complete Cross-App Access flow, the
 [Identity Assertion Authorization Grant](https://datatracker.ietf.org/doc/draft-ietf-oauth-identity-assertion-authz-grant/)
-(ID-JAG, an active IETF Internet-Draft) — against your authorization server and
+(ID-JAG, an active IETF Internet-Draft), against your authorization server and
 MCP server. MCPJam plays the **enterprise identity provider** (it mints and
 signs the ID-JAG) and the **client/agent** (it redeems the ID-JAG and calls
 your MCP server with the resulting access token). Your authorization server
@@ -31,7 +31,7 @@ npx skills add mcpjam/inspector --skill mcp-inspector
 ```
 
 Once installed, your agent will know how and when to invoke `mcpjam` commands
-automatically — and how to read `xaa run` output conservatively (advertisement
+automatically, and how to read `xaa run` output conservatively (advertisement
 is evidence, redemption is the verdict; an issuer it can't reach is your setup,
 not a server bug).
 
@@ -42,7 +42,7 @@ conflate. The CLI covers two of them and simulates the third:
 
 | Relationship | Who configures it | In this test |
 | --- | --- | --- |
-| Client ↔ IdP | Enterprise SSO registration | Simulated — the CLI **is** the IdP, so this leg always succeeds |
+| Client ↔ IdP | Enterprise SSO registration | Simulated: the CLI **is** the IdP, so this leg always succeeds |
 | RAS ↔ IdP | Your authorization server trusts the IdP's issuer + JWKS | **You set this up once** (see below) |
 | Client ↔ RAS | OAuth client registration at your authorization server | Exercised per run via `--registration` |
 
@@ -51,7 +51,7 @@ conflate. The CLI covers two of them and simulates the third:
 The CLI signs ID-JAGs with a local key pair (`~/.mcpjam/xaa-idp-private.pem`;
 override the directory with `XAA_IDP_KEY_DIR`). Your authorization server must
 be able to fetch the matching public key, so `--issuer-base-url` must be an
-origin that **publishes that same key** — not your real IdP's URL.
+origin that **publishes that same key**, not your real IdP's URL.
 
 The local MCPJam inspector serves exactly this: it publishes the issuer
 metadata and JWKS from the same key directory at
@@ -71,29 +71,29 @@ Then register the issuer in your authorization server: trust
 `<issuer-base-url>/xaa` as an ID-JAG issuer and point it at the JWKS URL above.
 
 The first flow step, `verify_issuer_publication`, fails fast if the issuer
-origin is unreachable or publishes a different key — nothing is sent to your
+origin is unreachable or publishes a different key. Nothing is sent to your
 servers until it passes.
 
 ## What a run checks
 
 Each run walks the grant chain and reports every step:
 
-1. **`verify_issuer_publication`** — the configured issuer publishes the CLI's
+1. **`verify_issuer_publication`**: the configured issuer publishes the CLI's
    local signing key
-2. **`discover_resource_metadata`** — protected-resource metadata
+2. **`discover_resource_metadata`**: protected-resource metadata
    ([RFC 9728](https://www.rfc-editor.org/rfc/rfc9728)) names the
    authorization server protecting `--url`
-3. **`discover_authz_metadata`** — authorization-server metadata
+3. **`discover_authz_metadata`**: authorization-server metadata
    ([RFC 8414](https://www.rfc-editor.org/rfc/rfc8414)) provides the token
    endpoint and capability advertisements
-4. **`mint_id_jag`** — the mock IdP exchanges the simulated user's identity
+4. **`mint_id_jag`**: the mock IdP exchanges the simulated user's identity
    assertion for an ID-JAG (`typ: oauth-id-jag+jwt`, audience = your
    authorization server, `resource` = your MCP server)
-5. **`redeem_id_jag`** — the ID-JAG is presented at your token endpoint via
+5. **`redeem_id_jag`**: the ID-JAG is presented at your token endpoint via
    the JWT bearer grant
    ([RFC 7523](https://www.rfc-editor.org/rfc/rfc7523)); your server
    validates it and issues its own access token
-6. **`authenticated_mcp_request`** — an MCP `initialize` with the issued
+6. **`authenticated_mcp_request`**: an MCP `initialize` with the issued
    token, advertising the
    [Enterprise-Managed Authorization extension](https://github.com/modelcontextprotocol/ext-auth/blob/main/specification/stable/enterprise-managed-authorization.mdx)
 
@@ -102,19 +102,19 @@ outcomes: whether your authorization server advertises the ID-JAG grant
 profile and the JWT bearer grant, which token-endpoint auth method was
 selected, and whether your MCP server advertises the enterprise-managed
 authorization extension back. Missing advertisements are reported as findings
-but never fail a flow that operationally succeeds — redemption is the verdict,
+but never fail a flow that operationally succeeds: redemption is the verdict,
 advertisement is evidence.
 
 Capability evidence fields are three-valued: `advertised`, `not_advertised`
 (the metadata key was present but did not include the expected value), or
 `unknown` (the metadata key was absent entirely). `unknown` is weaker evidence
-than `not_advertised` — the two are not equivalent.
+than `not_advertised`. The two are not equivalent.
 
 The decoded ID-JAG claims and a local signature-verification verdict
 (`idJag.verified`) are included in the result so you can inspect exactly what
 your authorization server received. `idJag.verified` confirms the CLI's own
 mint was well-formed and correctly signed; it is not evidence that your
-authorization server validated the assertion — the AS's behavior is in the
+authorization server validated the assertion. The AS's behavior is in the
 `redemption` block. Raw tokens, assertions, and secrets are always
 `[REDACTED]` in the output, including when a server reflects them back inside
 an error body.
@@ -128,17 +128,17 @@ server, mirroring the client-registration models MCP clients use:
 | --- | --- | --- |
 | `preregistered` (default) | `--client-id` (+ optional `--client-secret`) | Matches the draft's recommended deployment |
 | `dcr` | none | A diagnostic: the CLI performs open [RFC 7591](https://www.rfc-editor.org/rfc/rfc7591) registration and supplies the IdP→RAS client mapping itself. Each run may leave a registration behind. RFC 7591 conformance findings are reported as warnings in `registration.warnings[]` |
-| `cimd` | none | Public client by default — the run completes but is flagged: the draft recommends confidential clients |
+| `cimd` | none | Public client by default. The run completes but is flagged: the draft recommends confidential clients |
 | `cimd` + `--client-auth private-key-jwt` | none | Confidential CIMD: the CLI generates a local EC P-256 key, publishes it through the hosted reflector, and signs a `client_assertion`. The private key never leaves your machine |
 
 The `registration.warnings[]` array in the result uses these codes:
 
 | Code | Meaning | Weight |
 | --- | --- | --- |
-| `public_client` | Client authenticates with no key or secret | Posture note — the draft recommends confidential clients, but this is not itself a vulnerability |
-| `profile_metadata_not_echoed` | DCR response omitted `authorization_grant_profiles_supported` | Informational — RFC 7591 allows a server to ignore unknown metadata |
-| `grant_types_not_echoed` | DCR response omitted `grant_types` | Informational — same rationale; redemption is the real signal |
-| `missing_no_store` | DCR credential response lacked `Cache-Control: no-store` | Low compliance finding — RFC 7591 requires this header for credential-bearing responses |
+| `public_client` | Client authenticates with no key or secret | Posture note: the draft recommends confidential clients, but this is not itself a vulnerability |
+| `profile_metadata_not_echoed` | DCR response omitted `authorization_grant_profiles_supported` | Informational: RFC 7591 allows a server to ignore unknown metadata |
+| `grant_types_not_echoed` | DCR response omitted `grant_types` | Informational: same rationale; redemption is the real signal |
+| `missing_no_store` | DCR credential response lacked `Cache-Control: no-store` | Low compliance finding: RFC 7591 requires this header for credential-bearing responses |
 
 For confidential CIMD, **the key is the identity**: the reflector URL derived
 from the public key becomes the `client_id`. Deleting
@@ -150,9 +150,9 @@ be updated.
 
 `--assertion-format` selects the identity rail the simulated enterprise uses:
 
-- `oidc` (default) — the mock IdP mints an OIDC ID token as the
+- `oidc` (default): the mock IdP mints an OIDC ID token as the
   token-exchange subject token.
-- `saml` — the mock IdP mints a **SAML 2.0 assertion** as the subject token,
+- `saml`: the mock IdP mints a **SAML 2.0 assertion** as the subject token,
   and the ID-JAG carries a `saml-nameid` `sub_id` claim so a SAML-federated
   authorization server can resolve the user.
 
@@ -230,9 +230,9 @@ mcpjam xaa run \
 ## What this is not
 
 These are targeted debugging checks for the current ID-JAG draft, not a
-conformance suite. The negative-test scorecard — sending deliberately broken
+conformance suite. The negative-test scorecard, sending deliberately broken
 ID-JAGs (bad signature, wrong audience, expired, and six more) and verifying
-your authorization server rejects each — lives in the
+your authorization server rejects each, lives in the
 [inspector's XAA Debugger](/inspector/xaa-debugger), which also visualizes the
 flow and inspects the ID-JAG interactively before it is sent.
 

--- a/docs/contributing/evals-architecture.mdx
+++ b/docs/contributing/evals-architecture.mdx
@@ -14,13 +14,13 @@ The Evals system in MCPJam Inspector is a comprehensive testing framework design
 
 ## HostConfig consolidation
 
-The Playground (live chat) and Evals share a single, portable `hostConfig` core that lives in `@mcpjam/sdk/host-config/`. Everything that drives an LLM-plus-MCP loop — host style, model, sandbox/permission policy, OpenAI-Apps compat, tool-visibility, MCP server selection — flows through one canonical shape and one hash.
+The Playground (live chat) and Evals share a single, portable `hostConfig` core that lives in `@mcpjam/sdk/host-config/`. Everything that drives an LLM-plus-MCP loop (host style, model, sandbox/permission policy, OpenAI-Apps compat, tool-visibility, MCP server selection) flows through one canonical shape and one hash.
 
 ```
 @mcpjam/sdk/host-config/
   types.ts          # HostConfigInputV2, HostJson, CspDomainSet, …
-  canonicalize.ts   # canonicalizeHostConfigV2 — byte-stable JSON
-  hash.ts           # computeHostConfigHashV2 — sha256(canonical)
+  canonicalize.ts   # canonicalizeHostConfigV2: byte-stable JSON
+  hash.ts           # computeHostConfigHashV2: sha256(canonical)
   defaults.ts       # emptyHostConfigInputV2, resolveEffectiveMcpProtocolVersion, …
   host-policy.ts    # extractHostExecutionPolicy, buildHostIterationMetadata
   compat-runtime.ts # resolveOpenAiCompatForHostConfig
@@ -28,48 +28,48 @@ The Playground (live chat) and Evals share a single, portable `hostConfig` core 
   sdk-evals-normalizer.ts # normalizeSdkEvalHostConfigForWire (Stage 5)
 ```
 
-This module is the **one source of truth**. The MCPJam backend imports the canonicalizer + hasher directly from `@mcpjam/sdk/host-config/internal`; see `mcpjam-backend/convex/lib/hostConfigV2.ts` — the file is a thin Convex-bound wrapper (server-scope validation, `Id<'servers'>` boundary cast) over the SDK functions, not a parallel implementation.
+This module is the **one source of truth**. The MCPJam backend imports the canonicalizer + hasher directly from `@mcpjam/sdk/host-config/internal`; see `mcpjam-backend/convex/lib/hostConfigV2.ts`: the file is a thin Convex-bound wrapper (server-scope validation, `Id<'servers'>` boundary cast) over the SDK functions, not a parallel implementation.
 
 **Two boundaries inside the inspector consume this module:**
 
 - **Outbound (backend → target MCP server).** The eval runner builds an `MCPClientManager`, connects to the suite's servers, and drives an `HostRunner` over the resolved host. Imports:
-  - `extractHostExecutionPolicy` / `buildHostIterationMetadata` from `@mcpjam/sdk/host-config/internal` (Stage 3) — was previously `server/services/evals/host-execution-policy.ts`; the local file is now deleted.
-  - `resolveOpenAiCompatForHostConfig` from `@mcpjam/sdk/host-config/internal` (Stage 3) — was previously the local `compat-runtime.ts`; only the Convex-bound `loadSuiteHostConfig` remains in the inspector.
-  - `filterAppOnlyTools` from `@mcpjam/sdk/host-config/internal` (Stage 3) — same predicate the chat-v2 path uses, no fork.
+  - `extractHostExecutionPolicy` / `buildHostIterationMetadata` from `@mcpjam/sdk/host-config/internal` (Stage 3), previously `server/services/evals/host-execution-policy.ts`; the local file is now deleted.
+  - `resolveOpenAiCompatForHostConfig` from `@mcpjam/sdk/host-config/internal` (Stage 3), previously the local `compat-runtime.ts`; only the Convex-bound `loadSuiteHostConfig` remains in the inspector.
+  - `filterAppOnlyTools` from `@mcpjam/sdk/host-config/internal` (Stage 3): same predicate the chat-v2 path uses, no fork.
 - **Inbound (frontend → backend).** The eval results API persists per-iteration `hostConfigId` rows that reference the same `hostConfigs` table the chatbox/playground writes.
 
-The Playground's chat-v2 path consumes the same module — playground and evals are two surfaces over the same configuration vocabulary; see [playground-architecture.mdx](./playground-architecture#hostconfig-consolidation) for the live-path side of the same picture.
+The Playground's chat-v2 path consumes the same module: playground and evals are two surfaces over the same configuration vocabulary; see [playground-architecture.mdx](./playground-architecture#hostconfig-consolidation) for the live-path side of the same picture.
 
 ### `HostRunner`, `HostRuntime`, `HostExecutor` (Stage 4 rename)
 
 Inside `@mcpjam/sdk`, the executor surface was renamed in 1.11 to align with MCP spec vocabulary:
 
-- `TestAgent` → `HostRunner` — synchronous executor over a host snapshot with tools pre-resolved.
-- `EvalAgent` → `HostExecutor` — interface implemented by both `HostRunner` and `HostRuntime`.
+- `TestAgent` → `HostRunner`: synchronous executor over a host snapshot with tools pre-resolved.
+- `EvalAgent` → `HostExecutor`: interface implemented by both `HostRunner` and `HostRuntime`.
 - `.prompt()` → `.run()` on the interface and both impls.
 - `Host.addServer()` → `Host.requireServer()`.
-- `HostRuntime` (new) — live binding of a `Host` to an `MCPClientManager` (`host.withManager(manager, { apiKey })`). Snapshots the live host on every `.run()`; stateless across turns.
+- `HostRuntime` (new): live binding of a `Host` to an `MCPClientManager` (`host.withManager(manager, { apiKey })`). Snapshots the live host on every `.run()`; stateless across turns.
 - `EvalTest.run` / `EvalSuite.run` parameter renamed `agent` → `executor`.
 
 `EvalTest` and `EvalSuite` accept any `HostExecutor`, so an external user can run the same eval against their own runtime as long as it implements `getHostSnapshot?.()`.
 
 ### Per-iteration host metadata + Stage 5 wire-send
 
-`HostRunner` snapshots the host once at construction; `HostRuntime` re-snapshots on every `.run()`, so mid-eval mutation to the bound `Host` is captured per-iteration. Each `IterationResult` carries `hostSnapshot?: HostJson` and a derived metadata stamp (`buildHostSnapshotMetadata`) that is additively merged into `EvalResultInput.metadata` (existing keys are never overwritten — conflicting host keys are namespaced under `host.<key>`).
+`HostRunner` snapshots the host once at construction; `HostRuntime` re-snapshots on every `.run()`, so mid-eval mutation to the bound `Host` is captured per-iteration. Each `IterationResult` carries `hostSnapshot?: HostJson` and a derived metadata stamp (`buildHostSnapshotMetadata`) that is additively merged into `EvalResultInput.metadata` (existing keys are never overwritten; conflicting host keys are namespaced under `host.<key>`).
 
 When the MCPJam backend advertises the `evalsHostConfig` capability at `GET /sdk/v1/info`, the SDK eval reporter additionally sends `{ hostConfig, hostConfigHash }` at the run boundary:
 
-- `POST /sdk/v1/evals/runs/start` (chunked path) — body includes the pair when the capability probe succeeds and iteration snapshots are homogeneous.
-- `POST /sdk/v1/evals/report` (one-shot path) — same.
-- `POST /sdk/v1/evals/runs/:id/iterations` (chunked append) and `POST /sdk/v1/evals/runs/:id/finalize` — **never** carry the pair (per-run, not per-batch).
+- `POST /sdk/v1/evals/runs/start` (chunked path): body includes the pair when the capability probe succeeds and iteration snapshots are homogeneous.
+- `POST /sdk/v1/evals/report` (one-shot path): same.
+- `POST /sdk/v1/evals/runs/:id/iterations` (chunked append) and `POST /sdk/v1/evals/runs/:id/finalize` **never** carry the pair (per-run, not per-batch).
 
 Source order, run-level only: `iteration.hostSnapshot` → `executor.getHostSnapshot?.()` → `MCPJamReportingConfig.host`. Pass-1 homogeneity gate: send only when all available iteration snapshots canonicalize to the same hash; heterogeneous runs omit (per-iteration wire support is a later stage). Capability probe is **fail-safe to "no capability"** on any error.
 
-`hostConfigHash` is a transport-integrity check — the backend re-runs `normalizeSdkEvalHostConfigForWire → canonicalizeHostConfigV2 → computeHostConfigHashV2` and rejects on mismatch. It is **not** the persisted storage id; suite-resolved Convex `Id<'servers'>` are layered on top at storage time, so the persisted `hostConfigsV2` row's hash differs from the wire hash by design.
+`hostConfigHash` is a transport-integrity check: the backend re-runs `normalizeSdkEvalHostConfigForWire → canonicalizeHostConfigV2 → computeHostConfigHashV2` and rejects on mismatch. It is **not** the persisted storage id; suite-resolved Convex `Id<'servers'>` are layered on top at storage time, so the persisted `hostConfigsV2` row's hash differs from the wire hash by design.
 
 ### Two distinct sandbox layers
 
-- The persisted host-config sandbox shape (`mcpProfile.apps.sandbox.csp` + `.permissions`) is **allowlist-only** — there is no `deny` field. This is the shape the backend stores and the canonicalizer hashes.
+- The persisted host-config sandbox shape (`mcpProfile.apps.sandbox.csp` + `.permissions`) is **allowlist-only**; there is no `deny` field. This is the shape the backend stores and the canonicalizer hashes.
 - The SDK runtime CSP **resolver** (`sandbox-policy.ts`) carries `deny` plus a hosted clamp for render-time enforcement. It is NOT the same type; the two share only leaf subtypes (`SandboxCspMode`, `SandboxPermissionsMode`, four-directive domain-set).
 
 A canonicalize-time guard in the SDK rejects sandbox shapes that leak a `deny` key. Don't reuse `SandboxCspPolicy` / `SandboxPermissionsPolicy` for persisted host configs.

--- a/docs/contributing/playground-architecture.mdx
+++ b/docs/contributing/playground-architecture.mdx
@@ -10,17 +10,17 @@ icon: "message-circle"
 
 ## HostConfig consolidation
 
-Playground (live chat) and Evals share a single, portable `hostConfig` core that lives in `@mcpjam/sdk/host-config/`. Both surfaces are wired onto the **same** canonicalizer, host-execution policy resolver, OpenAI-Apps compat resolver, and `filterAppOnlyTools` predicate — there is no playground fork.
+Playground (live chat) and Evals share a single, portable `hostConfig` core that lives in `@mcpjam/sdk/host-config/`. Both surfaces are wired onto the **same** canonicalizer, host-execution policy resolver, OpenAI-Apps compat resolver, and `filterAppOnlyTools` predicate; there is no playground fork.
 
 Key consumption points in the inspector server:
 
-- `server/utils/chat-v2-orchestration.ts:prepareChatV2` — the live playground entry point. Imports `filterAppOnlyTools` from `@mcpjam/sdk/host-config/internal` (Stage 3); the local copy is deleted. The `@modelcontextprotocol/ext-apps` dep stays only because three other server files still use it.
-- `server/services/evals/host-execution-policy.ts` — **deleted** after Stage 4. The eval path imports `extractHostExecutionPolicy` and `buildHostIterationMetadata` directly from `@mcpjam/sdk/host-config/internal`.
-- `server/services/evals/compat-runtime.ts` — slimmed to only `loadSuiteHostConfig` (Convex-bound). `resolveOpenAiCompatForHostConfig` and friends moved to the SDK.
+- `server/utils/chat-v2-orchestration.ts:prepareChatV2`: the live playground entry point. Imports `filterAppOnlyTools` from `@mcpjam/sdk/host-config/internal` (Stage 3); the local copy is deleted. The `@modelcontextprotocol/ext-apps` dep stays only because three other server files still use it.
+- `server/services/evals/host-execution-policy.ts`: **deleted** after Stage 4. The eval path imports `extractHostExecutionPolicy` and `buildHostIterationMetadata` directly from `@mcpjam/sdk/host-config/internal`.
+- `server/services/evals/compat-runtime.ts`: slimmed to only `loadSuiteHostConfig` (Convex-bound). `resolveOpenAiCompatForHostConfig` and friends moved to the SDK.
 
-The MCPJam backend (`mcpjam-backend/convex/lib/hostConfigV2.ts`) imports the canonicalizer + hasher from the same `@mcpjam/sdk/host-config/internal` subpath — one source of truth, no hand-mirror. See [evals-architecture.mdx → HostConfig consolidation](./evals-architecture#hostconfig-consolidation) for the cross-surface picture.
+The MCPJam backend (`mcpjam-backend/convex/lib/hostConfigV2.ts`) imports the canonicalizer + hasher from the same `@mcpjam/sdk/host-config/internal` subpath: one source of truth, no hand-mirror. See [evals-architecture.mdx → HostConfig consolidation](./evals-architecture#hostconfig-consolidation) for the cross-surface picture.
 
-**Two distinct sandbox layers.** The persisted host-config sandbox shape (`mcpProfile.apps.sandbox.csp` + `.permissions`) is allowlist-only — no `deny`. The runtime CSP **resolver** in `sandbox-policy.ts` carries `deny` plus a hosted clamp. They share only leaf subtypes; do not reuse the resolver's policy types for persisted configs.
+**Two distinct sandbox layers.** The persisted host-config sandbox shape (`mcpProfile.apps.sandbox.csp` + `.permissions`) is allowlist-only: no `deny`. The runtime CSP **resolver** in `sandbox-policy.ts` carries `deny` plus a hosted clamp. They share only leaf subtypes; do not reuse the resolver's policy types for persisted configs.
 
 ## Overview
 

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -72,12 +72,12 @@ You should see your server show **Connected** with a green dot in the **Connect*
 
 <AccordionGroup>
   <Accordion title="Does MCPJam need a database?" icon="database">
-    No. MCPJam Inspector runs as a hosted web app, a desktop app, or via `npx` — none of them require you to install or configure a database. Accounts, sharing, and OAuth token storage on [app.mcpjam.com](https://app.mcpjam.com) are handled by the hosted backend; the Terminal and Desktop apps store config locally on disk.
+    No. MCPJam Inspector runs as a hosted web app, a desktop app, or via `npx`; none of them require you to install or configure a database. Accounts, sharing, and OAuth token storage on [app.mcpjam.com](https://app.mcpjam.com) are handled by the hosted backend; the Terminal and Desktop apps store config locally on disk.
   </Accordion>
   <Accordion title="How do I check which version of Inspector I'm running?" icon="tag">
     All three installs (Web, Desktop, Terminal) show the running version in the **Settings** tab under **About**.
 
-    To see what the latest published version on npm is — useful for confirming an `@latest` pull actually moved you forward — run:
+    To see what the latest published version on npm is (useful for confirming an `@latest` pull actually moved you forward), run:
 
     ```bash
     npm view @mcpjam/inspector version
@@ -86,10 +86,10 @@ You should see your server show **Connected** with a green dot in the **Connect*
     The Desktop and Web apps update on their own. For the Terminal install, the `@latest` tag in `npx @mcpjam/inspector@latest` pulls the most recent release every run.
   </Accordion>
   <Accordion title="Can MCPJam auto-install MCP servers into my repo?" icon="package">
-    Not directly — MCPJam doesn't reach into your repo. The closest workflow is **Skills**: install the MCPJam CLI skill into a project so an agent working in that repo knows how to use MCP tools and call MCPJam against your servers. See [Skills](/inspector/skills).
+    Not directly: MCPJam doesn't reach into your repo. The closest workflow is **Skills**: install the MCPJam CLI skill into a project so an agent working in that repo knows how to use MCP tools and call MCPJam against your servers. See [Skills](/inspector/skills).
   </Accordion>
   <Accordion title="Where are my files saved?" icon="folder">
-    It depends what you mean — the word covers three different things:
+    It depends what you mean; the word covers three different things:
 
     - **OAuth credentials** from `mcpjam login`: `~/.mcpjam/config.json`. Override per command with `--credentials-out`. See [CLI OAuth login](/cli/oauth-login).
     - **Eval results**: uploaded to your MCPJam project when `MCPJAM_API_KEY` is set to an MCPJam API key (`sk_…`). See [Saving Results](/sdk/concepts/saving-results).

--- a/docs/guides/first-chatgpt-app-react.mdx
+++ b/docs/guides/first-chatgpt-app-react.mdx
@@ -159,14 +159,14 @@ window.openai.setOpenInAppUrl({ href: "https://app.example.com/item/42" });
 
 Only `http` and `https` URLs are accepted. The link opens in a new tab with `noopener,noreferrer`.
 
-This capability is optional — hosts can turn it off, in which case `window.openai.setOpenInAppUrl` won't be defined. Guard for it before calling, for example `window.openai.setOpenInAppUrl?.({ href: "https://app.example.com/item/42" })`.
+This capability is optional; hosts can turn it off, in which case `window.openai.setOpenInAppUrl` won't be defined. Guard for it before calling, for example `window.openai.setOpenInAppUrl?.({ href: "https://app.example.com/item/42" })`.
 
 ### Content Security Policy (CSP)
 
 Widgets run in a sandboxed iframe, so you need to declare which external domains your widget can interact with. Configure these permissions in your resource's `_meta` using one of two formats:
 
-- **`_meta.ui.csp`** (preferred) — uses camelCase field names and is the standard MCP Apps format
-- **`_meta["openai/widgetCSP"]`** (legacy) — the original ChatGPT Apps format, still supported
+- **`_meta.ui.csp`** (preferred): uses camelCase field names and is the standard MCP Apps format
+- **`_meta["openai/widgetCSP"]`** (legacy): the original ChatGPT Apps format, still supported
 
 When both are present, `ui.csp` values take precedence field-by-field; any field absent from `ui.csp` falls back to `openai/widgetCSP`.
 

--- a/docs/guides/first-mcp-app.mdx
+++ b/docs/guides/first-mcp-app.mdx
@@ -483,7 +483,7 @@ The easiest way to test your app is using MCPJam Inspector:
 npx @mcpjam/inspector
 ```
 
-On first launch MCPJam auto-connects a sample Excalidraw server — open the **Servers** tab and add your own. Then head to the **Playground** to render widgets, debug CSP/device behavior, and drive your app with an LLM — test it all in one place!
+On first launch MCPJam auto-connects a sample Excalidraw server; open the **Servers** tab and add your own. Then head to the **Playground** to render widgets, debug CSP/device behavior, and drive your app with an LLM. Test it all in one place!
 
 ### What's next?
 

--- a/docs/hosted/overview.mdx
+++ b/docs/hosted/overview.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Hosted App"
-description: "Use MCPJam Inspector in the browser — no installation required"
+description: "Use MCPJam Inspector in the browser, no installation required"
 icon: "Cloud"
 ---
 
-MCPJam Inspector is available as a hosted web app at [app.mcpjam.com](https://app.mcpjam.com). Build, test, debug, and evaluate MCP servers and apps with frontier models — all from the web.
+MCPJam Inspector is available as a hosted web app at [app.mcpjam.com](https://app.mcpjam.com). Build, test, debug, and evaluate MCP servers and apps with frontier models, all from the web.
 
 <Card
   title="Open MCPJam Inspector"
@@ -17,9 +17,9 @@ MCPJam Inspector is available as a hosted web app at [app.mcpjam.com](https://ap
 
 ## Why use the hosted app?
 
-- **No installation** — Open a browser and start testing.
-- **Always up to date** — You're always on the latest version without running `npx @mcpjam/inspector@latest`.
-- **Shareable** — Share server URLs with your team. Everyone can inspect the same server without local setup.
+- **No installation**: Open a browser and start testing.
+- **Always up to date**: You're always on the latest version without running `npx @mcpjam/inspector@latest`.
+- **Shareable**: Share server URLs with your team. Everyone can inspect the same server without local setup.
 
 ## Share your MCP server
 
@@ -41,7 +41,7 @@ Try it yourself with the [Excalidraw MCP server](https://app.mcpjam.com/shared/e
 
 1. Go to [app.mcpjam.com](https://app.mcpjam.com)
 2. Click **Add server** and enter your MCP server's URL (must be HTTPS)
-3. Choose your authentication method (**Auto** is the default — connects without credentials and escalates to OAuth if the server requires it)
+3. Choose your authentication method (**Auto** is the default: connects without credentials and escalates to OAuth if the server requires it)
 4. Start inspecting tools, resources, and prompts
 
 ## Usage limits
@@ -121,4 +121,4 @@ The **Payment history** card on the org billing page lists your recent credit to
 
 If a receipt isn't available yet the cell shows **Processing** (for pending charges) or **Not available** (for succeeded charges without a receipt link).
 
-To add credits, click **Top up** — either from the empty state when you have no history, or from the credit balance card above.
+To add credits, click **Top up**, either from the empty state when you have no history, or from the credit balance card above.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -5,7 +5,7 @@ icon: "book-open"
 mode: "wide"
 ---
 
-MCPJam is the development platform for **MCP servers, MCP apps, and ChatGPT apps**. Debug every JSON-RPC message and OAuth exchange, run evaluations across multiple LLMs, and track accuracy over time — so you catch regressions early and ship with confidence.
+MCPJam is the development platform for **MCP servers, MCP apps, and ChatGPT apps**. Debug every JSON-RPC message and OAuth exchange, run evaluations across multiple LLMs, and track accuracy over time, so you catch regressions early and ship with confidence.
 
 <Frame>
   <img
@@ -32,7 +32,7 @@ MCPJam is the development platform for **MCP servers, MCP apps, and ChatGPT apps
     ```bash
     npm i -g @mcpjam/cli
     ```
-    Probe, doctor, OAuth, evals — in CI or your shell.
+    Probe, doctor, OAuth, and evals in CI or your shell.
   </Card>
 </CardGroup>
 
@@ -46,7 +46,7 @@ MCPJam is the development platform for **MCP servers, MCP apps, and ChatGPT apps
     Stateless tool for connectivity, OAuth, conformance, and tool execution. JUnit/JSON reporters built for CI.
   </Card>
   <Card title="SDK" icon="code" href="/sdk">
-    `@mcpjam/sdk` — TypeScript toolkit for unit tests, e2e tests, and evals. Works inside Jest or Vitest.
+    `@mcpjam/sdk`: TypeScript toolkit for unit tests, e2e tests, and evals. Works inside Jest or Vitest.
   </Card>
   <Card title="Hosted" icon="cloud" href="/hosted/overview">
     Run MCPJam in the browser at [app.mcpjam.com](https://app.mcpjam.com). Share servers and sessions with your team.
@@ -72,12 +72,12 @@ MCPJam is the development platform for **MCP servers, MCP apps, and ChatGPT apps
     [Guided OAuth →](/inspector/guided-oauth) · [CLI OAuth conformance →](/cli/oauth-conformance)
   </Accordion>
   <Accordion title="Run evals across LLMs and gate CI on regressions" icon="flask-conical">
-    Author cases with expected tool calls, optional expected outputs, and deterministic checks. Run across Claude, GPT, Gemini, and your own providers — or move the same suite into Jest/Vitest with `@mcpjam/sdk`.
+    Author cases with expected tool calls, optional expected outputs, and deterministic checks. Run across Claude, GPT, Gemini, and your own providers, or move the same suite into Jest/Vitest with `@mcpjam/sdk`.
 
     [Evaluate in Inspector →](/inspector/evals) · [Run evals from the SDK →](/sdk/concepts/running-evals) · [CI integration →](/cli/ci)
   </Accordion>
   <Accordion title="Auto-launch Inspector from your dev workflow" icon="code">
-    Launch the Inspector with a prefilled server URL, bearer token, and starting tab via CLI flags — wire it into your dev script or a framework integration.
+    Launch the Inspector with a prefilled server URL, bearer token, and starting tab via CLI flags; wire it into your dev script or a framework integration.
 
     [Launch from code →](/inspector/launch-from-code)
   </Accordion>

--- a/docs/inspector/clients.mdx
+++ b/docs/inspector/clients.mdx
@@ -8,7 +8,7 @@ icon: "user-cog"
 Open the **Connect** tab in the left sidebar to manage Clients (labelled **Servers** in some builds). The page name "Clients" refers to the configuration object, not the sidebar label.
 </Note>
 
-A **Client** is a named, reusable configuration that defines how MCPJam connects to and talks to your MCP servers when you test them in the Playground, Chatboxes, and Evals. It bundles everything that would normally be scattered across one-off settings — model, system prompt, attached servers, protocol-level knobs, and MCP App sandbox controls — behind a single picker.
+A **Client** is a named, reusable configuration that defines how MCPJam connects to and talks to your MCP servers when you test them in the Playground, Chatboxes, and Evals. It bundles everything that would normally be scattered across one-off settings (model, system prompt, attached servers, protocol-level knobs, and MCP App sandbox controls) behind a single picker.
 
 Real MCP hosts (Claude Desktop, ChatGPT, Cursor, your own product) each advertise slightly different capabilities and apply different sandbox policies to MCP Apps. Clients let you reproduce those environments in MCPJam so you can verify your server behaves correctly *before* shipping to a specific host.
 
@@ -16,9 +16,9 @@ Real MCP hosts (Claude Desktop, ChatGPT, Cursor, your own product) each advertis
 
 Without Clients, every Chat or Eval would be tied to whatever ambient settings were active when you ran it. That makes results hard to reproduce and hard to share. Clients fix this by giving you:
 
-- **Reproducibility** — A snapshot of every setting that affects a run, so a teammate hitting the same Client gets the same conditions.
-- **Host emulation** — Configure the inspector to look like Claude Desktop, ChatGPT, or your own host so you can verify your MCP server or MCP App degrades gracefully across them.
-- **Faster iteration** — Switch between configurations with one click instead of editing fields in five places.
+- **Reproducibility**: A snapshot of every setting that affects a run, so a teammate hitting the same Client gets the same conditions.
+- **Host emulation**: Configure the inspector to look like Claude Desktop, ChatGPT, or your own host so you can verify your MCP server or MCP App degrades gracefully across them.
+- **Faster iteration**: Switch between configurations with one click instead of editing fields in five places.
 
 ## What you can configure
 
@@ -28,13 +28,13 @@ A Client groups settings into two layers: the **protocol layer** (how the MCP co
 
 These map directly to fields the inspector sends during the standard MCP `initialize` handshake and on every subsequent request.
 
-- **Supported protocol versions** — The ordered list of MCP protocol versions the client advertises. The first entry is sent as `protocolVersion`; the rest form the accept-set. Useful for testing how your server handles older or newer clients.
-- **`clientInfo`** — The `name`, `version`, and any additional fields sent in `initialize.params.clientInfo`. Set this to match a real host's identifier when you want your server to take a host-specific code path.
-- **Client capabilities** — The capabilities object sent in `initialize` (sampling, roots, elicitation, experimental, etc.). Enable or disable each one to test what your server does when a capability is missing.
-- **Advertise EMA support by default** — Toggle in the **MCP Protocol** settings card that adds the `io.modelcontextprotocol/enterprise-managed-authorization` extension to the stored `clientCapabilities`. When on, the extension appears in the MCP Protocol JSON editor and host-card capability chips. This controls the stored baseline only — XAA-configured connections always advertise the extension at connect time regardless of this setting.
-- **Elicitation** — Toggle in the **MCP Protocol** settings card that controls the top-level `clientCapabilities.elicitation` key. When off, the key is absent. When on, the inspector advertises `{ form: {} }`, signalling that the client can handle elicitation requests from the server. An optional **URL mode** sub-checkbox (visible only when Elicitation is on) adds `{ url: {} }` to the elicitation object, indicating the client can also handle requests to open a URL. Enabling this before server-side elicitation support is active is safe — it is a no-op rather than a break.
-- **Request timeout** — Per-request timeout in milliseconds applied to all MCP calls (`tools/call`, `resources/read`, etc.). Lower it to verify your server handles cancellation correctly; raise it for long-running tools.
-- **Default headers** — Headers attached to every HTTP-transport request. Useful for auth tokens, tenant IDs, or anything else your server expects upstream.
+- **Supported protocol versions**: The ordered list of MCP protocol versions the client advertises. The first entry is sent as `protocolVersion`; the rest form the accept-set. Useful for testing how your server handles older or newer clients.
+- **`clientInfo`**: The `name`, `version`, and any additional fields sent in `initialize.params.clientInfo`. Set this to match a real host's identifier when you want your server to take a host-specific code path.
+- **Client capabilities**: The capabilities object sent in `initialize` (sampling, roots, elicitation, experimental, etc.). Enable or disable each one to test what your server does when a capability is missing.
+- **Advertise EMA support by default**: Toggle in the **MCP Protocol** settings card that adds the `io.modelcontextprotocol/enterprise-managed-authorization` extension to the stored `clientCapabilities`. When on, the extension appears in the MCP Protocol JSON editor and host-card capability chips. This controls the stored baseline only. XAA-configured connections always advertise the extension at connect time regardless of this setting.
+- **Elicitation**: Toggle in the **MCP Protocol** settings card that controls the top-level `clientCapabilities.elicitation` key. When off, the key is absent. When on, the inspector advertises `{ form: {} }`, signalling that the client can handle elicitation requests from the server. An optional **URL mode** sub-checkbox (visible only when Elicitation is on) adds `{ url: {} }` to the elicitation object, indicating the client can also handle requests to open a URL. Enabling this before server-side elicitation support is active is safe: it is a no-op rather than a break.
+- **Request timeout**: Per-request timeout in milliseconds applied to all MCP calls (`tools/call`, `resources/read`, etc.). Lower it to verify your server handles cancellation correctly; raise it for long-running tools.
+- **Default headers**: Headers attached to every HTTP-transport request. Useful for auth tokens, tenant IDs, or anything else your server expects upstream.
 
 ### Per-server connection overrides
 
@@ -44,34 +44,34 @@ You can override the request timeout and headers **per server** from the project
 
 These settings control how the model interacts with tools during a chat session. They appear in the **Agent** tab of the Client focus panel.
 
-- **Require tool approval** — When on, the model pauses before each tool call so you can approve or deny it manually.
-- **Respect tool visibility** — Controls whether the inspector honors the SEP-1865 `_meta.ui.visibility` field. When on (the default for all templates except Cursor), tools whose visibility is `["app"]` are hidden from the model's tool list. When off, every tool flows to the model regardless of visibility, matching hosts that don't yet implement visibility filtering (for example, real Cursor as of version 3.4.20).
-- **Progressive tools** — Three-state toggle (`On` / `Off` / `Auto`). When on, the inspector injects `search_mcp_tools` and `load_mcp_tools` meta-tools instead of sending the full tool catalog upfront, reducing context usage for large tool sets. `Auto` lets the backend decide based on catalog size.
-- **Built-in tools** — A checkbox list of host-managed built-in tools (for example, `web_search`) that the model can use on each turn. Selected tool IDs are forwarded with the chat request so the server can resolve them alongside your MCP server tools. This section only appears when the deployment has a populated built-in tool catalog; it is hidden otherwise.
+- **Require tool approval**: When on, the model pauses before each tool call so you can approve or deny it manually.
+- **Respect tool visibility**: Controls whether the inspector honors the SEP-1865 `_meta.ui.visibility` field. When on (the default for all templates except Cursor), tools whose visibility is `["app"]` are hidden from the model's tool list. When off, every tool flows to the model regardless of visibility, matching hosts that don't yet implement visibility filtering (for example, real Cursor as of version 3.4.20).
+- **Progressive tools**: Three-state toggle (`On` / `Off` / `Auto`). When on, the inspector injects `search_mcp_tools` and `load_mcp_tools` meta-tools instead of sending the full tool catalog upfront, reducing context usage for large tool sets. `Auto` lets the backend decide based on catalog size.
+- **Built-in tools**: A checkbox list of host-managed built-in tools (for example, `web_search`) that the model can use on each turn. Selected tool IDs are forwarded with the chat request so the server can resolve them alongside your MCP server tools. This section only appears when the deployment has a populated built-in tool catalog; it is hidden otherwise.
 
 ### MCP App settings (SEP-1865)
 
-When your server exposes [MCP Apps](https://modelcontextprotocol.io/docs/extensions/apps) — interactive UIs delivered via `ui://` resources — the Client controls how the inspector renders and sandboxes them. These map to the fields a real host advertises in `HostCapabilities` and `HostContext`.
+When your server exposes [MCP Apps](https://modelcontextprotocol.io/docs/extensions/apps) (interactive UIs delivered via `ui://` resources), the Client controls how the inspector renders and sandboxes them. These map to the fields a real host advertises in `HostCapabilities` and `HostContext`.
 
-- **Host capabilities** — The set of `HostCapabilities` keys the inspector advertises in the `ui/initialize` handshake. Each host preset reflects that host's published capability subset: for example, the **Copilot** preset advertises only `openLinks`, `serverTools`, `updateModelContext`, and `message` — matching Microsoft 365 Copilot's published Component-bridge table — and omits `serverResources` and `logging`. Use this to verify your app degrades gracefully when a capability it relies on is absent.
-- **Sandbox CSP mode** — `host-default`, `declared`, or `relaxed`. Controls the baseline Content Security Policy the inspector applies to your app's iframe.
-- **CSP restrictTo** — Per-directive intersections (`connectDomains`, `resourceDomains`, `frameDomains`, `baseUriDomains`) that further narrow what the app is allowed to fetch, embed, or set as a base URI. Restrict-only — the inspector never adds an undeclared domain.
-- **Custom CSP directives** — Verbatim source-expression overrides (e.g. `script-src: 'unsafe-eval' 'wasm-unsafe-eval'`) for cases where you need to model exactly what a particular host emits at the browser layer.
-- **Permission Policy** — Per-feature toggles for `camera`, `microphone`, `geolocation`, and `clipboard-write`. Choose `resource-declared` (grant what the app's resource metadata asks for), `deny-all`, or `custom` (your own allow map).
-- **Display modes** — Which of `inline`, `fullscreen`, and `pip` the inspector advertises in `HostContext.availableDisplayModes`. Test how your app responds when a requested mode isn't available.
-- **Theme and styles** — The CSS variables and font block the inspector injects into `HostContext.styles` so you can verify your app picks up host theming.
-- **`window.openai` injection** — Toggle whether the inspector injects the OpenAI Apps SDK `window.openai` shim into widget HTML before sandboxing. ChatGPT, Copilot, and MCPJam host presets enable this by default; Claude, Cursor, and Codex presets leave it off. You can override the preset per host using the toggle in the **Apps Extension** tab. The chip in the host capability matrix shows the current state and whether it comes from the preset or a manual override.
+- **Host capabilities**: The set of `HostCapabilities` keys the inspector advertises in the `ui/initialize` handshake. Each host preset reflects that host's published capability subset: for example, the **Copilot** preset advertises only `openLinks`, `serverTools`, `updateModelContext`, and `message` (matching Microsoft 365 Copilot's published Component-bridge table) and omits `serverResources` and `logging`. Use this to verify your app degrades gracefully when a capability it relies on is absent.
+- **Sandbox CSP mode**: `host-default`, `declared`, or `relaxed`. Controls the baseline Content Security Policy the inspector applies to your app's iframe.
+- **CSP restrictTo**: Per-directive intersections (`connectDomains`, `resourceDomains`, `frameDomains`, `baseUriDomains`) that further narrow what the app is allowed to fetch, embed, or set as a base URI. Restrict-only: the inspector never adds an undeclared domain.
+- **Custom CSP directives**: Verbatim source-expression overrides (e.g. `script-src: 'unsafe-eval' 'wasm-unsafe-eval'`) for cases where you need to model exactly what a particular host emits at the browser layer.
+- **Permission Policy**: Per-feature toggles for `camera`, `microphone`, `geolocation`, and `clipboard-write`. Choose `resource-declared` (grant what the app's resource metadata asks for), `deny-all`, or `custom` (your own allow map).
+- **Display modes**: Which of `inline`, `fullscreen`, and `pip` the inspector advertises in `HostContext.availableDisplayModes`. Test how your app responds when a requested mode isn't available.
+- **Theme and styles**: The CSS variables and font block the inspector injects into `HostContext.styles` so you can verify your app picks up host theming.
+- **`window.openai` injection**: Toggle whether the inspector injects the OpenAI Apps SDK `window.openai` shim into widget HTML before sandboxing. ChatGPT, Copilot, and MCPJam host presets enable this by default; Claude, Cursor, and Codex presets leave it off. You can override the preset per host using the toggle in the **Apps Extension** tab. The chip in the host capability matrix shows the current state and whether it comes from the preset or a manual override.
 
 #### Apps Extension tab
 
-The Apps Extension tab contains two independent capability matrices that never cross-gate — toggling a row in one has no effect on the other.
+The Apps Extension tab contains two independent capability matrices that never cross-gate: toggling a row in one has no effect on the other.
 
-**`window.openai` matrix (ChatGPT compat shim)** — Controls the `window.openai.*` surface advertised to apps using the ChatGPT compatibility shim. A master **Inject window.openai** toggle enables or disables injection entirely; a collapsed per-method disclosure lets you activate individual methods to build an exact subset from scratch. Switching on any single method turns injection on with only that method enabled; turning the last method off disables injection again.
+**`window.openai` matrix (ChatGPT compat shim)**: Controls the `window.openai.*` surface advertised to apps using the ChatGPT compatibility shim. A master **Inject window.openai** toggle enables or disables injection entirely; a collapsed per-method disclosure lets you activate individual methods to build an exact subset from scratch. Switching on any single method turns injection on with only that method enabled; turning the last method off disables injection again.
 
-**`app.*` matrix (SEP-1865 spec bridge)** — Controls the `app.*` surface advertised to apps using the primary MCP Apps protocol. A master **MCP App support** switch advertises the MCP UI client extension (`io.modelcontextprotocol/ui`). The matrix rows include:
-- **`availableDisplayModes`** — multi-checkbox cluster (`inline`, `fullscreen`, `pip`); unchecking the last mode force-enables `inline`.
-- **`widgetDisplayModeRequests`** — tri-state host policy (`accept`, `user-initiated-only`, `decline`) for widget-initiated display-mode requests.
-- **Boolean dimensions** — a flat list of all `app.*` capability flags (e.g. `toolInputPartial`, `toolCancelled`, `serverResources`, `logging`, `toolInfo`, `openLinks`, `serverTools`, `updateModelContext`, `message`). Rows that diverge from the selected host preset are stored as sparse overrides.
+**`app.*` matrix (SEP-1865 spec bridge)**: Controls the `app.*` surface advertised to apps using the primary MCP Apps protocol. A master **MCP App support** switch advertises the MCP UI client extension (`io.modelcontextprotocol/ui`). The matrix rows include:
+- **`availableDisplayModes`**: multi-checkbox cluster (`inline`, `fullscreen`, `pip`); unchecking the last mode force-enables `inline`.
+- **`widgetDisplayModeRequests`**: tri-state host policy (`accept`, `user-initiated-only`, `decline`) for widget-initiated display-mode requests.
+- **Boolean dimensions**: a flat list of all `app.*` capability flags (e.g. `toolInputPartial`, `toolCancelled`, `serverResources`, `logging`, `toolInfo`, `openLinks`, `serverTools`, `updateModelContext`, `message`). Rows that diverge from the selected host preset are stored as sparse overrides.
 
 <Note>
   Widget iframes are only rendered when the effective `clientCapabilities` advertise
@@ -103,22 +103,22 @@ The Apps Extension tab contains two independent capability matrices that never c
   there.
 </Note>
 
-The canvas on the left shows a live diagram of the Client — the model, attached servers, and any per-server overrides. Cards flash briefly when you switch between Clients so you can see what changed.
+The canvas on the left shows a live diagram of the Client: the model, attached servers, and any per-server overrides. Cards flash briefly when you switch between Clients so you can see what changed.
 
 ## Using a Client
 
 Once saved, a Client shows up in the picker at the top of every consumer:
 
-- **Chat** — Drives the model, system prompt, attached servers, and connection settings for the conversation.
-- **Chatboxes** — Same as Chat, but persisted as a saved chatbox configuration.
-- **Evals** — Every test run inside an Eval uses the selected Client, so results are reproducible across teammates.
-- **Swarms** — Journeys in the Swarms surface can target any project client, including standalone ones.
+- **Chat**: Drives the model, system prompt, attached servers, and connection settings for the conversation.
+- **Chatboxes**: Same as Chat, but persisted as a saved chatbox configuration.
+- **Evals**: Every test run inside an Eval uses the selected Client, so results are reproducible across teammates.
+- **Swarms**: Journeys in the Swarms surface can target any project client, including standalone ones.
 
 Switching the active Client in any of these views swaps the entire configuration in place. There's no separate "apply" step.
 
 ### Standalone clients (Swarms-managed)
 
-Some clients are **standalone** — they are owned by the Swarms surface and have no Chatbox or publish surface. If you select a standalone client in the Chatboxes tab, the tab shows a **"Managed by Swarms"** notice instead of a chatbox. The client picker stays visible so you can switch to a publishable client.
+Some clients are **standalone**: they are owned by the Swarms surface and have no Chatbox or publish surface. If you select a standalone client in the Chatboxes tab, the tab shows a **"Managed by Swarms"** notice instead of a chatbox. The client picker stays visible so you can switch to a publishable client.
 
 Standalone clients do not appear as options in the Chatboxes client picker dropdown. If you need a client for both Chatboxes and Swarms journeys, create a regular client from the Connect tab instead of from Swarms → Clients.
 
@@ -145,28 +145,28 @@ When you create an eval suite, you can pick a server attachment in the **Servers
 The **Servers** section on the chatbox Publish tab shows which project servers the chatbox connects to. Click **Edit servers** to open the attachment editor and update the selection.
 
 - If no servers are picked, the chatbox displays an amber warning. Chat sessions started from that chatbox will have no tools until at least one server is selected.
-- The server pick is sticky — editing the client's model or system prompt does not change it.
+- The server pick is sticky: editing the client's model or system prompt does not change it.
 
 ## Managing Clients
 
 From the Clients index page:
 
-- **Duplicate** — Copy a Client when you want a small variant (e.g. `Claude Desktop — strict CSP`) without rebuilding from scratch.
-- **Delete** — Removes the Client. The inspector blocks deletion if any chatbox or eval still depends on it; resolve those first, or use force delete if you're sure.
+- **Duplicate**: Copy a Client when you want a small variant (e.g. `Claude Desktop (strict CSP)`) without rebuilding from scratch.
+- **Delete**: Removes the Client. The inspector blocks deletion if any chatbox or eval still depends on it; resolve those first, or use force delete if you're sure.
 
 <Tip>
   Keep one Client per host you intend to ship to. Duplicate it to make scoped
-  variants for individual debugging sessions instead of editing the original —
-  that way your "known-good" baselines stay stable.
+  variants for individual debugging sessions instead of editing the original.
+  That way your "known-good" baselines stay stable.
 </Tip>
 
 ## Sharing across a project
 
-Clients are scoped to the project, like servers and views. Every member of a shared project sees the same Client list and any saves sync automatically. This means a teammate can reproduce your exact test conditions by selecting the same Client from the picker — no copy-pasting settings.
+Clients are scoped to the project, like servers and views. Every member of a shared project sees the same Client list and any saves sync automatically. This means a teammate can reproduce your exact test conditions by selecting the same Client from the picker: no copy-pasting settings.
 
 ## Comparing hosts
 
-The **Compare** view lets you see how multiple host configurations stack up side by side — useful for spotting differences in capabilities, sandbox policies, or protocol settings before you ship to a specific host.
+The **Compare** view lets you see how multiple host configurations stack up side by side, which is useful for spotting differences in capabilities, sandbox policies, or protocol settings before you ship to a specific host.
 
 ### Opening Compare
 
@@ -189,7 +189,7 @@ In the Eval Playground, the **Clients** row next to **+ Attach client** includes
 ## Best practices
 
 - **Mirror your target hosts.** Create one Client per real host you care about (`Claude Desktop`, `ChatGPT`, your own product) and keep its `clientInfo`, capabilities, and sandbox settings aligned with what that host actually advertises.
-- **Test the negative paths.** Build a "minimal" Client with most capabilities disabled and a strict CSP — running your server against it surfaces assumptions that won't hold on more restrictive hosts.
+- **Test the negative paths.** Build a "minimal" Client with most capabilities disabled and a strict CSP. Running your server against it surfaces assumptions that won't hold on more restrictive hosts.
 - **Pin Evals to a Client.** Always select a Client before running an eval suite so the results are reproducible. Evals run against ambient settings drift the moment someone toggles something elsewhere.
 - **Duplicate before debugging.** When you're chasing a bug, duplicate the Client first and tweak the copy. Your baseline stays intact for comparison.
-- **Share Compare links.** Toggle down to the hosts you care about and copy the URL — the `?hosts=` parameter preserves your selection for teammates.
+- **Share Compare links.** Toggle down to the hosts you care about and copy the URL. The `?hosts=` parameter preserves your selection for teammates.

--- a/docs/inspector/compatibility.mdx
+++ b/docs/inspector/compatibility.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Compatibility"
-description: "Check whether your MCP server works on each AI host — conformance gates, per-host findings, and live widget rendering."
+description: "Check whether your MCP server works on each AI host: conformance gates, per-host findings, and live widget rendering."
 icon: "boxes"
 ---
 
-The Compatibility destination answers one question: **does my server work on this host?** It evaluates your connected server against a catalog of real AI hosts (Claude, ChatGPT, Cursor, Copilot, Codex, and others) and surfaces blockers, degraded experiences, and protocol gaps — without requiring you to deploy to each host first.
+The Compatibility destination answers one question: **does my server work on this host?** It evaluates your connected server against a catalog of real AI hosts (Claude, ChatGPT, Cursor, Copilot, Codex, and others) and surfaces blockers, degraded experiences, and protocol gaps, without requiring you to deploy to each host first.
 
 ## How to open it
 
@@ -20,23 +20,23 @@ Each host row has a verdict and, when findings exist, an expandable detail secti
 |---------|---------|
 | **Works** | No blockers or degraded findings detected. |
 | **Degraded** | The server functions but some widgets fall back to text, or a capability the widget uses isn't supported by this host. |
-| **Blocked** | One or more app-only tools are unusable on this host — they have no text fallback and the host can't render their UI. |
+| **Blocked** | One or more app-only tools are unusable on this host: they have no text fallback and the host can't render their UI. |
 | **Unknown** | Widget HTML hasn't been analyzed yet, or a required dimension couldn't be determined. |
 
 Verdicts are derived from static connect-time data (tools list + `_meta` bags + the protocol version negotiated). They update as tools load.
 
 ### Conformance gate
 
-Above the per-host rows, a **Conformance gate** shows whether the server passes the MCP protocol conformance checks. A server that fails conformance may work on some hosts but is likely to behave inconsistently. Fix conformance issues first — they affect every host.
+Above the per-host rows, a **Conformance gate** shows whether the server passes the MCP protocol conformance checks. A server that fails conformance may work on some hosts but is likely to behave inconsistently. Fix conformance issues first: they affect every host.
 
 ### Findings
 
 Expand a host row to see the full findings list, split into two lanes:
 
-- **Apps lane** — widget render failures and capability gaps. Examples: an app-only tool whose UI the host can't render, a widget that calls `ui/open-link` on a host that doesn't support it.
-- **Server lane** — protocol-version compatibility. If the server negotiated a version the host doesn't advertise, this lane surfaces it as an informational note (the host may still negotiate a shared version).
+- **Apps lane**: widget render failures and capability gaps. Examples: an app-only tool whose UI the host can't render, a widget that calls `ui/open-link` on a host that doesn't support it.
+- **Server lane**: protocol-version compatibility. If the server negotiated a version the host doesn't advertise, this lane surfaces it as an informational note (the host may still negotiate a shared version).
 
-Each finding includes a title, a detail sentence, and where applicable a **remediation** hint — for example, "Declare an MCP Apps template alongside the OpenAI one."
+Each finding includes a title, a detail sentence, and where applicable a **remediation** hint: for example, "Declare an MCP Apps template alongside the OpenAI one."
 
 ### Provenance badges
 
@@ -47,7 +47,7 @@ Findings carry a provenance label that tells you how confident the data is:
 | **Probe-captured** | Values captured from a real host via DevTools or the inspector's JSON-RPC logger. |
 | **Vendor docs** | Verified from the host vendor's published documentation. |
 | **Observed** | Stamped by a live widget render run (see below). |
-| **Best-effort preset** | Unverified — the preset was authored without a live capture. |
+| **Best-effort preset** | Unverified: the preset was authored without a live capture. |
 
 ## Live widget rendering
 
@@ -67,7 +67,7 @@ When two or more servers are connected, the page leads with a **servers × hosts
 
 ## Relationship to host templates
 
-The host profiles used for evaluation are the same presets available in the [host template picker](/inspector/host-templates). If a host you care about isn't in the catalog, you can [contribute a preset](/inspector/host-templates) — the compatibility engine will pick it up automatically.
+The host profiles used for evaluation are the same presets available in the [host template picker](/inspector/host-templates). If a host you care about isn't in the catalog, you can [contribute a preset](/inspector/host-templates). The compatibility engine will pick it up automatically.
 
 ## Relationship to conformance testing
 

--- a/docs/inspector/computer.mdx
+++ b/docs/inspector/computer.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Computer"
-description: "A personal cloud Linux workstation for your project — open a terminal, run tools, and give your agents a real bash environment"
+description: "A personal cloud Linux workstation for your project: open a terminal, run tools, and give your agents a real bash environment"
 icon: "monitor"
 ---
 
@@ -16,7 +16,7 @@ provisions the machine; after that it resumes in about a second.
 ## Sleep and hibernate
 
 Your computer sleeps automatically when it has been idle for about 30 minutes,
-or shortly after you close the terminal. Sleeping is non-destructive — the disk
+or shortly after you close the terminal. Sleeping is non-destructive: the disk
 and memory are snapshotted and restored on wake, so everything you left running
 is still there.
 
@@ -35,17 +35,17 @@ shared with the whole project. Manage them from **Change** on the image strip.
 
 <Note>
   Environment definitions (their Dockerfiles) live in the project database, not
-  on any one computer's disk — see [Data & persistence](#data-and-persistence).
+  on any one computer's disk. See [Data & persistence](#data-and-persistence).
 </Note>
 
 ## Data & persistence
 
 Your computer is **scratch space, not durable storage.** Treat it like a fresh
-dev box you can rebuild at any time — convenient and fast, but not a place to
+dev box you can rebuild at any time: convenient and fast, but not a place to
 keep the only copy of anything.
 
 <Warning>
-  Files persist when your computer sleeps, but they aren't backed up — keep
+  Files persist when your computer sleeps, but they aren't backed up. Keep
   anything important in git or elsewhere.
 </Warning>
 
@@ -60,11 +60,11 @@ keep the only copy of anything.
 Each of these rebuilds the machine from its image and **deletes every file on
 the disk**:
 
-- **Reset** — restores the computer to a clean copy of its current image.
-- **Changing the image** — switching to a different environment (or back to the
+- **Reset**: restores the computer to a clean copy of its current image.
+- **Changing the image**: switching to a different environment (or back to the
   base image) rebuilds from that image.
-- **Delete** — tears the computer down entirely.
-- **Guest inactivity** — computers owned by signed-out (guest) sessions are
+- **Delete**: tears the computer down entirely.
+- **Guest inactivity**: computers owned by signed-out (guest) sessions are
   deleted when idle instead of paused, so their files don't carry over between
   sessions. Sign in for a computer that sleeps and resumes with its disk intact.
 
@@ -74,13 +74,13 @@ These live in the project database (Convex), not on the computer's disk, so they
 are unaffected by reset, image changes, or deletion:
 
 - **Cloud skills** attached to the project.
-- **Environment Dockerfiles** — the definitions of your custom images. Deleting
+- **Environment Dockerfiles**: the definitions of your custom images. Deleting
   a computer never deletes your environments; you can boot a fresh computer from
   the same image again.
 
 ### The no-backup caveat
 
-There is no backup and no volume behind the computer — the pause snapshot *is*
+There is no backup and no volume behind the computer: the pause snapshot *is*
 the storage. Once the disk is wiped by any of the actions above, its contents
 are gone for good. Anything you want to keep should live in version control, a
 remote, or another durable store.

--- a/docs/inspector/connecting-servers.mdx
+++ b/docs/inspector/connecting-servers.mdx
@@ -39,8 +39,8 @@ The **History** tab in the server detail modal shows a timeline of every revisio
 
 Click any revision row to expand it. The expanded panel shows:
 
-- **Diff view** (default for revisions 2 and later) — highlights tools added, removed, or updated compared to the previous revision.
-- **Snapshot view** — lists all tools captured at that revision, with each tool's name and description.
+- **Diff view** (default for revisions 2 and later): highlights tools added, removed, or updated compared to the previous revision.
+- **Snapshot view**: lists all tools captured at that revision, with each tool's name and description.
 
 A **Diff / Snapshot** toggle appears at the top of the expanded panel when a previous revision exists. Revision 1 opens directly in Snapshot view since there is nothing to diff against.
 
@@ -98,7 +98,7 @@ You can configure environment variables with STDIO. Click "Add Variable" in the 
 
 ## HTTP servers
 
-Connect to any Streamable HTTP MCP server by selecting **HTTP** in the transport dropdown and pasting in the URL — typically ending in `/mcp`.
+Connect to any Streamable HTTP MCP server by selecting **HTTP** in the transport dropdown and pasting in the URL, typically ending in `/mcp`.
 
 <Frame>
   <img
@@ -118,8 +118,8 @@ Expand **Custom Headers** to add arbitrary request headers (for example, proxy a
 MCPJam is compliant with the MCP authorization spec and supports Dynamic Client Registration (DCR), client pre-registration, and Client ID Metadata Documents (CIMD). You can:
 
 1. Choose **No Authentication**
-2. Choose **Bearer Token** — use this if you already have an API token and don't need to register an OAuth client.
-3. Choose **OAuth** — follow [MCP Authorization](https://modelcontextprotocol.io/specification/draft/basic/authorization) to obtain a bearer token. You can optionally set scopes or a custom client ID and secret. For step-by-step debugging, see the [OAuth Debugger](/inspector/guided-oauth).
+2. Choose **Bearer Token**: use this if you already have an API token and don't need to register an OAuth client.
+3. Choose **OAuth**: follow [MCP Authorization](https://modelcontextprotocol.io/specification/draft/basic/authorization) to obtain a bearer token. You can optionally set scopes or a custom client ID and secret. For step-by-step debugging, see the [OAuth Debugger](/inspector/guided-oauth).
 
 ### Request timeout
 
@@ -137,7 +137,7 @@ Each tunnel is scoped to a single server and secured at the network edge: the tu
 2. Click **Create Tunnel** on the server card you want to expose.
 3. Copy the tunnel URL from the server card and paste it into your MCP client (for example, ChatGPT's custom connector settings).
 
-The tunnel URL is stable — the base domain stays the same across sessions. If you close and recreate a tunnel for the same server, you get the same domain with a new secret key.
+The tunnel URL is stable: the base domain stays the same across sessions. If you close and recreate a tunnel for the same server, you get the same domain with a new secret key.
 
 ### Rotate the secret
 
@@ -152,7 +152,7 @@ Click the **log icon** on the tunnel pill to open the recent-requests panel. It 
 Click the **close (×) button** on the tunnel pill to stop remote access. The tunnel closes immediately and all remote connections are terminated. The domain is reserved so a future tunnel for the same server reuses it.
 
 <Warning>
-  Anyone with the full tunnel URL — including its secret key — can access this
+  Anyone with the full tunnel URL, including its secret key, can access this
   server. Share it carefully, rotate it if it leaks, and close the tunnel when
   you are done.
 </Warning>

--- a/docs/inspector/evals.mdx
+++ b/docs/inspector/evals.mdx
@@ -4,7 +4,7 @@ description: "Author test cases for your MCP server, run them across models, and
 icon: "flask-conical"
 ---
 
-A benchmark score doesn't tell you whether your server holds up in production. Evaluate lets you pin down the behaviors you care about — which tools fire, with what arguments, what the final answer looks like — and run them across the models your users actually use.
+A benchmark score doesn't tell you whether your server holds up in production. Evaluate lets you pin down the behaviors you care about (which tools fire, with what arguments, what the final answer looks like) and run them across the models your users actually use.
 
 ## Requirements
 
@@ -20,23 +20,23 @@ Evals are available to both signed-in users and guests. Guests authenticate auto
     A group of cases plus the defaults they share: attached servers, models to run against, default checks, judge config, and argument-matching mode.
   </Step>
   <Step title="Case">
-    One scenario you want to verify — a prompt (or a sequence of prompts), the tools you expect to fire, an optional expected output, and the checks that decide pass/fail.
+    One scenario you want to verify: a prompt (or a sequence of prompts), the tools you expect to fire, an optional expected output, and the checks that decide pass/fail.
   </Step>
   <Step title="Run">
-    One execution of a suite. Produces **iterations** — one per case × model. Each iteration has its own transcript, tool calls, tokens, duration, and verdict.
+    One execution of a suite. Produces **iterations**: one per case × model. Each iteration has its own transcript, tool calls, tokens, duration, and verdict.
   </Step>
 </Steps>
 
 ## Authoring a case
 
-Click **New case** in the suite header (or in the empty-state screen when no cases exist yet) to open a blank case editor. The case is a draft until you press **Save** — backing out without saving leaves your suite unchanged.
+Click **New case** in the suite header (or in the empty-state screen when no cases exist yet) to open a blank case editor. The case is a draft until you press **Save**. Backing out without saving leaves your suite unchanged.
 
 Each case has four moving parts:
 
-- **Scenario** — short label so you can find it later ("Draw a rectangle", "Refuses unsafe delete").
-- **Prompt turns** — one or more user messages. Multi-turn is supported; expected tools and checks attach per turn, so you can model "ask, get a result, follow up."
-- **Expected tools** — for each turn, the tool calls the model should make. Arguments can be exact values or typed placeholders (`"string"`, `"number"`) so you're not chasing flaky literals.
-- **Expected output** — optional free-text description of what a good final answer looks like. Used by the judge.
+- **Scenario**: short label so you can find it later ("Draw a rectangle", "Refuses unsafe delete").
+- **Prompt turns**: one or more user messages. Multi-turn is supported; expected tools and checks attach per turn, so you can model "ask, get a result, follow up."
+- **Expected tools**: for each turn, the tool calls the model should make. Arguments can be exact values or typed placeholders (`"string"`, `"number"`) so you're not chasing flaky literals.
+- **Expected output**: optional free-text description of what a good final answer looks like. Used by the judge.
 
 <Note>
   A **negative case** is just a case whose checks say "this tool should *not* fire." Meta questions ("what params does `search` take?"), conversational drift, and ambiguous prompts are the usual shape.
@@ -44,13 +44,13 @@ Each case has four moving parts:
 
 ## Recording widget interactions
 
-If your MCP server uses MCP Apps (widgets rendered in a sandboxed iframe), you can record real in-widget interactions — clicks and typing — directly into a test case as `interact` steps.
+If your MCP server uses MCP Apps (widgets rendered in a sandboxed iframe), you can record real in-widget interactions (clicks and typing) directly into a test case as `interact` steps.
 
 When you arm record mode on a test case, a recorder shim is injected into the widget sandbox. Every click and text input you make in the widget is captured as a locator-stable `interact` step and appended to the case. The locator is built from stable identifiers in priority order: `data-testid` → ARIA role + accessible name → visible text → CSS path. This means the recorded step resolves to the same element when the case runs headlessly.
 
 ### Widget `ui/message` follow-ups
 
-Some widget interactions send a `ui/message` back to the host (for example, a cart button that says "Show my cart") rather than calling a tool directly. During eval execution, these follow-up messages automatically drive a continuation model turn — the same way Playground handles them live. The resulting tool call (e.g. `view-cart`) is attributed to the same `interact` step's turn, so a **Tool was called** check on that turn sees the call.
+Some widget interactions send a `ui/message` back to the host (for example, a cart button that says "Show my cart") rather than calling a tool directly. During eval execution, these follow-up messages automatically drive a continuation model turn, the same way Playground handles them live. The resulting tool call (e.g. `view-cart`) is attributed to the same `interact` step's turn, so a **Tool was called** check on that turn sees the call.
 
 This means an eval case can faithfully verify a full widget interaction sequence: prompt → widget renders → user clicks → model reacts → tool fires → assertion passes.
 
@@ -60,7 +60,7 @@ The Chat/Trace tab renders widget tool calls as the same app-attributed cards yo
 
 
 
-Checks are what actually decide pass/fail. They're pure functions of the iteration transcript, so the verdict is the same every time you replay it — which is the property you want if you're using Evaluate as a regression gate.
+Checks are what actually decide pass/fail. They're pure functions of the iteration transcript, so the verdict is the same every time you replay it, which is the property you want if you're using Evaluate as a regression gate.
 
 Set defaults on the suite; override per case with **inherit** (use suite defaults), **replace** (use only the case's list), or **extend** (suite defaults, then the case's list).
 
@@ -79,11 +79,11 @@ Set defaults on the suite; override per case with **inherit** (use suite default
 | **Widget no console errors** | The widget rendered without console errors. | Turn or case |
 | **Token budget under N** | Total token usage stayed below the cap. | Case only |
 
-When a check is authored on an individual prompt turn it is evaluated against **that turn's slice** of the transcript — tool calls, assistant message, tool errors, and widget observations for that turn only. `Token budget under N` is case-only because per-turn token usage is not reliably captured; all other checks are turn-scopable.
+When a check is authored on an individual prompt turn it is evaluated against **that turn's slice** of the transcript: tool calls, assistant message, tool errors, and widget observations for that turn only. `Token budget under N` is case-only because per-turn token usage is not reliably captured; all other checks are turn-scopable.
 
 ### Harness system tools in assertion dropdowns
 
-When a suite is configured to run under a harness host (such as Claude Code or Codex), the tool-name pickers in the case editor also offer the harness's native **system tools** — for example `bash`, `read`, `webSearch`, `WebFetch` — alongside your MCP server tools. This lets you write assertions like **Tool was never called** for `bash` or **Tool was called with…** for `read` without having to type the wire name by hand.
+When a suite is configured to run under a harness host (such as Claude Code or Codex), the tool-name pickers in the case editor also offer the harness's native **system tools** (for example `bash`, `read`, `webSearch`, `WebFetch`) alongside your MCP server tools. This lets you write assertions like **Tool was never called** for `bash` or **Tool was called with…** for `read` without having to type the wire name by hand.
 
 System tools appear only in assertion pickers. They are not available in pinned tool-call steps or widget-assertion "View (tool)" selects, because those require a tool that MCPJam can invoke directly.
 
@@ -93,9 +93,9 @@ If an MCP tool and a system tool share the same name, the MCP tool takes precede
 
 Tool-call argument comparison runs in one of three modes, configured at the suite:
 
-- **partial** *(default)* — every expected key must be present and match; extra keys in the actual call are ignored. Best for "I care about `query` and `limit`, not what else the model put in."
-- **exact** — actual args must equal expected args, key-for-key.
-- **ignore** — only the tool name is checked.
+- **partial** *(default)*: every expected key must be present and match; extra keys in the actual call are ignored. Best for "I care about `query` and `limit`, not what else the model put in."
+- **exact**: actual args must equal expected args, key-for-key.
+- **ignore**: only the tool name is checked.
 
 Type placeholders (`"string"`, `"number"`, `"boolean"`) match any value of that type, which lets you assert shape without locking in a literal.
 
@@ -107,17 +107,17 @@ Each suite has default validator settings controlling how tool calls are matched
 |-------|-------|-----------|
 | Suite default | Suite settings → Default validators | Yes |
 | Case override | Test case editor → Validators | Yes |
-| Run override | Suite header → validators (sliders) icon | No — one run |
+| Run override | Suite header → validators (sliders) icon | No (one run) |
 
 A run override shows an **override** badge; click **Reset** in the popover to clear it.
 
 ## LLM as judge
 
-For cases where "did the right tools fire" isn't enough — anything graded on the quality of the final answer — the judge grades the run against your **expected output** if you set one, and against the user prompt otherwise. It's advisory: it produces a score and a rationale, but doesn't gate the run unless you ask it to.
+For cases where "did the right tools fire" isn't enough (anything graded on the quality of the final answer), the judge grades the run against your **expected output** if you set one, and against the user prompt otherwise. It's advisory: it produces a score and a rationale, but doesn't gate the run unless you ask it to.
 
-- **On by default** at the suite level. The cost is gated by an explicit **Run judge** click on the run-detail page — it won't run for every iteration unless you turn auto-run on.
+- **On by default** at the suite level. The cost is gated by an explicit **Run judge** click on the run-detail page. It won't run for every iteration unless you turn auto-run on.
 - **Calibrate per suite.** Judge scores aren't comparable across domains; a 0.7 on one suite isn't a 0.7 on another.
-- When grading against the prompt rather than an expected output, scores are capped at 0.85 — you can't get a "perfect" without saying what perfect means.
+- When grading against the prompt rather than an expected output, scores are capped at 0.85: you can't get a "perfect" without saying what perfect means.
 
 Open a completed run and find the **LLM as Judge** panel (labelled **Goal judge** when shown inside the suite results split). Pick a judge model (default: `openai/gpt-5.4-mini`) and a threshold (default 0.7), then click **Run judge**. Each case gets a score, an advisory verdict, a one-line reason, and rubric hits. The judge never runs automatically unless you enable **Auto-run** in suite settings.
 
@@ -125,9 +125,9 @@ Open a completed run and find the **LLM as Judge** panel (labelled **Goal judge*
 
 A run needs three things, all picked from the suite header:
 
-1. **Servers** — one or more attached to the suite. Cases can attach their own subsets if they only need part of the surface.
-2. **Models** — the multi-model picker is the whole point. Each model produces its own iteration per case, so you can see where Claude passes and ChatGPT trips.
-3. **Run all** — kicks off every case × every model. **Run one** from a case row runs just that case.
+1. **Servers**: one or more attached to the suite. Cases can attach their own subsets if they only need part of the surface.
+2. **Models**: the multi-model picker is the whole point. Each model produces its own iteration per case, so you can see where Claude passes and ChatGPT trips.
+3. **Run all**: kicks off every case × every model. **Run one** from a case row runs just that case.
 
 <Tip>
   If **Run all** is disabled, a connected server is missing, no models are selected, or a run for that suite is already in progress. The header pickers will tell you which condition applies.
@@ -143,7 +143,7 @@ The first run of a suite saves the set of MCP servers used as a frozen snapshot;
   The computer environment picker is only visible when the **computers** feature flag is enabled on your account and a project is selected for the suite.
 </Note>
 
-In suite settings, the **Computer environment** select lets you pin a built Docker environment so every eval iteration boots a fresh sandbox from the same image. This keeps results comparable across runs and edits — each iteration gets an identical starting state.
+In suite settings, the **Computer environment** select lets you pin a built Docker environment so every eval iteration boots a fresh sandbox from the same image. This keeps results comparable across runs and edits: each iteration gets an identical starting state.
 
 - Choose an environment from the list. Environments that have not finished building are labelled **(not built)**; selecting one will cause the run to fail immediately.
 - Choose **None (default image)** to run without a pinned environment.
@@ -155,20 +155,20 @@ Once a run completes, the **Run detail** page shows an **Environment** row with 
 
 Each eval suite has a **Default Execution Config** section that controls the model, system prompt, temperature, tool approval, connection settings, capabilities, and host context used when running the suite.
 
-- **Model and prompt** — Set the default model ID, system prompt, and temperature for all runs in the suite. When running evals against MCP Apps that render widgets, the eval harness automatically enables browser interaction (screenshot, click, type) for any model that supports both vision and tool calling — not just Claude. Models that lack vision or tool calling run without browser interaction.
-- **Tool approval** — Toggle `requireToolApproval` to pause before each tool call during a run.
-- **Server selection** — Servers are not configured here. They come from the suite's environment. The server picker is intentionally hidden in this editor.
-- **Save / Reset** — Click **Save config** to persist changes. Click **Reset** to revert to the last saved state. Unsaved edits are preserved if the page refreshes the config from the server, but are discarded when you switch to a different suite.
+- **Model and prompt**: Set the default model ID, system prompt, and temperature for all runs in the suite. When running evals against MCP Apps that render widgets, the eval harness automatically enables browser interaction (screenshot, click, type) for any model that supports both vision and tool calling, not just Claude. Models that lack vision or tool calling run without browser interaction.
+- **Tool approval**: Toggle `requireToolApproval` to pause before each tool call during a run.
+- **Server selection**: Servers are not configured here. They come from the suite's environment. The server picker is intentionally hidden in this editor.
+- **Save / Reset**: Click **Save config** to persist changes. Click **Reset** to revert to the last saved state. Unsaved edits are preserved if the page refreshes the config from the server, but are discarded when you switch to a different suite.
 
 Changes to the suite execution config apply to future runs only. Existing run snapshots are not affected.
 
 <Note>
-  **Personal computers are not available for eval suites.** The personal computer toggle and computer-backed tools (such as Bash) are hidden and blocked in the suite execution config editor. If the project's default host config has a computer attached, resetting a suite to that default automatically strips the computer and any computer-backed tool ids — so eval runs are never aborted by the backend's computer restriction.
+  **Personal computers are not available for eval suites.** The personal computer toggle and computer-backed tools (such as Bash) are hidden and blocked in the suite execution config editor. If the project's default host config has a computer attached, resetting a suite to that default automatically strips the computer and any computer-backed tool ids, so eval runs are never aborted by the backend's computer restriction.
 </Note>
 
 ### How suite defaults apply to test cases
 
-The suite-level **system prompt** and **temperature** are runtime defaults: when a test case does not set its own system prompt or temperature, the suite values are used for that iteration. A per-case override always wins — the suite default only fills the gap.
+The suite-level **system prompt** and **temperature** are runtime defaults: when a test case does not set its own system prompt or temperature, the suite values are used for that iteration. A per-case override always wins; the suite default only fills the gap.
 
 <Note>
   If you have existing suites where test cases do not specify a system prompt, those cases will now run with the suite's system prompt applied. Cases that already set their own system prompt are unaffected.
@@ -176,7 +176,7 @@ The suite-level **system prompt** and **temperature** are runtime defaults: when
 
 ## CI tab
 
-The **CI** tab (when enabled for your project) shows only CI-active suites — suites created by the SDK or suites that CI has reported into at least once. Playground-only suites stay in the **Evaluate** tab. If a project has no CI evals yet, the CI tab shows a quickstart prompt.
+The **CI** tab (when enabled for your project) shows only CI-active suites: suites created by the SDK or suites that CI has reported into at least once. Playground-only suites stay in the **Evaluate** tab. If a project has no CI evals yet, the CI tab shows a quickstart prompt.
 
 The commit rail in the CI tab groups runs by commit SHA and only includes CI (SDK-sourced) runs. Playground runs on mixed suites are excluded from the rail so they don't appear as spurious manual-commit groups.
 
@@ -184,8 +184,8 @@ The commit rail in the CI tab groups runs by commit SHA and only includes CI (SD
 
 The metric label shown in run headers, the runs table, charts, and hero stats follows the **run's source**, not the suite's creation source:
 
-- **Pass Rate** — shown for runs submitted by the SDK (CI runs). Reflects per-case pass/fail.
-- **Accuracy** — shown for runs triggered manually from the UI, via the API, or on a schedule.
+- **Pass Rate**: shown for runs submitted by the SDK (CI runs). Reflects per-case pass/fail.
+- **Accuracy**: shown for runs triggered manually from the UI, via the API, or on a schedule.
 
 On a mixed suite (one that has received both CI and playground runs), the label updates to match the most recent run. Legacy runs without a recorded source fall back to the suite's creation source.
 
@@ -195,21 +195,21 @@ Test cases written by a CI report carry a **CI** chip next to their name in the 
 
 ### Suite deletion
 
-The delete button in the suite switcher is hidden for any suite that is CI-active — either created by the SDK or one that CI has reported into. This protects CI run history; the next CI report would recreate the suite anyway.
+The delete button in the suite switcher is hidden for any suite that is CI-active: either created by the SDK or one that CI has reported into. This protects CI run history; the next CI report would recreate the suite anyway.
 
 ## Reading results
 
 ### Suite navigation
 
-Opening the Evaluate tab takes you directly into the most recent suite's dashboard. To switch suites, use the **suite switcher** in the breadcrumb — it lists all your suites and lets you jump to one, create a new suite, or delete the current suite. If no suites exist yet, the empty-state create prompt appears instead.
+Opening the Evaluate tab takes you directly into the most recent suite's dashboard. To switch suites, use the **suite switcher** in the breadcrumb. It lists all your suites and lets you jump to one, create a new suite, or delete the current suite. If no suites exist yet, the empty-state create prompt appears instead.
 
 ### Suite view
 
-- **Suite accuracy** — pass rate of the most recent run, with the last three runs' trend so you can see whether you're improving or regressing.
-- **Run insights** — an AI-written diff against your previous completed run: which cases moved, which tools changed behavior, which models diverged. Skim this first; it usually points at the right rabbit hole.
-- **Runs tab** — every run with its summary metrics. Click in for the iteration-level breakdown.
-- **Cases tab** — every case with its latest verdict and a quick replay button.
-- **Executions tab** — a flat, filterable list of every individual test execution across all cases, sorted most-recent-first. Each row shows the case name, result (passed/failed/pending/cancelled), and timestamp. Click any row to open it in the compare view.
+- **Suite accuracy**: pass rate of the most recent run, with the last three runs' trend so you can see whether you're improving or regressing.
+- **Run insights**: an AI-written diff against your previous completed run: which cases moved, which tools changed behavior, which models diverged. Skim this first; it usually points at the right rabbit hole.
+- **Runs tab**: every run with its summary metrics. Click in for the iteration-level breakdown.
+- **Cases tab**: every case with its latest verdict and a quick replay button.
+- **Executions tab**: a flat, filterable list of every individual test execution across all cases, sorted most-recent-first. Each row shows the case name, result (passed/failed/pending/cancelled), and timestamp. Click any row to open it in the compare view.
 
 When you run a suite against multiple host configurations at once, the Runs list groups them into a single collapsible **run group** row showing mean accuracy and longest duration across all hosts. Expand it to inspect each host's individual run.
 
@@ -217,20 +217,20 @@ The **Runs / Cases** segmented control switches between the run history list and
 
 #### Cross-host matrix
 
-When two or more host configurations are attached to a suite, a **By case / By host** toggle appears. **By host** shows a matrix — one column per host, one row per case. Each cell shows pass/fail dots, pass rate, median latency, and token usage. A host detached after runs were recorded stays visible, labelled **historical**.
+When two or more host configurations are attached to a suite, a **By case / By host** toggle appears. **By host** shows a matrix: one column per host, one row per case. Each cell shows pass/fail dots, pass rate, median latency, and token usage. A host detached after runs were recorded stays visible, labelled **historical**.
 
 ### Run view
 
 - **Per-iteration row** with case, model, pass/fail, tokens, duration, and the tool calls that actually happened.
 - **Expected vs actual** tool calls side-by-side when an iteration fails. For failed iterations, a **Categorized diff** above the raw Expected/Actual grids groups discrepancies into four categories:
-  - **Missing** — expected tool calls that were never made
-  - **Extra** — actual calls that weren't expected (reported but non-fatal by default)
-  - **Out of order** — calls that happened in the wrong sequence (when order checking is enabled)
-  - **Arg mismatch** — right tool name, wrong arguments (shown side-by-side)
-- **Full trace** — every turn, every tool call, every token. This is the thing you couldn't see before; spend time here. When a turn ran through a harness (e.g. Claude Code), the trace detail pane shows an **Engine** badge — "Claude Code" for harness turns, "Emulated" for turns that ran through MCPJam's built-in chat engine — so you can tell at a glance which runtime handled each turn.
+  - **Missing**: expected tool calls that were never made
+  - **Extra**: actual calls that weren't expected (reported but non-fatal by default)
+  - **Out of order**: calls that happened in the wrong sequence (when order checking is enabled)
+  - **Arg mismatch**: right tool name, wrong arguments (shown side-by-side)
+- **Full trace**: every turn, every tool call, every token. This is the thing you couldn't see before; spend time here. When a turn ran through a harness (e.g. Claude Code), the trace detail pane shows an **Engine** badge ("Claude Code" for harness turns, "Emulated" for turns that ran through MCPJam's built-in chat engine) so you can tell at a glance which runtime handled each turn.
 - **Per-model breakdown** to compare how the same case behaves across models.
-- **Suggested fixes** — after a run completes, a **Suggested fixes** panel ranks tool-quality and workflow issues by impact. Each issue has a **Copy** button that copies a ready-to-use fix prompt (tool description + input schema) for a coding agent; **Copy top N** copies the top issues combined.
-- **Predicate Gate** — when `successPredicates` are configured on a case, an expandable Predicate Gate section in the iteration detail lists each predicate with a PASS/FAIL verdict, a one-line summary, and the evaluator's reason. Hidden when no predicates are configured.
+- **Suggested fixes**: after a run completes, a **Suggested fixes** panel ranks tool-quality and workflow issues by impact. Each issue has a **Copy** button that copies a ready-to-use fix prompt (tool description + input schema) for a coding agent; **Copy top N** copies the top issues combined.
+- **Predicate Gate**: when `successPredicates` are configured on a case, an expandable Predicate Gate section in the iteration detail lists each predicate with a PASS/FAIL verdict, a one-line summary, and the evaluator's reason. Hidden when no predicates are configured.
 
 #### Comparing two runs
 
@@ -238,23 +238,23 @@ Select any two completed runs and click **Compare**. The diff view shows per-cas
 
 ### Case view
 
-- **Pass rate across runs** — is this case stable, flaky, or trending down?
-- **Pass rate by model** — does this case only work on one model?
+- **Pass rate across runs**: is this case stable, flaky, or trending down?
+- **Pass rate by model**: does this case only work on one model?
 - Every past iteration with its trace, so you can A/B a regression against a working run.
 
 ## Promoting sessions to cases
 
 Any completed chat session can be turned into a test case without rewriting it from scratch. The full conversation is compiled into multi-turn prompt turns, and the dialog lets you pick a destination suite or create a new one.
 
-**From the Playground** — Open the **Sessions** rail, hover a session, and click **Promote to test case**.
+**From the Playground**: Open the **Sessions** rail, hover a session, and click **Promote to test case**.
 
-**From the Swarms tab** — Open a completed run, click a session row to select it, then click **Promote to test case** above the session viewer. The session must belong to a completed run attempt; sessions from in-progress runs show an error in the dialog instead of blocking at submit.
+**From the Swarms tab**: Open a completed run, click a session row to select it, then click **Promote to test case** above the session viewer. The session must belong to a completed run attempt; sessions from in-progress runs show an error in the dialog instead of blocking at submit.
 
 In both cases the dialog shows the servers recorded for that session, lets you set a case title and suite name, and (when attachment pickers are enabled) lets you configure the server attachment and client host for the new suite.
 
 ## Generating cases from your tools
 
-The **Generate** button reads your attached servers' tool catalog and drafts realistic cases — a mix of positive ("call `search` with a query") and negative ("don't call `delete_user` on a meta-question"). Treat it as a draft: skim, edit the prompts to match how your users actually talk, tighten the checks, then save.
+The **Generate** button reads your attached servers' tool catalog and drafts realistic cases: a mix of positive ("call `search` with a query") and negative ("don't call `delete_user` on a meta-question"). Treat it as a draft: skim, edit the prompts to match how your users actually talk, tighten the checks, then save.
 
 When the suite has a saved server group spanning two or more servers, the generator produces coverage for each server individually plus at least one cross-server case. Suites without a saved server group treat all available servers as a single pool.
 

--- a/docs/inspector/guided-oauth.mdx
+++ b/docs/inspector/guided-oauth.mdx
@@ -29,13 +29,13 @@ The OAuth Debugger provides comprehensive tooling for testing OAuth implementati
 
 ### Resource indicator warnings
 
-When the server's Protected Resource Metadata (PRM) advertises a `resource` identifier that does not fully satisfy RFC 9728 — for example, a same-origin resource on a different path than the transport endpoint — the debugger logs a warning at the `received_resource_metadata` step and continues the flow. The warning includes the advertised value, the server URL, and whether strict MCP clients (such as Quick OAuth or the official MCP SDK) will refuse to connect.
+When the server's Protected Resource Metadata (PRM) advertises a `resource` identifier that does not fully satisfy RFC 9728 (for example, a same-origin resource on a different path than the transport endpoint), the debugger logs a warning at the `received_resource_metadata` step and continues the flow. The warning includes the advertised value, the server URL, and whether strict MCP clients (such as Quick OAuth or the official MCP SDK) will refuse to connect.
 
 The debugger intentionally proceeds rather than failing so you can observe real server behavior. Use the [OAuth Conformance](/cli/oauth-conformance) tool if you need strict RFC 9728 validation.
 
 ## Inline OAuth tracing
 
-When you connect a server using OAuth 2.0, Inspector automatically records a trace of every step in the flow and surfaces it in the connection UI — no separate tool required.
+When you connect a server using OAuth 2.0, Inspector automatically records a trace of every step in the flow and surfaces it in the connection UI, no separate tool required.
 
 **On the connection card**, if OAuth fails, a banner identifies the exact step where the failure occurred (for example, "OAuth failed during Token Request").
 
@@ -67,7 +67,7 @@ The header **Add Server** button also opens a blank form so you can add a new ta
 
 ## OAuth trace in server overview
 
-When you connect a server using OAuth, Inspector records a structured trace of the entire flow. You can view this trace at any time — even after a failed connection — by opening the server's detail panel and scrolling to the **Last OAuth Trace** section.
+When you connect a server using OAuth, Inspector records a structured trace of the entire flow. You can view this trace at any time, even after a failed connection, by opening the server's detail panel and scrolling to the **Last OAuth Trace** section.
 
 The trace shows:
 
@@ -106,9 +106,9 @@ Bearer tokens are stored securely and are never written to your browser's local 
 
 When you configure a pre-registered OAuth client with a client secret, the secret is stored securely and never exposed in the UI after saving. The client secret field shows the following controls:
 
-- **Reveal** (hosted mode only) — Fetches and displays the stored secret in an editable field. You can copy it or type directly in the field to replace it. Click **Hide** to collapse the field without saving changes.
-- **Clear** — Marks the secret for removal. The secret is deleted from storage when you save. Click **Undo** to cancel before saving.
-- **Replace** — After clicking **Reveal**, type a new value into the revealed field to replace the stored secret on the next save.
+- **Reveal** (hosted mode only): Fetches and displays the stored secret in an editable field. You can copy it or type directly in the field to replace it. Click **Hide** to collapse the field without saving changes.
+- **Clear**: Marks the secret for removal. The secret is deleted from storage when you save. Click **Undo** to cancel before saving.
+- **Replace**: After clicking **Reveal**, type a new value into the revealed field to replace the stored secret on the next save.
 
 When a secret is saved but not yet revealed, the field shows a "A client secret is saved" message in place of an input box. No empty input is shown until you click **Reveal**.
 
@@ -126,7 +126,7 @@ When an OAuth error appears in the request log, a **Continue in OAuth Debugger**
 
 ## Reconnecting OAuth servers
 
-The enable/connect toggle on a server card or detail modal reuses existing credentials only — it will not launch a new OAuth consent screen. If the existing tokens are expired or missing and a fresh consent flow is required, the toggle reports a re-authentication error instead of redirecting you to the authorization server.
+The enable/connect toggle on a server card or detail modal reuses existing credentials only. It will not launch a new OAuth consent screen. If the existing tokens are expired or missing and a fresh consent flow is required, the toggle reports a re-authentication error instead of redirecting you to the authorization server.
 
 To start a full OAuth flow, use the explicit **Reconnect** button on the server card or detail modal. This is the only path that will open the OAuth consent screen when new credentials are needed.
 

--- a/docs/inspector/home.mdx
+++ b/docs/inspector/home.mdx
@@ -20,11 +20,11 @@ If you are signing in for the first time, MCPJam routes you to the [Playground](
 
 With an organization selected, the dashboard shows:
 
-- **Greeting** — a time-aware greeting with your first name.
-- **Org stats strip** — live counts for teammates, projects, servers, eval suites, tool executions (last 30 days), and messages sent (last 30 days).
-- **MCPJam Agent composer** — a text input to start or resume an agent conversation directly from the home page.
-- **What's new** — a compact list of recent platform releases and changes, with per-item dismiss and a "Clear all" action.
-- **Recommended servers** and **Recommended clients** — displayed side by side in a two-column grid.
+- **Greeting**: a time-aware greeting with your first name.
+- **Org stats strip**: live counts for teammates, projects, servers, eval suites, tool executions (last 30 days), and messages sent (last 30 days).
+- **MCPJam Agent composer**: a text input to start or resume an agent conversation directly from the home page.
+- **What's new**: a compact list of recent platform releases and changes, with per-item dismiss and a "Clear all" action.
+- **Recommended servers** and **Recommended clients**: displayed side by side in a two-column grid.
 
 ## Org stats strip
 
@@ -73,7 +73,7 @@ The **What's new** section appears above the recommended servers and clients gri
 
 ## MCPJam Agent panel
 
-The MCPJam Agent is a persistent chat panel that lets you ask questions about docs, evals, and tools without leaving your current tab. It is available on every tab — Playground, Evals, Clients, and others — so you can keep a conversation going while you work.
+The MCPJam Agent is a persistent chat panel that lets you ask questions about docs, evals, and tools without leaving your current tab. It is available on every tab (Playground, Evals, Clients, and others), so you can keep a conversation going while you work.
 
 ### Opening the panel
 
@@ -91,22 +91,22 @@ The agent has access to your workspace data and can answer questions or take act
 | **Eval suites** | "List my eval suites", "Run my addition eval suite", "Show me the results of my last eval run" |
 | **Chatboxes** | "List my chatboxes", "Show me chatbox details", "List chat sessions" |
 
-Operations that connect to one of your saved MCP servers (such as calling a tool or reading a resource) respect your project's **Require tool approval** setting. Pure platform reads — listing projects, eval suites, chatboxes, and sessions — never require approval.
+Operations that connect to one of your saved MCP servers (such as calling a tool or reading a resource) respect your project's **Require tool approval** setting. Pure platform reads (listing projects, eval suites, chatboxes, and sessions) never require approval.
 
 ### Using the panel
 
-- **New chat** — Click **New chat** in the panel header to start a fresh conversation.
-- **Resume a session** — Previously started sessions are listed in the panel's home view. Click one to continue.
-- **Resize** — Drag the left edge of the panel to adjust its width. The minimum width is 360 px; the maximum is 50% of the viewport. Dragging below the minimum snaps the panel closed.
-- **Close** — Click the **✕** button in the panel header, or press the keyboard shortcut again.
+- **New chat**: Click **New chat** in the panel header to start a fresh conversation.
+- **Resume a session**: Previously started sessions are listed in the panel's home view. Click one to continue.
+- **Resize**: Drag the left edge of the panel to adjust its width. The minimum width is 360 px; the maximum is 50% of the viewport. Dragging below the minimum snaps the panel closed.
+- **Close**: Click the **✕** button in the panel header, or press the keyboard shortcut again.
 
 ### Tool approval
 
-The composer footer includes a **Tool approval** toggle (shield icon). When enabled, the agent pauses before each tool call and shows an Approve / Deny pill so you can review the action before it runs. Denying a call is final — the agent will not retry it automatically. The preference is saved to your browser's local storage and shared across the Home takeover and the side panel.
+The composer footer includes a **Tool approval** toggle (shield icon). When enabled, the agent pauses before each tool call and shows an Approve / Deny pill so you can review the action before it runs. Denying a call is final: the agent will not retry it automatically. The preference is saved to your browser's local storage and shared across the Home takeover and the side panel.
 
 ### Widget rendering
 
-The agent supports MCP Apps widget rendering. When a workspace tool returns an interactive widget — for example, asking "show my servers" — the widget renders inline in the chat, just like widgets in the LLM Playground. You can interact with the widget directly without leaving the panel.
+The agent supports MCP Apps widget rendering. When a workspace tool returns an interactive widget (for example, asking "show my servers"), the widget renders inline in the chat, just like widgets in the LLM Playground. You can interact with the widget directly without leaving the panel.
 
 ### Persistence
 
@@ -124,6 +124,6 @@ Notifications are accessible from the sidebar. Click **Notifications** next to t
 
 ## What's next
 
-- [Projects](/inspector/projects) — create and manage projects for your servers
-- [Clients](/inspector/clients) — configure and test MCP clients
-- [Servers](/getting-started#3-connect-your-own-server) — connect your own MCP servers
+- [Projects](/inspector/projects): create and manage projects for your servers
+- [Clients](/inspector/clients): configure and test MCP clients
+- [Servers](/getting-started#3-connect-your-own-server): connect your own MCP servers

--- a/docs/inspector/host-compat.mdx
+++ b/docs/inspector/host-compat.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Host Compatibility"
-description: "See which hosts your MCP server will work in — Claude, ChatGPT, Cursor, Copilot, Codex — the moment you connect"
+description: "See which hosts your MCP server will work in (Claude, ChatGPT, Cursor, Copilot, Codex) the moment you connect"
 icon: "circle-check"
 ---
 
-When you connect an MCP server, MCPJam automatically evaluates how well it will work in each major host and shows the result directly on the server card. No extra steps required — the data comes from what the inspector already captures at connect time.
+When you connect an MCP server, MCPJam automatically evaluates how well it will work in each major host and shows the result directly on the server card. No extra steps required: the data comes from what the inspector already captures at connect time.
 
 ## The compat strip
 
@@ -13,8 +13,8 @@ Once a server is connected, a **compat strip** appears on its card: a row of hos
 | Dot color | Verdict | Meaning |
 |-----------|---------|---------|
 | Green | **Works** | Every requirement the server expresses is supported by this host. |
-| Amber | **Degraded** | The server connects and runs, but some features are lost — for example, a widget falls back to plain text, or prompts aren't surfaced. |
-| Red | **Blocked** | A hard blocker prevents the server from working in this host — for example, the host can't reach a local stdio server. |
+| Amber | **Degraded** | The server connects and runs, but some features are lost: for example, a widget falls back to plain text, or prompts aren't surfaced. |
+| Red | **Blocked** | A hard blocker prevents the server from working in this host: for example, the host can't reach a local stdio server. |
 | Gray | **Unknown** | The report doesn't have enough information to produce a verdict for this host yet. |
 
 Hover any logo to see a tooltip with the verdict and the first finding. Click the strip to open the **Clients** tab in the server detail modal for the full report.
@@ -23,34 +23,34 @@ Hover any logo to see a tooltip with the verdict and the first finding. Click th
 
 The server detail modal has a **Clients** tab (alongside Config, Overview, Tools, and History). It shows a per-host breakdown:
 
-- **Verdict** — Works / Degraded / Blocked / Unknown, with a colored dot.
-- **Provenance** — How trustworthy the host profile is. Hover the verdict dot to see one of:
-  - *Verified from vendor docs* — the profile is based on a published vendor capability table.
-  - *Probe-captured from a real client* — the profile was captured from a live client session.
-  - *Best-effort preset — unverified* — the profile is a best-effort estimate.
-- **Findings** — Click the summary line to expand the full list of findings for that host. Each finding shows:
+- **Verdict**: Works / Degraded / Blocked / Unknown, with a colored dot.
+- **Provenance**: How trustworthy the host profile is. Hover the verdict dot to see one of:
+  - *Verified from vendor docs*: the profile is based on a published vendor capability table.
+  - *Probe-captured from a real client*: the profile was captured from a live client session.
+  - *Best-effort preset — unverified*: the profile is a best-effort estimate.
+- **Findings**: Click the summary line to expand the full list of findings for that host. Each finding shows:
   - A severity icon (blocker, degraded, or info).
   - A title and detail explaining what's affected and why.
   - A **remediation** hint where one exists (for example, "Declare an MCP Apps template alongside the OpenAI one").
-- **Test button** — Creates a new host pre-configured for that host's template with your server already attached, then opens the Playground. This is the one-click path from "degraded in Copilot" to testing the fix.
+- **Test button**: Creates a new host pre-configured for that host's template with your server already attached, then opens the Playground. This is the one-click path from "degraded in Copilot" to testing the fix.
 
 ## What the report checks
 
-The report is computed from data already on the client at connect time — no extra network calls beyond the normal tool list fetch.
+The report is computed from data already on the client at connect time: no extra network calls beyond the normal tool list fetch.
 
 ### Widget rendering
 
 The most common source of findings. The report checks whether each host can render the widget bridges your server's tools declare:
 
-- **MCP Apps** (`_meta.ui.resourceUri`) — rendered by Claude, ChatGPT, Cursor, and Copilot. Not rendered by Codex (a CLI with no widget surface).
-- **OpenAI Apps** (`openai/outputTemplate`) — rendered by ChatGPT and Copilot via the `window.openai` shim. Not rendered by Claude, Cursor, or Codex.
-- **Dual-bridge** (both keys declared) — renderable wherever either bridge is supported.
+- **MCP Apps** (`_meta.ui.resourceUri`): rendered by Claude, ChatGPT, Cursor, and Copilot. Not rendered by Codex (a CLI with no widget surface).
+- **OpenAI Apps** (`openai/outputTemplate`): rendered by ChatGPT and Copilot via the `window.openai` shim. Not rendered by Claude, Cursor, or Codex.
+- **Dual-bridge** (both keys declared): renderable wherever either bridge is supported.
 
 When a host can't render a widget, the verdict is **Degraded** (the tool falls back to its plain-text result). If the tool is declared app-only (`_meta.ui.visibility` excludes `"model"`), there is no text fallback and the verdict is **Blocked**.
 
 ### Widget capability gaps (L1 scan)
 
-For each widget, the inspector reads the widget's HTML via `resources/read` and scans it for the host APIs it actually calls — for example, `ui/message`, `tools/call`, `window.openai.sendFollowUpMessage`. A capability finding fires only when:
+For each widget, the inspector reads the widget's HTML via `resources/read` and scans it for the host APIs it actually calls: for example, `ui/message`, `tools/call`, `window.openai.sendFollowUpMessage`. A capability finding fires only when:
 
 1. A widget in your server actually uses a capability, **and**
 2. The host's capability matrix doesn't support it.
@@ -75,10 +75,10 @@ One or more features will be lost, but the server still connects and the model c
 
 ### Blocked
 
-A hard blocker makes the server unusable in this host. Currently this only fires when a widget tool is declared app-only and the host can't render it — the tool is hidden from the model and has no text fallback, so it's effectively dead.
+A hard blocker makes the server unusable in this host. Currently this only fires when a widget tool is declared app-only and the host can't render it: the tool is hidden from the model and has no text fallback, so it's effectively dead.
 
 <Note>
-Transport and auth blockers (for example, a local stdio server that a cloud host can't reach) are intentionally omitted from the report. A local dev server is expected not to be reachable from ChatGPT or Copilot — flagging it would be noise during development.
+Transport and auth blockers (for example, a local stdio server that a cloud host can't reach) are intentionally omitted from the report. A local dev server is expected not to be reachable from ChatGPT or Copilot. Flagging it would be noise during development.
 </Note>
 
 ### Unknown
@@ -88,7 +88,7 @@ The report doesn't have enough information. This happens when:
 - The tool list hasn't loaded yet (the strip shows "checking…" briefly after connect).
 - Every `resources/read` call for the server's widgets failed, so the capability scan couldn't run.
 
-Unknown is not the same as Works — the report withholds a verdict rather than guess.
+Unknown is not the same as Works: the report withholds a verdict rather than guess.
 
 ## Provenance and confidence
 
@@ -98,7 +98,7 @@ Host profiles are best-effort. The provenance label on each verdict tells you ho
 |------------|--------|------------|
 | Vendor doc | Published capability table (e.g. Microsoft's Copilot MCP Apps table) | High |
 | Probe | Captured from a live client session (e.g. Cursor 3.4.17) | High, but versioned |
-| Assumed | Best-effort preset judgment | Lower — treat as a starting point |
+| Assumed | Best-effort preset judgment | Lower: treat as a starting point |
 
 The copy in the Clients tab always says "prototype · static checks" to make clear this is not a live test against the real host. Use the **Test** button to open the Playground and verify behavior under the host's emulated environment.
 
@@ -108,8 +108,8 @@ The copy in the Clients tab always says "prototype · static checks" to make cle
 
 If a widget is degraded because the host doesn't render its bridge, the finding includes a remediation hint:
 
-- **MCP Apps widget on an OpenAI-only host** — add an `openai/outputTemplate` key alongside `_meta.ui.resourceUri` so the tool has both bridges.
-- **OpenAI Apps widget on an MCP-Apps-only host** — add a `_meta.ui.resourceUri` key alongside `openai/outputTemplate`.
+- **MCP Apps widget on an OpenAI-only host**: add an `openai/outputTemplate` key alongside `_meta.ui.resourceUri` so the tool has both bridges.
+- **OpenAI Apps widget on an MCP-Apps-only host**: add a `_meta.ui.resourceUri` key alongside `openai/outputTemplate`.
 
 After updating your server, reconnect and the compat strip will re-evaluate.
 
@@ -125,6 +125,6 @@ From there you can chat with your server under the host's emulated capabilities 
 
 ## Related
 
-- [Clients](/inspector/clients) — Configure host emulation settings, capability matrices, and sandbox policies.
-- [Playground](/inspector/playground) — Test your server under emulated host environments.
-- [Contribute a Host](/inspector/host-templates) — Add a new host preset to the registry.
+- [Clients](/inspector/clients): Configure host emulation settings, capability matrices, and sandbox policies.
+- [Playground](/inspector/playground): Test your server under emulated host environments.
+- [Contribute a Host](/inspector/host-templates): Add a new host preset to the registry.

--- a/docs/inspector/host-templates.mdx
+++ b/docs/inspector/host-templates.mdx
@@ -5,9 +5,9 @@ icon: "plus-square"
 tag: "NEW"
 ---
 
-MCPJam ships built-in host presets for Claude, ChatGPT, Cursor, Copilot, Codex, and MCPJam itself. Each preset captures what a real host publishes during MCP `initialize` and `ui/initialize` — `clientInfo`, `hostInfo`, capability advertise, `hostContext` (theme, viewport, device, locale), and sandbox policy (CSP directives, permissions, allow-features). With a preset selected, a widget rendered in the [Playground](/inspector/playground) behaves the way it would in production under that host.
+MCPJam ships built-in host presets for Claude, ChatGPT, Cursor, Copilot, Codex, and MCPJam itself. Each preset captures what a real host publishes during MCP `initialize` and `ui/initialize`: `clientInfo`, `hostInfo`, capability advertise, `hostContext` (theme, viewport, device, locale), and sandbox policy (CSP directives, permissions, allow-features). With a preset selected, a widget rendered in the [Playground](/inspector/playground) behaves the way it would in production under that host.
 
-If your host isn't in the list yet — or if Microsoft, Anthropic, OpenAI, etc. ship a new capability and the inspector hasn't caught up — adding a preset is a small, self-contained contribution. This page walks through it.
+If your host isn't in the list yet (or if Microsoft, Anthropic, OpenAI, etc. ship a new capability and the inspector hasn't caught up), adding a preset is a small, self-contained contribution. This page walks through it.
 
 <Note>
   Host presets are values, not code. There's no runtime to write. A new preset
@@ -18,8 +18,8 @@ If your host isn't in the list yet — or if Microsoft, Anthropic, OpenAI, etc. 
 
 A host preset has two pieces:
 
-1. **Host style** — branding, label, chatbox chrome, font CSS, and the capability **surface** the host supports (which MCP Apps and OpenAI Apps SDK features it implements). Defined in `client/src/lib/client-styles/built-ins.ts`.
-2. **Catalog host** — the backend-owned host row used for creation, compare, caniuse, and "update to latest". It includes label/provenance facts plus the full `HostConfigInputV2` template: `clientCapabilities`, `hostContext`, `mcpProfile`, image policy, sandbox policy, model defaults, and other host fields. Defined in `mcpjam-backend/convex/marketHostCatalog/templates.ts` and `mcpjam-backend/convex/marketHostCatalog/seed.ts`.
+1. **Host style**: branding, label, chatbox chrome, font CSS, and the capability **surface** the host supports (which MCP Apps and OpenAI Apps SDK features it implements). Defined in `client/src/lib/client-styles/built-ins.ts`.
+2. **Catalog host**: the backend-owned host row used for creation, compare, caniuse, and "update to latest". It includes label/provenance facts plus the full `HostConfigInputV2` template: `clientCapabilities`, `hostContext`, `mcpProfile`, image policy, sandbox policy, model defaults, and other host fields. Defined in `mcpjam-backend/convex/marketHostCatalog/templates.ts` and `mcpjam-backend/convex/marketHostCatalog/seed.ts`.
 
 The backend catalog is canonical at runtime. The SDK carries a generated fallback snapshot for CLI/offline/dev paths; do not hand-edit SDK fallback data when changing host facts.
 
@@ -27,18 +27,18 @@ The backend catalog is canonical at runtime. The SDK carries a generated fallbac
 
 The single most important rule when adding a host: **capture values from a live probe, don't invent them.**
 
-Every existing preset has inline comments citing a real source — a captured `ui/initialize` response, a DevTools Network capture of the host's response Content-Security-Policy header, or an official vendor doc. Examples from the codebase:
+Every existing preset has inline comments citing a real source: a captured `ui/initialize` response, a DevTools Network capture of the host's response Content-Security-Policy header, or an official vendor doc. Examples from the codebase:
 
-- `CLAUDE_HOST_STYLE_VARIABLES` — verbatim from Claude's published design tokens.
-- `CHATGPT` template `cspDirectives` — "captured 2026-05-18 via DevTools → Network → oaiusercontent.com response".
-- `COPILOT` template — links to Microsoft Learn's "Supported MCP Apps capabilities in Copilot" table.
+- `CLAUDE_HOST_STYLE_VARIABLES`: verbatim from Claude's published design tokens.
+- `CHATGPT` template `cspDirectives`: "captured 2026-05-18 via DevTools → Network → oaiusercontent.com response".
+- `COPILOT` template: links to Microsoft Learn's "Supported MCP Apps capabilities in Copilot" table.
 
 Inventing values silently misrepresents the host. A widget that works in MCPJam-as-YourHost but fails in production YourHost is the failure mode we're avoiding.
 
 <Info>
   When a field can't be probed (no live capture, no public doc), say so in a
   code comment. Several existing presets use phrases like *"Undocumented; chosen
-  to match the ChatGPT convention"* — that's honest. Don't hide guesses behind
+  to match the ChatGPT convention"*. That's honest. Don't hide guesses behind
   clean values.
 </Info>
 
@@ -48,12 +48,12 @@ Inventing values silently misrepresents the host. A widget that works in MCPJam-
   <Step title="Probe the real host">
     Capture as much as you can from the live host before writing any code:
 
-    - **MCP `initialize` response** — `serverInfo`, `clientInfo`, advertised `capabilities` (including the `experimental` block and the MCP UI extension).
-    - **`ui/initialize` response** — `hostInfo`, `hostCapabilities`, `hostContext` (theme, displayMode, containerDimensions, locale, timeZone, userAgent, platform, deviceCapabilities, safeAreaInsets, styles).
-    - **Outer iframe** — `sandbox=` attribute, `allow=` attribute, and the response `Content-Security-Policy` header.
-    - **Inner iframe** (if the host nests) — same three things.
+    - **MCP `initialize` response**: `serverInfo`, `clientInfo`, advertised `capabilities` (including the `experimental` block and the MCP UI extension).
+    - **`ui/initialize` response**: `hostInfo`, `hostCapabilities`, `hostContext` (theme, displayMode, containerDimensions, locale, timeZone, userAgent, platform, deviceCapabilities, safeAreaInsets, styles).
+    - **Outer iframe**: `sandbox=` attribute, `allow=` attribute, and the response `Content-Security-Policy` header.
+    - **Inner iframe** (if the host nests): same three things.
 
-    DevTools → Network → Response Headers + the inspector's own JSON-RPC logger ([Playground](/inspector/playground)) are the easiest capture surfaces. Save these somewhere referenceable — you'll cite them in code comments.
+    DevTools → Network → Response Headers + the inspector's own JSON-RPC logger ([Playground](/inspector/playground)) are the easiest capture surfaces. Save these somewhere referenceable; you'll cite them in code comments.
 
   </Step>
 
@@ -114,7 +114,7 @@ Inventing values silently misrepresents the host. A widget that works in MCPJam-
   <Step title="Add the backend catalog host">
     In `mcpjam-backend/convex/marketHostCatalog/templates.ts`, add the full `HostConfigInputV2` template keyed by host id. In `mcpjam-backend/convex/marketHostCatalog/seed.ts`, add the catalog metadata for that same id: label, provenance, MCP Apps rendering, protocol versions, verification date, and image support.
 
-    The template should include every host field that can change — model, colors/styles, host context, sandbox, visibility, progressive tool discovery, image policy, and MCP Apps capability matrix. Fill in what you probed, delete what doesn't apply (see [Field guide](#field-guide) for what each one does):
+    The template should include every host field that can change: model, colors/styles, host context, sandbox, visibility, progressive tool discovery, image policy, and MCP Apps capability matrix. Fill in what you probed, delete what doesn't apply (see [Field guide](#field-guide) for what each one does):
 
     ```ts
     // templates.ts
@@ -202,7 +202,7 @@ Inventing values silently misrepresents the host. A widget that works in MCPJam-
     - Does a widget that probes `hostInfo.name === "YourHost"` take that branch?
     - Are CSP violations reported in DevTools the same ones the real host would emit?
 
-    The Playground's "Compare hosts" mode lets you render the same tool call under YourHost alongside Claude or ChatGPT side-by-side — useful for catching capability gaps.
+    The Playground's "Compare hosts" mode lets you render the same tool call under YourHost alongside Claude or ChatGPT side-by-side, useful for catching capability gaps.
 
   </Step>
 </Steps>
@@ -226,7 +226,7 @@ A non-exhaustive reference for the fields most often gotten wrong:
 <Warning>
   **Almost never set `restrictTo` on `sandbox.csp`.** SEP-1865 makes
   `restrictTo` an *intersection* with the view's declared `_meta.ui.csp`, not a
-  union. Adding the host's production allowlist here can only narrow widgets —
+  union. Adding the host's production allowlist here can only narrow widgets,
   never help them. A view declaring `connect-src https://api.example.com`
   silently goes to zero if your `restrictTo.connectDomains` doesn't list
   `api.example.com`. Use `mode: "declared"` and trust the view's CSP. The only
@@ -237,15 +237,15 @@ A non-exhaustive reference for the fields most often gotten wrong:
 <Warning>
   **`mcpProfile.apps.mcpAppsOverrides` is what the host advertises for MCP
   Apps.** Listing capabilities the renderer doesn't actually implement misleads
-  widget authors — they'll gate on the advertised flag, hit a dead path at
+  widget authors: they'll gate on the advertised flag, hit a dead path at
   runtime, and blame their widget. If a capability's `listChanged` notifications
   aren't forwarded by the renderer yet, omit the sub-field. Several existing
-  presets call this out explicitly in comments — match that discipline.
+  presets call this out explicitly in comments; match that discipline.
 </Warning>
 
 <Tip>
   When mirroring a host that doesn't render widgets at all (e.g. Codex CLI),
-  replace `clientCapabilities` instead of spreading — a spread leaks the
+  replace `clientCapabilities` instead of spreading: a spread leaks the
   SDK-default MCP UI extension back in and misrepresents the host as UI-capable.
   See the Codex preset for the pattern.
 </Tip>
@@ -258,10 +258,10 @@ When the preset is working locally:
 2. Cite the sources for each non-default value (capture date for probes, doc URL for vendor specs).
 3. If any field is a guess, mark it as such in a comment.
 
-The maintainers will eyeball the values against the cited captures, run a couple of widgets under the preset, and merge. If your host evolves later — a new capability, a CSP change — open a follow-up PR with a fresh probe.
+The maintainers will eyeball the values against the cited captures, run a couple of widgets under the preset, and merge. If your host evolves later (a new capability, a CSP change), open a follow-up PR with a fresh probe.
 
 <Info>
   Stuck on a probe? Open a thread in the [MCPJam
-  Discord](https://discord.gg/JEnDtz8X6z) — the team can usually help with
+  Discord](https://discord.gg/JEnDtz8X6z). The team can usually help with
   capture techniques or sanity-check what a vendor's docs actually mean.
 </Info>

--- a/docs/inspector/playground.mdx
+++ b/docs/inspector/playground.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Playground"
-description: "Chat with your MCP servers, invoke tools by hand, render widgets, and inspect every step — all in one IDE-style workspace"
+description: "Chat with your MCP servers, invoke tools by hand, render widgets, and inspect every step, all in one IDE-style workspace"
 icon: "joystick"
 tag: "NEW"
 ---
@@ -24,51 +24,51 @@ The Playground is the main workspace for developing against your MCP servers. It
 
 ## Key Features
 
-- **Chat with frontier models** — Talk to your server using Claude, GPT, Gemini, DeepSeek, and more at no cost, no API key required. Organizations can configure additional model providers in their organization settings.
-- **Manual tool invocation** — Run any tool from the Tools rail with your own inputs to iterate on a widget or response without prompting a model.
-- **Widget emulator** — Render widgets exposed via `openai/outputTemplate` (ChatGPT Apps) or `ui.resourceUri` (MCP Apps) the same way a real host would, with Inline, Picture-in-Picture, and Fullscreen display modes.
-- **Chat / Trace / Raw views** — Switch between the conversation, a timestamped timeline of every step (with per-step latency and tokens), and the exact JSON payload sent to the model.
-- **Multi-model compare** — Send a single prompt to up to 3 models at once and watch the responses side by side.
-- **Multi-host compare** — Render the same tool call under multiple host configurations (ChatGPT vs Claude, different device sizes, different capability sets) at the same time.
-- **Display context controls** — Device viewport, light/dark theme, host style, locale, timezone, CSP mode, device capabilities, and safe area insets — all live in the toolbar.
-- **Per-widget debugging** — Inspect raw tool input/output, `widgetState`, model context, and CSP violations from icons above each widget.
-- **JSON-RPC logger** — Real-time, filterable feed of every message between the inspector and your servers.
-- **Sessions rail** — Resume, archive, and search past conversations from the left rail.
-- **Skills and prompts** — Type `/` to inject skills or MCP prompts directly into the chat.
-- **Edit tool input/output live** — Click **Edit** on any tool-result card to tweak the input or output JSON and watch the widget re-render instantly; **Run** re-executes the tool with your edited input.
-- **Voice input** — Click the mic button in the chat input to record your voice; the audio is transcribed and the text is inserted into the composer.
+- **Chat with frontier models**: Talk to your server using Claude, GPT, Gemini, DeepSeek, and more at no cost, no API key required. Organizations can configure additional model providers in their organization settings.
+- **Manual tool invocation**: Run any tool from the Tools rail with your own inputs to iterate on a widget or response without prompting a model.
+- **Widget emulator**: Render widgets exposed via `openai/outputTemplate` (ChatGPT Apps) or `ui.resourceUri` (MCP Apps) the same way a real host would, with Inline, Picture-in-Picture, and Fullscreen display modes.
+- **Chat / Trace / Raw views**: Switch between the conversation, a timestamped timeline of every step (with per-step latency and tokens), and the exact JSON payload sent to the model.
+- **Multi-model compare**: Send a single prompt to up to 3 models at once and watch the responses side by side.
+- **Multi-host compare**: Render the same tool call under multiple host configurations (ChatGPT vs Claude, different device sizes, different capability sets) at the same time.
+- **Display context controls**: Device viewport, light/dark theme, host style, locale, timezone, CSP mode, device capabilities, and safe area insets, all live in the toolbar.
+- **Per-widget debugging**: Inspect raw tool input/output, `widgetState`, model context, and CSP violations from icons above each widget.
+- **JSON-RPC logger**: Real-time, filterable feed of every message between the inspector and your servers.
+- **Sessions rail**: Resume, archive, and search past conversations from the left rail.
+- **Skills and prompts**: Type `/` to inject skills or MCP prompts directly into the chat.
+- **Edit tool input/output live**: Click **Edit** on any tool-result card to tweak the input or output JSON and watch the widget re-render instantly; **Run** re-executes the tool with your edited input.
+- **Voice input**: Click the mic button in the chat input to record your voice; the audio is transcribed and the text is inserted into the composer.
 
 ## Getting Started
 
-1. **Connect a server** — Add and connect an MCP server from the [Clients](/inspector/clients) tab (or the **+** button in the chat input).
-2. **Open the Playground** — Switch to the Playground tab.
-3. **Send a message or run a tool** — Either chat with your server from the input bar and let the model call tools, or pick a tool from the left rail and execute it with your own input.
+1. **Connect a server**: Add and connect an MCP server from the [Clients](/inspector/clients) tab (or the **+** button in the chat input).
+2. **Open the Playground**: Switch to the Playground tab.
+3. **Send a message or run a tool**: Either chat with your server from the input bar and let the model call tools, or pick a tool from the left rail and execute it with your own input.
 
 When a tool returns a widget, it renders immediately in the chat thread with a row of debug icons above it. When the model calls a tool, you see the call, the result, and any widget output inline.
 
 ## Layout
 
-The Playground is a three-column IDE shell. Each side rail is collapsible — drag the divider or click the peek strip to hide or restore it.
+The Playground is a three-column IDE shell. Each side rail is collapsible: drag the divider or click the peek strip to hide or restore it.
 
-**Left rail — Tools / Sessions**
-- **Tools** (default) — Every tool exposed by your connected server(s). Pick one to fill in inputs and run it manually. When more than one server is selected, tools are aggregated across all of them and routed automatically on execution.
-- **Sessions** — Browse, resume, rename, archive, and search past chat threads in the current project.
+**Left rail: Tools / Sessions**
+- **Tools** (default): Every tool exposed by your connected server(s). Pick one to fill in inputs and run it manually. When more than one server is selected, tools are aggregated across all of them and routed automatically on execution.
+- **Sessions**: Browse, resume, rename, archive, and search past chat threads in the current project.
 
-**Center — Chat surface**
+**Center: Chat surface**
 - Chat composer, conversation thread with inline tool calls and widgets, and the host context toolbar.
 - Top of the pane has a segmented control to switch between **Chat**, **Trace**, and **Raw** views.
 
-**Right rail — Logs / Shell**
-- **Logs** (always available) — Real-time feed of MCP protocol messages. Search, filter by source server, filter by log level, copy, download, or clear the buffer.
-- **Shell** (shown when the previewed host has a Project Computer) — A live terminal on the computer the harness runs on. Click **Open terminal** to provision or wake the computer and connect. Switching between Logs and Shell keeps both the terminal WebSocket and the log stream alive so neither is dropped.
+**Right rail: Logs / Shell**
+- **Logs** (always available): Real-time feed of MCP protocol messages. Search, filter by source server, filter by log level, copy, download, or clear the buffer.
+- **Shell** (shown when the previewed host has a Project Computer): A live terminal on the computer the harness runs on. Click **Open terminal** to provision or wake the computer and connect. Switching between Logs and Shell keeps both the terminal WebSocket and the log stream alive so neither is dropped.
 
 ## Chat, Trace, and Raw Views
 
 Switch between three perspectives on the same conversation from the segmented control at the top of the center pane:
 
-- **Chat** — The normal thread with inline messages, tool calls, and rendered widgets.
-- **Trace** — A timestamped timeline of every step (user turns, agent turns, tool calls) with per-step and total latency and token counts. Expand any step to inspect its raw input and output.
-- **Raw** — The full JSON payload sent to the model (system prompt, tool definitions, conversation history). Available for both live sessions and previously-saved sessions you reopen.
+- **Chat**: The normal thread with inline messages, tool calls, and rendered widgets.
+- **Trace**: A timestamped timeline of every step (user turns, agent turns, tool calls) with per-step and total latency and token counts. Expand any step to inspect its raw input and output.
+- **Raw**: The full JSON payload sent to the model (system prompt, tool definitions, conversation history). Available for both live sessions and previously-saved sessions you reopen.
 
 <Frame>
   <img
@@ -95,20 +95,20 @@ When multiple servers are selected at the same time, the Tools rail aggregates e
 
 The model picker in the chat input lets you choose which LLM to use. Models are organized into two tabs:
 
-- **Free models** — Frontier models (Claude, GPT, Gemini, DeepSeek, and more) available at no cost with no API key required.
-- **Your providers** — Models from providers configured in your organization's settings on mcpjam.com.
+- **Free models**: Frontier models (Claude, GPT, Gemini, DeepSeek, and more) available at no cost with no API key required.
+- **Your providers**: Models from providers configured in your organization's settings on mcpjam.com.
 
 The picker opens on the tab that matches your currently selected model. When you search, results from both tabs appear together.
 
 ### Out-of-credits state
 
-When your MCPJam credit balance reaches zero, free models are grayed out in the picker with a tooltip explaining the limit. Models from your own providers remain enabled — switching to one is the fastest way to keep working. Paid top-up credits (if you have any) keep free models available even after your daily free allowance is exhausted.
+When your MCPJam credit balance reaches zero, free models are grayed out in the picker with a tooltip explaining the limit. Models from your own providers remain enabled. Switching to one is the fastest way to keep working. Paid top-up credits (if you have any) keep free models available even after your daily free allowance is exhausted.
 
 If the out-of-credits dialog appears, clicking **Bring your own key** closes the dialog and opens the model picker directly on the **Your providers** tab so you can switch to an own-key model without leaving the chat.
 
 ## Multi-Model Compare
 
-Send one prompt to up to 3 models simultaneously. Open the model picker, toggle **Multiple models** on, and select the models you want to compare. Each model's response — including tool calls and rendered widgets — appears in its own column.
+Send one prompt to up to 3 models simultaneously. Open the model picker, toggle **Multiple models** on, and select the models you want to compare. Each model's response, including tool calls and rendered widgets, appears in its own column.
 
 <Note>
   The **Multiple models** toggle is hidden when the active session is shared
@@ -128,7 +128,7 @@ Send one prompt to up to 3 models simultaneously. Open the model picker, toggle 
 
 ## Multi-Host Compare
 
-Toggle **Multiple hosts** on in the host picker (top-left of the center header) to render the same tool calls under different host configurations side by side — for example, ChatGPT vs Claude host style, or desktop vs mobile viewports.
+Toggle **Multiple hosts** on in the host picker (top-left of the center header) to render the same tool calls under different host configurations side by side: for example, ChatGPT vs Claude host style, or desktop vs mobile viewports.
 
 One column is designated the **lead host**; chip tooltips in the toolbar say "Editing lead host: \<name\>" so it's clear which column the host controls (theme, device, locale, etc.) currently bind to. Click another column's chip to promote it to lead.
 
@@ -161,7 +161,7 @@ The toolbar above the chat thread controls how the active host renders your widg
 - **Desktop** (1280×800)
 - **Tablet** (820×1180)
 - **Mobile** (430×932)
-- **Custom** — Any width and height from 100 to 2560 pixels
+- **Custom**: Any width and height from 100 to 2560 pixels
 
 ### Theme
 
@@ -185,14 +185,14 @@ Each host style ships with a distinct `hostCapabilities` preset. Switching from 
 
 The **Host Capabilities** button in the toolbar (next to Host Context) lets you override the `hostCapabilities` blob advertised to MCP App widgets in the `ui/initialize` response.
 
-By default, the active host style's preset is used. Click **Host Capabilities** to open the editor and customize which capabilities the mock host claims to support. This is useful for testing how your widget behaves when specific capabilities are absent or present — for example, verifying that your widget degrades gracefully when `serverResources` is not advertised.
+By default, the active host style's preset is used. Click **Host Capabilities** to open the editor and customize which capabilities the mock host claims to support. This is useful for testing how your widget behaves when specific capabilities are absent or present: for example, verifying that your widget degrades gracefully when `serverResources` is not advertised.
 
-- **No override** — the active host style's preset is used (shown as the placeholder in the editor)
-- **Custom override** — your JSON object is advertised verbatim; an "Override" badge appears on the button
-- **Clear override** — resets back to the host style preset
+- **No override**: the active host style's preset is used (shown as the placeholder in the editor)
+- **Custom override**: your JSON object is advertised verbatim; an "Override" badge appears on the button
+- **Clear override**: resets back to the host style preset
 
 <Note>
-  Host Capabilities configures what the mock host *advertises*. Enforcement — rejecting widget requests for capabilities not in the blob — is a planned follow-up. Until then, the inspector will still service all widget requests regardless of what the handshake advertises.
+  Host Capabilities configures what the mock host *advertises*. Enforcement (rejecting widget requests for capabilities not in the blob) is a planned follow-up. Until then, the inspector will still service all widget requests regardless of what the handshake advertises.
 </Note>
 
 ### Locale
@@ -209,13 +209,13 @@ Choose from 19 IANA timezones plus `UTC` to test time-aware widgets.
 
 ### CSP Mode
 
-- **Permissive** (default) — Allows all HTTP and HTTPS resources. Recommended for development.
-- **Strict** — Only allows domains declared in your widget's CSP metadata (`openai/widgetCSP` or `_meta.ui.csp` for ChatGPT Apps, `ui.csp` for MCP Apps).
+- **Permissive** (default): Allows all HTTP and HTTPS resources. Recommended for development.
+- **Strict**: Only allows domains declared in your widget's CSP metadata (`openai/widgetCSP` or `_meta.ui.csp` for ChatGPT Apps, `ui.csp` for MCP Apps).
 
 ### Device Capabilities
 
-- **Hover** — Enable or disable hover support to test mouse vs touch-only behavior.
-- **Touch** — Toggle touch input to simulate mobile and tablet devices.
+- **Hover**: Enable or disable hover support to test mouse vs touch-only behavior.
+- **Touch**: Toggle touch input to simulate mobile and tablet devices.
 
 ### Safe Area Insets
 
@@ -225,7 +225,7 @@ Simulate notches, rounded corners, and gesture areas. Pick a preset (None, iPhon
 
 ### Download confirmation
 
-When an MCP App widget triggers a `ui/download-file` request, the inspector shows a confirmation dialog before the download runs. The dialog displays the filename, MIME type, and URI so you can make an informed decision. Click **Download** to allow it or **Cancel** to deny it — a denial is surfaced to the widget as a `{ isError: true }` result so the widget can handle it gracefully.
+When an MCP App widget triggers a `ui/download-file` request, the inspector shows a confirmation dialog before the download runs. The dialog displays the filename, MIME type, and URI so you can make an informed decision. Click **Download** to allow it or **Cancel** to deny it. A denial is surfaced to the widget as a `{ isError: true }` result so the widget can handle it gracefully.
 
 Only one confirmation prompt is shown at a time. If a second download request arrives while a prompt is open, it is automatically denied.
 
@@ -233,17 +233,17 @@ Only one confirmation prompt is shown at a time. If a second download request ar
 
 All three display modes are supported for both ChatGPT Apps and MCP Apps:
 
-- **Inline** (default) — Widget renders within the chat message flow.
-- **Picture-in-Picture** — Widget floats at the top of the screen, staying visible while scrolling.
-- **Fullscreen** — Widget expands to fill the entire viewport.
+- **Inline** (default): Widget renders within the chat message flow.
+- **Picture-in-Picture**: Widget floats at the top of the screen, staying visible while scrolling.
+- **Fullscreen**: Widget expands to fill the entire viewport.
 
 Widgets can request mode changes from their own code; users can exit PiP or Fullscreen via the close button.
 
 ### Widget rendering
 
-All widgets — whether they declare `openai/outputTemplate` (ChatGPT Apps), `_meta.ui.resourceUri` (MCP Apps), or both — render through a single unified renderer. The `window.openai` compatibility shim is always injected, so both `window.openai.*` calls and `ui/*` JSON-RPC messages work regardless of which metadata the tool declares.
+All widgets, whether they declare `openai/outputTemplate` (ChatGPT Apps), `_meta.ui.resourceUri` (MCP Apps), or both, render through a single unified renderer. The `window.openai` compatibility shim is always injected, so both `window.openai.*` calls and `ui/*` JSON-RPC messages work regardless of which metadata the tool declares.
 
-Widget rendering is gated on the active Client's `clientCapabilities`. Hosts that advertise the MCP UI extension (Claude, ChatGPT, MCPJam, Copilot, Cursor) render widgets as normal. Hosts that strip the extension — such as Codex, an elicitation-only CLI — show the plain tool result row instead. Per-server capability overrides are honored.
+Widget rendering is gated on the active Client's `clientCapabilities`. Hosts that advertise the MCP UI extension (Claude, ChatGPT, MCPJam, Copilot, Cursor) render widgets as normal. Hosts that strip the extension (such as Codex, an elicitation-only CLI) show the plain tool result row instead. Per-server capability overrides are honored.
 
 ## Per-Widget Debugging
 
@@ -251,7 +251,7 @@ Every tool result in the chat thread has a row of icons in its header. Click an 
 
 ### Sign-in links
 
-When a computer-backed tool (such as Bash) runs a command that triggers a device-flow authentication prompt — for example, `gh auth login` — any sign-in URLs surfaced by the tool appear as clickable links directly in the chat thread under a **Sign-in link** heading. This saves you from hunting through scrollback for the URL. Only `https:` URLs are rendered as links; plain `http:` and non-web schemes are never shown.
+When a computer-backed tool (such as Bash) runs a command that triggers a device-flow authentication prompt (for example, `gh auth login`), any sign-in URLs surfaced by the tool appear as clickable links directly in the chat thread under a **Sign-in link** heading. This saves you from hunting through scrollback for the URL. Only `https:` URLs are rendered as links; plain `http:` and non-web schemes are never shown.
 
 ### Data
 
@@ -269,9 +269,9 @@ The context your widget has sent back to the model via `ui/update-model-context`
 
 In Strict mode, a badge shows the number of blocked requests. The panel includes:
 
-- **Suggested fix** — Copyable JSON snippet to add to your `openai/widgetCSP` or `ui.csp` field.
-- **Blocked requests** — Each violation with the directive and source that was blocked.
-- **Declared domains** — The connect, resource, frame, and base URI domains your widget currently declares.
+- **Suggested fix**: Copyable JSON snippet to add to your `openai/widgetCSP` or `ui.csp` field.
+- **Blocked requests**: Each violation with the directive and source that was blocked.
+- **Declared domains**: The connect, resource, frame, and base URI domains your widget currently declares.
 
 #### Mounts
 
@@ -279,7 +279,7 @@ The debug panel includes a **Mounts** section that appears only when a widget if
 
 ### Edit input & output
 
-Click **Edit** on a tool-result card to make the **Input** and **Result** JSON editable in place. Edits re-render the widget live with no reload; **Run** re-executes the tool with the edited input, and **Revert** restores the original. Edits are local to the session — nothing is persisted.
+Click **Edit** on a tool-result card to make the **Input** and **Result** JSON editable in place. Edits re-render the widget live with no reload; **Run** re-executes the tool with the edited input, and **Revert** restores the original. Edits are local to the session. Nothing is persisted.
 
 ## Right Rail
 
@@ -322,9 +322,9 @@ A list of every server in your project, sorted by status. Each row shows the ser
 **Attach files**
 Add files to the conversation in any of these ways:
 
-- **File picker** — Click the **+** button and choose **Attach files** to browse and select files.
-- **Paste** — Copy an image to your clipboard and paste it directly into the chat input (`Ctrl+V` / `Cmd+V`). Pasted images without a filename are saved automatically as `pasted-image-1.png`, `pasted-image-2.png`, and so on.
-- **Drag and drop** — Drag one or more files from your desktop and drop them onto the chat input. A "Drop image or file to attach" overlay appears while you're dragging to confirm the drop target.
+- **File picker**: Click the **+** button and choose **Attach files** to browse and select files.
+- **Paste**: Copy an image to your clipboard and paste it directly into the chat input (`Ctrl+V` / `Cmd+V`). Pasted images without a filename are saved automatically as `pasted-image-1.png`, `pasted-image-2.png`, and so on.
+- **Drag and drop**: Drag one or more files from your desktop and drop them onto the chat input. A "Drop image or file to attach" overlay appears while you're dragging to confirm the drop target.
 
 Supported file types include images, PDFs, text, JSON, CSV, XLSX, and other common formats. Invalid file types show an error message below the input.
 
@@ -335,21 +335,21 @@ Edit the system prompt the model sees before your messages, and adjust the tempe
 When on, pauses the model before each tool call so you can approve or deny it manually.
 
 **Voice input**
-Click the mic button (right side of the input) to record your voice. The audio is transcribed using Whisper and the resulting text is appended to whatever you've already typed in the composer. Recording stops automatically after 3 minutes. The mic is disabled when your daily voice budget is exhausted; a warning appears in the composer when the remaining budget is low. While a recording is in progress, pressing Enter does not submit the draft — use the stop button (arrow-up) to finish recording first, or the ✕ button to cancel without transcribing.
+Click the mic button (right side of the input) to record your voice. The audio is transcribed using Whisper and the resulting text is appended to whatever you've already typed in the composer. Recording stops automatically after 3 minutes. The mic is disabled when your daily voice budget is exhausted; a warning appears in the composer when the remaining budget is low. While a recording is in progress, pressing Enter does not submit the draft. Use the stop button (arrow-up) to finish recording first, or the ✕ button to cancel without transcribing.
 
 **Context meter** (right side of the input)
-Open it to inspect the token breakdown for the current conversation — input, output, system prompt, and MCP tools usage.
+Open it to inspect the token breakdown for the current conversation: input, output, system prompt, and MCP tools usage.
 
 ## Skills
 
 The Playground respects every skill you've configured in the [Skills](/inspector/skills) tab. A skill ends up in a conversation in one of two ways:
 
-- **Inferred** — The model picks a skill based on your prompt, loads its instructions, and runs it against your MCP tools. Useful for observing skill behavior end-to-end.
-- **Explicit** — Type `/` in the input and pick a skill from the **SKILLS** section of the picker. The skill content is front-loaded before your message.
+- **Inferred**: The model picks a skill based on your prompt, loads its instructions, and runs it against your MCP tools. Useful for observing skill behavior end-to-end.
+- **Explicit**: Type `/` in the input and pick a skill from the **SKILLS** section of the picker. The skill content is front-loaded before your message.
 
 ## Prompts
 
-Prompts are MCP prompt templates exposed by your servers via `prompts/list`. Type `/` in the input and pick one from the **PROMPTS** section. Selected prompts appear as expandable cards above the input — source server ID, description, arguments (required ones marked with `*`), and a preview of the first message — so you can review or remove them before sending.
+Prompts are MCP prompt templates exposed by your servers via `prompts/list`. Type `/` in the input and pick one from the **PROMPTS** section. Selected prompts appear as expandable cards above the input, showing the source server ID, description, arguments (required ones marked with `*`), and a preview of the first message, so you can review or remove them before sending.
 
 ## Workspace tools
 
@@ -359,14 +359,14 @@ When you are signed in as a project member, the Playground gives the model a set
 |---|---|
 | `list_project_servers` | List all servers saved in the project with their names, transport types, and enabled status. |
 | `diagnose_server` | Probe a server's URL, connect, initialize, and report its capabilities and any connection errors. Use this when a server won't connect or you want to check its health. |
-| `list_server_tools` | List the tools a server exposes — names, descriptions, and input schemas. Paginated; pass `nextCursor` back as `cursor` for the next page. |
+| `list_server_tools` | List the tools a server exposes: names, descriptions, and input schemas. Paginated; pass `nextCursor` back as `cursor` for the next page. |
 | `call_server_tool` | Execute a tool on a server and return its result. Runs with your own authorization and may have side effects. Get the tool name and parameter schema from `list_server_tools` first. |
-| `list_server_prompts` | List the prompts a server exposes — names, descriptions, and arguments. Paginated. |
+| `list_server_prompts` | List the prompts a server exposes: names, descriptions, and arguments. Paginated. |
 | `get_server_prompt` | Render a prompt from a server with the given arguments and return its messages. |
-| `list_server_resources` | List the resources a server exposes — URIs, names, and MIME types. Paginated. |
+| `list_server_resources` | List the resources a server exposes: URIs, names, and MIME types. Paginated. |
 | `read_server_resource` | Read one resource from a server by URI and return its contents. |
 
-Servers are identified by name or ID as saved in the project. Stdio servers are not supported for live operations — the model will receive a clear error rather than a connection failure.
+Servers are identified by name or ID as saved in the project. Stdio servers are not supported for live operations. The model will receive a clear error rather than a connection failure.
 
 When **Tool Approval** is on, the model pauses before `diagnose_server`, `call_server_tool`, and `read_server_resource` (the operations that open a live connection) so you can approve or deny each one. Read-only listing tools (`list_project_servers`, `list_server_tools`, `list_server_prompts`, `list_server_resources`) never require approval.
 
@@ -384,7 +384,7 @@ The server presents a form with fields defined by its schema. Fill in the fields
 
 ### URL elicitation
 
-The server asks you to visit a URL to complete an out-of-band step — for example, an OAuth authorization or a payment flow. The dialog shows:
+The server asks you to visit a URL to complete an out-of-band step: for example, an OAuth authorization or a payment flow. The dialog shows:
 
 - The **full destination URL** as plain text (never as a clickable link, so you must read it before opening it).
 - The **host emphasized** so subdomain spoofing is visible at a glance.
@@ -392,18 +392,18 @@ The server asks you to visit a URL to complete an out-of-band step — for examp
 
 Non-`http(s)` schemes (such as `javascript:` or `data:`) are blocked outright and cannot be opened.
 
-Click **Open in new tab** to open the URL. If your browser blocks the pop-up, a notice appears with a **Copy link** button so you can open it manually. The dialog only records your consent once the tab actually opens — a blocked pop-up does not count as acceptance.
+Click **Open in new tab** to open the URL. If your browser blocks the pop-up, a notice appears with a **Copy link** button so you can open it manually. The dialog only records your consent once the tab actually opens. A blocked pop-up does not count as acceptance.
 
 Click **Decline** to refuse, or close the dialog to cancel without an explicit choice.
 
 ### URL-required notices
 
-If a tool call fails because the server requires you to complete an out-of-band interaction first (MCP error `-32042`), the Playground shows a URL-required notice. This is advisory — the tool call has already failed — so there is nothing to decline. Open the required URL(s), then retry the tool call or ask the model to try again.
+If a tool call fails because the server requires you to complete an out-of-band interaction first (MCP error `-32042`), the Playground shows a URL-required notice. This is advisory (the tool call has already failed), so there is nothing to decline. Open the required URL(s), then retry the tool call or ask the model to try again.
 
 When a server requires multiple interactions before a tool can run, the notice walks you through them one at a time and only dismisses once you have handled all of them.
 
 ## Related Features
 
-- [Clients](/inspector/clients) — Manage MCP server connections, transports, and OAuth.
-- [Skills](/inspector/skills) — Configure skills that the Playground can use.
-- [Projects](/inspector/projects) — Organize servers, sessions, and views into shared workspaces.
+- [Clients](/inspector/clients): Manage MCP server connections, transports, and OAuth.
+- [Skills](/inspector/skills): Configure skills that the Playground can use.
+- [Projects](/inspector/projects): Organize servers, sessions, and views into shared workspaces.

--- a/docs/inspector/projects.mdx
+++ b/docs/inspector/projects.mdx
@@ -32,8 +32,8 @@ When you switch projects, all servers disconnect automatically to give you a cle
 
 The context menu leads with the **Projects** list. At the bottom of the menu, a footer row shows your active organization name and its shared credit usage.
 
-- **Switch organization** — appears only when you belong to two or more organizations. Click it to expand an inline list of all your organizations and select a different one. Switching reloads the sidebar with that organization's projects — no page reload required.
-- **New organization** — appears at the bottom of the switch list (or directly in the footer when you have only one org and can create another).
+- **Switch organization**: appears only when you belong to two or more organizations. Click it to expand an inline list of all your organizations and select a different one. Switching reloads the sidebar with that organization's projects (no page reload required).
+- **New organization**: appears at the bottom of the switch list (or directly in the footer when you have only one org and can create another).
 - The **gear icon** next to an organization name navigates to that organization's settings.
 
 <Info>
@@ -58,7 +58,7 @@ If you are a member (not an owner or admin) of an organization, you will see an 
 You will lose access to the organization immediately and be redirected to the Servers page. To rejoin, you need to be re-invited by an admin or owner.
 
 <Note>
-Owners cannot leave an organization — transfer ownership or delete the organization instead.
+Owners cannot leave an organization. Transfer ownership or delete the organization instead.
 </Note>
 ## Sharing Projects
 
@@ -66,7 +66,7 @@ Project sharing lets your entire team work with the same servers. Set up your pr
 
 ### What Gets Shared
 
-Members get access to every server in the project with the same configuration. Project admins can also configure which servers auto-connect and set per-server overrides (headers, timeout) from the Servers tab — these settings apply across every host in the project.
+Members get access to every server in the project with the same configuration. Project admins can also configure which servers auto-connect and set per-server overrides (headers, timeout) from the Servers tab. These settings apply across every host in the project.
 
 <Note>
 For security, authorization headers and OAuth tokens are never shared. Each team member authenticates with their own credentials when connecting to servers that require authentication.
@@ -117,13 +117,13 @@ Open **Project Settings** (gear icon in the header) to manage project-level conf
 
 The **Default Host Config** section sets the seed configuration applied to new chatboxes, eval suites, and direct chat tabs when they are created. It controls the default model, system prompt, temperature, tool approval, connection settings, capabilities, and host context for anything new in the project.
 
-Editing the default host config does **not** change existing chatboxes or eval suites — each owns its own config once created.
+Editing the default host config does **not** change existing chatboxes or eval suites: each owns its own config once created.
 
 The editor is only visible when you are signed in and have a saved project. Members without manage permissions see the editor in read-only mode.
 
 #### Personal computer
 
-When your deployment exposes computer-backed tools (such as **Bash**), a **Personal computer** toggle appears in the built-in tools section of the host config editor. Turning it on attaches a per-member cloud workstation — a persistent Linux sandbox — to the host.
+When your deployment exposes computer-backed tools (such as **Bash**), a **Personal computer** toggle appears in the built-in tools section of the host config editor. Turning it on attaches a per-member cloud workstation (a persistent Linux sandbox) to the host.
 
 - **Computer-backed tools are disabled until a computer is attached.** The checkbox for tools like Bash is greyed out with a hint ("Requires a personal computer") until you turn the toggle on.
 - **Detaching the computer also removes computer-backed tool ids** from the config, so the saved config is always consistent.

--- a/docs/inspector/protocol-versions.mdx
+++ b/docs/inspector/protocol-versions.mdx
@@ -1,11 +1,11 @@
 ---
 title: "MCP protocol versions"
-description: "Pin the inspector to a specific MCP protocol version — including the 2026-07-28 stateless RC — to test how your server behaves across versions."
+description: "Pin the inspector to a specific MCP protocol version (including the 2026-07-28 stateless RC) to test how your server behaves across versions."
 icon: "git-branch"
 tag: "Preview"
 ---
 
-The inspector can speak more than one version of the MCP protocol. By default it negotiates whatever the SDK considers current, but you can pin a different version when you want to test how your server behaves against a specific draft — including the new **2026-07-28 stateless RC**.
+The inspector can speak more than one version of the MCP protocol. By default it negotiates whatever the SDK considers current, but you can pin a different version when you want to test how your server behaves against a specific draft, including the new **2026-07-28 stateless RC**.
 
 This page covers how to pick a version. Automatic per-server version detection is on the roadmap; for now you tell the inspector which version to use.
 
@@ -17,18 +17,18 @@ This page covers how to pick a version. Automatic per-server version detection i
 
 There are two places to set a version, and they layer:
 
-1. **Client → MCP Protocol** — the _host default_ applied to every server attached to that Client.
-2. **Server card → Edit → Advanced settings → Protocol version** — a _per-server override_ that wins over the host default.
+1. **Client → MCP Protocol**: the _host default_ applied to every server attached to that Client.
+2. **Server card → Edit → Advanced settings → Protocol version**: a _per-server override_ that wins over the host default.
 
-Use the host default when you want every server in a Client to speak the same version. Use per-server overrides when you're testing a mix — for example, a stable 2025-11-25 server alongside one you're upgrading to the 2026 RC.
+Use the host default when you want every server in a Client to speak the same version. Use per-server overrides when you're testing a mix: for example, a stable 2025-11-25 server alongside one you're upgrading to the 2026 RC.
 
 ## Available versions
 
 | Option                               | Protocol version | Transport                                       | Use it when                                                                                                                                 |
 | ------------------------------------ | ---------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Latest**                           | `2025-11-25`     | HTTP, STDIO, SSE                                | The current stable MCP. Default for everything not opted in to the RC.                                                                      |
-| **2026 RC**                          | `2026-07-28`     | HTTP in MCPJam's preview (Streamable HTTP POST) | You want to test your server against the stateless RC — no `initialize` handshake, `server/discover` for capabilities, per-request `_meta`. |
-| **Host default** _(per-server only)_ | —                | —                                               | Inherit whatever the Client's MCP Protocol tab is set to.                                                                                   |
+| **2026 RC**                          | `2026-07-28`     | HTTP in MCPJam's preview (Streamable HTTP POST) | You want to test your server against the stateless RC: no `initialize` handshake, `server/discover` for capabilities, per-request `_meta`. |
+| **Host default** _(per-server only)_ | N/A              | N/A                                             | Inherit whatever the Client's MCP Protocol tab is set to.                                                                                   |
 
 The 2026 RC applies the stateless model across transports. MCPJam's initial preview client is narrower: it currently supports the RC over Streamable HTTP POST. The per-server dropdown hides the RC option for STDIO and legacy SSE servers; if a host-level RC default reaches a non-HTTP server, the inspector fails the connection with a clear transport error instead of silently attempting the wrong protocol.
 
@@ -59,7 +59,7 @@ Every server attached to this Client now connects with that version unless it ha
 4. Find **Protocol version** and pick **Host default**, **Latest (2025-11-25)**, or **2026 RC (2026-07-28)**.
 5. Save and reconnect the server.
 
-The per-server override is the more specific signal — it wins over whatever the Client's MCP Protocol tab says.
+The per-server override is the more specific signal: it wins over whatever the Client's MCP Protocol tab says.
 
 ## What changes when you pick the 2026 RC
 
@@ -67,42 +67,42 @@ If your server already speaks `2026-07-28`, you mostly won't notice. A few thing
 
 - **No `initialize` handshake.** The inspector connects, immediately fires `server/discover`, and uses the result to populate the server card's name, version, capabilities, and instructions.
 - **Per-request metadata.** Every request the inspector sends carries `MCP-Protocol-Version: 2026-07-28` as an HTTP header and the same value inside `params._meta["io.modelcontextprotocol/protocolVersion"]`. `clientInfo` and `clientCapabilities` ride along on every request too.
-- **No session IDs.** The inspector never sends an `mcp-session-id`. If your server returns one, the inspector discards it and surfaces a warning — your server isn't conforming to the stateless RC.
+- **No session IDs.** The inspector never sends an `mcp-session-id`. If your server returns one, the inspector discards it and surfaces a warning: your server isn't conforming to the stateless RC.
 - **Cancellation is closing the stream.** For SSE responses, the inspector closes the response stream to cancel; your server should treat that as a cancel signal.
 
 ### What the inspector tells you
 
 - If your server doesn't speak `2026-07-28`, `server/discover` returns `-32004 UnsupportedProtocolVersionError` and the connection fails with the supported-versions list visible in the Activity log.
-- If your server is missing a capability the inspector needs for a request, you'll get `-32003 MissingRequiredClientCapability` back from your server — surface those in the Activity log to confirm they reach you.
-- The **Activity** log (server card → **Activity**) is the source of truth — every request and response, success or error, lands there so you can verify headers and `_meta` content.
+- If your server is missing a capability the inspector needs for a request, you'll get `-32003 MissingRequiredClientCapability` back from your server; surface those in the Activity log to confirm they reach you.
+- The **Activity** log (server card → **Activity**) is the source of truth: every request and response, success or error, lands there so you can verify headers and `_meta` content.
 
 ### Not yet supported in the RC client
 
-The 2026 RC client is a **preview**. A handful of pieces from the SEP family aren't wired up yet — if you try them, the inspector throws a labeled error instead of silently no-op'ing:
+The 2026 RC client is a **preview**. A handful of pieces from the SEP family aren't wired up yet. If you try them, the inspector throws a labeled error instead of silently no-op'ing:
 
 - `subscriptions/listen` (long-lived notification stream)
 - Server-initiated requests via MRTR / `InputRequiredResult` (sampling, elicitation, listRoots embedded in responses)
 - Resumption tokens
-- Backward-compat probes against pre-RC servers — if you point the RC client at an `initialize`-only server it will fail at `server/discover`, not fall back.
+- Backward-compat probes against pre-RC servers: if you point the RC client at an `initialize`-only server it will fail at `server/discover`, not fall back.
 
-For everything else — `tools/list`, `tools/call`, `resources/*`, `prompts/*`, OAuth refresh, custom headers, progress notifications — the RC client behaves like the legacy one.
+For everything else (`tools/list`, `tools/call`, `resources/*`, `prompts/*`, OAuth refresh, custom headers, progress notifications), the RC client behaves like the legacy one.
 
 ## Recommended testing flow
 
 1. Build a Client called something like `2026 RC sandbox` with **MCP Protocol → 2026 RC** as the host default.
 2. Attach the HTTP server you're upgrading.
-3. Connect — confirm the server card shows the server info populated from `server/discover` (name, version, capabilities, instructions).
+3. Connect, then confirm the server card shows the server info populated from `server/discover` (name, version, capabilities, instructions).
 4. Run a `tools/list` and a `tools/call` from the **Tools** tab.
 5. Watch the **Activity** log for the request `_meta` and the `MCP-Protocol-Version` header.
 6. Try an unsupported version on a second test server to confirm your `-32004` error envelope looks right.
 7. Once your server is happy on the RC, keep one Client on **Latest** so you can flip between versions without rewriting settings.
 
-If you need to talk to a mix of servers on different versions in the same Client, use per-server overrides — the RC server stays pinned to `2026-07-28`, the rest fall back to Latest.
+If you need to talk to a mix of servers on different versions in the same Client, use per-server overrides: the RC server stays pinned to `2026-07-28`, the rest fall back to Latest.
 
 ## Recommended reading
 
 Background on the 2026-07-28 RC and the stateless direction the protocol is moving in:
 
-- [MCP Is Growing Up](https://aaif.io/blog/mcp-is-growing-up/) — AAIF's overview of what the 2026-07-28 RC means for teams building agentic systems.
-- [2026-07-28 release candidate announcement](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/) — the official blog post walking through what the RC changes and why.
-- [MCP specification (draft)](https://modelcontextprotocol.io/specification/draft) — the in-progress spec text the inspector's RC client targets.
+- [MCP Is Growing Up](https://aaif.io/blog/mcp-is-growing-up/): AAIF's overview of what the 2026-07-28 RC means for teams building agentic systems.
+- [2026-07-28 release candidate announcement](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/): the official blog post walking through what the RC changes and why.
+- [MCP specification (draft)](https://modelcontextprotocol.io/specification/draft): the in-progress spec text the inspector's RC client targets.

--- a/docs/inspector/skills.mdx
+++ b/docs/inspector/skills.mdx
@@ -5,13 +5,13 @@ icon: "square-slash"
 tag: "NEW"
 ---
 
-[Skills](https://agentskills.io/what-are-skills) are an open format that provide instructions on how to use MCP tools and complete workflows. MCPJam lets you discover skills from your filesystem (local) or your project (hosted), upload new ones, and use them in the Playground — either automatically based on the user's prompt or deterministically with the `/` command.
+[Skills](https://agentskills.io/what-are-skills) are an open format that provide instructions on how to use MCP tools and complete workflows. MCPJam lets you discover skills from your filesystem (local) or your project (hosted), upload new ones, and use them in the Playground, either automatically based on the user's prompt or deterministically with the `/` command.
 
 ## Getting Started
 
 1. **Navigate to the Skills tab** in MCPJam Inspector to discover and manage skills
-2. **Load skills** — MCPJam automatically discovers skills from [supported directories](#skill-directories). You can also upload skills directly through the Skills tab, or run `npx skills` to install them
-3. **Use skills in the Playground** — the LLM discovers them automatically, or you can inject them with the `/` command
+2. **Load skills**: MCPJam automatically discovers skills from [supported directories](#skill-directories). You can also upload skills directly through the Skills tab, or run `npx skills` to install them
+3. **Use skills in the Playground**: the LLM discovers them automatically, or you can inject them with the `/` command
 
 <iframe
   className="w-full aspect-video rounded-xl"
@@ -48,7 +48,7 @@ MCPJam scans the following directories for skills. Each subdirectory is expected
 You can upload skill folders directly from the Skills tab. The upload dialog supports drag-and-drop or file browsing and validates the `SKILL.md` frontmatter in real time.
 
 - **Local:** Uploaded skills are stored in `~/.mcpjam/skills/`.
-- **Hosted (cloud):** Cloud skills are **SKILL.md-only**. Folders that contain files other than `SKILL.md` are rejected — inline any content that `SKILL.md` references directly into the file before uploading.
+- **Hosted (cloud):** Cloud skills are **SKILL.md-only**. Folders that contain files other than `SKILL.md` are rejected. Inline any content that `SKILL.md` references directly into the file before uploading.
 
 <Note>
   Uploading a skill with a name that already exists will be rejected. Delete the existing skill first if you need to replace it.
@@ -56,7 +56,7 @@ You can upload skill folders directly from the Skills tab. The upload dialog sup
 
 ## Updating Skills
 
-To pull the latest version of the `mcp-inspector` skill — which contains MCPJam's guidance for interpreting probe, doctor, OAuth, and conformance output — run:
+To pull the latest version of the `mcp-inspector` skill, which contains MCPJam's guidance for interpreting probe, doctor, OAuth, and conformance output, run:
 
 ```bash
 npx skills update mcp-inspector
@@ -76,9 +76,9 @@ When you have skills available, MCPJam injects a lightweight list of all skill n
 
 ### Deterministic Injection
 
-Type `/` in the input to open the skills popover. Select a skill to inject it directly into the conversation — this pre-loads the `SKILL.md` content before the LLM processes your message, so the skill is guaranteed to be used.
+Type `/` in the input to open the skills popover. Select a skill to inject it directly into the conversation. This pre-loads the `SKILL.md` content before the LLM processes your message, so the skill is guaranteed to be used.
 
-When you select a skill via `/`, it appears as a card above the input. You can expand the card to browse the skill's file tree and optionally select additional files to include. Only files you explicitly select are pre-loaded — by default, only the `SKILL.md` is injected.
+When you select a skill via `/`, it appears as a card above the input. You can expand the card to browse the skill's file tree and optionally select additional files to include. Only files you explicitly select are pre-loaded. By default, only the `SKILL.md` is injected.
 
 The `/` picker works in both local and hosted modes. In the hosted app, it lists your project's cloud skills.
 

--- a/docs/inspector/tools-prompts-resources.mdx
+++ b/docs/inspector/tools-prompts-resources.mdx
@@ -38,13 +38,13 @@ Test your MCP tools by manually invoking them with custom parameters:
 
 When a tool triggers an MCP elicitation request, a dialog appears asking you to provide additional input. The dialog renders a form built from the server's schema and supports the full MCP elicitation subset:
 
-- **Field labels and defaults** — Fields show the schema `title` when provided (the raw property key stays visible alongside it). Schema `default` values are pre-filled automatically.
-- **Field types** — Strings, numbers, integers, booleans (checkbox), single-select dropdowns, and multi-select checkbox lists are all rendered natively. Fields with `format: email`, `uri`, `date`, or `date-time` use the matching browser input type.
-- **Inline validation** — Clicking **Accept** validates all fields before submitting. Required fields, numeric `minimum`/`maximum`, string `minLength`/`maxLength`, `pattern`, and format constraints are all checked. Errors appear under the relevant field and block submission until resolved.
-- **Server identity** — The dialog header identifies which server is requesting information. When the server supplies both a name and an ID, both are shown — the ID is the trusted anchor and is always visible.
-- **Unsupported shapes** — Nested objects and other schema shapes outside the MCP elicitation spec fall back to a plain JSON textarea so you can still answer by hand.
+- **Field labels and defaults**: Fields show the schema `title` when provided (the raw property key stays visible alongside it). Schema `default` values are pre-filled automatically.
+- **Field types**: Strings, numbers, integers, booleans (checkbox), single-select dropdowns, and multi-select checkbox lists are all rendered natively. Fields with `format: email`, `uri`, `date`, or `date-time` use the matching browser input type.
+- **Inline validation**: Clicking **Accept** validates all fields before submitting. Required fields, numeric `minimum`/`maximum`, string `minLength`/`maxLength`, `pattern`, and format constraints are all checked. Errors appear under the relevant field and block submission until resolved.
+- **Server identity**: The dialog header identifies which server is requesting information. When the server supplies both a name and an ID, both are shown; the ID is the trusted anchor and is always visible.
+- **Unsupported shapes**: Nested objects and other schema shapes outside the MCP elicitation spec fall back to a plain JSON textarea so you can still answer by hand.
 
-**Decline** and **Cancel** are always available and bypass validation — they send the corresponding action to the server without any parameters.
+**Decline** and **Cancel** are always available and bypass validation: they send the corresponding action to the server without any parameters.
 
 ### Tool quality badges
 

--- a/docs/inspector/xaa-debugger.mdx
+++ b/docs/inspector/xaa-debugger.mdx
@@ -51,15 +51,15 @@ The header also shows an **Identity assertion** toggle that lets you choose the 
 | **OIDC** | An OIDC ID token (default). |
 | **SAML** | A signed SAML 2.0 assertion. The ID-JAG carries a `saml-nameid` subject identifier. |
 
-Selecting a format saves it as the per-server preset immediately — the same setting you can also change in **Configure Server to Test**. The two surfaces always agree: changing one updates the other.
+Selecting a format saves it as the per-server preset immediately (the same setting you can also change in **Configure Server to Test**). The two surfaces always agree: changing one updates the other.
 
 When SAML is active, a note appears below the header explaining that the discovery and JWKS URLs above are unchanged. The ID-JAG is still a JWT minted under this issuer in both formats; only the identity assertion inside it changes shape.
 
 The toggle is unavailable in these situations:
 
-- **Registered app target** — runs against a registered app always use the OIDC ID token; the per-server preset does not apply.
-- **Run in progress** — wait for the current run to finish before switching.
-- **No server configured** — configure a server to test first.
+- **Registered app target**: runs against a registered app always use the OIDC ID token; the per-server preset does not apply.
+- **Run in progress**: wait for the current run to finish before switching.
+- **No server configured**: configure a server to test first.
 
 If MCPJam is running locally and your authorization server is hosted in the
 cloud, turn on **Use hosted issuer** in the XAA Flow header. A cloud server
@@ -79,7 +79,7 @@ The hosted issuer is available to both signed-in users and guest (not-signed-in)
 | Session | Issuer path | Trust model |
 | ------- | ----------- | ----------- |
 | **Signed in** | `/o/<orgId>` | Membership-gated. Only org members can mint assertions under it. |
-| **Guest** | `/g/<personalOrgId>` | **Anonymous test issuer.** Its discovery document is marked `mcpjam:issuer_kind: anonymous-test`. Your authorization server must explicitly allowlist this issuer. Assertions prove control of an anonymous session — this is a testing convenience, not enterprise-managed authorization. Sign in to use the membership-gated issuer instead. |
+| **Guest** | `/g/<personalOrgId>` | **Anonymous test issuer.** Its discovery document is marked `mcpjam:issuer_kind: anonymous-test`. Your authorization server must explicitly allowlist this issuer. Assertions prove control of an anonymous session; this is a testing convenience, not enterprise-managed authorization. Sign in to use the membership-gated issuer instead. |
 
 When a guest session is active, hover the info icon next to the hosted-issuer toggle to see a reminder of this distinction.
 
@@ -234,7 +234,7 @@ The **Negative-test scorecard** sends invalid ID-JAGs to your authorization
 server and checks that it refuses the assertions that the ID-JAG profile
 requires it to reject. It also reports two policy-dependent probes separately.
 Run a successful flow first to unlock it.
-The scorecard reuses the client identity resolved by that flow — whether it was
+The scorecard reuses the client identity resolved by that flow, whether it was
 pre-registered, dynamically registered with DCR, or resolved via CIMD.
 
 Click **Run negative tests** to send intentionally broken ID-JAGs to the

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -24,17 +24,17 @@ MCPJam Inspector runs three ways: a hosted web app, a desktop app for Mac and Wi
 | --- | :---: | :---: | :---: | :---: |
 | Install required | None | Mac/Windows download | Node.js | Docker |
 | HTTPS MCP servers | ✓ | ✓ | ✓ | ✓ |
-| HTTP MCP servers | — | ✓ | ✓ | ✓ |
-| Local STDIO servers | — | ✓ | ✓ | ✓ (with `--` args) |
-| Skills | — | ✓ | ✓ | ✓ |
-| Shareable server URLs | ✓ | — | — | — |
+| HTTP MCP servers | ✗ | ✓ | ✓ | ✓ |
+| Local STDIO servers | ✗ | ✓ | ✓ | ✓ (with `--` args) |
+| Skills | ✗ | ✓ | ✓ | ✓ |
+| Shareable server URLs | ✓ | ✗ | ✗ | ✗ |
 | Always on latest version | ✓ | Re-download to update | Per-run (`@latest`) | Per-tag pull |
 
-If your server is local (running on `localhost`), the web app cannot reach it — pick **Desktop** or **Terminal**. If you want teammates to one-click into the same server, pick **Web App**.
+If your server is local (running on `localhost`), the web app cannot reach it; pick **Desktop** or **Terminal**. If you want teammates to one-click into the same server, pick **Web App**.
 
 ## Web app
 
-Go to [app.mcpjam.com](https://app.mcpjam.com) in your browser. No install required. The web app accepts HTTPS MCP server URLs only — for HTTP or local STDIO servers, use the desktop or terminal options below. See [Hosted App](/hosted/overview) for more.
+Go to [app.mcpjam.com](https://app.mcpjam.com) in your browser. No install required. The web app accepts HTTPS MCP server URLs only; for HTTP or local STDIO servers, use the desktop or terminal options below. See [Hosted App](/hosted/overview) for more.
 
 ## Desktop app
 
@@ -70,12 +70,12 @@ bunx @mcpjam/inspector@latest
 After installing the package, you should see a link to `localhost`. Open that link up to see the inspector.
 
 <Info>
-  **Widget rendering (Chromium):** On first startup, Inspector automatically downloads and installs the Playwright Chromium browser needed to render widgets. This happens in the background — you'll see download progress in the terminal. No manual `playwright install` step is required. Docker images already include Chromium and are unaffected.
+  **Widget rendering (Chromium):** On first startup, Inspector automatically downloads and installs the Playwright Chromium browser needed to render widgets. This happens in the background; you'll see download progress in the terminal. No manual `playwright install` step is required. Docker images already include Chromium and are unaffected.
 </Info>
 
 ### From your editor (VS Code, Cursor, Windsurf)
 
-There is no dedicated editor extension — and you don't need one. Open your editor's integrated terminal, run the same `npx @mcpjam/inspector@latest` command, and click the printed `localhost` link. The inspector runs alongside your dev server in any editor that has a terminal pane.
+There is no dedicated editor extension, and you don't need one. Open your editor's integrated terminal, run the same `npx @mcpjam/inspector@latest` command, and click the printed `localhost` link. The inspector runs alongside your dev server in any editor that has a terminal pane.
 
 If you want the inspector to auto-launch from your project's `dev` script (so it boots whenever you start your server), see [Launch from Code](/inspector/launch-from-code).
 
@@ -244,9 +244,9 @@ You can mix STDIO and HTTP (Streamable HTTP / SHTTP) server entries in the same 
 }
 ```
 
-The terminal and desktop installs accept both shapes in the same file. The hosted web app accepts HTTP/SHTTP entries only — STDIO entries are ignored because the hosted runtime cannot spawn local processes.
+The terminal and desktop installs accept both shapes in the same file. The hosted web app accepts HTTP/SHTTP entries only; STDIO entries are ignored because the hosted runtime cannot spawn local processes.
 
-For per-server `Authorization` headers, see [API keys → Playground BYOK](/reference/api-keys#3-playground-byok-bring-your-own-key).
+For per-server `Authorization` headers, see [API keys → Playground BYOK](/reference/api-keys#playground-byok-not-an-mcpjam-key).
 
 ## Start with Verbose Logging
 

--- a/docs/reference/api-keys.mdx
+++ b/docs/reference/api-keys.mdx
@@ -1,22 +1,22 @@
 ---
 title: "API keys"
-description: "Which 'API key' is which in MCPJam — and the one you need to call the MCPJam API."
+description: "Which 'API key' is which in MCPJam, and the one you need to call the MCPJam API."
 icon: "key"
 ---
 
 "API key" gets used for a few different things in MCPJam. The short version:
 
-- To call the **[MCPJam API](/reference/public-api)**, you want the **MCPJam API key** (`sk_…`) — the first one below.
-- Two others here are **third-party secrets you supply**, not keys MCPJam issues — they're listed only because the name collides.
+- To call the **[MCPJam API](/reference/public-api)**, you want the **MCPJam API key** (`sk_…`), the first one below.
+- Two others here are **third-party secrets you supply**, not keys MCPJam issues; they're listed only because the name collides.
 - One older key (`mcpjam_…`) is **retired** and no longer works.
 
 ## MCPJam API key (`sk_…`)
 
-The key for the **[MCPJam API](/reference/public-api)** — programmatic access to live MCP server diagnostics at `https://app.mcpjam.com/api/v1/...`. This is the one to reach for whenever you mean "the MCPJam API key."
+The key for the **[MCPJam API](/reference/public-api)**: programmatic access to live MCP server diagnostics at `https://app.mcpjam.com/api/v1/...`. This is the one to reach for whenever you mean "the MCPJam API key."
 
-**Where it lives:** [**Settings → API Keys**](https://app.mcpjam.com/settings/api-keys) in the hosted app — open Settings from the account menu in the sidebar, then click the **API Keys** tab. That link also takes you straight there (sign in if prompted; you'll land back on the page). Shown **exactly once** at creation — store it in your own secret manager or an environment variable.
+**Where it lives:** [**Settings → API Keys**](https://app.mcpjam.com/settings/api-keys) in the hosted app: open Settings from the account menu in the sidebar, then click the **API Keys** tab. That link also takes you straight there (sign in if prompted; you'll land back on the page). Shown **exactly once** at creation; store it in your own secret manager or an environment variable.
 
-**When it's used:** Every `Authorization: Bearer sk_…` request to `/api/v1/*` — validating servers, running the doctor, listing tools/prompts/resources, reading resources, exporting snapshots, and **saving `@mcpjam/sdk` eval results** (set `MCPJAM_API_KEY` to this key; see [Saving Results](/sdk/concepts/saving-results)).
+**When it's used:** Every `Authorization: Bearer sk_…` request to `/api/v1/*`: validating servers, running the doctor, listing tools/prompts/resources, reading resources, exporting snapshots, and **saving `@mcpjam/sdk` eval results** (set `MCPJAM_API_KEY` to this key; see [Saving Results](/sdk/concepts/saving-results)).
 
 **Errors you might see**
 - `401 UNAUTHORIZED` → invalid or revoked key.
@@ -26,9 +26,9 @@ The key for the **[MCPJam API](/reference/public-api)** — programmatic access 
 
 Full surface in the [MCPJam API reference](/reference/public-api).
 
-## LLM provider key — not an MCPJam key
+## LLM provider key (not an MCPJam key)
 
-A secret from an LLM provider (OpenAI, Anthropic, Google, xAI, Groq, Mistral, ...). MCPJam never issues this — it just uses the key you paste in to call that provider on your behalf.
+A secret from an LLM provider (OpenAI, Anthropic, Google, xAI, Groq, Mistral, ...). MCPJam never issues this; it just uses the key you paste in to call that provider on your behalf.
 
 **Where it lives:** **Settings → LLM Providers**.
 
@@ -36,9 +36,9 @@ A secret from an LLM provider (OpenAI, Anthropic, Google, xAI, Groq, Mistral, ..
 
 **Errors:** "Invalid API key for OpenAI / Anthropic / ..." → wrong, expired, or for a different project. ("MCPJam model limit reached" is a [different problem](/troubleshooting/common-errors#mcpjam-model-limit-reached).)
 
-You don't need one to run inspector probes (Tools, Resources, Prompts, OAuth Debugger, conformance) — those only talk to MCP servers.
+You don't need one to run inspector probes (Tools, Resources, Prompts, OAuth Debugger, conformance); those only talk to MCP servers.
 
-## Playground BYOK — not an MCPJam key
+## Playground BYOK (not an MCPJam key)
 
 A per-server bearer token for an HTTP MCP server that requires `Authorization: Bearer ...`. MCPJam forwards it to that one server only; it never authenticates you to MCPJam.
 
@@ -46,21 +46,21 @@ A per-server bearer token for an HTTP MCP server that requires `Authorization: B
 
 **When it's used:** Every request the inspector makes to that MCP server.
 
-**Errors:** [`auth/http_401`](/troubleshooting/error-codes#unauthorized-401), [`auth/http_403`](/troubleshooting/error-codes#forbidden-403) — the target server rejected the token.
+**Errors:** [`auth/http_401`](/troubleshooting/error-codes#unauthorized-401), [`auth/http_403`](/troubleshooting/error-codes#forbidden-403): the target server rejected the token.
 
-## Project API Key (`mcpjam_…`) — retired
+## Project API Key (`mcpjam_…`, retired)
 
 <Warning>
-**Retired.** Project API keys no longer work: existing keys no longer authenticate, new keys can't be generated, and the `/sdk/v1/evals/*` ingestion endpoints they protected return `410 Gone` for every request. Eval reporting now runs on the **MCPJam API key (`sk_…`)** through the [MCPJam API](/reference/public-api) — see [Saving Results](/sdk/concepts/saving-results).
+**Retired.** Project API keys no longer work: existing keys no longer authenticate, new keys can't be generated, and the `/sdk/v1/evals/*` ingestion endpoints they protected return `410 Gone` for every request. Eval reporting now runs on the **MCPJam API key (`sk_…`)** through the [MCPJam API](/reference/public-api); see [Saving Results](/sdk/concepts/saving-results).
 </Warning>
 
-This was a project-scoped token for `@mcpjam/sdk` / CLI traffic to the hosted backend, read from the `MCPJAM_API_KEY` environment variable. If your CI logs show `410` reporting errors, this retirement is why. **To fix CI:** upgrade `@mcpjam/sdk`, replace the `MCPJAM_API_KEY` value with an `sk_…` key from [Settings → API keys](https://app.mcpjam.com/settings/api-keys), and (optionally) set `MCPJAM_PROJECT_ID` to keep filing results under the same project — otherwise they land in your org's Default project. Old SDK versions' default auto-save path warns and continues, so eval runs themselves keep passing either way.
+This was a project-scoped token for `@mcpjam/sdk` / CLI traffic to the hosted backend, read from the `MCPJAM_API_KEY` environment variable. If your CI logs show `410` reporting errors, this retirement is why. **To fix CI:** upgrade `@mcpjam/sdk`, replace the `MCPJAM_API_KEY` value with an `sk_…` key from [Settings → API keys](https://app.mcpjam.com/settings/api-keys), and (optionally) set `MCPJAM_PROJECT_ID` to keep filing results under the same project; otherwise they land in your org's Default project. Old SDK versions' default auto-save path warns and continues, so eval runs themselves keep passing either way.
 
 ## Quick reference
 
 | Key | Format | Issued by | Use it for |
 | --- | --- | --- | --- |
 | **MCPJam API key** | `sk_…` | [Settings → API Keys](https://app.mcpjam.com/settings/api-keys) | The [MCPJam API](/reference/public-api) (`/api/v1/*`) |
-| LLM provider key | provider-specific | the LLM provider | Playground chat — *third-party* |
-| Playground BYOK | server-specific | your MCP server | Authenticating to one MCP server — *third-party* |
-| Project API Key | `mcpjam_…` | — (no longer issued) | **Retired** — no longer works |
+| LLM provider key | provider-specific | the LLM provider | Playground chat (*third-party*) |
+| Playground BYOK | server-specific | your MCP server | Authenticating to one MCP server (*third-party*) |
+| Project API Key | `mcpjam_…` | none (no longer issued) | **Retired**: no longer works |

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "MCPJam API",
     "version": "1.0.0-preview",
-    "description": "Programmatic access to MCP servers saved in your MCPJam projects — live diagnostics (validate, inspect, export) and operations: call tools, render prompts, run eval suites asynchronously and poll their results, and import OAuth tokens.\n\n**The API is in preview**: the surface may change while we finish the design. Error `code` values are stable; error `message` strings are not. Write clients that ignore unknown response fields.",
+    "description": "Programmatic access to MCP servers saved in your MCPJam projects: live diagnostics (validate, inspect, export) and operations: call tools, render prompts, run eval suites asynchronously and poll their results, and import OAuth tokens.\n\n**The API is in preview**: the surface may change while we finish the design. Error `code` values are stable; error `message` strings are not. Write clients that ignore unknown response fields.",
     "contact": {
       "name": "MCPJam",
       "url": "https://github.com/MCPJam/inspector/issues"
@@ -70,7 +70,7 @@
           "Catalog"
         ],
         "summary": "Get the host-compat catalog",
-        "description": "The versioned host-compatibility catalog backing `mcpjam compat` verdicts. Public and unauthenticated: static host facts and creation config with no project or user scope. Always returns a catalog — `source` is `live` when the backend publish was reachable and `bundled` when serving the SDK's built-in fallback.",
+        "description": "The versioned host-compatibility catalog backing `mcpjam compat` verdicts. Public and unauthenticated: static host facts and creation config with no project or user scope. Always returns a catalog: `source` is `live` when the backend publish was reachable and `bundled` when serving the SDK's built-in fallback.",
         "security": [],
         "responses": {
           "200": {
@@ -190,7 +190,7 @@
         "operationId": "listHarnessBuiltinTools",
         "tags": ["Harness"],
         "summary": "List a harness's native built-in tools",
-        "description": "The native tools an agent harness (e.g. `claude-code`) runs INSIDE its sandbox — Bash, Read, Edit, Glob, Grep, WebSearch, and the like. Display-only: these execute via the harness's own agent loop and are NOT callable through MCPJam. Static published-package metadata; no project scope.",
+        "description": "The native tools an agent harness (e.g. `claude-code`) runs INSIDE its sandbox: Bash, Read, Edit, Glob, Grep, WebSearch, and the like. Display-only: these execute via the harness's own agent loop and are NOT callable through MCPJam. Static published-package metadata; no project scope.",
         "parameters": [{ "name": "harnessId", "in": "path", "required": true, "schema": { "type": "string", "enum": ["claude-code"] }, "description": "The harness id." }],
         "responses": {
           "200": {
@@ -209,7 +209,7 @@
         "operationId": "listComputerEnvironments",
         "tags": ["Computer environments"],
         "summary": "List a project's computer environments",
-        "description": "The custom Computer images (digest-pinned Dockerfile environments) saved in the project — your own personal drafts plus the project-shared ones.",
+        "description": "The custom Computer images (digest-pinned Dockerfile environments) saved in the project: your own personal drafts plus the project-shared ones.",
         "parameters": [{ "$ref": "#/components/parameters/projectId" }],
         "responses": {
           "200": {
@@ -313,7 +313,7 @@
         "operationId": "deleteComputerEnvironment",
         "tags": ["Computer environments"],
         "summary": "Delete a computer environment",
-        "description": "Permanently delete an environment. Computers booted from it fall back to the base image. Deleting a project-shared environment requires project admin. Bodyless — any field is rejected. Guest callers are denied (a write).",
+        "description": "Permanently delete an environment. Computers booted from it fall back to the base image. Deleting a project-shared environment requires project admin. Bodyless: any field is rejected. Guest callers are denied (a write).",
         "parameters": [
           { "$ref": "#/components/parameters/projectId" },
           { "$ref": "#/components/parameters/environmentId" }
@@ -362,7 +362,7 @@
         "operationId": "buildComputerEnvironment",
         "tags": ["Computer environments"],
         "summary": "Build a computer environment",
-        "description": "Trigger a build of the environment's image and respond `202`. The build runs asynchronously — poll the builds list for status. Bodyless. Guest callers are denied (a write).",
+        "description": "Trigger a build of the environment's image and respond `202`. The build runs asynchronously. Poll the builds list for status. Bodyless. Guest callers are denied (a write).",
         "parameters": [
           { "$ref": "#/components/parameters/projectId" },
           { "$ref": "#/components/parameters/environmentId" }
@@ -463,7 +463,7 @@
         "operationId": "listHosts",
         "tags": ["Hosts"],
         "summary": "List a project's hosts",
-        "description": "The hosts saved in the project — the named model + capability profiles you attach to chats and eval suites. Returns the `id`s the host detail/update/delete routes take.",
+        "description": "The hosts saved in the project: the named model + capability profiles you attach to chats and eval suites. Returns the `id`s the host detail/update/delete routes take.",
         "parameters": [{ "$ref": "#/components/parameters/projectId" }],
         "responses": {
           "200": {
@@ -636,7 +636,7 @@
         "operationId": "runDoctor",
         "tags": ["Server diagnostics"],
         "summary": "Run the doctor",
-        "description": "Runs the full doctor workflow — probe → connect → initialize → capabilities → primitives — and returns a step-by-step report. The richest signal for \"is this server healthy, and why not.\"",
+        "description": "Runs the full doctor workflow (probe → connect → initialize → capabilities → primitives) and returns a step-by-step report. The richest signal for \"is this server healthy, and why not.\"",
         "parameters": [
           { "$ref": "#/components/parameters/projectId" },
           { "$ref": "#/components/parameters/serverId" }
@@ -857,7 +857,7 @@
         "operationId": "exportServer",
         "tags": ["Export"],
         "summary": "Export a server snapshot",
-        "description": "Lists tools, resources, and prompts in one call and returns a single JSON snapshot — handy for diffing a server's surface over time in CI.",
+        "description": "Lists tools, resources, and prompts in one call and returns a single JSON snapshot, handy for diffing a server's surface over time in CI.",
         "parameters": [
           { "$ref": "#/components/parameters/projectId" },
           { "$ref": "#/components/parameters/serverId" }
@@ -888,7 +888,7 @@
         "operationId": "callTool",
         "tags": ["Execution"],
         "summary": "Call a tool",
-        "description": "Executes a tool on the server and returns the MCP `CallToolResult` directly. Tool-level failures (`isError: true` in the result) are **successful calls** — the server answered; only transport/auth errors use the error envelope.",
+        "description": "Executes a tool on the server and returns the MCP `CallToolResult` directly. Tool-level failures (`isError: true` in the result) are **successful calls**: the server answered; only transport/auth errors use the error envelope.",
         "parameters": [
           { "$ref": "#/components/parameters/projectId" },
           { "$ref": "#/components/parameters/serverId" }
@@ -1152,7 +1152,7 @@
         "operationId": "getEvalIterationTrace",
         "tags": ["Eval runs"],
         "summary": "Get an iteration trace",
-        "description": "Full trace envelope for one iteration: conversation messages, expected-vs-actual tool call analysis, and spans. The shape is rich and may evolve — treat it as an open document. Returns `404` with `details.reason: \"TRACE_NOT_AVAILABLE\"` when the iteration finished without a stored trace.",
+        "description": "Full trace envelope for one iteration: conversation messages, expected-vs-actual tool call analysis, and spans. The shape is rich and may evolve. Treat it as an open document. Returns `404` with `details.reason: \"TRACE_NOT_AVAILABLE\"` when the iteration finished without a stored trace.",
         "parameters": [
           { "$ref": "#/components/parameters/projectId" },
           { "$ref": "#/components/parameters/runId" },
@@ -1184,7 +1184,7 @@
         "operationId": "getEvalRunSteps",
         "tags": ["Eval runs"],
         "summary": "Get an iteration's step results",
-        "description": "One row per authored test step, in order, with `status` (`ok`/`fail`/`skipped`/`pending`), a `reason`, and any `evidence` (screenshots, replay-video offset, widget tool calls). The fastest way to see which step failed and why. Unlike `/trace`, a missing trace is not a `404` — step verdicts still return, just without evidence.",
+        "description": "One row per authored test step, in order, with `status` (`ok`/`fail`/`skipped`/`pending`), a `reason`, and any `evidence` (screenshots, replay-video offset, widget tool calls). The fastest way to see which step failed and why. Unlike `/trace`, a missing trace is not a `404`: step verdicts still return, just without evidence.",
         "parameters": [
           { "$ref": "#/components/parameters/projectId" },
           { "$ref": "#/components/parameters/runId" },
@@ -1315,7 +1315,7 @@
         "operationId": "importOAuthTokens",
         "tags": ["OAuth"],
         "summary": "Import OAuth tokens",
-        "description": "Stores OAuth tokens you obtained yourself (e.g. via the SDK's `runOAuthLogin` — interactive loopback, headless, or client-credentials) for this server, scoped to your user, project, and server. Subsequent API calls against the server inject the stored access token automatically, and `401`s from the server trigger a server-side refresh — no further caller involvement.\n\nThis closes the loop after an `OAUTH_REQUIRED` error.",
+        "description": "Stores OAuth tokens you obtained yourself (e.g. via the SDK's `runOAuthLogin`: interactive loopback, headless, or client-credentials) for this server, scoped to your user, project, and server. Subsequent API calls against the server inject the stored access token automatically, and `401`s from the server trigger a server-side refresh (no further caller involvement).\n\nThis closes the loop after an `OAUTH_REQUIRED` error.",
         "parameters": [
           { "$ref": "#/components/parameters/projectId" },
           { "$ref": "#/components/parameters/serverId" }
@@ -1418,7 +1418,7 @@
         "operationId": "listProjectServers",
         "tags": ["Catalog"],
         "summary": "List a project's servers",
-        "description": "The MCP servers saved in the project — the `serverId`s every other route takes. STDIO command/args/env and raw headers are never exposed.",
+        "description": "The MCP servers saved in the project: the `serverId`s every other route takes. STDIO command/args/env and raw headers are never exposed.",
         "parameters": [{ "$ref": "#/components/parameters/projectId" }],
         "responses": {
           "200": {
@@ -1443,7 +1443,7 @@
         "operationId": "listEvalSuites",
         "tags": ["Catalog"],
         "summary": "List a project's eval suites",
-        "description": "Eval suites in the project with latest-run summaries and pass-rate trends — the `suiteId`s the eval-run routes take.",
+        "description": "Eval suites in the project with latest-run summaries and pass-rate trends: the `suiteId`s the eval-run routes take.",
         "parameters": [{ "$ref": "#/components/parameters/projectId" }],
         "responses": {
           "200": {
@@ -1466,7 +1466,7 @@
         "operationId": "createEvalSuite",
         "tags": ["Eval runs"],
         "summary": "Create an eval suite (author-only, does not run)",
-        "description": "Creates a runnable eval suite — the suite record plus its test cases — and responds `201` **synchronously**, WITHOUT executing anything. Use this to author a suite, then run it later with `POST /eval-runs` (passing the returned `suiteId`).\n\nThis is distinct from `POST /eval-runs`, which creates a run and **detaches execution**, responding `202` with a `runId`. There is no concurrency cap here (no run is started).\n\nThe body uses an ergonomic authoring shape: a suite-level default `model` (and optional `provider`) applies to every test unless the test overrides it; `provider` is derived from a `provider/model` id when neither is supplied. Each test's case body is an ordered `steps` array (prompt / toolCall / interact / assert).\n\nGuest callers are denied (suite creation is a write).",
+        "description": "Creates a runnable eval suite (the suite record plus its test cases) and responds `201` **synchronously**, WITHOUT executing anything. Use this to author a suite, then run it later with `POST /eval-runs` (passing the returned `suiteId`).\n\nThis is distinct from `POST /eval-runs`, which creates a run and **detaches execution**, responding `202` with a `runId`. There is no concurrency cap here (no run is started).\n\nThe body uses an ergonomic authoring shape: a suite-level default `model` (and optional `provider`) applies to every test unless the test overrides it; `provider` is derived from a `provider/model` id when neither is supplied. Each test's case body is an ordered `steps` array (prompt / toolCall / interact / assert).\n\nGuest callers are denied (suite creation is a write).",
         "parameters": [{ "$ref": "#/components/parameters/projectId" }],
         "requestBody": {
           "required": true,
@@ -1590,7 +1590,7 @@
         "operationId": "listChatboxes",
         "tags": ["Chatboxes"],
         "summary": "List a project's chatboxes",
-        "description": "The chatboxes published from this project — name, access mode, attached servers, and share link. Read-only.",
+        "description": "The chatboxes published from this project: name, access mode, attached servers, and share link. Read-only.",
         "parameters": [{ "$ref": "#/components/parameters/projectId" }],
         "responses": {
           "200": {
@@ -1645,7 +1645,7 @@
         "operationId": "createTunnel",
         "tags": ["Tunnels"],
         "summary": "Create (or revive) a relay tunnel for a named project server",
-        "description": "Registers a server record named `name` if missing, mints a relay tunnel grant for it, and **persists the tunnel bearer URL (including the plaintext `?k=` secret) onto the server record's `url`** so evals and chatboxes can target the tunnel like any remote server. The plaintext persistence is a deliberate trade-off of the current tunnel MVP — the backend otherwise stores only a hash of the secret — mitigated by rotation: **every call rotates the secret, revokes the previous grant at the edge (disconnecting any live tunnel session for the server), and updates the stored URL**, so re-calling this route is also the rotation/recovery path.\n\nThe caller hosts the tunnel itself: connect a WebSocket to `relayWsUrl` (subprotocol `mcpjam-tunnel.v1`, `Authorization: Bearer <connectToken>`) and serve the relayed requests — this is what `mcpjam tunnel` does. When the host disconnects, the server record stays and calls to the public URL fail fast at the edge.",
+        "description": "Registers a server record named `name` if missing, mints a relay tunnel grant for it, and **persists the tunnel bearer URL (including the plaintext `?k=` secret) onto the server record's `url`** so evals and chatboxes can target the tunnel like any remote server. The plaintext persistence is a deliberate trade-off of the current tunnel MVP (the backend otherwise stores only a hash of the secret), mitigated by rotation: **every call rotates the secret, revokes the previous grant at the edge (disconnecting any live tunnel session for the server), and updates the stored URL**, so re-calling this route is also the rotation/recovery path.\n\nThe caller hosts the tunnel itself: connect a WebSocket to `relayWsUrl` (subprotocol `mcpjam-tunnel.v1`, `Authorization: Bearer <connectToken>`) and serve the relayed requests. This is what `mcpjam tunnel` does. When the host disconnects, the server record stays and calls to the public URL fail fast at the edge.",
         "parameters": [{ "$ref": "#/components/parameters/projectId" }],
         "requestBody": {
           "required": true,
@@ -1691,7 +1691,7 @@
         "operationId": "closeTunnel",
         "tags": ["Tunnels"],
         "summary": "Revoke a tunnel's live grant",
-        "description": "Revokes the grant at the control plane and edge: the public URL stops working immediately and any live tunnel session is disconnected. The server record — including its now-dead `url` — is intentionally left untouched, so the next create revives the tunnel with the same slug.",
+        "description": "Revokes the grant at the control plane and edge: the public URL stops working immediately and any live tunnel session is disconnected. The server record, including its now-dead `url`, is intentionally left untouched, so the next create revives the tunnel with the same slug.",
         "parameters": [
           { "$ref": "#/components/parameters/projectId" },
           { "$ref": "#/components/parameters/serverId" }
@@ -1835,7 +1835,7 @@
           },
           "message": {
             "type": "string",
-            "description": "Human-readable description. May change between releases — don't match on it."
+            "description": "Human-readable description. May change between releases. Don't match on it."
           },
           "details": {
             "type": "object",
@@ -2111,7 +2111,7 @@
           },
           "isError": {
             "type": "boolean",
-            "description": "`true` when the **tool** reported a failure. The HTTP call still succeeds — the server answered."
+            "description": "`true` when the **tool** reported a failure. The HTTP call still succeeds: the server answered."
           }
         },
         "additionalProperties": true
@@ -2356,7 +2356,7 @@
       },
       "EvalRunCreateRequest": {
         "type": "object",
-        "description": "Two valid shapes: `suiteId` (rerun an existing suite, optionally upserting inline `tests` into it), or `suiteName` + `tests` + `serverIds` (create a new suite and run it). Inline `tests` alone — without a `suiteId` or a `suiteName` — are rejected with `VALIDATION_ERROR`.",
+        "description": "Two valid shapes: `suiteId` (rerun an existing suite, optionally upserting inline `tests` into it), or `suiteName` + `tests` + `serverIds` (create a new suite and run it). Inline `tests` alone (without a `suiteId` or a `suiteName`) are rejected with `VALIDATION_ERROR`.",
         "anyOf": [
           { "required": ["suiteId"] },
           {
@@ -2383,7 +2383,7 @@
           "serverIds": {
             "type": "array",
             "minItems": 1,
-            "description": "Servers (by ID) the run connects to. Required when creating a new suite; optional on reruns — when omitted, the run connects the suite's saved server selection (the set its snapshot references). A rerun of a suite with no saved selection is rejected with `VALIDATION_ERROR` (`details.reason: \"NO_SAVED_SERVER_SELECTION\"`).",
+            "description": "Servers (by ID) the run connects to. Required when creating a new suite; optional on reruns: when omitted, the run connects the suite's saved server selection (the set its snapshot references). A rerun of a suite with no saved selection is rejected with `VALIDATION_ERROR` (`details.reason: \"NO_SAVED_SERVER_SELECTION\"`).",
             "items": { "type": "string" }
           },
           "modelApiKeys": {
@@ -2416,7 +2416,7 @@
           "status": { "type": "string", "const": "running" },
           "servers": {
             "type": "array",
-            "description": "The servers the run connects to — explicit or derived from the suite's saved selection. `name` is present when known (always, on the derived path).",
+            "description": "The servers the run connects to: explicit or derived from the suite's saved selection. `name` is present when known (always, on the derived path).",
             "items": {
               "type": "object",
               "required": ["id"],
@@ -2578,7 +2578,7 @@
           },
           "clientInformation": {
             "type": "object",
-            "description": "OAuth client used to obtain the tokens. Optional, but without it server-side refresh cannot run — always include it when you provide a `refresh_token`.",
+            "description": "OAuth client used to obtain the tokens. Optional, but without it server-side refresh cannot run. Always include it when you provide a `refresh_token`.",
             "required": ["clientId"],
             "properties": {
               "clientId": { "type": "string" },
@@ -3169,7 +3169,7 @@
       },
       "ComputerEnvironmentBuildStarted": {
         "type": "object",
-        "description": "A build was accepted (202). It runs in the background — poll the builds list for status.",
+        "description": "A build was accepted (202). It runs in the background. Poll the builds list for status.",
         "required": ["id", "buildId", "reused"],
         "properties": {
           "id": { "type": "string", "description": "The environment id." },
@@ -3221,7 +3221,7 @@
         }
       },
       "Unauthorized": {
-        "description": "Missing, invalid, revoked, or orphaned key (`UNAUTHORIZED`) — or the **target MCP server** needs an OAuth grant (`OAUTH_REQUIRED`), which is a property of the server, not your key.",
+        "description": "Missing, invalid, revoked, or orphaned key (`UNAUTHORIZED`), or the **target MCP server** needs an OAuth grant (`OAUTH_REQUIRED`), which is a property of the server, not your key.",
         "content": {
           "application/json": {
             "schema": { "$ref": "#/components/schemas/Error" },

--- a/docs/reference/public-api.mdx
+++ b/docs/reference/public-api.mdx
@@ -1,14 +1,14 @@
 ---
 title: "MCPJam API"
-description: "Programmatic access to the MCP servers in your MCPJam projects — diagnostics, tool calls, prompt rendering, and asynchronous eval runs."
+description: "Programmatic access to the MCP servers in your MCPJam projects: diagnostics, tool calls, prompt rendering, and asynchronous eval runs."
 icon: "braces"
 tag: "Preview"
 ---
 
 <Warning>
 **The MCPJam API is in preview.** It works today and we use it ourselves, but
-it has not been generally announced and the surface may change — including in
-breaking ways — while we finish the design. Pin your integration to the
+it has not been generally announced and the surface may change, including in
+breaking ways, while we finish the design. Pin your integration to the
 behaviors documented on this page, build a [tolerant
 reader](#versioning--stability), and expect to revisit it. Feedback is very
 welcome on [Discord](https://discord.gg/JEnDtz8X6z) or
@@ -26,39 +26,39 @@ welcome on [Discord](https://discord.gg/JEnDtz8X6z) or
 </Card>
 
 The MCPJam API lets you operate the MCP servers saved in your
-[hosted](/hosted/overview) projects — from CI, scripts, or your own agents —
+[hosted](/hosted/overview) projects (from CI, scripts, or your own agents)
 without opening the UI.
 
 What you can do with it today:
 
-- **Discover your resources** — list your projects, their servers, eval
+- **Discover your resources**: list your projects, their servers, eval
   suites, and chat sessions, so every ID the other routes need is
   self-serve
-- **Validate a server** — connect, initialize, and capture a capability snapshot
-- **Run the doctor** — the probe → connect → initialize → capabilities workflow
-- **Check OAuth requirements** — does this server need an OAuth grant?
-- **List tools, prompts, and resources** — the server's MCP primitives
-- **Call a tool / render a prompt** — execute primitives and get the MCP result back verbatim
+- **Validate a server**: connect, initialize, and capture a capability snapshot
+- **Run the doctor**: the probe → connect → initialize → capabilities workflow
+- **Check OAuth requirements**: does this server need an OAuth grant?
+- **List tools, prompts, and resources**: the server's MCP primitives
+- **Call a tool / render a prompt**: execute primitives and get the MCP result back verbatim
 - **Read a resource** by URI
-- **Export a full snapshot** — tools, resources, and prompts as one JSON document
-- **Manage a project's hosts** — list, read, **create** (from a built-in
+- **Export a full snapshot**: tools, resources, and prompts as one JSON document
+- **Manage a project's hosts**: list, read, **create** (from a built-in
   template like `claude`/`chatgpt`/`cursor`, or from a full host config),
   rename, and delete the named model + capability profiles you run chats and
   eval suites against
-- **List a project's chatboxes** — name, access mode, attached servers, and
-  share link — and **read one chatbox's settings**: model, system prompt,
+- **List a project's chatboxes** (name, access mode, attached servers, and
+  share link) and **read one chatbox's settings**: model, system prompt,
   tool-approval policy, and resolved servers
-- **Author eval suites** — create a runnable suite (name, default model, servers, test cases) synchronously and get a `suiteId` back; no run is started and no credits are spent
-- **Run eval suites asynchronously** — create a run from a saved suite, get a `202` + `runId`
+- **Author eval suites**: create a runnable suite (name, default model, servers, test cases) synchronously and get a `suiteId` back; no run is started and no credits are spent
+- **Run eval suites asynchronously**: create a run from a saved suite, get a `202` + `runId`
   immediately, then poll status, per-iteration results (tool calls, token
   usage, latency), and full traces. Runs appear live in the hosted UI,
   tagged `source: "api"`
-- **Import OAuth tokens** — complete OAuth yourself (e.g. the SDK's
+- **Import OAuth tokens**: complete OAuth yourself (e.g. the SDK's
   `runOAuthLogin`) and push the tokens; subsequent calls inject and refresh
   them server-side
 
 All endpoints operate on servers you have already added to a project in the
-hosted inspector. Managing API keys remains UI-only — see
+hosted inspector. Managing API keys remains UI-only; see
 [Not in the API yet](#not-in-the-api-yet).
 
 ## Base URL
@@ -88,7 +88,7 @@ curl -X POST \
    in the hosted app (the card at the top of this page takes you there
    directly).
 2. Click **Create API key**, name it, and pick the **organization** it will act in.
-3. Copy the key (`sk_…`) immediately — **it is shown exactly once** and never
+3. Copy the key (`sk_…`) immediately: **it is shown exactly once** and never
    stored by MCPJam in retrievable form.
 
 Keys can be revoked from the same page at any time. Revocation takes effect
@@ -114,7 +114,7 @@ Two deliberate restrictions while in preview:
 
 Treat an API key like a password:
 
-- Load it from an environment variable or secret manager — never commit it to
+- Load it from an environment variable or secret manager. Never commit it to
   source control or ship it in client-side code.
 - Scope keys narrowly: one key per integration, named so you can tell them apart.
 - Rotate by creating a replacement key, switching traffic, then revoking the old one.
@@ -122,13 +122,13 @@ Treat an API key like a password:
   [**Settings → API keys**](https://app.mcpjam.com/settings/api-keys).
 
 If you see `401 UNAUTHORIZED` with `details.reason: "ORPHANED_KEY"`, the key
-is no longer bound to an organization and cannot be used — create a new key
+is no longer bound to an organization and cannot be used. Create a new key
 from [Settings](https://app.mcpjam.com/settings/api-keys).
 
 ## Conventions
 
 **Requests.** Operations on servers are `POST` with a JSON body (most accept
-an empty `{}`). **Reads** — the catalog listings and eval-run polling — are
+an empty `{}`). **Reads** (the catalog listings and eval-run polling) are
 `GET` and take their options (`cursor`, `limit`, filters) as query
 parameters.
 
@@ -137,16 +137,16 @@ parameters.
 | Kind | Shape |
 | --- | --- |
 | Single resource | The resource object directly |
-| Collection | `{ "items": [...], "nextCursor": "..." }` — `nextCursor` omitted on the last page |
+| Collection | `{ "items": [...], "nextCursor": "..." }` (`nextCursor` omitted on the last page) |
 | Error | `{ "code": "...", "message": "...", "details": {...} }` with a matching HTTP status |
 
 **Pagination.** Collections are cursor-based. Pass the previous response's
 `nextCursor` as `cursor` in the next request (body field on `POST` lists,
-query parameter on `GET` lists). Cursors are opaque — don't parse them.
+query parameter on `GET` lists). Cursors are opaque; don't parse them.
 
 **Authoring vs running suites.** `POST /eval-suites` creates a runnable suite
 (the suite plus its test cases) **synchronously** and responds `201` with the
-`suiteId`, WITHOUT running anything — author once, run later. `POST /eval-runs`
+`suiteId`, WITHOUT running anything: author once, run later. `POST /eval-runs`
 is the async counterpart: it validates and creates a run synchronously, then
 detaches execution and responds `202` with a `runId`. Poll
 `GET /eval-runs/{runId}` until `status` is `completed`, `failed`, or
@@ -167,12 +167,12 @@ is stable and machine-readable; `message` is human-readable and may change;
 | Code | HTTP | Meaning |
 | --- | --- | --- |
 | `UNAUTHORIZED` | 401 | Missing, invalid, revoked, or orphaned key |
-| `OAUTH_REQUIRED` | 401 | The **target MCP server** needs an OAuth grant — distinct from a bad key |
+| `OAUTH_REQUIRED` | 401 | The **target MCP server** needs an OAuth grant (distinct from a bad key) |
 | `FORBIDDEN` | 403 | Key is valid but not allowed to do this |
 | `VALIDATION_ERROR` | 400 | Malformed body or parameters |
 | `NOT_FOUND` | 404 | Unknown project, server, or resource |
 | `FEATURE_NOT_SUPPORTED` | 422 | The target server doesn't support this MCP capability |
-| `RATE_LIMITED` | 429 | Too many requests — see [Rate limits](#rate-limits) |
+| `RATE_LIMITED` | 429 | Too many requests; see [Rate limits](#rate-limits) |
 | `SERVER_UNREACHABLE` | 502 | Could not connect to the target MCP server |
 | `TIMEOUT` | 504 | The target MCP server connected but didn't respond in time |
 | `INTERNAL_ERROR` | 500 | Something failed on our side |
@@ -198,10 +198,10 @@ to be tuned during the preview.
 
 ## Endpoints
 
-Each endpoint is fully documented — request and response schemas, examples,
-and an interactive playground — under **Endpoints** in the sidebar.
+Each endpoint is fully documented (request and response schemas, examples,
+and an interactive playground) under **Endpoints** in the sidebar.
 
-**Catalog** — discover the IDs everything else takes:
+**Catalog**: discover the IDs everything else takes:
 
 | Endpoint | What it does |
 | --- | --- |
@@ -234,13 +234,13 @@ and an interactive playground — under **Endpoints** in the sidebar.
 | Endpoint | What it does |
 | --- | --- |
 | `POST .../eval-suites` | Author-only: create a suite + its test cases from `name` + `serverIds` + a default `model` + `tests`, WITHOUT running it; responds `201` + `suiteId`. Each test's case body is an ordered `steps` array (prompt / toolCall / interact / assert); per-test `model`/`provider`/`runs` are optional and fall back to suite defaults |
-| `POST .../eval-runs` | Create a run from a `suiteId` (rerun; `serverIds` optional — defaults to the suite's saved servers) or `suiteName` + inline `tests` + `serverIds` (new suite); responds `202` + `runId` |
-| `GET .../eval-runs/{runId}` | Run status, result, and summary — poll until terminal |
+| `POST .../eval-runs` | Create a run from a `suiteId` (rerun; `serverIds` optional, defaults to the suite's saved servers) or `suiteName` + inline `tests` + `serverIds` (new suite); responds `202` + `runId` |
+| `GET .../eval-runs/{runId}` | Run status, result, and summary; poll until terminal |
 | `GET .../eval-runs/{runId}/iterations` | Per-iteration results: tool calls, token usage, latency (paginated) |
 | `GET .../eval-runs/{runId}/iterations/{iterationId}/trace` | Full trace: messages + expected-vs-actual analysis |
 | `GET .../eval-suites/{suiteId}/runs` | Recent runs for a suite, newest first |
 
-**Eval result ingestion** (`/projects/{projectId}/eval-ingest/...`) — how `@mcpjam/sdk` saves results from eval runs executed outside the platform (local dev, CI). The `{projectId}` segment accepts the literal `default` for the key org's Default project. Most users never call these directly — set `MCPJAM_API_KEY` and the [SDK reporter](/sdk/concepts/saving-results) does:
+**Eval result ingestion** (`/projects/{projectId}/eval-ingest/...`): how `@mcpjam/sdk` saves results from eval runs executed outside the platform (local dev, CI). The `{projectId}` segment accepts the literal `default` for the key org's Default project. Most users never call these directly; set `MCPJAM_API_KEY` and the [SDK reporter](/sdk/concepts/saving-results) does:
 
 | Endpoint | What it does |
 | --- | --- |
@@ -250,7 +250,7 @@ and an interactive playground — under **Endpoints** in the sidebar.
 | `POST .../eval-ingest/runs/finalize` | Finalize a chunked run (idempotent) |
 | `POST .../eval-ingest/artifacts/upload-url` | Mint an upload URL for eval artifacts (JUnit XML, Jest/Vitest JSON) |
 
-**Chatboxes** (`/projects/{projectId}/chatboxes...`) — read-only:
+**Chatboxes** (`/projects/{projectId}/chatboxes...`), read-only:
 
 | Endpoint | What it does |
 | --- | --- |
@@ -263,7 +263,7 @@ for Postman, Swagger UI, or client generation.
 
 ## Run evals from the API
 
-The shortest useful loop — create a run with one inline test, then poll:
+The shortest useful loop: create a run with one inline test, then poll:
 
 ```bash
 # 1. Create (responds 202 immediately; -f + jq -e fail fast on errors)
@@ -303,8 +303,8 @@ curl -s "https://app.mcpjam.com/api/v1/projects/$PROJECT_ID/eval-runs/$RUN_ID/it
   -H "Authorization: Bearer $MCPJAM_API_KEY"
 ```
 
-`model` takes an id from the hosted catalog — `provider/name` form, e.g.
-`anthropic/claude-haiku-4.5` — and runs on your organization's credits.
+`model` takes an id from the hosted catalog (`provider/name` form, e.g.
+`anthropic/claude-haiku-4.5`) and runs on your organization's credits.
 Provider-native ids (e.g. `claude-sonnet-4-5`) are bring-your-own-key: pass
 the key in `modelApiKeys`. A model the API can't execute is rejected at
 create time with `VALIDATION_ERROR`; `details.hostedModels` lists the valid
@@ -316,7 +316,7 @@ lists the resolved `servers`). Pass `serverIds` to override the selection; a
 suite with no saved selection requires it (`VALIDATION_ERROR` with
 `details.reason: "NO_SAVED_SERVER_SELECTION"` otherwise). Per-organization
 concurrency is capped (default **2** concurrent runs); exceeding it returns
-`429` with `details.reason: "CONCURRENT_RUN_LIMIT"` — wait for an active run
+`429` with `details.reason: "CONCURRENT_RUN_LIMIT"`; wait for an active run
 to finish.
 
 If a server answers `401 OAUTH_REQUIRED`, complete the OAuth flow yourself
@@ -330,13 +330,13 @@ and refresh it server-side.
 To set expectations while in preview, these are **not** available over the API
 today (most exist in the hosted inspector UI):
 
-- Creating or revoking API keys (UI-only by design — see [Authentication](#authentication))
+- Creating or revoking API keys (UI-only by design; see [Authentication](#authentication))
 - Chat and conformance suites
 - Browser-based OAuth flows initiated by the API (use
   `oauth/import-tokens` after completing OAuth yourself)
 
 If one of these blocks you, tell us on
-[Discord](https://discord.gg/JEnDtz8X6z) — it directly shapes what we
+[Discord](https://discord.gg/JEnDtz8X6z); it directly shapes what we
 stabilize first.
 
 ## Versioning & stability
@@ -345,7 +345,7 @@ stabilize first.
   availability, breaking changes will require a new version path.
 - **During the preview**, breaking changes to v1 may still happen; we'll note
   them in the [changelog](/changelog/overview).
-- **Additive changes** — new endpoints, new optional request fields, new
-  response fields, new error codes — are considered non-breaking and can ship
+- **Additive changes** (new endpoints, new optional request fields, new
+  response fields, new error codes) are considered non-breaking and can ship
   at any time. Write clients that ignore unknown fields.
 - Error **codes** are stable identifiers; error **messages** are not.

--- a/docs/sdk/concepts/connecting-servers.mdx
+++ b/docs/sdk/concepts/connecting-servers.mdx
@@ -99,7 +99,7 @@ With this configuration, the SDK:
 
 #### Custom 401 recovery with onUnauthorized
 
-Use `onUnauthorized` when you supply an `accessToken` but manage token rotation yourself — for example, when tokens come from a secrets vault or a backend service rather than a standard OAuth flow:
+Use `onUnauthorized` when you supply an `accessToken` but manage token rotation yourself; for example, when tokens come from a secrets vault or a backend service rather than a standard OAuth flow:
 
 ```typescript
 const manager = new MCPClientManager({
@@ -123,7 +123,7 @@ When the server returns HTTP 401, the SDK:
 4. If the retry also returns 401, the error is surfaced to the caller.
 
 <Note>
-`onUnauthorized` only fires on strict HTTP 401 responses — not 403. It is also skipped when `refreshToken` or `authProvider` is configured, since those patterns handle token refresh internally. Parallel 401s for the same server share a single refresh call.
+`onUnauthorized` only fires on strict HTTP 401 responses, not 403. It is also skipped when `refreshToken` or `authProvider` is configured, since those patterns handle token refresh internally. Parallel 401s for the same server share a single refresh call.
 </Note>
 
 ## Connecting and Disconnecting
@@ -184,7 +184,7 @@ const allTools = await manager.getTools();
 
 ## Executing Tools Directly
 
-You can call tools without involving an LLM—useful for unit tests:
+You can call tools without involving an LLM (useful for unit tests):
 
 ```typescript
 // Direct tool execution

--- a/docs/sdk/concepts/running-evals.mdx
+++ b/docs/sdk/concepts/running-evals.mdx
@@ -4,7 +4,7 @@ description: "Measure tool accuracy with statistical evaluations"
 icon: "chart-bar"
 ---
 
-LLMs are probabilistic—the same prompt might produce different results each time. Running a test once tells you it *can* work, not that it *reliably* works. Evals run the same test many times and measure statistical accuracy.
+LLMs are probabilistic: the same prompt might produce different results each time. Running a test once tells you it *can* work, not that it *reliably* works. Evals run the same test many times and measure statistical accuracy.
 
 ## Why Run Evals?
 
@@ -166,11 +166,11 @@ await test.run(agent, {
 });
 ```
 
-See [Eval reporting — Tool execution and `passed`](/sdk/reference/eval-reporting#tool-execution-and-passed) for full detail and [`createEvalRunReporter`](/sdk/reference/eval-reporting#createevalrunreporter) overrides.
+See [Eval reporting: Tool execution and `passed`](/sdk/reference/eval-reporting#tool-execution-and-passed) for full detail and [`createEvalRunReporter`](/sdk/reference/eval-reporting#createevalrunreporter) overrides.
 
 ### Predicate gate
 
-`successPredicates` lets you express richer pass/fail criteria beyond tool-call matching — without an LLM judge. Predicates are pure functions of the iteration transcript, so they produce the same verdict every time and are safe to use as a CI release gate.
+`successPredicates` lets you express richer pass/fail criteria beyond tool-call matching, without an LLM judge. Predicates are pure functions of the iteration transcript, so they produce the same verdict every time and are safe to use as a CI release gate.
 
 A case passes iff **all** predicates pass. An absent or empty list means no predicate gate.
 
@@ -275,7 +275,7 @@ if (suite.accuracy() < 0.90) {
 
 ## Bring your own host
 
-`HostRunner` is the right starting point when you just need an LLM + tools + a model string. For richer setups — pinning a host style/profile, applying sandbox/permission policy, or running the same configuration in CI that the MCPJam Inspector uses for its Playground — start from a `Host` spec instead:
+`HostRunner` is the right starting point when you just need an LLM + tools + a model string. For richer setups (pinning a host style/profile, applying sandbox/permission policy, or running the same configuration in CI that the MCPJam Inspector uses for its Playground), start from a `Host` spec instead:
 
 ```typescript
 import { MCPClientManager, Host, EvalTest } from "@mcpjam/sdk";
@@ -304,7 +304,7 @@ const test = new EvalTest({
 await test.run(runtime, { iterations: 10 });
 ```
 
-`HostRuntime` (returned by `host.withManager(...)`) snapshots the live `Host` on every `.run()`, so mutating the bound host between iterations takes effect on the next iteration. `HostRunner` snapshots once at construction — pick `HostRunner` for a static spec, `HostRuntime` when you want the spec editable across calls.
+`HostRuntime` (returned by `host.withManager(...)`) snapshots the live `Host` on every `.run()`, so mutating the bound host between iterations takes effect on the next iteration. `HostRunner` snapshots once at construction. Pick `HostRunner` for a static spec, `HostRuntime` when you want the spec editable across calls.
 
 **Personal computer.** A `Host` can declare a personal cloud workstation via the `computer` property (type `HostComputer`, exported from `@mcpjam/sdk`). When set, the chatbox surfaces a `bash` tool and a web terminal for signed-in members. Use `setComputer()` to attach or detach it fluently:
 
@@ -332,7 +332,7 @@ const host = new Host({
 });
 ```
 
-`null` and an absent `computer` field hash identically, so existing host configs are unaffected. The `computer` field is automatically stripped from eval wire configs — evals never target personal computers.
+`null` and an absent `computer` field hash identically, so existing host configs are unaffected. The `computer` field is automatically stripped from eval wire configs: evals never target personal computers.
 
 **Statelessness.** `HostRuntime.run()` does NOT auto-replay history across turns. Use `PromptOptions.context` to thread context explicitly:
 

--- a/docs/sdk/concepts/saving-results.mdx
+++ b/docs/sdk/concepts/saving-results.mdx
@@ -5,7 +5,7 @@ icon: "cloud-upload"
 ---
 
 <Warning>
-Reporting authenticates with **MCPJam API keys (`sk_…`)** from Settings → API keys. The legacy project API keys (`mcpjam_…`) are retired and no longer work anywhere — see [API keys](/reference/api-keys).
+Reporting authenticates with **MCPJam API keys (`sk_…`)** from Settings → API keys. The legacy project API keys (`mcpjam_…`) are retired and no longer work anywhere. See [API keys](/reference/api-keys).
 </Warning>
 
 After running evals, you can save results to MCPJam to track accuracy over time, compare across branches, and get visibility in the CI Evals dashboard.
@@ -24,12 +24,12 @@ export MCPJAM_API_KEY=sk_...
 export MCPJAM_PROJECT_ID=<project id>
 ```
 
-That's it — both `EvalTest` and `EvalSuite` auto-save results when this key is available. Results land in the project named by `MCPJAM_PROJECT_ID` (or the `project` option in the `mcpjam:` config), falling back to your organization's **Default** project.
+That's it: both `EvalTest` and `EvalSuite` auto-save results when this key is available. Results land in the project named by `MCPJAM_PROJECT_ID` (or the `project` option in the `mcpjam:` config), falling back to your organization's **Default** project.
 
 **Attach the connected `MCPClientManager` to [`HostRunner`](/sdk/reference/host-runner)** (or pass `agent` / `mcpClientManager` to manual reporting APIs) when you need either of the following:
 
-1. **MCP App / widget replay in Evals traces** — After each MCP App tool call, the agent uses the manager’s [`readResource`](/sdk/reference/mcp-client-manager#readresource) to fetch HTML from the tool’s `ui.resourceUri` and fills [`widgetSnapshots`](/sdk/reference/prompt-result#mcp-app-widget-snapshots) on [`PromptResult`](/sdk/reference/prompt-result). Without the manager, traces still upload (messages + spans) but **widgets will not replay** in the dashboard. The tool’s JSON result alone is not enough for offline iframe replay.
-2. **Replay credentials (authenticated HTTP MCP)** — The SDK can persist server connection details for debugging and reruns. You do not need to build a second secret object yourself; replay config is derived automatically when the agent or manager is attached.
+1. **MCP App / widget replay in Evals traces:** After each MCP App tool call, the agent uses the manager’s [`readResource`](/sdk/reference/mcp-client-manager#readresource) to fetch HTML from the tool’s `ui.resourceUri` and fills [`widgetSnapshots`](/sdk/reference/prompt-result#mcp-app-widget-snapshots) on [`PromptResult`](/sdk/reference/prompt-result). Without the manager, traces still upload (messages + spans) but **widgets will not replay** in the dashboard. The tool’s JSON result alone is not enough for offline iframe replay.
+2. **Replay credentials (authenticated HTTP MCP):** The SDK can persist server connection details for debugging and reruns. You do not need to build a second secret object yourself; replay config is derived automatically when the agent or manager is attached.
 
 ## Auto-Save from EvalTest
 
@@ -107,7 +107,7 @@ When a suite runs, individual `EvalTest` auto-saves are suppressed to avoid dupl
 
 ## Manual Save APIs
 
-For more control — custom test runners, CI post-steps, or framework-agnostic flows — the SDK provides dedicated APIs:
+For more control (custom test runners, CI post-steps, or framework-agnostic flows), the SDK provides dedicated APIs:
 
 ```typescript
 import {
@@ -117,14 +117,14 @@ import {
   uploadEvalArtifact,
 } from "@mcpjam/sdk";
 
-// 1) One-shot save (strict — throws on failure)
+// 1) One-shot save (strict: throws on failure)
 await reportEvalResults({
   suiteName: "Nightly",
   mcpClientManager: manager,
   results: [{ caseTitle: "healthcheck", passed: true }],
 });
 
-// 2) One-shot save (safe — returns null on failure)
+// 2) One-shot save (safe: returns null on failure)
 const result = await reportEvalResultsSafely({
   suiteName: "Nightly",
   results: [{ caseTitle: "healthcheck", passed: true }],
@@ -158,7 +158,7 @@ Most users should pass `agent` or `mcpClientManager` and let the SDK derive repl
 
 When replay configs are inferred from `agent` or `mcpClientManager`, the SDK limits them to the `serverNames` you attach to the run when `serverNames` is provided.
 
-**Manual reporters (Vitest/Jest hooks):** Pass `agent` or `mcpClientManager` into [`createEvalRunReporter`](/sdk/reference/eval-reporting#createevalrunreporter) — not only on `HostRunner` — and call **`await reporter.finalize()` before `await manager.disconnectAllServers()`** so replay config is still available at upload time. See [Replay metadata for the MCPJam UI](/sdk/reference/eval-reporting#replay-metadata-for-the-mcpjam-ui).
+**Manual reporters (Vitest/Jest hooks):** Pass `agent` or `mcpClientManager` into [`createEvalRunReporter`](/sdk/reference/eval-reporting#createevalrunreporter), not only on `HostRunner`, and call **`await reporter.finalize()` before `await manager.disconnectAllServers()`** so replay config is still available at upload time. See [Replay metadata for the MCPJam UI](/sdk/reference/eval-reporting#replay-metadata-for-the-mcpjam-ui).
 
 ## CI Metadata
 

--- a/docs/sdk/index.mdx
+++ b/docs/sdk/index.mdx
@@ -81,7 +81,7 @@ console.log(`Accuracy: ${(test.accuracy() * 100).toFixed(1)}%`);
 
 ## Spec-first: `Host` + `HostRuntime`
 
-For richer setups — pinning a host style/profile, applying sandbox/permission policy, or running the same configuration in CI that the MCPJam Inspector uses — start from a `Host` spec instead of constructing a runner directly:
+For richer setups (pinning a host style/profile, applying sandbox/permission policy, or running the same configuration in CI that the MCPJam Inspector uses), start from a `Host` spec instead of constructing a runner directly:
 
 ```typescript
 import { MCPClientManager, Host, EvalTest } from "@mcpjam/sdk";

--- a/docs/sdk/quickstart.mdx
+++ b/docs/sdk/quickstart.mdx
@@ -59,7 +59,7 @@ The SDK will exchange the refresh token for an access token and automatically re
 
 ## Step 2: Execute Tools Directly
 
-Call tools without an LLM—useful for unit tests:
+Call tools without an LLM (useful for unit tests):
 
 ```typescript
 const result = await manager.executeTool("everything", "add", {
@@ -200,7 +200,7 @@ You can also generate eval code directly from the MCPJam Inspector:
 The copied markdown is a ready-to-use prompt that includes your server's capabilities and the full `@mcpjam/sdk` API reference, so the LLM has everything it needs to write your eval tests.
 
 <Tip>
-To save results to the MCPJam Evals dashboard, set `MCPJAM_API_KEY` to an **MCPJam API key (`sk_…`)** from Settings → API keys and add a `mcpjam: { suiteName: "…" }` block to `run()`. The retired project API keys (`mcpjam_…`) no longer work — see [Saving Results](/sdk/concepts/saving-results).
+To save results to the MCPJam Evals dashboard, set `MCPJAM_API_KEY` to an **MCPJam API key (`sk_…`)** from Settings → API keys and add a `mcpjam: { suiteName: "…" }` block to `run()`. The retired project API keys (`mcpjam_…`) no longer work. See [Saving Results](/sdk/concepts/saving-results).
 </Tip>
 
 ## Next Steps

--- a/docs/sdk/reference/eval-reporting.mdx
+++ b/docs/sdk/reference/eval-reporting.mdx
@@ -5,7 +5,7 @@ icon: "book"
 ---
 
 <Warning>
-Reporting authenticates with **MCPJam API keys (`sk_…`)** from Settings → API keys and uploads through the [MCPJam public API](/reference/public-api) (`/api/v1/projects/:projectId/eval-ingest/*`). The legacy project API keys (`mcpjam_…`) and their `/sdk/v1/evals/*` endpoints are retired — old SDK versions pointing there receive `410 Gone`. Upgrade `@mcpjam/sdk` to keep uploading.
+Reporting authenticates with **MCPJam API keys (`sk_…`)** from Settings → API keys and uploads through the [MCPJam public API](/reference/public-api) (`/api/v1/projects/:projectId/eval-ingest/*`). The legacy project API keys (`mcpjam_…`) and their `/sdk/v1/evals/*` endpoints are retired. Old SDK versions pointing there receive `410 Gone`. Upgrade `@mcpjam/sdk` to keep uploading.
 </Warning>
 
 The SDK provides APIs to save eval results to MCPJam for visualization in the CI Evals dashboard. Results can be saved automatically via `EvalTest`/`EvalSuite`, or manually using the APIs below.
@@ -28,10 +28,10 @@ Use `MCPJAM_BASE_URL` only when you need to override the default ingest host, su
 
 Uploaded iterations have a single boolean `passed` that drives pass rate on the dashboard. The SDK distinguishes:
 
-1. **Structural pass** — Your test returned `true`, or expected tool calls were satisfied (Inspector/UI flows use shared matching logic).
-2. **Tool execution** — The trace shows a real tool failure: MCP results with `isError: true`, timeline spans where a tool step ended in `error`, tool-result parts the UI would treat as errors, or a runner-level `iterationError` after a thrown tool step.
+1. **Structural pass:** Your test returned `true`, or expected tool calls were satisfied (Inspector/UI flows use shared matching logic).
+2. **Tool execution:** The trace shows a real tool failure: MCP results with `isError: true`, timeline spans where a tool step ended in `error`, tool-result parts the UI would treat as errors, or a runner-level `iterationError` after a thrown tool step.
 
-**Default behavior:** When the SDK **derives** `passed` from a trace (for example `EvalTest` / `EvalSuite` auto-save, [`PromptResult.toEvalResult()`](/sdk/reference/prompt-result#toevalresult), `createEvalRunReporter` helpers, or Inspector suite runs), structural success is **not enough** if tool execution failed — the iteration is recorded as **failed** unless you opt out.
+**Default behavior:** When the SDK **derives** `passed` from a trace (for example `EvalTest` / `EvalSuite` auto-save, [`PromptResult.toEvalResult()`](/sdk/reference/prompt-result#toevalresult), `createEvalRunReporter` helpers, or Inspector suite runs), structural success is **not enough** if tool execution failed: the iteration is recorded as **failed** unless you opt out.
 
 **Opt out:** set `failOnToolError: false` on [`MCPJamReportingConfig`](#mcpjamreportingconfig) (global for that reporter or auto-save), or pass it on specific helper options (`addFromPrompt` / `recordFromRun` / `RunToEvalResultsOptions`, etc.). Use this when you only care that the model *invoked* the right tools with the right arguments, not that every MCP call returned a success payload.
 
@@ -231,9 +231,9 @@ If you also provide `serverNames`, inferred replay configs are filtered to those
 
 Uploaded runs can show **Replay this run** / server-side MCP replay when the ingest payload includes derived **`serverReplayConfigs`** (stored as **`hasServerReplayConfig`** on the run). In practice:
 
-- **HTTP MCP (`url`)** — Replay configs are built for typical streamable HTTP connections. **Stdio** transports **do not** produce entries from [`MCPClientManager.getServerReplayConfigs()`](/sdk/reference/mcp-client-manager); use HTTP when you need dashboard replay.
-- **`HostRunner` vs reporter** — Putting `mcpClientManager` on [`HostRunner`](/sdk/reference/host-runner) fills **MCP App widget snapshots** on [`PromptResult`](/sdk/reference/prompt-result). The **reporter** (and one-shot `report*`) resolves **server replay** from its **own** `agent` / `mcpClientManager` fields. Pass `agent` or `mcpClientManager` into [`createEvalRunReporter`](#createevalrunreporter) as well; **agent-only** wiring can still upload traces and widgets but **omit** `hasServerReplayConfig`.
-- **Teardown order** — `finalize()` / one-shot reporting calls `getServerReplayConfigs()` against **connected** registrations. In `afterAll`, run **`await reporter.finalize()`** (or `reportEvalResults`) **before** **`await manager.disconnectAllServers()`**. Disconnecting first clears manager state and uploads **without** replay metadata.
+- **HTTP MCP (`url`):** Replay configs are built for typical streamable HTTP connections. **Stdio** transports **do not** produce entries from [`MCPClientManager.getServerReplayConfigs()`](/sdk/reference/mcp-client-manager); use HTTP when you need dashboard replay.
+- **`HostRunner` vs reporter:** Putting `mcpClientManager` on [`HostRunner`](/sdk/reference/host-runner) fills **MCP App widget snapshots** on [`PromptResult`](/sdk/reference/prompt-result). The **reporter** (and one-shot `report*`) resolves **server replay** from its **own** `agent` / `mcpClientManager` fields. Pass `agent` or `mcpClientManager` into [`createEvalRunReporter`](#createevalrunreporter) as well; **agent-only** wiring can still upload traces and widgets but **omit** `hasServerReplayConfig`.
+- **Teardown order:** `finalize()` / one-shot reporting calls `getServerReplayConfigs()` against **connected** registrations. In `afterAll`, run **`await reporter.finalize()`** (or `reportEvalResults`) **before** **`await manager.disconnectAllServers()`**. Disconnecting first clears manager state and uploads **without** replay metadata.
 
 **LLM API keys** are **not** stored on the run. Replaying in the MCPJam UI still requires provider keys (e.g. OpenRouter) in **Settings** for your suite’s models.
 
@@ -368,7 +368,7 @@ type ReportEvalResultsInput = MCPJamReportingConfig & {
 
 ### Run-level host snapshot
 
-When a usable host snapshot is available, the reporter includes a normalized + content-hashed host config alongside the run body (the v1 ingest surface always accepts the pair — the old per-`baseUrl` capability probe is gone):
+When a usable host snapshot is available, the reporter includes a normalized + content-hashed host config alongside the run body (the v1 ingest surface always accepts the pair; the old per-`baseUrl` capability probe is gone):
 
 ```jsonc
 POST /api/v1/projects/{projectId}/eval-ingest/runs/start
@@ -382,15 +382,15 @@ POST /api/v1/projects/{projectId}/eval-ingest/runs/start
 
 **Source order (highest priority first):**
 
-1. `iteration.hostSnapshot` — per-iteration capture from `HostRuntime` (Stage 4). Reflects the bound `Host` state at the iteration's end.
-2. `executor.getHostSnapshot?.()` — fallback for executors that don't expose per-iteration snapshots.
-3. `MCPJamReportingConfig.host` — explicit override, compatibility path.
+1. `iteration.hostSnapshot`: per-iteration capture from `HostRuntime` (Stage 4). Reflects the bound `Host` state at the iteration's end.
+2. `executor.getHostSnapshot?.()`: fallback for executors that don't expose per-iteration snapshots.
+3. `MCPJamReportingConfig.host`: explicit override, compatibility path.
 
-**Pass-1 homogeneity gate.** The reporter only sends a run-level `{ hostConfig, hostConfigHash }` when all available iteration snapshots canonicalize to the same hash. Heterogeneous runs (e.g. mutating the bound `Host` between iterations) omit the run-level field — per-iteration wire support is a later stage.
+**Pass-1 homogeneity gate.** The reporter only sends a run-level `{ hostConfig, hostConfigHash }` when all available iteration snapshots canonicalize to the same hash. Heterogeneous runs (e.g. mutating the bound `Host` between iterations) omit the run-level field. Per-iteration wire support is a later stage.
 
-**Fail-safe omission.** Any error while resolving or canonicalizing the snapshot — malformed `hostSnapshot`, an executor that throws, non-canonicalizable host JSON — logs a warning and omits the wire pair rather than failing the eval upload. The body shape stays the same without it.
+**Fail-safe omission.** Any error while resolving or canonicalizing the snapshot (malformed `hostSnapshot`, an executor that throws, non-canonicalizable host JSON) logs a warning and omits the wire pair rather than failing the eval upload. The body shape stays the same without it.
 
-**Server-id normalization.** Runtime-manager identifiers (`serverIds`, `optionalServerIds`, `serverConnectionOverrides`) are stripped by `normalizeSdkEvalHostConfigForWire` on both ends so SDK runtime ids like `"everything"` never reach the backend's `validateServerScope` as `Id<'servers'>`. The persisted `hostConfigsV2` row's hash will differ from the wire `hostConfigHash` because suite-resolved Convex server ids are layered on top at storage time — the wire hash is a transport-integrity check, not the storage id.
+**Server-id normalization.** Runtime-manager identifiers (`serverIds`, `optionalServerIds`, `serverConnectionOverrides`) are stripped by `normalizeSdkEvalHostConfigForWire` on both ends so SDK runtime ids like `"everything"` never reach the backend's `validateServerScope` as `Id<'servers'>`. The persisted `hostConfigsV2` row's hash will differ from the wire `hostConfigHash` because suite-resolved Convex server ids are layered on top at storage time: the wire hash is a transport-integrity check, not the storage id.
 
 ### MCPServerReplayConfig
 
@@ -443,7 +443,7 @@ Advanced replay override. Most users should not construct this manually.
 
 ### Predicate gate
 
-`successPredicates` adds a deterministic, state-based assertion layer on top of tool-call matching. Each predicate is a pure function of the iteration transcript — same transcript, same verdict — which makes it suitable as a CI release gate.
+`successPredicates` adds a deterministic, state-based assertion layer on top of tool-call matching. Each predicate is a pure function of the iteration transcript (same transcript, same verdict), which makes it suitable as a CI release gate.
 
 A case passes the predicate gate iff **all** predicates pass. An absent or empty list means no predicate gate (the case is judged solely by tool-call matching and `failOnToolError`).
 
@@ -456,8 +456,8 @@ A case passes the predicate gate iff **all** predicates pass. An absent or empty
 | `toolNeverCalled` | `toolName` | `toolName` was never called (forbidden-tool check). |
 | `responseContains` | `needle`, `caseSensitive?` | The final assistant message contains `needle`. Case-insensitive by default. |
 | `responseMatches` | `pattern` | The final assistant message matches the regular expression `pattern` (regex source string, no flags). |
-| `noToolErrors` | — | No tool produced an error (neither MCP `isError: true` nor a JSON-RPC/transport failure). |
-| `finalAssistantMessageNonEmpty` | — | The final assistant message is a non-empty, non-whitespace string. |
+| `noToolErrors` | (none) | No tool produced an error (neither MCP `isError: true` nor a JSON-RPC/transport failure). |
+| `finalAssistantMessageNonEmpty` | (none) | The final assistant message is a non-empty, non-whitespace string. |
 | `tokenBudgetUnder` | `tokens` | Total token usage for the iteration is strictly under `tokens`. Fails closed when usage is unavailable. |
 
 #### ArgMatcher

--- a/docs/sdk/reference/eval-suite.mdx
+++ b/docs/sdk/reference/eval-suite.mdx
@@ -32,7 +32,7 @@ new EvalSuite(options?: EvalSuiteConfig)
 | `mcpjam` | [`MCPJamReportingConfig`](/sdk/reference/eval-reporting) | No | Auto-save results to MCPJam when the suite completes |
 
 <Note>
-When an API key is available — via `mcpjam.apiKey` or the `MCPJAM_API_KEY` environment variable — all test results are consolidated into a single run and saved to MCPJam after the suite completes. Individual `EvalTest` auto-saves are suppressed to avoid duplicate uploads. Set `mcpjam.enabled: false` to disable.
+When an API key is available (via `mcpjam.apiKey` or the `MCPJAM_API_KEY` environment variable), all test results are consolidated into a single run and saved to MCPJam after the suite completes. Individual `EvalTest` auto-saves are suppressed to avoid duplicate uploads. Set `mcpjam.enabled: false` to disable.
 </Note>
 
 ### Example

--- a/docs/sdk/reference/host-compat.mdx
+++ b/docs/sdk/reference/host-compat.mdx
@@ -1,6 +1,6 @@
 ---
 title: "host-compat"
-description: "API reference for @mcpjam/sdk/host-compat — derive server requirements, evaluate host compatibility, and scan widget bridge usage."
+description: "API reference for @mcpjam/sdk/host-compat: derive server requirements, evaluate host compatibility, and scan widget bridge usage."
 icon: "book"
 ---
 
@@ -39,7 +39,7 @@ deriveServerRequirements(
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `toolsData` | `HostCompatToolsInput \| null` | Tools list from `ListToolsResult`, plus optional per-tool `_meta` metadata. |
-| `widgetUsage` | `WidgetUsage` | Capability needs derived from scanning widget HTML (from `scanWidgetSource`). Pass `undefined` when HTML hasn't been fetched yet — the result will include an `unknownDimensions` entry. |
+| `widgetUsage` | `WidgetUsage` | Capability needs derived from scanning widget HTML (from `scanWidgetSource`). Pass `undefined` when HTML hasn't been fetched yet; the result will include an `unknownDimensions` entry. |
 | `connectionFacts` | `ConnectionFacts` | Protocol version negotiated at connect time. |
 
 ### HostCompatToolsInput
@@ -70,7 +70,7 @@ import { deriveServerRequirements } from "@mcpjam/sdk/host-compat";
 const tools = await manager.listTools("my-server");
 const requirements = deriveServerRequirements(
   { tools: tools.tools },
-  undefined, // widgetUsage — not yet scanned
+  undefined, // widgetUsage: not yet scanned
   { protocolVersion: "2025-11-25" },
 );
 
@@ -182,7 +182,7 @@ const { requirements, reports } = evaluateAllHosts(
 for (const report of reports) {
   console.log(`${report.hostLabel}: ${report.verdict}`);
   for (const finding of report.findings) {
-    console.log(`  [${finding.severity}] ${finding.title} — ${finding.detail}`);
+    console.log(`  [${finding.severity}] ${finding.title} - ${finding.detail}`);
   }
 }
 ```
@@ -205,7 +205,7 @@ scanWidgetSource(html: string): WidgetUsage
 
 ### Returns: WidgetUsage
 
-A map from capability name to the list of tool names whose widgets use that capability. An empty object `{}` means the HTML was scanned and no capability usage was found — this is conclusive. `undefined` means the scan hasn't run yet.
+A map from capability name to the list of tool names whose widgets use that capability. An empty object `{}` means the HTML was scanned and no capability usage was found; this is conclusive. `undefined` means the scan hasn't run yet.
 
 ```typescript
 type WidgetUsage = Partial<Record<WidgetCapabilityNeed, string[]>>;
@@ -290,7 +290,7 @@ Describes a host's capabilities for evaluation purposes. Supply your own profile
 | `"probe"` | Captured from a real host via DevTools or the inspector. |
 | `"vendor-doc"` | Verified from vendor documentation. |
 | `"observed"` | Stamped by a live widget render run. |
-| `"assumed"` | Best-effort — unverified. |
+| `"assumed"` | Best-effort, unverified. |
 
 ### ConnectionFacts
 
@@ -302,6 +302,6 @@ Describes a host's capabilities for evaluation purposes. Supply your own profile
 
 ## Related
 
-- [Compatibility destination](/inspector/compatibility) — the Inspector UI powered by this engine
-- [Apps Conformance SDK](/sdk/reference/apps-conformance) — dynamic conformance testing
-- [Protocol Conformance SDK](/sdk/reference/protocol-conformance) — MCP protocol checks
+- [Compatibility destination](/inspector/compatibility): the Inspector UI powered by this engine
+- [Apps Conformance SDK](/sdk/reference/apps-conformance): dynamic conformance testing
+- [Protocol Conformance SDK](/sdk/reference/protocol-conformance): MCP protocol checks

--- a/docs/sdk/reference/host-runner.mdx
+++ b/docs/sdk/reference/host-runner.mdx
@@ -36,7 +36,7 @@ new HostRunner(options: HostRunnerOptions)
 | `maxSteps`        | `number`                         | No       | `10`        | Maximum agentic loop iterations                               |
 | `customProviders` | `Record<string, CustomProvider>` | No       | `undefined` | Custom LLM provider definitions                               |
 | `mcpClientManager`| `MCPClientManager`               | No       | `undefined` | Same connected manager used for `connectToServer` / `getToolsForAiSdk`. **Required** to populate [`getWidgetSnapshots()`](/sdk/reference/prompt-result#mcp-app-widget-snapshots) on each [`PromptResult`](/sdk/reference/prompt-result) (see note below). |
-| `injectOpenAiCompat` | `boolean`                     | No       | `false`     | When `true`, injects the OpenAI Apps SDK `window.openai` shim into captured widget HTML snapshots. Enable this when testing widgets written against the OpenAI Apps SDK (ChatGPT / Copilot hosts). Leave it off for SEP-1865-native widgets (Claude, Cursor, Codex) — those hosts don't expose `window.openai` and snapshots should match what the live host produces. |
+| `injectOpenAiCompat` | `boolean`                     | No       | `false`     | When `true`, injects the OpenAI Apps SDK `window.openai` shim into captured widget HTML snapshots. Enable this when testing widgets written against the OpenAI Apps SDK (ChatGPT / Copilot hosts). Leave it off for SEP-1865-native widgets (Claude, Cursor, Codex): those hosts don't expose `window.openai` and snapshots should match what the live host produces. |
 
 ### Example
 
@@ -52,7 +52,7 @@ const agent = new HostRunner({
 ```
 
 <Info>
-  **MCP Apps, traces, and `mcpClientManager`:** MCP App widgets are backed by HTML served from an MCP **resource** (`ui.resourceUri`), not by the tool’s JSON result alone. After each tool call, `HostRunner` uses the manager’s [`readResource`](/sdk/reference/mcp-client-manager#readresource) to fetch that HTML and attach **`widgetSnapshots`** to the [`PromptResult`](/sdk/reference/prompt-result). When you upload results to MCPJam, those snapshots are stored so the Evals trace viewer can **replay the widget offline**. If you omit `mcpClientManager`, prompts still run and tools still execute — but **`widgetSnapshots` stay empty** and uploaded traces will only contain messages and spans (no embedded app replay). Passing `manager` is also what enables **replay credential** capture for authenticated HTTP servers when reporting to MCPJam.
+  **MCP Apps, traces, and `mcpClientManager`:** MCP App widgets are backed by HTML served from an MCP **resource** (`ui.resourceUri`), not by the tool’s JSON result alone. After each tool call, `HostRunner` uses the manager’s [`readResource`](/sdk/reference/mcp-client-manager#readresource) to fetch that HTML and attach **`widgetSnapshots`** to the [`PromptResult`](/sdk/reference/prompt-result). When you upload results to MCPJam, those snapshots are stored so the Evals trace viewer can **replay the widget offline**. If you omit `mcpClientManager`, prompts still run and tools still execute, but **`widgetSnapshots` stay empty** and uploaded traces will only contain messages and spans (no embedded app replay). Passing `manager` is also what enables **replay credential** capture for authenticated HTTP servers when reporting to MCPJam.
 </Info>
 
 ---
@@ -287,7 +287,7 @@ maxSteps: 5; // Stop after 5 tool calls
 
 Controls whether the OpenAI Apps SDK `window.openai` shim is injected into captured widget HTML snapshots. Defaults to `false`.
 
-Set this to `true` when your widget is written against the OpenAI Apps SDK (i.e. it targets ChatGPT or Copilot). Leave it `false` for SEP-1865-native widgets targeting Claude, Cursor, Codex, or other hosts that don't expose `window.openai` — snapshots should match what the live host would have produced.
+Set this to `true` when your widget is written against the OpenAI Apps SDK (i.e. it targets ChatGPT or Copilot). Leave it `false` for SEP-1865-native widgets targeting Claude, Cursor, Codex, or other hosts that don't expose `window.openai`; snapshots should match what the live host would have produced.
 
 ```typescript
 // Testing an OpenAI Apps SDK widget (ChatGPT / Copilot host)
@@ -299,7 +299,7 @@ const agent = new HostRunner({
   injectOpenAiCompat: true,
 });
 
-// Testing a SEP-1865 widget (Claude / Cursor / Codex host) — default
+// Testing a SEP-1865 widget (Claude / Cursor / Codex host), the default
 const agent = new HostRunner({
   tools,
   model: "anthropic/claude-sonnet-4-20250514",

--- a/docs/sdk/reference/llm-providers.mdx
+++ b/docs/sdk/reference/llm-providers.mdx
@@ -250,7 +250,7 @@ Any locally installed model:
 - etc.
 
 <Note>
-Ensure Ollama is running locally before use. The API key parameter is required but not used—pass any string.
+Ensure Ollama is running locally before use. The API key parameter is required but not used; pass any string.
 </Note>
 
 #### Example

--- a/docs/sdk/reference/oauth-conformance.mdx
+++ b/docs/sdk/reference/oauth-conformance.mdx
@@ -4,7 +4,7 @@ description: "Programmatic OAuth conformance testing with OAuthConformanceTest a
 icon: "shield-check"
 ---
 
-The OAuth Conformance SDK classes let you run the same flows the [CLI `oauth conformance`](/cli/oauth-conformance) command runs, but programmatically — for custom reporters, test frameworks, recording/replay via custom `fetchFn`, or Playwright-driven consent via `openUrl`.
+The OAuth Conformance SDK classes let you run the same flows the [CLI `oauth conformance`](/cli/oauth-conformance) command runs, but programmatically: for custom reporters, test frameworks, recording/replay via custom `fetchFn`, or Playwright-driven consent via `openUrl`.
 
 <Note>
   For CLI usage (one-liners, CI recipes, troubleshooting), see [CLI: OAuth Conformance](/cli/oauth-conformance).
@@ -67,7 +67,7 @@ type OAuthConformanceAuthConfig =
     };
 ```
 
-- `interactive.openUrl` — override how the consent URL is opened. Default launches the system browser. Use for Playwright, custom launchers, or logging the URL.
+- `interactive.openUrl`: override how the consent URL is opened. Default launches the system browser. Use for Playwright, custom launchers, or logging the URL.
 
 ### OAuthConformanceClientConfig
 
@@ -138,12 +138,12 @@ const test = new OAuthConformanceTest({
 
 When enabled, six extra checks run after a successful flow:
 
-1. **DCR redirect URI policy** — attempts dynamic client registration with a non-loopback `http://` redirect URI; expects rejection under the MCP authorization profile.
-2. **Invalid client** — sends a token request with an unknown `client_id`; expects rejection.
-3. **Invalid redirect at the authorization endpoint** — sends an authorization request with a mismatched `redirect_uri` and looks for rejection before the server redirects back to it. This step may be `skipped` if the server defers validation behind user interaction.
-4. **Invalid token** — sends an authenticated MCP initialize request with an obviously invalid bearer token; expects HTTP 401 from the MCP server.
-5. **Invalid redirect at the token endpoint** — sends a token request with a mismatched `redirect_uri` to look for redirect exact-match enforcement. This step may be `skipped` if the request is rejected for another reason before redirect validation is demonstrated.
-6. **Token format** — validates the token response includes `access_token`, `token_type`, and expiration metadata.
+1. **DCR redirect URI policy:** attempts dynamic client registration with a non-loopback `http://` redirect URI; expects rejection under the MCP authorization profile.
+2. **Invalid client:** sends a token request with an unknown `client_id`; expects rejection.
+3. **Invalid redirect at the authorization endpoint:** sends an authorization request with a mismatched `redirect_uri` and looks for rejection before the server redirects back to it. This step may be `skipped` if the server defers validation behind user interaction.
+4. **Invalid token:** sends an authenticated MCP initialize request with an obviously invalid bearer token; expects HTTP 401 from the MCP server.
+5. **Invalid redirect at the token endpoint:** sends a token request with a mismatched `redirect_uri` to look for redirect exact-match enforcement. This step may be `skipped` if the request is rejected for another reason before redirect validation is demonstrated.
+6. **Token format:** validates the token response includes `access_token`, `token_type`, and expiration metadata.
 
 ```typescript
 const test = new OAuthConformanceTest({
@@ -250,6 +250,6 @@ for (const flow of result.results) {
 
 ## Related
 
-- [CLI: OAuth Conformance](/cli/oauth-conformance) — recipes, troubleshooting, CI integration
-- [CLI: OAuth Login](/cli/oauth-login) — interactive authentication and debugging
-- [MCPClientManager](/sdk/reference/mcp-client-manager) — connecting to MCP servers programmatically
+- [CLI: OAuth Conformance](/cli/oauth-conformance): recipes, troubleshooting, CI integration
+- [CLI: OAuth Login](/cli/oauth-login): interactive authentication and debugging
+- [MCPClientManager](/sdk/reference/mcp-client-manager): connecting to MCP servers programmatically

--- a/docs/sdk/reference/prompt-result.mdx
+++ b/docs/sdk/reference/prompt-result.mdx
@@ -394,7 +394,7 @@ getWidgetSnapshots(): EvalWidgetSnapshotInput[]
 
 #### Returns
 
-`EvalWidgetSnapshotInput[]` — metadata plus inline HTML (before upload) or storage ids after reporting. Empty if no MCP App tools ran or if [`HostRunner`](/sdk/reference/host-runner) was created **without** [`mcpClientManager`](/sdk/reference/host-runner#parameters).
+`EvalWidgetSnapshotInput[]`: metadata plus inline HTML (before upload) or storage ids after reporting. Empty if no MCP App tools ran or if [`HostRunner`](/sdk/reference/host-runner) was created **without** [`mcpClientManager`](/sdk/reference/host-runner#parameters).
 
 #### Why the manager matters
 

--- a/docs/sdk/reference/validators.mdx
+++ b/docs/sdk/reference/validators.mdx
@@ -4,7 +4,7 @@ description: "API reference for validator functions"
 icon: "book"
 ---
 
-The SDK provides 9 boolean validator functions for asserting tool call behavior in tests, plus `evaluateToolCalls` — a richer, configurable matcher that returns structured results.
+The SDK provides 9 boolean validator functions for asserting tool call behavior in tests, plus `evaluateToolCalls`, a richer, configurable matcher that returns structured results.
 
 ## Import
 

--- a/docs/troubleshooting/common-errors.mdx
+++ b/docs/troubleshooting/common-errors.mdx
@@ -5,7 +5,7 @@ icon: "circle-alert"
 ---
 
 <Info>
-Looking for a specific error code? See the [error code reference](/troubleshooting/error-codes) — every ErrorCard in the inspector deep-links to a section there.
+Looking for a specific error code? See the [error code reference](/troubleshooting/error-codes). Every ErrorCard in the inspector deep-links to a section there.
 </Info>
 
 This guide covers common errors you might encounter when working with MCP servers and how to resolve them.
@@ -14,14 +14,14 @@ This guide covers common errors you might encounter when working with MCP server
 
 ### Diagnose a connection failure
 
-Most "failed to connect" / `fetch failed` / `ECONNREFUSED` / `MCP error -32000: Connection closed` / `MCP error -32001: Request timed out` reports come down to one of five root causes. Work through them in order — each step takes seconds.
+Most "failed to connect" / `fetch failed` / `ECONNREFUSED` / `MCP error -32000: Connection closed` / `MCP error -32001: Request timed out` reports come down to one of five root causes. Work through them in order. Each step takes seconds.
 
 1. **Is the server actually running?**
 
-   Open a second terminal and run the same command you'd ask Inspector to run. If it exits or prints a stack trace, fix that first — Inspector can only attach to a server that stays alive.
+   Open a second terminal and run the same command you'd ask Inspector to run. If it exits or prints a stack trace, fix that first: Inspector can only attach to a server that stays alive.
 
    ```bash
-   # For STDIO servers — run the same command Inspector would run
+   # For STDIO servers: run the same command Inspector would run
    python /Users/yourname/project/server.py
    # or: uv run --directory /Users/yourname/project mcp.py
    # or: npx -y @modelcontextprotocol/server-everything
@@ -30,11 +30,11 @@ Most "failed to connect" / `fetch failed` / `ECONNREFUSED` / `MCP error -32000: 
    curl -i http://localhost:PORT/mcp
    ```
 
-   A clean stdio process should sit waiting on stdin; a healthy HTTP server should respond with something other than `Connection refused` (the exact code varies — common responses are `405 Method Not Allowed` for `GET`, `406 Not Acceptable` if Accept headers are missing, or `400 Bad Request` if the server expects a session header).
+   A clean stdio process should sit waiting on stdin; a healthy HTTP server should respond with something other than `Connection refused` (the exact code varies: common responses are `405 Method Not Allowed` for `GET`, `406 Not Acceptable` if Accept headers are missing, or `400 Bad Request` if the server expects a session header).
 
 2. **Right port, right path?**
 
-   `ECONNREFUSED 127.0.0.1:5555` means **nothing is listening on that port** — typo, wrong port, or the server is bound to `127.0.0.1` only while you're calling it via a different hostname (or vice versa). `SSE error: Non-200 status code (404)` means the port is correct but the path is wrong: most MCP servers mount under `/mcp` or `/sse`, not `/`.
+   `ECONNREFUSED 127.0.0.1:5555` means **nothing is listening on that port**: typo, wrong port, or the server is bound to `127.0.0.1` only while you're calling it via a different hostname (or vice versa). `SSE error: Non-200 status code (404)` means the port is correct but the path is wrong: most MCP servers mount under `/mcp` or `/sse`, not `/`.
 
 3. **Right transport selected?**
 
@@ -46,13 +46,13 @@ Most "failed to connect" / `fetch failed` / `ECONNREFUSED` / `MCP error -32000: 
 
 5. **Did the server actually finish booting before the handshake?**
 
-   `MCP error -32001: Request timed out` during `initialize` means the server didn't respond to the handshake in time — usually because it's still loading models, opening a database, or waiting on an upstream. Raise the **Request timeout** in **Clients → your client → Request timeout** (default 30,000ms), or reduce the server's startup work.
+   `MCP error -32001: Request timed out` during `initialize` means the server didn't respond to the handshake in time, usually because it's still loading models, opening a database, or waiting on an upstream. Raise the **Request timeout** in **Clients → your client → Request timeout** (default 30,000ms), or reduce the server's startup work.
 
 If all five check out and you still see a failure, copy the full error from the JSON-RPC log into a [GitHub issue](https://github.com/MCPJam/inspector/issues) or [Discord](https://discord.gg/JEnDtz8X6z) thread.
 
 ### `(intermediate value).subtle is undefined`
 
-The browser's Web Crypto API (`crypto.subtle`) is only available in **secure contexts** — that means HTTPS, or `http://localhost` / `http://127.0.0.1`. If you're hitting Inspector over a non-localhost HTTP URL (for example, a LAN IP like `http://192.168.1.10:6274`), the browser disables `crypto.subtle` and OAuth/PKCE flows fail.
+The browser's Web Crypto API (`crypto.subtle`) is only available in **secure contexts**: that means HTTPS, or `http://localhost` / `http://127.0.0.1`. If you're hitting Inspector over a non-localhost HTTP URL (for example, a LAN IP like `http://192.168.1.10:6274`), the browser disables `crypto.subtle` and OAuth/PKCE flows fail.
 
 **Fix:** open Inspector at `http://localhost:6274` or `http://127.0.0.1:6274`, or put HTTPS in front of it. The hosted app and the desktop app are unaffected.
 
@@ -77,11 +77,11 @@ The browser's Web Crypto API (`crypto.subtle`) is only available in **secure con
 
 This response comes from **your MCP server**, not from MCPJam Inspector. The server's HTTP layer is rejecting the request because the `Host` header isn't on its allowlist. Most common culprits:
 
-- **Next.js / webpack-dev-server** — both block unknown hosts by default in dev mode. Add your host to `allowedHosts` (webpack-dev-server) or `experimental.allowedDevOrigins` (Next.js).
-- **FastAPI / Starlette (Python)** — `TrustedHostMiddleware` rejects hosts not in `allowed_hosts`. Add the host the inspector is calling from, or temporarily set `allowed_hosts=["*"]` for local testing.
-- **Reverse proxies (nginx, Caddy)** — check the `server_name` / `host_match` config.
+- **Next.js / webpack-dev-server**: both block unknown hosts by default in dev mode. Add your host to `allowedHosts` (webpack-dev-server) or `experimental.allowedDevOrigins` (Next.js).
+- **FastAPI / Starlette (Python)**: `TrustedHostMiddleware` rejects hosts not in `allowed_hosts`. Add the host the inspector is calling from, or temporarily set `allowed_hosts=["*"]` for local testing.
+- **Reverse proxies (nginx, Caddy)**: check the `server_name` / `host_match` config.
 
-**Quick check:** test the same URL with `curl http://localhost:PORT/mcp` — if curl gets the same error, it's definitely server-side, not inspector.
+**Quick check:** test the same URL with `curl http://localhost:PORT/mcp`. If curl gets the same error, it's definitely server-side, not inspector.
 
 ## Authentication Issues
 
@@ -113,9 +113,9 @@ If you're seeing **401 Unauthorized** errors when trying to connect to your serv
 
 When an OAuth flow fails, Inspector surfaces the failure directly in the connection UI so you can diagnose the problem without leaving the Servers tab.
 
-**Connection card** — a banner above the error message identifies the exact OAuth step that failed (for example, "OAuth failed during Token Request").
+**Connection card**: a banner above the error message identifies the exact OAuth step that failed (for example, "OAuth failed during Token Request").
 
-**Server detail panel** — open the server's detail view to see the full **Last OAuth Trace**, which includes:
+**Server detail panel**: open the server's detail view to see the full **Last OAuth Trace**, which includes:
 
 - Each OAuth step with its status (pending / success / error) and a short message
 - The specific error for any failed step
@@ -160,13 +160,13 @@ This is an expected quota state, not an error with your MCP server.
 
 If the desktop app fails to start, it now shows a recovery dialog instead of quitting silently. The dialog offers three options:
 
-- **Reset app data and quit** — removes cached data (`Cache`, `Code Cache`, `GPUCache`, `Local Storage`) from the app's user data folder and relaunches. Use this when the app crashes consistently after an update or when local data appears corrupted.
-- **Open logs folder** — opens the folder containing `electron-log` output, then quits. Use this to inspect the error before deciding whether to reset.
-- **Quit** — exits without making any changes.
+- **Reset app data and quit**: removes cached data (`Cache`, `Code Cache`, `GPUCache`, `Local Storage`) from the app's user data folder and relaunches. Use this when the app crashes consistently after an update or when local data appears corrupted.
+- **Open logs folder**: opens the folder containing `electron-log` output, then quits. Use this to inspect the error before deciding whether to reset.
+- **Quit**: exits without making any changes.
 
 ### Port 6274 is already in use
 
-The desktop app defaults to port **6274**. If another process holds that port, the app automatically tries the next available port up to port **6283**. A warning is written to the app logs when a fallback port is used. No action is required — the app starts normally on the fallback port.
+The desktop app defaults to port **6274**. If another process holds that port, the app automatically tries the next available port up to port **6283**. A warning is written to the app logs when a fallback port is used. No action is required. The app starts normally on the fallback port.
 
 If you need to free port 6274 manually, find and stop the process occupying it:
 

--- a/docs/troubleshooting/error-codes.mdx
+++ b/docs/troubleshooting/error-codes.mdx
@@ -26,7 +26,7 @@ These come from the MCP transport itself. Numeric codes are defined by the [JSON
 
 ### Parse error
 
-`-32700 — jsonrpc/parse_error`
+`-32700` (`jsonrpc/parse_error`)
 
 The server returned a payload the client could not parse as JSON-RPC.
 
@@ -41,7 +41,7 @@ The server returned a payload the client could not parse as JSON-RPC.
 
 ### Invalid request
 
-`-32600 — jsonrpc/invalid_request`
+`-32600` (`jsonrpc/invalid_request`)
 
 The server rejected the payload as not a well-formed JSON-RPC request.
 
@@ -55,7 +55,7 @@ The server rejected the payload as not a well-formed JSON-RPC request.
 
 ### Method not found
 
-`-32601 — jsonrpc/method_not_found`
+`-32601` (`jsonrpc/method_not_found`)
 
 The server does not implement the JSON-RPC method that was called.
 
@@ -70,7 +70,7 @@ The server does not implement the JSON-RPC method that was called.
 
 ### Invalid params
 
-`-32602 — jsonrpc/invalid_params`
+`-32602` (`jsonrpc/invalid_params`)
 
 The server rejected the request parameters.
 
@@ -85,7 +85,7 @@ The server rejected the request parameters.
 
 ### Internal error
 
-`-32603 — jsonrpc/internal_error`
+`-32603` (`jsonrpc/internal_error`)
 
 The server hit an unexpected error while handling the request.
 
@@ -99,7 +99,7 @@ The server hit an unexpected error while handling the request.
 
 ### Connection closed
 
-`-32000 — jsonrpc/connection_closed`
+`-32000` (`jsonrpc/connection_closed`)
 
 The underlying transport closed before the response could be delivered.
 
@@ -112,11 +112,11 @@ The underlying transport closed before the response could be delivered.
 - Restart the server and reconnect.
 - Check the server logs for a crash or exit message.
 
-**Inspector-specific:** the inspector synthesizes this code when an active transport goes away mid-request. If you see it on every call, the server is probably exiting immediately after startup — check for a fatal log.
+**Inspector-specific:** the inspector synthesizes this code when an active transport goes away mid-request. If you see it on every call, the server is probably exiting immediately after startup. Check for a fatal log.
 
 ### Request timeout
 
-`-32001 — jsonrpc/request_timeout`
+`-32001` (`jsonrpc/request_timeout`)
 
 The server did not respond within the configured request timeout.
 
@@ -131,7 +131,7 @@ The server did not respond within the configured request timeout.
 
 ### Header mismatch
 
-`-32001 — jsonrpc/header_mismatch`
+`-32001` (`jsonrpc/header_mismatch`)
 
 The server returned an `MCP-Protocol-Version` header that does not match what the client negotiated.
 
@@ -147,7 +147,7 @@ The server returned an `MCP-Protocol-Version` header that does not match what th
 
 ### Unsupported protocol version
 
-`-32004 — jsonrpc/unsupported_protocol_version`
+`-32004` (`jsonrpc/unsupported_protocol_version`)
 
 The server does not support any protocol version this inspector offered.
 
@@ -161,7 +161,7 @@ The server does not support any protocol version this inspector offered.
 
 ### URL elicitation required
 
-`-32042 — jsonrpc/url_elicitation_required`
+`-32042` (`jsonrpc/url_elicitation_required`)
 
 The server needs the user to visit an external URL to complete the operation.
 


### PR DESCRIPTION
## Summary

Part 1 of [UER-50](https://app.kestral.ai/workspace/yhNILB2/task/13ycH81E) (Documentation Cleanup). Rewrites **643 em-dashes** across 49 MDX pages and `docs/reference/openapi.json` with contextual punctuation (colons, commas, parentheses, or sentence splits), chosen case by case rather than mechanically replaced.

## Intentionally kept (4)

These quote literal strings the product renders; changing the doc would misquote the UI. Removing them requires changing product strings (separate task):

- `docs/inspector/evals.mdx` — "Synced from CI — the next CI report may overwrite manual edits." (`test-template-editor.tsx`)
- `docs/inspector/host-compat.mdx` — "Best-effort preset — unverified" (`HostCompatContent.tsx`)
- `docs/inspector/projects.mdx` — "Hidden — Reveal to view" (`EnvVarsSection.tsx`)
- `docs/inspector/guided-oauth.mdx` — "Saved — enter a new value to replace" (`AuthenticationSection.tsx`)

## Notes for review

- Table cells that used an em-dash as a "no value" marker (not punctuation) now use explicit markers: `✗` in the installation capability matrix, `N/A` in the protocol-versions host-default row, `(none)` in eval-reporting's predicate table.
- Also fixes a pre-existing stale anchor in `installation.mdx` → `api-keys#playground-byok-not-an-mcpjam-key`.
- `openapi.json` edits are description-string-only; the route-parity drift test (`openapi-drift.test.ts`) passes 5/5.

## Verification

- Character-level scan confirms 0 em-dashes remain in `docs/**/*.mdx` + `openapi.json` outside the 4 quoted UI strings above.
- Em-dashes inside code blocks were audited one by one: all rewritten occurrences were doc-authored comments/formatting, never literal product output.
- No en-dashes or hyphens touched; diff is line-for-line (648/648).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced typographic em-dashes across documentation with clearer punctuation for consistency and readability, including `docs/reference/openapi.json`. Part 1 of UER-50; content only, no behavior changes.

- **Refactors**
  - Rewrote 643 em-dashes across 49 MDX pages and `openapi.json` using colons, commas, parentheses, or sentence splits as appropriate.
  - Kept 4 em-dashes that quote literal UI strings to avoid misquoting the product.
  - Replaced table “no value” glyphs with explicit markers (`✗`, `N/A`, `(none)`).
  - `openapi.json` edits are description-only; route-parity drift test still passes.

- **Bug Fixes**
  - Fixed a stale anchor in `installation.mdx` (now points to `api-keys#playground-byok-not-an-mcpjam-key`).

<sup>Written for commit 530f138f6bb35746389d1d8b21a833ad1ab8debc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

