### PR TITLE
feat(sdk): centralize MCP error codes + add renumbered 2026-07-28 codes (Phase 0B)

### DIFF
--- a/sdk/src/error-describer/catalog.ts
+++ b/sdk/src/error-describer/catalog.ts
@@ -151,7 +151,7 @@ export const ERROR_CATALOG: Record<string, ErrorCatalogEntry> = {
   ),
   "jsonrpc/header_mismatch": entry(
     "jsonrpc/header_mismatch",
-    "Protocol header mismatch (-32001)",
+    "Protocol header mismatch (-32020)",
     "The server returned an `MCP-Protocol-Version` header that does not match what the client negotiated.",
     [
       "Server is enforcing a different protocol version than the one negotiated at `initialize`.",
@@ -165,7 +165,7 @@ export const ERROR_CATALOG: Record<string, ErrorCatalogEntry> = {
   ),
   "jsonrpc/unsupported_protocol_version": entry(
     "jsonrpc/unsupported_protocol_version",
-    "Unsupported protocol version (-32004)",
+    "Unsupported protocol version (-32022)",
     "The server does not support any protocol version this inspector offered.",
     [
       "Server pinned to a newer MCP draft your inspector build does not understand.",
@@ -173,9 +173,23 @@ export const ERROR_CATALOG: Record<string, ErrorCatalogEntry> = {
     ],
     [
       "Update the inspector to a newer build.",
-      "Check the supported versions list in the server's `initialize` response.",
+      "Check the supported versions list in the server's `server/discover` result (modern) or `initialize` response (legacy).",
     ],
     "unsupported-protocol-version",
+  ),
+  "jsonrpc/missing_required_client_capability": entry(
+    "jsonrpc/missing_required_client_capability",
+    "Missing required client capability (-32021)",
+    "The server refused the request because the client did not advertise a capability the operation requires.",
+    [
+      "A server-initiated input request (elicitation, sampling) needs a client capability MCPJam did not declare.",
+      "The connection advertised a capability set the server considers insufficient for this operation.",
+    ],
+    [
+      "Enable the required client capability in the connection's Client settings.",
+      "Check the server's documentation for which client capabilities it requires.",
+    ],
+    "missing-required-client-capability",
   ),
   "jsonrpc/url_elicitation_required": entry(
     "jsonrpc/url_elicitation_required",

--- a/sdk/src/error-describer/describe.ts
+++ b/sdk/src/error-describer/describe.ts
@@ -15,6 +15,10 @@
 
 import { redactSensitiveValue } from "../redaction.js";
 import {
+  MCP_ERROR_CODES,
+  PRE_RENUMBER_DRAFT_ERROR_CODES,
+} from "../mcp-client-manager/mcp-error-codes.js";
+import {
   ERROR_CATALOG,
   type ErrorCatalogEntry,
 } from "./catalog.js";
@@ -167,19 +171,34 @@ function inspectorSentinelSlug(message: string): string | undefined {
 }
 
 const JSONRPC_SLUG_BY_CODE: Record<number, string> = {
-  [-32700]: "jsonrpc/parse_error",
-  [-32600]: "jsonrpc/invalid_request",
-  [-32601]: "jsonrpc/method_not_found",
-  [-32602]: "jsonrpc/invalid_params",
-  [-32603]: "jsonrpc/internal_error",
-  [-32000]: "jsonrpc/connection_closed",
-  [-32004]: "jsonrpc/unsupported_protocol_version",
-  [-32042]: "jsonrpc/url_elicitation_required",
+  [MCP_ERROR_CODES.ParseError]: "jsonrpc/parse_error",
+  [MCP_ERROR_CODES.InvalidRequest]: "jsonrpc/invalid_request",
+  [MCP_ERROR_CODES.MethodNotFound]: "jsonrpc/method_not_found",
+  [MCP_ERROR_CODES.InvalidParams]: "jsonrpc/invalid_params",
+  [MCP_ERROR_CODES.InternalError]: "jsonrpc/internal_error",
+  [MCP_ERROR_CODES.ConnectionClosed]: "jsonrpc/connection_closed",
+  // Modern 2026-07-28 protocol codes (post-renumber). `-32020` is the
+  // canonical HeaderMismatch code; the `-32001` overload below is the
+  // pre-renumber transitional path, removed in Phase 1.
+  [MCP_ERROR_CODES.HeaderMismatch]: "jsonrpc/header_mismatch",
+  [MCP_ERROR_CODES.MissingRequiredClientCapability]:
+    "jsonrpc/missing_required_client_capability",
+  [MCP_ERROR_CODES.UnsupportedProtocolVersion]:
+    "jsonrpc/unsupported_protocol_version",
+  // Pre-renumber 2026 DRAFT code, retained only for the Phase 0→1 window so
+  // errors from MCPJam's own not-yet-migrated preview client / fixtures still
+  // describe correctly. Delete with the preview client in Phase 1.
+  [PRE_RENUMBER_DRAFT_ERROR_CODES.UnsupportedProtocolVersion]:
+    "jsonrpc/unsupported_protocol_version",
+  [MCP_ERROR_CODES.UrlElicitationRequired]: "jsonrpc/url_elicitation_required",
 };
 
 /**
- * `-32001` is overloaded: upstream uses it for RequestTimeout, the inspector
- * uses the same numeric code for HeaderMismatch. Disambiguate by message.
+ * `-32001` is overloaded: the SDK uses it for RequestTimeout, and MCPJam's
+ * pre-renumber draft path used the same numeric code for HeaderMismatch.
+ * Disambiguate by message. The modern era gives HeaderMismatch its own code
+ * (`-32020`, mapped directly above), so this overload is transitional and is
+ * removed in Phase 1 once nothing emits `-32001` for a header mismatch.
  */
 function resolveDashThirtyTwoThousandOne(message: string): string {
   if (

--- a/sdk/src/mcp-client-manager/mcp-error-codes.ts
+++ b/sdk/src/mcp-client-manager/mcp-error-codes.ts
@@ -1,0 +1,76 @@
+/**
+ * Centralized MCP error codes — the single source of truth for the numeric
+ * JSON-RPC codes MCPJam reads off the wire and stamps onto its own errors.
+ *
+ * Why this module exists (and why the values look duplicated):
+ *
+ * The 2026-07-28 draft renumbered its new protocol codes late in review
+ * (HeaderMismatch `-32001`→`-32020`, MissingRequiredClientCapability
+ * `-32003`→`-32021`, UnsupportedProtocolVersion `-32004`→`-32022`) and folded
+ * resource-not-found into InvalidParams (`-32002`→`-32602`). The installed SDK
+ * (`@modelcontextprotocol/client` v2 alpha.2) predates that renumber: its
+ * `ProtocolErrorCode` still carries the pre-renumber values and omits
+ * HeaderMismatch / MissingRequiredClientCapability entirely. So the final
+ * values live here, MCPJam-side, until the SDK bump.
+ *
+ * PHASE 1 RECONCILIATION: once the SDK is on beta.4 (which ships the renumbered
+ * `ProtocolErrorCode`), `MCP_ERROR_CODES` should become a thin re-export /
+ * alias of the SDK enum and `PRE_RENUMBER_DRAFT_ERROR_CODES` should be deleted
+ * along with the preview client that still emits those codes. This module is
+ * the one place that swap happens.
+ *
+ * Provenance of each group is noted inline; keep them grouped so the Phase 1
+ * reconciliation is mechanical.
+ */
+
+/**
+ * Canonical, final wire codes. Stable JSON-RPC codes, the post-renumber
+ * 2026-07-28 protocol codes, and the SDK-local codes in the
+ * implementation-defined `-32000..-32019` range (grandfathered by the spec's
+ * error-code allocation policy).
+ */
+export const MCP_ERROR_CODES = {
+  // --- JSON-RPC 2.0 standard (stable across every MCP revision) ---
+  ParseError: -32700,
+  InvalidRequest: -32600,
+  MethodNotFound: -32601,
+  InvalidParams: -32602,
+  InternalError: -32603,
+
+  // --- 2026-07-28 modern protocol codes (post-renumber, final wire values) ---
+  HeaderMismatch: -32020,
+  MissingRequiredClientCapability: -32021,
+  UnsupportedProtocolVersion: -32022,
+
+  // 2026-07-28 folds resource-not-found into InvalidParams (was -32002).
+  // Numerically identical to InvalidParams — intentional, per the changelog.
+  ResourceNotFound: -32602,
+
+  // --- SDK-local / transport, implementation-defined -32000..-32019 ---
+  ConnectionClosed: -32000,
+  RequestTimeout: -32001,
+
+  // --- MCP extension ---
+  UrlElicitationRequired: -32042,
+} as const;
+
+/**
+ * Legacy (≤ 2025-11-25) resource-not-found code. Real pre-2026 servers emit
+ * `-32002`; the modern era uses {@link MCP_ERROR_CODES.ResourceNotFound}
+ * (`-32602`). Both remain valid on their respective eras for as long as legacy
+ * support is in scope.
+ */
+export const LEGACY_RESOURCE_NOT_FOUND = -32002;
+
+/**
+ * Pre-renumber 2026 DRAFT codes. These are NOT final wire codes. They are
+ * retained only so MCPJam still describes errors emitted by its own
+ * not-yet-migrated preview client and test fixtures during the Phase 0→1
+ * window. DELETE in Phase 1 once the preview client is gone and every fixture
+ * emits {@link MCP_ERROR_CODES}.
+ */
+export const PRE_RENUMBER_DRAFT_ERROR_CODES = {
+  HeaderMismatch: -32001,
+  MissingRequiredClientCapability: -32003,
+  UnsupportedProtocolVersion: -32004,
+} as const;

--- a/sdk/tests/error-describer/describe.test.ts
+++ b/sdk/tests/error-describer/describe.test.ts
@@ -94,10 +94,34 @@ const CASES: Case[] = [
     expectRawCode: -32001,
   },
   {
-    name: "-32004 unsupported protocol version",
+    name: "-32004 unsupported protocol version (pre-renumber draft, transitional)",
     build: () => makeError("Unsupported protocol version", { code: -32004 }),
     expectSlug: "jsonrpc/unsupported_protocol_version",
     expectRawCode: -32004,
+  },
+  // Modern 2026-07-28 protocol codes (post-renumber). These are the final wire
+  // codes; the -32001/-32004 cases above are the transitional pre-renumber path.
+  {
+    name: "-32020 header mismatch (modern, unambiguous)",
+    build: () =>
+      makeError("MCP-Protocol-Version header mismatch", { code: -32020 }),
+    expectSlug: "jsonrpc/header_mismatch",
+    expectRawCode: -32020,
+  },
+  {
+    name: "-32021 missing required client capability (modern)",
+    build: () =>
+      makeError("Missing required client capability: elicitation", {
+        code: -32021,
+      }),
+    expectSlug: "jsonrpc/missing_required_client_capability",
+    expectRawCode: -32021,
+  },
+  {
+    name: "-32022 unsupported protocol version (modern)",
+    build: () => makeError("Unsupported protocol version", { code: -32022 }),
+    expectSlug: "jsonrpc/unsupported_protocol_version",
+    expectRawCode: -32022,
   },
   {
     name: "-32042 url elicitation required",


### PR DESCRIPTION
## What & why

**Phase 0B** of the MCP `2026-07-28` migration (execution plan: `mcp-2026-final-phasing.md`). This is the self-contained error-code slice — no SDK bump, no runtime behavior change on existing connections.

The `2026-07-28` draft renumbered its new protocol error codes late in review. The installed SDK (`@modelcontextprotocol/client` v2 **alpha.2**) predates that renumber: its `ProtocolErrorCode` still carries the old values (`ResourceNotFound = -32002`) and omits `HeaderMismatch` / `MissingRequiredClientCapability` entirely. This PR establishes the final codes MCPJam-side so the rest of the migration has one source of truth.

## Changes

- **New `sdk/src/mcp-client-manager/mcp-error-codes.ts`** — single source of truth:
  - `HeaderMismatch -32020`, `MissingRequiredClientCapability -32021`, `UnsupportedProtocolVersion -32022`
  - resource-not-found folded into `-32602` (was `-32002`)
  - grouped by provenance (stable JSON-RPC / modern / SDK-local / pre-renumber draft) so the Phase 1 reconciliation is mechanical
- **`error-describer/describe.ts`** wired to the module and the modern codes added **additively** — the pre-renumber draft codes (`-32001` HeaderMismatch, `-32004`) and the `-32001` timeout/header-mismatch disambiguation are **retained**, so errors from MCPJam's own not-yet-migrated preview client and fixtures keep describing correctly through the Phase 0→1 window.
- **`error-describer/catalog.ts`** — new `missing_required_client_capability` entry; corrected the stale codes shown in the header-mismatch (`-32020`) and unsupported-version (`-32022`) titles.
- **`describe.test.ts`** — 3 new cases for `-32020` / `-32021` / `-32022`; the legacy `-32001` / `-32004` cases stay green.

## What this deliberately does NOT do

- No removal of the legacy `-32001` disambiguation or the draft codes — that is **Phase 1**, once the preview client is deleted and the SDK (beta.4) supplies the renumbered `ProtocolErrorCode`, at which point `mcp-error-codes.ts` collapses into a re-export of the SDK enum.
- `eval-trace.ts` and `trace-timeline.tsx` are intentionally untouched: their `-32001` is SDK-local RequestTimeout (grandfathered in the implementation-defined `-32000..-32019` range), not a stale modern code.

## Verification

- `tsc --noEmit` on `@mcpjam/sdk` — clean
- `sdk/tests/error-describer/describe.test.ts` — **72/72** (3 new modern-code cases; all prior cases unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> SDK error-catalog and describer mapping only; additive transitional paths preserve existing classifications.
> 
> **Overview**
> **Phase 0B** adds a single MCPJam-side source of truth for MCP JSON-RPC error codes (`mcp-error-codes.ts`) so the `2026-07-28` post-renumber wire values are available before the official client SDK catches up.
> 
> The error describer now maps **`-32020`** (header mismatch), **`-32021`** (missing required client capability), and **`-32022`** (unsupported protocol version), while keeping transitional handling for pre-renumber **`-32001`** / **`-32004`** and the **`-32001`** timeout vs header-mismatch message disambiguation. Catalog copy is updated to show the new codes in titles, adds a **`missing_required_client_capability`** entry, and tweaks unsupported-version guidance to mention **`server/discover`**. Tests add three cases for the modern codes; existing legacy cases stay unchanged.
> 
> No connection-runtime behavior change in this slice—classification and user-facing error text only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7d322450d810d861418c6aa562b90a81d4e551e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes MCP error codes and adds the renumbered 2026-07-28 protocol codes (-32020/-32021/-32022) for Phase 0B. No SDK bump or behavior changes; keeps legacy mappings to avoid regressions and prepares for Phase 1 re-export from `@modelcontextprotocol/client`.

- **Refactors**
  - Added `sdk/src/mcp-client-manager/mcp-error-codes.ts` as the single source of truth (modern codes; legacy constants). Resource-not-found now maps to `-32602`.
  - Updated `error-describer/describe.ts` to use the centralized codes; retained pre-renumber mappings (`-32001`, `-32004`) for the transition window.
  - Updated `error-describer/catalog.ts`: new `missing_required_client_capability` entry; fixed titles for header mismatch (`-32020`) and unsupported version (`-32022`).
  - Tests: added cases for `-32020/-32021/-32022`; existing cases remain unchanged.

<sup>Written for commit e7d322450d810d861418c6aa562b90a81d4e551e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

