### PR TITLE
feat(chat): parallelize tool execution within a step by default

### DIFF
--- a/mcpjam-inspector/shared/__tests__/http-tool-calls.test.ts
+++ b/mcpjam-inspector/shared/__tests__/http-tool-calls.test.ts
@@ -497,7 +497,7 @@ describe("executeToolCallsFromMessages", () => {
   });
 
   describe("multiple tool calls", () => {
-    it("executes multiple tool calls in sequence", async () => {
+    it("starts multiple tool calls in call order", async () => {
       const executionOrder: string[] = [];
       const tools = {
         tool_a: {
@@ -538,6 +538,214 @@ describe("executeToolCallsFromMessages", () => {
 
       expect(executionOrder).toEqual(["a", "b"]);
       expect(messages).toHaveLength(3);
+    });
+
+    it("executes tool calls within a step in parallel by default (HP-6)", async () => {
+      // tool_a only resolves when tool_b runs. Sequential execution would
+      // deadlock here (tool_b never starts until tool_a resolves); parallel
+      // execution completes.
+      let releaseA!: () => void;
+      const tools = {
+        tool_a: {
+          execute: () =>
+            new Promise<string>((resolve) => {
+              releaseA = () => resolve("a result");
+            }),
+        },
+        tool_b: {
+          execute: async () => {
+            releaseA();
+            return "b result";
+          },
+        },
+      };
+
+      const messages = [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "call-a",
+              toolName: "tool_a",
+              input: {},
+            },
+            {
+              type: "tool-call",
+              toolCallId: "call-b",
+              toolName: "tool_b",
+              input: {},
+            },
+          ],
+        },
+      ] as unknown as ModelMessage[];
+
+      const newMessages = await executeToolCallsFromMessages(messages, {
+        tools,
+      });
+
+      // Results stay in call order even though tool_b finished first.
+      expect(newMessages).toHaveLength(2);
+      expect((newMessages[0] as any).content[0].toolCallId).toBe("call-a");
+      expect((newMessages[1] as any).content[0].toolCallId).toBe("call-b");
+      expect(messages).toHaveLength(3);
+      expect((messages[1] as any).content[0].toolCallId).toBe("call-a");
+      expect((messages[2] as any).content[0].toolCallId).toBe("call-b");
+    });
+
+    it("isolates per-call failures in parallel execution", async () => {
+      let releaseSlow!: () => void;
+      const tools = {
+        slow_ok: {
+          execute: () =>
+            new Promise<string>((resolve) => {
+              releaseSlow = () => resolve("slow ok");
+            }),
+        },
+        fast_fail: {
+          execute: async () => {
+            releaseSlow();
+            throw new Error("fast one failed");
+          },
+        },
+      };
+
+      const messages = [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "call-slow",
+              toolName: "slow_ok",
+              input: {},
+            },
+            {
+              type: "tool-call",
+              toolCallId: "call-fail",
+              toolName: "fast_fail",
+              input: {},
+            },
+          ],
+        },
+      ] as unknown as ModelMessage[];
+
+      const newMessages = await executeToolCallsFromMessages(messages, {
+        tools,
+      });
+
+      expect(newMessages).toHaveLength(2);
+      expect((newMessages[0] as any).content[0].toolCallId).toBe("call-slow");
+      expect((newMessages[0] as any).content[0].output).toEqual({
+        type: "text",
+        value: "slow ok",
+      });
+      expect((newMessages[1] as any).content[0].toolCallId).toBe("call-fail");
+      expect((newMessages[1] as any).content[0].output.type).toBe(
+        "error-text"
+      );
+      expect((newMessages[1] as any).content[0].output.value).toBe(
+        "fast one failed"
+      );
+    });
+
+    it("runs strictly sequentially when parallelToolExecution is false", async () => {
+      const events: string[] = [];
+      const tools = {
+        tool_a: {
+          execute: async () => {
+            events.push("a:start");
+            await new Promise((resolve) => setTimeout(resolve, 5));
+            events.push("a:end");
+            return "a";
+          },
+        },
+        tool_b: {
+          execute: async () => {
+            events.push("b:start");
+            return "b";
+          },
+        },
+      };
+
+      const messages = [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "call-a",
+              toolName: "tool_a",
+              input: {},
+            },
+            {
+              type: "tool-call",
+              toolCallId: "call-b",
+              toolName: "tool_b",
+              input: {},
+            },
+          ],
+        },
+      ] as unknown as ModelMessage[];
+
+      await executeToolCallsFromMessages(messages, {
+        tools,
+        parallelToolExecution: false,
+      });
+
+      // tool_b must not start until tool_a fully resolved.
+      expect(events).toEqual(["a:start", "a:end", "b:start"]);
+    });
+
+    it("propagates an abort from one parallel call without persisting sibling results", async () => {
+      const controller = new AbortController();
+      let releaseSlow!: () => void;
+      const tools = {
+        slow_ok: {
+          execute: () =>
+            new Promise<string>((resolve) => {
+              releaseSlow = () => resolve("slow ok");
+            }),
+        },
+        aborter: {
+          execute: async () => {
+            controller.abort();
+            releaseSlow();
+            return "resolved after abort";
+          },
+        },
+      };
+
+      const messages = [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "call-slow",
+              toolName: "slow_ok",
+              input: {},
+            },
+            {
+              type: "tool-call",
+              toolCallId: "call-abort",
+              toolName: "aborter",
+              input: {},
+            },
+          ],
+        },
+      ] as unknown as ModelMessage[];
+
+      await expect(
+        executeToolCallsFromMessages(messages, {
+          tools,
+          abortSignal: controller.signal,
+        })
+      ).rejects.toMatchObject({ name: "AbortError" });
+
+      // Neither the aborted call nor its sibling persisted a result.
+      expect(messages).toHaveLength(1);
+      expect(messages[0].role).toBe("assistant");
     });
   });
 

--- a/mcpjam-inspector/shared/http-tool-calls.ts
+++ b/mcpjam-inspector/shared/http-tool-calls.ts
@@ -159,6 +159,15 @@ type ExecuteToolCallOptionsBase = {
    * `tool.execute is not a function`, corrupting the conversation history.
    */
   skipNonExecutableTools?: boolean;
+  /**
+   * Execute independent tool calls within a step concurrently. Defaults to
+   * true, so every hostconfig-driven engine sharing this executor gets
+   * parallel execution by default; a step emitting N calls costs one
+   * slowest-call latency instead of the sum. Pass `false` to restore strict
+   * sequential order for tools whose side effects depend on earlier calls
+   * in the same step.
+   */
+  parallelToolExecution?: boolean;
   /** Host/client policy for eligible MCP tool-result content/resources. */
   modelVisibleMcpToolResults?: McpModelVisibleToolResultPolicy["modelVisibleMcpToolResults"];
   /**
@@ -293,6 +302,12 @@ export async function executeToolCallsFromMessages(
   const resultsByAssistantIdx = new Map<number, ModelMessage[]>();
   const allNewResults: ModelMessage[] = [];
 
+  // Collect every unresolved tool call first, then execute. Calls within a
+  // step are independent by contract (the model emitted them in one step),
+  // so they run concurrently by default — a step emitting N calls costs one
+  // slowest-call latency instead of the sum (HP-6). Results are assembled in
+  // call order below, so history ordering is identical either way.
+  const pendingToolCalls: Array<{ assistantIdx: number; content: any }> = [];
   for (let i = 0; i < messages.length; i++) {
     const msg = messages[i];
     if (
@@ -308,253 +323,280 @@ export async function executeToolCallsFromMessages(
         (!options.filterToolName ||
           options.filterToolName(content.toolName as string))
       ) {
-        throwIfAborted(signal);
-        try {
-          const toolName: string = content.toolName;
-          const tool = index[toolName];
-          const directTool = tools[toolName];
-          const serverId = extractServerId(toolName);
-          const readResource = buildLinkedResourceReader(serverId);
-          if (!tool) {
-            if (
-              isSkippableClientFulfilledToolCall(
-                toolName,
-                directTool,
-                options.skipNonExecutableTools
-              )
-            ) {
-              continue;
-            }
-            throw new Error(`Tool '${toolName}' not found`);
-          }
-          if (typeof tool.execute !== "function") {
-            if (
-              isSkippableClientFulfilledToolCall(
-                toolName,
-                tool,
-                options.skipNonExecutableTools
-              )
-            ) {
-              continue;
-            }
-            throw new Error(`Tool '${toolName}' has no execute function`);
-          }
-          const toolCall = content as {
-            input?: unknown;
-            args?: unknown;
-          };
-          const input = toolCall.input ?? toolCall.args ?? {};
-          const result = await tool.execute(input, {
-            toolCallId: content.toolCallId,
-            messages,
-            ...(signal ? { abortSignal: signal } : {}),
-          });
-
-          // If a tool ignored the signal (or returned `result` after the
-          // signal fired) the result must NOT be serialized into a
-          // tool-result — that would persist into conversation history
-          // and look like a completed tool call to the next turn.
-          throwIfAborted(signal);
-
-          // AI SDK tool contract: when a tool defines `toModelOutput`, the
-          // model-visible output is its mapping of the implementation result
-          // — e.g. the eval `computer` tool turns `{screenshotBase64}` into
-          // `{type:"content", value:[{type:"media",…}]}` so the AI SDK
-          // can convert it to provider-level image data and make it model-visible.
-          // Generic toModelOutput tools (like the eval `computer` tool) do not
-          // duplicate raw implementation output, because content outputs can
-          // already carry large model-facing payloads. SDK-converted MCP tools
-          // opt in to preserving the raw result for UI/debug hydration.
-          const toModelOutput = (
-            tool as {
-              toModelOutput?: (ctx: {
-                output: unknown;
-                abortSignal?: AbortSignal;
-              }) => ToolResultPart | Promise<ToolResultPart>;
-            }
-          ).toModelOutput;
-          if (typeof toModelOutput === "function") {
-            const mappedOutput = await toModelOutput({
-              output: result,
-              ...(signal ? { abortSignal: signal } : {}),
-            });
-            throwIfAborted(signal);
-            const providerOptions = mergeMcpToolOriginMetadata(
-              undefined,
-              serverId
-            );
-            // MCP App tools scrub structuredContent from the model-facing copy
-            // (`mappedOutput`), but their widgets read structuredContent from
-            // the raw result. Preserve the raw result for UI hydration whenever
-            // it carries structuredContent — the model copy no longer does.
-            // Other toModelOutput tools (e.g. the eval `computer` tool) return
-            // no structuredContent, so they keep omitting `result:` and don't
-            // bloat subsequent per-step request bodies with large content.
-            const rawHasStructuredContent =
-              !!result &&
-              typeof result === "object" &&
-              "structuredContent" in (result as Record<string, unknown>);
-            const preserveRawResultForUi = shouldPreserveRawResultForUi(tool);
-            const toolResultMessage: ModelMessage = {
-              role: "tool" as const,
-              content: [
-                {
-                  type: "tool-result",
-                  toolCallId: content.toolCallId,
-                  toolName: toolName,
-                  output: mappedOutput,
-                  // UI-only raw result for app-tool widgets (stripped from the
-                  // model copy via `output`/toModelOutput above).
-                  ...(rawHasStructuredContent || preserveRawResultForUi
-                    ? { result }
-                    : {}),
-                  serverId,
-                  ...(providerOptions ? { providerOptions } : {}),
-                },
-              ],
-            } as any;
-            if (!resultsByAssistantIdx.has(i)) resultsByAssistantIdx.set(i, []);
-            resultsByAssistantIdx.get(i)!.push(toolResultMessage);
-            allNewResults.push(toolResultMessage);
-            continue;
-          }
-
-          let output: ToolResultPart;
-          if (result !== undefined && result !== null) {
-            if (typeof result === "object") {
-              const mcpOutput = await maybeMcpModelOutput(result, {
-                modelVisibleMcpToolResults: options.modelVisibleMcpToolResults,
-                readResource,
-                abortSignal: signal,
-              });
-              throwIfAborted(signal);
-              if (mcpOutput) {
-                output = mcpOutput;
-              } else {
-                const serialized = serializeToolResult(result);
-                if (serialized.success) {
-                  output = { type: "json", value: serialized.value } as any;
-                } else {
-                  output = {
-                    type: "text",
-                    value: serialized.fallbackText,
-                  } as any;
-                }
-              }
-            } else {
-              output = { type: "text", value: String(result) } as any;
-            }
-          } else {
-            output = { type: "json", value: null } as any;
-          }
-
-          // For MCP app tools, scrub _meta and structuredContent from the
-          // output that goes to the LLM, while preserving the full result
-          // for the UI.
-          let llmOutput = output;
-          if (
-            "clientManager" in options &&
-            serverId &&
-            result &&
-            typeof result === "object"
-          ) {
-            const toolsMetadata =
-              options.clientManager.getAllToolsMetadata(serverId);
-            const toolMeta = toolsMetadata[toolName];
-            if (isMcpAppTool(toolMeta)) {
-              const scrubbed = scrubMetaAndStructuredContentFromToolResult(
-                result as any
-              );
-              const scrubbedMcpOutput = await maybeMcpModelOutput(scrubbed, {
-                modelVisibleMcpToolResults: options.modelVisibleMcpToolResults,
-                readResource,
-                abortSignal: signal,
-              });
-              throwIfAborted(signal);
-              if (scrubbedMcpOutput) {
-                llmOutput = scrubbedMcpOutput;
-              } else {
-                const scrubbedSerialized = serializeToolResult(scrubbed);
-                if (scrubbedSerialized.success) {
-                  llmOutput = {
-                    type: "json",
-                    value: scrubbedSerialized.value,
-                  } as any;
-                }
-              }
-            }
-          }
-
-          throwIfAborted(signal);
-
-          const toolResultMessage: ModelMessage = {
-            role: "tool" as const,
-            content: [
-              {
-                type: "tool-result",
-                toolCallId: content.toolCallId,
-                toolName: toolName,
-                output: llmOutput,
-                // Preserve full result including _meta for UI hydration
-                result: result,
-                // Add serverId for OpenAI component resolution
-                serverId,
-                ...(serverId
-                  ? {
-                      providerOptions: mergeMcpToolOriginMetadata(
-                        undefined,
-                        serverId
-                      ),
-                    }
-                  : {}),
-              },
-            ],
-          } as any;
-          if (!resultsByAssistantIdx.has(i)) resultsByAssistantIdx.set(i, []);
-          resultsByAssistantIdx.get(i)!.push(toolResultMessage);
-          allNewResults.push(toolResultMessage);
-        } catch (error: any) {
-          // Abort errors must propagate — they represent user/client
-          // cancellation, NOT a tool failure. Capturing them as an
-          // error-text result would persist a phantom "tool failed" into
-          // conversation history.
-          if (isAbortError(error)) {
-            throw error;
-          }
-          // -32042: the server wants an out-of-band interaction first. Surface
-          // the URLs structurally to the UI and give the model an actionable
-          // retry hint instead of a raw protocol error it can't interpret.
-          // Surfacing the URL to the UI is the tool wrapper's job (see
-          // `web-chat-turn`), which sits on the shared tool set and therefore
-          // fires for every engine. Here we only reshape the model-visible
-          // result so it gets an actionable retry hint instead of a raw
-          // protocol error.
-          const urlElicitations = readUrlElicitations(error);
-          const errorOutput: ToolResultPart = {
-            type: "error-text",
-            value: urlElicitations
-              ? "This tool needs the user to complete an interaction at a URL first. The user has been shown the link and may complete it out of band. Retry this tool once they confirm they're done."
-              : error instanceof Error
-                ? error.message
-                : String(error),
-          } as any;
-          const errorToolResultMessage: ModelMessage = {
-            role: "tool" as const,
-            content: [
-              {
-                type: "tool-result",
-                toolCallId: content.toolCallId,
-                toolName: content.toolName,
-                output: errorOutput,
-              },
-            ],
-          } as any;
-          if (!resultsByAssistantIdx.has(i)) resultsByAssistantIdx.set(i, []);
-          resultsByAssistantIdx.get(i)!.push(errorToolResultMessage);
-          allNewResults.push(errorToolResultMessage);
-        }
+        pendingToolCalls.push({ assistantIdx: i, content });
       }
     }
+  }
+
+  // Executes one tool call to completion. Returns the tool-result message to
+  // insert, or null when the call must stay unresolved (skipNonExecutableTools
+  // client-fulfilled contract). Aborts throw; every other error is captured
+  // as an error-text tool-result.
+  const executeSingleToolCall = async (
+    content: any
+  ): Promise<ModelMessage | null> => {
+    throwIfAborted(signal);
+    try {
+      const toolName: string = content.toolName;
+      const tool = index[toolName];
+      const directTool = tools[toolName];
+      const serverId = extractServerId(toolName);
+      const readResource = buildLinkedResourceReader(serverId);
+      if (!tool) {
+        if (
+          isSkippableClientFulfilledToolCall(
+            toolName,
+            directTool,
+            options.skipNonExecutableTools
+          )
+        ) {
+          return null;
+        }
+        throw new Error(`Tool '${toolName}' not found`);
+      }
+      if (typeof tool.execute !== "function") {
+        if (
+          isSkippableClientFulfilledToolCall(
+            toolName,
+            tool,
+            options.skipNonExecutableTools
+          )
+        ) {
+          return null;
+        }
+        throw new Error(`Tool '${toolName}' has no execute function`);
+      }
+      const toolCall = content as {
+        input?: unknown;
+        args?: unknown;
+      };
+      const input = toolCall.input ?? toolCall.args ?? {};
+      const result = await tool.execute(input, {
+        toolCallId: content.toolCallId,
+        messages,
+        ...(signal ? { abortSignal: signal } : {}),
+      });
+
+      // If a tool ignored the signal (or returned `result` after the
+      // signal fired) the result must NOT be serialized into a
+      // tool-result — that would persist into conversation history
+      // and look like a completed tool call to the next turn.
+      throwIfAborted(signal);
+
+      // AI SDK tool contract: when a tool defines `toModelOutput`, the
+      // model-visible output is its mapping of the implementation result
+      // — e.g. the eval `computer` tool turns `{screenshotBase64}` into
+      // `{type:"content", value:[{type:"media",…}]}` so the AI SDK
+      // can convert it to provider-level image data and make it model-visible.
+      // Generic toModelOutput tools (like the eval `computer` tool) do not
+      // duplicate raw implementation output, because content outputs can
+      // already carry large model-facing payloads. SDK-converted MCP tools
+      // opt in to preserving the raw result for UI/debug hydration.
+      const toModelOutput = (
+        tool as {
+          toModelOutput?: (ctx: {
+            output: unknown;
+            abortSignal?: AbortSignal;
+          }) => ToolResultPart | Promise<ToolResultPart>;
+        }
+      ).toModelOutput;
+      if (typeof toModelOutput === "function") {
+        const mappedOutput = await toModelOutput({
+          output: result,
+          ...(signal ? { abortSignal: signal } : {}),
+        });
+        throwIfAborted(signal);
+        const providerOptions = mergeMcpToolOriginMetadata(
+          undefined,
+          serverId
+        );
+        // MCP App tools scrub structuredContent from the model-facing copy
+        // (`mappedOutput`), but their widgets read structuredContent from
+        // the raw result. Preserve the raw result for UI hydration whenever
+        // it carries structuredContent — the model copy no longer does.
+        // Other toModelOutput tools (e.g. the eval `computer` tool) return
+        // no structuredContent, so they keep omitting `result:` and don't
+        // bloat subsequent per-step request bodies with large content.
+        const rawHasStructuredContent =
+          !!result &&
+          typeof result === "object" &&
+          "structuredContent" in (result as Record<string, unknown>);
+        const preserveRawResultForUi = shouldPreserveRawResultForUi(tool);
+        return {
+          role: "tool" as const,
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: content.toolCallId,
+              toolName: toolName,
+              output: mappedOutput,
+              // UI-only raw result for app-tool widgets (stripped from the
+              // model copy via `output`/toModelOutput above).
+              ...(rawHasStructuredContent || preserveRawResultForUi
+                ? { result }
+                : {}),
+              serverId,
+              ...(providerOptions ? { providerOptions } : {}),
+            },
+          ],
+        } as any;
+      }
+
+      let output: ToolResultPart;
+      if (result !== undefined && result !== null) {
+        if (typeof result === "object") {
+          const mcpOutput = await maybeMcpModelOutput(result, {
+            modelVisibleMcpToolResults: options.modelVisibleMcpToolResults,
+            readResource,
+            abortSignal: signal,
+          });
+          throwIfAborted(signal);
+          if (mcpOutput) {
+            output = mcpOutput;
+          } else {
+            const serialized = serializeToolResult(result);
+            if (serialized.success) {
+              output = { type: "json", value: serialized.value } as any;
+            } else {
+              output = {
+                type: "text",
+                value: serialized.fallbackText,
+              } as any;
+            }
+          }
+        } else {
+          output = { type: "text", value: String(result) } as any;
+        }
+      } else {
+        output = { type: "json", value: null } as any;
+      }
+
+      // For MCP app tools, scrub _meta and structuredContent from the
+      // output that goes to the LLM, while preserving the full result
+      // for the UI.
+      let llmOutput = output;
+      if (
+        "clientManager" in options &&
+        serverId &&
+        result &&
+        typeof result === "object"
+      ) {
+        const toolsMetadata =
+          options.clientManager.getAllToolsMetadata(serverId);
+        const toolMeta = toolsMetadata[toolName];
+        if (isMcpAppTool(toolMeta)) {
+          const scrubbed = scrubMetaAndStructuredContentFromToolResult(
+            result as any
+          );
+          const scrubbedMcpOutput = await maybeMcpModelOutput(scrubbed, {
+            modelVisibleMcpToolResults: options.modelVisibleMcpToolResults,
+            readResource,
+            abortSignal: signal,
+          });
+          throwIfAborted(signal);
+          if (scrubbedMcpOutput) {
+            llmOutput = scrubbedMcpOutput;
+          } else {
+            const scrubbedSerialized = serializeToolResult(scrubbed);
+            if (scrubbedSerialized.success) {
+              llmOutput = {
+                type: "json",
+                value: scrubbedSerialized.value,
+              } as any;
+            }
+          }
+        }
+      }
+
+      throwIfAborted(signal);
+
+      return {
+        role: "tool" as const,
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: content.toolCallId,
+            toolName: toolName,
+            output: llmOutput,
+            // Preserve full result including _meta for UI hydration
+            result: result,
+            // Add serverId for OpenAI component resolution
+            serverId,
+            ...(serverId
+              ? {
+                  providerOptions: mergeMcpToolOriginMetadata(
+                    undefined,
+                    serverId
+                  ),
+                }
+              : {}),
+          },
+        ],
+      } as any;
+    } catch (error: any) {
+      // Abort errors must propagate — they represent user/client
+      // cancellation, NOT a tool failure. Capturing them as an
+      // error-text result would persist a phantom "tool failed" into
+      // conversation history.
+      if (isAbortError(error)) {
+        throw error;
+      }
+      // -32042: the server wants an out-of-band interaction first. Surface
+      // the URLs structurally to the UI and give the model an actionable
+      // retry hint instead of a raw protocol error it can't interpret.
+      // Surfacing the URL to the UI is the tool wrapper's job (see
+      // `web-chat-turn`), which sits on the shared tool set and therefore
+      // fires for every engine. Here we only reshape the model-visible
+      // result so it gets an actionable retry hint instead of a raw
+      // protocol error.
+      const urlElicitations = readUrlElicitations(error);
+      const errorOutput: ToolResultPart = {
+        type: "error-text",
+        value: urlElicitations
+          ? "This tool needs the user to complete an interaction at a URL first. The user has been shown the link and may complete it out of band. Retry this tool once they confirm they're done."
+          : error instanceof Error
+            ? error.message
+            : String(error),
+      } as any;
+      return {
+        role: "tool" as const,
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: content.toolCallId,
+            toolName: content.toolName,
+            output: errorOutput,
+          },
+        ],
+      } as any;
+    }
+  };
+
+  // An abort rejection from any call propagates (Promise.all rejects, nothing
+  // below runs, no results are inserted) — matching sequential abort
+  // semantics, where the throw prevented the final splice.
+  let outcomes: Array<ModelMessage | null>;
+  if (options.parallelToolExecution === false) {
+    outcomes = [];
+    for (const pending of pendingToolCalls) {
+      outcomes.push(await executeSingleToolCall(pending.content));
+    }
+  } else {
+    outcomes = await Promise.all(
+      pendingToolCalls.map((pending) => executeSingleToolCall(pending.content))
+    );
+  }
+
+  // Assemble in original call order so history is deterministic regardless
+  // of completion order.
+  for (let k = 0; k < pendingToolCalls.length; k++) {
+    const outcome = outcomes[k];
+    if (!outcome) continue;
+    const { assistantIdx } = pendingToolCalls[k];
+    if (!resultsByAssistantIdx.has(assistantIdx))
+      resultsByAssistantIdx.set(assistantIdx, []);
+    resultsByAssistantIdx.get(assistantIdx)!.push(outcome);
+    allNewResults.push(outcome);
   }
 
   // Insert right after corresponding assistant messages (reverse order to preserve indices)


### PR DESCRIPTION
Closes HP-6 (Kestral): https://app.kestral.ai/workspace/yhNILB2/task/132OhPL3

## Problem

`executeToolCallsFromMessages` (`mcpjam-inspector/shared/http-tool-calls.ts`) ran unresolved tool calls in a sequential `for` + `await` loop. A step emitting N tool calls paid the **sum** of all call latencies. The "What is progressive tool disclosure?" latency trace flagged this as unnecessary overhead for any multi-tool step.

## Change

- Refactored the executor into collect → execute → assemble phases. Unresolved calls now run concurrently via `Promise.all` — one slowest-call latency per step.
- **Parallel is the default** for every hostconfig-driven engine sharing this executor (MCPJam free-model chat loop, progressive-discovery meta-tool pass, evals runner). `parallelToolExecution: false` opts back into strict sequential order for tools whose side effects depend on earlier calls in the same step.
- Results are assembled in original call order, so conversation history is byte-identical regardless of completion order.

## Invariants preserved

- **Abort:** an abort from any call rejects the whole pass before results are spliced into history — same as before, no phantom results persist. Post-`await` abort re-checks retained per call.
- **Per-call error isolation:** a failing tool still becomes an `error-text` tool-result without affecting sibling calls.
- **`skipNonExecutableTools` (SEP-1865):** client-fulfilled `app_*`/`ui_*` calls stay unresolved, never produce synthetic results.
- **`-32042` URL elicitation reshaping** unchanged.

## Testing

- 4 new tests: true-concurrency proof (deadlocks if sequential), call-order preservation with out-of-order completion, per-call failure isolation, `parallelToolExecution: false` strict ordering, and abort-during-parallel with sibling-result suppression.
- Full `shared/__tests__/http-tool-calls.test.ts` suite: 54/54 passing.
- Downstream consumers green: `mcpjam-stream-handler` (47), `chat-v2` routes (65), `assistant-turn` (4+7), `evals-runner` (80), `runner-parity` (27), snapshot (2).

https://github.com/user-attachments/assets/4a6765b8-b7e6-4af9-a22b-2f02c14b7ba7


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parallelizes tool calls within a single assistant step by default to cut latency to the slowest call, addressing HP-6. Keeps history order stable and preserves abort and error behavior.

- **New Features**
  - `executeToolCallsFromMessages` now runs intra-step tool calls concurrently via `Promise.all` (collect → execute → assemble).
  - Default applies to all hostconfig-driven engines using this executor; results are inserted in original call order.
  - Per-call failures stay isolated as `error-text`; abort from any call cancels the whole pass; `skipNonExecutableTools` behavior is unchanged.

- **Migration**
  - Set `parallelToolExecution: false` to enforce strict sequential order if a tool’s side effects depend on earlier calls in the same step.

<sup>Written for commit c7125ba1fce7b2511b596371d9da3fde1b0d2809. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

