### PR TITLE
wrong hosted issuer for xaa

### DIFF
--- a/mcpjam-inspector/server/routes/mcp/xaa.ts
+++ b/mcpjam-inspector/server/routes/mcp/xaa.ts
@@ -94,6 +94,16 @@ function checkNegativeTestHostCap(host: string): boolean {
 // is rejected rather than normalized.
 const ORG_ID_RE = /^[A-Za-z0-9_-]{1,64}$/;
 
+type XaaResult<T> = { ok: true; value: T } | { ok: false; response: Response };
+
+function xaaSuccess<T>(value: T): XaaResult<T> {
+  return { ok: true, value };
+}
+
+function xaaFailure(response: Response): XaaResult<never> {
+  return { ok: false, response };
+}
+
 // Single source of truth for what a legal org path segment looks like, shared
 // by the well-known routes, the gated mint routes, and the hosted-issuer
 // forward so they can never validate org ids differently.
@@ -101,16 +111,18 @@ function isValidOrgId(value: unknown): value is string {
   return typeof value === "string" && ORG_ID_RE.test(value);
 }
 
-// Validates the `:orgId` route param; returns the id or the 400 Response.
-function validateOrgSegment(c: Context): string | Response {
+// Validates the `:orgId` route param without relying on Response class identity.
+function validateOrgSegment(c: Context): XaaResult<string> {
   const orgId = c.req.param("orgId");
   if (!isValidOrgId(orgId)) {
-    return toJsonError("Invalid organization id in issuer path", {
-      status: 400,
-      code: "VALIDATION_ERROR",
-    });
+    return xaaFailure(
+      toJsonError("Invalid organization id in issuer path", {
+        status: 400,
+        code: "VALIDATION_ERROR",
+      })
+    );
   }
-  return orgId;
+  return xaaSuccess(orgId);
 }
 
 // ── Mock OIDC IdP (authorization_code + userinfo) ─────────────────────────
@@ -914,31 +926,37 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
     c: Context,
     body: Record<string, unknown>
   ): Promise<
-    | { mints: Map<NegativeTestMode, MintedNegativeCase>; issuer: string }
-    | Response
+    XaaResult<{
+      mints: Map<NegativeTestMode, MintedNegativeCase>;
+      issuer: string;
+    }>
   > => {
     const relayed = await forwardToHostedIssuer(c, "/negative-tests", body, {
       mintOnly: true,
     });
-    if (!relayed.ok) return relayed;
+    if (!relayed.ok) return xaaFailure(relayed);
 
     let payload: unknown;
     try {
       payload = await relayed.json();
     } catch {
-      return toJsonError(
-        "The hosted issuer returned a malformed mint response",
-        { status: 502, code: "SERVER_UNREACHABLE" }
+      return xaaFailure(
+        toJsonError("The hosted issuer returned a malformed mint response", {
+          status: 502,
+          code: "SERVER_UNREACHABLE",
+        })
       );
     }
 
     const rawMints = (payload as { mints?: unknown })?.mints;
     const issuer = (payload as { issuer?: unknown })?.issuer;
     if (!Array.isArray(rawMints) || typeof issuer !== "string") {
-      return toJsonError("The hosted issuer returned no minted assertions", {
-        status: 502,
-        code: "SERVER_UNREACHABLE",
-      });
+      return xaaFailure(
+        toJsonError("The hosted issuer returned no minted assertions", {
+          status: 502,
+          code: "SERVER_UNREACHABLE",
+        })
+      );
     }
 
     const mints = new Map<NegativeTestMode, MintedNegativeCase>();
@@ -974,14 +992,16 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
     // clearer than letting a short map surface as scattered per-case errors.
     const missing = NEGATIVE_CASE_MODES.filter((mode) => !mints.has(mode));
     if (missing.length > 0) {
-      return toJsonError(
-        `The hosted issuer did not mint every scorecard case (missing: ${missing.join(
-          ", "
-        )})`,
-        { status: 502, code: "SERVER_UNREACHABLE" }
+      return xaaFailure(
+        toJsonError(
+          `The hosted issuer did not mint every scorecard case (missing: ${missing.join(
+            ", "
+          )})`,
+          { status: 502, code: "SERVER_UNREACHABLE" }
+        )
       );
     }
-    return { mints, issuer };
+    return xaaSuccess({ mints, issuer });
   };
 
   // Hosted-issuer forward for the standards-track /token endpoint. The RFC
@@ -1064,17 +1084,19 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
   const requireScopedIssuer = async (
     c: Context,
     issuerKind: "org" | "anonymous"
-  ): Promise<string | Response> => {
-    const orgIdOrError = validateOrgSegment(c);
-    if (orgIdOrError instanceof Response) return orgIdOrError;
-    const orgId = orgIdOrError;
+  ): Promise<XaaResult<string>> => {
+    const orgIdResult = validateOrgSegment(c);
+    if (!orgIdResult.ok) return orgIdResult;
+    const orgId = orgIdResult.value;
     const authHeader = c.req.header("authorization");
     if (!authHeader?.startsWith("Bearer ")) {
-      return toJsonError(
-        issuerKind === "anonymous"
-          ? "Minting under the anonymous test issuer requires a session"
-          : "Minting under an organization issuer requires signing in",
-        { status: 401, code: "UNAUTHORIZED" }
+      return xaaFailure(
+        toJsonError(
+          issuerKind === "anonymous"
+            ? "Minting under the anonymous test issuer requires a session"
+            : "Minting under an organization issuer requires signing in",
+          { status: 401, code: "UNAUTHORIZED" }
+        )
       );
     }
     try {
@@ -1086,19 +1108,23 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
       });
     } catch (error) {
       if (error instanceof WebRouteError) {
-        return toJsonError(error.message, {
-          status: error.status,
-          code: error.code,
-          details: error.details,
-        });
+        return xaaFailure(
+          toJsonError(error.message, {
+            status: error.status,
+            code: error.code,
+            details: error.details,
+          })
+        );
       }
       logger.error("[XAA Org Issuer] authorization failed", error);
-      return toJsonError("Couldn't authorize the organization issuer", {
-        status: 500,
-        code: "INTERNAL_ERROR",
-      });
+      return xaaFailure(
+        toJsonError("Couldn't authorize the organization issuer", {
+          status: 500,
+          code: "INTERNAL_ERROR",
+        })
+      );
     }
-    return orgId;
+    return xaaSuccess(orgId);
   };
   const requireScopedOrg = (c: Context) => requireScopedIssuer(c, "org");
   const requireScopedAnonymousOrg = (c: Context) =>
@@ -1897,8 +1923,8 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
         b.tokenEndpointAuthMethod === "private_key_jwt";
       if (isConfidential) {
         const minted = await mintNegativeViaHosted(c, b);
-        if (minted instanceof Response) return minted;
-        return handleNegativeTests(c, minted.issuer, minted.mints);
+        if (!minted.ok) return minted.response;
+        return handleNegativeTests(c, minted.value.issuer, minted.value.mints);
       }
       return forwardToHostedIssuer(c, "/negative-tests", b);
     }
@@ -1918,36 +1944,36 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
       `${unscopedIssuer(c)}/o/${orgId}`;
 
     router.get("/o/:orgId/.well-known/jwks.json", (c) => {
-      const orgIdOrError = validateOrgSegment(c);
-      if (orgIdOrError instanceof Response) return orgIdOrError;
+      const orgIdResult = validateOrgSegment(c);
+      if (!orgIdResult.ok) return orgIdResult.response;
       return serveJwks(c);
     });
 
     router.get("/o/:orgId/.well-known/openid-configuration", (c) => {
-      const orgIdOrError = validateOrgSegment(c);
-      if (orgIdOrError instanceof Response) return orgIdOrError;
+      const orgIdResult = validateOrgSegment(c);
+      if (!orgIdResult.ok) return orgIdResult.response;
       // The scoped /token serves token exchange (bearer + membership gated).
-      return serveOpenidConfiguration(c, scopedIssuer(c, orgIdOrError), {
+      return serveOpenidConfiguration(c, scopedIssuer(c, orgIdResult.value), {
         tokenExchangeAtToken: true,
       });
     });
 
     router.post("/o/:orgId/authenticate", async (c) => {
-      const orgIdOrError = await requireScopedOrg(c);
-      if (orgIdOrError instanceof Response) return orgIdOrError;
-      return handleAuthenticate(c, scopedIssuer(c, orgIdOrError));
+      const orgIdResult = await requireScopedOrg(c);
+      if (!orgIdResult.ok) return orgIdResult.response;
+      return handleAuthenticate(c, scopedIssuer(c, orgIdResult.value));
     });
 
     router.post("/o/:orgId/token-exchange", async (c) => {
-      const orgIdOrError = await requireScopedOrg(c);
-      if (orgIdOrError instanceof Response) return orgIdOrError;
-      return handleTokenExchange(c, scopedIssuer(c, orgIdOrError));
+      const orgIdResult = await requireScopedOrg(c);
+      if (!orgIdResult.ok) return orgIdResult.response;
+      return handleTokenExchange(c, scopedIssuer(c, orgIdResult.value));
     });
 
     router.post("/o/:orgId/negative-tests", async (c) => {
-      const orgIdOrError = await requireScopedOrg(c);
-      if (orgIdOrError instanceof Response) return orgIdOrError;
-      return handleNegativeTests(c, scopedIssuer(c, orgIdOrError));
+      const orgIdResult = await requireScopedOrg(c);
+      if (!orgIdResult.ok) return orgIdResult.response;
+      return handleNegativeTests(c, scopedIssuer(c, orgIdResult.value));
     });
 
     // Anonymous test issuer surface: the same mock IdP under /g/:orgId, in a
@@ -1962,17 +1988,17 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
       `${unscopedIssuer(c)}/g/${orgId}`;
 
     router.get("/g/:orgId/.well-known/jwks.json", (c) => {
-      const orgIdOrError = validateOrgSegment(c);
-      if (orgIdOrError instanceof Response) return orgIdOrError;
+      const orgIdResult = validateOrgSegment(c);
+      if (!orgIdResult.ok) return orgIdResult.response;
       return serveJwks(c);
     });
 
     router.get("/g/:orgId/.well-known/openid-configuration", (c) => {
-      const orgIdOrError = validateOrgSegment(c);
-      if (orgIdOrError instanceof Response) return orgIdOrError;
+      const orgIdResult = validateOrgSegment(c);
+      if (!orgIdResult.ok) return orgIdResult.response;
       return serveOpenidConfiguration(
         c,
-        anonymousScopedIssuer(c, orgIdOrError),
+        anonymousScopedIssuer(c, orgIdResult.value),
         {
           tokenExchangeAtToken: true,
           anonymousTestIssuer: true,
@@ -1981,21 +2007,27 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
     });
 
     router.post("/g/:orgId/authenticate", async (c) => {
-      const orgIdOrError = await requireScopedAnonymousOrg(c);
-      if (orgIdOrError instanceof Response) return orgIdOrError;
-      return handleAuthenticate(c, anonymousScopedIssuer(c, orgIdOrError));
+      const orgIdResult = await requireScopedAnonymousOrg(c);
+      if (!orgIdResult.ok) return orgIdResult.response;
+      return handleAuthenticate(c, anonymousScopedIssuer(c, orgIdResult.value));
     });
 
     router.post("/g/:orgId/token-exchange", async (c) => {
-      const orgIdOrError = await requireScopedAnonymousOrg(c);
-      if (orgIdOrError instanceof Response) return orgIdOrError;
-      return handleTokenExchange(c, anonymousScopedIssuer(c, orgIdOrError));
+      const orgIdResult = await requireScopedAnonymousOrg(c);
+      if (!orgIdResult.ok) return orgIdResult.response;
+      return handleTokenExchange(
+        c,
+        anonymousScopedIssuer(c, orgIdResult.value)
+      );
     });
 
     router.post("/g/:orgId/negative-tests", async (c) => {
-      const orgIdOrError = await requireScopedAnonymousOrg(c);
-      if (orgIdOrError instanceof Response) return orgIdOrError;
-      return handleNegativeTests(c, anonymousScopedIssuer(c, orgIdOrError));
+      const orgIdResult = await requireScopedAnonymousOrg(c);
+      if (!orgIdResult.ok) return orgIdResult.response;
+      return handleNegativeTests(
+        c,
+        anonymousScopedIssuer(c, orgIdResult.value)
+      );
     });
   }
 
@@ -2304,82 +2336,82 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
     // as anyone — it's a test IdP), but the token-exchange grant requires the
     // caller to be a member of the org, mapped to OAuth-shaped errors.
     if (authorizeOrgIssuer) {
-      const scopedIssuerFromParam = (c: Context): string | Response => {
+      const scopedIssuerFromParam = (c: Context): XaaResult<string> => {
         const orgId = c.req.param("orgId");
         if (!orgId || !ORG_ID_RE.test(orgId)) {
-          return oauthError(400, "invalid_request", "Invalid organization id");
+          return xaaFailure(
+            oauthError(400, "invalid_request", "Invalid organization id")
+          );
         }
-        return `${unscopedIssuer(c)}/o/${orgId}`;
+        return xaaSuccess(`${unscopedIssuer(c)}/o/${orgId}`);
       };
 
       router.get("/o/:orgId/authorize", (c) => {
-        const issuerOrError = scopedIssuerFromParam(c);
-        if (issuerOrError instanceof Response) return issuerOrError;
-        return handleAuthorize(c, issuerOrError);
+        const issuerResult = scopedIssuerFromParam(c);
+        if (!issuerResult.ok) return issuerResult.response;
+        return handleAuthorize(c, issuerResult.value);
       });
       router.post("/o/:orgId/authorize/confirm", (c) => {
-        const issuerOrError = scopedIssuerFromParam(c);
-        if (issuerOrError instanceof Response) return issuerOrError;
-        return handleAuthorizeConfirm(c, issuerOrError);
+        const issuerResult = scopedIssuerFromParam(c);
+        if (!issuerResult.ok) return issuerResult.response;
+        return handleAuthorizeConfirm(c, issuerResult.value);
       });
       router.post("/o/:orgId/token", (c) => {
-        const issuerOrError = scopedIssuerFromParam(c);
-        if (issuerOrError instanceof Response) return issuerOrError;
-        return handleToken(
-          c,
-          issuerOrError,
-          async () => {
-            const orgIdOrError = await requireScopedOrg(c);
-            if (!(orgIdOrError instanceof Response)) return null;
-            // Map the gate's JSON error shape onto OAuth token-endpoint errors.
-            const status = orgIdOrError.status;
-            return oauthError(
-              status,
-              status === 401
-                ? "invalid_client"
-                : status === 403
-                ? "access_denied"
-                : "invalid_request",
-              "Token exchange under an organization issuer requires an org member's bearer token"
-            );
-          }
-        );
+        const issuerResult = scopedIssuerFromParam(c);
+        if (!issuerResult.ok) return issuerResult.response;
+        return handleToken(c, issuerResult.value, async () => {
+          const orgIdResult = await requireScopedOrg(c);
+          if (orgIdResult.ok) return null;
+          // Map the gate's JSON error shape onto OAuth token-endpoint errors.
+          const status = orgIdResult.response.status;
+          return oauthError(
+            status,
+            status === 401
+              ? "invalid_client"
+              : status === 403
+              ? "access_denied"
+              : "invalid_request",
+            "Token exchange under an organization issuer requires an org member's bearer token"
+          );
+        });
       });
       router.get("/o/:orgId/userinfo", (c) => {
-        const issuerOrError = scopedIssuerFromParam(c);
-        if (issuerOrError instanceof Response) return issuerOrError;
-        return handleUserinfo(c, issuerOrError);
+        const issuerResult = scopedIssuerFromParam(c);
+        if (!issuerResult.ok) return issuerResult.response;
+        return handleUserinfo(c, issuerResult.value);
       });
 
       // Anonymous test issuer (/g/): same public front-channel endpoints;
       // the token-exchange grant is gated to the caller's own personal org
       // (guest sessions included) via the anonymous authorize flavor.
-      const anonymousIssuerFromParam = (c: Context): string | Response => {
+      const anonymousIssuerFromParam = (c: Context): XaaResult<string> => {
         const orgId = c.req.param("orgId");
         if (!orgId || !ORG_ID_RE.test(orgId)) {
-          return oauthError(400, "invalid_request", "Invalid organization id");
+          return xaaFailure(
+            oauthError(400, "invalid_request", "Invalid organization id")
+          );
         }
-        return `${unscopedIssuer(c)}/g/${orgId}`;
+        return xaaSuccess(`${unscopedIssuer(c)}/g/${orgId}`);
       };
 
       router.get("/g/:orgId/authorize", (c) => {
-        const issuerOrError = anonymousIssuerFromParam(c);
-        if (issuerOrError instanceof Response) return issuerOrError;
-        return handleAuthorize(c, issuerOrError);
+        const issuerResult = anonymousIssuerFromParam(c);
+        if (!issuerResult.ok) return issuerResult.response;
+        return handleAuthorize(c, issuerResult.value);
       });
       router.post("/g/:orgId/authorize/confirm", (c) => {
-        const issuerOrError = anonymousIssuerFromParam(c);
-        if (issuerOrError instanceof Response) return issuerOrError;
-        return handleAuthorizeConfirm(c, issuerOrError);
+        const issuerResult = anonymousIssuerFromParam(c);
+        if (!issuerResult.ok) return issuerResult.response;
+        return handleAuthorizeConfirm(c, issuerResult.value);
       });
       router.post("/g/:orgId/token", (c) => {
-        const issuerOrError = anonymousIssuerFromParam(c);
-        if (issuerOrError instanceof Response) return issuerOrError;
-        return handleToken(c, issuerOrError, async () => {
-          const orgIdOrError = await requireScopedAnonymousOrg(c);
-          if (!(orgIdOrError instanceof Response)) return null;
+        const issuerResult = anonymousIssuerFromParam(c);
+        if (!issuerResult.ok) return issuerResult.response;
+        return handleToken(c, issuerResult.value, async () => {
+          const orgIdResult = await requireScopedAnonymousOrg(c);
+          if (orgIdResult.ok) return null;
           // Map the gate's JSON error shape onto OAuth token-endpoint errors.
-          const status = orgIdOrError.status;
+          const status = orgIdResult.response.status;
           return oauthError(
             status,
             status === 401
@@ -2392,9 +2424,9 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
         });
       });
       router.get("/g/:orgId/userinfo", (c) => {
-        const issuerOrError = anonymousIssuerFromParam(c);
-        if (issuerOrError instanceof Response) return issuerOrError;
-        return handleUserinfo(c, issuerOrError);
+        const issuerResult = anonymousIssuerFromParam(c);
+        if (!issuerResult.ok) return issuerResult.response;
+        return handleUserinfo(c, issuerResult.value);
       });
     }
   }

--- a/mcpjam-inspector/server/routes/web/__tests__/fixtures/xaa-node-adapter.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/fixtures/xaa-node-adapter.ts
@@ -1,0 +1,23 @@
+import { createAdaptorServer } from "@hono/node-server";
+import { Hono } from "hono";
+import xaaWeb from "../../xaa.js";
+
+const app = new Hono();
+app.route("/api/web/xaa", xaaWeb);
+
+// The Node adapter replaces the global Request and Response constructors.
+// Keep this setup in a child process so the mutation cannot leak into Vitest.
+createAdaptorServer({ fetch: app.fetch });
+
+const malformedOrgId = encodeURIComponent("[object Response]");
+const response = await app.request(
+  `https://app.mcpjam.com/api/web/xaa/o/${malformedOrgId}/.well-known/openid-configuration`
+);
+const body = await response.json();
+
+process.stdout.write(
+  JSON.stringify({
+    status: response.status,
+    body,
+  })
+);

--- a/mcpjam-inspector/server/routes/web/__tests__/xaa-node-adapter.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/xaa-node-adapter.test.ts
@@ -1,0 +1,38 @@
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+describe("web xaa routes under the Hono Node adapter", () => {
+  it("rejects a malformed org segment instead of stringifying a Response", () => {
+    const fixturePath = fileURLToPath(
+      new URL("./fixtures/xaa-node-adapter.ts", import.meta.url)
+    );
+    const projectRoot = fileURLToPath(new URL("../../../../", import.meta.url));
+    const result = spawnSync(
+      process.execPath,
+      ["--import", "tsx", fixturePath],
+      {
+        cwd: projectRoot,
+        encoding: "utf8",
+        env: { ...process.env, NODE_ENV: "test" },
+      }
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.status, result.stderr).toBe(0);
+
+    const output = JSON.parse(result.stdout) as {
+      status: number;
+      body: Record<string, unknown>;
+    };
+    expect(output).toEqual({
+      status: 400,
+      body: {
+        code: "VALIDATION_ERROR",
+        message: "Invalid organization id in issuer path",
+        error: "Invalid organization id in issuer path",
+      },
+    });
+    expect(JSON.stringify(output.body)).not.toContain("[object Response]");
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes wrong hosted issuer handling in XAA by validating `:orgId` with an explicit result type instead of `Response` checks. This prevents `[object Response]` leaking into paths under the `@hono/node-server` adapter and returns proper 400 JSON errors.

- **Bug Fixes**
  - Replaced `instanceof Response` checks with `XaaResult` across org/anonymous issuer routes and hosted issuer forwarding.
  - Invalid `:orgId` now returns 400 (`VALIDATION_ERROR`) instead of being stringified into the path.
  - Consistent OAuth error mapping at `/token` for org and anonymous issuers.

- **Refactors**
  - Introduced `XaaResult`, `xaaSuccess`, `xaaFailure` and updated mint/authorize/token/userinfo flows to use them.
  - Added a child-process Vitest using `@hono/node-server` to confirm invalid org segments yield 400 JSON (no `[object Response]`).

<sup>Written for commit b06f7482fa07a89410f9e5fee142e94897c90da2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

