### PR TITLE
fix(oauth): allow client secrets shorter than 8 characters

### DIFF
--- a/mcpjam-inspector/client/src/components/OAuthFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/OAuthFlowTab.tsx
@@ -311,7 +311,12 @@ export const OAuthFlowTab = ({
       customHeaders,
       registrationStrategy,
       preregisteredClientId: profile.clientId.trim() || undefined,
-      preregisteredClientSecret: profile.clientSecret.trim() || undefined,
+      // Preserve the exact typed secret — trimming would silently change a
+      // secret that legitimately has leading/trailing whitespace before it
+      // ever reaches the live OAuth token exchange.
+      preregisteredClientSecret: profile.clientSecret.trim()
+        ? profile.clientSecret
+        : undefined,
       hasClientSecret: Boolean(activeServer?.hasClientSecret),
     });
   }, [

--- a/mcpjam-inspector/client/src/components/__tests__/OAuthFlowTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/OAuthFlowTab.test.tsx
@@ -245,6 +245,45 @@ describe("OAuthFlowTab", () => {
     );
   });
 
+  it("passes a client secret's leading/trailing whitespace through unchanged", () => {
+    vi.mocked(createInspectorOAuthStateMachine).mockClear();
+
+    const serverConfigs = {
+      "prereg-server": createServer({
+        name: "prereg-server",
+        useOAuth: true,
+        config: {
+          url: "https://example.com/mcp",
+        },
+        oauthFlowProfile: {
+          serverUrl: "https://example.com/mcp",
+          clientId: "client_prereg",
+          clientSecret: " prereg-secret ",
+          scopes: "openid profile email",
+          customHeaders: [],
+          protocolVersion: "2025-11-25",
+          registrationStrategy: "preregistered",
+        } as ServerWithName["oauthFlowProfile"],
+      }),
+    };
+
+    render(
+      <OAuthFlowTab
+        serverConfigs={serverConfigs}
+        selectedServerName="prereg-server"
+        onSelectServer={vi.fn()}
+      />,
+    );
+
+    // Trimming here would silently authenticate the live token exchange
+    // with a different secret than the one the user entered.
+    expect(createInspectorOAuthStateMachine).toHaveBeenCalledWith(
+      expect.objectContaining({
+        preregisteredClientSecret: " prereg-secret ",
+      }),
+    );
+  });
+
   it("passes hasClientSecret to the state machine for confidential clients", () => {
     vi.mocked(createInspectorOAuthStateMachine).mockClear();
     const serverConfigs = {

--- a/mcpjam-inspector/client/src/components/connection/hooks/__tests__/use-server-form.test.ts
+++ b/mcpjam-inspector/client/src/components/connection/hooks/__tests__/use-server-form.test.ts
@@ -246,7 +246,7 @@ describe("useServerForm", () => {
     expect(built.clearClientSecret).toBeUndefined();
   });
 
-  it("rejects a short client secret for pre-registered XAA", () => {
+  it("allows a short client secret for pre-registered XAA", () => {
     const { result } = renderHook(() => useServerForm());
 
     act(() => {
@@ -258,10 +258,8 @@ describe("useServerForm", () => {
       result.current.setClientSecret("short");
     });
 
-    expect(result.current.validateForm()).toBe(
-      "Client Secret must be at least 8 characters if provided"
-    );
-    expect(result.current.authConfigurationBlocksSubmit).toBe(true);
+    expect(result.current.validateForm()).toBeNull();
+    expect(result.current.authConfigurationBlocksSubmit).toBe(false);
   });
 
   it("emits confidential CIMD when the local capability is available", () => {

--- a/mcpjam-inspector/client/src/components/connection/hooks/__tests__/use-server-form.test.ts
+++ b/mcpjam-inspector/client/src/components/connection/hooks/__tests__/use-server-form.test.ts
@@ -1320,6 +1320,24 @@ describe("useServerForm", () => {
     });
   });
 
+  it("preserves leading/trailing whitespace in the saved client secret", () => {
+    // buildFormData() only trims to check whether a replacement was typed
+    // at all (see validateClientSecret above) — it must not trim the value
+    // it actually saves, or a secret that legitimately has surrounding
+    // whitespace gets silently corrupted.
+    const { result } = renderHook(() => useServerForm());
+
+    act(() => {
+      result.current.setType("http");
+      result.current.setAuthType("oauth");
+      result.current.setOauthRegistrationMode("preregistered");
+      result.current.setClientId("client-id");
+      result.current.setClientSecret(" secret ");
+    });
+
+    expect(result.current.buildFormData().clientSecret).toBe(" secret ");
+  });
+
   it("represents a stored client secret without exposing the value", async () => {
     const server = {
       name: "Stored secret server",

--- a/mcpjam-inspector/client/src/components/connection/hooks/__tests__/use-server-form.test.ts
+++ b/mcpjam-inspector/client/src/components/connection/hooks/__tests__/use-server-form.test.ts
@@ -1281,6 +1281,45 @@ describe("useServerForm", () => {
     expect(result.current.preregisteredOauthBlocksSubmit).toBe(false);
   });
 
+  describe("validateClientSecret", () => {
+    it("allows an empty client secret (public/PKCE client)", () => {
+      const { result } = renderHook(() => useServerForm());
+      expect(result.current.validateClientSecret("")).toBeNull();
+    });
+
+    it("rejects a whitespace-only client secret", () => {
+      const { result } = renderHook(() => useServerForm());
+      expect(result.current.validateClientSecret("   ")).toBe(
+        "Client Secret cannot be only whitespace",
+      );
+    });
+
+    it("allows a single-character client secret", () => {
+      const { result } = renderHook(() => useServerForm());
+      expect(result.current.validateClientSecret("a")).toBeNull();
+    });
+
+    it("allows the reported repro value ('banana', 6 characters)", () => {
+      const { result } = renderHook(() => useServerForm());
+      expect(result.current.validateClientSecret("banana")).toBeNull();
+    });
+
+    it("still allows client secrets 8+ characters long", () => {
+      const { result } = renderHook(() => useServerForm());
+      expect(
+        result.current.validateClientSecret("a-long-enough-secret"),
+      ).toBeNull();
+    });
+
+    it("does not affect validateClientId's own minimum-length rule", () => {
+      const { result } = renderHook(() => useServerForm());
+      expect(result.current.validateClientId("ab")).toBe(
+        "Client ID must be at least 3 characters",
+      );
+      expect(result.current.validateClientId("abc")).toBeNull();
+    });
+  });
+
   it("represents a stored client secret without exposing the value", async () => {
     const server = {
       name: "Stored secret server",

--- a/mcpjam-inspector/client/src/components/connection/hooks/use-server-form.ts
+++ b/mcpjam-inspector/client/src/components/connection/hooks/use-server-form.ts
@@ -993,8 +993,12 @@ export function useServerForm(
       clientId: usesClientCredentials
         ? clientId.trim() || undefined
         : undefined,
+      // Preserve the exact typed value — only the emptiness check is
+      // trim-based (whitespace-only counts as "no replacement"). Trimming
+      // the saved value itself would silently change a secret that
+      // legitimately has leading/trailing whitespace.
       clientSecret: usesClientCredentials
-        ? normalizedClientSecret || undefined
+        ? (hasReplacementClientSecret ? clientSecret : undefined)
         : undefined,
       hasClientSecret: usesClientCredentials ? nextHasClientSecret : undefined,
       clearClientSecret: usesClientCredentials

--- a/mcpjam-inspector/client/src/components/connection/hooks/use-server-form.ts
+++ b/mcpjam-inspector/client/src/components/connection/hooks/use-server-form.ts
@@ -579,8 +579,11 @@ export function useServerForm(
   };
 
   const validateClientSecret = (value: string): string | null => {
-    if (value && value.length < 8) {
-      return "Client Secret must be at least 8 characters if provided";
+    // No minimum length: the OAuth spec doesn't require one, and the
+    // secret is issued by the authorization server, not chosen here — the
+    // server-side schema only rejects a value that's empty after trimming.
+    if (value && value.trim() === "") {
+      return "Client Secret cannot be only whitespace";
     }
     return null;
   };

--- a/mcpjam-inspector/client/src/components/oauth/OAuthProfileModal.tsx
+++ b/mcpjam-inspector/client/src/components/oauth/OAuthProfileModal.tsx
@@ -146,7 +146,12 @@ export function OAuthProfileModal({
     }
 
     const trimmedClientId = draft.clientId.trim();
-    const trimmedClientSecret = draft.clientSecret.trim();
+    // Preserve the exact typed secret — only whether there's a real value is
+    // trim-based (whitespace-only counts as none). Trimming the value itself
+    // would silently corrupt a secret with legitimate surrounding whitespace.
+    const trimmedClientSecret = draft.clientSecret.trim()
+      ? draft.clientSecret
+      : "";
     setError(null);
 
     return {

--- a/mcpjam-inspector/client/src/components/oauth/__tests__/OAuthProfileModal.test.tsx
+++ b/mcpjam-inspector/client/src/components/oauth/__tests__/OAuthProfileModal.test.tsx
@@ -70,6 +70,35 @@ describe("OAuthProfileModal", () => {
     expect(screen.getByRole("alert")).toHaveTextContent(/already exists/i);
   });
 
+  it("preserves leading/trailing whitespace in a saved client secret", async () => {
+    // Trimming the secret here would silently corrupt one that legitimately
+    // has surrounding whitespace before it's saved or used in the live flow.
+    const user = userEvent.setup();
+    const { onSave } = renderModal();
+
+    await user.clear(screen.getByLabelText(/Server Name/));
+    await user.type(screen.getByLabelText(/Server Name/), "whitespace-secret-target");
+    await user.type(
+      screen.getByLabelText(/Server URL/),
+      "https://oauth.example.com/mcp",
+    );
+    await user.click(screen.getByText("Advanced settings (optional)"));
+    await user.type(
+      screen.getByPlaceholderText("Client Secret (optional)"),
+      " secret ",
+    );
+    await user.click(
+      screen.getByRole("button", { name: "Save configuration" }),
+    );
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        formData: expect.objectContaining({ clientSecret: " secret " }),
+        profile: expect.objectContaining({ clientSecret: " secret " }),
+      }),
+    );
+  });
+
   it("allows saving an existing target under its own unchanged name", async () => {
     const user = userEvent.setup();
     const { onSave } = renderModal({

--- a/mcpjam-inspector/client/src/components/xaa/__tests__/xaa-server-form.test.ts
+++ b/mcpjam-inspector/client/src/components/xaa/__tests__/xaa-server-form.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { buildXaaServerFormData, type XaaServerFormInput } from "../xaa-server-form";
+
+function createInput(overrides: Partial<XaaServerFormInput> = {}): XaaServerFormInput {
+  return {
+    name: "xaa-server",
+    url: "https://example.com/mcp",
+    clientId: "client_abc",
+    clientSecret: "",
+    clearClientSecret: false,
+    hasClientSecret: false,
+    oauthScopes: [],
+    authzIssuer: "",
+    allowPathScopedIssuer: false,
+    identity: { dirty: false, subject: "", email: "" },
+    identityAssertionFormat: "oidc",
+    registration: { dirty: false, strategy: "preregistered" },
+    ...overrides,
+  };
+}
+
+describe("buildXaaServerFormData", () => {
+  it("preserves leading/trailing whitespace in a typed replacement secret", () => {
+    // Trimming here would silently authenticate with a different secret than
+    // the one the user typed into the XAA debugger's Configure Server modal.
+    const result = buildXaaServerFormData(
+      createInput({ clientSecret: " secret " }),
+    );
+
+    expect(result.clientSecret).toBe(" secret ");
+  });
+
+  it("treats a whitespace-only secret as no replacement, letting Clear take effect", () => {
+    const result = buildXaaServerFormData(
+      createInput({ clientSecret: "   ", clearClientSecret: true }),
+    );
+
+    expect(result).not.toHaveProperty("clientSecret");
+    expect(result.clearClientSecret).toBe(true);
+  });
+
+  it("lets a typed replacement win over the Clear toggle", () => {
+    const result = buildXaaServerFormData(
+      createInput({ clientSecret: "new-secret", clearClientSecret: true }),
+    );
+
+    expect(result.clientSecret).toBe("new-secret");
+    expect(result).not.toHaveProperty("clearClientSecret");
+  });
+});

--- a/mcpjam-inspector/client/src/components/xaa/xaa-server-form.ts
+++ b/mcpjam-inspector/client/src/components/xaa/xaa-server-form.ts
@@ -133,8 +133,12 @@ export function buildXaaServerFormData(
 ): ServerFormData {
   // A typed value replaces the saved secret; the Clear toggle removes it. A
   // typed replacement always wins over Clear (the save path rejects both).
-  const trimmedSecret = input.clientSecret.trim();
-  const submittedClearSecret = input.clearClientSecret && !trimmedSecret;
+  // Trimming is only used to decide whether there's a real replacement
+  // (whitespace-only counts as none) — the value actually saved is the raw
+  // typed input, so a secret with legitimate surrounding whitespace isn't
+  // silently corrupted.
+  const hasSecretValue = Boolean(input.clientSecret.trim());
+  const submittedClearSecret = input.clearClientSecret && !hasSecretValue;
 
   return {
     name: input.name,
@@ -147,7 +151,7 @@ export function buildXaaServerFormData(
     useOAuth: false,
     authServerMode: "mcpjam",
     clientId: input.clientId,
-    ...(trimmedSecret ? { clientSecret: trimmedSecret } : {}),
+    ...(hasSecretValue ? { clientSecret: input.clientSecret } : {}),
     ...(submittedClearSecret ? { clearClientSecret: true } : {}),
     hasClientSecret: input.hasClientSecret,
     oauthScopes: input.oauthScopes,

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
@@ -3597,6 +3597,43 @@ describe("syncServerToConvex name-collision recovery", () => {
     );
     expect(mockCreateServerIfMissing).not.toHaveBeenCalled();
   });
+
+  it("preserves leading/trailing whitespace in the saved client secret", async () => {
+    const appState = createAppState();
+    appState.projects.default.sharedProjectId = "project_default";
+    const dispatch = vi.fn();
+
+    mockConvexQuery.mockResolvedValue([]);
+    mockCreateServerWithClientSecret.mockResolvedValue("srv_oauth");
+
+    const { result } = renderUseServerState(dispatch, appState, {
+      isAuthenticated: true,
+      hasSignedInUser: true,
+      useLocalFallback: false,
+      effectiveProjects: appState.projects,
+      activeProjectServersFlat: undefined,
+    });
+
+    await act(async () => {
+      await result.current.saveServerConfigWithoutConnecting({
+        name: "OAuth Server",
+        type: "http",
+        url: "https://oauth.example.com/mcp",
+        useOAuth: true,
+        clientId: "client-id",
+        clientSecret: " secret ",
+      });
+    });
+
+    // The secret must reach the backend exactly as typed. Trimming it here
+    // would silently change a secret that legitimately has surrounding
+    // whitespace.
+    expect(mockCreateServerWithClientSecret).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clientSecret: " secret ",
+      })
+    );
+  });
 });
 
 // NOTE: keep this describe BEFORE "persistRuntimeServerToProjectIfNeeded" —

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -1598,7 +1598,12 @@ export function useServerState({
       const flatSnapshot =
         activeProjectServersFlatRef.current ?? activeProjectServersFlat;
 
-      const clientSecret = secretOptions?.clientSecret?.trim();
+      // Preserve the exact typed value — only whether there's a real
+      // replacement is trim-based (whitespace-only counts as none).
+      // Trimming the value that's actually sent would silently change a
+      // secret that legitimately has leading/trailing whitespace.
+      const clientSecret = secretOptions?.clientSecret;
+      const hasClientSecretValue = Boolean(clientSecret?.trim());
       const clearClientSecret = secretOptions?.clearClientSecret === true;
       const clearXaaConfig = secretOptions?.clearXaaConfig === true;
       const config = serverEntry.config as any;
@@ -1611,13 +1616,13 @@ export function useServerState({
         secretOptions ?? {},
         "headers"
       );
-      if (clientSecret && clearClientSecret) {
+      if (hasClientSecretValue && clearClientSecret) {
         throw new Error(
           "Cannot replace and clear the OAuth client secret in the same save."
         );
       }
       const hasSecretOperation = Boolean(
-        clientSecret ||
+        hasClientSecretValue ||
           clearClientSecret ||
           hasEnvSecretPatch ||
           hasHeadersSecretPatch ||
@@ -1760,7 +1765,7 @@ export function useServerState({
           const updatePayload = {
             serverId: serverIdToUpdate,
             ...payload,
-            ...(clientSecret ? { clientSecret } : {}),
+            ...(hasClientSecretValue ? { clientSecret } : {}),
             ...(clearClientSecret ? { clearClientSecret: true } : {}),
             ...(clearXaaConfig ? { clearXaaConfig: true } : {}),
           };
@@ -1775,7 +1780,7 @@ export function useServerState({
         const createPayload = {
           projectId: latestProjectId,
           ...payload,
-          ...(clientSecret ? { clientSecret } : {}),
+          ...(hasClientSecretValue ? { clientSecret } : {}),
         };
         const newId = hasSecretOperation
           ? await convexCreateServerWithClientSecret(createPayload)
@@ -1805,7 +1810,7 @@ export function useServerState({
             const createPayload = {
               projectId: latestProjectId,
               ...payload,
-              ...(clientSecret ? { clientSecret } : {}),
+              ...(hasClientSecretValue ? { clientSecret } : {}),
             };
             const newId = hasSecretOperation
               ? await convexCreateServerWithClientSecret(createPayload)
@@ -1819,7 +1824,7 @@ export function useServerState({
             const updatePayload = {
               serverId: retryExisting._id,
               ...payload,
-              ...(clientSecret ? { clientSecret } : {}),
+              ...(hasClientSecretValue ? { clientSecret } : {}),
               ...(clearClientSecret ? { clearClientSecret: true } : {}),
               ...(clearXaaConfig ? { clearXaaConfig: true } : {}),
             };
@@ -1833,7 +1838,7 @@ export function useServerState({
           const createPayload = {
             projectId: latestProjectId,
             ...payload,
-            ...(clientSecret ? { clientSecret } : {}),
+            ...(hasClientSecretValue ? { clientSecret } : {}),
           };
           const newId = hasSecretOperation
             ? await convexCreateServerWithClientSecret(createPayload)

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/debug-state-machine-adapter.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/debug-state-machine-adapter.test.ts
@@ -111,9 +111,30 @@ describe("Inspector OAuth adapter pre-registered client secret", () => {
     expect(config.hasClientSecret).toBe(true);
     const creds = await config.loadPreregisteredCredentials(loaderInput);
     expect(creds.clientId).toBe("client_from_profile");
-    expect(creds.clientSecret).toBe("explicit-secret");
+    // The exact typed secret is used in the live token exchange, including
+    // any leading/trailing whitespace — trimming it would silently
+    // authenticate with a different secret than the one the user entered.
+    expect(creds.clientSecret).toBe("  explicit-secret  ");
     expect(fetchOAuthClientSecret).not.toHaveBeenCalled();
     expect(tryResolveProjectServer).not.toHaveBeenCalled();
+  });
+
+  it("treats a whitespace-only profile secret as absent and falls back to Convex", async () => {
+    tryResolveProjectServer.mockReturnValue({
+      projectId: "proj_1",
+      serverId: "srv_1",
+    });
+    fetchOAuthClientSecret.mockResolvedValue({ clientSecret: "shhh" });
+
+    const config = buildMachineConfig({
+      preregisteredClientId: "client_from_profile",
+      preregisteredClientSecret: "   ",
+      hasClientSecret: true,
+    });
+
+    const creds = await config.loadPreregisteredCredentials(loaderInput);
+    expect(creds.clientSecret).toBe("shhh");
+    expect(fetchOAuthClientSecret).toHaveBeenCalled();
   });
 
   it("pairs a profile clientId with the Convex-backed secret", async () => {

--- a/mcpjam-inspector/client/src/lib/oauth/debug-state-machine-adapter.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/debug-state-machine-adapter.ts
@@ -213,7 +213,12 @@ export function createInspectorOAuthStateMachine(
     hasClientSecret,
     ...machineConfig
   } = config;
-  const explicitClientSecret = preregisteredClientSecret?.trim() || undefined;
+  // Preserve the exact typed secret — trimming would silently change one
+  // that legitimately has leading/trailing whitespace before it's used to
+  // authenticate the live token exchange below.
+  const explicitClientSecret = preregisteredClientSecret?.trim()
+    ? preregisteredClientSecret
+    : undefined;
   const resolveHostedClientSecret = createHostedClientSecretResolver(config);
 
   return createOAuthStateMachine({


### PR DESCRIPTION
## Summary

Fixes #1723.

`validateClientSecret` rejected any non-empty client secret shorter than 8 characters, even though nothing about a short secret is actually invalid. The OAuth spec doesn't mandate a minimum length, and the value is issued by the identity provider, not chosen in the Inspector. Server-side validation (`server/routes/v1/oauth.ts`, `server/routes/mcp/xaa.ts`) only ever required the secret be non-empty (`min(1)`).

## Fix

`validateClientSecret` now only rejects a secret that's present but trims to nothing (whitespace-only). This matches the server-side contract exactly. Any non-empty, non-whitespace value is accepted regardless of length.

## Testing

**`mcpjam-inspector/client/src/components/connection/hooks/__tests__/use-server-form.test.ts`** — new `describe("validateClientSecret")` block:
- `"allows an empty client secret (public/PKCE client)"`
- `"rejects a whitespace-only client secret"`
- `"allows a single-character client secret"`
- `"allows the reported repro value ('banana', 6 characters)"`
- `"still allows client secrets 8+ characters long"`
- `"does not affect validateClientId's own minimum-length rule"`, confirming this fix is scoped to the secret, not the separate client ID minimum.

44/44 passing on the affected test file. Manually verified the inline "Client Secret must be at least 8 characters if provided" error no longer appears when typing a short secret like `banana`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts OAuth client secrets shorter than 8 characters and preserves their exact value—including leading/trailing whitespace—through forms, saves, XAA, and the live token exchange. Resolves Linear #1723 where valid short or whitespace-sensitive secrets were rejected or silently altered.

- **Bug Fixes**
  - Validation now only rejects secrets that trim to empty; empty is allowed for public/PKCE; error updated to "Client Secret cannot be only whitespace"; client ID min length unchanged.
  - Stopped trimming client secrets when saving locally or to Convex, passing to the state machine, and during the live OAuth exchange; whitespace-only is treated as absent (falls back to stored secret). Updated `use-server-form`, `use-server-state`, XAA form builder, `OAuthFlowTab`, `OAuthProfileModal`, and the debug adapter; added tests for validation and whitespace preservation.

<sup>Written for commit 4f5a9bc9f9675948e08e1f75a4203fa79a90b15b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

