### PR TITLE
feat(sdk)!: route modern connections through the official Client (Phase 1B)

### DIFF
--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -106,87 +106,11 @@ import {
   normalizeClientCapabilities,
 } from "./capabilities.js";
 import { assertCallToolResult, isCreateTaskResult } from "./result-guards.js";
-import {
-  createManagedMcpClient,
-  wrapLegacyClient,
-} from "./managed-mcp-client-factory.js";
-import {
-  isStatelessProtocolVersion,
-  type McpProtocolVersion,
-} from "./mcp-protocol-version.js";
-import {
-  StatelessRequiresHttpTransport,
-  type ManagedMcpClient,
-  type ManagedMcpClientConnectOptions,
-  type ManagedMcpClientNotificationHandler,
-  type ManagedMcpClientNotificationMethod,
-  type ManagedMcpClientRequestHandler,
-  type ManagedMcpClientRequestMethod,
-} from "./managed-mcp-client.js";
+import { wrapLegacyClient } from "./managed-mcp-client-factory.js";
+import { resolveVersionNegotiation } from "./version-negotiation.js";
+import { isStatelessProtocolVersion } from "./mcp-protocol-version.js";
+import { type ManagedMcpClient } from "./managed-mcp-client.js";
 
-/**
- * Temporary `ManagedMcpClient` slotted into `state.client` between the
- * early "construct + apply handlers" site and the
- * `connectViaHttp(protocolVersion: stateless)` branch that builds the real
- * preview client. Notification + elicitation handlers registered on
- * this stub are re-applied to the real client after construction; if
- * any RPC method is called against the stub we throw loudly to surface
- * the wiring bug.
- */
-function createPendingStatelessClientStub(): ManagedMcpClient {
-  const handlers = {
-    notifications: new Map<
-      ManagedMcpClientNotificationMethod,
-      ManagedMcpClientNotificationHandler
-    >(),
-    requests: new Map<
-      ManagedMcpClientRequestMethod,
-      ManagedMcpClientRequestHandler
-    >(),
-  };
-  const fail = (method: string) => {
-    throw new Error(
-      `MCPClientManager: ${method}() called on pending stateless client stub. This indicates a wiring bug — the real StatelessMcpHttpPreviewClient should have replaced the stub inside connectViaHttp before any RPC.`
-    );
-  };
-  return {
-    async connect(_t, _o?: ManagedMcpClientConnectOptions) {
-      // Accepted but no-op; the real preview client's connect() runs
-      // inside connectViaHttp before any RPC fires.
-    },
-    async close() {},
-    getServerCapabilities: () => undefined,
-    getServerVersion: () => undefined,
-    getInstructions: () => undefined,
-    listTools: () => fail("listTools"),
-    callTool: () => fail("callTool"),
-    request: () => fail("request"),
-    listResources: () => fail("listResources"),
-    readResource: () => fail("readResource"),
-    listResourceTemplates: () => fail("listResourceTemplates"),
-    listPrompts: () => fail("listPrompts"),
-    getPrompt: () => fail("getPrompt"),
-    ping: () => fail("ping"),
-    subscribeResource: () => fail("subscribeResource"),
-    unsubscribeResource: () => fail("unsubscribeResource"),
-    setLoggingLevel: async () => {
-      // Tolerate the manager's eager setLoggingLevel("debug") fire-and-
-      // forget at the end of connectClient — by the time it lands the
-      // stub may still be the active client. No-op until the real
-      // preview client replaces it; the post-connect guard at
-      // setLoggingLevel inside this manager prevents repeat calls.
-    },
-    setNotificationHandler: (method, handler) => {
-      handlers.notifications.set(method, handler);
-    },
-    setRequestHandler: (method, handler) => {
-      handlers.requests.set(method, handler);
-    },
-    removeRequestHandler: (method) => {
-      handlers.requests.delete(method);
-    },
-  };
-}
 
 /**
  * Manages multiple MCP server connections with support for tools, resources,
@@ -1334,41 +1258,27 @@ export class MCPClientManager {
         (!wantsStateless && resolvedProtocolVersion !== undefined
           ? [resolvedProtocolVersion]
           : undefined);
+      const versionNegotiation = resolveVersionNegotiation(
+        resolvedProtocolVersion
+      );
       const clientOptions: ClientOptions = {
         capabilities: clientCapabilities,
         ...(supportedProtocolVersions && supportedProtocolVersions.length > 0
           ? { supportedProtocolVersions }
           : {}),
+        ...(versionNegotiation ? { versionNegotiation } : {}),
       };
 
-      // Legacy path: construct upstream `Client` early at this site so
-      // the existing notification/elicitation/error wiring keeps
-      // working. Wrap in the adapter immediately so `state.client` is
-      // always `ManagedMcpClient`. Stateless preview defers
-      // construction until HTTP auth is resolved (see
-      // `connectViaHttp`), so the upstream Client is never created on
-      // that path.
-      let managedClient: ManagedMcpClient;
-      let upstreamClient: Client | undefined;
-      if (!wantsStateless) {
-        upstreamClient = new Client(
-          resolvedClientInfo as { name: string; version: string },
-          clientOptions
-        );
-        managedClient = wrapLegacyClient(upstreamClient);
-      } else {
-        // Stateless preview gate: must be HTTP. The connectViaHttp path
-        // builds + assigns the preview client when this branch is taken.
-        if (this.isStdioConfig(config)) {
-          throw new StatelessRequiresHttpTransport("stdio");
-        }
-        // Temporary placeholder — overwritten inside `connectViaHttp`
-        // once we have the resolved URL / headers / auth. Keep
-        // `managedClient` unassigned until then by using a tagged stub
-        // that fails loudly if any caller tries to use it before
-        // construction.
-        managedClient = createPendingStatelessClientStub();
-      }
+      // Both eras go through the official upstream `Client`, constructed
+      // early here so the notification / elicitation / error wiring
+      // attaches once and stays. A modern (2026-07-28) pin is a
+      // `versionNegotiation` on `clientOptions` (above), not a branch to a
+      // second client implementation.
+      const upstreamClient = new Client(
+        resolvedClientInfo as { name: string; version: string },
+        clientOptions
+      );
+      const managedClient: ManagedMcpClient = wrapLegacyClient(upstreamClient);
       client = managedClient;
 
       // Apply handlers (no-ops for the stateless stub; rewired after
@@ -1412,24 +1322,7 @@ export class MCPClientManager {
           client,
           config,
           timeout,
-          state,
-          {
-            protocolVersion: resolvedProtocolVersion,
-            // Pass the resolved clientInfo so the stateless preview can
-            // emit it in `_meta.io.modelcontextprotocol/clientInfo`
-            // without re-resolving from manager defaults.
-            clientInfo: resolvedClientInfo as {
-              name: string;
-              version: string;
-            },
-            // When the wire mode is stateless, the caller below
-            // replaces `client` and the upstream Client (if any) is
-            // discarded. Pass the slot so `connectViaHttp` can reassign.
-            assignClient: (next: ManagedMcpClient) => {
-              client = next;
-              state.client = next;
-            },
-          }
+          state
         );
       }
 
@@ -1516,18 +1409,7 @@ export class MCPClientManager {
     client: ManagedMcpClient,
     config: HttpServerConfig,
     timeout: number,
-    state: LiveClientState,
-    wireOpts?: {
-      /**
-       * Resolved per-server `mcpProtocolVersion` pin (already validated
-       * by `isKnownProtocolVersion` at the trust boundary). Absent OR
-       * stateful → legacy path; stateless (per
-       * `isStatelessProtocolVersion`) → preview path.
-       */
-      protocolVersion?: McpProtocolVersion;
-      clientInfo: { name: string; version: string };
-      assignClient: (next: ManagedMcpClient) => void;
-    }
+    state: LiveClientState
   ): Promise<Transport | undefined> {
     const url = new URL(config.url);
 
@@ -1588,215 +1470,6 @@ export class MCPClientManager {
     );
     const preferSSE = config.preferSSE ?? url.pathname.endsWith("/sse");
 
-    // Stateless preview branch. The preview owns fetch end-to-end and
-    // cannot be re-shaped after construction (per
-    // `upstream_v2alpha_extension_points`), so it must be built HERE —
-    // after auth / requestInit / 401 wiring is resolved. Streamable
-    // HTTP POST only; legacy SSE / preferSSE is rejected up-front.
-    if (
-      wireOpts?.protocolVersion !== undefined &&
-      isStatelessProtocolVersion(wireOpts.protocolVersion) &&
-      wireOpts.assignClient
-    ) {
-      if (preferSSE) {
-        throw new StatelessRequiresHttpTransport("sse");
-      }
-      // Build a header bag from the resolved `requestInit.headers` so
-      // the preview's own-fetch sees the same statics legacy would.
-      // `Authorization` is set by `getAccessToken` when a token source
-      // (`accessToken` / `authProvider` / `refreshToken`) is configured,
-      // so strip it from the static set in that case to avoid double-set
-      // and to keep the OAuth refresh path single-source. But when no
-      // token source is configured, callers can carry custom auth
-      // (non-Bearer schemes, API keys, etc.) on `requestInit.headers
-      // .Authorization`; the legacy `buildRequestInit` path preserves
-      // that header verbatim, and the stateless preview MUST behave the
-      // same way or static-auth setups break entirely in stateless mode.
-      const hasTokenSource =
-        effectiveAccessToken !== undefined || effectiveAuthProvider != null;
-      const staticHeaders: Record<string, string> = {};
-      const ri = requestInit as
-        | { headers?: HeadersInit | undefined }
-        | undefined;
-      if (ri?.headers) {
-        // `RequestInit.headers` accepts three shapes per the Fetch
-        // standard: `Headers`, `Record<string, string>`, AND
-        // `[string, string][]` (tuple-array form). Iterating with
-        // `Object.entries` on the tuple-array form would walk numeric
-        // indices and store arrays as header values, producing
-        // malformed outbound headers and silently dropping the
-        // intended auth/custom headers — a stateless-only regression
-        // because `StreamableHTTPClientTransport` normalizes via
-        // `new Headers(init)` on the legacy path. Funnel all three
-        // shapes through the `Headers` constructor here for the same
-        // normalization.
-        const normalized = new Headers(ri.headers);
-        normalized.forEach((v, k) => {
-          if (hasTokenSource && k.toLowerCase() === "authorization") return;
-          staticHeaders[k] = v;
-        });
-      }
-      // Resolve the access token at send-time so OAuth refresh stays
-      // single-source. Upstream HTTP transport adapts both shapes
-      // automatically; we have to duplicate that logic here because the
-      // preview owns its own fetch.
-      //
-      // - `AuthProvider` (lower-case `token()`): returns the current
-      //   token, may refresh internally. `onUnauthorized` is the refresh
-      //   hook on 401.
-      // - `OAuthClientProvider` (`tokens()` + `saveTokens()`): returns
-      //   cached only; running `auth(provider, { serverUrl })` from
-      //   upstream performs the actual refresh exchange and writes the
-      //   new tokens back via `saveTokens()`. Calling `tokens()` alone
-      //   (the original implementation here) would have shipped the
-      //   first request unauthenticated for refresh-token providers
-      //   because nothing populates the cache up-front.
-      // `UnauthorizedContext` shape mirrors `@modelcontextprotocol/client`'s
-      // exported interface. Typed here as a structural alias rather than
-      // imported because the import would be unused on non-stateless
-      // code paths and would pull the auth module into bundles that
-      // don't need it.
-      type UnauthorizedContextShape = {
-        response: Response;
-        serverUrl: URL;
-        fetchFn: typeof fetch;
-      };
-      const isAuthProvider = (
-        p: unknown
-      ): p is {
-        token: () => Promise<string | undefined>;
-        onUnauthorized?: (ctx: UnauthorizedContextShape) => Promise<void>;
-      } => !!p && typeof (p as { token?: unknown }).token === "function";
-      const isOAuthClientProvider = (
-        p: unknown
-      ): p is {
-        tokens: () =>
-          | { access_token?: string }
-          | undefined
-          | Promise<{ access_token?: string } | undefined>;
-      } => !!p && typeof (p as { tokens?: unknown }).tokens === "function";
-      const refreshOAuthTokens = async (): Promise<string | undefined> => {
-        if (!isOAuthClientProvider(effectiveAuthProvider)) return undefined;
-        // Lazy import to avoid pulling the auth helper into bundles that
-        // never construct a stateless OAuth client.
-        const { auth } = await import("@modelcontextprotocol/client");
-        try {
-          await auth(effectiveAuthProvider as never, { serverUrl: url });
-        } catch {
-          // `auth()` failures (refresh denied, network) surface as the
-          // original 401 at the call site; we don't want to throw here
-          // because the manager handles 401 explicitly.
-          return undefined;
-        }
-        return (await effectiveAuthProvider.tokens())?.access_token;
-      };
-      // Mutable holder so a successful `on401` refresh persists across
-      // requests. Without this, `getAccessToken` would keep returning
-      // the original `effectiveAccessToken` (captured at connect time)
-      // and every request after a refresh would ship the stale token,
-      // 401 again, refresh again — an infinite refresh loop that
-      // hammers the auth server and burns the user's token quota.
-      // For `AuthProvider` / `OAuthClientProvider` the provider itself
-      // owns the cache, so this holder is only consulted for the
-      // static-`accessToken` + `onUnauthorized` configuration.
-      const tokenHolder: { current: string | undefined } = {
-        current: effectiveAccessToken,
-      };
-      const getAccessToken = async (): Promise<string | undefined> => {
-        if (isAuthProvider(effectiveAuthProvider)) {
-          return await effectiveAuthProvider.token();
-        }
-        if (isOAuthClientProvider(effectiveAuthProvider)) {
-          const cached = (await effectiveAuthProvider.tokens())?.access_token;
-          if (cached) return cached;
-          // First call with a refresh-token provider: cache is empty,
-          // run the OAuth flow to populate it before the first request.
-          return await refreshOAuthTokens();
-        }
-        return tokenHolder.current;
-      };
-      const on401 = async (response: Response): Promise<string | undefined> => {
-        if (config.onUnauthorized) {
-          const refreshed = await config.onUnauthorized({
-            serverId,
-            error: new MCPAuthError("HTTP 401 on stateless preview", 401),
-          });
-          // Persist the refreshed token so subsequent requests use it
-          // instead of re-triggering the 401 / refresh cycle.
-          if (refreshed.accessToken) {
-            tokenHolder.current = refreshed.accessToken;
-          }
-          return refreshed.accessToken;
-        }
-        if (isAuthProvider(effectiveAuthProvider)) {
-          // Build the full `UnauthorizedContext` upstream consumers
-          // expect — providers read `WWW-Authenticate` off `response`
-          // for resource metadata and use `fetchFn` to honor the
-          // transport's configured fetch. Passing `{}` here (the prior
-          // behavior) made any provider that touched these fields
-          // crash with a TypeError on every 401.
-          await effectiveAuthProvider.onUnauthorized?.({
-            response,
-            serverUrl: new URL(url),
-            fetchFn: fetch.bind(globalThis),
-          });
-          return await effectiveAuthProvider.token();
-        }
-        if (isOAuthClientProvider(effectiveAuthProvider)) {
-          return await refreshOAuthTokens();
-        }
-        return undefined;
-      };
-      const rpcLogger = this.resolveRpcLogger(config);
-      const previewClient = createManagedMcpClient({
-        mcpProtocolVersion: wireOpts.protocolVersion,
-        clientInfo: wireOpts.clientInfo,
-        transportKind: "http",
-        preview: {
-          url,
-          staticHeaders,
-          getAccessToken,
-          on401,
-          rpcLogger,
-          serverId,
-        },
-      });
-      await previewClient.connect(undefined as never, { timeout });
-      // Swap the active client in the manager's state. Notification /
-      // elicitation handlers re-applied on the new client so they
-      // route to the preview adapter.
-      wireOpts.assignClient(previewClient);
-      this.notificationManager.applyToClient(serverId, previewClient);
-      if (this.defaultProgressHandler) {
-        applyProgressHandler(
-          serverId,
-          previewClient,
-          this.defaultProgressHandler
-        );
-      }
-      const elicitationCaps = (
-        this.buildCapabilities(serverId, config) as Record<string, unknown>
-      ).elicitation;
-      if (elicitationCaps != null) {
-        this.elicitationManager.applyToClient(
-          serverId,
-          previewClient,
-          elicitationCaps as DeclaredElicitationCapability
-        );
-      }
-      if (config.onError) {
-        previewClient.onerror = (error) => config.onError?.(error);
-      }
-      previewClient.onclose = () => {
-        if (this.liveClientStates.get(serverId) === state) {
-          this.clearClosedPendingConnectionState(serverId, state);
-        }
-      };
-      // Stateless has no Transport object; return undefined to signal
-      // that. Caller already widened the return type to
-      // `Transport | undefined`.
-      return undefined;
-    }
 
     let streamableError: unknown;
 


### PR DESCRIPTION
## What & why

**Phase 1B — the official-client cutover.** Modern (`2026-07-28`) connections now go through the upstream `Client` with `versionNegotiation`, instead of MCPJam's hand-rolled stateless preview. A modern pin becomes `versionNegotiation: { mode: { pin } }` on `ClientOptions` (via `resolveVersionNegotiation`, #3308), and the connection uses the **same** `StreamableHTTPClientTransport` path as legacy — auth via the transport's `authProvider`, not a second hand-rolled fetch.

## The change — a net **−327 lines** in `MCPClientManager`

- `performConnection` builds the official `Client` for **both** eras; the `createPendingStatelessClientStub` branch (and the stub itself) are gone.
- `connectViaHttp` drops its entire ~200-line preview branch — own-fetch, hand-rolled `getAccessToken`/`on401`/refresh auth — and the now-unused `wireOpts` param. Modern falls through to the standard transport path.

The routing predicate was fully scoped first: every removed symbol (`upstreamClient`, `wireOpts`, `isAuthProvider`/`isOAuthClientProvider`, the stub, and two now-unused imports) lived only in the deleted code.

## Consequences, now active (improvements)

- **Modern auth** flows through the transport `authProvider` — the standard SDK path — instead of the preview's bespoke 401 handling.
- **Modern capabilities**: connections now advertise the **full** `buildCapabilities` set (including elicitation) rather than the preview's `LOCKED_CLIENT_CAPABILITIES` (which dropped elicitation). Re-confirm advertise=enforce for elicitation when Phase 4 wires MRTR.

## Scope / follow-up

The preview client **class** and the factory's preview branch remain in the tree — now **dead code** — and are removed in **Phase 1C** once this parity has settled (per the plan's 1B→1C split).

## Verification — parity proven

- The **manager↔fixture HTTP integration harness** (merged in #3307) stays **2/2** — with modern now on the official Client, the exact same end-to-end assertions pass. That harness *is* the §9.3 parity gate.
- Full SDK suite: **2260 pass** / 1 skip (127 files) — no regressions.
- `tsc --noEmit` + tsup build clean.

Follows #3294/#3297/#3302/#3307/#3308.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes modern (`2026-07-28`) MCP connections through the official `Client` with `versionNegotiation`, removing the stateless preview path and unifying HTTP auth and transport. This simplifies `MCPClientManager` and enables full capability advertising.

- Refactors
  - Use a single upstream `Client` for legacy and modern; pass `versionNegotiation` from `resolveVersionNegotiation` into `ClientOptions`.
  - Remove preview/stub client and custom HTTP auth/401 logic from `connectViaHttp`; use `StreamableHTTPClientTransport` with its `authProvider`.
  - Net −327 LOC in `MCPClientManager`.

- New Features
  - Modern connections now advertise the full `buildCapabilities` set, including elicitation.

<sup>Written for commit 3304af8c7dcfee52f077248d8f49f2baf2c07e70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

