### PR TITLE
fix(home): sync product update video behavior

### DIFF
--- a/mcpjam-inspector/client/src/components/home/ProductUpdateExpandedPanel.tsx
+++ b/mcpjam-inspector/client/src/components/home/ProductUpdateExpandedPanel.tsx
@@ -25,7 +25,7 @@ function getViewportSize() {
 function getPanelLayout(viewWidth: number, viewHeight: number) {
   const width = Math.min(
     PANEL_WIDTH,
-    Math.max(viewWidth - PANEL_GUTTER * 2, 0),
+    Math.max(viewWidth - PANEL_GUTTER * 2, 0)
   );
   const left = Math.max((viewWidth - width) / 2, PANEL_GUTTER);
   const top = Math.max(viewHeight * 0.1, PANEL_GUTTER);
@@ -46,7 +46,7 @@ function ExpandedVideo({ entry }: { entry: ProductUpdateEntry }) {
           muted
           playsInline
           preload="auto"
-          controls
+          controls={!entry.hideControls}
         />
       </div>
     );
@@ -71,7 +71,9 @@ function ExpandedVideo({ entry }: { entry: ProductUpdateEntry }) {
     <div className="relative aspect-video w-full overflow-hidden rounded-lg bg-black">
       <iframe
         key={entry.slug}
-        src={`${embed.embedSrc}${embed.embedSrc.includes("?") ? "&" : "?"}autoplay=1`}
+        src={`${embed.embedSrc}${
+          embed.embedSrc.includes("?") ? "&" : "?"
+        }autoplay=1`}
         className="absolute inset-0 h-full w-full"
         allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
         allowFullScreen

--- a/mcpjam-inspector/client/src/components/home/ProductUpdateExpandedPanel.tsx
+++ b/mcpjam-inspector/client/src/components/home/ProductUpdateExpandedPanel.tsx
@@ -36,11 +36,11 @@ function getPanelLayout(viewWidth: number, viewHeight: number) {
 function ExpandedVideo({ entry }: { entry: ProductUpdateEntry }) {
   if (entry.previewVideoUrl) {
     return (
-      <div className="aspect-video w-full overflow-hidden rounded-lg bg-black">
+      <div className="relative aspect-video w-full overflow-hidden rounded-lg">
         <video
           src={entry.previewVideoUrl}
           poster={entry.videoPosterUrl}
-          className="h-full w-full object-cover"
+          className="absolute inset-0 block h-full w-full object-cover"
           autoPlay
           loop
           muted

--- a/mcpjam-inspector/client/src/components/home/ProductUpdateHoverCard.tsx
+++ b/mcpjam-inspector/client/src/components/home/ProductUpdateHoverCard.tsx
@@ -62,7 +62,9 @@ export function ProductUpdateHoverCard({
   const embed = entry.videoUrl ? parseVideoEmbed(entry.videoUrl) : null;
   const youtubeThumb =
     embed?.provider === "youtube"
-      ? `https://img.youtube.com/vi/${embed.embedSrc.split("/embed/")[1].split("?")[0]}/hqdefault.jpg`
+      ? `https://img.youtube.com/vi/${
+          embed.embedSrc.split("/embed/")[1].split("?")[0]
+        }/hqdefault.jpg`
       : null;
   const hasPreviewMp4 = !!entry.previewVideoUrl;
 
@@ -73,17 +75,22 @@ export function ProductUpdateHoverCard({
   };
 
   return (
-    <HoverCard openDelay={400} closeDelay={200} open={open} onOpenChange={setOpen}>
+    <HoverCard
+      openDelay={400}
+      closeDelay={200}
+      open={open}
+      onOpenChange={setOpen}
+    >
       <HoverCardTrigger asChild>{children}</HoverCardTrigger>
       <HoverCardContent side="bottom" sideOffset={8} className="w-80">
         <div ref={wrapperRef}>
-          <div className="relative mb-3 overflow-hidden rounded-md bg-muted group">
+          <div className="relative mb-3 aspect-video overflow-hidden rounded-md bg-muted group">
             {hasPreviewMp4 ? (
               <video
                 ref={videoRef}
                 src={blobCache[entry.previewVideoUrl!] ?? entry.previewVideoUrl}
                 poster={entry.videoPosterUrl}
-                className="w-full h-auto"
+                className="absolute inset-0 block h-full w-full object-cover"
                 autoPlay
                 loop
                 muted

--- a/mcpjam-inspector/client/src/components/home/ProductUpdatesRow.tsx
+++ b/mcpjam-inspector/client/src/components/home/ProductUpdatesRow.tsx
@@ -100,6 +100,7 @@ export function ProductUpdatesRow() {
   const [showAll, setShowAll] = useState(false);
   const [showHistory, setShowHistory] = useState(false);
   const [clearing, setClearing] = useState(false);
+  const [now, setNow] = useState(() => Date.now());
   const initRef = useRef(false);
 
   useEffect(() => {
@@ -111,13 +112,32 @@ export function ProductUpdatesRow() {
     });
   }, [isAuthenticated, initialize]);
 
+  useEffect(() => {
+    if (updateState === undefined) return;
+
+    const nextPublishAt = PRODUCT_UPDATES.reduce<number | undefined>(
+      (next, update) => {
+        if (update.archived || update.publishAt <= now) return next;
+        return next === undefined
+          ? update.publishAt
+          : Math.min(next, update.publishAt);
+      },
+      undefined
+    );
+    if (nextPublishAt === undefined) return;
+
+    const timeout = window.setTimeout(
+      () => setNow(Date.now()),
+      Math.max(nextPublishAt - now, 0) + 1
+    );
+    return () => window.clearTimeout(timeout);
+  }, [now, updateState]);
+
   const updates = useMemo(() => {
     if (updateState === undefined) return undefined;
 
     const dismissedSlugs = new Set(updateState.dismissedSlugs);
     const initializedAt = updateState.initializedAt ?? 0;
-    const now = Date.now();
-
     return [...PRODUCT_UPDATES]
       .filter((update) => update.publishAt <= now && !update.archived)
       .sort((a, b) => b.publishAt - a.publishAt)
@@ -129,7 +149,7 @@ export function ProductUpdatesRow() {
           isNew: update.publishAt > initializedAt && !dismissed,
         };
       });
-  }, [updateState]);
+  }, [now, updateState]);
 
   const handleDismiss = useCallback(
     async (slug: string) => {

--- a/mcpjam-inspector/client/src/components/home/ProductUpdatesRow.tsx
+++ b/mcpjam-inspector/client/src/components/home/ProductUpdatesRow.tsx
@@ -1,12 +1,18 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useConvexAuth, useMutation, useQuery } from "convex/react";
 import { ChevronLeft, ChevronRight, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { ProductUpdateHoverCard } from "./ProductUpdateHoverCard";
 import { ProductUpdateExpandedPanel } from "./ProductUpdateExpandedPanel";
 import type { ProductUpdateEntry } from "./productUpdateEntry";
+import { PRODUCT_UPDATES } from "./productUpdates";
 
 const PREVIEW_LIMIT = 3;
+
+interface ProductUpdateState {
+  initializedAt?: number;
+  dismissedSlugs: string[];
+}
 
 function formatPublishDate(ts: number): string {
   return new Date(ts).toLocaleDateString(undefined, {
@@ -32,7 +38,7 @@ function UpdateRow({
     <li
       className={cn(
         isLast ? "" : "border-b border-border/40",
-        muted && "opacity-60",
+        muted && "opacity-60"
       )}
     >
       <div className="group flex items-center">
@@ -45,20 +51,20 @@ function UpdateRow({
               }
               className="flex w-full min-w-0 items-center gap-3 px-4 py-2 text-left transition-colors hover:bg-accent/40"
             >
-            <p className="min-w-0 flex-1 truncate text-[13px] font-medium text-foreground">
-              {update.title}
-            </p>
-            <div className="flex shrink-0 items-center gap-1.5">
-              {update.isNew ? (
-                <span className="text-[10px] font-medium uppercase tracking-wide text-primary">
-                  New
+              <p className="min-w-0 flex-1 truncate text-[13px] font-medium text-foreground">
+                {update.title}
+              </p>
+              <div className="flex shrink-0 items-center gap-1.5">
+                {update.isNew ? (
+                  <span className="text-[10px] font-medium uppercase tracking-wide text-primary">
+                    New
+                  </span>
+                ) : null}
+                <span className="text-[11px] tabular-nums text-muted-foreground">
+                  {formatPublishDate(update.publishAt)}
                 </span>
-              ) : null}
-              <span className="text-[11px] tabular-nums text-muted-foreground">
-                {formatPublishDate(update.publishAt)}
-              </span>
-              <ChevronRight className="size-3 text-muted-foreground/40 transition group-hover:text-muted-foreground" />
-            </div>
+                <ChevronRight className="size-3 text-muted-foreground/40 transition group-hover:text-muted-foreground" />
+              </div>
             </button>
           </ProductUpdateHoverCard>
         </div>
@@ -79,14 +85,12 @@ function UpdateRow({
 
 export function ProductUpdatesRow() {
   const { isAuthenticated } = useConvexAuth();
-  const updates = useQuery(
-    "productUpdates:listVisibleUpdates" as any,
-    isAuthenticated ? ({} as any) : "skip",
-  ) as ProductUpdateEntry[] | undefined;
+  const updateState = useQuery(
+    "productUpdates:getState" as any,
+    isAuthenticated ? ({} as any) : "skip"
+  ) as ProductUpdateState | undefined;
 
-  const initialize = useMutation(
-    "productUpdates:initializeIfNeeded" as any,
-  );
+  const initialize = useMutation("productUpdates:initializeIfNeeded" as any);
   const dismissUpdate = useMutation("productUpdates:dismissUpdate" as any);
 
   const [expanded, setExpanded] = useState<{
@@ -107,18 +111,38 @@ export function ProductUpdatesRow() {
     });
   }, [isAuthenticated, initialize]);
 
+  const updates = useMemo(() => {
+    if (updateState === undefined) return undefined;
+
+    const dismissedSlugs = new Set(updateState.dismissedSlugs);
+    const initializedAt = updateState.initializedAt ?? 0;
+    const now = Date.now();
+
+    return [...PRODUCT_UPDATES]
+      .filter((update) => update.publishAt <= now && !update.archived)
+      .sort((a, b) => b.publishAt - a.publishAt)
+      .map((update) => {
+        const dismissed = dismissedSlugs.has(update.slug);
+        return {
+          ...update,
+          dismissed,
+          isNew: update.publishAt > initializedAt && !dismissed,
+        };
+      });
+  }, [updateState]);
+
   const handleDismiss = useCallback(
     async (slug: string) => {
       try {
         await dismissUpdate({ slug });
         setExpanded((current) =>
-          current?.entry.slug === slug ? null : current,
+          current?.entry.slug === slug ? null : current
         );
       } catch (err) {
         console.error("Failed to dismiss product update:", err);
       }
     },
-    [dismissUpdate],
+    [dismissUpdate]
   );
 
   const handleClearAll = useCallback(async () => {
@@ -129,7 +153,7 @@ export function ProductUpdatesRow() {
     setClearing(true);
     try {
       await Promise.all(
-        pending.map((update) => dismissUpdate({ slug: update.slug })),
+        pending.map((update) => dismissUpdate({ slug: update.slug }))
       );
       setExpanded(null);
       setShowAll(false);
@@ -142,7 +166,7 @@ export function ProductUpdatesRow() {
 
   const handleSelect = (
     entry: ProductUpdateEntry,
-    sourceRect: DOMRect | null,
+    sourceRect: DOMRect | null
   ) => {
     setExpanded({ entry, sourceRect });
   };
@@ -239,7 +263,9 @@ export function ProductUpdatesRow() {
     <>
       <section className="flex min-h-0 flex-col rounded-xl border border-border/60">
         <div className="flex shrink-0 items-center justify-between gap-3 border-b border-border/60 px-4 py-2">
-          <h2 className="text-[13px] font-medium text-foreground">What&apos;s new</h2>
+          <h2 className="text-[13px] font-medium text-foreground">
+            What&apos;s new
+          </h2>
           <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
             <span>
               {active.length} update{active.length === 1 ? "" : "s"}
@@ -275,7 +301,9 @@ export function ProductUpdatesRow() {
         <ul
           className={cn(
             "min-h-0",
-            showAll && active.length > PREVIEW_LIMIT && "max-h-40 overflow-y-auto",
+            showAll &&
+              active.length > PREVIEW_LIMIT &&
+              "max-h-40 overflow-y-auto"
           )}
         >
           {visible.map((update, i) => (
@@ -298,7 +326,9 @@ export function ProductUpdatesRow() {
             >
               {showAll
                 ? "Show less"
-                : `View ${hiddenCount} more update${hiddenCount === 1 ? "" : "s"}`}
+                : `View ${hiddenCount} more update${
+                    hiddenCount === 1 ? "" : "s"
+                  }`}
             </button>
           </div>
         ) : null}

--- a/mcpjam-inspector/client/src/components/home/__tests__/ProductUpdateExpandedPanel.test.tsx
+++ b/mcpjam-inspector/client/src/components/home/__tests__/ProductUpdateExpandedPanel.test.tsx
@@ -63,7 +63,9 @@ describe("ProductUpdateExpandedPanel", () => {
       />
     );
 
-    expect(container.querySelector("video")).not.toHaveAttribute("controls");
+    const video = container.querySelector("video");
+    expect(video).not.toHaveAttribute("controls");
+    expect(video).toHaveClass("inset-0");
 
     rerender(
       <ProductUpdateExpandedPanel

--- a/mcpjam-inspector/client/src/components/home/__tests__/ProductUpdateExpandedPanel.test.tsx
+++ b/mcpjam-inspector/client/src/components/home/__tests__/ProductUpdateExpandedPanel.test.tsx
@@ -42,7 +42,6 @@ function update(
   overrides: Partial<ProductUpdateEntry> = {}
 ): ProductUpdateEntry {
   return {
-    _id: "update-1",
     slug: "test-update",
     publishAt: Date.UTC(2026, 6, 17),
     title: "Test update",

--- a/mcpjam-inspector/client/src/components/home/__tests__/ProductUpdateExpandedPanel.test.tsx
+++ b/mcpjam-inspector/client/src/components/home/__tests__/ProductUpdateExpandedPanel.test.tsx
@@ -1,0 +1,79 @@
+import { render } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { ProductUpdateExpandedPanel } from "../ProductUpdateExpandedPanel";
+import type { ProductUpdateEntry } from "../productUpdateEntry";
+
+vi.mock("framer-motion", async () => {
+  const React = await import("react");
+  const MotionDiv = React.forwardRef<
+    HTMLDivElement,
+    React.HTMLAttributes<HTMLDivElement> & {
+      initial?: unknown;
+      animate?: unknown;
+      exit?: unknown;
+      transition?: unknown;
+    }
+  >(function MotionDiv(
+    {
+      children,
+      initial: _initial,
+      animate: _animate,
+      exit: _exit,
+      transition: _transition,
+      ...props
+    },
+    ref
+  ) {
+    return (
+      <div ref={ref} {...props}>
+        {children}
+      </div>
+    );
+  });
+
+  return {
+    AnimatePresence: ({ children }: { children: ReactNode }) => <>{children}</>,
+    motion: { div: MotionDiv },
+  };
+});
+
+function update(
+  overrides: Partial<ProductUpdateEntry> = {}
+): ProductUpdateEntry {
+  return {
+    _id: "update-1",
+    slug: "test-update",
+    publishAt: Date.UTC(2026, 6, 17),
+    title: "Test update",
+    body: "Body",
+    previewVideoUrl: "https://videos.example/test.mp4",
+    dismissed: false,
+    isNew: true,
+    ...overrides,
+  };
+}
+
+describe("ProductUpdateExpandedPanel", () => {
+  it("hides native controls only when the update requests it", () => {
+    const { container, rerender } = render(
+      <ProductUpdateExpandedPanel
+        entry={update({ hideControls: true })}
+        sourceRect={null}
+        onClose={vi.fn()}
+      />
+    );
+
+    expect(container.querySelector("video")).not.toHaveAttribute("controls");
+
+    rerender(
+      <ProductUpdateExpandedPanel
+        entry={update()}
+        sourceRect={null}
+        onClose={vi.fn()}
+      />
+    );
+
+    expect(container.querySelector("video")).toHaveAttribute("controls");
+  });
+});

--- a/mcpjam-inspector/client/src/components/home/__tests__/ProductUpdatesRow.test.tsx
+++ b/mcpjam-inspector/client/src/components/home/__tests__/ProductUpdatesRow.test.tsx
@@ -1,6 +1,6 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ProductUpdatesRow } from "../ProductUpdatesRow";
 
 const mockUseConvexAuth = vi.fn();
@@ -46,6 +46,10 @@ vi.mock("../ProductUpdateExpandedPanel", () => ({
 }));
 
 describe("ProductUpdatesRow", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
     mockUseConvexAuth.mockReturnValue({ isAuthenticated: true });
@@ -91,5 +95,20 @@ describe("ProductUpdatesRow", () => {
     fireEvent.click(screen.getByRole("button", { name: "View past updates" }));
     expect(screen.getByText("Active update")).toBeInTheDocument();
     expect(screen.getByText("Old dismissed update")).toBeInTheDocument();
+  });
+
+  it("shows an update when its scheduled publish time arrives", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(Date.UTC(2026, 5, 3, 23, 59, 59)));
+
+    render(<ProductUpdatesRow />);
+
+    expect(screen.getByText("You're all caught up.")).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(1001);
+    });
+
+    expect(screen.getByText("Active update")).toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/components/home/__tests__/ProductUpdatesRow.test.tsx
+++ b/mcpjam-inspector/client/src/components/home/__tests__/ProductUpdatesRow.test.tsx
@@ -2,7 +2,6 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ProductUpdatesRow } from "../ProductUpdatesRow";
-import type { ProductUpdateEntry } from "../productUpdateEntry";
 
 const mockUseConvexAuth = vi.fn();
 const mockUseQuery = vi.fn();
@@ -13,14 +12,27 @@ vi.mock("convex/react", () => ({
   useConvexAuth: (...args: unknown[]) => mockUseConvexAuth(...args),
   useQuery: (...args: unknown[]) => mockUseQuery(...args),
   useMutation: (name: string) => {
-    if (name === "productUpdates:initializeIfNeeded") {
-      return mockInitialize;
-    }
-    if (name === "productUpdates:dismissUpdate") {
-      return mockDismissUpdate;
-    }
+    if (name === "productUpdates:initializeIfNeeded") return mockInitialize;
+    if (name === "productUpdates:dismissUpdate") return mockDismissUpdate;
     return vi.fn();
   },
+}));
+
+vi.mock("../productUpdates", () => ({
+  PRODUCT_UPDATES: [
+    {
+      slug: "active",
+      publishAt: Date.UTC(2026, 5, 4),
+      title: "Active update",
+      body: "Body",
+    },
+    {
+      slug: "old",
+      publishAt: Date.UTC(2026, 4, 4),
+      title: "Old dismissed update",
+      body: "Body",
+    },
+  ],
 }));
 
 vi.mock("../ProductUpdateHoverCard", () => ({
@@ -33,93 +45,51 @@ vi.mock("../ProductUpdateExpandedPanel", () => ({
   ProductUpdateExpandedPanel: () => null,
 }));
 
-function createUpdate(
-  overrides: Partial<ProductUpdateEntry> = {},
-): ProductUpdateEntry {
-  return {
-    _id: "update-1",
-    slug: "test-update",
-    publishAt: Date.UTC(2026, 5, 4),
-    title: "Test stateless MCP servers",
-    body: "Body",
-    dismissed: false,
-    isNew: true,
-    ...overrides,
-  };
-}
-
 describe("ProductUpdatesRow", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockUseConvexAuth.mockReturnValue({ isAuthenticated: true });
+    mockUseQuery.mockReturnValue({
+      initializedAt: Date.UTC(2026, 4, 1),
+      dismissedSlugs: ["old"],
+    });
     mockInitialize.mockResolvedValue(undefined);
     mockDismissUpdate.mockResolvedValue(undefined);
   });
 
-  it("renders active updates with clear-all controls", () => {
-    mockUseQuery.mockReturnValue([createUpdate()]);
-
+  it("combines the shipped update list with per-user backend state", () => {
     render(<ProductUpdatesRow />);
 
-    expect(screen.getByRole("heading", { name: "What's new" })).toBeInTheDocument();
-    expect(screen.getByText("1 update")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Clear all" })).toBeInTheDocument();
-    expect(screen.getByText("Test stateless MCP servers")).toBeInTheDocument();
-    // No dismissed entries → nothing to look back at.
+    expect(mockUseQuery).toHaveBeenCalledWith("productUpdates:getState", {});
     expect(
-      screen.queryByRole("button", { name: "View all" }),
-    ).not.toBeInTheDocument();
+      screen.getByRole("heading", { name: "What's new" })
+    ).toBeInTheDocument();
+    expect(screen.getByText("1 update")).toBeInTheDocument();
+    expect(screen.getByText("Active update")).toBeInTheDocument();
+    expect(screen.queryByText("Old dismissed update")).not.toBeInTheDocument();
   });
 
-  it("exposes a history view when dismissed updates exist", () => {
-    mockUseQuery.mockReturnValue([
-      createUpdate({ slug: "active", title: "Active update", dismissed: false }),
-      createUpdate({ slug: "old", title: "Old dismissed update", dismissed: true }),
-    ]);
-
+  it("exposes dismissed shipped updates in history", () => {
     render(<ProductUpdatesRow />);
 
-    // Feed hides the dismissed entry but offers a way back to it.
-    expect(screen.queryByText("Old dismissed update")).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "View all" }));
 
-    // History lists every update, including the previously dismissed one.
     expect(screen.getByText("What's new · History")).toBeInTheDocument();
     expect(screen.getByText("Active update")).toBeInTheDocument();
     expect(screen.getByText("Old dismissed update")).toBeInTheDocument();
-
-    // And back returns to the feed.
-    fireEvent.click(screen.getByRole("button", { name: "Back to latest updates" }));
-    expect(screen.queryByText("Old dismissed update")).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Clear all" })).toBeInTheDocument();
   });
 
-  it("shows an empty state after all updates are dismissed", () => {
-    mockUseQuery.mockReturnValue([
-      createUpdate({ slug: "first", dismissed: true }),
-      createUpdate({ slug: "second", dismissed: true }),
-    ]);
+  it("shows the caught-up state when the user dismissed every update", () => {
+    mockUseQuery.mockReturnValue({
+      initializedAt: Date.UTC(2026, 4, 1),
+      dismissedSlugs: ["active", "old"],
+    });
 
     render(<ProductUpdatesRow />);
 
-    expect(screen.getByRole("heading", { name: "What's new" })).toBeInTheDocument();
     expect(screen.getByText("You're all caught up.")).toBeInTheDocument();
-    expect(
-      screen.getByText("New product updates will show up here."),
-    ).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Clear all" })).not.toBeInTheDocument();
-
-    // The caught-up state still lets users revisit what they cleared.
     fireEvent.click(screen.getByRole("button", { name: "View past updates" }));
-    expect(screen.getByText("What's new · History")).toBeInTheDocument();
-    expect(screen.getAllByText("Test stateless MCP servers")).toHaveLength(2);
-  });
-
-  it("renders nothing when there are no product updates", () => {
-    mockUseQuery.mockReturnValue([]);
-
-    const { container } = render(<ProductUpdatesRow />);
-
-    expect(container).toBeEmptyDOMElement();
+    expect(screen.getByText("Active update")).toBeInTheDocument();
+    expect(screen.getByText("Old dismissed update")).toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/components/home/__tests__/productUpdates.test.ts
+++ b/mcpjam-inspector/client/src/components/home/__tests__/productUpdates.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { PRODUCT_UPDATES } from "../productUpdates";
+
+describe("PRODUCT_UPDATES", () => {
+  it("contains each update slug once", () => {
+    const slugs = PRODUCT_UPDATES.map((entry) => entry.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+
+  it("keeps the XAA GA video as an uncontrolled looping demo", () => {
+    expect(
+      PRODUCT_UPDATES.find((entry) => entry.slug === "xaa-debugger-ga")
+    ).toMatchObject({
+      hideControls: true,
+      previewVideoUrl:
+        "https://outstanding-fennec-304.convex.cloud/api/storage/b3a2592b-ab5f-42df-ad2c-db4fa2f39172",
+    });
+  });
+});

--- a/mcpjam-inspector/client/src/components/home/productUpdateEntry.ts
+++ b/mcpjam-inspector/client/src/components/home/productUpdateEntry.ts
@@ -12,6 +12,7 @@ export interface ProductUpdateEntry {
   videoUrl?: string;
   videoPosterUrl?: string;
   previewVideoUrl?: string;
+  hideControls?: boolean;
   dismissed: boolean;
   isNew: boolean;
 }

--- a/mcpjam-inspector/client/src/components/home/productUpdateEntry.ts
+++ b/mcpjam-inspector/client/src/components/home/productUpdateEntry.ts
@@ -1,8 +1,6 @@
-// Shared type for the productUpdates feed. Kept in its own file so the
-// hover card and expanded panel can both import without creating an
-// import cycle through the row component that fetches them.
-export interface ProductUpdateEntry {
-  _id: string;
+// Product-owned content ships with Inspector. Per-user state is added in the
+// Home row after it is read from Convex.
+export interface ProductUpdateDefinition {
   slug: string;
   publishAt: number;
   title: string;
@@ -13,6 +11,13 @@ export interface ProductUpdateEntry {
   videoPosterUrl?: string;
   previewVideoUrl?: string;
   hideControls?: boolean;
+  archived?: boolean;
+}
+
+// Shared type for the rendered product-updates feed. Kept in its own file so
+// the hover card and expanded panel can import it without creating an import
+// cycle through the Home row.
+export interface ProductUpdateEntry extends ProductUpdateDefinition {
   dismissed: boolean;
   isNew: boolean;
 }

--- a/mcpjam-inspector/client/src/components/home/productUpdates.ts
+++ b/mcpjam-inspector/client/src/components/home/productUpdates.ts
@@ -1,0 +1,99 @@
+import type { ProductUpdateDefinition } from "./productUpdateEntry";
+
+// Product-owned Home content. This ships with Inspector; Convex stores only
+// per-user state such as dismissals and the first-seen timestamp.
+export const PRODUCT_UPDATES: readonly ProductUpdateDefinition[] = [
+  {
+    slug: "xaa-debugger-ga",
+    title: "XAA Debugger is GA",
+    body: "Configure and debug Cross-App Access flows with MCPJam as the test identity provider and client/agent",
+    tag: "NEW",
+    href: "https://docs.mcpjam.com/inspector/xaa-debugger",
+    previewVideoUrl:
+      "https://outstanding-fennec-304.convex.cloud/api/storage/b3a2592b-ab5f-42df-ad2c-db4fa2f39172",
+    hideControls: true,
+    publishAt: 1784179142000,
+  },
+  {
+    slug: "xaa-cli-debugger",
+    title: "Debug XAA from your terminal",
+    body: "`mcpjam xaa run` drives the whole Cross-App Access flow against your MCP server: discovery, mint an ID-JAG, redeem it at your auth server, then call the server with the access token. MCPJam plays the enterprise IdP, so you can test ID-JAG support without wiring one up — OIDC or SAML assertions, pre-registered, DCR, or CIMD clients.",
+    tag: "NEW",
+    href: "https://docs.mcpjam.com/cli/xaa",
+    previewVideoUrl:
+      "https://outstanding-fennec-304.convex.cloud/api/storage/d14ea926-0fd8-49ca-9507-ea9b5ebb4fee",
+    publishAt: 1784157265353,
+  },
+  {
+    slug: "slackbot-and-new-hosts",
+    title: "Slackbot + 8 new hosts",
+    body: "Slackbot just became an MCP host — and it lands alongside VS Code, Mistral, AgentCore, Goose, n8n, Cline, Perplexity, and Notion. That's 15 host templates you can run side-by-side to see what your users actually experience, dig into traces, and turn the differences into cross-host eval cases.",
+    tag: "NEW",
+    previewVideoUrl:
+      "https://outstanding-fennec-304.convex.cloud/api/storage/ab940203-5472-4a77-92e1-64aeca8e6fb3",
+    publishAt: 1783357200000,
+  },
+  {
+    slug: "app-tools",
+    title: "App Tools support",
+    body: "Inspector now supports App Tools (SEP-1865) — your agent calls directly into the live UI instead of the host tearing down the iframe every turn. Lower latency, stateful views, multi-turn UI conversations.",
+    tag: "NEW",
+    previewVideoUrl:
+      "https://outstanding-fennec-304.convex.cloud/api/storage/7d929dc3-3dcf-438b-8c58-88b209f7b50b",
+    publishAt: 1779796800000,
+  },
+  {
+    slug: "stateless-mcp-2026-07-28-rc",
+    title: "Test stateless MCP servers",
+    body: "Inspector now supports the 2026-07-28 stateless RC over Streamable HTTP alongside the current spec. Pin per-server or per-client and flip between versions — no more sticky sessions or initialize handshakes to scale around.",
+    tag: "NEW",
+    href: "https://lnkd.in/gGMpFb7H",
+    videoUrl: "https://www.youtube.com/watch?v=gaZeiEGC8oU",
+    previewVideoUrl:
+      "https://outstanding-fennec-304.convex.cloud/api/storage/76f4a81d-1594-4227-9b4b-ca3a2a22c518",
+    publishAt: 1780315200000,
+  },
+  {
+    slug: "multi-client-testing",
+    title: "Multi-client testing",
+    body: "Run the same prompt across ChatGPT, Claude, Cursor, and other client configs side-by-side in the Playground. Isolate client/runtime differences from agent differences before shipping your server.",
+    tag: "NEW",
+    previewVideoUrl:
+      "https://outstanding-fennec-304.convex.cloud/api/storage/c392d4b0-31b8-44d4-9f43-ff03332140dd",
+    publishAt: 1779800400000,
+  },
+  {
+    slug: "app-tools-support",
+    title: "App Tools support",
+    body: "(archived - replaced by app-tools)",
+    archived: true,
+    publishAt: 1779796800000,
+  },
+  {
+    slug: "progressive-tool-discovery",
+    title: "Progressive tool discovery",
+    body: "Test progressive tool disclosure in Inspector. Your agent only sees `search_mcp_tools` and `load_mcp_tools` upfront, hydrating full schemas on demand. Cuts context bloat when you wire up 5+ servers.",
+    tag: "NEW",
+    previewVideoUrl:
+      "https://outstanding-fennec-304.convex.cloud/api/storage/b57594c1-6632-4633-a32c-19e16f3e8e19",
+    publishAt: 1780228800000,
+  },
+  {
+    slug: "stateless-mcp-servers",
+    title: "Test stateless MCP servers",
+    body: "(archived - replaced by stateless-mcp-2026-07-28-rc)",
+    archived: true,
+    publishAt: 1780315200000,
+  },
+  {
+    slug: "mcpjam-evals-ga",
+    title: "MCPJam Evals is GA",
+    body: "Ship MCP servers with confidence — durable test suites with cross-client runs, N-iteration pass rates, structural diffs against tool calls, LLM-as-a-judge assertions, and one-click CI/CD quality gates.",
+    tag: "NEW",
+    href: "https://docs.mcpjam.com/inspector/evals",
+    videoUrl: "https://www.youtube.com/watch?v=WZPN9n87msg",
+    previewVideoUrl:
+      "https://outstanding-fennec-304.convex.cloud/api/storage/0ea4e98b-3ec4-40bc-9090-1595438270c7",
+    publishAt: 1780574400000,
+  },
+];


### PR DESCRIPTION
- Put the Home update content in the Inspector repo. ( we fetch files by url)
- Home renders that content directly.
- Backend only remembers per-user state: which updates did users dismiss and which are new.