### PR TITLE
fix(server): noindex the app shell and serve a real robots.txt

### DIFF
--- a/mcpjam-inspector/client/public/robots.txt
+++ b/mcpjam-inspector/client/public/robots.txt
@@ -1,0 +1,6 @@
+# robots.txt for app.mcpjam.com — authenticated app shell, not content.
+# Crawling is allowed on purpose: every response carries X-Robots-Tag: noindex,
+# and robots can only honor that directive if they are allowed to fetch the
+# page (a Disallow here would blind them to it and risk link-only indexing).
+User-agent: *
+Allow: /

--- a/mcpjam-inspector/server/middleware/__tests__/security-headers.test.ts
+++ b/mcpjam-inspector/server/middleware/__tests__/security-headers.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Security Headers Middleware Tests
+ *
+ * Tests for the security headers middleware that stamps standard security
+ * headers onto every response, including X-Robots-Tag: noindex — the hosted
+ * app shell (app.mcpjam.com) is an authenticated tool, not indexable content,
+ * and the SPA catch-all would otherwise let search engines index every route.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { Hono } from "hono";
+import { securityHeadersMiddleware } from "../security-headers.js";
+
+/**
+ * Creates a test Hono app with the security headers middleware.
+ */
+function createTestApp(): Hono {
+  const app = new Hono();
+
+  app.use("*", securityHeadersMiddleware);
+
+  app.get("/", (c) => c.html("<!doctype html><html></html>"));
+  app.get("/api/test", (c) => c.json({ message: "success" }));
+
+  return app;
+}
+
+describe("securityHeadersMiddleware", () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    app = createTestApp();
+  });
+
+  it("sets the standard security headers on every response", async () => {
+    const res = await app.request("/");
+
+    expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(res.headers.get("X-Frame-Options")).toBe("SAMEORIGIN");
+    expect(res.headers.get("X-XSS-Protection")).toBe("1; mode=block");
+    expect(res.headers.get("Referrer-Policy")).toBe(
+      "strict-origin-when-cross-origin",
+    );
+  });
+
+  it("marks responses noindex so the authenticated app shell stays out of search indexes", async () => {
+    const res = await app.request("/");
+
+    expect(res.headers.get("X-Robots-Tag")).toBe("noindex");
+  });
+
+  it("applies headers to API responses too", async () => {
+    const res = await app.request("/api/test");
+
+    expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(res.headers.get("X-Robots-Tag")).toBe("noindex");
+  });
+});

--- a/mcpjam-inspector/server/middleware/security-headers.ts
+++ b/mcpjam-inspector/server/middleware/security-headers.ts
@@ -6,6 +6,10 @@
  * - X-Frame-Options: Prevents clickjacking
  * - X-XSS-Protection: Enables XSS filter
  * - Referrer-Policy: Controls referrer information
+ * - X-Robots-Tag: Keeps the authenticated app shell out of search indexes
+ *   (the SPA catch-all serves 200s for every path, so without this crawlers
+ *   would index every route; crawling stays allowed via robots.txt so
+ *   robots can actually see this directive)
  *
  * Note: CSP is intentionally not included as the app integrates with many
  * external services (WorkOS, PostHog, Sentry, Convex, MCP servers with OAuth)
@@ -29,6 +33,8 @@ export async function securityHeadersMiddleware(
   c.header("X-Frame-Options", "SAMEORIGIN");
   c.header("X-XSS-Protection", "1; mode=block");
   c.header("Referrer-Policy", "strict-origin-when-cross-origin");
+  // Authenticated app shell — not indexable content (see robots.txt note above)
+  c.header("X-Robots-Tag", "noindex");
 
   return next();
 }


### PR DESCRIPTION
## Problem

`app.mcpjam.com`'s SPA catch-all returns `index.html` with a `200` for **every** path — including `/robots.txt`. Crawlers requesting it get unparseable HTML, which robots parsers treat as allow-all, so the authenticated app shell is fully crawlable **and indexable** (robots.txt is per-host; the marketing site's file doesn't cover this origin).

Verified on prod before the fix:
```
$ curl -s -o /dev/null -w "%{http_code} %{content_type}" https://app.mcpjam.com/robots.txt
200 text/html; charset=UTF-8        ← HTML, not robots.txt
```
No `X-Robots-Tag` or `<meta robots>` anywhere.

## Fix — policy: allow crawling + noindex

- **`client/public/robots.txt`** (new): valid, parseable robots.txt that *allows* crawling. It rides the same Vite `publicDir` pipeline as the favicon into `dist/client/`, where `serveStatic` (server/index.ts:563) wins over the SPA catch-all (:566).
- **`X-Robots-Tag: noindex`** on every response, added to the existing `securityHeadersMiddleware` (applies globally in both `server/index.ts` and the `server/app.ts` mirror).

Why not `Disallow: /`: a Disallow blinds robots to the noindex directive — Google can still index the URLs from external links (ugly, empty results). Allow + noindex is the reliable way to keep the shell out of search indexes. AI agents are unaffected (`noindex` only governs search indexing, not fetching).

## Tests

Red→green: new `server/middleware/__tests__/security-headers.test.ts` (mirrors the existing middleware test style) — baseline case for the 4 existing headers passed against the old code, the 2 `X-Robots-Tag` cases failed (`Received: null`), all 3 pass with the change.

Refs ARM-16 (Agent Readiness board).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serve a real robots.txt and add a global X-Robots-Tag: noindex to keep the authenticated app shell off search results while still allowing crawlers to fetch pages. Addresses ARM-16.

- **Bug Fixes**
  - Serve `client/public/robots.txt` so `/robots.txt` returns a valid file with `Allow: /`.
  - Add `X-Robots-Tag: noindex` in `securityHeadersMiddleware` for all routes (HTML and API).
  - Add tests covering the security headers, including `X-Robots-Tag`.

<sup>Written for commit cd4fb051722ba3a84abba749ba0b0d63284e05d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

