### PR TITLE
feat(learning): guided tours that teach by driving the UI

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -1279,7 +1279,8 @@ export function SkillsRoute() {
 }
 
 export function LearningRoute() {
-  return <LearningTab />;
+  const { activeProjectId } = useAppRouteContext();
+  return <LearningTab projectId={activeProjectId ?? null} />;
 }
 
 export function TasksRoute() {

--- a/mcpjam-inspector/client/src/components/HomeTab.tsx
+++ b/mcpjam-inspector/client/src/components/HomeTab.tsx
@@ -19,6 +19,10 @@ import { RecommendedHosts } from "./home/RecommendedHosts";
 import { ProductUpdatesRow } from "./home/ProductUpdatesRow";
 import { McpjamAgentHero } from "./mcpjam-agent/McpjamAgentHero";
 import { McpjamAgentThread } from "./mcpjam-agent/McpjamAgentThread";
+import {
+  clearPendingAgentPrompt,
+  writePendingAgentPrompt,
+} from "@/lib/mcpjam-agent/pending-prompt";
 
 interface HomeTabProps {
   organizationId: string | null;
@@ -112,21 +116,6 @@ function McpjamAgentTakeoverFrame({
   );
 }
 
-// Mirrors the key handleSessionStart writes and McpjamAgentThread's autosubmit
-// effect removes; lives here so the takeover Back / New chat handlers can
-// clean up unconsumed payloads when the thread unmounts before its effect
-// runs.
-function clearPendingForSession(sessionId: string | null | undefined) {
-  if (!sessionId || typeof window === "undefined") return;
-  try {
-    window.sessionStorage.removeItem(`mcpjam:agent-pending:${sessionId}`);
-  } catch {
-    // Quota/disabled storage — stale entry will be a no-op unless the user
-    // returns to this session, and even then the duplicate-send is the only
-    // visible regression. Not worth surfacing.
-  }
-}
-
 // Escape hatch: the loading signals feeding `isContextLoading` (notably the db
 // user bootstrap) can stick true indefinitely if a bootstrap mutation fails and
 // never retries. Without a cap, that strands the user on a permanent skeleton
@@ -172,16 +161,7 @@ export function HomeTab({
       // Chat pill". Without it, the thread can't tell the two apart and
       // would replay the prompt against an already-hydrated transcript if
       // hydration hadn't committed yet on the first effect pass.
-      try {
-        if (typeof window !== "undefined") {
-          window.sessionStorage.setItem(
-            `mcpjam:agent-pending:${id}`,
-            JSON.stringify({ text: firstMessage, fresh: true })
-          );
-        }
-      } catch {
-        // Ignore quota/disabled storage — worst case the user retypes.
-      }
+      writePendingAgentPrompt(id, firstMessage);
       setSearchParams(
         (prev) => {
           const next = new URLSearchParams(prev);
@@ -216,7 +196,7 @@ export function HomeTab({
         // Drop any unconsumed pending payload for the session we're leaving;
         // otherwise a later resume of the same id replays the prompt and
         // re-renders the optimistic bubble over the hydrated transcript.
-        clearPendingForSession(prev.get("session"));
+        clearPendingAgentPrompt(prev.get("session"));
         track("mcpjam_agent_back", {
           location: "home",
           surface: "home",
@@ -240,7 +220,7 @@ export function HomeTab({
       (prev) => {
         // Same rationale as handleBackToHome — drop the leaving session's
         // unconsumed pending payload so a later resume doesn't double-send.
-        clearPendingForSession(prev.get("session"));
+        clearPendingAgentPrompt(prev.get("session"));
         track("mcpjam_agent_new_chat", {
           location: "home",
           surface: "home",

--- a/mcpjam-inspector/client/src/components/LearningLandingPage.tsx
+++ b/mcpjam-inspector/client/src/components/LearningLandingPage.tsx
@@ -1,5 +1,6 @@
-import { ChevronDown, ChevronRight, Clock } from "lucide-react";
+import { ChevronDown, ChevronRight, Clock, Play } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
+import { Badge } from "@mcpjam/design-system/badge";
 import { Checkbox } from "@mcpjam/design-system/checkbox";
 import { Progress } from "@mcpjam/design-system/progress";
 import {
@@ -9,8 +10,9 @@ import {
 } from "@mcpjam/design-system/collapsible";
 import {
   LEARNING_GROUPS,
+  isGuidedTour,
   type LearningGroup,
-  type LearningConcept,
+  type LearningModule,
 } from "@/components/lifecycle/learning-concepts";
 
 interface LearningLandingPageProps {
@@ -56,12 +58,13 @@ function ModuleRow({
   onSelect,
   onToggleComplete,
 }: {
-  concept: LearningConcept;
+  concept: LearningModule;
   number: number;
   completed: boolean;
   onSelect: (id: string) => void;
   onToggleComplete: (id: string) => void;
 }) {
+  const guided = isGuidedTour(concept);
   return (
     <button
       type="button"
@@ -87,10 +90,22 @@ function ModuleRow({
       >
         {concept.title}
       </span>
+      {guided ? (
+        <Badge
+          variant="outline"
+          className="shrink-0 px-1.5 py-0 text-[10px] font-medium uppercase tracking-wide text-muted-foreground"
+        >
+          Guided
+        </Badge>
+      ) : null}
       <span className="flex shrink-0 items-center gap-1 text-xs text-muted-foreground/70">
         <Clock className="h-3 w-3" />~{concept.estimatedMinutes} min
       </span>
-      <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground/40 transition-colors group-hover:text-muted-foreground" />
+      {guided ? (
+        <Play className="h-3.5 w-3.5 shrink-0 text-muted-foreground/40 transition-colors group-hover:text-muted-foreground" />
+      ) : (
+        <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground/40 transition-colors group-hover:text-muted-foreground" />
+      )}
     </button>
   );
 }
@@ -110,7 +125,7 @@ function GroupSection({
   onSelect: (id: string) => void;
   onToggleComplete: (id: string) => void;
 }) {
-  const completedInGroup = group.modules.filter((m: LearningConcept) =>
+  const completedInGroup = group.modules.filter((m: LearningModule) =>
     isCompleted(m.id),
   ).length;
   const total = group.modules.length;
@@ -143,7 +158,7 @@ function GroupSection({
       {/* Module rows */}
       <CollapsibleContent>
         <div className="flex flex-col">
-          {group.modules.map((concept: LearningConcept, mi: number) => (
+          {group.modules.map((concept: LearningModule, mi: number) => (
             <ModuleRow
               key={concept.id}
               concept={concept}

--- a/mcpjam-inspector/client/src/components/LearningTab.tsx
+++ b/mcpjam-inspector/client/src/components/LearningTab.tsx
@@ -40,6 +40,8 @@ import { McpToolsArticle } from "@/components/mcp-tools/McpToolsArticle";
 import { McpResourcesArticle } from "@/components/mcp-resources/McpResourcesArticle";
 import { McpPromptsArticle } from "@/components/mcp-prompts/McpPromptsArticle";
 import { useLearningProgress } from "@/hooks/use-learning-progress";
+import { getGuidedTour } from "@/components/lifecycle/learning-concepts";
+import { launchLessonSession } from "@/lib/mcpjam-agent/launch-lesson";
 
 /**
  * Sentinel value used as `currentStep` when the lifecycle walkthrough is at step 0.
@@ -335,12 +337,31 @@ function AppsSdkWalkthrough({
 // LearningTab — routes to the selected concept
 // ---------------------------------------------------------------------------
 
-export function LearningTab() {
+export function LearningTab({
+  projectId,
+}: {
+  projectId: string | null;
+}) {
   const [selectedConcept, setSelectedConcept] = useState<string | null>(null);
   const { isCompleted, markComplete, toggleComplete, completionCount } =
     useLearningProgress();
 
   const goBack = useCallback(() => setSelectedConcept(null), []);
+
+  // Guided-tour rows don't open an in-tab article — they launch the agent side
+  // panel seeded with the tour prompt and leave the landing page in place.
+  // Everything else selects a concept and swaps in its shell/walkthrough.
+  const handleSelect = useCallback(
+    (id: string) => {
+      const tour = getGuidedTour(id);
+      if (tour) {
+        launchLessonSession({ tour, projectId });
+        return;
+      }
+      setSelectedConcept(id);
+    },
+    [projectId],
+  );
 
   if (selectedConcept === "why-mcp") {
     return (
@@ -471,7 +492,7 @@ export function LearningTab() {
 
   return (
     <LearningLandingPage
-      onSelect={setSelectedConcept}
+      onSelect={handleSelect}
       isCompleted={isCompleted}
       onToggleComplete={toggleComplete}
       completionCount={completionCount}

--- a/mcpjam-inspector/client/src/components/__tests__/LearningLandingPage.tours.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/LearningLandingPage.tours.test.tsx
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { LearningLandingPage } from "@/components/LearningLandingPage";
+
+function renderPage(overrides?: {
+  isCompleted?: (id: string) => boolean;
+  completionCount?: number;
+}) {
+  const onSelect = vi.fn();
+  const onToggleComplete = vi.fn();
+  render(
+    <LearningLandingPage
+      onSelect={onSelect}
+      isCompleted={overrides?.isCompleted ?? (() => false)}
+      onToggleComplete={onToggleComplete}
+      completionCount={overrides?.completionCount ?? 0}
+    />,
+  );
+  return { onSelect, onToggleComplete };
+}
+
+/** The guided group is collapsed by default (only the first group auto-opens). */
+function expandGuidedTours() {
+  fireEvent.click(screen.getByText("Guided tours"));
+}
+
+describe("LearningLandingPage — guided tours", () => {
+  it("counts guided tours in the header totals", () => {
+    renderPage();
+    // 4 reading tracks + the guided-tours track = 5; 11 reading modules + 5
+    // tours = 16.
+    const totals = screen.getByText(/tracks ·/);
+    expect(totals.textContent).toContain("5 tracks");
+    expect(totals.textContent).toContain("16 lessons");
+  });
+
+  it("renders a guided row with a Guided badge, play affordance, and duration", () => {
+    renderPage();
+    expandGuidedTours();
+
+    const row = screen
+      .getByText("Create and run an eval suite")
+      .closest("button") as HTMLElement;
+    expect(within(row).getByText("Guided")).toBeInTheDocument();
+    expect(within(row).getByText(/~5 min/)).toBeInTheDocument();
+  });
+
+  it("selecting a guided row calls onSelect with the tour id", () => {
+    const { onSelect } = renderPage();
+    expandGuidedTours();
+
+    fireEvent.click(screen.getByText("Create and run an eval suite"));
+    expect(onSelect).toHaveBeenCalledWith("tour-eval-suite");
+  });
+
+  it("toggling a guided row's checkbox marks completion without selecting it", () => {
+    const { onSelect, onToggleComplete } = renderPage();
+    expandGuidedTours();
+
+    const row = screen
+      .getByText("Create and run an eval suite")
+      .closest("button") as HTMLElement;
+    fireEvent.click(within(row).getByRole("checkbox"));
+
+    expect(onToggleComplete).toHaveBeenCalledWith("tour-eval-suite");
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("does not show the Guided badge on a reading module", () => {
+    renderPage();
+    // "Getting Started" auto-opens at completionCount 0.
+    const row = screen.getByText("Why MCP?").closest("button") as HTMLElement;
+    expect(within(row).queryByText("Guided")).not.toBeInTheDocument();
+  });
+});

--- a/mcpjam-inspector/client/src/components/__tests__/LearningLandingPage.tours.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/LearningLandingPage.tours.test.tsx
@@ -43,6 +43,9 @@ describe("LearningLandingPage — guided tours", () => {
       .closest("button") as HTMLElement;
     expect(within(row).getByText("Guided")).toBeInTheDocument();
     expect(within(row).getByText(/~5 min/)).toBeInTheDocument();
+    // Play icon (lucide) instead of the reading rows' chevron.
+    expect(row.querySelector(".lucide-play")).toBeTruthy();
+    expect(row.querySelector(".lucide-chevron-right")).toBeNull();
   });
 
   it("selecting a guided row calls onSelect with the tour id", () => {

--- a/mcpjam-inspector/client/src/components/__tests__/LearningTab.tours.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/LearningTab.tours.test.tsx
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+const { launchMock } = vi.hoisted(() => ({ launchMock: vi.fn() }));
+vi.mock("@/lib/mcpjam-agent/launch-lesson", () => ({
+  launchLessonSession: launchMock,
+}));
+
+vi.mock("@/hooks/use-learning-progress", () => ({
+  useLearningProgress: () => ({
+    isCompleted: () => false,
+    markComplete: vi.fn(),
+    toggleComplete: vi.fn(),
+    completionCount: 0,
+  }),
+}));
+
+import { LearningTab } from "@/components/LearningTab";
+import { GUIDED_TOURS } from "@/components/lifecycle/guided-tour-lessons";
+import { LEARNING_CONCEPTS } from "@/components/lifecycle/learning-concepts";
+
+const LANDING_MARKER = "Learn MCP step by step";
+
+describe("LearningTab — guided tour dispatch", () => {
+  it("launches the agent for a guided row and keeps the landing page mounted", () => {
+    render(<LearningTab projectId="proj-1" />);
+    fireEvent.click(screen.getByText("Guided tours"));
+    fireEvent.click(screen.getByText("Create and run an eval suite"));
+
+    expect(launchMock).toHaveBeenCalledTimes(1);
+    expect(launchMock).toHaveBeenCalledWith({
+      tour: expect.objectContaining({ id: "tour-eval-suite" }),
+      projectId: "proj-1",
+    });
+    // Landing stays — guided tours never route to an in-tab shell.
+    expect(screen.getByText(LANDING_MARKER)).toBeInTheDocument();
+  });
+
+  it("routes a reading module to its article shell (no agent launch)", () => {
+    render(<LearningTab projectId="proj-1" />);
+    // "Getting Started" is auto-open at 0 completions.
+    fireEvent.click(screen.getByText("Why MCP?"));
+
+    expect(launchMock).not.toHaveBeenCalled();
+    expect(screen.queryByText(LANDING_MARKER)).not.toBeInTheDocument();
+  });
+});
+
+describe("guided tour content invariants", () => {
+  it("every tour is a guided module with a usable prompt", () => {
+    expect(GUIDED_TOURS.length).toBeGreaterThan(0);
+    for (const tour of GUIDED_TOURS) {
+      expect(tour.kind).toBe("guided");
+      expect(tour.agentPrompt.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it("every tour prompt encodes the never-submit and mark-complete rules", () => {
+    for (const tour of GUIDED_TOURS) {
+      const prompt = tour.agentPrompt.toLowerCase();
+      // never click the final submit for the user
+      expect(prompt).toContain("never click the final");
+      // close by pointing back to the Learning tab
+      expect(prompt).toContain("complete");
+    }
+  });
+
+  it("tour ids are unique across all learning modules", () => {
+    const ids = LEARNING_CONCEPTS.map((m) => m.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/mcpjam-inspector/client/src/components/lifecycle/guided-tour-lessons.ts
+++ b/mcpjam-inspector/client/src/components/lifecycle/guided-tour-lessons.ts
@@ -1,0 +1,161 @@
+import {
+  Cable,
+  FlaskConical,
+  Gamepad2,
+  Package,
+  Users,
+} from "lucide-react";
+import type { GuidedTourConcept, LearningGroup } from "./learning-concepts";
+
+/**
+ * Guided tours. Unlike the reading modules, selecting one of these does not
+ * open an in-tab article — it launches the MCPJam agent in the side panel,
+ * seeded with the tour's `agentPrompt` as the user's first message. The agent
+ * then teaches by driving the real inspector UI (navigate, narrate, prefill
+ * forms) through the existing `ui_*` tool catalog, handing the final,
+ * consequential click back to the user.
+ *
+ * The teaching quality lives entirely in these prompts. They are natural
+ * language and deliberately do NOT name `ui_*` tools — the agent already knows
+ * its catalog; hard-coding tool names would rot as the catalog changes and
+ * fight the model's own planning. Each prompt = a goal + a numbered walk +
+ * TOUR_GROUND_RULES.
+ */
+
+/**
+ * Appended to every tour prompt. Encodes the safety and pedagogy invariants the
+ * agent must hold regardless of which tour is running: narrate before acting,
+ * adapt to the user's real state, prefill but never submit, never spend
+ * money/quota without asking, and close by pointing the user back to mark the
+ * tour complete.
+ */
+const TOUR_GROUND_RULES = `
+Ground rules for this tour — follow all of them:
+1. Before you act on any screen, explain in 1-2 sentences what that screen or control is for. Keep narration short; this is a tour, not a lecture.
+2. Start by taking a snapshot of the app so the tour matches my real state. If something you need is already set up, say so and skip ahead instead of redoing it.
+3. If the tour needs a connected MCP server and I don't have one, detour first: help me connect one (a public demo server is fine), then continue.
+4. Prefill any forms for me and explain each field, but never click the final submit / create / run button yourself — hand that click back to me and tell me exactly what to press.
+5. Never start anything that spends money, tokens, or run quota (model calls, eval runs, swarm runs) without asking me first.
+6. Move one step at a time and check in briefly so I can follow along.
+7. When we're done, recap what I learned in 2-3 bullets and remind me to go back to the Learning tab and check this tour off as complete.
+`.trim();
+
+function withGroundRules(body: string): string {
+  return `${body.trim()}\n\n${TOUR_GROUND_RULES}`;
+}
+
+export const GUIDED_TOURS: GuidedTourConcept[] = [
+  {
+    kind: "guided",
+    id: "tour-connect-server",
+    title: "Connect your first MCP server",
+    description:
+      "The agent walks you through adding a server and seeing its tools.",
+    icon: Cable,
+    category: "Guided tour",
+    estimatedMinutes: 3,
+    agentPrompt: withGroundRules(`
+Give me a hands-on guided tour of connecting my first MCP server in the MCPJam inspector (about 3 minutes). I'm brand new — assume I've never connected one.
+
+Walk me through, in order:
+1. In a sentence, what an MCP server connection is and why I'd add one here.
+2. Take a snapshot to see whether I already have a server connected. If I do, point it out and offer to show me its tools instead of adding another.
+3. Open the form to add a new server and explain the transport choice — a remote HTTP URL versus a local command (STDIO) — so I know which to pick.
+4. Prefill the form with a reputable public demo MCP server over HTTP so I can try it without any setup. Explain what each field is.
+5. Stop and hand me the Connect button — tell me exactly what to click.
+6. Once it's connected, show me where the server's tools (and resources, if any) appear, so I know the connection worked.
+`),
+  },
+  {
+    kind: "guided",
+    id: "tour-playground-tool",
+    title: "Run a tool in the Playground",
+    description:
+      "Chat with a model and watch it call one of your server's tools.",
+    icon: Gamepad2,
+    category: "Guided tour",
+    estimatedMinutes: 4,
+    agentPrompt: withGroundRules(`
+Give me a hands-on guided tour of the Playground in the MCPJam inspector (about 4 minutes). I want to see a model actually call one of my MCP server's tools.
+
+Walk me through, in order:
+1. In a sentence or two, what the Playground is — a chat where a model can use my connected server's tools.
+2. Snapshot my state. I need a connected server with at least one tool; if I don't have one, detour and help me connect one first.
+3. Take me to the Playground and explain what I'm looking at.
+4. Explain the model picker and that every message sends a real, billable model call. Help me pick an inexpensive model.
+5. Draft a chat message that should make the model call a specific tool my server exposes, and tell me which tool you expect it to use and why.
+6. Stop before sending — ask me to hit send myself (this spends a model call).
+7. After it runs, walk me through the result: where the tool call shows up, the arguments the model chose, and what the tool returned.
+`),
+  },
+  {
+    kind: "guided",
+    id: "tour-eval-suite",
+    title: "Create and run an eval suite",
+    description:
+      "Build a test suite for your server's tools and score a run.",
+    icon: FlaskConical,
+    category: "Guided tour",
+    estimatedMinutes: 5,
+    agentPrompt: withGroundRules(`
+Give me a hands-on guided tour of evals in the MCPJam inspector (about 5 minutes). I want to learn how to create an eval suite for an MCP server and run it.
+
+Walk me through, in order:
+1. In a couple of sentences, what evals are for in MCPJam — testing that a model uses my MCP server's tools correctly.
+2. Check my current state. I need a connected MCP server to eval against; if I don't have one, help me connect one first.
+3. Take me to the evals area and explain what I'm looking at.
+4. Open the form to create a new eval suite and prefill it with a sensible example based on the tools my connected server actually exposes: a suite name, a test prompt a real user might ask, and the tool(s) you expect the model to call. Explain what each field means, especially how expected tool calls are judged.
+5. If there's a way to generate test cases automatically, mention it and what it costs before suggesting it.
+6. Stop before running anything. Tell me exactly which button to press to save and run the suite, warn me that running it calls a real model, and let me decide.
+7. If I choose to run it, explain how to read the results — what a pass and a fail look like, and what I'd change to fix a failing test.
+`),
+  },
+  {
+    kind: "guided",
+    id: "tour-swarms",
+    title: "Simulate users with Swarms",
+    description:
+      "Create a persona and a journey to stress-test your server.",
+    icon: Users,
+    category: "Guided tour",
+    estimatedMinutes: 5,
+    agentPrompt: withGroundRules(`
+Give me a hands-on guided tour of Swarms in the MCPJam inspector (about 5 minutes). I want to simulate real users exercising my MCP server.
+
+Walk me through, in order:
+1. In a couple of sentences, what Swarms are — synthetic user personas that run through journeys against my server — and why that's useful.
+2. Snapshot my state. Swarms need a connected server; if I don't have one, detour and help me connect one first.
+3. Take me to Swarms and explain the pieces: personas and journeys.
+4. Explain what a persona is, then prefill one that fits my server.
+5. Explain what a journey is, then prefill one that this persona would plausibly attempt with my server's tools.
+6. Explain that launching a swarm run consumes run quota and model calls. Stop before launching — hand me the launch button and let me decide.
+`),
+  },
+  {
+    kind: "guided",
+    id: "tour-hosts",
+    title: "Package servers into a Host",
+    description:
+      "Bundle your connected servers into a named, reusable Host.",
+    icon: Package,
+    category: "Guided tour",
+    estimatedMinutes: 4,
+    agentPrompt: withGroundRules(`
+Give me a hands-on guided tour of Hosts in the MCPJam inspector (about 4 minutes). I want to package my servers into a reusable Host.
+
+Walk me through, in order:
+1. In a couple of sentences, what a Host is — a named bundle of MCP servers exposed together to a client — and when I'd want one.
+2. Snapshot my state so we can use my actual connected server(s). If I have none, detour and help me connect one first.
+3. Take me to Hosts and open the host editor.
+4. Prefill a new host: give it a clear name and attach my connected server(s). Explain each part as you fill it in.
+5. Explain what I'll be able to do with the Host once it exists.
+6. Stop and hand me the create/save button — tell me exactly what to click to finish.
+`),
+  },
+];
+
+export const GUIDED_TOURS_GROUP: LearningGroup = {
+  title: "Guided tours",
+  subtitle: "Hands-on tours where the MCPJam agent drives the app with you",
+  modules: GUIDED_TOURS,
+};

--- a/mcpjam-inspector/client/src/components/lifecycle/guided-tour-lessons.ts
+++ b/mcpjam-inspector/client/src/components/lifecycle/guided-tour-lessons.ts
@@ -148,7 +148,7 @@ Walk me through, in order:
 2. Snapshot my state so we can use my actual connected server(s). If I have none, detour and help me connect one first.
 3. Take me to Hosts and explain what I'm looking at.
 4. Walk me through creating a host: suggest a clear name and tell me exactly what to click to create it (creating the host, and later attaching servers, are commits I'll make myself — describe the values to use rather than doing it for me).
-5. Once the host exists, open its editor and show me where I attach my connected server(s) and where I'd adjust its config (model, system prompt, behavior).
+5. Once the host exists, open its editor and show me where I'd adjust its config — model, system prompt, and behavior. Then explain that servers are selected project-wide (not inside this editor): take me to the Servers tab and show me how to include my connected server(s) so the host can use them.
 6. Recap what the Host lets me do and what I'd change next.
 `),
   },

--- a/mcpjam-inspector/client/src/components/lifecycle/guided-tour-lessons.ts
+++ b/mcpjam-inspector/client/src/components/lifecycle/guided-tour-lessons.ts
@@ -104,7 +104,7 @@ Walk me through, in order:
 1. In a couple of sentences, what evals are for in MCPJam — testing that a model uses my MCP server's tools correctly.
 2. Check my current state. I need a connected MCP server to eval against; if I don't have one, help me connect one first.
 3. Take me to the evals area and explain what I'm looking at.
-4. Open the form to create a new eval suite and prefill it with a sensible example based on the tools my connected server actually exposes: a suite name, a test prompt a real user might ask, and the tool(s) you expect the model to call. Explain what each field means, especially how expected tool calls are judged.
+4. Open the create-suite dialog and prefill the suite name for me. The test prompts and expected tool calls are mine to fill in — walk me through a good first test case based on the tools my server actually exposes (a prompt a real user might ask, and the tool you'd expect the model to call), and explain how expected tool calls are judged.
 5. If there's a way to generate test cases automatically, mention it and what it costs before suggesting it.
 6. Stop before running anything. Tell me exactly which button to press to save and run the suite, warn me that running it calls a real model, and let me decide.
 7. If I choose to run it, explain how to read the results — what a pass and a fail look like, and what I'd change to fix a failing test.
@@ -126,8 +126,8 @@ Walk me through, in order:
 1. In a couple of sentences, what Swarms are — synthetic user personas that run through journeys against my server — and why that's useful.
 2. Snapshot my state. Swarms need a connected server; if I don't have one, detour and help me connect one first.
 3. Take me to Swarms and explain the pieces: personas and journeys.
-4. Explain what a persona is, then prefill one that fits my server.
-5. Explain what a journey is, then prefill one that this persona would plausibly attempt with my server's tools.
+4. Explain what a persona is and suggest a good starter persona for my server — a name, a role, and a note or two. Creating it is a quick form; tell me exactly what to enter rather than creating it for me.
+5. Explain what a journey is, then open the new-journey form and prefill the goal text for a task this persona would plausibly attempt with my server's tools. Picking the host and how many sessions is mine to choose — walk me through those.
 6. Explain that launching a swarm run consumes run quota and model calls. Stop before launching — hand me the launch button and let me decide.
 `),
   },
@@ -146,10 +146,10 @@ Give me a hands-on guided tour of Hosts in the MCPJam inspector (about 4 minutes
 Walk me through, in order:
 1. In a couple of sentences, what a Host is — a named bundle of MCP servers exposed together to a client — and when I'd want one.
 2. Snapshot my state so we can use my actual connected server(s). If I have none, detour and help me connect one first.
-3. Take me to Hosts and open the host editor.
-4. Prefill a new host: give it a clear name and attach my connected server(s). Explain each part as you fill it in.
-5. Explain what I'll be able to do with the Host once it exists.
-6. Stop and hand me the create/save button — tell me exactly what to click to finish.
+3. Take me to Hosts and explain what I'm looking at.
+4. Walk me through creating a host: suggest a clear name and tell me exactly what to click to create it (creating the host, and later attaching servers, are commits I'll make myself — describe the values to use rather than doing it for me).
+5. Once the host exists, open its editor and show me where I attach my connected server(s) and where I'd adjust its config (model, system prompt, behavior).
+6. Recap what the Host lets me do and what I'd change next.
 `),
   },
 ];

--- a/mcpjam-inspector/client/src/components/lifecycle/learning-concepts.ts
+++ b/mcpjam-inspector/client/src/components/lifecycle/learning-concepts.ts
@@ -12,21 +12,52 @@ import {
   Wrench,
   type LucideIcon,
 } from "lucide-react";
+import { GUIDED_TOURS_GROUP } from "./guided-tour-lessons";
 
-export interface LearningConcept {
+interface LearningModuleBase {
   id: string;
   title: string;
   description: string;
   icon: LucideIcon;
-  totalSteps: number;
   category: string;
   estimatedMinutes: number;
+}
+
+/**
+ * A reading module — an in-tab article or diagram walkthrough. This is the
+ * implicit (kind-less) shape; existing modules are unchanged.
+ */
+export interface LearningConcept extends LearningModuleBase {
+  totalSteps: number;
+}
+
+/**
+ * A guided tour — selecting it launches the MCPJam agent in the side panel
+ * seeded with `agentPrompt`, rather than opening an in-tab article. Has no
+ * `totalSteps` (the tour isn't a fixed step sequence); the union makes that
+ * absence explicit instead of a lying `0`. See `guided-tour-lessons.ts`.
+ */
+export interface GuidedTourConcept extends LearningModuleBase {
+  kind: "guided";
+  agentPrompt: string;
+}
+
+export type LearningModule = LearningConcept | GuidedTourConcept;
+
+export function isGuidedTour(m: LearningModule): m is GuidedTourConcept {
+  return "kind" in m && m.kind === "guided";
+}
+
+export function getGuidedTour(id: string): GuidedTourConcept | undefined {
+  return LEARNING_CONCEPTS.find(
+    (m): m is GuidedTourConcept => isGuidedTour(m) && m.id === id,
+  );
 }
 
 export interface LearningGroup {
   title: string;
   subtitle: string;
-  modules: LearningConcept[];
+  modules: LearningModule[];
 }
 
 export const LEARNING_GROUPS: LearningGroup[] = [
@@ -54,6 +85,10 @@ export const LEARNING_GROUPS: LearningGroup[] = [
       },
     ],
   },
+  // Hands-on tours where the MCPJam agent drives the app. Placed second — right
+  // after the intro — because the first tour (connect a server) is the fastest
+  // path from "what is MCP" to "I did the thing" in my own workspace.
+  GUIDED_TOURS_GROUP,
   {
     title: "The Protocol",
     subtitle: "Learn the main pieces MCP servers expose",
@@ -161,6 +196,6 @@ export const LEARNING_GROUPS: LearningGroup[] = [
 ];
 
 // Flat list for backward compatibility
-export const LEARNING_CONCEPTS: LearningConcept[] = LEARNING_GROUPS.flatMap(
+export const LEARNING_CONCEPTS: LearningModule[] = LEARNING_GROUPS.flatMap(
   (g) => g.modules,
 );

--- a/mcpjam-inspector/client/src/components/mcpjam-agent/AgentSidePanel.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-agent/AgentSidePanel.tsx
@@ -37,6 +37,7 @@ import {
   useAgentPanelStore,
 } from "@/stores/agent-panel/agent-panel-store";
 import { track } from "@/lib/analytics";
+import { writePendingAgentPrompt } from "@/lib/mcpjam-agent/pending-prompt";
 
 interface AgentSidePanelProps {
   projectId: string | null;
@@ -95,16 +96,7 @@ export function AgentSidePanel({
       // mirroring the home-tab hero → thread handoff. `fresh: true` flags it
       // as a freshly-minted session so the thread doesn't replay it against
       // a hydrated transcript (see `McpjamAgentThread`'s consumePending).
-      try {
-        if (typeof window !== "undefined") {
-          window.sessionStorage.setItem(
-            `mcpjam:agent-pending:${sessionId}`,
-            JSON.stringify({ text: firstMessage, fresh: true })
-          );
-        }
-      } catch {
-        // Quota/disabled storage — user will retype if it doesn't autosubmit.
-      }
+      writePendingAgentPrompt(sessionId, firstMessage);
       setActiveSession(sessionId, projectId);
     },
     [projectId, setActiveSession]

--- a/mcpjam-inspector/client/src/components/mcpjam-agent/McpjamAgentThread.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-agent/McpjamAgentThread.tsx
@@ -33,6 +33,7 @@ import {
   appendRecentMcpjamAgentSession,
   loadRecentMcpjamAgentSessions,
 } from "@/components/mcpjam-agent/recent-sessions";
+import { pendingAgentPromptKey } from "@/lib/mcpjam-agent/pending-prompt";
 
 export interface McpjamAgentThreadProps {
   sessionId: string;
@@ -81,7 +82,7 @@ export function McpjamAgentThread({
     if (typeof window === "undefined") return null;
     try {
       const raw = window.sessionStorage.getItem(
-        `mcpjam:agent-pending:${sessionId}`
+        pendingAgentPromptKey(sessionId)
       );
       if (!raw) return null;
       const parsed = JSON.parse(raw) as unknown;
@@ -159,8 +160,8 @@ export function McpjamAgentThread({
     if (typeof window === "undefined") return;
     let raw: string | null = null;
     try {
-      raw = window.sessionStorage.getItem(`mcpjam:agent-pending:${sessionId}`);
-      window.sessionStorage.removeItem(`mcpjam:agent-pending:${sessionId}`);
+      raw = window.sessionStorage.getItem(pendingAgentPromptKey(sessionId));
+      window.sessionStorage.removeItem(pendingAgentPromptKey(sessionId));
     } catch {
       raw = null;
     }

--- a/mcpjam-inspector/client/src/lib/mcpjam-agent/__tests__/launch-lesson.test.ts
+++ b/mcpjam-inspector/client/src/lib/mcpjam-agent/__tests__/launch-lesson.test.ts
@@ -156,6 +156,23 @@ describe("launchLessonSession", () => {
     expect(state.isOpen).toBe(true); // re-opened
   });
 
+  it("persists the last-launch record so dedup survives a reload", () => {
+    launchLessonSession({ tour: TOUR, projectId: "proj-1" });
+    // The refocus guard reads from localStorage, not a module var, so a reload
+    // (module re-eval, other tab) that keeps the panel's persisted
+    // activeSessionId still dedups.
+    expect(
+      window.localStorage.getItem("mcpjam:agent-tour-last-launch:v1"),
+    ).not.toBeNull();
+
+    // Simulate a reload: the panel store still holds the persisted session,
+    // but there is no in-memory launch state to rely on.
+    const ok = launchLessonSession({ tour: TOUR, projectId: "proj-1" });
+    expect(ok).toBe(true);
+    expect(generateIdMock).toHaveBeenCalledTimes(1); // still no duplicate
+    expect(useAgentPanelStore.getState().activeSessionId).toBe("sess-1");
+  });
+
   it("still activates the session when sessionStorage.setItem throws", () => {
     vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
       throw new Error("quota");

--- a/mcpjam-inspector/client/src/lib/mcpjam-agent/__tests__/launch-lesson.test.ts
+++ b/mcpjam-inspector/client/src/lib/mcpjam-agent/__tests__/launch-lesson.test.ts
@@ -121,6 +121,29 @@ describe("launchLessonSession", () => {
     );
   });
 
+  it("treats the \"none\" sentinel as no project (skips, no session scoped to it)", () => {
+    const ok = launchLessonSession({ tour: TOUR, projectId: "none" });
+    expect(ok).toBe(false);
+    expect(generateIdMock).not.toHaveBeenCalled();
+    expect(useAgentPanelStore.getState().activeSessionId).toBeNull();
+    expect(trackMock).toHaveBeenCalledWith(
+      "mcpjam_agent_tour_launch_skipped",
+      expect.objectContaining({ reason: "no_project_id" }),
+    );
+  });
+
+  it("mints a fresh session when the same tour is re-clicked under a different project", () => {
+    launchLessonSession({ tour: TOUR, projectId: "proj-A" });
+    // Project switched since the first launch.
+    const ok = launchLessonSession({ tour: TOUR, projectId: "proj-B" });
+
+    expect(ok).toBe(true);
+    expect(generateIdMock).toHaveBeenCalledTimes(2); // NOT a refocus
+    const state = useAgentPanelStore.getState();
+    expect(state.activeSessionId).toBe("sess-2");
+    expect(state.activeSessionProjectId).toBe("proj-B");
+  });
+
   it("refocuses (no duplicate session) when the same tour is re-clicked while active", () => {
     launchLessonSession({ tour: TOUR, projectId: "proj-1" });
     useAgentPanelStore.setState({ isOpen: false }); // user closed the panel

--- a/mcpjam-inspector/client/src/lib/mcpjam-agent/__tests__/launch-lesson.test.ts
+++ b/mcpjam-inspector/client/src/lib/mcpjam-agent/__tests__/launch-lesson.test.ts
@@ -173,8 +173,11 @@ describe("launchLessonSession", () => {
     expect(useAgentPanelStore.getState().activeSessionId).toBe("sess-1");
   });
 
+  // NOTE: jsdom's window.localStorage/sessionStorage do NOT route through
+  // Storage.prototype, so spying the prototype is a no-op. Spy the instances.
+
   it("still activates the session when sessionStorage.setItem throws", () => {
-    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+    vi.spyOn(window.sessionStorage, "setItem").mockImplementation(() => {
       throw new Error("quota");
     });
     const ok = launchLessonSession({ tour: TOUR, projectId: "proj-1" });
@@ -182,14 +185,12 @@ describe("launchLessonSession", () => {
     expect(useAgentPanelStore.getState().activeSessionId).toBe("sess-1");
   });
 
-  it("dedups a same-tab repeat click even when localStorage is unavailable", () => {
-    // Storage fully disabled: the persisted layer can't record the launch, so
-    // dedup must fall back to the in-memory record.
-    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
-      throw new Error("disabled");
-    });
-    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
-      throw new Error("disabled");
+  it("dedups a same-tab repeat click when localStorage cannot persist", () => {
+    // Quota-full / write-disabled: the persisted layer reads empty and can't
+    // write, so dedup must come from the in-memory fallback.
+    vi.spyOn(window.localStorage, "getItem").mockReturnValue(null);
+    vi.spyOn(window.localStorage, "setItem").mockImplementation(() => {
+      throw new Error("quota");
     });
 
     launchLessonSession({ tour: TOUR, projectId: "proj-1" });
@@ -197,6 +198,21 @@ describe("launchLessonSession", () => {
 
     expect(ok).toBe(true);
     expect(generateIdMock).toHaveBeenCalledTimes(1); // no duplicate session
+    expect(useAgentPanelStore.getState().activeSessionId).toBe("sess-1");
+  });
+
+  it("still launches when localStorage access throws (denied/privacy mode)", () => {
+    // Every localStorage op throws — including the unguarded getItem inside
+    // loadRecentMcpjamAgentSessions. The launch must survive it.
+    vi.spyOn(window.localStorage, "getItem").mockImplementation(() => {
+      throw new Error("denied");
+    });
+    vi.spyOn(window.localStorage, "setItem").mockImplementation(() => {
+      throw new Error("denied");
+    });
+
+    const ok = launchLessonSession({ tour: TOUR, projectId: "proj-1" });
+    expect(ok).toBe(true);
     expect(useAgentPanelStore.getState().activeSessionId).toBe("sess-1");
   });
 });

--- a/mcpjam-inspector/client/src/lib/mcpjam-agent/__tests__/launch-lesson.test.ts
+++ b/mcpjam-inspector/client/src/lib/mcpjam-agent/__tests__/launch-lesson.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Cable } from "lucide-react";
+import type { GuidedTourConcept } from "@/components/lifecycle/learning-concepts";
+
+// generateId: deterministic, incrementing so each real launch gets a distinct
+// session id (and we can assert it was NOT called again on a refocus). The
+// counter is reset per test so each starts at sess-1.
+const { generateIdMock, idCounter } = vi.hoisted(() => {
+  const idCounter = { n: 0 };
+  return {
+    generateIdMock: vi.fn(() => `sess-${++idCounter.n}`),
+    idCounter,
+  };
+});
+vi.mock("ai", () => ({ generateId: generateIdMock }));
+
+const { trackMock } = vi.hoisted(() => ({ trackMock: vi.fn() }));
+vi.mock("@/lib/analytics", () => ({ track: trackMock }));
+
+import {
+  __resetLaunchLessonForTests,
+  launchLessonSession,
+} from "../launch-lesson";
+import { pendingAgentPromptKey } from "../pending-prompt";
+import { useAgentPanelStore } from "@/stores/agent-panel/agent-panel-store";
+import { loadRecentMcpjamAgentSessions } from "@/components/mcpjam-agent/recent-sessions";
+
+const TOUR: GuidedTourConcept = {
+  kind: "guided",
+  id: "tour-eval-suite",
+  title: "Create and run an eval suite",
+  description: "desc",
+  icon: Cable,
+  category: "Guided tour",
+  estimatedMinutes: 5,
+  agentPrompt: "Give me a tour of evals.",
+};
+
+beforeEach(() => {
+  __resetLaunchLessonForTests();
+  idCounter.n = 0;
+  generateIdMock.mockClear();
+  window.sessionStorage.clear();
+  window.localStorage.clear();
+  useAgentPanelStore.setState({
+    isOpen: false,
+    activeSessionId: null,
+    activeSessionProjectId: null,
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("launchLessonSession", () => {
+  it("seeds the prompt and opens the panel to a fresh session", () => {
+    const ok = launchLessonSession({ tour: TOUR, projectId: "proj-1" });
+    expect(ok).toBe(true);
+
+    const raw = window.sessionStorage.getItem(pendingAgentPromptKey("sess-1"));
+    expect(JSON.parse(raw as string)).toEqual({
+      text: TOUR.agentPrompt,
+      fresh: true,
+    });
+
+    const state = useAgentPanelStore.getState();
+    expect(state.activeSessionId).toBe("sess-1");
+    expect(state.activeSessionProjectId).toBe("proj-1");
+    expect(state.isOpen).toBe(true);
+
+    expect(loadRecentMcpjamAgentSessions()[0]).toMatchObject({
+      id: "sess-1",
+      title: "Tour: Create and run an eval suite",
+    });
+
+    expect(trackMock).toHaveBeenCalledWith(
+      "mcpjam_agent_tour_launched",
+      expect.objectContaining({
+        location: "learning_tab",
+        tour_id: "tour-eval-suite",
+        session_id: "sess-1",
+      }),
+    );
+  });
+
+  it("writes the pending prompt BEFORE activating the session", () => {
+    // The thread's optimistic-bubble initializer peeks the pending key
+    // synchronously the moment setActiveSession mounts it — so the key must
+    // already be present when setActiveSession fires.
+    let pendingAtActivation: string | null = "UNSET";
+    const real = useAgentPanelStore.getState().setActiveSession;
+    vi.spyOn(useAgentPanelStore.getState(), "setActiveSession").mockImplementation(
+      (id, projectId) => {
+        pendingAtActivation = id
+          ? window.sessionStorage.getItem(pendingAgentPromptKey(id))
+          : null;
+        real(id, projectId);
+      },
+    );
+
+    launchLessonSession({ tour: TOUR, projectId: "proj-1" });
+
+    expect(pendingAtActivation).not.toBeNull();
+    expect(pendingAtActivation).not.toBe("UNSET");
+    expect(JSON.parse(pendingAtActivation as string)).toEqual({
+      text: TOUR.agentPrompt,
+      fresh: true,
+    });
+  });
+
+  it("skips (with telemetry) when there is no project id", () => {
+    const ok = launchLessonSession({ tour: TOUR, projectId: null });
+    expect(ok).toBe(false);
+    expect(generateIdMock).not.toHaveBeenCalled();
+    expect(useAgentPanelStore.getState().activeSessionId).toBeNull();
+    expect(window.sessionStorage.length).toBe(0);
+    expect(trackMock).toHaveBeenCalledWith(
+      "mcpjam_agent_tour_launch_skipped",
+      expect.objectContaining({ tour_id: "tour-eval-suite", reason: "no_project_id" }),
+    );
+  });
+
+  it("refocuses (no duplicate session) when the same tour is re-clicked while active", () => {
+    launchLessonSession({ tour: TOUR, projectId: "proj-1" });
+    useAgentPanelStore.setState({ isOpen: false }); // user closed the panel
+    const ok = launchLessonSession({ tour: TOUR, projectId: "proj-1" });
+
+    expect(ok).toBe(true);
+    expect(generateIdMock).toHaveBeenCalledTimes(1); // no new session minted
+    const state = useAgentPanelStore.getState();
+    expect(state.activeSessionId).toBe("sess-1");
+    expect(state.isOpen).toBe(true); // re-opened
+  });
+
+  it("still activates the session when sessionStorage.setItem throws", () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("quota");
+    });
+    const ok = launchLessonSession({ tour: TOUR, projectId: "proj-1" });
+    expect(ok).toBe(true);
+    expect(useAgentPanelStore.getState().activeSessionId).toBe("sess-1");
+  });
+});

--- a/mcpjam-inspector/client/src/lib/mcpjam-agent/__tests__/launch-lesson.test.ts
+++ b/mcpjam-inspector/client/src/lib/mcpjam-agent/__tests__/launch-lesson.test.ts
@@ -201,6 +201,26 @@ describe("launchLessonSession", () => {
     expect(useAgentPanelStore.getState().activeSessionId).toBe("sess-1");
   });
 
+  it("refocuses via the in-memory record when a stale persisted record lingers (writes failing)", () => {
+    // A prior record is readable in localStorage, but writes now fail — so the
+    // fresh launch only updates the in-memory record. Re-clicking must refocus
+    // via in-memory rather than trust the stale persisted record and duplicate.
+    window.localStorage.setItem(
+      "mcpjam:agent-tour-last-launch:v1",
+      JSON.stringify({ tourId: TOUR.id, sessionId: "stale", projectId: "proj-1" }),
+    );
+    vi.spyOn(window.localStorage, "setItem").mockImplementation(() => {
+      throw new Error("quota");
+    });
+
+    launchLessonSession({ tour: TOUR, projectId: "proj-1" }); // mints sess-1
+    const ok = launchLessonSession({ tour: TOUR, projectId: "proj-1" });
+
+    expect(ok).toBe(true);
+    expect(generateIdMock).toHaveBeenCalledTimes(1); // refocused, not duplicated
+    expect(useAgentPanelStore.getState().activeSessionId).toBe("sess-1");
+  });
+
   it("still launches when localStorage access throws (denied/privacy mode)", () => {
     // Every localStorage op throws — including the unguarded getItem inside
     // loadRecentMcpjamAgentSessions. The launch must survive it.

--- a/mcpjam-inspector/client/src/lib/mcpjam-agent/__tests__/launch-lesson.test.ts
+++ b/mcpjam-inspector/client/src/lib/mcpjam-agent/__tests__/launch-lesson.test.ts
@@ -181,4 +181,22 @@ describe("launchLessonSession", () => {
     expect(ok).toBe(true);
     expect(useAgentPanelStore.getState().activeSessionId).toBe("sess-1");
   });
+
+  it("dedups a same-tab repeat click even when localStorage is unavailable", () => {
+    // Storage fully disabled: the persisted layer can't record the launch, so
+    // dedup must fall back to the in-memory record.
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("disabled");
+    });
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("disabled");
+    });
+
+    launchLessonSession({ tour: TOUR, projectId: "proj-1" });
+    const ok = launchLessonSession({ tour: TOUR, projectId: "proj-1" });
+
+    expect(ok).toBe(true);
+    expect(generateIdMock).toHaveBeenCalledTimes(1); // no duplicate session
+    expect(useAgentPanelStore.getState().activeSessionId).toBe("sess-1");
+  });
 });

--- a/mcpjam-inspector/client/src/lib/mcpjam-agent/__tests__/pending-prompt.test.ts
+++ b/mcpjam-inspector/client/src/lib/mcpjam-agent/__tests__/pending-prompt.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  PENDING_AGENT_PROMPT_KEY_PREFIX,
+  clearPendingAgentPrompt,
+  pendingAgentPromptKey,
+  writePendingAgentPrompt,
+} from "../pending-prompt";
+
+afterEach(() => {
+  window.sessionStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("pendingAgentPromptKey", () => {
+  it("namespaces the session id under the shared prefix", () => {
+    expect(pendingAgentPromptKey("abc")).toBe(
+      `${PENDING_AGENT_PROMPT_KEY_PREFIX}abc`,
+    );
+  });
+});
+
+describe("writePendingAgentPrompt", () => {
+  it("stores the message as fresh JSON the thread can autosubmit", () => {
+    writePendingAgentPrompt("s1", "hello world");
+    const raw = window.sessionStorage.getItem(pendingAgentPromptKey("s1"));
+    expect(raw).not.toBeNull();
+    expect(JSON.parse(raw as string)).toEqual({
+      text: "hello world",
+      fresh: true,
+    });
+  });
+
+  it("swallows storage failures instead of throwing", () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("quota exceeded");
+    });
+    expect(() => writePendingAgentPrompt("s2", "x")).not.toThrow();
+  });
+});
+
+describe("clearPendingAgentPrompt", () => {
+  it("removes a stashed payload", () => {
+    writePendingAgentPrompt("s3", "bye");
+    clearPendingAgentPrompt("s3");
+    expect(
+      window.sessionStorage.getItem(pendingAgentPromptKey("s3")),
+    ).toBeNull();
+  });
+
+  it("is a no-op for a null/empty session id", () => {
+    expect(() => clearPendingAgentPrompt(null)).not.toThrow();
+    expect(() => clearPendingAgentPrompt(undefined)).not.toThrow();
+    expect(() => clearPendingAgentPrompt("")).not.toThrow();
+  });
+});

--- a/mcpjam-inspector/client/src/lib/mcpjam-agent/launch-lesson.ts
+++ b/mcpjam-inspector/client/src/lib/mcpjam-agent/launch-lesson.ts
@@ -44,7 +44,49 @@ const NO_PROJECT_SENTINEL = "none";
 // the tour. Clicking a *different* tour intentionally mints a new session; the
 // previous chat instance survives in the hoisted instance map and is
 // recoverable from Recent Chats.
-let lastLaunch: { tourId: string; sessionId: string } | null = null;
+//
+// Persisted to localStorage (not just a module var) because the panel store
+// persists `activeSessionId` across reloads and tabs — a module-scoped record
+// would be lost on refresh, so re-clicking the same tour after a reload would
+// mint a duplicate and re-autosubmit the whole lesson. localStorage is shared
+// across tabs and survives reload, keeping the dedup in step with the panel.
+const LAST_LAUNCH_KEY = "mcpjam:agent-tour-last-launch:v1";
+
+interface LastLaunch {
+  tourId: string;
+  sessionId: string;
+  projectId: string;
+}
+
+function readLastLaunch(): LastLaunch | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(LAST_LAUNCH_KEY);
+    if (!raw) return null;
+    const p = JSON.parse(raw) as Partial<LastLaunch>;
+    if (
+      p &&
+      typeof p.tourId === "string" &&
+      typeof p.sessionId === "string" &&
+      typeof p.projectId === "string"
+    ) {
+      return { tourId: p.tourId, sessionId: p.sessionId, projectId: p.projectId };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function writeLastLaunch(value: LastLaunch): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(LAST_LAUNCH_KEY, JSON.stringify(value));
+  } catch {
+    // Quota/disabled storage — dedup degrades to per-turn only; a duplicate
+    // session is the worst case, not data loss.
+  }
+}
 
 export function launchLessonSession({
   tour,
@@ -69,16 +111,19 @@ export function launchLessonSession({
   }
 
   const panel = useAgentPanelStore.getState();
+  const lastLaunch = readLastLaunch();
 
   if (
     lastLaunch?.tourId === tour.id &&
+    lastLaunch.projectId === resolvedProjectId &&
     panel.activeSessionId === lastLaunch.sessionId &&
     panel.activeSessionProjectId === resolvedProjectId
   ) {
-    // Same tour AND same project — the session is still valid, just bring the
-    // panel back into view. If the project changed since, fall through and mint
-    // a fresh session scoped to it (else the panel's project gate shows the
-    // empty hero).
+    // Same tour AND same project, and that session is still the active panel
+    // session — just bring the panel back into view. If the project changed or
+    // the panel moved on to a different session, fall through and mint a fresh
+    // session scoped to the current project (else the panel's project gate
+    // shows the empty hero, or we'd re-seed over a live chat).
     panel.setOpen(true);
     return true;
   }
@@ -111,11 +156,16 @@ export function launchLessonSession({
     prompt_length: tour.agentPrompt.length,
   });
 
-  lastLaunch = { tourId: tour.id, sessionId };
+  writeLastLaunch({ tourId: tour.id, sessionId, projectId: resolvedProjectId });
   return true;
 }
 
 /** Test-only: clears the same-tour refocus memory between cases. */
 export function __resetLaunchLessonForTests(): void {
-  lastLaunch = null;
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(LAST_LAUNCH_KEY);
+  } catch {
+    // ignore
+  }
 }

--- a/mcpjam-inspector/client/src/lib/mcpjam-agent/launch-lesson.ts
+++ b/mcpjam-inspector/client/src/lib/mcpjam-agent/launch-lesson.ts
@@ -45,19 +45,20 @@ const NO_PROJECT_SENTINEL = "none";
 // previous chat instance survives in the hoisted instance map and is
 // recoverable from Recent Chats.
 //
-// Two layers, read persisted-first:
-//   - localStorage: the cross-tab source of truth, kept in step with the panel
-//     store's own localStorage-persisted `activeSessionId`. Reading it first
-//     means re-clicking a tour after a reload — or in another tab that adopted
-//     the session — refocuses the live session instead of minting a duplicate
-//     that re-autosubmits the whole lesson.
-//   - In-memory module var: fallback for when localStorage is disabled or full
-//     (can't be written or read), so repeat clicks still dedup within this tab.
+// The refocus guard keeps two dedup records and trusts neither by priority —
+// it asks which one (if any) identifies the panel's CURRENTLY active session:
+//   - localStorage: the cross-tab record, kept in step with the panel store's
+//     own localStorage-persisted `activeSessionId`. Fresh across tabs/reloads,
+//     but can go stale in-tab when a write fails (reads still return the old
+//     value).
+//   - In-memory module var: fresh in this tab even when storage is disabled or
+//     write-blocked, but blind to what other tabs did.
+// Because either can be stale in some failure mode, we refocus only when one of
+// them matches `panel.activeSessionId` — the authoritative "what's open now".
 // A genuinely concurrent cross-tab race (two tabs clicking the SAME tour within
-// the same tick) can still mint twice — the persisted value and the panel's
-// in-memory state are read at slightly different times. That is the same
-// cross-tab semantics the panel store itself has; a distributed claim/lock is
-// not worth it for a tutorial launch whose only cost is a duplicate chat.
+// the same tick) can still mint twice — that is the same cross-tab semantics
+// the panel store itself has; a distributed claim/lock is not worth it for a
+// tutorial launch whose only cost is a duplicate chat.
 const LAST_LAUNCH_KEY = "mcpjam:agent-tour-last-launch:v1";
 
 interface LastLaunch {
@@ -86,12 +87,6 @@ function readPersistedLastLaunch(): LastLaunch | null {
   } catch {
     return null;
   }
-}
-
-function readLastLaunch(): LastLaunch | null {
-  // Persisted (cross-tab, panel-synced) first; in-memory only as a fallback
-  // when storage is unavailable or has no valid entry.
-  return readPersistedLastLaunch() ?? inMemoryLastLaunch;
 }
 
 function writeLastLaunch(value: LastLaunch): void {
@@ -129,19 +124,25 @@ export function launchLessonSession({
   }
 
   const panel = useAgentPanelStore.getState();
-  const lastLaunch = readLastLaunch();
+
+  // Does this dedup record describe the session the panel currently has open,
+  // for this tour and project? Only then is refocusing correct.
+  const identifiesActiveSession = (record: LastLaunch | null): boolean =>
+    record !== null &&
+    record.tourId === tour.id &&
+    record.projectId === resolvedProjectId &&
+    record.sessionId === panel.activeSessionId &&
+    panel.activeSessionProjectId === resolvedProjectId;
 
   if (
-    lastLaunch?.tourId === tour.id &&
-    lastLaunch.projectId === resolvedProjectId &&
-    panel.activeSessionId === lastLaunch.sessionId &&
-    panel.activeSessionProjectId === resolvedProjectId
+    identifiesActiveSession(readPersistedLastLaunch()) ||
+    identifiesActiveSession(inMemoryLastLaunch)
   ) {
-    // Same tour AND same project, and that session is still the active panel
-    // session — just bring the panel back into view. If the project changed or
-    // the panel moved on to a different session, fall through and mint a fresh
-    // session scoped to the current project (else the panel's project gate
-    // shows the empty hero, or we'd re-seed over a live chat).
+    // The tour's session is still the active panel session — just bring the
+    // panel back into view. If the project changed or the panel moved on to a
+    // different session, fall through and mint a fresh session scoped to the
+    // current project (else the panel's project gate shows the empty hero, or
+    // we'd re-seed over a live chat).
     panel.setOpen(true);
     return true;
   }

--- a/mcpjam-inspector/client/src/lib/mcpjam-agent/launch-lesson.ts
+++ b/mcpjam-inspector/client/src/lib/mcpjam-agent/launch-lesson.ts
@@ -29,10 +29,14 @@ interface LaunchLessonOptions {
    * get a non-null synthetic id, so this is populated for them too; it must be
    * the same value the panel is scoped to (`AgentSidePanel`'s `projectId`
    * prop), or the panel's project-match gate would show the empty hero instead
-   * of the seeded thread.
+   * of the seeded thread. The `"none"` sentinel (and null/empty) count as "no
+   * project" and take the skip path.
    */
   projectId: string | null;
 }
+
+/** The no-project sentinel `activeProjectId` can carry, alongside null. */
+const NO_PROJECT_SENTINEL = "none";
 
 // Remembers the most recent launch so a double-click (or re-clicking the same
 // tour while its session is still active) refocuses that session instead of
@@ -46,7 +50,13 @@ export function launchLessonSession({
   tour,
   projectId,
 }: LaunchLessonOptions): boolean {
-  if (!projectId) {
+  // Normalize the no-project states ("none" is truthy but not a real project)
+  // to null so the skip path and session scoping agree. Guest ids (synthetic
+  // UUID / local_ / project_) are real projects and pass through untouched.
+  const resolvedProjectId =
+    projectId && projectId !== NO_PROJECT_SENTINEL ? projectId : null;
+
+  if (!resolvedProjectId) {
     // Without a project id the panel-mount GC (AgentSidePanelMount) would clear
     // the session pointer immediately — same rationale as maybeHandoffToPanel's
     // null-project skip. Rare in practice: guests have a synthetic id.
@@ -62,9 +72,13 @@ export function launchLessonSession({
 
   if (
     lastLaunch?.tourId === tour.id &&
-    panel.activeSessionId === lastLaunch.sessionId
+    panel.activeSessionId === lastLaunch.sessionId &&
+    panel.activeSessionProjectId === resolvedProjectId
   ) {
-    // Same tour, session still active — just bring the panel back into view.
+    // Same tour AND same project — the session is still valid, just bring the
+    // panel back into view. If the project changed since, fall through and mint
+    // a fresh session scoped to it (else the panel's project gate shows the
+    // empty hero).
     panel.setOpen(true);
     return true;
   }
@@ -86,7 +100,7 @@ export function launchLessonSession({
     ts: Date.now(),
   });
 
-  panel.setActiveSession(sessionId, projectId);
+  panel.setActiveSession(sessionId, resolvedProjectId);
   panel.setOpen(true);
 
   track("mcpjam_agent_tour_launched", {

--- a/mcpjam-inspector/client/src/lib/mcpjam-agent/launch-lesson.ts
+++ b/mcpjam-inspector/client/src/lib/mcpjam-agent/launch-lesson.ts
@@ -1,0 +1,107 @@
+import { generateId } from "ai";
+import type { GuidedTourConcept } from "@/components/lifecycle/learning-concepts";
+import { appendRecentMcpjamAgentSession } from "@/components/mcpjam-agent/recent-sessions";
+import { useAgentPanelStore } from "@/stores/agent-panel/agent-panel-store";
+import { track } from "@/lib/analytics";
+import { writePendingAgentPrompt } from "./pending-prompt";
+
+/**
+ * Launches a Learning-tab guided tour: mints a fresh agent chat session seeded
+ * with the tour's prompt and opens the always-mounted agent side panel to it.
+ * `McpjamAgentThread` consumes the seeded prompt and autosubmits it on mount,
+ * so the agent begins the tour on its own.
+ *
+ * This deliberately replicates the side panel's own session-start
+ * (`AgentSidePanel.handleSessionStart`) and the home→panel handoff
+ * (`maybeHandoffToPanel`) rather than routing anywhere: the same
+ * pending-prompt write + `setActiveSession` + `setOpen` sequence, in the same
+ * order (the write must precede `setActiveSession`, which is what mounts the
+ * thread whose optimistic-bubble initializer peeks the key synchronously).
+ *
+ * Returns `true` if a session was launched or refocused, `false` if it was
+ * skipped (no project id).
+ */
+
+interface LaunchLessonOptions {
+  tour: GuidedTourConcept;
+  /**
+   * The active project id, from `useAppRouteContext().activeProjectId`. Guests
+   * get a non-null synthetic id, so this is populated for them too; it must be
+   * the same value the panel is scoped to (`AgentSidePanel`'s `projectId`
+   * prop), or the panel's project-match gate would show the empty hero instead
+   * of the seeded thread.
+   */
+  projectId: string | null;
+}
+
+// Remembers the most recent launch so a double-click (or re-clicking the same
+// tour while its session is still active) refocuses that session instead of
+// minting a duplicate — a duplicate would burn a fresh model turn re-running
+// the tour. Clicking a *different* tour intentionally mints a new session; the
+// previous chat instance survives in the hoisted instance map and is
+// recoverable from Recent Chats.
+let lastLaunch: { tourId: string; sessionId: string } | null = null;
+
+export function launchLessonSession({
+  tour,
+  projectId,
+}: LaunchLessonOptions): boolean {
+  if (!projectId) {
+    // Without a project id the panel-mount GC (AgentSidePanelMount) would clear
+    // the session pointer immediately — same rationale as maybeHandoffToPanel's
+    // null-project skip. Rare in practice: guests have a synthetic id.
+    track("mcpjam_agent_tour_launch_skipped", {
+      location: "learning_tab",
+      tour_id: tour.id,
+      reason: "no_project_id",
+    });
+    return false;
+  }
+
+  const panel = useAgentPanelStore.getState();
+
+  if (
+    lastLaunch?.tourId === tour.id &&
+    panel.activeSessionId === lastLaunch.sessionId
+  ) {
+    // Same tour, session still active — just bring the panel back into view.
+    panel.setOpen(true);
+    return true;
+  }
+
+  const sessionId = generateId();
+
+  // Order matters: write the pending prompt BEFORE setActiveSession (which
+  // mounts the thread) so the thread's synchronous optimistic-bubble peek sees
+  // it, then setActiveSession before setOpen to match the handoff and avoid a
+  // one-frame hero flash in the opening panel.
+  writePendingAgentPrompt(sessionId, tour.agentPrompt);
+
+  // Pre-seed the recents title so the Recent Chats pill reads "Tour: <title>"
+  // instead of the first 50 chars of the lesson prompt (the thread's submit
+  // keeps an existing title when present).
+  appendRecentMcpjamAgentSession({
+    id: sessionId,
+    title: `Tour: ${tour.title}`,
+    ts: Date.now(),
+  });
+
+  panel.setActiveSession(sessionId, projectId);
+  panel.setOpen(true);
+
+  track("mcpjam_agent_tour_launched", {
+    location: "learning_tab",
+    tour_id: tour.id,
+    session_id: sessionId,
+    estimated_minutes: tour.estimatedMinutes,
+    prompt_length: tour.agentPrompt.length,
+  });
+
+  lastLaunch = { tourId: tour.id, sessionId };
+  return true;
+}
+
+/** Test-only: clears the same-tour refocus memory between cases. */
+export function __resetLaunchLessonForTests(): void {
+  lastLaunch = null;
+}

--- a/mcpjam-inspector/client/src/lib/mcpjam-agent/launch-lesson.ts
+++ b/mcpjam-inspector/client/src/lib/mcpjam-agent/launch-lesson.ts
@@ -45,13 +45,14 @@ const NO_PROJECT_SENTINEL = "none";
 // previous chat instance survives in the hoisted instance map and is
 // recoverable from Recent Chats.
 //
-// Two layers, read in-memory-first:
-//   - In-memory module var: dedups repeat clicks within this tab even when
-//     localStorage is disabled or full (the persisted layer can't write).
-//   - localStorage: survives reload and is visible to other tabs, because the
-//     panel store also persists `activeSessionId` there — so re-clicking the
-//     same tour after a refresh refocuses instead of minting a duplicate that
-//     re-autosubmits the whole lesson.
+// Two layers, read persisted-first:
+//   - localStorage: the cross-tab source of truth, kept in step with the panel
+//     store's own localStorage-persisted `activeSessionId`. Reading it first
+//     means re-clicking a tour after a reload — or in another tab that adopted
+//     the session — refocuses the live session instead of minting a duplicate
+//     that re-autosubmits the whole lesson.
+//   - In-memory module var: fallback for when localStorage is disabled or full
+//     (can't be written or read), so repeat clicks still dedup within this tab.
 // A genuinely concurrent cross-tab race (two tabs clicking the SAME tour within
 // the same tick) can still mint twice — the persisted value and the panel's
 // in-memory state are read at slightly different times. That is the same
@@ -67,10 +68,7 @@ interface LastLaunch {
 
 let inMemoryLastLaunch: LastLaunch | null = null;
 
-function readLastLaunch(): LastLaunch | null {
-  // In-memory first: this tab's own last launch, always available even with
-  // storage disabled. Fall back to the persisted value for reload/other-tab.
-  if (inMemoryLastLaunch) return inMemoryLastLaunch;
+function readPersistedLastLaunch(): LastLaunch | null {
   if (typeof window === "undefined") return null;
   try {
     const raw = window.localStorage.getItem(LAST_LAUNCH_KEY);
@@ -88,6 +86,12 @@ function readLastLaunch(): LastLaunch | null {
   } catch {
     return null;
   }
+}
+
+function readLastLaunch(): LastLaunch | null {
+  // Persisted (cross-tab, panel-synced) first; in-memory only as a fallback
+  // when storage is unavailable or has no valid entry.
+  return readPersistedLastLaunch() ?? inMemoryLastLaunch;
 }
 
 function writeLastLaunch(value: LastLaunch): void {
@@ -152,12 +156,18 @@ export function launchLessonSession({
 
   // Pre-seed the recents title so the Recent Chats pill reads "Tour: <title>"
   // instead of the first 50 chars of the lesson prompt (the thread's submit
-  // keeps an existing title when present).
-  appendRecentMcpjamAgentSession({
-    id: sessionId,
-    title: `Tour: ${tour.title}`,
-    ts: Date.now(),
-  });
+  // keeps an existing title when present). This is cosmetic and reads
+  // localStorage unguarded (`loadRecentMcpjamAgentSessions`), which can throw
+  // where storage access is denied — never let it abort the launch.
+  try {
+    appendRecentMcpjamAgentSession({
+      id: sessionId,
+      title: `Tour: ${tour.title}`,
+      ts: Date.now(),
+    });
+  } catch {
+    // Recents pill just won't show this session's friendly title.
+  }
 
   panel.setActiveSession(sessionId, resolvedProjectId);
   panel.setOpen(true);

--- a/mcpjam-inspector/client/src/lib/mcpjam-agent/launch-lesson.ts
+++ b/mcpjam-inspector/client/src/lib/mcpjam-agent/launch-lesson.ts
@@ -45,11 +45,18 @@ const NO_PROJECT_SENTINEL = "none";
 // previous chat instance survives in the hoisted instance map and is
 // recoverable from Recent Chats.
 //
-// Persisted to localStorage (not just a module var) because the panel store
-// persists `activeSessionId` across reloads and tabs — a module-scoped record
-// would be lost on refresh, so re-clicking the same tour after a reload would
-// mint a duplicate and re-autosubmit the whole lesson. localStorage is shared
-// across tabs and survives reload, keeping the dedup in step with the panel.
+// Two layers, read in-memory-first:
+//   - In-memory module var: dedups repeat clicks within this tab even when
+//     localStorage is disabled or full (the persisted layer can't write).
+//   - localStorage: survives reload and is visible to other tabs, because the
+//     panel store also persists `activeSessionId` there — so re-clicking the
+//     same tour after a refresh refocuses instead of minting a duplicate that
+//     re-autosubmits the whole lesson.
+// A genuinely concurrent cross-tab race (two tabs clicking the SAME tour within
+// the same tick) can still mint twice — the persisted value and the panel's
+// in-memory state are read at slightly different times. That is the same
+// cross-tab semantics the panel store itself has; a distributed claim/lock is
+// not worth it for a tutorial launch whose only cost is a duplicate chat.
 const LAST_LAUNCH_KEY = "mcpjam:agent-tour-last-launch:v1";
 
 interface LastLaunch {
@@ -58,7 +65,12 @@ interface LastLaunch {
   projectId: string;
 }
 
+let inMemoryLastLaunch: LastLaunch | null = null;
+
 function readLastLaunch(): LastLaunch | null {
+  // In-memory first: this tab's own last launch, always available even with
+  // storage disabled. Fall back to the persisted value for reload/other-tab.
+  if (inMemoryLastLaunch) return inMemoryLastLaunch;
   if (typeof window === "undefined") return null;
   try {
     const raw = window.localStorage.getItem(LAST_LAUNCH_KEY);
@@ -79,12 +91,14 @@ function readLastLaunch(): LastLaunch | null {
 }
 
 function writeLastLaunch(value: LastLaunch): void {
+  inMemoryLastLaunch = value;
   if (typeof window === "undefined") return;
   try {
     window.localStorage.setItem(LAST_LAUNCH_KEY, JSON.stringify(value));
   } catch {
-    // Quota/disabled storage — dedup degrades to per-turn only; a duplicate
-    // session is the worst case, not data loss.
+    // Quota/disabled storage — the in-memory layer still dedups within this
+    // tab; only cross-reload/cross-tab dedup is lost. Worst case is a
+    // duplicate session, not data loss.
   }
 }
 
@@ -160,8 +174,9 @@ export function launchLessonSession({
   return true;
 }
 
-/** Test-only: clears the same-tour refocus memory between cases. */
+/** Test-only: clears both refocus-memory layers between cases. */
 export function __resetLaunchLessonForTests(): void {
+  inMemoryLastLaunch = null;
   if (typeof window === "undefined") return;
   try {
     window.localStorage.removeItem(LAST_LAUNCH_KEY);

--- a/mcpjam-inspector/client/src/lib/mcpjam-agent/pending-prompt.ts
+++ b/mcpjam-inspector/client/src/lib/mcpjam-agent/pending-prompt.ts
@@ -1,0 +1,56 @@
+/**
+ * Shared contract for the "pending prompt" handoff between a session opener and
+ * the thread that autosubmits it.
+ *
+ * When a caller mints a fresh agent session id and wants the thread to send a
+ * first message on mount (the hero → thread swap, the home takeover, and the
+ * Learning-tab guided tours), it stashes the message under a per-session
+ * sessionStorage key. `McpjamAgentThread` peeks it for an optimistic bubble and
+ * then consumes it exactly once. sessionStorage (not localStorage) so a stale
+ * pending message can't leak across browser sessions.
+ *
+ * The stored shape is `{ text, fresh: true }`. The `fresh` flag distinguishes
+ * "just minted + submitted" from "resumed via a Recent Chat pill" (which writes
+ * no pending value); the thread refuses to autosubmit anything not marked fresh
+ * so a resumed transcript never replays. Parsing/consumption stays in the
+ * thread — this module owns only the key format and the write.
+ */
+
+export const PENDING_AGENT_PROMPT_KEY_PREFIX = "mcpjam:agent-pending:";
+
+export function pendingAgentPromptKey(sessionId: string): string {
+  return `${PENDING_AGENT_PROMPT_KEY_PREFIX}${sessionId}`;
+}
+
+/**
+ * Stash a first message for `McpjamAgentThread` to autosubmit on mount.
+ * Swallows quota/disabled-storage failures — worst case the thread opens on an
+ * empty composer and the user retypes.
+ */
+export function writePendingAgentPrompt(sessionId: string, text: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.setItem(
+      pendingAgentPromptKey(sessionId),
+      JSON.stringify({ text, fresh: true }),
+    );
+  } catch {
+    // Quota/disabled storage — non-fatal, see doc comment above.
+  }
+}
+
+/**
+ * Remove an unconsumed pending payload. Used by openers that abandon a session
+ * before its thread mounts (takeover Back / New chat).
+ */
+export function clearPendingAgentPrompt(
+  sessionId: string | null | undefined,
+): void {
+  if (!sessionId || typeof window === "undefined") return;
+  try {
+    window.sessionStorage.removeItem(pendingAgentPromptKey(sessionId));
+  } catch {
+    // Quota/disabled storage — a stale entry is a no-op unless the user returns
+    // to this exact session id.
+  }
+}

--- a/mcpjam-inspector/shared/analytics-events.ts
+++ b/mcpjam-inspector/shared/analytics-events.ts
@@ -168,6 +168,8 @@ export const ANALYTICS_EVENTS = {
   mcpjam_agent_resume: { source: "client" },
   mcpjam_agent_submit: { source: "client" },
   mcpjam_agent_suggested_prompt: { source: "client" },
+  mcpjam_agent_tour_launch_skipped: { source: "client" },
+  mcpjam_agent_tour_launched: { source: "client" },
   move_server_to_project_clicked: { source: "client" },
   oauth_debugger_error_boundary: { source: "client" },
   oauth_flow_tab_next_step_button_clicked: { source: "client" },


### PR DESCRIPTION
## What

Adds a **Guided tours** group to the Learning tab. Instead of routing to a static article, selecting a tour launches the MCPJam agent in the side panel seeded with a lesson prompt (rendered as the user's first message). The agent then teaches by **driving the real inspector UI** through the existing `ui_*` tool catalog — navigate, narrate each screen, prefill forms, and hand the final consequential click back to the user.

Five tours over the core funnel: connect a server, run a tool in the Playground, create & run an eval suite, simulate users with Swarms, package servers into a Host.

Plan + UX mockups: https://claude.ai/code/artifact/8702f480-c7f3-4c86-b0d4-5815923464c3

## Why this is safe/small

The `ui_*` agent-tools framework already gives show-don't-tell for free: every agent action is a visible UI action, prefill tools stop at the form, and destructive/billable tools gate behind the confirmation pill and the buttons' billing gates. The only missing piece was a launcher — and the side panel already had a pending-prompt seeding mechanism to reuse.

**Client-only. No `client/src/lib/webmcp/` framework changes, no new inspector commands, no backend, no system-prompt changes** (the lesson rides as the user's first message).

## How

- **Content model** — `learning-concepts.ts` becomes a `LearningConcept | GuidedTourConcept` discriminated union (`kind: "guided"` carries a required `agentPrompt`, no `totalSteps`). Tours + shared ground rules (narrate-before-act, snapshot-first, prefill-never-submit, ask-before-spend, end-with-mark-complete) live in new `guided-tour-lessons.ts`.
- **Seeding** — extracted the `mcpjam:agent-pending:` convention (previously inline in `AgentSidePanel` / `HomeTab` / `McpjamAgentThread`) into a shared `pending-prompt.ts` helper and reused it.
- **Launcher** — `launch-lesson.ts` replicates the panel's own session-start ordering (pending write **before** `setActiveSession`, which mounts the thread whose optimistic-bubble peek reads the key), with a null-`projectId` skip and a same-tour double-click refocus guard. Telemetry: `mcpjam_agent_tour_launched` / `mcpjam_agent_tour_launch_skipped`.
- **projectId** reaches `LearningTab` via `useAppRouteContext().activeProjectId` (the established route pattern). Guests get a non-null synthetic id, so no guest special-casing.

## Not in v1 (deliberate)

Auto-complete on tour finish (manual checkbox stays), a `ui_highlight` coach-mark tool, a lesson-script engine, and any `app-surfaces.ts` change (the agent never operates the Learning surface itself).

## Testing

- `npm run typecheck:client` — clean.
- New: `launch-lesson.test.ts`, `pending-prompt.test.ts`, `LearningLandingPage.tours.test.tsx`, `LearningTab.tours.test.tsx` (20 tests).
- Regression sweep green: `client/src/lib/mcpjam-agent`, `client/src/lib/webmcp` (coverage suites — no framework drift), analytics ratchet (306 tests total).

Manual: Learning → "Create and run an eval suite" → side panel opens with the lesson as the visible first message → agent navigates to Evals, narrates, prefills the suite form, hands back the Create click; destructive pill appears if asked to run; double-click doesn't spawn two sessions; works as a guest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Client-only but changes agent session bootstrap, sessionStorage/localStorage behavior, and panel project scoping; incorrect ordering or dedup could double-send prompts or show an empty panel.
> 
> **Overview**
> Adds a **Guided tours** track on the Learning landing page. Choosing a tour no longer opens an in-tab article—it **opens the MCPJam agent side panel** with the lesson prompt stashed as the user’s first message so the thread autosubmits and walks the real inspector via existing `ui_*` tools.
> 
> **Content & UI:** Five tours (connect server, Playground tool call, eval suite, Swarms, Host packaging) live in `guided-tour-lessons.ts` with shared ground rules (narrate, snapshot-first, prefill never final submit, ask before spend). The syllabus uses a `LearningModule` union (`kind: "guided"` + `agentPrompt`); guided rows show a **Guided** badge and play icon, and totals include tours.
> 
> **Plumbing:** `pending-prompt.ts` centralizes the `mcpjam:agent-pending:` sessionStorage handoff (replacing inline code in Home, side panel, and thread). `launch-lesson.ts` mirrors panel session-start ordering (write pending **before** `setActiveSession`), skips when `projectId` is null/`"none"`, and refocuses the same tour session on repeat clicks using localStorage + in-memory dedup. `LearningRoute` passes `activeProjectId` into `LearningTab`. Telemetry: `mcpjam_agent_tour_launched` / `_skipped`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9abdb29250e1c6223b6d9b81a94f6877fc77c192. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds “Guided tours” to the Learning tab. Picking a tour opens the side panel and seeds the MCPJam agent with a lesson prompt so it teaches by driving the real UI; repeat clicks now refocus without duplicating, even across reloads/tabs or when storage writes fail.

- New Features
  - Five tours: connect a server, run a tool in Playground, create/run an eval suite, simulate users with Swarms, and package servers into a Host. Client-only; uses existing `ui_*` tools and keeps destructive/billable actions gated.
  - Landing rows show a Guided badge and Play icon; totals include tours.
  - `LearningTab` takes `projectId` and launches tours via `launch-lesson` (writes pending prompt before `setActiveSession`, opens panel; analytics: `mcpjam_agent_tour_launched` / `_skipped`). Pending-prompt logic extracted to `pending-prompt` and reused in Home, Agent panel, and thread.

- Bug Fixes
  - `launch-lesson`: dedup now refocuses only when a persisted or in-memory last-launch record matches the panel’s currently active session and project, preventing duplicate sessions across reloads, other tabs, disabled storage, and stale persisted records; treats `"none"` as no project and skips with telemetry; re-click after a project switch mints a new session (fixes empty-hero). `appendRecent` is guarded so denied localStorage access doesn’t abort a launch.
  - Tour prompts aligned with real tool capabilities: eval suite prefills name only; personas/hosts are user-committed; Host tour points to the Servers tab for server selection (editor is config-only). Tests cover reload/cross-tab dedup, storage-disabled/denied paths, the `"none"` skip, and project-switch re-mint.

<sup>Written for commit 9abdb29250e1c6223b6d9b81a94f6877fc77c192. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

