### PR TITLE
Fix Connect nav header overlap via container queries

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -859,7 +859,7 @@ export function HostCompareRoute({ bare = false }: { bare?: boolean } = {}) {
         rightSlot={
           // Host/Compare sub-nav inline in the header row (single bar) rather
           // than stacked beneath the primary nav.
-          <div className="flex min-w-0 items-center justify-center md:justify-end">
+          <div className="flex min-w-0 flex-wrap items-center justify-center gap-2 @2xl:justify-end">
             <HostSectionTabs
               value="compare"
               hostEnabled={Boolean(previewedHostId)}

--- a/mcpjam-inspector/client/src/components/HostsTab.tsx
+++ b/mcpjam-inspector/client/src/components/HostsTab.tsx
@@ -172,7 +172,7 @@ export function HostsTab({
                     rightSlot={
                       <div
                         ref={setAddServerSlotEl}
-                        className="flex min-w-0 flex-wrap items-center justify-center gap-3 md:justify-end"
+                        className="flex min-w-0 flex-wrap items-center justify-center gap-3 @2xl:justify-end"
                         data-testid="hosts-tab-add-server-slot"
                       />
                     }

--- a/mcpjam-inspector/client/src/components/hosts/ConnectViewHeader.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/ConnectViewHeader.tsx
@@ -29,11 +29,15 @@ export function ConnectViewHeader({
   const computersEnabled = useComputersEnabled();
   return (
     <div
-      className="relative shrink-0 border-b border-border/40 px-4 py-2.5 md:px-8"
+      className="@container relative shrink-0 border-b border-border/40 px-4 py-2.5 md:px-8"
       data-testid={testId}
     >
-      <div className="flex flex-col items-stretch gap-2 md:grid md:grid-cols-[1fr_auto_1fr] md:items-center md:gap-3">
-        <div className="hidden md:block" aria-hidden="true" />
+      {/* The layout switch is gated on the header's own width via `@container`
+          (not the viewport) so it stacks correctly when the sidebar is open
+          and the container — not the window — is narrow. Below the container
+          breakpoint the selector and right slot stack into one column. */}
+      <div className="flex flex-col items-stretch gap-2 @2xl:grid @2xl:grid-cols-[1fr_auto_1fr] @2xl:items-center @2xl:gap-3">
+        <div className="hidden @2xl:block" aria-hidden="true" />
         <div className="flex min-w-0 justify-center">
           <ViewModeSelector
             value={value}
@@ -54,7 +58,7 @@ export function ConnectViewHeader({
             ]}
           />
         </div>
-        {rightSlot ?? <div className="hidden md:block" aria-hidden="true" />}
+        {rightSlot ?? <div className="hidden @2xl:block" aria-hidden="true" />}
       </div>
     </div>
   );

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/HostBuilderViewRedesigned.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/HostBuilderViewRedesigned.tsx
@@ -449,51 +449,16 @@ export function HostBuilderViewRedesigned({
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-background text-foreground">
-      <div className="relative shrink-0 border-b border-border/40 px-8 py-2.5">
-        <div className="flex min-w-0 items-center justify-end gap-2 sm:gap-3">
-          {/* Host/Compare sub-nav sits inline beside Save — a single header
-              row instead of a second segmented bar stacked over the canvas. */}
-          <HostSectionTabs
-            value="host"
-            hostEnabled
-            onSelect={(next) => {
-              if (next === "compare") navigate("/host-compare");
-            }}
-          />
-          <Tooltip>
-            <TooltipTrigger asChild>
-              {/* Span wrapper: a disabled <button> swallows pointer events,
-                  so the tooltip must hang off an always-interactive parent. */}
-              <span className="inline-flex shrink-0">
-                <Button
-                  size="sm"
-                  onClick={() => void handleSave()}
-                  disabled={!canSave}
-                  variant={isDirty ? "default" : "ghost"}
-                  className={
-                    isDirty
-                      ? "shrink-0"
-                      : "shrink-0 text-muted-foreground hover:text-foreground disabled:opacity-40"
-                  }
-                >
-                  {isSaving ? (
-                    <Loader2 className="size-4 animate-spin" />
-                  ) : (
-                    <Save className="size-4" />
-                  )}
-                  {isDirty ? "Save client" : "Saved"}
-                </Button>
-              </span>
-            </TooltipTrigger>
-            {saveDisabledReason ? (
-              <TooltipContent side="bottom" variant="muted">
-                {saveDisabledReason}
-              </TooltipContent>
-            ) : null}
-          </Tooltip>
-        </div>
-        <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
-          <div className="pointer-events-auto">
+      <div className="@container relative shrink-0 border-b border-border/40 px-4 py-2.5 md:px-8">
+        {/* 3-column grid mirrors the Servers view (ConnectViewHeader): the
+            centered selector and the right-side controls each own a column so
+            they can never overlap. The switch is gated on the header's own
+            width via `@container` (not the viewport) so it stacks correctly
+            when the sidebar is open and the container — not the window — is
+            narrow. Below the container breakpoint it stacks into one column. */}
+        <div className="flex flex-col items-stretch gap-2 @2xl:grid @2xl:grid-cols-[1fr_auto_1fr] @2xl:items-center @2xl:gap-3">
+          <div className="hidden @2xl:block" aria-hidden="true" />
+          <div className="flex min-w-0 justify-center">
             <ViewModeSelector
               value="host"
               ariaLabel="Connect view"
@@ -518,6 +483,50 @@ export function HostBuilderViewRedesigned({
                   : []),
               ]}
             />
+          </div>
+          <div className="flex min-w-0 flex-wrap items-center justify-center gap-2 @2xl:justify-end sm:gap-3">
+            {/* Host/Compare sub-nav sits inline beside Save — a single header
+                row instead of a second segmented bar stacked over the canvas.
+                `flex-wrap` lets the pill + Save drop to their own line rather
+                than overlap if the column is ever squeezed. */}
+            <HostSectionTabs
+              value="host"
+              hostEnabled
+              onSelect={(next) => {
+                if (next === "compare") navigate("/host-compare");
+              }}
+            />
+            <Tooltip>
+              <TooltipTrigger asChild>
+                {/* Span wrapper: a disabled <button> swallows pointer events,
+                    so the tooltip must hang off an always-interactive parent. */}
+                <span className="inline-flex shrink-0">
+                  <Button
+                    size="sm"
+                    onClick={() => void handleSave()}
+                    disabled={!canSave}
+                    variant={isDirty ? "default" : "ghost"}
+                    className={
+                      isDirty
+                        ? "shrink-0"
+                        : "shrink-0 text-muted-foreground hover:text-foreground disabled:opacity-40"
+                    }
+                  >
+                    {isSaving ? (
+                      <Loader2 className="size-4 animate-spin" />
+                    ) : (
+                      <Save className="size-4" />
+                    )}
+                    {isDirty ? "Save client" : "Saved"}
+                  </Button>
+                </span>
+              </TooltipTrigger>
+              {saveDisabledReason ? (
+                <TooltipContent side="bottom" variant="muted">
+                  {saveDisabledReason}
+                </TooltipContent>
+              ) : null}
+            </Tooltip>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Problem

On **Connect**, the sub-nav header (Servers / Client / Compare / Computer) overlapped its own controls as the available width shrank — the centered view selector collided with the right-side Client|Compare pill and Save button. It reproduced most reliably **with the sidebar open** on the **Client** and **Compare** views (Servers was mostly spared only because its right slot is nearly empty).

## Root cause

The header used Tailwind `md:` breakpoints, which respond to the **viewport** width. Opening the sidebar shrinks the header's **container** without changing the viewport, so the 3-column grid stayed active while the container was too narrow to fit three columns → overlap. The Client view was additionally fragile because it absolutely positioned the centered selector on top of a `justify-end` row, so nothing reserved space for it at all.

## Fix

Switch the layout from viewport breakpoints to **Tailwind v4 container queries**, so it responds to the header's own width instead of the window:

- **`ConnectViewHeader`** (shared by Servers / Compare / Computer): outer element marked `@container`; the 3-column grid and its spacers gated on `@2xl:` instead of `md:`.
- **`HostBuilderViewRedesigned`** (Client): the absolute-overlay header was rebuilt as the same `@container` + `@2xl:` grid used everywhere else.
- **`App.tsx` / `HostsTab.tsx`**: right-slot alignment moved from `md:justify-end` → `@2xl:justify-end` so it tracks the same container breakpoint, plus `flex-wrap` on the control groups as a belt-and-suspenders guard against overlap.

Net effect: every Connect sub-view now stacks cleanly when the container is narrow, regardless of sidebar state, and all four views share one consistent header layout.

## Testing

- Verified manually in the dev inspector: Client and Compare no longer overlap with the sidebar open at narrow widths; the selector and controls stack onto separate rows instead.
- The `@2xl` (672px) threshold is where three columns stop fitting; adjustable if a different cutoff feels better.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Connect sub-nav header overlapping its controls by switching from viewport breakpoints to container queries. Headers now reflow based on their own width, so Client and Compare stack correctly even with the sidebar open.

- **Bug Fixes**
  - `ConnectViewHeader`: mark header as `@container` and gate the 3-column grid on `@2xl`.
  - `HostBuilderViewRedesigned`: replace absolute overlay with the same `@container` + `@@2xl` grid.
  - `App.tsx` / `HostsTab.tsx`: move right-slot alignment from `md:justify-end` to `@2xl:justify-end` and add `flex-wrap` to prevent overlap.

<sup>Written for commit 941c83b8db37e9cbe533186e240bab73e5e9d6b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

