### PR TITLE
fix(chatbox): skip project-scoped org model config query for chatbox guests

### DIFF
--- a/mcpjam-inspector/client/src/components/ChatTabV2.tsx
+++ b/mcpjam-inspector/client/src/components/ChatTabV2.tsx
@@ -329,6 +329,11 @@ export function ChatTabV2({
   const hostedOrgModelConfig = useHostedOrgModelConfig({
     projectId: effectiveHostedProjectId,
     organizationId: modelConfigOrganizationId,
+    // Chatbox surfaces resolve their model from the chatbox row
+    // (executionConfig.modelId), and share-link guests aren't members of the
+    // host's project — so the project-scoped config query would throw and crash
+    // the page. Skip it whenever we're inside a chatbox.
+    disabled: Boolean(hostedChatboxId),
   });
   const { serversById, serversByName } = useProjectServers({
     isAuthenticated: isConvexAuthenticated,

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-hosted-org-model-config.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-hosted-org-model-config.test.tsx
@@ -96,4 +96,31 @@ describe("useHostedOrgModelConfig", () => {
       args: "skip",
     });
   });
+
+  it("skips both queries when disabled, even while authenticated with ids", () => {
+    // Chatbox share-link guests are authenticated (anonymous) but not project
+    // members; firing getVisibleConfigForProject would throw and crash the page.
+    mockState.queryResults.set(
+      "organizationModelProviders:getVisibleConfigForProject",
+      { providers: [{ providerKey: "anthropic", enabled: true }] }
+    );
+
+    const { result } = renderHook(() =>
+      useHostedOrgModelConfig({
+        projectId: "project-1",
+        organizationId: "org-1",
+        disabled: true,
+      })
+    );
+
+    expect(result.current).toBeUndefined();
+    expect(mockState.queryCalls).toContainEqual({
+      name: "organizationModelProviders:getVisibleConfigForProject",
+      args: "skip",
+    });
+    expect(mockState.queryCalls).toContainEqual({
+      name: "organizationModelProviders:getVisibleConfig",
+      args: "skip",
+    });
+  });
 });

--- a/mcpjam-inspector/client/src/hooks/use-hosted-org-model-config.ts
+++ b/mcpjam-inspector/client/src/hooks/use-hosted-org-model-config.ts
@@ -9,12 +9,25 @@ export type HostedOrgModelConfig = {
 export function useHostedOrgModelConfig({
   projectId,
   organizationId,
+  disabled = false,
 }: {
   projectId?: string | null;
   organizationId?: string | null;
+  /**
+   * Skip both org/project-scoped config queries entirely.
+   *
+   * Chatbox share-link viewers are authenticated as anonymous guests but hold
+   * NO membership in the host's project. `getVisibleConfigForProject` is gated
+   * by `requireProjectRole`, so it throws "Not a member of this project" for
+   * them — and with no route-level ErrorBoundary that Convex error takes down
+   * the whole page. The chatbox already resolves its model server-side from the
+   * chatbox row (surfaced as `executionConfig.modelId`), so this config is
+   * unused on that surface anyway. Chatbox callers pass `disabled: true`.
+   */
+  disabled?: boolean;
 }): HostedOrgModelConfig | undefined {
   const { isAuthenticated } = useConvexAuth();
-  const shouldQuery = isAuthenticated;
+  const shouldQuery = isAuthenticated && !disabled;
 
   const projectConfig = useQuery(
     "organizationModelProviders:getVisibleConfigForProject" as any,


### PR DESCRIPTION
## Problem

Opening a published chatbox **share link** crashes the whole page with an *"Unexpected Application Error!"* screen:

```
[CONVEX Q(organizationModelProviders:getVisibleConfigForProject)] Server Error
Uncaught Error: Not a member of this project
    at requireProjectRole (convex/lib/authorization.ts:513)
    at handler (convex/organizationModelProviders.ts:264)
```

(Confirmed in prod Convex logs.)

## Root cause

Two independent authorization systems are in play, and the chatbox surface accidentally leans on the wrong one:

- **Chatbox access** ("Anyone with the link", guest execution) is granted through the chatbox row + link token — it deliberately does **not** create a project membership for the viewer.
- **`getVisibleConfigForProject`** is gated by `requireProjectRole`, which checks real `organizationMembers` rows.

`useHostedOrgModelConfig` only gated on `isAuthenticated`. A chatbox share-link guest **is** authenticated (as an anonymous guest), so the hook fired `getVisibleConfigForProject` with the host's `projectId`. The guest has chatbox access but no project membership → the query throws. With no route-level `ErrorBoundary`, that Convex error propagates into render and React Router's default error page replaces the entire app.

The guest never needed that data: the chatbox resolves its model **server-side** from the chatbox row (surfaced to the client as `executionConfig.modelId`), so the project-scoped org provider config is unused on the chatbox surface.

## Fix

- Add a `disabled` flag to `useHostedOrgModelConfig` that skips **both** the project- and org-scoped queries.
- In `ChatTabV2`, pass `disabled: Boolean(hostedChatboxId)` so any chatbox surface (preview or share link) skips the query. `composeAvailableModels` already tolerates an undefined org config.

## Testing

- New unit test: `useHostedOrgModelConfig` skips both queries when `disabled: true`, even while authenticated with ids present.
- Existing `use-hosted-org-model-config` (4) and `ChatTabV2.history-sync` (13) suites pass.
- Targeted `tsc` on the changed files is clean.

## Follow-ups (not in this PR)

- Add an `ErrorBoundary`/`errorElement` to the chatbox route so no single query error can ever take down the whole page again.
- Optionally make `getVisibleConfigForProject` return `{ providers: [] }` for non-members (backend, separate repo) as defense-in-depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted client-side query gating on chatbox surfaces; model resolution is unchanged and `composeAvailableModels` already handles missing org config.
> 
> **Overview**
> Fixes **chatbox share-link** pages crashing with *"Not a member of this project"* when anonymous guests load the hosted chat UI.
> 
> **`useHostedOrgModelConfig`** now accepts **`disabled`**, which skips both `getVisibleConfigForProject` and `getVisibleConfig` when set. **`ChatTabV2`** passes **`disabled: Boolean(hostedChatboxId)`** so chatbox preview and share links never hit project-gated org provider config—model choice already comes from **`executionConfig.modelId`** on the chatbox row.
> 
> Adds a unit test asserting both queries stay **`skip`** when **`disabled: true`** even with auth and IDs present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ac999ff25b320e499db953e04c6c126654b6e29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes chatbox share-link crashes by skipping project- and org-scoped model provider queries for guest viewers. Adds a disabled flag to `useHostedOrgModelConfig` and enables it in `ChatTabV2` for chatbox views.

- **Bug Fixes**
  - Skip both queries when `disabled` to avoid "Not a member of this project" errors for anonymous guests.
  - Pass `disabled: true` in chatbox views (based on `hostedChatboxId`); the model still comes from `executionConfig.modelId`.
  - Added a unit test verifying both queries are skipped even when authenticated with IDs.

<sup>Written for commit 5ac999ff25b320e499db953e04c6c126654b6e29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

