### PR TITLE
fix(harness): COMP-39 spike — Codex can't deliver selected MCP servers; clarify preflight copy

### DIFF
--- a/mcpjam-inspector/server/utils/harness/__tests__/harness-availability.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/harness-availability.test.ts
@@ -148,7 +148,12 @@ describe("checkHarnessRuntimeAvailable", () => {
       args({ harnessId: "codex", hasSelectedMcpServers: true })
     );
     expect(r.ok).toBe(false);
-    if (!r.ok) expect(r.reason).toMatch(/doesn't support MCP servers/);
+    // Copy explains the upstream limitation and points to the Claude Code
+    // alternative rather than just telling the user to remove their servers.
+    if (!r.ok) {
+      expect(r.reason).toMatch(/can't use attached MCP servers/);
+      expect(r.reason).toMatch(/Claude Code host/);
+    }
   });
 
   it("allows a Claude Code host with selected MCP servers (it delivers them)", () => {

--- a/mcpjam-inspector/server/utils/harness/docs/codex-mcp-spike.md
+++ b/mcpjam-inspector/server/utils/harness/docs/codex-mcp-spike.md
@@ -1,0 +1,117 @@
+# Spike (COMP-39): Can the Codex harness deliver a host's selected MCP servers?
+
+**Answer: No — not by delivering a `~/.codex/config.toml`, and not in Codex v1.**
+The blocker is an upstream Codex runtime limitation, not a merge/clobber problem on
+our side. `deliverMcpServers` for Codex would *look* like it works (the file survives)
+but the model would never see the tools. **Do not flip `supportsSelectedMcpServers` to
+`true` for Codex.**
+
+Audited 2026-07-18 against `@ai-sdk/harness-codex@1.0.0-canary.9`
+(bridge pins `@openai/codex-sdk@0.130.0`).
+
+---
+
+## The question, precisely
+
+The task asked one sharp question: if MCPJam writes `~/.codex/config.toml` (`mcp_servers`)
+into the sandbox before the turn, does the bridge's programmatic
+`codexConfig.mcp_servers` (set only when host tools are present) **MERGE with** or
+**CLOBBER** that file? And it asked to test both cases — host tools present and absent.
+
+## What the bridge actually does (evidence)
+
+`node_modules/@ai-sdk/harness-codex/dist/bridge/index.mjs`, `runTurn()`:
+
+- L522–557: `mcpServers` starts `{}`. The bridge adds a single `"harness-tools"` entry
+  **only when `start.tools` is non-empty** (host-executed AI SDK tools). It never adds
+  entries for arbitrary user MCP servers — there is no pass-through.
+- L556–557: `codexConfig.mcp_servers` is assigned **only if** `mcpServers` is non-empty.
+  So with no host tools, `codexConfig` has no `mcp_servers` key at all.
+- L573–582: `codexConfig` is passed **in memory** as `config:` to
+  `new codexSdk.Codex({ ..., config: codexConfig })`. The bridge does **not** write
+  `~/.codex/config.toml` (the only `writeFile` in the bridge, L550, is the CLI shim).
+
+How the SDK delivers `config` (OpenAI Codex TS SDK, verified against the public docs):
+it flattens the object into dotted paths and passes them as repeated
+`--config key=value` (`-c`) flags to `codex exec`. Codex precedence layers `-c` flags
+**on top of** `~/.codex/config.toml` at the *key path* level.
+
+### Merge vs clobber — both cases
+
+| Case | Bridge sets `codexConfig.mcp_servers`? | Effect on our `config.toml` `mcp_servers` |
+|---|---|---|
+| **Host tools present** | Yes: `{ "harness-tools": {…} }` → `-c mcp_servers.harness-tools.*` | **Merges.** Distinct key path; our `mcp_servers.<userServer>` entries survive. |
+| **Host tools absent** | No `mcp_servers` key at all | **Merges (untouched).** No `-c mcp_servers.*` flags emitted; our file is the only source. |
+
+**So the answer to the literal question is: MERGE, not clobber, in both cases.** Writing
+`config.toml` is mechanically safe.
+
+## Why that isn't enough — the real blocker
+
+Even with a perfectly-merged `mcp_servers` table, the tools never reach the model.
+
+**The proof is the shipped code, not a GitHub issue.**
+`node_modules/@ai-sdk/harness-codex/src/bridge/cli-relay.ts` (L1–27) states directly that
+MCP tools registered via `mcp_servers.*` are **not exposed to the model in
+`codex exec --experimental-json` mode** — which is exactly the mode `@openai/codex-sdk`
+uses (`thread.runStreamed`). The MCP handshake completes and `tools/list` succeeds, but
+Codex never registers the tools as model-callable functions.
+
+The decisive evidence is that **the harness authors hit this same wall for their own
+host tools.** They could not expose `harness-tools` through `mcp_servers` either, so they
+built the `cli-relay` workaround: describe each tool in the prompt and have the model
+shell out via `bash <shim> <toolName> <json>` to an HTTP relay (wired at
+`dist/bridge/index.mjs:525-554`). If `mcp_servers` worked in exec mode, that entire
+workaround would not exist. This is version-pinned to what we ship — it does not depend on
+the state of any external tracker.
+
+The upstream tracker the authors reference is **openai/codex#19425**. Note (verified
+2026-07-18): that issue's current title/body describe the **Codex Desktop** surface
+("stdio MCP server discovered by `/mcp` but tools not exposed to threads"), not the
+`codex exec` path — same root-cause class (discovered via `tools/list`, never made
+model-callable), different surface. Corroborating the recurring pattern: openai/codex
+#3441, #9676, #13025 ("MCP servers defined in config.toml not detected/used"). Treat these
+as supporting context; the `cli-relay` code above is the authoritative evidence.
+
+## Consequence for the implementation
+
+`deliverMcpServers` on `codexAdapter` writing `config.toml` would be a **silent no-op
+trap**: the file merges, the handshake succeeds, and the model still can't call the
+tools. Flipping `supportsSelectedMcpServers: true` on that basis would lift the preflight
+gate and let users attach servers that appear connected but do nothing — strictly worse
+than today's hard block. **Do not do it.**
+
+## The only known path that could actually work (for the GA task, not this spike)
+
+Mirror the host-tool relay for user MCP servers: represent each selected server's tools
+as **host-executed AI SDK tools** (`start.tools`) that MCPJam's server runs by calling
+the user's server **through the existing signed MCP proxy** (`routes/web/harness-mcp.ts`,
+same route Claude Code uses — no direct server URLs handed to Codex). The bridge already
+relays these via the CLI shim, sidestepping #19425 entirely.
+
+This is a substantially larger lift than `deliverMcpServers` (tool schemas must be
+enumerated up front; tools execute host-side, not in-sandbox; approval/streaming
+semantics differ) and belongs to the "Codex host to GA quality" task. It is noted here so
+that task starts from the right mechanism.
+
+## Decisions this spike hands off
+
+1. **Launch call (Marcelo, product):** ship Codex with MCP unsupported, or hold Codex
+   from launch? This spike only establishes that Codex+MCP is not achievable via
+   `config.toml` and is a real engineering project via the relay path. Record the call on
+   COMP-39.
+2. **If we ship Codex without MCP:** the limit must surface at **host creation** (before a
+   user attaches a server), not as a post-hoc turn error. The gate that produces the error
+   is capability-driven (`harness-availability.ts`, `supportsSelectedMcpServers`); the
+   frontend host-creation flow should read the same capability and disable/annotate server
+   selection for Codex hosts. (Frontend work — contingent on decision 1.)
+
+## Done in this spike
+
+- Error copy fixed (`harness-availability.ts`): the old text told users to "remove the
+  selected servers" with no reason and no alternative. New copy explains it's an upstream
+  Codex runtime limitation and points them to a Claude Code host. Test updated
+  (`__tests__/harness-availability.test.ts`).
+- `supportsSelectedMcpServers` stays `false`; no `deliverMcpServers` added for Codex. The
+  "blocks a Codex host that has selected MCP servers" test stays (still the correct
+  behavior) — only its message assertion changed.

--- a/mcpjam-inspector/server/utils/harness/harness-availability.ts
+++ b/mcpjam-inspector/server/utils/harness/harness-availability.ts
@@ -152,14 +152,21 @@ export function checkHarnessRuntimeAvailable(args: {
   }
 
   // MCP gate: a harness that can't deliver the host's selected servers (Codex
-  // v1) must not silently run without them.
+  // v1) must not silently run without them. The limitation is upstream, not an
+  // MCPJam gap — the Codex runtime doesn't expose mcp_servers tools to the model
+  // in the exec mode it runs, so even a delivered config would leave the servers
+  // connected-but-dead. The bundled bridge documents and works around this for
+  // its own tools (@ai-sdk/harness-codex src/bridge/cli-relay.ts; upstream
+  // tracker openai/codex#19425). Full analysis: docs/codex-mcp-spike.md.
   if (args.hasSelectedMcpServers && !adapter.supportsSelectedMcpServers) {
     return {
       ok: false,
       kind: "mcp-servers",
       reason:
-        `the ${name} harness doesn't support MCP servers yet — remove the ` +
-        "selected servers from this host to run it",
+        `the ${name} harness can't use attached MCP servers yet — its runtime ` +
+        "doesn't expose MCP-server tools to the model, so they would stay " +
+        "connected but unusable. Run these servers on a Claude Code host " +
+        `instead, or remove them to use ${name} for tasks that don't need MCP`,
     };
   }
 


### PR DESCRIPTION
## Spike result (COMP-39): No — Codex can't run a host's selected MCP servers in v1

**Task:** [COMP-39](https://app.kestral.ai/workspace/yhNILB2/task/13gbDzhu) — can the Codex harness deliver a host's selected MCP servers?

*Audited 2026-07-18 against `@ai-sdk/harness-codex@1.0.0-canary.9` (bridge pins `@openai/codex-sdk@0.130.0`).*

### The literal question (merge vs clobber): it MERGES, in both cases
- The bridge never writes `~/.codex/config.toml`. It passes its config **in-memory** as `config:` to the Codex SDK constructor (`dist/bridge/index.mjs:573-582`), which the SDK flattens into `-c key=value` overrides layered *on top of* the on-disk file.
- Its only `mcp_servers` entry is `harness-tools`, added **only when host tools are present** (`index.mjs:522-557`), under a distinct key path. A `config.toml` we write survives whether host tools are present or absent. Writing it is mechanically safe.

### Why that's not enough — the real blocker
Even a perfectly-merged `mcp_servers` table never reaches the model. The bundled bridge documents this directly (`src/bridge/cli-relay.ts:1-27`): MCP tools registered via `mcp_servers.*` are **not exposed to the model in `codex exec --experimental-json` mode**, which is the mode `@openai/codex-sdk` uses (`thread.runStreamed`).

**Decisive evidence:** the harness authors hit the same wall for their *own* host tools and built a `bash`-shim CLI relay to route around it (`cli-relay.ts`, wired at `index.mjs:525-554`) instead of using `mcp_servers`. If `mcp_servers` worked in exec mode, that workaround wouldn't exist. This is version-pinned to what we ship — independent of any external tracker.

Upstream tracker referenced by the authors: `openai/codex#19425` — note its page currently describes the **Codex Desktop** surface, not `codex exec` (same root-cause class, different surface). Corroborating: #3441, #9676, #13025.

### Consequence
A `deliverMcpServers` that writes `config.toml` would be a silent no-op trap: servers appear connected but do nothing — strictly worse than today's hard block. **`supportsSelectedMcpServers` stays `false`; no `deliverMcpServers` added for Codex.**

### The only path that could actually work (→ Codex GA task, not this spike)
Mirror the host-tool relay: represent each selected server's tools as host-executed AI SDK tools that MCPJam runs through the existing signed MCP proxy (`routes/web/harness-mcp.ts`, same route as Claude Code; no direct URLs to Codex). Larger lift (schemas enumerated up front, tools run host-side, different approval/streaming semantics).

## What this PR changes
- **Preflight copy** (`harness-availability.ts`): the old error told users to "remove the selected servers" with no reason or alternative. New copy explains it's an upstream Codex runtime limit and points to a Claude Code host. Kept capability-driven (uses `${name}`).
- **Test** (`__tests__/harness-availability.test.ts`): asserts the new copy + the Claude Code hint. The "blocks a Codex host with selected MCP servers" case **stays** — still correct behavior. (31/31 harness tests pass.)
- **Docs** (`docs/codex-mcp-spike.md`): full findings, merge-vs-clobber analysis for both cases, and the handoff decisions.

## Decisions this hands off (not in this PR)
1. **Launch call (product / @Marcelo):** ship Codex with MCP unsupported, or hold Codex from launch? Also supersedes **COMP-19 item 3** (`codex-host-enabled` internal-at-launch) — needs separate editing.
2. **If we ship Codex without MCP:** surface the limit at **host creation**, before a user attaches a server — not as a post-hoc turn error. Same capability (`supportsSelectedMcpServers`) drives it; frontend reads it to disable/annotate server selection for Codex hosts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Codex harness cannot use a host’s selected MCP servers in v1 due to an upstream runtime limit; `supportsSelectedMcpServers` stays false and we do not add a no-op `deliverMcpServers`. Preflight copy now explains the limit and points users to a Claude Code host; tests assert the new message and `docs/codex-mcp-spike.md` records the spike outcome for COMP-39.

<sup>Written for commit 083f02e3043d035b0c7a669ac83bf956ad1d77b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

