### PR TITLE
feat(webmcp): ownership-guarded registry, globals-first snapshot, readiness helper

### DIFF
--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tools-registry.hardening.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tools-registry.hardening.test.ts
@@ -1,0 +1,231 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mirrorUiToolToNativeMock } = vi.hoisted(() => ({
+  mirrorUiToolToNativeMock: vi.fn(),
+}));
+
+vi.mock("../native-mirror", () => ({
+  mirrorUiToolToNative: mirrorUiToolToNativeMock,
+}));
+
+import {
+  useUiToolsRegistry,
+  type UiToolDefinition,
+} from "../ui-tools-registry";
+import { waitForUiToolNames } from "../ui-tools-readiness";
+
+function makeTool(name: string, extra?: Partial<UiToolDefinition>): UiToolDefinition {
+  return {
+    name,
+    description: `Test tool ${name}`,
+    inputSchema: { type: "object", properties: {} },
+    readOnly: false,
+    execute: vi.fn(async () => ({
+      content: [{ type: "text" as const, text: "ok" }],
+    })),
+    ...extra,
+  };
+}
+
+function resetRegistry() {
+  useUiToolsRegistry.setState({
+    tools: new Map(),
+    nativeDisposers: new Map(),
+    globalNames: new Set(),
+    shippedNames: new Set(),
+  });
+}
+
+describe("ownership-guarded unregistration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mirrorUiToolToNativeMock.mockReturnValue(null);
+    resetRegistry();
+  });
+
+  it("a stale unregister closure never removes the replacement", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const disposeA = vi.fn();
+    const disposeB = vi.fn();
+    mirrorUiToolToNativeMock
+      .mockReturnValueOnce(disposeA)
+      .mockReturnValueOnce(disposeB);
+    const a = makeTool("ui_navigate");
+    const b = makeTool("ui_navigate");
+    const unregisterA = useUiToolsRegistry.getState().registerUiTool(a);
+    const unregisterB = useUiToolsRegistry.getState().registerUiTool(b);
+    expect(disposeA).toHaveBeenCalledTimes(1); // disposed at replace time
+
+    unregisterA(); // stale: B owns the name now — must be a no-op
+    expect(useUiToolsRegistry.getState().resolve("ui_navigate")).toBe(b);
+    expect(disposeB).not.toHaveBeenCalled();
+
+    unregisterB();
+    expect(useUiToolsRegistry.getState().resolve("ui_navigate")).toBeNull();
+    expect(disposeB).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+
+  it("a stale abort never removes the replacement", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const disposeB = vi.fn();
+    mirrorUiToolToNativeMock
+      .mockReturnValueOnce(vi.fn())
+      .mockReturnValueOnce(disposeB);
+    const controllerA = new AbortController();
+    const a = makeTool("ui_navigate");
+    const b = makeTool("ui_navigate");
+    useUiToolsRegistry
+      .getState()
+      .registerUiTool(a, { signal: controllerA.signal });
+    const unregisterB = useUiToolsRegistry.getState().registerUiTool(b);
+
+    controllerA.abort(); // A's abort fires after B replaced it
+    expect(useUiToolsRegistry.getState().resolve("ui_navigate")).toBe(b);
+    expect(disposeB).not.toHaveBeenCalled();
+
+    unregisterB();
+    expect(useUiToolsRegistry.getState().resolve("ui_navigate")).toBeNull();
+    expect(disposeB).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+
+  it("StrictMode setup→cleanup→setup leaves one live registration, no warn", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    // StrictMode/HMR rebuild the definition object on each setup; cleanup
+    // runs BEFORE the re-setup, so no live collision (and no throw/warn).
+    const cleanup = useUiToolsRegistry
+      .getState()
+      .registerUiTool(makeTool("ui_navigate"));
+    cleanup();
+    const second = makeTool("ui_navigate");
+    useUiToolsRegistry.getState().registerUiTool(second);
+
+    expect(useUiToolsRegistry.getState().tools.size).toBe(1);
+    expect(useUiToolsRegistry.getState().resolve("ui_navigate")).toBe(second);
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});
+
+describe("globals-first snapshot ordering", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mirrorUiToolToNativeMock.mockReturnValue(null);
+    resetRegistry();
+  });
+
+  it("emits all global-scope tools before any surface-scope tools", () => {
+    const registry = useUiToolsRegistry.getState();
+    // Surface tools register FIRST (a surface's useLayoutEffect can beat
+    // App's useEffect); globals must still lead the snapshot.
+    registry.registerUiTool(makeTool("ui_surface_a"));
+    registry.registerUiTool(makeTool("ui_surface_b"), { scope: "surface" });
+    registry.registerUiTool(makeTool("ui_global_a"), { scope: "global" });
+    registry.registerUiTool(makeTool("ui_global_b"), { scope: "global" });
+
+    expect(registry.snapshotForChatBody().map((t) => t.name)).toEqual([
+      "ui_global_a",
+      "ui_global_b",
+      "ui_surface_a",
+      "ui_surface_b",
+    ]);
+  });
+
+  it("overflow keeps ALL globals inside the surviving 64", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const registry = useUiToolsRegistry.getState();
+    for (let i = 0; i < 60; i++) {
+      registry.registerUiTool(makeTool(`ui_surface_${i}`));
+    }
+    for (let i = 0; i < 10; i++) {
+      registry.registerUiTool(makeTool(`ui_global_${i}`), { scope: "global" });
+    }
+
+    const names = registry.snapshotForChatBody().map((t) => t.name);
+    expect(names).toHaveLength(64);
+    expect(names.slice(0, 10)).toEqual(
+      Array.from({ length: 10 }, (_, i) => `ui_global_${i}`),
+    );
+    expect(names.slice(10)).toEqual(
+      Array.from({ length: 54 }, (_, i) => `ui_surface_${i}`),
+    );
+    warn.mockRestore();
+  });
+
+  it("a replacement's scope wins over the replaced registration's", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const registry = useUiToolsRegistry.getState();
+    registry.registerUiTool(makeTool("ui_navigate"), { scope: "global" });
+    registry.registerUiTool(makeTool("ui_navigate")); // replace as surface
+    registry.registerUiTool(makeTool("ui_select_server"), { scope: "global" });
+
+    expect(registry.snapshotForChatBody().map((t) => t.name)).toEqual([
+      "ui_select_server",
+      "ui_navigate",
+    ]);
+    warn.mockRestore();
+  });
+});
+
+describe("waitForUiToolNames", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mirrorUiToolToNativeMock.mockReturnValue(null);
+    resetRegistry();
+  });
+
+  /** Wrap subscribe so tests can assert every subscription was detached. */
+  function trackSubscriptions() {
+    const realSubscribe = useUiToolsRegistry.subscribe.bind(useUiToolsRegistry);
+    const unsubscribers: Array<ReturnType<typeof vi.fn>> = [];
+    const spy = vi
+      .spyOn(useUiToolsRegistry, "subscribe")
+      .mockImplementation((listener) => {
+        const unsubscribe = vi.fn(realSubscribe(listener));
+        unsubscribers.push(unsubscribe);
+        return unsubscribe;
+      });
+    return { spy, unsubscribers };
+  }
+
+  it("resolves true immediately (no subscription) when already present", async () => {
+    useUiToolsRegistry.getState().registerUiTool(makeTool("ui_navigate"));
+    const { spy } = trackSubscriptions();
+    await expect(waitForUiToolNames(["ui_navigate"], 1000)).resolves.toBe(true);
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it("resolves true immediately for an empty name list", async () => {
+    await expect(waitForUiToolNames([], 5)).resolves.toBe(true);
+  });
+
+  it("resolves true when the last missing name registers, and unsubscribes", async () => {
+    useUiToolsRegistry.getState().registerUiTool(makeTool("ui_navigate"));
+    const { spy, unsubscribers } = trackSubscriptions();
+    const wait = waitForUiToolNames(["ui_navigate", "ui_select_server"], 1000);
+    useUiToolsRegistry.getState().registerUiTool(makeTool("ui_select_server"));
+
+    await expect(wait).resolves.toBe(true);
+    expect(unsubscribers).toHaveLength(1);
+    expect(unsubscribers[0]).toHaveBeenCalledTimes(1);
+    spy.mockRestore();
+  });
+
+  it("resolves false after the timeout, and unsubscribes", async () => {
+    const { unsubscribers, spy } = trackSubscriptions();
+    await expect(waitForUiToolNames(["ui_never_mounts"], 25)).resolves.toBe(
+      false,
+    );
+    expect(unsubscribers).toHaveLength(1);
+    expect(unsubscribers[0]).toHaveBeenCalledTimes(1);
+    spy.mockRestore();
+  });
+
+  it("ignores unrelated registrations while waiting", async () => {
+    const wait = waitForUiToolNames(["ui_never_mounts"], 25);
+    useUiToolsRegistry.getState().registerUiTool(makeTool("ui_navigate"));
+    await expect(wait).resolves.toBe(false);
+  });
+});

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tools-registry.hardening.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tools-registry.hardening.test.ts
@@ -228,4 +228,20 @@ describe("waitForUiToolNames", () => {
     useUiToolsRegistry.getState().registerUiTool(makeTool("ui_navigate"));
     await expect(wait).resolves.toBe(false);
   });
+
+  it("a shared def object registered twice: stale cleanup doesn't remove the live one", () => {
+    // Two registrars share ONE UiToolDefinition object (module-level def).
+    const shared = makeTool("ui_navigate");
+    const unregA = useUiToolsRegistry.getState().registerUiTool(shared);
+    // B re-registers the SAME object (prod warn+replace path, MODE!=development).
+    const unregB = useUiToolsRegistry.getState().registerUiTool(shared);
+    expect(useUiToolsRegistry.getState().resolve("ui_navigate")).toBe(shared);
+    // A's stale cleanup must NOT remove B's live registration (token guard).
+    unregA();
+    expect(useUiToolsRegistry.getState().resolve("ui_navigate")).toBe(shared);
+    // B's own cleanup removes it.
+    unregB();
+    expect(useUiToolsRegistry.getState().resolve("ui_navigate")).toBeNull();
+  });
+
 });

--- a/mcpjam-inspector/client/src/lib/webmcp/ui-tools-readiness.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/ui-tools-readiness.ts
@@ -1,0 +1,49 @@
+/**
+ * Readiness primitive over the UI tools registry.
+ *
+ * Callers (e.g. a navigate handler waiting for a just-mounted surface's tool
+ * group) need "are these tools live yet?" without racing registration. The
+ * contract is deliberately strict: never rejects, always detaches its
+ * subscription (resolve, timeout, or setup failure), so a tool that never
+ * mounts can neither hang the caller nor leak a listener.
+ */
+
+import { useUiToolsRegistry } from "./ui-tools-registry";
+
+/**
+ * Resolve `true` as soon as every name in `names` is present in the registry
+ * (immediately when they already are — an empty list is trivially present),
+ * `false` once `timeoutMs` elapses first.
+ */
+export function waitForUiToolNames(
+  names: readonly string[],
+  timeoutMs: number,
+): Promise<boolean> {
+  const allPresent = () => {
+    const { tools } = useUiToolsRegistry.getState();
+    return names.every((name) => tools.has(name));
+  };
+  if (allPresent()) return Promise.resolve(true);
+  return new Promise<boolean>((resolve) => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let unsubscribe: (() => void) | undefined;
+    let settled = false;
+    const settle = (value: boolean) => {
+      if (settled) return;
+      settled = true;
+      if (timer !== undefined) clearTimeout(timer);
+      unsubscribe?.();
+      resolve(value);
+    };
+    try {
+      unsubscribe = useUiToolsRegistry.subscribe(() => {
+        if (allPresent()) settle(true);
+      });
+      timer = setTimeout(() => settle(false), timeoutMs);
+    } catch {
+      // Never reject, never leak: a throwing subscribe/timer setup settles
+      // like a timeout.
+      settle(false);
+    }
+  });
+}

--- a/mcpjam-inspector/client/src/lib/webmcp/ui-tools-registry.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/ui-tools-registry.ts
@@ -85,6 +85,12 @@ interface UiToolsRegistryState {
   /** Disposers for native `modelContext` mirrors, keyed by tool name. */
   nativeDisposers: Map<string, () => void>;
   /**
+   * Names registered with `scope: "global"` (the app-wide catalog). Kept as
+   * a parallel set — not on the map values — so `resolve()` and the executor
+   * keep seeing plain `UiToolDefinition`s. Drives snapshot ordering only.
+   */
+  globalNames: Set<string>;
+  /**
    * Every name ever shipped to the server in a snapshot, unioned at snapshot
    * time and NEVER evicted: a `ui_*` tool call only reaches `onToolCall`
    * when that stream's own snapshot advertised the name, and an in-flight
@@ -98,8 +104,22 @@ interface UiToolsRegistryState {
 
   registerUiTool: (
     def: UiToolDefinition,
-    opts?: { signal?: AbortSignal },
+    opts?: {
+      signal?: AbortSignal;
+      /**
+       * `"global"` = app-wide catalog, `"surface"` (default) = mounted while
+       * a specific surface is. `snapshotForChatBody` emits globals first so
+       * the 64-entry cap can never evict the global catalog in favor of
+       * whichever surface's effect happened to register earlier.
+       */
+      scope?: "global" | "surface";
+    },
   ) => () => void;
+  /**
+   * Unconditional by-name removal, for callers that explicitly own a name.
+   * The closure returned by `registerUiTool` is NOT this: it is ownership-
+   * guarded, a no-op once another registration has replaced the name.
+   */
   unregisterUiTool: (name: string) => void;
   resolve: (name: string) => UiToolDefinition | null;
   snapshotForChatBody: () => UiToolSnapshotEntry[];
@@ -109,6 +129,7 @@ interface UiToolsRegistryState {
 export const useUiToolsRegistry = create<UiToolsRegistryState>((set, get) => ({
   tools: new Map(),
   nativeDisposers: new Map(),
+  globalNames: new Set(),
   shippedNames: new Set(),
 
   registerUiTool: (def, opts) => {
@@ -132,9 +153,22 @@ export const useUiToolsRegistry = create<UiToolsRegistryState>((set, get) => ({
     if (opts?.signal?.aborted) {
       return () => {};
     }
-    if (get().tools.has(def.name)) {
-      // HMR / StrictMode double-mounts re-register the same catalog; replace
-      // (dropping the stale native mirror) instead of throwing.
+    const existing = get().tools.get(def.name);
+    if (existing) {
+      // A LIVE same-name registration means two registrars claim one name:
+      // legitimate re-registration (HMR / StrictMode remounts) runs cleanup
+      // before setup, so no collision exists by the time setup re-registers.
+      // Escalate in the dev server (MODE, not DEV — vitest sets DEV=true and
+      // the warn+replace contract must stay testable); in prod, replace with
+      // a warn so a missed cleanup degrades instead of blanking the tool.
+      if (import.meta.env.MODE === "development") {
+        throw new Error(
+          `[webmcp] UI tool "${def.name}" registered while an earlier ` +
+            `registration is still live (existing: "${existing.description.slice(0, 80)}"; ` +
+            `incoming: "${def.description.slice(0, 80)}"). ` +
+            `Unregister the previous owner first.`,
+        );
+      }
       console.warn(`[webmcp] UI tool "${def.name}" re-registered; replacing.`);
       get().nativeDisposers.get(def.name)?.();
     }
@@ -145,9 +179,19 @@ export const useUiToolsRegistry = create<UiToolsRegistryState>((set, get) => ({
       const nativeDisposers = new Map(s.nativeDisposers);
       if (dispose) nativeDisposers.set(def.name, dispose);
       else nativeDisposers.delete(def.name);
-      return { tools, nativeDisposers };
+      const globalNames = new Set(s.globalNames);
+      if (opts?.scope === "global") globalNames.add(def.name);
+      else globalNames.delete(def.name);
+      return { tools, nativeDisposers, globalNames };
     });
-    const unregister = () => get().unregisterUiTool(def.name);
+    const unregister = () => {
+      // Ownership guard (same pattern as surface-snapshot-registry's
+      // disposer): tear down only while OUR definition is still the live
+      // one. After a warn+replace, the replaced registration's unregister/
+      // abort must not delete the replacement or dispose its native mirror.
+      if (get().tools.get(def.name) !== def) return;
+      get().unregisterUiTool(def.name);
+    };
     opts?.signal?.addEventListener("abort", unregister, { once: true });
     return unregister;
   },
@@ -165,7 +209,13 @@ export const useUiToolsRegistry = create<UiToolsRegistryState>((set, get) => ({
       nextTools.delete(name);
       const nextDisposers = new Map(s.nativeDisposers);
       nextDisposers.delete(name);
-      return { tools: nextTools, nativeDisposers: nextDisposers };
+      const nextGlobals = new Set(s.globalNames);
+      nextGlobals.delete(name);
+      return {
+        tools: nextTools,
+        nativeDisposers: nextDisposers,
+        globalNames: nextGlobals,
+      };
     });
   },
 
@@ -174,7 +224,17 @@ export const useUiToolsRegistry = create<UiToolsRegistryState>((set, get) => ({
   snapshotForChatBody: () => {
     const out: UiToolSnapshotEntry[] = [];
     let dropped = 0;
-    for (const def of get().tools.values()) {
+    // Globals first, then surface tools, each in insertion order: the
+    // 64-entry cap drops from the tail, and a surface's useLayoutEffect can
+    // register before App's useEffect — pure insertion order could evict the
+    // app-wide catalog on overflow.
+    const { tools, globalNames } = get();
+    const defs = [...tools.values()];
+    const ordered = [
+      ...defs.filter((d) => globalNames.has(d.name)),
+      ...defs.filter((d) => !globalNames.has(d.name)),
+    ];
+    for (const def of ordered) {
       if (out.length >= MAX_SNAPSHOT_ENTRIES) {
         dropped += 1;
         continue;

--- a/mcpjam-inspector/client/src/lib/webmcp/ui-tools-registry.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/ui-tools-registry.ts
@@ -91,6 +91,12 @@ interface UiToolsRegistryState {
    */
   globalNames: Set<string>;
   /**
+   * Current owner token per registered name. A registration's unregister
+   * closure only tears down while its own token is still the live one, so a
+   * `UiToolDefinition` object shared by two registrars can't be mis-owned.
+   */
+  ownerTokens: Map<string, symbol>;
+  /**
    * Every name ever shipped to the server in a snapshot, unioned at snapshot
    * time and NEVER evicted: a `ui_*` tool call only reaches `onToolCall`
    * when that stream's own snapshot advertised the name, and an in-flight
@@ -130,6 +136,7 @@ export const useUiToolsRegistry = create<UiToolsRegistryState>((set, get) => ({
   tools: new Map(),
   nativeDisposers: new Map(),
   globalNames: new Set(),
+  ownerTokens: new Map(),
   shippedNames: new Set(),
 
   registerUiTool: (def, opts) => {
@@ -173,6 +180,12 @@ export const useUiToolsRegistry = create<UiToolsRegistryState>((set, get) => ({
       get().nativeDisposers.get(def.name)?.();
     }
     const dispose = mirrorUiToolToNative(def);
+    // Per-registration ownership token. NOT `def` identity: two registrars can
+    // share the same module-level `UiToolDefinition` object, so a def-identity
+    // guard would let a replaced registration's stale unregister still match
+    // (and delete) the replacement. Each register() call mints a fresh token;
+    // cleanup only fires while its own token is the live one for the name.
+    const ownerToken = Symbol(def.name);
     set((s) => {
       const tools = new Map(s.tools);
       tools.set(def.name, def);
@@ -182,14 +195,16 @@ export const useUiToolsRegistry = create<UiToolsRegistryState>((set, get) => ({
       const globalNames = new Set(s.globalNames);
       if (opts?.scope === "global") globalNames.add(def.name);
       else globalNames.delete(def.name);
-      return { tools, nativeDisposers, globalNames };
+      const ownerTokens = new Map(s.ownerTokens);
+      ownerTokens.set(def.name, ownerToken);
+      return { tools, nativeDisposers, globalNames, ownerTokens };
     });
     const unregister = () => {
-      // Ownership guard (same pattern as surface-snapshot-registry's
-      // disposer): tear down only while OUR definition is still the live
-      // one. After a warn+replace, the replaced registration's unregister/
-      // abort must not delete the replacement or dispose its native mirror.
-      if (get().tools.get(def.name) !== def) return;
+      // Ownership guard: tear down only while OUR registration is still the
+      // live one (checked by token, so a shared def object can't confuse it).
+      // After a warn+replace, the replaced registration's unregister/abort
+      // must not delete the replacement or dispose its native mirror.
+      if (get().ownerTokens.get(def.name) !== ownerToken) return;
       get().unregisterUiTool(def.name);
     };
     opts?.signal?.addEventListener("abort", unregister, { once: true });
@@ -211,10 +226,13 @@ export const useUiToolsRegistry = create<UiToolsRegistryState>((set, get) => ({
       nextDisposers.delete(name);
       const nextGlobals = new Set(s.globalNames);
       nextGlobals.delete(name);
+      const nextOwnerTokens = new Map(s.ownerTokens);
+      nextOwnerTokens.delete(name);
       return {
         tools: nextTools,
         nativeDisposers: nextDisposers,
         globalNames: nextGlobals,
+        ownerTokens: nextOwnerTokens,
       };
     });
   },

--- a/mcpjam-inspector/client/src/lib/webmcp/use-register-ui-tools.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/use-register-ui-tools.ts
@@ -24,7 +24,9 @@ export function useRegisterUiTools(options?: { enabled?: boolean }): void {
     const controller = new AbortController();
     const registerUiTool = useUiToolsRegistry.getState().registerUiTool;
     for (const def of buildUiToolsCatalog()) {
-      registerUiTool(def, { signal: controller.signal });
+      // Global scope: the app-wide catalog must survive the snapshot's
+      // 64-entry cap ahead of any surface-scoped registrations.
+      registerUiTool(def, { signal: controller.signal, scope: "global" });
     }
     return () => controller.abort();
   }, [enabled]);


### PR DESCRIPTION
## What

Base PR of the stack that puts `ui_*` agent tools on every product surface. Makes the tool registry structurally safe for **multiple registrars** (today: one global catalog; next: per-surface tool groups that register on mount / unregister on unmount):

1. **Ownership-guarded unregistration** — the closure returned by `registerUiTool` (and its abort path) tears down only while its own definition is still live, so a stale unregister after a warn+replace can no longer delete the replacement's tool or dispose its native mirror (identity-guard pattern from `surface-snapshot-registry`). A live same-name collision now throws in the dev server; StrictMode/HMR remounts (cleanup-before-setup) stay silent. Public `unregisterUiTool(name)` keeps unconditional semantics, documented.
2. **Globals-first snapshot ordering** — `registerUiTool` accepts `scope: "global" | "surface"` (default surface, catalog passes global). `snapshotForChatBody` emits globals first, so the 64-entry cap can never evict the app-wide catalog just because a surface's `useLayoutEffect` registered before App's `useEffect`.
3. **`waitForUiToolNames(names, timeoutMs)`** — readiness primitive (resolves true when all names are registered, false on timeout, never rejects, always unsubscribes). The next PR wires it into the `navigate` handler so a surface's tools are advertised in the same logical turn as the navigation.

## Tests

New 11-test hardening suite: ownership (stale unregister + abort path), StrictMode lifecycle, scope ordering incl. synthetic overflow (all globals survive), readiness (resolve/timeout/immediate/unsubscribe). Original 13 registry tests pass **unmodified**; webmcp (148), agent + hooks (523) suites green; `typecheck:client` clean.

Stack: this PR → foundation (groups + `useSurfaceAgentBridge` + required `agentTools` manifest field + coverage tests) → per-surface tool PRs (Registry first as lifecycle prover, then Evals, then telemetry-ordered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect which `ui_*` tools appear in chat POST snapshots and when registrations are removed; mistakes could break agent tool availability or cause subtle race bugs, but behavior is heavily tested and scoped to client WebMCP registration.
> 
> **Overview**
> Hardens the WebMCP UI tools registry for **multiple registrars** (global catalog plus future per-surface tools).
> 
> **Ownership-guarded lifecycle:** Each `registerUiTool` call mints an owner token; the returned unregister (and abort handler) only tears down when that token is still live, so stale cleanup after warn+replace cannot remove a replacement or dispose its native mirror. Live same-name collisions **throw in development** (`MODE === "development"`) and **warn+replace in production**. The app catalog hook now registers with **`scope: "global"`**.
> 
> **Globals-first chat snapshots:** `registerUiTool` accepts optional `scope: "global" | "surface"` (default surface). `snapshotForChatBody` orders globals before surface tools so the 64-entry cap drops surface tools first.
> 
> **Readiness:** New `waitForUiToolNames(names, timeoutMs)` resolves when all names are registered (or `false` on timeout), never rejects, and always unsubscribes.
> 
> Adds an 11-test hardening suite covering ownership, snapshot ordering/overflow, and readiness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e526a4cbe9bbe00ab5dda4f20a3697b9baac5034. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the web MCP UI tools registry for multiple registrars with ownership-token-guarded unregistration, globals-first snapshots, and a readiness helper. Prevents stale unregisters from deleting replacements and ensures the global catalog is never pushed out by surface tools.

- New Features
  - Ownership-guarded `registerUiTool`: per-registration token guard; the returned unregister/abort only removes if it still owns the name; dev throws on live same‑name collisions; `unregisterUiTool(name)` stays unconditional.
  - Globals-first snapshots: `registerUiTool(def, { scope: "global" | "surface" })`, with `snapshotForChatBody` emitting globals first so the 64-entry cap never evicts the app-wide catalog; the global catalog now registers with `scope: "global"`.
  - Readiness helper: `waitForUiToolNames(names, timeoutMs)` resolves true when all names are present, false on timeout; never rejects and always unsubscribes.

- Bug Fixes
  - Ownership guard now uses a per-registration token instead of `UiToolDefinition` identity, so shared definition objects can’t let stale cleanups remove live replacements.

<sup>Written for commit e526a4cbe9bbe00ab5dda4f20a3697b9baac5034. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

