### PR TITLE
feat(hp-10): OAuth full-capability reference MCP server + per-client capture

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "widget-react",
         "soundcheck",
         "quality-labeler",
-        "mcp"
+        "mcp",
+        "reference-servers/oauth-full"
       ],
       "dependencies": {
         "react-force-graph-2d": "^1.29.1"
@@ -868,7 +869,7 @@
       "version": "0.9.31",
       "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
       "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@adobe/css-tools": {
@@ -1687,7 +1688,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
       "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@csstools/css-calc": "^3.0.0",
@@ -1701,7 +1702,7 @@
       "version": "11.3.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
       "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -1711,7 +1712,7 @@
       "version": "6.8.1",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
       "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/nwsapi": "^2.3.9",
@@ -1725,7 +1726,7 @@
       "version": "11.3.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
       "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -1735,7 +1736,7 @@
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@aws-crypto/crc32": {
@@ -2925,7 +2926,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
       "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -2945,7 +2946,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
       "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -2969,7 +2970,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
       "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -2997,7 +2998,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
       "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -3020,7 +3021,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
       "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -3045,7 +3046,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
       "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -5285,7 +5286,7 @@
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
       "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
@@ -6809,7 +6810,7 @@
       "version": "0.3.11",
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
       "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -7096,6 +7097,10 @@
       "resolved": "mcp",
       "link": true
     },
+    "node_modules/@mcpjam/oauth-reference-server": {
+      "resolved": "reference-servers/oauth-full",
+      "link": true
+    },
     "node_modules/@mcpjam/sdk": {
       "resolved": "sdk",
       "link": true
@@ -7184,7 +7189,6 @@
       "version": "2.0.0-alpha.2",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/node/-/node-2.0.0-alpha.2.tgz",
       "integrity": "sha512-7DQS8Nf3d/9Cv85hEtDjDU2kQg3UPuxcNvMDAvub91OJe4LmWkD5ZTTb/isrPzGBd2x8/I78dz8RPz/tkpqGDQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9"
@@ -9022,7 +9026,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
       "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.59.1"
@@ -14345,7 +14349,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -14355,7 +14358,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -16897,7 +16900,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
       "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
@@ -17119,7 +17122,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/bundle-name": {
@@ -18232,7 +18235,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
       "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "mdn-data": "2.27.1",
@@ -18253,7 +18256,7 @@
       "version": "5.3.7",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
       "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/css-color": "^4.1.1",
@@ -18269,7 +18272,7 @@
       "version": "11.3.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
       "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -18840,7 +18843,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
       "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-mimetype": "^5.0.0",
@@ -18854,7 +18857,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
       "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -18951,7 +18954,7 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/decimal.js-light": {
@@ -20328,7 +20331,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -20339,7 +20341,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -23121,7 +23122,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
       "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@exodus/bytes": "^1.6.0"
@@ -23188,7 +23189,7 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.0",
@@ -23202,7 +23203,7 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -24015,7 +24016,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/is-promise": {
@@ -25418,7 +25419,7 @@
       "version": "27.4.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.4.0.tgz",
       "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
@@ -25458,7 +25459,7 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -25468,7 +25469,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -25482,7 +25483,7 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -25877,7 +25878,7 @@
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -25910,7 +25911,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -25931,7 +25931,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -25952,7 +25951,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -25973,7 +25971,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -25994,7 +25991,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -26015,7 +26011,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -26036,7 +26031,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -26057,7 +26051,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -26078,7 +26071,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -26099,7 +26091,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -26120,7 +26111,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -27039,7 +27029,7 @@
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "CC0-1.0"
     },
     "node_modules/media-typer": {
@@ -29790,7 +29780,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
       "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
@@ -30706,7 +30696,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -32129,7 +32119,7 @@
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -32221,7 +32211,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "xmlchars": "^2.2.0"
@@ -32895,7 +32885,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -32914,7 +32904,7 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -33611,7 +33601,7 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/synckit": {
@@ -33758,7 +33748,7 @@
       "version": "5.46.1",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.1.tgz",
       "integrity": "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -33842,7 +33832,7 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/test-exclude": {
@@ -34100,7 +34090,7 @@
       "version": "7.0.28",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
       "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "tldts-core": "^7.0.28"
@@ -34113,7 +34103,7 @@
       "version": "7.0.28",
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
       "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/tmp": {
@@ -34217,7 +34207,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
       "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tldts": "^7.0.5"
@@ -34230,7 +34220,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
       "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
@@ -34578,7 +34568,7 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -34761,7 +34751,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -35774,7 +35764,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
       "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "xml-name-validator": "^5.0.0"
@@ -35850,7 +35840,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
       "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=20"
@@ -35955,7 +35945,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
       "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -35965,7 +35955,7 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
       "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "^6.0.0",
@@ -36836,7 +36826,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
       "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
@@ -36856,7 +36846,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/xpath": {
@@ -37070,6 +37060,39 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "reference-servers/oauth-full": {
+      "name": "@mcpjam/oauth-reference-server",
+      "version": "0.1.0",
+      "dependencies": {
+        "@modelcontextprotocol/node": "2.0.0-alpha.2",
+        "@modelcontextprotocol/server": "2.0.0-alpha.2",
+        "jose": "^5.10.0",
+        "zod": "^4.1.12"
+      },
+      "devDependencies": {
+        "@types/node": "^22.9.0",
+        "tsx": "^4.19.2",
+        "typescript": "^5.6.3",
+        "vitest": "^3.0.0"
+      }
+    },
+    "reference-servers/oauth-full/node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "reference-servers/oauth-full/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "sdk": {
       "name": "@mcpjam/sdk",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "widget-react",
     "soundcheck",
     "quality-labeler",
-    "mcp"
+    "mcp",
+    "reference-servers/oauth-full"
   ],
   "scripts": {
     "build": "npm run build -w @mcpjam/sdk && npm run build -w @mcpjam/cli && npm run build -w @mcpjam/chat-ui && npm run build -w @mcpjam/widget-react && npm run build -w @mcpjam/inspector",

--- a/reference-servers/oauth-full/.gitignore
+++ b/reference-servers/oauth-full/.gitignore
@@ -1,0 +1,2 @@
+captures/
+RESULTS.md

--- a/reference-servers/oauth-full/README.md
+++ b/reference-servers/oauth-full/README.md
@@ -1,0 +1,49 @@
+# OAuth reference MCP server (HP-10)
+
+A full-capability MCP server — tools, resources (static / binary / templates / subscribable), prompts, MCP Apps UI, logging, progress, completions, and **elicitation** — gated behind an embedded OAuth 2.1 authorization server. Built to validate, per MCP client, which auth flows actually work, and to **record** how each client performs the handshake.
+
+The embedded AS exercises the full auth surface:
+
+| Surface | Endpoint / behavior |
+|---|---|
+| Protected resource metadata (RFC 9728) | `/.well-known/oauth-protected-resource[/mcp]` + `WWW-Authenticate: … resource_metadata=…` on 401 |
+| AS metadata (RFC 8414 + OIDC) | `/.well-known/oauth-authorization-server[/mcp]`, `/.well-known/openid-configuration` |
+| Dynamic Client Registration (RFC 7591) | `POST /register` — real client store, redirect_uri pinning |
+| CIMD (draft-ietf-oauth-client-id-metadata-document) | `client_id` may be an HTTPS URL; the document is fetched and validated |
+| PKCE (RFC 7636) | S256 **validated**, `plain` rejected; PKCE required by default |
+| Authorization code + refresh | `/authorize` (auto-approve or `--consent`), `/token`; refresh **rotation** with reuse detection |
+| Resource indicators (RFC 8707) | `resource` recorded at authorize/token/refresh; `--require-resource` for strict mode |
+| XAA / ID-JAG (RFC 7523 redemption) | `grant_type=jwt-bearer` verified against `--xaa-issuer`'s JWKS |
+
+Every request is captured into a per-run report that derives the client's OAuth traits and an HP-1-shaped `HostConfigOAuthProfileV1` — the data HP-10 exists to produce.
+
+## Run it
+
+```bash
+# from the repo root (one-time: npm install)
+npm run start -w @mcpjam/oauth-reference-server -- --label mcpjam
+```
+
+Server comes up at `http://localhost:4747` (landing page has live status). Useful flags: `--port`, `--public-url <tunnel-url>`, `--access-ttl 60` (force refresh mid-session), `--no-dcr`, `--require-resource`, `--allow-no-pkce`, `--consent`, `--xaa-issuer <url>`. `--help` for all.
+
+A preregistered client (`oauth-ref-preregistered` / `oauth-ref-preregistered-secret`) exists for clients without DCR support.
+
+## Capture workflow (per client)
+
+1. Label the run: start with `--label <client>` or `curl -X POST localhost:4747/capture/reset -d '{"label":"cursor"}'` (flushes the previous run to `captures/<label>.json`).
+2. Connect the client to `http://localhost:4747/mcp` (or your `--public-url`), complete OAuth, then exercise tools / resources / prompts — including `test_elicitation` and `whoami`.
+3. Flush: `curl -X POST localhost:4747/capture/flush` (also happens on Ctrl-C).
+4. After all clients: `npm run matrix -w @mcpjam/oauth-reference-server` → `RESULTS.md` (client × feature matrix, failure categories, paste-ready `oauthProfile` blocks).
+
+Live inspection: `GET /capture/report`.
+
+## Per-client notes (the 10 catalog clients)
+
+- **mcpjam** — Inspector OAuth debugger (`/oauth-flow`) against `http://localhost:4747/mcp`, all three protocol versions × registration strategies; or CLI: `mcpjam oauth conformance --url http://localhost:4747/mcp`.
+- **claude / chatgpt / mistral / slack** — remote-hosted clients need a public HTTPS URL: `cloudflared tunnel --url http://localhost:4747` (or ngrok), then restart with `--public-url https://<tunnel-host>` and add the connector in the client's UI.
+- **cursor / vscode / copilot / goose / codex** — local clients: add `http://localhost:4747/mcp` as a remote/HTTP MCP server in each client's MCP config; localhost HTTP is allowed.
+- Failure taxonomy is derived automatically per capture: `no-oauth-attempt`, `discovery-only`, `broken-redirect-or-exchange`, `no-pkce`, `no-prm-discovery` (same-origin assumption), `token-refresh-failed`, `refresh-rotation-unsupported`, `token-unused`.
+
+## Encoding findings
+
+Each capture's `oauthProfile` block matches HP-1's `HostConfigOAuthProfileV1` (authClass, sendsResourceParam, asEndpointDiscovery, scopeRequestPolicy, registrationStrategy, dcrIdentity), with run evidence under `extensions["mcpjam.dev/hp10"]`. Once HP-1's SDK/backend PRs land, these paste into the host catalog seed / per-host `oauthProfile`; until then, `RESULTS.md` is the source of truth to attach to the task.

--- a/reference-servers/oauth-full/package.json
+++ b/reference-servers/oauth-full/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@mcpjam/oauth-reference-server",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Full-capability reference MCP server gated behind OAuth, with per-client handshake capture (HP-10).",
+  "type": "module",
+  "scripts": {
+    "start": "tsx src/index.ts",
+    "dev": "tsx watch src/index.ts",
+    "typecheck": "tsc --noEmit",
+    "matrix": "node scripts/build-matrix.mjs",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/node": "2.0.0-alpha.2",
+    "@modelcontextprotocol/server": "2.0.0-alpha.2",
+    "jose": "^5.10.0",
+    "zod": "^4.1.12"
+  },
+  "devDependencies": {
+    "@types/node": "^22.9.0",
+    "tsx": "^4.19.2",
+    "typescript": "^5.6.3",
+    "vitest": "^3.0.0"
+  }
+}

--- a/reference-servers/oauth-full/scripts/build-matrix.mjs
+++ b/reference-servers/oauth-full/scripts/build-matrix.mjs
@@ -1,0 +1,97 @@
+// Merge captures/*.json into RESULTS.md — the HP-10 client × OAuth-feature matrix.
+import { readdirSync, readFileSync, writeFileSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const capturesDir = process.argv[2] ?? join(here, "..", "captures");
+const outFile = process.argv[3] ?? join(here, "..", "RESULTS.md");
+
+// Canonical HP-10 client order; captures with other labels are appended.
+const CLIENT_ORDER = [
+  "mcpjam", "claude", "chatgpt", "mistral", "goose",
+  "slack", "cursor", "codex", "copilot", "vscode",
+];
+
+if (!existsSync(capturesDir)) {
+  console.error(`No captures directory at ${capturesDir}. Run the reference server first.`);
+  process.exit(1);
+}
+
+const reports = readdirSync(capturesDir)
+  .filter((f) => f.endsWith(".json"))
+  .map((f) => JSON.parse(readFileSync(join(capturesDir, f), "utf8")));
+
+reports.sort((a, b) => {
+  const ia = CLIENT_ORDER.indexOf(a.label);
+  const ib = CLIENT_ORDER.indexOf(b.label);
+  return (ia === -1 ? 99 : ia) - (ib === -1 ? 99 : ib) || a.label.localeCompare(b.label);
+});
+
+const yn = (v) => (v === true ? "✅" : v === false ? "❌" : "—");
+
+const FEATURES = [
+  ["Completed flow", (r) => yn(r.traits.completedFlow)],
+  ["PRM discovery (RFC 9728)", (r) => yn(r.traits.discovery.fetchedProtectedResourceMetadata)],
+  ["AS metadata format", (r) => r.traits.discovery.asMetadataFormat],
+  ["Registration", (r) => r.traits.registration.strategy],
+  ["DCR client_name", (r) => r.traits.registration.dcrIdentity?.clientName ?? "—"],
+  ["PKCE", (r) => (r.traits.authorization.usedPkce ? r.traits.authorization.pkceMethod ?? "yes" : "❌")],
+  ["state param", (r) => yn(r.traits.authorization.sentState)],
+  ["resource param (authorize)", (r) => yn(r.traits.authorization.sendsResourceParamAuthorize)],
+  ["resource param (token)", (r) => yn(r.traits.token.sendsResourceParamToken)],
+  ["Scope policy", (r) => r.traits.authorization.scopeRequestPolicy],
+  ["Redirect URI kind", (r) => r.traits.authorization.redirectUriKind],
+  ["Token endpoint auth", (r) => r.traits.token.tokenEndpointAuthMethod],
+  ["Refresh works", (r) => (r.traits.token.refreshAttempted ? yn(r.traits.token.refreshSucceeded) : "not attempted")],
+  ["XAA / ID-JAG", (r) => yn(r.traits.token.usedJwtBearerIdJag)],
+  ["Exercised tools", (r) => yn(r.traits.capabilityExercise.calledTools)],
+  ["Exercised resources", (r) => yn(r.traits.capabilityExercise.calledResources)],
+  ["Exercised prompts", (r) => yn(r.traits.capabilityExercise.calledPrompts)],
+  ["Elicitation answered", (r) => yn(r.traits.capabilityExercise.respondedToElicitation)],
+];
+
+const lines = [];
+lines.push("# HP-10 results matrix — client × OAuth feature");
+lines.push("");
+lines.push(`Generated ${new Date().toISOString()} from ${reports.length} capture(s) in \`${capturesDir}\`.`);
+lines.push("");
+lines.push(`| Feature | ${reports.map((r) => `**${r.label}**`).join(" | ")} |`);
+lines.push(`|---|${reports.map(() => "---").join("|")}|`);
+for (const [name, get] of FEATURES) {
+  lines.push(`| ${name} | ${reports.map((r) => String(get(r))).join(" | ")} |`);
+}
+lines.push("");
+lines.push("## Failure categories per client");
+lines.push("");
+for (const r of reports) {
+  lines.push(`### ${r.label}`);
+  lines.push("");
+  if (r.traits.failures.length === 0) {
+    lines.push("- none observed");
+  } else {
+    for (const f of r.traits.failures) lines.push(`- ${f}`);
+  }
+  lines.push("");
+}
+lines.push("## Derived oauthProfile (HP-1 `HostConfigOAuthProfileV1`) per client");
+lines.push("");
+lines.push("Paste-ready values for the host catalog seed / backend `oauthProfile` once HP-1's PRs land.");
+lines.push("");
+for (const r of reports) {
+  lines.push(`### ${r.label}`);
+  lines.push("");
+  lines.push("```json");
+  lines.push(JSON.stringify(r.oauthProfile, null, 2));
+  lines.push("```");
+  lines.push("");
+}
+
+const missing = CLIENT_ORDER.filter((c) => !reports.some((r) => r.label === c));
+if (missing.length) {
+  lines.push(`> Still missing captures for: ${missing.join(", ")}`);
+  lines.push("");
+}
+
+writeFileSync(outFile, lines.join("\n"));
+console.log(`Wrote ${outFile} (${reports.length} clients, ${missing.length} missing)`);

--- a/reference-servers/oauth-full/src/capture.ts
+++ b/reference-servers/oauth-full/src/capture.ts
@@ -1,0 +1,406 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  CHALLENGE_SCOPES,
+  SUPPORTED_SCOPES,
+  type ReferenceServerConfig,
+} from "./config.js";
+
+/** One observed interaction with the reference server. Bodies/params are
+ * pre-redacted by the caller — never store secrets, codes, or tokens. */
+export interface CaptureEvent {
+  ts: string;
+  kind:
+    | "prm_discovery"
+    | "as_metadata_discovery"
+    | "dcr_registration"
+    | "cimd_fetch"
+    | "authorize"
+    | "consent"
+    | "token_authorization_code"
+    | "token_refresh"
+    | "token_jwt_bearer"
+    | "token_error"
+    | "mcp_unauthenticated"
+    | "mcp_invalid_token"
+    | "mcp_request"
+    | "other";
+  method: string;
+  path: string;
+  status: number;
+  userAgent?: string;
+  detail?: Record<string, unknown>;
+}
+
+/** Derived per-client OAuth behavior — the data HP-10 exists to produce.
+ * Field vocabulary intentionally mirrors HostConfigOAuthProfileV1 (HP-1). */
+export interface DerivedTraits {
+  completedFlow: boolean;
+  discovery: {
+    fetchedProtectedResourceMetadata: boolean;
+    prmPathVariant: "path-suffixed" | "root" | "both" | "none";
+    asMetadataFormat: "oauth-authorization-server" | "openid-configuration" | "both" | "none";
+    asMetadataPathVariant: "path-suffixed" | "root" | "both" | "none";
+    triedUnauthenticatedFirst: boolean;
+  };
+  registration: {
+    strategy: "dcr" | "cimd" | "preregistered" | "none";
+    dcrIdentity?: {
+      clientName?: string;
+      clientUri?: string;
+      logoUri?: string;
+      redirectUris?: string[];
+      grantTypes?: string[];
+      tokenEndpointAuthMethod?: string;
+    };
+    cimdClientId?: string;
+  };
+  authorization: {
+    usedPkce: boolean;
+    pkceMethod?: string;
+    sentState: boolean;
+    sendsResourceParamAuthorize: boolean;
+    requestedScopes: string[];
+    scopeRequestPolicy: "all-advertised" | "challenge-derived" | "subset" | "none-requested" | "other";
+    redirectUriKind: "loopback" | "localhost" | "https" | "custom-scheme" | "other" | "none";
+    redirectUris: string[];
+  };
+  token: {
+    sendsResourceParamToken: boolean;
+    tokenEndpointAuthMethod: "none" | "client_secret_post" | "client_secret_basic" | "other" | "n/a";
+    refreshAttempted: boolean;
+    refreshSucceeded: boolean;
+    sendsResourceParamRefresh: boolean | null;
+    reusedRotatedRefreshToken: boolean;
+    usedJwtBearerIdJag: boolean;
+  };
+  capabilityExercise: {
+    mcpMethodsCalled: string[];
+    calledTools: boolean;
+    calledResources: boolean;
+    calledPrompts: boolean;
+    respondedToElicitation: boolean;
+  };
+  failures: string[];
+}
+
+/** HP-1 HostConfigOAuthProfileV1-shaped encoding of the derived traits,
+ * ready to paste into the host catalog seed / backend oauthProfile once
+ * HP-1's PRs land. */
+export interface OAuthProfileV1 {
+  profileVersion: 1;
+  authClass: "oauth" | "header-api-key" | "none";
+  sendsResourceParam?: boolean;
+  asEndpointDiscovery?: "prm" | "same-origin";
+  scopeRequestPolicy?: "all-advertised" | "challenge-derived";
+  registrationStrategy?: "cimd" | "dcr" | "preregistered";
+  dcrIdentity?: { clientName: string; clientUri?: string; logoUri?: string };
+  extensions?: Record<string, unknown>;
+}
+
+export interface CaptureReport {
+  label: string;
+  startedAt: string;
+  finishedAt: string;
+  serverConfig: {
+    publicUrl: string;
+    dcr: boolean;
+    refreshTokens: boolean;
+    requireResource: boolean;
+    requirePkce: boolean;
+    accessTokenTtl: number;
+    xaaEnabled: boolean;
+  };
+  traits: DerivedTraits;
+  oauthProfile: OAuthProfileV1;
+  events: CaptureEvent[];
+}
+
+const ADVERTISED = new Set<string>(SUPPORTED_SCOPES);
+const CHALLENGE = new Set<string>(CHALLENGE_SCOPES);
+
+function classifyScopes(requested: string[]): DerivedTraits["authorization"]["scopeRequestPolicy"] {
+  if (requested.length === 0) return "none-requested";
+  const set = new Set(requested);
+  if (set.size === ADVERTISED.size && [...set].every((s) => ADVERTISED.has(s))) {
+    return "all-advertised";
+  }
+  if (set.size === CHALLENGE.size && [...set].every((s) => CHALLENGE.has(s))) {
+    return "challenge-derived";
+  }
+  if ([...set].every((s) => ADVERTISED.has(s))) return "subset";
+  return "other";
+}
+
+function classifyRedirectUri(uri: string | undefined): DerivedTraits["authorization"]["redirectUriKind"] {
+  if (!uri) return "none";
+  try {
+    const url = new URL(uri);
+    if (url.protocol === "https:") return "https";
+    if (url.protocol === "http:") {
+      if (url.hostname === "127.0.0.1" || url.hostname === "[::1]") return "loopback";
+      if (url.hostname === "localhost") return "localhost";
+      return "other";
+    }
+    return "custom-scheme";
+  } catch {
+    return "other";
+  }
+}
+
+export class CaptureSession {
+  private events: CaptureEvent[] = [];
+  private startedAt = new Date().toISOString();
+  label: string;
+
+  constructor(
+    label: string,
+    private readonly config: ReferenceServerConfig,
+  ) {
+    this.label = label;
+  }
+
+  record(event: Omit<CaptureEvent, "ts">): void {
+    this.events.push({ ts: new Date().toISOString(), ...event });
+  }
+
+  eventCount(): number {
+    return this.events.length;
+  }
+
+  deriveTraits(): DerivedTraits {
+    const events = this.events;
+    const byKind = (kind: CaptureEvent["kind"]) => events.filter((e) => e.kind === kind);
+
+    const prm = byKind("prm_discovery");
+    const asMeta = byKind("as_metadata_discovery");
+    const dcr = byKind("dcr_registration").filter((e) => e.status < 400);
+    const cimd = byKind("cimd_fetch").filter((e) => e.status < 400);
+    const authorizes = byKind("authorize");
+    const codeGrants = byKind("token_authorization_code");
+    const okCodeGrants = codeGrants.filter((e) => e.status < 400);
+    const refreshes = byKind("token_refresh");
+    const jwtBearer = byKind("token_jwt_bearer").filter((e) => e.status < 400);
+    const mcpAuthed = byKind("mcp_request");
+
+    const pathVariant = (hits: CaptureEvent[]): "path-suffixed" | "root" | "both" | "none" => {
+      const suffixed = hits.some((e) => /\/mcp$/.test(e.path));
+      const root = hits.some((e) => !/\/mcp$/.test(e.path));
+      if (suffixed && root) return "both";
+      if (suffixed) return "path-suffixed";
+      if (root) return "root";
+      return "none";
+    };
+
+    const asFormat = ((): DerivedTraits["discovery"]["asMetadataFormat"] => {
+      const oauth = asMeta.some((e) => e.path.includes("oauth-authorization-server"));
+      const oidc = asMeta.some((e) => e.path.includes("openid-configuration"));
+      if (oauth && oidc) return "both";
+      if (oauth) return "oauth-authorization-server";
+      if (oidc) return "openid-configuration";
+      return "none";
+    })();
+
+    // Prefer the last authorize that actually redirected — clients often make
+    // failed attempts first, and the successful one is the representative
+    // sample of the client's behavior.
+    const lastAuthorize =
+      [...authorizes].reverse().find((e) => e.status === 302) ?? authorizes.at(-1);
+    const authDetail = (lastAuthorize?.detail ?? {}) as Record<string, unknown>;
+    const requestedScopes = (authDetail.scopes as string[]) ?? [];
+    const redirectUris = [
+      ...new Set(
+        authorizes
+          .map((e) => (e.detail as Record<string, unknown> | undefined)?.redirectUri)
+          .filter((u): u is string => typeof u === "string"),
+      ),
+    ];
+
+    const lastOkCodeGrant = okCodeGrants.at(-1);
+    const tokenDetail = (lastOkCodeGrant?.detail ?? {}) as Record<string, unknown>;
+
+    const registrationStrategy = ((): DerivedTraits["registration"]["strategy"] => {
+      if (cimd.length > 0) return "cimd";
+      if (dcr.length > 0) return "dcr";
+      if (authorizes.length > 0 || okCodeGrants.length > 0) return "preregistered";
+      return "none";
+    })();
+
+    const lastDcr = dcr.at(-1)?.detail as Record<string, unknown> | undefined;
+
+    const mcpMethods = [
+      ...new Set(
+        mcpAuthed
+          .map((e) => (e.detail as Record<string, unknown> | undefined)?.rpcMethod)
+          .filter((m): m is string => typeof m === "string"),
+      ),
+    ];
+
+    const failures: string[] = [];
+    if (authorizes.length === 0 && okCodeGrants.length === 0 && jwtBearer.length === 0) {
+      failures.push(
+        prm.length + asMeta.length > 0
+          ? "discovery-only: fetched metadata but never reached /authorize (possible metadata-handling or redirect gap)"
+          : "no-oauth-attempt: client never engaged the authorization server",
+      );
+    }
+    if (authorizes.length > 0 && okCodeGrants.length === 0) {
+      failures.push("broken-redirect-or-exchange: authorization started but no successful token exchange");
+    }
+    if (lastAuthorize && !(authDetail.pkce as boolean)) {
+      failures.push("no-pkce: authorization request omitted code_challenge");
+    }
+    if (prm.length === 0 && (authorizes.length > 0 || asMeta.length > 0)) {
+      failures.push("no-prm-discovery: skipped RFC 9728 protected-resource metadata (assumed same-origin AS)");
+    }
+    const refreshFailed = refreshes.length > 0 && !refreshes.some((e) => e.status < 400);
+    if (refreshFailed) {
+      failures.push("token-refresh-failed: refresh grant attempted but never succeeded");
+    }
+    const reusedRotated = refreshes.some(
+      (e) => (e.detail as Record<string, unknown> | undefined)?.reusedRotatedToken === true,
+    );
+    if (reusedRotated) {
+      failures.push("refresh-rotation-unsupported: client reused a rotated (invalidated) refresh token");
+    }
+    if (okCodeGrants.length > 0 && mcpAuthed.length === 0) {
+      failures.push("token-unused: obtained an access token but never called the MCP server with it");
+    }
+
+    return {
+      completedFlow: (okCodeGrants.length > 0 || jwtBearer.length > 0) && mcpAuthed.length > 0,
+      discovery: {
+        fetchedProtectedResourceMetadata: prm.length > 0,
+        prmPathVariant: pathVariant(prm),
+        asMetadataFormat: asFormat,
+        asMetadataPathVariant: pathVariant(asMeta),
+        triedUnauthenticatedFirst: byKind("mcp_unauthenticated").length > 0,
+      },
+      registration: {
+        strategy: registrationStrategy,
+        dcrIdentity: lastDcr
+          ? {
+              clientName: lastDcr.clientName as string | undefined,
+              clientUri: lastDcr.clientUri as string | undefined,
+              logoUri: lastDcr.logoUri as string | undefined,
+              redirectUris: lastDcr.redirectUris as string[] | undefined,
+              grantTypes: lastDcr.grantTypes as string[] | undefined,
+              tokenEndpointAuthMethod: lastDcr.tokenEndpointAuthMethod as string | undefined,
+            }
+          : undefined,
+        cimdClientId: (cimd.at(-1)?.detail as Record<string, unknown> | undefined)?.clientId as
+          | string
+          | undefined,
+      },
+      authorization: {
+        usedPkce: Boolean(authDetail.pkce),
+        pkceMethod: authDetail.pkceMethod as string | undefined,
+        sentState: Boolean(authDetail.state),
+        sendsResourceParamAuthorize: Boolean(authDetail.resource),
+        requestedScopes,
+        scopeRequestPolicy: classifyScopes(requestedScopes),
+        redirectUriKind: classifyRedirectUri(authDetail.redirectUri as string | undefined),
+        redirectUris,
+      },
+      token: {
+        sendsResourceParamToken: Boolean(tokenDetail.resource),
+        tokenEndpointAuthMethod:
+          (tokenDetail.authMethod as DerivedTraits["token"]["tokenEndpointAuthMethod"]) ??
+          (okCodeGrants.length > 0 ? "other" : "n/a"),
+        refreshAttempted: refreshes.length > 0,
+        refreshSucceeded: refreshes.some((e) => e.status < 400),
+        sendsResourceParamRefresh:
+          refreshes.length > 0
+            ? refreshes.some((e) => Boolean((e.detail as Record<string, unknown>)?.resource))
+            : null,
+        reusedRotatedRefreshToken: reusedRotated,
+        usedJwtBearerIdJag: jwtBearer.length > 0,
+      },
+      capabilityExercise: {
+        mcpMethodsCalled: mcpMethods,
+        calledTools: mcpMethods.some((m) => m.startsWith("tools/")),
+        calledResources: mcpMethods.some((m) => m.startsWith("resources/")),
+        calledPrompts: mcpMethods.some((m) => m.startsWith("prompts/")),
+        respondedToElicitation: mcpAuthed.some(
+          (e) => (e.detail as Record<string, unknown> | undefined)?.elicitationResult === "answered",
+        ),
+      },
+      failures,
+    };
+  }
+
+  deriveOAuthProfile(traits: DerivedTraits): OAuthProfileV1 {
+    const engaged =
+      traits.completedFlow ||
+      traits.registration.strategy !== "none" ||
+      traits.authorization.redirectUriKind !== "none";
+
+    const profile: OAuthProfileV1 = {
+      profileVersion: 1,
+      authClass: engaged ? "oauth" : "none",
+    };
+    if (!engaged) return profile;
+
+    profile.sendsResourceParam =
+      traits.authorization.sendsResourceParamAuthorize || traits.token.sendsResourceParamToken;
+    profile.asEndpointDiscovery = traits.discovery.fetchedProtectedResourceMetadata
+      ? "prm"
+      : "same-origin";
+    if (traits.authorization.scopeRequestPolicy === "all-advertised") {
+      profile.scopeRequestPolicy = "all-advertised";
+    } else if (traits.authorization.scopeRequestPolicy === "challenge-derived") {
+      profile.scopeRequestPolicy = "challenge-derived";
+    }
+    if (traits.registration.strategy !== "none") {
+      profile.registrationStrategy = traits.registration.strategy;
+    }
+    if (traits.registration.dcrIdentity?.clientName) {
+      profile.dcrIdentity = {
+        clientName: traits.registration.dcrIdentity.clientName,
+        clientUri: traits.registration.dcrIdentity.clientUri,
+        logoUri: traits.registration.dcrIdentity.logoUri,
+      };
+    }
+    profile.extensions = {
+      "mcpjam.dev/hp10": {
+        completedFlow: traits.completedFlow,
+        usedPkce: traits.authorization.usedPkce,
+        redirectUriKind: traits.authorization.redirectUriKind,
+        refreshSucceeded: traits.token.refreshSucceeded,
+        usedJwtBearerIdJag: traits.token.usedJwtBearerIdJag,
+        failures: traits.failures,
+      },
+    };
+    return profile;
+  }
+
+  buildReport(): CaptureReport {
+    const traits = this.deriveTraits();
+    return {
+      label: this.label,
+      startedAt: this.startedAt,
+      finishedAt: new Date().toISOString(),
+      serverConfig: {
+        publicUrl: this.config.publicUrl,
+        dcr: this.config.dcr,
+        refreshTokens: this.config.refreshTokens,
+        requireResource: this.config.requireResource,
+        requirePkce: this.config.requirePkce,
+        accessTokenTtl: this.config.accessTokenTtl,
+        xaaEnabled: this.config.xaaIssuer.length > 0,
+      },
+      traits,
+      oauthProfile: this.deriveOAuthProfile(traits),
+      events: this.events,
+    };
+  }
+
+  /** Write the report to <captureDir>/<label>.json. Returns the path. */
+  flush(): string {
+    mkdirSync(this.config.captureDir, { recursive: true });
+    const safeLabel = this.label.replace(/[^a-z0-9_-]/gi, "_");
+    const file = join(this.config.captureDir, `${safeLabel}.json`);
+    writeFileSync(file, JSON.stringify(this.buildReport(), null, 2));
+    return file;
+  }
+}

--- a/reference-servers/oauth-full/src/config.ts
+++ b/reference-servers/oauth-full/src/config.ts
@@ -1,0 +1,121 @@
+import { parseArgs } from "node:util";
+import { fileURLToPath } from "node:url";
+
+export interface ReferenceServerConfig {
+  /** TCP port to listen on. */
+  port: number;
+  /** Origin advertised in metadata (issuer, endpoints). Defaults to http://localhost:<port>. Set to a tunnel URL when exposing to remote clients (ChatGPT, Claude web). */
+  publicUrl: string;
+  /** Label for the current capture run — normally the client under test (e.g. "claude", "cursor"). */
+  label: string;
+  /** Directory where per-run capture JSON files are written. */
+  captureDir: string;
+  /** Access-token lifetime in seconds. Use something short (e.g. 60) to force refresh during a session. */
+  accessTokenTtl: number;
+  /** Advertise + accept Dynamic Client Registration. Disable to probe clients' no-DCR fallback. */
+  dcr: boolean;
+  /** Issue refresh tokens. Disable to probe re-auth behavior on expiry. */
+  refreshTokens: boolean;
+  /** Reject token requests that omit the RFC 8707 `resource` parameter (strict mode). Default: record but accept. */
+  requireResource: boolean;
+  /** Reject authorization requests without PKCE. Default true (2025-06-18+ behavior); disable to let non-PKCE clients complete the flow while the gap is recorded. */
+  requirePkce: boolean;
+  /** Show a manual consent page at /authorize instead of instantly redirecting. */
+  consentPage: boolean;
+  /** Trusted external issuer for XAA / ID-JAG jwt-bearer redemption (RFC 7523). JWKS is fetched from <issuer>/.well-known/jwks.json. Empty = grant disabled. */
+  xaaIssuer: string;
+}
+
+export const PREREGISTERED_CLIENT_ID = "oauth-ref-preregistered";
+export const PREREGISTERED_CLIENT_SECRET = "oauth-ref-preregistered-secret";
+
+export const SUPPORTED_SCOPES = [
+  "mcp:tools",
+  "mcp:resources",
+  "mcp:prompts",
+  "offline_access",
+] as const;
+
+/** Scopes hinted in the WWW-Authenticate challenge. Deliberately a strict
+ * subset of SUPPORTED_SCOPES so we can distinguish clients that request
+ * exactly the challenge scopes ("challenge-derived") from clients that
+ * request everything the PRM advertises ("all-advertised"). */
+export const CHALLENGE_SCOPES = ["mcp:tools", "mcp:resources", "mcp:prompts"] as const;
+
+export function parseConfig(argv: string[]): ReferenceServerConfig {
+  const { values } = parseArgs({
+    args: argv,
+    options: {
+      port: { type: "string", default: process.env.PORT ?? "4747" },
+      "public-url": { type: "string", default: "" },
+      label: { type: "string", default: "unlabeled" },
+      "capture-dir": { type: "string", default: "" },
+      "access-ttl": { type: "string", default: "3600" },
+      "no-dcr": { type: "boolean", default: false },
+      "no-refresh": { type: "boolean", default: false },
+      "require-resource": { type: "boolean", default: false },
+      "allow-no-pkce": { type: "boolean", default: false },
+      consent: { type: "boolean", default: false },
+      "xaa-issuer": { type: "string", default: "" },
+      help: { type: "boolean", default: false },
+    },
+  });
+
+  if (values.help) {
+    printHelp();
+    process.exit(0);
+  }
+
+  const port = Number(values.port);
+  if (!Number.isInteger(port) || port < 0 || port > 65535) {
+    throw new Error(`Invalid --port: ${values.port}`);
+  }
+  const accessTokenTtl = Number(values["access-ttl"]);
+  if (!Number.isFinite(accessTokenTtl) || accessTokenTtl <= 0) {
+    throw new Error(`Invalid --access-ttl: ${values["access-ttl"]}`);
+  }
+
+  const publicUrl = (values["public-url"] || `http://localhost:${port}`).replace(/\/+$/, "");
+
+  return {
+    port,
+    publicUrl,
+    label: values.label ?? "unlabeled",
+    captureDir: values["capture-dir"] || fileURLToPath(new URL("../captures", import.meta.url)),
+    accessTokenTtl,
+    dcr: !values["no-dcr"],
+    refreshTokens: !values["no-refresh"],
+    requireResource: values["require-resource"] ?? false,
+    requirePkce: !values["allow-no-pkce"],
+    consentPage: values.consent ?? false,
+    xaaIssuer: (values["xaa-issuer"] ?? "").replace(/\/+$/, ""),
+  };
+}
+
+function printHelp(): void {
+  console.log(`
+MCPJam OAuth reference server (HP-10)
+
+Full-capability MCP server (tools, resources, prompts, apps/UI, logging,
+elicitation, completions) gated behind an embedded OAuth authorization server
+(RFC 9728 PRM, RFC 8414 metadata, DCR, CIMD, PKCE S256, refresh rotation,
+optional XAA/ID-JAG jwt-bearer). Every request is captured per labeled run and
+distilled into per-client OAuth traits + an HP-1 oauthProfile.
+
+Usage: npm run start -w @mcpjam/oauth-reference-server -- [flags]
+
+  --port <n>            Listen port (default 4747, env PORT)
+  --public-url <url>    Advertised origin (default http://localhost:<port>).
+                        Set to your tunnel URL for remote clients.
+  --label <name>        Capture label — the client under test (default "unlabeled").
+                        Can be switched at runtime: POST /capture/reset {"label":"cursor"}
+  --capture-dir <dir>   Where capture JSON lands (default ./captures)
+  --access-ttl <sec>    Access-token TTL (default 3600; use 60 to force refresh)
+  --no-dcr              Do not advertise/accept Dynamic Client Registration
+  --no-refresh          Do not issue refresh tokens
+  --require-resource    Reject token requests missing the RFC 8707 resource param
+  --allow-no-pkce       Let non-PKCE clients complete the flow (gap still recorded)
+  --consent             Show a manual consent page instead of auto-approving
+  --xaa-issuer <url>    Trust this issuer for XAA/ID-JAG jwt-bearer redemption
+`);
+}

--- a/reference-servers/oauth-full/src/http.ts
+++ b/reference-servers/oauth-full/src/http.ts
@@ -1,0 +1,321 @@
+import http from "node:http";
+import { randomUUID } from "node:crypto";
+import { NodeStreamableHTTPServerTransport } from "@modelcontextprotocol/node";
+import type { McpServer } from "@modelcontextprotocol/server";
+import { CaptureSession } from "./capture.js";
+import { PREREGISTERED_CLIENT_ID, PREREGISTERED_CLIENT_SECRET, type ReferenceServerConfig } from "./config.js";
+import { createReferenceMcpServer } from "./mcp.js";
+import {
+  authorizationServerMetadata,
+  createOAuthContext,
+  handleAuthorize,
+  handleConsent,
+  handleRegister,
+  handleToken,
+  protectedResourceMetadata,
+  readBody,
+  sendHtml,
+  sendJson,
+  type OAuthContext,
+} from "./oauth.js";
+
+const CORS_HEADERS: Record<string, string> = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
+  "Access-Control-Allow-Headers":
+    "Authorization, Content-Type, Accept, mcp-session-id, mcp-protocol-version, Last-Event-ID",
+  "Access-Control-Expose-Headers": "mcp-session-id, WWW-Authenticate",
+};
+
+interface McpSession {
+  transport: NodeStreamableHTTPServerTransport;
+  server: McpServer;
+}
+
+export interface ReferenceServer {
+  httpServer: http.Server;
+  ctx: OAuthContext;
+  currentCapture: () => CaptureSession;
+  close: () => Promise<void>;
+}
+
+export function createReferenceServer(config: ReferenceServerConfig): ReferenceServer {
+  let capture = new CaptureSession(config.label, config);
+  const captureRef = () => capture;
+  const ctx = createOAuthContext(config, captureRef);
+  const sessions = new Map<string, McpSession>();
+
+  const allowedHosts = new Set<string>(["localhost", "127.0.0.1", "::1", "[::1]"]);
+  try {
+    allowedHosts.add(new URL(config.publicUrl).hostname.toLowerCase());
+  } catch {
+    // publicUrl is validated at startup; ignore here.
+  }
+
+  const isAllowedHost = (req: http.IncomingMessage): boolean => {
+    const raw = Array.isArray(req.headers.host) ? req.headers.host[0] : req.headers.host;
+    if (!raw) return true;
+    try {
+      return allowedHosts.has(new URL(`http://${raw}`).hostname.toLowerCase());
+    } catch {
+      return false;
+    }
+  };
+
+  const wwwAuthenticate = (error?: string) =>
+    [
+      `Bearer realm="mcpjam-oauth-reference"`,
+      error ? `error="${error}"` : undefined,
+      `resource_metadata="${config.publicUrl}/.well-known/oauth-protected-resource/mcp"`,
+      `scope="mcp:tools mcp:resources mcp:prompts"`,
+    ]
+      .filter(Boolean)
+      .join(", ");
+
+  const httpServer = http.createServer(async (req, res) => {
+    const url = new URL(req.url ?? "/", config.publicUrl);
+    const path = url.pathname;
+    const method = req.method ?? "GET";
+
+    if (method === "OPTIONS") {
+      res.writeHead(204, CORS_HEADERS);
+      res.end();
+      return;
+    }
+    if (!isAllowedHost(req)) {
+      sendJson(res, 403, { error: "forbidden_host", detail: "Host header not in the allowed set; pass --public-url" });
+      return;
+    }
+
+    try {
+      // ---- discovery ------------------------------------------------------
+      if (method === "GET" && path.startsWith("/.well-known/oauth-protected-resource")) {
+        capture.record({
+          kind: "prm_discovery",
+          method,
+          path,
+          status: 200,
+          userAgent: req.headers["user-agent"],
+        });
+        sendJson(res, 200, protectedResourceMetadata(ctx), CORS_HEADERS);
+        return;
+      }
+      if (
+        method === "GET" &&
+        (path.startsWith("/.well-known/oauth-authorization-server") ||
+          path.startsWith("/.well-known/openid-configuration"))
+      ) {
+        capture.record({
+          kind: "as_metadata_discovery",
+          method,
+          path,
+          status: 200,
+          userAgent: req.headers["user-agent"],
+        });
+        sendJson(res, 200, authorizationServerMetadata(ctx), CORS_HEADERS);
+        return;
+      }
+
+      // ---- authorization server --------------------------------------------
+      if (path === "/authorize" && method === "GET") {
+        await handleAuthorize(ctx, req, res, url);
+        return;
+      }
+      if (path === "/authorize/consent" && method === "POST") {
+        await handleConsent(ctx, req, res);
+        return;
+      }
+      if (path === "/token" && method === "POST") {
+        await handleToken(ctx, req, res);
+        return;
+      }
+      if (path === "/register" && method === "POST") {
+        await handleRegister(ctx, req, res);
+        return;
+      }
+
+      // ---- capture control --------------------------------------------------
+      if (path === "/capture/report" && method === "GET") {
+        sendJson(res, 200, capture.buildReport());
+        return;
+      }
+      if (path === "/capture/reset" && method === "POST") {
+        const body = await readBody(req);
+        let label = capture.label;
+        try {
+          const parsed = JSON.parse(body || "{}");
+          if (typeof parsed.label === "string" && parsed.label.trim()) label = parsed.label.trim();
+        } catch {
+          // keep previous label
+        }
+        const flushed = capture.eventCount() > 0 ? capture.flush() : undefined;
+        capture = new CaptureSession(label, config);
+        sendJson(res, 200, { ok: true, label, previousReportFile: flushed ?? null });
+        return;
+      }
+      if (path === "/capture/flush" && method === "POST") {
+        sendJson(res, 200, { ok: true, file: capture.flush() });
+        return;
+      }
+
+      // ---- MCP (bearer-gated) ------------------------------------------------
+      if (path === "/mcp") {
+        const authHeader = req.headers.authorization;
+        if (!authHeader?.startsWith("Bearer ")) {
+          capture.record({
+            kind: "mcp_unauthenticated",
+            method,
+            path,
+            status: 401,
+            userAgent: req.headers["user-agent"],
+            detail: { hadAuthorizationHeader: Boolean(authHeader) },
+          });
+          sendJson(res, 401, { error: "unauthorized" }, { ...CORS_HEADERS, "WWW-Authenticate": wwwAuthenticate() });
+          return;
+        }
+        const lookup = ctx.store.lookupAccessToken(authHeader.slice(7));
+        if (!lookup.token) {
+          capture.record({
+            kind: "mcp_invalid_token",
+            method,
+            path,
+            status: 401,
+            userAgent: req.headers["user-agent"],
+            detail: { reason: lookup.reason },
+          });
+          sendJson(
+            res,
+            401,
+            { error: "invalid_token", error_description: `access token is ${lookup.reason}` },
+            { ...CORS_HEADERS, "WWW-Authenticate": wwwAuthenticate("invalid_token") },
+          );
+          return;
+        }
+
+        for (const [key, value] of Object.entries(CORS_HEADERS)) res.setHeader(key, value);
+        await handleMcp(req, res, lookup.token);
+        return;
+      }
+
+      // ---- landing page ------------------------------------------------------
+      if (path === "/" && method === "GET") {
+        sendHtml(res, 200, landingPage(config, capture));
+        return;
+      }
+
+      sendJson(res, 404, { error: "not_found", path });
+    } catch (error) {
+      if (!res.headersSent) {
+        sendJson(res, 500, {
+          error: "internal_error",
+          detail: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+  });
+
+  async function handleMcp(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    token: NonNullable<ReturnType<typeof ctx.store.lookupAccessToken>["token"]>,
+  ): Promise<void> {
+    const rawSession = req.headers["mcp-session-id"];
+    const sessionId = Array.isArray(rawSession) ? rawSession[0] : rawSession;
+
+    if (req.method === "POST") {
+      const bodyText = await readBody(req);
+      let body: unknown;
+      try {
+        body = bodyText ? JSON.parse(bodyText) : undefined;
+      } catch {
+        sendJson(res, 400, { error: "invalid_json" });
+        return;
+      }
+
+      const rpcMethod =
+        body && typeof body === "object" && typeof (body as { method?: unknown }).method === "string"
+          ? ((body as { method: string }).method)
+          : undefined;
+      if (rpcMethod) {
+        capture.record({
+          kind: "mcp_request",
+          method: "POST",
+          path: "/mcp",
+          status: 200,
+          userAgent: req.headers["user-agent"],
+          detail: { rpcMethod, clientId: token.clientId },
+        });
+      }
+
+      if (sessionId && sessions.has(sessionId)) {
+        await sessions.get(sessionId)!.transport.handleRequest(req, res, body);
+        return;
+      }
+
+      if (!sessionId && rpcMethod === "initialize") {
+        const server = createReferenceMcpServer(token, captureRef);
+        const transport = new NodeStreamableHTTPServerTransport({
+          sessionIdGenerator: () => randomUUID(),
+          onsessioninitialized: (newSessionId) => {
+            sessions.set(newSessionId, { transport, server });
+          },
+        });
+        transport.onclose = () => {
+          if (transport.sessionId) sessions.delete(transport.sessionId);
+        };
+        await server.connect(transport);
+        await transport.handleRequest(req, res, body);
+        return;
+      }
+
+      sendJson(res, 400, {
+        jsonrpc: "2.0",
+        error: { code: -32000, message: "Invalid or missing session ID" },
+        id: null,
+      });
+      return;
+    }
+
+    if (req.method === "GET" || req.method === "DELETE") {
+      if (!sessionId || !sessions.has(sessionId)) {
+        sendJson(res, 400, { error: "invalid_session" });
+        return;
+      }
+      await sessions.get(sessionId)!.transport.handleRequest(req, res);
+      return;
+    }
+
+    sendJson(res, 405, { error: "method_not_allowed" });
+  }
+
+  return {
+    httpServer,
+    ctx,
+    currentCapture: captureRef,
+    close: async () => {
+      for (const session of sessions.values()) {
+        await session.transport.close().catch(() => undefined);
+        await session.server.close().catch(() => undefined);
+      }
+      await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+    },
+  };
+}
+
+function landingPage(config: ReferenceServerConfig, capture: CaptureSession): string {
+  return `<!doctype html>
+<html lang="en"><head><meta charset="utf-8" /><title>MCPJam OAuth reference server</title></head>
+<body style="font-family:system-ui;max-width:44rem;margin:3rem auto;line-height:1.5">
+<h1>MCPJam OAuth reference server (HP-10)</h1>
+<p>Current capture label: <b>${capture.label}</b> — ${capture.eventCount()} events recorded.</p>
+<ul>
+  <li>MCP endpoint (OAuth-gated): <code>${config.publicUrl}/mcp</code></li>
+  <li>Protected resource metadata: <code>/.well-known/oauth-protected-resource/mcp</code></li>
+  <li>AS metadata: <code>/.well-known/oauth-authorization-server</code> · OIDC: <code>/.well-known/openid-configuration</code></li>
+  <li>DCR: <code>POST /register</code> ${config.dcr ? "(enabled)" : "(disabled)"} · CIMD client_ids accepted</li>
+  <li>Preregistered client: <code>${PREREGISTERED_CLIENT_ID}</code> / <code>${PREREGISTERED_CLIENT_SECRET}</code></li>
+  <li>Capture: <code>GET /capture/report</code> · <code>POST /capture/reset {"label":"&lt;client&gt;"}</code> · <code>POST /capture/flush</code></li>
+</ul>
+<p>Point the client under test at <code>${config.publicUrl}/mcp</code>, complete OAuth, exercise tools/resources/prompts, then flush the capture.</p>
+</body></html>`;
+}

--- a/reference-servers/oauth-full/src/http.ts
+++ b/reference-servers/oauth-full/src/http.ts
@@ -12,6 +12,7 @@ import {
   handleConsent,
   handleRegister,
   handleToken,
+  escapeHtml,
   protectedResourceMetadata,
   readBody,
   sendHtml,
@@ -307,7 +308,7 @@ function landingPage(config: ReferenceServerConfig, capture: CaptureSession): st
 <html lang="en"><head><meta charset="utf-8" /><title>MCPJam OAuth reference server</title></head>
 <body style="font-family:system-ui;max-width:44rem;margin:3rem auto;line-height:1.5">
 <h1>MCPJam OAuth reference server (HP-10)</h1>
-<p>Current capture label: <b>${capture.label}</b> — ${capture.eventCount()} events recorded.</p>
+<p>Current capture label: <b>${escapeHtml(capture.label)}</b> — ${capture.eventCount()} events recorded.</p>
 <ul>
   <li>MCP endpoint (OAuth-gated): <code>${config.publicUrl}/mcp</code></li>
   <li>Protected resource metadata: <code>/.well-known/oauth-protected-resource/mcp</code></li>

--- a/reference-servers/oauth-full/src/index.ts
+++ b/reference-servers/oauth-full/src/index.ts
@@ -1,0 +1,30 @@
+import { parseConfig, PREREGISTERED_CLIENT_ID, PREREGISTERED_CLIENT_SECRET } from "./config.js";
+import { createReferenceServer } from "./http.js";
+
+const config = parseConfig(process.argv.slice(2));
+const server = createReferenceServer(config);
+
+server.httpServer.listen(config.port, () => {
+  console.log(`\nMCPJam OAuth reference server (HP-10)`);
+  console.log(`  MCP endpoint : ${config.publicUrl}/mcp`);
+  console.log(`  Landing page : ${config.publicUrl}/`);
+  console.log(`  Capture label: ${config.label}  (dir: ${config.captureDir})`);
+  console.log(`  DCR ${config.dcr ? "on" : "OFF"} · refresh ${config.refreshTokens ? "on" : "OFF"} · PKCE ${config.requirePkce ? "required" : "optional"} · resource ${config.requireResource ? "REQUIRED" : "recorded"} · access TTL ${config.accessTokenTtl}s`);
+  if (config.xaaIssuer) console.log(`  XAA jwt-bearer enabled, trusted issuer: ${config.xaaIssuer}`);
+  console.log(`  Preregistered client: ${PREREGISTERED_CLIENT_ID} / ${PREREGISTERED_CLIENT_SECRET}`);
+  console.log(`\nSwitch client under test without restarting:`);
+  console.log(`  curl -X POST ${config.publicUrl}/capture/reset -d "{\\"label\\":\\"cursor\\"}"`);
+  console.log(`Write the current capture: curl -X POST ${config.publicUrl}/capture/flush\n`);
+});
+
+const shutdown = () => {
+  const capture = server.currentCapture();
+  if (capture.eventCount() > 0) {
+    const file = capture.flush();
+    console.log(`\nCapture written: ${file}`);
+  }
+  void server.close().finally(() => process.exit(0));
+};
+
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);

--- a/reference-servers/oauth-full/src/mcp.ts
+++ b/reference-servers/oauth-full/src/mcp.ts
@@ -1,0 +1,362 @@
+import { McpServer, ResourceTemplate } from "@modelcontextprotocol/server";
+import { z } from "zod";
+import type { CaptureSession } from "./capture.js";
+import type { AccessToken } from "./store.js";
+
+const TEST_IMAGE_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==";
+
+export const UI_TOOL_NAME = "reference_ui_dashboard";
+export const UI_RESOURCE_URI = "ui://oauth-reference/dashboard";
+const UI_RESOURCE_MIME_TYPE = "text/html;profile=mcp-app";
+
+const DASHBOARD_HTML = `<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8" /><title>OAuth Reference Dashboard</title></head>
+<body><main id="app"><h1>OAuth reference server</h1><p>You are seeing this through an authenticated MCP Apps render.</p></main></body>
+</html>`;
+
+/** Build one full-capability MCP server bound to the authenticated token that
+ * opened the session. Everything here sits behind the bearer gate in http.ts. */
+export function createReferenceMcpServer(auth: AccessToken, capture: () => CaptureSession): McpServer {
+  const server = new McpServer(
+    { name: "mcpjam-oauth-reference-server", version: "0.1.0" },
+    {
+      capabilities: {
+        tools: {},
+        resources: { subscribe: true },
+        prompts: {},
+        logging: {},
+        completions: {},
+      },
+    },
+  );
+
+  // --- tools ---------------------------------------------------------------
+
+  server.registerTool(
+    "whoami",
+    {
+      description:
+        "Echo the authenticated OAuth context (client_id, scopes, grant, expiry). Proves end-to-end auth.",
+      inputSchema: z.object({}),
+    },
+    async () => ({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            {
+              clientId: auth.clientId,
+              scopes: auth.scopes,
+              grant: auth.grant,
+              resource: auth.resource ?? null,
+              expiresAt: new Date(auth.expiresAt).toISOString(),
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+    }),
+  );
+
+  server.registerTool(
+    "test_simple_text",
+    {
+      description: "Returns a simple text response.",
+      inputSchema: z.object({}),
+    },
+    async () => ({
+      content: [{ type: "text", text: "Simple text response from the OAuth reference server." }],
+    }),
+  );
+
+  server.registerTool(
+    "test_image_content",
+    {
+      description: "Returns PNG image content.",
+      inputSchema: z.object({}),
+    },
+    async () => ({
+      content: [{ type: "image", data: TEST_IMAGE_BASE64, mimeType: "image/png" }],
+    }),
+  );
+
+  server.registerTool(
+    "test_tool_with_logging",
+    {
+      description: "Emits logging notifications during execution.",
+      inputSchema: z.object({}),
+    },
+    async (_args, ctx) => {
+      for (const step of ["started", "processing", "completed"]) {
+        await ctx.mcpReq.log("info", `Tool execution ${step}`);
+      }
+      return { content: [{ type: "text", text: "Tool with logging executed successfully" }] };
+    },
+  );
+
+  server.registerTool(
+    "test_tool_with_progress",
+    {
+      description: "Emits progress notifications during execution.",
+      inputSchema: z.object({}),
+    },
+    async (_args, ctx) => {
+      const progressToken = ctx.mcpReq._meta?.progressToken ?? 0;
+      for (const progress of [0, 50, 100]) {
+        await ctx.mcpReq.notify({
+          method: "notifications/progress",
+          params: { progressToken, progress, total: 100, message: `Step ${progress}/100` },
+        });
+      }
+      return { content: [{ type: "text", text: "Tool with progress executed successfully" }] };
+    },
+  );
+
+  server.registerTool(
+    "test_error_handling",
+    {
+      description: "Intentionally returns a tool error.",
+      inputSchema: z.object({}),
+    },
+    async () => {
+      throw new Error("This tool intentionally returns an error for testing");
+    },
+  );
+
+  server.registerTool(
+    "test_elicitation",
+    {
+      description:
+        "Requests user input via elicitation/create and reports what the client did (answered, declined, or unsupported).",
+      inputSchema: z.object({}),
+    },
+    async (_args, ctx) => {
+      try {
+        const result = await ctx.mcpReq.elicitInput({
+          message: "The OAuth reference server wants one detail to complete the capability check.",
+          requestedSchema: {
+            type: "object",
+            properties: {
+              favorite_color: {
+                type: "string",
+                title: "Favorite color",
+                description: "Any value works — this only probes elicitation support.",
+              },
+            },
+            required: ["favorite_color"],
+          },
+        });
+        capture().record({
+          kind: "mcp_request",
+          method: "POST",
+          path: "/mcp",
+          status: 200,
+          detail: {
+            rpcMethod: "elicitation/create",
+            elicitationResult: result.action === "accept" ? "answered" : result.action,
+          },
+        });
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Elicitation result: action=${result.action}${
+                result.action === "accept" ? `, content=${JSON.stringify(result.content)}` : ""
+              }`,
+            },
+          ],
+        };
+      } catch (error) {
+        capture().record({
+          kind: "mcp_request",
+          method: "POST",
+          path: "/mcp",
+          status: 200,
+          detail: { rpcMethod: "elicitation/create", elicitationResult: "rejected-or-unsupported" },
+        });
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Elicitation not completed: ${error instanceof Error ? error.message : "unknown error"}`,
+            },
+          ],
+        };
+      }
+    },
+  );
+
+  server.registerTool(
+    UI_TOOL_NAME,
+    {
+      description: "Returns dashboard data and advertises an MCP Apps HTML resource.",
+      inputSchema: z.object({}),
+      _meta: {
+        ui: { resourceUri: UI_RESOURCE_URI, visibility: ["model", "app"] },
+      },
+    },
+    async () => ({
+      content: [{ type: "text", text: "Dashboard ready." }],
+      structuredContent: { status: "ready", authenticatedClient: auth.clientId },
+    }),
+  );
+
+  // --- resources -----------------------------------------------------------
+
+  server.registerResource(
+    "static-text",
+    "reference://static-text",
+    {
+      title: "Static Text Resource",
+      description: "A static text resource behind OAuth.",
+      mimeType: "text/plain",
+    },
+    async () => ({
+      contents: [
+        {
+          uri: "reference://static-text",
+          mimeType: "text/plain",
+          text: "Static text resource content (authenticated).",
+        },
+      ],
+    }),
+  );
+
+  server.registerResource(
+    "static-binary",
+    "reference://static-binary",
+    {
+      title: "Static Binary Resource",
+      description: "A static PNG resource behind OAuth.",
+      mimeType: "image/png",
+    },
+    async () => ({
+      contents: [
+        { uri: "reference://static-binary", mimeType: "image/png", blob: TEST_IMAGE_BASE64 },
+      ],
+    }),
+  );
+
+  server.registerResource(
+    "template",
+    new ResourceTemplate("reference://template/{id}/data", { list: undefined }),
+    {
+      title: "Template Resource",
+      description: "A resource template with path parameter substitution.",
+      mimeType: "application/json",
+    },
+    async (uri, variables) => ({
+      contents: [
+        {
+          uri: uri.toString(),
+          mimeType: "application/json",
+          text: JSON.stringify({ id: variables.id, data: `Data for ID: ${variables.id}` }),
+        },
+      ],
+    }),
+  );
+
+  server.registerResource(
+    "watched-resource",
+    "reference://watched-resource",
+    {
+      title: "Watched Resource",
+      description: "A subscribable resource.",
+      mimeType: "text/plain",
+    },
+    async () => ({
+      contents: [
+        {
+          uri: "reference://watched-resource",
+          mimeType: "text/plain",
+          text: "Watched resource content",
+        },
+      ],
+    }),
+  );
+
+  server.registerResource(
+    "ui-dashboard",
+    UI_RESOURCE_URI,
+    {
+      title: "UI Dashboard",
+      description: "An MCP Apps HTML resource behind OAuth.",
+      mimeType: UI_RESOURCE_MIME_TYPE,
+    },
+    async () => ({
+      contents: [
+        {
+          uri: UI_RESOURCE_URI,
+          mimeType: UI_RESOURCE_MIME_TYPE,
+          text: DASHBOARD_HTML,
+          _meta: {
+            ui: {
+              csp: { connectDomains: [], resourceDomains: [] },
+              permissions: {},
+              prefersBorder: true,
+            },
+          },
+        },
+      ],
+    }),
+  );
+
+  // --- prompts ---------------------------------------------------------------
+
+  server.registerPrompt(
+    "test_simple_prompt",
+    {
+      title: "Simple Prompt",
+      description: "A simple prompt without arguments.",
+    },
+    async () => ({
+      messages: [
+        {
+          role: "user",
+          content: { type: "text", text: "This is a simple prompt from the OAuth reference server." },
+        },
+      ],
+    }),
+  );
+
+  server.registerPrompt(
+    "test_prompt_with_arguments",
+    {
+      title: "Prompt With Arguments",
+      description: "A prompt that substitutes provided arguments.",
+      argsSchema: z.object({
+        topic: z.string().describe("Topic to ask about"),
+      }),
+    },
+    async (args) => ({
+      messages: [
+        {
+          role: "user",
+          content: { type: "text", text: `Tell me about: ${args.topic}` },
+        },
+      ],
+    }),
+  );
+
+  // --- logging / completion / subscriptions ---------------------------------
+
+  const resourceSubscriptions = new Set<string>();
+
+  server.server.setRequestHandler("resources/subscribe", async (request: any) => {
+    resourceSubscriptions.add(request.params.uri);
+    return {};
+  });
+  server.server.setRequestHandler("resources/unsubscribe", async (request: any) => {
+    resourceSubscriptions.delete(request.params.uri);
+    return {};
+  });
+  server.server.setRequestHandler("logging/setLevel", async () => ({}));
+  server.server.setRequestHandler("completion/complete", async () => ({
+    completion: { values: ["alpha", "beta", "gamma"], total: 3, hasMore: false },
+  }));
+
+  return server;
+}

--- a/reference-servers/oauth-full/src/oauth.ts
+++ b/reference-servers/oauth-full/src/oauth.ts
@@ -1,0 +1,753 @@
+import { createHash, timingSafeEqual } from "node:crypto";
+import { lookup } from "node:dns/promises";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { createRemoteJWKSet, jwtVerify } from "jose";
+import type { CaptureSession } from "./capture.js";
+import {
+  CHALLENGE_SCOPES,
+  PREREGISTERED_CLIENT_ID,
+  PREREGISTERED_CLIENT_SECRET,
+  SUPPORTED_SCOPES,
+  type ReferenceServerConfig,
+} from "./config.js";
+import { OAuthStore, type RegisteredClient } from "./store.js";
+
+const JWT_BEARER_GRANT = "urn:ietf:params:oauth:grant-type:jwt-bearer";
+const ID_JAG_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:id-jag";
+
+export interface OAuthContext {
+  config: ReferenceServerConfig;
+  store: OAuthStore;
+  capture: () => CaptureSession;
+}
+
+export function createOAuthContext(config: ReferenceServerConfig, capture: () => CaptureSession): OAuthContext {
+  const store = new OAuthStore();
+  store.registerClient({
+    clientId: PREREGISTERED_CLIENT_ID,
+    clientSecret: PREREGISTERED_CLIENT_SECRET,
+    redirectUris: [],
+    tokenEndpointAuthMethod: "client_secret_post",
+    source: "preregistered",
+    clientName: "Preregistered reference client",
+  });
+  return { config, store, capture };
+}
+
+export function sendJson(
+  res: ServerResponse,
+  status: number,
+  body: unknown,
+  headers: Record<string, string> = {},
+): void {
+  res.writeHead(status, {
+    "Content-Type": "application/json",
+    "Cache-Control": "no-store",
+    Pragma: "no-cache",
+    "Access-Control-Allow-Origin": "*",
+    ...headers,
+  });
+  res.end(JSON.stringify(body));
+}
+
+export function sendHtml(res: ServerResponse, status: number, html: string): void {
+  res.writeHead(status, { "Content-Type": "text/html; charset=utf-8" });
+  res.end(html);
+}
+
+export async function readBody(req: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+export function parseFormOrJson(raw: string, contentType: string | undefined): Record<string, string> {
+  if (!raw) return {};
+  if (contentType?.includes("application/json")) {
+    try {
+      const parsed = JSON.parse(raw);
+      return typeof parsed === "object" && parsed ? (parsed as Record<string, string>) : {};
+    } catch {
+      return {};
+    }
+  }
+  return Object.fromEntries(new URLSearchParams(raw).entries());
+}
+
+const userAgentOf = (req: IncomingMessage): string | undefined => {
+  const ua = req.headers["user-agent"];
+  return Array.isArray(ua) ? ua[0] : ua;
+};
+
+// ---------------------------------------------------------------------------
+// Metadata (RFC 9728 + RFC 8414 / OIDC)
+// ---------------------------------------------------------------------------
+
+export function protectedResourceMetadata(ctx: OAuthContext): Record<string, unknown> {
+  return {
+    resource: `${ctx.config.publicUrl}/mcp`,
+    authorization_servers: [ctx.config.publicUrl],
+    scopes_supported: [...SUPPORTED_SCOPES],
+    bearer_methods_supported: ["header"],
+    resource_name: "MCPJam OAuth reference MCP server",
+  };
+}
+
+export function authorizationServerMetadata(ctx: OAuthContext): Record<string, unknown> {
+  const origin = ctx.config.publicUrl;
+  const grantTypes = ["authorization_code"];
+  if (ctx.config.refreshTokens) grantTypes.push("refresh_token");
+  if (ctx.config.xaaIssuer) grantTypes.push(JWT_BEARER_GRANT);
+  return {
+    issuer: origin,
+    authorization_endpoint: `${origin}/authorize`,
+    token_endpoint: `${origin}/token`,
+    ...(ctx.config.dcr ? { registration_endpoint: `${origin}/register` } : {}),
+    response_types_supported: ["code"],
+    response_modes_supported: ["query"],
+    grant_types_supported: grantTypes,
+    token_endpoint_auth_methods_supported: ["none", "client_secret_post", "client_secret_basic"],
+    code_challenge_methods_supported: ["S256"],
+    scopes_supported: [...SUPPORTED_SCOPES],
+    // CIMD (draft-ietf-oauth-client-id-metadata-document): URL client_ids accepted.
+    client_id_metadata_document_supported: true,
+    ...(ctx.config.xaaIssuer
+      ? { identity_chaining_requested_token_types_supported: [ID_JAG_TOKEN_TYPE] }
+      : {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Dynamic Client Registration (RFC 7591)
+// ---------------------------------------------------------------------------
+
+export async function handleRegister(ctx: OAuthContext, req: IncomingMessage, res: ServerResponse): Promise<void> {
+  if (!ctx.config.dcr) {
+    ctx.capture().record({
+      kind: "dcr_registration",
+      method: "POST",
+      path: "/register",
+      status: 403,
+      userAgent: userAgentOf(req),
+      detail: { rejected: "dcr-disabled" },
+    });
+    sendJson(res, 403, { error: "access_denied", error_description: "DCR is disabled on this run (--no-dcr)" });
+    return;
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = JSON.parse(await readBody(req));
+  } catch {
+    sendJson(res, 400, { error: "invalid_client_metadata", error_description: "Body must be JSON" });
+    return;
+  }
+
+  const redirectUris = Array.isArray(body.redirect_uris)
+    ? body.redirect_uris.filter((u): u is string => typeof u === "string")
+    : [];
+  if (redirectUris.length === 0) {
+    ctx.capture().record({
+      kind: "dcr_registration",
+      method: "POST",
+      path: "/register",
+      status: 400,
+      userAgent: userAgentOf(req),
+      detail: { rejected: "missing-redirect-uris" },
+    });
+    sendJson(res, 400, { error: "invalid_redirect_uri", error_description: "redirect_uris is required" });
+    return;
+  }
+
+  const requestedAuthMethod =
+    typeof body.token_endpoint_auth_method === "string" ? body.token_endpoint_auth_method : "none";
+  const tokenEndpointAuthMethod =
+    requestedAuthMethod === "client_secret_post" || requestedAuthMethod === "client_secret_basic"
+      ? requestedAuthMethod
+      : "none";
+
+  const client = ctx.store.registerClient({
+    redirectUris,
+    tokenEndpointAuthMethod,
+    clientSecret: tokenEndpointAuthMethod === "none" ? undefined : `secret_${crypto.randomUUID()}`,
+    source: "dcr",
+    clientName: typeof body.client_name === "string" ? body.client_name : undefined,
+    clientUri: typeof body.client_uri === "string" ? body.client_uri : undefined,
+    logoUri: typeof body.logo_uri === "string" ? body.logo_uri : undefined,
+    grantTypes: Array.isArray(body.grant_types)
+      ? body.grant_types.filter((g): g is string => typeof g === "string")
+      : undefined,
+  });
+
+  ctx.capture().record({
+    kind: "dcr_registration",
+    method: "POST",
+    path: "/register",
+    status: 201,
+    userAgent: userAgentOf(req),
+    detail: {
+      clientName: client.clientName,
+      clientUri: client.clientUri,
+      logoUri: client.logoUri,
+      redirectUris,
+      grantTypes: client.grantTypes,
+      tokenEndpointAuthMethod,
+      requestedScope: typeof body.scope === "string" ? body.scope : undefined,
+    },
+  });
+
+  sendJson(
+    res,
+    201,
+    {
+      client_id: client.clientId,
+      ...(client.clientSecret ? { client_secret: client.clientSecret } : {}),
+      redirect_uris: redirectUris,
+      token_endpoint_auth_method: tokenEndpointAuthMethod,
+      grant_types: client.grantTypes ?? ["authorization_code", "refresh_token"],
+      response_types: ["code"],
+      ...(client.clientName ? { client_name: client.clientName } : {}),
+    },
+    // RFC 7591: credential responses MUST NOT be cached.
+    { "Cache-Control": "no-store" },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// CIMD (client_id as HTTPS URL pointing at a metadata document)
+// ---------------------------------------------------------------------------
+
+/** SSRF guard for CIMD fetches: the AS fetches a caller-supplied URL by
+ * design, so when this server is exposed publicly (tunnel), that fetch must
+ * not be steerable at loopback/private/link-local targets (cloud metadata,
+ * internal services). Loopback CIMD documents stay allowed while the server
+ * itself runs on a loopback publicUrl — the local-dev testing path. */
+function isPrivateAddress(address: string, family: number): boolean {
+  if (family === 4) {
+    const octets = address.split(".").map(Number);
+    if (octets.length !== 4 || octets.some((o) => Number.isNaN(o))) return true;
+    const [a, b] = octets;
+    return (
+      a === 0 || // unspecified
+      a === 127 || // loopback
+      a === 10 ||
+      (a === 172 && b >= 16 && b <= 31) ||
+      (a === 192 && b === 168) ||
+      (a === 169 && b === 254) // link-local / cloud metadata
+    );
+  }
+  const lower = address.toLowerCase();
+  if (lower === "::" || lower === "::1") return true;
+  if (lower.startsWith("fc") || lower.startsWith("fd")) return true; // fc00::/7
+  if (lower.startsWith("fe8") || lower.startsWith("fe9") || lower.startsWith("fea") || lower.startsWith("feb")) {
+    return true; // fe80::/10
+  }
+  if (lower.startsWith("::ffff:")) {
+    return isPrivateAddress(lower.slice(7), 4); // IPv4-mapped
+  }
+  return false;
+}
+
+const LOOPBACK_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
+
+async function assertCimdUrlAllowed(ctx: OAuthContext, url: URL): Promise<string | undefined> {
+  const publicIsLocal = LOOPBACK_HOSTNAMES.has(new URL(ctx.config.publicUrl).hostname.toLowerCase());
+  const targetIsLocal = LOOPBACK_HOSTNAMES.has(url.hostname.toLowerCase());
+
+  if (targetIsLocal) {
+    return publicIsLocal
+      ? undefined
+      : "loopback CIMD URLs are not allowed while the server is published on a non-loopback --public-url";
+  }
+  if (url.protocol !== "https:") {
+    return "CIMD client_id must be https (or http on localhost for local testing)";
+  }
+  try {
+    const addresses = await lookup(url.hostname, { all: true, verbatim: true });
+    if (addresses.some((entry) => isPrivateAddress(entry.address, entry.family))) {
+      return "CIMD host resolves to a private, loopback, or link-local address";
+    }
+  } catch {
+    return "CIMD host did not resolve";
+  }
+  return undefined;
+}
+
+async function resolveCimdClient(ctx: OAuthContext, clientId: string): Promise<RegisteredClient | { error: string }> {
+  const existing = ctx.store.clients.get(clientId);
+  if (existing) return existing;
+
+  let url: URL;
+  try {
+    url = new URL(clientId);
+  } catch {
+    return { error: "client_id is neither registered nor a valid CIMD URL" };
+  }
+  const blocked = await assertCimdUrlAllowed(ctx, url);
+  if (blocked) {
+    ctx.capture().record({
+      kind: "cimd_fetch",
+      method: "GET",
+      path: url.toString(),
+      status: 403,
+      detail: { clientId, rejected: blocked },
+    });
+    return { error: blocked };
+  }
+
+  let status = 0;
+  try {
+    const response = await fetch(url, {
+      headers: { Accept: "application/json" },
+      redirect: "error",
+      signal: AbortSignal.timeout(5000),
+    });
+    status = response.status;
+    if (!response.ok) {
+      ctx.capture().record({
+        kind: "cimd_fetch",
+        method: "GET",
+        path: url.toString(),
+        status,
+        detail: { clientId, rejected: "non-200" },
+      });
+      return { error: `CIMD document fetch returned ${status}` };
+    }
+    const doc = (await response.json()) as Record<string, unknown>;
+    if (doc.client_id !== clientId) {
+      ctx.capture().record({
+        kind: "cimd_fetch",
+        method: "GET",
+        path: url.toString(),
+        status,
+        detail: { clientId, rejected: "client_id-mismatch" },
+      });
+      return { error: "CIMD document client_id does not match the requesting client_id" };
+    }
+    const redirectUris = Array.isArray(doc.redirect_uris)
+      ? doc.redirect_uris.filter((u): u is string => typeof u === "string")
+      : [];
+    const client = ctx.store.registerClient({
+      clientId,
+      redirectUris,
+      tokenEndpointAuthMethod: "none",
+      source: "cimd",
+      clientName: typeof doc.client_name === "string" ? doc.client_name : undefined,
+      clientUri: typeof doc.client_uri === "string" ? doc.client_uri : undefined,
+      logoUri: typeof doc.logo_uri === "string" ? doc.logo_uri : undefined,
+    });
+    ctx.capture().record({
+      kind: "cimd_fetch",
+      method: "GET",
+      path: url.toString(),
+      status,
+      detail: { clientId, clientName: client.clientName, redirectUris },
+    });
+    return client;
+  } catch (error) {
+    ctx.capture().record({
+      kind: "cimd_fetch",
+      method: "GET",
+      path: url.toString(),
+      status: status || 599,
+      detail: { clientId, rejected: error instanceof Error ? error.message : "fetch-failed" },
+    });
+    return { error: "CIMD document fetch failed" };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// /authorize
+// ---------------------------------------------------------------------------
+
+const escapeHtml = (value: string) =>
+  value.replace(/[&<>"']/g, (ch) => `&#${ch.charCodeAt(0)};`);
+
+export async function handleAuthorize(ctx: OAuthContext, req: IncomingMessage, res: ServerResponse, url: URL): Promise<void> {
+  const q = url.searchParams;
+  const clientId = q.get("client_id") ?? "";
+  const redirectUri = q.get("redirect_uri") ?? "";
+  const state = q.get("state") ?? undefined;
+  const codeChallenge = q.get("code_challenge") ?? undefined;
+  const codeChallengeMethod = q.get("code_challenge_method") ?? undefined;
+  const resource = q.get("resource") ?? undefined;
+  const scopes = (q.get("scope") ?? "").split(/[\s+]+/).filter(Boolean);
+  const responseType = q.get("response_type") ?? "";
+
+  const detail = {
+    clientId,
+    redirectUri,
+    state: Boolean(state),
+    pkce: Boolean(codeChallenge),
+    pkceMethod: codeChallengeMethod,
+    resource,
+    scopes,
+    responseType,
+  };
+
+  const fail = (status: number, error: string, description: string) => {
+    ctx.capture().record({
+      kind: "authorize",
+      method: "GET",
+      path: "/authorize",
+      status,
+      userAgent: userAgentOf(req),
+      detail: { ...detail, rejected: `${error}: ${description}` },
+    });
+    // Per RFC 6749: only redirect errors when redirect_uri is valid; here we
+    // render them so the tester can read the reason in the client's browser.
+    sendHtml(
+      res,
+      status,
+      `<h1>Authorization error</h1><p><b>${escapeHtml(error)}</b>: ${escapeHtml(description)}</p>`,
+    );
+  };
+
+  if (responseType !== "code") {
+    fail(400, "unsupported_response_type", `response_type must be "code", got "${responseType}"`);
+    return;
+  }
+  if (!redirectUri) {
+    fail(400, "invalid_request", "redirect_uri is required");
+    return;
+  }
+
+  const client = await resolveCimdClient(ctx, clientId);
+  if ("error" in client) {
+    fail(400, "invalid_client", client.error);
+    return;
+  }
+
+  // Preregistered clients have no pinned redirect URIs (first use pins them);
+  // DCR/CIMD clients must match their registered list exactly.
+  if (client.redirectUris.length > 0 && !client.redirectUris.includes(redirectUri)) {
+    fail(400, "invalid_request", `redirect_uri "${redirectUri}" is not registered for this client`);
+    return;
+  }
+  if (client.source === "preregistered" && client.redirectUris.length === 0) {
+    client.redirectUris = [redirectUri];
+  }
+
+  if (ctx.config.requirePkce && !codeChallenge) {
+    fail(400, "invalid_request", "PKCE code_challenge is required (start with --allow-no-pkce to permit this client)");
+    return;
+  }
+  if (codeChallenge && codeChallengeMethod !== "S256") {
+    fail(400, "invalid_request", `code_challenge_method must be S256, got "${codeChallengeMethod ?? "none"}"`);
+    return;
+  }
+  if (ctx.config.requireResource && !resource) {
+    fail(400, "invalid_target", "resource parameter is required on this run (--require-resource)");
+    return;
+  }
+
+  const grantedScopes = scopes.length
+    ? scopes.filter((s) => (SUPPORTED_SCOPES as readonly string[]).includes(s))
+    : [...SUPPORTED_SCOPES];
+
+  const issue = () => {
+    const code = ctx.store.issueCode({
+      clientId: client.clientId,
+      redirectUri,
+      codeChallenge,
+      codeChallengeMethod,
+      scopes: grantedScopes,
+      resource,
+      expiresAt: Date.now() + 5 * 60_000,
+    });
+    const callback = new URL(redirectUri);
+    callback.searchParams.set("code", code.code);
+    if (state) callback.searchParams.set("state", state);
+    ctx.capture().record({
+      kind: "authorize",
+      method: "GET",
+      path: "/authorize",
+      status: 302,
+      userAgent: userAgentOf(req),
+      detail,
+    });
+    res.writeHead(302, { Location: callback.toString(), "Cache-Control": "no-store" });
+    res.end();
+  };
+
+  if (!ctx.config.consentPage) {
+    issue();
+    return;
+  }
+
+  // Manual consent: stash the issue parameters behind a one-time id.
+  const consentId = crypto.randomUUID();
+  pendingConsents.set(consentId, issue);
+  ctx.capture().record({
+    kind: "authorize",
+    method: "GET",
+    path: "/authorize",
+    status: 200,
+    userAgent: userAgentOf(req),
+    detail: { ...detail, consentShown: true },
+  });
+  sendHtml(
+    res,
+    200,
+    `<!doctype html><html><body style="font-family:system-ui;max-width:32rem;margin:4rem auto">
+      <h1>MCPJam OAuth reference server</h1>
+      <p><b>${escapeHtml(client.clientName ?? client.clientId)}</b> is requesting access with scopes:
+      <code>${escapeHtml(grantedScopes.join(" ") || "(none)")}</code></p>
+      <form method="post" action="/authorize/consent">
+        <input type="hidden" name="consent_id" value="${consentId}" />
+        <button type="submit" style="font-size:1.1rem;padding:.5rem 1.5rem">Approve</button>
+      </form>
+    </body></html>`,
+  );
+}
+
+const pendingConsents = new Map<string, () => void>();
+
+export async function handleConsent(ctx: OAuthContext, req: IncomingMessage, res: ServerResponse): Promise<void> {
+  const body = parseFormOrJson(await readBody(req), req.headers["content-type"]);
+  const issue = pendingConsents.get(body.consent_id ?? "");
+  if (!issue) {
+    sendHtml(res, 400, "<h1>Unknown or expired consent</h1>");
+    return;
+  }
+  pendingConsents.delete(body.consent_id);
+  ctx.capture().record({ kind: "consent", method: "POST", path: "/authorize/consent", status: 302 });
+  issue();
+}
+
+// ---------------------------------------------------------------------------
+// /token
+// ---------------------------------------------------------------------------
+
+function verifyPkce(verifier: string, challenge: string): boolean {
+  const computed = createHash("sha256").update(verifier).digest("base64url");
+  const a = Buffer.from(computed);
+  const b = Buffer.from(challenge);
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+
+interface ClientAuthResult {
+  client?: RegisteredClient;
+  method: "none" | "client_secret_post" | "client_secret_basic" | "other";
+  error?: string;
+}
+
+function authenticateClient(ctx: OAuthContext, req: IncomingMessage, body: Record<string, string>): ClientAuthResult {
+  const header = req.headers.authorization;
+  if (header?.startsWith("Basic ")) {
+    const [id, secret] = Buffer.from(header.slice(6), "base64").toString("utf8").split(":");
+    const client = ctx.store.clients.get(decodeURIComponent(id ?? ""));
+    if (!client) return { method: "client_secret_basic", error: "unknown client_id" };
+    if (client.clientSecret && client.clientSecret !== decodeURIComponent(secret ?? "")) {
+      return { method: "client_secret_basic", error: "bad client_secret" };
+    }
+    return { client, method: "client_secret_basic" };
+  }
+  const clientId = body.client_id;
+  if (!clientId) return { method: "other", error: "client_id missing" };
+  const client = ctx.store.clients.get(clientId);
+  if (!client) return { method: body.client_secret ? "client_secret_post" : "none", error: "unknown client_id" };
+  if (body.client_secret) {
+    if (client.clientSecret && client.clientSecret !== body.client_secret) {
+      return { method: "client_secret_post", error: "bad client_secret" };
+    }
+    return { client, method: "client_secret_post" };
+  }
+  if (client.clientSecret && client.tokenEndpointAuthMethod !== "none") {
+    return { client, method: "none", error: "client_secret required for this client" };
+  }
+  return { client, method: "none" };
+}
+
+export async function handleToken(ctx: OAuthContext, req: IncomingMessage, res: ServerResponse): Promise<void> {
+  const body = parseFormOrJson(await readBody(req), req.headers["content-type"]);
+  const grantType = body.grant_type ?? "";
+  const ua = userAgentOf(req);
+
+  const tokenError = (status: number, error: string, description: string, kind: "token_authorization_code" | "token_refresh" | "token_jwt_bearer" | "token_error", detail: Record<string, unknown> = {}) => {
+    ctx.capture().record({
+      kind,
+      method: "POST",
+      path: "/token",
+      status,
+      userAgent: ua,
+      detail: { ...detail, rejected: `${error}: ${description}` },
+    });
+    sendJson(res, status, { error, error_description: description });
+  };
+
+  if (grantType === "authorization_code") {
+    const auth = authenticateClient(ctx, req, body);
+    const detail: Record<string, unknown> = {
+      authMethod: auth.method,
+      resource: body.resource,
+      redirectUri: body.redirect_uri,
+      pkceVerifierPresent: Boolean(body.code_verifier),
+    };
+    if (auth.error || !auth.client) {
+      tokenError(401, "invalid_client", auth.error ?? "client authentication failed", "token_authorization_code", detail);
+      return;
+    }
+    const code = ctx.store.codes.get(body.code ?? "");
+    if (!code || code.used || Date.now() > code.expiresAt) {
+      tokenError(400, "invalid_grant", "authorization code is unknown, used, or expired", "token_authorization_code", detail);
+      return;
+    }
+    if (code.clientId !== auth.client.clientId) {
+      tokenError(400, "invalid_grant", "authorization code was issued to a different client", "token_authorization_code", detail);
+      return;
+    }
+    if (body.redirect_uri && body.redirect_uri !== code.redirectUri) {
+      tokenError(400, "invalid_grant", "redirect_uri does not match the authorization request", "token_authorization_code", detail);
+      return;
+    }
+    if (code.codeChallenge) {
+      if (!body.code_verifier || !verifyPkce(body.code_verifier, code.codeChallenge)) {
+        tokenError(400, "invalid_grant", "PKCE code_verifier missing or does not match code_challenge", "token_authorization_code", detail);
+        return;
+      }
+    }
+    if (ctx.config.requireResource && !body.resource) {
+      tokenError(400, "invalid_target", "resource parameter is required on this run (--require-resource)", "token_authorization_code", detail);
+      return;
+    }
+    code.used = true;
+
+    const access = ctx.store.issueAccessToken({
+      clientId: auth.client.clientId,
+      scopes: code.scopes,
+      resource: body.resource ?? code.resource,
+      expiresAt: Date.now() + ctx.config.accessTokenTtl * 1000,
+      grant: "authorization_code",
+    });
+    const refresh = ctx.config.refreshTokens
+      ? ctx.store.issueRefreshToken({
+          clientId: auth.client.clientId,
+          scopes: code.scopes,
+          resource: body.resource ?? code.resource,
+        })
+      : undefined;
+
+    ctx.capture().record({
+      kind: "token_authorization_code",
+      method: "POST",
+      path: "/token",
+      status: 200,
+      userAgent: ua,
+      detail,
+    });
+    sendJson(res, 200, {
+      access_token: access.token,
+      token_type: "Bearer",
+      expires_in: ctx.config.accessTokenTtl,
+      scope: code.scopes.join(" "),
+      ...(refresh ? { refresh_token: refresh.token } : {}),
+    });
+    return;
+  }
+
+  if (grantType === "refresh_token") {
+    const auth = authenticateClient(ctx, req, body);
+    const refresh = ctx.store.refreshTokens.get(body.refresh_token ?? "");
+    const detail: Record<string, unknown> = {
+      authMethod: auth.method,
+      resource: body.resource,
+      reusedRotatedToken: refresh?.rotated === true,
+    };
+    if (!refresh) {
+      tokenError(400, "invalid_grant", "unknown refresh_token", "token_refresh", detail);
+      return;
+    }
+    if (refresh.rotated) {
+      tokenError(400, "invalid_grant", "refresh_token was rotated and is no longer valid", "token_refresh", detail);
+      return;
+    }
+    if (auth.client && auth.client.clientId !== refresh.clientId) {
+      tokenError(400, "invalid_grant", "refresh_token belongs to a different client", "token_refresh", detail);
+      return;
+    }
+    refresh.rotated = true;
+    const access = ctx.store.issueAccessToken({
+      clientId: refresh.clientId,
+      scopes: refresh.scopes,
+      resource: body.resource ?? refresh.resource,
+      expiresAt: Date.now() + ctx.config.accessTokenTtl * 1000,
+      grant: "refresh_token",
+    });
+    const nextRefresh = ctx.store.issueRefreshToken({
+      clientId: refresh.clientId,
+      scopes: refresh.scopes,
+      resource: refresh.resource,
+    });
+    ctx.capture().record({
+      kind: "token_refresh",
+      method: "POST",
+      path: "/token",
+      status: 200,
+      userAgent: ua,
+      detail,
+    });
+    sendJson(res, 200, {
+      access_token: access.token,
+      token_type: "Bearer",
+      expires_in: ctx.config.accessTokenTtl,
+      scope: refresh.scopes.join(" "),
+      refresh_token: nextRefresh.token,
+    });
+    return;
+  }
+
+  if (grantType === JWT_BEARER_GRANT) {
+    if (!ctx.config.xaaIssuer) {
+      tokenError(400, "unsupported_grant_type", "jwt-bearer (XAA/ID-JAG) is disabled; start with --xaa-issuer <url>", "token_jwt_bearer");
+      return;
+    }
+    const assertion = body.assertion;
+    if (!assertion) {
+      tokenError(400, "invalid_request", "assertion is required", "token_jwt_bearer");
+      return;
+    }
+    try {
+      const jwks = createRemoteJWKSet(new URL(`${ctx.config.xaaIssuer}/.well-known/jwks.json`));
+      const { payload } = await jwtVerify(assertion, jwks, { issuer: ctx.config.xaaIssuer });
+      const access = ctx.store.issueAccessToken({
+        clientId: typeof payload.client_id === "string" ? payload.client_id : "xaa-client",
+        scopes: [...CHALLENGE_SCOPES],
+        resource: typeof payload.resource === "string" ? payload.resource : undefined,
+        expiresAt: Date.now() + ctx.config.accessTokenTtl * 1000,
+        grant: "jwt-bearer",
+      });
+      ctx.capture().record({
+        kind: "token_jwt_bearer",
+        method: "POST",
+        path: "/token",
+        status: 200,
+        userAgent: ua,
+        detail: {
+          issuer: payload.iss,
+          audience: payload.aud,
+          subject: typeof payload.sub === "string" ? payload.sub : undefined,
+          resource: typeof payload.resource === "string" ? payload.resource : undefined,
+        },
+      });
+      sendJson(res, 200, {
+        access_token: access.token,
+        token_type: "Bearer",
+        expires_in: ctx.config.accessTokenTtl,
+        scope: access.scopes.join(" "),
+      });
+    } catch (error) {
+      tokenError(
+        400,
+        "invalid_grant",
+        `ID-JAG verification failed: ${error instanceof Error ? error.message : "unknown"}`,
+        "token_jwt_bearer",
+      );
+    }
+    return;
+  }
+
+  tokenError(400, "unsupported_grant_type", `grant_type "${grantType}" is not supported`, "token_error", { grantType });
+}

--- a/reference-servers/oauth-full/src/oauth.ts
+++ b/reference-servers/oauth-full/src/oauth.ts
@@ -362,7 +362,7 @@ async function resolveCimdClient(ctx: OAuthContext, clientId: string): Promise<R
 // /authorize
 // ---------------------------------------------------------------------------
 
-const escapeHtml = (value: string) =>
+export const escapeHtml = (value: string) =>
   value.replace(/[&<>"']/g, (ch) => `&#${ch.charCodeAt(0)};`);
 
 export async function handleAuthorize(ctx: OAuthContext, req: IncomingMessage, res: ServerResponse, url: URL): Promise<void> {

--- a/reference-servers/oauth-full/src/store.ts
+++ b/reference-servers/oauth-full/src/store.ts
@@ -1,0 +1,87 @@
+import { randomBytes } from "node:crypto";
+
+export interface RegisteredClient {
+  clientId: string;
+  clientSecret?: string;
+  redirectUris: string[];
+  tokenEndpointAuthMethod: "none" | "client_secret_post" | "client_secret_basic";
+  source: "dcr" | "cimd" | "preregistered";
+  clientName?: string;
+  clientUri?: string;
+  logoUri?: string;
+  grantTypes?: string[];
+}
+
+export interface AuthorizationCode {
+  code: string;
+  clientId: string;
+  redirectUri: string;
+  codeChallenge?: string;
+  codeChallengeMethod?: string;
+  scopes: string[];
+  resource?: string;
+  expiresAt: number;
+  used: boolean;
+}
+
+export interface AccessToken {
+  token: string;
+  clientId: string;
+  scopes: string[];
+  resource?: string;
+  expiresAt: number;
+  grant: "authorization_code" | "refresh_token" | "jwt-bearer";
+}
+
+export interface RefreshToken {
+  token: string;
+  clientId: string;
+  scopes: string[];
+  resource?: string;
+  /** Rotated-out tokens stay in the store, flagged, so reuse is detectable. */
+  rotated: boolean;
+}
+
+const id = (prefix: string) => `${prefix}_${randomBytes(24).toString("base64url")}`;
+
+export class OAuthStore {
+  readonly clients = new Map<string, RegisteredClient>();
+  readonly codes = new Map<string, AuthorizationCode>();
+  readonly accessTokens = new Map<string, AccessToken>();
+  readonly refreshTokens = new Map<string, RefreshToken>();
+
+  registerClient(client: Omit<RegisteredClient, "clientId"> & { clientId?: string }): RegisteredClient {
+    const full: RegisteredClient = {
+      ...client,
+      clientId: client.clientId ?? id("oauth-ref-client"),
+    };
+    this.clients.set(full.clientId, full);
+    return full;
+  }
+
+  issueCode(params: Omit<AuthorizationCode, "code" | "used">): AuthorizationCode {
+    const code: AuthorizationCode = { ...params, code: id("code"), used: false };
+    this.codes.set(code.code, code);
+    return code;
+  }
+
+  issueAccessToken(params: Omit<AccessToken, "token">): AccessToken {
+    const token: AccessToken = { ...params, token: id("ref_at") };
+    this.accessTokens.set(token.token, token);
+    return token;
+  }
+
+  issueRefreshToken(params: Omit<RefreshToken, "token" | "rotated">): RefreshToken {
+    const token: RefreshToken = { ...params, token: id("ref_rt"), rotated: false };
+    this.refreshTokens.set(token.token, token);
+    return token;
+  }
+
+  /** Returns the live token or an expiry/miss reason. */
+  lookupAccessToken(raw: string): { token?: AccessToken; reason?: "unknown" | "expired" } {
+    const token = this.accessTokens.get(raw);
+    if (!token) return { reason: "unknown" };
+    if (Date.now() > token.expiresAt) return { reason: "expired" };
+    return { token };
+  }
+}

--- a/reference-servers/oauth-full/tests/oauth-flow.test.ts
+++ b/reference-servers/oauth-full/tests/oauth-flow.test.ts
@@ -1,0 +1,180 @@
+import { createHash, randomBytes } from "node:crypto";
+import type { AddressInfo } from "node:net";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { parseConfig } from "../src/config.js";
+import { createReferenceServer, type ReferenceServer } from "../src/http.js";
+
+let server: ReferenceServer;
+let origin: string;
+
+beforeAll(async () => {
+  const config = parseConfig(["--port", "0", "--label", "vitest"]);
+  config.captureDir = mkdtempSync(join(tmpdir(), "oauth-ref-"));
+  server = createReferenceServer(config);
+  await new Promise<void>((resolve) => server.httpServer.listen(0, "127.0.0.1", resolve));
+  const address = server.httpServer.address() as AddressInfo;
+  origin = `http://127.0.0.1:${address.port}`;
+  // Rebuild advertised URLs against the ephemeral port.
+  config.publicUrl = origin;
+});
+
+afterAll(async () => {
+  await server.close();
+});
+
+describe("oauth reference server", () => {
+  it("serves PRM and AS metadata", async () => {
+    const prm = await (await fetch(`${origin}/.well-known/oauth-protected-resource/mcp`)).json();
+    expect(prm.resource).toBe(`${origin}/mcp`);
+    expect(prm.authorization_servers).toEqual([origin]);
+
+    const meta = await (await fetch(`${origin}/.well-known/oauth-authorization-server`)).json();
+    expect(meta.issuer).toBe(origin);
+    expect(meta.code_challenge_methods_supported).toEqual(["S256"]);
+    expect(meta.registration_endpoint).toBe(`${origin}/register`);
+  });
+
+  it("401s unauthenticated MCP requests with a resource_metadata challenge", async () => {
+    const res = await fetch(`${origin}/mcp`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", method: "initialize", id: 1 }),
+    });
+    expect(res.status).toBe(401);
+    expect(res.headers.get("www-authenticate")).toContain("resource_metadata=");
+  });
+
+  it("completes DCR + PKCE + token + authenticated MCP call, and derives traits", async () => {
+    const redirectUri = "http://127.0.0.1:33418/callback";
+    const reg = await (
+      await fetch(`${origin}/register`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          client_name: "vitest-client",
+          redirect_uris: [redirectUri],
+          token_endpoint_auth_method: "none",
+        }),
+      })
+    ).json();
+    expect(reg.client_id).toBeTruthy();
+
+    const verifier = randomBytes(48).toString("base64url");
+    const challenge = createHash("sha256").update(verifier).digest("base64url");
+    const authorizeUrl = new URL(`${origin}/authorize`);
+    authorizeUrl.search = new URLSearchParams({
+      response_type: "code",
+      client_id: reg.client_id,
+      redirect_uri: redirectUri,
+      state: "st4te",
+      code_challenge: challenge,
+      code_challenge_method: "S256",
+      scope: "mcp:tools mcp:resources mcp:prompts",
+      resource: `${origin}/mcp`,
+    }).toString();
+    const authRes = await fetch(authorizeUrl, { redirect: "manual" });
+    expect(authRes.status).toBe(302);
+    const location = new URL(authRes.headers.get("location")!);
+    expect(location.searchParams.get("state")).toBe("st4te");
+    const code = location.searchParams.get("code")!;
+
+    // Wrong verifier must be rejected.
+    const bad = await fetch(`${origin}/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        code,
+        client_id: reg.client_id,
+        redirect_uri: redirectUri,
+        code_verifier: "wrong-verifier-wrong-verifier-wrong-verifier",
+      }),
+    });
+    expect(bad.status).toBe(400);
+
+    // A rejected exchange must not consume the code? (RFC: it should be
+    // invalidated — our store marks used only on success, matching AS
+    // implementations that allow retry until expiry. Re-issue a code.)
+    const authRes2 = await fetch(authorizeUrl, { redirect: "manual" });
+    const code2 = new URL(authRes2.headers.get("location")!).searchParams.get("code")!;
+
+    const tokens = await (
+      await fetch(`${origin}/token`, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "authorization_code",
+          code: code2,
+          client_id: reg.client_id,
+          redirect_uri: redirectUri,
+          code_verifier: verifier,
+          resource: `${origin}/mcp`,
+        }),
+      })
+    ).json();
+    expect(tokens.access_token).toMatch(/^ref_at_/);
+    expect(tokens.refresh_token).toMatch(/^ref_rt_/);
+
+    const init = await fetch(`${origin}/mcp`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        Authorization: `Bearer ${tokens.access_token}`,
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        method: "initialize",
+        id: 1,
+        params: {
+          protocolVersion: "2025-06-18",
+          capabilities: {},
+          clientInfo: { name: "vitest", version: "0" },
+        },
+      }),
+    });
+    expect(init.status).toBe(200);
+    const initText = await init.text();
+    expect(initText).toContain("mcpjam-oauth-reference-server");
+
+    // Refresh rotation: old token becomes invalid after use.
+    const refreshed = await (
+      await fetch(`${origin}/token`, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "refresh_token",
+          refresh_token: tokens.refresh_token,
+          client_id: reg.client_id,
+        }),
+      })
+    ).json();
+    expect(refreshed.access_token).toBeTruthy();
+    const reuse = await fetch(`${origin}/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "refresh_token",
+        refresh_token: tokens.refresh_token,
+        client_id: reg.client_id,
+      }),
+    });
+    expect(reuse.status).toBe(400);
+
+    // Derived traits reflect the run.
+    const report = await (await fetch(`${origin}/capture/report`)).json();
+    expect(report.traits.completedFlow).toBe(true);
+    expect(report.traits.registration.strategy).toBe("dcr");
+    expect(report.traits.registration.dcrIdentity.clientName).toBe("vitest-client");
+    expect(report.traits.authorization.usedPkce).toBe(true);
+    expect(report.traits.authorization.scopeRequestPolicy).toBe("challenge-derived");
+    expect(report.traits.authorization.sendsResourceParamAuthorize).toBe(true);
+    expect(report.traits.token.refreshSucceeded).toBe(true);
+    expect(report.oauthProfile.authClass).toBe("oauth");
+    expect(report.oauthProfile.registrationStrategy).toBe("dcr");
+    expect(report.oauthProfile.sendsResourceParam).toBe(true);
+  });
+});

--- a/reference-servers/oauth-full/tsconfig.json
+++ b/reference-servers/oauth-full/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*.ts", "scripts/**/*.mjs"]
+}


### PR DESCRIPTION
## What & why

HP-10 ([HP-10 in Kestral](https://app.kestral.ai/workspace/yhNILB2/task/13L68bSk)): validate OAuth support per client against a full-capability reference MCP server, and **start storing per-client OAuth data**.

We have deep OAuth machinery in the SDK (DCR, CIMD, PKCE, XAA/ID-JAG debugger) but no server that gates the full capability surface behind OAuth, and no ground truth on how each client actually performs the handshake. This PR adds that server and the capture pipeline that turns real client runs into stored OAuth traits.

## What's here

A new npm workspace `reference-servers/oauth-full` (`@mcpjam/oauth-reference-server`):

- **Full capability surface** — tools (incl. `whoami`, `test_elicitation`, MCP Apps UI), resources (static / binary / template / subscribable), prompts, logging, progress, completions, elicitation.
- **Embedded OAuth 2.1 authorization server** exercising the full auth surface the task calls for:
  - RFC 9728 protected-resource metadata (root + `/mcp` path variants) + `WWW-Authenticate` challenge
  - RFC 8414 + OIDC authorization-server metadata
  - Dynamic Client Registration (real client store, redirect-uri pinning)
  - CIMD — URL `client_id`s, document fetched and validated (with a DNS-resolving SSRF guard; loopback allowed only in local mode)
  - PKCE S256 **validated** (`plain` rejected; required by default)
  - Authorization-code + refresh with **rotation + reuse detection**
  - RFC 8707 `resource` indicators (recorded; `--require-resource` for strict mode)
  - XAA / ID-JAG jwt-bearer redemption against a trusted issuer's JWKS
- **Per-client capture** — every request is recorded per labeled run and distilled into derived OAuth traits, an automatic failure taxonomy (`no-oauth-attempt`, `discovery-only`, `broken-redirect-or-exchange`, `no-pkce`, `no-prm-discovery`, `token-refresh-failed`, `refresh-rotation-unsupported`, `token-unused`), and an HP-1 `HostConfigOAuthProfileV1`-shaped `oauthProfile`. `scripts/build-matrix.mjs` merges captures into the client × OAuth-feature results matrix.

## Verification

- `npm run test -w @mcpjam/oauth-reference-server` — 3 integration tests (metadata, 401 challenge, full DCR+PKCE+token+MCP+refresh-rotation flow) pass; typecheck passes.
- Validated live against the real **mcpjam** client: `mcpjam oauth login … --verify-call-tool whoami` completes the full flow; and the Inspector OAuth debugger (`/oauth-flow`, local mode) steps through end to end.
- CIMD and XAA jwt-bearer redemption verified against a local issuer; negative paths (wrong PKCE verifier, invalid bearer, `plain` PKCE, tampered ID-JAG, rotated-refresh reuse) all reject correctly.

https://github.com/user-attachments/assets/878ece08-b106-4e7d-b4d7-6a995d03f040



## Scope / follow-ups

- This PR is the **harness + the mcpjam row**. The other 9 catalog clients are manual runs that fill the rest of the matrix (runbook in the package README); `captures/` and `RESULTS.md` are gitignored run artifacts attached to the Kestral task.
- The `oauthProfile` blocks are **paste-ready but not yet wired** — that waits on HP-1's SDK/backend PRs (`HostConfigOAuthProfileV1`), which are still open.
- OAuth support verdicts will eventually surface through the `CompatDisplayStatus` surface added in #3257 (this PR is the data producer; that's the future display consumer).
- The new package is intentionally **not** wired into root build/test CI yet — happy to add it if desired.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Builds `@mcpjam/oauth-reference-server`, a full-capability MCP server gated by OAuth 2.1, to validate OAuth support per client and store per-client OAuth traits for HP-10.

- **New Features**
  - Full MCP surface behind OAuth: tools, resources (static/binary/templates/subscribable), prompts, MCP Apps UI, logging, progress, completions, elicitation.
  - Embedded auth server: protected-resource metadata + `WWW-Authenticate`, AS metadata (OIDC), Dynamic Client Registration, CIMD with SSRF guard, PKCE S256 (required), auth code + refresh with rotation/reuse detection, resource indicators, XAA/ID-JAG JWT-bearer via JWKS.
  - Per-client capture: records labeled runs, derives OAuth traits and failure taxonomy, outputs HP‑1‑shaped `oauthProfile`; `scripts/build-matrix.mjs` builds the client × feature matrix.

- **Bug Fixes**
  - Escape the capture label on the landing page to prevent stored XSS when set via `/capture/reset`.

<sup>Written for commit 01254808448f4ba60e22058b222d41318ead4121. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

