### PR TITLE
feat(webmcp): agent tool group for the OAuth debugger

### DIFF
--- a/mcpjam-inspector/client/src/components/OAuthFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/OAuthFlowTab.tsx
@@ -1,6 +1,8 @@
 import { useState, useCallback, useEffect, useMemo, useRef } from "react";
 import {
   EMPTY_OAUTH_FLOW_STATE,
+  buildOAuthSequenceActions,
+  getSupportedRegistrationStrategies,
   type OAuthFlowState,
   type OAuthFlowStep,
 } from "@mcpjam/sdk/browser";
@@ -13,13 +15,31 @@ import {
   ResizablePanelGroup,
 } from "./ui/resizable";
 import { track } from "@/lib/analytics";
-import { OAuthProfileModal } from "./oauth/OAuthProfileModal";
-import { type OAuthTestProfile } from "@/lib/oauth/profile";
+import {
+  OAuthProfileModal,
+  type OAuthProfileAgentSeed,
+} from "./oauth/OAuthProfileModal";
+import {
+  normalizeOAuthRegistrationStrategy,
+  type OAuthTestProfile,
+} from "@/lib/oauth/profile";
 import { OAuthFlowLogger } from "./oauth/OAuthFlowLogger";
 import type { ServerFormData } from "@/shared/types.js";
 import type { ServerWithName } from "@/hooks/use-app-state";
 import { deriveOAuthProfileFromServer } from "./oauth/utils";
 import { RefreshTokensConfirmModal } from "./oauth/RefreshTokensConfirmModal";
+import { useSurfaceAgentBridge } from "@/lib/webmcp/use-surface-agent-bridge";
+import {
+  buildOAuthFlowSnapshot,
+  toSafeSequenceSteps,
+} from "@/lib/webmcp/oauth-flow-snapshot";
+import { extractOauthErrorCode } from "@/lib/webmcp/oauth-error-code";
+import { planAuthConfigModal } from "@/lib/webmcp/auth-config-command";
+import { createInspectorCommandClientError } from "@/lib/inspector-command-handlers";
+import type {
+  InspectorCommand,
+  OpenOauthServerConfigInspectorCommand,
+} from "@/shared/inspector-command.js";
 
 export interface OAuthTokensFromFlow {
   accessToken: string;
@@ -84,6 +104,25 @@ const describeRegistrationStrategy = (strategy: string): string => {
 const isHttpServer = (server?: ServerWithName) =>
   Boolean(server && "url" in server.config);
 
+/**
+ * Honest post-step result for the advanceOauthFlow command. Never echoes the
+ * raw error string — only presence and an allowlisted OAuth error code.
+ */
+const buildAdvanceResult = (
+  previousStep: OAuthFlowStep,
+  state: OAuthFlowState,
+) => {
+  const oauthErrorCode = extractOauthErrorCode(state.error, state.lastResponse);
+  return {
+    status: "advanced" as const,
+    previousStep,
+    currentStep: state.currentStep,
+    ok: !state.error,
+    ...(oauthErrorCode ? { oauthErrorCode } : {}),
+    ...(state.lastResponse ? { httpStatus: state.lastResponse.status } : {}),
+  };
+};
+
 interface OAuthFlowTabProps {
   serverConfigs: Record<string, ServerWithName>;
   selectedServerName: string;
@@ -131,9 +170,20 @@ export const OAuthFlowTab = ({
   const [profileModalMode, setProfileModalMode] = useState<"edit" | "add">(
     "edit",
   );
+  // Prefill set by the openOauthServerConfig agent command. Human-opened
+  // modals clear it first so a stale agent seed never bleeds into them; it is
+  // also cleared whenever the modal closes.
+  const [agentSeed, setAgentSeed] = useState<OAuthProfileAgentSeed | null>(
+    null,
+  );
   const openProfileModal = useCallback((mode: "edit" | "add") => {
+    setAgentSeed(null);
     setProfileModalMode(mode);
     setIsProfileModalOpen(true);
+  }, []);
+  const handleProfileModalOpenChange = useCallback((open: boolean) => {
+    setIsProfileModalOpen(open);
+    if (!open) setAgentSeed(null);
   }, []);
 
   // Open the modal when the shell bumps the signal (header "Add Server"). Skip
@@ -191,13 +241,15 @@ export const OAuthFlowTab = ({
     // by the earlier empty state.
     if (!areServersHydrated) return;
     if (hasHeaderServers) {
-      setIsProfileModalOpen(false);
+      // Don't force-close a modal the agent just opened with a pending
+      // prefill (servers can hydrate right after the command ran).
+      if (!agentSeed) setIsProfileModalOpen(false);
       return;
     }
     if (httpServerCount === 0) {
       setIsProfileModalOpen(true);
     }
-  }, [areServersHydrated, hasHeaderServers, httpServerCount]);
+  }, [areServersHydrated, hasHeaderServers, httpServerCount, agentSeed]);
 
   const profile = useMemo(
     () => deriveOAuthProfileFromServer(activeServer),
@@ -213,10 +265,20 @@ export const OAuthFlowTab = ({
   const protocolVersion = profile.protocolVersion;
   const registrationStrategy = profile.registrationStrategy;
 
+  // Synced SYNCHRONOUSLY by every writer below (not only via this effect):
+  // the state machine's getState, the agent advance handler, and the surface
+  // snapshot all read the ref right after an awaited step, where an
+  // effect-only sync would still be one commit stale. Mirrors XAAFlowTab's
+  // applyFlowState/updateFlowState. The effect stays as belt-and-braces.
   const oauthFlowStateRef = useRef(oauthFlowState);
   useEffect(() => {
     oauthFlowStateRef.current = oauthFlowState;
   }, [oauthFlowState]);
+
+  const applyOAuthFlowState = useCallback((next: OAuthFlowState) => {
+    oauthFlowStateRef.current = next;
+    setOAuthFlowState(next);
+  }, []);
 
   useEffect(() => {
     if (
@@ -243,6 +305,7 @@ export const OAuthFlowTab = ({
 
   const updateOAuthFlowState = useCallback(
     (updates: Partial<OAuthFlowState>) => {
+      oauthFlowStateRef.current = { ...oauthFlowStateRef.current, ...updates };
       setOAuthFlowState((prev) => ({ ...prev, ...updates }));
     },
     [],
@@ -256,7 +319,7 @@ export const OAuthFlowTab = ({
   useEffect(() => {
     if (prevServerNameRef.current !== selectedServerName) {
       prevServerNameRef.current = selectedServerName;
-      setOAuthFlowState({
+      applyOAuthFlowState({
         ...EMPTY_OAUTH_FLOW_STATE,
         serverUrl: profile.serverUrl || undefined,
       });
@@ -266,12 +329,12 @@ export const OAuthFlowTab = ({
         exchangeTimeoutRef.current = null;
       }
     }
-  }, [selectedServerName, profile.serverUrl]);
+  }, [selectedServerName, profile.serverUrl, applyOAuthFlowState]);
 
   const resetOAuthFlow = useCallback(
     (serverUrlOverride?: string) => {
       const nextServerUrl = serverUrlOverride ?? profile.serverUrl;
-      setOAuthFlowState({
+      applyOAuthFlowState({
         ...EMPTY_OAUTH_FLOW_STATE,
         serverUrl: nextServerUrl || undefined,
       });
@@ -281,7 +344,7 @@ export const OAuthFlowTab = ({
         exchangeTimeoutRef.current = null;
       }
     },
-    [profile.serverUrl],
+    [profile.serverUrl, applyOAuthFlowState],
   );
 
   const clearInfoLogs = () => {
@@ -386,6 +449,162 @@ export const OAuthFlowTab = ({
     oauthFlowState.currentStep === "complete" &&
     oauthFlowState.accessToken &&
     activeServer;
+
+  // Memoized: the modal's reseed-on-open effect depends on this array (via
+  // generateDefaultName), so a fresh Object.keys() per render re-seeds the
+  // open modal on any parent re-render and wipes typed values.
+  const existingServerNames = useMemo(
+    () => Object.keys(serverConfigs),
+    [serverConfigs],
+  );
+
+  useSurfaceAgentBridge({
+    surfaceId: "oauth-flow",
+    handlers: {
+      openOauthServerConfig: (command: InspectorCommand) => {
+        const { payload } = command as OpenOauthServerConfigInspectorCommand;
+        const requestedName = payload.serverName?.trim() || undefined;
+        const requestedUrl = payload.serverUrl?.trim() || undefined;
+        let registrationStrategy;
+        if (payload.registrationMode !== undefined) {
+          registrationStrategy = normalizeOAuthRegistrationStrategy(
+            payload.registrationMode,
+          );
+          if (!registrationStrategy) {
+            throw createInspectorCommandClientError(
+              "invalid_request",
+              `Unknown registration mode "${String(payload.registrationMode)}" — use preregistered, dcr, or cimd.`,
+            );
+          }
+        }
+        const plan = planAuthConfigModal({
+          requestedServerName: requestedName,
+          selectedServerName: activeServer?.name ?? null,
+          existingServerNames,
+        });
+        if ("reject" in plan) {
+          throw createInspectorCommandClientError("invalid_request", plan.reject);
+        }
+        // Editing the selected server: a seeded registration mode must be one
+        // its configured protocol version supports (e.g. 2025-03-26 has no
+        // CIMD) — reject naming the supported set instead of letting the form
+        // show an impossible value.
+        if (plan.mode === "edit" && registrationStrategy && hasProfile) {
+          const supported = getSupportedRegistrationStrategies(protocolVersion);
+          if (!supported.includes(registrationStrategy)) {
+            throw createInspectorCommandClientError(
+              "invalid_request",
+              `Registration mode "${registrationStrategy}" is not supported by protocol ${protocolVersion}. Supported: ${supported.join(", ")}.`,
+            );
+          }
+        }
+        setAgentSeed({
+          ...(requestedName ? { serverName: requestedName } : {}),
+          ...(requestedUrl ? { serverUrl: requestedUrl } : {}),
+          ...(registrationStrategy ? { registrationStrategy } : {}),
+        });
+        setProfileModalMode(plan.mode);
+        setIsProfileModalOpen(true);
+        return {
+          status: "form_opened",
+          mode: plan.mode,
+          note: "The Configure-Server modal is open for the user to review, complete (credentials are typed by the human), and save.",
+        };
+      },
+      advanceOauthFlow: async () => {
+        if (!hasProfile || !oauthStateMachine) {
+          throw createInspectorCommandClientError(
+            "invalid_request",
+            "No OAuth target is configured — open one with ui_open_oauth_server_config first.",
+          );
+        }
+        const before = oauthFlowStateRef.current;
+        if (before.isInitiatingAuth) {
+          throw createInspectorCommandClientError(
+            "execution_failed",
+            "A protocol step is already in flight — check ui_snapshot_app and retry once it settles.",
+          );
+        }
+        if (before.currentStep === "complete") {
+          throw createInspectorCommandClientError(
+            "invalid_request",
+            "The flow is already complete — use ui_reset_oauth_flow to run it again.",
+          );
+        }
+        const previousStep = before.currentStep;
+        // Mirror handleAdvance exactly, including its order at the PKCE step:
+        // advance FIRST (that generates the authorizationUrl the auth modal
+        // needs to render), then hand off to the human popup.
+        if (
+          previousStep === "authorization_request" ||
+          previousStep === "generate_pkce_parameters"
+        ) {
+          if (previousStep === "generate_pkce_parameters") {
+            await proceedToNextStep();
+          }
+          const after = oauthFlowStateRef.current;
+          if (!after.authorizationUrl || after.error) {
+            return buildAdvanceResult(previousStep, after);
+          }
+          setIsAuthModalOpen(true);
+          return {
+            status: "authorization_modal_opened",
+            currentStep: after.currentStep,
+            note: "A human must complete sign-in in the authorization popup — the agent cannot and must not do this. If no popup appeared, ask the user to check their popup blocker. The flow advances automatically after the callback; observe with ui_snapshot_app instead of calling this again.",
+          };
+        }
+        // Known race, accepted: the 500ms post-callback exchange timer can
+        // auto-advance concurrently — identical exposure to the human button.
+        await proceedToNextStep();
+        return buildAdvanceResult(previousStep, oauthFlowStateRef.current);
+      },
+      resetOauthFlow: () => {
+        if (!hasProfile) {
+          throw createInspectorCommandClientError(
+            "invalid_request",
+            "No OAuth target is configured — nothing to reset.",
+          );
+        }
+        if (oauthFlowStateRef.current.isInitiatingAuth) {
+          throw createInspectorCommandClientError(
+            "execution_failed",
+            "A protocol step is in flight — wait for it to settle before resetting.",
+          );
+        }
+        resetOAuthFlow();
+        return { status: "reset", currentStep: "idle" };
+      },
+    },
+    snapshot: () => {
+      const view = oauthFlowStateRef.current;
+      return buildOAuthFlowSnapshot({
+        hasProfile,
+        serverName: hasProfile ? serverIdentifier : undefined,
+        protocolVersion: hasProfile ? protocolVersion : undefined,
+        registrationStrategy: hasProfile
+          ? describeRegistrationStrategy(registrationStrategy)
+          : undefined,
+        scopes: hasProfile ? profile.scopes.trim() || undefined : undefined,
+        clientId: hasProfile ? profile.clientId.trim() || undefined : undefined,
+        customHeaderCount: profile.customHeaders.filter((h) => h.key.trim())
+          .length,
+        hasAccessToken: Boolean(view.accessToken),
+        hasRefreshToken: Boolean(view.refreshToken),
+        serverConnected: isServerConnected,
+        readyToApplyTokens: Boolean(canApplyTokens),
+        steps: hasProfile
+          ? toSafeSequenceSteps(
+              buildOAuthSequenceActions({
+                protocolVersion,
+                registrationStrategy,
+                flowState: view,
+              }),
+            )
+          : [],
+        view,
+      });
+    },
+  });
 
   // Extract tokens from flow state
   const extractTokensFromFlowState = useCallback(
@@ -685,9 +904,10 @@ export const OAuthFlowTab = ({
 
       <OAuthProfileModal
         open={isProfileModalOpen}
-        onOpenChange={setIsProfileModalOpen}
+        onOpenChange={handleProfileModalOpenChange}
         server={profileModalMode === "add" ? undefined : activeServer}
-        existingServerNames={Object.keys(serverConfigs)}
+        existingServerNames={existingServerNames}
+        agentSeed={agentSeed}
         onSave={async ({ formData, profile: savedProfile }) => {
           // Await and check the result: a failed save must not close the modal,
           // reset the flow, or move the selection onto a server that was never

--- a/mcpjam-inspector/client/src/components/__tests__/OAuthFlowTab.agent.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/OAuthFlowTab.agent.test.tsx
@@ -1,0 +1,411 @@
+/**
+ * OAuthFlowTab agent bridge handlers, dispatched through the REAL command bus
+ * against a mounted tab (fake state machine, stubbed children).
+ *
+ * Findings this pins:
+ * - advance replicates the Continue button's gates: no profile →
+ *   invalid_request; step in flight → execution_failed (retryable); complete →
+ *   invalid_request;
+ * - at the PKCE step it advances FIRST (generating authorizationUrl), then
+ *   opens the human auth modal and reports authorization_modal_opened — the
+ *   machine is NOT advanced past the authorization step;
+ * - a normal advance reports the post-step state read through the
+ *   synchronously-synced ref (previousStep/currentStep/httpStatus), with only
+ *   an allowlisted OAuth error code, never raw error text;
+ * - openOauthServerConfig prefills via agentSeed + mode and rejects a name
+ *   that matches a different existing server;
+ * - the surface snapshot never leaks token material and strips sequence steps
+ *   to id/label.
+ */
+import { act, render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { executeInspectorCommand } from "@/lib/inspector-command-handlers";
+import { readSurfaceSnapshot } from "@/lib/webmcp/surface-snapshot-registry";
+import type {
+  InspectorCommand,
+  InspectorCommandResponse,
+} from "@/shared/inspector-command.js";
+import type { ServerWithName } from "@/hooks/use-app-state";
+import type { OAuthFlowState } from "@mcpjam/sdk/browser";
+
+vi.mock("@/lib/analytics", () => ({ track: vi.fn() }));
+
+const STEP_ORDER_FOR_TEST = [
+  "idle",
+  "request_without_token",
+  "generate_pkce_parameters",
+  "authorization_request",
+  "token_request",
+  "complete",
+];
+
+vi.mock("@mcpjam/sdk/browser", () => ({
+  EMPTY_OAUTH_FLOW_STATE: {
+    currentStep: "idle",
+    isInitiatingAuth: false,
+    httpHistory: [],
+    infoLogs: [],
+  },
+  getStepIndex: (step: string) => {
+    const index = STEP_ORDER_FOR_TEST.indexOf(step);
+    return index === -1 ? Number.MAX_SAFE_INTEGER : index;
+  },
+  getSupportedRegistrationStrategies: (version: string) =>
+    version === "2025-03-26"
+      ? ["dcr", "preregistered"]
+      : ["cimd", "dcr", "preregistered"],
+  buildOAuthSequenceActions: () => [
+    {
+      id: "request_without_token",
+      label: "MCP request without token",
+      description: "Contains SENTINEL_DIAGRAM_DETAIL",
+      details: [{ label: "url", value: "SENTINEL_DIAGRAM_DETAIL" }],
+    },
+  ],
+}));
+
+// Fake machine: proceedToNextStep applies whatever the test scripted through
+// the component's own updateState (the synced-ref write path under test).
+const machineCtl = vi.hoisted(() => ({
+  onAdvance: null as
+    | ((update: (u: Partial<OAuthFlowState>) => void) => void)
+    | null,
+  updateState: null as ((u: Partial<OAuthFlowState>) => void) | null,
+}));
+
+vi.mock("@/lib/oauth/debug-state-machine-adapter", () => ({
+  createInspectorOAuthStateMachine: (opts: {
+    updateState: (u: Partial<OAuthFlowState>) => void;
+  }) => {
+    machineCtl.updateState = opts.updateState;
+    return {
+      proceedToNextStep: async () => {
+        machineCtl.onAdvance?.(opts.updateState);
+      },
+    };
+  },
+}));
+
+vi.mock("@/components/oauth/OAuthSequenceDiagram", () => ({
+  OAuthSequenceDiagram: () => <div data-testid="oauth-sequence-diagram" />,
+}));
+
+const captureAuthModalProps = vi.hoisted(() => vi.fn());
+vi.mock("@/components/oauth/OAuthAuthorizationModal", () => ({
+  OAuthAuthorizationModal: (props: unknown) => {
+    captureAuthModalProps(props);
+    return null;
+  },
+}));
+
+const captureProfileModalProps = vi.hoisted(() => vi.fn());
+vi.mock("../oauth/OAuthProfileModal", () => ({
+  OAuthProfileModal: (props: unknown) => {
+    captureProfileModalProps(props);
+    return null;
+  },
+}));
+
+vi.mock("../oauth/OAuthFlowLogger", () => ({
+  OAuthFlowLogger: () => <div data-testid="oauth-flow-logger" />,
+}));
+vi.mock("../oauth/RefreshTokensConfirmModal", () => ({
+  RefreshTokensConfirmModal: () => null,
+}));
+vi.mock("../ui/resizable", () => ({
+  ResizablePanelGroup: ({ children }: { children?: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ResizablePanel: ({ children }: { children?: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ResizableHandle: () => <div />,
+}));
+
+import { OAuthFlowTab } from "@/components/OAuthFlowTab";
+
+const httpServer = (name: string, protocolVersion = "2025-11-25") =>
+  ({
+    name,
+    connectionStatus: "disconnected",
+    enabled: true,
+    retryCount: 0,
+    useOAuth: true,
+    lastConnectionTime: new Date("2024-01-01"),
+    config: { url: "https://mcp.example.com/mcp" },
+    oauthFlowProfile: {
+      serverUrl: "https://mcp.example.com/mcp",
+      clientId: "",
+      clientSecret: "",
+      scopes: "",
+      customHeaders: [],
+      protocolVersion,
+      registrationStrategy: "dcr",
+    } as ServerWithName["oauthFlowProfile"],
+  }) as ServerWithName;
+
+let commandSeq = 0;
+async function dispatch(command: Omit<InspectorCommand, "id">) {
+  commandSeq += 1;
+  let response!: InspectorCommandResponse;
+  await act(async () => {
+    response = await executeInspectorCommand({
+      ...command,
+      id: `oauth-bridge-${commandSeq}`,
+    } as InspectorCommand);
+  });
+  return response;
+}
+
+function renderTab(overrides?: {
+  serverConfigs?: Record<string, ServerWithName>;
+  selectedServerName?: string;
+}) {
+  const serverConfigs = overrides?.serverConfigs ?? {
+    linear: httpServer("linear"),
+    other: httpServer("other"),
+  };
+  return render(
+    <OAuthFlowTab
+      serverConfigs={serverConfigs}
+      selectedServerName={overrides?.selectedServerName ?? "linear"}
+      hasHeaderServers
+      areServersHydrated
+      onSelectServer={vi.fn()}
+    />,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  machineCtl.onAdvance = null;
+  machineCtl.updateState = null;
+});
+
+describe("OAuthFlowTab — advanceOauthFlow", () => {
+  it("rejects when no target is configured (invalid_request, machine untouched)", async () => {
+    renderTab({ serverConfigs: {}, selectedServerName: "none" });
+    const response = await dispatch({ type: "advanceOauthFlow", payload: {} });
+    expect(response).toMatchObject({
+      status: "error",
+      error: { code: "invalid_request" },
+    });
+  });
+
+  it("advances one step and reports the post-step state from the synced ref", async () => {
+    renderTab();
+    machineCtl.onAdvance = (update) =>
+      update({
+        currentStep: "request_without_token",
+        lastResponse: {
+          status: 401,
+          statusText: "Unauthorized",
+          headers: {},
+          body: {},
+        },
+      });
+    const response = await dispatch({ type: "advanceOauthFlow", payload: {} });
+    expect(response).toMatchObject({
+      status: "success",
+      result: {
+        status: "advanced",
+        previousStep: "idle",
+        currentStep: "request_without_token",
+        ok: true,
+        httpStatus: 401,
+      },
+    });
+  });
+
+  it("reduces a step error to an allowlisted code, never the raw text", async () => {
+    renderTab();
+    machineCtl.onAdvance = (update) =>
+      update({
+        currentStep: "request_without_token",
+        error: "AS exploded: token=SENTINEL_LEAK invalid_client",
+      });
+    const response = await dispatch({ type: "advanceOauthFlow", payload: {} });
+    expect(response.status).toBe("success");
+    const result = (response as { result: Record<string, unknown> }).result;
+    expect(result).toMatchObject({ ok: false, oauthErrorCode: "invalid_client" });
+    expect(JSON.stringify(result)).not.toContain("SENTINEL_LEAK");
+  });
+
+  it("at the PKCE step: advances first, then opens the human auth modal without passing authorization", async () => {
+    renderTab();
+    // Step 1: land on generate_pkce_parameters.
+    machineCtl.onAdvance = (update) =>
+      update({ currentStep: "generate_pkce_parameters" });
+    await dispatch({ type: "advanceOauthFlow", payload: {} });
+
+    // Step 2: the PKCE advance produces the authorization URL; the handler
+    // must then hand off to the human, not keep advancing.
+    let advances = 0;
+    machineCtl.onAdvance = (update) => {
+      advances += 1;
+      update({
+        currentStep: "authorization_request",
+        authorizationUrl: "https://auth.example.com/authorize?x=1",
+      });
+    };
+    const response = await dispatch({ type: "advanceOauthFlow", payload: {} });
+    expect(response).toMatchObject({
+      status: "success",
+      result: {
+        status: "authorization_modal_opened",
+        currentStep: "authorization_request",
+      },
+    });
+    expect(advances).toBe(1);
+    await waitFor(() => {
+      expect(captureAuthModalProps).toHaveBeenLastCalledWith(
+        expect.objectContaining({ open: true }),
+      );
+    });
+  });
+
+  it("rejects while a step is in flight (execution_failed) and after completion (invalid_request)", async () => {
+    renderTab();
+    machineCtl.onAdvance = (update) => update({ isInitiatingAuth: true });
+    await dispatch({ type: "advanceOauthFlow", payload: {} });
+    const busy = await dispatch({ type: "advanceOauthFlow", payload: {} });
+    expect(busy).toMatchObject({
+      status: "error",
+      error: { code: "execution_failed" },
+    });
+
+    machineCtl.updateState?.({ isInitiatingAuth: false, currentStep: "complete" });
+    const done = await dispatch({ type: "advanceOauthFlow", payload: {} });
+    expect(done).toMatchObject({
+      status: "error",
+      error: { code: "invalid_request" },
+    });
+  });
+});
+
+describe("OAuthFlowTab — resetOauthFlow", () => {
+  it("resets the flow back to idle", async () => {
+    renderTab();
+    machineCtl.onAdvance = (update) =>
+      update({ currentStep: "token_request", accessToken: "SENTINEL_TOKEN" });
+    await dispatch({ type: "advanceOauthFlow", payload: {} });
+
+    const response = await dispatch({ type: "resetOauthFlow", payload: {} });
+    expect(response).toMatchObject({
+      status: "success",
+      result: { status: "reset", currentStep: "idle" },
+    });
+    const snapshot = await readSurfaceSnapshot("oauth-flow");
+    expect(JSON.stringify(snapshot)).toContain('"currentStep":"idle"');
+  });
+});
+
+describe("OAuthFlowTab — openOauthServerConfig", () => {
+  it("opens the modal in edit mode with the agent seed for the selected server", async () => {
+    renderTab();
+    const response = await dispatch({
+      type: "openOauthServerConfig",
+      payload: { serverUrl: "https://new.example.com/mcp", registrationMode: "dcr" },
+    });
+    expect(response).toMatchObject({
+      status: "success",
+      result: { status: "form_opened", mode: "edit" },
+    });
+    await waitFor(() => {
+      expect(captureProfileModalProps).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          open: true,
+          agentSeed: {
+            serverUrl: "https://new.example.com/mcp",
+            registrationStrategy: "dcr",
+          },
+        }),
+      );
+    });
+  });
+
+  it("opens add mode for a new name and rejects a different existing server's name", async () => {
+    renderTab();
+    const added = await dispatch({
+      type: "openOauthServerConfig",
+      payload: { serverName: "brand-new" },
+    });
+    expect(added).toMatchObject({
+      status: "success",
+      result: { status: "form_opened", mode: "add" },
+    });
+
+    const collision = await dispatch({
+      type: "openOauthServerConfig",
+      payload: { serverName: "other" },
+    });
+    expect(collision).toMatchObject({
+      status: "error",
+      error: { code: "invalid_request" },
+    });
+    expect(
+      (collision as { error: { message: string } }).error.message,
+    ).toContain("ui_select_server");
+  });
+
+  it("rejects a registration mode the target's protocol version does not support", async () => {
+    renderTab({
+      serverConfigs: { legacy: httpServer("legacy", "2025-03-26") },
+      selectedServerName: "legacy",
+    });
+    const response = await dispatch({
+      type: "openOauthServerConfig",
+      payload: { registrationMode: "cimd" },
+    });
+    expect(response).toMatchObject({
+      status: "error",
+      error: { code: "invalid_request" },
+    });
+    expect((response as { error: { message: string } }).error.message).toContain(
+      "2025-03-26",
+    );
+  });
+});
+
+describe("OAuthFlowTab — surface snapshot", () => {
+  it("never leaks token material and strips sequence steps to id/label", async () => {
+    renderTab();
+    machineCtl.onAdvance = (update) =>
+      update({
+        currentStep: "token_request",
+        accessToken: "SENTINEL_ACCESS_TOKEN",
+        refreshToken: "SENTINEL_REFRESH_TOKEN",
+        codeVerifier: "SENTINEL_VERIFIER",
+        authorizationCode: "SENTINEL_AUTH_CODE",
+        state: "SENTINEL_CSRF",
+        error: "boom SENTINEL_RAW_ERROR invalid_grant",
+        lastResponse: {
+          status: 400,
+          statusText: "Bad Request",
+          headers: { "set-cookie": "SENTINEL_COOKIE" },
+          body: { access_token: "SENTINEL_ACCESS_TOKEN" },
+        },
+      });
+    await dispatch({ type: "advanceOauthFlow", payload: {} });
+
+    const snapshot = await readSurfaceSnapshot("oauth-flow");
+    const serialized = JSON.stringify(snapshot);
+    for (const sentinel of [
+      "SENTINEL_ACCESS_TOKEN",
+      "SENTINEL_REFRESH_TOKEN",
+      "SENTINEL_VERIFIER",
+      "SENTINEL_AUTH_CODE",
+      "SENTINEL_CSRF",
+      "SENTINEL_RAW_ERROR",
+      "SENTINEL_COOKIE",
+      "SENTINEL_DIAGRAM_DETAIL",
+    ]) {
+      expect(serialized).not.toContain(sentinel);
+    }
+    expect(serialized).toContain('"hasAccessToken":true');
+    expect(serialized).toContain('"oauthErrorCode":"invalid_grant"');
+    expect(serialized).toContain(
+      '"steps":[{"id":"request_without_token","label":"MCP request without token"}]',
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/components/oauth/OAuthProfileModal.tsx
+++ b/mcpjam-inspector/client/src/components/oauth/OAuthProfileModal.tsx
@@ -36,11 +36,23 @@ import {
   AccordionTrigger,
 } from "@mcpjam/design-system/accordion";
 
+/**
+ * Prefill an agent command may seed the form with when it opens. Deliberately
+ * cannot carry credentials — there are no clientId/clientSecret fields here;
+ * the human types those. Overlays the server-derived seed on open.
+ */
+export interface OAuthProfileAgentSeed {
+  serverName?: string;
+  serverUrl?: string;
+  registrationStrategy?: OAuthRegistrationStrategy;
+}
+
 interface OAuthProfileModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   server?: ServerWithName;
   existingServerNames: string[];
+  agentSeed?: OAuthProfileAgentSeed | null;
   onSave: (payload: {
     formData: ServerFormData;
     profile: OAuthTestProfile;
@@ -77,6 +89,7 @@ export function OAuthProfileModal({
   onOpenChange,
   server,
   existingServerNames,
+  agentSeed,
   onSave,
 }: OAuthProfileModalProps) {
   const derivedProfile = useMemo(
@@ -104,8 +117,17 @@ export function OAuthProfileModal({
 
   useEffect(() => {
     if (open) {
-      setServerName(generateDefaultName());
-      setDraft(derivedProfile);
+      // The agent seed overlays the server-derived values; anything it omits
+      // keeps the derived default. It never carries credentials (see the
+      // OAuthProfileAgentSeed type).
+      setServerName(agentSeed?.serverName ?? generateDefaultName());
+      setDraft({
+        ...derivedProfile,
+        ...(agentSeed?.serverUrl ? { serverUrl: agentSeed.serverUrl } : {}),
+        ...(agentSeed?.registrationStrategy
+          ? { registrationStrategy: agentSeed.registrationStrategy }
+          : {}),
+      });
       setHeaderRows(
         derivedProfile.customHeaders.length
           ? derivedProfile.customHeaders.map((header) =>
@@ -115,7 +137,7 @@ export function OAuthProfileModal({
       );
       setError(null);
     }
-  }, [open, derivedProfile, generateDefaultName]);
+  }, [open, derivedProfile, generateDefaultName, agentSeed]);
 
   const normalizedHeaders = useMemo(
     () =>

--- a/mcpjam-inspector/client/src/components/oauth/__tests__/OAuthProfileModal.test.tsx
+++ b/mcpjam-inspector/client/src/components/oauth/__tests__/OAuthProfileModal.test.tsx
@@ -115,3 +115,71 @@ describe("OAuthProfileModal", () => {
     releaseSave?.();
   });
 });
+
+describe("OAuthProfileModal — agentSeed", () => {
+  it("overlays name, URL, and registration mode on open", () => {
+    renderModal({
+      agentSeed: {
+        serverName: "agent-target",
+        serverUrl: "https://agent.example.com/mcp",
+        registrationStrategy: "preregistered",
+      },
+    });
+
+    expect(screen.getByLabelText(/Server Name/)).toHaveValue("agent-target");
+    expect(screen.getByLabelText(/Server URL/)).toHaveValue(
+      "https://agent.example.com/mcp",
+    );
+    // The Select renders the value text in the trigger and its option list.
+    expect(screen.getAllByText("Pre-registered").length).toBeGreaterThan(0);
+  });
+
+  it("keeps derived defaults for anything the seed omits", () => {
+    renderModal({
+      agentSeed: { serverUrl: "https://agent.example.com/mcp" },
+    });
+
+    // Default name (no server prop, no seeded name)…
+    expect(screen.getByLabelText(/Server Name/)).toHaveValue(
+      "oauth-flow-target",
+    );
+    // …and the fresh-profile default registration strategy.
+    expect(screen.getAllByText("Dynamic (DCR)").length).toBeGreaterThan(0);
+  });
+
+  it("does not retain a seed across a reopen without one", () => {
+    const { rerender } = render(
+      <OAuthProfileModal
+        open
+        onOpenChange={vi.fn()}
+        existingServerNames={[]}
+        onSave={vi.fn()}
+        agentSeed={{ serverName: "agent-target" }}
+      />,
+    );
+    expect(screen.getByLabelText(/Server Name/)).toHaveValue("agent-target");
+
+    // Close, then reopen WITHOUT a seed (the tab clears it on close).
+    rerender(
+      <OAuthProfileModal
+        open={false}
+        onOpenChange={vi.fn()}
+        existingServerNames={[]}
+        onSave={vi.fn()}
+        agentSeed={null}
+      />,
+    );
+    rerender(
+      <OAuthProfileModal
+        open
+        onOpenChange={vi.fn()}
+        existingServerNames={[]}
+        onSave={vi.fn()}
+        agentSeed={null}
+      />,
+    );
+    expect(screen.getByLabelText(/Server Name/)).toHaveValue(
+      "oauth-flow-target",
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -30,6 +30,7 @@ import {
 import type { ServerWithName } from "@/hooks/use-app-state";
 import type { ServerFormData } from "@/shared/types.js";
 import { useXaaRunSettings } from "@/hooks/useXaaRunSettings";
+import { extractOauthErrorCode } from "@/lib/webmcp/oauth-error-code";
 import { useXaaPeople } from "@/hooks/useXaaPeople";
 import {
   useXaaTestTarget,
@@ -168,44 +169,6 @@ function computeTargetFingerprint(
     // at the AS is a different question.
     registrationStrategy,
   ].join("|");
-}
-
-/** RFC 6749/8693/8707 error codes we recognize. Only an allowlisted code is
- * ever stored/rendered — never a raw error string, which can embed tokens. */
-const OAUTH_ERROR_CODES = [
-  "invalid_grant",
-  "access_denied",
-  "invalid_client",
-  "invalid_request",
-  "unauthorized_client",
-  "unsupported_grant_type",
-  "invalid_scope",
-  "invalid_target",
-] as const;
-
-function extractOauthErrorCode(
-  error: string | undefined,
-  lastResponse: XAAFlowState["lastResponse"]
-): string | undefined {
-  // Prefer the structured token response (`{error}` or the proxy envelope's
-  // `{body: {error}}`) over substring-matching the message.
-  const body = lastResponse?.body as Record<string, unknown> | undefined;
-  const candidates = [
-    body?.error,
-    (body?.body as Record<string, unknown> | undefined)?.error,
-  ];
-  for (const candidate of candidates) {
-    if (
-      typeof candidate === "string" &&
-      (OAUTH_ERROR_CODES as readonly string[]).includes(candidate)
-    ) {
-      return candidate;
-    }
-  }
-  if (typeof error === "string") {
-    return OAUTH_ERROR_CODES.find((code) => error.includes(code));
-  }
-  return undefined;
 }
 
 function parseScopeSet(value: string | undefined): Set<string> {

--- a/mcpjam-inspector/client/src/lib/__tests__/agent-bridge-modules.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/agent-bridge-modules.ts
@@ -67,4 +67,8 @@ export const BRIDGE_MODULES: Record<string, string> = {
   "ci-evals": "client/src/components/CiEvalsTab.tsx",
   // TasksTab owns the selected server's long-running MCP task list.
   tasks: "client/src/components/TasksTab.tsx",
+  // OAuthFlowTab owns the debugger's flow state, the state machine, and the
+  // Configure-Server modal the prefill command opens. Not a shared hook, so
+  // the "oauth-flow" group can't be mis-scoped.
+  "oauth-flow": "client/src/components/OAuthFlowTab.tsx",
 };

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/auth-config-command.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/auth-config-command.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { planAuthConfigModal } from "../auth-config-command";
+
+describe("planAuthConfigModal", () => {
+  const existing = ["linear", "asana"];
+
+  it("no requested name + a selected server → edit", () => {
+    expect(
+      planAuthConfigModal({
+        selectedServerName: "linear",
+        existingServerNames: existing,
+      }),
+    ).toEqual({ mode: "edit" });
+  });
+
+  it("no requested name + no selection → add (blank form)", () => {
+    expect(
+      planAuthConfigModal({
+        selectedServerName: null,
+        existingServerNames: existing,
+      }),
+    ).toEqual({ mode: "add" });
+  });
+
+  it("requested name equals the selected server → edit", () => {
+    expect(
+      planAuthConfigModal({
+        requestedServerName: "linear",
+        selectedServerName: "linear",
+        existingServerNames: existing,
+      }),
+    ).toEqual({ mode: "edit" });
+  });
+
+  it("requested name matches a DIFFERENT existing server → reject, never a silent switch", () => {
+    const plan = planAuthConfigModal({
+      requestedServerName: "asana",
+      selectedServerName: "linear",
+      existingServerNames: existing,
+    });
+    expect("reject" in plan && plan.reject).toMatch(/ui_select_server/);
+  });
+
+  it("requested new name → add", () => {
+    expect(
+      planAuthConfigModal({
+        requestedServerName: "new-target",
+        selectedServerName: "linear",
+        existingServerNames: existing,
+      }),
+    ).toEqual({ mode: "add" });
+
+    expect(
+      planAuthConfigModal({
+        requestedServerName: "new-target",
+        selectedServerName: null,
+        existingServerNames: existing,
+      }),
+    ).toEqual({ mode: "add" });
+  });
+
+  it("exact match only — near-misses are new names, not fuzzy edits", () => {
+    expect(
+      planAuthConfigModal({
+        requestedServerName: "Linear",
+        selectedServerName: "linear",
+        existingServerNames: existing,
+      }),
+    ).toEqual({ mode: "add" });
+  });
+});

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/oauth-flow-snapshot.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/oauth-flow-snapshot.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Denylist contract for the oauth-flow snapshot: feed the builder a maximally
+ * poisoned flow state (sentinel token material in every tainted field) and
+ * assert none of it — value OR key — survives into the serialized snapshot.
+ * The chat transcript is downstream of this function; leakage here is a
+ * secret-exfiltration bug, not a formatting bug.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  buildOAuthFlowSnapshot,
+  isAwaitingHumanAuthorization,
+  toSafeSequenceSteps,
+  type OAuthFlowSnapshotInput,
+} from "../oauth-flow-snapshot";
+
+const SENTINELS = [
+  "SENTINEL_ACCESS_TOKEN",
+  "SENTINEL_REFRESH_TOKEN",
+  "SENTINEL_CLIENT_SECRET",
+  "SENTINEL_VERIFIER",
+  "SENTINEL_CHALLENGE",
+  "SENTINEL_AUTH_CODE",
+  "SENTINEL_CSRF_STATE",
+  "SENTINEL_AUTHZ_URL",
+  "SENTINEL_WWW_AUTH",
+  "SENTINEL_HISTORY_BODY",
+  "SENTINEL_LOG_DATA",
+  "SENTINEL_REQ_HEADER",
+  "SENTINEL_LEAK",
+];
+
+const FORBIDDEN_KEYS = [
+  "accessToken",
+  "refreshToken",
+  "clientSecret",
+  "codeVerifier",
+  "codeChallenge",
+  "authorizationCode",
+  "authorizationUrl",
+  "wwwAuthenticateHeader",
+  "httpHistory",
+  "lastRequest",
+  "lastResponse",
+  "headers",
+  "body",
+];
+// (counts.infoLogs is deliberately fine — it's counts by level, not entries.)
+
+/**
+ * The REAL OAuthFlowState shape, poisoned. The builder's view type omits the
+ * sensitive fields, but the runtime object a component passes is the full
+ * state — exactly what this test feeds in.
+ */
+function poisonedInput(): OAuthFlowSnapshotInput {
+  const poisonedState = {
+    currentStep: "token_request" as const,
+    isInitiatingAuth: false,
+    serverUrl: "https://mcp.example.com/mcp",
+    authorizationServerUrl: "https://auth.example.com",
+    accessToken: "SENTINEL_ACCESS_TOKEN",
+    refreshToken: "SENTINEL_REFRESH_TOKEN",
+    clientSecret: "SENTINEL_CLIENT_SECRET",
+    codeVerifier: "SENTINEL_VERIFIER",
+    codeChallenge: "SENTINEL_CHALLENGE",
+    authorizationCode: "SENTINEL_AUTH_CODE",
+    state: "SENTINEL_CSRF_STATE",
+    authorizationUrl: "https://auth.example.com/authorize?SENTINEL_AUTHZ_URL",
+    wwwAuthenticateHeader: "Bearer SENTINEL_WWW_AUTH",
+    tokenType: "Bearer",
+    expiresIn: 3600,
+    error: "AS said: token=SENTINEL_LEAK invalid_client",
+    lastRequest: {
+      method: "POST",
+      url: "https://auth.example.com/token",
+      headers: { Authorization: "SENTINEL_REQ_HEADER" },
+      body: "code=SENTINEL_AUTH_CODE",
+    },
+    lastResponse: {
+      status: 401,
+      statusText: "Unauthorized",
+      headers: { "www-authenticate": "SENTINEL_WWW_AUTH" },
+      body: { error: "invalid_client", access_token: "SENTINEL_LEAK" },
+    },
+    httpHistory: [{ body: "SENTINEL_HISTORY_BODY" }],
+    infoLogs: [
+      { level: "info" as const, data: "SENTINEL_LOG_DATA" },
+      { level: "error" as const, data: "SENTINEL_LOG_DATA" },
+      { level: "warning" as const, data: "SENTINEL_LOG_DATA" },
+      { level: "warning" as const, data: "SENTINEL_LOG_DATA" },
+    ],
+  };
+  return {
+    hasProfile: true,
+    serverName: "example",
+    protocolVersion: "2025-11-25",
+    registrationStrategy: "Dynamic (DCR)",
+    scopes: "openid profile",
+    clientId: "public-client-id",
+    customHeaderCount: 2,
+    hasAccessToken: true,
+    hasRefreshToken: true,
+    serverConnected: false,
+    readyToApplyTokens: false,
+    steps: [
+      {
+        id: "token_request",
+        label: "Token request",
+        // A component bug that forgot toSafeSequenceSteps would pass these:
+        description: "POST with code SENTINEL_AUTH_CODE",
+        details: [{ label: "verifier", value: "SENTINEL_VERIFIER" }],
+      } as { id: string; label: string },
+    ],
+    view: poisonedState,
+  };
+}
+
+describe("buildOAuthFlowSnapshot", () => {
+  it("emits no sentinel value and no forbidden key", () => {
+    const serialized = JSON.stringify(buildOAuthFlowSnapshot(poisonedInput()));
+    for (const sentinel of SENTINELS) {
+      expect(serialized).not.toContain(sentinel);
+    }
+    for (const key of FORBIDDEN_KEYS) {
+      expect(serialized, key).not.toContain(`"${key}"`);
+    }
+  });
+
+  it("reduces the error to presence + allowlisted code, never the raw text", () => {
+    const snapshot = buildOAuthFlowSnapshot(poisonedInput());
+    expect(snapshot.error).toEqual({
+      present: true,
+      oauthErrorCode: "invalid_client",
+    });
+  });
+
+  it("keeps only id/label on steps, even when handed full diagram actions", () => {
+    const snapshot = buildOAuthFlowSnapshot(poisonedInput());
+    expect(snapshot.flow.steps).toEqual([
+      { id: "token_request", label: "Token request" },
+    ]);
+    for (const step of snapshot.flow.steps) {
+      expect(Object.keys(step).sort()).toEqual(["id", "label"]);
+    }
+  });
+
+  it("reduces lastResponse to status/statusText and history/logs to counts", () => {
+    const snapshot = buildOAuthFlowSnapshot(poisonedInput());
+    expect(snapshot.lastHttp).toEqual({ status: 401, statusText: "Unauthorized" });
+    expect(snapshot.counts).toEqual({
+      httpRequests: 1,
+      infoLogs: { info: 1, warning: 2, error: 1 },
+    });
+  });
+
+  it("reports token presence as booleans plus non-secret metadata", () => {
+    const snapshot = buildOAuthFlowSnapshot(poisonedInput());
+    expect(snapshot.tokens).toEqual({
+      hasAccessToken: true,
+      hasRefreshToken: true,
+      tokenType: "Bearer",
+      expiresInSeconds: 3600,
+    });
+  });
+
+  it("flags the human-authorization handoff steps", () => {
+    expect(isAwaitingHumanAuthorization("generate_pkce_parameters")).toBe(true);
+    expect(isAwaitingHumanAuthorization("authorization_request")).toBe(true);
+    expect(isAwaitingHumanAuthorization("token_request")).toBe(false);
+
+    const input = poisonedInput();
+    input.view = { ...input.view, currentStep: "authorization_request" };
+    expect(
+      buildOAuthFlowSnapshot(input).flow.awaitingHumanAuthorization,
+    ).toBe(true);
+  });
+
+  it("reports an unconfigured tab as configured:false with a null target", () => {
+    const input = poisonedInput();
+    input.hasProfile = false;
+    input.steps = [];
+    const snapshot = buildOAuthFlowSnapshot(input);
+    expect(snapshot.configured).toBe(false);
+    expect(snapshot.target).toBeNull();
+  });
+
+  it("maps known steps to their index and unknown diagram ids stay opaque", () => {
+    const snapshot = buildOAuthFlowSnapshot(poisonedInput());
+    expect(typeof snapshot.flow.stepIndex).toBe("number");
+    expect(snapshot.flow.stepIndex).not.toBeNull();
+  });
+});
+
+describe("toSafeSequenceSteps", () => {
+  it("drops every field except id and label", () => {
+    const stripped = toSafeSequenceSteps([
+      {
+        id: "browser_to_auth_server",
+        label: "Redirect to authorization server",
+        description: "Contains https://auth?code_challenge=SENTINEL",
+        details: [{ label: "url", value: "SENTINEL" }],
+      } as { id: string; label: string },
+    ]);
+    expect(stripped).toEqual([
+      {
+        id: "browser_to_auth_server",
+        label: "Redirect to authorization server",
+      },
+    ]);
+    expect(Object.keys(stripped[0])).toEqual(["id", "label"]);
+  });
+});

--- a/mcpjam-inspector/client/src/lib/webmcp/auth-config-command.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/auth-config-command.ts
@@ -1,0 +1,39 @@
+/**
+ * Shared edit-vs-add resolution for the auth debuggers' "open the
+ * Configure-Server modal" agent commands (oauth-flow today, xaa-flow next).
+ *
+ * The rule mirrors the registry/hosts groups' no-fuzzy-guess posture: a
+ * requested name either IS the selected server (edit), is brand new (add), or
+ * names a different existing server — which is rejected rather than silently
+ * switched to or overwritten. Pure so the truth table is testable without
+ * mounting a tab.
+ */
+
+export type AuthConfigModalPlan = { mode: "edit" | "add" } | { reject: string };
+
+export function planAuthConfigModal(input: {
+  /** Trimmed serverName from the command payload, if any. */
+  requestedServerName?: string;
+  /** The tab's selected HTTP server name, or null when none is eligible. */
+  selectedServerName: string | null;
+  existingServerNames: string[];
+}): AuthConfigModalPlan {
+  const { requestedServerName, selectedServerName, existingServerNames } =
+    input;
+
+  if (!requestedServerName) {
+    return { mode: selectedServerName ? "edit" : "add" };
+  }
+  if (requestedServerName === selectedServerName) {
+    return { mode: "edit" };
+  }
+  if (existingServerNames.includes(requestedServerName)) {
+    return {
+      reject:
+        `A server named "${requestedServerName}" already exists but is not the ` +
+        `selected one. Select it with ui_select_server first, or pass a new ` +
+        `name to create a new test target.`,
+    };
+  }
+  return { mode: "add" };
+}

--- a/mcpjam-inspector/client/src/lib/webmcp/groups/__tests__/oauth-flow.bridge.test.tsx
+++ b/mcpjam-inspector/client/src/lib/webmcp/groups/__tests__/oauth-flow.bridge.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * Bridge integration with the REAL oauth-flow group (no groups mock): mount
+ * registers the group surface-scoped, `waitForUiToolNames` bridges the
+ * same-turn discovery path, unmount removes everything.
+ */
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/webmcp/native-mirror", () => ({
+  mirrorUiToolToNative: vi.fn(() => null),
+}));
+
+import { useUiToolsRegistry } from "../../ui-tools-registry";
+import { waitForUiToolNames } from "../../ui-tools-readiness";
+import { useSurfaceAgentBridge } from "../../use-surface-agent-bridge";
+import {
+  __resetSurfaceSnapshotProvidersForTests,
+  hasSurfaceSnapshotProvider,
+} from "../../surface-snapshot-registry";
+import { listSurfaceGroupToolNames } from "../index";
+
+const OAUTH_FLOW_TOOL_NAMES = [
+  "ui_open_oauth_server_config",
+  "ui_advance_oauth_flow",
+  "ui_reset_oauth_flow",
+];
+
+describe("oauth-flow group through useSurfaceAgentBridge", () => {
+  beforeEach(() => {
+    useUiToolsRegistry.setState({
+      tools: new Map(),
+      nativeDisposers: new Map(),
+      globalNames: new Set(),
+      shippedNames: new Set(),
+    });
+    __resetSurfaceSnapshotProvidersForTests();
+  });
+
+  it("listSurfaceGroupToolNames knows the oauth-flow group", () => {
+    expect(listSurfaceGroupToolNames("oauth-flow")).toEqual(
+      OAUTH_FLOW_TOOL_NAMES,
+    );
+  });
+
+  it("mount registers all three tools surface-scoped; unmount removes them", () => {
+    const { unmount } = renderHook(() =>
+      useSurfaceAgentBridge({
+        surfaceId: "oauth-flow",
+        snapshot: () => ({ configured: false }),
+      }),
+    );
+
+    const state = useUiToolsRegistry.getState();
+    for (const name of OAUTH_FLOW_TOOL_NAMES) {
+      expect(state.resolve(name), name).not.toBeNull();
+      // Surface scope: behind the global catalog in the 64-entry snapshot cap.
+      expect(state.globalNames.has(name), name).toBe(false);
+    }
+    expect(hasSurfaceSnapshotProvider("oauth-flow")).toBe(true);
+
+    unmount();
+    for (const name of OAUTH_FLOW_TOOL_NAMES) {
+      expect(useUiToolsRegistry.getState().resolve(name), name).toBeNull();
+    }
+    expect(hasSurfaceSnapshotProvider("oauth-flow")).toBe(false);
+  });
+
+  it("waitForUiToolNames resolves once the just-mounted group is live (same-turn discovery)", async () => {
+    const pending = waitForUiToolNames(
+      listSurfaceGroupToolNames("oauth-flow"),
+      1_500,
+    );
+
+    const { unmount } = renderHook(() =>
+      useSurfaceAgentBridge({ surfaceId: "oauth-flow" }),
+    );
+
+    await expect(pending).resolves.toBe(true);
+
+    unmount();
+    await expect(
+      waitForUiToolNames(listSurfaceGroupToolNames("oauth-flow"), 50),
+    ).resolves.toBe(false);
+  });
+});

--- a/mcpjam-inspector/client/src/lib/webmcp/groups/__tests__/oauth-flow.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/groups/__tests__/oauth-flow.test.ts
@@ -1,0 +1,191 @@
+/**
+ * The oauth-flow group's own contract: exact tool set, honest annotations
+ * (the destructive set is exactly the advance tool — one step can POST a
+ * persistent DCR registration to a third-party AS), dispatch shapes, and
+ * command errors passing through as tool errors. The handler-side gate
+ * behavior (no profile / in-flight / complete) lives in OAuthFlowTab's
+ * handlers (see OAuthFlowTab.agent.test.tsx).
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { InspectorCommandResponse } from "@/shared/inspector-command.js";
+
+const { dispatchInspectorCommandMock } = vi.hoisted(() => ({
+  dispatchInspectorCommandMock: vi.fn(),
+}));
+
+vi.mock("../../ui-actions", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../ui-actions")>();
+  return { ...actual, dispatchInspectorCommand: dispatchInspectorCommandMock };
+});
+
+import { buildOAuthFlowUiTools } from "../oauth-flow";
+
+const OAUTH_FLOW_TOOL_NAMES = [
+  "ui_open_oauth_server_config",
+  "ui_advance_oauth_flow",
+  "ui_reset_oauth_flow",
+];
+
+function getTool(name: string) {
+  const tool = buildOAuthFlowUiTools().find((t) => t.name === name);
+  if (!tool) throw new Error(`oauth-flow group is missing ${name}`);
+  return tool;
+}
+
+function success(result: unknown): InspectorCommandResponse {
+  return { id: "cmd-1", status: "success", result };
+}
+
+describe("buildOAuthFlowUiTools", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dispatchInspectorCommandMock.mockResolvedValue(success({ status: "ok" }));
+  });
+
+  it("builds exactly the three oauth-flow tools", () => {
+    expect(buildOAuthFlowUiTools().map((t) => t.name)).toEqual(
+      OAUTH_FLOW_TOOL_NAMES,
+    );
+  });
+
+  it("annotates every tool completely and honestly", () => {
+    // open config: prefill-over-commit, converges on the same open modal.
+    expect(getTool("ui_open_oauth_server_config").annotations).toEqual({
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    });
+    // advance: one step can create a persistent third-party client
+    // registration and always drives real third-party HTTP; each call is a
+    // distinct step.
+    expect(getTool("ui_advance_oauth_flow").annotations).toEqual({
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
+    });
+    // reset: local re-runnable debug state; double-reset converges.
+    expect(getTool("ui_reset_oauth_flow").annotations).toEqual({
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    });
+    for (const tool of buildOAuthFlowUiTools()) {
+      expect(tool.readOnly).toBe(tool.annotations?.readOnlyHint);
+    }
+  });
+
+  it("gates exactly the advance tool behind the destructive approval pill", () => {
+    const destructive = buildOAuthFlowUiTools()
+      .filter((tool) => tool.annotations?.destructiveHint === true)
+      .map((tool) => tool.name);
+    expect(destructive).toEqual(["ui_advance_oauth_flow"]);
+  });
+
+  it("advance declares one-step, human sign-in, and third-party registration in its description", () => {
+    const description = getTool("ui_advance_oauth_flow").description;
+    expect(description).toMatch(/ONE protocol step/);
+    expect(description).toMatch(/HUMAN must complete/);
+    expect(description).toMatch(/popup blocker/i);
+    expect(description).toMatch(/persistent/i);
+  });
+
+  it("open-config declares that credentials cannot be passed", () => {
+    const { description, inputSchema } = getTool(
+      "ui_open_oauth_server_config",
+    );
+    expect(description).toMatch(/typed by the human/i);
+    // No credential fields in the schema — the no-secrets-in-schemas rule.
+    const properties = (inputSchema as { properties: Record<string, unknown> })
+      .properties;
+    expect(Object.keys(properties)).toEqual([
+      "serverName",
+      "serverUrl",
+      "registrationMode",
+    ]);
+  });
+
+  it("ui_open_oauth_server_config dispatches openOauthServerConfig with only provided fields", async () => {
+    await getTool("ui_open_oauth_server_config").execute({});
+    expect(dispatchInspectorCommandMock).toHaveBeenCalledWith({
+      type: "openOauthServerConfig",
+      payload: {},
+    });
+
+    await getTool("ui_open_oauth_server_config").execute({
+      serverName: "linear",
+      serverUrl: "https://mcp.linear.app/mcp",
+      registrationMode: "dcr",
+    });
+    expect(dispatchInspectorCommandMock).toHaveBeenLastCalledWith({
+      type: "openOauthServerConfig",
+      payload: {
+        serverName: "linear",
+        serverUrl: "https://mcp.linear.app/mcp",
+        registrationMode: "dcr",
+      },
+    });
+  });
+
+  it("ui_open_oauth_server_config rejects bad input without dispatching", async () => {
+    const badMode = await getTool("ui_open_oauth_server_config").execute({
+      registrationMode: "bogus",
+    });
+    expect(badMode.isError).toBe(true);
+    expect(dispatchInspectorCommandMock).not.toHaveBeenCalled();
+
+    const badName = await getTool("ui_open_oauth_server_config").execute({
+      serverName: 42,
+    });
+    expect(badName.isError).toBe(true);
+    expect(dispatchInspectorCommandMock).not.toHaveBeenCalled();
+
+    const badUrl = await getTool("ui_open_oauth_server_config").execute({
+      serverUrl: "   ",
+    });
+    expect(badUrl.isError).toBe(true);
+    expect(dispatchInspectorCommandMock).not.toHaveBeenCalled();
+  });
+
+  it("ui_advance_oauth_flow and ui_reset_oauth_flow dispatch empty payloads", async () => {
+    await getTool("ui_advance_oauth_flow").execute({});
+    expect(dispatchInspectorCommandMock).toHaveBeenCalledWith({
+      type: "advanceOauthFlow",
+      payload: {},
+    });
+
+    await getTool("ui_reset_oauth_flow").execute({});
+    expect(dispatchInspectorCommandMock).toHaveBeenLastCalledWith({
+      type: "resetOauthFlow",
+      payload: {},
+    });
+  });
+
+  it("surfaces command errors as tool errors with their code", async () => {
+    dispatchInspectorCommandMock.mockResolvedValue({
+      id: "cmd-1",
+      status: "error",
+      error: {
+        code: "invalid_request",
+        message: "The flow is already complete — use ui_reset_oauth_flow.",
+      },
+    } satisfies InspectorCommandResponse);
+    const invalid = await getTool("ui_advance_oauth_flow").execute({});
+    expect(invalid.isError).toBe(true);
+    expect(invalid.content[0].text).toContain("invalid_request");
+
+    dispatchInspectorCommandMock.mockResolvedValue({
+      id: "cmd-1",
+      status: "error",
+      error: {
+        code: "execution_failed",
+        message: "A protocol step is already in flight.",
+      },
+    } satisfies InspectorCommandResponse);
+    const busy = await getTool("ui_advance_oauth_flow").execute({});
+    expect(busy.isError).toBe(true);
+    expect(busy.content[0].text).toContain("execution_failed");
+  });
+});

--- a/mcpjam-inspector/client/src/lib/webmcp/groups/index.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/groups/index.ts
@@ -21,6 +21,7 @@ import { buildComputerUiTools } from "./computer";
 import { buildChatboxesUiTools } from "./chatboxes";
 import { buildResourcesUiTools } from "./resources";
 import { buildPromptsUiTools } from "./prompts";
+import { buildOAuthFlowUiTools } from "./oauth-flow";
 
 export type { UiToolGroup } from "./types";
 
@@ -34,6 +35,10 @@ export const SURFACE_TOOL_GROUPS: Partial<Record<AppSurfaceId, UiToolGroup>> =
     chatboxes: { surfaceId: "chatboxes", buildTools: buildChatboxesUiTools },
     resources: { surfaceId: "resources", buildTools: buildResourcesUiTools },
     prompts: { surfaceId: "prompts", buildTools: buildPromptsUiTools },
+    "oauth-flow": {
+      surfaceId: "oauth-flow",
+      buildTools: buildOAuthFlowUiTools,
+    },
   };
 
 /**

--- a/mcpjam-inspector/client/src/lib/webmcp/groups/oauth-flow.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/groups/oauth-flow.ts
@@ -1,0 +1,170 @@
+/**
+ * OAuth-debugger tools: open the Configure-Server modal (prefilled), advance
+ * the flow one protocol step, and reset the flow.
+ *
+ * Mount-scoped: `OAuthFlowTab` owns the state machine and the modal, so the
+ * tools exist exactly while `/oauth-flow` is mounted. Three deliberate
+ * postures:
+ *
+ * - **Prefill vs. commit.** `ui_open_oauth_server_config` only opens the
+ *   Configure modal for the human to review and save (the
+ *   `ui_open_server_form` precedent). Its payload can never carry credentials:
+ *   there are no clientId/clientSecret fields, by design.
+ * - **One step per advance, human consent stays human.**
+ *   `ui_advance_oauth_flow` mirrors the Continue button exactly — a single
+ *   state-machine step per call. At the authorization step it opens the
+ *   sign-in popup to the third party's authorization server and reports that
+ *   honestly; the agent cannot complete consent, only the user can. It is
+ *   `destructiveHint: true` because a single step can POST a PERSISTENT
+ *   dynamic-client registration to a third-party AS (and every step drives
+ *   real third-party HTTP → `openWorldHint: true`), so the confirmation pill
+ *   gates each advance.
+ * - **Reset is cheap.** `ui_reset_oauth_flow` clears local, re-runnable debug
+ *   state; the UI's own Reset button has no confirmation dialog either (unlike
+ *   clearing a chat, no unrecoverable user content is lost), so it is not
+ *   destructive.
+ */
+
+import type { UiToolDefinition } from "../ui-tools-registry";
+import {
+  commandResponseToActionResult,
+  dispatchInspectorCommand,
+} from "../ui-actions";
+import { asOptionalString, errorResult, fromActionResult } from "./shared";
+
+const REGISTRATION_MODES = ["preregistered", "dcr", "cimd"] as const;
+
+export function buildOAuthFlowUiTools(): UiToolDefinition[] {
+  return [
+    {
+      name: "ui_open_oauth_server_config",
+      description:
+        "Open the OAuth debugger's Configure-Server modal for the user to review and save. Optionally prefills the server name, MCP server URL, and registration mode. Credentials (client ID/secret) are always typed by the human — they cannot be passed here. Omit serverName to edit the currently selected server; pass a new name to create a new test target. Never commits anything itself.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          serverName: {
+            type: "string",
+            description:
+              "Server to configure, as the server tabs show it. Omitted → the selected server (or a blank form when none is selected). A name matching a different existing server is rejected.",
+          },
+          serverUrl: {
+            type: "string",
+            description: "MCP base URL to prefill (e.g. https://example.com/mcp).",
+          },
+          registrationMode: {
+            type: "string",
+            enum: [...REGISTRATION_MODES],
+            description:
+              "Client registration mode to prefill: 'preregistered' (human enters a client ID), 'dcr' (Dynamic Client Registration), or 'cimd' (URL-based client metadata; 2025-11-25 only).",
+          },
+        },
+        additionalProperties: false,
+      },
+      readOnly: false,
+      // Opens a form for the human; re-invoking with the same seed converges
+      // on the same open modal. Nothing external, no route change.
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+      execute: async (args) => {
+        const serverName = asOptionalString(args.serverName);
+        if (args.serverName !== undefined && serverName === undefined) {
+          return errorResult(
+            "'serverName' must be a non-empty string when provided.",
+          );
+        }
+        const serverUrl = asOptionalString(args.serverUrl);
+        if (args.serverUrl !== undefined && serverUrl === undefined) {
+          return errorResult(
+            "'serverUrl' must be a non-empty string when provided.",
+          );
+        }
+        const registrationMode = asOptionalString(args.registrationMode);
+        if (args.registrationMode !== undefined) {
+          if (
+            !registrationMode ||
+            !(REGISTRATION_MODES as readonly string[]).includes(
+              registrationMode,
+            )
+          ) {
+            return errorResult(
+              `'registrationMode' must be one of: ${REGISTRATION_MODES.join(", ")}.`,
+            );
+          }
+        }
+        const response = await dispatchInspectorCommand({
+          type: "openOauthServerConfig",
+          payload: {
+            ...(serverName ? { serverName } : {}),
+            ...(serverUrl ? { serverUrl } : {}),
+            ...(registrationMode
+              ? {
+                  registrationMode:
+                    registrationMode as (typeof REGISTRATION_MODES)[number],
+                }
+              : {}),
+          },
+        });
+        return fromActionResult(commandResponseToActionResult(response));
+      },
+    },
+    {
+      name: "ui_advance_oauth_flow",
+      description:
+        "Advance the OAuth debugger exactly ONE protocol step — the same as clicking Continue. Steps make REAL requests to the target and its authorization server; the registration step can create a PERSISTENT client registration there. At the authorization step this opens a sign-in popup a HUMAN must complete (if none appeared, ask the user to check their popup blocker) — observe with ui_snapshot_app instead of re-calling. Errors if unconfigured, mid-step, or already complete.",
+      inputSchema: {
+        type: "object",
+        properties: {},
+        additionalProperties: false,
+      },
+      readOnly: false,
+      // One step can POST a persistent DCR registration to a third-party AS →
+      // destructive (pill gates every advance) + open-world. Each call is a
+      // distinct step, so NOT idempotent. The sign-in popup is a browser
+      // window, not an SPA route → no mayNavigate.
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
+      execute: async () => {
+        const response = await dispatchInspectorCommand({
+          type: "advanceOauthFlow",
+          payload: {},
+        });
+        return fromActionResult(commandResponseToActionResult(response));
+      },
+    },
+    {
+      name: "ui_reset_oauth_flow",
+      description:
+        "Reset the OAuth debugger's flow back to the start for the configured target. Clears the local step-by-step state (tokens, codes, logged requests) so the flow can be run again. Nothing is sent to any server.",
+      inputSchema: {
+        type: "object",
+        properties: {},
+        additionalProperties: false,
+      },
+      readOnly: false,
+      // Local, re-runnable debug state; double-reset converges. The UI Reset
+      // button has no confirmation dialog either.
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+      execute: async () => {
+        const response = await dispatchInspectorCommand({
+          type: "resetOauthFlow",
+          payload: {},
+        });
+        return fromActionResult(commandResponseToActionResult(response));
+      },
+    },
+  ];
+}

--- a/mcpjam-inspector/client/src/lib/webmcp/oauth-error-code.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/oauth-error-code.ts
@@ -1,0 +1,44 @@
+/**
+ * OAuth error-code allowlist shared by transcript-facing surfaces (the XAA
+ * debugger UI and the oauth-flow agent snapshot/tool results).
+ *
+ * Only an allowlisted RFC 6749/8693/8707 code is ever stored, rendered, or
+ * shipped into a chat transcript — never a raw error string, which can embed
+ * tokens, URLs, or provider-specific detail.
+ */
+
+export const OAUTH_ERROR_CODES = [
+  "invalid_grant",
+  "access_denied",
+  "invalid_client",
+  "invalid_request",
+  "unauthorized_client",
+  "unsupported_grant_type",
+  "invalid_scope",
+  "invalid_target",
+] as const;
+
+export function extractOauthErrorCode(
+  error: string | undefined,
+  lastResponse: { body?: unknown } | null | undefined,
+): string | undefined {
+  // Prefer the structured token response (`{error}` or the proxy envelope's
+  // `{body: {error}}`) over substring-matching the message.
+  const body = lastResponse?.body as Record<string, unknown> | undefined;
+  const candidates = [
+    body?.error,
+    (body?.body as Record<string, unknown> | undefined)?.error,
+  ];
+  for (const candidate of candidates) {
+    if (
+      typeof candidate === "string" &&
+      (OAUTH_ERROR_CODES as readonly string[]).includes(candidate)
+    ) {
+      return candidate;
+    }
+  }
+  if (typeof error === "string") {
+    return OAUTH_ERROR_CODES.find((code) => error.includes(code));
+  }
+  return undefined;
+}

--- a/mcpjam-inspector/client/src/lib/webmcp/oauth-flow-snapshot.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/oauth-flow-snapshot.ts
@@ -1,0 +1,185 @@
+/**
+ * Pure snapshot shaping for the oauth-flow surface.
+ *
+ * The OAuth debugger's flow state is wall-to-wall secrets: tokens, PKCE
+ * verifiers, authorization codes, the client secret, and full raw HTTP
+ * request/response bodies. Everything a snapshot emits lands in the chat
+ * transcript (and crosses to the server), so shaping lives HERE, in a pure
+ * builder with a denylist test — not inline in the component.
+ *
+ * Redaction strategy, in layers:
+ * - `OAuthFlowStateView` structurally OMITS the sensitive fields (accessToken,
+ *   refreshToken, clientSecret, codeVerifier/Challenge, authorizationCode,
+ *   `state`, authorizationUrl, wwwAuthenticateHeader, lastRequest), so builder
+ *   code cannot read them. Token PRESENCE arrives as booleans computed at the
+ *   call site.
+ * - The fields that are present but tainted are reduced to safe projections:
+ *   `error` → presence + allowlisted OAuth error code, `lastResponse` →
+ *   status/statusText (+ code extraction from its body), `httpHistory` →
+ *   length, `infoLogs` → counts by level.
+ * - Sequence-diagram steps pass through `toSafeSequenceSteps`, which keeps
+ *   ONLY `id`/`label` (static strings) — `description`/`details` carry URLs,
+ *   challenges, and token material. Ids are opaque diagram ids, not
+ *   necessarily `OAuthFlowStep` values (the builders also emit e.g.
+ *   `browser_to_auth_server`), so they are never cross-referenced with step
+ *   indices.
+ */
+
+import { getStepIndex, type OAuthFlowStep } from "@mcpjam/sdk/browser";
+import { extractOauthErrorCode } from "./oauth-error-code";
+
+/**
+ * The two steps where the Continue button (and `ui_advance_oauth_flow`) hand
+ * off to the human sign-in popup instead of advancing the machine.
+ */
+export function isAwaitingHumanAuthorization(step: OAuthFlowStep): boolean {
+  return step === "generate_pkce_parameters" || step === "authorization_request";
+}
+
+/**
+ * The safe projection of `OAuthFlowState`. Sensitive fields are ABSENT from
+ * this type on purpose — the real state object satisfies it structurally, but
+ * builder code cannot reach what isn't declared.
+ */
+export interface OAuthFlowStateView {
+  currentStep: OAuthFlowStep;
+  isInitiatingAuth: boolean;
+  serverUrl?: string;
+  authorizationServerUrl?: string;
+  tokenType?: string;
+  expiresIn?: number;
+  /** Reduced to presence + allowlisted code — never emitted verbatim. */
+  error?: string;
+  /** Only status/statusText survive; the body is used for code extraction. */
+  lastResponse?: { status: number; statusText: string; body?: unknown };
+  /** Reduced to a count. */
+  httpHistory?: ReadonlyArray<unknown>;
+  /** Reduced to counts by level. */
+  infoLogs?: ReadonlyArray<{ level: "info" | "warning" | "error" }>;
+}
+
+export interface OAuthFlowSnapshotInput {
+  hasProfile: boolean;
+  serverName?: string;
+  protocolVersion?: string;
+  /** Human-readable registration label (e.g. "Dynamic (DCR)"). */
+  registrationStrategy?: string;
+  scopes?: string;
+  /** Public client identifier — the one identity field that is not a secret. */
+  clientId?: string;
+  customHeaderCount: number;
+  hasAccessToken: boolean;
+  hasRefreshToken: boolean;
+  serverConnected: boolean;
+  readyToApplyTokens: boolean;
+  /** Pre-stripped via `toSafeSequenceSteps`. */
+  steps: ReadonlyArray<{ id: string; label: string }>;
+  view: OAuthFlowStateView;
+}
+
+export interface OAuthFlowSnapshot {
+  configured: boolean;
+  target: {
+    serverName?: string;
+    serverUrl?: string;
+    authorizationServerUrl?: string;
+    protocolVersion?: string;
+    registrationStrategy?: string;
+    scopes?: string;
+    clientId?: string;
+    customHeaderCount: number;
+  } | null;
+  flow: {
+    currentStep: OAuthFlowStep;
+    stepIndex: number | null;
+    isInitiatingAuth: boolean;
+    complete: boolean;
+    awaitingHumanAuthorization: boolean;
+    steps: Array<{ id: string; label: string }>;
+  };
+  tokens: {
+    hasAccessToken: boolean;
+    hasRefreshToken: boolean;
+    tokenType?: string;
+    expiresInSeconds?: number;
+  };
+  lastHttp: { status: number; statusText: string } | null;
+  error: { present: true; oauthErrorCode?: string } | null;
+  counts: {
+    httpRequests: number;
+    infoLogs: { info: number; warning: number; error: number };
+  };
+  readyToApplyTokens: boolean;
+  serverConnected: boolean;
+}
+
+/**
+ * Keep ONLY the static identity of each diagram action. Never widen this —
+ * `description` and `details` are where dynamic values (URLs, challenges,
+ * token material) live.
+ */
+export function toSafeSequenceSteps(
+  actions: ReadonlyArray<{ id: string; label: string }>,
+): Array<{ id: string; label: string }> {
+  return actions.map((action) => ({ id: action.id, label: action.label }));
+}
+
+export function buildOAuthFlowSnapshot(
+  input: OAuthFlowSnapshotInput,
+): OAuthFlowSnapshot {
+  const { view } = input;
+  const stepIndex = getStepIndex(view.currentStep);
+  const oauthErrorCode = extractOauthErrorCode(view.error, view.lastResponse);
+
+  const logCounts = { info: 0, warning: 0, error: 0 };
+  for (const entry of view.infoLogs ?? []) {
+    if (entry.level in logCounts) logCounts[entry.level] += 1;
+  }
+
+  return {
+    configured: input.hasProfile,
+    target: input.hasProfile
+      ? {
+          serverName: input.serverName,
+          serverUrl: view.serverUrl,
+          authorizationServerUrl: view.authorizationServerUrl,
+          protocolVersion: input.protocolVersion,
+          registrationStrategy: input.registrationStrategy,
+          scopes: input.scopes,
+          clientId: input.clientId,
+          customHeaderCount: input.customHeaderCount,
+        }
+      : null,
+    flow: {
+      currentStep: view.currentStep,
+      stepIndex: stepIndex === Number.MAX_SAFE_INTEGER ? null : stepIndex,
+      isInitiatingAuth: view.isInitiatingAuth,
+      complete: view.currentStep === "complete",
+      awaitingHumanAuthorization: isAwaitingHumanAuthorization(
+        view.currentStep,
+      ),
+      steps: toSafeSequenceSteps(input.steps),
+    },
+    tokens: {
+      hasAccessToken: input.hasAccessToken,
+      hasRefreshToken: input.hasRefreshToken,
+      tokenType: view.tokenType,
+      expiresInSeconds: view.expiresIn,
+    },
+    lastHttp: view.lastResponse
+      ? {
+          status: view.lastResponse.status,
+          statusText: view.lastResponse.statusText,
+        }
+      : null,
+    error: view.error
+      ? { present: true, ...(oauthErrorCode ? { oauthErrorCode } : {}) }
+      : null,
+    counts: {
+      httpRequests: view.httpHistory?.length ?? 0,
+      infoLogs: logCounts,
+    },
+    readyToApplyTokens: input.readyToApplyTokens,
+    serverConnected: input.serverConnected,
+  };
+}

--- a/mcpjam-inspector/shared/app-surfaces.ts
+++ b/mcpjam-inspector/shared/app-surfaces.ts
@@ -464,11 +464,12 @@ export const APP_SURFACES = [
       "Run an OAuth flow against a server step by step",
       "Inspect discovery metadata and each request/response",
     ],
-    agentTools: {
-      kind: "none",
-      reason:
-        "Interactive auth debugger — human-in-the-loop by design; the agent must not drive authorization steps.",
-    },
+    hasSnapshotProvider: true,
+    // The agent can prefill the config form, advance ONE step at a time
+    // (approval-gated), and reset. Consent stays structurally human: the
+    // authorization step opens a sign-in popup on the third party's page,
+    // which the agent cannot complete. See groups/oauth-flow.ts.
+    agentTools: { kind: "group" },
     showInAtlas: true,
   },
   {

--- a/mcpjam-inspector/shared/inspector-command.ts
+++ b/mcpjam-inspector/shared/inspector-command.ts
@@ -67,7 +67,10 @@ export type InspectorCommandType =
   | "resetChat"
   | "stopGeneration"
   | "readResource"
-  | "getPrompt";
+  | "getPrompt"
+  | "openOauthServerConfig"
+  | "advanceOauthFlow"
+  | "resetOauthFlow";
 
 export const KNOWN_INSPECTOR_COMMAND_TYPES = [
   "navigate",
@@ -111,6 +114,9 @@ export const KNOWN_INSPECTOR_COMMAND_TYPES = [
   "stopGeneration",
   "readResource",
   "getPrompt",
+  "openOauthServerConfig",
+  "advanceOauthFlow",
+  "resetOauthFlow",
 ] as const satisfies readonly InspectorCommandType[];
 
 export interface InspectorCommandError {
@@ -702,6 +708,51 @@ export interface GetPromptInspectorCommand {
   timeoutMs?: number;
 }
 
+/**
+ * OAuth-debugger commands, handled by `OAuthFlowTab` while `/oauth-flow` is
+ * mounted.
+ *
+ * Two deliberate postures:
+ * - **Prefill-over-commit for config.** `openOauthServerConfig` only opens the
+ *   Configure-Server modal for the USER to finish and save. The payload can
+ *   never carry credentials (no clientId/clientSecret fields — the no-env /
+ *   no-headers precedent): the human types those into the modal.
+ * - **One protocol step per dispatch.** `advanceOauthFlow` mirrors the
+ *   Continue button exactly: it runs a single state-machine step. At the
+ *   authorization step it opens the human sign-in popup instead of advancing —
+ *   consent always happens on the third party's page, never in the agent.
+ */
+export interface OpenOauthServerConfigInspectorCommand {
+  id: string;
+  type: "openOauthServerConfig";
+  payload: {
+    /**
+     * Server to configure. Omitted → edit the selected server (or open blank
+     * when none is selected). A name matching a DIFFERENT existing server is
+     * rejected — select it first instead of silently editing it.
+     */
+    serverName?: string;
+    serverUrl?: string;
+    registrationMode?: "preregistered" | "dcr" | "cimd";
+  };
+  timeoutMs?: number;
+}
+
+export interface AdvanceOauthFlowInspectorCommand {
+  id: string;
+  type: "advanceOauthFlow";
+  payload?: Record<string, never>;
+  timeoutMs?: number;
+}
+
+/** Reset the debugger's local flow state (re-runnable; nothing external). */
+export interface ResetOauthFlowInspectorCommand {
+  id: string;
+  type: "resetOauthFlow";
+  payload?: Record<string, never>;
+  timeoutMs?: number;
+}
+
 export type InspectorCommand =
   | NavigateInspectorCommand
   | SelectServerInspectorCommand
@@ -743,7 +794,10 @@ export type InspectorCommand =
   | ResetChatInspectorCommand
   | StopGenerationInspectorCommand
   | ReadResourceInspectorCommand
-  | GetPromptInspectorCommand;
+  | GetPromptInspectorCommand
+  | OpenOauthServerConfigInspectorCommand
+  | AdvanceOauthFlowInspectorCommand
+  | ResetOauthFlowInspectorCommand;
 
 export interface InspectorCommandSuccessResponse {
   id: string;


### PR DESCRIPTION
## Why

The `oauth-flow` surface was opted out of agent tools with *"the agent must not drive authorization steps"* — but consent there is **structurally human-gated**: the authorization step opens a sign-in popup on the third party's page (`OAuthAuthorizationModal` → `window.open`), which an agent cannot complete. The opt-out was actually blocking setup and observability, not consent.

## What

**New `oauth-flow` tool group** (mount-scoped via `useSurfaceAgentBridge`):

| Tool | Annotations | Behavior |
|---|---|---|
| `ui_open_oauth_server_config` | idempotent, non-destructive | Prefills the Configure-Server modal (name/URL/registration mode) via a new `agentSeed` prop. **No credential fields in the schema** — the human types those. Rejects a name matching a *different* existing server (`planAuthConfigModal`, no fuzzy guessing). |
| `ui_advance_oauth_flow` | **destructive** ⚠, open-world, not idempotent | Exactly ONE protocol step per call, replicating the Continue button's gates (`no profile` → invalid_request, `in flight` → retryable execution_failed, `complete` → invalid_request). Destructive because a step can POST a **persistent DCR registration** to a third-party AS — the pill gates every advance. At the authorization step it advances first (generating the authorization URL), opens the human popup, and returns `authorization_modal_opened` honestly, with a popup-blocker caveat. |
| `ui_reset_oauth_flow` | idempotent, non-destructive | Clears local, re-runnable debug state (the UI Reset button has no confirm either). |

**Snapshot = pure, denylist-tested builder** (`oauth-flow-snapshot.ts`): step progress, badges, HTTP status codes, token *presence* booleans, and an **allowlisted** OAuth error code. The view type structurally omits tokens/PKCE/auth-code/raw-body fields; sequence-diagram steps are stripped to `id`/`label` (their `description`/`details` carry URLs and challenge material). The denylist test feeds a fully poisoned state and asserts no sentinel or forbidden key survives serialization.

## Supporting fixes

- **`oauthFlowStateRef` synced synchronously by all three writers** (mirroring XAAFlowTab's deliberate pattern) — previously effect-synced, so post-step reads were one commit stale.
- **`existingServerNames` memoized**: the modal's reseed-on-open effect depends on it via `generateDefaultName`, so a fresh `Object.keys()` per parent render re-seeded the open modal and wiped typed values (pre-existing bug, hotter now that agents send humans into this modal).
- The servers-hydrated force-close effect no longer closes an agent-opened modal with a pending seed.
- `OAUTH_ERROR_CODES`/`extractOauthErrorCode` extracted from XAAFlowTab into `lib/webmcp/oauth-error-code.ts` (one allowlist, shared with the snapshot builder).

## Deliberately NOT included

XAA stays opted out: once started, its flow mints **real signed org-issuer identity assertions with no human step after the click** (the mock-IdP SSO step is a server-side mint, not a login). A prefill+snapshot-only XAA integration is planned as its own follow-up PR, which will also rewrite that surface's reason string.

## Testing

- `npm run typecheck:client` clean (manifest flip type-forces the reason-field deletion).
- 106 files / 1061 tests green across `client/src/lib/webmcp`, `client/src/lib/__tests__` (coverage suites), the group unit + bridge tests, the snapshot denylist test, `planAuthConfigModal` truth table, the modal `agentSeed` tests, and a new `OAuthFlowTab.agent.test.tsx` driving all handler branches through the real command bus against the mounted tab.
- Budget: global catalog (16) + largest group (5) = 21 ≤ 56 — unchanged by this 3-tool group.

Known accepted race (documented in-code): the 500 ms post-callback exchange timer can auto-advance concurrently with an agent advance — identical exposure to the human Continue button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Agents can drive real third-party OAuth HTTP and persistent DCR via approval-gated advance, but consent stays human-only and snapshots aggressively redact secrets; misconfiguration or concurrent advance races match existing UI exposure.
> 
> **Overview**
> **Enables agent assistance on the OAuth debugger** by flipping `oauth-flow` from opted-out to a mount-scoped tool group (`ui_open_oauth_server_config`, `ui_advance_oauth_flow`, `ui_reset_oauth_flow`) wired through new inspector commands and `useSurfaceAgentBridge` on `OAuthFlowTab`.
> 
> **Config is prefill-only:** `openOauthServerConfig` opens the Configure-Server modal with an `agentSeed` (name/URL/registration mode—no credential fields), resolves edit vs add via `planAuthConfigModal`, and rejects naming a different existing server or an unsupported registration mode for the protocol version.
> 
> **Advance mirrors Continue:** one protocol step per call, approval-gated as destructive/open-world; at PKCE/authorization it generates the URL, opens the human popup, and returns `authorization_modal_opened`. Results and snapshots expose only allowlisted OAuth error codes, not raw errors. **`buildOAuthFlowSnapshot`** strips tokens, PKCE material, HTTP bodies, and diagram details from agent-visible state.
> 
> **Supporting fixes:** synchronous `oauthFlowStateRef` updates for post-await reads; memoized `existingServerNames` so the modal doesn’t re-seed on parent re-renders; hydration no longer closes an agent-opened modal with a pending seed; shared `extractOauthErrorCode` extracted from XAA.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5d639c456bd8a7539665764e91306cab03bc339. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an agent tool group for the OAuth debugger to enable setup and one-step advancement while keeping consent human. Also adds a safe, denylist-tested snapshot that avoids leaking secrets.

- **New Features**
  - `oauth-flow` tool group (mount-scoped):
    - `ui_open_oauth_server_config`: opens the Configure-Server modal with optional prefill (name/URL/registration mode). No credential fields; the user types those.
    - `ui_advance_oauth_flow`: advances exactly one protocol step per call. At authorization, opens the human sign-in popup and returns `authorization_modal_opened`. Marked destructive and open-world.
    - `ui_reset_oauth_flow`: clears local debug state to restart the flow.
  - Safe snapshot builder (`oauth-flow-snapshot.ts`): exposes step progress, HTTP status, token presence, and an allowlisted OAuth error code. Never emits tokens, PKCE, auth codes, raw errors, or HTTP bodies. Sequence steps stripped to `id`/`label`.
  - Group wiring: registered via `useSurfaceAgentBridge`; new inspector commands `openOauthServerConfig`, `advanceOauthFlow`, `resetOauthFlow`.

- **Bug Fixes**
  - Synchronous `oauthFlowStateRef` updates to avoid stale post-step reads.
  - Memoized `existingServerNames` to prevent modal reseed wiping typed values.
  - Skip force-closing an agent-opened modal during server hydration.
  - Shared `oauth-error-code` helper for allowlisted code extraction.

<sup>Written for commit b5d639c456bd8a7539665764e91306cab03bc339. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

