### PR TITLE
feat(sdk): send application_type in DCR (SEP-837, Phase 2)

### DIFF
--- a/sdk/src/oauth/state-machines/shared/dynamic-client-registration.ts
+++ b/sdk/src/oauth/state-machines/shared/dynamic-client-registration.ts
@@ -27,6 +27,38 @@ export interface DynamicClientRegistrationRequestInput {
 }
 
 /**
+ * Derive the OIDC / SEP-837 `application_type` from the redirect URIs. A `"web"`
+ * client requires HTTPS redirect URIs and forbids localhost; loopback and
+ * custom-scheme (e.g. `mcpjam://`) redirects are `"native"`. If any redirect is
+ * native-only, the whole registration is native — an OIDC-strict authorization
+ * server would otherwise reject MCPJam's loopback / desktop redirects
+ * registered as `"web"`.
+ */
+export function deriveApplicationType(
+  redirectUris: readonly string[]
+): "native" | "web" {
+  const isNativeRedirect = (uri: string): boolean => {
+    let parsed: URL;
+    try {
+      parsed = new URL(uri);
+    } catch {
+      return true; // unparseable → treat conservatively as native
+    }
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return true; // custom scheme (mcpjam://, …)
+    }
+    const host = parsed.hostname;
+    return (
+      host === "localhost" ||
+      host === "127.0.0.1" ||
+      host === "::1" ||
+      host === "[::1]"
+    );
+  };
+  return redirectUris.some(isNativeRedirect) ? "native" : "web";
+}
+
+/**
  * Builds the RFC 7591 registration POST exactly as the debug OAuth machines
  * historically did: caller-supplied metadata defaults win, with
  * authorization-code-flavored fallbacks for anything absent. Callers that are
@@ -51,6 +83,13 @@ export function buildDynamicClientRegistrationRequest(
     token_endpoint_auth_method:
       dynamicRegistrationDefaults.token_endpoint_auth_method ?? "none",
   };
+
+  // SEP-837: register the OIDC `application_type` so an OIDC-strict AS accepts
+  // MCPJam's loopback / custom-scheme (native) or hosted HTTPS (web) redirects.
+  // An explicit caller-supplied value (spread above) wins.
+  clientMetadata.application_type =
+    clientMetadata.application_type ??
+    deriveApplicationType(clientMetadata.redirect_uris);
 
   if (input.scope) {
     clientMetadata.scope = input.scope;
@@ -256,6 +295,7 @@ export async function executeDynamicClientRegistration<
     "Redirect URIs": clientInfo.redirect_uris,
     "Grant Types": clientInfo.grant_types,
     "Response Types": clientInfo.response_types,
+    "Application Type": clientInfo.application_type,
   };
 
   if (clientInfo.client_secret) {

--- a/sdk/src/oauth/state-machines/types.ts
+++ b/sdk/src/oauth/state-machines/types.ts
@@ -182,6 +182,8 @@ export interface OAuthDynamicRegistrationMetadata {
   grant_types?: string[];
   response_types?: string[];
   token_endpoint_auth_method?: string;
+  /** OIDC / SEP-837 client application type. */
+  application_type?: "native" | "web";
   [key: string]: unknown;
 }
 

--- a/sdk/tests/oauth/dynamic-client-registration.test.ts
+++ b/sdk/tests/oauth/dynamic-client-registration.test.ts
@@ -1,5 +1,6 @@
 import {
   buildDynamicClientRegistrationRequest,
+  deriveApplicationType,
   executeDynamicClientRegistration,
   redactDynamicClientRegistrationResponse,
 } from "../../src/oauth/state-machines/shared/dynamic-client-registration.js";
@@ -54,6 +55,8 @@ describe("buildDynamicClientRegistrationRequest", () => {
       grant_types: ["authorization_code", "refresh_token"],
       response_types: ["code"],
       token_endpoint_auth_method: "none",
+      // REDIRECT_URI is https + non-localhost → web (SEP-837).
+      application_type: "web",
     });
   });
 
@@ -73,6 +76,7 @@ describe("buildDynamicClientRegistrationRequest", () => {
       grant_types: ["client_credentials"],
       response_types: [],
       token_endpoint_auth_method: "client_secret_post",
+      application_type: "web",
     });
   });
 
@@ -88,6 +92,51 @@ describe("buildDynamicClientRegistrationRequest", () => {
     });
     expect(request.headers.Authorization).toBeUndefined();
     expect(request.headers["X-Custom"]).toBe("yes");
+  });
+});
+
+describe("application_type (SEP-837)", () => {
+  it("derives web for HTTPS non-localhost redirects", () => {
+    expect(deriveApplicationType(["https://client.example.com/cb"])).toBe("web");
+    expect(buildRequest().body.application_type).toBe("web");
+  });
+
+  it("derives native for loopback redirects", () => {
+    for (const uri of [
+      "http://localhost:8090/callback",
+      "http://127.0.0.1:8090/callback",
+      "http://[::1]:8090/callback",
+    ]) {
+      expect(deriveApplicationType([uri])).toBe("native");
+    }
+    const request = buildRequest({
+      redirectUri: "http://localhost:8090/callback",
+    });
+    expect(request.body.application_type).toBe("native");
+  });
+
+  it("derives native for custom-scheme redirects", () => {
+    expect(deriveApplicationType(["mcpjam://oauth/callback"])).toBe("native");
+  });
+
+  it("is native if ANY redirect is native", () => {
+    expect(
+      deriveApplicationType([
+        "https://hosted.example.com/cb",
+        "http://localhost:8090/cb",
+      ])
+    ).toBe("native");
+  });
+
+  it("lets a caller-supplied application_type win over the derived value", () => {
+    const request = buildRequest({
+      dynamicRegistrationDefaults: {
+        client_name: "Test Client",
+        application_type: "web",
+        redirect_uris: ["http://localhost:8090/callback"],
+      },
+    });
+    expect(request.body.application_type).toBe("web");
   });
 });
 


### PR DESCRIPTION
## What & why

First step of **Phase 2 (authorization)** — the 2026-07-28 auth requirements, which MCPJam currently has **zero** awareness of.

MCPJam's Dynamic Client Registration omitted `application_type`. The OIDC default is `"web"`, which **forbids non-HTTPS and localhost redirect URIs** — exactly what the desktop/CLI debugger registers (`http://localhost:*`, `mcpjam://`). An OIDC-strict authorization server can reject those registrations outright. SEP-837 requires clients to specify an appropriate `application_type`.

## What's here

- **`deriveApplicationType(redirectUris)`** — loopback (`localhost` / `127.0.0.1` / `::1`) and custom-scheme (`mcpjam://`) → `"native"`; HTTPS non-localhost → `"web"`; **native if any** redirect is native (a mixed set can't be `"web"`). Unparseable URIs are treated as native (conservative).
- Wired into the DCR request body; an explicit caller-supplied `application_type` still wins.
- Surfaced in the OAuth debugger's registration summary so you can see what was submitted.

## Verification

- **sdk 2218 tests pass** (5 new `application_type` cases + 2 existing body-shape assertions updated to include the field); `tsc --noEmit` clean.

## Scope

This is the cheapest, most isolated piece of the Phase 2 auth work. The bigger foundational pieces — RFC 9207 `iss` validation before code redemption (SEP-2468) and issuer-keyed credential storage (SEP-2352) — follow as their own PRs. Phase 1 is complete (#3294/#3297/#3302/#3307/#3308/#3315/#3317).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sends OIDC `application_type` during Dynamic Client Registration to meet SEP-837 Phase 2 auth requirements. Ensures loopback and custom-scheme redirects are registered as native to avoid rejections by strict servers.

- **New Features**
  - Derives `application_type` from `redirect_uris`: native for loopback (localhost/127.0.0.1/::1) and custom schemes; web for HTTPS non-localhost; native if any redirect is native; unparseable URIs default to native.
  - Adds `application_type` to the DCR request; an explicit caller value still wins.
  - Shows Application Type in the OAuth debugger registration summary.

<sup>Written for commit aefecbaaad658385922c8961d5547dcbe77122e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

