### PR TITLE
feat(swarms): pixel golem persona avatars + running state

### DIFF
--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -14,7 +14,7 @@ import {
   SquareSlash,
   MessageCircleQuestionIcon,
   GraduationCap,
-  Box,
+  Network,
   PackageOpen,
   LayoutGrid,
   GitBranch,
@@ -218,7 +218,7 @@ const navigationSections: NavSection[] = [
       {
         title: "Swarms",
         url: "/swarms",
-        icon: Box,
+        icon: Network,
         featureFlag: "sandboxes-enabled",
         billingFeature: "chatboxes",
       },

--- a/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
@@ -39,10 +39,12 @@ import { Label } from "@mcpjam/design-system/label";
 import { Textarea } from "@mcpjam/design-system/textarea";
 import { toast } from "@/lib/toast";
 import { cn } from "@/lib/utils";
+import { ErrorBoundary } from "@/components/ui/error-boundary";
 import { InlineEditableText } from "@/components/ui/inline-editable-text";
 import { TextareaAutosize } from "@/components/ui/textarea-autosize";
 import { PersonaPixelAvatar } from "@/components/swarms/persona-pixel-avatar";
 import { PersonaAvatarLookPicker } from "@/components/swarms/persona-avatar-look-picker";
+import { JourneyNetworkBackdrop } from "@/components/swarms/journey-network-backdrop";
 import {
   launchJourneyRun,
   LaunchJourneyRunError,
@@ -270,6 +272,30 @@ function usePersonaTrackRecord(personaRefId: string | null) {
   ) as PersonaTrackRecord | undefined;
 }
 
+/**
+ * Owns the `listRunningPersonaRefIds` subscription in isolation so a missing
+ * backend deploy (unknown query) cannot white-screen Swarms — the parent
+ * wraps this in `ErrorBoundary` and keeps an empty running set on failure.
+ */
+function RunningPersonasSubscriber({
+  projectId,
+  onChange,
+}: {
+  projectId: string | null;
+  onChange: (ids: string[]) => void;
+}) {
+  const ids = useQuery(
+    SWARM_QUERIES.listRunningPersonaRefIds as any,
+    projectId ? ({ projectId } as any) : "skip",
+  ) as string[] | undefined;
+
+  useEffect(() => {
+    onChange(ids ?? []);
+  }, [ids, onChange]);
+
+  return null;
+}
+
 export function SwarmsTab({
   projectId,
   isAuthenticated,
@@ -281,6 +307,14 @@ export function SwarmsTab({
   const effectiveProjectId = isAuthenticated ? projectId : null;
   const personas = usePersonas(effectiveProjectId);
   const hosts = useProjectHosts(effectiveProjectId);
+  const [runningPersonaIds, setRunningPersonaIds] = useState<string[]>([]);
+  const runningSet = useMemo(
+    () => new Set(runningPersonaIds),
+    [runningPersonaIds],
+  );
+  const onRunningPersonasChange = useCallback((ids: string[]) => {
+    setRunningPersonaIds(ids);
+  }, []);
   const [swarmView, setSwarmView] = useState<"journeys" | "clients">(
     "journeys",
   );
@@ -668,6 +702,12 @@ export function SwarmsTab({
 
   return (
     <div className="flex h-full min-h-0 flex-col">
+      <ErrorBoundary fallback={null}>
+        <RunningPersonasSubscriber
+          projectId={effectiveProjectId}
+          onChange={onRunningPersonasChange}
+        />
+      </ErrorBoundary>
       {/* Product sub-nav: Journeys (personas/journeys/runs) vs Clients
           (product-scoped host management). */}
       <div className="flex shrink-0 items-center justify-center border-b px-4 py-2">
@@ -727,6 +767,7 @@ export function SwarmsTab({
                     paletteIndex={p.avatarPalette}
                     size="md"
                     active={selected}
+                    state={runningSet.has(p._id) ? "running" : "idle"}
                   />
                   <span className="flex min-w-0 flex-col items-start gap-0.5">
                     <span className="truncate text-sm font-medium">
@@ -746,13 +787,12 @@ export function SwarmsTab({
       {/* Journeys for the selected persona */}
       <main className="min-w-0 flex-1 overflow-y-auto">
         {!selectedPersona ? (
-          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-            Select a persona to see its journeys.
-          </div>
+          <JourneyNetworkBackdrop />
         ) : (
           <div className="mx-auto max-w-3xl px-8 py-6">
             <PersonaDetailHeader
               persona={selectedPersona}
+              running={runningSet.has(selectedPersona._id)}
               onSave={(patch) => savePersonaField(selectedPersona._id, patch)}
               onDelete={async () => {
                 if (
@@ -1178,10 +1218,12 @@ function RunSessionsView({
 
 function PersonaDetailHeader({
   persona,
+  running,
   onSave,
   onDelete,
 }: {
   persona: Persona;
+  running: boolean;
   onSave: (patch: {
     name?: string;
     role?: string;
@@ -1215,6 +1257,7 @@ function PersonaDetailHeader({
           seed={persona._id}
           avatarShape={persona.avatarShape}
           avatarPalette={persona.avatarPalette}
+          state={running ? "running" : "idle"}
           onSave={(look) => onSave(look)}
         />
         <div className="min-w-0 flex-1">

--- a/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
@@ -24,8 +24,25 @@
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQuery, useMutation, usePaginatedQuery } from "convex/react";
+import { Loader2, Plus } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@mcpjam/design-system/dialog";
+import { Input } from "@mcpjam/design-system/input";
+import { Label } from "@mcpjam/design-system/label";
+import { Textarea } from "@mcpjam/design-system/textarea";
 import { toast } from "@/lib/toast";
+import { cn } from "@/lib/utils";
+import { InlineEditableText } from "@/components/ui/inline-editable-text";
+import { TextareaAutosize } from "@/components/ui/textarea-autosize";
+import { PersonaPixelAvatar } from "@/components/swarms/persona-pixel-avatar";
+import { PersonaAvatarLookPicker } from "@/components/swarms/persona-avatar-look-picker";
 import {
   launchJourneyRun,
   LaunchJourneyRunError,
@@ -179,7 +196,7 @@ export function SessionGoalScoreBadge({
   );
 }
 
-/** `· goal 78% avg (4 judged)` — shared by the run card + persona strip. */
+/** `· goal 78% avg (4 judged)` — used on journey run cards. */
 export function goalScoreAvgLabel(rollup: GoalScoreRollup | undefined): string | null {
   if (!rollup || rollup.gradedCount === 0 || rollup.avgScore === null) {
     return null;
@@ -193,6 +210,9 @@ type Persona = {
   name: string;
   role: string;
   notes: string;
+  /** Optional 8-bit look (Inspector PersonaPixelAvatar). */
+  avatarShape?: number;
+  avatarPalette?: number;
 };
 type Journey = {
   _id: string;
@@ -275,11 +295,35 @@ export function SwarmsTab({
     () => deepLink.personaRefId ?? null,
   );
   const journeys = useJourneys(selectedPersonaId);
-  // Lifted for the agent snapshot AND the persona strip (one subscription).
+  // Lifted for the agent snapshot (one subscription).
 
   const createPersona = useMutation("personas:createPersona" as any);
+  const updatePersona = useMutation("personas:updatePersona" as any);
   const deletePersona = useMutation("personas:deletePersona" as any);
   const createJourney = useMutation("journeys:createJourney" as any);
+
+  const savePersonaField = useCallback(
+    async (
+      personaRefId: string,
+      patch: {
+        name?: string;
+        role?: string;
+        notes?: string;
+        avatarShape?: number;
+        avatarPalette?: number;
+      },
+    ) => {
+      try {
+        await updatePersona({ personaRefId, ...patch } as any);
+      } catch (error) {
+        toast.error(
+          error instanceof Error ? error.message : "Failed to update persona",
+        );
+        throw error;
+      }
+    },
+    [updatePersona],
+  );
 
   const selectedPersona = useMemo(
     () => personas?.find((p) => p._id === selectedPersonaId) ?? null,
@@ -650,7 +694,7 @@ export function SwarmsTab({
           <aside className="flex w-72 shrink-0 flex-col border-r">
         <div className="flex items-center justify-between border-b px-4 py-3">
           <h2 className="text-sm font-semibold">Personas</h2>
-          <NewPersonaButton
+          <NewPersonaDialog
             onCreate={async (draft) => {
               const row = await createPersona({ projectId, ...draft } as any);
               setSelectedPersonaId(row._id);
@@ -665,19 +709,36 @@ export function SwarmsTab({
               No personas yet. Create one to get started.
             </div>
           ) : (
-            personas.map((p) => (
-              <button
-                key={p._id}
-                type="button"
-                onClick={() => setSelectedPersonaId(p._id)}
-                className={`flex w-full flex-col items-start gap-0.5 border-b px-4 py-3 text-left hover:bg-muted/50 ${
-                  p._id === selectedPersonaId ? "bg-muted" : ""
-                }`}
-              >
-                <span className="text-sm font-medium">{p.name}</span>
-                <span className="text-xs text-muted-foreground">{p.role}</span>
-              </button>
-            ))
+            personas.map((p) => {
+              const selected = p._id === selectedPersonaId;
+              return (
+                <button
+                  key={p._id}
+                  type="button"
+                  onClick={() => setSelectedPersonaId(p._id)}
+                  className={cn(
+                    "flex w-full items-center gap-3 border-b px-4 py-3 text-left hover:bg-muted/50",
+                    selected && "bg-muted",
+                  )}
+                >
+                  <PersonaPixelAvatar
+                    seed={p._id}
+                    shapeIndex={p.avatarShape}
+                    paletteIndex={p.avatarPalette}
+                    size="md"
+                    active={selected}
+                  />
+                  <span className="flex min-w-0 flex-col items-start gap-0.5">
+                    <span className="truncate text-sm font-medium">
+                      {p.name}
+                    </span>
+                    <span className="truncate text-xs text-muted-foreground">
+                      {p.role}
+                    </span>
+                  </span>
+                </button>
+              );
+            })
           )}
         </div>
       </aside>
@@ -690,36 +751,23 @@ export function SwarmsTab({
           </div>
         ) : (
           <div className="mx-auto max-w-3xl px-8 py-6">
-            <div className="mb-4 flex items-center justify-between">
-              <div>
-                <h2 className="text-lg font-semibold">{selectedPersona.name}</h2>
-                <p className="text-sm text-muted-foreground">
-                  {selectedPersona.role}
-                </p>
-              </div>
-              <Button
-                type="button"
-                size="sm"
-                variant="ghost"
-                onClick={async () => {
-                  if (
-                    !window.confirm(
-                      `Delete persona "${selectedPersona.name}"? Its journeys are hidden but historical runs are kept.`
-                    )
-                  ) {
-                    return;
-                  }
-                  await deletePersona({
-                    personaRefId: selectedPersona._id,
-                  } as any);
-                  setSelectedPersonaId(null);
-                }}
-              >
-                Delete persona
-              </Button>
-            </div>
-
-            <PersonaTrackRecordStrip record={trackRecord} />
+            <PersonaDetailHeader
+              persona={selectedPersona}
+              onSave={(patch) => savePersonaField(selectedPersona._id, patch)}
+              onDelete={async () => {
+                if (
+                  !window.confirm(
+                    `Delete persona "${selectedPersona.name}"? Its journeys are hidden but historical runs are kept.`,
+                  )
+                ) {
+                  return;
+                }
+                await deletePersona({
+                  personaRefId: selectedPersona._id,
+                } as any);
+                setSelectedPersonaId(null);
+              }}
+            />
 
             <div className="mb-3 flex items-center justify-between">
               <h3 className="text-sm font-semibold">Journeys</h3>
@@ -769,29 +817,6 @@ export function SwarmsTab({
       </main>
         </div>
       )}
-    </div>
-  );
-}
-
-// ── persona track record ─────────────────────────────────────────────────────
-// The record is fetched once in SwarmsTab (shared with the agent snapshot) and
-// passed in, rather than re-subscribing here.
-function PersonaTrackRecordStrip({
-  record,
-}: {
-  record: PersonaTrackRecord | undefined;
-}) {
-  if (!record || record.sessionCount === 0) return null;
-  return (
-    <div className="mb-4 flex flex-wrap items-center gap-2 rounded-lg border bg-muted/30 px-3 py-2 text-xs">
-      <span className="font-medium text-muted-foreground">Track record</span>
-      <span className="text-muted-foreground">
-        {record.sessionCount} session{record.sessionCount === 1 ? "" : "s"} ·{" "}
-        {record.runCount} run{record.runCount === 1 ? "" : "s"}
-        {goalScoreAvgLabel(record.goalScore)
-          ? ` · ${goalScoreAvgLabel(record.goalScore)}`
-          : ""}
-      </span>
     </div>
   );
 }
@@ -1149,8 +1174,93 @@ function RunSessionsView({
   );
 }
 
-// ── dialogs (minimal inline forms) ───────────────────────────────────────────
-function NewPersonaButton({
+// ── persona detail (evals-style editable header) ─────────────────────────────
+
+function PersonaDetailHeader({
+  persona,
+  onSave,
+  onDelete,
+}: {
+  persona: Persona;
+  onSave: (patch: {
+    name?: string;
+    role?: string;
+    notes?: string;
+    avatarShape?: number;
+    avatarPalette?: number;
+  }) => Promise<void>;
+  onDelete: () => Promise<void>;
+}) {
+  const [notes, setNotes] = useState(persona.notes ?? "");
+
+  useEffect(() => {
+    setNotes(persona.notes ?? "");
+  }, [persona._id, persona.notes]);
+
+  const persistNotes = async () => {
+    const next = notes.trim();
+    const prev = (persona.notes ?? "").trim();
+    if (next === prev) return;
+    try {
+      await onSave({ notes: next });
+    } catch {
+      setNotes(persona.notes ?? "");
+    }
+  };
+
+  return (
+    <div className="mb-4 flex items-start justify-between gap-4">
+      <div className="flex min-w-0 flex-1 items-start gap-3">
+        <PersonaAvatarLookPicker
+          seed={persona._id}
+          avatarShape={persona.avatarShape}
+          avatarPalette={persona.avatarPalette}
+          onSave={(look) => onSave(look)}
+        />
+        <div className="min-w-0 flex-1">
+          <InlineEditableText
+            value={persona.name}
+            onSave={(name) => onSave({ name })}
+            className="block w-full text-lg font-semibold tracking-tight sm:text-xl"
+            truncate={false}
+          />
+          <InlineEditableText
+            value={persona.role}
+            onSave={(role) => onSave({ role })}
+            className="mt-0.5 block w-full text-sm text-muted-foreground"
+            truncate={false}
+          />
+          <TextareaAutosize
+            aria-label="Notes / personality"
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            onBlur={() => void persistNotes()}
+            minRows={1}
+            maxRows={4}
+            placeholder="Add personality notes…"
+            className={cn(
+              "mt-2 min-h-0 resize-none border-0 bg-transparent px-0 py-0 text-sm",
+              "text-muted-foreground shadow-none placeholder:text-muted-foreground/60",
+              "focus-visible:border-0 focus-visible:ring-0",
+            )}
+          />
+        </div>
+      </div>
+      <Button
+        type="button"
+        size="sm"
+        variant="ghost"
+        className="shrink-0 text-muted-foreground hover:text-destructive"
+        onClick={() => void onDelete()}
+      >
+        Delete persona
+      </Button>
+    </div>
+  );
+}
+
+// ── create persona dialog (design-system; replaces the floating raw form) ────
+function NewPersonaDialog({
   onCreate,
 }: {
   onCreate: (draft: {
@@ -1163,53 +1273,126 @@ function NewPersonaButton({
   const [name, setName] = useState("");
   const [role, setRole] = useState("");
   const [notes, setNotes] = useState("");
-  if (!open) {
-    return (
-      <Button type="button" size="sm" variant="outline" onClick={() => setOpen(true)}>
-        + New
-      </Button>
-    );
-  }
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!open) {
+      setName("");
+      setRole("");
+      setNotes("");
+      setSaving(false);
+    }
+  }, [open]);
+
+  const handleCreate = async () => {
+    if (!name.trim() || !role.trim()) {
+      toast.error("Name and role are required");
+      return;
+    }
+    setSaving(true);
+    try {
+      await onCreate({
+        name: name.trim(),
+        role: role.trim(),
+        notes: notes.trim() || undefined,
+      });
+      toast.success("Persona created");
+      setOpen(false);
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to create persona",
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
   return (
-    <div className="absolute right-4 top-12 z-10 w-64 rounded-lg border bg-background p-3 shadow-lg">
-      <input
-        className="mb-2 w-full rounded border px-2 py-1 text-sm"
-        placeholder="Name"
-        value={name}
-        onChange={(e) => setName(e.target.value)}
-      />
-      <input
-        className="mb-2 w-full rounded border px-2 py-1 text-sm"
-        placeholder="Role"
-        value={role}
-        onChange={(e) => setRole(e.target.value)}
-      />
-      <textarea
-        className="mb-2 w-full rounded border px-2 py-1 text-sm"
-        placeholder="Notes / personality"
-        value={notes}
-        onChange={(e) => setNotes(e.target.value)}
-      />
-      <div className="flex justify-end gap-2">
-        <Button type="button" size="sm" variant="ghost" onClick={() => setOpen(false)}>
-          Cancel
-        </Button>
-        <Button
-          type="button"
-          size="sm"
-          disabled={!name.trim() || !role.trim()}
-          onClick={async () => {
-            await onCreate({ name, role, notes });
-            setOpen(false);
-            setName("");
-            setRole("");
-            setNotes("");
-          }}
-        >
-          Create
-        </Button>
-      </div>
-    </div>
+    <>
+      <Button
+        type="button"
+        size="sm"
+        variant="outline"
+        onClick={() => setOpen(true)}
+      >
+        <Plus className="mr-1 size-3" />
+        New
+      </Button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>New persona</DialogTitle>
+            <DialogDescription>
+              A synthetic user who pursues journeys across your clients.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-col gap-3 py-1">
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="swarm-persona-name">Name</Label>
+              <Input
+                id="swarm-persona-name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="Test User"
+                autoFocus
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    void handleCreate();
+                  }
+                }}
+              />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="swarm-persona-role">Role</Label>
+              <Input
+                id="swarm-persona-role"
+                value={role}
+                onChange={(e) => setRole(e.target.value)}
+                placeholder="SWE evaluating the product"
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    void handleCreate();
+                  }
+                }}
+              />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="swarm-persona-notes">Notes / personality</Label>
+              <Textarea
+                id="swarm-persona-notes"
+                value={notes}
+                onChange={(e) => setNotes(e.target.value)}
+                placeholder="Background, tone, what they care about…"
+                rows={4}
+                className="leading-relaxed"
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setOpen(false)}
+              disabled={saving}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              disabled={saving || !name.trim() || !role.trim()}
+              onClick={() => void handleCreate()}
+            >
+              {saving ? (
+                <Loader2 className="mr-1 size-3 animate-spin" />
+              ) : null}
+              Create persona
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }
 
@@ -1260,7 +1443,8 @@ function NewJourneyButton({
   if (!open) {
     return (
       <Button type="button" size="sm" variant="outline" onClick={() => setOpen(true)}>
-        + New journey
+        <Plus className="mr-1 size-3" />
+        New journey
       </Button>
     );
   }
@@ -1269,14 +1453,24 @@ function NewJourneyButton({
       prev.includes(id) ? prev.filter((h) => h !== id) : [...prev, id]
     );
   return (
-    <div className="w-full rounded-lg border p-4">
-      <textarea
-        className="mb-3 w-full rounded border px-2 py-1 text-sm"
-        placeholder="Goal — what this persona is trying to accomplish"
-        value={goal}
-        onChange={(e) => setGoal(e.target.value)}
-      />
-      <p className="mb-1 text-xs font-medium">Clients</p>
+    <div
+      className={cn(
+        "w-full rounded-xl border border-border/50 bg-card/50 p-4 shadow-sm",
+        "ring-1 ring-black/[0.03] dark:ring-white/[0.06]",
+      )}
+    >
+      <div className="mb-3 flex flex-col gap-1.5">
+        <Label htmlFor="swarm-journey-goal">Goal</Label>
+        <Textarea
+          id="swarm-journey-goal"
+          placeholder="What this persona is trying to accomplish"
+          value={goal}
+          onChange={(e) => setGoal(e.target.value)}
+          rows={3}
+          className="leading-relaxed"
+        />
+      </div>
+      <p className="mb-1.5 text-xs font-medium">Clients</p>
       <div className="mb-3 flex flex-wrap gap-2">
         {hosts.length === 0 ? (
           <span className="text-xs text-muted-foreground">
@@ -1299,11 +1493,12 @@ function NewJourneyButton({
                 key={h.hostId}
                 type="button"
                 onClick={() => toggleHost(h.hostId)}
-                className={`flex flex-col items-start gap-0.5 rounded-lg border px-2.5 py-1.5 text-left text-xs ${
+                className={cn(
+                  "flex flex-col items-start gap-0.5 rounded-lg border px-2.5 py-1.5 text-left text-xs",
                   hostIds.includes(h.hostId)
                     ? "border-primary bg-primary/10"
-                    : "hover:bg-muted"
-                }`}
+                    : "hover:bg-muted",
+                )}
               >
                 <span className="flex items-center gap-1.5 font-medium">
                   {h.name}
@@ -1326,29 +1521,35 @@ function NewJourneyButton({
           })
         )}
       </div>
-      <div className="mb-3 flex gap-4 text-xs">
-        <label className="flex items-center gap-1">
-          Sessions/host
-          <input
+      <div className="mb-3 flex flex-wrap gap-4">
+        <div className="flex flex-col gap-1">
+          <Label htmlFor="swarm-journey-sessions" className="text-xs">
+            Sessions/host
+          </Label>
+          <Input
+            id="swarm-journey-sessions"
             type="number"
             min={1}
             max={5}
-            className="w-14 rounded border px-1 py-0.5"
+            className="h-8 w-20"
             value={sessionsPerHost}
             onChange={(e) => setSessionsPerHost(Number(e.target.value))}
           />
-        </label>
-        <label className="flex items-center gap-1">
-          Max turns
-          <input
+        </div>
+        <div className="flex flex-col gap-1">
+          <Label htmlFor="swarm-journey-turns" className="text-xs">
+            Max turns
+          </Label>
+          <Input
+            id="swarm-journey-turns"
             type="number"
             min={1}
             max={20}
-            className="w-14 rounded border px-1 py-0.5"
+            className="h-8 w-20"
             value={maxTurns}
             onChange={(e) => setMaxTurns(Number(e.target.value))}
           />
-        </label>
+        </div>
       </div>
       <div className="flex justify-end gap-2">
         <Button type="button" size="sm" variant="ghost" onClick={() => setOpen(false)}>

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.personas.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.personas.test.tsx
@@ -1,7 +1,7 @@
 /**
  * Personas create/edit UX on SwarmsTab — dialog create + blur-save profile notes.
  */
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const persona = {
@@ -12,9 +12,14 @@ const persona = {
   notes: "curious and impatient",
 };
 
-const { createPersonaMutation, updatePersonaMutation } = vi.hoisted(() => ({
+const {
+  createPersonaMutation,
+  updatePersonaMutation,
+  runningPersonaRefIds,
+} = vi.hoisted(() => ({
   createPersonaMutation: vi.fn(),
   updatePersonaMutation: vi.fn(),
+  runningPersonaRefIds: { current: [] as string[] },
 }));
 
 vi.mock("convex/react", () => ({
@@ -27,6 +32,8 @@ vi.mock("convex/react", () => ({
         return [];
       case "hosts:listHosts":
         return [];
+      case "journeyRuns:listRunningPersonaRefIds":
+        return runningPersonaRefIds.current;
       default:
         return undefined;
     }
@@ -66,6 +73,7 @@ import { SwarmsTab } from "../SwarmsTab";
 
 beforeEach(() => {
   vi.clearAllMocks();
+  runningPersonaRefIds.current = [];
   createPersonaMutation.mockResolvedValue({ _id: "persona-new" });
   updatePersonaMutation.mockResolvedValue({ ...persona });
 });
@@ -157,6 +165,17 @@ describe("SwarmsTab — persona create/edit", () => {
         avatarShape: (seeded.shapeIndex + 1) % 6,
         avatarPalette: seeded.paletteIndex,
       });
+    });
+  });
+
+  it("lights the sidebar avatar when the persona has a running journey", async () => {
+    runningPersonaRefIds.current = ["persona-1"];
+    render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+
+    await waitFor(() => {
+      const aside = screen.getByRole("complementary");
+      const avatar = within(aside).getByTestId("persona-pixel-avatar");
+      expect(avatar.getAttribute("data-state")).toBe("running");
     });
   });
 });

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.personas.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.personas.test.tsx
@@ -1,0 +1,163 @@
+/**
+ * Personas create/edit UX on SwarmsTab — dialog create + blur-save profile notes.
+ */
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const persona = {
+  _id: "persona-1",
+  personaId: "p1",
+  name: "Persona One",
+  role: "tester",
+  notes: "curious and impatient",
+};
+
+const { createPersonaMutation, updatePersonaMutation } = vi.hoisted(() => ({
+  createPersonaMutation: vi.fn(),
+  updatePersonaMutation: vi.fn(),
+}));
+
+vi.mock("convex/react", () => ({
+  useQuery: (name: string, args: unknown) => {
+    if (args === "skip") return undefined;
+    switch (name) {
+      case "personas:listPersonas":
+        return [persona];
+      case "journeys:listJourneysByPersona":
+        return [];
+      case "hosts:listHosts":
+        return [];
+      default:
+        return undefined;
+    }
+  },
+  useMutation: (name: string) => {
+    if (name === "personas:createPersona") return createPersonaMutation;
+    if (name === "personas:updatePersona") return updatePersonaMutation;
+    return vi.fn().mockResolvedValue(undefined);
+  },
+  usePaginatedQuery: () => ({
+    results: [],
+    status: "Exhausted",
+    loadMore: vi.fn(),
+    isLoading: false,
+  }),
+}));
+
+vi.mock("@/lib/swarm-api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/swarm-api")>();
+  return {
+    ...actual,
+    launchJourneyRun: vi.fn(),
+  };
+});
+
+vi.mock("@/components/connection/share-usage/ShareUsageThreadDetail", () => ({
+  ShareUsageThreadDetail: () => null,
+}));
+vi.mock("@/lib/chatbox-session", () => ({
+  getShareableAppOrigin: () => "https://app.test",
+}));
+vi.mock("@/lib/toast", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import { SwarmsTab } from "../SwarmsTab";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  createPersonaMutation.mockResolvedValue({ _id: "persona-new" });
+  updatePersonaMutation.mockResolvedValue({ ...persona });
+});
+
+describe("SwarmsTab — persona create/edit", () => {
+  it("opens a labeled create dialog instead of a floating raw form", async () => {
+    render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+
+    fireEvent.click(screen.getByRole("button", { name: /new/i }));
+
+    expect(screen.getByRole("heading", { name: "New persona" })).toBeTruthy();
+    expect(screen.getByLabelText("Name")).toBeTruthy();
+    expect(screen.getByLabelText("Role")).toBeTruthy();
+    expect(screen.getByLabelText("Notes / personality")).toBeTruthy();
+
+    fireEvent.change(screen.getByLabelText("Name"), {
+      target: { value: "Nacho" },
+    });
+    fireEvent.change(screen.getByLabelText("Role"), {
+      target: { value: "SWE" },
+    });
+    fireEvent.change(screen.getByLabelText("Notes / personality"), {
+      target: { value: "pragmatic" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /create persona/i }));
+
+    await waitFor(() => {
+      expect(createPersonaMutation).toHaveBeenCalledWith({
+        projectId: "proj-1",
+        name: "Nacho",
+        role: "SWE",
+        notes: "pragmatic",
+      });
+    });
+  });
+
+  it("saves personality notes on blur via updatePersona", async () => {
+    render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+    fireEvent.click(screen.getByText("Persona One"));
+
+    const notes = screen.getByLabelText("Notes / personality");
+    expect((notes as HTMLTextAreaElement).value).toBe("curious and impatient");
+
+    fireEvent.change(notes, { target: { value: "calm and thorough" } });
+    fireEvent.blur(notes);
+
+    await waitFor(() => {
+      expect(updatePersonaMutation).toHaveBeenCalledWith({
+        personaRefId: "persona-1",
+        notes: "calm and thorough",
+      });
+    });
+  });
+
+  it("saves an inline name edit via updatePersona", async () => {
+    render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+    fireEvent.click(screen.getByText("Persona One"));
+
+    // Sidebar + detail header both render the name; edit the detail copy.
+    const nameLabels = screen.getAllByText("Persona One");
+    fireEvent.click(nameLabels[nameLabels.length - 1]!);
+    const input = screen.getByDisplayValue("Persona One");
+    fireEvent.change(input, { target: { value: "Persona Two" } });
+    fireEvent.blur(input);
+
+    await waitFor(() => {
+      expect(updatePersonaMutation).toHaveBeenCalledWith({
+        personaRefId: "persona-1",
+        name: "Persona Two",
+      });
+    });
+  });
+
+  it("saves avatar look changes from the picker via updatePersona", async () => {
+    const { resolvePersonaPixelLook } = await import(
+      "../persona-pixel-avatar"
+    );
+    const seeded = resolvePersonaPixelLook("persona-1");
+
+    render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+    fireEvent.click(screen.getByText("Persona One"));
+
+    fireEvent.click(screen.getByTestId("persona-avatar-look-trigger"));
+    fireEvent.click(screen.getByTestId("persona-avatar-next-shape"));
+
+    await waitFor(() => {
+      expect(updatePersonaMutation).toHaveBeenCalledWith({
+        personaRefId: "persona-1",
+        avatarShape: (seeded.shapeIndex + 1) % 6,
+        avatarPalette: seeded.paletteIndex,
+      });
+    });
+  });
+});
+

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/journey-network-backdrop.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/journey-network-backdrop.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { JourneyNetworkBackdrop } from "../journey-network-backdrop";
+
+beforeAll(() => {
+  class ResizeObserverMock {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+
+  HTMLCanvasElement.prototype.getContext = vi.fn(() => ({
+    setTransform: vi.fn(),
+    clearRect: vi.fn(),
+    beginPath: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    stroke: vi.fn(),
+    fill: vi.fn(),
+    arc: vi.fn(),
+    createRadialGradient: vi.fn(() => ({
+      addColorStop: vi.fn(),
+    })),
+    measureText: vi.fn(() => ({ width: 40 })),
+    fillText: vi.fn(),
+    arcTo: vi.fn(),
+    closePath: vi.fn(),
+  })) as unknown as typeof HTMLCanvasElement.prototype.getContext;
+});
+
+describe("JourneyNetworkBackdrop", () => {
+  it("renders the empty-state message over the network canvas", () => {
+    render(<JourneyNetworkBackdrop />);
+
+    expect(
+      screen.getByText("Select a persona to see its journeys."),
+    ).toBeTruthy();
+    expect(screen.getByTestId("journey-network-backdrop")).toBeTruthy();
+    expect(
+      screen.getByTestId("journey-network-backdrop").querySelector("canvas"),
+    ).toBeTruthy();
+  });
+
+  it("accepts a custom message", () => {
+    render(<JourneyNetworkBackdrop message="Pick someone to continue." />);
+    expect(screen.getByText("Pick someone to continue.")).toBeTruthy();
+  });
+});

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/persona-pixel-avatar.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/persona-pixel-avatar.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+  PERSONA_PIXEL_PALETTE_COUNT,
+  PERSONA_PIXEL_SHAPE_COUNT,
+  PersonaPixelAvatar,
+  resolvePersonaPixelLook,
+  resolvePersonaPixelVariant,
+  wrapPersonaPixelIndex,
+} from "../persona-pixel-avatar";
+
+describe("PersonaPixelAvatar", () => {
+  it("picks a stable shape + palette from the seed", () => {
+    const a = resolvePersonaPixelVariant("persona-1");
+    const b = resolvePersonaPixelVariant("persona-1");
+    const c = resolvePersonaPixelVariant("persona-2");
+    expect(a).toEqual(b);
+    expect(a).not.toEqual(c);
+  });
+
+  it("honors explicit shape/palette overrides over the seed", () => {
+    const seeded = resolvePersonaPixelVariant("persona-bob");
+    const overrideShape =
+      (seeded.shapeIndex + 1) % PERSONA_PIXEL_SHAPE_COUNT;
+    const overridePalette =
+      (seeded.paletteIndex + 2) % PERSONA_PIXEL_PALETTE_COUNT;
+
+    expect(
+      resolvePersonaPixelLook("persona-bob", {
+        shapeIndex: overrideShape,
+        paletteIndex: overridePalette,
+      }),
+    ).toEqual({
+      shapeIndex: overrideShape,
+      paletteIndex: overridePalette,
+    });
+
+    render(
+      <PersonaPixelAvatar
+        seed="persona-bob"
+        shapeIndex={overrideShape}
+        paletteIndex={overridePalette}
+      />,
+    );
+    const el = screen.getByTestId("persona-pixel-avatar");
+    expect(el.getAttribute("data-shape")).toBe(String(overrideShape));
+    expect(el.getAttribute("data-palette")).toBe(String(overridePalette));
+  });
+
+  it("falls back to seed when overrides are unset", () => {
+    const seeded = resolvePersonaPixelVariant("persona-bob");
+    expect(resolvePersonaPixelLook("persona-bob")).toEqual(seeded);
+    expect(
+      resolvePersonaPixelLook("persona-bob", {
+        shapeIndex: null,
+        paletteIndex: null,
+      }),
+    ).toEqual(seeded);
+  });
+
+  it("wraps look indices into range", () => {
+    expect(wrapPersonaPixelIndex(-1, 6)).toBe(5);
+    expect(wrapPersonaPixelIndex(6, 6)).toBe(0);
+    expect(wrapPersonaPixelIndex(2, 6)).toBe(2);
+  });
+
+  it("renders an SVG sprite with the resolved variant attrs", () => {
+    const { shapeIndex, paletteIndex } =
+      resolvePersonaPixelVariant("persona-bob");
+    render(<PersonaPixelAvatar seed="persona-bob" />);
+    const el = screen.getByTestId("persona-pixel-avatar");
+    expect(el.getAttribute("data-shape")).toBe(String(shapeIndex));
+    expect(el.getAttribute("data-palette")).toBe(String(paletteIndex));
+    expect(el.querySelector("svg")).toBeTruthy();
+  });
+});

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/persona-pixel-avatar.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/persona-pixel-avatar.test.tsx
@@ -73,4 +73,36 @@ describe("PersonaPixelAvatar", () => {
     expect(el.getAttribute("data-palette")).toBe(String(paletteIndex));
     expect(el.querySelector("svg")).toBeTruthy();
   });
+
+  it("renders identical SVG markup for the same seed + indices", () => {
+    const { container: a } = render(
+      <PersonaPixelAvatar seed="twin-seed" shapeIndex={4} paletteIndex={1} />,
+    );
+    const markupA = a.querySelector("svg")?.innerHTML;
+    const { container: b } = render(
+      <PersonaPixelAvatar seed="twin-seed" shapeIndex={4} paletteIndex={1} />,
+    );
+    const markupB = b.querySelector("svg")?.innerHTML;
+    expect(markupA).toBeTruthy();
+    expect(markupA).toBe(markupB);
+  });
+
+  it("varies SVG markup across seeds within the same family/mineral", () => {
+    const { container: a } = render(
+      <PersonaPixelAvatar seed="seed-alpha" shapeIndex={0} paletteIndex={0} />,
+    );
+    const { container: b } = render(
+      <PersonaPixelAvatar seed="seed-omega" shapeIndex={0} paletteIndex={0} />,
+    );
+    expect(a.querySelector("svg")?.innerHTML).not.toBe(
+      b.querySelector("svg")?.innerHTML,
+    );
+  });
+
+  it("sets data-state from the state prop", () => {
+    render(<PersonaPixelAvatar seed="persona-bob" state="running" />);
+    expect(
+      screen.getByTestId("persona-pixel-avatar").getAttribute("data-state"),
+    ).toBe("running");
+  });
 });

--- a/mcpjam-inspector/client/src/components/swarms/journey-network-backdrop.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/journey-network-backdrop.tsx
@@ -1,0 +1,401 @@
+import { useEffect, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+type Rgb = { r: number; g: number; b: number };
+
+type Node = {
+  x: number;
+  y: number;
+  ox: number;
+  oy: number;
+  phase: number;
+};
+
+type Edge = { a: number; b: number };
+
+type Journey = {
+  nodes: Node[];
+  edges: Edge[];
+  path: number[];
+  color: Rgb;
+  edgeIndex: number;
+  t: number;
+  speed: number;
+  dash: number;
+  pulse: number;
+};
+
+/** Muted jewel tones — low saturation, premium feel. */
+const PALETTE: Rgb[] = [
+  { r: 196, g: 112, b: 96 },
+  { r: 96, g: 148, b: 168 },
+  { r: 140, g: 124, b: 176 },
+  { r: 176, g: 140, b: 88 },
+  { r: 104, g: 148, b: 128 },
+  { r: 168, g: 108, b: 132 },
+  { r: 112, g: 132, b: 172 },
+  { r: 148, g: 128, b: 96 },
+];
+
+function prefersReducedMotion(): boolean {
+  if (typeof window === "undefined") return false;
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+function isDarkTheme(el: HTMLElement): boolean {
+  return (
+    el.classList.contains("dark") ||
+    !!el.closest(".dark") ||
+    document.documentElement.classList.contains("dark")
+  );
+}
+
+function mulberry32(seed: number) {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function makeJourney(
+  ax: number,
+  ay: number,
+  scale: number,
+  color: Rgb,
+  rand: () => number,
+  startT: number,
+  pulse: number,
+): Journey {
+  const sx = 64 * scale;
+  const sy = 44 * scale;
+  const tilt = (rand() - 0.5) * 0.28;
+  const cos = Math.cos(tilt);
+  const sin = Math.sin(tilt);
+
+  // Sparse fork: start → two branches → soft converge → tip
+  const raw: Array<[number, number]> = [
+    [-sx * 2.0, 0],
+    [-sx * 0.7, -sy],
+    [sx * 0.55, -sy * 0.95],
+    [-sx * 0.75, sy * 0.95],
+    [sx * 0.5, sy * 0.55],
+    [sx * 1.65, sy * 0.1],
+  ];
+
+  const nodes: Node[] = raw.map(([x, y], i) => {
+    const rx = x * cos - y * sin;
+    const ry = x * sin + y * cos;
+    return {
+      x: ax + rx,
+      y: ay + ry,
+      ox: ax + rx,
+      oy: ay + ry,
+      phase: i * 0.9 + rand() * Math.PI,
+    };
+  });
+
+  const edges: Edge[] = [
+    { a: 0, b: 1 },
+    { a: 1, b: 2 },
+    { a: 0, b: 3 },
+    { a: 3, b: 4 },
+    { a: 4, b: 5 },
+    { a: 2, b: 5 },
+  ];
+
+  const path = [0, 2, 3, 4, 5, 1];
+
+  return {
+    nodes,
+    edges,
+    path,
+    color,
+    edgeIndex: Math.floor(rand() * path.length),
+    t: startT,
+    speed: 0.12 + rand() * 0.1,
+    dash: rand() * 20,
+    pulse,
+  };
+}
+
+function scatterJourneys(w: number, h: number): Journey[] {
+  const rand = mulberry32(Math.floor(w * 13 + h * 29) || 1);
+  // More presence, still breathable — scale with pane size
+  const count = w < 640 ? 4 : w < 1100 ? 6 : 8;
+  const journeys: Journey[] = [];
+
+  // Hand-placed anchors across the pane (loose grid, not a pile-up)
+  const layout: Array<[number, number]> = [
+    [0.22, 0.28],
+    [0.55, 0.22],
+    [0.82, 0.3],
+    [0.18, 0.55],
+    [0.48, 0.5],
+    [0.78, 0.58],
+    [0.32, 0.78],
+    [0.68, 0.8],
+    [0.9, 0.72],
+    [0.1, 0.78],
+  ];
+
+  for (let i = 0; i < count; i++) {
+    const [nx, ny] = layout[i]!;
+    const jitterX = (rand() - 0.5) * 0.05;
+    const jitterY = (rand() - 0.5) * 0.045;
+    journeys.push(
+      makeJourney(
+        w * (nx + jitterX),
+        h * (ny + jitterY),
+        0.7 + rand() * 0.4,
+        PALETTE[i % PALETTE.length]!,
+        rand,
+        rand(),
+        i * 1.3,
+      ),
+    );
+  }
+
+  return journeys;
+}
+
+function rgba(c: Rgb, a: number) {
+  return `rgba(${c.r},${c.g},${c.b},${a})`;
+}
+
+/**
+ * Quiet, premium journey constellation for the Swarms empty pane.
+ * Few sparse graphs, muted color, slow travelers, soft vignette.
+ */
+export function JourneyNetworkBackdrop({
+  className,
+  message = "Select a persona to see its journeys.",
+}: {
+  className?: string;
+  message?: string;
+}) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const wrapRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const wrap = wrapRef.current;
+    if (!canvas || !wrap) return;
+
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    let raf = 0;
+    let journeys: Journey[] = [];
+    let w = 0;
+    let h = 0;
+    let dpr = 1;
+    let lastTs = 0;
+
+    const resize = () => {
+      const rect = wrap.getBoundingClientRect();
+      dpr = Math.min(window.devicePixelRatio || 1, 2);
+      w = Math.max(1, Math.floor(rect.width));
+      h = Math.max(1, Math.floor(rect.height));
+      canvas.width = Math.floor(w * dpr);
+      canvas.height = Math.floor(h * dpr);
+      canvas.style.width = `${w}px`;
+      canvas.style.height = `${h}px`;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      journeys = scatterJourneys(w, h);
+    };
+
+    const drawFrame = (ts: number) => {
+      const dark = isDarkTheme(wrap);
+      const reduce = prefersReducedMotion();
+      const dt = lastTs ? Math.min(0.048, (ts - lastTs) / 1000) : 0.016;
+      lastTs = ts;
+
+      ctx.clearRect(0, 0, w, h);
+
+      // Soft atmospheric wash — keeps the canvas from feeling flat/cheap
+      const wash = ctx.createRadialGradient(
+        w * 0.5,
+        h * 0.48,
+        0,
+        w * 0.5,
+        h * 0.48,
+        Math.max(w, h) * 0.55,
+      );
+      if (dark) {
+        wash.addColorStop(0, "rgba(255,255,255,0.018)");
+        wash.addColorStop(1, "rgba(255,255,255,0)");
+      } else {
+        wash.addColorStop(0, "rgba(40,44,52,0.03)");
+        wash.addColorStop(1, "rgba(40,44,52,0)");
+      }
+      ctx.fillStyle = wash;
+      ctx.fillRect(0, 0, w, h);
+
+      const edgeAlpha = dark ? 0.16 : 0.12;
+      const nodeStroke = dark
+        ? "rgba(210, 214, 220, 0.28)"
+        : "rgba(70, 76, 86, 0.22)";
+      const nodeFill = dark
+        ? "rgba(12, 12, 14, 0.55)"
+        : "rgba(255, 255, 253, 0.65)";
+
+      for (const j of journeys) {
+        for (const n of j.nodes) {
+          n.phase += dt * 0.28;
+          const amp = reduce ? 0 : 1.1;
+          n.x = n.ox + Math.sin(n.phase) * amp;
+          n.y = n.oy + Math.cos(n.phase * 0.85) * amp * 0.6;
+        }
+
+        const activeIdx = j.path[j.edgeIndex] ?? 0;
+        const active = j.edges[activeIdx]!;
+
+        if (!reduce) {
+          j.t += dt * j.speed;
+          j.dash += dt * 14;
+          if (j.t >= 1) {
+            j.t = 0;
+            j.edgeIndex = (j.edgeIndex + 1) % j.path.length;
+          }
+        }
+
+        // Edges — hairline, almost whisper-quiet
+        for (let i = 0; i < j.edges.length; i++) {
+          const e = j.edges[i]!;
+          const a = j.nodes[e.a]!;
+          const b = j.nodes[e.b]!;
+          const isActive = i === activeIdx;
+
+          ctx.lineWidth = isActive ? 1.1 : 0.9;
+          if (isActive) {
+            ctx.strokeStyle = rgba(j.color, dark ? 0.32 : 0.24);
+            ctx.setLineDash([3.5, 7]);
+            ctx.lineDashOffset = -j.dash;
+          } else {
+            ctx.strokeStyle = dark
+              ? `rgba(190,196,205,${edgeAlpha})`
+              : `rgba(80,86,96,${edgeAlpha})`;
+            ctx.setLineDash([]);
+            ctx.lineDashOffset = 0;
+          }
+          ctx.beginPath();
+          ctx.moveTo(a.x, a.y);
+          ctx.lineTo(b.x, b.y);
+          ctx.stroke();
+        }
+        ctx.setLineDash([]);
+        ctx.lineDashOffset = 0;
+
+        const from = j.nodes[active.a]!;
+        const to = j.nodes[active.b]!;
+        // Smoothstep for premium easing
+        const u = reduce ? 0.45 : j.t;
+        const ease = u * u * (3 - 2 * u);
+        const tx = from.x + (to.x - from.x) * ease;
+        const ty = from.y + (to.y - from.y) * ease;
+
+        // Quiet trail
+        if (!reduce) {
+          for (let k = 1; k <= 3; k++) {
+            const tt = Math.max(0, ease - k * 0.08);
+            const px = from.x + (to.x - from.x) * tt;
+            const py = from.y + (to.y - from.y) * tt;
+            ctx.beginPath();
+            ctx.arc(px, py, 1.4, 0, Math.PI * 2);
+            ctx.fillStyle = rgba(j.color, 0.06 * (1 - k / 4));
+            ctx.fill();
+          }
+        }
+
+        // Nodes — small rings, no checkmarks
+        for (const n of j.nodes) {
+          ctx.beginPath();
+          ctx.arc(n.x, n.y, 3.2, 0, Math.PI * 2);
+          ctx.fillStyle = nodeFill;
+          ctx.fill();
+          ctx.lineWidth = 1;
+          ctx.strokeStyle = nodeStroke;
+          ctx.stroke();
+        }
+
+        // Active tip — soft bloom + crisp core
+        const breath = reduce
+          ? 1
+          : 0.82 + 0.18 * Math.sin(ts / 900 + j.pulse);
+        const glowR = 26 * breath;
+        const grad = ctx.createRadialGradient(tx, ty, 0, tx, ty, glowR);
+        grad.addColorStop(0, rgba(j.color, dark ? 0.38 : 0.28));
+        grad.addColorStop(0.35, rgba(j.color, dark ? 0.12 : 0.09));
+        grad.addColorStop(1, rgba(j.color, 0));
+        ctx.fillStyle = grad;
+        ctx.beginPath();
+        ctx.arc(tx, ty, glowR, 0, Math.PI * 2);
+        ctx.fill();
+
+        ctx.beginPath();
+        ctx.arc(tx, ty, 2.6 * breath, 0, Math.PI * 2);
+        ctx.fillStyle = rgba(j.color, dark ? 0.85 : 0.75);
+        ctx.fill();
+      }
+
+      if (!reduce) raf = requestAnimationFrame(drawFrame);
+    };
+
+    resize();
+    if (prefersReducedMotion()) {
+      drawFrame(performance.now());
+    } else {
+      raf = requestAnimationFrame(drawFrame);
+    }
+
+    const ro = new ResizeObserver(resize);
+    ro.observe(wrap);
+
+    const onMotion = () => {
+      cancelAnimationFrame(raf);
+      lastTs = 0;
+      if (prefersReducedMotion()) drawFrame(performance.now());
+      else raf = requestAnimationFrame(drawFrame);
+    };
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    mq.addEventListener("change", onMotion);
+
+    return () => {
+      cancelAnimationFrame(raf);
+      ro.disconnect();
+      mq.removeEventListener("change", onMotion);
+    };
+  }, []);
+
+  return (
+    <div
+      ref={wrapRef}
+      className={cn(
+        "relative flex h-full min-h-[280px] w-full items-center justify-center overflow-hidden bg-background",
+        className,
+      )}
+      data-testid="journey-network-backdrop"
+    >
+      <div className="pointer-events-none absolute inset-0 overflow-hidden">
+        <canvas
+          ref={canvasRef}
+          aria-hidden
+          className="absolute inset-0 h-full w-full opacity-90"
+          style={{
+            maskImage:
+              "radial-gradient(110% 95% at 50% 48%, rgba(0,0,0,0.62) 0%, rgba(0,0,0,0.32) 48%, rgba(0,0,0,0) 86%)",
+            WebkitMaskImage:
+              "radial-gradient(110% 95% at 50% 48%, rgba(0,0,0,0.62) 0%, rgba(0,0,0,0.32) 48%, rgba(0,0,0,0) 86%)",
+          }}
+        />
+      </div>
+      <p className="relative z-10 max-w-[16rem] text-center text-sm tracking-wide text-muted-foreground/80">
+        {message}
+      </p>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/swarms/persona-avatar-look-picker.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/persona-avatar-look-picker.tsx
@@ -1,5 +1,5 @@
 /**
- * Compact shape + palette look picker for swarm persona pixel avatars.
+ * Compact form + mineral look picker for swarm persona pixel golems.
  * Saves immediately via the parent `onSave` (→ `personas:updatePersona`).
  */
 
@@ -12,22 +12,28 @@ import {
   PopoverTrigger,
 } from "@mcpjam/design-system/popover";
 import {
+  PERSONA_PIXEL_FAMILY_NAMES,
+  PERSONA_PIXEL_MINERAL_NAMES,
   PERSONA_PIXEL_PALETTE_COUNT,
   PERSONA_PIXEL_SHAPE_COUNT,
   PersonaPixelAvatar,
   resolvePersonaPixelLook,
   wrapPersonaPixelIndex,
+  type PersonaPixelState,
 } from "@/components/swarms/persona-pixel-avatar";
 
 export function PersonaAvatarLookPicker({
   seed,
   avatarShape,
   avatarPalette,
+  state,
   onSave,
 }: {
   seed: string;
   avatarShape?: number | null;
   avatarPalette?: number | null;
+  /** Forwarded to both avatar instances (trigger + preview). */
+  state?: PersonaPixelState;
   onSave: (look: {
     avatarShape: number;
     avatarPalette: number;
@@ -82,6 +88,9 @@ export function PersonaAvatarLookPicker({
     void persist(shapeIndex, next);
   };
 
+  const familyName = PERSONA_PIXEL_FAMILY_NAMES[shapeIndex] ?? "Form";
+  const mineralName = PERSONA_PIXEL_MINERAL_NAMES[paletteIndex] ?? "Mineral";
+
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
@@ -98,10 +107,11 @@ export function PersonaAvatarLookPicker({
             paletteIndex={avatarPalette}
             size="lg"
             active
+            state={state}
           />
         </button>
       </PopoverTrigger>
-      <PopoverContent className="w-56 p-3" align="start">
+      <PopoverContent className="w-64 p-3" align="start">
         <div className="flex flex-col items-center gap-3">
           <PersonaPixelAvatar
             seed={seed}
@@ -109,10 +119,11 @@ export function PersonaAvatarLookPicker({
             paletteIndex={paletteIndex}
             size="lg"
             active
+            state={state}
           />
           <div className="flex w-full items-center justify-between gap-2">
             <span className="text-xs font-medium text-muted-foreground">
-              Shape
+              Form
             </span>
             <div className="flex items-center gap-1">
               <Button
@@ -121,13 +132,13 @@ export function PersonaAvatarLookPicker({
                 variant="outline"
                 className="h-7 w-7 p-0"
                 disabled={saving}
-                aria-label="Previous shape"
+                aria-label="Previous form"
                 onClick={() => stepShape(-1)}
               >
                 <ChevronLeft className="h-3.5 w-3.5" />
               </Button>
-              <span className="w-8 text-center text-xs tabular-nums text-muted-foreground">
-                {shapeIndex + 1}/{PERSONA_PIXEL_SHAPE_COUNT}
+              <span className="min-w-16 text-center text-xs tabular-nums text-muted-foreground">
+                {familyName} · {shapeIndex + 1}/{PERSONA_PIXEL_SHAPE_COUNT}
               </span>
               <Button
                 type="button"
@@ -135,7 +146,7 @@ export function PersonaAvatarLookPicker({
                 variant="outline"
                 className="h-7 w-7 p-0"
                 disabled={saving}
-                aria-label="Next shape"
+                aria-label="Next form"
                 data-testid="persona-avatar-next-shape"
                 onClick={() => stepShape(1)}
               >
@@ -145,7 +156,7 @@ export function PersonaAvatarLookPicker({
           </div>
           <div className="flex w-full items-center justify-between gap-2">
             <span className="text-xs font-medium text-muted-foreground">
-              Colors
+              Mineral
             </span>
             <div className="flex items-center gap-1">
               <Button
@@ -154,13 +165,13 @@ export function PersonaAvatarLookPicker({
                 variant="outline"
                 className="h-7 w-7 p-0"
                 disabled={saving}
-                aria-label="Previous colors"
+                aria-label="Previous mineral"
                 onClick={() => stepPalette(-1)}
               >
                 <ChevronLeft className="h-3.5 w-3.5" />
               </Button>
-              <span className="w-8 text-center text-xs tabular-nums text-muted-foreground">
-                {paletteIndex + 1}/{PERSONA_PIXEL_PALETTE_COUNT}
+              <span className="min-w-16 text-center text-xs tabular-nums text-muted-foreground">
+                {mineralName} · {paletteIndex + 1}/{PERSONA_PIXEL_PALETTE_COUNT}
               </span>
               <Button
                 type="button"
@@ -168,7 +179,7 @@ export function PersonaAvatarLookPicker({
                 variant="outline"
                 className="h-7 w-7 p-0"
                 disabled={saving}
-                aria-label="Next colors"
+                aria-label="Next mineral"
                 data-testid="persona-avatar-next-palette"
                 onClick={() => stepPalette(1)}
               >

--- a/mcpjam-inspector/client/src/components/swarms/persona-avatar-look-picker.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/persona-avatar-look-picker.tsx
@@ -1,0 +1,186 @@
+/**
+ * Compact shape + palette look picker for swarm persona pixel avatars.
+ * Saves immediately via the parent `onSave` (→ `personas:updatePersona`).
+ */
+
+import { useEffect, useState } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { Button } from "@mcpjam/design-system/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@mcpjam/design-system/popover";
+import {
+  PERSONA_PIXEL_PALETTE_COUNT,
+  PERSONA_PIXEL_SHAPE_COUNT,
+  PersonaPixelAvatar,
+  resolvePersonaPixelLook,
+  wrapPersonaPixelIndex,
+} from "@/components/swarms/persona-pixel-avatar";
+
+export function PersonaAvatarLookPicker({
+  seed,
+  avatarShape,
+  avatarPalette,
+  onSave,
+}: {
+  seed: string;
+  avatarShape?: number | null;
+  avatarPalette?: number | null;
+  onSave: (look: {
+    avatarShape: number;
+    avatarPalette: number;
+  }) => Promise<void>;
+}) {
+  const resolved = resolvePersonaPixelLook(seed, {
+    shapeIndex: avatarShape,
+    paletteIndex: avatarPalette,
+  });
+  const [open, setOpen] = useState(false);
+  const [shapeIndex, setShapeIndex] = useState(resolved.shapeIndex);
+  const [paletteIndex, setPaletteIndex] = useState(resolved.paletteIndex);
+  const [saving, setSaving] = useState(false);
+
+  // Sync draft when the persona or persisted look changes (and when closed).
+  useEffect(() => {
+    if (open) return;
+    setShapeIndex(resolved.shapeIndex);
+    setPaletteIndex(resolved.paletteIndex);
+  }, [open, resolved.shapeIndex, resolved.paletteIndex]);
+
+  const persist = async (nextShape: number, nextPalette: number) => {
+    setShapeIndex(nextShape);
+    setPaletteIndex(nextPalette);
+    setSaving(true);
+    try {
+      await onSave({
+        avatarShape: nextShape,
+        avatarPalette: nextPalette,
+      });
+    } catch {
+      setShapeIndex(resolved.shapeIndex);
+      setPaletteIndex(resolved.paletteIndex);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const stepShape = (delta: number) => {
+    const next = wrapPersonaPixelIndex(
+      shapeIndex + delta,
+      PERSONA_PIXEL_SHAPE_COUNT,
+    );
+    void persist(next, paletteIndex);
+  };
+
+  const stepPalette = (delta: number) => {
+    const next = wrapPersonaPixelIndex(
+      paletteIndex + delta,
+      PERSONA_PIXEL_PALETTE_COUNT,
+    );
+    void persist(shapeIndex, next);
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="rounded-md outline-none ring-offset-background hover:bg-muted/40 focus-visible:ring-2 focus-visible:ring-ring"
+          aria-label="Edit persona look"
+          title="Edit look"
+          data-testid="persona-avatar-look-trigger"
+        >
+          <PersonaPixelAvatar
+            seed={seed}
+            shapeIndex={avatarShape}
+            paletteIndex={avatarPalette}
+            size="lg"
+            active
+          />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent className="w-56 p-3" align="start">
+        <div className="flex flex-col items-center gap-3">
+          <PersonaPixelAvatar
+            seed={seed}
+            shapeIndex={shapeIndex}
+            paletteIndex={paletteIndex}
+            size="lg"
+            active
+          />
+          <div className="flex w-full items-center justify-between gap-2">
+            <span className="text-xs font-medium text-muted-foreground">
+              Shape
+            </span>
+            <div className="flex items-center gap-1">
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                className="h-7 w-7 p-0"
+                disabled={saving}
+                aria-label="Previous shape"
+                onClick={() => stepShape(-1)}
+              >
+                <ChevronLeft className="h-3.5 w-3.5" />
+              </Button>
+              <span className="w-8 text-center text-xs tabular-nums text-muted-foreground">
+                {shapeIndex + 1}/{PERSONA_PIXEL_SHAPE_COUNT}
+              </span>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                className="h-7 w-7 p-0"
+                disabled={saving}
+                aria-label="Next shape"
+                data-testid="persona-avatar-next-shape"
+                onClick={() => stepShape(1)}
+              >
+                <ChevronRight className="h-3.5 w-3.5" />
+              </Button>
+            </div>
+          </div>
+          <div className="flex w-full items-center justify-between gap-2">
+            <span className="text-xs font-medium text-muted-foreground">
+              Colors
+            </span>
+            <div className="flex items-center gap-1">
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                className="h-7 w-7 p-0"
+                disabled={saving}
+                aria-label="Previous colors"
+                onClick={() => stepPalette(-1)}
+              >
+                <ChevronLeft className="h-3.5 w-3.5" />
+              </Button>
+              <span className="w-8 text-center text-xs tabular-nums text-muted-foreground">
+                {paletteIndex + 1}/{PERSONA_PIXEL_PALETTE_COUNT}
+              </span>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                className="h-7 w-7 p-0"
+                disabled={saving}
+                aria-label="Next colors"
+                data-testid="persona-avatar-next-palette"
+                onClick={() => stepPalette(1)}
+              >
+                <ChevronRight className="h-3.5 w-3.5" />
+              </Button>
+            </div>
+          </div>
+          <p className="text-[11px] text-muted-foreground">
+            Changes save automatically.
+          </p>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/mcpjam-inspector/client/src/components/swarms/persona-pixel-avatar.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/persona-pixel-avatar.tsx
@@ -1,0 +1,370 @@
+/**
+ * Cursor-style 8-bit persona sprites — deterministic per seed, idle bob + blink.
+ * Pure SVG (no asset pack) so each roster row gets a little personality without
+ * shipping sprite sheets. Optional shape/palette overrides persist via
+ * `personas.avatarShape` / `personas.avatarPalette` (backend).
+ */
+
+import { useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
+
+type Cell = "." | "O" | "S" | "H" | "T" | "P" | "E" | "A" | "L";
+
+type Palette = {
+  outline: string;
+  skin: string;
+  hair: string;
+  top: string;
+  pants: string;
+  accent: string;
+};
+
+const PALETTES: Palette[] = [
+  {
+    outline: "#1a1a1a",
+    skin: "#f0c4a0",
+    hair: "#3d2314",
+    top: "#e85d4c",
+    pants: "#3b4a6b",
+    accent: "#f4d35e",
+  },
+  {
+    outline: "#1a1a1a",
+    skin: "#d4a574",
+    hair: "#1f1f1f",
+    top: "#4a90d9",
+    pants: "#2c3e50",
+    accent: "#7bed9f",
+  },
+  {
+    outline: "#1a1a1a",
+    skin: "#ffe0bd",
+    hair: "#c0392b",
+    top: "#9b59b6",
+    pants: "#34495e",
+    accent: "#f39c12",
+  },
+  {
+    outline: "#1a1a1a",
+    skin: "#8d5524",
+    hair: "#2c1810",
+    top: "#27ae60",
+    pants: "#1a252f",
+    accent: "#e74c3c",
+  },
+  {
+    outline: "#1a1a1a",
+    skin: "#f5d0c5",
+    hair: "#f7d794",
+    top: "#fd79a8",
+    pants: "#636e72",
+    accent: "#00cec9",
+  },
+  {
+    outline: "#1a1a1a",
+    skin: "#c68642",
+    hair: "#4a3728",
+    top: "#0984e3",
+    pants: "#2d3436",
+    accent: "#fdcb6e",
+  },
+];
+
+/** 12×14 pixel silhouettes. `.` empty, letters map to palette slots. */
+const SHAPES: Cell[][][] = [
+  // Classic bob-cut
+  [
+    "....HHHH....",
+    "...HHHHHH...",
+    "..SSSSSSSS..",
+    "..SE.E.ESS..",
+    "..SSSSSSSS..",
+    "...TTTTTT...",
+    "..ATATTTTA..",
+    ".AA.TTTT.AA.",
+    "....TTTT....",
+    "....PP.PP...",
+    "....PP.PP...",
+    "....LL.LL...",
+  ].map((row) => row.split("") as Cell[]),
+  // Cap / explorer
+  [
+    "...OOOOOO...",
+    "..OHHHHHHO..",
+    "..SSSSSSSS..",
+    "..SE.E.ESS..",
+    "..SSSSSSSS..",
+    "...TTTTTT...",
+    "..TATTTTAT..",
+    ".A..TTTT..A.",
+    "....TTTT....",
+    "....PP.PP...",
+    "....PP.PP...",
+    "....LL.LL...",
+  ].map((row) => row.split("") as Cell[]),
+  // Spiky hair
+  [
+    "..H..HH..H..",
+    "...HHHHHH...",
+    "..SSSSSSSS..",
+    "..SE.E.ESS..",
+    "..SSSSSSSS..",
+    "...TTTTTT...",
+    "..ATATATTA..",
+    "AA..TTTT..AA",
+    "....TTTT....",
+    "....PP.PP...",
+    "....PP.PP...",
+    "....LL.LL...",
+  ].map((row) => row.split("") as Cell[]),
+  // Ponytail
+  [
+    ".....HHH.H..",
+    "....HHHHHH..",
+    "..SSSSSSSS..",
+    "..SE.E.ESS..",
+    "..SSSSSSSS..",
+    "...TTTTTT...",
+    "..TATTTTAT..",
+    ".A..TTTT..A.",
+    "....TTTT....",
+    "....PP.PP...",
+    "....PP.PP...",
+    "....LL.LL...",
+  ].map((row) => row.split("") as Cell[]),
+  // Short crop + scarf accent
+  [
+    "....HHHH....",
+    "...HHHHHH...",
+    "..SSSSSSSS..",
+    "..SE.E.ESS..",
+    "..SSSSSSSS..",
+    "...AAAAAA...",
+    "..TTTTTTTT..",
+    ".A..TTTT..A.",
+    "....TTTT....",
+    "....PP.PP...",
+    "....PP.PP...",
+    "....LL.LL...",
+  ].map((row) => row.split("") as Cell[]),
+  // Tall hair / wizard vibe
+  [
+    ".....HH.....",
+    "....HHHH....",
+    "...HHHHHH...",
+    "..SSSSSSSS..",
+    "..SE.E.ESS..",
+    "..SSSSSSSS..",
+    "...TTTTTT...",
+    "..ATATTTTA..",
+    "AA..TTTT..AA",
+    "....TTTT....",
+    "....PP.PP...",
+    "....LL.LL...",
+  ].map((row) => row.split("") as Cell[]),
+];
+
+/** Keep in sync with backend `PERSONA_AVATAR_SHAPE_COUNT`. */
+export const PERSONA_PIXEL_SHAPE_COUNT = SHAPES.length;
+/** Keep in sync with backend `PERSONA_AVATAR_PALETTE_COUNT`. */
+export const PERSONA_PIXEL_PALETTE_COUNT = PALETTES.length;
+
+function hashSeed(seed: string): number {
+  let hash = 0;
+  for (let i = 0; i < seed.length; i++) {
+    hash = (hash * 31 + seed.charCodeAt(i)) | 0;
+  }
+  return Math.abs(hash);
+}
+
+function cellColor(cell: Cell, palette: Palette): string | null {
+  switch (cell) {
+    case "O":
+      return palette.outline;
+    case "S":
+      return palette.skin;
+    case "H":
+      return palette.hair;
+    case "T":
+      return palette.top;
+    case "P":
+      return palette.pants;
+    case "L":
+      return palette.pants;
+    case "E":
+      return palette.outline;
+    case "A":
+      return palette.accent;
+    default:
+      return null;
+  }
+}
+
+function withBlink(shape: Cell[][], blinking: boolean): Cell[][] {
+  if (!blinking) return shape;
+  return shape.map((row) =>
+    row.map((cell) => (cell === "E" ? "S" : cell)),
+  );
+}
+
+export function resolvePersonaPixelVariant(seed: string): {
+  shapeIndex: number;
+  paletteIndex: number;
+} {
+  const hash = hashSeed(seed || "persona");
+  return {
+    shapeIndex: hash % PERSONA_PIXEL_SHAPE_COUNT,
+    paletteIndex:
+      Math.floor(hash / PERSONA_PIXEL_SHAPE_COUNT) % PERSONA_PIXEL_PALETTE_COUNT,
+  };
+}
+
+/** Wrap an index into `[0, count)`. */
+export function wrapPersonaPixelIndex(index: number, count: number): number {
+  if (!Number.isFinite(index) || count <= 0) return 0;
+  const n = Math.trunc(index);
+  return ((n % count) + count) % count;
+}
+
+/**
+ * Resolve the look for a persona: explicit saved indices win; otherwise seed
+ * from `_id` so existing personas keep a stable default.
+ */
+export function resolvePersonaPixelLook(
+  seed: string,
+  overrides?: {
+    shapeIndex?: number | null;
+    paletteIndex?: number | null;
+  },
+): { shapeIndex: number; paletteIndex: number } {
+  const seeded = resolvePersonaPixelVariant(seed);
+  return {
+    shapeIndex:
+      overrides?.shapeIndex === undefined || overrides.shapeIndex === null
+        ? seeded.shapeIndex
+        : wrapPersonaPixelIndex(
+            overrides.shapeIndex,
+            PERSONA_PIXEL_SHAPE_COUNT,
+          ),
+    paletteIndex:
+      overrides?.paletteIndex === undefined || overrides.paletteIndex === null
+        ? seeded.paletteIndex
+        : wrapPersonaPixelIndex(
+            overrides.paletteIndex,
+            PERSONA_PIXEL_PALETTE_COUNT,
+          ),
+  };
+}
+
+export function PersonaPixelAvatar({
+  seed,
+  shapeIndex: shapeOverride,
+  paletteIndex: paletteOverride,
+  size = "md",
+  active = false,
+  className,
+}: {
+  /** Stable id (persona `_id`) — picks shape + palette when overrides absent. */
+  seed: string;
+  /** Persisted look override (`personas.avatarShape`). */
+  shapeIndex?: number | null;
+  /** Persisted look override (`personas.avatarPalette`). */
+  paletteIndex?: number | null;
+  size?: "sm" | "md" | "lg";
+  /** Selected / focused — slightly peppier bob. */
+  active?: boolean;
+  className?: string;
+}) {
+  const { shapeIndex, paletteIndex } = resolvePersonaPixelLook(seed, {
+    shapeIndex: shapeOverride,
+    paletteIndex: paletteOverride,
+  });
+  const shape = SHAPES[shapeIndex]!;
+  const palette = PALETTES[paletteIndex]!;
+  const [blinking, setBlinking] = useState(false);
+  const [reduceMotion, setReduceMotion] = useState(false);
+
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const sync = () => setReduceMotion(mq.matches);
+    sync();
+    mq.addEventListener("change", sync);
+    return () => mq.removeEventListener("change", sync);
+  }, []);
+
+  useEffect(() => {
+    if (reduceMotion) return;
+    let timeout: ReturnType<typeof setTimeout>;
+    let cancelled = false;
+    const schedule = () => {
+      timeout = setTimeout(
+        () => {
+          if (cancelled) return;
+          setBlinking(true);
+          timeout = setTimeout(() => {
+            if (cancelled) return;
+            setBlinking(false);
+            schedule();
+          }, 120);
+        },
+        2200 + (hashSeed(seed) % 1800),
+      );
+    };
+    schedule();
+    return () => {
+      cancelled = true;
+      clearTimeout(timeout);
+    };
+  }, [seed, reduceMotion]);
+
+  const frame = withBlink(shape, blinking && !reduceMotion);
+  const rows = frame.length;
+  const cols = frame[0]?.length ?? 12;
+  const px = size === "lg" ? 3 : size === "sm" ? 2 : 2.5;
+  const width = cols * px;
+  const height = rows * px;
+
+  return (
+    <span
+      className={cn(
+        "inline-flex shrink-0 items-end justify-center",
+        !reduceMotion &&
+          (active
+            ? "animate-persona-pixel-bob-active"
+            : "animate-persona-pixel-bob"),
+        className,
+      )}
+      style={{ width, height: height + (size === "lg" ? 4 : 2) }}
+      aria-hidden
+      data-testid="persona-pixel-avatar"
+      data-shape={shapeIndex}
+      data-palette={paletteIndex}
+    >
+      <svg
+        width={width}
+        height={height}
+        viewBox={`0 0 ${cols} ${rows}`}
+        shapeRendering="crispEdges"
+        className="block"
+        style={{ imageRendering: "pixelated" }}
+      >
+        {frame.flatMap((row, y) =>
+          row.map((cell, x) => {
+            const fill = cellColor(cell, palette);
+            if (!fill) return null;
+            return (
+              <rect
+                key={`${x}-${y}`}
+                x={x}
+                y={y}
+                width={1}
+                height={1}
+                fill={fill}
+              />
+            );
+          }),
+        )}
+      </svg>
+    </span>
+  );
+}

--- a/mcpjam-inspector/client/src/components/swarms/persona-pixel-avatar.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/persona-pixel-avatar.tsx
@@ -1,174 +1,173 @@
 /**
- * Cursor-style 8-bit persona sprites — deterministic per seed, idle bob + blink.
- * Pure SVG (no asset pack) so each roster row gets a little personality without
- * shipping sprite sheets. Optional shape/palette overrides persist via
- * `personas.avatarShape` / `personas.avatarPalette` (backend).
+ * Generated 8-bit "pixel golem" persona avatars — faceted stone workers with a
+ * floating sensor head. Deterministic per seed; optional family/mineral
+ * overrides persist via `personas.avatarShape` / `personas.avatarPalette`.
+ * Motion is CSS-only (head hop + sensor/levitation pulse).
  */
 
-import { useEffect, useState } from "react";
+import { useMemo } from "react";
 import { cn } from "@/lib/utils";
 
-type Cell = "." | "O" | "S" | "H" | "T" | "P" | "E" | "A" | "L";
+export type PersonaPixelState = "idle" | "thinking" | "running" | "error";
 
-type Palette = {
-  outline: string;
-  skin: string;
-  hair: string;
-  top: string;
-  pants: string;
-  accent: string;
+type Mineral = {
+  name: string;
+  dark: string;
+  mid: string;
+  light: string;
+  glow: string;
 };
 
-const PALETTES: Palette[] = [
+type Family = {
+  name: string;
+  bw: [number, number];
+  bh: [number, number];
+  legH: [number, number];
+  hw: [number, number];
+  hh: [number, number];
+  taper?: boolean;
+  legs?: 2 | 3;
+  arms?: boolean;
+  crest?: boolean;
+  shoulder?: boolean;
+  gapExtra?: boolean;
+};
+
+type GolemRect = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  fill: string;
+  opacity?: number;
+  className?: string;
+};
+
+type GolemParts = {
+  body: GolemRect[];
+  head: GolemRect[];
+  headDelay: number;
+};
+
+const GRID_W = 16;
+const GRID_H = 19;
+const ERROR_GLOW = "#c9584a";
+
+const FAMILIES: Family[] = [
   {
-    outline: "#1a1a1a",
-    skin: "#f0c4a0",
-    hair: "#3d2314",
-    top: "#e85d4c",
-    pants: "#3b4a6b",
-    accent: "#f4d35e",
+    name: "Brute",
+    bw: [4, 5],
+    bh: [4, 5],
+    legH: [1, 2],
+    hw: [2, 3],
+    hh: [2, 3],
+    taper: true,
+    arms: true,
   },
   {
-    outline: "#1a1a1a",
-    skin: "#d4a574",
-    hair: "#1f1f1f",
-    top: "#4a90d9",
-    pants: "#2c3e50",
-    accent: "#7bed9f",
+    name: "Stele",
+    bw: [2, 3],
+    bh: [6, 7],
+    legH: [1, 1],
+    hw: [2, 2],
+    hh: [3, 4],
   },
   {
-    outline: "#1a1a1a",
-    skin: "#ffe0bd",
-    hair: "#c0392b",
-    top: "#9b59b6",
-    pants: "#34495e",
-    accent: "#f39c12",
+    name: "Runt",
+    bw: [2, 3],
+    bh: [3, 4],
+    legH: [1, 2],
+    hw: [2, 3],
+    hh: [2, 2],
+    arms: true,
   },
   {
-    outline: "#1a1a1a",
-    skin: "#8d5524",
-    hair: "#2c1810",
-    top: "#27ae60",
-    pants: "#1a252f",
-    accent: "#e74c3c",
+    name: "Tripod",
+    bw: [3, 4],
+    bh: [3, 5],
+    legH: [2, 3],
+    hw: [2, 2],
+    hh: [2, 3],
+    taper: true,
+    legs: 3,
   },
   {
-    outline: "#1a1a1a",
-    skin: "#f5d0c5",
-    hair: "#f7d794",
-    top: "#fd79a8",
-    pants: "#636e72",
-    accent: "#00cec9",
+    name: "Warden",
+    bw: [3, 4],
+    bh: [4, 6],
+    legH: [1, 2],
+    hw: [3, 3],
+    hh: [2, 3],
+    arms: true,
+    crest: true,
+    shoulder: true,
   },
   {
-    outline: "#1a1a1a",
-    skin: "#c68642",
-    hair: "#4a3728",
-    top: "#0984e3",
-    pants: "#2d3436",
-    accent: "#fdcb6e",
+    name: "Waif",
+    bw: [2, 2],
+    bh: [4, 5],
+    legH: [2, 3],
+    hw: [2, 3],
+    hh: [2, 3],
+    arms: true,
+    gapExtra: true,
   },
 ];
 
-/** 12×14 pixel silhouettes. `.` empty, letters map to palette slots. */
-const SHAPES: Cell[][][] = [
-  // Classic bob-cut
-  [
-    "....HHHH....",
-    "...HHHHHH...",
-    "..SSSSSSSS..",
-    "..SE.E.ESS..",
-    "..SSSSSSSS..",
-    "...TTTTTT...",
-    "..ATATTTTA..",
-    ".AA.TTTT.AA.",
-    "....TTTT....",
-    "....PP.PP...",
-    "....PP.PP...",
-    "....LL.LL...",
-  ].map((row) => row.split("") as Cell[]),
-  // Cap / explorer
-  [
-    "...OOOOOO...",
-    "..OHHHHHHO..",
-    "..SSSSSSSS..",
-    "..SE.E.ESS..",
-    "..SSSSSSSS..",
-    "...TTTTTT...",
-    "..TATTTTAT..",
-    ".A..TTTT..A.",
-    "....TTTT....",
-    "....PP.PP...",
-    "....PP.PP...",
-    "....LL.LL...",
-  ].map((row) => row.split("") as Cell[]),
-  // Spiky hair
-  [
-    "..H..HH..H..",
-    "...HHHHHH...",
-    "..SSSSSSSS..",
-    "..SE.E.ESS..",
-    "..SSSSSSSS..",
-    "...TTTTTT...",
-    "..ATATATTA..",
-    "AA..TTTT..AA",
-    "....TTTT....",
-    "....PP.PP...",
-    "....PP.PP...",
-    "....LL.LL...",
-  ].map((row) => row.split("") as Cell[]),
-  // Ponytail
-  [
-    ".....HHH.H..",
-    "....HHHHHH..",
-    "..SSSSSSSS..",
-    "..SE.E.ESS..",
-    "..SSSSSSSS..",
-    "...TTTTTT...",
-    "..TATTTTAT..",
-    ".A..TTTT..A.",
-    "....TTTT....",
-    "....PP.PP...",
-    "....PP.PP...",
-    "....LL.LL...",
-  ].map((row) => row.split("") as Cell[]),
-  // Short crop + scarf accent
-  [
-    "....HHHH....",
-    "...HHHHHH...",
-    "..SSSSSSSS..",
-    "..SE.E.ESS..",
-    "..SSSSSSSS..",
-    "...AAAAAA...",
-    "..TTTTTTTT..",
-    ".A..TTTT..A.",
-    "....TTTT....",
-    "....PP.PP...",
-    "....PP.PP...",
-    "....LL.LL...",
-  ].map((row) => row.split("") as Cell[]),
-  // Tall hair / wizard vibe
-  [
-    ".....HH.....",
-    "....HHHH....",
-    "...HHHHHH...",
-    "..SSSSSSSS..",
-    "..SE.E.ESS..",
-    "..SSSSSSSS..",
-    "...TTTTTT...",
-    "..ATATTTTA..",
-    "AA..TTTT..AA",
-    "....TTTT....",
-    "....PP.PP...",
-    "....LL.LL...",
-  ].map((row) => row.split("") as Cell[]),
+const MINERALS: Mineral[] = [
+  {
+    name: "Basalt",
+    dark: "#22262b",
+    mid: "#3c444d",
+    light: "#5e6a75",
+    glow: "#e8945c",
+  },
+  {
+    name: "Jade",
+    dark: "#1d332a",
+    mid: "#32584a",
+    light: "#568a70",
+    glow: "#a9e6c0",
+  },
+  {
+    name: "Oxide",
+    dark: "#3a2420",
+    mid: "#6b3d2e",
+    light: "#9c6246",
+    glow: "#f0b078",
+  },
+  {
+    name: "Lapis",
+    dark: "#1d2740",
+    mid: "#334570",
+    light: "#54679b",
+    glow: "#9ec1f0",
+  },
+  {
+    name: "Bone",
+    dark: "#5c5346",
+    mid: "#8b7f6b",
+    light: "#c4b696",
+    glow: "#f2ddab",
+  },
+  {
+    name: "Amethyst",
+    dark: "#2d2340",
+    mid: "#4c3a6b",
+    light: "#755f9c",
+    glow: "#c9a8ef",
+  },
 ];
 
 /** Keep in sync with backend `PERSONA_AVATAR_SHAPE_COUNT`. */
-export const PERSONA_PIXEL_SHAPE_COUNT = SHAPES.length;
+export const PERSONA_PIXEL_SHAPE_COUNT = FAMILIES.length;
 /** Keep in sync with backend `PERSONA_AVATAR_PALETTE_COUNT`. */
-export const PERSONA_PIXEL_PALETTE_COUNT = PALETTES.length;
+export const PERSONA_PIXEL_PALETTE_COUNT = MINERALS.length;
 
+export const PERSONA_PIXEL_FAMILY_NAMES = FAMILIES.map((f) => f.name);
+export const PERSONA_PIXEL_MINERAL_NAMES = MINERALS.map((m) => m.name);
+
+/** Byte-identical to the previous sprite hasher — do not change. */
 function hashSeed(seed: string): number {
   let hash = 0;
   for (let i = 0; i < seed.length; i++) {
@@ -177,34 +176,195 @@ function hashSeed(seed: string): number {
   return Math.abs(hash);
 }
 
-function cellColor(cell: Cell, palette: Palette): string | null {
-  switch (cell) {
-    case "O":
-      return palette.outline;
-    case "S":
-      return palette.skin;
-    case "H":
-      return palette.hair;
-    case "T":
-      return palette.top;
-    case "P":
-      return palette.pants;
-    case "L":
-      return palette.pants;
-    case "E":
-      return palette.outline;
-    case "A":
-      return palette.accent;
-    default:
-      return null;
+function fnv1a(seed: string): number {
+  let h = 2166136261;
+  for (let i = 0; i < seed.length; i++) {
+    h ^= seed.charCodeAt(i);
+    h = Math.imul(h, 16777619);
   }
+  return h >>> 0;
 }
 
-function withBlink(shape: Cell[][], blinking: boolean): Cell[][] {
-  if (!blinking) return shape;
-  return shape.map((row) =>
-    row.map((cell) => (cell === "E" ? "S" : cell)),
+function mulberry32(a: number): () => number {
+  return function next() {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function pulseClass(state: PersonaPixelState, kind: "sensor" | "gap"): string | undefined {
+  if (state === "error") return undefined;
+  if (state === "thinking" && kind === "sensor") {
+    return "animate-persona-golem-flicker";
+  }
+  if (state === "running") return "animate-persona-golem-pulse-fast";
+  return "animate-persona-golem-pulse";
+}
+
+function generatePixelGolem(
+  seed: string,
+  familyIndex: number,
+  mineralIndex: number,
+  state: PersonaPixelState,
+): GolemParts {
+  const rng = mulberry32(fnv1a(seed));
+  const F = FAMILIES[familyIndex % FAMILIES.length]!;
+  const mat = MINERALS[mineralIndex % MINERALS.length]!;
+  const ri = (a: number, b: number) => a + Math.floor(rng() * (b - a + 1));
+
+  const bw = ri(F.bw[0], F.bw[1]);
+  const bh = ri(F.bh[0], F.bh[1]);
+  const legH = ri(F.legH[0], F.legH[1]);
+  const hw = ri(F.hw[0], F.hw[1]);
+  const hh = ri(F.hh[0], F.hh[1]);
+  const gap = 1 + (F.gapExtra ? 1 : 0);
+  const legs = F.legs ?? 2;
+
+  const cxL = 7;
+  const cxR = 8;
+  const groundY = GRID_H - 2;
+  const bodyBot = groundY - legH;
+  const bodyTop = bodyBot - bh + 1;
+  const headBot = bodyTop - gap - 1;
+  const headTop = headBot - hh + 1;
+
+  const grid: number[][] = Array.from({ length: GRID_H }, () =>
+    Array(GRID_W).fill(0),
   );
+  const put = (x: number, y: number, v: number) => {
+    if (x >= 0 && x < GRID_W && y >= 0 && y < GRID_H) grid[y]![x] = v;
+  };
+
+  for (let y = bodyTop; y <= bodyBot; y++) {
+    let w = bw;
+    if (F.taper && y === bodyTop) w = Math.max(1, bw - 1);
+    for (let d = 0; d < w; d++) {
+      put(cxR + d, y, 1);
+      put(cxL - d, y, 1);
+    }
+  }
+  if (F.shoulder) {
+    put(cxR + bw, bodyTop, 1);
+    put(cxL - bw, bodyTop, 1);
+  }
+  // Chipped corners (asymmetry)
+  if (rng() < 0.45) {
+    put(cxR + (F.taper ? Math.max(0, bw - 2) : bw - 1), bodyTop, 0);
+  }
+  if (rng() < 0.45) {
+    put(cxL - (bw - 1), bodyBot, 0);
+  }
+
+  const lx = Math.min(bw - 1, 1 + Math.floor(rng() * 2));
+  for (let y = bodyBot + 1; y <= groundY; y++) {
+    put(cxR + lx, y, 1);
+    put(cxL - lx, y, 1);
+    if (legs === 3) {
+      put(cxL, y, 1);
+      put(cxR, y, 1);
+    }
+  }
+
+  if (F.arms && rng() < 0.85) {
+    const al = ri(2, 3);
+    for (let y = bodyTop + 1; y < Math.min(bodyTop + 1 + al, bodyBot); y++) {
+      put(cxR + bw, y, 1);
+      put(cxL - bw, y, 1);
+    }
+  }
+
+  for (let y = headTop; y <= headBot; y++) {
+    let w = hw;
+    if (y === headTop && hh > 2 && rng() < 0.6) w = hw - 1;
+    for (let d = 0; d < Math.max(1, w); d++) {
+      put(cxR + d, y, 2);
+      put(cxL - d, y, 2);
+    }
+  }
+  if (F.crest && rng() < 0.85) {
+    put(rng() < 0.5 ? cxL : cxR, headTop - 1, 2);
+    if (rng() < 0.4) {
+      put(rng() < 0.5 ? cxL - 1 : cxR + 1, headTop - 1, 2);
+    }
+  }
+
+  const glowCol = state === "error" ? ERROR_GLOW : mat.glow;
+  const senCls = pulseClass(state, "sensor");
+  const gapCls = pulseClass(state, "gap");
+  const empty = (x: number, y: number) => !(grid[y] && grid[y]![x]);
+
+  const body: GolemRect[] = [];
+  const head: GolemRect[] = [];
+  for (let y = 0; y < GRID_H; y++) {
+    for (let x = 0; x < GRID_W; x++) {
+      const v = grid[y]![x]!;
+      if (!v) continue;
+      let col = mat.mid;
+      if (empty(x, y - 1)) col = mat.light;
+      else if (empty(x + 1, y) || empty(x, y + 1)) col = mat.dark;
+      if (rng() < 0.1) col = col === mat.dark ? mat.mid : mat.dark;
+      const rect: GolemRect = { x, y, width: 1, height: 1, fill: col };
+      if (v === 2) head.push(rect);
+      else body.push(rect);
+    }
+  }
+
+  // Sensor: visor or single dot
+  const sy = headTop + Math.floor(hh / 2);
+  if (rng() < 0.35) {
+    for (let x = cxL; x <= cxR; x++) {
+      head.push({
+        x,
+        y: sy,
+        width: 1,
+        height: 1,
+        fill: glowCol,
+        className: senCls,
+      });
+    }
+  } else {
+    const sx =
+      rng() < 0.5
+        ? cxL - Math.floor(rng() * Math.max(1, hw - 1))
+        : cxR + Math.floor(rng() * Math.max(1, hw - 1));
+    head.push({
+      x: sx,
+      y: sy,
+      width: 1,
+      height: 1,
+      fill: glowCol,
+      className: senCls,
+    });
+  }
+
+  // Levitation glow in the gap row
+  body.push({
+    x: cxL,
+    y: bodyTop - 1,
+    width: 2,
+    height: 1,
+    fill: glowCol,
+    opacity: 0.85,
+    className: gapCls,
+  });
+  // Ground shadow
+  body.push({
+    x: cxL - bw,
+    y: GRID_H - 1,
+    width: bw * 2 + 2,
+    height: 0.8,
+    fill: "#000",
+    opacity: 0.22,
+  });
+
+  return {
+    body,
+    head,
+    headDelay: -(rng() * 2.6),
+  };
 }
 
 export function resolvePersonaPixelVariant(seed: string): {
@@ -256,82 +416,55 @@ export function resolvePersonaPixelLook(
   };
 }
 
+function cellPx(size: "sm" | "md" | "lg"): number {
+  if (size === "sm") return 1.5;
+  if (size === "lg") return 2.75;
+  return 2;
+}
+
 export function PersonaPixelAvatar({
   seed,
   shapeIndex: shapeOverride,
   paletteIndex: paletteOverride,
   size = "md",
   active = false,
+  state = "idle",
   className,
 }: {
-  /** Stable id (persona `_id`) — picks shape + palette when overrides absent. */
+  /** Stable id (persona `_id`) — picks family + mineral when overrides absent. */
   seed: string;
-  /** Persisted look override (`personas.avatarShape`). */
+  /** Persisted look override (`personas.avatarShape`) — body family. */
   shapeIndex?: number | null;
-  /** Persisted look override (`personas.avatarPalette`). */
+  /** Persisted look override (`personas.avatarPalette`) — mineral. */
   paletteIndex?: number | null;
   size?: "sm" | "md" | "lg";
   /** Selected / focused — slightly peppier bob. */
   active?: boolean;
+  /** Activity language: light does the status work. */
+  state?: PersonaPixelState;
   className?: string;
 }) {
   const { shapeIndex, paletteIndex } = resolvePersonaPixelLook(seed, {
     shapeIndex: shapeOverride,
     paletteIndex: paletteOverride,
   });
-  const shape = SHAPES[shapeIndex]!;
-  const palette = PALETTES[paletteIndex]!;
-  const [blinking, setBlinking] = useState(false);
-  const [reduceMotion, setReduceMotion] = useState(false);
 
-  useEffect(() => {
-    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
-    const sync = () => setReduceMotion(mq.matches);
-    sync();
-    mq.addEventListener("change", sync);
-    return () => mq.removeEventListener("change", sync);
-  }, []);
+  const parts = useMemo(
+    () => generatePixelGolem(seed, shapeIndex, paletteIndex, state),
+    [seed, shapeIndex, paletteIndex, state],
+  );
 
-  useEffect(() => {
-    if (reduceMotion) return;
-    let timeout: ReturnType<typeof setTimeout>;
-    let cancelled = false;
-    const schedule = () => {
-      timeout = setTimeout(
-        () => {
-          if (cancelled) return;
-          setBlinking(true);
-          timeout = setTimeout(() => {
-            if (cancelled) return;
-            setBlinking(false);
-            schedule();
-          }, 120);
-        },
-        2200 + (hashSeed(seed) % 1800),
-      );
-    };
-    schedule();
-    return () => {
-      cancelled = true;
-      clearTimeout(timeout);
-    };
-  }, [seed, reduceMotion]);
-
-  const frame = withBlink(shape, blinking && !reduceMotion);
-  const rows = frame.length;
-  const cols = frame[0]?.length ?? 12;
-  const px = size === "lg" ? 3 : size === "sm" ? 2 : 2.5;
-  const width = cols * px;
-  const height = rows * px;
+  const px = cellPx(size);
+  const width = GRID_W * px;
+  const height = GRID_H * px;
 
   return (
     <span
       className={cn(
         "inline-flex shrink-0 items-end justify-center",
-        !reduceMotion &&
-          (active
-            ? "animate-persona-pixel-bob-active"
-            : "animate-persona-pixel-bob"),
+        active
+          ? "animate-persona-pixel-bob-active"
+          : "animate-persona-pixel-bob",
         className,
       )}
       style={{ width, height: height + (size === "lg" ? 4 : 2) }}
@@ -339,31 +472,45 @@ export function PersonaPixelAvatar({
       data-testid="persona-pixel-avatar"
       data-shape={shapeIndex}
       data-palette={paletteIndex}
+      data-state={state}
     >
       <svg
         width={width}
         height={height}
-        viewBox={`0 0 ${cols} ${rows}`}
+        viewBox={`0 0 ${GRID_W} ${GRID_H}`}
         shapeRendering="crispEdges"
         className="block"
         style={{ imageRendering: "pixelated" }}
       >
-        {frame.flatMap((row, y) =>
-          row.map((cell, x) => {
-            const fill = cellColor(cell, palette);
-            if (!fill) return null;
-            return (
-              <rect
-                key={`${x}-${y}`}
-                x={x}
-                y={y}
-                width={1}
-                height={1}
-                fill={fill}
-              />
-            );
-          }),
-        )}
+        {parts.body.map((r, i) => (
+          <rect
+            key={`b-${i}`}
+            x={r.x}
+            y={r.y}
+            width={r.width}
+            height={r.height}
+            fill={r.fill}
+            opacity={r.opacity}
+            className={r.className}
+          />
+        ))}
+        <g
+          className="animate-persona-golem-head"
+          style={{ animationDelay: `${parts.headDelay}s` }}
+        >
+          {parts.head.map((r, i) => (
+            <rect
+              key={`h-${i}`}
+              x={r.x}
+              y={r.y}
+              width={r.width}
+              height={r.height}
+              fill={r.fill}
+              opacity={r.opacity}
+              className={r.className}
+            />
+          ))}
+        </g>
       </svg>
     </span>
   );

--- a/mcpjam-inspector/client/src/index.css
+++ b/mcpjam-inspector/client/src/index.css
@@ -304,7 +304,7 @@
   }
 }
 
-/* Swarm persona 8-bit avatars — idle bob (Cursor-style little characters). */
+/* Swarm persona pixel golems — idle bob on the wrapper span. */
 @keyframes persona-pixel-bob {
   0%,
   100% {
@@ -327,6 +327,42 @@
   }
 }
 
+/* Head hop: 1px = one grid cell inside the scaled SVG. */
+@keyframes persona-golem-head {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+
+  50% {
+    transform: translateY(-1px);
+  }
+}
+
+@keyframes persona-golem-pulse {
+  50% {
+    opacity: 0.45;
+  }
+}
+
+@keyframes persona-golem-pulse-fast {
+  50% {
+    opacity: 0.45;
+  }
+}
+
+@keyframes persona-golem-flicker {
+  0%,
+  55% {
+    opacity: 1;
+  }
+
+  30%,
+  80% {
+    opacity: 0.2;
+  }
+}
+
 .animate-persona-pixel-bob {
   animation: persona-pixel-bob 1.6s ease-in-out infinite;
 }
@@ -335,9 +371,29 @@
   animation: persona-pixel-bob-active 0.9s ease-in-out infinite;
 }
 
+.animate-persona-golem-head {
+  animation: persona-golem-head 2.6s steps(1, end) infinite;
+}
+
+.animate-persona-golem-pulse {
+  animation: persona-golem-pulse 3s ease-in-out infinite;
+}
+
+.animate-persona-golem-pulse-fast {
+  animation: persona-golem-pulse-fast 1.1s ease-in-out infinite;
+}
+
+.animate-persona-golem-flicker {
+  animation: persona-golem-flicker 1.7s steps(2, end) infinite;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .animate-persona-pixel-bob,
-  .animate-persona-pixel-bob-active {
+  .animate-persona-pixel-bob-active,
+  .animate-persona-golem-head,
+  .animate-persona-golem-pulse,
+  .animate-persona-golem-pulse-fast,
+  .animate-persona-golem-flicker {
     animation: none;
   }
 }

--- a/mcpjam-inspector/client/src/index.css
+++ b/mcpjam-inspector/client/src/index.css
@@ -304,6 +304,44 @@
   }
 }
 
+/* Swarm persona 8-bit avatars — idle bob (Cursor-style little characters). */
+@keyframes persona-pixel-bob {
+  0%,
+  100% {
+    transform: translateY(1px);
+  }
+
+  50% {
+    transform: translateY(-2px);
+  }
+}
+
+@keyframes persona-pixel-bob-active {
+  0%,
+  100% {
+    transform: translateY(1px);
+  }
+
+  50% {
+    transform: translateY(-3px);
+  }
+}
+
+.animate-persona-pixel-bob {
+  animation: persona-pixel-bob 1.6s ease-in-out infinite;
+}
+
+.animate-persona-pixel-bob-active {
+  animation: persona-pixel-bob-active 0.9s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-persona-pixel-bob,
+  .animate-persona-pixel-bob-active {
+    animation: none;
+  }
+}
+
 @keyframes thinking-dot-pulse {
   0%,
   100% {

--- a/mcpjam-inspector/client/src/lib/swarm-api.ts
+++ b/mcpjam-inspector/client/src/lib/swarm-api.ts
@@ -22,6 +22,7 @@ export const SWARM_QUERIES = {
   listHosts: "hosts:listHosts",
   listJourneyRuns: "journeyRuns:listJourneyRuns",
   listSessionsByJourneyRun: "journeyRuns:listSessionsByJourneyRun",
+  listRunningPersonaRefIds: "journeyRuns:listRunningPersonaRefIds",
 } as const;
 
 // ── Convex action names (string-keyed calls) ────────────────────────────────


### PR DESCRIPTION
## Summary
- Replace hand-drawn 8-bit sprites with generated pixel golems (6 body families × 6 minerals).
- Relabel the look picker to Form/Mineral and forward optional activity `state`.
- Subscribe to `journeyRuns:listRunningPersonaRefIds` via an ErrorBoundary-guarded child so a missing backend query cannot white-screen Swarms.
- Light sidebar + detail-header golems while a persona has a running journey.

**Depends on:** companion backend PR deploying `listRunningPersonaRefIds` (client degrades to idle if the query is absent).

## Test plan
- [x] `npx vitest run --project client persona`
- [x] `npx vitest run --project client`
- [ ] Visual: Swarms roster shows diverse golems; Form/Mineral picker persists across reload
- [ ] `prefers-reduced-motion` freezes bob/head/pulse
- [ ] Launch a journey run → avatar `data-state="running"`; completion/stale → idle
- [ ] Safari: confirm head-hop `translateY` on SVG `<g>` looks correct

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only Swarms UI and persona mutations; running-state query is isolated behind an ErrorBoundary with idle fallback if the companion backend deploy is absent.
> 
> **Overview**
> Swarms personas get **deterministic pixel golem avatars** (six body forms × six minerals), shown in the sidebar and on an evals-style **editable detail header** (inline name/role, blur-save notes, Form/Mineral picker that persists via `personas:updatePersona`). **Create persona** moves from a floating form to a design-system dialog; the no-selection main pane uses an animated **journey network backdrop** instead of plain copy. The persona **track record strip** is removed from this header area.
> 
> **Running journeys** subscribe to `journeyRuns:listRunningPersonaRefIds` through an `ErrorBoundary`-wrapped child so a missing backend query does not white-screen the tab; matching personas get avatar `data-state="running"`. Sidebar Swarms icon switches to `Network`. Journey create UI gets labeled inputs and light styling polish. CSS adds golem bob/head/pulse animations with `prefers-reduced-motion` off switches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec1f412dce886bfdca4a4d51cbd75f96ac7dbd2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced persona sprites with deterministic 8-bit pixel golem avatars and surfaced running-journey state in Swarms. Added inline persona editing, an auto-save look picker, and a calm network backdrop for the empty state; the running-state subscriber is safely wrapped to avoid crashes if the query isn’t deployed.

- **New Features**
  - Generated pixel golems (6 families × 6 minerals), seeded per persona with saved Form/Mineral overrides.
  - Avatar look picker with auto-save; inline edit for name/role and blur-save notes; new “New persona” dialog.
  - Running state via `journeyRuns:listRunningPersonaRefIds`; avatars/header reflect “running”; ErrorBoundary guard with idle fallback if the query is missing.
  - Empty-state network backdrop canvas for the Swarms pane; honors dark mode and `prefers-reduced-motion`.
  - Tests cover avatar determinism/overrides, persona create/edit, running-state lighting, and the backdrop render.

- **Bug Fixes**
  - Included the `JourneyNetworkBackdrop` module to restore typecheck, client build, and PR preview.

<sup>Written for commit ec1f412dce886bfdca4a4d51cbd75f96ac7dbd2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

