### PR TITLE
fix(webmcp): accurate Tracing/Tasks/Compare snapshot-only surfaces

### DIFF
--- a/mcpjam-inspector/client/src/components/TasksTab.tsx
+++ b/mcpjam-inspector/client/src/components/TasksTab.tsx
@@ -464,9 +464,10 @@ export function TasksTab({
   // Agent bridge: SNAPSHOT-ONLY (no tools). Tasks is a read-only view of a
   // server's long-running tasks (agentTools kind "none") the agent may OBSERVE.
   // Must run before the early return below (rules of hooks). Redacted STATE
-  // only: the selected server, task rows by id/status/created-time, and the
-  // selected task's progress fraction — NEVER a task's input, result, or status
-  // message. `hostedBlocked`, so this only registers where the screen mounts.
+  // only: the selected server and task rows by id/status/created-time — NEVER a
+  // task's input, result, or status message, and NOT the server-wide progress
+  // (it can't be attributed to the selected task). `hostedBlocked`, so this only
+  // registers where the screen mounts.
   useSurfaceAgentBridge({
     surfaceId: "tasks",
     snapshot: () =>
@@ -480,9 +481,6 @@ export function TasksTab({
         selectedTaskId: selectedTaskId || null,
         hasActiveTasks,
         autoRefresh,
-        selectedProgress: progress
-          ? { progress: progress.progress, total: progress.total }
-          : null,
       }),
   });
 

--- a/mcpjam-inspector/client/src/components/hosts/comparison/HostConfigCompareView.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/HostConfigCompareView.tsx
@@ -503,20 +503,31 @@ export function HostConfigCompareView({
   // and capability LABELS, never a host's resolved config.
   useSurfaceAgentBridge({
     surfaceId: "host-compare",
-    snapshot: () =>
-      buildHostCompareSnapshot({
+    snapshot: () => {
+      // List EVERY selected host (not only hydrated `orderedSubjects`), so the
+      // snapshot names the hosts in the selector throughout loading. Prefer the
+      // resolved subject name, else the known-host name, else null (loading).
+      const subjectNameById = new Map(
+        orderedSubjects.map((s) => [s.hostId, s.hostName] as const),
+      );
+      const hostNameById = new Map(
+        hosts.map((h) => [h.hostId, h.name] as const),
+      );
+      return buildHostCompareSnapshot({
         totalSelectableHosts: knownHostIds.length,
-        selectedHosts: orderedSubjects.map((subject) => ({
-          hostId: subject.hostId,
-          hostName: subject.hostName,
+        selectedHosts: selectedHostIds.map((hostId) => ({
+          hostId,
+          hostName: subjectNameById.get(hostId) ?? hostNameById.get(hostId) ?? null,
         })),
         capabilityFields: compareFields,
         viewMode,
         searchQuery: fieldSearchQuery,
         supportFilter: effectiveSupportFilter,
+        divergingOnly,
         loadedSelectedCount,
         totalSelectedCount,
-      }),
+      });
+    },
   });
 
   if (!presetOnly && !projectId) {

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/review-surface-snapshots.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/review-surface-snapshots.test.ts
@@ -103,6 +103,7 @@ describe("review-surface snapshots redact and bound", () => {
       viewMode: "table",
       searchQuery: "paste-of-a-secret-token",
       supportFilter: "all",
+      divergingOnly: true,
       loadedSelectedCount: 40,
       totalSelectedCount: 40,
     });
@@ -111,6 +112,9 @@ describe("review-surface snapshots redact and bound", () => {
     expect(snapshot.capabilityRows).toHaveLength(REVIEW_SNAPSHOT_MAX_ITEMS);
     expect(snapshot.comparedHostCount).toBe(40);
     expect(snapshot.capabilityRowCount).toBe(40);
+    // The "Only show differences" toggle is reflected so the agent's view
+    // matches the matrix.
+    expect(snapshot.divergingOnly).toBe(true);
     // The raw field-search text is user input — presence only, never echoed.
     expect(snapshot).not.toHaveProperty("searchQuery");
     expect(snapshot.hasSearchQuery).toBe(true);
@@ -174,7 +178,7 @@ describe("review-surface snapshots redact and bound", () => {
     ]);
   });
 
-  it("tasks: reports id/status/progress, never task payloads", () => {
+  it("tasks: reports id/status, never task payloads or mis-attributed progress", () => {
     const tasks = Array.from({ length: 45 }, (_, i) => ({
       taskId: `task-${i}`,
       status: "working",
@@ -189,16 +193,43 @@ describe("review-surface snapshots redact and bound", () => {
       selectedTaskId: "task-0",
       hasActiveTasks: true,
       autoRefresh: true,
-      selectedProgress: { progress: 2, total: 5 },
     });
     expectNoSecrets(snapshot);
     expect(snapshot.taskCount).toBe(45);
     expect(snapshot.tasks).toHaveLength(REVIEW_SNAPSHOT_MAX_ITEMS);
-    expect(snapshot.selectedProgress).toEqual({ progress: 2, total: 5 });
+    // Server-wide progress can't be attributed to the selected task, so it's
+    // omitted rather than mis-reported.
+    expect(snapshot).not.toHaveProperty("selectedProgress");
     expect(Object.keys(snapshot.tasks[0])).toEqual([
       "taskId",
       "status",
       "createdAt",
     ]);
+  });
+
+  it("tracing: `recent` is globally newest-first across server AND app items", () => {
+    // Server items are OLDER; a single app item is the newest. A naive
+    // concat-then-slice would bury the app item behind the server run.
+    const serverItems = Array.from({ length: 40 }, (_, i) => ({
+      source: "mcp-server" as const,
+      method: "tools/call",
+      direction: "SEND",
+      serverId: `srv-${i}`,
+      serverName: `Server ${i}`,
+      timestamp: "2026-07-18T00:00:00Z",
+    }));
+    const appItems = [
+      {
+        source: "mcp-apps" as const,
+        method: "render",
+        direction: "HOST→UI",
+        serverId: "srv-app",
+        serverName: "App",
+        timestamp: "2026-07-19T12:00:00Z", // newest
+      },
+    ];
+    const snapshot = buildTracingSnapshot({ serverItems, appItems });
+    expect(snapshot.recent[0]?.source).toBe("mcp-apps");
+    expect(snapshot.recent[0]?.timestamp).toBe("2026-07-19T12:00:00Z");
   });
 });

--- a/mcpjam-inspector/client/src/lib/webmcp/review-surface-snapshots.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/review-surface-snapshots.ts
@@ -49,10 +49,21 @@ export function buildTracingSnapshot(input: TracingSnapshotInput) {
     else if (entry.source === "oauth") counts.oauth += 1;
     else counts.other += 1;
   }
+  // Both slices are newest-first INDEPENDENTLY; concatenating and slicing would
+  // report the first 30 server entries even when app traffic is newer. Sort the
+  // merged stream by timestamp (ISO strings → epoch ms) so `recent` is globally
+  // recent; an unparseable timestamp sorts oldest.
+  const asMillis = (ts: string) => {
+    const parsed = Date.parse(ts);
+    return Number.isNaN(parsed) ? 0 : parsed;
+  };
+  const recentEntries = [...combined].sort(
+    (a, b) => asMillis(b.timestamp) - asMillis(a.timestamp),
+  );
   return {
     totalItems: combined.length,
     counts,
-    recent: combined.slice(0, REVIEW_SNAPSHOT_MAX_ITEMS).map((entry) => ({
+    recent: recentEntries.slice(0, REVIEW_SNAPSHOT_MAX_ITEMS).map((entry) => ({
       source: entry.source,
       method: entry.method,
       direction: entry.direction,
@@ -87,11 +98,13 @@ export function buildCompatibilitySnapshot(input: CompatibilitySnapshotInput) {
 
 export interface HostCompareSnapshotInput {
   totalSelectableHosts: number;
-  selectedHosts: ReadonlyArray<{ hostId: string; hostName: string }>;
+  selectedHosts: ReadonlyArray<{ hostId: string; hostName: string | null }>;
   capabilityFields: ReadonlyArray<{ label: string }>;
   viewMode: string;
   searchQuery: string;
   supportFilter: string;
+  /** The "Only show differences" toggle — an agent should see the same matrix. */
+  divergingOnly: boolean;
   loadedSelectedCount: number;
   totalSelectedCount: number;
 }
@@ -117,6 +130,7 @@ export function buildHostCompareSnapshot(input: HostCompareSnapshotInput) {
     // filter is active, never its contents.
     hasSearchQuery: Boolean(input.searchQuery && input.searchQuery.trim()),
     supportFilter: input.supportFilter,
+    divergingOnly: input.divergingOnly,
     loadedSelectedCount: input.loadedSelectedCount,
   };
 }
@@ -217,7 +231,6 @@ export interface TasksSnapshotInput {
   selectedTaskId: string | null;
   hasActiveTasks: boolean;
   autoRefresh: boolean;
-  selectedProgress: { progress: number; total?: number | null } | null;
 }
 
 /**
@@ -237,11 +250,9 @@ export function buildTasksSnapshot(input: TasksSnapshotInput) {
       createdAt: task.createdAt,
     })),
     selectedTaskId: input.selectedTaskId,
-    selectedProgress: input.selectedProgress
-      ? {
-          progress: input.selectedProgress.progress,
-          total: input.selectedProgress.total ?? null,
-        }
-      : null,
+    // No per-task progress: getLatestProgress is server-WIDE (keyed by
+    // progressToken, which a Task object doesn't carry), so reporting it as the
+    // selected task's progress would mis-attribute another task's fraction.
+    // Omit until the progress API exposes task correlation.
   };
 }


### PR DESCRIPTION
The remaining four `#3306` snapshot-accuracy P2s, deferred out of the P1/safety follow-up (#3322) to keep that branch scoped. All read-only snapshot providers — no tool or behavior changes.

## Fixes
- **Tracing** — `recent` concatenated server-then-app items and sliced, so it reported the first 30 server entries even when app traffic was newer. Now merges + timestamp-sorts both sources (ISO → epoch ms) → globally newest-first.
- **Tasks** — dropped `selectedProgress`. It came from `getLatestProgress` (server-**wide**, keyed by `progressToken`, which an MCP `Task` object doesn't carry), so reporting it as the selected task's progress mis-attributed another task's fraction. Omitted until the progress API exposes task correlation.
- **Host compare** — snapshot now reflects the "Only show differences" toggle (`divergingOnly`), and lists **every** selected host (names resolved from the known-host list, not only hydrated subjects) so hosts stay named throughout loading.

## Tests
`review-surface-snapshots.test.ts`: global-ordering assertion for Tracing; `selectedProgress` absence for Tasks; `divergingOnly` reflection for Compare. Full webmcp + coverage sweep green (1011 tests); `typecheck:client` clean.

This closes out the bot findings on the surface agent-tools stack (#3300–#3306).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to redacted snapshot builders and agent-bridge wiring; no auth, APIs, or user-facing compare/tasks/tracing behavior beyond what agents observe in chat transcripts.
> 
> **Overview**
> Read-only **WebMCP review snapshots** for Tracing, Tasks, and Host Compare are corrected so agents see the same orientation as the UI, without new tools or screen behavior.
> 
> **Tracing** — `buildTracingSnapshot` now **merges server and app log entries and sorts by timestamp** before capping `recent`, instead of concatenating server-then-app and slicing (which hid newer app traffic).
> 
> **Tasks** — **`selectedProgress` is removed** from the tasks agent snapshot and from `buildTasksSnapshot` input; server-wide `getLatestProgress` cannot be tied to the selected task, so it was dropped rather than mis-reported. The Tasks tab UI still shows progress locally.
> 
> **Host compare** — The snapshot adds **`divergingOnly`** (“Only show differences”) and lists **every selected host id** with names from hydrated subjects or the known-host list (`null` while loading), not only fully loaded `orderedSubjects`.
> 
> Tests in `review-surface-snapshots.test.ts` cover global tracing order, absent task progress, and compare `divergingOnly`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59f99f37bceaff9e8501fe965eb3965fc01e0b82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes snapshot accuracy for Tracing, Tasks, and Host Compare surfaces so agents see the correct state. Read-only snapshots only; no tools or behavior changes.

- **Bug Fixes**
  - Tracing: merge server and app streams and sort by timestamp for globally newest-first `recent` results.
  - Tasks: remove `selectedProgress` (it’s server-wide and not tied to the selected task); snapshot keeps only id/status/createdAt.
  - Host Compare: snapshot reflects the "Only show differences" (`divergingOnly`) toggle and includes every selected host, resolving names from subjects or known hosts (null while loading).

<sup>Written for commit 59f99f37bceaff9e8501fe965eb3965fc01e0b82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

