### PR TITLE
test(sdk): raw wire-capture helpers for pre-normalization assertions (Phase 0A)

### DIFF
--- a/sdk/tests/support/raw-capture.test.ts
+++ b/sdk/tests/support/raw-capture.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it } from "vitest";
+import {
+  createCapturingFetch,
+  getWireField,
+  hasWireField,
+  parseSseEvents,
+  redactHeadersForLog,
+  type FetchLike,
+} from "./raw-capture.js";
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+    ...init,
+  });
+}
+
+function sseResponse(frames: string): Response {
+  return new Response(frames, {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+/** A fetch whose response is fixed regardless of the request. */
+function respondWith(response: () => Response): FetchLike {
+  return async () => response();
+}
+
+describe("createCapturingFetch — response capture", () => {
+  it("captures unnormalized JSON including wire-only 2026 members", async () => {
+    // A modern tools/list result carrying members the SDK client would strip
+    // (resultType) or hide (ttlMs/cacheScope, _meta serverInfo) before handing
+    // the result to application code.
+    const wire = {
+      jsonrpc: "2.0",
+      id: 1,
+      result: {
+        resultType: "complete",
+        tools: [{ name: "echo", inputSchema: { type: "object" } }],
+        ttlMs: 5000,
+        cacheScope: "public",
+        _meta: {
+          "io.modelcontextprotocol/serverInfo": {
+            name: "fixture",
+            version: "1.0.0",
+          },
+        },
+      },
+    };
+    const cap = createCapturingFetch(respondWith(() => jsonResponse(wire)));
+    await cap.fetch("http://test.local/mcp", { method: "POST" });
+
+    expect(cap.exchanges).toHaveLength(1);
+    const { response } = cap.exchanges[0];
+    expect(response.status).toBe(200);
+    expect(response.headers["content-type"]).toContain("application/json");
+    // The raw fields survive capture untouched.
+    expect(getWireField(response.json, "result.resultType")).toBe("complete");
+    expect(getWireField(response.json, "result.ttlMs")).toBe(5000);
+    expect(getWireField(response.json, "result.cacheScope")).toBe("public");
+    // `_meta` keys contain dots, so address them with the array form.
+    expect(
+      hasWireField(response.json, [
+        "result",
+        "_meta",
+        "io.modelcontextprotocol/serverInfo",
+      ]),
+    ).toBe(true);
+    // bodyText is the exact wire bytes.
+    expect(response.bodyText).toBe(JSON.stringify(wire));
+  });
+
+  it("does not consume the response — the real consumer still reads it", async () => {
+    const wire = { jsonrpc: "2.0", id: 1, result: { resultType: "complete" } };
+    const cap = createCapturingFetch(respondWith(() => jsonResponse(wire)));
+    const res = await cap.fetch("http://test.local/mcp", { method: "POST" });
+    // If capture had consumed the body, this would throw "body already read".
+    const consumed = await res.json();
+    expect(consumed).toEqual(wire);
+    // And the capture still has its own copy.
+    expect(cap.exchanges[0].response.json).toEqual(wire);
+  });
+
+  it("parses an SSE response into raw frames while teeing the stream", async () => {
+    const frames =
+      `event: message\n` +
+      `data: ${JSON.stringify({ jsonrpc: "2.0", method: "notifications/progress", params: { progress: 1 } })}\n\n` +
+      `event: message\n` +
+      `data: ${JSON.stringify({ jsonrpc: "2.0", id: 1, result: { resultType: "complete" } })}\n\n`;
+    const cap = createCapturingFetch(respondWith(() => sseResponse(frames)));
+    const res = await cap.fetch("http://test.local/mcp", { method: "POST" });
+
+    const sse = cap.exchanges[0].response.sse;
+    expect(sse).toBeDefined();
+    expect(sse).toHaveLength(2);
+    expect(getWireField(sse![0].json, "method")).toBe("notifications/progress");
+    expect(getWireField(sse![1].json, "result.resultType")).toBe("complete");
+    // The passthrough stream is still fully readable by the real consumer.
+    expect(await res.text()).toBe(frames);
+  });
+
+  it("captures a 400 JSON-RPC protocol error with its numeric code", async () => {
+    const errBody = {
+      jsonrpc: "2.0",
+      id: 1,
+      error: { code: -32020, message: "Mcp-Method header does not match body" },
+    };
+    const cap = createCapturingFetch(
+      respondWith(() => jsonResponse(errBody, { status: 400 })),
+    );
+    await cap.fetch("http://test.local/mcp", { method: "POST" });
+    const { response } = cap.exchanges[0];
+    expect(response.status).toBe(400);
+    expect(getWireField(response.json, "error.code")).toBe(-32020);
+  });
+});
+
+describe("createCapturingFetch — request capture", () => {
+  it("records method, url, standard headers, and the _meta envelope in the body", async () => {
+    const cap = createCapturingFetch(
+      respondWith(() => jsonResponse({ jsonrpc: "2.0", id: 1, result: {} })),
+    );
+    const body = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: {
+        name: "echo",
+        _meta: { "io.modelcontextprotocol/protocolVersion": "2026-07-28" },
+      },
+    });
+    await cap.fetch("http://test.local/mcp", {
+      method: "post",
+      headers: {
+        "Mcp-Method": "tools/call",
+        "Mcp-Name": "echo",
+        "MCP-Protocol-Version": "2026-07-28",
+      },
+      body,
+    });
+
+    const { request } = cap.exchanges[0];
+    expect(request.method).toBe("POST");
+    expect(request.url).toBe("http://test.local/mcp");
+    // Header names are lowercased by the Headers contract.
+    expect(request.headers["mcp-method"]).toBe("tools/call");
+    expect(request.headers["mcp-name"]).toBe("echo");
+    expect(request.headers["mcp-protocol-version"]).toBe("2026-07-28");
+    expect(request.bodyText).toBe(body);
+    expect(
+      getWireField(request.json, [
+        "params",
+        "_meta",
+        "io.modelcontextprotocol/protocolVersion",
+      ]),
+    ).toBe("2026-07-28");
+  });
+
+  it("captures a body carried on a Request object (no init.body)", async () => {
+    const cap = createCapturingFetch(
+      respondWith(() => jsonResponse({ ok: true })),
+    );
+    const req = new Request("http://test.local/mcp", {
+      method: "POST",
+      body: JSON.stringify({ hello: "world" }),
+    });
+    await cap.fetch(req);
+    expect(cap.exchanges[0].request.method).toBe("POST");
+    expect(getWireField(cap.exchanges[0].request.json, "hello")).toBe("world");
+  });
+});
+
+describe("parseSseEvents", () => {
+  it("joins multiple data lines and strips one leading space", () => {
+    const [evt] = parseSseEvents("event: note\ndata: line one\ndata: line two\n\n");
+    expect(evt.event).toBe("note");
+    expect(evt.data).toBe("line one\nline two");
+  });
+
+  it("ignores comment lines and blank frames", () => {
+    const events = parseSseEvents(": keep-alive\n\ndata: 1\n\n\n\ndata: 2\n\n");
+    expect(events.map((e) => e.data)).toEqual(["1", "2"]);
+  });
+
+  it("carries id and parses JSON data", () => {
+    const [evt] = parseSseEvents('id: 42\ndata: {"a":1}\n\n');
+    expect(evt.id).toBe("42");
+    expect(evt.json).toEqual({ a: 1 });
+  });
+});
+
+describe("getWireField / hasWireField", () => {
+  const obj = { a: { b: { c: 1 } }, empty: null };
+  it("reads nested present paths", () => {
+    expect(getWireField(obj, "a.b.c")).toBe(1);
+  });
+  it("returns undefined for absent paths without throwing", () => {
+    expect(getWireField(obj, "a.x.y")).toBeUndefined();
+    expect(hasWireField(obj, "a.b.c")).toBe(true);
+    expect(hasWireField(obj, "a.b.z")).toBe(false);
+  });
+  it("treats a null intermediate as absent", () => {
+    expect(hasWireField(obj, "empty.whatever")).toBe(false);
+  });
+  it("addresses keys that contain dots via the array form", () => {
+    const meta = { _meta: { "io.modelcontextprotocol/serverInfo": { name: "x" } } };
+    // Dot-path cannot reach it (the key itself has dots)...
+    expect(getWireField(meta, "_meta.io.modelcontextprotocol/serverInfo")).toBeUndefined();
+    // ...but the array form can.
+    expect(
+      getWireField(meta, ["_meta", "io.modelcontextprotocol/serverInfo", "name"]),
+    ).toBe("x");
+  });
+});
+
+describe("redactHeadersForLog", () => {
+  it("redacts secret-bearing headers and leaves the raw capture intact", () => {
+    const raw = {
+      authorization: "Bearer secret.token.value",
+      "mcp-method": "tools/call",
+      cookie: "session=abc",
+    };
+    const logged = redactHeadersForLog(raw);
+    expect(logged["authorization"]).toBe("<redacted>");
+    expect(logged["cookie"]).toBe("<redacted>");
+    expect(logged["mcp-method"]).toBe("tools/call");
+    // Original is unchanged — assertions still see the real token.
+    expect(raw["authorization"]).toBe("Bearer secret.token.value");
+  });
+});

--- a/sdk/tests/support/raw-capture.ts
+++ b/sdk/tests/support/raw-capture.ts
@@ -1,0 +1,266 @@
+/**
+ * Raw wire capture for MCP integration and conformance assertions.
+ *
+ * The migration plan (mcp-2026-final-phasing.md §18.4) requires wire-compliance
+ * assertions to inspect frames BEFORE any SDK normalization: the v2 client
+ * consumes and hides wire-only members (`resultType`, the `_meta` envelope,
+ * `ttlMs`/`cacheScope` cache hints), so "the object the client returned" is not
+ * evidence that the server put a field on the wire. This helper wraps a `fetch`
+ * and records each exchange verbatim — request line, headers, raw body text,
+ * parsed-but-unnormalized JSON, and SSE event frames — while teeing the response
+ * so the real consumer is unaffected.
+ *
+ * Scope: bounded request/response exchanges and bounded SSE streams (the shape
+ * conformance drives). It buffers the full response body to capture it, so it is
+ * NOT suitable for wrapping a long-lived `subscriptions/listen` stream — capture
+ * those at a different seam.
+ *
+ * Lives in test support today. Phase 7 promotes the raw-request facility into
+ * `sdk/src/mcp-conformance` when the conformance runner needs hostile framing.
+ */
+
+/** Fetch-compatible callable. The wrapped fetch is assignable to `typeof fetch`. */
+export type FetchLike = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<Response>;
+
+export interface RawSseEvent {
+  /** `event:` field, if present. */
+  event?: string;
+  /** Concatenated `data:` lines (newline-joined), verbatim. */
+  data: string;
+  /** `id:` field, if present. */
+  id?: string;
+  /** Parsed `data` payload when it is a single JSON document, else undefined. */
+  json?: unknown;
+}
+
+export interface RawRequest {
+  method: string;
+  url: string;
+  /** Header names lowercased (per the Fetch `Headers` iteration contract). */
+  headers: Record<string, string>;
+  bodyText: string;
+  /** Parsed request body when JSON, else undefined. */
+  json?: unknown;
+}
+
+export interface RawResponse {
+  status: number;
+  statusText: string;
+  headers: Record<string, string>;
+  /** Full response body as text ("" for a body-less response). */
+  bodyText: string;
+  /** Parsed body when the payload is a single JSON document, else undefined. */
+  json?: unknown;
+  /** Parsed SSE frames when `content-type` is `text/event-stream`. */
+  sse?: RawSseEvent[];
+}
+
+export interface RawExchange {
+  request: RawRequest;
+  response: RawResponse;
+}
+
+export interface CapturingFetch {
+  /** Drop-in `fetch` that records every exchange into `exchanges`. */
+  fetch: FetchLike;
+  /** Exchanges in call order. */
+  exchanges: RawExchange[];
+}
+
+function headersToObject(headers: Headers): Record<string, string> {
+  const out: Record<string, string> = {};
+  headers.forEach((value, key) => {
+    out[key] = value;
+  });
+  return out;
+}
+
+function tryJson(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Parse a Server-Sent Events body into its frames without normalizing. Frames
+ * are separated by a blank line; within a frame, `event:`/`data:`/`id:` fields
+ * accumulate and lines beginning with `:` are comments (ignored). Multiple
+ * `data:` lines join with a newline, per the SSE spec.
+ */
+export function parseSseEvents(body: string): RawSseEvent[] {
+  const events: RawSseEvent[] = [];
+  // Frames are delimited by a blank line. Normalize CRLF first.
+  const frames = body.replace(/\r\n/g, "\n").split(/\n\n+/);
+  for (const frame of frames) {
+    if (!frame.trim()) continue;
+    let event: string | undefined;
+    let id: string | undefined;
+    const dataLines: string[] = [];
+    let sawField = false;
+    for (const line of frame.split("\n")) {
+      if (line.startsWith(":")) continue; // comment
+      const colon = line.indexOf(":");
+      const field = colon === -1 ? line : line.slice(0, colon);
+      // A single leading space after the colon is stripped, per spec.
+      let value = colon === -1 ? "" : line.slice(colon + 1);
+      if (value.startsWith(" ")) value = value.slice(1);
+      switch (field) {
+        case "event":
+          event = value;
+          sawField = true;
+          break;
+        case "data":
+          dataLines.push(value);
+          sawField = true;
+          break;
+        case "id":
+          id = value;
+          sawField = true;
+          break;
+        default:
+          break;
+      }
+    }
+    if (!sawField) continue;
+    const data = dataLines.join("\n");
+    const parsed = data ? tryJson(data) : undefined;
+    events.push({ event, id, data, json: parsed });
+  }
+  return events;
+}
+
+async function captureRequest(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Promise<RawRequest> {
+  const isRequest = typeof Request !== "undefined" && input instanceof Request;
+  const url =
+    typeof input === "string"
+      ? input
+      : input instanceof URL
+        ? input.href
+        : (input as Request).url;
+  const method = (
+    init?.method ?? (isRequest ? (input as Request).method : "GET")
+  ).toUpperCase();
+
+  const headers = new Headers(isRequest ? (input as Request).headers : undefined);
+  if (init?.headers) {
+    new Headers(init.headers).forEach((value, key) => headers.set(key, value));
+  }
+
+  let bodyText = "";
+  if (typeof init?.body === "string") {
+    bodyText = init.body;
+  } else if (init?.body == null && isRequest) {
+    try {
+      bodyText = await (input as Request).clone().text();
+    } catch {
+      bodyText = "";
+    }
+  }
+
+  const request: RawRequest = {
+    method,
+    url,
+    headers: headersToObject(headers),
+    bodyText,
+  };
+  const parsed = bodyText ? tryJson(bodyText) : undefined;
+  if (parsed !== undefined) request.json = parsed;
+  return request;
+}
+
+async function captureResponse(response: Response): Promise<RawResponse> {
+  // Read a clone so the original body stays intact for the real consumer.
+  const clone = response.clone();
+  const contentType = response.headers.get("content-type") ?? "";
+  const bodyText = await clone.text();
+  const raw: RawResponse = {
+    status: response.status,
+    statusText: response.statusText,
+    headers: headersToObject(response.headers),
+    bodyText,
+  };
+  if (contentType.includes("text/event-stream")) {
+    raw.sse = parseSseEvents(bodyText);
+  } else if (bodyText) {
+    const parsed = tryJson(bodyText);
+    if (parsed !== undefined) raw.json = parsed;
+  }
+  return raw;
+}
+
+/**
+ * Wrap a fetch so every exchange is recorded verbatim into `exchanges`. The
+ * returned `fetch` is a drop-in replacement (pass it to an SDK transport's
+ * `fetch` option); the real caller receives an untouched response.
+ */
+export function createCapturingFetch(
+  underlying: FetchLike = fetch,
+): CapturingFetch {
+  const exchanges: RawExchange[] = [];
+  const wrapped: FetchLike = async (input, init) => {
+    const request = await captureRequest(input, init);
+    const response = await underlying(input, init);
+    const captured = await captureResponse(response);
+    exchanges.push({ request, response: captured });
+    return response;
+  };
+  return { fetch: wrapped, exchanges };
+}
+
+/**
+ * Read a nested field off an unnormalized JSON value. Returns undefined if any
+ * segment is absent.
+ *
+ * `path` is a dot-path string for the common case, OR an explicit key array —
+ * use the array form for MCP `_meta` keys, whose names themselves contain dots
+ * (e.g. `["result", "_meta", "io.modelcontextprotocol/serverInfo"]`), which a
+ * dot-split cannot address.
+ */
+export function getWireField(
+  value: unknown,
+  path: string | readonly string[],
+): unknown {
+  const keys = typeof path === "string" ? path.split(".") : path;
+  return keys.reduce<unknown>((acc, key) => {
+    if (acc == null || typeof acc !== "object") return undefined;
+    return (acc as Record<string, unknown>)[key];
+  }, value);
+}
+
+/** Whether a field is present (and not undefined). See {@link getWireField} for `path`. */
+export function hasWireField(
+  value: unknown,
+  path: string | readonly string[],
+): boolean {
+  return getWireField(value, path) !== undefined;
+}
+
+const REDACTED = "<redacted>";
+const SENSITIVE_HEADER_PREFIXES = ["authorization", "cookie", "set-cookie"];
+
+/**
+ * A copy of captured headers safe to log: secret-bearing headers are redacted.
+ * The raw {@link RawExchange} is never mutated — capture keeps the true values
+ * for assertions; only this log view is scrubbed.
+ */
+export function redactHeadersForLog(
+  headers: Record<string, string>,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    out[key] = SENSITIVE_HEADER_PREFIXES.some((p) =>
+      key.toLowerCase().startsWith(p),
+    )
+      ? REDACTED
+      : value;
+  }
+  return out;
+}


### PR DESCRIPTION
## What & why

**Phase 0A (partial)** of the MCP `2026-07-28` migration. Adds the raw-frame capture primitive the plan requires (`mcp-2026-final-phasing.md` §18.4): wire assertions must inspect frames **before** SDK normalization.

The v2 client consumes and hides wire-only members — `resultType`, the `_meta` envelope, `ttlMs`/`cacheScope` — so the object the client hands application code is **not** evidence that the server put a field on the wire. Both the beta.4 dual-era fixture (next) and the Phase 7 conformance raw harness build on this.

## What's here — `sdk/tests/support/raw-capture.ts`

- **`createCapturingFetch(underlying?)`** — a drop-in `fetch` (pass it to an SDK transport's `fetch` option) that records every exchange verbatim: method, url, headers, raw body text, parsed-but-unnormalized JSON, and SSE event frames — while **teeing** the response (`Response.clone()`) so the real consumer reads an untouched body.
- **`parseSseEvents()`** — raw SSE frames (multi-`data:` joining, comment lines, `id`/`event`).
- **`getWireField()` / `hasWireField()`** — accept a dot-path string **or** an explicit key array. The array form is required for MCP `_meta` keys, whose names contain dots (`io.modelcontextprotocol/*`) and defeat a dot-split — this surfaced as a real test failure and is now covered directly.
- **`redactHeadersForLog()`** — a log-safe header view; the raw capture keeps the true `Authorization`/`Cookie` values for assertions.

## Scope

- Test support today; **no dependency changes**, no runtime surface. Phase 7 promotes the raw-request facility into `sdk/src/mcp-conformance`.
- Buffers the full response to capture it → suitable for bounded request/response and bounded SSE, **not** a long-lived `subscriptions/listen` stream (capture that at a different seam; noted in the file).

## Verification

- `sdk/tests/support/raw-capture.test.ts` — **14/14** (JSON wire-field capture, tee/no-consume, SSE framing, 400 JSON-RPC error, request+header+`_meta` capture, dotted-key addressing, redaction)
- `@mcpjam/sdk` `tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New test-support code only; no production paths or dependency changes.
> 
> **Overview**
> Adds **test-only** wire capture utilities under `sdk/tests/support/` so integration and conformance tests can assert on HTTP frames **before** the v2 SDK strips wire-only MCP fields (`resultType`, `_meta`, cache hints).
> 
> **`createCapturingFetch`** wraps an underlying `fetch`, records each request/response (headers, raw body, parsed JSON, SSE frames), and tees the response via `clone()` so callers can still read the body. Helpers include **`parseSseEvents`**, **`getWireField` / `hasWireField`** (dot paths plus array paths for dotted `_meta` keys), and **`redactHeadersForLog`** for safe logging without mutating captured secrets.
> 
> **`raw-capture.test.ts`** covers JSON/SSE/error capture, request/`Request` body capture, SSE parsing edge cases, dotted-key lookup, and header redaction. No runtime SDK surface or dependency changes; intended promotion to `mcp-conformance` in a later phase.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7629270cf99791fe0b4fb0d5cf8d996bdaeb4002. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds raw wire-capture helpers for MCP 2026 Phase 0A so tests can assert fields before SDK normalization across JSON and SSE responses. Test-only utilities; no runtime or dependency changes.

- **New Features**
  - `createCapturingFetch(underlying?)`: drop-in `fetch` that records method, URL, headers, raw body, unnormalized JSON, and SSE frames, while teeing the response via `Response.clone()`.
  - `parseSseEvents()`: parses raw SSE frames (multi-line `data:`, comments, `id`/`event`) and joins `data:` lines; parses JSON when possible.
  - `getWireField()` / `hasWireField()`: accept dot-path or key array; array form addresses MCP `_meta` keys with dots (e.g. `io.modelcontextprotocol/*`).
  - `redactHeadersForLog()`: log-safe header copy with `authorization`/`cookie` redacted; raw capture keeps true values for assertions.
  - Note: buffers full bodies; intended for bounded request/response and SSE, not long-lived `subscriptions/listen` streams.

<sup>Written for commit 7629270cf99791fe0b4fb0d5cf8d996bdaeb4002. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

