### PR TITLE
feat(telemetry): outcome events for ui_* tool calls and agent turns

### DIFF
--- a/mcpjam-inspector/client/src/hooks/__tests__/agent-turn-terminal.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/agent-turn-terminal.test.ts
@@ -52,6 +52,14 @@ describe("lastAssistantHasUnresolvedToolParts", () => {
     ).toBe(false);
   });
 
+  it("treats a denied tool output as resolved (denied turns still complete)", () => {
+    expect(
+      lastAssistantHasUnresolvedToolParts(
+        msg([{ type: "tool-ui_remove_server", state: "output-denied" }]),
+      ),
+    ).toBe(false);
+  });
+
   it("is false for undefined / non-assistant messages", () => {
     expect(lastAssistantHasUnresolvedToolParts(undefined)).toBe(false);
     expect(

--- a/mcpjam-inspector/client/src/hooks/__tests__/agent-turn-terminal.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/agent-turn-terminal.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { lastAssistantHasUnresolvedToolParts } from "../use-mcpjam-agent-session";
+import {
+  lastAssistantHasUnresolvedToolParts,
+  turnAssistantMessage,
+} from "../use-mcpjam-agent-session";
 import type { UIMessage } from "ai";
 
 const msg = (parts: unknown[]): UIMessage =>
@@ -68,5 +71,31 @@ describe("lastAssistantHasUnresolvedToolParts", () => {
         parts: [{ type: "tool-x", state: "input-available" }],
       } as unknown as UIMessage),
     ).toBe(false);
+  });
+});
+
+describe("turnAssistantMessage", () => {
+  const withId = (id: string): UIMessage =>
+    ({ id, role: "assistant", parts: [] } as unknown as UIMessage);
+
+  it("returns the message when it's new (id differs from the boundary)", () => {
+    const m = withId("assistant-2");
+    expect(turnAssistantMessage(m, "assistant-1")).toBe(m);
+  });
+
+  it("returns undefined when last is the pre-submit boundary (stale)", () => {
+    // Error before the turn produced its own assistant message: `last` is the
+    // previous answer, whose id equals the boundary → not this turn's.
+    const stale = withId("assistant-1");
+    expect(turnAssistantMessage(stale, "assistant-1")).toBeUndefined();
+  });
+
+  it("returns the message on a fresh session (null boundary)", () => {
+    const m = withId("assistant-1");
+    expect(turnAssistantMessage(m, null)).toBe(m);
+  });
+
+  it("returns undefined when there is no last message", () => {
+    expect(turnAssistantMessage(undefined, "x")).toBeUndefined();
   });
 });

--- a/mcpjam-inspector/client/src/hooks/__tests__/agent-turn-terminal.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/agent-turn-terminal.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { lastAssistantHasUnresolvedToolParts } from "../use-mcpjam-agent-session";
+import type { UIMessage } from "ai";
+
+const msg = (parts: unknown[]): UIMessage =>
+  ({ role: "assistant", parts } as unknown as UIMessage);
+
+describe("lastAssistantHasUnresolvedToolParts", () => {
+  it("is false for a plain text answer (turn genuinely done)", () => {
+    expect(
+      lastAssistantHasUnresolvedToolParts(
+        msg([{ type: "text", text: "hi" }]),
+      ),
+    ).toBe(false);
+  });
+
+  it("is true while a tool call awaits its result (intermediate ready)", () => {
+    // The SDK reaches `ready` here with the tool part input-available — the
+    // turn is NOT done; emitting now would truncate duration and suppress the
+    // real completion.
+    expect(
+      lastAssistantHasUnresolvedToolParts(
+        msg([{ type: "tool-ui_navigate", state: "input-available" }]),
+      ),
+    ).toBe(true);
+  });
+
+  it("is true while a tool call awaits approval", () => {
+    expect(
+      lastAssistantHasUnresolvedToolParts(
+        msg([{ type: "tool-ui_execute_tool", state: "approval-requested" }]),
+      ),
+    ).toBe(true);
+  });
+
+  it("is false once every tool call has resolved (final ready)", () => {
+    expect(
+      lastAssistantHasUnresolvedToolParts(
+        msg([
+          { type: "tool-ui_navigate", state: "output-available" },
+          { type: "text", text: "done" },
+        ]),
+      ),
+    ).toBe(false);
+  });
+
+  it("treats an errored tool output as resolved", () => {
+    expect(
+      lastAssistantHasUnresolvedToolParts(
+        msg([{ type: "tool-ui_navigate", state: "output-error" }]),
+      ),
+    ).toBe(false);
+  });
+
+  it("is false for undefined / non-assistant messages", () => {
+    expect(lastAssistantHasUnresolvedToolParts(undefined)).toBe(false);
+    expect(
+      lastAssistantHasUnresolvedToolParts({
+        role: "user",
+        parts: [{ type: "tool-x", state: "input-available" }],
+      } as unknown as UIMessage),
+    ).toBe(false);
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -2132,8 +2132,10 @@ export function useChatSession(
         addToolOutput: addToolOutput as Parameters<
           typeof createUiAwareApprovalResponseHandler
         >[0]["addToolOutput"],
+        // Keeps reload-approved calls in this session's duplicate ring.
+        telemetryScope: chatSessionId,
       }),
-    [addToolApprovalResponse, addToolOutput]
+    [addToolApprovalResponse, addToolOutput, chatSessionId]
   );
 
   // Orphaned-defer fallback: a UI tool call deferred for approval whose

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -1955,6 +1955,8 @@ export function useChatSession(
           // Defers mutating UI tools to the approval pill when the toggle is
           // on — must mirror the server's gate (shared predicate).
           requireToolApproval: requireToolApprovalRef.current,
+          // Duplicate detection is per chat session, not per module.
+          telemetryScope: chatSessionIdRef.current,
         })
       ) {
         return;

--- a/mcpjam-inspector/client/src/hooks/use-mcpjam-agent-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-mcpjam-agent-session.ts
@@ -67,7 +67,11 @@ export function lastAssistantHasUnresolvedToolParts(
     const type = (part as { type?: unknown }).type;
     if (typeof type !== "string" || !type.startsWith("tool-")) return false;
     const state = (part as { state?: unknown }).state;
-    return state !== "output-available" && state !== "output-error";
+    // Resolved = any terminal `output-*` state: output-available (incl. a
+    // synthesized denial result), output-error, output-denied. Anything else
+    // (input-streaming/input-available/approval-requested) is mid-flight, so
+    // a denied turn — which ends in a terminal output part — still completes.
+    return !(typeof state === "string" && state.startsWith("output-"));
   });
 }
 

--- a/mcpjam-inspector/client/src/hooks/use-mcpjam-agent-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-mcpjam-agent-session.ts
@@ -57,6 +57,19 @@ import { getChatHistoryDetail } from "@/lib/apis/web/chat-history-api";
  * output-error. Any tool part not in a terminal output state means the turn
  * is mid-flight.
  */
+/**
+ * The assistant message THIS turn produced, or undefined. On an error before
+ * the SDK appended the turn's own assistant message, `last` is the previous
+ * turn's answer (same id as the pre-submit boundary) — return undefined so its
+ * tools/usage aren't misattributed to the failed turn.
+ */
+export function turnAssistantMessage(
+  last: UIMessage | undefined,
+  boundaryMessageId: string | null,
+): UIMessage | undefined {
+  return last && last.id !== boundaryMessageId ? last : undefined;
+}
+
 export function lastAssistantHasUnresolvedToolParts(
   last: UIMessage | undefined,
 ): boolean {
@@ -354,6 +367,12 @@ export function useMcpjamAgentSession(
     turnStartedAtRef.current = null;
     const startedAt = claim.startedAt;
     const durationMs = startedAt != null ? Date.now() - startedAt : null;
+    // Only attribute tool counts / usage to an assistant message THIS turn
+    // produced. On an error before the SDK appended the turn's assistant
+    // message, `last` is the previous turn's answer — attributing its tools
+    // to the failed turn would corrupt the experiment. A new message has an
+    // id different from the pre-submit boundary.
+    const turnAssistant = turnAssistantMessage(last, claim.boundaryMessageId);
     // Observation-only: a throwing analytics client must never break the
     // session's effect.
     try {
@@ -372,15 +391,19 @@ export function useMcpjamAgentSession(
           session_id: chatSessionId,
           model: claim.model,
           provider: claim.provider,
-          ...summarizeUiToolCalls(last),
+          ...summarizeUiToolCalls(turnAssistant),
           had_error: true,
-          ...usageTokens(last),
+          ...usageTokens(turnAssistant),
           duration_ms: durationMs,
         });
       } else {
         let toolCallCount = 0;
-        if (last && last.role === "assistant" && Array.isArray(last.parts)) {
-          toolCallCount = last.parts.filter((p) =>
+        if (
+          turnAssistant &&
+          turnAssistant.role === "assistant" &&
+          Array.isArray(turnAssistant.parts)
+        ) {
+          toolCallCount = turnAssistant.parts.filter((p) =>
             typeof (p as { type?: unknown }).type === "string" &&
             (p as { type: string }).type.startsWith("tool-")
           ).length;
@@ -400,9 +423,9 @@ export function useMcpjamAgentSession(
           session_id: chatSessionId,
           model: claim.model,
           provider: claim.provider,
-          ...summarizeUiToolCalls(last),
+          ...summarizeUiToolCalls(turnAssistant),
           had_error: false,
-          ...usageTokens(last),
+          ...usageTokens(turnAssistant),
           duration_ms: durationMs,
         });
       }
@@ -474,10 +497,16 @@ export function useMcpjamAgentSession(
       // Turn timing/attribution lives on the shared Chat entry so a hand-off
       // to another surface mid-turn still reports the right duration and
       // emits the completion exactly once.
+      const priorMessages = messagesForDeferRef.current;
+      const boundaryMessageId =
+        priorMessages.length > 0
+          ? (priorMessages[priorMessages.length - 1]?.id ?? null)
+          : null;
       markAgentTurnStarted(chatSessionId, {
         model: config.model?.id ?? null,
         provider: config.model?.provider ?? null,
         messageIndex: turnIndexRef.current,
+        boundaryMessageId,
       });
       track("mcpjam_agent_message_sent", {
         location: "mcpjam_agent",

--- a/mcpjam-inspector/client/src/hooks/use-mcpjam-agent-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-mcpjam-agent-session.ts
@@ -48,6 +48,29 @@ import { getChatHistoryDetail } from "@/lib/apis/web/chat-history-api";
  * membership / shipped names) — never the `ui_` prefix alone. Names and
  * counts only; args/outputs never leave the message.
  */
+/**
+ * A turn is only truly finished when its tool calls have resolved. During a
+ * UI-tool turn the SDK reaches an intermediate `ready` with the tool part
+ * still awaiting a result (input-streaming/input-available) or the user's
+ * approval (approval-requested); the real completion is the LATER `ready`
+ * after the tool-resume chain. Terminal tool states are output-available /
+ * output-error. Any tool part not in a terminal output state means the turn
+ * is mid-flight.
+ */
+export function lastAssistantHasUnresolvedToolParts(
+  last: UIMessage | undefined,
+): boolean {
+  if (!last || last.role !== "assistant" || !Array.isArray(last.parts)) {
+    return false;
+  }
+  return last.parts.some((part) => {
+    const type = (part as { type?: unknown }).type;
+    if (typeof type !== "string" || !type.startsWith("tool-")) return false;
+    const state = (part as { state?: unknown }).state;
+    return state !== "output-available" && state !== "output-error";
+  });
+}
+
 function summarizeUiToolCalls(last: UIMessage | undefined): {
   ui_tool_call_count: number;
   distinct_tool_count: number;
@@ -303,34 +326,39 @@ export function useMcpjamAgentSession(
   // useChat `onFinish` callback in this @ai-sdk/react version.
   const turnStartedAtRef = useRef<number | null>(null);
   const turnIndexRef = useRef<number>(0);
-  const prevStatusRef = useRef(status);
+  // Completion is detected from the SHARED entry + terminal state, NOT a
+  // hook-local status edge. Three reasons this matters for the agent chat:
+  //   1. A UI-tool turn passes through an intermediate `ready` while the tool
+  //      part is still input-available/approval-requested (AI SDK #7430:
+  //      streaming→ready→submitted→streaming→ready). Emitting there would
+  //      report a truncated duration and, via the one-shot claim, SUPPRESS
+  //      the real final completion. So we only treat `ready` as terminal when
+  //      the last assistant message has no unresolved tool parts.
+  //   2. On a hand-off, the adopting surface may mount AFTER the shared Chat
+  //      already reached `ready` — no status edge occurs. A state-driven
+  //      effect still runs on mount and can claim the pending completion once.
+  //   3. Dedup + timing + attribution live on the shared entry, so exactly
+  //      one surface emits per turn with the submit-time duration/model.
   useEffect(() => {
-    const prev = prevStatusRef.current;
-    prevStatusRef.current = status;
-    if (prev === status) return;
-    const terminal =
-      ((prev === "submitted" || prev === "streaming") && status === "ready") ||
-      status === "error";
-    if (!terminal) return;
-    // Claim the completion on the SHARED entry: the first surface to observe
-    // this turn's terminal edge wins and emits; a post-hand-off observer of
-    // the same Chat gets null and stays silent (no double count, no
-    // null-duration row). Also clears the per-hook ref for tidiness.
-    turnStartedAtRef.current = null;
+    const last = messages[messages.length - 1];
+    const isTerminal =
+      status === "error" ||
+      (status === "ready" && !lastAssistantHasUnresolvedToolParts(last));
+    if (!isTerminal) return;
     const claim = claimAgentTurnCompletion(chatSessionId);
     if (!claim) return;
+    turnStartedAtRef.current = null;
     const startedAt = claim.startedAt;
     const durationMs = startedAt != null ? Date.now() - startedAt : null;
-    const last = messages[messages.length - 1];
     // Observation-only: a throwing analytics client must never break the
-    // session's status-edge effect.
+    // session's effect.
     try {
       if (status === "error") {
         track("mcpjam_agent_response_error", {
           location: "mcpjam_agent",
           surface,
           session_id: chatSessionId,
-          message_index: turnIndexRef.current,
+          message_index: claim.messageIndex,
           duration_ms: durationMs,
           error_message: error?.message ?? null,
         });
@@ -357,7 +385,7 @@ export function useMcpjamAgentSession(
           location: "mcpjam_agent",
           surface,
           session_id: chatSessionId,
-          message_index: turnIndexRef.current,
+          message_index: claim.messageIndex,
           duration_ms: durationMs,
           tool_call_count: toolCallCount,
           message_count: messages.length,
@@ -377,7 +405,7 @@ export function useMcpjamAgentSession(
     } catch {
       // swallow — telemetry is observation-only
     }
-  }, [chatSessionId, config, error, messages, status, surface]);
+  }, [chatSessionId, error, messages, status, surface]);
 
   // Orphaned-defer fallback: a UI tool call deferred for approval whose
   // approval request never arrived (client/server flag disagreement for one
@@ -445,6 +473,7 @@ export function useMcpjamAgentSession(
       markAgentTurnStarted(chatSessionId, {
         model: config.model?.id ?? null,
         provider: config.model?.provider ?? null,
+        messageIndex: turnIndexRef.current,
       });
       track("mcpjam_agent_message_sent", {
         location: "mcpjam_agent",

--- a/mcpjam-inspector/client/src/hooks/use-mcpjam-agent-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-mcpjam-agent-session.ts
@@ -49,15 +49,6 @@ import { getChatHistoryDetail } from "@/lib/apis/web/chat-history-api";
  * counts only; args/outputs never leave the message.
  */
 /**
- * A turn is only truly finished when its tool calls have resolved. During a
- * UI-tool turn the SDK reaches an intermediate `ready` with the tool part
- * still awaiting a result (input-streaming/input-available) or the user's
- * approval (approval-requested); the real completion is the LATER `ready`
- * after the tool-resume chain. Terminal tool states are output-available /
- * output-error. Any tool part not in a terminal output state means the turn
- * is mid-flight.
- */
-/**
  * The assistant message THIS turn produced, or undefined. On an error before
  * the SDK appended the turn's own assistant message, `last` is the previous
  * turn's answer (same id as the pre-submit boundary) — return undefined so its
@@ -70,6 +61,15 @@ export function turnAssistantMessage(
   return last && last.id !== boundaryMessageId ? last : undefined;
 }
 
+/**
+ * A turn is only truly finished when its tool calls have resolved. During a
+ * UI-tool turn the SDK reaches an intermediate `ready` with the tool part
+ * still awaiting a result (input-streaming/input-available) or the user's
+ * approval (approval-requested); the real completion is the LATER `ready`
+ * after the tool-resume chain. Terminal tool states are output-available /
+ * output-error. Any tool part not in a terminal output state means the turn
+ * is mid-flight.
+ */
 export function lastAssistantHasUnresolvedToolParts(
   last: UIMessage | undefined,
 ): boolean {

--- a/mcpjam-inspector/client/src/hooks/use-mcpjam-agent-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-mcpjam-agent-session.ts
@@ -15,7 +15,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useChat, type UIMessage } from "@ai-sdk/react";
 import { generateId } from "ai";
-import { getOrCreateAgentChat } from "@/lib/mcpjam-agent/agent-chat-instances";
+import {
+  getOrCreateAgentChat,
+  markAgentTurnStarted,
+  claimAgentTurnCompletion,
+} from "@/lib/mcpjam-agent/agent-chat-instances";
 import { fulfillOrphanedDeferredUiToolCalls } from "@/lib/webmcp/ui-tool-approval";
 import { buildUiContextPart } from "@/lib/webmcp/ui-context-snapshot";
 import { useUiToolsRegistry } from "@/lib/webmcp/ui-tools-registry";
@@ -304,60 +308,74 @@ export function useMcpjamAgentSession(
     const prev = prevStatusRef.current;
     prevStatusRef.current = status;
     if (prev === status) return;
-    if ((prev === "submitted" || prev === "streaming") && status === "ready") {
-      const startedAt = turnStartedAtRef.current;
-      turnStartedAtRef.current = null;
-      const last = messages[messages.length - 1];
-      let toolCallCount = 0;
-      if (last && last.role === "assistant" && Array.isArray(last.parts)) {
-        toolCallCount = last.parts.filter((p) =>
-          typeof (p as { type?: unknown }).type === "string" &&
-          (p as { type: string }).type.startsWith("tool-")
-        ).length;
+    const terminal =
+      ((prev === "submitted" || prev === "streaming") && status === "ready") ||
+      status === "error";
+    if (!terminal) return;
+    // Claim the completion on the SHARED entry: the first surface to observe
+    // this turn's terminal edge wins and emits; a post-hand-off observer of
+    // the same Chat gets null and stays silent (no double count, no
+    // null-duration row). Also clears the per-hook ref for tidiness.
+    turnStartedAtRef.current = null;
+    const claim = claimAgentTurnCompletion(chatSessionId);
+    if (!claim) return;
+    const startedAt = claim.startedAt;
+    const durationMs = startedAt != null ? Date.now() - startedAt : null;
+    const last = messages[messages.length - 1];
+    // Observation-only: a throwing analytics client must never break the
+    // session's status-edge effect.
+    try {
+      if (status === "error") {
+        track("mcpjam_agent_response_error", {
+          location: "mcpjam_agent",
+          surface,
+          session_id: chatSessionId,
+          message_index: turnIndexRef.current,
+          duration_ms: durationMs,
+          error_message: error?.message ?? null,
+        });
+        track("agent_turn_completed", {
+          location: "mcpjam_agent",
+          surface,
+          session_id: chatSessionId,
+          model: claim.model,
+          provider: claim.provider,
+          ...summarizeUiToolCalls(last),
+          had_error: true,
+          ...usageTokens(last),
+          duration_ms: durationMs,
+        });
+      } else {
+        let toolCallCount = 0;
+        if (last && last.role === "assistant" && Array.isArray(last.parts)) {
+          toolCallCount = last.parts.filter((p) =>
+            typeof (p as { type?: unknown }).type === "string" &&
+            (p as { type: string }).type.startsWith("tool-")
+          ).length;
+        }
+        track("mcpjam_agent_response_finished", {
+          location: "mcpjam_agent",
+          surface,
+          session_id: chatSessionId,
+          message_index: turnIndexRef.current,
+          duration_ms: durationMs,
+          tool_call_count: toolCallCount,
+          message_count: messages.length,
+        });
+        track("agent_turn_completed", {
+          location: "mcpjam_agent",
+          surface,
+          session_id: chatSessionId,
+          model: claim.model,
+          provider: claim.provider,
+          ...summarizeUiToolCalls(last),
+          had_error: false,
+          ...usageTokens(last),
+          duration_ms: durationMs,
+        });
       }
-      track("mcpjam_agent_response_finished", {
-        location: "mcpjam_agent",
-        surface,
-        session_id: chatSessionId,
-        message_index: turnIndexRef.current,
-        duration_ms: startedAt != null ? Date.now() - startedAt : null,
-        tool_call_count: toolCallCount,
-        message_count: messages.length,
-      });
-      track("agent_turn_completed", {
-        location: "mcpjam_agent",
-        surface,
-        session_id: chatSessionId,
-        model: config.model?.id ?? null,
-        provider: config.model?.provider ?? null,
-        ...summarizeUiToolCalls(last),
-        had_error: false,
-        ...usageTokens(last),
-        duration_ms: startedAt != null ? Date.now() - startedAt : null,
-      });
-    } else if (status === "error") {
-      const startedAt = turnStartedAtRef.current;
-      turnStartedAtRef.current = null;
-      track("mcpjam_agent_response_error", {
-        location: "mcpjam_agent",
-        surface,
-        session_id: chatSessionId,
-        message_index: turnIndexRef.current,
-        duration_ms: startedAt != null ? Date.now() - startedAt : null,
-        error_message: error?.message ?? null,
-      });
-      const last = messages[messages.length - 1];
-      track("agent_turn_completed", {
-        location: "mcpjam_agent",
-        surface,
-        session_id: chatSessionId,
-        model: config.model?.id ?? null,
-        provider: config.model?.provider ?? null,
-        ...summarizeUiToolCalls(last),
-        had_error: true,
-        ...usageTokens(last),
-        duration_ms: startedAt != null ? Date.now() - startedAt : null,
-      });
+    } catch {
+      // swallow — telemetry is observation-only
     }
   }, [chatSessionId, config, error, messages, status, surface]);
 
@@ -421,6 +439,13 @@ export function useMcpjamAgentSession(
       }
       turnIndexRef.current += 1;
       turnStartedAtRef.current = Date.now();
+      // Turn timing/attribution lives on the shared Chat entry so a hand-off
+      // to another surface mid-turn still reports the right duration and
+      // emits the completion exactly once.
+      markAgentTurnStarted(chatSessionId, {
+        model: config.model?.id ?? null,
+        provider: config.model?.provider ?? null,
+      });
       track("mcpjam_agent_message_sent", {
         location: "mcpjam_agent",
         surface,

--- a/mcpjam-inspector/client/src/hooks/use-mcpjam-agent-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-mcpjam-agent-session.ts
@@ -18,6 +18,7 @@ import { generateId } from "ai";
 import { getOrCreateAgentChat } from "@/lib/mcpjam-agent/agent-chat-instances";
 import { fulfillOrphanedDeferredUiToolCalls } from "@/lib/webmcp/ui-tool-approval";
 import { buildUiContextPart } from "@/lib/webmcp/ui-context-snapshot";
+import { useUiToolsRegistry } from "@/lib/webmcp/ui-tools-registry";
 import {
   loadAgentRequireToolApproval,
   saveAgentRequireToolApproval,
@@ -36,6 +37,60 @@ import {
   transcriptToUIMessages,
 } from "@/lib/transcript-to-ui-messages";
 import { getChatHistoryDetail } from "@/lib/apis/web/chat-history-api";
+
+/**
+ * Count the `ui_*` client-fulfilled tool calls on the turn's assistant
+ * message. Ownership mirrors the executor's dispatch gate (registry
+ * membership / shipped names) — never the `ui_` prefix alone. Names and
+ * counts only; args/outputs never leave the message.
+ */
+function summarizeUiToolCalls(last: UIMessage | undefined): {
+  ui_tool_call_count: number;
+  distinct_tool_count: number;
+} {
+  if (!last || last.role !== "assistant" || !Array.isArray(last.parts)) {
+    return { ui_tool_call_count: 0, distinct_tool_count: 0 };
+  }
+  const registry = useUiToolsRegistry.getState();
+  const names: string[] = [];
+  for (const part of last.parts) {
+    const type = (part as { type?: unknown }).type;
+    if (typeof type !== "string" || !type.startsWith("tool-")) continue;
+    const name = type.slice("tool-".length);
+    if (registry.resolve(name) !== null || registry.wasShipped(name)) {
+      names.push(name);
+    }
+  }
+  return {
+    ui_tool_call_count: names.length,
+    distinct_tool_count: new Set(names).size,
+  };
+}
+
+/**
+ * Token usage IF the session already carries it on the assistant message's
+ * metadata. The agent route doesn't stream usage metadata today, so these
+ * are usually null — deliberately no new server plumbing here.
+ */
+function usageTokens(last: UIMessage | undefined): {
+  input_tokens: number | null;
+  output_tokens: number | null;
+} {
+  const usage =
+    last && last.role === "assistant"
+      ? (
+          last as {
+            metadata?: { usage?: { inputTokens?: unknown; outputTokens?: unknown } };
+          }
+        ).metadata?.usage
+      : undefined;
+  return {
+    input_tokens:
+      typeof usage?.inputTokens === "number" ? usage.inputTokens : null,
+    output_tokens:
+      typeof usage?.outputTokens === "number" ? usage.outputTokens : null,
+  };
+}
 
 export interface UseMcpjamAgentSessionArgs {
   /**
@@ -269,6 +324,17 @@ export function useMcpjamAgentSession(
         tool_call_count: toolCallCount,
         message_count: messages.length,
       });
+      track("agent_turn_completed", {
+        location: "mcpjam_agent",
+        surface,
+        session_id: chatSessionId,
+        model: config.model?.id ?? null,
+        provider: config.model?.provider ?? null,
+        ...summarizeUiToolCalls(last),
+        had_error: false,
+        ...usageTokens(last),
+        duration_ms: startedAt != null ? Date.now() - startedAt : null,
+      });
     } else if (status === "error") {
       const startedAt = turnStartedAtRef.current;
       turnStartedAtRef.current = null;
@@ -280,8 +346,20 @@ export function useMcpjamAgentSession(
         duration_ms: startedAt != null ? Date.now() - startedAt : null,
         error_message: error?.message ?? null,
       });
+      const last = messages[messages.length - 1];
+      track("agent_turn_completed", {
+        location: "mcpjam_agent",
+        surface,
+        session_id: chatSessionId,
+        model: config.model?.id ?? null,
+        provider: config.model?.provider ?? null,
+        ...summarizeUiToolCalls(last),
+        had_error: true,
+        ...usageTokens(last),
+        duration_ms: startedAt != null ? Date.now() - startedAt : null,
+      });
     }
-  }, [chatSessionId, error, messages, status, surface]);
+  }, [chatSessionId, config, error, messages, status, surface]);
 
   // Orphaned-defer fallback: a UI tool call deferred for approval whose
   // approval request never arrived (client/server flag disagreement for one

--- a/mcpjam-inspector/client/src/lib/mcpjam-agent/__tests__/agent-chat-instances.test.ts
+++ b/mcpjam-inspector/client/src/lib/mcpjam-agent/__tests__/agent-chat-instances.test.ts
@@ -350,7 +350,7 @@ describe("agent-chat-instances", () => {
   describe("turn lifecycle (shared across surfaces)", () => {
     it("claims a completion exactly once — a second observer gets null", () => {
       getOrCreateAgentChat("t1");
-      markAgentTurnStarted("t1", { model: "m", provider: "p" });
+      markAgentTurnStarted("t1", { model: "m", provider: "p", messageIndex: 1 });
 
       const first = claimAgentTurnCompletion("t1");
       expect(first).not.toBeNull();
@@ -361,29 +361,64 @@ describe("agent-chat-instances", () => {
       expect(claimAgentTurnCompletion("t1")).toBeNull();
     });
 
-    it("carries submit-time attribution even if config changes mid-turn", () => {
+    it("carries submit-time attribution + message index even if config changes mid-turn", () => {
       const entry = getOrCreateAgentChat("t2");
-      markAgentTurnStarted("t2", { model: "gpt", provider: "openai" });
+      markAgentTurnStarted("t2", {
+        model: "gpt",
+        provider: "openai",
+        messageIndex: 4,
+      });
       // Simulate a config swap during streaming.
       entry.config.model = { id: "claude", provider: "anthropic" } as never;
       const claim = claimAgentTurnCompletion("t2");
-      expect(claim).toMatchObject({ model: "gpt", provider: "openai" });
+      expect(claim).toMatchObject({
+        model: "gpt",
+        provider: "openai",
+        messageIndex: 4,
+      });
     });
 
     it("a fresh submit re-arms the claim for the next turn", () => {
       getOrCreateAgentChat("t3");
-      markAgentTurnStarted("t3", { model: null, provider: null });
+      markAgentTurnStarted("t3", {
+        model: null,
+        provider: null,
+        messageIndex: 1,
+      });
       expect(claimAgentTurnCompletion("t3")).not.toBeNull();
       expect(claimAgentTurnCompletion("t3")).toBeNull();
-      markAgentTurnStarted("t3", { model: null, provider: null });
-      expect(claimAgentTurnCompletion("t3")).not.toBeNull();
+      markAgentTurnStarted("t3", {
+        model: null,
+        provider: null,
+        messageIndex: 2,
+      });
+      expect(claimAgentTurnCompletion("t3")).toMatchObject({ messageIndex: 2 });
     });
 
     it("claim on an unknown session is null, never throws", () => {
       expect(claimAgentTurnCompletion("nope")).toBeNull();
       expect(() =>
-        markAgentTurnStarted("nope", { model: null, provider: null }),
+        markAgentTurnStarted("nope", {
+          model: null,
+          provider: null,
+          messageIndex: 0,
+        }),
       ).not.toThrow();
+    });
+
+    it("a hand-off surface can claim once even with no local status edge", () => {
+      // Original surface submits (bumps seq) then unmounts WITHOUT emitting —
+      // the completion is still claimable exactly once by whoever attaches.
+      getOrCreateAgentChat("t4");
+      markAgentTurnStarted("t4", {
+        model: "m",
+        provider: "p",
+        messageIndex: 3,
+      });
+      const adopted = claimAgentTurnCompletion("t4");
+      expect(adopted).toMatchObject({ messageIndex: 3, model: "m" });
+      // No second emission from any other observer.
+      expect(claimAgentTurnCompletion("t4")).toBeNull();
     });
   });
 });

--- a/mcpjam-inspector/client/src/lib/mcpjam-agent/__tests__/agent-chat-instances.test.ts
+++ b/mcpjam-inspector/client/src/lib/mcpjam-agent/__tests__/agent-chat-instances.test.ts
@@ -59,6 +59,8 @@ vi.mock("@/lib/analytics", () => ({
 import {
   __resetAgentChatInstancesForTests,
   getOrCreateAgentChat,
+  markAgentTurnStarted,
+  claimAgentTurnCompletion,
 } from "../agent-chat-instances";
 import { __resetUiToolExecutorForTests } from "@/lib/webmcp/ui-tool-executor";
 import {
@@ -341,6 +343,47 @@ describe("agent-chat-instances", () => {
       );
       expect(def.execute).toHaveBeenCalled();
       expect((entry.chat as any).addToolOutput).toHaveBeenCalled();
+    });
+  });
+
+
+  describe("turn lifecycle (shared across surfaces)", () => {
+    it("claims a completion exactly once — a second observer gets null", () => {
+      getOrCreateAgentChat("t1");
+      markAgentTurnStarted("t1", { model: "m", provider: "p" });
+
+      const first = claimAgentTurnCompletion("t1");
+      expect(first).not.toBeNull();
+      expect(first).toMatchObject({ model: "m", provider: "p" });
+      expect(typeof first!.startedAt).toBe("number");
+
+      // A post-hand-off surface observing the same edge must stay silent.
+      expect(claimAgentTurnCompletion("t1")).toBeNull();
+    });
+
+    it("carries submit-time attribution even if config changes mid-turn", () => {
+      const entry = getOrCreateAgentChat("t2");
+      markAgentTurnStarted("t2", { model: "gpt", provider: "openai" });
+      // Simulate a config swap during streaming.
+      entry.config.model = { id: "claude", provider: "anthropic" } as never;
+      const claim = claimAgentTurnCompletion("t2");
+      expect(claim).toMatchObject({ model: "gpt", provider: "openai" });
+    });
+
+    it("a fresh submit re-arms the claim for the next turn", () => {
+      getOrCreateAgentChat("t3");
+      markAgentTurnStarted("t3", { model: null, provider: null });
+      expect(claimAgentTurnCompletion("t3")).not.toBeNull();
+      expect(claimAgentTurnCompletion("t3")).toBeNull();
+      markAgentTurnStarted("t3", { model: null, provider: null });
+      expect(claimAgentTurnCompletion("t3")).not.toBeNull();
+    });
+
+    it("claim on an unknown session is null, never throws", () => {
+      expect(claimAgentTurnCompletion("nope")).toBeNull();
+      expect(() =>
+        markAgentTurnStarted("nope", { model: null, provider: null }),
+      ).not.toThrow();
     });
   });
 });

--- a/mcpjam-inspector/client/src/lib/mcpjam-agent/__tests__/agent-chat-instances.test.ts
+++ b/mcpjam-inspector/client/src/lib/mcpjam-agent/__tests__/agent-chat-instances.test.ts
@@ -350,7 +350,12 @@ describe("agent-chat-instances", () => {
   describe("turn lifecycle (shared across surfaces)", () => {
     it("claims a completion exactly once — a second observer gets null", () => {
       getOrCreateAgentChat("t1");
-      markAgentTurnStarted("t1", { model: "m", provider: "p", messageIndex: 1 });
+      markAgentTurnStarted("t1", {
+        model: "m",
+        provider: "p",
+        messageIndex: 1,
+        boundaryMessageId: null,
+      });
 
       const first = claimAgentTurnCompletion("t1");
       expect(first).not.toBeNull();
@@ -367,6 +372,7 @@ describe("agent-chat-instances", () => {
         model: "gpt",
         provider: "openai",
         messageIndex: 4,
+        boundaryMessageId: "prev-msg",
       });
       // Simulate a config swap during streaming.
       entry.config.model = { id: "claude", provider: "anthropic" } as never;
@@ -375,6 +381,7 @@ describe("agent-chat-instances", () => {
         model: "gpt",
         provider: "openai",
         messageIndex: 4,
+        boundaryMessageId: "prev-msg",
       });
     });
 
@@ -384,6 +391,7 @@ describe("agent-chat-instances", () => {
         model: null,
         provider: null,
         messageIndex: 1,
+        boundaryMessageId: null,
       });
       expect(claimAgentTurnCompletion("t3")).not.toBeNull();
       expect(claimAgentTurnCompletion("t3")).toBeNull();
@@ -391,6 +399,7 @@ describe("agent-chat-instances", () => {
         model: null,
         provider: null,
         messageIndex: 2,
+        boundaryMessageId: null,
       });
       expect(claimAgentTurnCompletion("t3")).toMatchObject({ messageIndex: 2 });
     });
@@ -402,6 +411,7 @@ describe("agent-chat-instances", () => {
           model: null,
           provider: null,
           messageIndex: 0,
+          boundaryMessageId: null,
         }),
       ).not.toThrow();
     });
@@ -414,6 +424,7 @@ describe("agent-chat-instances", () => {
         model: "m",
         provider: "p",
         messageIndex: 3,
+        boundaryMessageId: "boundary-1",
       });
       const adopted = claimAgentTurnCompletion("t4");
       expect(adopted).toMatchObject({ messageIndex: 3, model: "m" });

--- a/mcpjam-inspector/client/src/lib/mcpjam-agent/agent-chat-instances.ts
+++ b/mcpjam-inspector/client/src/lib/mcpjam-agent/agent-chat-instances.ts
@@ -90,6 +90,14 @@ export interface AgentTurnLifecycle {
   provider: string | null;
   /** 1-based turn index snapshotted at submit (survives surface hand-off). */
   messageIndex: number;
+  /**
+   * Id of the last message BEFORE this turn was submitted. Completion only
+   * attributes tool counts / usage to an assistant message whose id differs
+   * from this — so an error that fires before the turn produced its own
+   * assistant message can't inherit the PREVIOUS turn's tools. `null` when
+   * the session had no messages yet.
+   */
+  boundaryMessageId: string | null;
 }
 
 export interface AgentChatEntry {
@@ -178,6 +186,7 @@ export function markAgentTurnStarted(
     model: string | null;
     provider: string | null;
     messageIndex: number;
+    boundaryMessageId: string | null;
   },
 ): void {
   const entry = instances.get(chatSessionId);
@@ -187,6 +196,7 @@ export function markAgentTurnStarted(
   entry.turn.model = attribution.model;
   entry.turn.provider = attribution.provider;
   entry.turn.messageIndex = attribution.messageIndex;
+  entry.turn.boundaryMessageId = attribution.boundaryMessageId;
 }
 
 /**
@@ -201,6 +211,7 @@ export function claimAgentTurnCompletion(chatSessionId: string): {
   model: string | null;
   provider: string | null;
   messageIndex: number;
+  boundaryMessageId: string | null;
 } | null {
   const entry = instances.get(chatSessionId);
   if (!entry) return null;
@@ -211,6 +222,7 @@ export function claimAgentTurnCompletion(chatSessionId: string): {
     model: entry.turn.model,
     provider: entry.turn.provider,
     messageIndex: entry.turn.messageIndex,
+    boundaryMessageId: entry.turn.boundaryMessageId,
   };
   entry.turn.startedAt = null;
   return snapshot;
@@ -311,6 +323,7 @@ export function getOrCreateAgentChat(chatSessionId: string): AgentChatEntry {
       model: null,
       provider: null,
       messageIndex: 0,
+      boundaryMessageId: null,
     },
   };
   instances.set(chatSessionId, entry);

--- a/mcpjam-inspector/client/src/lib/mcpjam-agent/agent-chat-instances.ts
+++ b/mcpjam-inspector/client/src/lib/mcpjam-agent/agent-chat-instances.ts
@@ -75,9 +75,26 @@ export interface AgentChatConfig {
   requireToolApproval: boolean;
 }
 
+/**
+ * Turn lifecycle shared by every surface attached to this session's Chat.
+ * Timing and attribution live here, NOT in a per-hook ref, so a turn started
+ * on one surface (e.g. Home) and finishing after a hand-off to another (the
+ * side panel) still reports the correct duration — and is emitted exactly
+ * once. `seq` increments per submit; `lastEmittedSeq` is the dedupe marker.
+ */
+export interface AgentTurnLifecycle {
+  startedAt: number | null;
+  seq: number;
+  lastEmittedSeq: number;
+  model: string | null;
+  provider: string | null;
+}
+
 export interface AgentChatEntry {
   chat: Chat<UIMessage>;
   config: AgentChatConfig;
+  /** Cross-surface turn timing/attribution — see AgentTurnLifecycle. */
+  turn: AgentTurnLifecycle;
   /**
    * UI-tool-aware approval responses for this instance: Approve on a `ui_*`
    * part executes in the browser and ships the result; Deny and non-UI
@@ -146,6 +163,46 @@ function evictIdleInstances(excludeKey: string): void {
       instances.delete(key);
     }
   }
+}
+
+/**
+ * Mark a new turn started on the shared entry: bumps `seq` and snapshots the
+ * start time + model/provider AT SUBMIT, so a config change mid-stream can't
+ * misattribute the completion. No-op if the entry is gone.
+ */
+export function markAgentTurnStarted(
+  chatSessionId: string,
+  attribution: { model: string | null; provider: string | null },
+): void {
+  const entry = instances.get(chatSessionId);
+  if (!entry) return;
+  entry.turn.seq += 1;
+  entry.turn.startedAt = Date.now();
+  entry.turn.model = attribution.model;
+  entry.turn.provider = attribution.provider;
+}
+
+/**
+ * Claim the current turn's completion for emission. Returns the submit-time
+ * snapshot exactly once per turn — the first surface to observe the terminal
+ * status edge wins; a second observer (e.g. a post-handoff panel watching the
+ * same shared Chat) gets `null` and must not emit. `null` also when no entry
+ * exists. Clears `startedAt` so a stray later edge can't double-count.
+ */
+export function claimAgentTurnCompletion(
+  chatSessionId: string,
+): { startedAt: number | null; model: string | null; provider: string | null } | null {
+  const entry = instances.get(chatSessionId);
+  if (!entry) return null;
+  if (entry.turn.lastEmittedSeq === entry.turn.seq) return null;
+  entry.turn.lastEmittedSeq = entry.turn.seq;
+  const snapshot = {
+    startedAt: entry.turn.startedAt,
+    model: entry.turn.model,
+    provider: entry.turn.provider,
+  };
+  entry.turn.startedAt = null;
+  return snapshot;
 }
 
 export function getOrCreateAgentChat(chatSessionId: string): AgentChatEntry {
@@ -232,7 +289,18 @@ export function getOrCreateAgentChat(chatSessionId: string): AgentChatEntry {
     telemetryScope: chatSessionId,
   });
 
-  const entry: AgentChatEntry = { chat, config, handleToolApprovalResponse };
+  const entry: AgentChatEntry = {
+    chat,
+    config,
+    handleToolApprovalResponse,
+    turn: {
+      startedAt: null,
+      seq: 0,
+      lastEmittedSeq: 0,
+      model: null,
+      provider: null,
+    },
+  };
   instances.set(chatSessionId, entry);
   evictIdleInstances(chatSessionId);
   return entry;

--- a/mcpjam-inspector/client/src/lib/mcpjam-agent/agent-chat-instances.ts
+++ b/mcpjam-inspector/client/src/lib/mcpjam-agent/agent-chat-instances.ts
@@ -88,6 +88,8 @@ export interface AgentTurnLifecycle {
   lastEmittedSeq: number;
   model: string | null;
   provider: string | null;
+  /** 1-based turn index snapshotted at submit (survives surface hand-off). */
+  messageIndex: number;
 }
 
 export interface AgentChatEntry {
@@ -172,7 +174,11 @@ function evictIdleInstances(excludeKey: string): void {
  */
 export function markAgentTurnStarted(
   chatSessionId: string,
-  attribution: { model: string | null; provider: string | null },
+  attribution: {
+    model: string | null;
+    provider: string | null;
+    messageIndex: number;
+  },
 ): void {
   const entry = instances.get(chatSessionId);
   if (!entry) return;
@@ -180,6 +186,7 @@ export function markAgentTurnStarted(
   entry.turn.startedAt = Date.now();
   entry.turn.model = attribution.model;
   entry.turn.provider = attribution.provider;
+  entry.turn.messageIndex = attribution.messageIndex;
 }
 
 /**
@@ -189,9 +196,12 @@ export function markAgentTurnStarted(
  * same shared Chat) gets `null` and must not emit. `null` also when no entry
  * exists. Clears `startedAt` so a stray later edge can't double-count.
  */
-export function claimAgentTurnCompletion(
-  chatSessionId: string,
-): { startedAt: number | null; model: string | null; provider: string | null } | null {
+export function claimAgentTurnCompletion(chatSessionId: string): {
+  startedAt: number | null;
+  model: string | null;
+  provider: string | null;
+  messageIndex: number;
+} | null {
   const entry = instances.get(chatSessionId);
   if (!entry) return null;
   if (entry.turn.lastEmittedSeq === entry.turn.seq) return null;
@@ -200,6 +210,7 @@ export function claimAgentTurnCompletion(
     startedAt: entry.turn.startedAt,
     model: entry.turn.model,
     provider: entry.turn.provider,
+    messageIndex: entry.turn.messageIndex,
   };
   entry.turn.startedAt = null;
   return snapshot;
@@ -299,6 +310,7 @@ export function getOrCreateAgentChat(chatSessionId: string): AgentChatEntry {
       lastEmittedSeq: 0,
       model: null,
       provider: null,
+      messageIndex: 0,
     },
   };
   instances.set(chatSessionId, entry);

--- a/mcpjam-inspector/client/src/lib/mcpjam-agent/agent-chat-instances.ts
+++ b/mcpjam-inspector/client/src/lib/mcpjam-agent/agent-chat-instances.ts
@@ -228,6 +228,8 @@ export function getOrCreateAgentChat(chatSessionId: string): AgentChatEntry {
     onNavigationToolCall: (toolName) => {
       maybeHandoffToPanel(config, toolName);
     },
+    // Keeps reload-approved calls in this session's duplicate ring.
+    telemetryScope: chatSessionId,
   });
 
   const entry: AgentChatEntry = { chat, config, handleToolApprovalResponse };

--- a/mcpjam-inspector/client/src/lib/mcpjam-agent/agent-chat-instances.ts
+++ b/mcpjam-inspector/client/src/lib/mcpjam-agent/agent-chat-instances.ts
@@ -199,6 +199,8 @@ export function getOrCreateAgentChat(chatSessionId: string): AgentChatEntry {
           maybeHandoffToPanel(config, toolName);
         },
         requireToolApproval: config.requireToolApproval,
+        // Duplicate detection is per chat session — this instance's key.
+        telemetryScope: chatSessionId,
       });
     },
     // Resume the turn automatically once every tool call has an output —

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-actions.hosted.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-actions.hosted.test.ts
@@ -1,11 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { executeInspectorCommandMock } = vi.hoisted(() => ({
+const { executeInspectorCommandMock, trackMock } = vi.hoisted(() => ({
   executeInspectorCommandMock: vi.fn(),
+  trackMock: vi.fn(),
 }));
 
 vi.mock("@/lib/inspector-command-handlers", () => ({
   executeInspectorCommand: executeInspectorCommandMock,
+}));
+
+vi.mock("@/lib/analytics", () => ({
+  track: trackMock,
 }));
 
 vi.mock("@/lib/config", () => ({
@@ -40,6 +45,10 @@ describe("ui-actions (hosted mode)", () => {
     if (!result.ok) {
       expect(result.reason).toContain('"tracing" is not available in hosted mode');
     }
+    expect(trackMock).toHaveBeenCalledWith(
+      "ui_navigation_rejected",
+      expect.objectContaining({ segment: "tracing", reason: "hosted_blocked" }),
+    );
   });
 
   it("navigateAction never dispatches a blocked target", async () => {

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-actions.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-actions.test.ts
@@ -1,12 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { InspectorCommand } from "@/shared/inspector-command.js";
 
-const { executeInspectorCommandMock } = vi.hoisted(() => ({
+const { executeInspectorCommandMock, trackMock } = vi.hoisted(() => ({
   executeInspectorCommandMock: vi.fn(),
+  trackMock: vi.fn(),
 }));
 
 vi.mock("@/lib/inspector-command-handlers", () => ({
   executeInspectorCommand: executeInspectorCommandMock,
+}));
+
+vi.mock("@/lib/analytics", () => ({
+  track: trackMock,
 }));
 
 import {
@@ -58,6 +63,27 @@ describe("ui-actions (local mode)", () => {
         expect(unknown.reason).toContain("playground");
       }
       expect(resolveUiNavigationTarget("   ")).toMatchObject({ ok: false });
+    });
+
+    it("emits ui_navigation_rejected with reason unknown (segment only, truncated)", () => {
+      resolveUiNavigationTarget("bogus-page");
+      expect(trackMock).toHaveBeenCalledWith(
+        "ui_navigation_rejected",
+        expect.objectContaining({ segment: "bogus-page", reason: "unknown" }),
+      );
+
+      trackMock.mockClear();
+      const longTarget = "x".repeat(200);
+      resolveUiNavigationTarget(longTarget);
+      const [, props] = trackMock.mock.calls[0];
+      expect((props as { segment: string }).segment).toHaveLength(64);
+      expect((props as { reason: string }).reason).toBe("unknown");
+    });
+
+    it("emits no rejection event for accepted or empty targets", () => {
+      resolveUiNavigationTarget("playground");
+      resolveUiNavigationTarget("   ");
+      expect(trackMock).not.toHaveBeenCalled();
     });
   });
 

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-actions.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-actions.test.ts
@@ -65,18 +65,20 @@ describe("ui-actions (local mode)", () => {
       expect(resolveUiNavigationTarget("   ")).toMatchObject({ ok: false });
     });
 
-    it("emits ui_navigation_rejected with reason unknown (segment only, truncated)", () => {
+    it("emits reason unknown with the constant segment, never the target text", () => {
       resolveUiNavigationTarget("bogus-page");
       expect(trackMock).toHaveBeenCalledWith(
         "ui_navigation_rejected",
-        expect.objectContaining({ segment: "bogus-page", reason: "unknown" }),
+        expect.objectContaining({ segment: "unrecognized", reason: "unknown" }),
       );
 
       trackMock.mockClear();
-      const longTarget = "x".repeat(200);
-      resolveUiNavigationTarget(longTarget);
+      // Model-supplied free text (could echo anything) must not reach props.
+      const secretish = "sk-super-secret-token-value";
+      resolveUiNavigationTarget(secretish);
       const [, props] = trackMock.mock.calls[0];
-      expect((props as { segment: string }).segment).toHaveLength(64);
+      expect((props as { segment: string }).segment).toBe("unrecognized");
+      expect(JSON.stringify(props)).not.toContain(secretish);
       expect((props as { reason: string }).reason).toBe("unknown");
     });
 

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tool-executor.telemetry.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tool-executor.telemetry.test.ts
@@ -1,0 +1,328 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../native-mirror", () => ({
+  mirrorUiToolToNative: vi.fn(() => null),
+}));
+
+const { trackMock } = vi.hoisted(() => ({
+  trackMock: vi.fn(),
+}));
+
+vi.mock("@/lib/analytics", () => ({
+  track: trackMock,
+}));
+
+import {
+  __resetUiToolExecutorForTests,
+  fulfillApprovedUiToolCall,
+  handleUiToolCall,
+  settleDeniedUiToolCall,
+} from "../ui-tool-executor";
+import {
+  useUiToolsRegistry,
+  type UiToolDefinition,
+} from "../ui-tools-registry";
+
+// Sentinels that must NEVER appear in any emitted property: args in, output
+// out. The hard telemetry rule is names/booleans/counts/durations only.
+const SECRET_ARG = "SECRET_ARG_never_in_telemetry";
+const SECRET_OUTPUT = "SECRET_OUTPUT_never_in_telemetry";
+
+function makeTool(extra?: Partial<UiToolDefinition>): UiToolDefinition {
+  return {
+    name: "ui_navigate",
+    description: "Navigate",
+    readOnly: false,
+    execute: vi.fn(async () => ({
+      content: [{ type: "text" as const, text: SECRET_OUTPUT }],
+    })),
+    ...extra,
+  };
+}
+
+function eventCalls(
+  event: string,
+): Array<Record<string, unknown>> {
+  return trackMock.mock.calls
+    .filter(([name]) => name === event)
+    .map(([, props]) => props as Record<string, unknown>);
+}
+
+describe("ui-tool-executor outcome telemetry", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    __resetUiToolExecutorForTests();
+    useUiToolsRegistry.setState({
+      tools: new Map(),
+      nativeDisposers: new Map(),
+      shippedNames: new Set(),
+    });
+  });
+
+  it("success path: one started + one completed with outcome success", async () => {
+    useUiToolsRegistry.getState().registerUiTool(makeTool());
+
+    await handleUiToolCall({
+      toolName: "ui_navigate",
+      toolCallId: "tc-success",
+      input: { target: SECRET_ARG },
+      addToolOutput: vi.fn(),
+    });
+
+    const started = eventCalls("ui_tool_call_started");
+    const completed = eventCalls("ui_tool_call_completed");
+    expect(started).toHaveLength(1);
+    expect(completed).toHaveLength(1);
+    expect(started[0]).toMatchObject({
+      tool_name: "ui_navigate",
+      needs_approval: false,
+    });
+    expect(typeof started[0].surface_id).toBe("string");
+    expect(started[0].surface_id).not.toBe("");
+    expect(completed[0]).toMatchObject({
+      tool_name: "ui_navigate",
+      outcome: "success",
+      approval: "not_required",
+      duplicate_of_previous: false,
+    });
+    expect(typeof completed[0].duration_ms).toBe("number");
+    expect(completed[0]).not.toHaveProperty("error_code");
+    expect(completed[0]).not.toHaveProperty("calls_since_duplicate");
+  });
+
+  it("throwing execute completes with outcome error and code tool_threw", async () => {
+    useUiToolsRegistry.getState().registerUiTool(
+      makeTool({
+        execute: async () => {
+          throw new Error(SECRET_OUTPUT);
+        },
+      }),
+    );
+
+    await handleUiToolCall({
+      toolName: "ui_navigate",
+      toolCallId: "tc-throw",
+      input: { target: SECRET_ARG },
+      addToolOutput: vi.fn(),
+    });
+
+    const completed = eventCalls("ui_tool_call_completed");
+    expect(completed).toHaveLength(1);
+    expect(completed[0]).toMatchObject({
+      outcome: "error",
+      error_code: "tool_threw",
+      approval: "not_required",
+    });
+  });
+
+  it("extracts ONLY whitelisted structured codes from isError outputs", async () => {
+    useUiToolsRegistry.getState().registerUiTool(
+      makeTool({
+        execute: async () => ({
+          content: [
+            {
+              type: "text" as const,
+              text: `unsupported_in_mode: ${SECRET_OUTPUT}`,
+            },
+          ],
+          isError: true,
+        }),
+      }),
+    );
+
+    await handleUiToolCall({
+      toolName: "ui_navigate",
+      toolCallId: "tc-coded",
+      input: {},
+      addToolOutput: vi.fn(),
+    });
+
+    const completed = eventCalls("ui_tool_call_completed");
+    expect(completed[0]).toMatchObject({
+      outcome: "error",
+      error_code: "unsupported_in_mode",
+    });
+  });
+
+  it("free-text error outputs emit NO error_code at all", async () => {
+    useUiToolsRegistry.getState().registerUiTool(
+      makeTool({
+        execute: async () => ({
+          content: [
+            { type: "text" as const, text: "Missing required 'target' string." },
+          ],
+          isError: true,
+        }),
+      }),
+    );
+
+    await handleUiToolCall({
+      toolName: "ui_navigate",
+      toolCallId: "tc-freetext",
+      input: {},
+      addToolOutput: vi.fn(),
+    });
+
+    const completed = eventCalls("ui_tool_call_completed");
+    expect(completed[0]).toMatchObject({ outcome: "error" });
+    expect(completed[0]).not.toHaveProperty("error_code");
+  });
+
+  it("deferred → denied: started at defer time, one completed with outcome denied", async () => {
+    const def = makeTool();
+    useUiToolsRegistry.getState().registerUiTool(def);
+
+    await handleUiToolCall({
+      toolName: "ui_navigate",
+      toolCallId: "tc-deny",
+      input: { target: SECRET_ARG },
+      addToolOutput: vi.fn(),
+      requireToolApproval: true,
+    });
+
+    const started = eventCalls("ui_tool_call_started");
+    expect(started).toHaveLength(1);
+    expect(started[0]).toMatchObject({ needs_approval: true });
+    expect(eventCalls("ui_tool_call_completed")).toHaveLength(0);
+
+    settleDeniedUiToolCall("tc-deny");
+
+    const completed = eventCalls("ui_tool_call_completed");
+    expect(completed).toHaveLength(1);
+    expect(completed[0]).toMatchObject({
+      tool_name: "ui_navigate",
+      outcome: "denied",
+      approval: "denied",
+    });
+    expect(typeof completed[0].duration_ms).toBe("number");
+    expect(def.execute).not.toHaveBeenCalled();
+  });
+
+  it("deferred → approved: one completed with approval approved", async () => {
+    useUiToolsRegistry.getState().registerUiTool(makeTool());
+    const addToolOutput = vi.fn();
+
+    await handleUiToolCall({
+      toolName: "ui_navigate",
+      toolCallId: "tc-approve",
+      input: { target: SECRET_ARG },
+      addToolOutput,
+      requireToolApproval: true,
+    });
+    await fulfillApprovedUiToolCall({ toolCallId: "tc-approve", addToolOutput });
+
+    expect(eventCalls("ui_tool_call_started")).toHaveLength(1);
+    const completed = eventCalls("ui_tool_call_completed");
+    expect(completed).toHaveLength(1);
+    expect(completed[0]).toMatchObject({
+      outcome: "success",
+      approval: "approved",
+    });
+  });
+
+  it("re-emitted calls for a settled id emit no additional events", async () => {
+    useUiToolsRegistry.getState().registerUiTool(makeTool());
+    const opts = {
+      toolName: "ui_navigate",
+      toolCallId: "tc-reemit",
+      input: {},
+      addToolOutput: vi.fn(),
+    };
+
+    await handleUiToolCall(opts);
+    await handleUiToolCall(opts);
+
+    expect(eventCalls("ui_tool_call_started")).toHaveLength(1);
+    expect(eventCalls("ui_tool_call_completed")).toHaveLength(1);
+  });
+
+  it("NO event property ever contains args or output content", async () => {
+    useUiToolsRegistry.getState().registerUiTool(makeTool());
+    const addToolOutput = vi.fn();
+
+    await handleUiToolCall({
+      toolName: "ui_navigate",
+      toolCallId: "tc-leak-1",
+      input: { target: SECRET_ARG, nested: { deep: SECRET_ARG } },
+      addToolOutput,
+    });
+    await handleUiToolCall({
+      toolName: "ui_navigate",
+      toolCallId: "tc-leak-2",
+      input: { target: SECRET_ARG },
+      addToolOutput,
+      requireToolApproval: true,
+    });
+    settleDeniedUiToolCall("tc-leak-2");
+
+    expect(trackMock.mock.calls.length).toBeGreaterThan(0);
+    for (const [, props] of trackMock.mock.calls) {
+      const serialized = JSON.stringify(props);
+      expect(serialized).not.toContain(SECRET_ARG);
+      expect(serialized).not.toContain(SECRET_OUTPUT);
+    }
+  });
+
+  describe("duplicate-call detection", () => {
+    it("flags an identical repeat with calls_since_duplicate 1", async () => {
+      useUiToolsRegistry.getState().registerUiTool(makeTool());
+      const addToolOutput = vi.fn();
+
+      await handleUiToolCall({
+        toolName: "ui_navigate",
+        toolCallId: "tc-dup-1",
+        // Key order deliberately differs from the repeat below — the
+        // signature canonicalizes, so these are the SAME call.
+        input: { a: 1, target: "servers" },
+        addToolOutput,
+      });
+      await handleUiToolCall({
+        toolName: "ui_navigate",
+        toolCallId: "tc-dup-2",
+        input: { target: "servers", a: 1 },
+        addToolOutput,
+      });
+
+      const completed = eventCalls("ui_tool_call_completed");
+      expect(completed).toHaveLength(2);
+      expect(completed[0]).toMatchObject({ duplicate_of_previous: false });
+      expect(completed[0]).not.toHaveProperty("calls_since_duplicate");
+      expect(completed[1]).toMatchObject({
+        duplicate_of_previous: true,
+        calls_since_duplicate: 1,
+      });
+    });
+
+    it("different args are not duplicates; distance counts intervening calls", async () => {
+      useUiToolsRegistry.getState().registerUiTool(makeTool());
+      const addToolOutput = vi.fn();
+
+      await handleUiToolCall({
+        toolName: "ui_navigate",
+        toolCallId: "tc-d-1",
+        input: { target: "servers" },
+        addToolOutput,
+      });
+      await handleUiToolCall({
+        toolName: "ui_navigate",
+        toolCallId: "tc-d-2",
+        input: { target: "playground" },
+        addToolOutput,
+      });
+      await handleUiToolCall({
+        toolName: "ui_navigate",
+        toolCallId: "tc-d-3",
+        input: { target: "servers" },
+        addToolOutput,
+      });
+
+      const completed = eventCalls("ui_tool_call_completed");
+      expect(completed).toHaveLength(3);
+      expect(completed[1]).toMatchObject({ duplicate_of_previous: false });
+      expect(completed[2]).toMatchObject({
+        duplicate_of_previous: true,
+        calls_since_duplicate: 2,
+      });
+    });
+  });
+});

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tool-executor.telemetry.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tool-executor.telemetry.test.ts
@@ -407,6 +407,42 @@ describe("ui-tool-executor outcome telemetry", () => {
       expect(addToolOutput).not.toHaveBeenCalled();
     });
 
+    it("shipped-but-never-resolved tool: unavailable emitted once, re-emit is silent", async () => {
+      // Name was advertised (shippedNames) but the tool was never live this
+      // load (unregistered before its first onToolCall) — goes through the
+      // wasShipped/unavailable branch, which must claim the id.
+      useUiToolsRegistry.setState({
+        tools: new Map(),
+        nativeDisposers: new Map(),
+        shippedNames: new Set(["ui_navigate"]),
+      });
+      const addToolOutput = vi.fn();
+
+      const first = await handleUiToolCall({
+        toolName: "ui_navigate",
+        toolCallId: "tc-unavail-re",
+        input: { target: "servers" },
+        addToolOutput,
+      });
+      expect(first).toBe(true);
+      expect(addToolOutput).toHaveBeenCalledTimes(1);
+      expect(eventCalls("ui_tool_call_completed")).toHaveLength(1);
+
+      addToolOutput.mockClear();
+      trackMock.mockClear();
+      // SDK re-emits the same input-available part on resume/replay.
+      const second = await handleUiToolCall({
+        toolName: "ui_navigate",
+        toolCallId: "tc-unavail-re",
+        input: { target: "servers" },
+        addToolOutput,
+      });
+      expect(second).toBe(true);
+      expect(addToolOutput).not.toHaveBeenCalled();
+      expect(eventCalls("ui_tool_call_started")).toHaveLength(0);
+      expect(eventCalls("ui_tool_call_completed")).toHaveLength(0);
+    });
+
     it("re-emitted settled call with an unregistered tool emits no telemetry", async () => {
       const unregister = useUiToolsRegistry
         .getState()

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tool-executor.telemetry.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tool-executor.telemetry.test.ts
@@ -351,6 +351,24 @@ describe("ui-tool-executor outcome telemetry", () => {
       });
     });
 
+    it("a duplicate denial callback emits only one denied pair", () => {
+      settleDeniedUiToolCall("tc-dup-deny", {
+        toolName: "ui_remove_server",
+        input: { serverName: "x" },
+        telemetryScope: "s",
+      });
+      // Replayed/double-dispatched denial for the same call id.
+      settleDeniedUiToolCall("tc-dup-deny", {
+        toolName: "ui_remove_server",
+        input: { serverName: "x" },
+        telemetryScope: "s",
+      });
+      expect(eventCalls("ui_tool_call_started")).toHaveLength(1);
+      const completed = eventCalls("ui_tool_call_completed");
+      expect(completed).toHaveLength(1);
+      expect(completed[0]).toMatchObject({ outcome: "denied" });
+    });
+
     it("reload-then-deny reports null duration (reconstructed lifecycle)", () => {
       settleDeniedUiToolCall("tc-recon-deny", {
         toolName: "ui_remove_server",

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tool-executor.telemetry.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tool-executor.telemetry.test.ts
@@ -325,6 +325,38 @@ describe("ui-tool-executor outcome telemetry", () => {
       });
     });
 
+    it("re-emitted settled call with an unregistered tool emits no telemetry", async () => {
+      const unregister = useUiToolsRegistry
+        .getState()
+        .registerUiTool(makeTool());
+      const addToolOutput = vi.fn();
+
+      await handleUiToolCall({
+        toolName: "ui_navigate",
+        toolCallId: "tc-r-1",
+        input: { target: "servers" },
+        addToolOutput,
+      });
+      expect(eventCalls("ui_tool_call_completed")).toHaveLength(1);
+
+      // HMR/unmount: tool gone, name still shipped. The SDK re-emits the
+      // already-fulfilled call during resume.
+      unregister();
+      trackMock.mockClear();
+      addToolOutput.mockClear();
+      const claimed = await handleUiToolCall({
+        toolName: "ui_navigate",
+        toolCallId: "tc-r-1",
+        input: { target: "servers" },
+        addToolOutput,
+      });
+
+      expect(claimed).toBe(true); // still ours — but nothing re-runs
+      expect(addToolOutput).not.toHaveBeenCalled();
+      expect(eventCalls("ui_tool_call_started")).toHaveLength(0);
+      expect(eventCalls("ui_tool_call_completed")).toHaveLength(0);
+    });
+
     it("identical calls in different telemetry scopes are not duplicates", async () => {
       useUiToolsRegistry.getState().registerUiTool(makeTool());
       const addToolOutput = vi.fn();

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tool-executor.telemetry.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tool-executor.telemetry.test.ts
@@ -351,6 +351,18 @@ describe("ui-tool-executor outcome telemetry", () => {
       });
     });
 
+    it("reload-then-deny reports null duration (reconstructed lifecycle)", () => {
+      settleDeniedUiToolCall("tc-recon-deny", {
+        toolName: "ui_remove_server",
+        input: { serverName: "x" },
+        telemetryScope: "s",
+      });
+      const completed = eventCalls("ui_tool_call_completed");
+      expect(completed).toHaveLength(1);
+      // No real start time survived the reload → null, not a misleading ~0ms.
+      expect(completed[0].duration_ms).toBeNull();
+    });
+
     it("re-emitted deferred call is claimed without a second started event", async () => {
       useUiToolsRegistry.getState().registerUiTool(
         makeTool({ readOnly: false, annotations: { destructiveHint: true } }),

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tool-executor.telemetry.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tool-executor.telemetry.test.ts
@@ -324,5 +324,42 @@ describe("ui-tool-executor outcome telemetry", () => {
         calls_since_duplicate: 2,
       });
     });
+
+    it("identical calls in different telemetry scopes are not duplicates", async () => {
+      useUiToolsRegistry.getState().registerUiTool(makeTool());
+      const addToolOutput = vi.fn();
+
+      await handleUiToolCall({
+        toolName: "ui_navigate",
+        toolCallId: "tc-s-1",
+        input: { target: "servers" },
+        addToolOutput,
+        telemetryScope: "chat-session-a",
+      });
+      await handleUiToolCall({
+        toolName: "ui_navigate",
+        toolCallId: "tc-s-2",
+        input: { target: "servers" },
+        addToolOutput,
+        telemetryScope: "chat-session-b",
+      });
+      await handleUiToolCall({
+        toolName: "ui_navigate",
+        toolCallId: "tc-s-3",
+        input: { target: "servers" },
+        addToolOutput,
+        telemetryScope: "chat-session-a",
+      });
+
+      const completed = eventCalls("ui_tool_call_completed");
+      expect(completed).toHaveLength(3);
+      // Session B's identical call is NOT a duplicate of session A's.
+      expect(completed[1]).toMatchObject({ duplicate_of_previous: false });
+      // Session A's own repeat is, at distance 1 within its scope.
+      expect(completed[2]).toMatchObject({
+        duplicate_of_previous: true,
+        calls_since_duplicate: 1,
+      });
+    });
   });
 });

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tool-executor.telemetry.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tool-executor.telemetry.test.ts
@@ -325,6 +325,58 @@ describe("ui-tool-executor outcome telemetry", () => {
       });
     });
 
+    it("reload-then-deny emits a full started/completed pair from part metadata", () => {
+      // No handleUiToolCall first: simulates a deny after a page reload,
+      // where the defer happened in a previous load and no in-memory entry
+      // exists. The approval part's persisted metadata establishes the
+      // lifecycle.
+      settleDeniedUiToolCall("tc-reload-deny", {
+        toolName: "ui_remove_server",
+        input: { serverName: "disposable" },
+        telemetryScope: "chat-session-a",
+      });
+
+      const started = eventCalls("ui_tool_call_started");
+      const completed = eventCalls("ui_tool_call_completed");
+      expect(started).toHaveLength(1);
+      expect(started[0]).toMatchObject({
+        tool_name: "ui_remove_server",
+        needs_approval: true,
+      });
+      expect(completed).toHaveLength(1);
+      expect(completed[0]).toMatchObject({
+        tool_name: "ui_remove_server",
+        outcome: "denied",
+        approval: "denied",
+      });
+    });
+
+    it("re-emitted deferred call is claimed without a second started event", async () => {
+      useUiToolsRegistry.getState().registerUiTool(
+        makeTool({ readOnly: false, annotations: { destructiveHint: true } }),
+      );
+      const addToolOutput = vi.fn();
+
+      await handleUiToolCall({
+        toolName: "ui_navigate",
+        toolCallId: "tc-defer-re",
+        input: { target: "servers" },
+        addToolOutput,
+      });
+      expect(eventCalls("ui_tool_call_started")).toHaveLength(1);
+
+      // SDK re-emits the same still-deferred call (e.g. stream resume).
+      const claimed = await handleUiToolCall({
+        toolName: "ui_navigate",
+        toolCallId: "tc-defer-re",
+        input: { target: "servers" },
+        addToolOutput,
+      });
+      expect(claimed).toBe(true);
+      expect(eventCalls("ui_tool_call_started")).toHaveLength(1);
+      expect(addToolOutput).not.toHaveBeenCalled();
+    });
+
     it("re-emitted settled call with an unregistered tool emits no telemetry", async () => {
       const unregister = useUiToolsRegistry
         .getState()

--- a/mcpjam-inspector/client/src/lib/webmcp/ui-actions.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/ui-actions.ts
@@ -26,6 +26,28 @@ import {
   normalizeHostedHashTab,
 } from "@/lib/hosted-tab-policy";
 import { HOSTED_MODE } from "@/lib/config";
+import { track } from "@/lib/analytics";
+
+/**
+ * Observation-only telemetry for rejected navigation targets. The segment is
+ * an enum-ish app segment, but an unknown one is arbitrary model output —
+ * truncate hard so free text can't ride along; a throwing capture must never
+ * break the action.
+ */
+function trackNavigationRejected(
+  segment: string,
+  reason: "unknown" | "hosted_blocked",
+): void {
+  try {
+    track("ui_navigation_rejected", {
+      location: "webmcp",
+      segment: segment.slice(0, 64),
+      reason,
+    });
+  } catch {
+    // Telemetry must never break the navigation result.
+  }
+}
 
 export type UiActionResult =
   | { ok: true; data?: unknown }
@@ -118,12 +140,14 @@ export function resolveUiNavigationTarget(
   const firstSegment = stripped.split(/[/?]/)[0] || "servers";
   const tab = normalizeHostedHashTab(firstSegment);
   if (!isKnownAppTabSegment(tab)) {
+    trackNavigationRejected(tab, "unknown");
     return {
       ok: false,
       reason: `Unknown navigation target "${rawTarget}". Valid targets: ${listUiNavigationTargets().join(", ")}.`,
     };
   }
   if (HOSTED_MODE && isHostedHashTabBlocked(tab)) {
+    trackNavigationRejected(tab, "hosted_blocked");
     return {
       ok: false,
       reason: `"${tab}" is not available in hosted mode. Valid targets: ${listUiNavigationTargets().join(", ")}.`,

--- a/mcpjam-inspector/client/src/lib/webmcp/ui-actions.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/ui-actions.ts
@@ -29,10 +29,11 @@ import { HOSTED_MODE } from "@/lib/config";
 import { track } from "@/lib/analytics";
 
 /**
- * Observation-only telemetry for rejected navigation targets. The segment is
- * an enum-ish app segment, but an unknown one is arbitrary model output —
- * truncate hard so free text can't ride along; a throwing capture must never
- * break the action.
+ * Observation-only telemetry for rejected navigation targets. Only KNOWN
+ * segments (the hosted_blocked case) are emitted verbatim; an unknown target
+ * is arbitrary model output and must never reach analytics, so it collapses
+ * to the constant "unrecognized" (the rejection count is the signal). A
+ * throwing capture must never break the action.
  */
 function trackNavigationRejected(
   segment: string,
@@ -41,7 +42,7 @@ function trackNavigationRejected(
   try {
     track("ui_navigation_rejected", {
       location: "webmcp",
-      segment: segment.slice(0, 64),
+      segment: reason === "unknown" ? "unrecognized" : segment,
       reason,
     });
   } catch {

--- a/mcpjam-inspector/client/src/lib/webmcp/ui-tool-approval.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/ui-tool-approval.ts
@@ -101,6 +101,8 @@ export interface UiAwareApprovalHandlerDeps {
   addToolApprovalResponse: (response: { id: string; approved: boolean }) => void;
   addToolOutput: HandleUiToolCallOptions["addToolOutput"];
   onNavigationToolCall?: (toolName: string) => void;
+  /** Duplicate-detection scope (the chat's session id) — survives reloads. */
+  telemetryScope?: string;
 }
 
 export function createUiAwareApprovalResponseHandler(
@@ -127,6 +129,9 @@ export function createUiAwareApprovalResponseHandler(
       // authoritative anyway.
       input: located.input,
       addToolOutput: deps.addToolOutput,
+      ...(deps.telemetryScope !== undefined
+        ? { telemetryScope: deps.telemetryScope }
+        : {}),
       ...(deps.onNavigationToolCall
         ? { onNavigationToolCall: deps.onNavigationToolCall }
         : {}),
@@ -146,13 +151,19 @@ export function fulfillOrphanedDeferredUiToolCalls(deps: {
   addToolOutput: HandleUiToolCallOptions["addToolOutput"];
   onNavigationToolCall?: (toolName: string) => void;
 }): void {
-  for (const { toolCallId, toolName, input } of listDeferredUiToolCalls()) {
+  for (const {
+    toolCallId,
+    toolName,
+    input,
+    telemetryScope,
+  } of listDeferredUiToolCalls()) {
     const part = findPartByToolCallId(deps.messages, toolCallId);
     if (!part || part.state !== "input-available") continue;
     void fulfillApprovedUiToolCall({
       toolCallId,
       toolName,
       input,
+      ...(telemetryScope !== undefined ? { telemetryScope } : {}),
       addToolOutput: deps.addToolOutput,
       ...(deps.onNavigationToolCall
         ? { onNavigationToolCall: deps.onNavigationToolCall }

--- a/mcpjam-inspector/client/src/lib/webmcp/ui-tool-approval.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/ui-tool-approval.ts
@@ -118,7 +118,13 @@ export function createUiAwareApprovalResponseHandler(
       // Settle first: the server's denial machinery supplies the result,
       // and a later duplicate approve event must not be able to execute a
       // call the user explicitly rejected.
-      settleDeniedUiToolCall(located.toolCallId);
+      settleDeniedUiToolCall(located.toolCallId, {
+        toolName: located.toolName,
+        input: located.input,
+        ...(deps.telemetryScope !== undefined
+          ? { telemetryScope: deps.telemetryScope }
+          : {}),
+      });
       deps.addToolApprovalResponse({ id, approved: false });
       return;
     }

--- a/mcpjam-inspector/client/src/lib/webmcp/ui-tool-executor.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/ui-tool-executor.ts
@@ -20,6 +20,9 @@
  */
 
 import { uiToolCallNeedsApproval } from "@/shared/client-fulfilled-tools.js";
+import type { InspectorCommandErrorCode } from "@/shared/inspector-command.js";
+import { track } from "@/lib/analytics";
+import { pathnameToActiveTab } from "@/lib/app-navigation";
 import {
   useUiToolsRegistry,
   type UiToolDefinition,
@@ -64,7 +67,167 @@ const deferredUiToolCalls = new Map<
 export function __resetUiToolExecutorForTests(): void {
   settledOrInFlightToolCallIds.clear();
   deferredUiToolCalls.clear();
+  telemetryByToolCallId.clear();
+  recentCallSignatures.length = 0;
 }
+
+// --- Outcome telemetry ------------------------------------------------
+//
+// Observation-only: every emit is wrapped so a throwing analytics call can
+// never break tool fulfillment (a lost output would hang the stream). HARD
+// RULE: event properties are names/booleans/counts/durations only — never
+// tool args, tool outputs, or free-text messages. Duplicate detection
+// hashes args into an in-memory signature that never leaves this module.
+
+type UiToolCallOutcome = "success" | "error" | "denied";
+type UiToolCallApproval = "not_required" | "approved" | "denied";
+
+interface UiToolCallTelemetry {
+  toolName: string;
+  surfaceId: string;
+  startedAt: number;
+  duplicateOfPrevious: boolean;
+  callsSinceDuplicate?: number;
+}
+
+/** Started-time facts carried to the (possibly much later) completed emit. */
+const telemetryByToolCallId = new Map<string, UiToolCallTelemetry>();
+
+/**
+ * Last N call signatures this session, oldest first, for duplicate-call
+ * detection (a looping agent re-issuing the same call). Signatures include
+ * canonicalized args and therefore NEVER leave this module — only the
+ * duplicate boolean and the call distance are emitted.
+ */
+const RECENT_SIGNATURE_LIMIT = 20;
+const recentCallSignatures: string[] = [];
+
+function emitTelemetry(
+  event: "ui_tool_call_started" | "ui_tool_call_completed",
+  props: Record<string, unknown>,
+): void {
+  try {
+    track(event, { location: "webmcp", ...props });
+  } catch {
+    // Telemetry must never break tool execution.
+  }
+}
+
+/** Recursively sort object keys so equal args always hash equal. */
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === "object") {
+    const source = value as Record<string, unknown>;
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(source).sort()) {
+      out[key] = canonicalize(source[key]);
+    }
+    return out;
+  }
+  return value;
+}
+
+function callSignature(toolName: string, input: unknown): string {
+  try {
+    return `${toolName}:${JSON.stringify(canonicalize(input))}`;
+  } catch {
+    return `${toolName}:<unserializable>`;
+  }
+}
+
+/** Low-cardinality app segment for the surface the call ran against. */
+function currentSurfaceId(): string {
+  try {
+    if (typeof window === "undefined") return "unknown";
+    return pathnameToActiveTab(window.location.pathname);
+  } catch {
+    return "unknown";
+  }
+}
+
+function beginUiToolCallTelemetry(opts: {
+  toolCallId: string;
+  toolName: string;
+  input: unknown;
+  needsApproval: boolean;
+}): void {
+  const signature = callSignature(opts.toolName, opts.input);
+  const matchIndex = recentCallSignatures.lastIndexOf(signature);
+  const duplicateOfPrevious = matchIndex >= 0;
+  // Distance measured BEFORE the push mutates indices: 1 = previous call.
+  const callsSinceDuplicate = duplicateOfPrevious
+    ? recentCallSignatures.length - matchIndex
+    : undefined;
+  recentCallSignatures.push(signature);
+  if (recentCallSignatures.length > RECENT_SIGNATURE_LIMIT) {
+    recentCallSignatures.shift();
+  }
+  const entry: UiToolCallTelemetry = {
+    toolName: opts.toolName,
+    surfaceId: currentSurfaceId(),
+    startedAt: Date.now(),
+    duplicateOfPrevious,
+    ...(callsSinceDuplicate !== undefined ? { callsSinceDuplicate } : {}),
+  };
+  telemetryByToolCallId.set(opts.toolCallId, entry);
+  emitTelemetry("ui_tool_call_started", {
+    tool_name: entry.toolName,
+    surface_id: entry.surfaceId,
+    needs_approval: opts.needsApproval,
+  });
+}
+
+function completeUiToolCallTelemetry(
+  toolCallId: string,
+  outcome: UiToolCallOutcome,
+  approval: UiToolCallApproval,
+  errorCode?: string,
+): void {
+  const entry = telemetryByToolCallId.get(toolCallId);
+  // No started entry (e.g. a deny after reload, where the defer happened in
+  // a previous page load): skip rather than emit an unpaired completed.
+  if (!entry) return;
+  telemetryByToolCallId.delete(toolCallId);
+  emitTelemetry("ui_tool_call_completed", {
+    tool_name: entry.toolName,
+    surface_id: entry.surfaceId,
+    duration_ms: Date.now() - entry.startedAt,
+    outcome,
+    ...(errorCode ? { error_code: errorCode } : {}),
+    approval,
+    duplicate_of_previous: entry.duplicateOfPrevious,
+    ...(entry.callsSinceDuplicate !== undefined
+      ? { calls_since_duplicate: entry.callsSinceDuplicate }
+      : {}),
+  });
+}
+
+/**
+ * Structured error codes only: the leading `code:` prefix of a command-bus
+ * error (see `commandResponseToActionResult`), validated against the CLOSED
+ * `InspectorCommandErrorCode` set so a free-text message can never be
+ * emitted. Unrecognized error texts emit no code at all.
+ */
+const INSPECTOR_COMMAND_ERROR_CODES = new Set<string>([
+  "no_active_client",
+  "unknown_server",
+  "disconnected_server",
+  "unknown_tool",
+  "unknown_command_id",
+  "timeout",
+  "unsupported_in_mode",
+  "invalid_request",
+  "execution_failed",
+] satisfies InspectorCommandErrorCode[]);
+
+function structuredErrorCode(output: UiToolResult): string | undefined {
+  if (!output.isError) return undefined;
+  const first = output.content?.[0];
+  const text = first?.type === "text" ? first.text : "";
+  const code = text.split(":", 1)[0]?.trim();
+  return code && INSPECTOR_COMMAND_ERROR_CODES.has(code) ? code : undefined;
+}
+// --- End outcome telemetry ---------------------------------------------
 
 /** Deferred calls, for the orphaned-defer fallback (see ui-tool-approval). */
 export function listDeferredUiToolCalls(): Array<{
@@ -87,6 +250,9 @@ export function listDeferredUiToolCalls(): Array<{
 export function settleDeniedUiToolCall(toolCallId: string): void {
   settledOrInFlightToolCallIds.add(toolCallId);
   deferredUiToolCalls.delete(toolCallId);
+  // Denied approvals are terminal for the client: exactly one completed
+  // event, outcome "denied" (the server synthesizes the denial result).
+  completeUiToolCallTelemetry(toolCallId, "denied", "denied");
 }
 
 async function executeResolvedUiTool(
@@ -94,12 +260,14 @@ async function executeResolvedUiTool(
   opts: Pick<
     HandleUiToolCallOptions,
     "toolName" | "toolCallId" | "input" | "addToolOutput"
-  >
+  >,
+  approval: UiToolCallApproval,
 ): Promise<void> {
   const { toolName, toolCallId, input, addToolOutput } = opts;
   settledOrInFlightToolCallIds.add(toolCallId);
   deferredUiToolCalls.delete(toolCallId);
   let output: UiToolResult;
+  let threw = false;
   try {
     const args =
       input && typeof input === "object" && !Array.isArray(input)
@@ -107,6 +275,7 @@ async function executeResolvedUiTool(
         : {};
     output = await def.execute(args);
   } catch (error) {
+    threw = true;
     output = {
       content: [
         {
@@ -120,6 +289,12 @@ async function executeResolvedUiTool(
     };
   }
   addToolOutput({ tool: toolName, toolCallId, output });
+  completeUiToolCallTelemetry(
+    toolCallId,
+    output.isError ? "error" : "success",
+    approval,
+    threw ? "tool_threw" : structuredErrorCode(output),
+  );
 }
 
 function unavailableOutput(toolName: string): UiToolResult {
@@ -153,11 +328,23 @@ export async function handleUiToolCall(
     // supplied or the paused server stream waits forever — same rule as
     // closed app iframes in the app-tool path.
     if (registry.wasShipped(toolName)) {
+      beginUiToolCallTelemetry({
+        toolCallId,
+        toolName,
+        input,
+        needsApproval: false,
+      });
       addToolOutput({
         tool: toolName,
         toolCallId,
         output: unavailableOutput(toolName),
       });
+      completeUiToolCallTelemetry(
+        toolCallId,
+        "error",
+        "not_required",
+        "tool_unavailable",
+      );
       return true;
     }
     return false;
@@ -167,13 +354,14 @@ export async function handleUiToolCall(
   // and its output already exists in the transcript — do nothing.
   if (settledOrInFlightToolCallIds.has(toolCallId)) return true;
 
-  if (
-    uiToolCallNeedsApproval({
-      readOnly: def.readOnly,
-      annotations: def.annotations,
-      requireToolApproval: opts.requireToolApproval === true,
-    })
-  ) {
+  const needsApproval = uiToolCallNeedsApproval({
+    readOnly: def.readOnly,
+    annotations: def.annotations,
+    requireToolApproval: opts.requireToolApproval === true,
+  });
+  beginUiToolCallTelemetry({ toolCallId, toolName, input, needsApproval });
+
+  if (needsApproval) {
     deferredUiToolCalls.set(toolCallId, { toolName, input });
     return true;
   }
@@ -190,7 +378,11 @@ export async function handleUiToolCall(
     }
   }
 
-  await executeResolvedUiTool(def, { toolName, toolCallId, input, addToolOutput });
+  await executeResolvedUiTool(
+    def,
+    { toolName, toolCallId, input, addToolOutput },
+    "not_required",
+  );
   return true;
 }
 
@@ -214,6 +406,17 @@ export async function fulfillApprovedUiToolCall(opts: {
   if (!toolName) return;
   const input = opts.input !== undefined ? opts.input : stashed?.input;
 
+  // Reload case: the defer (and its started event) happened in a previous
+  // page load, so this execution attempt is where handling begins here.
+  if (!telemetryByToolCallId.has(toolCallId)) {
+    beginUiToolCallTelemetry({
+      toolCallId,
+      toolName,
+      input,
+      needsApproval: true,
+    });
+  }
+
   const registry = useUiToolsRegistry.getState();
   const def = registry.resolve(toolName);
   if (!def) {
@@ -224,6 +427,12 @@ export async function fulfillApprovedUiToolCall(opts: {
       toolCallId,
       output: unavailableOutput(toolName),
     });
+    completeUiToolCallTelemetry(
+      toolCallId,
+      "error",
+      "approved",
+      "tool_unavailable",
+    );
     return;
   }
 
@@ -238,5 +447,9 @@ export async function fulfillApprovedUiToolCall(opts: {
     }
   }
 
-  await executeResolvedUiTool(def, { toolName, toolCallId, input, addToolOutput });
+  await executeResolvedUiTool(
+    def,
+    { toolName, toolCallId, input, addToolOutput },
+    "approved",
+  );
 }

--- a/mcpjam-inspector/client/src/lib/webmcp/ui-tool-executor.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/ui-tool-executor.ts
@@ -347,6 +347,9 @@ export function settleDeniedUiToolCall(
   toolCallId: string,
   meta?: { toolName?: string; input?: unknown; telemetryScope?: string },
 ): void {
+  // Idempotent: a denial callback delivered twice (replay/double-dispatch)
+  // must not reconstruct a second lifecycle and emit another denied pair.
+  if (settledOrInFlightToolCallIds.has(toolCallId)) return;
   settledOrInFlightToolCallIds.add(toolCallId);
   const stashed = deferredUiToolCalls.get(toolCallId);
   deferredUiToolCalls.delete(toolCallId);

--- a/mcpjam-inspector/client/src/lib/webmcp/ui-tool-executor.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/ui-tool-executor.ts
@@ -146,19 +146,47 @@ function emitTelemetry(
 // won't dedupe against each other, which is safe).
 const SIGNATURE_MAX_DEPTH = 6;
 const SIGNATURE_MAX_CHARS = 2048;
+// Node budget: a hard cap on how many values canonicalize will visit, so a
+// WIDE payload (huge flat array/object) is bounded the same way depth bounds
+// a deep one — the traversal stops before it can build a megabyte string.
+const SIGNATURE_MAX_NODES = 512;
 
 /**
- * Recursively sort object keys so equal args hash equal, truncating past
- * SIGNATURE_MAX_DEPTH with a marker so a deep payload can't run away.
+ * Recursively sort object keys so equal args hash equal. Bounded three ways —
+ * depth, node count, and (at the caller) serialized length — because `input`
+ * is arbitrary model output and the fingerprint is observation-only: it must
+ * never process unbounded data on the UI thread. Over-budget subtrees collapse
+ * to a deterministic marker (distinct giant inputs then simply don't dedupe,
+ * which is safe for a loop-detection heuristic).
  */
-function canonicalize(value: unknown, depth = 0): unknown {
+function canonicalize(
+  value: unknown,
+  depth: number,
+  budget: { nodes: number },
+): unknown {
+  if (budget.nodes <= 0) return "<budget>";
+  budget.nodes -= 1;
   if (depth >= SIGNATURE_MAX_DEPTH) return "<depth>";
-  if (Array.isArray(value)) return value.map((v) => canonicalize(v, depth + 1));
+  if (Array.isArray(value)) {
+    const out: unknown[] = [];
+    for (const v of value) {
+      if (budget.nodes <= 0) {
+        out.push("<budget>");
+        break;
+      }
+      out.push(canonicalize(v, depth + 1, budget));
+    }
+    return out;
+  }
   if (value && typeof value === "object") {
     const source = value as Record<string, unknown>;
     const out: Record<string, unknown> = {};
     for (const key of Object.keys(source).sort()) {
-      out[key] = canonicalize(source[key], depth + 1);
+      if (budget.nodes <= 0) {
+        out["<budget>"] = true;
+        break;
+      }
+      out[key] = canonicalize(source[key], depth + 1, budget);
     }
     return out;
   }
@@ -167,10 +195,10 @@ function canonicalize(value: unknown, depth = 0): unknown {
 
 function callSignature(toolName: string, input: unknown): string {
   try {
-    const body = JSON.stringify(canonicalize(input));
-    // Cap the retained string. A collision after truncation just means two
-    // giant distinct inputs are treated as one — acceptable for a loop-
-    // detection heuristic, and far cheaper than holding megabytes.
+    const body = JSON.stringify(canonicalize(input, 0, { nodes: SIGNATURE_MAX_NODES }));
+    // Final length cap in case the bounded traversal still produced a long
+    // string. A collision after truncation just means two giant distinct
+    // inputs are treated as one — acceptable, and far cheaper than megabytes.
     const bounded =
       body.length > SIGNATURE_MAX_CHARS
         ? `${body.slice(0, SIGNATURE_MAX_CHARS)}…<${body.length}>`

--- a/mcpjam-inspector/client/src/lib/webmcp/ui-tool-executor.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/ui-tool-executor.ts
@@ -458,6 +458,11 @@ export async function handleUiToolCall(
     // supplied or the paused server stream waits forever — same rule as
     // closed app iframes in the app-tool path.
     if (registry.wasShipped(toolName)) {
+      // Claim BEFORE emitting so a re-emitted `tool-input-available` for this
+      // same id (resume/replay) hits the settled-guard at the top and can't
+      // send a second output or a duplicate started/completed pair — same
+      // contract as executeResolvedUiTool.
+      settledOrInFlightToolCallIds.add(toolCallId);
       beginUiToolCallTelemetry({
         toolCallId,
         toolName,

--- a/mcpjam-inspector/client/src/lib/webmcp/ui-tool-executor.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/ui-tool-executor.ts
@@ -67,7 +67,7 @@ const settledOrInFlightToolCallIds = new Set<string>();
 /** Calls claimed-but-deferred, awaiting the user's approval. */
 const deferredUiToolCalls = new Map<
   string,
-  { toolName: string; input: unknown }
+  { toolName: string; input: unknown; telemetryScope?: string }
 >();
 
 export function __resetUiToolExecutorForTests(): void {
@@ -261,6 +261,7 @@ export function listDeferredUiToolCalls(): Array<{
   toolCallId: string;
   toolName: string;
   input: unknown;
+  telemetryScope?: string;
 }> {
   return [...deferredUiToolCalls.entries()].map(([toolCallId, v]) => ({
     toolCallId,
@@ -349,6 +350,14 @@ export async function handleUiToolCall(
   const registry = useUiToolsRegistry.getState();
   const def = registry.resolve(toolName);
 
+  // Re-emission of an already-executed call (approval-resume re-fires
+  // onToolCall): claimed, output already in the transcript — do nothing.
+  // Checked BEFORE the unavailable branch so a settled call whose tool has
+  // since unregistered (HMR/unmount) can't send a second output or inflate
+  // telemetry with a duplicate started/completed pair. Only IDs this module
+  // executed are ever in the set, so claiming here is always ours to claim.
+  if (settledOrInFlightToolCallIds.has(toolCallId)) return true;
+
   if (!def) {
     // The name was advertised to the server in an earlier snapshot but the
     // tool is gone (HMR teardown, unmount). An output MUST still be
@@ -378,10 +387,6 @@ export async function handleUiToolCall(
     return false;
   }
 
-  // Re-emission of an already-executed call (approval-resume path): claimed,
-  // and its output already exists in the transcript — do nothing.
-  if (settledOrInFlightToolCallIds.has(toolCallId)) return true;
-
   const needsApproval = uiToolCallNeedsApproval({
     readOnly: def.readOnly,
     annotations: def.annotations,
@@ -396,7 +401,11 @@ export async function handleUiToolCall(
   });
 
   if (needsApproval) {
-    deferredUiToolCalls.set(toolCallId, { toolName, input });
+    deferredUiToolCalls.set(toolCallId, {
+      toolName,
+      input,
+      telemetryScope: opts.telemetryScope,
+    });
     return true;
   }
 
@@ -432,6 +441,8 @@ export async function fulfillApprovedUiToolCall(opts: {
   input?: unknown;
   addToolOutput: HandleUiToolCallOptions["addToolOutput"];
   onNavigationToolCall?: (toolName: string) => void;
+  /** Duplicate-detection scope; falls back to the deferred stash's scope. */
+  telemetryScope?: string;
 }): Promise<void> {
   const { toolCallId, addToolOutput } = opts;
   if (settledOrInFlightToolCallIds.has(toolCallId)) return;
@@ -448,6 +459,7 @@ export async function fulfillApprovedUiToolCall(opts: {
       toolName,
       input,
       needsApproval: true,
+      telemetryScope: opts.telemetryScope ?? stashed?.telemetryScope,
     });
   }
 

--- a/mcpjam-inspector/client/src/lib/webmcp/ui-tool-executor.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/ui-tool-executor.ts
@@ -275,9 +275,27 @@ export function listDeferredUiToolCalls(): Array<{
  * approve event (double-emitted pill handlers, replayed state) could still
  * execute a side-effectful tool the user explicitly rejected.
  */
-export function settleDeniedUiToolCall(toolCallId: string): void {
+export function settleDeniedUiToolCall(
+  toolCallId: string,
+  meta?: { toolName?: string; input?: unknown; telemetryScope?: string },
+): void {
   settledOrInFlightToolCallIds.add(toolCallId);
+  const stashed = deferredUiToolCalls.get(toolCallId);
   deferredUiToolCalls.delete(toolCallId);
+  // Reload-then-deny: the defer (and its started event) happened in a
+  // previous page load, so no in-memory entry exists. The approval part's
+  // persisted metadata lets us establish the lifecycle here so denied calls
+  // are not silently absent from outcome telemetry.
+  const toolName = meta?.toolName ?? stashed?.toolName;
+  if (!telemetryByToolCallId.has(toolCallId) && toolName) {
+    beginUiToolCallTelemetry({
+      toolCallId,
+      toolName,
+      input: meta?.input !== undefined ? meta.input : stashed?.input,
+      needsApproval: true,
+      telemetryScope: meta?.telemetryScope ?? stashed?.telemetryScope,
+    });
+  }
   // Denied approvals are terminal for the client: exactly one completed
   // event, outcome "denied" (the server synthesizes the denial result).
   completeUiToolCallTelemetry(toolCallId, "denied", "denied");
@@ -357,6 +375,10 @@ export async function handleUiToolCall(
   // telemetry with a duplicate started/completed pair. Only IDs this module
   // executed are ever in the set, so claiming here is always ours to claim.
   if (settledOrInFlightToolCallIds.has(toolCallId)) return true;
+  // Same idempotency for a call that is still parked awaiting approval: a
+  // re-emitted deferred call is claimed but must not re-begin telemetry or
+  // re-stash.
+  if (deferredUiToolCalls.has(toolCallId)) return true;
 
   if (!def) {
     // The name was advertised to the server in an earlier snapshot but the

--- a/mcpjam-inspector/client/src/lib/webmcp/ui-tool-executor.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/ui-tool-executor.ts
@@ -94,6 +94,13 @@ interface UiToolCallTelemetry {
   startedAt: number;
   duplicateOfPrevious: boolean;
   callsSinceDuplicate?: number;
+  /**
+   * True when this started entry was rebuilt after a page reload (the original
+   * tool-call/defer happened in a previous load). The real start time is lost,
+   * so duration is reported as null rather than a misleading ~0 ms covering
+   * only local execution.
+   */
+  reconstructed?: boolean;
 }
 
 /** Started-time facts carried to the (possibly much later) completed emit. */
@@ -150,6 +157,10 @@ const SIGNATURE_MAX_CHARS = 2048;
 // WIDE payload (huge flat array/object) is bounded the same way depth bounds
 // a deep one — the traversal stops before it can build a megabyte string.
 const SIGNATURE_MAX_NODES = 512;
+// Per-string cap: a single multi-megabyte scalar is one node, so the node
+// budget wouldn't catch it — truncate long strings DURING traversal, before
+// JSON.stringify ever materializes them.
+const SIGNATURE_MAX_STRING = 256;
 
 /**
  * Recursively sort object keys so equal args hash equal. Bounded three ways —
@@ -190,6 +201,10 @@ function canonicalize(
     }
     return out;
   }
+  // Truncate long scalars in place so one giant string can't blow the budget.
+  if (typeof value === "string" && value.length > SIGNATURE_MAX_STRING) {
+    return `${value.slice(0, SIGNATURE_MAX_STRING)}…<${value.length}>`;
+  }
   return value;
 }
 
@@ -225,6 +240,7 @@ function beginUiToolCallTelemetry(opts: {
   input: unknown;
   needsApproval: boolean;
   telemetryScope?: string;
+  reconstructed?: boolean;
 }): void {
   const ring = signatureRingFor(opts.telemetryScope ?? "default");
   const signature = callSignature(opts.toolName, opts.input);
@@ -244,6 +260,7 @@ function beginUiToolCallTelemetry(opts: {
     startedAt: Date.now(),
     duplicateOfPrevious,
     ...(callsSinceDuplicate !== undefined ? { callsSinceDuplicate } : {}),
+    ...(opts.reconstructed ? { reconstructed: true } : {}),
   };
   telemetryByToolCallId.set(opts.toolCallId, entry);
   emitTelemetry("ui_tool_call_started", {
@@ -267,7 +284,9 @@ function completeUiToolCallTelemetry(
   emitTelemetry("ui_tool_call_completed", {
     tool_name: entry.toolName,
     surface_id: entry.surfaceId,
-    duration_ms: Date.now() - entry.startedAt,
+    // A reconstructed (post-reload) lifecycle never saw the real start, so its
+    // elapsed time would be a misleading ~0 ms — report null instead.
+    duration_ms: entry.reconstructed ? null : Date.now() - entry.startedAt,
     outcome,
     ...(errorCode ? { error_code: errorCode } : {}),
     approval,
@@ -343,6 +362,7 @@ export function settleDeniedUiToolCall(
       input: meta?.input !== undefined ? meta.input : stashed?.input,
       needsApproval: true,
       telemetryScope: meta?.telemetryScope ?? stashed?.telemetryScope,
+      reconstructed: true,
     });
   }
   // Denied approvals are terminal for the client: exactly one completed
@@ -531,6 +551,7 @@ export async function fulfillApprovedUiToolCall(opts: {
       input,
       needsApproval: true,
       telemetryScope: opts.telemetryScope ?? stashed?.telemetryScope,
+      reconstructed: true,
     });
   }
 

--- a/mcpjam-inspector/client/src/lib/webmcp/ui-tool-executor.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/ui-tool-executor.ts
@@ -47,6 +47,12 @@ export interface HandleUiToolCallOptions {
   onNavigationToolCall?: (toolName: string) => void;
   /** The turn's approval flag — defers mutating tools to the approval pill. */
   requireToolApproval?: boolean;
+  /**
+   * Duplicate-detection scope, normally the caller's chatSessionId. Calls
+   * with the same scope share one signature ring; omitting it falls back to
+   * a shared "default" ring.
+   */
+  telemetryScope?: string;
 }
 
 /**
@@ -68,7 +74,7 @@ export function __resetUiToolExecutorForTests(): void {
   settledOrInFlightToolCallIds.clear();
   deferredUiToolCalls.clear();
   telemetryByToolCallId.clear();
-  recentCallSignatures.length = 0;
+  recentCallSignaturesByScope.clear();
 }
 
 // --- Outcome telemetry ------------------------------------------------
@@ -94,13 +100,32 @@ interface UiToolCallTelemetry {
 const telemetryByToolCallId = new Map<string, UiToolCallTelemetry>();
 
 /**
- * Last N call signatures this session, oldest first, for duplicate-call
- * detection (a looping agent re-issuing the same call). Signatures include
+ * Last N call signatures PER CHAT SESSION, oldest first, for duplicate-call
+ * detection (a looping agent re-issuing the same call). Scoped by the
+ * caller's `telemetryScope` (its chatSessionId) because this executor serves
+ * both the regular chat session and the MCPJam-agent chat — a shared ring
+ * would report cross-session false duplicates. Signatures include
  * canonicalized args and therefore NEVER leave this module — only the
  * duplicate boolean and the call distance are emitted.
  */
 const RECENT_SIGNATURE_LIMIT = 20;
-const recentCallSignatures: string[] = [];
+const SIGNATURE_SCOPE_LIMIT = 8;
+const recentCallSignaturesByScope = new Map<string, string[]>();
+
+function signatureRingFor(scope: string): string[] {
+  let ring = recentCallSignaturesByScope.get(scope);
+  if (!ring) {
+    ring = [];
+    // Bound total memory: evict the oldest scope (Map preserves insertion
+    // order) once defunct sessions accumulate.
+    if (recentCallSignaturesByScope.size >= SIGNATURE_SCOPE_LIMIT) {
+      const oldest = recentCallSignaturesByScope.keys().next().value;
+      if (oldest !== undefined) recentCallSignaturesByScope.delete(oldest);
+    }
+    recentCallSignaturesByScope.set(scope, ring);
+  }
+  return ring;
+}
 
 function emitTelemetry(
   event: "ui_tool_call_started" | "ui_tool_call_completed",
@@ -150,17 +175,19 @@ function beginUiToolCallTelemetry(opts: {
   toolName: string;
   input: unknown;
   needsApproval: boolean;
+  telemetryScope?: string;
 }): void {
+  const ring = signatureRingFor(opts.telemetryScope ?? "default");
   const signature = callSignature(opts.toolName, opts.input);
-  const matchIndex = recentCallSignatures.lastIndexOf(signature);
+  const matchIndex = ring.lastIndexOf(signature);
   const duplicateOfPrevious = matchIndex >= 0;
   // Distance measured BEFORE the push mutates indices: 1 = previous call.
   const callsSinceDuplicate = duplicateOfPrevious
-    ? recentCallSignatures.length - matchIndex
+    ? ring.length - matchIndex
     : undefined;
-  recentCallSignatures.push(signature);
-  if (recentCallSignatures.length > RECENT_SIGNATURE_LIMIT) {
-    recentCallSignatures.shift();
+  ring.push(signature);
+  if (ring.length > RECENT_SIGNATURE_LIMIT) {
+    ring.shift();
   }
   const entry: UiToolCallTelemetry = {
     toolName: opts.toolName,
@@ -333,6 +360,7 @@ export async function handleUiToolCall(
         toolName,
         input,
         needsApproval: false,
+        telemetryScope: opts.telemetryScope,
       });
       addToolOutput({
         tool: toolName,
@@ -359,7 +387,13 @@ export async function handleUiToolCall(
     annotations: def.annotations,
     requireToolApproval: opts.requireToolApproval === true,
   });
-  beginUiToolCallTelemetry({ toolCallId, toolName, input, needsApproval });
+  beginUiToolCallTelemetry({
+    toolCallId,
+    toolName,
+    input,
+    needsApproval,
+    telemetryScope: opts.telemetryScope,
+  });
 
   if (needsApproval) {
     deferredUiToolCalls.set(toolCallId, { toolName, input });

--- a/mcpjam-inspector/client/src/lib/webmcp/ui-tool-executor.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/ui-tool-executor.ts
@@ -138,14 +138,27 @@ function emitTelemetry(
   }
 }
 
-/** Recursively sort object keys so equal args always hash equal. */
-function canonicalize(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(canonicalize);
+// Bounds on the duplicate-detection fingerprint. `input` is arbitrary model
+// output, so an unbounded recursive clone + stringify of a huge or deeply
+// nested payload could freeze the tab — which would violate the
+// observation-only guarantee. Cap both traversal depth and the serialized
+// length; over-budget inputs collapse to a deterministic marker (they simply
+// won't dedupe against each other, which is safe).
+const SIGNATURE_MAX_DEPTH = 6;
+const SIGNATURE_MAX_CHARS = 2048;
+
+/**
+ * Recursively sort object keys so equal args hash equal, truncating past
+ * SIGNATURE_MAX_DEPTH with a marker so a deep payload can't run away.
+ */
+function canonicalize(value: unknown, depth = 0): unknown {
+  if (depth >= SIGNATURE_MAX_DEPTH) return "<depth>";
+  if (Array.isArray(value)) return value.map((v) => canonicalize(v, depth + 1));
   if (value && typeof value === "object") {
     const source = value as Record<string, unknown>;
     const out: Record<string, unknown> = {};
     for (const key of Object.keys(source).sort()) {
-      out[key] = canonicalize(source[key]);
+      out[key] = canonicalize(source[key], depth + 1);
     }
     return out;
   }
@@ -154,7 +167,15 @@ function canonicalize(value: unknown): unknown {
 
 function callSignature(toolName: string, input: unknown): string {
   try {
-    return `${toolName}:${JSON.stringify(canonicalize(input))}`;
+    const body = JSON.stringify(canonicalize(input));
+    // Cap the retained string. A collision after truncation just means two
+    // giant distinct inputs are treated as one — acceptable for a loop-
+    // detection heuristic, and far cheaper than holding megabytes.
+    const bounded =
+      body.length > SIGNATURE_MAX_CHARS
+        ? `${body.slice(0, SIGNATURE_MAX_CHARS)}…<${body.length}>`
+        : body;
+    return `${toolName}:${bounded}`;
   } catch {
     return `${toolName}:<unserializable>`;
   }

--- a/mcpjam-inspector/shared/analytics-events.ts
+++ b/mcpjam-inspector/shared/analytics-events.ts
@@ -222,6 +222,21 @@ export const ANALYTICS_EVENTS = {
   xaa_tab_viewed: { source: "client" },
   playground_compare_host_removed: { source: "client" },
   playground_compare_host_added: { source: "client" },
+
+  // --- UI-only agent chat: ui_* tool + turn outcomes ---
+  // Props are ids/names/booleans/counts/durations ONLY — never message
+  // text, tool args, tool outputs, URLs, headers, or env values.
+  // agent_turn_completed: one agent-chat turn finished (model/provider,
+  //   ui-tool counts, token counts, duration, had_error).
+  // ui_navigation_rejected: resolveUiNavigationTarget refused a segment
+  //   (reason: unknown | hosted_blocked).
+  // ui_tool_call_started / ui_tool_call_completed: lifecycle of one ui_*
+  //   client-fulfilled tool call (outcome, approval, structured error code,
+  //   duplicate-call detection).
+  agent_turn_completed: { source: "client" },
+  ui_navigation_rejected: { source: "client" },
+  ui_tool_call_completed: { source: "client" },
+  ui_tool_call_started: { source: "client" },
 } as const satisfies Record<string, { source: "client" | "server" }>;
 
 export type AnalyticsEventName = keyof typeof ANALYTICS_EVENTS;


### PR DESCRIPTION
## What

Four new client analytics events (typed registry, ratchet-safe — no free-string captures):

| Event | Where | Key props |
|---|---|---|
| `ui_tool_call_started` | WebMCP executor, at the defer/execute decision | `tool_name`, `surface_id`, `needs_approval` (reuses the one `uiToolCallNeedsApproval` result) |
| `ui_tool_call_completed` | every terminal executor path (success, error, denied, unavailable, reload-approved) — exactly one per call | `duration_ms`, `outcome`, `approval`, whitelisted `error_code`, `duplicate_of_previous`, `calls_since_duplicate` |
| `ui_navigation_rejected` | `resolveUiNavigationTarget` refusals | `segment` (normalized tab, 64-char cap), `reason` (`unknown` \| `hosted_blocked`) — doubles as capability-demand signal |
| `agent_turn_completed` | agent session ready/error edges | model/provider, ui-tool counts via registry ownership, tokens when metadata carries them, `had_error` |

**Privacy:** props are ids/names/booleans/counts/durations only. `error_code` is whitelist-only (closed `InspectorCommandErrorCode` set + two constants; unrecognized error text emits nothing). Duplicate detection uses an in-memory canonical-JSON signature (bounded ring of 20) that never leaves the module — only the boolean/count are emitted; a test drives a secret string through success/error/denied paths and asserts no prop contains it.

**Robustness:** all emits are try/catch-wrapped — a throwing capture can never break tool fulfillment. Approval policy, registry/catalog behavior, native mirror, and server code untouched.

## Tests

New 10-test executor telemetry suite (started/completed pairing on every path, denial, duplicates, secret-leak assertion); ui-actions rejection tests extended; full webmcp + ratchet + agent-session suites pass; `typecheck:client` clean.

This is PR **T-2** of [UI_ONLY_CHAT_IMPLEMENTATION.md](https://github.com/MCPJam/inspector/pull/3286) (§4, §7). Feeds the baseline dashboard and the demand ranking for catalog expansion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are observation-only client telemetry and idempotency guards around existing tool/approval flows; no auth, persistence, or server execution paths are altered.
> 
> **Overview**
> Adds **client analytics** for WebMCP `ui_*` tools and MCPJam agent turns, with strict privacy (names, counts, durations, whitelisted error codes only—never args, outputs, or raw model navigation text).
> 
> **`ui_tool_call_started` / `ui_tool_call_completed`** are emitted from the UI tool executor on every terminal path (success, error, denied, unavailable), with per-session **duplicate-call detection** via a bounded in-memory signature ring (`telemetryScope` = chat session id, threaded through chat session, agent instances, and approval handlers). Re-emitted SDK tool calls and idempotent denials avoid double telemetry; post-reload approve/deny can reconstruct a lifecycle with `duration_ms: null`.
> 
> **`ui_navigation_rejected`** fires on refused navigation targets; unknown segments are bucketed as `unrecognized` so arbitrary model text never lands in analytics.
> 
> **Agent turn completion** moves to shared `AgentTurnLifecycle` on each agent chat instance (`markAgentTurnStarted` / `claimAgentTurnCompletion`): one emission per turn across surface hand-offs, terminal `ready` only when tool parts are fully resolved (not intermediate SDK `ready` during UI tools), and tool/token attribution limited to the assistant message created after the submit boundary.
> 
> Registry entries for the new events plus unit tests cover terminal-turn helpers, shared claim semantics, executor telemetry, and navigation rejection behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd96be5265c5838a6f41854b104b76051b2d6732. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds client telemetry for `ui_*` tool calls and agent turns to measure outcomes and detect loops, without exposing args or outputs. Emits turn completions exactly once on terminal state across surfaces, scopes duplicates per session, treats denied tool outputs as resolved, reports null duration for reconstructed lifecycles, and buckets unknown nav targets as `unrecognized`.

- **Bug Fixes**
  - Settled-ID guard runs before the shipped‑but‑unavailable branch, and shipped‑but‑unavailable calls are claimed before emitting, so replays don’t send a second output or extra started/completed events.
  - `telemetryScope` is stashed and passed through approval and orphaned‑defer paths, keeping reload‑approved calls in their session’s duplicate ring.
  - Re‑emitted deferred calls are claimed without starting telemetry again or re‑stashing, avoiding duplicate started events.
  - Denials after a page reload emit a full started/completed pair using persisted metadata; reconstructed lifecycles report `duration_ms: null`.
  - Duplicate denial callbacks are idempotent; only one denied started/completed pair is emitted.
  - Agent turn completion fires only on terminal state (error, or final ready with all tool parts resolved, including `output-denied`), is claimed once across surfaces, and snapshots model/provider and `message_index` at submit; emission is try/catch‑guarded.
  - Duplicate-call signature is bounded by depth, node count, per‑string truncation, and length to prevent large/deep inputs from freezing the tab.
  - Tool counts and token usage are attributed only to the assistant message created by the current turn; early errors no longer inherit the previous turn’s stats.

<sup>Written for commit bd96be5265c5838a6f41854b104b76051b2d6732. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

