### PR TITLE
COMP-8 (data plane): enforce upload quota at every writer + fix Electron 404

### DIFF
--- a/mcpjam-inspector/server/app.ts
+++ b/mcpjam-inspector/server/app.ts
@@ -65,6 +65,9 @@ import { requestLogContextMiddleware } from "./middleware/request-log-context.js
 import { registerSelfFetch } from "./utils/self-app.js";
 import { getInspectorFrontendUrl } from "./utils/inspector-frontend-url.js";
 import { initComputersStartup } from "./utils/computers/remote-data-plane.js";
+import { createNodeWebSocket } from "@hono/node-ws";
+import { createComputerTerminalWsHandler } from "./routes/web/computer-terminal.js";
+import { createComputerUploadHandler } from "./routes/web/computer-upload.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -100,6 +103,12 @@ export async function createHonoApp() {
   await initComputersStartup();
 
   const app = new Hono();
+  // Computer terminal WebSocket support (Project Computers). Mirror of
+  // server/index.ts — the Electron/embedded entry must wire the SAME upgrade
+  // handler so the Computer tab's Shell + drag-and-drop upload work here too.
+  // `injectWebSocket` is returned to the caller (src/main.ts) to attach to the
+  // node server, exactly as server/index.ts calls it on its own server.
+  const { upgradeWebSocket, injectWebSocket } = createNodeWebSocket({ app });
   const strictModeResponse = (c: any, path: string) =>
     c.json(
       {
@@ -256,6 +265,29 @@ export async function createHonoApp() {
     );
   }
   app.route("/api/web", webRoutes);
+  // Computer terminal WebSocket + file upload (Project Computers). Registered
+  // directly on the root app because the WS upgrade handler comes from
+  // `createNodeWebSocket`; the upload route carries its own 30MB bodyLimit (the
+  // global /api/web/* 1MB cap excludes this path). Mirror of the mount in
+  // server/index.ts — both production entries must wire this up, else the
+  // Electron/embedded entry 404s these paths. When computers aren't configured
+  // the handlers return a clean 503 (not a raw 404).
+  app.get(
+    "/api/web/computers/terminal",
+    createComputerTerminalWsHandler(upgradeWebSocket)
+  );
+  app.post(
+    "/api/web/computers/upload",
+    bodyLimit({
+      maxSize: 30 * 1024 * 1024,
+      onError: (c) =>
+        c.json(
+          { ok: false, error: "Upload exceeds the 30MB request limit." },
+          413
+        ),
+    }),
+    createComputerUploadHandler()
+  );
 
   // Hosted public API (v1). Same 1MB JSON cap as /api/web; the canonical
   // resource-oriented routes wrap the same core helpers and emit the v1
@@ -271,9 +303,9 @@ export async function createHonoApp() {
             code: "VALIDATION_ERROR",
             message: "Request body exceeds 1MB limit",
           },
-          400,
+          400
         ),
-    }),
+    })
   );
   app.route("/api/v1", v1Routes);
 
@@ -436,8 +468,9 @@ export async function createHonoApp() {
           })
         ) {
           try {
-            const { session, setCookies } =
-              await mintGuestSessionForDocument(c);
+            const { session, setCookies } = await mintGuestSessionForDocument(
+              c
+            );
             if (session && session.expiresAt > Date.now()) {
               const bootstrapScript = buildGuestBootstrapScript(session);
               html = html.replace("</head>", `${bootstrapScript}</head>`);
@@ -448,7 +481,7 @@ export async function createHonoApp() {
           } catch (error) {
             appLogger.warn(
               "[guest-bootstrap] document mint failed; serving without blob",
-              { error: error instanceof Error ? error.message : String(error) },
+              { error: error instanceof Error ? error.message : String(error) }
             );
           }
         }
@@ -485,5 +518,7 @@ export async function createHonoApp() {
   // client (see utils/self-app.ts) — their /api/v1 calls skip the network.
   registerSelfFetch((request) => app.fetch(request));
 
-  return app;
+  // Return `injectWebSocket` alongside the app so the caller (src/main.ts) can
+  // attach the WS upgrade handler to its node server — same as server/index.ts.
+  return { app, injectWebSocket };
 }

--- a/mcpjam-inspector/server/routes/web/__tests__/computer-upload.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/computer-upload.test.ts
@@ -34,7 +34,9 @@ beforeAll(async () => {
   jwksDoc = { keys: [{ ...jwk, kid: KID, alg: "RS256", use: "sig" }] };
 });
 
-async function signToken(claims: Record<string, unknown> = {}): Promise<string> {
+async function signToken(
+  claims: Record<string, unknown> = {}
+): Promise<string> {
   const now = Math.floor(Date.now() / 1000);
   const {
     iss = ISSUER,
@@ -112,6 +114,12 @@ function installSandboxInfoStub(
           headers: { "content-type": "application/json" },
         });
       }
+      if (path === "/computers/reserve-upload-bytes") {
+        return new Response(
+          JSON.stringify({ ok: true, total: 100, cap: 500 * 1024 * 1024 }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        );
+      }
       throw new Error(`unexpected path ${path}`);
     })
   );
@@ -121,7 +129,10 @@ function stubConfiguredEnv() {
   vi.stubEnv("CONVEX_HTTP_URL", CONVEX_URL);
   vi.stubEnv("INSPECTOR_SERVICE_TOKEN", "test-svc-token");
   vi.stubEnv("E2B_API_KEY", "e2b_test");
-  vi.stubEnv("COMPUTERS_TERMINAL_TOKEN_SECRET", "test-terminal-secret-0123456789");
+  vi.stubEnv(
+    "COMPUTERS_TERMINAL_TOKEN_SECRET",
+    "test-terminal-secret-0123456789"
+  );
 }
 
 function createApp(connectSandbox: (id: string) => Promise<UploadSandbox>) {
@@ -203,7 +214,9 @@ describe("POST /api/web/computers/upload", () => {
     const form = new FormData();
     form.append("files", new File([new Uint8Array([1, 2])], "a.txt"));
     const res = await app.request(
-      `/api/web/computers/upload?token=${encodeURIComponent(await signToken())}`,
+      `/api/web/computers/upload?token=${encodeURIComponent(
+        await signToken()
+      )}`,
       { method: "POST", body: form }
     );
     expect(res.status).toBe(401);
@@ -387,6 +400,50 @@ describe("POST /api/web/computers/upload", () => {
     ]);
     expect(res.status).toBe(401);
     expect(fake.writes).toHaveLength(0);
+  });
+
+  it("413s and writes nothing when the upload exceeds the cumulative quota", async () => {
+    stubConfiguredEnv();
+    installSandboxInfoStub((path) =>
+      path === "/computers/reserve-upload-bytes"
+        ? {
+            status: 413,
+            json: {
+              error: "Upload would exceed this computer's storage quota.",
+              total: 500 * 1024 * 1024,
+              cap: 500 * 1024 * 1024,
+            },
+          }
+        : undefined
+    );
+    const fake = fakeSandbox();
+    const app = createApp(async () => fake.sandbox);
+    const res = await uploadRequest(app, await signToken(), [
+      new File([new Uint8Array([1, 2, 3])], "a.txt"),
+    ]);
+    expect(res.status).toBe(413);
+    expect(fake.writes).toHaveLength(0);
+    const body = (await res.json()) as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toMatch(/quota/i);
+  });
+
+  it("fails OPEN (still writes) when the quota reserve route is unavailable (404)", async () => {
+    // An older backend without the reserve route returns 404. The quota is a
+    // hygiene control, not the trust boundary, so the upload proceeds.
+    stubConfiguredEnv();
+    installSandboxInfoStub((path) =>
+      path === "/computers/reserve-upload-bytes"
+        ? { status: 404, json: { error: "Computer not found" } }
+        : undefined
+    );
+    const fake = fakeSandbox();
+    const app = createApp(async () => fake.sandbox);
+    const res = await uploadRequest(app, await signToken(), [
+      new File([new Uint8Array([1, 2, 3])], "a.txt"),
+    ]);
+    expect(res.status).toBe(200);
+    expect(fake.writes).toHaveLength(1);
   });
 
   it("503s when the computer is still provisioning (no providerComputerId)", async () => {

--- a/mcpjam-inspector/server/routes/web/computer-upload.ts
+++ b/mcpjam-inspector/server/routes/web/computer-upload.ts
@@ -35,14 +35,12 @@ import { verifyComputerTerminalToken } from "../../utils/computers/terminal-toke
 import {
   getComputerSandboxInfo,
   isComputersDataPlaneConfigured,
+  reserveUploadBytes,
 } from "../../utils/computers/control-plane-client.js";
+import { confineToHome } from "../../utils/computers/path-confine.js";
 import { logger } from "../../utils/logger.js";
 import { classifyError } from "../../utils/error-classify.js";
 
-/** The box home. The client may request a specific destination dir (the Shell's
- *  cwd — e.g. the harness session workdir `/home/user/claude-code-<id>`); we
- *  confine any requested dir under this root and fall back to `UPLOAD_ROOT`. */
-const HOME_ROOT = "/home/user";
 /** Fallback destination when the client provides no (or an invalid) target dir
  *  — e.g. a plain computer host, or the Shell opened before any harness turn. */
 const UPLOAD_ROOT = "/home/user/uploads";
@@ -68,20 +66,13 @@ export interface ComputerUploadDeps {
 
 /** Resolve the destination directory. The client passes the Shell's cwd (the
  *  harness workdir) so uploads land where the user is actually working, not in a
- *  detached bucket. We confine it under the box home and reject traversal; any
- *  missing/invalid value falls back to `UPLOAD_ROOT`. This is hygiene, not a
- *  trust boundary — the terminal token already grants full shell write access —
- *  but it keeps the endpoint from being a write-anywhere primitive and avoids
- *  footguns like a stray dir landing files in `/etc`. */
+ *  detached bucket. We confine it under the box home (shared `confineToHome`);
+ *  any missing/invalid/escaping value falls back to `UPLOAD_ROOT`. This is
+ *  hygiene, not a trust boundary — the terminal token already grants full shell
+ *  write access — but it keeps the endpoint from being a write-anywhere
+ *  primitive and avoids footguns like a stray dir landing files in `/etc`. */
 function resolveUploadDir(requested: string | undefined): string {
-  if (!requested || requested.length > MAX_DIR_LEN) return UPLOAD_ROOT;
-  if (!requested.startsWith("/")) return UPLOAD_ROOT;
-  const normalized = posix.normalize(requested).replace(/\/+$/, "");
-  if (normalized !== HOME_ROOT && !normalized.startsWith(`${HOME_ROOT}/`)) {
-    return UPLOAD_ROOT;
-  }
-  if (normalized.split("/").includes("..")) return UPLOAD_ROOT;
-  return normalized;
+  return confineToHome(requested, { maxLen: MAX_DIR_LEN }) ?? UPLOAD_ROOT;
 }
 
 /** Turn a user-supplied filename into a safe, collision-free basename. Strips
@@ -91,7 +82,8 @@ function resolveUploadDir(requested: string | undefined): string {
 function safeUploadName(rawName: string): string {
   const base = posix.basename(rawName || "");
   const cleaned = base.replace(/[^\w.\- ]/g, "_").trim();
-  const safe = cleaned && cleaned !== "." && cleaned !== ".." ? cleaned : "file";
+  const safe =
+    cleaned && cleaned !== "." && cleaned !== ".." ? cleaned : "file";
   return `${randomUUID().slice(0, 8)}-${safe}`;
 }
 
@@ -120,7 +112,9 @@ export function createComputerUploadHandler(deps: ComputerUploadDeps = {}) {
         401
       );
     }
-    const info = await getComputerSandboxInfo({ computerId: claims.computerId });
+    const info = await getComputerSandboxInfo({
+      computerId: claims.computerId,
+    });
     if (!info.ok) {
       return c.json(
         { ok: false, error: `Computer unavailable: ${info.error}` },
@@ -139,7 +133,10 @@ export function createComputerUploadHandler(deps: ComputerUploadDeps = {}) {
       );
     }
     if (!info.value.providerComputerId) {
-      return c.json({ ok: false, error: "Computer is still provisioning." }, 503);
+      return c.json(
+        { ok: false, error: "Computer is still provisioning." },
+        503
+      );
     }
     const sandboxId = info.value.providerComputerId;
 
@@ -168,7 +165,9 @@ export function createComputerUploadHandler(deps: ComputerUploadDeps = {}) {
         return c.json(
           {
             ok: false,
-            error: `File "${f.name}" exceeds the ${MAX_FILE_BYTES / 1024 / 1024} MB per-file limit.`,
+            error: `File "${f.name}" exceeds the ${
+              MAX_FILE_BYTES / 1024 / 1024
+            } MB per-file limit.`,
           },
           413
         );
@@ -179,6 +178,41 @@ export function createComputerUploadHandler(deps: ComputerUploadDeps = {}) {
       return c.json(
         { ok: false, error: "Upload exceeds the total size limit." },
         413
+      );
+    }
+
+    // Cumulative-upload quota: reserve the bytes on the Convex row BEFORE
+    // writing (atomic check-and-increment, so concurrent uploads can't both slip
+    // past the cap). Over quota → 413, write nothing. Any OTHER failure fails
+    // OPEN with a loud log: the quota is an anti-abuse/hygiene control, not the
+    // tenant-isolation boundary (that's the terminal token), and the per-file /
+    // total / count caps above still bound this single request. A 404 here means
+    // the route isn't deployed yet (older backend) — we already confirmed the
+    // computer exists via getComputerSandboxInfo — so it too fails open during a
+    // staged rollout rather than blocking uploads.
+    const reservation = await reserveUploadBytes({
+      computerId: claims.computerId,
+      bytes: totalBytes,
+    });
+    if (!reservation.ok) {
+      if (reservation.status === 413) {
+        return c.json(
+          {
+            ok: false,
+            error:
+              reservation.error ||
+              "Upload would exceed this computer's storage quota.",
+          },
+          413
+        );
+      }
+      logger.warn(
+        "[computer-upload] quota reserve unavailable — allowing upload",
+        {
+          computerId: claims.computerId,
+          status: reservation.status,
+          error: reservation.error,
+        }
       );
     }
 

--- a/mcpjam-inspector/server/utils/computers/__tests__/path-confine.test.ts
+++ b/mcpjam-inspector/server/utils/computers/__tests__/path-confine.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { confineToHome, HOME_ROOT } from "../path-confine.js";
+
+describe("confineToHome", () => {
+  it("accepts the home root itself", () => {
+    expect(confineToHome("/home/user")).toBe("/home/user");
+  });
+
+  it("accepts a descendant of the home root", () => {
+    expect(confineToHome("/home/user/.claude/skills/x")).toBe(
+      "/home/user/.claude/skills/x"
+    );
+    expect(confineToHome("/home/user/claude-code-abc")).toBe(
+      "/home/user/claude-code-abc"
+    );
+  });
+
+  it("normalizes redundant separators and trailing slashes", () => {
+    expect(confineToHome("/home/user//uploads/")).toBe("/home/user/uploads");
+  });
+
+  it("rejects paths that escape via ..", () => {
+    expect(confineToHome("/home/user/../etc")).toBeNull();
+    expect(confineToHome("/home/user/../../etc/passwd")).toBeNull();
+    expect(confineToHome("/home/user/a/../../root")).toBeNull();
+  });
+
+  it("rejects absolute paths outside the home root", () => {
+    expect(confineToHome("/etc/passwd")).toBeNull();
+    expect(confineToHome("/tmp/x")).toBeNull();
+    expect(confineToHome("/")).toBeNull();
+  });
+
+  it("rejects a sibling directory sharing the home prefix", () => {
+    // `/home/user2` must not be treated as under `/home/user`.
+    expect(confineToHome("/home/user2/secret")).toBeNull();
+  });
+
+  it("rejects missing, relative, and over-length inputs", () => {
+    expect(confineToHome(undefined)).toBeNull();
+    expect(confineToHome("")).toBeNull();
+    expect(confineToHome("relative/path")).toBeNull();
+    expect(confineToHome("home/user/x")).toBeNull();
+    expect(confineToHome(`/home/user/${"a".repeat(2000)}`)).toBeNull();
+  });
+
+  it("honors a custom maxLen", () => {
+    const p = "/home/user/short";
+    expect(confineToHome(p, { maxLen: 5 })).toBeNull();
+    expect(confineToHome(p, { maxLen: 1000 })).toBe(p);
+  });
+
+  it("exposes the home root constant", () => {
+    expect(HOME_ROOT).toBe("/home/user");
+  });
+});

--- a/mcpjam-inspector/server/utils/computers/control-plane-client.ts
+++ b/mcpjam-inspector/server/utils/computers/control-plane-client.ts
@@ -278,6 +278,46 @@ export async function recordComputerCommand(args: {
   }
 }
 
+export interface UploadBytesReservation {
+  total: number;
+  cap: number;
+}
+
+/**
+ * Reserve `bytes` against the computer's cumulative-upload quota BEFORE writing
+ * them into the box (service-token auth). The check-and-increment is atomic in
+ * Convex, so this is the race-safe chokepoint shared by every metered file-API
+ * writer (the `/computers/upload` route and harness skill-file materialization).
+ * Callers MUST write only on `{ ok: true }`:
+ *   - ok:true              → reserved; proceed with the write.
+ *   - ok:false, status 413 → over quota; surface a 413-style error, write nothing.
+ *   - ok:false, status 404 → computer gone; treat as unavailable (503).
+ *   - ok:false, status 0   → not configured / network error; caller decides its
+ *                            fail-open vs fail-closed policy.
+ * Not idempotent — one successful call reserves the bytes exactly once, so call
+ * it once per write with the total byte count.
+ */
+export async function reserveUploadBytes(args: {
+  computerId: string;
+  bytes: number;
+  signal?: AbortSignal;
+}): Promise<ControlPlaneResult<UploadBytesReservation>> {
+  const headers = authHeaders();
+  if (!headers) {
+    return {
+      ok: false,
+      status: 0,
+      error: "INSPECTOR_SERVICE_TOKEN is not set or was rejected",
+    };
+  }
+  return postJson<UploadBytesReservation>(
+    "/computers/reserve-upload-bytes",
+    headers,
+    { computerId: args.computerId, bytes: args.bytes },
+    args.signal
+  );
+}
+
 /** Record a terminal session transition (service-token auth; idempotent). */
 export async function recordTerminalSession(args: {
   sessionId: string;

--- a/mcpjam-inspector/server/utils/computers/path-confine.ts
+++ b/mcpjam-inspector/server/utils/computers/path-confine.ts
@@ -1,0 +1,45 @@
+/**
+ * Shared path confinement for the computer file-API writers (the
+ * `/computers/upload` route and the harness sandbox provider). Keeps every
+ * writer's destination under the box home (`/home/user`) so none becomes a
+ * casual write-anywhere primitive.
+ *
+ * This is HYGIENE, not a security boundary. Any holder of a computer terminal
+ * token can already run arbitrary shell commands in the box (`cat > /etc/x`,
+ * `dd`), so the file writers grant no capability the shell doesn't. In
+ * particular a symlinked parent (e.g. `/home/user/uploads -> /etc`) would defeat
+ * pure string normalization, and defending it would need a per-write `realpath`
+ * round-trip into the sandbox — not worth it under the current
+ * terminal-token/shell trust model. Revisit with a runtime `realpath` check only
+ * if a file writer is ever decoupled from shell access.
+ */
+import { posix } from "node:path";
+
+/** The box home. Confinement root for every metered file-API writer. */
+export const HOME_ROOT = "/home/user";
+
+const DEFAULT_MAX_PATH_LEN = 1024;
+
+/**
+ * Confine an absolute path to `/home/user`. Returns the normalized path when it
+ * is `/home/user` or a descendant, or `null` when the input is missing, not
+ * absolute, over `maxLen`, or escapes the home root (via `..` or a sibling
+ * prefix like `/home/user2`). `posix.normalize` collapses `.`/`..` so
+ * `/home/user/../etc` resolves to `/etc` and is rejected by the prefix check;
+ * the explicit `..` scan is a belt-and-suspenders guard for any residual
+ * segment.
+ */
+export function confineToHome(
+  path: string | undefined,
+  opts?: { maxLen?: number }
+): string | null {
+  const maxLen = opts?.maxLen ?? DEFAULT_MAX_PATH_LEN;
+  if (!path || path.length > maxLen) return null;
+  if (!path.startsWith("/")) return null;
+  const normalized = posix.normalize(path).replace(/\/+$/, "") || "/";
+  if (normalized !== HOME_ROOT && !normalized.startsWith(`${HOME_ROOT}/`)) {
+    return null;
+  }
+  if (normalized.split("/").includes("..")) return null;
+  return normalized;
+}

--- a/mcpjam-inspector/server/utils/harness/__tests__/materialize-skill-files.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/materialize-skill-files.test.ts
@@ -1,10 +1,25 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { materializeSkillFiles } from "../materialize-skill-files";
 import type { RuntimeSkillFile } from "../runtime-skills";
+import { reserveUploadBytes } from "../../computers/control-plane-client.js";
+
+// The quota client is a network call; stub it so metering is deterministic.
+// Default: allow (reserved). Existing tests pass no `computerId`, so it's never
+// called there and the default is irrelevant to them.
+vi.mock("../../computers/control-plane-client.js", () => ({
+  reserveUploadBytes: vi.fn(async () => ({
+    ok: true as const,
+    value: { total: 0, cap: 500 * 1024 * 1024 },
+  })),
+}));
+const mockReserve = vi.mocked(reserveUploadBytes);
 
 const SKILLS_BASE = "/home/user/.claude/skills";
 
-function fakeSession(onBoxFiles: string[] = []) {
+function fakeSession(
+  onBoxFiles: string[] = [],
+  sizeByPath: Record<string, number> = {}
+) {
   const writes: { path: string; bytes: number }[] = [];
   const removed: string[] = [];
   return {
@@ -16,6 +31,14 @@ function fakeSession(onBoxFiles: string[] = []) {
       ),
       run: vi.fn(async ({ command }: { command: string }) => {
         if (command.startsWith("find")) {
+          // The size-gathering sweep (getOnBoxFileSizes) uses `-printf` and
+          // expects "<size>\t<path>" lines; the prune sweep lists bare paths.
+          if (command.includes("-printf")) {
+            const lines = Object.entries(sizeByPath).map(
+              ([p, s]) => `${s}\t${p}`
+            );
+            return { exitCode: 0, stdout: lines.join("\n"), stderr: "" };
+          }
           return { exitCode: 0, stdout: onBoxFiles.join("\n"), stderr: "" };
         }
         if (command.startsWith("rm")) {
@@ -48,6 +71,11 @@ beforeEach(() => {
       arrayBuffer: async () => new Uint8Array([1, 2, 3, 4, 5]).buffer,
     }))
   );
+  mockReserve.mockReset();
+  mockReserve.mockResolvedValue({
+    ok: true,
+    value: { total: 0, cap: 500 * 1024 * 1024 },
+  });
 });
 afterEach(() => vi.unstubAllGlobals());
 
@@ -198,5 +226,100 @@ describe("materializeSkillFiles", () => {
       skillNamesById: new Map([["sk_1", "pdf-tools"]]),
     });
     expect(removed).toEqual([]);
+  });
+
+  describe("cumulative upload quota (computerId present)", () => {
+    const target = `${SKILLS_BASE}/pdf-tools/scripts/run.py`;
+
+    it("does not meter at all when computerId is absent", async () => {
+      const { session } = fakeSession();
+      await materializeSkillFiles({
+        session,
+        files: [file({})],
+        skillNamesById: new Map([["sk_1", "pdf-tools"]]),
+      });
+      expect(mockReserve).not.toHaveBeenCalled();
+    });
+
+    it("reserves the full size for a net-new file (not on box)", async () => {
+      const { session, writes } = fakeSession();
+      const res = await materializeSkillFiles({
+        session,
+        files: [file({})], // 5 bytes from the fetch stub
+        skillNamesById: new Map([["sk_1", "pdf-tools"]]),
+        computerId: "computers_1",
+      });
+      expect(mockReserve).toHaveBeenCalledWith({
+        computerId: "computers_1",
+        bytes: 5,
+      });
+      expect(res.written).toBe(1);
+      expect(writes).toHaveLength(1);
+    });
+
+    it("reserves only the delta when a larger version replaces a smaller on-box file", async () => {
+      // On box: 2 bytes at the target; new content is 5 → delta 3.
+      const { session } = fakeSession([], { [target]: 2 });
+      await materializeSkillFiles({
+        session,
+        files: [file({})],
+        skillNamesById: new Map([["sk_1", "pdf-tools"]]),
+        computerId: "computers_1",
+      });
+      expect(mockReserve).toHaveBeenCalledWith({
+        computerId: "computers_1",
+        bytes: 3,
+      });
+    });
+
+    it("reserves nothing when re-materializing an unchanged file (same size)", async () => {
+      // On box: already 5 bytes at the target; content is 5 → delta 0.
+      const { session, writes } = fakeSession([], { [target]: 5 });
+      const res = await materializeSkillFiles({
+        session,
+        files: [file({})],
+        skillNamesById: new Map([["sk_1", "pdf-tools"]]),
+        computerId: "computers_1",
+      });
+      expect(mockReserve).not.toHaveBeenCalled();
+      // Still written (idempotent rewrite) — the quota just isn't charged again.
+      expect(res.written).toBe(1);
+      expect(writes).toHaveLength(1);
+    });
+
+    it("skips the file (no write) when the reserve is over quota (413)", async () => {
+      mockReserve.mockResolvedValue({
+        ok: false,
+        status: 413,
+        error: "over quota",
+      });
+      const { session, writes } = fakeSession();
+      const res = await materializeSkillFiles({
+        session,
+        files: [file({})],
+        skillNamesById: new Map([["sk_1", "pdf-tools"]]),
+        computerId: "computers_1",
+      });
+      expect(res.written).toBe(0);
+      expect(res.skipped).toBe(1);
+      expect(writes).toHaveLength(0);
+    });
+
+    it("fails OPEN (still writes) when the reserve route is unavailable (non-413)", async () => {
+      mockReserve.mockResolvedValue({
+        ok: false,
+        status: 404,
+        error: "route not deployed",
+      });
+      const { session, writes } = fakeSession();
+      const res = await materializeSkillFiles({
+        session,
+        files: [file({})],
+        skillNamesById: new Map([["sk_1", "pdf-tools"]]),
+        computerId: "computers_1",
+      });
+      expect(res.written).toBe(1);
+      expect(writes).toHaveLength(1);
+    });
   });
 });

--- a/mcpjam-inspector/server/utils/harness/e2b-sandbox-provider.ts
+++ b/mcpjam-inspector/server/utils/harness/e2b-sandbox-provider.ts
@@ -22,6 +22,8 @@ import type {
   HarnessV1NetworkSandboxSession,
   HarnessV1SandboxProvider,
 } from "@ai-sdk/harness";
+import { confineToHome } from "../computers/path-confine.js";
+import { logger } from "../logger.js";
 
 export interface E2BHarnessSandboxProviderOptions {
   /** E2B sandbox id of the host's computer — resolved via the control plane
@@ -48,6 +50,29 @@ export interface E2BHarnessSandboxProviderOptions {
 }
 
 const enc = new TextEncoder();
+
+/**
+ * Path confinement for the harness file writers — keeps every `write*` under the
+ * box home (`/home/user`), the same hygiene the `/computers/upload` route
+ * applies. Shipped LOG-ONLY by default: the Claude Code adapter writes its
+ * workdir, `.claude/skills`, and `.mcp.json` (all under `/home/user`), but this
+ * layer had zero confinement before, so a hard reject could break a turn on a
+ * legitimate write we haven't accounted for. Set
+ * `HARNESS_WRITE_CONFINE_ENFORCE=true` to reject once real traffic confirms no
+ * legitimate escapes. Like the upload route this is hygiene, not the trust
+ * boundary — the harness runs arbitrary code in the box by design.
+ */
+function enforceHarnessWritePath(path: string): void {
+  if (confineToHome(path) !== null) return;
+  const enforce = process.env.HARNESS_WRITE_CONFINE_ENFORCE === "true";
+  logger.warn("[e2b-sandbox-provider] write path escapes /home/user", {
+    path,
+    enforce,
+  });
+  if (enforce) {
+    throw new Error(`refusing to write outside /home/user: ${path}`);
+  }
+}
 
 /** E2B throws `FileNotFoundError` for a missing path; the SandboxSession
  *  contract wants `null` there, but real failures (transport / permission /
@@ -82,7 +107,7 @@ function bytesToStream(bytes: Uint8Array): ReadableStream<Uint8Array> {
 }
 
 async function streamToBytes(
-  stream: ReadableStream<Uint8Array>,
+  stream: ReadableStream<Uint8Array>
 ): Promise<Uint8Array> {
   const chunks: Uint8Array[] = [];
   const reader = stream.getReader();
@@ -102,7 +127,7 @@ async function streamToBytes(
 }
 
 export function createE2BHarnessSandboxProvider(
-  opts: E2BHarnessSandboxProviderOptions,
+  opts: E2BHarnessSandboxProviderOptions
 ): HarnessV1SandboxProvider {
   const bridgePort = opts.bridgePort ?? 39271;
   const cwd = opts.defaultWorkingDirectory ?? "/home/user";
@@ -117,196 +142,200 @@ export function createE2BHarnessSandboxProvider(
   // On resume the Claude Code adapter rehydrates its thread from the workdir
   // (which persists on the box) using the `resumeFrom` state; our provider just
   // has to supply the sandbox connection.
-  const connectSession =
-    async (): Promise<HarnessV1NetworkSandboxSession> => {
-      // Reuse the host's existing computer. It must already be awake — the
-      // caller wakes it via the control plane (`ensureComputerReady`) before
-      // resolving the sandboxId. We never create or kill a box here.
-      const sandbox = await Sandbox.connect(opts.sandboxId, {
-        apiKey: opts.apiKey,
-        timeoutMs: opts.connectTimeoutMs,
-      });
+  const connectSession = async (): Promise<HarnessV1NetworkSandboxSession> => {
+    // Reuse the host's existing computer. It must already be awake — the
+    // caller wakes it via the control plane (`ensureComputerReady`) before
+    // resolving the sandboxId. We never create or kill a box here.
+    const sandbox = await Sandbox.connect(opts.sandboxId, {
+      apiKey: opts.apiKey,
+      timeoutMs: opts.connectTimeoutMs,
+    });
 
-      // Mutated in place by setPorts so `session.ports` (same ref) stays live.
-      const ports: number[] = [bridgePort];
+    // Mutated in place by setPorts so `session.ports` (same ref) stays live.
+    const ports: number[] = [bridgePort];
 
-      // The @ai-sdk/harness-claude-code bootstrap shells `pnpm install` BEFORE
-      // any session hook runs. pnpm is baked into the computer template
-      // (mcpjam-backend templates/computer/e2b.Dockerfile); this idempotent
-      // guard is a stopgap for boxes provisioned before that template rebuild
-      // lands, and no-ops once pnpm is present. We do not own the box, so a
-      // failure here propagates (the control plane still owns teardown).
-      await sandbox.commands.run("command -v pnpm || npm install -g pnpm", {
-        timeoutMs: commandTimeoutMs,
-      });
+    // The @ai-sdk/harness-claude-code bootstrap shells `pnpm install` BEFORE
+    // any session hook runs. pnpm is baked into the computer template
+    // (mcpjam-backend templates/computer/e2b.Dockerfile); this idempotent
+    // guard is a stopgap for boxes provisioned before that template rebuild
+    // lands, and no-ops once pnpm is present. We do not own the box, so a
+    // failure here propagates (the control plane still owns teardown).
+    await sandbox.commands.run("command -v pnpm || npm install -g pnpm", {
+      timeoutMs: commandTimeoutMs,
+    });
 
-      const session: HarnessV1NetworkSandboxSession = {
-        id: sandbox.sandboxId,
-        defaultWorkingDirectory: cwd,
-        description:
-          `E2B sandbox ${sandbox.sandboxId} (host computer). Working dir ${cwd}. ` +
-          `Bridge port ${bridgePort} reachable at ${sandbox.getHost(bridgePort)}.`,
+    const session: HarnessV1NetworkSandboxSession = {
+      id: sandbox.sandboxId,
+      defaultWorkingDirectory: cwd,
+      description:
+        `E2B sandbox ${sandbox.sandboxId} (host computer). Working dir ${cwd}. ` +
+        `Bridge port ${bridgePort} reachable at ${sandbox.getHost(
+          bridgePort
+        )}.`,
 
-        // ── file I/O ──────────────────────────────────────────────────────
-        readTextFile: async ({ path }) => {
-          try {
-            return await sandbox.files.read(path);
-          } catch (err) {
-            return nullIfMissing(err); // null only for a genuinely missing file
-          }
-        },
-        readBinaryFile: async ({ path }) => {
-          try {
-            return await sandbox.files.read(path, { format: "bytes" });
-          } catch (err) {
-            return nullIfMissing(err);
-          }
-        },
-        readFile: async ({ path }) => {
-          try {
-            const bytes = await sandbox.files.read(path, { format: "bytes" });
-            return bytesToStream(bytes);
-          } catch (err) {
-            return nullIfMissing(err);
-          }
-        },
-        writeTextFile: async ({ path, content }) => {
-          await sandbox.files.write([{ path, data: content }]);
-        },
-        writeBinaryFile: async ({ path, content }) => {
-          await sandbox.files.write([{ path, data: u8ToArrayBuffer(content) }]);
-        },
-        writeFile: async ({ path, content }) => {
-          const bytes = await streamToBytes(content);
-          await sandbox.files.write([{ path, data: u8ToArrayBuffer(bytes) }]);
-        },
+      // ── file I/O ──────────────────────────────────────────────────────
+      readTextFile: async ({ path }) => {
+        try {
+          return await sandbox.files.read(path);
+        } catch (err) {
+          return nullIfMissing(err); // null only for a genuinely missing file
+        }
+      },
+      readBinaryFile: async ({ path }) => {
+        try {
+          return await sandbox.files.read(path, { format: "bytes" });
+        } catch (err) {
+          return nullIfMissing(err);
+        }
+      },
+      readFile: async ({ path }) => {
+        try {
+          const bytes = await sandbox.files.read(path, { format: "bytes" });
+          return bytesToStream(bytes);
+        } catch (err) {
+          return nullIfMissing(err);
+        }
+      },
+      writeTextFile: async ({ path, content }) => {
+        enforceHarnessWritePath(path);
+        await sandbox.files.write([{ path, data: content }]);
+      },
+      writeBinaryFile: async ({ path, content }) => {
+        enforceHarnessWritePath(path);
+        await sandbox.files.write([{ path, data: u8ToArrayBuffer(content) }]);
+      },
+      writeFile: async ({ path, content }) => {
+        enforceHarnessWritePath(path);
+        const bytes = await streamToBytes(content);
+        await sandbox.files.write([{ path, data: u8ToArrayBuffer(bytes) }]);
+      },
 
-        // ── exec ──────────────────────────────────────────────────────────
-        run: async ({ command, workingDirectory, env }) => {
-          try {
-            const res = await sandbox.commands.run(command, {
-              cwd: workingDirectory ?? cwd,
-              envs: env,
-              timeoutMs: commandTimeoutMs,
-            });
-            return {
-              exitCode: res.exitCode,
-              stdout: res.stdout,
-              stderr: res.stderr,
-            };
-          } catch (err) {
-            // E2B throws on non-zero exit; the contract wants the result
-            // (exitCode + streams) surfaced, not a rejection.
-            if (err instanceof CommandExitError) {
-              return {
-                exitCode: err.exitCode,
-                stdout: err.stdout,
-                stderr: err.stderr,
-              };
-            }
-            throw err;
-          }
-        },
-
-        // ── spawn (long-lived; adapt E2B callbacks → ReadableStreams) ──────
-        spawn: async ({ command, workingDirectory, env }) => {
-          let outCtl!: ReadableStreamDefaultController<Uint8Array>;
-          let errCtl!: ReadableStreamDefaultController<Uint8Array>;
-          let streamsClosed = false;
-          const closeStreams = () => {
-            if (streamsClosed) return;
-            streamsClosed = true;
-            try {
-              outCtl.close();
-            } catch {
-              /* already closed */
-            }
-            try {
-              errCtl.close();
-            } catch {
-              /* already closed */
-            }
-          };
-          const stdout = new ReadableStream<Uint8Array>({
-            start: (c) => (outCtl = c),
-          });
-          const stderr = new ReadableStream<Uint8Array>({
-            start: (c) => (errCtl = c),
-          });
-          const handle = await sandbox.commands.run(command, {
-            background: true,
+      // ── exec ──────────────────────────────────────────────────────────
+      run: async ({ command, workingDirectory, env }) => {
+        try {
+          const res = await sandbox.commands.run(command, {
             cwd: workingDirectory ?? cwd,
             envs: env,
-            // Guard against enqueue-after-close once the process ends/is killed.
-            onStdout: (d: string) => {
-              if (!streamsClosed) outCtl.enqueue(enc.encode(d));
-            },
-            onStderr: (d: string) => {
-              if (!streamsClosed) errCtl.enqueue(enc.encode(d));
-            },
+            timeoutMs: commandTimeoutMs,
           });
-          // Observe exit exactly once; normalize E2B's throw-on-nonzero into an
-          // exit code so wait() resolves (contract) instead of rejecting.
-          const exitPromise: Promise<{ exitCode: number }> = handle
-            .wait()
-            .then((r) => ({ exitCode: r.exitCode }))
-            .catch((err) => {
-              if (err instanceof CommandExitError) {
-                return { exitCode: err.exitCode };
-              }
-              throw err;
-            });
-          // Close streams when the process ends on its OWN — not only via
-          // wait()/kill() — so a consumer reading to EOF never hangs.
-          void exitPromise.then(closeStreams, closeStreams);
           return {
-            pid: handle.pid,
-            stdout,
-            stderr,
-            wait: async () => {
-              try {
-                return await exitPromise;
-              } finally {
-                closeStreams();
-              }
-            },
-            kill: async () => {
-              try {
-                await handle.kill();
-              } finally {
-                closeStreams(); // parity with wait; never leave readers hanging
-              }
-            },
+            exitCode: res.exitCode,
+            stdout: res.stdout,
+            stderr: res.stderr,
           };
-        },
+        } catch (err) {
+          // E2B throws on non-zero exit; the contract wants the result
+          // (exitCode + streams) surfaced, not a rejection.
+          if (err instanceof CommandExitError) {
+            return {
+              exitCode: err.exitCode,
+              stdout: err.stdout,
+              stderr: err.stderr,
+            };
+          }
+          throw err;
+        }
+      },
 
-        // ── infra surface ─────────────────────────────────────────────────
-        ports,
-        getPortUrl: async ({ port, protocol }) => {
-          const host = sandbox.getHost(port);
-          const scheme = protocol === "ws" ? "wss" : (protocol ?? "https");
-          return `${scheme}://${host}`;
-        },
-        // Never tear down a shared host computer: the control plane owns its
-        // lifecycle (provision / wake / hibernate / delete). Ending a harness
-        // session leaves the box running. The harness cleans up its own bridge
-        // process via the spawn handle's kill(), not via the sandbox.
-        stop: async () => {
-          /* no-op — control-plane-owned box */
-        },
-        // destroy intentionally omitted (undefined) for the same reason.
-        setPorts: async (next) => {
-          // Mutate in place so `session.ports` (same reference) reflects it.
-          ports.splice(0, ports.length, ...next);
-        },
-        // setNetworkPolicy omitted — E2B sets egress at create time; the
-        // optional-call contract treats a missing impl as a no-op.
+      // ── spawn (long-lived; adapt E2B callbacks → ReadableStreams) ──────
+      spawn: async ({ command, workingDirectory, env }) => {
+        let outCtl!: ReadableStreamDefaultController<Uint8Array>;
+        let errCtl!: ReadableStreamDefaultController<Uint8Array>;
+        let streamsClosed = false;
+        const closeStreams = () => {
+          if (streamsClosed) return;
+          streamsClosed = true;
+          try {
+            outCtl.close();
+          } catch {
+            /* already closed */
+          }
+          try {
+            errCtl.close();
+          } catch {
+            /* already closed */
+          }
+        };
+        const stdout = new ReadableStream<Uint8Array>({
+          start: (c) => (outCtl = c),
+        });
+        const stderr = new ReadableStream<Uint8Array>({
+          start: (c) => (errCtl = c),
+        });
+        const handle = await sandbox.commands.run(command, {
+          background: true,
+          cwd: workingDirectory ?? cwd,
+          envs: env,
+          // Guard against enqueue-after-close once the process ends/is killed.
+          onStdout: (d: string) => {
+            if (!streamsClosed) outCtl.enqueue(enc.encode(d));
+          },
+          onStderr: (d: string) => {
+            if (!streamsClosed) errCtl.enqueue(enc.encode(d));
+          },
+        });
+        // Observe exit exactly once; normalize E2B's throw-on-nonzero into an
+        // exit code so wait() resolves (contract) instead of rejecting.
+        const exitPromise: Promise<{ exitCode: number }> = handle
+          .wait()
+          .then((r) => ({ exitCode: r.exitCode }))
+          .catch((err) => {
+            if (err instanceof CommandExitError) {
+              return { exitCode: err.exitCode };
+            }
+            throw err;
+          });
+        // Close streams when the process ends on its OWN — not only via
+        // wait()/kill() — so a consumer reading to EOF never hangs.
+        void exitPromise.then(closeStreams, closeStreams);
+        return {
+          pid: handle.pid,
+          stdout,
+          stderr,
+          wait: async () => {
+            try {
+              return await exitPromise;
+            } finally {
+              closeStreams();
+            }
+          },
+          kill: async () => {
+            try {
+              await handle.kill();
+            } finally {
+              closeStreams(); // parity with wait; never leave readers hanging
+            }
+          },
+        };
+      },
 
-        restricted: () => session, // same resource, narrower static type
-      };
+      // ── infra surface ─────────────────────────────────────────────────
+      ports,
+      getPortUrl: async ({ port, protocol }) => {
+        const host = sandbox.getHost(port);
+        const scheme = protocol === "ws" ? "wss" : protocol ?? "https";
+        return `${scheme}://${host}`;
+      },
+      // Never tear down a shared host computer: the control plane owns its
+      // lifecycle (provision / wake / hibernate / delete). Ending a harness
+      // session leaves the box running. The harness cleans up its own bridge
+      // process via the spawn handle's kill(), not via the sandbox.
+      stop: async () => {
+        /* no-op — control-plane-owned box */
+      },
+      // destroy intentionally omitted (undefined) for the same reason.
+      setPorts: async (next) => {
+        // Mutate in place so `session.ports` (same reference) reflects it.
+        ports.splice(0, ports.length, ...next);
+      },
+      // setNetworkPolicy omitted — E2B sets egress at create time; the
+      // optional-call contract treats a missing impl as a no-op.
 
-      return session;
+      restricted: () => session, // same resource, narrower static type
     };
+
+    return session;
+  };
 
   return {
     specificationVersion: "harness-sandbox-v1",

--- a/mcpjam-inspector/server/utils/harness/materialize-skill-files.ts
+++ b/mcpjam-inspector/server/utils/harness/materialize-skill-files.ts
@@ -23,6 +23,7 @@ import { isPathWithinDirectory } from "../skill-parser.js";
 import type { RuntimeSkillFile } from "./runtime-skills.js";
 import { shellQuote } from "./shell-quote.js";
 import { logger } from "../logger.js";
+import { reserveUploadBytes } from "../computers/control-plane-client.js";
 
 const SKILLS_BASE = "/home/user/.claude/skills";
 /** Per-turn write budget across ALL skills (matches the backend per-skill cap). */
@@ -94,6 +95,39 @@ async function pruneStaleSkillFiles(
 }
 
 /**
+ * Map of on-box supporting-file abs path → byte size, gathered in one `find`
+ * sweep. Used to meter only NET-NEW bytes against the cumulative upload quota:
+ * re-materializing an unchanged file (same size) reserves nothing, so a
+ * long-lived box re-running materialization every turn can't inflate the counter
+ * past the real disk footprint. Fail-soft: on any error returns an empty map, so
+ * files are treated as net-new (conservative — over-counts toward the cap,
+ * never under).
+ */
+async function getOnBoxFileSizes(
+  session: MaterializeSession
+): Promise<Map<string, number>> {
+  const sizes = new Map<string, number>();
+  try {
+    const ls = await session.run({
+      command: `find ${shellQuote(
+        SKILLS_BASE
+      )} -mindepth 2 -type f ! -name SKILL.md -printf '%s\\t%p\\n'`,
+    });
+    if (ls.exitCode !== 0) return sizes;
+    for (const line of ls.stdout.split("\n")) {
+      const tab = line.indexOf("\t");
+      if (tab <= 0) continue;
+      const size = Number(line.slice(0, tab));
+      const path = line.slice(tab + 1).trim();
+      if (Number.isFinite(size) && path) sizes.set(path, size);
+    }
+  } catch {
+    // Best-effort — treat as no known sizes (every write counts as net-new).
+  }
+  return sizes;
+}
+
+/**
  * Write every runtime skill file onto the box under its skill dir. `skillNamesById`
  * maps skillId → on-box dir name for ALL skills delivered this turn (not only
  * those with files); a file whose skill isn't in the map is skipped (its dir
@@ -106,11 +140,20 @@ export async function materializeSkillFiles(args: {
   session: MaterializeSession;
   files: RuntimeSkillFile[];
   skillNamesById: Map<string, string>;
+  /** Convex computer row id. When present, each write reserves its NET-NEW bytes
+   *  against the computer's cumulative-upload quota (a file already on the box at
+   *  the same size reserves nothing); over quota → that file is skipped. Absent
+   *  (e.g. a non-computer host or tests) ⇒ no metering. */
+  computerId?: string;
   signal?: AbortSignal;
 }): Promise<{ written: number; skipped: number }> {
   let written = 0;
   let skipped = 0;
   let budget = MATERIALIZE_BUDGET_BYTES;
+  // Only pay for the size sweep when we're actually metering.
+  const onBoxSizes = args.computerId
+    ? await getOnBoxFileSizes(args.session)
+    : new Map<string, number>();
 
   // Every delivered skill dir is a prune candidate (even with zero files this
   // turn). Build the keep-set (valid target paths) per dir from the file list;
@@ -189,9 +232,46 @@ export async function materializeSkillFiles(args: {
         skipped += 1;
         continue;
       }
+      const targetPath = `${skillDir}/${file.path}`;
+      // Cumulative upload quota: reserve only the NET-NEW bytes (delta over any
+      // existing on-box copy) so re-materializing unchanged files each turn can't
+      // inflate the counter. Over quota → skip this file (413-style); other
+      // reserve failures (route not deployed / not configured / network) fail
+      // OPEN — the per-turn budget above still bounds the write.
+      if (args.computerId) {
+        const existing = onBoxSizes.get(targetPath) ?? 0;
+        const delta = bytes.byteLength - existing;
+        if (delta > 0) {
+          const reservation = await reserveUploadBytes({
+            computerId: args.computerId,
+            bytes: delta,
+          });
+          if (!reservation.ok) {
+            if (reservation.status === 413) {
+              logger.info(
+                "[materialize-skill-files] skip: over storage quota",
+                {
+                  skill: skillName,
+                  path: file.path,
+                }
+              );
+              skipped += 1;
+              continue;
+            }
+            logger.warn(
+              "[materialize-skill-files] quota reserve unavailable — allowing write",
+              { skill: skillName, status: reservation.status }
+            );
+          } else {
+            // Reflect the reservation locally so a repeated path in the same
+            // batch can't double-reserve.
+            onBoxSizes.set(targetPath, bytes.byteLength);
+          }
+        }
+      }
       budget -= bytes.byteLength;
       await args.session.writeBinaryFile({
-        path: `${skillDir}/${file.path}`,
+        path: targetPath,
         content: bytes,
       });
       written += 1;

--- a/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
+++ b/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
@@ -719,7 +719,9 @@ export async function runHarnessTurn(
           ...(chatboxId ? { chatboxId } : {}),
           // Swarm continuity lane — the run + pinned host key the owner so a
           // multi-turn swarm harness session resumes ONLY its own sidecar.
-          ...(ownerType === "swarm-chat" && journeyRunId ? { journeyRunId } : {}),
+          ...(ownerType === "swarm-chat" && journeyRunId
+            ? { journeyRunId }
+            : {}),
           ...(ownerType === "swarm-chat" && hostId ? { hostId } : {}),
           // Phase 3: route owner resolution through resolveExecutionAccess so a
           // host-funded swarm guest can claim/resume their OWN lane.
@@ -939,6 +941,7 @@ export async function runHarnessTurn(
                   skillNamesById: new Map(
                     runtimeSkills.map((s) => [s.skillId, s.name])
                   ),
+                  computerId: String(computerId),
                   ...(abortSignal ? { signal: abortSignal } : {}),
                 }).catch(() => {});
               }

--- a/mcpjam-inspector/src/main.ts
+++ b/mcpjam-inspector/src/main.ts
@@ -283,9 +283,7 @@ async function startHonoServer(): Promise<number> {
       // picking a different free port and silently desyncing CORS,
       // origin validation, and LOCAL_SERVER_ADDR from the bound port.
       port = cachedProbedPort;
-      log.info(
-        `Reusing previously-probed port ${port} for server restart`,
-      );
+      log.info(`Reusing previously-probed port ${port} for server restart`);
     } else {
       // Probe for a free port BEFORE loading server modules. server/config.ts
       // reads SERVER_PORT from process.env once, at module-init time, and that
@@ -300,10 +298,12 @@ async function startHonoServer(): Promise<number> {
         {
           onAttemptFailed: (failedPort, err) => {
             log.warn(
-              `Port ${failedPort} unavailable (${err.code ?? err.message}); trying next port`,
+              `Port ${failedPort} unavailable (${
+                err.code ?? err.message
+              }); trying next port`
             );
           },
-        },
+        }
       );
       process.env.SERVER_PORT = String(port);
       cachedProbedPort = port;
@@ -314,17 +314,20 @@ async function startHonoServer(): Promise<number> {
     // Node's cache; subsequent calls just return the cached exports, which
     // is exactly what we want now that we're reusing the same port.
     const { createHonoApp } = await import("../server/app.js");
-    const honoApp = await createHonoApp();
+    const { app: honoApp, injectWebSocket } = await createHonoApp();
 
     server = serve({
       fetch: honoApp.fetch,
       port,
       hostname,
     });
+    // Attach the computer terminal WebSocket upgrade handler (mirror of
+    // server/index.ts). Without this the Computer tab's Shell can't upgrade.
+    injectWebSocket(server);
 
     if (port !== DEFAULT_SERVER_PORT) {
       log.warn(
-        `🚀 MCPJam Server started on fallback port ${port} (default ${DEFAULT_SERVER_PORT} was unavailable)`,
+        `🚀 MCPJam Server started on fallback port ${port} (default ${DEFAULT_SERVER_PORT} was unavailable)`
       );
     } else {
       log.info(`🚀 MCPJam Server started on port ${port}`);
@@ -611,7 +614,9 @@ function pruneStaleCachesOnVersionChange(): void {
   }
 
   log.info(
-    `App version changed (${previousVersion ?? "<none>"} → ${currentVersion}); pruning stale GPU/HTTP caches`,
+    `App version changed (${
+      previousVersion ?? "<none>"
+    } → ${currentVersion}); pruning stale GPU/HTTP caches`
   );
 
   for (const sub of ["Cache", "Code Cache", "GPUCache"]) {
@@ -634,7 +639,9 @@ function summarizeInitError(error: unknown): {
   detail: string;
 } {
   const err =
-    error instanceof Error ? error : new Error(String(error ?? "Unknown error"));
+    error instanceof Error
+      ? error
+      : new Error(String(error ?? "Unknown error"));
 
   const isServerStartFailure = /bind server|EADDRINUSE|Hono/i.test(err.message);
   const message = isServerStartFailure
@@ -687,7 +694,7 @@ function showStartupFailureDialog(error: unknown): void {
     } catch (rmErr) {
       log.warn(
         "Failed to remove .last-launched-version during recovery reset:",
-        rmErr,
+        rmErr
       );
     }
     app.relaunch();
@@ -706,7 +713,9 @@ function showStartupFailureDialog(error: unknown): void {
       .openPath(app.getPath("logs"))
       .then((result) => {
         if (result) {
-          log.warn(`shell.openPath reported error opening logs folder: ${result}`);
+          log.warn(
+            `shell.openPath reported error opening logs folder: ${result}`
+          );
         }
       })
       .catch((openErr) => log.warn("Failed to open logs folder:", openErr))
@@ -763,7 +772,7 @@ app.whenReady().then(async () => {
     } catch (dialogErr) {
       log.error(
         "Failed to show startup failure dialog; quitting silently:",
-        dialogErr,
+        dialogErr
       );
       app.quit();
     }


### PR DESCRIPTION
## COMP-8 (data plane): enforce upload quota at every writer + fix Electron 404

Part of **COMP-8**. Enforces the per-computer cumulative-upload quota at every code path that writes user-supplied files into a computer's E2B sandbox, and fixes the Electron variant of the upload route that 404'd (found in the #2996 review).

> **Deploy order:** merge/deploy **after** the backend PR (MCPJam/mcpjam-backend#comp-8), which adds the `/computers/reserve-upload-bytes` route this calls. Until then the inspector fails **open** (logs a warning, still writes) — the per-request 30 MB / 25 MB / 20-file caps still bound a single request.

### Writers that put user files into the sandbox (enumerated)
| Writer | Quota metered | Path-confined |
|--------|---------------|---------------|
| `POST /api/web/computers/upload` route | ✅ reserves total bytes before write → 413 over quota | ✅ `confineToHome` (fallback to `/home/user/uploads`) |
| Harness skill-file materialization (`materialize-skill-files`) | ✅ reserves **net-new** bytes only (delta vs on-box size) | ✅ existing `isPathWithinDirectory` |
| Harness provider `write*` methods (`e2b-sandbox-provider`) | — (covered transitively above) | ✅ `confineToHome`, **log-only** default |
| `bash` tool (`commands.run`) | ❌ by design — shell trust boundary, unbounded | n/a |
| Local skills upload (`~/.mcpjam/skills`) | n/a — host FS, not the sandbox | n/a |

No writer auto-unpacks archives (verified) — an uploaded `.zip` lands opaque.

### Key points
- **Net-new metering** for skill files: re-materializing unchanged files each turn reserves nothing (delta vs on-box size), so idempotent re-materialization can't inflate the counter and wedge a long-lived box.
- **Provider path confinement ships log-only** (`HARNESS_WRITE_CONFINE_ENFORCE=true` to reject) so a legitimate adapter write we haven't accounted for can't break a turn before real traffic confirms it's safe to enforce.
- **Fail-open on reserve outage:** a 404 (route not deployed) / network error logs loudly and still writes; only a `413` blocks.
- Extracted shared `confineToHome()` util; added `reserveUploadBytes` control-plane client fn.

### Electron fix
`createHonoApp()` (the factory the Electron/embedded entry uses) never mounted `POST /api/web/computers/upload` or the `/api/web/computers/terminal` WS — so both 404'd there. This mirrors both mounts from `server/index.ts` and returns `injectWebSocket` for `src/main.ts` to attach. Where computers aren't configured the handler now returns a clean **503**, not a raw 404.

### Tests (50)
```
npx vitest run \
  server/utils/computers/__tests__/path-confine.test.ts \
  server/utils/harness/__tests__/materialize-skill-files.test.ts \
  server/routes/web/__tests__/computer-upload.test.ts \
  server/routes/web/__tests__/computer-terminal.test.ts
```
Covers: `confineToHome` (traversal / sibling-prefix / relative / over-length); upload-route quota 413 + fail-open-on-404; materializer net-new / unchanged / over-quota / fail-open cases.

### Acceptance criteria
- [x] Upload past quota → clear 413 on every metered writer (tested per-writer)
- [x] Path-traversal rejected on every writer (tests)
- [x] Quota state visible/debuggable (`uploadBytesTotal` on the Convex row)
- [x] Electron upload works end-to-end (or clean 503 when unconfigured) — no longer a raw 404


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces a per-computer cumulative upload quota across all file writers and fixes the Electron upload/terminal 404 by mounting the routes and WebSocket (returns 503 when unconfigured). Part of COMP-8.

- **New Features**
  - Reserve bytes via `/computers/reserve-upload-bytes` before `/api/web/computers/upload` writes; 413 on over-quota, fail-open on 404/network errors.
  - Meter skill-file materialization by net-new bytes only (delta vs on-box size), so unchanged files aren’t re-charged.
  - Constrain harness provider `write*` paths to `/home/user` (log-only by default; set `HARNESS_WRITE_CONFINE_ENFORCE=true` to hard-enforce).

- **Migration**
  - Deploy after the backend adds `/computers/reserve-upload-bytes`; until then uploads proceed with warnings (per-request limits still apply).

<sup>Written for commit 2bc3b1856d4f5c31ed96a5638a8c461d26042521. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

