### PR TITLE
feat(agent): agent-chat-enabled kill switch for the in-app agent chat

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -58,6 +58,7 @@ import { ConnectViewHeader } from "./components/hosts/ConnectViewHeader";
 import { ComputerView } from "./components/computer/ComputerView";
 import { useComputersEnabledState } from "./hooks/useComputersEnabled";
 import { useSkillsEnabledState } from "./hooks/useSkillsEnabled";
+import { useAgentChatEnabled } from "./hooks/useAgentChatEnabled";
 import { motion } from "framer-motion";
 import { SNAPPY_RAIL } from "./components/hosts/transition-tokens";
 import OAuthDebugCallback from "./components/oauth/OAuthDebugCallback";
@@ -1586,6 +1587,8 @@ export default function App() {
   const compatibilityEnabled = useFeatureFlagEnabled("mcpjam-compatibility");
   const evaluateRunsEnabled = useFeatureFlagEnabled("evaluate-ci");
   const xaaEnabled = useFeatureFlagEnabled("xaa");
+  // Fail-open kill switch (undefined ⇒ on); see useAgentChatEnabled.
+  const agentChatEnabled = useAgentChatEnabled();
 
   // Per-tab "hide from this header" list for the OAuth / XAA debugger chip strip.
   // View-only (localStorage) — the x on a chip dismisses it from this header
@@ -2047,8 +2050,10 @@ export default function App() {
   // agents via the chat POST snapshot and mirrored to the browser's native
   // modelContext when present. Disabled on the standalone chatbox chat route:
   // its end user is not the inspector operator, so inspector-driving tools
-  // must not exist on that page (chat snapshot OR native mirror).
-  useRegisterUiTools({ enabled: !isChatboxChatRoute });
+  // must not exist on that page (chat snapshot OR native mirror). Also
+  // dropped when the agent-chat kill switch is thrown: without the agent
+  // there is no consumer, and the catalog must not leak to the native mirror.
+  useRegisterUiTools({ enabled: !isChatboxChatRoute && agentChatEnabled });
   // One-time migration from legacy localStorage state to Convex. No-op in
   // hosted mode and after the first successful run; safe to keep in the tree.
   useLocalStateMigration({
@@ -3813,11 +3818,13 @@ export default function App() {
           </AppRouteReactContext.Provider>
         </div>
       </SidebarInset>
-      <AgentSidePanelMount
-        projectId={activeProjectId ?? null}
-        organizationId={activeOrganizationId ?? null}
-        activeTab={activeTab}
-      />
+      {agentChatEnabled ? (
+        <AgentSidePanelMount
+          projectId={activeProjectId ?? null}
+          organizationId={activeOrganizationId ?? null}
+          activeTab={activeTab}
+        />
+      ) : null}
       <Dialog
         open={showTrialDecisionModal}
         onOpenChange={(open) => {

--- a/mcpjam-inspector/client/src/components/HomeTab.tsx
+++ b/mcpjam-inspector/client/src/components/HomeTab.tsx
@@ -19,6 +19,7 @@ import { RecommendedHosts } from "./home/RecommendedHosts";
 import { ProductUpdatesRow } from "./home/ProductUpdatesRow";
 import { McpjamAgentHero } from "./mcpjam-agent/McpjamAgentHero";
 import { McpjamAgentThread } from "./mcpjam-agent/McpjamAgentThread";
+import { useAgentChatEnabled } from "@/hooks/useAgentChatEnabled";
 
 interface HomeTabProps {
   organizationId: string | null;
@@ -144,6 +145,10 @@ export function HomeTab({
   const [searchParams, setSearchParams] = useSearchParams();
   const sessionParam = searchParams.get("session");
   const composeParam = searchParams.get("compose") === "1";
+  // Fail-open kill switch (undefined ⇒ on); see useAgentChatEnabled. When
+  // thrown, the hero/thread/takeover drop out and home renders greeting +
+  // stats + updates + recommendations only.
+  const agentChatEnabled = useAgentChatEnabled();
 
   // Re-arms whenever loading restarts; only fires while still loading.
   const [loadingTimedOut, setLoadingTimedOut] = useState(false);
@@ -334,7 +339,7 @@ export function HomeTab({
   // chose "New chat" from inside the takeover, the entire home screen *becomes*
   // the conversation surface. The greeting, stats, and recommended cards drop
   // out until the user clicks Back.
-  if (sessionParam || composeParam) {
+  if (agentChatEnabled && (sessionParam || composeParam)) {
     return (
       <McpjamAgentTakeoverFrame
         onBack={handleBackToHome}
@@ -385,12 +390,14 @@ export function HomeTab({
           />
         </header>
 
-        <McpjamAgentHero
-          surface="home"
-          onSessionStart={handleSessionStart}
-          onResumeSession={handleResumeSession}
-          ready={Boolean(projectId)}
-        />
+        {agentChatEnabled ? (
+          <McpjamAgentHero
+            surface="home"
+            onSessionStart={handleSessionStart}
+            onResumeSession={handleResumeSession}
+            ready={Boolean(projectId)}
+          />
+        ) : null}
 
         <ProductUpdatesRow />
 

--- a/mcpjam-inspector/client/src/components/mcpjam-agent/AgentSidePanelTrigger.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-agent/AgentSidePanelTrigger.tsx
@@ -10,6 +10,7 @@ import {
   TooltipTrigger,
 } from "@mcpjam/design-system/tooltip";
 import { useActiveTab } from "@/lib/app-navigation";
+import { useAgentChatEnabled } from "@/hooks/useAgentChatEnabled";
 import { useAgentPanelStore } from "@/stores/agent-panel/agent-panel-store";
 import { track } from "@/lib/analytics";
 
@@ -19,6 +20,7 @@ const SHORTCUT_LABEL =
     : "Ctrl+\\";
 
 export function AgentSidePanelTrigger() {
+  const agentChatEnabled = useAgentChatEnabled();
   const isOpen = useAgentPanelStore((s) => s.isOpen);
   const toggle = useAgentPanelStore((s) => s.toggle);
   const activeTab = useActiveTab();
@@ -34,6 +36,12 @@ export function AgentSidePanelTrigger() {
     }
     toggle();
   }, [activeTab, isOpen, toggle]);
+
+  // Kill switch: the panel mount is gated on the same flag in App.tsx, so a
+  // visible trigger would toggle store state with nothing mounted to show.
+  if (!agentChatEnabled) {
+    return null;
+  }
 
   return (
     <Tooltip>

--- a/mcpjam-inspector/client/src/hooks/__tests__/useAgentChatEnabled.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useAgentChatEnabled.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * Kill-switch semantics for the agent-chat flag: unlike the repo's fail-closed
+ * pre-launch gates (`=== true`), this hook is deliberately fail-OPEN — the
+ * feature is on unless PostHog explicitly returns `false`. The `undefined ⇒
+ * true` case is the load-bearing one: it covers the flag-hydration window and
+ * a deleted/absent flag, both of which must NOT dark-ship a launched feature.
+ */
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+let flagValue: boolean | undefined;
+let requestedFlag: string | undefined;
+
+vi.mock("posthog-js/react", () => ({
+  useFeatureFlagEnabled: (flag: string) => {
+    requestedFlag = flag;
+    return flagValue;
+  },
+}));
+
+import {
+  AGENT_CHAT_FEATURE_FLAG,
+  useAgentChatEnabled,
+} from "../useAgentChatEnabled";
+
+describe("useAgentChatEnabled", () => {
+  it("reads the agent-chat-enabled flag", () => {
+    flagValue = undefined;
+    renderHook(() => useAgentChatEnabled());
+    expect(AGENT_CHAT_FEATURE_FLAG).toBe("agent-chat-enabled");
+    expect(requestedFlag).toBe("agent-chat-enabled");
+  });
+
+  it("is enabled while the flag is undefined (hydrating or absent)", () => {
+    flagValue = undefined;
+    const { result } = renderHook(() => useAgentChatEnabled());
+    expect(result.current).toBe(true);
+  });
+
+  it("is enabled when the flag is true", () => {
+    flagValue = true;
+    const { result } = renderHook(() => useAgentChatEnabled());
+    expect(result.current).toBe(true);
+  });
+
+  it("is disabled only on an explicit false (kill switch thrown)", () => {
+    flagValue = false;
+    const { result } = renderHook(() => useAgentChatEnabled());
+    expect(result.current).toBe(false);
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/useAgentChatEnabled.ts
+++ b/mcpjam-inspector/client/src/hooks/useAgentChatEnabled.ts
@@ -1,0 +1,20 @@
+import { useFeatureFlagEnabled } from "posthog-js/react";
+
+/**
+ * PostHog KILL SWITCH for the in-app agent chat (home hero/thread, the agent
+ * side panel, and the `ui_*` WebMCP tool catalog registration that backs it).
+ *
+ * Deliberately fail-OPEN, unlike the repo's usual pre-launch gates (see
+ * `useSkillsEnabled`, which is fail-closed `=== true` so an unlaunched surface
+ * stays dark while flags hydrate or the flag doesn't exist). Agent chat is
+ * already launched: treating the hydration-window `undefined` as "off" would
+ * dark-ship a live feature on every page load and churn the ui_* catalog
+ * through a register → unregister → register cycle while PostHog loads. So
+ * `undefined` (flags loading, flag absent) ⇒ ON; only an explicit `false`
+ * — the operator flipping the kill switch — turns the feature off.
+ */
+export const AGENT_CHAT_FEATURE_FLAG = "agent-chat-enabled";
+
+export function useAgentChatEnabled(): boolean {
+  return useFeatureFlagEnabled(AGENT_CHAT_FEATURE_FLAG) !== false;
+}

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/use-register-ui-tools.kill-switch.test.tsx
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/use-register-ui-tools.kill-switch.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * Flag matrix for the App.tsx registration gate
+ * `useRegisterUiTools({ enabled: !isChatboxChatRoute && agentChatEnabled })`:
+ * the composed condition is reproduced here (App-level rendering is
+ * impractical) so the kill switch provably empties the ui_* catalog, the
+ * fail-open hydration window provably does NOT, and the chatbox-route guard
+ * wins regardless of the flag.
+ */
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/webmcp/native-mirror", () => ({
+  mirrorUiToolToNative: vi.fn(() => null),
+}));
+
+let agentChatFlag: boolean | undefined;
+
+vi.mock("posthog-js/react", () => ({
+  useFeatureFlagEnabled: (flag: string) =>
+    flag === "agent-chat-enabled" ? agentChatFlag : undefined,
+}));
+
+import { useRegisterUiTools } from "../use-register-ui-tools";
+import { useUiToolsRegistry } from "../ui-tools-registry";
+import { useAgentChatEnabled } from "@/hooks/useAgentChatEnabled";
+
+// Mirrors the App.tsx call site's composed condition.
+function useAppRegistrationGate({
+  isChatboxChatRoute,
+}: {
+  isChatboxChatRoute: boolean;
+}) {
+  const agentChatEnabled = useAgentChatEnabled();
+  useRegisterUiTools({ enabled: !isChatboxChatRoute && agentChatEnabled });
+}
+
+const registrySize = () => useUiToolsRegistry.getState().tools.size;
+
+describe("useRegisterUiTools agent-chat kill switch", () => {
+  beforeEach(() => {
+    agentChatFlag = undefined;
+    useUiToolsRegistry.setState({
+      tools: new Map(),
+      nativeDisposers: new Map(),
+      shippedNames: new Set(),
+    });
+  });
+
+  it("registers while the flag is undefined (fail-open hydration window)", () => {
+    const { unmount } = renderHook(() =>
+      useAppRegistrationGate({ isChatboxChatRoute: false })
+    );
+    expect(useUiToolsRegistry.getState().resolve("ui_navigate")).not.toBeNull();
+    unmount();
+    expect(registrySize()).toBe(0);
+  });
+
+  it("registers nothing when the flag is false, and follows flag flips", () => {
+    agentChatFlag = false;
+    const { rerender, unmount } = renderHook(() =>
+      useAppRegistrationGate({ isChatboxChatRoute: false })
+    );
+    expect(registrySize()).toBe(0);
+
+    agentChatFlag = true;
+    rerender();
+    expect(useUiToolsRegistry.getState().resolve("ui_navigate")).not.toBeNull();
+
+    agentChatFlag = false;
+    rerender();
+    expect(registrySize()).toBe(0);
+    unmount();
+  });
+
+  it("keeps the chatbox-route guard regardless of the flag", () => {
+    agentChatFlag = true;
+    const { unmount } = renderHook(() =>
+      useAppRegistrationGate({ isChatboxChatRoute: true })
+    );
+    expect(registrySize()).toBe(0);
+    unmount();
+  });
+});


### PR DESCRIPTION
## What

One PostHog flag — `agent-chat-enabled` — gating the three agent-chat surfaces:

- `ui_*` WebMCP catalog registration (`useRegisterUiTools` composition in App.tsx; off ⇒ catalog unregistered and native mirror clean)
- `AgentSidePanelMount` (off ⇒ not rendered, ⌘\ inert)
- Home hero/thread + the `?session=`/`?compose=` takeover branch (off ⇒ normal home layout, no empty takeover frame)

**Semantics: kill switch, fail-OPEN (`!== false`).** Deliberate deviation from the repo's fail-closed `=== true` convention (`useSkillsEnabled`): agent chat is already launched, so the `undefined` returned while PostHog flags hydrate (or if the flag was never created) must not dark-ship the feature or churn the catalog through register→unregister on every page load. Only an explicit `false` turns it off. Rationale documented head-to-head in the new `useAgentChatEnabled` hook.

Mid-session flip rides existing machinery: the registration effect's AbortController unregisters all tools + disposes native mirrors; in-flight streams error cleanly instead of hanging (`shippedNames`). No approval-policy changes (`shared/client-fulfilled-tools.ts` untouched).

**Ops note:** create `agent-chat-enabled` in PostHog rolled out "on for all" before this deploys — absence already means on, but pre-creating makes the switch one click.

## Tests

- `useAgentChatEnabled` matrix: undefined ⇒ on, true ⇒ on, false ⇒ off; queries exactly `agent-chat-enabled`.
- Kill-switch registration matrix: undefined ⇒ catalog registered; false ⇒ empty registry; flip cycles register/unregister; chatbox route wins regardless of flag.
- Full webmcp + hooks suites and the four App-rendering suites pass; `typecheck:client` clean.

This is PR **F-1** of [UI_ONLY_CHAT_IMPLEMENTATION.md](https://github.com/MCPJam/inspector/pull/3286) (§2 Layer 1, §7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only feature-flag gating with no auth or data-path changes; disabling agent chat is intentional ops behavior and existing unregister logic handles mid-session flag flips.
> 
> **Overview**
> Introduces **`useAgentChatEnabled`** reading PostHog flag **`agent-chat-enabled`** with **fail-open** semantics (`!== false`), so agent chat stays on while flags hydrate or if the flag is missing—only an explicit `false` disables it.
> 
> That hook gates **three surfaces**: **`useRegisterUiTools`** (stops `ui_*` catalog + native mirror when off), **`AgentSidePanelMount`** in `App.tsx`, and **Home** agent UX (`McpjamAgentHero`, `?session=` / `?compose=` takeover). **`AgentSidePanelTrigger`** returns null when disabled so the header button does not toggle panel state with nothing mounted.
> 
> Tests cover the hook’s undefined/true/false matrix and the composed registration gate (including chatbox-route still blocking tools).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2eba65faf320e1ee2b05c6ec026c99729f9b8e79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a fail-open kill switch for in-app agent chat using the PostHog flag `agent-chat-enabled`. When off, the agent side panel and trigger, Home hero/thread/takeover, and the `ui_*` WebMCP tool catalog are removed; Home falls back to the normal layout.

- **New Features**
  - Added `useAgentChatEnabled` with fail-open semantics (`!== false`) via `posthog-js/react`.
  - Gated `useRegisterUiTools`, `AgentSidePanelMount`, Home agent surfaces, and `AgentSidePanelTrigger` behind the flag.
  - Mid-session flips unregister tools and dispose native mirrors; streams end cleanly. Tests cover flag behavior and registration gate.

- **Migration**
  - Create `agent-chat-enabled` in PostHog and default it to on. Set to `false` to disable agent chat.

<sup>Written for commit 2eba65faf320e1ee2b05c6ec026c99729f9b8e79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

