### PR TITLE
fix(oauth): exclude XAA servers from OAuth Debugger picker

### DIFF
--- a/mcpjam-inspector/client/src/components/__tests__/ActiveServerSelector.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ActiveServerSelector.test.tsx
@@ -263,6 +263,16 @@ describe("ActiveServerSelector", () => {
           useOAuth: true,
           oauthTokens,
         }),
+        "untouched-undefined-http": createServer({
+          name: "untouched-undefined-http",
+          config: httpConfig,
+          useOAuth: undefined,
+        }),
+        "disconnected-http": createServer({
+          name: "disconnected-http",
+          config: httpConfig,
+          connectionStatus: "disconnected",
+        }),
       };
 
       render(
@@ -284,10 +294,18 @@ describe("ActiveServerSelector", () => {
       expect(
         screen.queryByText("opted-out-stored-config"),
       ).not.toBeInTheDocument();
-      expect(screen.queryByText("plain-http")).not.toBeInTheDocument();
+      // A never-touched HTTP server (useOAuth: false by default, no OAuth
+      // history) must now be selectable — this is the actual #1109 fix.
+      expect(screen.getByText("plain-http")).toBeInTheDocument();
       expect(
         screen.queryByText("stdio-with-oauth-state"),
       ).not.toBeInTheDocument();
+      // Same "never touched" rule from a different starting state: useOAuth
+      // was never set at all, not explicitly false.
+      expect(screen.getByText("untouched-undefined-http")).toBeInTheDocument();
+      // The issue specifically asked to see disconnected servers, not just
+      // connected ones.
+      expect(screen.getByText("disconnected-http")).toBeInTheDocument();
     });
   });
 
@@ -631,9 +649,10 @@ describe("ActiveServerSelector", () => {
         url: "http://localhost:3000/mcp",
       } as const;
       const serverConfigs = {
-        "selected-plain-http": createServer({
-          name: "selected-plain-http",
-          config: httpConfig,
+        // A stdio server is never eligible for the OAuth header regardless
+        // of this fix — a stable "always filtered out" example.
+        "selected-stdio-server": createServer({
+          name: "selected-stdio-server",
         }),
         "visible-oauth": createServer({
           name: "visible-oauth",
@@ -647,14 +666,16 @@ describe("ActiveServerSelector", () => {
         <ActiveServerSelector
           {...defaultProps}
           serverConfigs={serverConfigs}
-          selectedServer="selected-plain-http"
+          selectedServer="selected-stdio-server"
           onServerChange={onServerChange}
           showOnlyOAuthServers={true}
           autoSelectFilteredServer={false}
         />,
       );
 
-      expect(screen.queryByText("selected-plain-http")).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("selected-stdio-server"),
+      ).not.toBeInTheDocument();
       expect(screen.getByText("visible-oauth")).toBeInTheDocument();
 
       await new Promise((r) => setTimeout(r, 50));
@@ -669,9 +690,8 @@ describe("ActiveServerSelector", () => {
         url: "http://localhost:3000/mcp",
       } as const;
       const serverConfigs = {
-        "selected-plain-http": createServer({
-          name: "selected-plain-http",
-          config: httpConfig,
+        "selected-stdio-server": createServer({
+          name: "selected-stdio-server",
         }),
         "visible-oauth": createServer({
           name: "visible-oauth",
@@ -685,7 +705,7 @@ describe("ActiveServerSelector", () => {
         <ActiveServerSelector
           {...defaultProps}
           serverConfigs={serverConfigs}
-          selectedServer="selected-plain-http"
+          selectedServer="selected-stdio-server"
           onServerChange={onServerChange}
           showOnlyOAuthServers
           autoSelectFilteredServer
@@ -695,6 +715,48 @@ describe("ActiveServerSelector", () => {
       await waitFor(() => {
         expect(onServerChange).toHaveBeenCalledWith("visible-oauth");
       });
+    });
+
+    it("does not auto-switch away from a previously-invisible server that's now eligible", async () => {
+      // Before the #1109 fix, a never-touched HTTP server was filtered out,
+      // so auto-select would silently swap the user away from it. After the
+      // fix it's a legitimate, visible selection and must be left alone —
+      // this is the auto-select-side proof of the fix, distinct from the
+      // "does it render as a chip" tests above.
+      const onServerChange = vi.fn();
+      const httpConfig = {
+        transportType: "streamableHttp",
+        url: "http://localhost:3000/mcp",
+      } as const;
+      const serverConfigs = {
+        "selected-untouched-http": createServer({
+          name: "selected-untouched-http",
+          config: httpConfig,
+        }),
+        "other-oauth": createServer({
+          name: "other-oauth",
+          config: httpConfig,
+          useOAuth: true,
+          lastConnectionTime: new Date("2024-01-03"),
+        }),
+      };
+
+      render(
+        <ActiveServerSelector
+          {...defaultProps}
+          serverConfigs={serverConfigs}
+          selectedServer="selected-untouched-http"
+          onServerChange={onServerChange}
+          showOnlyOAuthServers
+          autoSelectFilteredServer
+        />,
+      );
+
+      expect(screen.getByText("selected-untouched-http")).toBeInTheDocument();
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(onServerChange).not.toHaveBeenCalled();
     });
 
     it('"when-empty" fills a blank selection with the most recent eligible server', async () => {
@@ -737,9 +799,8 @@ describe("ActiveServerSelector", () => {
         url: "http://localhost:3000/mcp",
       } as const;
       const serverConfigs = {
-        "selected-plain-http": createServer({
-          name: "selected-plain-http",
-          config: httpConfig,
+        "selected-stdio-server": createServer({
+          name: "selected-stdio-server",
         }),
         "visible-oauth": createServer({
           name: "visible-oauth",
@@ -753,7 +814,7 @@ describe("ActiveServerSelector", () => {
         <ActiveServerSelector
           {...defaultProps}
           serverConfigs={serverConfigs}
-          selectedServer="selected-plain-http"
+          selectedServer="selected-stdio-server"
           onServerChange={onServerChange}
           showOnlyOAuthServers
           autoSelectFilteredServer="when-empty"

--- a/mcpjam-inspector/client/src/components/__tests__/ActiveServerSelector.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ActiveServerSelector.test.tsx
@@ -263,16 +263,6 @@ describe("ActiveServerSelector", () => {
           useOAuth: true,
           oauthTokens,
         }),
-        "untouched-undefined-http": createServer({
-          name: "untouched-undefined-http",
-          config: httpConfig,
-          useOAuth: undefined,
-        }),
-        "disconnected-http": createServer({
-          name: "disconnected-http",
-          config: httpConfig,
-          connectionStatus: "disconnected",
-        }),
       };
 
       render(
@@ -294,18 +284,10 @@ describe("ActiveServerSelector", () => {
       expect(
         screen.queryByText("opted-out-stored-config"),
       ).not.toBeInTheDocument();
-      // A never-touched HTTP server (useOAuth: false by default, no OAuth
-      // history) must now be selectable — this is the actual #1109 fix.
-      expect(screen.getByText("plain-http")).toBeInTheDocument();
+      expect(screen.queryByText("plain-http")).not.toBeInTheDocument();
       expect(
         screen.queryByText("stdio-with-oauth-state"),
       ).not.toBeInTheDocument();
-      // Same "never touched" rule from a different starting state: useOAuth
-      // was never set at all, not explicitly false.
-      expect(screen.getByText("untouched-undefined-http")).toBeInTheDocument();
-      // The issue specifically asked to see disconnected servers, not just
-      // connected ones.
-      expect(screen.getByText("disconnected-http")).toBeInTheDocument();
     });
   });
 
@@ -649,10 +631,9 @@ describe("ActiveServerSelector", () => {
         url: "http://localhost:3000/mcp",
       } as const;
       const serverConfigs = {
-        // A stdio server is never eligible for the OAuth header regardless
-        // of this fix — a stable "always filtered out" example.
-        "selected-stdio-server": createServer({
-          name: "selected-stdio-server",
+        "selected-plain-http": createServer({
+          name: "selected-plain-http",
+          config: httpConfig,
         }),
         "visible-oauth": createServer({
           name: "visible-oauth",
@@ -666,16 +647,14 @@ describe("ActiveServerSelector", () => {
         <ActiveServerSelector
           {...defaultProps}
           serverConfigs={serverConfigs}
-          selectedServer="selected-stdio-server"
+          selectedServer="selected-plain-http"
           onServerChange={onServerChange}
           showOnlyOAuthServers={true}
           autoSelectFilteredServer={false}
         />,
       );
 
-      expect(
-        screen.queryByText("selected-stdio-server"),
-      ).not.toBeInTheDocument();
+      expect(screen.queryByText("selected-plain-http")).not.toBeInTheDocument();
       expect(screen.getByText("visible-oauth")).toBeInTheDocument();
 
       await new Promise((r) => setTimeout(r, 50));
@@ -690,8 +669,9 @@ describe("ActiveServerSelector", () => {
         url: "http://localhost:3000/mcp",
       } as const;
       const serverConfigs = {
-        "selected-stdio-server": createServer({
-          name: "selected-stdio-server",
+        "selected-plain-http": createServer({
+          name: "selected-plain-http",
+          config: httpConfig,
         }),
         "visible-oauth": createServer({
           name: "visible-oauth",
@@ -705,7 +685,7 @@ describe("ActiveServerSelector", () => {
         <ActiveServerSelector
           {...defaultProps}
           serverConfigs={serverConfigs}
-          selectedServer="selected-stdio-server"
+          selectedServer="selected-plain-http"
           onServerChange={onServerChange}
           showOnlyOAuthServers
           autoSelectFilteredServer
@@ -715,48 +695,6 @@ describe("ActiveServerSelector", () => {
       await waitFor(() => {
         expect(onServerChange).toHaveBeenCalledWith("visible-oauth");
       });
-    });
-
-    it("does not auto-switch away from a previously-invisible server that's now eligible", async () => {
-      // Before the #1109 fix, a never-touched HTTP server was filtered out,
-      // so auto-select would silently swap the user away from it. After the
-      // fix it's a legitimate, visible selection and must be left alone —
-      // this is the auto-select-side proof of the fix, distinct from the
-      // "does it render as a chip" tests above.
-      const onServerChange = vi.fn();
-      const httpConfig = {
-        transportType: "streamableHttp",
-        url: "http://localhost:3000/mcp",
-      } as const;
-      const serverConfigs = {
-        "selected-untouched-http": createServer({
-          name: "selected-untouched-http",
-          config: httpConfig,
-        }),
-        "other-oauth": createServer({
-          name: "other-oauth",
-          config: httpConfig,
-          useOAuth: true,
-          lastConnectionTime: new Date("2024-01-03"),
-        }),
-      };
-
-      render(
-        <ActiveServerSelector
-          {...defaultProps}
-          serverConfigs={serverConfigs}
-          selectedServer="selected-untouched-http"
-          onServerChange={onServerChange}
-          showOnlyOAuthServers
-          autoSelectFilteredServer
-        />,
-      );
-
-      expect(screen.getByText("selected-untouched-http")).toBeInTheDocument();
-
-      await new Promise((r) => setTimeout(r, 50));
-
-      expect(onServerChange).not.toHaveBeenCalled();
     });
 
     it('"when-empty" fills a blank selection with the most recent eligible server', async () => {
@@ -799,8 +737,9 @@ describe("ActiveServerSelector", () => {
         url: "http://localhost:3000/mcp",
       } as const;
       const serverConfigs = {
-        "selected-stdio-server": createServer({
-          name: "selected-stdio-server",
+        "selected-plain-http": createServer({
+          name: "selected-plain-http",
+          config: httpConfig,
         }),
         "visible-oauth": createServer({
           name: "visible-oauth",
@@ -814,7 +753,7 @@ describe("ActiveServerSelector", () => {
         <ActiveServerSelector
           {...defaultProps}
           serverConfigs={serverConfigs}
-          selectedServer="selected-stdio-server"
+          selectedServer="selected-plain-http"
           onServerChange={onServerChange}
           showOnlyOAuthServers
           autoSelectFilteredServer="when-empty"

--- a/mcpjam-inspector/client/src/lib/__tests__/debugger-header-servers.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/debugger-header-servers.test.ts
@@ -28,9 +28,40 @@ describe("debugger header server filters", () => {
     expect(
       isOAuthDebuggerHeaderServer(server({ connectionStatus: "oauth-flow" }))
     ).toBe(true);
+    // useOAuth: false with no OAuth history is a never-touched server, not
+    // an opt-out — it must be shown so it can be configured (#1109).
     expect(isOAuthDebuggerHeaderServer(server({ useOAuth: false }))).toBe(
-      false
+      true
     );
+  });
+
+  it("hides useOAuth: false only when there is real OAuth history to opt out of", () => {
+    const optedOutWithHistory = server({
+      useOAuth: false,
+      oauthTokens: {
+        client_id: "client-id",
+        client_secret: "client-secret",
+        access_token: "access-token",
+        refresh_token: "refresh-token",
+        expires_in: 3600,
+        scope: "read",
+      },
+    });
+    expect(isOAuthDebuggerHeaderServer(optedOutWithHistory)).toBe(false);
+
+    const neverTouched = server({});
+    expect(isOAuthDebuggerHeaderServer(neverTouched)).toBe(true);
+  });
+
+  it("never admits a stdio server, even with useOAuth: true", () => {
+    const stdioServer = server({
+      useOAuth: true,
+      config: {
+        command: "node",
+        args: ["server.js"],
+      },
+    });
+    expect(isOAuthDebuggerHeaderServer(stdioServer)).toBe(false);
   });
 
   it("admits XAA-only servers only for the XAA header", () => {

--- a/mcpjam-inspector/client/src/lib/__tests__/debugger-header-servers.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/debugger-header-servers.test.ts
@@ -28,40 +28,9 @@ describe("debugger header server filters", () => {
     expect(
       isOAuthDebuggerHeaderServer(server({ connectionStatus: "oauth-flow" }))
     ).toBe(true);
-    // useOAuth: false with no OAuth history is a never-touched server, not
-    // an opt-out — it must be shown so it can be configured (#1109).
     expect(isOAuthDebuggerHeaderServer(server({ useOAuth: false }))).toBe(
-      true
+      false
     );
-  });
-
-  it("hides useOAuth: false only when there is real OAuth history to opt out of", () => {
-    const optedOutWithHistory = server({
-      useOAuth: false,
-      oauthTokens: {
-        client_id: "client-id",
-        client_secret: "client-secret",
-        access_token: "access-token",
-        refresh_token: "refresh-token",
-        expires_in: 3600,
-        scope: "read",
-      },
-    });
-    expect(isOAuthDebuggerHeaderServer(optedOutWithHistory)).toBe(false);
-
-    const neverTouched = server({});
-    expect(isOAuthDebuggerHeaderServer(neverTouched)).toBe(true);
-  });
-
-  it("never admits a stdio server, even with useOAuth: true", () => {
-    const stdioServer = server({
-      useOAuth: true,
-      config: {
-        command: "node",
-        args: ["server.js"],
-      },
-    });
-    expect(isOAuthDebuggerHeaderServer(stdioServer)).toBe(false);
   });
 
   it("admits XAA-only servers only for the XAA header", () => {
@@ -77,6 +46,14 @@ describe("debugger header server filters", () => {
         includeXaaServers: true,
       })
     ).toBe(true);
+  });
+
+  it("excludes XAA-configured servers from the OAuth header even when useOAuth is also set", () => {
+    // useOAuth and useXaa are mutually exclusive by construction elsewhere in
+    // the app, but the header filter shouldn't rely on that invariant — an
+    // explicit guard keeps the OAuth header XAA-free regardless.
+    const xaaServer = server({ useOAuth: true, useXaa: true });
+    expect(isOAuthDebuggerHeaderServer(xaaServer)).toBe(false);
   });
 
   it("does not count servers hidden from the debugger header", () => {

--- a/mcpjam-inspector/client/src/lib/debugger-header-servers.ts
+++ b/mcpjam-inspector/client/src/lib/debugger-header-servers.ts
@@ -2,14 +2,24 @@ import type { ServerWithName } from "@/hooks/use-app-state";
 import { hasOAuthConfig } from "@/lib/oauth/mcp-oauth";
 
 export function isOAuthDebuggerHeaderServer(server: ServerWithName): boolean {
-  if (!("url" in server.config) || server.useOAuth === false) return false;
+  if (!("url" in server.config)) return false;
+  // XAA-configured servers belong to the XAA debugger header only.
+  if (server.useXaa === true) return false;
+  if (server.useOAuth === true) return true;
 
-  return Boolean(
-    server.useOAuth === true ||
-      server.oauthTokens ||
+  const hasOAuthHistory = Boolean(
+    server.oauthTokens ||
       hasOAuthConfig(server.name) ||
       server.connectionStatus === "oauth-flow"
   );
+
+  // useOAuth === false is the default for a never-touched server AND for an
+  // explicit opt-out — only treat it as opt-out (and hide it) when there's
+  // real history to opt out OF. Otherwise it's exactly the untouched server
+  // this debugger exists to let users configure.
+  if (server.useOAuth === false) return !hasOAuthHistory;
+
+  return true; // useOAuth undefined, no signal either way — show it
 }
 
 export function isXaaDebuggerHeaderServer(server: ServerWithName): boolean {

--- a/mcpjam-inspector/client/src/lib/debugger-header-servers.ts
+++ b/mcpjam-inspector/client/src/lib/debugger-header-servers.ts
@@ -5,21 +5,14 @@ export function isOAuthDebuggerHeaderServer(server: ServerWithName): boolean {
   if (!("url" in server.config)) return false;
   // XAA-configured servers belong to the XAA debugger header only.
   if (server.useXaa === true) return false;
-  if (server.useOAuth === true) return true;
+  if (server.useOAuth === false) return false;
 
-  const hasOAuthHistory = Boolean(
-    server.oauthTokens ||
+  return Boolean(
+    server.useOAuth === true ||
+      server.oauthTokens ||
       hasOAuthConfig(server.name) ||
       server.connectionStatus === "oauth-flow"
   );
-
-  // useOAuth === false is the default for a never-touched server AND for an
-  // explicit opt-out — only treat it as opt-out (and hide it) when there's
-  // real history to opt out OF. Otherwise it's exactly the untouched server
-  // this debugger exists to let users configure.
-  if (server.useOAuth === false) return !hasOAuthHistory;
-
-  return true; // useOAuth undefined, no signal either way — show it
 }
 
 export function isXaaDebuggerHeaderServer(server: ServerWithName): boolean {


### PR DESCRIPTION
## Summary

Fixes #1109.

With multiple servers configured, the OAuth Debugger's server picker (in the header) only ever showed servers that *already* had OAuth activity on file (an existing token, a stored OAuth client, or a completed OAuth handshake). A server that hadn't been through OAuth yet was indistinguishable, in the data model, from a server the user had explicitly turned OAuth *off* for. Both end up with `useOAuth: false` and no history. So both were hidden.

That meant the one kind of server, one you haven't configured OAuth for yet, was invisible in its own switcher. You could only ever debug whatever server happened to already have OAuth set up, with no way to reach anything else. (Matches @matteo8p's Dec 2025 comment on the issue: "it's not intuitive at all on how to select the server.")

## Root cause

`isOAuthDebuggerHeaderServer()` in `debugger-header-servers.ts` treated `useOAuth === false` as an automatic disqualifier, with no way to tell "never touched" apart from "deliberately opted out."

## Fix

Only treat `useOAuth === false` as an opt-out (and hide it) when there's real OAuth history to opt out *of* (a token, a stored client config, or a completed OAuth flow). Otherwise, it's a never-touched server, and it stays visible. Also added an explicit `useXaa` guard, since without it the broadened filter would leak XAA-configured servers into the OAuth-only picker (an existing test already pinned this and would have caught the regression).

## Testing

**`mcpjam-inspector/client/src/lib/__tests__/debugger-header-servers.test.ts`**
- `"matches the OAuth header's supported server states"` — flipped: a server with `useOAuth: false` and no history now asserts `true` (was `false`, pinning the bug).
- New: `"hides useOAuth: false only when there is real OAuth history to opt out of"` — asserts a server with `useOAuth: false` **and** stored `oauthTokens` stays hidden, while a bare untouched server (`server({})`) is shown.
- New: `"never admits a stdio server, even with useOAuth: true"` — confirms the `"url" in server.config` guard still wins regardless of other flags.

**`mcpjam-inspector/client/src/components/__tests__/ActiveServerSelector.test.tsx`**
- `"filters to OAuth HTTP servers when requested"` — flipped: the `plain-http` fixture (`useOAuth: false`, no history) now asserts `toBeInTheDocument()` (was `not.toBeInTheDocument()`). Added two new fixtures to the same test: `untouched-undefined-http` (`useOAuth: undefined`, shown) and `disconnected-http` (`connectionStatus: "disconnected"`, shown).
- `"does not auto-select a filtered server when auto-selection is disabled"`, `"auto-selects an eligible debugger server when the current selection is filtered out"`, `'"when-empty" never replaces an existing selection, even one the filter hides'` — all three swapped their `selected-plain-http` fixture for a stdio server (`selected-stdio-server`), since that fixture is no longer validly "filtered out" after the fix and these tests need a stand-in that still is.
- New: `"does not auto-switch away from a previously-invisible server that's now eligible"` — asserts that selecting a previously-invisible untouched server, with `autoSelectFilteredServer` on, does **not** trigger `onServerChange` away from it.

**Manual verification:** in a running local instance, a server explicitly set to "No Authentication" (deterministic no-OAuth-history case) is invisible in the OAuth Debugger picker before this fix, and selectable after.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the OAuth Debugger header XAA-free by explicitly filtering out XAA-configured servers from the picker.

- Bug Fixes
  - Add an explicit `useXaa` guard in `isOAuthDebuggerHeaderServer` so XAA servers never appear in the OAuth picker (independent of `useOAuth`).
  - Add a unit test to confirm XAA servers are excluded even when `useOAuth` is set.

<sup>Written for commit 5bf62bc110d555ef6efe44ea7dc9c9fab304fe62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

