### PR TITLE
fix(webmcp): post-merge follow-ups for the surface agent-tools stack

### DIFF
--- a/mcpjam-inspector/client/src/components/ChatboxesTab.tsx
+++ b/mcpjam-inspector/client/src/components/ChatboxesTab.tsx
@@ -182,6 +182,11 @@ export function ChatboxesTab({
     "chatboxes:ensureChatboxForHost" as any
   );
   const ensureLatchRef = useRef<Set<string>>(new Set());
+  // Hosts whose chatbox was INTENTIONALLY deleted (ui_delete_chatbox). The
+  // back-mint effect below treats a reactive `chatbox === null` as drift and
+  // re-provisions; an intentional delete must stay deleted, so we suppress the
+  // remint for that host until a chatbox exists again (explicit re-publish).
+  const suppressEnsureHostsRef = useRef<Set<string>>(new Set());
   // Tracks hostIds where ensure resolved successfully but the reactive
   // query is *still* returning null. That's not provisioning latency —
   // it's the backend silently dropping the chatbox for some reason the
@@ -207,6 +212,8 @@ export function ChatboxesTab({
     // back-mint entirely (the notice below handles the empty render).
     if (isJourneysHost) return;
     if (chatbox !== null) return;
+    // Intentionally deleted → keep it deleted (don't re-mint on the null).
+    if (suppressEnsureHostsRef.current.has(previewedHostId)) return;
     if (ensureLatchRef.current.has(previewedHostId)) return;
     ensureLatchRef.current.add(previewedHostId);
     const targetHostId = previewedHostId;
@@ -260,6 +267,9 @@ export function ChatboxesTab({
     if (!previewedHostId) return;
     if (chatbox === null || chatbox === undefined) return;
     ensureLatchRef.current.delete(previewedHostId);
+    // A chatbox exists again for this host, so any intentional-delete
+    // suppression is spent: future backend drift should re-mint as before.
+    suppressEnsureHostsRef.current.delete(previewedHostId);
     setEnsureCompletedNullHosts((prev) => {
       if (!prev.has(previewedHostId)) return prev;
       const next = new Set(prev);
@@ -367,6 +377,9 @@ export function ChatboxesTab({
             `"${target.name}" belongs to the Swarms surface and has no publish surface. Manage its journeys and runs on the Swarms screen, or publish a different client.`,
           );
         }
+        // Explicit publish intent — lift any prior intentional-delete
+        // suppression so provisioning (and future drift-remint) works again.
+        suppressEnsureHostsRef.current.delete(target.hostId);
         try {
           await ensureChatboxForHost({ hostId: target.hostId } as any);
           setPreviewedHostId(target.hostId);
@@ -396,6 +409,11 @@ export function ChatboxesTab({
             `"${target.name}" has no chatbox to delete.`,
           );
         }
+        // Suppress the auto-remint BEFORE the delete lands: the reactive query
+        // flipping to null must not trigger ensureChatboxForHost, or the tool
+        // would report chatbox_deleted while the surface is immediately reminted.
+        suppressEnsureHostsRef.current.add(target.hostId);
+        ensureLatchRef.current.delete(target.hostId);
         try {
           await deleteChatbox({ chatboxId: match.chatboxId } as any);
           return {
@@ -405,6 +423,8 @@ export function ChatboxesTab({
             name: target.name,
           };
         } catch (e) {
+          // Delete failed — the chatbox still exists, so allow provisioning.
+          suppressEnsureHostsRef.current.delete(target.hostId);
           throw createInspectorCommandClientError(
             "execution_failed",
             e instanceof Error ? e.message : "Failed to delete the chatbox.",

--- a/mcpjam-inspector/client/src/components/PromptsTab.tsx
+++ b/mcpjam-inspector/client/src/components/PromptsTab.tsx
@@ -373,10 +373,17 @@ export function PromptsTab({
         setSelectedPrompt(target.name);
         setError("");
         setPromptContent(null);
+        // Claim the render-version (same ref the on-screen Run path bumps) so a
+        // slower render can't overwrite a newer selection's result.
+        const getVersion = ++promptGetVersionRef.current;
         try {
           // SAME api the Run button uses (getPrompt → getPromptApi).
           const data = await getPromptApi(serverName, target.name, providedArgs);
-          setPromptContent(data.content);
+          // Commit to the on-screen pane only if this is still the newest
+          // render; the tool still returns what IT fetched.
+          if (getVersion === promptGetVersionRef.current) {
+            setPromptContent(data.content);
+          }
           const capped = capPromptContentForTranscript(data.content);
           return {
             status: "prompt_rendered",

--- a/mcpjam-inspector/client/src/components/PromptsTab.tsx
+++ b/mcpjam-inspector/client/src/components/PromptsTab.tsx
@@ -68,10 +68,15 @@ function capPromptContentForTranscript(content: unknown): {
     };
   });
   if (messages.length > PROMPT_MESSAGE_MAX_BLOCKS) truncated = true;
+  let description: string | undefined;
+  if (typeof src?.description === "string") {
+    description = clampText(src.description);
+    // A clamped description is also truncation — flag it so the agent doesn't
+    // read `truncated: false` and treat the shortened text as complete.
+    if (description !== src.description) truncated = true;
+  }
   return {
-    ...(typeof src?.description === "string"
-      ? { description: clampText(src.description) }
-      : {}),
+    ...(description !== undefined ? { description } : {}),
     messages: out,
     truncated,
   };

--- a/mcpjam-inspector/client/src/components/ResourcesTab.tsx
+++ b/mcpjam-inspector/client/src/components/ResourcesTab.tsx
@@ -100,6 +100,31 @@ function extractTemplateParameters(uriTemplate: string): string[] {
   return Array.from(params);
 }
 
+/**
+ * The variables an agent MUST supply to read a template. Only simple `{var}`
+ * and reserved `{+var}` (path) expansions are required; query (`?`/`&`),
+ * fragment (`#`), label (`.`) and path-segment (`/`/`;`) expansions omit
+ * undefined variables cleanly under RFC 6570, so `search{?q,limit}` is readable
+ * with only `q` — matching the on-screen Read flow (`buildParameters()` passes
+ * only non-empty fields and `parseTemplate().expand()` drops the rest).
+ */
+function extractRequiredTemplateParameters(uriTemplate: string): string[] {
+  const params = new Set<string>();
+  const exprRegex = /\{([+#./;?&]?)([^}]+)\}/g;
+  let match;
+
+  while ((match = exprRegex.exec(uriTemplate)) !== null) {
+    const operator = match[1];
+    if (operator !== "" && operator !== "+") continue;
+    match[2].split(",").forEach((v) => {
+      const varName = v.split(":")[0].replace(/\*$/, "").trim();
+      if (varName) params.add(varName);
+    });
+  }
+
+  return Array.from(params);
+}
+
 // RFC 6570 compliant URI template expansion
 function buildUriFromTemplate(
   uriTemplate: string,
@@ -537,8 +562,12 @@ export function ResourcesTab({
         } else {
           const template = templateMatches[0];
           templateUriTemplate = template.uriTemplate;
-          const paramNames = extractTemplateParameters(template.uriTemplate);
-          const missing = paramNames.filter(
+          // Only path variables are required; optional query/fragment/etc.
+          // expansions may be omitted, exactly as the on-screen Read allows.
+          const requiredNames = extractRequiredTemplateParameters(
+            template.uriTemplate,
+          );
+          const missing = requiredNames.filter(
             (name) => !args[name] || args[name].trim() === "",
           );
           if (missing.length > 0) {
@@ -547,21 +576,38 @@ export function ResourcesTab({
               `Template "${template.name}" needs templateArguments for: ${missing.join(", ")}.`,
             );
           }
+          // Pass only the non-empty supplied values, like buildParameters();
+          // expand() drops any omitted optional variable from the URI.
           const provided: Record<string, string> = {};
-          for (const name of paramNames) provided[name] = args[name];
+          for (const name of extractTemplateParameters(template.uriTemplate)) {
+            const val = args[name];
+            if (typeof val === "string" && val.trim() !== "") {
+              provided[name] = val;
+            }
+          }
           uri = buildUriFromTemplate(template.uriTemplate, provided);
           setActiveTab("templates");
           setTemplateOverrides(provided);
           setSelectedTemplate(template.uriTemplate);
         }
 
+        // Claim the read-version for the relevant pane BEFORE awaiting, using
+        // the SAME refs the on-screen Read path bumps. A slower read (this one
+        // or a concurrent UI/agent read) must not commit over a newer selection.
+        const readVersion = templateUriTemplate
+          ? ++templateReadVersionRef.current
+          : ++resourceReadVersionRef.current;
         try {
           // SAME api the Read button uses (readResource → readResourceApi).
           const data = await readResourceApi(serverName, uri);
           const content = data?.content ?? null;
+          // Only commit to the on-screen pane if this is still the newest read
+          // for it; the tool still returns what IT fetched regardless.
           if (templateUriTemplate) {
-            setTemplateContent(content);
-          } else {
+            if (readVersion === templateReadVersionRef.current) {
+              setTemplateContent(content);
+            }
+          } else if (readVersion === resourceReadVersionRef.current) {
             setResourceContent(content);
           }
           const { contentBlocks, truncated } =
@@ -590,7 +636,14 @@ export function ResourcesTab({
     // NAMES+uris (bounded), the current selection, and whether a body was read
     // (presence/size only — never the content, which can be large or secret).
     snapshot: () => {
-      const lastRead = resourceContent ?? templateContent;
+      // Pick the body for the ACTIVE tab: after reading a concrete resource and
+      // then a template, a fixed `resourceContent ?? templateContent` would keep
+      // reporting the stale concrete body while the Templates screen shows the
+      // template one.
+      const lastRead =
+        activeTab === "templates"
+          ? (templateContent ?? resourceContent)
+          : (resourceContent ?? templateContent);
       let lastResultBytes = 0;
       let lastResultTruncated = false;
       if (lastRead) {

--- a/mcpjam-inspector/client/src/components/__tests__/ChatboxesTab.agent.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ChatboxesTab.agent.test.tsx
@@ -274,6 +274,35 @@ describe("ChatboxesTab — agent bridge handlers", () => {
     expect(deleteChatboxMock).toHaveBeenCalledWith({ chatboxId: "cb-2" });
   });
 
+  it("keeps the PREVIEWED host's chatbox deleted — no auto-remint after delete", async () => {
+    // host-1 (Claude) is the previewed host and is currently published.
+    const { rerender } = render(
+      <ChatboxesTab projectId="proj-1" isAuthenticated product="swarm" />,
+    );
+    const response = await dispatch({
+      type: "deleteChatbox",
+      payload: { host: "Claude" },
+    });
+    expect(response).toMatchObject({
+      status: "success",
+      result: { status: "chatbox_deleted", chatboxId: "cb-1" },
+    });
+    expect(deleteChatboxMock).toHaveBeenCalledWith({ chatboxId: "cb-1" });
+
+    // The reactive query now reports null for the deleted host. Without the
+    // suppression, the back-mint effect would call ensureChatboxForHost and
+    // re-provision it — contradicting chatbox_deleted.
+    currentChatbox = null;
+    await act(async () => {
+      rerender(
+        <ChatboxesTab projectId="proj-1" isAuthenticated product="swarm" />,
+      );
+    });
+    expect(ensureChatboxForHostMock).not.toHaveBeenCalledWith({
+      hostId: "host-1",
+    });
+  });
+
   it("deleteChatbox rejects an unknown host without touching the mutation", async () => {
     renderChatboxes();
     const response = await dispatch({

--- a/mcpjam-inspector/client/src/components/__tests__/ResourcesTab.agent.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ResourcesTab.agent.test.tsx
@@ -94,6 +94,7 @@ beforeEach(() => {
   });
   mockListTemplates.mockResolvedValue([
     { name: "greeting", uriTemplate: "greeting://{name}" },
+    { name: "search", uriTemplate: "search{?q,limit}" },
   ]);
   mockReadResource.mockResolvedValue({
     content: { contents: [{ type: "text", text: SECRET_BODY }] },
@@ -125,6 +126,21 @@ describe("ResourcesTab — agent bridge handler", () => {
       result: { status: "resource_read", uri: "greeting://Ada" },
     });
     expect(mockReadResource).toHaveBeenCalledWith("srv", "greeting://Ada");
+  });
+
+  it("reads a template with only some OPTIONAL query variables supplied", async () => {
+    // search{?q,limit}: RFC 6570 query expansion — optional. The on-screen Read
+    // allows omitting `limit`, so the agent must too (expand drops it).
+    await renderLoaded();
+    const response = await dispatch({
+      type: "readResource",
+      payload: { resource: "search", templateArguments: { q: "mcp" } },
+    });
+    expect(response).toMatchObject({
+      status: "success",
+      result: { status: "resource_read", uri: "search?q=mcp" },
+    });
+    expect(mockReadResource).toHaveBeenCalledWith("srv", "search?q=mcp");
   });
 
   it("rejects a template with missing params as invalid_request (no read)", async () => {

--- a/mcpjam-inspector/client/src/components/compat/HostCompatPage.tsx
+++ b/mcpjam-inspector/client/src/components/compat/HostCompatPage.tsx
@@ -1,4 +1,5 @@
 import { Boxes } from "lucide-react";
+import { useFeatureFlagEnabled } from "posthog-js/react";
 import type { ServerWithName } from "@/state/app-types";
 import { useServerToolsData } from "@/lib/host-compat/use-host-compat";
 import { HostCompatContent } from "@/components/compat/HostCompatContent";
@@ -47,8 +48,14 @@ export function HostCompatPage({
   // servers are on the matrix and which one's report is open. Must run before
   // the early return below (rules of hooks). Redacted STATE only — server names
   // and selection, never a server's config or the per-host findings.
+  // Gate the provider on the SAME flag as the surface: ui_snapshot_app reads
+  // the registry independent of sidebar visibility, so without this an agent
+  // could observe Compatibility even where the flag is off. `=== true` keeps it
+  // unregistered while the flag is still loading; the bridge re-runs on flip.
+  const compatibilityEnabled = useFeatureFlagEnabled("mcpjam-compatibility");
   useSurfaceAgentBridge({
     surfaceId: "compatibility",
+    enabled: compatibilityEnabled === true,
     snapshot: () =>
       buildCompatibilitySnapshot({
         servers,

--- a/mcpjam-inspector/client/src/components/computer/ComputerView.tsx
+++ b/mcpjam-inspector/client/src/components/computer/ComputerView.tsx
@@ -228,6 +228,17 @@ export function ComputerView({
         "The Computer tools need a signed-in project — sign in and select a project first.",
       );
     }
+    // Config still loading: `dataPlaneUnavailable` is false while `dataPlane`
+    // is undefined, so without this a same-turn call right after navigation
+    // could reach reserve() and BILL/provision before we know there's even a
+    // usable data plane. Treat unresolved config as pending (retryable), the
+    // way the terminal controller refuses to open until dataPlane resolves.
+    if (dataPlane === undefined) {
+      throw createInspectorCommandClientError(
+        "execution_failed",
+        "The Computer configuration is still loading — try again in a moment.",
+      );
+    }
     if (dataPlaneUnavailable) {
       throw createInspectorCommandClientError(
         "unsupported_in_mode",
@@ -284,6 +295,15 @@ export function ComputerView({
       },
       resetComputer: async () => {
         const pid = requireComputerProject();
+        // Same gate as the Reset button (disabled unless `canReset`): a reset
+        // wipes/rebuilds the box, so it's only valid once the computer is
+        // settled (ready or hibernating), never mid-provision/waking/error.
+        if (!canReset) {
+          throw createInspectorCommandClientError(
+            "execution_failed",
+            `The computer can't be reset from "${liveStatus ?? "none"}" — reset only when it's ready or hibernating.`,
+          );
+        }
         try {
           const res = await resetComputer({ projectId: pid });
           return {
@@ -337,8 +357,13 @@ export function ComputerView({
           : null,
         imageLabel,
         terminalOpen,
-        // Short, redacted error text only (no stack, no payload).
-        lastError: status?.lastError ? status.lastError.slice(0, 300) : null,
+        // Presence only — the raw provider error can carry tokens/URLs/PII, and
+        // slicing bounds length but not content. The agent gets a fixed summary;
+        // the human sees the full text on the Computer screen.
+        hasError: Boolean(status?.lastError),
+        lastError: status?.lastError
+          ? "The computer reported an error — open the Computer screen for details."
+          : null,
       };
     },
   });

--- a/mcpjam-inspector/client/src/components/computer/__tests__/ComputerView.agent.test.tsx
+++ b/mcpjam-inspector/client/src/components/computer/__tests__/ComputerView.agent.test.tsx
@@ -227,4 +227,45 @@ describe("ComputerView — agent bridge handlers", () => {
     const snapshot = await readSurfaceSnapshot("computer");
     expect(snapshot).toMatchObject({ ok: true, data: { gated: true } });
   });
+
+  it("does NOT reserve/bill while the data-plane config is still loading", async () => {
+    // dataPlane undefined = config unresolved: dataPlaneUnavailable is false,
+    // but we must not reach reserve() before we know a data plane exists.
+    mockDataPlane = undefined;
+    renderComputer();
+    const response = await dispatch({ type: "startComputer" });
+    // Retryable, not "unsupported" — the config just hasn't landed yet.
+    expect(response).toMatchObject({
+      status: "error",
+      error: { code: "execution_failed" },
+    });
+    expect(reserve).not.toHaveBeenCalled();
+  });
+
+  it("refuses reset from a non-resettable status (same gate as the disabled button)", async () => {
+    mockStatus = { computerId: "c-1", status: "provisioning", provider: "e2b" };
+    renderComputer();
+    const response = await dispatch({ type: "resetComputer" });
+    expect(response).toMatchObject({
+      status: "error",
+      error: { code: "execution_failed" },
+    });
+    // The destructive wipe/rebuild mutation is never invoked from this state.
+    expect(resetComputer).not.toHaveBeenCalled();
+  });
+
+  it("snapshot never passes raw provider error text into the transcript", async () => {
+    mockStatus = {
+      computerId: "c-1",
+      status: "error",
+      provider: "e2b",
+      lastError: "auth failed token=SECRET-abc123 at https://internal.example/vm",
+    } as ComputerViewModel;
+    renderComputer();
+    const snapshot = await readSurfaceSnapshot("computer");
+    expect(snapshot).toMatchObject({ ok: true, data: { hasError: true } });
+    const serialized = JSON.stringify(snapshot);
+    expect(serialized).not.toContain("SECRET-abc123");
+    expect(serialized).not.toContain("internal.example");
+  });
 });

--- a/mcpjam-inspector/client/src/components/playground/__tests__/playground-agent-controls-bridge.test.ts
+++ b/mcpjam-inspector/client/src/components/playground/__tests__/playground-agent-controls-bridge.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   getPlaygroundAgentControls,
   resolvePlaygroundModelIdentifier,
+  resolveSelectablePlaygroundModel,
   usePlaygroundAgentControlsBridgeStore,
   type PlaygroundAgentControls,
 } from "../playground-agent-controls-bridge";
@@ -25,6 +26,33 @@ describe("resolvePlaygroundModelIdentifier", () => {
   it("returns undefined for an unknown or empty identifier", () => {
     expect(resolvePlaygroundModelIdentifier("nope", MODELS)).toBeUndefined();
     expect(resolvePlaygroundModelIdentifier("   ", MODELS)).toBeUndefined();
+  });
+});
+
+describe("resolveSelectablePlaygroundModel (availability policy)", () => {
+  const LOCKED = [
+    { id: "claude-sonnet-5", name: "Claude Sonnet 5" },
+    {
+      id: "gpt-4.1",
+      name: "GPT-4.1",
+      disabled: true,
+      disabledReason: "Sign in to use this model.",
+    },
+  ];
+
+  it("returns the model for an enabled row", () => {
+    const r = resolveSelectablePlaygroundModel("claude-sonnet-5", LOCKED);
+    expect(r).toEqual({ ok: true, model: LOCKED[0] });
+  });
+
+  it("rejects a disabled row with its reason (no bypass of the picker lock)", () => {
+    const r = resolveSelectablePlaygroundModel("gpt-4.1", LOCKED);
+    expect(r).toEqual({ ok: false, error: "Sign in to use this model." });
+  });
+
+  it("rejects an unknown identifier", () => {
+    const r = resolveSelectablePlaygroundModel("nope", LOCKED);
+    expect(r.ok).toBe(false);
   });
 });
 

--- a/mcpjam-inspector/client/src/components/playground/playground-agent-controls-bridge.ts
+++ b/mcpjam-inspector/client/src/components/playground/playground-agent-controls-bridge.ts
@@ -89,3 +89,39 @@ export function resolvePlaygroundModelIdentifier<
   const lower = trimmed.toLowerCase();
   return models.find((model) => model.name.toLowerCase() === lower);
 }
+
+/**
+ * Resolve an identifier AND apply the picker's availability policy: a disabled
+ * row (guest lock, exhausted credits, no tool-calling support) is rejected the
+ * same way the visible `ModelSelector` disables it, so an agent can't select a
+ * model the UI deliberately locks. Pure, so the policy is unit-testable without
+ * a PlaygroundMain render. The caller commits the change only on `ok: true`.
+ */
+export function resolveSelectablePlaygroundModel<
+  M extends {
+    id: unknown;
+    name: string;
+    disabled?: boolean;
+    disabledReason?: string;
+  },
+>(
+  identifier: string,
+  models: readonly M[],
+): { ok: true; model: M } | { ok: false; error: string } {
+  const match = resolvePlaygroundModelIdentifier(identifier, models);
+  if (!match) {
+    return {
+      ok: false,
+      error: `Unknown model "${identifier}". It must match an available model's id or display name.`,
+    };
+  }
+  if (match.disabled) {
+    return {
+      ok: false,
+      error:
+        match.disabledReason ??
+        `The model "${match.name}" isn't available right now.`,
+    };
+  }
+  return { ok: true, model: match };
+}

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -179,7 +179,7 @@ import {
 } from "@/components/chat-v2/history/chat-history-prefetch";
 import { usePlaygroundChatHistoryBridgeStore } from "@/components/playground/playground-chat-history-bridge";
 import {
-  resolvePlaygroundModelIdentifier,
+  resolveSelectablePlaygroundModel,
   usePlaygroundAgentControlsBridgeStore,
 } from "@/components/playground/playground-agent-controls-bridge";
 import { WebApiError } from "@/lib/apis/web/base";
@@ -2735,18 +2735,16 @@ export function PlaygroundMain({
       // Multi-model-aware streaming flag, matching the composer's stop control.
       isGenerating: isStreamingActive,
       selectModel: (identifier) => {
-        const match = resolvePlaygroundModelIdentifier(
+        // Resolves the identifier AND enforces the picker's availability policy
+        // (disabled rows rejected), so the agent can't select a locked model.
+        const resolution = resolveSelectablePlaygroundModel(
           identifier,
           availableModels
         );
-        if (!match) {
-          return {
-            ok: false,
-            error: `Unknown model "${identifier}". It must match an available model's id or display name.`,
-          };
-        }
-        handleSingleModelChange(match);
-        return { ok: true, model: { id: String(match.id), name: match.name } };
+        if (!resolution.ok) return resolution;
+        const { model } = resolution;
+        handleSingleModelChange(model);
+        return { ok: true, model: { id: String(model.id), name: model.name } };
       },
       setSystemPrompt: (prompt) => setSystemPrompt(prompt),
       resetChat: () => handleResetAllChats(),

--- a/mcpjam-inspector/client/src/components/ui-playground/hooks/use-playground-state.ts
+++ b/mcpjam-inspector/client/src/components/ui-playground/hooks/use-playground-state.ts
@@ -810,7 +810,23 @@ export function usePlaygroundState(options: UsePlaygroundStateOptions) {
       return controls;
     };
 
-    const unregisterSelectModel = registerInspectorCommandHandler(
+    // The chat-composer handlers drive the SINGLETON PlaygroundMain controls,
+    // so they must exist only for the real Playground surface — not the Evals
+    // recorder's embedded chat, which mounts this same hook without a
+    // `snapshotSurfaceId`. Registering them there would make
+    // `hasInspectorCommandHandler('resetChat')` true off /playground, skip the
+    // auto-open-playground fallback, and let whichever PlaygroundMain published
+    // its controls last own the action (e.g. ui_reset_chat clearing the eval
+    // preview). Same gate the snapshot provider below already uses.
+    const registerChatControlHandler: typeof registerInspectorCommandHandler = (
+      type,
+      handler,
+    ) =>
+      snapshotSurfaceId
+        ? registerInspectorCommandHandler(type, handler)
+        : () => {};
+
+    const unregisterSelectModel = registerChatControlHandler(
       "selectModel",
       async (rawCommand) => {
         const command = rawCommand as SelectModelInspectorCommand;
@@ -834,19 +850,29 @@ export function usePlaygroundState(options: UsePlaygroundStateOptions) {
       },
     );
 
-    const unregisterSetSystemPrompt = registerInspectorCommandHandler(
+    const unregisterSetSystemPrompt = registerChatControlHandler(
       "setSystemPrompt",
       async (rawCommand) => {
         const command = rawCommand as SetSystemPromptInspectorCommand;
         const controls = requireChatControls();
-        // Free text the user is directing; empty string clears the prompt.
-        controls.setSystemPrompt(command.payload.prompt ?? "");
+        // `prompt` is a required string. The WebMCP wrapper enforces that, but
+        // the server /api/mcp/command path only checks payload is an object, so
+        // validate here too — a nullish coalesce would silently CLEAR the
+        // user's prompt on `{}` / `{ prompt: null }` and report success. An
+        // explicit "" is still a legitimate clear.
+        if (typeof command.payload.prompt !== "string") {
+          throw createInspectorCommandClientError(
+            "invalid_request",
+            "Missing required 'prompt' string (pass an empty string to clear it).",
+          );
+        }
+        controls.setSystemPrompt(command.payload.prompt);
         await waitForUiCommit();
         return buildPlaygroundSnapshot();
       },
     );
 
-    const unregisterResetChat = registerInspectorCommandHandler(
+    const unregisterResetChat = registerChatControlHandler(
       "resetChat",
       async () => {
         const controls = requireChatControls();
@@ -856,7 +882,7 @@ export function usePlaygroundState(options: UsePlaygroundStateOptions) {
       },
     );
 
-    const unregisterStopGeneration = registerInspectorCommandHandler(
+    const unregisterStopGeneration = registerChatControlHandler(
       "stopGeneration",
       async () => {
         const controls = requireChatControls();

--- a/mcpjam-inspector/client/src/hooks/useChatboxes.ts
+++ b/mcpjam-inspector/client/src/hooks/useChatboxes.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQuery } from "convex/react";
+import { shouldQueryProjectId } from "./useProjects";
 import type { ChatboxHostStyle } from "@/lib/chatbox-client-style";
 import type {
   ChatUiSettings,
@@ -120,14 +121,19 @@ export function useChatboxList({
   isAuthenticated: boolean;
   projectId: string | null;
 }) {
+  // Skip until `projectId` is a real Convex id: a transient LOCAL id (UUID or
+  // `local_`/`project_` placeholder) is truthy but throws an
+  // ArgumentValidationError against `listChatboxes` during project hydration —
+  // the same guard useHostList uses.
+  const enabled = isAuthenticated && shouldQueryProjectId(projectId);
   const chatboxes = useQuery(
     "chatboxes:listChatboxes" as any,
-    isAuthenticated && projectId ? ({ projectId } as any) : "skip",
+    enabled ? ({ projectId } as any) : "skip",
   ) as ChatboxListItem[] | undefined;
 
   return {
     chatboxes,
-    isLoading: isAuthenticated && !!projectId && chatboxes === undefined,
+    isLoading: enabled && chatboxes === undefined,
   };
 }
 

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/bounded-size.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/bounded-size.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { boundedJsonByteLength } from "../bounded-size";
+
+describe("boundedJsonByteLength", () => {
+  it("reports an approximate size for a small value without truncating", () => {
+    const { bytes, truncated } = boundedJsonByteLength({ a: "hello", n: 1 });
+    expect(truncated).toBe(false);
+    expect(bytes).toBeGreaterThan(0);
+    expect(bytes).toBeLessThan(64 * 1024);
+  });
+
+  it("truncates on a large SCALAR payload (byte cap)", () => {
+    const big = "x".repeat(200_000);
+    const { truncated } = boundedJsonByteLength(big, 64 * 1024);
+    expect(truncated).toBe(true);
+  });
+
+  it("truncates on a NODE-heavy shape that carries almost no scalar bytes", () => {
+    // Millions of nulls: near-zero scalar bytes, but a scalar-only cap would
+    // let JSON.stringify walk every node and block the thread. The node budget
+    // must abort this.
+    const nodeHeavy = new Array(500_000).fill(null);
+    const { truncated } = boundedJsonByteLength(nodeHeavy, 64 * 1024);
+    expect(truncated).toBe(true);
+  });
+
+  it("respects a custom node budget", () => {
+    const arr = new Array(1_000).fill(null);
+    expect(boundedJsonByteLength(arr, 64 * 1024, 100).truncated).toBe(true);
+    expect(boundedJsonByteLength(arr, 64 * 1024, 10_000).truncated).toBe(false);
+  });
+
+  it("returns a finite, non-throwing result for a cyclic structure", () => {
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    // JSON.stringify throws on cycles; the helper must swallow that, not crash.
+    expect(() => boundedJsonByteLength(cyclic)).not.toThrow();
+  });
+});

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/review-surface-snapshots.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/review-surface-snapshots.test.ts
@@ -101,7 +101,7 @@ describe("review-surface snapshots redact and bound", () => {
       selectedHosts,
       capabilityFields,
       viewMode: "table",
-      searchQuery: "elicitation",
+      searchQuery: "paste-of-a-secret-token",
       supportFilter: "all",
       loadedSelectedCount: 40,
       totalSelectedCount: 40,
@@ -111,6 +111,10 @@ describe("review-surface snapshots redact and bound", () => {
     expect(snapshot.capabilityRows).toHaveLength(REVIEW_SNAPSHOT_MAX_ITEMS);
     expect(snapshot.comparedHostCount).toBe(40);
     expect(snapshot.capabilityRowCount).toBe(40);
+    // The raw field-search text is user input — presence only, never echoed.
+    expect(snapshot).not.toHaveProperty("searchQuery");
+    expect(snapshot.hasSearchQuery).toBe(true);
+    expect(JSON.stringify(snapshot)).not.toContain("paste-of-a-secret-token");
   });
 
   it("host-compare (permalink): reports support levels, never configs", () => {

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tools-catalog.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tools-catalog.test.ts
@@ -468,6 +468,8 @@ describe("buildUiToolsCatalog", () => {
   it("ui_reset_chat is destructive and dispatches an empty-payload reset", async () => {
     const reset = getTool("ui_reset_chat");
     expect(reset.annotations?.destructiveHint).toBe(true);
+    // Each reset spawns a fresh session, so a retry is not a no-op.
+    expect(reset.annotations?.idempotentHint).toBe(false);
     expect(reset.description).toContain("cannot be undone");
 
     await reset.execute({});

--- a/mcpjam-inspector/client/src/lib/webmcp/bounded-size.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/bounded-size.ts
@@ -8,15 +8,29 @@
  * `cap`, so the work is bounded regardless of the input. The returned byte count
  * is approximate (it sums primitive lengths, ignoring JSON punctuation/keys) —
  * enough for an "approxSizeBytes" signal, never a payload.
+ *
+ * TWO budgets, because a scalar-byte cap alone doesn't bound traversal: the
+ * replacer runs per node, but a node-heavy shape (deeply nested containers,
+ * millions of `null`s / `{}`s) carries almost no scalar bytes, so it would walk
+ * the whole structure before tripping `cap`. A separate node budget aborts on
+ * container/null-heavy inputs too, so the work is bounded for ALL shapes.
  */
+const DEFAULT_NODE_BUDGET = 200_000;
+
 export function boundedJsonByteLength(
   value: unknown,
   cap = 64 * 1024,
+  nodeBudget = DEFAULT_NODE_BUDGET,
 ): { bytes: number; truncated: boolean } {
   let emitted = 0;
+  let nodes = 0;
   const OVER = Symbol("over-cap");
   try {
     JSON.stringify(value, (_key, v) => {
+      // Every node — string, number, boolean, null, object, array — costs one
+      // traversal step; bound the count so node-heavy shapes can't run away.
+      nodes += 1;
+      if (nodes > nodeBudget) throw OVER;
       if (typeof v === "string") {
         emitted += v.length;
         if (emitted > cap) throw OVER;
@@ -28,7 +42,7 @@ export function boundedJsonByteLength(
     });
     return { bytes: emitted, truncated: false };
   } catch (e) {
-    if (e === OVER) return { bytes: cap, truncated: true };
+    if (e === OVER) return { bytes: Math.min(emitted, cap) || cap, truncated: true };
     return { bytes: 0, truncated: false };
   }
 }

--- a/mcpjam-inspector/client/src/lib/webmcp/groups/__tests__/computer.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/groups/__tests__/computer.test.ts
@@ -94,7 +94,7 @@ describe("buildComputerUiTools", () => {
     }
   });
 
-  it("gates exactly reset + delete behind the destructive approval pill", () => {
+  it("gates exactly start + reset + delete behind the destructive approval pill", () => {
     const destructive = buildComputerUiTools()
       .filter((tool) => tool.annotations?.destructiveHint === true)
       .map((tool) => tool.name);
@@ -107,11 +107,14 @@ describe("buildComputerUiTools", () => {
 
   it("every tool takes an empty, closed input schema (no target, no secrets)", () => {
     for (const tool of buildComputerUiTools()) {
-      expect(tool.inputSchema).toMatchObject({
+      // toEqual, not toMatchObject: `{ properties: {} }` is vacuously satisfied
+      // by ANY properties object, so it wouldn't catch a field creeping in.
+      expect(tool.inputSchema).toEqual({
         type: "object",
         properties: {},
         additionalProperties: false,
       });
+      expect(Object.keys((tool.inputSchema as { properties: object }).properties)).toHaveLength(0);
     }
   });
 

--- a/mcpjam-inspector/client/src/lib/webmcp/groups/playground.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/groups/playground.ts
@@ -265,11 +265,13 @@ export function buildPlaygroundUiTools(): UiToolDefinition[] {
       readOnly: false,
       // Irreversible: the conversation is gone. `destructiveHint: true` shows
       // the confirmation pill even in the default approval mode — the pill IS
-      // the confirmation, so the handler performs the reset directly.
+      // the confirmation, so the handler performs the reset directly. Each
+      // reset starts a FRESH chat session, so a retry is not a no-op →
+      // idempotentHint false (an interrupted retry spawns another session).
       annotations: {
         readOnlyHint: false,
         destructiveHint: true,
-        idempotentHint: true,
+        idempotentHint: false,
         openWorldHint: false,
       },
       mayNavigate: true,

--- a/mcpjam-inspector/client/src/lib/webmcp/groups/prompts.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/groups/prompts.ts
@@ -21,22 +21,12 @@ import {
   commandResponseToActionResult,
   dispatchInspectorCommand,
 } from "../ui-actions";
-import { asOptionalString, errorResult, fromActionResult } from "./shared";
-
-function asStringRecord(
-  value: unknown,
-): { ok: true; record?: Record<string, string> } | { ok: false } {
-  if (value === undefined) return { ok: true };
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    return { ok: false };
-  }
-  const record: Record<string, string> = {};
-  for (const [key, raw] of Object.entries(value as Record<string, unknown>)) {
-    if (typeof raw !== "string") return { ok: false };
-    record[key] = raw;
-  }
-  return { ok: true, record };
-}
+import {
+  asOptionalString,
+  asStringRecord,
+  errorResult,
+  fromActionResult,
+} from "./shared";
 
 export function buildPromptsUiTools(): UiToolDefinition[] {
   return [

--- a/mcpjam-inspector/client/src/lib/webmcp/groups/resources.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/groups/resources.ts
@@ -22,22 +22,12 @@ import {
   commandResponseToActionResult,
   dispatchInspectorCommand,
 } from "../ui-actions";
-import { asOptionalString, errorResult, fromActionResult } from "./shared";
-
-function asStringRecord(
-  value: unknown,
-): { ok: true; record?: Record<string, string> } | { ok: false } {
-  if (value === undefined) return { ok: true };
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    return { ok: false };
-  }
-  const record: Record<string, string> = {};
-  for (const [key, raw] of Object.entries(value as Record<string, unknown>)) {
-    if (typeof raw !== "string") return { ok: false };
-    record[key] = raw;
-  }
-  return { ok: true, record };
-}
+import {
+  asOptionalString,
+  asStringRecord,
+  errorResult,
+  fromActionResult,
+} from "./shared";
 
 export function buildResourcesUiTools(): UiToolDefinition[] {
   return [

--- a/mcpjam-inspector/client/src/lib/webmcp/groups/shared.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/groups/shared.ts
@@ -77,6 +77,27 @@ export function asOptionalString(value: unknown): string | undefined {
 }
 
 /**
+ * Validate an optional `string → string` record argument (resource/prompt
+ * template variables). `undefined` is allowed (no variables); anything that
+ * isn't a flat object of string values is rejected. Shared by the resources
+ * and prompts groups so the shape is validated in exactly one place.
+ */
+export function asStringRecord(
+  value: unknown,
+): { ok: true; record?: Record<string, string> } | { ok: false } {
+  if (value === undefined) return { ok: true };
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return { ok: false };
+  }
+  const record: Record<string, string> = {};
+  for (const [key, raw] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof raw !== "string") return { ok: false };
+    record[key] = raw;
+  }
+  return { ok: true, record };
+}
+
+/**
  * The playground-scoped command handlers only exist while the playground
  * surface is mounted (`usePlaygroundState` in `PlaygroundTab` on
  * `/playground`). Gate on the HANDLER being registered — not on UI store

--- a/mcpjam-inspector/client/src/lib/webmcp/review-surface-snapshots.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/review-surface-snapshots.ts
@@ -112,7 +112,10 @@ export function buildHostCompareSnapshot(input: HostCompareSnapshotInput) {
       .slice(0, REVIEW_SNAPSHOT_MAX_ITEMS)
       .map((field) => field.label),
     viewMode: input.viewMode,
-    searchQuery: input.searchQuery,
+    // Presence only — the raw field-search text is user input that can carry a
+    // pasted secret or PII, and it lands in the chat transcript. Report that a
+    // filter is active, never its contents.
+    hasSearchQuery: Boolean(input.searchQuery && input.searchQuery.trim()),
     supportFilter: input.supportFilter,
     loadedSelectedCount: input.loadedSelectedCount,
   };

--- a/mcpjam-inspector/client/src/lib/webmcp/use-surface-agent-bridge.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/use-surface-agent-bridge.ts
@@ -68,12 +68,23 @@ export interface SurfaceAgentBridgeOptions {
    * manifest's `hasSnapshotProvider: true` honest.
    */
   snapshot?: () => unknown;
+  /**
+   * Gate registration on a runtime condition (default `true`). A flag-gated
+   * surface passes its flag here so the group/handlers/snapshot register ONLY
+   * while the surface is actually enabled — `ui_snapshot_app` reads the
+   * registry independently of sidebar visibility, so a bridge that registered
+   * regardless would expose a disabled surface. Pass `flag === true` (not the
+   * raw `boolean | undefined`) so a still-loading flag stays unregistered until
+   * it resolves; the effect re-runs and registers when it flips true.
+   */
+  enabled?: boolean;
 }
 
 export function useSurfaceAgentBridge(
   options: SurfaceAgentBridgeOptions,
 ): void {
   const { surfaceId } = options;
+  const enabled = options.enabled ?? true;
   const handlersRef = useRef(options.handlers);
   const snapshotRef = useRef(options.snapshot);
   // Sync the latest closures in a layout effect (every commit, no deps) rather
@@ -89,6 +100,9 @@ export function useSurfaceAgentBridge(
   // tools must be live before the App navigate handler's readiness wait
   // (`waitForUiToolNames`) samples the registry after the route commits.
   useLayoutEffect(() => {
+    // Disabled (or flag still loading): register nothing, so ui_snapshot_app
+    // can't reach a gated surface. The effect re-runs when `enabled` flips.
+    if (!enabled) return;
     const controller = new AbortController();
     const disposers: Array<() => void> = [];
 
@@ -137,5 +151,5 @@ export function useSurfaceAgentBridge(
       controller.abort();
       for (const dispose of disposers) dispose();
     };
-  }, [surfaceId]);
+  }, [surfaceId, enabled]);
 }


### PR DESCRIPTION
Bot-review findings that landed in `main` unaddressed when the surface
agent-tools PRs (#3300–#3306) were merged. One branch, one commit per surface;
each fix has tests. All 375 webmcp + touched-component tests pass; `typecheck:client` clean.

## Computer (`fab5587`)
- **P1 billing:** `ui_start_computer` could reach `reserve()` and bill/provision while the data-plane config was still loading (`dataPlaneUnavailable` is false while `dataPlane` is `undefined`). Now retryable-gated until config resolves.
- `ui_reset_computer` now enforces the same `canReset` gate as the UI button (no wipe/rebuild from provisioning/waking/error).
- Snapshot no longer passes raw provider error text (tokens/URLs/PII) into the transcript — reports `hasError` + a fixed summary.

## Playground (`556b0d2`)
- **P1:** `ui_select_model` could pick models the picker locks (guest locks, exhausted credits). Extracted `resolveSelectablePlaygroundModel` (pure, tested) applying the picker's availability policy.
- **Wrong-surface:** the chat-composer handlers registered for the Evals recorder's embedded chat too (so `ui_reset_chat` could clear the eval preview). Now register only for the real Playground surface.
- `ui_set_system_prompt` validates `typeof prompt === "string"` (the server path skipped it); `ui_reset_chat` marked non-idempotent (each reset spawns a fresh session).

## Primitives (`1c07b3b`, `1f99230`)
- **P1 freeze:** `boundedJsonByteLength` only counted scalar bytes, so a node-heavy body still walked every container/null. Added a node-traversal budget (covers Resources/Prompts/Tools snapshots).
- **Read race:** `ui_read_resource`/`ui_get_prompt` committed their body without the read-version guard the UI uses — a slow read could overwrite a newer selection. Both now claim the same version ref and commit only if still newest.
- **RFC 6570:** `ui_read_resource` required *every* template variable; optional query/fragment expansions (`search{?q,limit}`) are now omittable, matching the on-screen Read.
- `asStringRecord` deduped into `shared.ts`; clamped prompt descriptions now report `truncated: true`; compare-snapshot size picks the active tab's body.

## Snapshot-only surfaces (`b2a1455`)
- **Transcript safety:** host-compare snapshot echoed the raw field-search text; now reports `hasSearchQuery` (boolean).
- **Flag gating:** the Compatibility snapshot provider registered regardless of the `mcpjam-compatibility` flag. Added an `enabled` gate to `useSurfaceAgentBridge` and wired the flag in.

## Chatboxes (`218e4c3`)
- **P1:** `ui_delete_chatbox` returned `chatbox_deleted` while the back-mint effect immediately re-provisioned the previewed host. The delete now suppresses the auto-remint (cleared on explicit re-publish / when a chatbox exists again, so genuine drift still re-mints).
- `useChatboxList` now gates on `shouldQueryProjectId` (no invalid Convex query on a transient local id), matching `useHostList`.

## Not included (lower-severity, flagged for a separate pass)
A few `#3306` snapshot-accuracy P2s (Tracing "recent" global ordering; Tasks per-task progress correlation; compare `divergingOnly` filter reflection; loading host-name list) are correctness-of-observability refinements left out to keep this branch scoped to safety/correctness/P1s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches billing (`reserve`), destructive computer/chatbox flows, and agent-visible snapshots; changes are gated and covered by tests but span multiple critical UI automation paths.
> 
> **Overview**
> Follow-up fixes for the surface agent-tools stack so agent commands and `ui_snapshot_app` match UI gates and avoid unsafe side effects.
> 
> **Chatboxes:** Intentional `ui_delete_chatbox` no longer triggers the back-mint `ensureChatboxForHost` effect; suppression clears on re-publish or when a chatbox exists again. **`useChatboxList`** skips Convex until `shouldQueryProjectId` (same as host list).
> 
> **Computer:** Blocks **`reserve()`** while data-plane config is loading; **`ui_reset_computer`** uses the same **`canReset`** gate as the button; snapshots expose **`hasError`** and a fixed message instead of raw provider errors.
> 
> **Playground:** **`resolveSelectablePlaygroundModel`** rejects picker-disabled models; chat-composer commands register only on the real Playground surface (not Evals embed); **`setSystemPrompt`** requires a string; **`ui_reset_chat`** is non-idempotent.
> 
> **Prompts / Resources:** Agent read/render paths use the same **version refs** as the UI to avoid stale overwrites. Resource templates follow **RFC 6570** (optional query vars, required path vars only). Prompt clamped descriptions set **`truncated`**. Resource snapshots size the **active tab’s** last read.
> 
> **Snapshots / infra:** **`boundedJsonByteLength`** adds a **node traversal budget**; host-compare drops raw search text for **`hasSearchQuery`**; **`useSurfaceAgentBridge`** supports **`enabled`** (Compatibility behind **`mcpjam-compatibility`**); **`asStringRecord`** shared for prompts/resources groups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 218e4c3e6703ccbef61488987aacd912f9a50832. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Safeguards and correctness follow-ups across WebMCP agent tools to prevent unintended billing, respect UI locks, avoid data leaks, and align agent actions with on-screen state.

- **Bug Fixes**
  - Computer: block start until data-plane config resolves; require `canReset` for resets; snapshot reports `hasError` with a fixed summary (no provider error text).
  - Playground: `selectModel` enforces the picker’s availability policy; chat control handlers register only on the real Playground surface; `setSystemPrompt` requires a string; `ui_reset_chat` marked non-idempotent.
  - Primitives: `boundedJsonByteLength` adds a node-traversal budget to prevent freezes; `asStringRecord` deduped; clamped prompt descriptions set `truncated: true`.
  - Reads: guard `ui_read_resource`/`ui_get_prompt` with the same read-version refs as the UI to avoid stale commits; allow RFC 6570 optional vars; pass only non-empty args; resource snapshot size follows the active tab.
  - Snapshots: host-compare exposes `hasSearchQuery` (not the raw search text); Compatibility provider gated by `mcpjam-compatibility` via `useSurfaceAgentBridge({ enabled })`.
  - Chatboxes: keep an intentional delete deleted (suppress auto-remint until republish or a chatbox exists again); gate list query on `shouldQueryProjectId`.

<sup>Written for commit 218e4c3e6703ccbef61488987aacd912f9a50832. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

