### PR TITLE
fix(sidebar): show sign-in button in local/npx mode

### DIFF
--- a/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-user.test.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-user.test.tsx
@@ -34,8 +34,11 @@ vi.mock("@/components/notifications/NotificationsPanel", () => ({
   NotificationsPanelContent: () => <div data-testid="notifications-panel" />,
 }));
 
+// Represent local/npx mode (VITE_MCPJAM_HOSTED_MODE unset). The sidebar
+// sign-in affordance is intentionally mode-agnostic — a guest must see it in
+// both hosted and local, since the header sign-in is hidden on the Home route.
 vi.mock("@/lib/config", () => ({
-  HOSTED_MODE: true,
+  HOSTED_MODE: false,
 }));
 
 vi.mock("@/hooks/useProfilePicture", () => ({
@@ -111,7 +114,7 @@ describe("SidebarUser", () => {
     window.isElectron = false;
   });
 
-  it("renders sign-in button when unauthenticated in hosted mode", () => {
+  it("renders sign-in button when unauthenticated", () => {
     render(<SidebarUser />);
     expect(screen.getByText("Sign in")).toBeDefined();
     const signInButton = screen.getByRole("button", { name: "Sign in" });

--- a/mcpjam-inspector/client/src/components/sidebar/sidebar-user.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/sidebar-user.tsx
@@ -36,7 +36,6 @@ import { Popover, PopoverAnchor } from "@mcpjam/design-system/popover";
 import { NotificationsPanelContent } from "@/components/notifications/NotificationsPanel";
 import { useNotifications } from "@/hooks/useNotifications";
 import { useProfilePicture } from "@/hooks/useProfilePicture";
-import { HOSTED_MODE } from "@/lib/config";
 import { useAppNavigate } from "@/lib/app-navigation";
 
 interface SidebarUserProps {
@@ -121,34 +120,36 @@ export function SidebarUser({ onBeforeSignOut }: SidebarUserProps = {}) {
   // While WorkOS/Convex are still resolving the session, `user` is null even for
   // signed-in users. Show the neutral loading state before the `!user` guest
   // branch so authenticated users don't flash the "Sign in" footer on load.
-  const authResolving =
-    HOSTED_MODE && !user && (isWorkOsAuthLoading || isLoading);
+  // Applies in both modes: local/npx users can also sign in with WorkOS, so a
+  // signed-in local user would otherwise flash "Sign in" while auth resolves.
+  const authResolving = !user && (isWorkOsAuthLoading || isLoading);
 
   if (authResolving) {
     return loadingState;
   }
 
+  // No WorkOS user → offer sign-in. In local/npx mode the actor is an anonymous
+  // guest (the raw WorkOS `user` stays null), and the header's sign-in button is
+  // hidden on the Home route, so the sidebar footer is the only sign-in
+  // affordance there. Surface it in both modes for parity with hosted.
   if (!user) {
-    if (HOSTED_MODE) {
-      return (
-        <SidebarMenu>
-          <SidebarMenuItem>
-            <SidebarMenuButton
-              size="lg"
-              onClick={() => signIn()}
-              aria-label="Sign in"
-              className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
-            >
-              <LogIn className="size-4" />
-              <span className="truncate group-data-[collapsible=icon]:hidden">
-                Sign in
-              </span>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
-        </SidebarMenu>
-      );
-    }
-    return null;
+    return (
+      <SidebarMenu>
+        <SidebarMenuItem>
+          <SidebarMenuButton
+            size="lg"
+            onClick={() => signIn()}
+            aria-label="Sign in"
+            className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+          >
+            <LogIn className="size-4" />
+            <span className="truncate group-data-[collapsible=icon]:hidden">
+              Sign in
+            </span>
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+      </SidebarMenu>
+    );
   }
 
   if (isLoading) {


### PR DESCRIPTION
## Problem

On the **npx / local** build, the Home page had no "Sign in" affordance, while the **hosted** build did.

The "Sign in" button on the Home page comes from the **sidebar footer** (`SidebarUser`), not the header — the header's own sign-in button is hidden on the Home route in both modes (`App.tsx`: `hidden={... || activeTab === "home"}`), while the sidebar stays visible there.

`SidebarUser` gated its button behind `HOSTED_MODE`:

```ts
if (!user) {
  if (HOSTED_MODE) { return <Sign in button> }
  return null;   // ← npx/local: nothing
}
```

In npx mode `HOSTED_MODE` is `false`, so a signed-out guest on the Home page had no way to sign in — even though local mode fully supports WorkOS sign-in (the header already offers it on non-Home tabs).

## Fix

- Render the sidebar "Sign in" button in **both** modes (parity with hosted).
- Extend the auth-resolving flash guard to local mode too — local users can also sign in with WorkOS, so a signed-in local user would otherwise briefly flash "Sign in" while auth settles.
- Drop the now-unused `HOSTED_MODE` import.

## Testing

- `sidebar-user.test.tsx` updated to run in local-mode config (`HOSTED_MODE: false`), proving the button renders in the npx scenario. **7/7 pass.**
- Client typecheck clean (0 errors).
- Verified live in a local `npm run dev` build: the sidebar "Sign in" button now appears at the bottom of the sidebar on the Home page.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the "Sign in" button in the sidebar on Home for local/npx builds, matching hosted. Also prevent the brief "Sign in" flash by applying the auth-resolving state in both modes.

- **Bug Fixes**
  - Render the sidebar "Sign in" when `user` is null in both hosted and local; remove the `HOSTED_MODE` gate and unused import.
  - Apply the auth-resolving guard in both modes to avoid a flash of "Sign in" for signed-in users.
  - Update `sidebar-user.test.tsx` to run with `HOSTED_MODE: false` and verify the button renders.

<sup>Written for commit af5f25245670b5112c9998eb9b9ae5d0f175b42b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

