### PR TITLE
feat(sdk): resolveVersionNegotiation — pin → versionNegotiation (Phase 1B, step 1)

### DIFF
--- a/sdk/src/mcp-client-manager/version-negotiation.ts
+++ b/sdk/src/mcp-client-manager/version-negotiation.ts
@@ -1,0 +1,49 @@
+/**
+ * Translate a resolved per-server `mcpProtocolVersion` pin into the official
+ * SDK client's `ClientOptions.versionNegotiation`.
+ *
+ * This is the config → SDK-policy mapping the official-client cutover (Phase
+ * 1B of the MCP 2026-07-28 migration) routes on: once modern connections go
+ * through the upstream `Client` instead of the hand-rolled preview, a
+ * `2026-07-28` pin becomes a `versionNegotiation` pin rather than a branch to a
+ * second client implementation.
+ *
+ * The manager resolves the pin (host default + per-server override +
+ * `isKnownProtocolVersion` validation) before this runs; this module only maps
+ * a validated value to negotiation policy. It is intentionally separate from
+ * `mcp-protocol-version.ts` (which is hand-mirrored into the backend and must
+ * stay free of any `@modelcontextprotocol/client` dependency).
+ */
+
+import type { VersionNegotiationOptions } from "@modelcontextprotocol/client";
+import {
+  isStatelessProtocolVersion,
+  type McpProtocolVersion,
+} from "./mcp-protocol-version.js";
+
+/**
+ * Map a resolved pin to `ClientOptions.versionNegotiation`.
+ *
+ * - **Modern-era pin** (`2026-07-28`, per `isStatelessProtocolVersion`) →
+ *   `{ mode: { pin } }`: negotiate exactly that revision. The connect-time
+ *   `server/discover` must offer it; there is no legacy fallback.
+ * - **Stateful pin** (`2025-*`) **or no pin** → `undefined`: leave negotiation
+ *   at the SDK default (the plain 2025 `initialize` connect). The specific 2025
+ *   revision still travels via `ClientOptions.supportedProtocolVersions`,
+ *   unchanged — this function does not touch that accept-list.
+ *
+ * `'auto'` negotiation is deliberately NOT produced here: making `auto` the
+ * unconfigured default is the sequenced Phase-5 activation, decided by the
+ * caller, not a property of a validated pin.
+ */
+export function resolveVersionNegotiation(
+  mcpProtocolVersion: McpProtocolVersion | undefined,
+): VersionNegotiationOptions | undefined {
+  if (
+    mcpProtocolVersion !== undefined &&
+    isStatelessProtocolVersion(mcpProtocolVersion)
+  ) {
+    return { mode: { pin: mcpProtocolVersion } };
+  }
+  return undefined;
+}

--- a/sdk/tests/version-negotiation.test.ts
+++ b/sdk/tests/version-negotiation.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { resolveVersionNegotiation } from "../src/mcp-client-manager/version-negotiation.js";
+import { MCP_PROTOCOL_VERSIONS } from "../src/mcp-client-manager/mcp-protocol-version.js";
+
+describe("resolveVersionNegotiation", () => {
+  it("pins the modern era for a 2026-07-28 pin", () => {
+    expect(resolveVersionNegotiation("2026-07-28")).toEqual({
+      mode: { pin: "2026-07-28" },
+    });
+  });
+
+  it("leaves negotiation at the SDK default (undefined) for every stateful pin", () => {
+    expect(resolveVersionNegotiation("2025-11-25")).toBeUndefined();
+    expect(resolveVersionNegotiation("2025-06-18")).toBeUndefined();
+    expect(resolveVersionNegotiation("2025-03-26")).toBeUndefined();
+  });
+
+  it("leaves negotiation at the SDK default when no pin is set", () => {
+    expect(resolveVersionNegotiation(undefined)).toBeUndefined();
+  });
+
+  it("returns a pin only for versions classified stateless/modern", () => {
+    // Guards the mapping against a future protocol-version addition: any known
+    // version either produces a modern pin or stays at the legacy default,
+    // never a malformed shape.
+    for (const v of MCP_PROTOCOL_VERSIONS) {
+      const out = resolveVersionNegotiation(v);
+      if (out !== undefined) {
+        expect(out).toEqual({ mode: { pin: v } });
+      }
+    }
+  });
+});


### PR DESCRIPTION
## What & why

First step of the **official-client cutover (Phase 1B)**: the `config → SDK-policy` translation that lets a resolved `mcpProtocolVersion` pin drive the upstream `Client`'s negotiation, instead of branching modern connections to the hand-rolled stateless preview.

## What's here

`sdk/src/mcp-client-manager/version-negotiation.ts` — `resolveVersionNegotiation(pin)`:
- **`2026-07-28` pin** → `{ mode: { pin } }` — negotiate exactly that revision; `server/discover` must offer it, no legacy fallback.
- **stateful pin (`2025-*`) / no pin** → `undefined` — leave negotiation at the SDK legacy default. The specific 2025 revision still travels via `supportedProtocolVersions`, untouched.
- **`'auto'` is deliberately not produced here** — making it the unconfigured default is the sequenced Phase-5 activation (the day-one-posture decision), not a property of a validated pin.

Kept out of `mcp-protocol-version.ts` on purpose: that module is hand-mirrored into the backend and must stay free of any `@modelcontextprotocol/client` dependency.

## What comes next (mapped, not in this PR)

The routing surgery that consumes this — `performConnection` building the official `Client` for modern (dropping the stateless stub) and `connectViaHttp` letting modern fall through to `StreamableHTTPClientTransport` — is mapped precisely in the phasing doc §9.2, along with the two consequences to validate (modern auth via the transport's `authProvider`; modern advertising the full `buildCapabilities` set). It'll be verified end-to-end against the dual-era fixture (#3307). Splitting the safe translation layer from the load-bearing connection surgery keeps each reviewable.

Verify: **4/4 tests**; sdk `tsc --noEmit` clean; no v1 SDK import. Follows #3294/#3297/#3302 (merged) and #3307 (open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Isolated mapping helper with unit tests only; no changes to live connection or auth paths until a follow-up PR wires it in.
> 
> **Overview**
> Adds the **Phase 1B** config → SDK policy layer: `resolveVersionNegotiation` maps a validated `mcpProtocolVersion` pin to upstream `ClientOptions.versionNegotiation`.
> 
> A **modern / stateless** pin (`2026-07-28`, via `isStatelessProtocolVersion`) becomes `{ mode: { pin } }` so negotiation targets that revision only. **2025-* pins** and **no pin** return `undefined`, leaving SDK default negotiation; `supportedProtocolVersions` behavior is unchanged. **`auto`** is intentionally not emitted here (reserved for a later phase).
> 
> The logic lives in `version-negotiation.ts`, separate from hand-mirrored `mcp-protocol-version.ts`, so the backend mirror stays free of `@modelcontextprotocol/client`. **Four unit tests** cover modern pin, stateful pins, undefined, and all entries in `MCP_PROTOCOL_VERSIONS`. Connection routing that consumes this is **not** in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 351e387a1d57f5b2972db31a486c45a8a5584303. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Start the official-client cutover by mapping a resolved `mcpProtocolVersion` pin to `ClientOptions.versionNegotiation`. Modern pins (`2026-07-28`) now negotiate directly; legacy pins and no pin keep the SDK default.

- **New Features**
  - Added `resolveVersionNegotiation(pin)` to translate pins into `versionNegotiation` for the upstream client.
  - Returns `{ mode: { pin } }` only for stateless/modern pins; returns `undefined` for `2025-*` pins or no pin.
  - Does not produce `'auto'`; that remains a later activation choice.
  - Kept separate from `mcp-protocol-version.ts` to avoid a dependency on `@modelcontextprotocol/client`.

<sup>Written for commit 351e387a1d57f5b2972db31a486c45a8a5584303. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

