### PR TITLE
feat(sdk): debug-oauth-2026-07-28 OAuth machine + application_type (Phase 2, 2M-a)

### DIFF
--- a/sdk/src/oauth/authorization-plan.ts
+++ b/sdk/src/oauth/authorization-plan.ts
@@ -285,7 +285,7 @@ export function resolveAuthorizationPlan(
     }
   } else if (registrationMode === "cimd") {
     registrationStrategy = "cimd";
-    if (protocolVersion !== "2025-11-25") {
+    if (protocolVersion !== "2025-11-25" && protocolVersion !== "2026-07-28") {
       pushBlocker(
         "CIMD_UNSUPPORTED_PROTOCOL",
         `CIMD registration is not supported for protocol version ${protocolVersion}.`,

--- a/sdk/src/oauth/authorization-plan.ts
+++ b/sdk/src/oauth/authorization-plan.ts
@@ -188,7 +188,7 @@ export function resolveRegistrationStrategies(
   }
 
   if (
-    protocolVersion === "2025-11-25" &&
+    (protocolVersion === "2025-11-25" || protocolVersion === "2026-07-28") &&
     authServerMetadata?.client_id_metadata_document_supported === true
   ) {
     strategies.push("cimd");

--- a/sdk/src/oauth/client-identity.ts
+++ b/sdk/src/oauth/client-identity.ts
@@ -12,6 +12,7 @@ const BROWSER_DEBUG_CLIENT_NAMES: Record<OAuthProtocolVersion, string> = {
   "2025-03-26": "MCP Inspector Debug Client",
   "2025-06-18": "MCPJam Inspector Debug Client",
   "2025-11-25": "MCPJam Inspector Debug Client",
+  "2026-07-28": "MCPJam Inspector Debug Client",
 };
 
 export function getBrowserDebugDynamicRegistrationMetadata(

--- a/sdk/src/oauth/sequence-actions.ts
+++ b/sdk/src/oauth/sequence-actions.ts
@@ -7,12 +7,16 @@ import {
 import {
   buildActions_2025_11_25,
 } from "./state-machines/debug-oauth-2025-11-25.js";
+import {
+  buildActions_2026_07_28,
+} from "./state-machines/debug-oauth-2026-07-28.js";
 import type {
   OAuthFlowState,
   OAuthProtocolVersion,
   RegistrationStrategy2025_03_26,
   RegistrationStrategy2025_06_18,
   RegistrationStrategy2025_11_25,
+  RegistrationStrategy2026_07_28,
 } from "./state-machines/types.js";
 import type { DiagramAction } from "./state-machines/shared/types.js";
 
@@ -21,7 +25,8 @@ type OAuthSequenceActionInput = {
   registrationStrategy:
     | RegistrationStrategy2025_03_26
     | RegistrationStrategy2025_06_18
-    | RegistrationStrategy2025_11_25;
+    | RegistrationStrategy2025_11_25
+    | RegistrationStrategy2026_07_28;
   flowState: OAuthFlowState;
 };
 
@@ -43,6 +48,8 @@ export function buildOAuthSequenceActions({
       );
     case "2025-11-25":
       return buildActions_2025_11_25(flowState, registrationStrategy);
+    case "2026-07-28":
+      return buildActions_2026_07_28(flowState, registrationStrategy);
     default: {
       const _exhaustive: never = protocolVersion;
       throw new Error(`Unknown protocol version: ${_exhaustive}`);

--- a/sdk/src/oauth/state-machines/debug-oauth-2026-07-28.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2026-07-28.ts
@@ -1341,10 +1341,15 @@ export const createDebugOAuthStateMachine = (
                   // SEP-837 (2026-07-28 MUST): register an appropriate
                   // application_type so an OIDC-strict AS accepts loopback /
                   // custom-scheme redirects. Native for the local debugger
-                  // redirect; an explicit caller value wins.
+                  // redirect; an explicit caller value wins. Derive from the
+                  // SAME effective redirect_uris the builder sends (a caller
+                  // override wins there too), so a `web` redirect override can't
+                  // ship alongside a `native` type.
                   application_type:
                     dynamicRegistrationDefaults.application_type ??
-                    deriveApplicationType([redirectUri]),
+                    deriveApplicationType(
+                      dynamicRegistrationDefaults.redirect_uris ?? [redirectUri],
+                    ),
                 },
                 scope: requestedScopeValue,
                 customHeaders,

--- a/sdk/src/oauth/state-machines/debug-oauth-2026-07-28.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2026-07-28.ts
@@ -1,0 +1,2374 @@
+/**
+ * OAuth 2.0 State Machine for MCP - 2026-07-28 Protocol (Draft)
+ *
+ * This implementation follows the 2026-07-28 MCP OAuth specification:
+ * - Registration priority: CIMD (SHOULD) > Pre-registered > DCR (MAY)
+ * - Discovery: OAuth 2.0 (RFC8414) OR OpenID Connect Discovery 1.0 with path insertion priority
+ * - PKCE: REQUIRED - MUST verify code_challenge_methods_supported
+ * - Client ID Metadata Documents (CIMD) support per draft-parecki-oauth-client-id-metadata-document-03
+ */
+
+import { decodeJWT, formatJWTTimestamp } from "./shared/jwt.js";
+import { EMPTY_OAUTH_FLOW_STATE } from "./types.js";
+import type {
+  BaseOAuthStateMachineConfig,
+  OAuthFlowStep,
+  OAuthFlowState,
+  OAuthStateMachine,
+  HttpHistoryEntry,
+  RegistrationStrategy2026_07_28,
+} from "./types.js";
+import type { DiagramAction } from "./shared/types.js";
+import {
+  addInfoLog,
+  markLatestHttpEntryAsError,
+  toLogErrorDetails,
+} from "./shared/logging.js";
+import {
+  mergeHeaders,
+  mergeHeadersForAuthServer,
+  mergeHeadersForResourceMetadataRequest,
+  normalizeHeaders,
+} from "./shared/headers.js";
+import {
+  generateRandomString,
+  generateCodeChallenge,
+} from "./shared/pkce.js";
+import { buildResourceMetadataUrl } from "./shared/urls.js";
+import {
+  resolveDiscoveryResourceIndicator,
+  resolveFlowResourceValue,
+} from "./shared/resource-indicator.js";
+import {
+  buildInitializeRequestBody,
+  resolveInitializeProtocolVersion,
+} from "./shared/initialize.js";
+import {
+  parseBearerAuthenticateParameters,
+  parseScopeString,
+  resolveRequestedScopeValue,
+} from "./shared/challenges.js";
+import {
+  buildTokenRequestClientAuth,
+  normalizeRegisteredClientAuthMethod,
+  resolvePreregisteredClientAuthMethod,
+} from "./shared/client-auth.js";
+import {
+  buildDynamicClientRegistrationRequest,
+  deriveApplicationType,
+  executeDynamicClientRegistration,
+} from "./shared/dynamic-client-registration.js";
+import { validateClientIdMetadataUrl } from "./shared/client-id-metadata.js";
+import { discoverOAuthProtectedResourceMetadata } from "../browser-auth.js";
+
+export type { OAuthFlowStep, OAuthFlowState };
+export { EMPTY_OAUTH_FLOW_STATE };
+
+// Configuration for creating the state machine (2026-07-28 specific)
+export interface DebugOAuthStateMachineConfig
+  extends BaseOAuthStateMachineConfig {
+  registrationStrategy?: RegistrationStrategy2026_07_28; // cimd | dcr | preregistered
+}
+
+
+// Sequence-diagram previews must show the resource value the flow actually
+// sends (the decision persisted at PRM discovery), not the raw server URL.
+const previewResourceValue = (
+  flowState: OAuthFlowState,
+): string | undefined => resolveFlowResourceValue(flowState);
+
+/**
+ * Build the sequence of actions for the 2026-07-28 OAuth flow
+ * This function creates the visual representation of the OAuth flow steps
+ * that will be displayed in the sequence diagram.
+ */
+export function buildActions_2026_07_28(
+  flowState: OAuthFlowState,
+  registrationStrategy: "cimd" | "dcr" | "preregistered"
+): DiagramAction[] {
+  return [
+    {
+      id: "request_without_token",
+      label: "MCP request without token",
+      description: "Client makes initial request without authorization",
+      from: "client",
+      to: "mcpServer",
+      details: flowState.serverUrl
+        ? [
+            { label: "POST", value: flowState.serverUrl },
+            { label: "method", value: "initialize" },
+          ]
+        : undefined,
+    },
+    {
+      id: "received_401_unauthorized",
+      label: "HTTP 401 Unauthorized with WWW-Authenticate header",
+      description: "Server returns 401 with WWW-Authenticate header",
+      from: "mcpServer",
+      to: "client",
+      details: flowState.resourceMetadataUrl
+        ? [{ label: "Note", value: "Extract resource_metadata URL" }]
+        : undefined,
+    },
+    {
+      id: "request_resource_metadata",
+      label: "Request Protected Resource Metadata",
+      description: "Client requests metadata from well-known URI",
+      from: "client",
+      to: "mcpServer",
+      details: flowState.resourceMetadataUrl
+        ? [
+            {
+              label: "GET",
+              value: new URL(flowState.resourceMetadataUrl).pathname,
+            },
+          ]
+        : undefined,
+    },
+    {
+      id: "received_resource_metadata",
+      label: "Return metadata",
+      description: "Server returns OAuth protected resource metadata",
+      from: "mcpServer",
+      to: "client",
+      details: flowState.resourceMetadata?.authorization_servers
+        ? [
+            {
+              label: "Auth Server",
+              value: flowState.resourceMetadata.authorization_servers[0],
+            },
+          ]
+        : undefined,
+    },
+    {
+      id: "request_authorization_server_metadata",
+      label: "GET Authorization server metadata endpoint",
+      description:
+        "Try OAuth path insertion, OIDC path insertion, OIDC path appending",
+      from: "client",
+      to: "authServer",
+      details: flowState.authorizationServerUrl
+        ? [
+            { label: "URL", value: flowState.authorizationServerUrl },
+            { label: "Protocol", value: "2026-07-28" },
+          ]
+        : undefined,
+    },
+    {
+      id: "received_authorization_server_metadata",
+      label: "Authorization server metadata response",
+      description: "Authorization Server returns metadata",
+      from: "authServer",
+      to: "client",
+      details: flowState.authorizationServerMetadata
+        ? [
+            {
+              label: "Token",
+              value: new URL(
+                flowState.authorizationServerMetadata.token_endpoint
+              ).pathname,
+            },
+            {
+              label: "Auth",
+              value: new URL(
+                flowState.authorizationServerMetadata.authorization_endpoint
+              ).pathname,
+            },
+          ]
+        : undefined,
+    },
+    // CIMD steps
+    ...(registrationStrategy === "cimd"
+      ? [
+          {
+            id: "cimd_prepare",
+            label: "Client uses HTTPS URL as client_id",
+            description:
+              "Client prepares to use URL-based client identification",
+            from: "client",
+            to: "client",
+            details: flowState.clientId
+              ? [
+                  {
+                    label: "client_id (URL)",
+                    value: flowState.clientId.includes("http")
+                      ? flowState.clientId
+                      : "https://www.mcpjam.com/.well-known/oauth/client-metadata.json",
+                  },
+                  {
+                    label: "Method",
+                    value: "Client ID Metadata Document (CIMD)",
+                  },
+                ]
+              : [
+                  {
+                    label: "Note",
+                    value: "HTTPS URL points to metadata document",
+                  },
+                ],
+          },
+          {
+            id: "cimd_fetch_request",
+            label: "Fetch metadata from client_id URL",
+            description:
+              "Authorization Server fetches client metadata from the URL",
+            from: "authServer",
+            to: "client",
+            details: [
+              {
+                label: "Action",
+                value: "GET client_id URL",
+              },
+              {
+                label: "Note",
+                value: "Server initiates metadata fetch during authorization",
+              },
+            ],
+          },
+          {
+            id: "cimd_metadata_response",
+            label: "JSON metadata document",
+            description:
+              "Client hosting returns metadata with redirect_uris and client info",
+            from: "client",
+            to: "authServer",
+            details: [
+              {
+                label: "Content-Type",
+                value: "application/json",
+              },
+              {
+                label: "Contains",
+                value: "client_id, client_name, redirect_uris, etc.",
+              },
+            ],
+          },
+          {
+            id: "received_client_credentials",
+            label: "Validate metadata and redirect_uris",
+            description: "Authorization Server validates fetched metadata",
+            from: "authServer",
+            to: "authServer",
+            details: [
+              {
+                label: "Validates",
+                value: "client_id matches URL, redirect_uris are valid",
+              },
+              {
+                label: "Security",
+                value: "SSRF protection, domain trust policies",
+              },
+            ],
+          },
+        ]
+      : registrationStrategy === "dcr"
+        ? [
+            {
+              id: "request_client_registration",
+              label: "POST /register (2026-07-28)",
+              description:
+                "Client registers dynamically with Authorization Server",
+              from: "client",
+              to: "authServer",
+              details: [
+                {
+                  label: "Note",
+                  value: "Dynamic client registration (DCR)",
+                },
+              ],
+            },
+            {
+              id: "received_client_credentials",
+              label: "Client Credentials",
+              description:
+                "Authorization Server returns client ID and credentials",
+              from: "authServer",
+              to: "client",
+              details: flowState.clientId
+                ? [
+                    {
+                      label: "client_id",
+                      value: flowState.clientId.substring(0, 20) + "...",
+                    },
+                  ]
+                : undefined,
+            },
+          ]
+        : [
+            {
+              id: "received_client_credentials",
+              label: "Use Pre-registered Client (2026-07-28)",
+              description:
+                "Client uses pre-configured credentials (skipped DCR)",
+              from: "client",
+              to: "client",
+              details: flowState.clientId
+                ? [
+                    {
+                      label: "client_id",
+                      value: flowState.clientId.substring(0, 20) + "...",
+                    },
+                    {
+                      label: "Note",
+                      value: "Pre-registered (no DCR needed)",
+                    },
+                  ]
+                : [
+                    {
+                      label: "Note",
+                      value: "Pre-registered client credentials",
+                    },
+                  ],
+            },
+          ]),
+    {
+      id: "generate_pkce_parameters",
+      label: "Generate PKCE (REQUIRED)\nInclude resource parameter",
+      description:
+        "Client generates code verifier and challenge (REQUIRED), includes resource parameter",
+      from: "client",
+      to: "client",
+      details: flowState.codeChallenge
+        ? [
+            {
+              label: "code_challenge",
+              value: flowState.codeChallenge.substring(0, 15) + "...",
+            },
+            {
+              label: "method",
+              value: flowState.codeChallengeMethod || "S256",
+            },
+            {
+              label: "resource",
+              value: previewResourceValue(flowState) || "—",
+            },
+            { label: "Protocol", value: "2026-07-28" },
+          ]
+        : undefined,
+    },
+    {
+      id: "authorization_request",
+      label: "Open browser with authorization URL",
+      description:
+        "Client opens browser with authorization URL + code_challenge + resource",
+      from: "client",
+      to: "browser",
+      details: flowState.authorizationUrl
+        ? [
+            {
+              label: "code_challenge",
+              value:
+                flowState.codeChallenge?.substring(0, 12) + "..." || "S256",
+            },
+            {
+              label: "resource",
+              value: previewResourceValue(flowState) || "",
+            },
+          ]
+        : undefined,
+    },
+    {
+      id: "browser_to_auth_server",
+      label: "Authorization request with resource parameter",
+      description: "Browser navigates to authorization endpoint",
+      from: "browser",
+      to: "authServer",
+      details: flowState.authorizationUrl
+        ? [{ label: "Note", value: "User authorizes in browser" }]
+        : undefined,
+    },
+    {
+      id: "auth_redirect_to_browser",
+      label: "Redirect to callback with authorization code",
+      description:
+        "Authorization Server redirects browser back to callback URL",
+      from: "authServer",
+      to: "browser",
+      details: flowState.authorizationCode
+        ? [
+            {
+              label: "code",
+              value: flowState.authorizationCode.substring(0, 20) + "...",
+            },
+          ]
+        : undefined,
+    },
+    {
+      id: "received_authorization_code",
+      label: "Authorization code callback",
+      description: "Browser redirects back to client with authorization code",
+      from: "browser",
+      to: "client",
+      details: flowState.authorizationCode
+        ? [
+            {
+              label: "code",
+              value: flowState.authorizationCode.substring(0, 20) + "...",
+            },
+          ]
+        : undefined,
+    },
+    {
+      id: "token_request",
+      label: "Token request + code_verifier + resource",
+      description: "Client exchanges authorization code for access token",
+      from: "client",
+      to: "authServer",
+      details: flowState.codeVerifier
+        ? [
+            { label: "grant_type", value: "authorization_code" },
+            {
+              label: "resource",
+              value: previewResourceValue(flowState) || "",
+            },
+          ]
+        : undefined,
+    },
+    {
+      id: "received_access_token",
+      label: "Access token (+ refresh token)",
+      description: "Authorization Server returns access token",
+      from: "authServer",
+      to: "client",
+      details: flowState.accessToken
+        ? [
+            { label: "token_type", value: flowState.tokenType || "Bearer" },
+            {
+              label: "expires_in",
+              value: flowState.expiresIn?.toString() || "3600",
+            },
+          ]
+        : undefined,
+    },
+    {
+      id: "authenticated_mcp_request",
+      label: "MCP request with access token",
+      description: "Client makes authenticated request to MCP server",
+      from: "client",
+      to: "mcpServer",
+      details: flowState.accessToken
+        ? [
+            { label: "POST", value: "tools/list" },
+            {
+              label: "Authorization",
+              value: "Bearer " + flowState.accessToken.substring(0, 15) + "...",
+            },
+          ]
+        : undefined,
+    },
+    {
+      id: "complete",
+      label: "MCP response",
+      description: "MCP Server returns successful response",
+      from: "mcpServer",
+      to: "client",
+      details: flowState.accessToken
+        ? [
+            { label: "Status", value: "200 OK" },
+            { label: "Content", value: "tools, resources, prompts" },
+          ]
+        : undefined,
+    },
+  ];
+}
+
+// Helper: Build authorization server metadata URLs to try (RFC 8414 + OIDC Discovery)
+// 2026-07-28 spec: Path insertion first, then path appending (NO root fallback for paths)
+function buildAuthServerMetadataUrls(authServerUrl: string): string[] {
+  const url = new URL(authServerUrl);
+  const urls: string[] = [];
+
+  if (url.pathname === "/" || url.pathname === "") {
+    // Root path - standard endpoints
+    urls.push(
+      new URL("/.well-known/oauth-authorization-server", url.origin).toString()
+    );
+    urls.push(
+      new URL("/.well-known/openid-configuration", url.origin).toString()
+    );
+  } else {
+    // Path-aware discovery
+    const pathname = url.pathname.endsWith("/")
+      ? url.pathname.slice(0, -1)
+      : url.pathname;
+
+    // 2026-07-28 spec: OAuth path insertion, OIDC path insertion, OIDC path appending
+    // Key difference: NO root fallback
+    urls.push(
+      new URL(
+        `/.well-known/oauth-authorization-server${pathname}`,
+        url.origin
+      ).toString()
+    );
+    urls.push(
+      new URL(
+        `/.well-known/openid-configuration${pathname}`,
+        url.origin
+      ).toString()
+    );
+    urls.push(
+      new URL(
+        `${pathname}/.well-known/openid-configuration`,
+        url.origin
+      ).toString()
+    );
+  }
+
+  return urls;
+}
+
+// Factory function to create the 2026-07-28 state machine
+export const createDebugOAuthStateMachine = (
+  config: DebugOAuthStateMachineConfig
+): OAuthStateMachine => {
+  const {
+    state: initialState,
+    getState,
+    updateState,
+    serverUrl,
+    serverName,
+    redirectUrl,
+    requestExecutor,
+    scheduleAutoAdvance,
+    loadPreregisteredCredentials,
+    dynamicRegistration,
+    clientIdMetadataUrl,
+    customScopes,
+    customHeaders,
+    authMode,
+    hasClientSecret = false,
+    strictConformance = false,
+    resourceIndicatorEnforcement = "warn",
+    registrationStrategy = "cimd", // Default to CIMD for 2026-07-28
+  } = config;
+
+  const redirectUri = redirectUrl;
+  const initializeProtocolVersion = resolveInitializeProtocolVersion("2026-07-28");
+  const dynamicRegistrationDefaults = dynamicRegistration ?? {};
+  let cimdClientId = clientIdMetadataUrl ?? "";
+
+  if (
+    registrationStrategy === "dcr" &&
+    !dynamicRegistrationDefaults.client_name
+  ) {
+    throw new Error("Dynamic registration metadata must include client_name");
+  }
+
+  if (registrationStrategy === "cimd" && !cimdClientId) {
+    throw new Error(
+      "Client ID metadata URL is required for CIMD registration",
+    );
+  }
+
+  if (registrationStrategy === "cimd") {
+    cimdClientId = validateClientIdMetadataUrl(cimdClientId);
+  }
+
+  // Helper to get current state (use getState if provided, otherwise use initial state)
+  const getCurrentState = () => (getState ? getState() : initialState);
+
+  // The resource indicator is decided once at PRM discovery and persisted as
+  // state.resourceIndicator (see resource-policy.ts). Reading through this
+  // helper keeps every request site — authorization URL, token body, token
+  // POST — on the identical value, and re-evaluates lazily for flows seeded
+  // past the discovery step.
+  const resolveResourceParameter = (): string =>
+    resolveFlowResourceValue(getCurrentState(), serverUrl);
+
+  const executeRequest = (url: string, options: RequestInit = {}) =>
+    requestExecutor({
+      url,
+      method: options.method || "GET",
+      headers: normalizeHeaders(options.headers as HeadersInit | undefined),
+      body: options.body as any,
+    });
+
+  const resolvePreregisteredClientAuth = (clientSecret?: string) => {
+    const result = resolvePreregisteredClientAuthMethod({
+      authorizationServerMetadata: getCurrentState()
+        .authorizationServerMetadata as Record<string, unknown> | undefined,
+      hasClientSecret: Boolean(clientSecret || hasClientSecret),
+    });
+    if (!result.ok) {
+      throw new Error(result.message);
+    }
+    return result.method;
+  };
+
+  const loadFallbackPreregisteredClient = async (note: string) => {
+    const { clientId, clientSecret } =
+      (await loadPreregisteredCredentials?.({
+        serverName,
+        serverUrl,
+      })) ?? {};
+
+    if (!clientId) {
+      return undefined;
+    }
+
+    const tokenEndpointAuthMethod =
+      resolvePreregisteredClientAuth(clientSecret);
+    const preregInfo: Record<string, any> = {
+      "Client ID": clientId,
+      "Client Secret": clientSecret || hasClientSecret
+        ? "Configured"
+        : "Not provided (public client)",
+      "Token Auth Method": tokenEndpointAuthMethod,
+      Note: note,
+    };
+
+    return {
+      clientId,
+      clientSecret: clientSecret || undefined,
+      tokenEndpointAuthMethod,
+      infoLogs: addInfoLog(
+        getCurrentState(),
+        "received_client_credentials",
+        "preregistered-fallback",
+        "Pre-registered Client",
+        preregInfo,
+      ),
+    };
+  };
+
+  // Create machine object that can reference itself
+  const machine: OAuthStateMachine = {
+    state: initialState,
+    updateState,
+
+    // Proceed to next step in the flow (matches SDK's actual approach)
+    proceedToNextStep: async () => {
+      const state = getCurrentState();
+
+      updateState({ isInitiatingAuth: true });
+
+      const autoAdvance = (delayMs: number) => {
+        scheduleAutoAdvance?.(() => {
+          void machine.proceedToNextStep();
+        }, delayMs);
+      };
+
+      try {
+        switch (state.currentStep) {
+          case "idle": {
+            // Step 1: Make initial MCP request without token
+            const initialRequestHeaders = mergeHeaders(customHeaders, {
+              "Content-Type": "application/json",
+              Accept: "application/json, text/event-stream",
+            });
+            const initializeRequestBody = buildInitializeRequestBody({
+              protocolVersion: initializeProtocolVersion,
+              authMode,
+              clientName: "MCPJam Inspector",
+              clientVersion: "1.0.0",
+              id: 1,
+            });
+
+            const initialRequest = {
+              method: "POST",
+              url: serverUrl,
+              headers: initialRequestHeaders,
+              body: initializeRequestBody,
+            };
+
+            // Update state with the request
+            updateState({
+              currentStep: "request_without_token",
+              serverUrl,
+              lastRequest: initialRequest,
+              lastResponse: undefined,
+              httpHistory: [
+                ...(state.httpHistory || []),
+                {
+                  step: "request_without_token",
+                  timestamp: Date.now(),
+                  request: initialRequest,
+                },
+              ],
+              isInitiatingAuth: false,
+            });
+
+            // Automatically proceed to make the actual request
+            autoAdvance(50);
+            return;
+          }
+
+          case "request_without_token":
+            // Step 2: Request MCP server and expect 401 Unauthorized via backend proxy
+            if (!state.serverUrl) {
+              throw new Error("No server URL available");
+            }
+
+            try {
+              // Use backend proxy to bypass CORS and capture all headers
+              const response = await executeRequest(state.serverUrl, {
+                method: "POST",
+                headers: mergeHeaders(customHeaders, {
+                  "Content-Type": "application/json",
+                  Accept: "application/json, text/event-stream",
+                }),
+                body: JSON.stringify(
+                  buildInitializeRequestBody({
+                    protocolVersion: initializeProtocolVersion,
+                    authMode,
+                    clientName: "MCPJam Inspector",
+                    clientVersion: "1.0.0",
+                    id: 1,
+                  }),
+                ),
+              });
+
+              // Capture response data for all status codes
+              const responseData = {
+                status: response.status,
+                statusText: response.statusText,
+                headers: response.headers,
+                body: response.body,
+              };
+
+              // Update the last history entry with the response and calculate duration
+              const updatedHistory = [...(state.httpHistory || [])];
+              if (updatedHistory.length > 0) {
+                const lastEntry = updatedHistory[updatedHistory.length - 1];
+                lastEntry.response = responseData;
+                lastEntry.duration =
+                  Date.now() - (lastEntry.timestamp || Date.now());
+              }
+
+              if (response.status === 401) {
+                // Expected 401 response with WWW-Authenticate header
+                const wwwAuthenticateHeader =
+                  response.headers["www-authenticate"];
+                const challengeParams = parseBearerAuthenticateParameters(
+                  wwwAuthenticateHeader,
+                );
+                const challengedScopes = parseScopeString(
+                  challengeParams.scope,
+                );
+
+                // Add info log for WWW-Authenticate header
+                const infoLogs = wwwAuthenticateHeader
+                  ? addInfoLog(
+                      state,
+                      "received_401_unauthorized",
+                      "www-authenticate",
+                      "WWW-Authenticate Header",
+                      {
+                        header: wwwAuthenticateHeader,
+                        ...(challengedScopes && challengedScopes.length > 0
+                          ? { scope: challengedScopes.join(" ") }
+                          : {}),
+                        "Received from": state.serverUrl || "Unknown",
+                      }
+                    )
+                  : state.infoLogs;
+
+                updateState({
+                  currentStep: "received_401_unauthorized",
+                  wwwAuthenticateHeader: wwwAuthenticateHeader || undefined,
+                  challengedScopes,
+                  lastResponse: responseData,
+                  httpHistory: updatedHistory,
+                  infoLogs,
+                  isInitiatingAuth: false,
+                });
+              } else if (response.status === 200) {
+                // Server allows anonymous access - try proactive OAuth discovery
+                // Add info log explaining optional auth
+                const infoLogs = addInfoLog(
+                  state,
+                  "received_401_unauthorized",
+                  "optional-auth",
+                  "Optional Authentication Detected",
+                  {
+                    message: "Server allows anonymous access",
+                    note: "Proceeding with OAuth discovery for authenticated features",
+                  }
+                );
+
+                updateState({
+                  currentStep: "received_401_unauthorized", // Reuse the same flow
+                  wwwAuthenticateHeader: undefined, // No WWW-Authenticate header
+                  lastResponse: responseData,
+                  httpHistory: updatedHistory,
+                  infoLogs,
+                  isInitiatingAuth: false,
+                });
+              } else {
+                // Unexpected status code - capture response and throw error
+                updateState({
+                  lastResponse: responseData,
+                  httpHistory: updatedHistory,
+                });
+                throw new Error(
+                  `Expected 401 Unauthorized but got HTTP ${response.status}: ${response.body?.error?.message || response.statusText}`
+                );
+              }
+            } catch (error) {
+              throw new Error(
+                `Failed to request MCP server: ${error instanceof Error ? error.message : String(error)}`
+              );
+            }
+            break;
+
+          case "received_401_unauthorized":
+            // Step 3: Extract resource metadata URL and prepare request
+            const challengeParams = parseBearerAuthenticateParameters(
+              state.wwwAuthenticateHeader,
+            );
+            let extractedResourceMetadataUrl =
+              challengeParams.resource_metadata;
+
+            // Fallback to building the URL if not found in header
+            if (!extractedResourceMetadataUrl && state.serverUrl) {
+              extractedResourceMetadataUrl = buildResourceMetadataUrl(
+                state.serverUrl
+              );
+            }
+
+            if (!extractedResourceMetadataUrl) {
+              throw new Error("Could not determine resource metadata URL");
+            }
+
+            const resourceMetadataRequest = {
+              method: "GET",
+              url: extractedResourceMetadataUrl,
+              headers: mergeHeaders(customHeaders, {}),
+            };
+
+            // Update state with the URL and request
+            updateState({
+              currentStep: "request_resource_metadata",
+              resourceMetadataUrl: extractedResourceMetadataUrl,
+              lastRequest: resourceMetadataRequest,
+              lastResponse: undefined,
+              httpHistory: [
+                ...(state.httpHistory || []),
+                {
+                  step: "request_resource_metadata",
+                  timestamp: Date.now(),
+                  request: resourceMetadataRequest,
+                },
+              ],
+              isInitiatingAuth: false,
+            });
+
+            // Automatically proceed to make the actual request
+            autoAdvance(50);
+            return;
+
+          case "request_resource_metadata":
+            // Step 2: Fetch and parse resource metadata using official SDK helper
+            if (!state.serverUrl) {
+              throw new Error("No server URL available");
+            }
+
+            const historyWithoutPlaceholder = [...(state.httpHistory || [])];
+            let pendingHistoryEntry =
+              historyWithoutPlaceholder.length > 0 &&
+              historyWithoutPlaceholder[historyWithoutPlaceholder.length - 1]
+                ?.step === "request_resource_metadata" &&
+              !historyWithoutPlaceholder[historyWithoutPlaceholder.length - 1]
+                ?.response
+                ? historyWithoutPlaceholder.pop()
+                : undefined;
+
+            const attempts: HttpHistoryEntry[] = [];
+
+            const loggingFetch: typeof fetch = async (url, init = {}) => {
+              const requestUrl = typeof url === "string" ? url : url.toString();
+              // Protected resource metadata discovery can use an explicit
+              // resourceMetadataUrl from WWW-Authenticate, which may hop
+              // cross-origin. Strip MCP-server Authorization headers when it does.
+              const mergedHeaders = mergeHeadersForResourceMetadataRequest(
+                serverUrl,
+                requestUrl,
+                customHeaders,
+                normalizeHeaders(init.headers as HeadersInit | undefined)
+              );
+
+              const historyEntry: HttpHistoryEntry = pendingHistoryEntry
+                ? {
+                    ...pendingHistoryEntry,
+                    timestamp: Date.now(),
+                    request: {
+                      method: init.method || "GET",
+                      url: requestUrl,
+                      headers: mergedHeaders,
+                      body: init.body,
+                    },
+                  }
+                : {
+                    step: "request_resource_metadata",
+                    timestamp: Date.now(),
+                    request: {
+                      method: init.method || "GET",
+                      url: requestUrl,
+                      headers: mergedHeaders,
+                      body: init.body,
+                    },
+                  };
+
+              pendingHistoryEntry = undefined;
+              attempts.push(historyEntry);
+
+              try {
+                const response = await executeRequest(requestUrl, {
+                  method: init.method || "GET",
+                  headers: mergedHeaders,
+                  body: init.body as any,
+                });
+
+                historyEntry.response = {
+                  status: response.status,
+                  statusText: response.statusText,
+                  headers: response.headers,
+                  body: response.body,
+                };
+                historyEntry.duration = Date.now() - historyEntry.timestamp;
+
+                const responseInit: ResponseInit = {
+                  status: response.status,
+                  statusText: response.statusText,
+                  headers: response.headers,
+                };
+                const responseBody =
+                  typeof response.body === "string"
+                    ? response.body
+                    : JSON.stringify(response.body ?? {});
+                return new Response(responseBody, responseInit);
+              } catch (fetchError) {
+                historyEntry.error = toLogErrorDetails(fetchError);
+                historyEntry.duration = Date.now() - historyEntry.timestamp;
+                throw fetchError;
+              }
+            };
+
+            try {
+              const metadataOptions =
+                state.wwwAuthenticateHeader && state.resourceMetadataUrl
+                  ? { resourceMetadataUrl: state.resourceMetadataUrl }
+                  : undefined;
+
+              const resourceMetadata =
+                await discoverOAuthProtectedResourceMetadata(
+                  state.serverUrl,
+                  metadataOptions,
+                  loggingFetch
+                );
+
+              const finalHistory = [...historyWithoutPlaceholder, ...attempts];
+
+              const lastAttempt = attempts[attempts.length - 1];
+              const authorizationServerUrl =
+                resourceMetadata.authorization_servers?.[0] || serverUrl;
+
+              // The response card is the complete protected-resource metadata.
+              // Keep existing logs only for distinct findings, such as a
+              // resource identifier mismatch below.
+              let infoLogs = state.infoLogs ?? [];
+
+              // Resolve the resource indicator ONCE (rejecting/warning per
+              // the surface's enforcement mode); every later request and
+              // preview site reads state.resourceIndicator instead of
+              // re-deriving it.
+              const discoveryResource = resolveDiscoveryResourceIndicator({
+                state,
+                fallbackServerUrl: serverUrl,
+                prmResource: resourceMetadata.resource,
+                enforcement: resourceIndicatorEnforcement,
+                infoLogs,
+              });
+              const resourceIndicator = discoveryResource.resourceIndicator;
+              infoLogs = discoveryResource.infoLogs;
+
+              updateState({
+                currentStep: "received_resource_metadata",
+                resourceMetadata,
+                resourceIndicator,
+                resourceMetadataUrl:
+                  lastAttempt?.request?.url || state.resourceMetadataUrl,
+                authorizationServerUrl,
+                lastRequest: lastAttempt?.request,
+                lastResponse: lastAttempt?.response,
+                httpHistory: finalHistory,
+                infoLogs,
+                isInitiatingAuth: false,
+              });
+            } catch (error) {
+              const updatedHistory = markLatestHttpEntryAsError(
+                [...historyWithoutPlaceholder, ...attempts],
+                toLogErrorDetails(error)
+              );
+
+              updateState({
+                lastResponse: attempts[attempts.length - 1]?.response,
+                httpHistory: updatedHistory,
+              });
+
+              throw new Error(
+                `Failed to request resource metadata: ${error instanceof Error ? error.message : String(error)}`
+              );
+            }
+            break;
+
+          case "received_resource_metadata":
+            // Step 3: Request Authorization Server Metadata
+            if (!state.authorizationServerUrl) {
+              throw new Error("No authorization server URL available");
+            }
+
+            const authServerUrls = buildAuthServerMetadataUrls(
+              state.authorizationServerUrl
+            );
+
+            const authServerRequest = {
+              method: "GET",
+              url: authServerUrls[0], // Show the first URL we'll try
+              headers: mergeHeadersForAuthServer(customHeaders, {}),
+            };
+
+            // Update state with the request
+            updateState({
+              currentStep: "request_authorization_server_metadata",
+              lastRequest: authServerRequest,
+              lastResponse: undefined,
+              httpHistory: [
+                ...(state.httpHistory || []),
+                {
+                  step: "request_authorization_server_metadata",
+                  timestamp: Date.now(),
+                  request: authServerRequest,
+                },
+              ],
+              isInitiatingAuth: false,
+            });
+
+            // Automatically proceed to make the actual request
+            autoAdvance(50);
+            return;
+
+          case "request_authorization_server_metadata":
+            // Step 4: Fetch authorization server metadata (try multiple endpoints) via backend proxy
+            if (!state.authorizationServerUrl) {
+              throw new Error("No authorization server URL available");
+            }
+
+            const urlsToTry = buildAuthServerMetadataUrls(
+              state.authorizationServerUrl
+            );
+            let authServerMetadata = null;
+            let lastError = null;
+            let finalResponseHeaders: Record<string, string> = {};
+            let finalResponseData: any = null;
+
+            for (const url of urlsToTry) {
+              try {
+                const requestHeaders = mergeHeadersForAuthServer(
+                  customHeaders,
+                  {}
+                );
+
+                // Update request URL as we try different endpoints
+                const updatedHistoryForRetry = [...(state.httpHistory || [])];
+                if (updatedHistoryForRetry.length > 0) {
+                  updatedHistoryForRetry[
+                    updatedHistoryForRetry.length - 1
+                  ].request = {
+                    method: "GET",
+                    url: url,
+                    headers: requestHeaders,
+                  };
+                }
+
+                updateState({
+                  lastRequest: {
+                    method: "GET",
+                    url: url,
+                    headers: requestHeaders,
+                  },
+                  httpHistory: updatedHistoryForRetry,
+                });
+
+                // Use backend proxy to bypass CORS
+                const response = await executeRequest(url, {
+                  method: "GET",
+                  headers: mergeHeadersForAuthServer(customHeaders, {}),
+                });
+
+                if (response.ok) {
+                  authServerMetadata = response.body;
+                  finalResponseHeaders = response.headers;
+                  finalResponseData = response;
+
+                  break;
+                } else if (response.status >= 400 && response.status < 500) {
+                  // Client error, try next URL
+                  continue;
+                } else {
+                  // Server error, might be temporary
+                  lastError = new Error(`HTTP ${response.status} from ${url}`);
+                }
+              } catch (error) {
+                lastError = error;
+                continue;
+              }
+            }
+
+            if (!authServerMetadata || !finalResponseData) {
+              throw new Error(
+                `Could not discover authorization server metadata. Last error: ${lastError instanceof Error ? lastError.message : String(lastError)}`
+              );
+            }
+
+            // Validate required AS metadata fields per RFC 8414
+            if (!authServerMetadata.issuer) {
+              throw new Error(
+                "Authorization server metadata missing required 'issuer' field"
+              );
+            }
+            if (!authServerMetadata.authorization_endpoint) {
+              throw new Error(
+                "Authorization server metadata missing 'authorization_endpoint'"
+              );
+            }
+            if (!authServerMetadata.token_endpoint) {
+              throw new Error(
+                "Authorization server metadata missing 'token_endpoint'"
+              );
+            }
+            if (
+              !authServerMetadata.response_types_supported?.includes("code")
+            ) {
+              throw new Error(
+                "Authorization server does not support 'code' response type"
+              );
+            }
+
+            const authServerResponseData = {
+              status: finalResponseData.status,
+              statusText: finalResponseData.statusText,
+              headers: finalResponseHeaders,
+              body: authServerMetadata,
+            };
+
+            // Update the last history entry with the response
+            const updatedHistoryFinal = [...(state.httpHistory || [])];
+            if (updatedHistoryFinal.length > 0) {
+              const lastEntry =
+                updatedHistoryFinal[updatedHistoryFinal.length - 1];
+              lastEntry.response = authServerResponseData;
+              lastEntry.duration =
+                Date.now() - (lastEntry.timestamp || Date.now());
+            }
+
+            // Validate PKCE support (REQUIRED for 2026-07-28)
+            const supportedMethods =
+              authServerMetadata.code_challenge_methods_supported || [];
+
+            // 2026-07-28 spec: MUST verify PKCE support
+            if (!supportedMethods || supportedMethods.length === 0) {
+              throw new Error(
+                "PKCE is REQUIRED for 2026-07-28 protocol, but authorization server " +
+                  "does not advertise code_challenge_methods_supported. " +
+                  "Server is not compliant with 2026-07-28 spec."
+              );
+            }
+
+            // The response card already shows the complete metadata document.
+            // Keep only the CIMD decision, which is derived from an absent-or-
+            // boolean field and therefore is not otherwise visible in raw JSON.
+            const cimdSupported =
+              typeof authServerMetadata.client_id_metadata_document_supported ===
+              "boolean"
+                ? authServerMetadata.client_id_metadata_document_supported
+                : "false (not advertised, defaults to false per spec)";
+            const infoLogs = addInfoLog(
+              getCurrentState(),
+              "received_authorization_server_metadata",
+              "cimd-support",
+              "Derived: CIMD Support",
+              { "CIMD Supported": cimdSupported }
+            );
+
+            if (!supportedMethods.includes("S256")) {
+              const s256Error =
+                "Authorization server metadata must advertise S256 in code_challenge_methods_supported for 2026-07-28 conformance.";
+
+              if (strictConformance) {
+                updateState({
+                  lastResponse: authServerResponseData,
+                  httpHistory: updatedHistoryFinal,
+                  infoLogs,
+                  error: s256Error,
+                  isInitiatingAuth: false,
+                });
+                return;
+              }
+
+              console.warn(
+                "Authorization server may not support S256 PKCE method. Supported methods:",
+                supportedMethods
+              );
+              // Add warning to state but continue
+              updateState({
+                currentStep: "received_authorization_server_metadata",
+                authorizationServerMetadata: authServerMetadata,
+                lastResponse: authServerResponseData,
+                httpHistory: updatedHistoryFinal,
+                infoLogs,
+                error:
+                  "Warning: Authorization server may not support S256 PKCE method",
+                isInitiatingAuth: false,
+              });
+            } else {
+              updateState({
+                currentStep: "received_authorization_server_metadata",
+                authorizationServerMetadata: authServerMetadata,
+                lastResponse: authServerResponseData,
+                httpHistory: updatedHistoryFinal,
+                infoLogs,
+                isInitiatingAuth: false,
+              });
+            }
+            break;
+
+          case "received_authorization_server_metadata":
+            // Step 5: Client Registration (CIMD > Pre-registered > DCR)
+            if (!state.authorizationServerMetadata) {
+              throw new Error("No authorization server metadata available");
+            }
+
+            // Check registration strategy - 2026-07-28 priority: CIMD > Pre-registered > DCR
+            if (registrationStrategy === "cimd") {
+              // Per spec: clients SHOULD check client_id_metadata_document_supported
+              // before using CIMD. Fail early instead of redirecting to an AS that
+              // will reject the URL-formatted client_id.
+              if (
+                state.authorizationServerMetadata
+                  .client_id_metadata_document_supported !== true
+              ) {
+                updateState({
+                  error:
+                    "The authorization server does not support Client ID Metadata Documents " +
+                    "(client_id_metadata_document_supported is not advertised in AS metadata). " +
+                    "Try using 'dcr' or 'preregistered' registration strategy instead.",
+                  isInitiatingAuth: false,
+                });
+                return;
+              }
+
+              // CIMD Step 1: Prepare client_id URL
+              updateState({
+                currentStep: "cimd_prepare",
+                clientId: cimdClientId,
+                isInitiatingAuth: false,
+              });
+
+              // Auto-proceed to next step
+              autoAdvance(800);
+              return;
+            } else if (registrationStrategy === "preregistered") {
+              // Skip DCR - use injected pre-registered client credentials
+              const { clientId, clientSecret } =
+                (await loadPreregisteredCredentials?.({
+                  serverName,
+                  serverUrl,
+                })) ?? {};
+
+              if (!clientId) {
+                updateState({
+                  error:
+                    "Pre-registered client ID is required. Please configure OAuth credentials in the server settings.",
+                  isInitiatingAuth: false,
+                });
+                return;
+              }
+
+              const tokenEndpointAuthMethod =
+                resolvePreregisteredClientAuth(clientSecret);
+
+              // Add info log for pre-registered client
+              const preregInfo: Record<string, any> = {
+                "Client ID": clientId,
+                "Client Secret": clientSecret || hasClientSecret
+                  ? "Configured"
+                  : "Not provided (public client)",
+                "Token Auth Method": tokenEndpointAuthMethod,
+                Note: "Using pre-registered client credentials from server config (skipped DCR)",
+              };
+
+              const infoLogs = addInfoLog(
+                getCurrentState(),
+                "received_client_credentials",
+                "dcr",
+                "Pre-registered Client",
+                preregInfo
+              );
+
+              updateState({
+                currentStep: "received_client_credentials",
+                clientId,
+                clientSecret: clientSecret || undefined,
+                tokenEndpointAuthMethod,
+                infoLogs,
+                isInitiatingAuth: false,
+              });
+            } else if (
+              state.authorizationServerMetadata.registration_endpoint
+            ) {
+              // Dynamic Client Registration (DCR)
+              // Prepare client metadata with scopes if available
+              const scopesSupported =
+                state.resourceMetadata?.scopes_supported ||
+                state.authorizationServerMetadata.scopes_supported;
+              const requestedScopeValue = resolveRequestedScopeValue({
+                customScopes,
+                challengedScopes: state.challengedScopes,
+                supportedScopes: scopesSupported,
+              });
+
+              const registrationRequest = buildDynamicClientRegistrationRequest({
+                registrationEndpoint:
+                  state.authorizationServerMetadata.registration_endpoint,
+                redirectUri,
+                dynamicRegistrationDefaults: {
+                  ...dynamicRegistrationDefaults,
+                  // SEP-837 (2026-07-28 MUST): register an appropriate
+                  // application_type so an OIDC-strict AS accepts loopback /
+                  // custom-scheme redirects. Native for the local debugger
+                  // redirect; an explicit caller value wins.
+                  application_type:
+                    dynamicRegistrationDefaults.application_type ??
+                    deriveApplicationType([redirectUri]),
+                },
+                scope: requestedScopeValue,
+                customHeaders,
+              });
+
+              // Update state with the request
+              updateState({
+                currentStep: "request_client_registration",
+                lastRequest: registrationRequest,
+                lastResponse: undefined,
+                httpHistory: [
+                  ...(state.httpHistory || []),
+                  {
+                    step: "request_client_registration",
+                    timestamp: Date.now(),
+                    request: registrationRequest,
+                  },
+                ],
+                isInitiatingAuth: false,
+              });
+
+              // Automatically proceed to make the actual request
+              autoAdvance(50);
+              return;
+            } else {
+              if (strictConformance) {
+                updateState({
+                  error:
+                    "Authorization server metadata does not include a registration_endpoint required for DCR conformance.",
+                  isInitiatingAuth: false,
+                });
+                return;
+              }
+
+              const fallbackClient =
+                await loadFallbackPreregisteredClient(
+                  "Authorization server did not advertise registration_endpoint; using pre-registered client credentials.",
+                );
+
+              if (!fallbackClient) {
+                updateState({
+                  error:
+                    "Authorization server metadata does not include a registration_endpoint. Configure a pre-registered client or use a different registration strategy.",
+                  isInitiatingAuth: false,
+                });
+                return;
+              }
+
+              updateState({
+                currentStep: "received_client_credentials",
+                clientId: fallbackClient.clientId,
+                clientSecret: fallbackClient.clientSecret,
+                tokenEndpointAuthMethod:
+                  fallbackClient.tokenEndpointAuthMethod,
+                infoLogs: fallbackClient.infoLogs,
+                error: undefined,
+                isInitiatingAuth: false,
+              });
+            }
+            break;
+
+          case "request_client_registration":
+            // Step 6: Dynamic Client Registration (RFC 7591)
+            if (!state.authorizationServerMetadata?.registration_endpoint) {
+              throw new Error("No registration endpoint available");
+            }
+
+            if (!state.lastRequest?.body) {
+              throw new Error("No client metadata in request");
+            }
+
+            {
+              // Execute the exact request recorded in lastRequest so the
+              // displayed request and the executed request cannot drift.
+              const dcr = await executeDynamicClientRegistration({
+                request: state.lastRequest,
+                requestExecutor,
+                httpHistory: state.httpHistory,
+              });
+
+              if (dcr.status !== "registered") {
+                // Update state with error but continue with fallback
+                updateState({
+                  lastResponse: dcr.response,
+                  httpHistory: dcr.httpHistory,
+                  error: dcr.error,
+                  isInitiatingAuth: false,
+                });
+
+                if (strictConformance) {
+                  return;
+                }
+
+                const fallbackClient = await loadFallbackPreregisteredClient(
+                  dcr.fallbackNote,
+                );
+
+                if (!fallbackClient) {
+                  updateState({
+                    error: dcr.errorWithFallbackHint,
+                    isInitiatingAuth: false,
+                  });
+                  return;
+                }
+
+                updateState({
+                  currentStep: "received_client_credentials",
+                  clientId: fallbackClient.clientId,
+                  clientSecret: fallbackClient.clientSecret,
+                  tokenEndpointAuthMethod:
+                    fallbackClient.tokenEndpointAuthMethod,
+                  infoLogs: fallbackClient.infoLogs,
+                  error: undefined,
+                  isInitiatingAuth: false,
+                });
+                break;
+              }
+
+              // Registration successful
+              if (strictConformance && dcr.missingClientId) {
+                updateState({
+                  lastResponse: dcr.response,
+                  httpHistory: dcr.httpHistory,
+                  error:
+                    "Dynamic Client Registration response is missing a client_id.",
+                  isInitiatingAuth: false,
+                });
+                return;
+              }
+
+              const infoLogs = addInfoLog(
+                getCurrentState(),
+                "received_client_credentials",
+                "dcr",
+                "Dynamic Client Registration",
+                dcr.infoLogData
+              );
+
+              updateState({
+                currentStep: "received_client_credentials",
+                clientId: dcr.credentials.clientId,
+                clientSecret: dcr.credentials.clientSecret,
+                tokenEndpointAuthMethod: normalizeRegisteredClientAuthMethod(
+                  dcr.clientInfo,
+                ),
+                lastResponse: dcr.response,
+                httpHistory: dcr.httpHistory,
+                infoLogs,
+                error: undefined,
+                isInitiatingAuth: false,
+              });
+            }
+            break;
+
+          case "cimd_prepare":
+            // CIMD Step 2: Simulate server detecting URL-formatted client_id and fetching metadata
+            updateState({
+              currentStep: "cimd_fetch_request",
+              isInitiatingAuth: false,
+            });
+
+            // Auto-proceed to next step
+            autoAdvance(800);
+            return;
+
+          case "cimd_fetch_request":
+            // CIMD Step 3: Fetch and validate the CIMD document
+            try {
+              // Fetch the CIMD document (simulating what the auth server does)
+              const cimdResponse = await executeRequest(cimdClientId, {
+                method: "GET",
+              });
+
+              if (!cimdResponse.ok) {
+                throw new Error(
+                  `CIMD endpoint returned HTTP ${cimdResponse.status}`
+                );
+              }
+
+              // Store metadata for next step
+              updateState({
+                currentStep: "cimd_metadata_response",
+                isInitiatingAuth: false,
+              });
+
+              // Auto-proceed to validation step
+              autoAdvance(800);
+              return;
+            } catch (error) {
+              updateState({
+                error:
+                  `CIMD metadata fetch failed: ${error instanceof Error ? error.message : String(error)}. ` +
+                  "Try using 'dcr' or 'preregistered' registration strategy instead.",
+                isInitiatingAuth: false,
+              });
+              return;
+            }
+
+          case "cimd_metadata_response":
+            // CIMD Step 4: Validate the fetched metadata and complete registration
+            try {
+              // Re-fetch to validate
+              const cimdResponse = await executeRequest(cimdClientId, {
+                method: "GET",
+              });
+
+              if (!cimdResponse.ok) {
+                throw new Error(
+                  `CIMD endpoint returned HTTP ${cimdResponse.status}`
+                );
+              }
+
+              const cimdDoc = cimdResponse.body;
+
+              // Validate CIMD document
+              if (cimdDoc.client_id !== cimdClientId) {
+                throw new Error("CIMD client_id mismatch");
+              }
+
+              // Add info log for CIMD validation
+              const cimdSupported = (state.authorizationServerMetadata as any)
+                ?.client_id_metadata_document_supported;
+
+              const cimdInfo: Record<string, any> = {
+                "Client ID": cimdClientId,
+                "Registration Method": "Client ID Metadata Document (CIMD)",
+                "Client Name": cimdDoc.client_name || "MCPJam",
+                "Redirect URIs": cimdDoc.redirect_uris || [],
+                "Token Auth Method":
+                  cimdDoc.token_endpoint_auth_method || "none",
+                Validation: "✓ Metadata fetched and validated",
+                Note: "Server fetched and validated client metadata from URL",
+              };
+
+              if (cimdSupported) {
+                cimdInfo["Server Support"] =
+                  "✓ Advertised in metadata (client_id_metadata_document_supported: true)";
+              } else {
+                cimdInfo["Server Support"] =
+                  "⚠ Not advertised (attempting anyway)";
+              }
+
+              const infoLogs = addInfoLog(
+                getCurrentState(),
+                "received_client_credentials",
+                "cimd",
+                "Client ID Metadata Document",
+                cimdInfo
+              );
+
+              updateState({
+                currentStep: "received_client_credentials",
+                clientId: cimdClientId,
+                clientSecret: undefined, // Public client with CIMD
+                tokenEndpointAuthMethod: "none",
+                infoLogs,
+                isInitiatingAuth: false,
+              });
+            } catch (error) {
+              updateState({
+                error:
+                  `CIMD validation failed: ${error instanceof Error ? error.message : String(error)}. ` +
+                  "Try using 'dcr' or 'preregistered' registration strategy instead.",
+                isInitiatingAuth: false,
+              });
+              return;
+            }
+            break;
+
+          case "received_client_credentials":
+            // Step 7: Generate PKCE parameters
+
+            // Generate PKCE parameters (simplified for demo)
+            const codeVerifier = generateRandomString(43);
+            const codeChallenge = await generateCodeChallenge(codeVerifier);
+
+            // Add info log for PKCE parameters
+            const pkceInfoLogs = addInfoLog(
+              getCurrentState(),
+              "generate_pkce_parameters",
+              "pkce-generation",
+              "Generate PKCE Parameters",
+              {
+                code_challenge: codeChallenge,
+                method: "S256",
+                resource: resolveResourceParameter(),
+              }
+            );
+
+            updateState({
+              currentStep: "generate_pkce_parameters",
+              codeVerifier,
+              codeChallenge,
+              codeChallengeMethod: "S256",
+              state: generateRandomString(16),
+              infoLogs: pkceInfoLogs,
+              isInitiatingAuth: false,
+            });
+            break;
+
+          case "generate_pkce_parameters":
+            // Step 8: Build authorization URL
+            if (
+              !state.authorizationServerMetadata?.authorization_endpoint ||
+              !state.clientId
+            ) {
+              throw new Error("Missing authorization endpoint or client ID");
+            }
+
+            const authUrl = new URL(
+              state.authorizationServerMetadata.authorization_endpoint
+            );
+            authUrl.searchParams.set("response_type", "code");
+            authUrl.searchParams.set("client_id", state.clientId);
+            authUrl.searchParams.set("redirect_uri", redirectUri);
+            authUrl.searchParams.set(
+              "code_challenge",
+              state.codeChallenge || ""
+            );
+            authUrl.searchParams.set("code_challenge_method", "S256");
+            authUrl.searchParams.set("state", state.state || "");
+            authUrl.searchParams.set("resource", resolveResourceParameter());
+
+            const requestedScopeValue = resolveRequestedScopeValue({
+              customScopes,
+              challengedScopes: state.challengedScopes,
+              supportedScopes:
+                state.resourceMetadata?.scopes_supported ||
+                state.authorizationServerMetadata.scopes_supported,
+            });
+            if (requestedScopeValue) {
+              authUrl.searchParams.set("scope", requestedScopeValue);
+            }
+
+            // Add info log for Authorization URL
+            const authUrlInfoLogs = addInfoLog(
+              getCurrentState(),
+              "authorization_request",
+              "auth-url",
+              "Authorization URL",
+              {
+                url: authUrl.toString(),
+              }
+            );
+
+            updateState({
+              currentStep: "authorization_request",
+              authorizationUrl: authUrl.toString(),
+              authorizationCode: undefined, // Clear any old authorization code
+              accessToken: undefined, // Clear any old tokens
+              refreshToken: undefined,
+              tokenType: undefined,
+              expiresIn: undefined,
+              infoLogs: authUrlInfoLogs,
+              isInitiatingAuth: false,
+            });
+            break;
+
+          case "authorization_request":
+            // Step 9: Authorization URL is ready - user should open it in browser
+
+            // Move to the next step where user can enter the authorization code
+            updateState({
+              currentStep: "received_authorization_code",
+              isInitiatingAuth: false,
+            });
+            break;
+
+          case "received_authorization_code": {
+            // Step 10: Validate authorization code and prepare for token exchange
+
+            if (
+              !state.authorizationCode ||
+              state.authorizationCode.trim() === ""
+            ) {
+              updateState({
+                error:
+                  "Authorization code is required. Please paste the code you received from the authorization server.",
+                isInitiatingAuth: false,
+              });
+              return;
+            }
+
+            if (!state.authorizationServerMetadata?.token_endpoint) {
+              throw new Error("Missing token endpoint");
+            }
+
+            // Build the token request body as an object (will be shown in HTTP history)
+            const previewClientAuth = buildTokenRequestClientAuth({
+              clientId: state.clientId,
+              clientSecret: state.clientSecret,
+              tokenEndpointAuthMethod: state.tokenEndpointAuthMethod,
+            });
+
+            const tokenRequestBodyObj: Record<string, string> = {
+              grant_type: "authorization_code",
+              code: state.authorizationCode,
+              redirect_uri: redirectUri,
+              ...previewClientAuth.bodyParams,
+            };
+
+            if (state.codeVerifier) {
+              tokenRequestBodyObj.code_verifier = state.codeVerifier;
+            }
+
+            tokenRequestBodyObj.resource = resolveResourceParameter();
+
+            const tokenRequest = {
+              method: "POST",
+              url: state.authorizationServerMetadata.token_endpoint,
+              headers: {
+                "Content-Type": "application/x-www-form-urlencoded",
+                ...previewClientAuth.headers,
+              },
+              body: tokenRequestBodyObj,
+            };
+
+            // Update state with the request (clear old tokens)
+            updateState({
+              currentStep: "token_request",
+              lastRequest: tokenRequest,
+              lastResponse: undefined,
+              accessToken: undefined, // Clear old token
+              refreshToken: undefined, // Clear old refresh token
+              httpHistory: [
+                ...(state.httpHistory || []),
+                {
+                  step: "token_request",
+                  timestamp: Date.now(),
+                  request: tokenRequest,
+                },
+              ],
+              isInitiatingAuth: false,
+            });
+
+            // Automatically proceed to make the actual request
+            autoAdvance(50);
+            return;
+          }
+
+          case "token_request":
+            // Step 11: Exchange authorization code for access token
+            if (!state.authorizationServerMetadata?.token_endpoint) {
+              throw new Error("Missing token endpoint");
+            }
+
+            if (!state.authorizationCode) {
+              throw new Error("Missing authorization code");
+            }
+
+            if (!state.codeVerifier) {
+              throw new Error(
+                "PKCE code_verifier is missing - cannot exchange token"
+              );
+            }
+
+            try {
+              // Prepare token request body (form-urlencoded)
+              const clientAuth = buildTokenRequestClientAuth({
+                clientId: state.clientId,
+                clientSecret: state.clientSecret,
+                tokenEndpointAuthMethod: state.tokenEndpointAuthMethod,
+              });
+
+              const tokenRequestBody = new URLSearchParams({
+                grant_type: "authorization_code",
+                code: state.authorizationCode,
+                redirect_uri: redirectUri,
+                code_verifier: state.codeVerifier || "",
+                ...clientAuth.bodyParams,
+              });
+
+              // Add resource parameter (per RFC 8707; prefers the PRM-advertised
+              // resource identifier, falling back to the canonical server URL)
+              tokenRequestBody.set("resource", resolveResourceParameter());
+
+              // Make the token request via backend proxy. The client-auth
+              // Authorization header is applied AFTER the merge: the merge
+              // strips user-configured Authorization headers so MCP-server
+              // credentials never leak to the AS, but the Basic credential
+              // here IS addressed to the AS (client_secret_basic).
+              const response = await executeRequest(
+                state.authorizationServerMetadata.token_endpoint,
+                {
+                  method: "POST",
+                  headers: {
+                    ...mergeHeadersForAuthServer(customHeaders, {
+                      "Content-Type": "application/x-www-form-urlencoded",
+                    }),
+                    ...clientAuth.headers,
+                  },
+                  body: tokenRequestBody.toString(),
+                }
+              );
+
+              const tokenResponseData = {
+                status: response.status,
+                statusText: response.statusText,
+                headers: response.headers,
+                body: response.body,
+              };
+
+              // Update the last history entry with the response
+              const updatedHistoryToken = [...(state.httpHistory || [])];
+              if (updatedHistoryToken.length > 0) {
+                const lastEntry =
+                  updatedHistoryToken[updatedHistoryToken.length - 1];
+                lastEntry.response = tokenResponseData;
+                lastEntry.duration =
+                  Date.now() - (lastEntry.timestamp || Date.now());
+              }
+
+              if (!response.ok) {
+                // Token request failed
+                updateState({
+                  lastResponse: tokenResponseData,
+                  httpHistory: updatedHistoryToken,
+                  // Clear the authorization code so it won't be retried
+                  authorizationCode: undefined,
+                  error: `Token request failed: ${response.body?.error || response.statusText} - ${response.body?.error_description || "Unknown error"}`,
+                  isInitiatingAuth: false,
+                });
+                return;
+              }
+
+              // Token request successful
+              const tokens = response.body;
+
+              // Start with existing logs, filtering out any token-related logs we're about to add
+              // to prevent duplicates
+              const existingLogs = (getCurrentState().infoLogs || []).filter(
+                (log) =>
+                  log.id !== "auth-code" &&
+                  log.id !== "oauth-tokens" &&
+                  log.id !== "token"
+              );
+
+              let tokenInfoLogs = existingLogs;
+
+              // Add Authorization Code log
+              if (state.authorizationCode) {
+                tokenInfoLogs = [
+                  ...tokenInfoLogs,
+                  {
+                    id: "auth-code",
+                    level: "info",
+                    step: "authorization_request",
+                    label: "Authorization Code",
+                    data: {
+                      code: state.authorizationCode,
+                    },
+                    timestamp: Date.now(),
+                  },
+                ];
+              }
+
+              if (tokens.access_token) {
+                const tokenData: Record<string, any> = {
+                  access_token: tokens.access_token,
+                };
+
+                if (tokens.refresh_token) {
+                  tokenData.refresh_token = tokens.refresh_token;
+                }
+
+                tokenInfoLogs = [
+                  ...tokenInfoLogs,
+                  {
+                    id: "oauth-tokens",
+                    level: "info",
+                    step: "token_request",
+                    label: "OAuth Tokens",
+                    data: tokenData,
+                    timestamp: Date.now(),
+                  },
+                ];
+              }
+
+              // Decode and add access token JWT log
+              if (tokens.access_token) {
+                const decoded = decodeJWT(tokens.access_token);
+                if (decoded) {
+                  const formatted = { ...decoded };
+                  // Format timestamp fields
+                  if (formatted.exp) {
+                    formatted.exp = `${formatted.exp} (${formatJWTTimestamp(formatted.exp)})`;
+                  }
+                  if (formatted.iat) {
+                    formatted.iat = `${formatted.iat} (${formatJWTTimestamp(formatted.iat)})`;
+                  }
+                  if (formatted.nbf) {
+                    formatted.nbf = `${formatted.nbf} (${formatJWTTimestamp(formatted.nbf)})`;
+                  }
+
+                  // Add audience validation note
+                  const audienceNote: Record<string, any> = {
+                    ...formatted,
+                  };
+
+                  // Check if audience claim exists and validate it
+                  if (formatted.aud) {
+                    const expectedResource = state.serverUrl;
+                    const audArray = Array.isArray(formatted.aud)
+                      ? formatted.aud
+                      : [formatted.aud];
+
+                    const isValidAudience = audArray.some(
+                      (aud: string) => aud === expectedResource
+                    );
+
+                    audienceNote._validation = {
+                      expected_audience: expectedResource,
+                      audience_matches: isValidAudience,
+                      note: isValidAudience
+                        ? "✓ Token audience matches MCP server"
+                        : "⚠ Token audience does not match MCP server (security risk)",
+                    };
+                  } else {
+                    audienceNote._validation = {
+                      note: "⚠ No audience claim found - server should validate token binding",
+                    };
+                  }
+
+                  tokenInfoLogs = [
+                    ...tokenInfoLogs,
+                    {
+                      id: "token",
+                      level: "info",
+                      step: "token_request",
+                      label: "Access Token (Decoded JWT)",
+                      data: audienceNote,
+                      timestamp: Date.now(),
+                    },
+                  ];
+                }
+              }
+
+              // Decode and add ID token JWT log (OIDC flows)
+              if (tokens.id_token) {
+                const decodedIdToken = decodeJWT(tokens.id_token);
+                if (decodedIdToken) {
+                  const formattedIdToken = { ...decodedIdToken };
+                  // Format timestamp fields
+                  if (formattedIdToken.exp) {
+                    formattedIdToken.exp = `${formattedIdToken.exp} (${formatJWTTimestamp(formattedIdToken.exp)})`;
+                  }
+                  if (formattedIdToken.iat) {
+                    formattedIdToken.iat = `${formattedIdToken.iat} (${formatJWTTimestamp(formattedIdToken.iat)})`;
+                  }
+                  if (formattedIdToken.nbf) {
+                    formattedIdToken.nbf = `${formattedIdToken.nbf} (${formatJWTTimestamp(formattedIdToken.nbf)})`;
+                  }
+                  if (formattedIdToken.auth_time) {
+                    formattedIdToken.auth_time = `${formattedIdToken.auth_time} (${formatJWTTimestamp(formattedIdToken.auth_time)})`;
+                  }
+
+                  // Add OIDC-specific validation note
+                  formattedIdToken._note =
+                    "OIDC ID Token - Used for user identity verification";
+
+                  tokenInfoLogs = [
+                    ...tokenInfoLogs,
+                    {
+                      id: "id-token",
+                      level: "info",
+                      step: "token_request",
+                      label: "ID Token (OIDC - Decoded JWT)",
+                      data: formattedIdToken,
+                      timestamp: Date.now(),
+                    },
+                  ];
+                }
+              }
+
+              updateState({
+                currentStep: "received_access_token",
+                accessToken: tokens.access_token,
+                refreshToken: tokens.refresh_token,
+                tokenType: tokens.token_type || "Bearer",
+                expiresIn: tokens.expires_in,
+                lastResponse: tokenResponseData,
+                httpHistory: updatedHistoryToken,
+                infoLogs: tokenInfoLogs,
+                error: undefined,
+                isInitiatingAuth: false,
+              });
+            } catch (error) {
+              // Capture the error
+              const errorResponse = {
+                status: 0,
+                statusText: "Network Error",
+                headers: {},
+                body: {
+                  error: error instanceof Error ? error.message : String(error),
+                },
+              };
+
+              const updatedHistoryError = [...(state.httpHistory || [])];
+              if (updatedHistoryError.length > 0) {
+                const lastEntry =
+                  updatedHistoryError[updatedHistoryError.length - 1];
+                lastEntry.response = errorResponse;
+                lastEntry.duration =
+                  Date.now() - (lastEntry.timestamp || Date.now());
+              }
+
+              updateState({
+                lastResponse: errorResponse,
+                httpHistory: updatedHistoryError,
+                error: `Token exchange failed: ${error instanceof Error ? error.message : String(error)}`,
+                isInitiatingAuth: false,
+              });
+            }
+            break;
+
+          case "received_access_token":
+            // Step 12: Make authenticated MCP request (initialize to establish session)
+            if (!state.serverUrl || !state.accessToken) {
+              throw new Error("Missing server URL or access token");
+            }
+
+            const authenticatedRequest = {
+              method: "POST",
+              url: state.serverUrl,
+              headers: {
+                Authorization: `Bearer ${state.accessToken}`,
+                "Content-Type": "application/json",
+                Accept: "application/json, text/event-stream",
+                "MCP-Protocol-Version": "2026-07-28",
+              },
+              body: buildInitializeRequestBody({
+                protocolVersion: initializeProtocolVersion,
+                authMode,
+                clientName: "MCPJam Inspector",
+                clientVersion: "1.0.0",
+                id: 2,
+              }),
+            };
+
+            // Add info log for authenticated initialize request
+            const authenticatedRequestInfoLogs = addInfoLog(
+              getCurrentState(),
+              "authenticated_mcp_request",
+              "authenticated-init",
+              "Authenticated MCP Initialize Request",
+              {
+                Request: "MCP initialize with OAuth bearer token",
+                "Protocol Version": "2026-07-28",
+                Client: "MCPJam Inspector v1.0.0",
+                Endpoint: state.serverUrl,
+              }
+            );
+
+            // Update state with the request
+            updateState({
+              currentStep: "authenticated_mcp_request",
+              lastRequest: authenticatedRequest,
+              lastResponse: undefined,
+              httpHistory: [
+                ...(state.httpHistory || []),
+                {
+                  step: "authenticated_mcp_request",
+                  timestamp: Date.now(),
+                  request: authenticatedRequest,
+                },
+              ],
+              infoLogs: authenticatedRequestInfoLogs,
+              isInitiatingAuth: false,
+            });
+
+            // Automatically proceed to make the actual request
+            autoAdvance(50);
+            return;
+
+          case "authenticated_mcp_request":
+            // Step 13: Make actual authenticated request to verify token (initialize with auth)
+            if (!state.serverUrl || !state.accessToken) {
+              throw new Error("Missing server URL or access token");
+            }
+
+            try {
+              const response = await executeRequest(state.serverUrl, {
+                method: "POST",
+                headers: mergeHeaders(customHeaders, {
+                  Authorization: `Bearer ${state.accessToken}`,
+                  "Content-Type": "application/json",
+                  Accept: "application/json, text/event-stream",
+                }),
+                body: JSON.stringify(
+                  buildInitializeRequestBody({
+                    protocolVersion: initializeProtocolVersion,
+                    authMode,
+                    clientName: "MCPJam Inspector",
+                    clientVersion: "1.0.0",
+                    id: 2,
+                  }),
+                ),
+              });
+
+              const mcpResponseData = {
+                status: response.status,
+                statusText: response.statusText,
+                headers: response.headers,
+                body: response.body,
+              };
+
+              // Update the last history entry with the response
+              const updatedHistoryMcp = [...(state.httpHistory || [])];
+              if (updatedHistoryMcp.length > 0) {
+                const lastEntry =
+                  updatedHistoryMcp[updatedHistoryMcp.length - 1];
+                lastEntry.response = mcpResponseData;
+                lastEntry.duration =
+                  Date.now() - (lastEntry.timestamp || Date.now());
+              }
+
+              if (!response.ok) {
+                updateState({
+                  lastResponse: mcpResponseData,
+                  httpHistory: updatedHistoryMcp,
+                  error: `Authenticated request failed: ${response.status} ${response.statusText}`,
+                  isInitiatingAuth: false,
+                });
+                return;
+              }
+
+              // Add info log for MCP protocol version
+              let mcpInfoLogs = getCurrentState().infoLogs || [];
+
+              // Check if response is SSE (Streamable HTTP transport)
+              const contentType = response.headers["content-type"] || "";
+              const isSSE = contentType.includes("text/event-stream");
+
+              // Extract MCP response from body (could be direct JSON or parsed SSE)
+              let mcpResponse = null;
+              // Handle structured SSE response from debug proxy
+              if (isSSE && response.body?.transport === "sse") {
+                // SSE response - extract MCP response from parsed events
+                mcpResponse = response.body.mcpResponse;
+              } else {
+                // Direct JSON response
+                mcpResponse = response.body;
+              }
+
+              if (isSSE && mcpResponse?.result?.protocolVersion) {
+                // SSE streaming response with parsed MCP response
+                const protocolInfo: Record<string, any> = {
+                  Transport: "Streamable HTTP",
+                  "Response Format": "Server-Sent Events (streaming)",
+                  "Protocol Version": mcpResponse.result.protocolVersion,
+                };
+
+                // Include server info if available
+                if (mcpResponse.result.serverInfo) {
+                  protocolInfo["Server Name"] =
+                    mcpResponse.result.serverInfo.name;
+                  protocolInfo["Server Version"] =
+                    mcpResponse.result.serverInfo.version;
+                }
+
+                // Include capabilities if available
+                if (mcpResponse.result.capabilities) {
+                  protocolInfo["Capabilities"] =
+                    mcpResponse.result.capabilities;
+                }
+
+                mcpInfoLogs = addInfoLog(
+                  getCurrentState(),
+                  "authenticated_mcp_request",
+                  "mcp-protocol",
+                  "MCP Server Information",
+                  protocolInfo
+                );
+              } else if (isSSE) {
+                // SSE streaming response but no MCP response parsed yet
+                mcpInfoLogs = addInfoLog(
+                  getCurrentState(),
+                  "authenticated_mcp_request",
+                  "mcp-transport",
+                  "MCP Transport Detected",
+                  {
+                    Transport: "Streamable HTTP",
+                    "Response Format": "Server-Sent Events (streaming)",
+                    "Content-Type": contentType,
+                    Note: "Server returned streaming response. Initialize response delivered via SSE stream.",
+                    Events: response.body?.events
+                      ? `${response.body.events.length} events parsed`
+                      : "No events parsed",
+                  }
+                );
+              } else if (mcpResponse?.result?.protocolVersion) {
+                // JSON response - extract protocol version from response body
+                const protocolInfo: Record<string, any> = {
+                  Transport: "Streamable HTTP",
+                  "Response Format": "JSON",
+                  "Protocol Version": mcpResponse.result.protocolVersion,
+                };
+
+                // Include server info if available
+                if (mcpResponse.result.serverInfo) {
+                  protocolInfo["Server Name"] =
+                    mcpResponse.result.serverInfo.name;
+                  protocolInfo["Server Version"] =
+                    mcpResponse.result.serverInfo.version;
+                }
+
+                // Include capabilities if available
+                if (mcpResponse.result.capabilities) {
+                  protocolInfo["Capabilities"] =
+                    mcpResponse.result.capabilities;
+                }
+
+                mcpInfoLogs = addInfoLog(
+                  getCurrentState(),
+                  "authenticated_mcp_request",
+                  "mcp-protocol",
+                  "MCP Server Information",
+                  protocolInfo
+                );
+              }
+
+              updateState({
+                currentStep: "complete",
+                lastResponse: mcpResponseData,
+                httpHistory: updatedHistoryMcp,
+                infoLogs: mcpInfoLogs,
+                error: undefined,
+                isInitiatingAuth: false,
+              });
+            } catch (error) {
+              // Capture the error
+              const errorResponse = {
+                status: 0,
+                statusText: "Network Error",
+                headers: {},
+                body: {
+                  error: error instanceof Error ? error.message : String(error),
+                },
+              };
+
+              const updatedHistoryError = [...(state.httpHistory || [])];
+              if (updatedHistoryError.length > 0) {
+                const lastEntry =
+                  updatedHistoryError[updatedHistoryError.length - 1];
+                lastEntry.response = errorResponse;
+                lastEntry.duration =
+                  Date.now() - (lastEntry.timestamp || Date.now());
+              }
+
+              updateState({
+                lastResponse: errorResponse,
+                httpHistory: updatedHistoryError,
+                error: `Authenticated MCP request failed: ${error instanceof Error ? error.message : String(error)}`,
+                isInitiatingAuth: false,
+              });
+            }
+            break;
+
+          case "complete":
+            // Terminal state
+            updateState({ isInitiatingAuth: false });
+            break;
+
+          default:
+            updateState({ isInitiatingAuth: false });
+            break;
+        }
+      } catch (error) {
+        const currentState = getCurrentState();
+        const errorDetails = toLogErrorDetails(error);
+        const infoLogs = addInfoLog(
+          currentState,
+          currentState.currentStep,
+          `error-${currentState.currentStep}-${Date.now()}`,
+          "Step failed",
+          {
+            step: currentState.currentStep,
+            request: currentState.lastRequest,
+            response: currentState.lastResponse,
+            error: errorDetails,
+          },
+          { level: "error", error: errorDetails }
+        );
+        const updatedHistory = markLatestHttpEntryAsError(
+          currentState.httpHistory,
+          errorDetails
+        );
+
+        const updates: Partial<OAuthFlowState> = {
+          error: errorDetails.message,
+          infoLogs,
+          isInitiatingAuth: false,
+        };
+
+        if (updatedHistory) {
+          updates.httpHistory = updatedHistory;
+        }
+
+        updateState(updates);
+      }
+    },
+
+    // Start the guided flow from the beginning
+    startGuidedFlow: async () => {
+      updateState({
+        currentStep: "idle",
+        isInitiatingAuth: false,
+      });
+    },
+
+    // Reset the flow to initial state
+    resetFlow: () => {
+      updateState({
+        ...EMPTY_OAUTH_FLOW_STATE,
+        lastRequest: undefined,
+        lastResponse: undefined,
+        httpHistory: [],
+        infoLogs: [],
+        authorizationCode: undefined,
+        authorizationUrl: undefined,
+        accessToken: undefined,
+        refreshToken: undefined,
+        codeVerifier: undefined,
+        codeChallenge: undefined,
+        error: undefined,
+      });
+    },
+  };
+
+  return machine;
+};

--- a/sdk/src/oauth/state-machines/debug-oauth-2026-07-28.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2026-07-28.ts
@@ -543,6 +543,10 @@ export const createDebugOAuthStateMachine = (
   } = config;
 
   const redirectUri = redirectUrl;
+  // TODO(2026 delta): 2026-07-28 is stateless — no `initialize` handshake. The
+  // idle + authenticated verify steps below still send `initialize` (forked
+  // from 2025-11-25); they should become stateless requests. See the note in
+  // resolveInitializeProtocolVersion. Deferred; behavior is otherwise inherited.
   const initializeProtocolVersion = resolveInitializeProtocolVersion("2026-07-28");
   const dynamicRegistrationDefaults = dynamicRegistration ?? {};
   let cimdClientId = clientIdMetadataUrl ?? "";

--- a/sdk/src/oauth/state-machines/factory.ts
+++ b/sdk/src/oauth/state-machines/factory.ts
@@ -12,6 +12,7 @@ import type {
   RegistrationStrategy2025_03_26,
   RegistrationStrategy2025_06_18,
   RegistrationStrategy2025_11_25,
+  RegistrationStrategy2026_07_28,
 } from "./types.js";
 
 import {
@@ -29,6 +30,11 @@ import {
   type DebugOAuthStateMachineConfig as Config2025_11_25,
 } from "./debug-oauth-2025-11-25.js";
 
+import {
+  createDebugOAuthStateMachine as create2026_07_28,
+  type DebugOAuthStateMachineConfig as Config2026_07_28,
+} from "./debug-oauth-2026-07-28.js";
+
 /**
  * Configuration for creating an OAuth state machine with protocol version selection
  */
@@ -37,7 +43,8 @@ export interface OAuthStateMachineFactoryConfig extends BaseOAuthStateMachineCon
   registrationStrategy:
     | RegistrationStrategy2025_03_26
     | RegistrationStrategy2025_06_18
-    | RegistrationStrategy2025_11_25;
+    | RegistrationStrategy2025_11_25
+    | RegistrationStrategy2026_07_28;
 }
 
 /**
@@ -99,6 +106,10 @@ export function createOAuthStateMachine(
       // All registration strategies are valid for 2025-11-25
       return create2025_11_25(baseConfig as Config2025_11_25);
 
+    case "2026-07-28":
+      // All registration strategies are valid for 2026-07-28
+      return create2026_07_28(baseConfig as Config2026_07_28);
+
     default:
       // TypeScript exhaustiveness check
       const _exhaustive: never = protocolVersion;
@@ -119,6 +130,8 @@ export function getDefaultRegistrationStrategy(
       return "dcr";
     case "2025-11-25":
       return "cimd";
+    case "2026-07-28":
+      return "cimd";
     default:
       return "dcr";
   }
@@ -136,6 +149,8 @@ export function getSupportedRegistrationStrategies(
     case "2025-06-18":
       return ["dcr", "preregistered"] as const;
     case "2025-11-25":
+      return ["cimd", "dcr", "preregistered"] as const;
+    case "2026-07-28":
       return ["cimd", "dcr", "preregistered"] as const;
     default:
       return ["dcr", "preregistered"] as const;

--- a/sdk/src/oauth/state-machines/factory.ts
+++ b/sdk/src/oauth/state-machines/factory.ts
@@ -193,4 +193,16 @@ export const PROTOCOL_VERSION_INFO = {
       "Enhanced security with URL-based client IDs",
     ],
   },
+  "2026-07-28": {
+    label: "2026-07-28 (Draft)",
+    description:
+      "Draft MCP OAuth specification: 2025-11-25 discovery plus OIDC application_type",
+    features: [
+      "Client ID Metadata Documents (CIMD) SHOULD be supported",
+      "Protected Resource Metadata (RFC9728) required",
+      "RFC8414 OR OIDC discovery without root fallback",
+      "PKCE strictly required and enforced",
+      "SEP-837: OIDC application_type sent on Dynamic Client Registration",
+    ],
+  },
 } as const;

--- a/sdk/src/oauth/state-machines/shared/dynamic-client-registration.ts
+++ b/sdk/src/oauth/state-machines/shared/dynamic-client-registration.ts
@@ -51,13 +51,13 @@ export function deriveApplicationType(
     if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
       return true; // custom scheme (mcpjam://, …)
     }
+    // OIDC loopback redirects are native and use http (not https); an https
+    // loopback is not a native loopback, so keep the loopback→native
+    // classification http-only. `URL.hostname` serializes IPv6 with brackets
+    // (`[::1]`), so the bracketed form is the only one that can match.
+    if (parsed.protocol !== "http:") return false;
     const host = parsed.hostname;
-    return (
-      host === "localhost" ||
-      host === "127.0.0.1" ||
-      host === "::1" ||
-      host === "[::1]"
-    );
+    return host === "localhost" || host === "127.0.0.1" || host === "[::1]";
   };
   return redirectUris.some(isNativeRedirect) ? "native" : "web";
 }

--- a/sdk/src/oauth/state-machines/shared/dynamic-client-registration.ts
+++ b/sdk/src/oauth/state-machines/shared/dynamic-client-registration.ts
@@ -27,6 +27,42 @@ export interface DynamicClientRegistrationRequestInput {
 }
 
 /**
+ * Derive the OIDC / SEP-837 `application_type` from the redirect URIs. A `"web"`
+ * client requires HTTPS redirect URIs and forbids localhost; loopback and
+ * custom-scheme (e.g. `mcpjam://`) redirects are `"native"`. If any redirect is
+ * native-only, the whole registration is native.
+ *
+ * This helper is version-agnostic, but it is deliberately NOT wired into
+ * `buildDynamicClientRegistrationRequest` — `application_type` is an OIDC-DCR
+ * field the 2026-07-28 spec introduced as a client MUST, so only the
+ * `debug-oauth-2026-07-28` machine attaches it. The three 2025 machines keep
+ * their RFC-7591 registration body unchanged (fidelity to their spec version).
+ */
+export function deriveApplicationType(
+  redirectUris: readonly string[]
+): "native" | "web" {
+  const isNativeRedirect = (uri: string): boolean => {
+    let parsed: URL;
+    try {
+      parsed = new URL(uri);
+    } catch {
+      return true; // unparseable → treat conservatively as native
+    }
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return true; // custom scheme (mcpjam://, …)
+    }
+    const host = parsed.hostname;
+    return (
+      host === "localhost" ||
+      host === "127.0.0.1" ||
+      host === "::1" ||
+      host === "[::1]"
+    );
+  };
+  return redirectUris.some(isNativeRedirect) ? "native" : "web";
+}
+
+/**
  * Builds the RFC 7591 registration POST exactly as the debug OAuth machines
  * historically did: caller-supplied metadata defaults win, with
  * authorization-code-flavored fallbacks for anything absent. Callers that are

--- a/sdk/src/oauth/state-machines/shared/initialize.ts
+++ b/sdk/src/oauth/state-machines/shared/initialize.ts
@@ -10,8 +10,12 @@ export function resolveInitializeProtocolVersion(
     case "2025-11-25":
       return "2025-11-25";
     case "2026-07-28":
-      // The 2026-07-28 wire is stateless (no initialize handshake); the OAuth
-      // flow's token-verification request still carries this version header.
+      // TODO(2026 machine delta): the 2026-07-28 wire is stateless — there is
+      // no `initialize` handshake. The OAuth flow's final token-verification
+      // step (forked verbatim from 2025-11-25) still sends `initialize` with
+      // this header; it should instead issue a stateless request (e.g.
+      // `tools/list` carrying the `_meta` envelope). Deferred to the larger
+      // 2026 delta; this returns the correct header value for now.
       return "2026-07-28";
     case "2025-06-18":
     case "2025-03-26":

--- a/sdk/src/oauth/state-machines/shared/initialize.ts
+++ b/sdk/src/oauth/state-machines/shared/initialize.ts
@@ -9,6 +9,10 @@ export function resolveInitializeProtocolVersion(
   switch (protocolVersion) {
     case "2025-11-25":
       return "2025-11-25";
+    case "2026-07-28":
+      // The 2026-07-28 wire is stateless (no initialize handshake); the OAuth
+      // flow's token-verification request still carries this version header.
+      return "2026-07-28";
     case "2025-06-18":
     case "2025-03-26":
       return "2024-11-05";

--- a/sdk/src/oauth/state-machines/types.ts
+++ b/sdk/src/oauth/state-machines/types.ts
@@ -182,6 +182,8 @@ export interface OAuthDynamicRegistrationMetadata {
   grant_types?: string[];
   response_types?: string[];
   token_endpoint_auth_method?: string;
+  /** OIDC / SEP-837 client application type. */
+  application_type?: "native" | "web";
   [key: string]: unknown;
 }
 
@@ -245,6 +247,11 @@ export interface BaseOAuthStateMachineConfig {
 export type RegistrationStrategy2025_03_26 = "dcr" | "preregistered";
 export type RegistrationStrategy2025_06_18 = "dcr" | "preregistered";
 export type RegistrationStrategy2025_11_25 = "cimd" | "dcr" | "preregistered";
+export type RegistrationStrategy2026_07_28 = "cimd" | "dcr" | "preregistered";
 
 // Protocol versions
-export type OAuthProtocolVersion = "2025-03-26" | "2025-06-18" | "2025-11-25";
+export type OAuthProtocolVersion =
+  | "2025-03-26"
+  | "2025-06-18"
+  | "2025-11-25"
+  | "2026-07-28";

--- a/sdk/src/server-probe.ts
+++ b/sdk/src/server-probe.ts
@@ -149,7 +149,10 @@ function buildAuthServerMetadataUrls(
   const url = new URL(authServerUrl);
   const urls: string[] = [];
 
-  if (protocolVersion === "2025-11-25") {
+  // 2025-11-25 and 2026-07-28 share the same AS-metadata discovery: OAuth
+  // path-insertion, then OIDC path-insertion / path-appending, with NO root
+  // fallback for path-containing issuers (the older branch below keeps it).
+  if (protocolVersion === "2025-11-25" || protocolVersion === "2026-07-28") {
     if (url.pathname === "/" || url.pathname === "") {
       urls.push(
         new URL(

--- a/sdk/src/server-probe.ts
+++ b/sdk/src/server-probe.ts
@@ -133,6 +133,8 @@ function initializeProtocolVersion(
       return "2024-11-05";
     case "2025-11-25":
       return "2025-11-25";
+    case "2026-07-28":
+      return "2026-07-28";
     default: {
       const exhaustive: never = protocolVersion;
       return exhaustive;

--- a/sdk/tests/oauth/authorization-plan.test.ts
+++ b/sdk/tests/oauth/authorization-plan.test.ts
@@ -182,4 +182,20 @@ describe("resolveAuthorizationPlan", () => {
     expect(plan.blockerDetails[0]?.code).toBe("CIMD_UNSUPPORTED_PROTOCOL");
     expect(plan.blockers[0]).toContain("not supported for protocol version 2025-06-18");
   });
+
+  it("permits explicit CIMD on 2026-07-28 (parity with the auto-select gate)", () => {
+    // 2026-07-28 advertises CIMD (resolveRegistrationStrategies), so explicitly
+    // selecting it must not raise CIMD_UNSUPPORTED_PROTOCOL — otherwise auto and
+    // explicit selection disagree.
+    const plan = resolveAuthorizationPlan({
+      serverUrl: "https://example.com/mcp",
+      authMode: "interactive",
+      protocolVersion: "2026-07-28",
+      registrationStrategy: "cimd",
+    });
+
+    expect(
+      plan.blockerDetails.some((b) => b.code === "CIMD_UNSUPPORTED_PROTOCOL"),
+    ).toBe(false);
+  });
 });

--- a/sdk/tests/oauth/debug-oauth-2026.test.ts
+++ b/sdk/tests/oauth/debug-oauth-2026.test.ts
@@ -1,0 +1,91 @@
+import { createOAuthStateMachine } from "../../src/oauth/state-machines/factory.js";
+import { deriveApplicationType } from "../../src/oauth/state-machines/shared/dynamic-client-registration.js";
+import { EMPTY_OAUTH_FLOW_STATE } from "../../src/oauth/state-machines/types.js";
+import type { OAuthFlowState } from "../../src/oauth/state-machines/types.js";
+
+const REDIRECT_URI = "http://127.0.0.1:3333/callback";
+const SERVER_URL = "https://mcp.example.com/mcp";
+
+describe("deriveApplicationType (SEP-837)", () => {
+  it("is native for loopback and custom-scheme redirects", () => {
+    for (const uri of [
+      "http://localhost:3000/callback",
+      "http://127.0.0.1:3000/callback",
+      "http://[::1]:3000/callback",
+      "mcpjam://oauth/callback",
+    ]) {
+      expect(deriveApplicationType([uri])).toBe("native");
+    }
+  });
+
+  it("is web for HTTPS non-localhost redirects", () => {
+    expect(deriveApplicationType(["https://app.example.com/callback"])).toBe(
+      "web",
+    );
+  });
+
+  it("is native if any redirect is native", () => {
+    expect(
+      deriveApplicationType([
+        "https://app.example.com/callback",
+        "http://localhost:3000/callback",
+      ]),
+    ).toBe("native");
+  });
+});
+
+describe("debug-oauth-2026-07-28 machine", () => {
+  const build = (overrides: Partial<OAuthFlowState> = {}) => {
+    let state: OAuthFlowState = {
+      ...EMPTY_OAUTH_FLOW_STATE,
+      serverUrl: SERVER_URL,
+      ...overrides,
+    };
+    const machine = createOAuthStateMachine({
+      protocolVersion: "2026-07-28",
+      registrationStrategy: "dcr",
+      state,
+      getState: () => state,
+      updateState: (updates) => {
+        state = { ...state, ...updates };
+      },
+      serverUrl: SERVER_URL,
+      serverName: "Test Server",
+      redirectUrl: REDIRECT_URI,
+      requestExecutor: jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        body: {},
+      }),
+      dynamicRegistration: { client_name: "Test Client" },
+    });
+    return { machine, getState: () => state };
+  };
+
+  it("is buildable via the factory (no silent fallback to 2025-11-25)", () => {
+    const { machine } = build();
+    expect(machine).toBeDefined();
+    expect(typeof machine.proceedToNextStep).toBe("function");
+  });
+
+  it("attaches application_type on the DCR registration request (native for loopback)", async () => {
+    const { machine, getState } = build({
+      currentStep: "received_authorization_server_metadata",
+      authorizationServerMetadata: {
+        issuer: "https://auth.example.com",
+        authorization_endpoint: "https://auth.example.com/authorize",
+        token_endpoint: "https://auth.example.com/token",
+        registration_endpoint: "https://auth.example.com/register",
+        response_types_supported: ["code"],
+        code_challenge_methods_supported: ["S256"],
+        // no client_id_metadata_document_supported → DCR path
+      },
+    });
+    await machine.proceedToNextStep();
+    const req = getState().lastRequest;
+    expect(req?.url).toBe("https://auth.example.com/register");
+    expect(req?.body?.application_type).toBe("native");
+  });
+});

--- a/sdk/tests/oauth/debug-oauth-2026.test.ts
+++ b/sdk/tests/oauth/debug-oauth-2026.test.ts
@@ -32,6 +32,12 @@ describe("deriveApplicationType (SEP-837)", () => {
       ]),
     ).toBe("native");
   });
+
+  it("classifies an https loopback as web (OIDC loopback is http-only)", () => {
+    expect(deriveApplicationType(["https://localhost:3000/callback"])).toBe(
+      "web",
+    );
+  });
 });
 
 describe("debug-oauth-2026-07-28 machine", () => {
@@ -87,5 +93,54 @@ describe("debug-oauth-2026-07-28 machine", () => {
     const req = getState().lastRequest;
     expect(req?.url).toBe("https://auth.example.com/register");
     expect(req?.body?.application_type).toBe("native");
+  });
+
+  it("derives application_type from the caller's redirect_uris override, not the loopback default", async () => {
+    // A caller-supplied redirect_uris override lands in the DCR body; the
+    // application_type must be derived from that SAME effective list, so an
+    // https/web override cannot ship alongside a `native` type.
+    let state: OAuthFlowState = {
+      ...EMPTY_OAUTH_FLOW_STATE,
+      serverUrl: SERVER_URL,
+      currentStep: "received_authorization_server_metadata",
+      authorizationServerMetadata: {
+        issuer: "https://auth.example.com",
+        authorization_endpoint: "https://auth.example.com/authorize",
+        token_endpoint: "https://auth.example.com/token",
+        registration_endpoint: "https://auth.example.com/register",
+        response_types_supported: ["code"],
+        code_challenge_methods_supported: ["S256"],
+      },
+    };
+    const machine = createOAuthStateMachine({
+      protocolVersion: "2026-07-28",
+      registrationStrategy: "dcr",
+      state,
+      getState: () => state,
+      updateState: (updates) => {
+        state = { ...state, ...updates };
+      },
+      serverUrl: SERVER_URL,
+      serverName: "Test Server",
+      redirectUrl: REDIRECT_URI, // loopback
+      requestExecutor: jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        body: {},
+      }),
+      // Override the redirect with a hosted https (web) URI.
+      dynamicRegistration: {
+        client_name: "Test Client",
+        redirect_uris: ["https://hosted.example.com/callback"],
+      },
+    });
+    await machine.proceedToNextStep();
+    const req = state.lastRequest;
+    expect(req?.body?.redirect_uris).toEqual([
+      "https://hosted.example.com/callback",
+    ]);
+    expect(req?.body?.application_type).toBe("web");
   });
 });

--- a/sdk/tests/server-probe.test.ts
+++ b/sdk/tests/server-probe.test.ts
@@ -118,6 +118,62 @@ describe("probeMcpServer", () => {
     ]);
   });
 
+  it("uses modern path-insertion AS discovery (no root fallback) for 2026-07-28 + path issuer", async () => {
+    // Regression guard: 2026-07-28 must share the 2025-11-25 AS-metadata
+    // discovery (path insertion, NO root fallback for path-containing issuers).
+    // Before the fix, 2026 fell through to the older branch that adds a root
+    // fallback URL the spec forbids.
+    const serverUrl = "https://mcp.example.com/mcp";
+    const resourceMetadataUrl =
+      "https://mcp.example.com/.well-known/oauth-protected-resource/mcp";
+    const authServerUrl = "https://auth.example.com/tenant1"; // path-containing
+    const pathInsertionUrl =
+      "https://auth.example.com/.well-known/oauth-authorization-server/tenant1";
+    const rootFallbackUrl =
+      "https://auth.example.com/.well-known/oauth-authorization-server";
+    const requested: string[] = [];
+
+    const fetchFn: typeof fetch = jest.fn(async (input) => {
+      const url = String(input);
+      requested.push(url);
+      if (url === serverUrl) {
+        return new Response(null, {
+          status: 401,
+          headers: {
+            "WWW-Authenticate": `Bearer resource_metadata="${resourceMetadataUrl}"`,
+          },
+        });
+      }
+      if (url === resourceMetadataUrl) {
+        return jsonResponse({
+          resource: serverUrl,
+          authorization_servers: [authServerUrl],
+        });
+      }
+      if (url === pathInsertionUrl) {
+        return jsonResponse({
+          issuer: authServerUrl,
+          authorization_endpoint: `${authServerUrl}/authorize`,
+          token_endpoint: `${authServerUrl}/token`,
+          response_types_supported: ["code"],
+          code_challenge_methods_supported: ["S256"],
+        });
+      }
+      return jsonResponse({ error: "unexpected" }, 404);
+    }) as typeof fetch;
+
+    const result = await probeMcpServer({
+      url: serverUrl,
+      protocolVersion: "2026-07-28",
+      fetchFn,
+    });
+
+    expect(result.oauth.authorizationServerMetadataUrl).toBe(pathInsertionUrl);
+    // The root fallback is forbidden for path-containing issuers and must
+    // never be requested on the 2026-07-28 discovery path.
+    expect(requested).not.toContain(rootFallbackUrl);
+  });
+
   it("retries transient probe failures and preserves attempts across retries", async () => {
     const serverUrl = "https://mcp.example.com/mcp";
     let initializeCalls = 0;

--- a/sdk/tests/server-probe.test.ts
+++ b/sdk/tests/server-probe.test.ts
@@ -123,12 +123,24 @@ describe("probeMcpServer", () => {
     // discovery (path insertion, NO root fallback for path-containing issuers).
     // Before the fix, 2026 fell through to the older branch that adds a root
     // fallback URL the spec forbids.
+    //
+    // The metadata succeeds ONLY on a modern-branch-exclusive candidate (the
+    // OIDC path-APPENDING URL) and 404s the shared path-insertion URL, so the
+    // loop must advance past the first candidate to where the two branches
+    // diverge: the modern branch tries path-appending next, the old branch
+    // requests the root fallback. This is what makes the guard actually fail
+    // on the un-fixed code — succeeding on path-insertion (candidate #1 in
+    // BOTH branches) would pass either way and guard nothing.
     const serverUrl = "https://mcp.example.com/mcp";
     const resourceMetadataUrl =
       "https://mcp.example.com/.well-known/oauth-protected-resource/mcp";
     const authServerUrl = "https://auth.example.com/tenant1"; // path-containing
     const pathInsertionUrl =
       "https://auth.example.com/.well-known/oauth-authorization-server/tenant1";
+    // Modern-branch-only candidate (OIDC path appending); absent from the old
+    // branch, which would reach the root fallback instead.
+    const pathAppendOidcUrl =
+      "https://auth.example.com/tenant1/.well-known/openid-configuration";
     const rootFallbackUrl =
       "https://auth.example.com/.well-known/oauth-authorization-server";
     const requested: string[] = [];
@@ -150,7 +162,7 @@ describe("probeMcpServer", () => {
           authorization_servers: [authServerUrl],
         });
       }
-      if (url === pathInsertionUrl) {
+      if (url === pathAppendOidcUrl) {
         return jsonResponse({
           issuer: authServerUrl,
           authorization_endpoint: `${authServerUrl}/authorize`,
@@ -159,6 +171,8 @@ describe("probeMcpServer", () => {
           code_challenge_methods_supported: ["S256"],
         });
       }
+      // Everything else (including path-insertion) 404s, forcing the loop to
+      // advance to the branch-divergence point.
       return jsonResponse({ error: "unexpected" }, 404);
     }) as typeof fetch;
 
@@ -168,9 +182,13 @@ describe("probeMcpServer", () => {
       fetchFn,
     });
 
-    expect(result.oauth.authorizationServerMetadataUrl).toBe(pathInsertionUrl);
-    // The root fallback is forbidden for path-containing issuers and must
-    // never be requested on the 2026-07-28 discovery path.
+    // Resolved via the modern path-appending candidate...
+    expect(result.oauth.authorizationServerMetadataUrl).toBe(pathAppendOidcUrl);
+    // ...and the shared path-insertion candidate was tried first (proving we
+    // advanced past candidate #1)...
+    expect(requested).toContain(pathInsertionUrl);
+    // ...but the root fallback (old-branch candidate #2) was NEVER requested.
+    // On the un-fixed code this assertion fails.
     expect(requested).not.toContain(rootFallbackUrl);
   });
 


### PR DESCRIPTION
## What & why

Phase 2 (authorization), first step — **the new state machine, built first** (as the #3318 reviewer asked). Until now, a server pinned to `2026-07-28` was **silently modeled by the 2025-11-25 OAuth machine**: the OAuth debugger runs on its own `OAuthProtocolVersion` union, separate from the wire pin, and it topped out at 2025-11-25 (`normalizeOAuthProtocolVersion` dropped `"2026-07-28"` → default 11-25).

This replaces #3318, whose objection was correct: putting `application_type` in the *shared* DCR builder changed the wire output of all three version-faithful 2025 machines (which — investigation confirmed — are the **production** OAuth engine, not just a debugger view). Here it lands on the 2026 machine only.

## Changes

- **Widen `OAuthProtocolVersion`** to include `2026-07-28`; add `RegistrationStrategy2026_07_28`.
- **Fork** `debug-oauth-2025-11-25.ts` → `debug-oauth-2026-07-28.ts` (the repo's per-version copy-fork convention — the 06-18→11-25 delta was likewise fork+delta) and wire it through the factory + `sequence-actions`.
- **Fix every version-selection site** the widened union touches: factory switch + registration-strategy defaults, `sequence-actions`, `server-probe` initialize version, the `client-identity` debug-client-name `Record`, the `authorization-plan` CIMD gate (2026 offers CIMD like 11-25), and the shared `initialize` resolver.
- **2026 delta — SEP-837 `application_type`:** the 2026 machine attaches an appropriate `application_type` (`native` for the loopback debugger redirect) on its DCR request. `deriveApplicationType` is a version-agnostic helper **deliberately not wired into the shared RFC-7591 builder** — only the 2026 machine attaches it, so the three 2025 machines' wire output is **byte-unchanged**.

## Verification

- **sdk 2218 tests pass** (5 new), including a drive-to-registration test that proves the 2026 machine actually emits `application_type: "native"` on its DCR request — not just that the helper derives it.
- `tsc --noEmit` + tsup build clean. The 2025 machines' behavior is unchanged (parity fork + no shared-builder edit).

## Scope / follow-ups

- **2M-b** (next): make the 2026 machine user-selectable — inspector profile normalization, the version dropdown, the CLI allow-list, and auto-selecting it when the wire pin is `2026-07-28` (bridging the two-union seam).
- The **larger 2026 delta** — `iss` validation, AS-metadata issuer exact-match, AS-binding, scope-union — lands as focused follow-ups on this machine, several overlapping the era-agnostic runtime gates (**2R**), per the phasing-doc §10 revision (D15–D17).

Follows the full Phase-1 set (#3294/#3297/#3302/#3307/#3308/#3315/#3317); supersedes closed #3318.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth registration and discovery for a new protocol version with a large new state machine, but existing 2025 machines and shared DCR bodies are intentionally unchanged; risk is mainly correctness of the new 2026 path and probe discovery alignment.
> 
> **Overview**
> Introduces **`2026-07-28`** on the SDK OAuth path so servers pinned to that version are no longer modeled by the **2025-11-25** machine. A new **`debug-oauth-2026-07-28`** state machine (forked from 11-25) implements the draft flow: CIMD-first registration, required PKCE, path-aware authorization-server discovery without root fallback, and the same resource-indicator behavior as 11-25.
> 
> **Wiring** updates the factory, sequence diagram actions, authorization-plan CIMD gates, client debug names, initialize protocol header resolution, and **`server-probe`** AS-metadata discovery so **2026** shares the modern discovery rules with **11-25**.
> 
> **2026-specific DCR:** **`deriveApplicationType`** classifies redirect URIs as **`native`** vs **`web`**; only the 2026 machine attaches **`application_type`** on registration requests (shared RFC-7591 builder unchanged so 2025 wire output stays the same).
> 
> Tests cover CIMD on 2026 in the plan, **`application_type`** on DCR, and probe discovery without forbidden root fallback. Follow-ups noted in code: stateless MCP verify instead of **`initialize`** for 2026.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 201f7f0e49d60f621e50af431e252fca57d3f4a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a version-faithful OAuth state machine for protocol 2026-07-28 and wires it into the SDK, including `application_type` on DCR. Also aligns AS metadata discovery with 2025 rules and updates the client type map to fix typecheck.

- New Features
  - New `debug-oauth-2026-07-28` machine with CIMD/DCR/preregistered, PKCE required, path-aware AS discovery, and resource param persistence.
  - Sends `application_type` on DCR (loopback/custom-scheme → "native") via `deriveApplicationType`; 2025 machines’ wire output unchanged.
  - Adds `"2026-07-28"` to `OAuthProtocolVersion` and `RegistrationStrategy2026_07_28`; wired through factory, `sequence-actions`, CIMD in `authorization-plan`, initialize header, and client identity label; tests cover factory selection and DCR output.

- Bug Fixes
  - `server-probe` AS metadata discovery treats `2026-07-28` like `2025-11-25`: path-insertion for path issuers with no root fallback; regression test added.
  - `authorization-plan` now permits explicit `cimd` on `2026-07-28` (parity with auto-select); tested.
  - Adds `2026-07-28` to client `PROTOCOL_VERSION_INFO` to fix typecheck; does not make the version user-selectable.
  - Notes a stateless-verify TODO in `resolveInitializeProtocolVersion` for 2026 (no behavior change).

<sup>Written for commit 201f7f0e49d60f621e50af431e252fca57d3f4a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

