### PR TITLE
Swarm journeys: live SSE streaming, evals-style matrix, and compact journey UI

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/metric-strip.tsx
+++ b/mcpjam-inspector/client/src/components/evals/metric-strip.tsx
@@ -8,7 +8,7 @@ import {
   type MetricStripPoint,
 } from "./metric-strip-data";
 
-function LatencyTrendMetric({
+export function LatencyTrendMetric({
   p50,
   p95,
   p50Series,
@@ -18,6 +18,8 @@ function LatencyTrendMetric({
   compact,
   layout = "horizontal",
   matrixCell = false,
+  subLabel = "per run",
+  divider,
 }: {
   p50: number | null;
   p95: number | null;
@@ -28,6 +30,10 @@ function LatencyTrendMetric({
   compact?: boolean;
   layout?: "horizontal" | "vertical";
   matrixCell?: boolean;
+  /** Caption under the P50/P95 pair. Defaults to "per run" (evals context). */
+  subLabel?: string;
+  /** Draw the left divider. Defaults to the horizontal-layout behavior. */
+  divider?: boolean;
 }) {
   const valueClass = cn(
     "font-semibold leading-none tabular-nums tracking-tight text-foreground",
@@ -49,7 +55,7 @@ function LatencyTrendMetric({
     <div
       className={cn(
         "flex min-w-0 flex-col justify-between",
-        layout === "horizontal" && "border-l border-border/60",
+        (divider ?? layout === "horizontal") && "border-l border-border/60",
         matrixCell ? "px-2 py-2" : compact ? "px-3 py-2.5" : "px-4 py-3.5",
       )}
       data-testid="metric-strip-latency"
@@ -93,7 +99,7 @@ function LatencyTrendMetric({
         </div>
         {!matrixCell ? (
           <div className="mt-1 text-[10.5px] text-muted-foreground">
-            per run
+            {subLabel}
           </div>
         ) : null}
       </div>
@@ -113,7 +119,7 @@ function LatencyTrendMetric({
   );
 }
 
-function TrendMetric({
+export function TrendMetric({
   label,
   value,
   sub,
@@ -121,6 +127,7 @@ function TrendMetric({
   compact,
   layout = "horizontal",
   matrixCell = false,
+  divider,
 }: {
   label: string;
   value: string;
@@ -129,12 +136,14 @@ function TrendMetric({
   compact?: boolean;
   layout?: "horizontal" | "vertical";
   matrixCell?: boolean;
+  /** Draw the left divider. Defaults to the horizontal-layout behavior. */
+  divider?: boolean;
 }) {
   return (
     <div
       className={cn(
         "flex min-w-0 flex-col justify-between",
-        layout === "horizontal" && "border-l border-border/60",
+        (divider ?? layout === "horizontal") && "border-l border-border/60",
         matrixCell ? "px-2 py-2" : compact ? "px-3 py-2.5" : "px-4 py-3.5",
       )}
     >

--- a/mcpjam-inspector/client/src/components/swarms/SwarmsSessionsPanel.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/SwarmsSessionsPanel.tsx
@@ -1,0 +1,235 @@
+/**
+ * Flat Sessions browser for Swarms — list + detail over project `chatSessions`
+ * with `sourceType: "swarm"`. Defaults to all personas; selecting a persona in
+ * the sidebar (or clearing via "All personas") narrows to
+ * `listSessionsByPersona`. Mirrors the Chatboxes Sessions layout.
+ */
+import { useEffect, useMemo, useRef, useState } from "react";
+import { usePaginatedQuery } from "convex/react";
+import { MessageSquare, X } from "lucide-react";
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from "@/components/ui/resizable";
+import { Button } from "@mcpjam/design-system/button";
+import { ShareUsageThreadList } from "@/components/connection/share-usage/ShareUsageThreadList";
+import { ShareUsageThreadDetail } from "@/components/connection/share-usage/ShareUsageThreadDetail";
+import { ConvertSwarmSessionDialog } from "@/components/swarms/convert-swarm-session-dialog";
+import {
+  DEFAULT_PAGE_SIZE,
+  SWARM_QUERIES,
+  journeySessionRowToThread,
+  type JourneySessionRow,
+} from "@/lib/swarm-api";
+import {
+  buildEvalsPath,
+  buildSwarmSessionPath,
+  navigateApp,
+} from "@/lib/app-navigation";
+import { getShareableAppOrigin } from "@/lib/chatbox-session";
+
+export function SwarmsSessionsPanel({
+  projectId,
+  personaRefId,
+  personaName,
+  onClearPersonaFilter,
+  initialThreadId,
+}: {
+  projectId: string;
+  /** When set, narrows the list to that persona; `null` = all project sessions. */
+  personaRefId: string | null;
+  personaName?: string;
+  /** Clear the persona filter back to "all sessions". */
+  onClearPersonaFilter?: () => void;
+  /** Deep-link session (`chatSessions` `_id`) to preselect. */
+  initialThreadId?: string | null;
+}) {
+  const filtered = Boolean(personaRefId);
+  const queryName = filtered
+    ? SWARM_QUERIES.listSessionsByPersona
+    : SWARM_QUERIES.listSessionsByProject;
+  const queryArgs = filtered
+    ? ({ personaRefId } as any)
+    : ({ projectId } as any);
+
+  const {
+    results: sessions,
+    status,
+    loadMore,
+  } = usePaginatedQuery(queryName as any, queryArgs, {
+    initialNumItems: Math.max(DEFAULT_PAGE_SIZE, 25),
+  });
+
+  const rows = sessions as JourneySessionRow[];
+  const [selectedThreadId, setSelectedThreadId] = useState<string | null>(
+    initialThreadId ?? null,
+  );
+  const [sessionToPromote, setSessionToPromote] =
+    useState<JourneySessionRow | null>(null);
+
+  // Reset selection when the persona filter changes; re-seed from the deep
+  // link when it still applies.
+  const prevPersonaRef = useRef(personaRefId);
+  useEffect(() => {
+    if (prevPersonaRef.current === personaRefId) return;
+    prevPersonaRef.current = personaRefId;
+    setSelectedThreadId(initialThreadId ?? null);
+    setSessionToPromote(null);
+  }, [personaRefId, initialThreadId]);
+
+  // Apply deep-link once the matching row appears (may need Load more).
+  const appliedInitialRef = useRef(false);
+  useEffect(() => {
+    if (appliedInitialRef.current || !initialThreadId) return;
+    if (rows.some((r) => r.id === initialThreadId)) {
+      appliedInitialRef.current = true;
+      setSelectedThreadId(initialThreadId);
+    }
+  }, [initialThreadId, rows]);
+
+  const threads = useMemo(
+    () => rows.map((r) => journeySessionRowToThread(r, personaName)),
+    [rows, personaName],
+  );
+
+  const selectedRow = useMemo(
+    () => rows.find((r) => r.id === selectedThreadId) ?? null,
+    [rows, selectedThreadId],
+  );
+
+  const linkPersonaRefId =
+    selectedRow?.personaRefId ?? personaRefId ?? undefined;
+  const sessionLink =
+    selectedRow &&
+    linkPersonaRefId &&
+    selectedRow.journeyRunId &&
+    selectedRow.hostId
+      ? `${getShareableAppOrigin()}${buildSwarmSessionPath({
+          personaRefId: linkPersonaRefId,
+          runId: selectedRow.journeyRunId,
+          hostId: selectedRow.hostId,
+          threadId: selectedRow.id,
+        })}`
+      : undefined;
+
+  const emptyListCopy = filtered
+    ? "No sessions for this persona yet"
+    : "No swarm sessions yet";
+
+  return (
+    <div className="flex h-full min-h-0 flex-col" data-testid="swarms-sessions-panel">
+      <div className="flex shrink-0 items-center justify-between gap-2 border-b border-border/40 px-4 py-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <p className="truncate text-xs text-muted-foreground">
+            {status === "LoadingFirstPage"
+              ? "Loading sessions…"
+              : `${threads.length}${status === "CanLoadMore" ? "+" : ""} session${
+                  threads.length === 1 ? "" : "s"
+                }`}
+          </p>
+          {filtered && personaName ? (
+            <button
+              type="button"
+              data-testid="swarms-sessions-persona-filter"
+              className="inline-flex max-w-[12rem] items-center gap-1 truncate rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-foreground hover:bg-muted/80"
+              onClick={() => onClearPersonaFilter?.()}
+              title="Clear persona filter"
+            >
+              <span className="truncate">{personaName}</span>
+              <X className="size-3 shrink-0 opacity-60" aria-hidden />
+            </button>
+          ) : (
+            <span className="text-[11px] text-muted-foreground/70">
+              All personas
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          {selectedRow ? (
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              className="rounded-xl"
+              onClick={() => setSessionToPromote(selectedRow)}
+            >
+              Promote to test case
+            </Button>
+          ) : null}
+          {status === "CanLoadMore" ? (
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              className="rounded-xl"
+              onClick={() => loadMore(DEFAULT_PAGE_SIZE)}
+            >
+              Load more
+            </Button>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-hidden">
+        <ResizablePanelGroup direction="horizontal" className="h-full">
+          <ResizablePanel defaultSize={32} minSize={22}>
+            <div className="h-full overflow-hidden">
+              <ShareUsageThreadList
+                threads={threads}
+                selectedThreadId={selectedThreadId}
+                onSelectThread={setSelectedThreadId}
+              />
+            </div>
+          </ResizablePanel>
+          <ResizableHandle withHandle />
+          <ResizablePanel defaultSize={68} minSize={40}>
+            <div className="h-full overflow-hidden">
+              {selectedThreadId ? (
+                <ShareUsageThreadDetail
+                  threadId={selectedThreadId}
+                  sessionLink={sessionLink}
+                />
+              ) : (
+                <div className="flex h-full items-center justify-center">
+                  <div className="text-center">
+                    <MessageSquare className="mx-auto mb-2 h-8 w-8 text-muted-foreground/50" />
+                    <p className="text-sm text-muted-foreground">
+                      {threads.length === 0
+                        ? emptyListCopy
+                        : "Select a conversation to view"}
+                    </p>
+                    {!filtered && threads.length === 0 ? (
+                      <p className="mt-1 text-xs text-muted-foreground/70">
+                        Run a journey to generate sessions, or pick a persona to
+                        filter.
+                      </p>
+                    ) : null}
+                  </div>
+                </div>
+              )}
+            </div>
+          </ResizablePanel>
+        </ResizablePanelGroup>
+      </div>
+
+      <ConvertSwarmSessionDialog
+        open={sessionToPromote !== null}
+        session={sessionToPromote}
+        onOpenChange={(open) => {
+          if (!open) setSessionToPromote(null);
+        }}
+        onImported={({ suiteId, testCaseId }) => {
+          setSessionToPromote(null);
+          navigateApp(
+            buildEvalsPath({
+              type: "test-edit",
+              suiteId,
+              testId: testCaseId,
+            }),
+          );
+        }}
+      />
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/swarms/SwarmsSessionsPanel.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/SwarmsSessionsPanel.tsx
@@ -1,18 +1,24 @@
 /**
  * Flat Sessions browser for Swarms — list + detail over project `chatSessions`
- * with `sourceType: "swarm"`. Defaults to all personas; selecting a persona in
- * the sidebar (or clearing via "All personas") narrows to
- * `listSessionsByPersona`. Mirrors the Chatboxes Sessions layout.
+ * with `sourceType: "swarm"`. Defaults to all personas; the top-bar persona
+ * picker narrows to `listSessionsByPersona`. Mirrors the Chatboxes Sessions layout.
  */
 import { useEffect, useMemo, useRef, useState } from "react";
 import { usePaginatedQuery } from "convex/react";
-import { MessageSquare, X } from "lucide-react";
+import { MessageSquare } from "lucide-react";
 import {
   ResizableHandle,
   ResizablePanel,
   ResizablePanelGroup,
 } from "@/components/ui/resizable";
 import { Button } from "@mcpjam/design-system/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@mcpjam/design-system/select";
 import { ShareUsageThreadList } from "@/components/connection/share-usage/ShareUsageThreadList";
 import { ShareUsageThreadDetail } from "@/components/connection/share-usage/ShareUsageThreadDetail";
 import { ConvertSwarmSessionDialog } from "@/components/swarms/convert-swarm-session-dialog";
@@ -31,21 +37,21 @@ import { getShareableAppOrigin } from "@/lib/chatbox-session";
 
 export function SwarmsSessionsPanel({
   projectId,
+  personas,
   personaRefId,
-  personaName,
-  onClearPersonaFilter,
+  onPersonaRefIdChange,
   initialThreadId,
 }: {
   projectId: string;
+  personas: ReadonlyArray<{ _id: string; name: string; role?: string }>;
   /** When set, narrows the list to that persona; `null` = all project sessions. */
   personaRefId: string | null;
-  personaName?: string;
-  /** Clear the persona filter back to "all sessions". */
-  onClearPersonaFilter?: () => void;
+  onPersonaRefIdChange: (personaRefId: string | null) => void;
   /** Deep-link session (`chatSessions` `_id`) to preselect. */
   initialThreadId?: string | null;
 }) {
   const filtered = Boolean(personaRefId);
+  const personaName = personas.find((p) => p._id === personaRefId)?.name;
   const queryName = filtered
     ? SWARM_QUERIES.listSessionsByPersona
     : SWARM_QUERIES.listSessionsByProject;
@@ -119,31 +125,37 @@ export function SwarmsSessionsPanel({
 
   return (
     <div className="flex h-full min-h-0 flex-col" data-testid="swarms-sessions-panel">
-      <div className="flex shrink-0 items-center justify-between gap-2 border-b border-border/40 px-4 py-2">
-        <div className="flex min-w-0 items-center gap-2">
-          <p className="truncate text-xs text-muted-foreground">
+      <div className="flex shrink-0 items-center justify-between gap-3 border-b border-border/40 px-4 py-2.5">
+        <div className="flex min-w-0 flex-1 items-center gap-3">
+          <p className="shrink-0 truncate text-xs text-muted-foreground">
             {status === "LoadingFirstPage"
               ? "Loading sessions…"
               : `${threads.length}${status === "CanLoadMore" ? "+" : ""} session${
                   threads.length === 1 ? "" : "s"
                 }`}
           </p>
-          {filtered && personaName ? (
-            <button
-              type="button"
+          <Select
+            value={personaRefId ?? "all"}
+            onValueChange={(value) =>
+              onPersonaRefIdChange(value === "all" ? null : value)
+            }
+          >
+            <SelectTrigger
               data-testid="swarms-sessions-persona-filter"
-              className="inline-flex max-w-[12rem] items-center gap-1 truncate rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-foreground hover:bg-muted/80"
-              onClick={() => onClearPersonaFilter?.()}
-              title="Clear persona filter"
+              className="h-8 w-[min(100%,12rem)] text-xs"
+              aria-label="Filter sessions by persona"
             >
-              <span className="truncate">{personaName}</span>
-              <X className="size-3 shrink-0 opacity-60" aria-hidden />
-            </button>
-          ) : (
-            <span className="text-[11px] text-muted-foreground/70">
-              All personas
-            </span>
-          )}
+              <SelectValue placeholder="All personas" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All personas</SelectItem>
+              {personas.map((persona) => (
+                <SelectItem key={persona._id} value={persona._id}>
+                  {persona.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </div>
         <div className="flex items-center gap-2">
           {selectedRow ? (
@@ -201,8 +213,8 @@ export function SwarmsSessionsPanel({
                     </p>
                     {!filtered && threads.length === 0 ? (
                       <p className="mt-1 text-xs text-muted-foreground/70">
-                        Run a journey to generate sessions, or pick a persona to
-                        filter.
+                        Run a journey to generate sessions, or filter by persona
+                        above.
                       </p>
                     ) : null}
                   </div>

--- a/mcpjam-inspector/client/src/components/swarms/SwarmsSessionsPanel.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/SwarmsSessionsPanel.tsx
@@ -22,6 +22,8 @@ import {
 import { ShareUsageThreadList } from "@/components/connection/share-usage/ShareUsageThreadList";
 import { ShareUsageThreadDetail } from "@/components/connection/share-usage/ShareUsageThreadDetail";
 import { ConvertSwarmSessionDialog } from "@/components/swarms/convert-swarm-session-dialog";
+import { SwarmSessionsMetricStrip } from "@/components/swarms/swarm-sessions-metric-strip";
+import { ErrorBoundary } from "@/components/ui/error-boundary";
 import {
   DEFAULT_PAGE_SIZE,
   SWARM_QUERIES,
@@ -38,12 +40,15 @@ import { getShareableAppOrigin } from "@/lib/chatbox-session";
 export function SwarmsSessionsPanel({
   projectId,
   personas,
+  hosts = [],
   personaRefId,
   onPersonaRefIdChange,
   initialThreadId,
 }: {
   projectId: string;
   personas: ReadonlyArray<{ _id: string; name: string; role?: string }>;
+  /** Project hosts — resolves display names for the host filter. */
+  hosts?: ReadonlyArray<{ hostId: string; name: string }>;
   /** When set, narrows the list to that persona; `null` = all project sessions. */
   personaRefId: string | null;
   onPersonaRefIdChange: (personaRefId: string | null) => void;
@@ -67,7 +72,30 @@ export function SwarmsSessionsPanel({
     initialNumItems: Math.max(DEFAULT_PAGE_SIZE, 25),
   });
 
-  const rows = sessions as JourneySessionRow[];
+  const allRows = sessions as JourneySessionRow[];
+
+  // Host filter — client-side over the loaded pages (there is no per-host
+  // backend query; the persona filter stays server-side as before). "Load
+  // more" keeps paginating the unfiltered list.
+  const [hostFilter, setHostFilter] = useState<string | null>(null);
+  const hostOptions = useMemo(() => {
+    const seen = new Map<string, string>();
+    for (const r of allRows) {
+      if (r.hostId && !seen.has(r.hostId)) {
+        seen.set(
+          r.hostId,
+          hosts.find((h) => h.hostId === r.hostId)?.name ?? r.hostId.slice(0, 8),
+        );
+      }
+    }
+    return Array.from(seen, ([hostId, name]) => ({ hostId, name }));
+  }, [allRows, hosts]);
+  const rows = useMemo(
+    () =>
+      hostFilter ? allRows.filter((r) => r.hostId === hostFilter) : allRows,
+    [allRows, hostFilter],
+  );
+
   const [selectedThreadId, setSelectedThreadId] = useState<string | null>(
     initialThreadId ?? null,
   );
@@ -80,9 +108,20 @@ export function SwarmsSessionsPanel({
   useEffect(() => {
     if (prevPersonaRef.current === personaRefId) return;
     prevPersonaRef.current = personaRefId;
+    setHostFilter(null);
     setSelectedThreadId(initialThreadId ?? null);
     setSessionToPromote(null);
   }, [personaRefId, initialThreadId]);
+
+  // Drop a selection the host filter just hid — the detail pane must not show
+  // a session missing from the visible list.
+  useEffect(() => {
+    if (!hostFilter || !selectedThreadId) return;
+    if (!rows.some((r) => r.id === selectedThreadId)) {
+      setSelectedThreadId(null);
+      setSessionToPromote(null);
+    }
+  }, [hostFilter, rows, selectedThreadId]);
 
   // Apply deep-link once the matching row appears (may need Load more).
   const appliedInitialRef = useRef(false);
@@ -119,9 +158,11 @@ export function SwarmsSessionsPanel({
         })}`
       : undefined;
 
-  const emptyListCopy = filtered
-    ? "No sessions for this persona yet"
-    : "No swarm sessions yet";
+  const emptyListCopy = hostFilter
+    ? "No loaded sessions for this client"
+    : filtered
+      ? "No sessions for this persona yet"
+      : "No swarm sessions yet";
 
   return (
     <div className="flex h-full min-h-0 flex-col" data-testid="swarms-sessions-panel">
@@ -156,6 +197,30 @@ export function SwarmsSessionsPanel({
               ))}
             </SelectContent>
           </Select>
+          {hostOptions.length > 0 ? (
+            <Select
+              value={hostFilter ?? "all"}
+              onValueChange={(value) =>
+                setHostFilter(value === "all" ? null : value)
+              }
+            >
+              <SelectTrigger
+                data-testid="swarms-sessions-host-filter"
+                className="h-8 w-[min(100%,12rem)] text-xs"
+                aria-label="Filter sessions by client"
+              >
+                <SelectValue placeholder="All clients" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All clients</SelectItem>
+                {hostOptions.map((h) => (
+                  <SelectItem key={h.hostId} value={h.hostId}>
+                    {h.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          ) : null}
         </div>
         <div className="flex items-center gap-2">
           {selectedRow ? (
@@ -181,6 +246,15 @@ export function SwarmsSessionsPanel({
             </Button>
           ) : null}
         </div>
+      </div>
+
+      <div className="shrink-0 px-4 pt-3">
+        <ErrorBoundary fallback={null}>
+          <SwarmSessionsMetricStrip
+            projectId={projectId}
+            personaRefId={personaRefId}
+          />
+        </ErrorBoundary>
       </div>
 
       <div className="min-h-0 flex-1 overflow-hidden">

--- a/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
@@ -5,6 +5,11 @@
  * journeys live at the project level; a journey targets one-or-more hosts and,
  * when run, fans out one single-host session per (host × sessionsPerHost).
  *
+ * Top-level views (ViewModeSelector):
+ *   - Journeys — persona detail, journey cards, run matrix / live stream
+ *   - Sessions — flat chatSessions browser for the selected persona
+ *     (`listSessionsByPersona` + shared ShareUsageThreadList/Detail)
+ *
  * Consumes the project-scoped backend: personas:*, journeys:*, journeyRuns:*.
  *
  * ## Agent bridge (v1 scope)
@@ -87,6 +92,7 @@ import {
 import { getShareableAppOrigin } from "@/lib/chatbox-session";
 import { resolveHostLogoByDisplayName } from "@/lib/chatbox-client-style";
 import { ConvertSwarmSessionDialog } from "@/components/swarms/convert-swarm-session-dialog";
+import { SwarmsSessionsPanel } from "@/components/swarms/SwarmsSessionsPanel";
 import {
   SwarmLiveStreamPane,
   SwarmSessionsMatrix,
@@ -96,6 +102,7 @@ import {
   liveSessionTrace,
   useJourneyRunStream,
 } from "@/components/swarms/use-journey-run-stream";
+import { ViewModeSelector } from "@/components/shared/view-mode-selector";
 import { ServerGroupPicker } from "@/components/hosts/ServerGroupPicker";
 import { useProjectServerAttachments } from "@/hooks/useViews";
 import { useSurfaceAgentBridge } from "@/lib/webmcp/use-surface-agent-bridge";
@@ -295,6 +302,16 @@ export function SwarmsTab({
   const deepLink = useMemo(
     () => parseSwarmSessionParams(window.location.search),
     [],
+  );
+  type SwarmViewMode = "journeys" | "sessions";
+  const SWARM_VIEW_OPTIONS = [
+    { value: "journeys" as const, label: "Journeys" },
+    { value: "sessions" as const, label: "Sessions" },
+  ];
+  // Session deep-links open the flat Sessions browser; run-only links stay on
+  // Journeys so the matrix / live stream can restore.
+  const [viewMode, setViewMode] = useState<SwarmViewMode>(() =>
+    deepLink.threadId ? "sessions" : "journeys",
   );
   const [selectedPersonaId, setSelectedPersonaId] = useState<string | null>(
     () => deepLink.personaRefId ?? null,
@@ -674,6 +691,19 @@ export function SwarmsTab({
           onChange={onRunningPersonasChange}
         />
       </ErrorBoundary>
+      <div
+        className="relative shrink-0 border-b border-border/40 px-8 py-2.5"
+        data-testid="swarms-tab-header-chrome"
+      >
+        <div className="flex min-w-0 items-center justify-center">
+          <ViewModeSelector
+            value={viewMode}
+            ariaLabel="Swarm view"
+            onChange={setViewMode}
+            options={SWARM_VIEW_OPTIONS}
+          />
+        </div>
+      </div>
       <div className="flex min-h-0 flex-1">
         {/* Personas */}
         <aside className="flex w-72 shrink-0 flex-col border-r">
@@ -729,87 +759,99 @@ export function SwarmsTab({
           </div>
         </aside>
 
-        {/* Journeys for the selected persona */}
-        <main className="min-w-0 flex-1 overflow-y-auto">
-        {!selectedPersona ? (
-          <JourneyNetworkBackdrop />
-        ) : (
-          <div className="mx-auto max-w-3xl px-8 py-6">
-            <PersonaDetailHeader
-              persona={selectedPersona}
-              running={runningSet.has(selectedPersona._id)}
-              onSave={(patch) => savePersonaField(selectedPersona._id, patch)}
-              onDelete={async () => {
-                if (
-                  !window.confirm(
-                    `Delete persona "${selectedPersona.name}"? Its journeys are hidden but historical runs are kept.`,
-                  )
-                ) {
-                  return;
-                }
-                await deletePersona({
-                  personaRefId: selectedPersona._id,
-                } as any);
-                setSelectedPersonaId(null);
-              }}
+        {viewMode === "sessions" ? (
+          <main className="min-w-0 flex-1 overflow-hidden">
+            <SwarmsSessionsPanel
+              projectId={projectId}
+              personaRefId={selectedPersona?._id ?? null}
+              personaName={selectedPersona?.name}
+              onClearPersonaFilter={() => setSelectedPersonaId(null)}
+              initialThreadId={deepLink.threadId}
             />
-
-            <div
-              className={cn(
-                "mb-3",
-                journeyFormOpen
-                  ? "space-y-2"
-                  : "flex items-center justify-between",
-              )}
-            >
-              <h3 className="text-sm font-semibold">Journeys</h3>
-              <NewJourneyButton
-                projectId={projectId}
-                hosts={hosts ?? []}
-                open={journeyFormOpen}
-                onOpenChange={(o) => {
-                  setJourneyFormOpen(o);
-                  // Drop the agent prefill on close so a later manual open
-                  // starts blank.
-                  if (!o) setJourneyGoalSeed("");
-                }}
-                goalSeed={journeyGoalSeed}
-                onCreate={async (draft) => {
-                  await createJourney({
-                    projectId,
-                    personaRefId: selectedPersona._id,
-                    ...draft,
-                  } as any);
-                }}
-              />
-            </div>
-
-            {journeys === undefined ? (
-              <div className="text-sm text-muted-foreground">Loading…</div>
-            ) : journeys.length === 0 ? (
-              <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
-                No journeys yet. A journey is a goal this persona pursues across
-                one or more hosts.
-              </div>
+          </main>
+        ) : (
+          /* Journeys for the selected persona */
+          <main className="min-w-0 flex-1 overflow-y-auto">
+            {!selectedPersona ? (
+              <JourneyNetworkBackdrop />
             ) : (
-              <div className="flex flex-col gap-3">
-                {journeys.map((j) => (
-                  <JourneyCard
-                    key={j._id}
-                    journey={j}
-                    onLaunch={launchJourney}
-                    hosts={hosts ?? []}
-                    isAuthenticated={isAuthenticated}
+              <div className="mx-auto max-w-3xl px-8 py-6">
+                <PersonaDetailHeader
+                  persona={selectedPersona}
+                  running={runningSet.has(selectedPersona._id)}
+                  onSave={(patch) => savePersonaField(selectedPersona._id, patch)}
+                  onDelete={async () => {
+                    if (
+                      !window.confirm(
+                        `Delete persona "${selectedPersona.name}"? Its journeys are hidden but historical runs are kept.`,
+                      )
+                    ) {
+                      return;
+                    }
+                    await deletePersona({
+                      personaRefId: selectedPersona._id,
+                    } as any);
+                    setSelectedPersonaId(null);
+                  }}
+                />
+
+                <div
+                  className={cn(
+                    "mb-3",
+                    journeyFormOpen
+                      ? "space-y-2"
+                      : "flex items-center justify-between",
+                  )}
+                >
+                  <h3 className="text-sm font-semibold">Journeys</h3>
+                  <NewJourneyButton
                     projectId={projectId}
-                    initialRunId={deepLink.runId}
-                    initialThreadId={deepLink.threadId}
+                    hosts={hosts ?? []}
+                    open={journeyFormOpen}
+                    onOpenChange={(o) => {
+                      setJourneyFormOpen(o);
+                      // Drop the agent prefill on close so a later manual open
+                      // starts blank.
+                      if (!o) setJourneyGoalSeed("");
+                    }}
+                    goalSeed={journeyGoalSeed}
+                    onCreate={async (draft) => {
+                      await createJourney({
+                        projectId,
+                        personaRefId: selectedPersona._id,
+                        ...draft,
+                      } as any);
+                    }}
                   />
-                ))}
+                </div>
+
+                {journeys === undefined ? (
+                  <div className="text-sm text-muted-foreground">Loading…</div>
+                ) : journeys.length === 0 ? (
+                  <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
+                    No journeys yet. A journey is a goal this persona pursues
+                    across one or more hosts.
+                  </div>
+                ) : (
+                  <div className="flex flex-col gap-3">
+                    {journeys.map((j) => (
+                      <JourneyCard
+                        key={j._id}
+                        journey={j}
+                        onLaunch={launchJourney}
+                        hosts={hosts ?? []}
+                        isAuthenticated={isAuthenticated}
+                        projectId={projectId}
+                        initialRunId={deepLink.runId}
+                        initialThreadId={deepLink.threadId}
+                      />
+                    ))}
+                  </div>
+                )}
               </div>
             )}
-          </div>
+          </main>
         )}
-      </main>
       </div>
     </div>
   );

--- a/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
@@ -888,6 +888,24 @@ function runSummaryLine(r: JourneyRun): string {
   return parts.join(" · ");
 }
 
+/**
+ * Chat-session lifecycle (`active`) is NOT "journey running" — sessions stay
+ * `active` after the run completes. Map to copy that matches the run so the
+ * sessions list doesn't contradict Completed / Running above.
+ */
+function sessionLifecycleLabel(
+  sessionStatus: string | undefined,
+  runStatus: string,
+): string | null {
+  if (!sessionStatus) return null;
+  if (sessionStatus === "failed") return "failed";
+  if (sessionStatus === "completed") return "done";
+  if (sessionStatus === "active" || sessionStatus === "running") {
+    return runStatus === "running" ? "running" : "done";
+  }
+  return sessionStatus.replace(/_/g, " ");
+}
+
 // ── journey card + runs ──────────────────────────────────────────────────────
 function JourneyCard({
   journey,
@@ -1144,6 +1162,7 @@ function JourneyCard({
                       hosts={hosts}
                       hostSummaries={r.hostSummaries}
                       runSummary={r.summary}
+                      runStatus={r.status}
                       initialThreadId={
                         initialRunId === r._id ? initialThreadId : undefined
                       }
@@ -1175,6 +1194,7 @@ function RunSessionsView({
   hosts,
   hostSummaries,
   runSummary,
+  runStatus,
   initialThreadId,
 }: {
   runId: string;
@@ -1183,6 +1203,7 @@ function RunSessionsView({
   hosts: HostItem[];
   hostSummaries: JourneyRun["hostSummaries"];
   runSummary: JourneyRun["summary"];
+  runStatus: JourneyRun["status"];
   /** Deep-link session (`id`) to auto-select once it's on a loaded page. */
   initialThreadId?: string;
 }) {
@@ -1360,6 +1381,8 @@ function RunSessionsView({
           {visible.map((s) => {
             const isFailed =
               s.status === "failed" || s.readiness?.status === "failed";
+            const lifecycle = sessionLifecycleLabel(s.status, runStatus);
+            const meta = [lifecycle, s.modelId].filter(Boolean).join(" · ");
             return (
               <button
                 key={s.id}
@@ -1379,11 +1402,12 @@ function RunSessionsView({
                       "truncate text-[10px]",
                       isFailed
                         ? "text-red-600 dark:text-red-400"
-                        : "text-muted-foreground",
+                        : lifecycle === "running"
+                          ? "text-foreground/80"
+                          : "text-muted-foreground",
                     )}
                   >
-                    {s.status ?? "—"}
-                    {s.modelId ? ` · ${s.modelId}` : ""}
+                    {meta || "—"}
                   </span>
                 </span>
                 <span className="flex shrink-0 items-center gap-1.5">

--- a/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
@@ -6,8 +6,8 @@
  * when run, fans out one single-host session per (host × sessionsPerHost).
  *
  * Top-level views (ViewModeSelector):
- *   - Journeys — persona detail, journey cards, run matrix / live stream
- *   - Sessions — flat chatSessions browser for the selected persona
+ *   - Personas — persona sidebar, journey cards, run matrix / live stream
+ *   - Journeys — flat chatSessions browser with top-bar persona filter
  *     (`listSessionsByPersona` + shared ShareUsageThreadList/Detail)
  *
  * Consumes the project-scoped backend: personas:*, journeys:*, journeyRuns:*.
@@ -305,8 +305,8 @@ export function SwarmsTab({
   );
   type SwarmViewMode = "journeys" | "sessions";
   const SWARM_VIEW_OPTIONS = [
-    { value: "journeys" as const, label: "Journeys" },
-    { value: "sessions" as const, label: "Sessions" },
+    { value: "journeys" as const, label: "Personas" },
+    { value: "sessions" as const, label: "Journeys" },
   ];
   // Session deep-links open the flat Sessions browser; run-only links stay on
   // Journeys so the matrix / live stream can restore.
@@ -705,151 +705,153 @@ export function SwarmsTab({
         </div>
       </div>
       <div className="flex min-h-0 flex-1">
-        {/* Personas */}
-        <aside className="flex w-72 shrink-0 flex-col border-r">
-          <div className="flex items-center justify-between border-b px-4 py-3">
-            <h2 className="text-sm font-semibold">Personas</h2>
-            <NewPersonaDialog
-              onCreate={async (draft) => {
-                const row = await createPersona({ projectId, ...draft } as any);
-                setSelectedPersonaId(row._id);
-              }}
-            />
-          </div>
-          <div className="min-h-0 flex-1 overflow-y-auto">
-            {personas === undefined ? (
-              <div className="p-4 text-sm text-muted-foreground">Loading…</div>
-            ) : personas.length === 0 ? (
-              <div className="p-4 text-sm text-muted-foreground">
-                No personas yet. Create one to get started.
+        {viewMode === "journeys" ? (
+          <>
+            {/* Personas sidebar — Personas tab only */}
+            <aside className="flex w-72 shrink-0 flex-col border-r">
+              <div className="flex items-center justify-between border-b px-4 py-3">
+                <h2 className="text-sm font-semibold">Personas</h2>
+                <NewPersonaDialog
+                  onCreate={async (draft) => {
+                    const row = await createPersona({ projectId, ...draft } as any);
+                    setSelectedPersonaId(row._id);
+                  }}
+                />
               </div>
-            ) : (
-              personas.map((p) => {
-                const selected = p._id === selectedPersonaId;
-                return (
-                  <button
-                    key={p._id}
-                    type="button"
-                    onClick={() => setSelectedPersonaId(p._id)}
+              <div className="min-h-0 flex-1 overflow-y-auto">
+                {personas === undefined ? (
+                  <div className="p-4 text-sm text-muted-foreground">Loading…</div>
+                ) : personas.length === 0 ? (
+                  <div className="p-4 text-sm text-muted-foreground">
+                    No personas yet. Create one to get started.
+                  </div>
+                ) : (
+                  personas.map((p) => {
+                    const selected = p._id === selectedPersonaId;
+                    return (
+                      <button
+                        key={p._id}
+                        type="button"
+                        onClick={() => setSelectedPersonaId(p._id)}
+                        className={cn(
+                          "flex w-full items-center gap-3 border-b px-4 py-3 text-left hover:bg-muted/50",
+                          selected && "bg-muted",
+                        )}
+                      >
+                        <PersonaPixelAvatar
+                          seed={p._id}
+                          shapeIndex={p.avatarShape}
+                          paletteIndex={p.avatarPalette}
+                          size="md"
+                          active={selected}
+                          state={runningSet.has(p._id) ? "running" : "idle"}
+                        />
+                        <span className="flex min-w-0 flex-col items-start gap-0.5">
+                          <span className="truncate text-sm font-medium">
+                            {p.name}
+                          </span>
+                          <span className="truncate text-xs text-muted-foreground">
+                            {p.role}
+                          </span>
+                        </span>
+                      </button>
+                    );
+                  })
+                )}
+              </div>
+            </aside>
+
+            {/* Persona detail + journey cards */}
+            <main className="min-w-0 flex-1 overflow-y-auto">
+              {!selectedPersona ? (
+                <JourneyNetworkBackdrop />
+              ) : (
+                <div className="mx-auto max-w-3xl px-8 py-6">
+                  <PersonaDetailHeader
+                    persona={selectedPersona}
+                    running={runningSet.has(selectedPersona._id)}
+                    onSave={(patch) => savePersonaField(selectedPersona._id, patch)}
+                    onDelete={async () => {
+                      if (
+                        !window.confirm(
+                          `Delete persona "${selectedPersona.name}"? Its journeys are hidden but historical runs are kept.`,
+                        )
+                      ) {
+                        return;
+                      }
+                      await deletePersona({
+                        personaRefId: selectedPersona._id,
+                      } as any);
+                      setSelectedPersonaId(null);
+                    }}
+                  />
+
+                  <div
                     className={cn(
-                      "flex w-full items-center gap-3 border-b px-4 py-3 text-left hover:bg-muted/50",
-                      selected && "bg-muted",
+                      "mb-3",
+                      journeyFormOpen
+                        ? "space-y-2"
+                        : "flex items-center justify-between",
                     )}
                   >
-                    <PersonaPixelAvatar
-                      seed={p._id}
-                      shapeIndex={p.avatarShape}
-                      paletteIndex={p.avatarPalette}
-                      size="md"
-                      active={selected}
-                      state={runningSet.has(p._id) ? "running" : "idle"}
+                    <h3 className="text-sm font-semibold">Journeys</h3>
+                    <NewJourneyButton
+                      projectId={projectId}
+                      hosts={hosts ?? []}
+                      open={journeyFormOpen}
+                      onOpenChange={(o) => {
+                        setJourneyFormOpen(o);
+                        // Drop the agent prefill on close so a later manual open
+                        // starts blank.
+                        if (!o) setJourneyGoalSeed("");
+                      }}
+                      goalSeed={journeyGoalSeed}
+                      onCreate={async (draft) => {
+                        await createJourney({
+                          projectId,
+                          personaRefId: selectedPersona._id,
+                          ...draft,
+                        } as any);
+                      }}
                     />
-                    <span className="flex min-w-0 flex-col items-start gap-0.5">
-                      <span className="truncate text-sm font-medium">
-                        {p.name}
-                      </span>
-                      <span className="truncate text-xs text-muted-foreground">
-                        {p.role}
-                      </span>
-                    </span>
-                  </button>
-                );
-              })
-            )}
-          </div>
-        </aside>
+                  </div>
 
-        {viewMode === "sessions" ? (
+                  {journeys === undefined ? (
+                    <div className="text-sm text-muted-foreground">Loading…</div>
+                  ) : journeys.length === 0 ? (
+                    <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
+                      No journeys yet. A journey is a goal this persona pursues
+                      across one or more hosts.
+                    </div>
+                  ) : (
+                    <div className="flex flex-col gap-3">
+                      {journeys.map((j) => (
+                        <JourneyCard
+                          key={j._id}
+                          journey={j}
+                          onLaunch={launchJourney}
+                          hosts={hosts ?? []}
+                          isAuthenticated={isAuthenticated}
+                          projectId={projectId}
+                          initialRunId={deepLink.runId}
+                          initialThreadId={deepLink.threadId}
+                        />
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
+            </main>
+          </>
+        ) : (
           <main className="min-w-0 flex-1 overflow-hidden">
             <SwarmsSessionsPanel
               projectId={projectId}
-              personaRefId={selectedPersona?._id ?? null}
-              personaName={selectedPersona?.name}
-              onClearPersonaFilter={() => setSelectedPersonaId(null)}
+              personas={personas ?? []}
+              personaRefId={selectedPersonaId}
+              onPersonaRefIdChange={setSelectedPersonaId}
               initialThreadId={deepLink.threadId}
             />
-          </main>
-        ) : (
-          /* Journeys for the selected persona */
-          <main className="min-w-0 flex-1 overflow-y-auto">
-            {!selectedPersona ? (
-              <JourneyNetworkBackdrop />
-            ) : (
-              <div className="mx-auto max-w-3xl px-8 py-6">
-                <PersonaDetailHeader
-                  persona={selectedPersona}
-                  running={runningSet.has(selectedPersona._id)}
-                  onSave={(patch) => savePersonaField(selectedPersona._id, patch)}
-                  onDelete={async () => {
-                    if (
-                      !window.confirm(
-                        `Delete persona "${selectedPersona.name}"? Its journeys are hidden but historical runs are kept.`,
-                      )
-                    ) {
-                      return;
-                    }
-                    await deletePersona({
-                      personaRefId: selectedPersona._id,
-                    } as any);
-                    setSelectedPersonaId(null);
-                  }}
-                />
-
-                <div
-                  className={cn(
-                    "mb-3",
-                    journeyFormOpen
-                      ? "space-y-2"
-                      : "flex items-center justify-between",
-                  )}
-                >
-                  <h3 className="text-sm font-semibold">Journeys</h3>
-                  <NewJourneyButton
-                    projectId={projectId}
-                    hosts={hosts ?? []}
-                    open={journeyFormOpen}
-                    onOpenChange={(o) => {
-                      setJourneyFormOpen(o);
-                      // Drop the agent prefill on close so a later manual open
-                      // starts blank.
-                      if (!o) setJourneyGoalSeed("");
-                    }}
-                    goalSeed={journeyGoalSeed}
-                    onCreate={async (draft) => {
-                      await createJourney({
-                        projectId,
-                        personaRefId: selectedPersona._id,
-                        ...draft,
-                      } as any);
-                    }}
-                  />
-                </div>
-
-                {journeys === undefined ? (
-                  <div className="text-sm text-muted-foreground">Loading…</div>
-                ) : journeys.length === 0 ? (
-                  <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
-                    No journeys yet. A journey is a goal this persona pursues
-                    across one or more hosts.
-                  </div>
-                ) : (
-                  <div className="flex flex-col gap-3">
-                    {journeys.map((j) => (
-                      <JourneyCard
-                        key={j._id}
-                        journey={j}
-                        onLaunch={launchJourney}
-                        hosts={hosts ?? []}
-                        isAuthenticated={isAuthenticated}
-                        projectId={projectId}
-                        initialRunId={deepLink.runId}
-                        initialThreadId={deepLink.threadId}
-                      />
-                    ))}
-                  </div>
-                )}
-              </div>
-            )}
           </main>
         )}
       </div>

--- a/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
@@ -29,15 +29,7 @@
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQuery, useMutation, usePaginatedQuery } from "convex/react";
-import {
-  Check,
-  ChevronDown,
-  ChevronRight,
-  Info,
-  Loader2,
-  Plus,
-  Users,
-} from "lucide-react";
+import { Check, ChevronDown, Info, Loader2, Plus, Users, X } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
 import {
   Dialog,
@@ -74,11 +66,10 @@ import {
   SWARM_QUERIES,
   DEFAULT_PAGE_SIZE,
   swarmAttemptChatSessionId,
-  type GoalScoreRollup,
   type JourneyRun,
+  type JourneyRollup,
   type JourneySessionRow,
   type PersonaTrackRecord,
-  type JourneyRollup,
   type SessionGoalScore,
 } from "@/lib/swarm-api";
 import { formatScore } from "@/components/shared/session-quality/judge-presentation";
@@ -90,7 +81,6 @@ import {
   parseSwarmSessionParams,
 } from "@/lib/app-navigation";
 import { getShareableAppOrigin } from "@/lib/chatbox-session";
-import { resolveHostLogoByDisplayName } from "@/lib/chatbox-client-style";
 import { ConvertSwarmSessionDialog } from "@/components/swarms/convert-swarm-session-dialog";
 import { SwarmsSessionsPanel } from "@/components/swarms/SwarmsSessionsPanel";
 import {
@@ -99,12 +89,30 @@ import {
   type SwarmMatrixSelection,
 } from "@/components/swarms/journey-run-results";
 import {
+  JourneyList,
+  type JourneyListJourney,
+  type JourneyRunSelection,
+} from "@/components/swarms/journey-list";
+import { JourneyHostLogoMark } from "@/components/swarms/journey-host-logo";
+import {
+  formatJourneyRelativeTime,
+  runNumberLabel,
+  runStatusChipClass,
+  runSummaryLine,
+} from "@/components/swarms/journey-run-format";
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from "@/components/ui/resizable";
+// Re-exported for the goal-score unit test, which imports from `../SwarmsTab`.
+export { goalScoreAvgLabel } from "@/components/swarms/journey-run-format";
+import {
   liveSessionTrace,
   useJourneyRunStream,
 } from "@/components/swarms/use-journey-run-stream";
 import { ViewModeSelector } from "@/components/shared/view-mode-selector";
 import { ServerGroupPicker } from "@/components/hosts/ServerGroupPicker";
-import { useProjectServerAttachments } from "@/hooks/useViews";
 import { useSurfaceAgentBridge } from "@/lib/webmcp/use-surface-agent-bridge";
 import { createInspectorCommandClientError } from "@/lib/inspector-command-handlers";
 import type {
@@ -184,14 +192,6 @@ export function SessionGoalScoreBadge({
       {formatScore(gs.score ?? NaN)} · {gs.passed ? "meets goal" : "below threshold"}
     </span>
   );
-}
-
-/** `· goal 78% avg (4 judged)` — used on journey run cards. */
-export function goalScoreAvgLabel(rollup: GoalScoreRollup | undefined): string | null {
-  if (!rollup || rollup.gradedCount === 0 || rollup.avgScore === null) {
-    return null;
-  }
-  return `goal ${formatScore(rollup.avgScore)} avg (${rollup.gradedCount} judged)`;
 }
 
 type Persona = {
@@ -364,6 +364,41 @@ export function SwarmsTab({
   // config, so the human finishes and submits it).
   const [journeyFormOpen, setJourneyFormOpen] = useState(false);
   const [journeyGoalSeed, setJourneyGoalSeed] = useState("");
+
+  // Run detail opened in the right-hand panel. `runSnapshot` seeds the panel
+  // until its own `listJourneyRuns` subscription resolves the run (identical
+  // query args as the journey block, so Convex dedupes the subscription).
+  const [runDetail, setRunDetail] = useState<
+    (JourneyRunSelection & { runSnapshot: JourneyRun }) | null
+  >(null);
+  const openRunDetail = useCallback(
+    (journey: JourneyListJourney, run: JourneyRun, hostId: string | null) => {
+      setRunDetail({
+        journeyId: journey._id,
+        runId: run._id,
+        hostId,
+        runSnapshot: run,
+      });
+    },
+    [],
+  );
+  const closeRunDetail = useCallback(() => setRunDetail(null), []);
+  // Close the panel when the persona changes or its journey disappears.
+  useEffect(() => {
+    setRunDetail(null);
+  }, [selectedPersonaId]);
+  useEffect(() => {
+    if (
+      runDetail &&
+      journeys !== undefined &&
+      !journeys.some((j) => j._id === runDetail.journeyId)
+    ) {
+      setRunDetail(null);
+    }
+  }, [journeys, runDetail]);
+  const detailJourney = runDetail
+    ? (journeys?.find((j) => j._id === runDetail.journeyId) ?? null)
+    : null;
 
   // ── Agent bridge ──────────────────────────────────────────────────────────
   // The swarms tool group + this screen's command handlers and snapshot. Lives
@@ -760,85 +795,129 @@ export function SwarmsTab({
               </div>
             </aside>
 
-            {/* Persona detail + journey cards */}
-            <main className="min-w-0 flex-1 overflow-y-auto">
+            {/* Persona detail + journey blocks; run detail opens on the right */}
+            <main className="min-w-0 flex-1 overflow-hidden">
               {!selectedPersona ? (
                 <JourneyNetworkBackdrop />
               ) : (
-                <div className="mx-auto max-w-3xl px-8 py-6">
-                  <PersonaDetailHeader
-                    persona={selectedPersona}
-                    running={runningSet.has(selectedPersona._id)}
-                    onSave={(patch) => savePersonaField(selectedPersona._id, patch)}
-                    onDelete={async () => {
-                      if (
-                        !window.confirm(
-                          `Delete persona "${selectedPersona.name}"? Its journeys are hidden but historical runs are kept.`,
-                        )
-                      ) {
-                        return;
-                      }
-                      await deletePersona({
-                        personaRefId: selectedPersona._id,
-                      } as any);
-                      setSelectedPersonaId(null);
-                    }}
-                  />
+                (() => {
+                  const personaDetail = (
+                    <>
+                      <PersonaDetailHeader
+                        persona={selectedPersona}
+                        running={runningSet.has(selectedPersona._id)}
+                        onSave={(patch) =>
+                          savePersonaField(selectedPersona._id, patch)
+                        }
+                        onDelete={async () => {
+                          if (
+                            !window.confirm(
+                              `Delete persona "${selectedPersona.name}"? Its journeys are hidden but historical runs are kept.`,
+                            )
+                          ) {
+                            return;
+                          }
+                          await deletePersona({
+                            personaRefId: selectedPersona._id,
+                          } as any);
+                          setSelectedPersonaId(null);
+                        }}
+                      />
 
-                  <div
-                    className={cn(
-                      "mb-3",
-                      journeyFormOpen
-                        ? "space-y-2"
-                        : "flex items-center justify-between",
-                    )}
-                  >
-                    <h3 className="text-sm font-semibold">Journeys</h3>
-                    <NewJourneyButton
-                      projectId={projectId}
-                      hosts={hosts ?? []}
-                      open={journeyFormOpen}
-                      onOpenChange={(o) => {
-                        setJourneyFormOpen(o);
-                        // Drop the agent prefill on close so a later manual open
-                        // starts blank.
-                        if (!o) setJourneyGoalSeed("");
-                      }}
-                      goalSeed={journeyGoalSeed}
-                      onCreate={async (draft) => {
-                        await createJourney({
-                          projectId,
-                          personaRefId: selectedPersona._id,
-                          ...draft,
-                        } as any);
-                      }}
-                    />
-                  </div>
+                      <div
+                        className={cn(
+                          "mb-3",
+                          journeyFormOpen
+                            ? "space-y-2"
+                            : "flex items-center justify-between",
+                        )}
+                      >
+                        <h3 className="text-sm font-semibold">Journeys</h3>
+                        <NewJourneyButton
+                          projectId={projectId}
+                          hosts={hosts ?? []}
+                          open={journeyFormOpen}
+                          onOpenChange={(o) => {
+                            setJourneyFormOpen(o);
+                            // Drop the agent prefill on close so a later manual
+                            // open starts blank.
+                            if (!o) setJourneyGoalSeed("");
+                          }}
+                          goalSeed={journeyGoalSeed}
+                          onCreate={async (draft) => {
+                            await createJourney({
+                              projectId,
+                              personaRefId: selectedPersona._id,
+                              ...draft,
+                            } as any);
+                          }}
+                        />
+                      </div>
 
-                  {journeys === undefined ? (
-                    <div className="text-sm text-muted-foreground">Loading…</div>
-                  ) : journeys.length === 0 ? (
-                    <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
-                      No journeys yet. A journey is a goal this persona pursues
-                      across one or more hosts.
-                    </div>
-                  ) : (
-                    <div className="flex flex-col gap-3">
-                      {journeys.map((j) => (
-                        <JourneyCard
-                          key={j._id}
-                          journey={j}
-                          onLaunch={launchJourney}
+                      {journeys === undefined ? (
+                        <div className="text-sm text-muted-foreground">
+                          Loading…
+                        </div>
+                      ) : journeys.length === 0 ? (
+                        <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
+                          No journeys yet. A journey is a goal this persona
+                          pursues across one or more hosts.
+                        </div>
+                      ) : (
+                        <JourneyList
+                          journeys={journeys}
                           hosts={hosts ?? []}
                           isAuthenticated={isAuthenticated}
                           projectId={projectId}
+                          onLaunch={launchJourney}
                           initialRunId={deepLink.runId}
-                          initialThreadId={deepLink.threadId}
+                          selection={runDetail}
+                          onOpenRun={openRunDetail}
+                          onCloseRun={closeRunDetail}
                         />
-                      ))}
-                    </div>
-                  )}
-                </div>
+                      )}
+                    </>
+                  );
+
+                  if (!runDetail || !detailJourney) {
+                    return (
+                      <div className="h-full overflow-y-auto">
+                        <div className="mx-auto max-w-3xl px-8 py-6">
+                          {personaDetail}
+                        </div>
+                      </div>
+                    );
+                  }
+                  return (
+                    <ResizablePanelGroup
+                      direction="horizontal"
+                      className="h-full"
+                    >
+                      <ResizablePanel defaultSize={38} minSize={26}>
+                        <div className="h-full overflow-y-auto px-6 py-6">
+                          {personaDetail}
+                        </div>
+                      </ResizablePanel>
+                      <ResizableHandle withHandle />
+                      <ResizablePanel defaultSize={62} minSize={35}>
+                        <RunDetailPanel
+                          key={`${runDetail.runId}:${runDetail.hostId ?? ""}`}
+                          journey={detailJourney}
+                          runId={runDetail.runId}
+                          runSnapshot={runDetail.runSnapshot}
+                          hostId={runDetail.hostId}
+                          hosts={hosts ?? []}
+                          initialThreadId={
+                            deepLink.runId === runDetail.runId
+                              ? deepLink.threadId
+                              : undefined
+                          }
+                          onClose={closeRunDetail}
+                        />
+                      </ResizablePanel>
+                    </ResizablePanelGroup>
+                  );
+                })()
               )}
             </main>
           </>
@@ -847,6 +926,7 @@ export function SwarmsTab({
             <SwarmsSessionsPanel
               projectId={projectId}
               personas={personas ?? []}
+              hosts={hosts ?? []}
               personaRefId={selectedPersonaId}
               onPersonaRefIdChange={setSelectedPersonaId}
               initialThreadId={deepLink.threadId}
@@ -858,324 +938,98 @@ export function SwarmsTab({
   );
 }
 
-// ── run status treatment ─────────────────────────────────────────────────────
-function runStatusChipClass(status: string): string {
-  switch (status) {
-    case "completed":
-      return "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400";
-    case "partial":
-    case "rate_limited":
-      return "bg-muted text-muted-foreground";
-    case "failed":
-      return "bg-red-500/10 text-red-700 dark:text-red-400";
-    case "stale":
-      return "bg-muted text-muted-foreground";
-    default:
-      return "bg-muted text-foreground"; // running
-  }
-}
-
-function formatJourneyRelativeTime(timestamp: number): string {
-  const diff = Date.now() - timestamp;
-  const minutes = Math.floor(diff / 60000);
-  if (minutes < 1) return "just now";
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  if (days < 7) return `${days}d ago`;
-  return new Date(timestamp).toLocaleDateString();
-}
-
-function runSummaryLine(r: JourneyRun): string {
-  const parts = [
-    `${r.summary.succeeded}/${r.summary.total} ok`,
-    r.summary.failed > 0 ? `${r.summary.failed} failed` : null,
-    r.summary.rateLimited > 0 ? `${r.summary.rateLimited} rate-limited` : null,
-    goalScoreAvgLabel(r.goalScoreSummary),
-  ].filter(Boolean);
-  return parts.join(" · ");
-}
-
-// ── journey card + runs ──────────────────────────────────────────────────────
-function JourneyCard({
+// ── run detail (right panel): header + sessions matrix + live stream ─────────
+function RunDetailPanel({
   journey,
+  runId,
+  runSnapshot,
+  hostId,
   hosts,
-  isAuthenticated,
-  projectId,
-  initialRunId,
   initialThreadId,
-  onLaunch,
+  onClose,
 }: {
   journey: Journey;
+  runId: string;
+  /** Seed until this panel's own runs subscription resolves the run. */
+  runSnapshot: JourneyRun;
+  hostId: string | null;
   hosts: HostItem[];
-  isAuthenticated: boolean;
-  projectId: string;
-  /** Shared launch coordinator — see SwarmsTab.launchJourney. */
-  onLaunch: (
-    journeyId: string,
-  ) => Promise<
-    { status: "launched"; runId?: string } | { status: "already_launching" }
-  >;
-  /** Deep-link run to auto-open (only the card that owns it reacts). */
-  initialRunId?: string;
-  /** Deep-link session to auto-select inside the opened run. */
   initialThreadId?: string;
+  onClose: () => void;
 }) {
-  const { serverAttachments } = useProjectServerAttachments({
-    isAuthenticated,
-    projectId,
-  });
-  const serverGroupName = journey.serverAttachmentId
-    ? (serverAttachments.find((a) => a._id === journey.serverAttachmentId)
-        ?.name ?? null)
-    : null;
-  // Real Convex pagination (numItems + cursor) over the journey's runs.
-  const {
-    results: runs,
-    status: runsStatus,
-    loadMore,
-  } = usePaginatedQuery(
+  // Same (name, args) as the journey block's subscription — Convex dedupes it —
+  // so a running run keeps updating even though the panel was opened from a
+  // snapshot. Old runs past the first page fall back to the (terminal,
+  // immutable) snapshot.
+  const { results: runs } = usePaginatedQuery(
     SWARM_QUERIES.listJourneyRuns as any,
     { journeyRefId: journey._id } as any,
-    { initialNumItems: DEFAULT_PAGE_SIZE }
+    { initialNumItems: DEFAULT_PAGE_SIZE },
   );
   const rollup = useQuery(
     SWARM_QUERIES.journeyRollup as any,
-    { journeyRefId: journey._id } as any
+    { journeyRefId: journey._id } as any,
   ) as JourneyRollup | undefined;
-
-  const [launching, setLaunching] = useState(false);
-  const [launchError, setLaunchError] = useState<string | null>(null);
-  const [expanded, setExpanded] = useState(false);
-  const [openRunId, setOpenRunId] = useState<string | null>(null);
-
-  // Deep-link restore: expand this journey and open the linked run so
-  // RunSessionsView mounts. Runs once — later user toggling isn't overridden.
-  const appliedInitialRunRef = useRef(false);
-  useEffect(() => {
-    if (appliedInitialRunRef.current || !initialRunId) return;
-    if ((runs as JourneyRun[]).some((r) => r._id === initialRunId)) {
-      appliedInitialRunRef.current = true;
-      setExpanded(true);
-      setOpenRunId(initialRunId);
-    }
-  }, [initialRunId, runs]);
-
-  const hostName = (id: string) =>
-    hosts.find((h) => h.hostId === id)?.name ?? id.slice(0, 8);
-
-  const journeyHostNames = useMemo(
-    () => journey.hostIds.map(hostName),
-    // hostName closes over `hosts`; recompute when either changes.
-    [journey.hostIds, hosts],
-  );
-  const firstHostName = journeyHostNames[0] ?? null;
-  const extraHosts = Math.max(0, journeyHostNames.length - 1);
   const typedRuns = runs as JourneyRun[];
-  const latestRun = typedRuns[0] ?? null;
-  const runCount = rollup?.runCount ?? typedRuns.length;
-  const hasRuns = runCount > 0 || typedRuns.length > 0;
-  const configHint = `${journey.config.sessionsPerHost}/host · ${journey.config.maxTurns} turns`;
-
-  const onRun = async () => {
-    if (launching) return;
-    setLaunchError(null);
-    setLaunching(true);
-    try {
-      // Shared coordinator: same launchKey store as the agent path, so a
-      // concurrent agent launch of this journey dedupes to one paid run.
-      const result = await onLaunch(journey._id);
-      if (result.status === "already_launching") {
-        return; // another launch of this journey is already in flight
-      }
-      toast.success("Journey run started");
-    } catch (e) {
-      // The coordinator retains the key on ANY failure and reuses it on retry,
-      // so the backend dedupes rather than double-spending.
-      setLaunchError(e instanceof Error ? e.message : "Failed to start run");
-    } finally {
-      setLaunching(false);
-    }
-  };
+  const runIndex = typedRuns.findIndex((r) => r._id === runId);
+  const run = (runIndex >= 0 ? typedRuns[runIndex] : null) ?? runSnapshot;
+  const runName =
+    runIndex >= 0
+      ? runNumberLabel(rollup?.runCount ?? typedRuns.length, runIndex)
+      : "Run";
+  const clientCount = run.hostSummaries.length || journey.hostIds.length;
 
   return (
-    <div className="rounded-lg border border-border/60 px-3 py-2.5">
-      <div className="flex items-start gap-1.5">
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="flex shrink-0 items-start justify-between gap-3 border-b border-border/40 px-4 py-3">
+        <div className="min-w-0">
+          <p className="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-sm font-medium">
+            <span>{runName}</span>
+            <span
+              className={cn(
+                "rounded-full px-1.5 py-px text-[10px] font-medium capitalize",
+                runStatusChipClass(run.status),
+              )}
+            >
+              {run.status.replace(/_/g, " ")}
+            </span>
+            <span className="min-w-0 truncate font-normal text-muted-foreground">
+              {journey.goal}
+            </span>
+          </p>
+          <p className="mt-0.5 flex flex-wrap items-center gap-x-1.5 gap-y-0.5 text-xs text-muted-foreground">
+            <span>
+              {clientCount} client{clientCount === 1 ? "" : "s"} ×{" "}
+              {journey.config.sessionsPerHost} session
+              {journey.config.sessionsPerHost === 1 ? "" : "s"}
+            </span>
+            <span aria-hidden>·</span>
+            <span>{runSummaryLine(run)}</span>
+            <span aria-hidden>·</span>
+            <span>launched {formatJourneyRelativeTime(run.createdAt)}</span>
+          </p>
+        </div>
         <button
           type="button"
-          className={cn(
-            "mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground outline-none transition-colors",
-            "hover:bg-muted/60 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring",
-            !hasRuns && "cursor-default opacity-40 hover:bg-transparent",
-          )}
-          aria-expanded={expanded}
-          aria-label={expanded ? "Hide runs" : "Show runs"}
-          disabled={!hasRuns}
-          onClick={() => setExpanded((v) => !v)}
+          aria-label="Close run detail"
+          className="rounded-md p-1 text-muted-foreground outline-none transition-colors hover:bg-muted/60 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
+          onClick={onClose}
         >
-          {expanded ? (
-            <ChevronDown className="size-3.5" />
-          ) : (
-            <ChevronRight className="size-3.5" />
-          )}
+          <X className="size-4" />
         </button>
-
-        <div className="min-w-0 flex-1">
-          <div className="flex items-start justify-between gap-3">
-            <button
-              type="button"
-              className="min-w-0 flex-1 text-left outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-sm"
-              disabled={!hasRuns}
-              onClick={() => hasRuns && setExpanded((v) => !v)}
-            >
-              <p className="truncate text-sm font-medium">{journey.goal}</p>
-            </button>
-            <Button
-              type="button"
-              size="sm"
-              className="h-7 shrink-0 px-2.5 text-xs"
-              disabled={launching}
-              onClick={onRun}
-            >
-              {launching ? "Starting…" : "Run"}
-            </Button>
-          </div>
-
-          <div className="mt-1 flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-1 text-xs text-muted-foreground">
-            {firstHostName ? (
-              <span className="inline-flex min-w-0 max-w-[160px] items-center gap-1">
-                <JourneyHostLogoMark label={firstHostName} />
-                <span className="truncate font-medium text-foreground/80">
-                  {firstHostName}
-                </span>
-                {extraHosts > 0 ? (
-                  <span className="shrink-0 text-[10px]">+{extraHosts}</span>
-                ) : null}
-              </span>
-            ) : (
-              <span>No clients</span>
-            )}
-            {serverGroupName ? (
-              <>
-                <span aria-hidden>·</span>
-                <span className="truncate">{serverGroupName}</span>
-              </>
-            ) : null}
-            <span aria-hidden>·</span>
-            <span>
-              {runCount} run{runCount === 1 ? "" : "s"}
-            </span>
-            {latestRun ? (
-              <>
-                <span aria-hidden>·</span>
-                <span
-                  className={cn(
-                    "rounded-full px-1.5 py-px text-[10px] font-medium capitalize",
-                    runStatusChipClass(latestRun.status),
-                  )}
-                >
-                  {latestRun.status.replace(/_/g, " ")}
-                </span>
-              </>
-            ) : null}
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  aria-label="Journey config"
-                  className="rounded-full p-0.5 text-muted-foreground outline-none transition-colors hover:bg-muted/60 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
-                >
-                  <Info className="size-3" />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="top" className="max-w-[220px]">
-                <p className="text-xs leading-snug">{configHint}</p>
-              </TooltipContent>
-            </Tooltip>
-          </div>
-        </div>
       </div>
-
-      {launchError && (
-        <p className="mt-2 ml-7 rounded border border-red-500/40 bg-red-500/10 px-2 py-1 text-xs text-red-600 dark:text-red-400">
-          {launchError}
-        </p>
-      )}
-
-      {expanded && (
-        <div className="mt-2 ml-7 space-y-0.5 border-t border-border/40 pt-2">
-          {typedRuns.length === 0 ? (
-            <p className="px-1 py-1.5 text-[11px] text-muted-foreground">
-              No runs yet.
-            </p>
-          ) : (
-            typedRuns.map((r) => {
-              const isOpen = openRunId === r._id;
-              return (
-                <div key={r._id}>
-                  <button
-                    type="button"
-                    className={cn(
-                      "flex w-full items-center gap-2 rounded-md px-1.5 py-1.5 text-left text-xs outline-none transition-colors",
-                      "hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-ring",
-                      isOpen && "bg-muted/40",
-                    )}
-                    aria-expanded={isOpen}
-                    aria-label={
-                      isOpen
-                        ? `Hide sessions for run ${r.status}`
-                        : `View sessions for run ${r.status}`
-                    }
-                    onClick={() =>
-                      setOpenRunId((cur) => (cur === r._id ? null : r._id))
-                    }
-                  >
-                    {isOpen ? (
-                      <ChevronDown className="size-3 shrink-0 text-muted-foreground" />
-                    ) : (
-                      <ChevronRight className="size-3 shrink-0 text-muted-foreground" />
-                    )}
-                    <span className="capitalize text-foreground/90">
-                      {r.status.replace(/_/g, " ")}
-                    </span>
-                    <span className="min-w-0 flex-1 truncate text-muted-foreground">
-                      {runSummaryLine(r)}
-                    </span>
-                    <span className="shrink-0 text-[10px] text-muted-foreground">
-                      {formatJourneyRelativeTime(r.createdAt)}
-                    </span>
-                  </button>
-                  {isOpen && (
-                    <RunSessionsView
-                      runId={r._id}
-                      personaRefId={journey.personaRefId}
-                      hosts={hosts}
-                      hostSummaries={r.hostSummaries}
-                      runSummary={r.summary}
-                      runStatus={r.status}
-                      sessionsPerHost={journey.config.sessionsPerHost}
-                      createdAt={r.createdAt}
-                      initialThreadId={
-                        initialRunId === r._id ? initialThreadId : undefined
-                      }
-                    />
-                  )}
-                </div>
-              );
-            })
-          )}
-          {runsStatus === "CanLoadMore" && (
-            <button
-              type="button"
-              className="mt-0.5 px-1.5 text-[11px] font-medium text-primary hover:underline"
-              onClick={() => loadMore(DEFAULT_PAGE_SIZE)}
-            >
-              Load more runs
-            </button>
-          )}
-        </div>
-      )}
+      <div className="min-h-0 flex-1">
+        <RunSessionsView
+          runId={run._id}
+          personaRefId={journey.personaRefId}
+          hosts={hosts}
+          hostSummaries={run.hostSummaries}
+          runStatus={run.status}
+          sessionsPerHost={journey.config.sessionsPerHost}
+          initialHostId={hostId ?? undefined}
+          initialThreadId={initialThreadId}
+        />
+      </div>
     </div>
   );
 }
@@ -1186,10 +1040,9 @@ function RunSessionsView({
   personaRefId,
   hosts,
   hostSummaries,
-  runSummary,
   runStatus,
   sessionsPerHost,
-  createdAt,
+  initialHostId,
   initialThreadId,
 }: {
   runId: string;
@@ -1197,10 +1050,10 @@ function RunSessionsView({
   personaRefId: string;
   hosts: HostItem[];
   hostSummaries: JourneyRun["hostSummaries"];
-  runSummary: JourneyRun["summary"];
   runStatus: JourneyRun["status"];
   sessionsPerHost: number;
-  createdAt: number;
+  /** Matrix drill-in: preselect this host's first session (deferred to `initialThreadId`). */
+  initialHostId?: string;
   /** Deep-link session (`id`) to auto-select once it's on a loaded page. */
   initialThreadId?: string;
 }) {
@@ -1272,6 +1125,39 @@ function RunSessionsView({
     setDetailSession(match);
   }, [initialThreadId, rows]);
 
+  // Matrix drill-in: preselect the clicked host's first session. `initialThreadId`
+  // (an explicit deep-linked session) always wins, so skip when it's present.
+  const appliedInitialHostRef = useRef(false);
+  useEffect(() => {
+    if (appliedInitialHostRef.current || !initialHostId || initialThreadId) {
+      return;
+    }
+    const match = rows.find((s) => s.hostId === initialHostId);
+    if (match) {
+      appliedInitialHostRef.current = true;
+      const sessionIndex = Number(match.chatSessionId.split("_").pop() ?? "0");
+      setSelection({
+        hostId: match.hostId,
+        sessionIndex: Number.isFinite(sessionIndex) ? sessionIndex : 0,
+        chatSessionId: match.chatSessionId,
+      });
+      return;
+    }
+    // No persisted row yet: for a terminal run with attempts on this host,
+    // synthesize the first attempt's cell so the pane opens on that host.
+    if (
+      runStatus !== "running" &&
+      hostSummaries.some((h) => h.hostId === initialHostId && h.total > 0)
+    ) {
+      appliedInitialHostRef.current = true;
+      setSelection({
+        hostId: initialHostId,
+        sessionIndex: 0,
+        chatSessionId: swarmAttemptChatSessionId(runId, initialHostId, 0),
+      });
+    }
+  }, [initialHostId, initialThreadId, rows, runStatus, hostSummaries, runId]);
+
   // Auto-select the first running cell when a live stream starts.
   useEffect(() => {
     if (selection || !streamEnabled) return;
@@ -1292,34 +1178,26 @@ function RunSessionsView({
   }, [selection, streamEnabled, stream.cellStatus, runId]);
 
   return (
-    <div className="mt-2 space-y-3 rounded-lg border bg-muted/20 p-3">
-      <div className="flex flex-wrap items-center justify-between gap-2">
-        <div className="min-w-0">
-          <p className="text-[12px] font-semibold capitalize text-foreground/90">
-            {String(runStatus).replace(/_/g, " ")}
-            <span className="ml-2 font-normal text-muted-foreground">
-              {runSummary.succeeded}/{runSummary.total} ok
-              {runSummary.failed > 0 ? ` · ${runSummary.failed} failed` : ""}
-            </span>
-          </p>
+    <div className="flex h-full min-h-0 flex-col gap-3 overflow-y-auto p-4">
+      {stream.connected || stream.error || status === "CanLoadMore" ? (
+        <div className="flex shrink-0 flex-wrap items-center justify-between gap-2">
           <p className="text-[10px] text-muted-foreground">
-            {formatJourneyRelativeTime(createdAt)}
-            {stream.connected ? " · live" : null}
-            {stream.error ? ` · stream error: ${stream.error}` : null}
+            {stream.connected ? "live" : null}
+            {stream.error ? `stream error: ${stream.error}` : null}
           </p>
+          {status === "CanLoadMore" ? (
+            <button
+              type="button"
+              className="text-[11px] font-medium text-primary hover:underline"
+              onClick={() => loadMore(DEFAULT_PAGE_SIZE)}
+            >
+              Load more sessions
+            </button>
+          ) : null}
         </div>
-        {status === "CanLoadMore" ? (
-          <button
-            type="button"
-            className="text-[11px] font-medium text-primary hover:underline"
-            onClick={() => loadMore(DEFAULT_PAGE_SIZE)}
-          >
-            Load more sessions
-          </button>
-        ) : null}
-      </div>
+      ) : null}
 
-      <div className="grid min-w-0 gap-3 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)]">
+      <div className="shrink-0">
         <SwarmSessionsMatrix
           runId={runId}
           hostIds={hostIds}
@@ -1335,6 +1213,8 @@ function RunSessionsView({
             setDetailSession(null);
           }}
         />
+      </div>
+      <div className="flex min-h-[24rem] flex-1 flex-col">
         <SwarmLiveStreamPane
           selection={selection}
           stream={stream}
@@ -1342,6 +1222,7 @@ function RunSessionsView({
           fallbackTrace={fallbackTrace}
           runStatus={String(runStatus)}
           onOpenCompleted={(session) => setDetailSession(session)}
+          fillHeight
         />
       </div>
 
@@ -1922,21 +1803,5 @@ function NewJourneyButton({
         </Button>
       </div>
     </div>
-  );
-}
-
-function JourneyHostLogoMark({ label }: { label: string }) {
-  const logoSrc = resolveHostLogoByDisplayName(label);
-  if (logoSrc) {
-    return (
-      <img
-        src={logoSrc}
-        alt=""
-        className="size-3.5 shrink-0 object-contain"
-      />
-    );
-  }
-  return (
-    <span aria-hidden className="size-3.5 shrink-0 rounded-full bg-muted" />
   );
 }

--- a/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
@@ -1143,6 +1143,7 @@ function JourneyCard({
                       personaRefId={journey.personaRefId}
                       hosts={hosts}
                       hostSummaries={r.hostSummaries}
+                      runSummary={r.summary}
                       initialThreadId={
                         initialRunId === r._id ? initialThreadId : undefined
                       }
@@ -1173,6 +1174,7 @@ function RunSessionsView({
   personaRefId,
   hosts,
   hostSummaries,
+  runSummary,
   initialThreadId,
 }: {
   runId: string;
@@ -1180,6 +1182,7 @@ function RunSessionsView({
   personaRefId: string;
   hosts: HostItem[];
   hostSummaries: JourneyRun["hostSummaries"];
+  runSummary: JourneyRun["summary"];
   /** Deep-link session (`id`) to auto-select once it's on a loaded page. */
   initialThreadId?: string;
 }) {
@@ -1194,7 +1197,17 @@ function RunSessionsView({
     { journeyRunId: runId } as any,
     { initialNumItems: DEFAULT_PAGE_SIZE }
   );
-  const [filter, setFilter] = useState<SessionFilterState>(EMPTY_SESSION_FILTER);
+  // Prefer landing on a host that failed — progressive discovery into the
+  // problem. Deep-link restore still wins once the linked session appears.
+  const defaultFailedHostId = useMemo(() => {
+    const withFails = hostSummaries.find((hs) => hs.failed > 0);
+    return withFails?.hostId ?? null;
+  }, [hostSummaries]);
+  const [filter, setFilter] = useState<SessionFilterState>(() =>
+    defaultFailedHostId
+      ? { hostId: defaultFailedHostId }
+      : EMPTY_SESSION_FILTER,
+  );
   const [selected, setSelected] = useState<JourneySessionRow | null>(null);
   const [sessionToPromote, setSessionToPromote] =
     useState<JourneySessionRow | null>(null);
@@ -1203,10 +1216,51 @@ function RunSessionsView({
     hosts.find((h) => h.hostId === id)?.name ?? id.slice(0, 8);
 
   const rows = sessions as JourneySessionRow[];
-  const visible = useMemo(
-    () => rows.filter((s) => sessionMatchesFilter(s, filter)),
-    [rows, filter]
-  );
+  const visible = useMemo(() => {
+    const matched = rows.filter((s) => sessionMatchesFilter(s, filter));
+    // Surface failed / errored sessions first so "N failed" is findable.
+    return [...matched].sort((a, b) => {
+      const rank = (s: JourneySessionRow) => {
+        if (s.status === "failed") return 0;
+        if (s.readiness?.status === "failed") return 1;
+        if (s.readiness?.verdict === "not_ready") return 2;
+        return 3;
+      };
+      return rank(a) - rank(b);
+    });
+  }, [rows, filter]);
+
+  // Attempts that failed before a chatSession was persisted never appear in
+  // `listSessionsByJourneyRun`. Derive placeholders from hostSummaries so the
+  // "N failed" rollup is inspectable instead of silently empty.
+  const missingAttemptHints = useMemo(() => {
+    return hostSummaries
+      .map((hs) => {
+        const listed = rows.filter((s) => s.hostId === hs.hostId).length;
+        // Unaccounted terminals ≈ claimed total minus listed rows. Prefer the
+        // failed/rate-limited counts when they exceed what's missing so we
+        // never under-report vs the run summary the user already saw.
+        const unlisted = Math.max(0, hs.total - listed);
+        const failedUnlisted = Math.min(hs.failed, unlisted);
+        const rateLimitedUnlisted = Math.min(
+          hs.rateLimited,
+          Math.max(0, unlisted - failedUnlisted),
+        );
+        if (failedUnlisted === 0 && rateLimitedUnlisted === 0) return null;
+        return {
+          hostId: hs.hostId,
+          failed: failedUnlisted,
+          rateLimited: rateLimitedUnlisted,
+        };
+      })
+      .filter((h): h is NonNullable<typeof h> => h != null)
+      .filter((h) => filter.hostId == null || filter.hostId === h.hostId);
+  }, [hostSummaries, rows, filter.hostId]);
+
+  const showRunFailureHint =
+    runSummary.failed > 0 &&
+    rows.every((s) => s.status !== "failed") &&
+    missingAttemptHints.length > 0;
 
   // Deep-link restore: auto-select the linked session once it appears on a
   // loaded page. Runs once. NOTE (remainder): a session on a not-yet-loaded
@@ -1218,60 +1272,141 @@ function RunSessionsView({
     const match = rows.find((s) => s.id === initialThreadId);
     if (match) {
       appliedInitialThreadRef.current = true;
+      setFilter({ hostId: match.hostId });
       setSelected(match);
     }
   }, [initialThreadId, rows]);
 
   return (
     <div className="mt-2 rounded-lg border bg-muted/20 p-2">
-      {/* Host filter chips */}
+      {/* Host filter chips — include outcome counts so failures are locatable. */}
       <div className="mb-2 flex flex-wrap gap-1.5">
-        {hostSummaries.map((hs) => (
-          <button
-            key={hs.hostId}
-            type="button"
-            onClick={() =>
-              setFilter((f) => toggleSessionFilter(f, "hostId", hs.hostId))
-            }
-            className={`rounded-full border px-2 py-0.5 text-[11px] ${
-              filter.hostId === hs.hostId
-                ? "border-primary bg-primary/10"
-                : "hover:bg-muted"
-            }`}
-          >
-            {hostName(hs.hostId)}
-          </button>
-        ))}
+        {hostSummaries.map((hs) => {
+          const selectedHost = filter.hostId === hs.hostId;
+          const hasFails = hs.failed > 0 || hs.rateLimited > 0;
+          return (
+            <button
+              key={hs.hostId}
+              type="button"
+              onClick={() =>
+                setFilter((f) => toggleSessionFilter(f, "hostId", hs.hostId))
+              }
+              className={cn(
+                "rounded-full border px-2 py-0.5 text-[11px] outline-none transition-colors",
+                "focus-visible:ring-2 focus-visible:ring-ring",
+                selectedHost
+                  ? "border-primary bg-primary/10"
+                  : "hover:bg-muted",
+                hasFails && !selectedHost && "border-red-500/30",
+              )}
+              aria-label={`${hostName(hs.hostId)}: ${hs.succeeded}/${hs.total} ok${hs.failed > 0 ? `, ${hs.failed} failed` : ""}`}
+            >
+              <span className="font-medium">{hostName(hs.hostId)}</span>
+              <span className="ml-1 text-muted-foreground">
+                {hs.succeeded}/{hs.total}
+              </span>
+              {hs.failed > 0 ? (
+                <span className="ml-1 text-red-600 dark:text-red-400">
+                  · {hs.failed} failed
+                </span>
+              ) : null}
+            </button>
+          );
+        })}
       </div>
 
-      {rows.length === 0 ? (
+      {showRunFailureHint ? (
+        <p
+          className="mb-2 rounded-md border border-red-500/25 bg-red-500/5 px-2 py-1.5 text-[11px] text-red-700 dark:text-red-400"
+          role="status"
+        >
+          {runSummary.failed} attempt
+          {runSummary.failed === 1 ? "" : "s"} failed without a session
+          transcript — open a host chip with failures to see which clients
+          never persisted a run.
+        </p>
+      ) : null}
+
+      {rows.length === 0 && missingAttemptHints.length === 0 ? (
         <p className="px-1 py-2 text-[11px] text-muted-foreground">
-          No sessions recorded yet for this run.
+          {runSummary.total === 0
+            ? "No sessions recorded yet for this run."
+            : "Sessions are still starting…"}
         </p>
       ) : (
         <div className="flex flex-col divide-y">
-          {visible.map((s) => (
-            <button
-              key={s.id}
-              type="button"
-              onClick={() => setSelected(s)}
-              className={`flex items-center justify-between gap-2 px-1 py-1.5 text-left hover:bg-muted/50 ${
-                selected?.id === s.id ? "bg-muted" : ""
-              }`}
+          {missingAttemptHints.map((hint) => (
+            <div
+              key={`missing-${hint.hostId}`}
+              className="flex items-start justify-between gap-2 px-1 py-1.5"
+              data-testid={`missing-attempts-${hint.hostId}`}
             >
               <span className="flex min-w-0 flex-col">
                 <span className="truncate text-[11px] font-medium">
-                  {hostName(s.hostId)}
+                  {hostName(hint.hostId)}
                 </span>
-                <span className="truncate text-[10px] text-muted-foreground">
-                  {s.status ?? "—"}
-                  {s.modelId ? ` · ${s.modelId}` : ""}
+                <span className="text-[10px] text-muted-foreground">
+                  Failed before a session was recorded
+                  {hint.rateLimited > 0
+                    ? ` · ${hint.rateLimited} rate-limited`
+                    : ""}
                 </span>
               </span>
-              <SessionGoalScoreBadge goalScore={s.goalScore} />
-              <SessionReadinessBadge readiness={toSessionReadiness(s.readiness)} />
-            </button>
+              <span className="shrink-0 rounded-full bg-red-500/10 px-1.5 py-0.5 text-[10px] font-medium text-red-700 dark:text-red-400">
+                {hint.failed} failed
+              </span>
+            </div>
           ))}
+          {visible.map((s) => {
+            const isFailed =
+              s.status === "failed" || s.readiness?.status === "failed";
+            return (
+              <button
+                key={s.id}
+                type="button"
+                onClick={() => setSelected(s)}
+                className={cn(
+                  "flex items-center justify-between gap-2 px-1 py-1.5 text-left hover:bg-muted/50",
+                  selected?.id === s.id && "bg-muted",
+                )}
+              >
+                <span className="flex min-w-0 flex-col">
+                  <span className="truncate text-[11px] font-medium">
+                    {hostName(s.hostId)}
+                  </span>
+                  <span
+                    className={cn(
+                      "truncate text-[10px]",
+                      isFailed
+                        ? "text-red-600 dark:text-red-400"
+                        : "text-muted-foreground",
+                    )}
+                  >
+                    {s.status ?? "—"}
+                    {s.modelId ? ` · ${s.modelId}` : ""}
+                  </span>
+                </span>
+                <span className="flex shrink-0 items-center gap-1.5">
+                  {isFailed ? (
+                    <span className="rounded-full bg-red-500/10 px-1.5 py-0.5 text-[10px] font-medium text-red-700 dark:text-red-400">
+                      Failed
+                    </span>
+                  ) : null}
+                  <SessionGoalScoreBadge goalScore={s.goalScore} />
+                  {!isFailed ? (
+                    <SessionReadinessBadge
+                      readiness={toSessionReadiness(s.readiness)}
+                    />
+                  ) : null}
+                </span>
+              </button>
+            );
+          })}
+          {visible.length === 0 && missingAttemptHints.length === 0 ? (
+            <p className="px-1 py-2 text-[11px] text-muted-foreground">
+              No sessions for this client in the loaded page.
+            </p>
+          ) : null}
         </div>
       )}
 
@@ -1695,8 +1830,15 @@ function NewJourneyButton({
               <ChevronDown className="size-3 shrink-0 text-muted-foreground" />
             </button>
           </PopoverTrigger>
-          <PopoverContent className="w-64 p-1" align="start" sideOffset={4}>
-            <div className="space-y-0.5">
+          <PopoverContent
+            className="w-64 p-1"
+            align="start"
+            sideOffset={4}
+            // Multi-select: don't dismiss when focus moves between rows
+            // (Radix otherwise treats the click as "outside" the trigger).
+            onCloseAutoFocus={(e) => e.preventDefault()}
+          >
+            <div className="space-y-0.5" role="group" aria-label="Clients">
               <div className="flex items-center justify-between gap-2 px-2 pb-1 pt-0.5">
                 <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
                   Clients
@@ -1713,8 +1855,8 @@ function NewJourneyButton({
                   </TooltipTrigger>
                   <TooltipContent side="top" className="max-w-[240px]">
                     <p className="text-xs leading-snug">
-                      Each selected client fans out into its own sessions for
-                      this journey.
+                      Pick one or more. Each selected client fans out into its
+                      own sessions for this journey.
                     </p>
                   </TooltipContent>
                 </Tooltip>
@@ -1735,6 +1877,11 @@ function NewJourneyButton({
                     <button
                       key={h.hostId}
                       type="button"
+                      role="checkbox"
+                      aria-checked={selected}
+                      // Prevent focus steal from closing the multi-select popover
+                      // before the toggle applies (same pattern as evals).
+                      onPointerDown={(e) => e.preventDefault()}
                       onClick={() => toggleHost(h.hostId)}
                       className={cn(
                         "flex w-full items-center gap-2 rounded py-1.5 pl-2 pr-2 text-left text-sm",

--- a/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
@@ -68,6 +68,7 @@ import {
   LaunchJourneyRunError,
   SWARM_QUERIES,
   DEFAULT_PAGE_SIZE,
+  swarmAttemptChatSessionId,
   type GoalScoreRollup,
   type JourneyRun,
   type JourneySessionRow,
@@ -76,16 +77,6 @@ import {
   type SessionGoalScore,
 } from "@/lib/swarm-api";
 import { formatScore } from "@/components/shared/session-quality/judge-presentation";
-import {
-  EMPTY_SESSION_FILTER,
-  sessionMatchesFilter,
-  toggleSessionFilter,
-  type SessionFilterState,
-} from "@/lib/session-usage-filters";
-import {
-  SessionReadinessBadge,
-  type SessionReadiness,
-} from "@/components/chatboxes/session-readiness";
 import { ShareUsageThreadDetail } from "@/components/connection/share-usage/ShareUsageThreadDetail";
 import {
   buildEvalsPath,
@@ -96,6 +87,15 @@ import {
 import { getShareableAppOrigin } from "@/lib/chatbox-session";
 import { resolveHostLogoByDisplayName } from "@/lib/chatbox-client-style";
 import { ConvertSwarmSessionDialog } from "@/components/swarms/convert-swarm-session-dialog";
+import {
+  SwarmLiveStreamPane,
+  SwarmSessionsMatrix,
+  type SwarmMatrixSelection,
+} from "@/components/swarms/journey-run-results";
+import {
+  liveSessionTrace,
+  useJourneyRunStream,
+} from "@/components/swarms/use-journey-run-stream";
 import { ServerGroupPicker } from "@/components/hosts/ServerGroupPicker";
 import { useProjectServerAttachments } from "@/hooks/useViews";
 import { useSurfaceAgentBridge } from "@/lib/webmcp/use-surface-agent-bridge";
@@ -112,43 +112,9 @@ import type {
 const AGENT_SNAPSHOT_MAX_PERSONAS = 30;
 const AGENT_SNAPSHOT_MAX_JOURNEYS = 30;
 
-// Valid readiness enums (mirror `session-readiness.tsx`). The backend
-// denormalizes a WIDE `{ status?: string; verdict?: string }` subset onto the
-// session row, so guard it into a well-typed `SessionReadiness` before handing
-// it to the badge instead of an unchecked `as` cast — an unexpected string must
-// degrade to "no badge", not render a bogus pill.
-const READINESS_STATUSES = ["pending", "completed", "partial", "failed"] as const;
-const READINESS_VERDICTS = ["ready", "needs_attention", "not_ready"] as const;
-
-function toSessionReadiness(
-  raw: JourneySessionRow["readiness"],
-): SessionReadiness | undefined {
-  if (!raw) return undefined;
-  const status = (READINESS_STATUSES as readonly string[]).includes(
-    raw.status ?? "",
-  )
-    ? (raw.status as SessionReadiness["status"])
-    : undefined;
-  // Without a valid status the badge has nothing meaningful to show.
-  if (!status) return undefined;
-  const verdict = (READINESS_VERDICTS as readonly string[]).includes(
-    raw.verdict ?? "",
-  )
-    ? (raw.verdict as SessionReadiness["verdict"])
-    : undefined;
-  return {
-    status,
-    ...(verdict ? { verdict } : {}),
-    issueCount:
-      typeof raw.issueCount === "number" && Number.isFinite(raw.issueCount)
-        ? raw.issueCount
-        : 0,
-  };
-}
-
-// Judge-verdict guard, same philosophy as `toSessionReadiness`: the backend
-// denormalizes a WIDE `goalScore` subset; validate the status enum + score
-// before rendering so a malformed record degrades to "no badge".
+// Judge-verdict guard: the backend denormalizes a WIDE `goalScore` subset;
+// validate the status enum + score before rendering so a malformed record
+// degrades to "no badge".
 const GOAL_SCORE_STATUSES = ["running", "completed", "failed"] as const;
 type GoalScoreStatus = (typeof GOAL_SCORE_STATUSES)[number];
 
@@ -888,24 +854,6 @@ function runSummaryLine(r: JourneyRun): string {
   return parts.join(" · ");
 }
 
-/**
- * Chat-session lifecycle (`active`) is NOT "journey running" — sessions stay
- * `active` after the run completes. Map to copy that matches the run so the
- * sessions list doesn't contradict Completed / Running above.
- */
-function sessionLifecycleLabel(
-  sessionStatus: string | undefined,
-  runStatus: string,
-): string | null {
-  if (!sessionStatus) return null;
-  if (sessionStatus === "failed") return "failed";
-  if (sessionStatus === "completed") return "done";
-  if (sessionStatus === "active" || sessionStatus === "running") {
-    return runStatus === "running" ? "running" : "done";
-  }
-  return sessionStatus.replace(/_/g, " ");
-}
-
 // ── journey card + runs ──────────────────────────────────────────────────────
 function JourneyCard({
   journey,
@@ -1163,6 +1111,8 @@ function JourneyCard({
                       hostSummaries={r.hostSummaries}
                       runSummary={r.summary}
                       runStatus={r.status}
+                      sessionsPerHost={journey.config.sessionsPerHost}
+                      createdAt={r.createdAt}
                       initialThreadId={
                         initialRunId === r._id ? initialThreadId : undefined
                       }
@@ -1187,7 +1137,7 @@ function JourneyCard({
   );
 }
 
-// ── sessions by host (per run) ───────────────────────────────────────────────
+// ── sessions × hosts matrix + live stream (per run) ──────────────────────────
 function RunSessionsView({
   runId,
   personaRefId,
@@ -1195,6 +1145,8 @@ function RunSessionsView({
   hostSummaries,
   runSummary,
   runStatus,
+  sessionsPerHost,
+  createdAt,
   initialThreadId,
 }: {
   runId: string;
@@ -1204,32 +1156,28 @@ function RunSessionsView({
   hostSummaries: JourneyRun["hostSummaries"];
   runSummary: JourneyRun["summary"];
   runStatus: JourneyRun["status"];
+  sessionsPerHost: number;
+  createdAt: number;
   /** Deep-link session (`id`) to auto-select once it's on a loaded page. */
   initialThreadId?: string;
 }) {
-  // Paginated sessions for this run; grouped/filterable by host client-side.
   const {
     results: sessions,
     status,
     loadMore,
   } = usePaginatedQuery(
     SWARM_QUERIES.listSessionsByJourneyRun as any,
-    // Backend arg name is `journeyRunId` (NOT `runId`).
     { journeyRunId: runId } as any,
-    { initialNumItems: DEFAULT_PAGE_SIZE }
+    { initialNumItems: Math.max(DEFAULT_PAGE_SIZE, sessionsPerHost * 4) },
   );
-  // Prefer landing on a host that failed — progressive discovery into the
-  // problem. Deep-link restore still wins once the linked session appears.
-  const defaultFailedHostId = useMemo(() => {
-    const withFails = hostSummaries.find((hs) => hs.failed > 0);
-    return withFails?.hostId ?? null;
-  }, [hostSummaries]);
-  const [filter, setFilter] = useState<SessionFilterState>(() =>
-    defaultFailedHostId
-      ? { hostId: defaultFailedHostId }
-      : EMPTY_SESSION_FILTER,
+
+  const streamEnabled = runStatus === "running";
+  const stream = useJourneyRunStream(runId, streamEnabled);
+
+  const [selection, setSelection] = useState<SwarmMatrixSelection | null>(null);
+  const [detailSession, setDetailSession] = useState<JourneySessionRow | null>(
+    null,
   );
-  const [selected, setSelected] = useState<JourneySessionRow | null>(null);
   const [sessionToPromote, setSessionToPromote] =
     useState<JourneySessionRow | null>(null);
 
@@ -1237,239 +1185,159 @@ function RunSessionsView({
     hosts.find((h) => h.hostId === id)?.name ?? id.slice(0, 8);
 
   const rows = sessions as JourneySessionRow[];
-  const visible = useMemo(() => {
-    const matched = rows.filter((s) => sessionMatchesFilter(s, filter));
-    // Surface failed / errored sessions first so "N failed" is findable.
-    return [...matched].sort((a, b) => {
-      const rank = (s: JourneySessionRow) => {
-        if (s.status === "failed") return 0;
-        if (s.readiness?.status === "failed") return 1;
-        if (s.readiness?.verdict === "not_ready") return 2;
-        return 3;
-      };
-      return rank(a) - rank(b);
-    });
-  }, [rows, filter]);
+  const hostIds = useMemo(() => {
+    const fromSummary = hostSummaries.map((h) => h.hostId);
+    if (fromSummary.length > 0) return fromSummary;
+    const seen = new Set<string>();
+    for (const s of rows) seen.add(s.hostId);
+    return Array.from(seen);
+  }, [hostSummaries, rows]);
 
-  // Attempts that failed before a chatSession was persisted never appear in
-  // `listSessionsByJourneyRun`. Derive placeholders from hostSummaries so the
-  // "N failed" rollup is inspectable instead of silently empty.
-  const missingAttemptHints = useMemo(() => {
-    return hostSummaries
-      .map((hs) => {
-        const listed = rows.filter((s) => s.hostId === hs.hostId).length;
-        // Unaccounted terminals ≈ claimed total minus listed rows. Prefer the
-        // failed/rate-limited counts when they exceed what's missing so we
-        // never under-report vs the run summary the user already saw.
-        const unlisted = Math.max(0, hs.total - listed);
-        const failedUnlisted = Math.min(hs.failed, unlisted);
-        const rateLimitedUnlisted = Math.min(
-          hs.rateLimited,
-          Math.max(0, unlisted - failedUnlisted),
-        );
-        if (failedUnlisted === 0 && rateLimitedUnlisted === 0) return null;
-        return {
-          hostId: hs.hostId,
-          failed: failedUnlisted,
-          rateLimited: rateLimitedUnlisted,
-        };
-      })
-      .filter((h): h is NonNullable<typeof h> => h != null)
-      .filter((h) => filter.hostId == null || filter.hostId === h.hostId);
-  }, [hostSummaries, rows, filter.hostId]);
+  const convexByChatId = useMemo(() => {
+    const map = new Map<string, JourneySessionRow>();
+    for (const s of rows) map.set(s.chatSessionId, s);
+    return map;
+  }, [rows]);
 
-  const showRunFailureHint =
-    runSummary.failed > 0 &&
-    rows.every((s) => s.status !== "failed") &&
-    missingAttemptHints.length > 0;
+  const selectedConvex = selection
+    ? (convexByChatId.get(selection.chatSessionId) ?? null)
+    : null;
 
-  // Deep-link restore: auto-select the linked session once it appears on a
-  // loaded page. Runs once. NOTE (remainder): a session on a not-yet-loaded
-  // page won't auto-select until the user pages to it — full cross-page
-  // restore would need the backend list query to accept a session cursor.
+  const fallbackTrace = useMemo(
+    () =>
+      selection
+        ? liveSessionTrace(stream.sessions[selection.chatSessionId])
+        : null,
+    [selection, stream.sessions],
+  );
+
+  // Deep-link restore: select the matrix cell for the linked Convex session.
   const appliedInitialThreadRef = useRef(false);
   useEffect(() => {
     if (appliedInitialThreadRef.current || !initialThreadId) return;
     const match = rows.find((s) => s.id === initialThreadId);
-    if (match) {
-      appliedInitialThreadRef.current = true;
-      setFilter({ hostId: match.hostId });
-      setSelected(match);
-    }
+    if (!match) return;
+    appliedInitialThreadRef.current = true;
+    const sessionIndex = Number(
+      match.chatSessionId.split("_").pop() ?? "0",
+    );
+    setSelection({
+      hostId: match.hostId,
+      sessionIndex: Number.isFinite(sessionIndex) ? sessionIndex : 0,
+      chatSessionId: match.chatSessionId,
+    });
+    setDetailSession(match);
   }, [initialThreadId, rows]);
 
+  // Auto-select the first running cell when a live stream starts.
+  useEffect(() => {
+    if (selection || !streamEnabled) return;
+    const runningEntry = Object.entries(stream.cellStatus).find(
+      ([, status]) => status === "running",
+    );
+    if (!runningEntry) return;
+    const [key] = runningEntry;
+    const [hostId, idxStr] = key.split(":");
+    if (!hostId || idxStr == null) return;
+    const sessionIndex = Number(idxStr);
+    if (!Number.isFinite(sessionIndex)) return;
+    setSelection({
+      hostId,
+      sessionIndex,
+      chatSessionId: swarmAttemptChatSessionId(runId, hostId, sessionIndex),
+    });
+  }, [selection, streamEnabled, stream.cellStatus, runId]);
+
   return (
-    <div className="mt-2 rounded-lg border bg-muted/20 p-2">
-      {/* Host filter chips — include outcome counts so failures are locatable. */}
-      <div className="mb-2 flex flex-wrap gap-1.5">
-        {hostSummaries.map((hs) => {
-          const selectedHost = filter.hostId === hs.hostId;
-          const hasFails = hs.failed > 0 || hs.rateLimited > 0;
-          return (
-            <button
-              key={hs.hostId}
-              type="button"
-              onClick={() =>
-                setFilter((f) => toggleSessionFilter(f, "hostId", hs.hostId))
-              }
-              className={cn(
-                "rounded-full border px-2 py-0.5 text-[11px] outline-none transition-colors",
-                "focus-visible:ring-2 focus-visible:ring-ring",
-                selectedHost
-                  ? "border-primary bg-primary/10"
-                  : "hover:bg-muted",
-                hasFails && !selectedHost && "border-red-500/30",
-              )}
-              aria-label={`${hostName(hs.hostId)}: ${hs.succeeded}/${hs.total} ok${hs.failed > 0 ? `, ${hs.failed} failed` : ""}`}
-            >
-              <span className="font-medium">{hostName(hs.hostId)}</span>
-              <span className="ml-1 text-muted-foreground">
-                {hs.succeeded}/{hs.total}
-              </span>
-              {hs.failed > 0 ? (
-                <span className="ml-1 text-red-600 dark:text-red-400">
-                  · {hs.failed} failed
-                </span>
-              ) : null}
-            </button>
-          );
-        })}
+    <div className="mt-2 space-y-3 rounded-lg border bg-muted/20 p-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="min-w-0">
+          <p className="text-[12px] font-semibold capitalize text-foreground/90">
+            {String(runStatus).replace(/_/g, " ")}
+            <span className="ml-2 font-normal text-muted-foreground">
+              {runSummary.succeeded}/{runSummary.total} ok
+              {runSummary.failed > 0 ? ` · ${runSummary.failed} failed` : ""}
+            </span>
+          </p>
+          <p className="text-[10px] text-muted-foreground">
+            {formatJourneyRelativeTime(createdAt)}
+            {stream.connected ? " · live" : null}
+            {stream.error ? ` · stream error: ${stream.error}` : null}
+          </p>
+        </div>
+        {status === "CanLoadMore" ? (
+          <button
+            type="button"
+            className="text-[11px] font-medium text-primary hover:underline"
+            onClick={() => loadMore(DEFAULT_PAGE_SIZE)}
+          >
+            Load more sessions
+          </button>
+        ) : null}
       </div>
 
-      {showRunFailureHint ? (
-        <p
-          className="mb-2 rounded-md border border-red-500/25 bg-red-500/5 px-2 py-1.5 text-[11px] text-red-700 dark:text-red-400"
-          role="status"
-        >
-          {runSummary.failed} attempt
-          {runSummary.failed === 1 ? "" : "s"} failed without a session
-          transcript — open a host chip with failures to see which clients
-          never persisted a run.
-        </p>
-      ) : null}
+      <div className="grid min-w-0 gap-3 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)]">
+        <SwarmSessionsMatrix
+          runId={runId}
+          hostIds={hostIds}
+          hostName={hostName}
+          sessionsPerHost={sessionsPerHost}
+          sessions={rows}
+          hostSummaries={hostSummaries}
+          stream={stream}
+          runStatus={String(runStatus)}
+          selection={selection}
+          onSelect={(sel) => {
+            setSelection(sel);
+            setDetailSession(null);
+          }}
+        />
+        <SwarmLiveStreamPane
+          selection={selection}
+          stream={stream}
+          convexSession={selectedConvex}
+          fallbackTrace={fallbackTrace}
+          runStatus={String(runStatus)}
+          onOpenCompleted={(session) => setDetailSession(session)}
+        />
+      </div>
 
-      {rows.length === 0 && missingAttemptHints.length === 0 ? (
-        <p className="px-1 py-2 text-[11px] text-muted-foreground">
-          {runSummary.total === 0
-            ? "No sessions recorded yet for this run."
-            : "Sessions are still starting…"}
-        </p>
-      ) : (
-        <div className="flex flex-col divide-y">
-          {missingAttemptHints.map((hint) => (
-            <div
-              key={`missing-${hint.hostId}`}
-              className="flex items-start justify-between gap-2 px-1 py-1.5"
-              data-testid={`missing-attempts-${hint.hostId}`}
-            >
-              <span className="flex min-w-0 flex-col">
-                <span className="truncate text-[11px] font-medium">
-                  {hostName(hint.hostId)}
-                </span>
-                <span className="text-[10px] text-muted-foreground">
-                  Failed before a session was recorded
-                  {hint.rateLimited > 0
-                    ? ` · ${hint.rateLimited} rate-limited`
-                    : ""}
-                </span>
-              </span>
-              <span className="shrink-0 rounded-full bg-red-500/10 px-1.5 py-0.5 text-[10px] font-medium text-red-700 dark:text-red-400">
-                {hint.failed} failed
-              </span>
-            </div>
-          ))}
-          {visible.map((s) => {
-            const isFailed =
-              s.status === "failed" || s.readiness?.status === "failed";
-            const lifecycle = sessionLifecycleLabel(s.status, runStatus);
-            const meta = [lifecycle, s.modelId].filter(Boolean).join(" · ");
-            return (
-              <button
-                key={s.id}
-                type="button"
-                onClick={() => setSelected(s)}
-                className={cn(
-                  "flex items-center justify-between gap-2 px-1 py-1.5 text-left hover:bg-muted/50",
-                  selected?.id === s.id && "bg-muted",
-                )}
-              >
-                <span className="flex min-w-0 flex-col">
-                  <span className="truncate text-[11px] font-medium">
-                    {hostName(s.hostId)}
-                  </span>
-                  <span
-                    className={cn(
-                      "truncate text-[10px]",
-                      isFailed
-                        ? "text-red-600 dark:text-red-400"
-                        : lifecycle === "running"
-                          ? "text-foreground/80"
-                          : "text-muted-foreground",
-                    )}
-                  >
-                    {meta || "—"}
-                  </span>
-                </span>
-                <span className="flex shrink-0 items-center gap-1.5">
-                  {isFailed ? (
-                    <span className="rounded-full bg-red-500/10 px-1.5 py-0.5 text-[10px] font-medium text-red-700 dark:text-red-400">
-                      Failed
-                    </span>
-                  ) : null}
-                  <SessionGoalScoreBadge goalScore={s.goalScore} />
-                  {!isFailed ? (
-                    <SessionReadinessBadge
-                      readiness={toSessionReadiness(s.readiness)}
-                    />
-                  ) : null}
-                </span>
-              </button>
-            );
-          })}
-          {visible.length === 0 && missingAttemptHints.length === 0 ? (
-            <p className="px-1 py-2 text-[11px] text-muted-foreground">
-              No sessions for this client in the loaded page.
+      {detailSession ? (
+        <div className="space-y-1">
+          <div className="flex items-center justify-between gap-2">
+            <p className="text-[11px] font-medium text-muted-foreground">
+              Session detail
             </p>
-          ) : null}
-        </div>
-      )}
-
-      {status === "CanLoadMore" && (
-        <button
-          type="button"
-          className="mt-1 text-[11px] font-medium text-primary hover:underline"
-          onClick={() => loadMore(DEFAULT_PAGE_SIZE)}
-        >
-          Load more sessions
-        </button>
-      )}
-
-      {/* Reuse the existing project-scoped session viewer — do NOT build a new
-          one. `ShareUsageThreadDetail` takes the session row's `id`. */}
-      {selected && (
-        <div className="mt-2">
-          <div className="mb-1 flex justify-end">
-            <button
-              type="button"
-              className="text-[11px] font-medium text-primary hover:underline"
-              onClick={() => setSessionToPromote(selected)}
-            >
-              Promote to test case
-            </button>
+            <div className="flex items-center gap-3">
+              <button
+                type="button"
+                className="text-[11px] font-medium text-primary hover:underline"
+                onClick={() => setSessionToPromote(detailSession)}
+              >
+                Promote to test case
+              </button>
+              <button
+                type="button"
+                className="text-[11px] text-muted-foreground hover:underline"
+                onClick={() => setDetailSession(null)}
+              >
+                Close
+              </button>
+            </div>
           </div>
           <div className="h-[420px] overflow-hidden rounded-lg border">
             <ShareUsageThreadDetail
-              threadId={selected.id}
+              threadId={detailSession.id}
               sessionLink={`${getShareableAppOrigin()}${buildSwarmSessionPath({
                 personaRefId,
                 runId,
-                hostId: selected.hostId,
-                threadId: selected.id,
+                hostId: detailSession.hostId,
+                threadId: detailSession.id,
               })}`}
             />
           </div>
         </div>
-      )}
+      ) : null}
 
       <ConvertSwarmSessionDialog
         open={sessionToPromote !== null}

--- a/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
@@ -743,7 +743,6 @@ export function SwarmsTab({
                           shapeIndex={p.avatarShape}
                           paletteIndex={p.avatarPalette}
                           size="md"
-                          active={selected}
                           state={runningSet.has(p._id) ? "running" : "idle"}
                         />
                         <span className="flex min-w-0 flex-col items-start gap-0.5">

--- a/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
@@ -24,7 +24,7 @@
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQuery, useMutation, usePaginatedQuery } from "convex/react";
-import { Loader2, Plus } from "lucide-react";
+import { Check, ChevronDown, Info, Loader2, Plus, Users } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
 import {
   Dialog,
@@ -36,7 +36,17 @@ import {
 } from "@mcpjam/design-system/dialog";
 import { Input } from "@mcpjam/design-system/input";
 import { Label } from "@mcpjam/design-system/label";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@mcpjam/design-system/popover";
 import { Textarea } from "@mcpjam/design-system/textarea";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@mcpjam/design-system/tooltip";
 import { toast } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
@@ -76,6 +86,7 @@ import {
   parseSwarmSessionParams,
 } from "@/lib/app-navigation";
 import { getShareableAppOrigin } from "@/lib/chatbox-session";
+import { resolveHostLogoByDisplayName } from "@/lib/chatbox-client-style";
 import { ConvertSwarmSessionDialog } from "@/components/swarms/convert-swarm-session-dialog";
 import { ServerGroupPicker } from "@/components/hosts/ServerGroupPicker";
 import { useProjectServerAttachments } from "@/hooks/useViews";
@@ -769,7 +780,14 @@ export function SwarmsTab({
               }}
             />
 
-            <div className="mb-3 flex items-center justify-between">
+            <div
+              className={cn(
+                "mb-3",
+                journeyFormOpen
+                  ? "space-y-2"
+                  : "flex items-center justify-between",
+              )}
+            >
               <h3 className="text-sm font-semibold">Journeys</h3>
               <NewJourneyButton
                 projectId={projectId}
@@ -1443,6 +1461,7 @@ function NewJourneyButton({
   );
   const [sessionsPerHost, setSessionsPerHost] = useState(2);
   const [maxTurns, setMaxTurns] = useState(6);
+  const [clientsPickerOpen, setClientsPickerOpen] = useState(false);
   // Seed the goal from the agent prefill (or reset to "") whenever the form
   // transitions open. Manual "+ New journey" opens pass goalSeed="".
   useEffect(() => {
@@ -1464,6 +1483,17 @@ function NewJourneyButton({
       }),
     [hosts],
   );
+  const selectedHosts = useMemo(
+    () => sortedHosts.filter((h) => hostIds.includes(h.hostId)),
+    [sortedHosts, hostIds],
+  );
+  const clientsTriggerLabel =
+    selectedHosts.length === 0
+      ? "No clients · pick one"
+      : (selectedHosts[0]?.name ?? "Clients");
+  const clientsExtra =
+    selectedHosts.length > 1 ? selectedHosts.length - 1 : 0;
+
   if (!open) {
     return (
       <Button type="button" size="sm" variant="outline" onClick={() => setOpen(true)}>
@@ -1479,131 +1509,173 @@ function NewJourneyButton({
   return (
     <div
       className={cn(
-        "w-full rounded-xl border border-border/50 bg-card/50 p-4 shadow-sm",
+        "w-full rounded-xl border border-border/50 bg-card/50 p-3 shadow-sm",
         "ring-1 ring-black/[0.03] dark:ring-white/[0.06]",
       )}
     >
-      <div className="mb-3 flex flex-col gap-1.5">
-        <Label htmlFor="swarm-journey-goal">Goal</Label>
+      <div className="mb-2.5 flex flex-col gap-1">
+        <Label htmlFor="swarm-journey-goal" className="text-xs">
+          Goal
+        </Label>
         <Textarea
           id="swarm-journey-goal"
           placeholder="What this persona is trying to accomplish"
           value={goal}
           onChange={(e) => setGoal(e.target.value)}
-          rows={3}
-          className="leading-relaxed"
+          rows={2}
+          className="min-h-[56px] resize-none leading-relaxed"
         />
       </div>
-      <div className="mb-3 divide-y rounded-lg border bg-muted/20">
-        <div className="flex items-start justify-between gap-4 p-3">
-          <div className="min-w-0 space-y-0.5">
-            <h3 className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-              Servers
-            </h3>
-            <p className="text-xs text-muted-foreground">
-              Server group all clients run against for this journey.
-            </p>
-          </div>
-          <div className="shrink-0">
-            <ServerGroupPicker
-              projectId={projectId}
-              value={serverAttachmentId}
-              onChange={(id) => setServerAttachmentId(id)}
-              onClearSelection={() => setServerAttachmentId(null)}
-              emptyTriggerLabel="No server group · pick one"
-              infoText="A named set of MCP servers shared across every client this journey targets — same pattern as eval suites."
-            />
-          </div>
-        </div>
-        <div className="space-y-2 p-3">
-          <div className="space-y-0.5">
-            <h3 className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-              Clients
-            </h3>
-            <p className="text-xs text-muted-foreground">
-              Each selected client fans out into its own sessions.
-            </p>
-          </div>
-          <div className="flex flex-wrap gap-2">
-            {hosts.length === 0 ? (
-              <span className="text-xs text-muted-foreground">
-                No clients in this project.
+
+      {/* Compact picker bar — same pill language as SuiteOverviewClientBar. */}
+      <div className="mb-2.5 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-2">
+        <ServerGroupPicker
+          projectId={projectId}
+          value={serverAttachmentId}
+          onChange={(id) => setServerAttachmentId(id)}
+          onClearSelection={() => setServerAttachmentId(null)}
+          emptyTriggerLabel="No server group · pick one"
+          infoText="A named set of MCP servers shared across every client this journey targets — same pattern as eval suites."
+        />
+
+        <Popover open={clientsPickerOpen} onOpenChange={setClientsPickerOpen}>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              className={cn(
+                "flex h-8 max-w-[260px] shrink-0 items-center gap-1 rounded-full border px-2 text-foreground",
+                "outline-none transition-colors",
+                hostIds.length === 0
+                  ? "border-dashed border-border/60 bg-muted/30 hover:bg-muted/45"
+                  : "border-border/60 bg-muted/40 hover:bg-muted/60",
+              )}
+              aria-label="Attached clients"
+            >
+              {selectedHosts[0] ? (
+                <JourneyHostLogoMark label={selectedHosts[0].name} />
+              ) : (
+                <Users className="size-3.5 shrink-0 text-muted-foreground" />
+              )}
+              <span className="min-w-0 flex-1 truncate text-xs font-medium">
+                {clientsTriggerLabel}
               </span>
-            ) : (
-              sortedHosts.map((h) => {
-                // Compact config chips so the picker shows what each client
-                // brings (model · computer) without opening the editor. Server
-                // count is journey-scoped via the group above, not the host.
-                const meta = [
-                  h.modelId || null,
-                  h.hasComputer ? "computer" : null,
-                ].filter(Boolean);
-                const shared = !isSwarmClient(h);
-                return (
-                  <button
-                    key={h.hostId}
-                    type="button"
-                    onClick={() => toggleHost(h.hostId)}
-                    className={cn(
-                      "flex flex-col items-start gap-0.5 rounded-lg border px-2.5 py-1.5 text-left text-xs",
-                      hostIds.includes(h.hostId)
-                        ? "border-primary bg-primary/10"
-                        : "hover:bg-muted",
-                    )}
-                  >
-                    <span className="flex items-center gap-1.5 font-medium">
-                      {h.name}
-                      {shared ? (
-                        <span
-                          className="rounded-full border border-border/60 px-1 py-0 text-[9px] font-normal text-muted-foreground"
-                          title="Managed in another product surface — still runnable by this journey"
-                        >
-                          shared
-                        </span>
-                      ) : null}
-                    </span>
-                    {meta.length > 0 ? (
-                      <span className="text-[10px] text-muted-foreground">
-                        {meta.join(" · ")}
+              {clientsExtra > 0 ? (
+                <span className="text-[10px] text-muted-foreground">
+                  +{clientsExtra}
+                </span>
+              ) : null}
+              <ChevronDown className="size-3 shrink-0 text-muted-foreground" />
+            </button>
+          </PopoverTrigger>
+          <PopoverContent className="w-64 p-1" align="start" sideOffset={4}>
+            <div className="space-y-0.5">
+              <div className="flex items-center justify-between gap-2 px-2 pb-1 pt-0.5">
+                <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                  Clients
+                </span>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      aria-label="What is a client?"
+                      className="rounded-full p-0.5 text-muted-foreground outline-none transition-colors hover:bg-muted/60 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
+                    >
+                      <Info className="size-3" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="top" className="max-w-[240px]">
+                    <p className="text-xs leading-snug">
+                      Each selected client fans out into its own sessions for
+                      this journey.
+                    </p>
+                  </TooltipContent>
+                </Tooltip>
+              </div>
+              {hosts.length === 0 ? (
+                <p className="px-2 py-1.5 text-xs text-muted-foreground">
+                  No clients in this project.
+                </p>
+              ) : (
+                sortedHosts.map((h) => {
+                  const selected = hostIds.includes(h.hostId);
+                  const shared = !isSwarmClient(h);
+                  const meta = [
+                    h.modelId || null,
+                    h.hasComputer ? "computer" : null,
+                  ].filter(Boolean);
+                  return (
+                    <button
+                      key={h.hostId}
+                      type="button"
+                      onClick={() => toggleHost(h.hostId)}
+                      className={cn(
+                        "flex w-full items-center gap-2 rounded py-1.5 pl-2 pr-2 text-left text-sm",
+                        "hover:bg-accent hover:text-accent-foreground",
+                        selected && "bg-accent/50",
+                      )}
+                    >
+                      <Check
+                        className={cn(
+                          "size-3.5 shrink-0",
+                          selected ? "opacity-100" : "opacity-0",
+                        )}
+                      />
+                      <JourneyHostLogoMark label={h.name} />
+                      <span className="min-w-0 flex-1 truncate">
+                        <span className="font-medium">{h.name}</span>
+                        {shared ? (
+                          <span className="ml-1 text-[10px] font-normal text-muted-foreground">
+                            shared
+                          </span>
+                        ) : null}
+                        {meta.length > 0 ? (
+                          <span className="mt-0.5 block truncate text-[10px] text-muted-foreground">
+                            {meta.join(" · ")}
+                          </span>
+                        ) : null}
                       </span>
-                    ) : null}
-                  </button>
-                );
-              })
-            )}
-          </div>
-        </div>
-      </div>
-      <div className="mb-3 flex flex-wrap gap-4">
-        <div className="flex flex-col gap-1">
-          <Label htmlFor="swarm-journey-sessions" className="text-xs">
-            Sessions/host
+                    </button>
+                  );
+                })
+              )}
+            </div>
+          </PopoverContent>
+        </Popover>
+
+        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <Label
+            htmlFor="swarm-journey-sessions"
+            className="shrink-0 text-[11px] text-muted-foreground"
+          >
+            Sessions
           </Label>
           <Input
             id="swarm-journey-sessions"
             type="number"
             min={1}
             max={5}
-            className="h-8 w-20"
+            className="h-8 w-14"
             value={sessionsPerHost}
             onChange={(e) => setSessionsPerHost(Number(e.target.value))}
           />
-        </div>
-        <div className="flex flex-col gap-1">
-          <Label htmlFor="swarm-journey-turns" className="text-xs">
-            Max turns
+          <Label
+            htmlFor="swarm-journey-turns"
+            className="ml-1 shrink-0 text-[11px] text-muted-foreground"
+          >
+            Turns
           </Label>
           <Input
             id="swarm-journey-turns"
             type="number"
             min={1}
             max={20}
-            className="h-8 w-20"
+            className="h-8 w-14"
             value={maxTurns}
             onChange={(e) => setMaxTurns(Number(e.target.value))}
           />
         </div>
       </div>
+
       <div className="flex justify-end gap-2">
         <Button type="button" size="sm" variant="ghost" onClick={() => setOpen(false)}>
           Cancel
@@ -1640,5 +1712,21 @@ function NewJourneyButton({
         </Button>
       </div>
     </div>
+  );
+}
+
+function JourneyHostLogoMark({ label }: { label: string }) {
+  const logoSrc = resolveHostLogoByDisplayName(label);
+  if (logoSrc) {
+    return (
+      <img
+        src={logoSrc}
+        alt=""
+        className="size-3.5 shrink-0 object-contain"
+      />
+    );
+  }
+  return (
+    <span aria-hidden className="size-3.5 shrink-0 rounded-full bg-muted" />
   );
 }

--- a/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
@@ -24,7 +24,15 @@
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQuery, useMutation, usePaginatedQuery } from "convex/react";
-import { Check, ChevronDown, Info, Loader2, Plus, Users } from "lucide-react";
+import {
+  Check,
+  ChevronDown,
+  ChevronRight,
+  Info,
+  Loader2,
+  Plus,
+  Users,
+} from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
 import {
   Dialog,
@@ -842,21 +850,42 @@ export function SwarmsTab({
 }
 
 // ── run status treatment ─────────────────────────────────────────────────────
-function runStatusClass(status: string): string {
+function runStatusChipClass(status: string): string {
   switch (status) {
     case "completed":
-      return "text-emerald-600 dark:text-emerald-400";
+      return "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400";
     case "partial":
-      return "text-amber-600 dark:text-amber-400";
     case "rate_limited":
-      return "text-amber-600 dark:text-amber-400";
+      return "bg-muted text-muted-foreground";
     case "failed":
-      return "text-red-600 dark:text-red-400";
+      return "bg-red-500/10 text-red-700 dark:text-red-400";
     case "stale":
-      return "text-muted-foreground";
+      return "bg-muted text-muted-foreground";
     default:
-      return "text-foreground"; // running
+      return "bg-muted text-foreground"; // running
   }
+}
+
+function formatJourneyRelativeTime(timestamp: number): string {
+  const diff = Date.now() - timestamp;
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Date(timestamp).toLocaleDateString();
+}
+
+function runSummaryLine(r: JourneyRun): string {
+  const parts = [
+    `${r.summary.succeeded}/${r.summary.total} ok`,
+    r.summary.failed > 0 ? `${r.summary.failed} failed` : null,
+    r.summary.rateLimited > 0 ? `${r.summary.rateLimited} rate-limited` : null,
+    goalScoreAvgLabel(r.goalScoreSummary),
+  ].filter(Boolean);
+  return parts.join(" · ");
 }
 
 // ── journey card + runs ──────────────────────────────────────────────────────
@@ -909,22 +938,36 @@ function JourneyCard({
 
   const [launching, setLaunching] = useState(false);
   const [launchError, setLaunchError] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState(false);
   const [openRunId, setOpenRunId] = useState<string | null>(null);
 
-  // Deep-link restore: once this journey's runs load, if the linked run belongs
-  // to THIS card, open it (so RunSessionsView mounts and can select the
-  // session). Runs itself once — later user toggling isn't overridden.
+  // Deep-link restore: expand this journey and open the linked run so
+  // RunSessionsView mounts. Runs once — later user toggling isn't overridden.
   const appliedInitialRunRef = useRef(false);
   useEffect(() => {
     if (appliedInitialRunRef.current || !initialRunId) return;
     if ((runs as JourneyRun[]).some((r) => r._id === initialRunId)) {
       appliedInitialRunRef.current = true;
+      setExpanded(true);
       setOpenRunId(initialRunId);
     }
   }, [initialRunId, runs]);
 
   const hostName = (id: string) =>
     hosts.find((h) => h.hostId === id)?.name ?? id.slice(0, 8);
+
+  const journeyHostNames = useMemo(
+    () => journey.hostIds.map(hostName),
+    // hostName closes over `hosts`; recompute when either changes.
+    [journey.hostIds, hosts],
+  );
+  const firstHostName = journeyHostNames[0] ?? null;
+  const extraHosts = Math.max(0, journeyHostNames.length - 1);
+  const typedRuns = runs as JourneyRun[];
+  const latestRun = typedRuns[0] ?? null;
+  const runCount = rollup?.runCount ?? typedRuns.length;
+  const hasRuns = runCount > 0 || typedRuns.length > 0;
+  const configHint = `${journey.config.sessionsPerHost}/host · ${journey.config.maxTurns} turns`;
 
   const onRun = async () => {
     if (launching) return;
@@ -948,86 +991,171 @@ function JourneyCard({
   };
 
   return (
-    <div className="rounded-lg border p-4">
-      <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0">
-          <p className="truncate text-sm font-medium">{journey.goal}</p>
-          <p className="mt-1 text-xs text-muted-foreground">
-            {serverGroupName ? `${serverGroupName} · ` : null}
-            {journey.hostIds.map(hostName).join(", ")} ·{" "}
-            {journey.config.sessionsPerHost}/host · {journey.config.maxTurns} turns
-          </p>
-          {rollup && rollup.runCount > 0 && (
-            <p className="mt-1 text-[11px] text-muted-foreground">
-              {rollup.runCount} run{rollup.runCount === 1 ? "" : "s"} total
-            </p>
+    <div className="rounded-lg border border-border/60 px-3 py-2.5">
+      <div className="flex items-start gap-1.5">
+        <button
+          type="button"
+          className={cn(
+            "mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground outline-none transition-colors",
+            "hover:bg-muted/60 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring",
+            !hasRuns && "cursor-default opacity-40 hover:bg-transparent",
           )}
+          aria-expanded={expanded}
+          aria-label={expanded ? "Hide runs" : "Show runs"}
+          disabled={!hasRuns}
+          onClick={() => setExpanded((v) => !v)}
+        >
+          {expanded ? (
+            <ChevronDown className="size-3.5" />
+          ) : (
+            <ChevronRight className="size-3.5" />
+          )}
+        </button>
+
+        <div className="min-w-0 flex-1">
+          <div className="flex items-start justify-between gap-3">
+            <button
+              type="button"
+              className="min-w-0 flex-1 text-left outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-sm"
+              disabled={!hasRuns}
+              onClick={() => hasRuns && setExpanded((v) => !v)}
+            >
+              <p className="truncate text-sm font-medium">{journey.goal}</p>
+            </button>
+            <Button
+              type="button"
+              size="sm"
+              className="h-7 shrink-0 px-2.5 text-xs"
+              disabled={launching}
+              onClick={onRun}
+            >
+              {launching ? "Starting…" : "Run"}
+            </Button>
+          </div>
+
+          <div className="mt-1 flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-1 text-xs text-muted-foreground">
+            {firstHostName ? (
+              <span className="inline-flex min-w-0 max-w-[160px] items-center gap-1">
+                <JourneyHostLogoMark label={firstHostName} />
+                <span className="truncate font-medium text-foreground/80">
+                  {firstHostName}
+                </span>
+                {extraHosts > 0 ? (
+                  <span className="shrink-0 text-[10px]">+{extraHosts}</span>
+                ) : null}
+              </span>
+            ) : (
+              <span>No clients</span>
+            )}
+            {serverGroupName ? (
+              <>
+                <span aria-hidden>·</span>
+                <span className="truncate">{serverGroupName}</span>
+              </>
+            ) : null}
+            <span aria-hidden>·</span>
+            <span>
+              {runCount} run{runCount === 1 ? "" : "s"}
+            </span>
+            {latestRun ? (
+              <>
+                <span aria-hidden>·</span>
+                <span
+                  className={cn(
+                    "rounded-full px-1.5 py-px text-[10px] font-medium capitalize",
+                    runStatusChipClass(latestRun.status),
+                  )}
+                >
+                  {latestRun.status.replace(/_/g, " ")}
+                </span>
+              </>
+            ) : null}
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  aria-label="Journey config"
+                  className="rounded-full p-0.5 text-muted-foreground outline-none transition-colors hover:bg-muted/60 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  <Info className="size-3" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="top" className="max-w-[220px]">
+                <p className="text-xs leading-snug">{configHint}</p>
+              </TooltipContent>
+            </Tooltip>
+          </div>
         </div>
-        <Button type="button" size="sm" disabled={launching} onClick={onRun}>
-          {launching ? "Starting…" : "Run journey"}
-        </Button>
       </div>
 
       {launchError && (
-        <p className="mt-2 rounded border border-red-500/40 bg-red-500/10 px-2 py-1 text-xs text-red-600 dark:text-red-400">
+        <p className="mt-2 ml-7 rounded border border-red-500/40 bg-red-500/10 px-2 py-1 text-xs text-red-600 dark:text-red-400">
           {launchError}
         </p>
       )}
 
-      {runs.length > 0 && (
-        <div className="mt-3 border-t pt-3">
-          {(runs as JourneyRun[]).map((r) => (
-            <div key={r._id} className="mb-3 last:mb-0">
-              <div className="flex items-center justify-between text-xs">
-                <span className={`font-medium ${runStatusClass(r.status)}`}>
-                  {r.status}
-                </span>
-                <span className="text-muted-foreground">
-                  {r.summary.succeeded}/{r.summary.total} ok
-                  {r.summary.failed > 0 && ` · ${r.summary.failed} failed`}
-                  {r.summary.rateLimited > 0 &&
-                    ` · ${r.summary.rateLimited} rate-limited`}
-                  {goalScoreAvgLabel(r.goalScoreSummary)
-                    ? ` · ${goalScoreAvgLabel(r.goalScoreSummary)}`
-                    : ""}
-                </span>
-              </div>
-              <div className="mt-1 flex flex-wrap items-center gap-2">
-                {r.hostSummaries.map((hs) => (
-                  <span
-                    key={hs.hostId}
-                    className="rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground"
+      {expanded && (
+        <div className="mt-2 ml-7 space-y-0.5 border-t border-border/40 pt-2">
+          {typedRuns.length === 0 ? (
+            <p className="px-1 py-1.5 text-[11px] text-muted-foreground">
+              No runs yet.
+            </p>
+          ) : (
+            typedRuns.map((r) => {
+              const isOpen = openRunId === r._id;
+              return (
+                <div key={r._id}>
+                  <button
+                    type="button"
+                    className={cn(
+                      "flex w-full items-center gap-2 rounded-md px-1.5 py-1.5 text-left text-xs outline-none transition-colors",
+                      "hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-ring",
+                      isOpen && "bg-muted/40",
+                    )}
+                    aria-expanded={isOpen}
+                    aria-label={
+                      isOpen
+                        ? `Hide sessions for run ${r.status}`
+                        : `View sessions for run ${r.status}`
+                    }
+                    onClick={() =>
+                      setOpenRunId((cur) => (cur === r._id ? null : r._id))
+                    }
                   >
-                    {hostName(hs.hostId)}: {hs.succeeded}/{hs.total}
-                  </span>
-                ))}
-                <button
-                  type="button"
-                  className="text-[11px] font-medium text-primary hover:underline"
-                  onClick={() =>
-                    setOpenRunId((cur) => (cur === r._id ? null : r._id))
-                  }
-                >
-                  {openRunId === r._id ? "Hide sessions" : "View sessions"}
-                </button>
-              </div>
-              {openRunId === r._id && (
-                <RunSessionsView
-                  runId={r._id}
-                  personaRefId={journey.personaRefId}
-                  hosts={hosts}
-                  hostSummaries={r.hostSummaries}
-                  initialThreadId={
-                    initialRunId === r._id ? initialThreadId : undefined
-                  }
-                />
-              )}
-            </div>
-          ))}
+                    {isOpen ? (
+                      <ChevronDown className="size-3 shrink-0 text-muted-foreground" />
+                    ) : (
+                      <ChevronRight className="size-3 shrink-0 text-muted-foreground" />
+                    )}
+                    <span className="capitalize text-foreground/90">
+                      {r.status.replace(/_/g, " ")}
+                    </span>
+                    <span className="min-w-0 flex-1 truncate text-muted-foreground">
+                      {runSummaryLine(r)}
+                    </span>
+                    <span className="shrink-0 text-[10px] text-muted-foreground">
+                      {formatJourneyRelativeTime(r.createdAt)}
+                    </span>
+                  </button>
+                  {isOpen && (
+                    <RunSessionsView
+                      runId={r._id}
+                      personaRefId={journey.personaRefId}
+                      hosts={hosts}
+                      hostSummaries={r.hostSummaries}
+                      initialThreadId={
+                        initialRunId === r._id ? initialThreadId : undefined
+                      }
+                    />
+                  )}
+                </div>
+              );
+            })
+          )}
           {runsStatus === "CanLoadMore" && (
             <button
               type="button"
-              className="mt-1 text-[11px] font-medium text-primary hover:underline"
+              className="mt-0.5 px-1.5 text-[11px] font-medium text-primary hover:underline"
               onClick={() => loadMore(DEFAULT_PAGE_SIZE)}
             >
               Load more runs

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.journeyForm.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.journeyForm.test.tsx
@@ -115,6 +115,11 @@ beforeEach(() => {
   serverGroupPickerState.onChange = null;
 });
 
+async function pickClient(name: string | RegExp) {
+  fireEvent.click(screen.getByRole("button", { name: /attached clients/i }));
+  fireEvent.click(await screen.findByRole("button", { name }));
+}
+
 describe("SwarmsTab — new journey form server group", () => {
   it("keeps Create disabled until a server group and client are picked", async () => {
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
@@ -129,7 +134,7 @@ describe("SwarmsTab — new journey form server group", () => {
     });
     expect(createBtn).toBeDisabled();
 
-    fireEvent.click(screen.getByText("Host One"));
+    await pickClient(/host one/i);
     expect(createBtn).toBeDisabled();
 
     fireEvent.click(screen.getByTestId("mock-server-group-picker"));
@@ -144,7 +149,7 @@ describe("SwarmsTab — new journey form server group", () => {
     fireEvent.change(screen.getByLabelText("Goal"), {
       target: { value: "Draw a dog" },
     });
-    fireEvent.click(screen.getByText("Host One"));
+    await pickClient(/host one/i);
     fireEvent.click(screen.getByTestId("mock-server-group-picker"));
     fireEvent.click(screen.getByRole("button", { name: /create journey/i }));
 

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.journeyForm.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.journeyForm.test.tsx
@@ -17,6 +17,12 @@ const host = {
   modelId: "openai/gpt-4o-mini",
   ownerScope: { type: "journeys" },
 };
+const hostTwo = {
+  hostId: "host-2",
+  name: "Host Two",
+  modelId: "anthropic/claude-haiku-4.5",
+  ownerScope: { type: "journeys" },
+};
 
 const { createJourneyMutation, serverGroupPickerState } = vi.hoisted(() => ({
   createJourneyMutation: vi.fn(),
@@ -34,7 +40,7 @@ vi.mock("convex/react", () => ({
       case "journeys:listJourneysByPersona":
         return [];
       case "hosts:listHosts":
-        return [host];
+        return [host, hostTwo];
       default:
         return undefined;
     }
@@ -115,9 +121,13 @@ beforeEach(() => {
   serverGroupPickerState.onChange = null;
 });
 
-async function pickClient(name: string | RegExp) {
+async function openClientPicker() {
   fireEvent.click(screen.getByRole("button", { name: /attached clients/i }));
-  fireEvent.click(await screen.findByRole("button", { name }));
+}
+
+async function pickClient(name: string | RegExp) {
+  await openClientPicker();
+  fireEvent.click(await screen.findByRole("checkbox", { name }));
 }
 
 describe("SwarmsTab — new journey form server group", () => {
@@ -165,5 +175,42 @@ describe("SwarmsTab — new journey form server group", () => {
         }),
       );
     });
+  });
+
+  it("lets you toggle multiple clients without closing the picker", async () => {
+    render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+    fireEvent.click(screen.getByText("Persona One"));
+    fireEvent.click(screen.getByRole("button", { name: /new journey/i }));
+
+    fireEvent.change(screen.getByLabelText("Goal"), {
+      target: { value: "Draw a dog" },
+    });
+    fireEvent.click(screen.getByTestId("mock-server-group-picker"));
+
+    await openClientPicker();
+    const one = await screen.findByRole("checkbox", { name: /host one/i });
+    const two = await screen.findByRole("checkbox", { name: /host two/i });
+    fireEvent.click(one);
+    fireEvent.click(two);
+
+    expect(one).toHaveAttribute("aria-checked", "true");
+    expect(two).toHaveAttribute("aria-checked", "true");
+    // Trigger reflects multi-select like evals ("Host One +1").
+    expect(
+      screen.getByRole("button", { name: /attached clients/i }),
+    ).toHaveTextContent(/\+1/);
+
+    fireEvent.click(screen.getByRole("button", { name: /create journey/i }));
+    await waitFor(() => {
+      expect(createJourneyMutation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          hostIds: expect.arrayContaining(["host-1", "host-2"]),
+        }),
+      );
+    });
+    const passed = createJourneyMutation.mock.calls[0]![0] as {
+      hostIds: string[];
+    };
+    expect(passed.hostIds).toHaveLength(2);
   });
 });

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.launch.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.launch.test.tsx
@@ -75,7 +75,7 @@ import { LaunchJourneyRunError } from "@/lib/swarm-api";
 function selectPersonaAndRun() {
   render(<SwarmsTab projectId="proj-1" isAuthenticated />);
   fireEvent.click(screen.getByText("Persona One"));
-  return screen.getByRole("button", { name: "Run journey" });
+  return screen.getByRole("button", { name: "Run" });
 }
 
 beforeEach(() => {

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.personas.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.personas.test.tsx
@@ -186,6 +186,21 @@ describe("SwarmsTab — persona create/edit", () => {
       const aside = screen.getByRole("complementary");
       const avatar = within(aside).getByTestId("persona-pixel-avatar");
       expect(avatar.getAttribute("data-state")).toBe("running");
+      // Peppy bob is for running journeys — not merely being selected.
+      expect(avatar.getAttribute("data-busy")).toBe("true");
+    });
+  });
+
+  it("does not mark a selected idle persona as busy", async () => {
+    runningPersonaRefIds.current = [];
+    render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+    fireEvent.click(await screen.findByText("Persona One"));
+
+    await waitFor(() => {
+      const aside = screen.getByRole("complementary");
+      const avatar = within(aside).getByTestId("persona-pixel-avatar");
+      expect(avatar.getAttribute("data-state")).toBe("idle");
+      expect(avatar.getAttribute("data-busy")).toBe("false");
     });
   });
 });

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.sessions.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.sessions.test.tsx
@@ -51,13 +51,15 @@ const runWithMissingFailures = {
 };
 
 // A real JourneySessionDto row — identifier is `id`.
+// `status: "active"` is the chat-session lifecycle (often sticks after the
+// journey run finishes) — UI must not show it as "journey still happening".
 const session = {
   id: "thread-xyz",
   chatSessionId: "synth_run-1_host-1_0",
   projectId: "proj-1",
   hostId: "host-1",
   personaRefId: "persona-1",
-  status: "completed",
+  status: "active",
   modelId: "anthropic/claude-haiku-4.5",
   startedAt: 1,
   lastActivityAt: 2,
@@ -270,5 +272,19 @@ describe("SwarmsTab — sessions-by-run query contract", () => {
     expect(
       screen.getByText(/2 attempts failed without a session transcript/i),
     ).toBeInTheDocument();
+  });
+
+  it("maps sticky chat-session 'active' to 'done' once the run completed", async () => {
+    render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+    fireEvent.click(screen.getByText("Persona One"));
+    await expandJourneyAndOpenRunSessions();
+
+    // Completed run + session.status=active must not read as still happening.
+    expect(
+      await screen.findByRole("button", {
+        name: /done · anthropic\/claude-haiku-4\.5/i,
+      }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/^active ·/i)).not.toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.sessions.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.sessions.test.tsx
@@ -10,9 +10,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
  * and assert the actual (name, args) the component dispatches, then assert the
  * row's `id` is what the viewer opens.
  *
- * The top-level Sessions tab defaults to `journeyRuns:listSessionsByProject`
+ * The top-level Journeys tab defaults to `journeyRuns:listSessionsByProject`
  * (`{ projectId }`) and narrows to `listSessionsByPersona` (`{ personaRefId }`)
- * when a persona filter is applied — same `id`-keyed DTO.
+ * when a persona filter is applied via the top bar — same `id`-keyed DTO.
  */
 
 const persona = {
@@ -237,6 +237,20 @@ async function selectFirstDoneCell() {
   fireEvent.click(doneCell!);
 }
 
+function openJourneysTab() {
+  fireEvent.click(
+    within(screen.getByLabelText("Swarm view")).getByRole("button", {
+      name: /^journeys$/i,
+    }),
+  );
+}
+
+async function selectPersonaFilter(name: string) {
+  const filter = await screen.findByTestId("swarms-sessions-persona-filter");
+  fireEvent.click(filter);
+  fireEvent.click(await screen.findByRole("option", { name }));
+}
+
 describe("SwarmsTab — sessions-by-run query contract", () => {
   it("queries listSessionsByJourneyRun with { journeyRunId } and opens the viewer on the row's `id`", async () => {
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
@@ -337,10 +351,10 @@ describe("SwarmsTab — sessions-by-run query contract", () => {
   });
 });
 
-describe("SwarmsTab — top-level Sessions view", () => {
+describe("SwarmsTab — top-level Journeys view", () => {
   it("defaults to listSessionsByProject and opens the viewer on `id`", async () => {
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
-    fireEvent.click(screen.getByRole("button", { name: /^sessions$/i }));
+    openJourneysTab();
 
     await waitFor(() => {
       const call = paginatedCalls.find(
@@ -351,7 +365,9 @@ describe("SwarmsTab — top-level Sessions view", () => {
     });
 
     const panel = await screen.findByTestId("swarms-sessions-panel");
-    expect(within(panel).getByText("All personas")).toBeInTheDocument();
+    expect(
+      within(panel).getByTestId("swarms-sessions-persona-filter"),
+    ).toHaveTextContent("All personas");
 
     // Select via preview text — name appears twice (title + persona badge).
     fireEvent.click(within(panel).getByText("hello"));
@@ -365,9 +381,8 @@ describe("SwarmsTab — top-level Sessions view", () => {
 
   it("narrows to listSessionsByPersona when a persona is selected, and clears back to all", async () => {
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
-    fireEvent.click(screen.getByRole("button", { name: /^sessions$/i }));
-    // Sidebar row (role=tester) — not the list-card title which also says Persona One.
-    fireEvent.click(screen.getByText("tester"));
+    openJourneysTab();
+    await selectPersonaFilter("Persona One");
 
     await waitFor(() => {
       const call = paginatedCalls.find(
@@ -377,14 +392,11 @@ describe("SwarmsTab — top-level Sessions view", () => {
       expect(call!.args).toEqual({ personaRefId: "persona-1" });
     });
 
-    const filterChip = await screen.findByTestId(
-      "swarms-sessions-persona-filter",
-    );
-    expect(filterChip).toHaveTextContent("Persona One");
-    fireEvent.click(filterChip);
+    await selectPersonaFilter("All personas");
 
     await waitFor(() => {
-      expect(screen.getByText("All personas")).toBeInTheDocument();
+      const filter = screen.getByTestId("swarms-sessions-persona-filter");
+      expect(filter).toHaveTextContent("All personas");
       const projectCalls = paginatedCalls.filter(
         (c) => c.name === "journeyRuns:listSessionsByProject",
       );

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.sessions.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.sessions.test.tsx
@@ -139,7 +139,16 @@ vi.mock("convex/react", () => ({
     }
     if (name === "journeyRuns:listSessionsByProject") {
       return {
-        results: [session],
+        results: [
+          session,
+          {
+            ...session,
+            id: "thread-h2",
+            hostId: "host-2",
+            chatSessionId: "synth_run-1_host-2_0",
+            firstMessagePreview: "hola",
+          },
+        ],
         status: "Exhausted",
         loadMore: vi.fn(),
         isLoading: false,
@@ -220,12 +229,27 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-/** Progressive discovery: expand journey → open a specific run's sessions. */
+/**
+ * Progressive discovery: click Host One's matrix cell (opens the LATEST run,
+ * which the fixtures make `run-fail`/partial), then — for the completed run —
+ * pick it from the run history list. The partial run is already the latest, so
+ * the cell click alone opens it.
+ */
 async function expandJourneyAndOpenRunSessions(
-  runAriaLabel = /view sessions for run completed/i,
+  target: "completed" | "partial" = "completed",
 ) {
-  fireEvent.click(await screen.findByRole("button", { name: /show runs/i }));
-  fireEvent.click(await screen.findByRole("button", { name: runAriaLabel }));
+  fireEvent.click(
+    await screen.findByRole("button", {
+      name: /open runs for book a flight on host one/i,
+    }),
+  );
+  if (target === "completed") {
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: /view sessions for run completed/i,
+      }),
+    );
+  }
 }
 
 async function selectFirstDoneCell() {
@@ -259,11 +283,13 @@ describe("SwarmsTab — sessions-by-run query contract", () => {
     await expandJourneyAndOpenRunSessions();
 
     // CONTRACT: the session query is dispatched with the arg name `journeyRunId`
-    // (NOT `runId`) carrying the run's id.
+    // (NOT `runId`) carrying the run's id. The cell click opens the latest run
+    // (run-fail) first, then the run-picker switches to run-1, so assert the
+    // most-recent dispatch.
     await waitFor(() => {
-      const call = paginatedCalls.find(
-        (c) => c.name === "journeyRuns:listSessionsByJourneyRun"
-      );
+      const call = [...paginatedCalls]
+        .reverse()
+        .find((c) => c.name === "journeyRuns:listSessionsByJourneyRun");
       expect(call).toBeTruthy();
       expect(call!.args).toEqual({ journeyRunId: "run-1" });
       // The wrong (old) arg name must not be present.
@@ -302,16 +328,36 @@ describe("SwarmsTab — sessions-by-run query contract", () => {
     });
   });
 
+  it("opens a specific run when its trend segment is clicked", async () => {
+    render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+    fireEvent.click(screen.getByText("Persona One"));
+
+    // Host One's strip has one segment per run; clicking the completed (run-1)
+    // segment must open THAT run, not the latest.
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: /open run completed .*on host one/i,
+      }),
+    );
+
+    await waitFor(() => {
+      const call = [...paginatedCalls]
+        .reverse()
+        .find((c) => c.name === "journeyRuns:listSessionsByJourneyRun");
+      expect(call).toBeTruthy();
+      expect(call!.args).toEqual({ journeyRunId: "run-1" });
+    });
+  });
+
   it("surfaces failed attempts that never persisted a session transcript", async () => {
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
     fireEvent.click(screen.getByText("Persona One"));
-    await expandJourneyAndOpenRunSessions(
-      /view sessions for run partial/i,
-    );
+    await expandJourneyAndOpenRunSessions("partial");
 
     const matrix = await screen.findByTestId("swarm-sessions-matrix");
-    expect(within(matrix).getByText("Host Two")).toBeInTheDocument();
-    // Host Two's unpersisted failures surface as Fail cells in the matrix.
+    // One chip per (host, session) — Host Two appears on each of its chips.
+    expect(within(matrix).getAllByText("Host Two").length).toBeGreaterThan(0);
+    // Host Two's unpersisted failures surface as Fail chips.
     const failCells = within(matrix)
       .getAllByTestId("swarm-host-cell")
       .filter((el) => el.getAttribute("data-outcome") === "failed");
@@ -377,6 +423,40 @@ describe("SwarmsTab — top-level Journeys view", () => {
     expect(viewer.getAttribute("data-link")).toContain("persona=persona-1");
     expect(viewer.getAttribute("data-link")).toContain("run=run-1");
     expect(viewer.getAttribute("data-link")).toContain("session=thread-xyz");
+  });
+
+  it("filters the visible list by client (host) without changing the query", async () => {
+    render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+    openJourneysTab();
+
+    // Both hosts' sessions are listed before filtering.
+    const panel = await screen.findByTestId("swarms-sessions-panel");
+    expect(within(panel).getByText("hello")).toBeInTheDocument();
+    expect(within(panel).getByText("hola")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("swarms-sessions-host-filter"));
+    fireEvent.click(await screen.findByRole("option", { name: "Host Two" }));
+
+    await waitFor(() => {
+      expect(within(panel).queryByText("hello")).toBeNull();
+      expect(within(panel).getByText("hola")).toBeInTheDocument();
+    });
+
+    // Client filtering is client-side: still the project-level query, no new
+    // query name.
+    expect(
+      paginatedCalls.every(
+        (c) =>
+          c.name !== "journeyRuns:listSessionsByHost" &&
+          c.name !== "journeyRuns:listSessionsByClient",
+      ),
+    ).toBe(true);
+
+    fireEvent.click(screen.getByTestId("swarms-sessions-host-filter"));
+    fireEvent.click(await screen.findByRole("option", { name: "All clients" }));
+    await waitFor(() => {
+      expect(within(panel).getByText("hello")).toBeInTheDocument();
+    });
   });
 
   it("narrows to listSessionsByPersona when a persona is selected, and clears back to all", async () => {

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.sessions.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.sessions.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 /**
@@ -107,12 +107,15 @@ vi.mock("convex/react", () => ({
       const results =
         journeyRunId === "run-fail"
           ? [
-              session,
+              {
+                ...session,
+                chatSessionId: "synth_run-fail_host-1_0",
+              },
               {
                 ...session,
                 id: "thread-abc",
                 hostId: "host-1",
-                chatSessionId: "synth_2",
+                chatSessionId: "synth_run-fail_host-1_1",
               },
             ]
           : [session];
@@ -198,6 +201,15 @@ async function expandJourneyAndOpenRunSessions(
   fireEvent.click(await screen.findByRole("button", { name: runAriaLabel }));
 }
 
+async function selectFirstDoneCell() {
+  const matrix = await screen.findByTestId("swarm-sessions-matrix");
+  const doneCell = within(matrix).getAllByTestId("swarm-host-cell").find(
+    (el) => el.getAttribute("data-outcome") === "succeeded",
+  );
+  expect(doneCell).toBeTruthy();
+  fireEvent.click(doneCell!);
+}
+
 describe("SwarmsTab — sessions-by-run query contract", () => {
   it("queries listSessionsByJourneyRun with { journeyRunId } and opens the viewer on the row's `id`", async () => {
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
@@ -217,12 +229,9 @@ describe("SwarmsTab — sessions-by-run query contract", () => {
       expect((call!.args as Record<string, unknown>).runId).toBeUndefined();
     });
 
-    // The session row renders (its unique modelId is in the accessible name) —
-    // click it to open the viewer.
+    await selectFirstDoneCell();
     fireEvent.click(
-      await screen.findByRole("button", {
-        name: /anthropic\/claude-haiku-4\.5/i,
-      })
+      await screen.findByRole("button", { name: /open full session detail/i }),
     );
 
     // CONTRACT: the viewer + deep-link consume the row's `id` (thread-xyz).
@@ -240,10 +249,9 @@ describe("SwarmsTab — sessions-by-run query contract", () => {
     const dialog = await screen.findByTestId("promote-dialog");
     expect(dialog.getAttribute("data-open")).toBe("false");
 
+    await selectFirstDoneCell();
     fireEvent.click(
-      await screen.findByRole("button", {
-        name: /anthropic\/claude-haiku-4\.5/i,
-      })
+      await screen.findByRole("button", { name: /open full session detail/i }),
     );
     fireEvent.click(await screen.findByText("Promote to test case"));
 
@@ -260,18 +268,13 @@ describe("SwarmsTab — sessions-by-run query contract", () => {
       /view sessions for run partial/i,
     );
 
-    // Auto-focuses the failing host and shows a placeholder (no chatSession).
-    expect(
-      await screen.findByRole("button", {
-        name: /host two: 0\/2 ok, 2 failed/i,
-      }),
-    ).toBeInTheDocument();
-    expect(
-      await screen.findByTestId("missing-attempts-host-2"),
-    ).toHaveTextContent(/failed before a session was recorded/i);
-    expect(
-      screen.getByText(/2 attempts failed without a session transcript/i),
-    ).toBeInTheDocument();
+    const matrix = await screen.findByTestId("swarm-sessions-matrix");
+    expect(within(matrix).getByText("Host Two")).toBeInTheDocument();
+    // Host Two's unpersisted failures surface as Fail cells in the matrix.
+    const failCells = within(matrix)
+      .getAllByTestId("swarm-host-cell")
+      .filter((el) => el.getAttribute("data-outcome") === "failed");
+    expect(failCells.length).toBeGreaterThanOrEqual(2);
   });
 
   it("maps sticky chat-session 'active' to 'done' once the run completed", async () => {
@@ -279,12 +282,16 @@ describe("SwarmsTab — sessions-by-run query contract", () => {
     fireEvent.click(screen.getByText("Persona One"));
     await expandJourneyAndOpenRunSessions();
 
-    // Completed run + session.status=active must not read as still happening.
-    expect(
-      await screen.findByRole("button", {
-        name: /done · anthropic\/claude-haiku-4\.5/i,
-      }),
-    ).toBeInTheDocument();
-    expect(screen.queryByText(/^active ·/i)).not.toBeInTheDocument();
+    const matrix = await screen.findByTestId("swarm-sessions-matrix");
+    // Completed run + session.status=active must not pulse as Running.
+    const running = within(matrix)
+      .getAllByTestId("swarm-host-cell")
+      .filter((el) => el.getAttribute("data-outcome") === "running");
+    expect(running).toHaveLength(0);
+    const done = within(matrix)
+      .getAllByTestId("swarm-host-cell")
+      .filter((el) => el.getAttribute("data-outcome") === "succeeded");
+    expect(done.length).toBeGreaterThan(0);
+    expect(within(done[0]!).getByText("Done")).toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.sessions.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.sessions.test.tsx
@@ -157,13 +157,22 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
+/** Progressive discovery: expand journey → open run sessions. */
+async function expandJourneyAndOpenRunSessions() {
+  fireEvent.click(await screen.findByRole("button", { name: /show runs/i }));
+  fireEvent.click(
+    await screen.findByRole("button", {
+      name: /view sessions for run completed/i,
+    }),
+  );
+}
+
 describe("SwarmsTab — sessions-by-run query contract", () => {
   it("queries listSessionsByJourneyRun with { journeyRunId } and opens the viewer on the row's `id`", async () => {
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
     fireEvent.click(screen.getByText("Persona One"));
 
-    // Open the run's sessions.
-    fireEvent.click(await screen.findByText("View sessions"));
+    await expandJourneyAndOpenRunSessions();
 
     // CONTRACT: the session query is dispatched with the arg name `journeyRunId`
     // (NOT `runId`) carrying the run's id.
@@ -194,7 +203,7 @@ describe("SwarmsTab — sessions-by-run query contract", () => {
   it("opens the promote dialog with the selected session row", async () => {
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
     fireEvent.click(screen.getByText("Persona One"));
-    fireEvent.click(await screen.findByText("View sessions"));
+    await expandJourneyAndOpenRunSessions();
 
     // The dialog is mounted closed until a session is selected + promoted.
     const dialog = await screen.findByTestId("promote-dialog");

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.sessions.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.sessions.test.tsx
@@ -5,10 +5,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
  * CONTRACT (finding 4): the sessions-by-run view must call the backend query
  * `journeyRuns:listSessionsByJourneyRun` with the arg name `journeyRunId` (NOT
  * `runId`), and consume the REAL `JourneySessionDto` — whose identifier is `id`
- * (there is no `_id` / `personaLabel` / `messageCount`). A test that mocked the
- * query away wouldn't catch the wrong arg name (Convex would throw at runtime).
- * Here we intercept `usePaginatedQuery` and assert the actual (name, args) the
- * component dispatches, then assert the row's `id` is what the viewer opens.
+ * (not `_id`). A test that mocked the query away wouldn't catch the wrong arg
+ * name (Convex would throw at runtime). Here we intercept `usePaginatedQuery`
+ * and assert the actual (name, args) the component dispatches, then assert the
+ * row's `id` is what the viewer opens.
+ *
+ * The top-level Sessions tab defaults to `journeyRuns:listSessionsByProject`
+ * (`{ projectId }`) and narrows to `listSessionsByPersona` (`{ personaRefId }`)
+ * when a persona filter is applied — same `id`-keyed DTO.
  */
 
 const persona = {
@@ -59,10 +63,17 @@ const session = {
   projectId: "proj-1",
   hostId: "host-1",
   personaRefId: "persona-1",
+  journeyRunId: "run-1",
+  journeyRefId: "journey-1",
   status: "active",
   modelId: "anthropic/claude-haiku-4.5",
   startedAt: 1,
   lastActivityAt: 2,
+  messageCount: 4,
+  firstMessagePreview: "hello",
+  personaLabel: "Persona One",
+  visitorDisplayName: "Persona One",
+  synthetic: true,
   readiness: { status: "completed", verdict: "ready", issueCount: 0 },
 };
 
@@ -121,6 +132,22 @@ vi.mock("convex/react", () => ({
           : [session];
       return {
         results,
+        status: "Exhausted",
+        loadMore: vi.fn(),
+        isLoading: false,
+      };
+    }
+    if (name === "journeyRuns:listSessionsByProject") {
+      return {
+        results: [session],
+        status: "Exhausted",
+        loadMore: vi.fn(),
+        isLoading: false,
+      };
+    }
+    if (name === "journeyRuns:listSessionsByPersona") {
+      return {
+        results: [session],
         status: "Exhausted",
         loadMore: vi.fn(),
         isLoading: false,
@@ -293,5 +320,75 @@ describe("SwarmsTab — sessions-by-run query contract", () => {
       .filter((el) => el.getAttribute("data-outcome") === "succeeded");
     expect(done.length).toBeGreaterThan(0);
     expect(within(done[0]!).getByText("Done")).toBeInTheDocument();
+  });
+
+  it("shows playground-style Trace / Chat / Raw tabs in the live pane", async () => {
+    render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+    fireEvent.click(screen.getByText("Persona One"));
+    await expandJourneyAndOpenRunSessions();
+    await selectFirstDoneCell();
+
+    const tabs = await screen.findByTestId("swarm-live-trace-view-tabs");
+    expect(within(tabs).getByRole("button", { name: /^trace$/i })).toBeInTheDocument();
+    expect(within(tabs).getByRole("button", { name: /^chat$/i })).toBeInTheDocument();
+    expect(within(tabs).getByRole("button", { name: /^raw$/i })).toBeInTheDocument();
+    // Playground parity: no Tool Calls / Steps / App tabs on this surface.
+    expect(within(tabs).queryByRole("button", { name: /tool calls/i })).toBeNull();
+  });
+});
+
+describe("SwarmsTab — top-level Sessions view", () => {
+  it("defaults to listSessionsByProject and opens the viewer on `id`", async () => {
+    render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+    fireEvent.click(screen.getByRole("button", { name: /^sessions$/i }));
+
+    await waitFor(() => {
+      const call = paginatedCalls.find(
+        (c) => c.name === "journeyRuns:listSessionsByProject",
+      );
+      expect(call).toBeTruthy();
+      expect(call!.args).toEqual({ projectId: "proj-1" });
+    });
+
+    const panel = await screen.findByTestId("swarms-sessions-panel");
+    expect(within(panel).getByText("All personas")).toBeInTheDocument();
+
+    // Select via preview text — name appears twice (title + persona badge).
+    fireEvent.click(within(panel).getByText("hello"));
+
+    const viewer = await screen.findByTestId("viewer");
+    expect(viewer.getAttribute("data-thread-id")).toBe("thread-xyz");
+    expect(viewer.getAttribute("data-link")).toContain("persona=persona-1");
+    expect(viewer.getAttribute("data-link")).toContain("run=run-1");
+    expect(viewer.getAttribute("data-link")).toContain("session=thread-xyz");
+  });
+
+  it("narrows to listSessionsByPersona when a persona is selected, and clears back to all", async () => {
+    render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+    fireEvent.click(screen.getByRole("button", { name: /^sessions$/i }));
+    // Sidebar row (role=tester) — not the list-card title which also says Persona One.
+    fireEvent.click(screen.getByText("tester"));
+
+    await waitFor(() => {
+      const call = paginatedCalls.find(
+        (c) => c.name === "journeyRuns:listSessionsByPersona",
+      );
+      expect(call).toBeTruthy();
+      expect(call!.args).toEqual({ personaRefId: "persona-1" });
+    });
+
+    const filterChip = await screen.findByTestId(
+      "swarms-sessions-persona-filter",
+    );
+    expect(filterChip).toHaveTextContent("Persona One");
+    fireEvent.click(filterChip);
+
+    await waitFor(() => {
+      expect(screen.getByText("All personas")).toBeInTheDocument();
+      const projectCalls = paginatedCalls.filter(
+        (c) => c.name === "journeyRuns:listSessionsByProject",
+      );
+      expect(projectCalls.length).toBeGreaterThan(0);
+    });
   });
 });

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.sessions.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.sessions.test.tsx
@@ -22,10 +22,11 @@ const journey = {
   _id: "journey-1",
   personaRefId: "persona-1",
   goal: "Book a flight",
-  hostIds: ["host-1"],
+  hostIds: ["host-1", "host-2"],
   config: { sessionsPerHost: 2, maxTurns: 6 },
 };
 const host = { hostId: "host-1", name: "Host One" };
+const hostTwo = { hostId: "host-2", name: "Host Two" };
 
 const run = {
   _id: "run-1",
@@ -35,6 +36,18 @@ const run = {
     { hostId: "host-1", total: 1, succeeded: 1, failed: 0, rateLimited: 0 },
   ],
   createdAt: 1,
+};
+
+/** Partial run: Host Two failed both attempts with no persisted chatSessions. */
+const runWithMissingFailures = {
+  _id: "run-fail",
+  status: "partial",
+  summary: { total: 4, succeeded: 2, failed: 2, rateLimited: 0 },
+  hostSummaries: [
+    { hostId: "host-1", total: 2, succeeded: 2, failed: 0, rateLimited: 0 },
+    { hostId: "host-2", total: 2, succeeded: 0, failed: 2, rateLimited: 0 },
+  ],
+  createdAt: 2,
 };
 
 // A real JourneySessionDto row — identifier is `id`.
@@ -64,9 +77,9 @@ vi.mock("convex/react", () => ({
       case "journeys:listJourneysByPersona":
         return [journey];
       case "hosts:listHosts":
-        return [host];
+        return [host, hostTwo];
       case "journeys:getJourneyRollup":
-        return { journeyRefId: "journey-1", runCount: 1, hosts: [] };
+        return { journeyRefId: "journey-1", runCount: 2, hosts: [] };
       default:
         return undefined;
     }
@@ -76,15 +89,33 @@ vi.mock("convex/react", () => ({
     paginatedCalls.push({ name, args });
     if (name === "journeyRuns:listJourneyRuns") {
       return {
-        results: [run],
+        results: [runWithMissingFailures, run],
         status: "Exhausted",
         loadMore: vi.fn(),
         isLoading: false,
       };
     }
     if (name === "journeyRuns:listSessionsByJourneyRun") {
+      const journeyRunId =
+        args && typeof args === "object" && "journeyRunId" in args
+          ? (args as { journeyRunId: string }).journeyRunId
+          : null;
+      // Partial run: only Host One persisted sessions; Host Two failures have
+      // no chatSession rows. Completed run: single session fixture.
+      const results =
+        journeyRunId === "run-fail"
+          ? [
+              session,
+              {
+                ...session,
+                id: "thread-abc",
+                hostId: "host-1",
+                chatSessionId: "synth_2",
+              },
+            ]
+          : [session];
       return {
-        results: [session],
+        results,
         status: "Exhausted",
         loadMore: vi.fn(),
         isLoading: false,
@@ -157,14 +188,12 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-/** Progressive discovery: expand journey → open run sessions. */
-async function expandJourneyAndOpenRunSessions() {
+/** Progressive discovery: expand journey → open a specific run's sessions. */
+async function expandJourneyAndOpenRunSessions(
+  runAriaLabel = /view sessions for run completed/i,
+) {
   fireEvent.click(await screen.findByRole("button", { name: /show runs/i }));
-  fireEvent.click(
-    await screen.findByRole("button", {
-      name: /view sessions for run completed/i,
-    }),
-  );
+  fireEvent.click(await screen.findByRole("button", { name: runAriaLabel }));
 }
 
 describe("SwarmsTab — sessions-by-run query contract", () => {
@@ -220,5 +249,26 @@ describe("SwarmsTab — sessions-by-run query contract", () => {
       expect(dialog.getAttribute("data-open")).toBe("true");
       expect(dialog.getAttribute("data-session-id")).toBe("thread-xyz");
     });
+  });
+
+  it("surfaces failed attempts that never persisted a session transcript", async () => {
+    render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+    fireEvent.click(screen.getByText("Persona One"));
+    await expandJourneyAndOpenRunSessions(
+      /view sessions for run partial/i,
+    );
+
+    // Auto-focuses the failing host and shows a placeholder (no chatSession).
+    expect(
+      await screen.findByRole("button", {
+        name: /host two: 0\/2 ok, 2 failed/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByTestId("missing-attempts-host-2"),
+    ).toHaveTextContent(/failed before a session was recorded/i);
+    expect(
+      screen.getByText(/2 attempts failed without a session transcript/i),
+    ).toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/journey-list.test.ts
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/journey-list.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import type { JourneyRun } from "@/lib/swarm-api";
+import { journeyHostColumns, journeyHostOutcome } from "../journey-list";
+
+function run(
+  partial: Partial<JourneyRun> & {
+    hostSummaries: JourneyRun["hostSummaries"];
+  },
+): JourneyRun {
+  return {
+    _id: partial._id ?? "run-x",
+    status: partial.status ?? "completed",
+    summary: partial.summary ?? {
+      total: 0,
+      succeeded: 0,
+      failed: 0,
+      rateLimited: 0,
+    },
+    hostSummaries: partial.hostSummaries,
+    goalScoreSummary: partial.goalScoreSummary,
+    createdAt: partial.createdAt ?? 1,
+  };
+}
+
+const hs = (
+  hostId: string,
+  total: number,
+  succeeded: number,
+  failed = 0,
+  rateLimited = 0,
+) => ({ hostId, total, succeeded, failed, rateLimited });
+
+describe("journeyHostColumns", () => {
+  it("unions target hosts, orders by the project host list, appends unknowns", () => {
+    const journeys = [
+      { _id: "j1", personaRefId: "p", goal: "g1", hostIds: ["b", "z"], config: { sessionsPerHost: 1, maxTurns: 1 } },
+      { _id: "j2", personaRefId: "p", goal: "g2", hostIds: ["a", "b"], config: { sessionsPerHost: 1, maxTurns: 1 } },
+    ];
+    const hosts = [
+      { hostId: "a", name: "Alpha" },
+      { hostId: "b", name: "Bravo" },
+    ];
+    const cols = journeyHostColumns(journeys, hosts);
+    // a, b come first (project order); z is unknown → appended, name falls back.
+    expect(cols.map((c) => c.hostId)).toEqual(["a", "b", "z"]);
+    expect(cols.map((c) => c.name)).toEqual(["Alpha", "Bravo", "z"]);
+  });
+});
+
+describe("journeyHostOutcome", () => {
+  it("classifies pass / fail / partial for a terminal run", () => {
+    const r = run({
+      status: "partial",
+      hostSummaries: [hs("h1", 2, 2), hs("h2", 2, 0, 2), hs("h3", 3, 1, 2)],
+    });
+    expect(journeyHostOutcome(r, "h1")).toBe("pass");
+    expect(journeyHostOutcome(r, "h2")).toBe("fail");
+    expect(journeyHostOutcome(r, "h3")).toBe("part");
+  });
+
+  it("returns none for a host absent from the run's summaries", () => {
+    const r = run({ status: "completed", hostSummaries: [hs("h1", 1, 1)] });
+    expect(journeyHostOutcome(r, "other")).toBe("none");
+  });
+
+  it("returns running while a running run's host has incomplete attempts", () => {
+    const r = run({ status: "running", hostSummaries: [hs("h1", 3, 1)] });
+    expect(journeyHostOutcome(r, "h1")).toBe("running");
+    // Absent host under a running run also reads as running (not yet reported).
+    expect(journeyHostOutcome(r, "h2")).toBe("running");
+  });
+
+  it("resolves a running run's host once all attempts are accounted for", () => {
+    const r = run({ status: "running", hostSummaries: [hs("h1", 2, 2)] });
+    expect(journeyHostOutcome(r, "h1")).toBe("pass");
+  });
+});

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/swarm-sessions-metric-strip.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/swarm-sessions-metric-strip.test.tsx
@@ -1,0 +1,154 @@
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * CONTRACT: the Sessions metric strip must subscribe to the backend query
+ * `journeyRuns:getSwarmSessionMetrics` with `{ projectId }` (and add
+ * `personaRefId` only when a persona filter is active). These are string-keyed
+ * `as any` reads — no codegen catches a typo — so we intercept `useQuery` and
+ * assert the exact (name, args) dispatched. We also assert the strip renders
+ * null-safely: "—" for a missing token average, and nothing at all when there
+ * are no sessions or the query is still loading.
+ */
+
+const queryCalls: Array<{ name: string; args: unknown }> = [];
+let metricsFixture: unknown;
+
+vi.mock("convex/react", () => ({
+  useQuery: (name: string, args: unknown) => {
+    queryCalls.push({ name, args });
+    if (args === "skip") return undefined;
+    return metricsFixture;
+  },
+}));
+
+import { SwarmSessionsMetricStrip } from "../swarm-sessions-metric-strip";
+import { SWARM_QUERIES, type SwarmSessionMetrics } from "@/lib/swarm-api";
+
+function fullMetrics(
+  overrides: Partial<SwarmSessionMetrics> = {},
+): SwarmSessionMetrics {
+  return {
+    sessionCount: 12,
+    analyzedCount: 12,
+    truncated: false,
+    toolCallCount: 100,
+    toolErrorCount: 8,
+    toolErrorRate: 0.08,
+    sessionsWithToolErrors: 5,
+    topFailingTool: { toolName: "search_web", errorCount: 4 },
+    avgToolCallsPerSession: 8.3,
+    latencyP50Ms: 10500,
+    latencyP95Ms: 18500,
+    avgTokensPerSession: 3200,
+    tokenSampleCount: 12,
+    trend: [
+      {
+        dayStartMs: 0,
+        sessionCount: 6,
+        toolErrorRate: 0.1,
+        avgToolCallsPerSession: 8,
+        latencyP50Ms: 10000,
+        latencyP95Ms: 18000,
+        avgTokensPerSession: 3000,
+      },
+      {
+        dayStartMs: 86_400_000,
+        sessionCount: 6,
+        toolErrorRate: 0.06,
+        avgToolCallsPerSession: 9,
+        latencyP50Ms: 11000,
+        latencyP95Ms: 19000,
+        avgTokensPerSession: 3400,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  queryCalls.length = 0;
+  metricsFixture = undefined;
+  cleanup();
+});
+
+const metricsCall = () =>
+  queryCalls.find((c) => c.name === SWARM_QUERIES.getSwarmSessionMetrics);
+
+describe("SwarmSessionsMetricStrip", () => {
+  it("dispatches the metrics query with { projectId } when unfiltered", () => {
+    metricsFixture = fullMetrics();
+    render(<SwarmSessionsMetricStrip projectId="proj-1" personaRefId={null} />);
+    expect(metricsCall()).toBeTruthy();
+    expect(metricsCall()!.args).toEqual({ projectId: "proj-1" });
+  });
+
+  it("adds personaRefId to the args when a persona filter is active", () => {
+    metricsFixture = fullMetrics();
+    render(
+      <SwarmSessionsMetricStrip projectId="proj-1" personaRefId="persona-9" />,
+    );
+    expect(metricsCall()!.args).toEqual({
+      projectId: "proj-1",
+      personaRefId: "persona-9",
+    });
+  });
+
+  it("renders all four metric tiles including both latency percentiles", () => {
+    metricsFixture = fullMetrics();
+    render(<SwarmSessionsMetricStrip projectId="proj-1" personaRefId={null} />);
+    expect(screen.getByTestId("swarm-sessions-metric-strip")).toBeTruthy();
+    expect(screen.getByText("Tool errors")).toBeTruthy();
+    expect(screen.getByText("Latency")).toBeTruthy();
+    expect(screen.getByText("Tool calls")).toBeTruthy();
+    expect(screen.getByText("Tokens")).toBeTruthy();
+    expect(screen.getByText("P50")).toBeTruthy();
+    expect(screen.getByText("P95")).toBeTruthy();
+    expect(screen.getByText(/^8(\.0)?%$/)).toBeTruthy();
+    expect(screen.getByText(/search_web/)).toBeTruthy();
+  });
+
+  it("surfaces a partial token sample as 'n of m sessions'", () => {
+    metricsFixture = fullMetrics({ tokenSampleCount: 8, sessionCount: 12 });
+    render(<SwarmSessionsMetricStrip projectId="proj-1" personaRefId={null} />);
+    expect(screen.getByText("8 of 12 sessions")).toBeTruthy();
+  });
+
+  it("renders an em dash for a missing token average (backfill gap)", () => {
+    metricsFixture = fullMetrics({
+      avgTokensPerSession: null,
+      tokenSampleCount: 0,
+    });
+    render(<SwarmSessionsMetricStrip projectId="proj-1" personaRefId={null} />);
+    const strip = screen.getByTestId("swarm-sessions-metric-strip");
+    expect(within(strip).getAllByText("—").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders nothing when there are no sessions", () => {
+    metricsFixture = fullMetrics({ sessionCount: 0 });
+    const { container } = render(
+      <SwarmSessionsMetricStrip projectId="proj-1" personaRefId={null} />,
+    );
+    expect(
+      container.querySelector("[data-testid='swarm-sessions-metric-strip']"),
+    ).toBeNull();
+  });
+
+  it("renders nothing while the query is loading (undefined)", () => {
+    metricsFixture = undefined;
+    const { container } = render(
+      <SwarmSessionsMetricStrip projectId="proj-1" personaRefId={null} />,
+    );
+    expect(
+      container.querySelector("[data-testid='swarm-sessions-metric-strip']"),
+    ).toBeNull();
+  });
+
+  it("omits sparklines when the trend has fewer than two points", () => {
+    metricsFixture = fullMetrics({ trend: [fullMetrics().trend[0]!] });
+    render(<SwarmSessionsMetricStrip projectId="proj-1" personaRefId={null} />);
+    expect(
+      screen.queryByTestId("swarm-metric-sparkline-tool-errors"),
+    ).toBeNull();
+  });
+});

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/swarm-stream-reduce.test.ts
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/swarm-stream-reduce.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import {
+  reduceSwarmStreamEvent,
+  swarmCellKey,
+  type JourneyRunStreamState,
+} from "../use-journey-run-stream";
+import { resolveSwarmCellOutcome } from "../journey-run-results";
+import type { SwarmStreamEvent } from "@/shared/swarm-stream-events";
+import { swarmEventToEvalPayload } from "@/shared/swarm-stream-events";
+
+function empty(): JourneyRunStreamState {
+  return {
+    sessions: {},
+    cellStatus: {},
+    runComplete: false,
+    connected: false,
+    error: null,
+  };
+}
+
+function evt(
+  partial: Partial<SwarmStreamEvent> & Pick<SwarmStreamEvent, "type">,
+): SwarmStreamEvent {
+  return {
+    runId: "run_1",
+    hostId: "host_a",
+    chatSessionId: "synth_run_1_host_a_0",
+    sessionIndex: 0,
+    ...partial,
+  } as SwarmStreamEvent;
+}
+
+describe("swarmEventToEvalPayload", () => {
+  it("strips envelope for turn events", () => {
+    const payload = swarmEventToEvalPayload(
+      evt({ type: "text_delta", content: "hello" }),
+    );
+    expect(payload).toEqual({ type: "text_delta", content: "hello" });
+  });
+
+  it("returns null for lifecycle events", () => {
+    expect(swarmEventToEvalPayload(evt({ type: "session_start" }))).toBeNull();
+    expect(
+      swarmEventToEvalPayload(evt({ type: "run_complete" })),
+    ).toBeNull();
+  });
+});
+
+describe("reduceSwarmStreamEvent", () => {
+  it("tracks attempt_status on the matrix cell key", () => {
+    let state = empty();
+    state = reduceSwarmStreamEvent(
+      state,
+      evt({ type: "attempt_status", status: "running" }),
+    );
+    expect(state.cellStatus[swarmCellKey("host_a", 0)]).toBe("running");
+    expect(state.sessions["synth_run_1_host_a_0"]?.attemptStatus).toBe(
+      "running",
+    );
+  });
+
+  it("folds text_delta into the session stream drafts", () => {
+    let state = empty();
+    state = reduceSwarmStreamEvent(
+      state,
+      evt({ type: "turn_start", turnIndex: 0, prompt: "draw a dog" }),
+    );
+    state = reduceSwarmStreamEvent(
+      state,
+      evt({ type: "text_delta", content: "Sure" }),
+    );
+    const drafts =
+      state.sessions["synth_run_1_host_a_0"]?.stream.draftMessages ?? [];
+    expect(drafts[0]).toMatchObject({ role: "user", content: "draw a dog" });
+    expect(drafts[1]).toMatchObject({ role: "assistant", content: "Sure" });
+  });
+
+  it("marks runComplete on run_complete", () => {
+    const state = reduceSwarmStreamEvent(
+      empty(),
+      evt({
+        type: "run_complete",
+        hostId: "",
+        chatSessionId: "",
+        sessionIndex: -1,
+      }),
+    );
+    expect(state.runComplete).toBe(true);
+  });
+});
+
+describe("resolveSwarmCellOutcome", () => {
+  it("prefers live running status", () => {
+    expect(
+      resolveSwarmCellOutcome({
+        liveStatus: "running",
+        session: null,
+        runStatus: "running",
+      }),
+    ).toBe("running");
+  });
+
+  it("uses Convex failed when no live status", () => {
+    expect(
+      resolveSwarmCellOutcome({
+        session: {
+          id: "x",
+          chatSessionId: "c",
+          projectId: "p",
+          hostId: "h",
+          startedAt: 0,
+          status: "failed",
+        },
+        runStatus: "completed",
+      }),
+    ).toBe("failed");
+  });
+
+  it("maps completed Convex session to succeeded", () => {
+    expect(
+      resolveSwarmCellOutcome({
+        session: {
+          id: "x",
+          chatSessionId: "c",
+          projectId: "p",
+          hostId: "h",
+          startedAt: 0,
+          status: "completed",
+        },
+        runStatus: "completed",
+      }),
+    ).toBe("succeeded");
+  });
+
+  it("maps sticky active chat-session to succeeded when the run finished", () => {
+    expect(
+      resolveSwarmCellOutcome({
+        session: {
+          id: "x",
+          chatSessionId: "c",
+          projectId: "p",
+          hostId: "h",
+          startedAt: 0,
+          status: "active",
+        },
+        runStatus: "completed",
+      }),
+    ).toBe("succeeded");
+  });
+});

--- a/mcpjam-inspector/client/src/components/swarms/journey-host-logo.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/journey-host-logo.tsx
@@ -1,0 +1,17 @@
+import { resolveHostLogoByDisplayName } from "@/lib/chatbox-client-style";
+
+/**
+ * Small host logo mark keyed by display name. Shared by the new-journey form
+ * (host picker) and the journey matrix header/cells.
+ */
+export function JourneyHostLogoMark({ label }: { label: string }) {
+  const logoSrc = resolveHostLogoByDisplayName(label);
+  if (logoSrc) {
+    return (
+      <img src={logoSrc} alt="" className="size-3.5 shrink-0 object-contain" />
+    );
+  }
+  return (
+    <span aria-hidden className="size-3.5 shrink-0 rounded-full bg-muted" />
+  );
+}

--- a/mcpjam-inspector/client/src/components/swarms/journey-list.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/journey-list.tsx
@@ -1,0 +1,540 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useQuery, usePaginatedQuery } from "convex/react";
+import { Info } from "lucide-react";
+import { Button } from "@mcpjam/design-system/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@mcpjam/design-system/tooltip";
+import { cn } from "@/lib/utils";
+import { toast } from "@/lib/toast";
+import {
+  SWARM_QUERIES,
+  DEFAULT_PAGE_SIZE,
+  type JourneyRun,
+  type JourneyRollup,
+} from "@/lib/swarm-api";
+import { useProjectServerAttachments } from "@/hooks/useViews";
+import { JourneyHostLogoMark } from "./journey-host-logo";
+import {
+  formatJourneyRelativeTime,
+  runNumberLabel,
+  runStatusChipClass,
+  runSummaryLine,
+} from "./journey-run-format";
+
+// Structural view of the SwarmsTab `Journey` / `HostItem` shapes — kept local so
+// this module stays decoupled from the surface component (no import cycle).
+export type JourneyListJourney = {
+  _id: string;
+  personaRefId: string;
+  name?: string;
+  goal: string;
+  hostIds: string[];
+  serverAttachmentId?: string | null;
+  config: { sessionsPerHost: number; maxTurns: number };
+};
+export type JourneyListHost = { hostId: string; name: string };
+type ServerAttachment = { _id: string; name: string };
+
+/** The run currently open in the surface's detail panel. */
+export type JourneyRunSelection = {
+  journeyId: string;
+  runId: string;
+  hostId: string | null;
+};
+
+export type JourneyCellOutcome = "pass" | "fail" | "part" | "running" | "none";
+
+const CELL_STATUS_META: Record<
+  Exclude<JourneyCellOutcome, "none">,
+  { label: string; dot: string; text: string }
+> = {
+  pass: { label: "Pass", dot: "bg-success", text: "text-success" },
+  fail: { label: "Fail", dot: "bg-destructive", text: "text-destructive" },
+  part: {
+    label: "Partial",
+    dot: "bg-amber-500",
+    text: "text-amber-600 dark:text-amber-400",
+  },
+  running: {
+    label: "Running",
+    dot: "bg-muted-foreground animate-pulse",
+    text: "text-muted-foreground",
+  },
+};
+
+/** Trend-segment fills — same palette as the evals RunTrendStrip. */
+const SEGMENT_CLASS: Record<Exclude<JourneyCellOutcome, "none">, string> = {
+  pass: "bg-success/70",
+  fail: "bg-destructive/70",
+  part: "bg-amber-500/70 dark:bg-amber-400/70",
+  running: "bg-warning/50 animate-pulse",
+};
+
+/** Run-level status dot for the run rows (status string, not per-host). */
+function runStatusDotClass(status: string): string {
+  switch (status) {
+    case "completed":
+      return "bg-success";
+    case "failed":
+      return "bg-destructive";
+    case "partial":
+    case "rate_limited":
+      return "bg-amber-500";
+    case "stale":
+      return "bg-muted-foreground/50";
+    default:
+      return "bg-muted-foreground animate-pulse"; // running
+  }
+}
+
+const MAX_TREND_SEGMENTS = 12;
+
+/**
+ * The journeys' target hosts, ordered by the project `hosts` array with any
+ * hosts not in that list appended in first-seen order. Names fall back to a
+ * truncated id.
+ */
+export function journeyHostColumns(
+  journeys: JourneyListJourney[],
+  hosts: JourneyListHost[],
+): JourneyListHost[] {
+  const targeted = new Set<string>();
+  for (const j of journeys) for (const id of j.hostIds) targeted.add(id);
+
+  const ordered: string[] = [];
+  for (const h of hosts) {
+    if (targeted.has(h.hostId) && !ordered.includes(h.hostId)) {
+      ordered.push(h.hostId);
+    }
+  }
+  for (const j of journeys) {
+    for (const id of j.hostIds) {
+      if (!ordered.includes(id)) ordered.push(id);
+    }
+  }
+
+  const nameOf = (id: string) =>
+    hosts.find((h) => h.hostId === id)?.name ?? id.slice(0, 8);
+  return ordered.map((id) => ({ hostId: id, name: nameOf(id) }));
+}
+
+/** Per-(run, host) outcome from the run's host rollup summary. */
+export function journeyHostOutcome(
+  run: JourneyRun,
+  hostId: string,
+): JourneyCellOutcome {
+  const entry = run.hostSummaries.find((h) => h.hostId === hostId);
+  if (!entry || entry.total === 0) {
+    return run.status === "running" ? "running" : "none";
+  }
+  const done = entry.succeeded + entry.failed + entry.rateLimited;
+  if (run.status === "running" && done < entry.total) return "running";
+  if (entry.succeeded === entry.total) return "pass";
+  if (entry.succeeded === 0) return "fail";
+  return "part";
+}
+
+function hostSummaryFor(run: JourneyRun, hostId: string) {
+  return run.hostSummaries.find((h) => h.hostId === hostId) ?? null;
+}
+
+/** Per-journey blocks: each journey shows its own hosts as result cells. */
+export function JourneyList({
+  journeys,
+  hosts,
+  isAuthenticated,
+  projectId,
+  onLaunch,
+  initialRunId,
+  selection,
+  onOpenRun,
+  onCloseRun,
+}: {
+  journeys: JourneyListJourney[];
+  hosts: JourneyListHost[];
+  isAuthenticated: boolean;
+  projectId: string;
+  onLaunch: (
+    journeyId: string,
+  ) => Promise<
+    { status: "launched"; runId?: string } | { status: "already_launching" }
+  >;
+  initialRunId?: string;
+  selection: JourneyRunSelection | null;
+  /** Open a run in the surface's detail panel (optionally focused on a host). */
+  onOpenRun: (
+    journey: JourneyListJourney,
+    run: JourneyRun,
+    hostId: string | null,
+  ) => void;
+  onCloseRun: () => void;
+}) {
+  const { serverAttachments } = useProjectServerAttachments({
+    isAuthenticated,
+    projectId,
+  });
+
+  return (
+    <div className="flex flex-col gap-3">
+      {journeys.map((journey) => (
+        <JourneyBlock
+          key={journey._id}
+          journey={journey}
+          hosts={hosts}
+          serverAttachments={serverAttachments}
+          onLaunch={onLaunch}
+          initialRunId={initialRunId}
+          selection={selection?.journeyId === journey._id ? selection : null}
+          onOpenRun={onOpenRun}
+          onCloseRun={onCloseRun}
+        />
+      ))}
+    </div>
+  );
+}
+
+function JourneyBlock({
+  journey,
+  hosts,
+  serverAttachments,
+  onLaunch,
+  initialRunId,
+  selection,
+  onOpenRun,
+  onCloseRun,
+}: {
+  journey: JourneyListJourney;
+  hosts: JourneyListHost[];
+  serverAttachments: ServerAttachment[];
+  onLaunch: (
+    journeyId: string,
+  ) => Promise<
+    { status: "launched"; runId?: string } | { status: "already_launching" }
+  >;
+  initialRunId?: string;
+  /** Non-null only when the open run belongs to THIS journey. */
+  selection: JourneyRunSelection | null;
+  onOpenRun: (
+    journey: JourneyListJourney,
+    run: JourneyRun,
+    hostId: string | null,
+  ) => void;
+  onCloseRun: () => void;
+}) {
+  const {
+    results: runs,
+    status: runsStatus,
+    loadMore,
+  } = usePaginatedQuery(
+    SWARM_QUERIES.listJourneyRuns as any,
+    { journeyRefId: journey._id } as any,
+    { initialNumItems: DEFAULT_PAGE_SIZE },
+  );
+  const rollup = useQuery(
+    SWARM_QUERIES.journeyRollup as any,
+    { journeyRefId: journey._id } as any,
+  ) as JourneyRollup | undefined;
+
+  const [launching, setLaunching] = useState(false);
+  const [launchError, setLaunchError] = useState<string | null>(null);
+
+  const typedRuns = runs as JourneyRun[];
+  const latestRun = typedRuns[0] ?? null;
+  const runCount = rollup?.runCount ?? typedRuns.length;
+  const hostCols = useMemo(
+    () => journeyHostColumns([journey], hosts),
+    [journey, hosts],
+  );
+  const serverGroupName = journey.serverAttachmentId
+    ? (serverAttachments.find((a) => a._id === journey.serverAttachmentId)
+        ?.name ?? null)
+    : null;
+  const configHint = `${journey.config.sessionsPerHost}/host · ${journey.config.maxTurns} turns`;
+
+  // Deep-link restore: open the linked run in the detail panel. Runs once.
+  const appliedInitialRunRef = useRef(false);
+  useEffect(() => {
+    if (appliedInitialRunRef.current || !initialRunId) return;
+    const match = typedRuns.find((r) => r._id === initialRunId);
+    if (match) {
+      appliedInitialRunRef.current = true;
+      onOpenRun(journey, match, null);
+    }
+  }, [initialRunId, typedRuns, journey, onOpenRun]);
+
+  const onRun = async () => {
+    if (launching) return;
+    setLaunchError(null);
+    setLaunching(true);
+    try {
+      const result = await onLaunch(journey._id);
+      if (result.status === "already_launching") return;
+      toast.success("Journey run started");
+    } catch (e) {
+      setLaunchError(e instanceof Error ? e.message : "Failed to start run");
+    } finally {
+      setLaunching(false);
+    }
+  };
+
+  const openRun = (run: JourneyRun, hostId: string | null) => {
+    if (selection?.runId === run._id && selection.hostId === hostId) {
+      onCloseRun();
+      return;
+    }
+    onOpenRun(journey, run, hostId);
+  };
+
+  return (
+    <div
+      className={cn(
+        "rounded-lg border px-3 py-2.5",
+        selection ? "border-primary/50" : "border-border/60",
+      )}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <p
+          className="min-w-0 flex-1 truncate text-sm font-medium"
+          title={journey.goal}
+        >
+          {journey.goal}
+        </p>
+        <Button
+          type="button"
+          size="sm"
+          className="h-7 shrink-0 px-2.5 text-xs"
+          disabled={launching}
+          onClick={onRun}
+        >
+          {launching ? "Starting…" : "Run"}
+        </Button>
+      </div>
+
+      <div className="mt-1 flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-1 text-xs text-muted-foreground">
+        <span>
+          {runCount} run{runCount === 1 ? "" : "s"}
+        </span>
+        {latestRun ? (
+          <>
+            <span aria-hidden>·</span>
+            <span>latest:</span>
+            <span
+              className={cn(
+                "rounded-full px-1.5 py-px text-[10px] font-medium capitalize",
+                runStatusChipClass(latestRun.status),
+              )}
+            >
+              {latestRun.status.replace(/_/g, " ")}
+            </span>
+            <span>{formatJourneyRelativeTime(latestRun.createdAt)}</span>
+          </>
+        ) : null}
+        {serverGroupName ? (
+          <>
+            <span aria-hidden>·</span>
+            <span className="truncate">{serverGroupName}</span>
+          </>
+        ) : null}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              aria-label="Journey config"
+              className="rounded-full p-0.5 text-muted-foreground outline-none transition-colors hover:bg-muted/60 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <Info className="size-3" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="top" className="max-w-[220px]">
+            <p className="text-xs leading-snug">{configHint}</p>
+          </TooltipContent>
+        </Tooltip>
+      </div>
+
+      {launchError ? (
+        <p className="mt-2 rounded border border-red-500/40 bg-red-500/10 px-2 py-1 text-xs text-red-600 dark:text-red-400">
+          {launchError}
+        </p>
+      ) : null}
+
+      {/* One result cell per targeted host — latest outcome + clickable run trend. */}
+      <div className="mt-2.5 grid grid-cols-[repeat(auto-fill,minmax(11rem,1fr))] gap-1.5">
+        {hostCols.map((col) => {
+          if (!latestRun) {
+            return (
+              <div
+                key={col.hostId}
+                data-testid="journey-cell-empty"
+                className="flex min-h-[4rem] flex-col items-start justify-center gap-1 rounded-md border border-dashed border-border/50 bg-muted/5 px-2.5 py-2"
+              >
+                <span className="inline-flex min-w-0 max-w-full items-center gap-1.5">
+                  <JourneyHostLogoMark label={col.name} />
+                  <span className="truncate text-[11px] font-medium text-foreground/80">
+                    {col.name}
+                  </span>
+                </span>
+                <span className="text-[11px] text-muted-foreground">
+                  Not run
+                </span>
+              </div>
+            );
+          }
+
+          const outcome = journeyHostOutcome(latestRun, col.hostId);
+          const meta = outcome === "none" ? null : CELL_STATUS_META[outcome];
+          const summary = hostSummaryFor(latestRun, col.hostId);
+          // Oldest → newest, capped like the evals trend strip.
+          const trendRuns = [...typedRuns]
+            .reverse()
+            .map((r) => ({
+              run: r,
+              outcome: journeyHostOutcome(r, col.hostId),
+            }))
+            .filter(
+              (
+                p,
+              ): p is {
+                run: JourneyRun;
+                outcome: Exclude<JourneyCellOutcome, "none">;
+              } => p.outcome !== "none",
+            )
+            .slice(-MAX_TREND_SEGMENTS);
+          const cellSelected =
+            selection?.runId === latestRun._id &&
+            selection.hostId === col.hostId;
+
+          return (
+            <div
+              key={col.hostId}
+              className={cn(
+                "flex min-h-[4rem] w-full flex-col items-start justify-center gap-1 rounded-md border px-2.5 py-2 text-left transition-colors",
+                cellSelected
+                  ? "border-primary bg-primary/5"
+                  : "border-border/50 bg-background/60",
+              )}
+            >
+              <button
+                type="button"
+                data-testid="journey-host-cell"
+                data-outcome={outcome}
+                aria-label={`Open runs for ${journey.goal} on ${col.name}`}
+                title={
+                  summary
+                    ? `Latest run on ${col.name}: ${summary.succeeded}/${summary.total} sessions ok`
+                    : undefined
+                }
+                onClick={() => openRun(latestRun, col.hostId)}
+                className="flex w-full min-w-0 items-center justify-between gap-1.5 rounded-sm outline-none hover:opacity-80 focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <span className="inline-flex min-w-0 items-center gap-1.5">
+                  <JourneyHostLogoMark label={col.name} />
+                  <span className="truncate text-[11px] font-medium text-foreground/80">
+                    {col.name}
+                  </span>
+                </span>
+                <span className="inline-flex shrink-0 items-center gap-1.5">
+                  {meta ? (
+                    <span className={cn("size-1.5 rounded-full", meta.dot)} />
+                  ) : null}
+                  <span
+                    className={cn(
+                      "text-[11px] font-semibold tabular-nums",
+                      meta?.text ?? "text-muted-foreground",
+                    )}
+                  >
+                    {summary
+                      ? `${summary.succeeded}/${summary.total} ok`
+                      : (meta?.label ?? "No data")}
+                  </span>
+                </span>
+              </button>
+              {trendRuns.length > 0 ? (
+                <div
+                  className="flex h-4 w-full items-stretch gap-[2px]"
+                  data-testid="journey-trend-strip"
+                >
+                  {trendRuns.map(({ run, outcome: segOutcome }) => (
+                    <button
+                      key={run._id}
+                      type="button"
+                      aria-label={`Open run ${run.status} (${runSummaryLine(run)}) on ${col.name}`}
+                      title={`${runNumberLabel(runCount, typedRuns.indexOf(run))} · ${run.status.replace(/_/g, " ")} · ${runSummaryLine(run)} · ${formatJourneyRelativeTime(run.createdAt)}`}
+                      onClick={() => openRun(run, col.hostId)}
+                      className={cn(
+                        "min-w-[4px] flex-1 rounded-[2px] outline-none transition-opacity hover:opacity-70 focus-visible:ring-2 focus-visible:ring-ring",
+                        SEGMENT_CLASS[segOutcome],
+                        selection?.runId === run._id &&
+                          "ring-1 ring-primary ring-offset-1 ring-offset-background",
+                      )}
+                    />
+                  ))}
+                </div>
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Run history — visible while one of this journey's runs is open. */}
+      {selection ? (
+        <div className="mt-2 space-y-0.5 border-t border-border/40 pt-2">
+          <p className="px-1.5 pb-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+            Runs
+          </p>
+          {typedRuns.map((r, index) => {
+            const isOpen = selection.runId === r._id;
+            return (
+              <button
+                key={r._id}
+                type="button"
+                className={cn(
+                  "flex w-full items-center gap-2 rounded-md px-1.5 py-1.5 text-left text-xs outline-none transition-colors",
+                  "hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-ring",
+                  isOpen && "bg-muted/40",
+                )}
+                aria-expanded={isOpen}
+                aria-label={
+                  isOpen
+                    ? `Hide sessions for run ${r.status}`
+                    : `View sessions for run ${r.status}`
+                }
+                onClick={() => (isOpen ? onCloseRun() : openRun(r, null))}
+              >
+                <span
+                  className={cn(
+                    "size-1.5 shrink-0 rounded-full",
+                    runStatusDotClass(r.status),
+                  )}
+                />
+                <span className="shrink-0 font-medium text-foreground/90">
+                  {runNumberLabel(runCount, index)}
+                </span>
+                <span className="capitalize text-muted-foreground">
+                  {r.status.replace(/_/g, " ")}
+                </span>
+                <span className="min-w-0 flex-1 truncate text-muted-foreground">
+                  {runSummaryLine(r)}
+                </span>
+                <span className="shrink-0 text-[10px] text-muted-foreground">
+                  {formatJourneyRelativeTime(r.createdAt)}
+                </span>
+              </button>
+            );
+          })}
+          {runsStatus === "CanLoadMore" ? (
+            <button
+              type="button"
+              className="mt-0.5 px-1.5 text-[11px] font-medium text-primary hover:underline"
+              onClick={() => loadMore(DEFAULT_PAGE_SIZE)}
+            >
+              Load more runs
+            </button>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/swarms/journey-run-format.ts
+++ b/mcpjam-inspector/client/src/components/swarms/journey-run-format.ts
@@ -1,0 +1,61 @@
+import { formatScore } from "@/components/shared/session-quality/judge-presentation";
+import type { GoalScoreRollup, JourneyRun } from "@/lib/swarm-api";
+
+// ── run status treatment ─────────────────────────────────────────────────────
+export function runStatusChipClass(status: string): string {
+  switch (status) {
+    case "completed":
+      return "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400";
+    case "partial":
+    case "rate_limited":
+      return "bg-muted text-muted-foreground";
+    case "failed":
+      return "bg-red-500/10 text-red-700 dark:text-red-400";
+    case "stale":
+      return "bg-muted text-muted-foreground";
+    default:
+      return "bg-muted text-foreground"; // running
+  }
+}
+
+export function formatJourneyRelativeTime(timestamp: number): string {
+  const diff = Date.now() - timestamp;
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Date(timestamp).toLocaleDateString();
+}
+
+/** `· goal 78% avg (4 judged)` — used on journey run rows. */
+export function goalScoreAvgLabel(
+  rollup: GoalScoreRollup | undefined,
+): string | null {
+  if (!rollup || rollup.gradedCount === 0 || rollup.avgScore === null) {
+    return null;
+  }
+  return `goal ${formatScore(rollup.avgScore)} avg (${rollup.gradedCount} judged)`;
+}
+
+export function runSummaryLine(r: JourneyRun): string {
+  const parts = [
+    `${r.summary.succeeded}/${r.summary.total} sessions ok`,
+    r.summary.failed > 0 ? `${r.summary.failed} failed` : null,
+    r.summary.rateLimited > 0 ? `${r.summary.rateLimited} rate-limited` : null,
+    goalScoreAvgLabel(r.goalScoreSummary),
+  ].filter(Boolean);
+  return parts.join(" · ");
+}
+
+/**
+ * Stable run name: #1 is the journey's first-ever run. `index` is the run's
+ * position in the newest-first list; `runCount` the journey's lifetime total
+ * (rollup), so the number doesn't shift when new runs land.
+ */
+export function runNumberLabel(runCount: number, index: number): string {
+  const n = runCount - index;
+  return n > 0 ? `Run #${n}` : "Run";
+}

--- a/mcpjam-inspector/client/src/components/swarms/journey-run-results.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/journey-run-results.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
@@ -8,13 +8,17 @@ import {
 } from "@/lib/swarm-api";
 import { formatScore } from "@/components/shared/session-quality/judge-presentation";
 import { TraceViewer } from "@/components/evals/trace-viewer";
+import {
+  TraceViewModeTabs,
+  type TraceViewMode,
+} from "@/components/evals/trace-view-mode-tabs";
 import type { TraceEnvelope } from "@/components/evals/trace-viewer-adapter";
 import {
   swarmCellKey,
   type JourneyRunStreamState,
   type SwarmCellLiveStatus,
-  type SwarmLiveSessionState,
 } from "./use-journey-run-stream";
+import { usePersistedSessionTrace } from "./use-persisted-session-trace";
 
 export type SwarmMatrixCellOutcome =
   | "pending"
@@ -270,52 +274,10 @@ export function SwarmSessionsMatrix({
   );
 }
 
-function LiveToolCallList({
-  session,
-}: {
-  session: SwarmLiveSessionState | undefined;
-}) {
-  const calls = session?.stream.actualToolCalls ?? [];
-  // Also surface draft tool-calls while actualToolCalls is empty (no snapshot).
-  const draftNames: string[] = [];
-  for (const msg of session?.stream.draftMessages ?? []) {
-    if (msg.role !== "assistant" || !Array.isArray(msg.content)) continue;
-    for (const part of msg.content) {
-      if (
-        part &&
-        typeof part === "object" &&
-        (part as { type?: string }).type === "tool-call" &&
-        typeof (part as { toolName?: string }).toolName === "string"
-      ) {
-        draftNames.push((part as { toolName: string }).toolName);
-      }
-    }
-  }
-  const names =
-    calls.length > 0 ? calls.map((c) => c.toolName) : draftNames;
-
-  if (names.length === 0) {
-    return (
-      <p className="text-[11px] text-muted-foreground">
-        Waiting for tool calls…
-      </p>
-    );
-  }
-
-  return (
-    <div className="flex flex-wrap gap-1">
-      {names.map((name, i) => (
-        <span
-          key={`${name}-${i}`}
-          className="rounded border border-border/60 bg-muted/30 px-1.5 py-0.5 font-mono text-[10px]"
-        >
-          {name}
-        </span>
-      ))}
-    </div>
-  );
-}
-
+/**
+ * Live session detail — same Trace / Chat / Raw streaming surface as
+ * playground (`TraceViewModeTabs` + `TraceViewer` with `forcedViewMode`).
+ */
 export function SwarmLiveStreamPane({
   selection,
   stream,
@@ -332,6 +294,20 @@ export function SwarmLiveStreamPane({
   /** Open the full ShareUsageThreadDetail for a completed Convex session. */
   onOpenCompleted: (session: JourneySessionRow) => void;
 }) {
+  // Match playground default: Chat while the stream is live.
+  const [viewMode, setViewMode] = useState<TraceViewMode>("chat");
+
+  useEffect(() => {
+    // Reset to Chat when the selected cell changes so each session opens on
+    // the streaming-friendly view (same idea as playground turn start).
+    setViewMode("chat");
+  }, [selection?.chatSessionId]);
+
+  // Completed / late-open sessions: SSE buffer is gone — load the persisted
+  // transcript blob the same way ShareUsageThreadDetail does.
+  const persisted = usePersistedSessionTrace(convexSession?.id ?? null);
+  const displayTrace = fallbackTrace ?? persisted.trace;
+
   if (!selection) {
     return (
       <div
@@ -356,10 +332,12 @@ export function SwarmLiveStreamPane({
     outcome === "failed" ||
     outcome === "rate_limited";
   const meta = CELL_META[outcome];
+  const isStreaming = outcome === "running" || outcome === "pending";
+  const showLoading = !displayTrace && (isStreaming || persisted.loading);
 
   return (
     <div
-      className="flex min-h-0 flex-col gap-3 rounded-lg border border-border/60 bg-background/80 p-3"
+      className="flex min-h-0 flex-col gap-2 rounded-lg border border-border/60 bg-background/80 p-3"
       data-testid="swarm-live-pane"
     >
       <div className="flex items-center justify-between gap-2">
@@ -372,7 +350,7 @@ export function SwarmLiveStreamPane({
           </p>
         </div>
         <span className="inline-flex items-center gap-1.5 shrink-0">
-          {outcome === "running" ? (
+          {isStreaming || persisted.loading ? (
             <Loader2 className="size-3 animate-spin text-muted-foreground" />
           ) : (
             <span className={cn("size-1.5 rounded-full", meta.dot)} />
@@ -392,30 +370,50 @@ export function SwarmLiveStreamPane({
         </p>
       )}
 
-      <div className="space-y-1.5">
-        <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
-          Tool calls
-        </p>
-        <LiveToolCallList session={live} />
+      <div data-testid="swarm-live-trace-view-tabs">
+        <TraceViewModeTabs
+          layout="fullWidth"
+          appearance="segment"
+          mode={viewMode}
+          onModeChange={(next) => {
+            if (next === "tools") return;
+            setViewMode(next);
+          }}
+          showToolsTab={false}
+        />
       </div>
 
-      <div className="min-h-[10rem] flex-1 overflow-hidden rounded-md border border-border/40">
-        {fallbackTrace ? (
-          <div className="h-[280px] overflow-auto">
-            <TraceViewer
-              trace={fallbackTrace}
-              toolsMetadata={{}}
-              toolServerMap={{}}
-              connectedServerIds={[]}
-              chromeDensity="compact"
-              hideToolbar
-            />
-          </div>
+      {/* TraceViewer (fillContent) must be a flex child; otherwise nested
+          flex-1 / min-h-0 inside TraceTimeline collapse and paint empty. */}
+      <div className="flex min-h-[14rem] max-h-[min(70vh,36rem)] flex-1 flex-col overflow-hidden rounded-md border border-border/40">
+        {displayTrace ? (
+          <TraceViewer
+            trace={displayTrace}
+            toolsMetadata={{}}
+            toolServerMap={{}}
+            connectedServerIds={[]}
+            chromeDensity="compact"
+            hideToolbar
+            forcedViewMode={viewMode}
+            isLoading={isStreaming && !fallbackTrace}
+            fillContent
+          />
         ) : (
-          <div className="flex h-full min-h-[10rem] items-center justify-center px-4 text-center text-[12px] text-muted-foreground">
-            {outcome === "running" || outcome === "pending"
-              ? "Stream will appear as the agent runs…"
-              : "No live transcript for this attempt."}
+          <div className="flex h-full min-h-[14rem] items-center justify-center px-4 text-center text-[12px] text-muted-foreground">
+            {showLoading ? (
+              <span className="inline-flex items-center gap-2">
+                <Loader2 className="size-3.5 animate-spin" />
+                {isStreaming
+                  ? "Stream will appear as the agent runs…"
+                  : "Loading transcript…"}
+              </span>
+            ) : persisted.error ? (
+              persisted.error
+            ) : !convexSession ? (
+              "No session transcript for this attempt."
+            ) : (
+              "No transcript for this attempt."
+            )}
           </div>
         )}
       </div>

--- a/mcpjam-inspector/client/src/components/swarms/journey-run-results.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/journey-run-results.tsx
@@ -1,0 +1,434 @@
+import { useMemo } from "react";
+import { Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  swarmAttemptChatSessionId,
+  type JourneySessionRow,
+  type SessionGoalScore,
+} from "@/lib/swarm-api";
+import { formatScore } from "@/components/shared/session-quality/judge-presentation";
+import { TraceViewer } from "@/components/evals/trace-viewer";
+import type { TraceEnvelope } from "@/components/evals/trace-viewer-adapter";
+import {
+  swarmCellKey,
+  type JourneyRunStreamState,
+  type SwarmCellLiveStatus,
+  type SwarmLiveSessionState,
+} from "./use-journey-run-stream";
+
+export type SwarmMatrixCellOutcome =
+  | "pending"
+  | "running"
+  | "succeeded"
+  | "failed"
+  | "rate_limited";
+
+const CELL_META: Record<
+  SwarmMatrixCellOutcome,
+  { label: string; dot: string; text: string }
+> = {
+  pending: {
+    label: "Pending",
+    dot: "bg-muted-foreground/40",
+    text: "text-muted-foreground",
+  },
+  running: {
+    label: "Running",
+    dot: "bg-muted-foreground animate-pulse",
+    text: "text-muted-foreground",
+  },
+  succeeded: {
+    label: "Done",
+    dot: "bg-success",
+    text: "text-success",
+  },
+  failed: {
+    label: "Fail",
+    dot: "bg-destructive",
+    text: "text-destructive",
+  },
+  rate_limited: {
+    label: "Limited",
+    dot: "bg-amber-500",
+    text: "text-amber-600 dark:text-amber-400",
+  },
+};
+
+export function resolveSwarmCellOutcome(args: {
+  liveStatus?: SwarmCellLiveStatus;
+  session?: JourneySessionRow | null;
+  runStatus: string;
+}): SwarmMatrixCellOutcome {
+  const { liveStatus, session, runStatus } = args;
+  if (liveStatus && liveStatus !== "pending") {
+    return liveStatus;
+  }
+  if (!session) {
+    // Unpersisted attempt: pending while the run is live; otherwise treat as
+    // failed-shaped empty (host summary failures show as Fail via liveStatus
+    // or missing rows under a non-running run stay pending until selected).
+    if (runStatus === "running") return "pending";
+    return "pending";
+  }
+  if (session.status === "failed") return "failed";
+  if (session.status === "rate_limited") return "rate_limited";
+  if (session.status === "completed" || session.status === "succeeded") {
+    return "succeeded";
+  }
+  // Chat-session lifecycle often sticks at `active` after the journey run
+  // finishes — that is NOT "still running". Only pulse Running while the
+  // journey run itself is in flight.
+  if (session.status === "running" || session.status === "active") {
+    return runStatus === "running" ? "running" : "succeeded";
+  }
+  if (runStatus === "running") return "running";
+  return "pending";
+}
+
+function GoalScoreHint({ score }: { score?: SessionGoalScore }) {
+  if (score?.score == null) return null;
+  return (
+    <span className="text-[10px] tabular-nums text-muted-foreground">
+      {formatScore(score.score)}
+      {score.passed != null ? (score.passed ? " · pass" : " · miss") : ""}
+    </span>
+  );
+}
+
+export function SwarmHostCell({
+  outcome,
+  goalScore,
+  selected,
+  onSelect,
+}: {
+  outcome: SwarmMatrixCellOutcome;
+  goalScore?: SessionGoalScore;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  const meta = CELL_META[outcome];
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      data-testid="swarm-host-cell"
+      data-outcome={outcome}
+      className={cn(
+        "flex min-h-[3.25rem] w-full flex-col items-start justify-center gap-1 rounded-md border px-2.5 py-2 text-left transition-colors",
+        "hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        selected
+          ? "border-primary bg-primary/5"
+          : "border-border/50 bg-background/60",
+      )}
+    >
+      <span className="inline-flex items-center gap-1.5">
+        <span className={cn("size-1.5 rounded-full", meta.dot)} />
+        <span className={cn("text-[11px] font-semibold", meta.text)}>
+          {meta.label}
+        </span>
+      </span>
+      <GoalScoreHint score={goalScore} />
+    </button>
+  );
+}
+
+export type SwarmMatrixSelection = {
+  hostId: string;
+  sessionIndex: number;
+  chatSessionId: string;
+};
+
+export function SwarmSessionsMatrix({
+  runId,
+  hostIds,
+  hostName,
+  sessionsPerHost,
+  sessions,
+  hostSummaries,
+  stream,
+  runStatus,
+  selection,
+  onSelect,
+}: {
+  runId: string;
+  hostIds: string[];
+  hostName: (id: string) => string;
+  sessionsPerHost: number;
+  sessions: JourneySessionRow[];
+  hostSummaries: Array<{
+    hostId: string;
+    total: number;
+    succeeded: number;
+    failed: number;
+    rateLimited: number;
+  }>;
+  stream: JourneyRunStreamState;
+  runStatus: string;
+  selection: SwarmMatrixSelection | null;
+  onSelect: (sel: SwarmMatrixSelection) => void;
+}) {
+  const sessionByChatId = useMemo(() => {
+    const map = new Map<string, JourneySessionRow>();
+    for (const s of sessions) {
+      map.set(s.chatSessionId, s);
+    }
+    return map;
+  }, [sessions]);
+
+  const rows = Math.max(1, sessionsPerHost);
+
+  return (
+    <div
+      className="min-w-0 overflow-x-auto rounded-lg border border-border/60"
+      data-testid="swarm-sessions-matrix"
+    >
+      <table className="w-full min-w-[28rem] border-collapse text-left">
+        <thead>
+          <tr className="border-b border-border/50 bg-muted/20">
+            <th className="sticky left-0 z-[1] bg-muted/20 px-3 py-2 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+              Session
+            </th>
+            {hostIds.map((hostId) => (
+              <th
+                key={hostId}
+                className="px-2 py-2 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground"
+              >
+                {hostName(hostId)}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {Array.from({ length: rows }, (_, sessionIndex) => (
+            <tr
+              key={sessionIndex}
+              className="border-b border-border/40 last:border-b-0"
+            >
+              <td className="sticky left-0 z-[1] bg-background/95 px-3 py-2 align-middle text-[11px] font-medium text-foreground/80">
+                #{sessionIndex + 1}
+              </td>
+              {hostIds.map((hostId) => {
+                const chatSessionId = swarmAttemptChatSessionId(
+                  runId,
+                  hostId,
+                  sessionIndex,
+                );
+                const convexSession = sessionByChatId.get(chatSessionId);
+                const liveStatus =
+                  stream.cellStatus[swarmCellKey(hostId, sessionIndex)];
+                let outcome = resolveSwarmCellOutcome({
+                  liveStatus,
+                  session: convexSession,
+                  runStatus,
+                });
+                // Unpersisted failures never appear in listSessionsByJourneyRun.
+                // When the host rollup reports failures and this slot has no
+                // Convex row (and isn't live-running), mark Fail so the matrix
+                // matches the run summary.
+                if (
+                  !convexSession &&
+                  (!liveStatus || liveStatus === "pending") &&
+                  runStatus !== "running"
+                ) {
+                  const hs = hostSummaries.find((h) => h.hostId === hostId);
+                  const listed = sessions.filter(
+                    (s) => s.hostId === hostId,
+                  ).length;
+                  const unlistedFailed = hs
+                    ? Math.min(hs.failed, Math.max(0, hs.total - listed))
+                    : 0;
+                  // Fill failed slots from the end of the session index range
+                  // so succeeded rows (usually early indices) stay Done.
+                  if (
+                    unlistedFailed > 0 &&
+                    sessionIndex >= sessionsPerHost - unlistedFailed
+                  ) {
+                    outcome = "failed";
+                  }
+                }
+                const selected =
+                  selection?.hostId === hostId &&
+                  selection.sessionIndex === sessionIndex;
+                return (
+                  <td key={hostId} className="px-1.5 py-1.5 align-middle">
+                    <SwarmHostCell
+                      outcome={outcome}
+                      goalScore={convexSession?.goalScore}
+                      selected={selected}
+                      onSelect={() =>
+                        onSelect({ hostId, sessionIndex, chatSessionId })
+                      }
+                    />
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function LiveToolCallList({
+  session,
+}: {
+  session: SwarmLiveSessionState | undefined;
+}) {
+  const calls = session?.stream.actualToolCalls ?? [];
+  // Also surface draft tool-calls while actualToolCalls is empty (no snapshot).
+  const draftNames: string[] = [];
+  for (const msg of session?.stream.draftMessages ?? []) {
+    if (msg.role !== "assistant" || !Array.isArray(msg.content)) continue;
+    for (const part of msg.content) {
+      if (
+        part &&
+        typeof part === "object" &&
+        (part as { type?: string }).type === "tool-call" &&
+        typeof (part as { toolName?: string }).toolName === "string"
+      ) {
+        draftNames.push((part as { toolName: string }).toolName);
+      }
+    }
+  }
+  const names =
+    calls.length > 0 ? calls.map((c) => c.toolName) : draftNames;
+
+  if (names.length === 0) {
+    return (
+      <p className="text-[11px] text-muted-foreground">
+        Waiting for tool calls…
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-wrap gap-1">
+      {names.map((name, i) => (
+        <span
+          key={`${name}-${i}`}
+          className="rounded border border-border/60 bg-muted/30 px-1.5 py-0.5 font-mono text-[10px]"
+        >
+          {name}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+export function SwarmLiveStreamPane({
+  selection,
+  stream,
+  convexSession,
+  fallbackTrace,
+  runStatus,
+  onOpenCompleted,
+}: {
+  selection: SwarmMatrixSelection | null;
+  stream: JourneyRunStreamState;
+  convexSession: JourneySessionRow | null;
+  fallbackTrace: TraceEnvelope | null;
+  runStatus: string;
+  /** Open the full ShareUsageThreadDetail for a completed Convex session. */
+  onOpenCompleted: (session: JourneySessionRow) => void;
+}) {
+  if (!selection) {
+    return (
+      <div
+        className="flex min-h-[12rem] items-center justify-center rounded-lg border border-dashed border-border/50 bg-muted/10 px-4 text-center text-[12px] text-muted-foreground"
+        data-testid="swarm-live-pane-empty"
+      >
+        Select a cell to watch the live stream
+      </div>
+    );
+  }
+
+  const live = stream.sessions[selection.chatSessionId];
+  const outcome = resolveSwarmCellOutcome({
+    liveStatus: stream.cellStatus[
+      swarmCellKey(selection.hostId, selection.sessionIndex)
+    ],
+    session: convexSession,
+    runStatus,
+  });
+  const isTerminal =
+    outcome === "succeeded" ||
+    outcome === "failed" ||
+    outcome === "rate_limited";
+  const meta = CELL_META[outcome];
+
+  return (
+    <div
+      className="flex min-h-0 flex-col gap-3 rounded-lg border border-border/60 bg-background/80 p-3"
+      data-testid="swarm-live-pane"
+    >
+      <div className="flex items-center justify-between gap-2">
+        <div className="min-w-0">
+          <p className="truncate text-[12px] font-semibold">
+            Session #{selection.sessionIndex + 1}
+          </p>
+          <p className="truncate font-mono text-[10px] text-muted-foreground">
+            {selection.chatSessionId}
+          </p>
+        </div>
+        <span className="inline-flex items-center gap-1.5 shrink-0">
+          {outcome === "running" ? (
+            <Loader2 className="size-3 animate-spin text-muted-foreground" />
+          ) : (
+            <span className={cn("size-1.5 rounded-full", meta.dot)} />
+          )}
+          <span className={cn("text-[11px] font-semibold", meta.text)}>
+            {meta.label}
+          </span>
+        </span>
+      </div>
+
+      {(live?.errorMessage || convexSession?.readiness) && (
+        <p className="text-[11px] text-muted-foreground">
+          {live?.errorMessage ??
+            (convexSession?.readiness?.verdict
+              ? `Readiness: ${convexSession.readiness.verdict}`
+              : null)}
+        </p>
+      )}
+
+      <div className="space-y-1.5">
+        <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+          Tool calls
+        </p>
+        <LiveToolCallList session={live} />
+      </div>
+
+      <div className="min-h-[10rem] flex-1 overflow-hidden rounded-md border border-border/40">
+        {fallbackTrace ? (
+          <div className="h-[280px] overflow-auto">
+            <TraceViewer
+              trace={fallbackTrace}
+              toolsMetadata={{}}
+              toolServerMap={{}}
+              connectedServerIds={[]}
+              chromeDensity="compact"
+              hideToolbar
+            />
+          </div>
+        ) : (
+          <div className="flex h-full min-h-[10rem] items-center justify-center px-4 text-center text-[12px] text-muted-foreground">
+            {outcome === "running" || outcome === "pending"
+              ? "Stream will appear as the agent runs…"
+              : "No live transcript for this attempt."}
+          </div>
+        )}
+      </div>
+
+      {isTerminal && convexSession ? (
+        <button
+          type="button"
+          className="self-start text-[11px] font-medium text-primary hover:underline"
+          onClick={() => onOpenCompleted(convexSession)}
+        >
+          Open full session detail
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/swarms/journey-run-results.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/journey-run-results.tsx
@@ -99,12 +99,20 @@ function GoalScoreHint({ score }: { score?: SessionGoalScore }) {
   );
 }
 
+/**
+ * One session chip: `<host> #<n> · <outcome>`. Kept `data-testid`
+ * "swarm-host-cell" from the old grid so outcome assertions carry over.
+ */
 export function SwarmHostCell({
+  hostLabel,
+  sessionIndex,
   outcome,
   goalScore,
   selected,
   onSelect,
 }: {
+  hostLabel: string;
+  sessionIndex: number;
   outcome: SwarmMatrixCellOutcome;
   goalScore?: SessionGoalScore;
   selected: boolean;
@@ -117,20 +125,21 @@ export function SwarmHostCell({
       onClick={onSelect}
       data-testid="swarm-host-cell"
       data-outcome={outcome}
+      aria-label={`Open session ${sessionIndex + 1} on ${hostLabel} (${meta.label})`}
       className={cn(
-        "flex min-h-[3.25rem] w-full flex-col items-start justify-center gap-1 rounded-md border px-2.5 py-2 text-left transition-colors",
+        "inline-flex items-center gap-1.5 rounded-md border px-2 py-1.5 text-left text-[11px] transition-colors",
         "hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
         selected
           ? "border-primary bg-primary/5"
           : "border-border/50 bg-background/60",
       )}
     >
-      <span className="inline-flex items-center gap-1.5">
-        <span className={cn("size-1.5 rounded-full", meta.dot)} />
-        <span className={cn("text-[11px] font-semibold", meta.text)}>
-          {meta.label}
-        </span>
+      <span className="font-medium text-foreground/80">{hostLabel}</span>
+      <span className="font-mono text-[10px] text-muted-foreground">
+        #{sessionIndex + 1}
       </span>
+      <span className={cn("size-1.5 rounded-full", meta.dot)} />
+      <span className={cn("font-semibold", meta.text)}>{meta.label}</span>
       <GoalScoreHint score={goalScore} />
     </button>
   );
@@ -182,94 +191,68 @@ export function SwarmSessionsMatrix({
   const rows = Math.max(1, sessionsPerHost);
 
   return (
-    <div
-      className="min-w-0 overflow-x-auto rounded-lg border border-border/60"
-      data-testid="swarm-sessions-matrix"
-    >
-      <table className="w-full min-w-[28rem] border-collapse text-left">
-        <thead>
-          <tr className="border-b border-border/50 bg-muted/20">
-            <th className="sticky left-0 z-[1] bg-muted/20 px-3 py-2 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
-              Session
-            </th>
-            {hostIds.map((hostId) => (
-              <th
-                key={hostId}
-                className="px-2 py-2 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground"
-              >
-                {hostName(hostId)}
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {Array.from({ length: rows }, (_, sessionIndex) => (
-            <tr
-              key={sessionIndex}
-              className="border-b border-border/40 last:border-b-0"
-            >
-              <td className="sticky left-0 z-[1] bg-background/95 px-3 py-2 align-middle text-[11px] font-medium text-foreground/80">
-                #{sessionIndex + 1}
-              </td>
-              {hostIds.map((hostId) => {
-                const chatSessionId = swarmAttemptChatSessionId(
-                  runId,
-                  hostId,
-                  sessionIndex,
-                );
-                const convexSession = sessionByChatId.get(chatSessionId);
-                const liveStatus =
-                  stream.cellStatus[swarmCellKey(hostId, sessionIndex)];
-                let outcome = resolveSwarmCellOutcome({
-                  liveStatus,
-                  session: convexSession,
-                  runStatus,
-                });
-                // Unpersisted failures never appear in listSessionsByJourneyRun.
-                // When the host rollup reports failures and this slot has no
-                // Convex row (and isn't live-running), mark Fail so the matrix
-                // matches the run summary.
-                if (
-                  !convexSession &&
-                  (!liveStatus || liveStatus === "pending") &&
-                  runStatus !== "running"
-                ) {
-                  const hs = hostSummaries.find((h) => h.hostId === hostId);
-                  const listed = sessions.filter(
-                    (s) => s.hostId === hostId,
-                  ).length;
-                  const unlistedFailed = hs
-                    ? Math.min(hs.failed, Math.max(0, hs.total - listed))
-                    : 0;
-                  // Fill failed slots from the end of the session index range
-                  // so succeeded rows (usually early indices) stay Done.
-                  if (
-                    unlistedFailed > 0 &&
-                    sessionIndex >= sessionsPerHost - unlistedFailed
-                  ) {
-                    outcome = "failed";
-                  }
+    <div className="min-w-0" data-testid="swarm-sessions-matrix">
+      <p className="mb-1.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+        Sessions
+      </p>
+      <div className="flex flex-wrap gap-1.5">
+        {hostIds.flatMap((hostId) =>
+          Array.from({ length: rows }, (_, sessionIndex) => {
+            const chatSessionId = swarmAttemptChatSessionId(
+              runId,
+              hostId,
+              sessionIndex,
+            );
+            const convexSession = sessionByChatId.get(chatSessionId);
+            const liveStatus =
+              stream.cellStatus[swarmCellKey(hostId, sessionIndex)];
+            let outcome = resolveSwarmCellOutcome({
+              liveStatus,
+              session: convexSession,
+              runStatus,
+            });
+            // Unpersisted failures never appear in listSessionsByJourneyRun.
+            // When the host rollup reports failures and this slot has no
+            // Convex row (and isn't live-running), mark Fail so the chips
+            // match the run summary.
+            if (
+              !convexSession &&
+              (!liveStatus || liveStatus === "pending") &&
+              runStatus !== "running"
+            ) {
+              const hs = hostSummaries.find((h) => h.hostId === hostId);
+              const listed = sessions.filter((s) => s.hostId === hostId).length;
+              const unlistedFailed = hs
+                ? Math.min(hs.failed, Math.max(0, hs.total - listed))
+                : 0;
+              // Fill failed slots from the end of the session index range so
+              // succeeded slots (usually early indices) stay Done.
+              if (
+                unlistedFailed > 0 &&
+                sessionIndex >= sessionsPerHost - unlistedFailed
+              ) {
+                outcome = "failed";
+              }
+            }
+            const selected =
+              selection?.hostId === hostId &&
+              selection.sessionIndex === sessionIndex;
+            return (
+              <SwarmHostCell
+                key={`${hostId}:${sessionIndex}`}
+                hostLabel={hostName(hostId)}
+                sessionIndex={sessionIndex}
+                outcome={outcome}
+                goalScore={convexSession?.goalScore}
+                selected={selected}
+                onSelect={() =>
+                  onSelect({ hostId, sessionIndex, chatSessionId })
                 }
-                const selected =
-                  selection?.hostId === hostId &&
-                  selection.sessionIndex === sessionIndex;
-                return (
-                  <td key={hostId} className="px-1.5 py-1.5 align-middle">
-                    <SwarmHostCell
-                      outcome={outcome}
-                      goalScore={convexSession?.goalScore}
-                      selected={selected}
-                      onSelect={() =>
-                        onSelect({ hostId, sessionIndex, chatSessionId })
-                      }
-                    />
-                  </td>
-                );
-              })}
-            </tr>
-          ))}
-        </tbody>
-      </table>
+              />
+            );
+          }),
+        )}
+      </div>
     </div>
   );
 }
@@ -285,6 +268,7 @@ export function SwarmLiveStreamPane({
   fallbackTrace,
   runStatus,
   onOpenCompleted,
+  fillHeight = false,
 }: {
   selection: SwarmMatrixSelection | null;
   stream: JourneyRunStreamState;
@@ -293,6 +277,8 @@ export function SwarmLiveStreamPane({
   runStatus: string;
   /** Open the full ShareUsageThreadDetail for a completed Convex session. */
   onOpenCompleted: (session: JourneySessionRow) => void;
+  /** Fill the parent's height instead of capping the trace viewport. */
+  fillHeight?: boolean;
 }) {
   // Match playground default: Chat while the stream is live.
   const [viewMode, setViewMode] = useState<TraceViewMode>("chat");
@@ -311,7 +297,10 @@ export function SwarmLiveStreamPane({
   if (!selection) {
     return (
       <div
-        className="flex min-h-[12rem] items-center justify-center rounded-lg border border-dashed border-border/50 bg-muted/10 px-4 text-center text-[12px] text-muted-foreground"
+        className={cn(
+          "flex min-h-[12rem] items-center justify-center rounded-lg border border-dashed border-border/50 bg-muted/10 px-4 text-center text-[12px] text-muted-foreground",
+          fillHeight && "h-full",
+        )}
         data-testid="swarm-live-pane-empty"
       >
         Select a cell to watch the live stream
@@ -337,7 +326,10 @@ export function SwarmLiveStreamPane({
 
   return (
     <div
-      className="flex min-h-0 flex-col gap-2 rounded-lg border border-border/60 bg-background/80 p-3"
+      className={cn(
+        "flex min-h-0 flex-col gap-2 rounded-lg border border-border/60 bg-background/80 p-3",
+        fillHeight && "h-full flex-1",
+      )}
       data-testid="swarm-live-pane"
     >
       <div className="flex items-center justify-between gap-2">
@@ -385,7 +377,12 @@ export function SwarmLiveStreamPane({
 
       {/* TraceViewer (fillContent) must be a flex child; otherwise nested
           flex-1 / min-h-0 inside TraceTimeline collapse and paint empty. */}
-      <div className="flex min-h-[14rem] max-h-[min(70vh,36rem)] flex-1 flex-col overflow-hidden rounded-md border border-border/40">
+      <div
+        className={cn(
+          "flex min-h-[14rem] flex-1 flex-col overflow-hidden rounded-md border border-border/40",
+          !fillHeight && "max-h-[min(70vh,36rem)]",
+        )}
+      >
         {displayTrace ? (
           <TraceViewer
             trace={displayTrace}

--- a/mcpjam-inspector/client/src/components/swarms/persona-avatar-look-picker.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/persona-avatar-look-picker.tsx
@@ -106,7 +106,6 @@ export function PersonaAvatarLookPicker({
             shapeIndex={avatarShape}
             paletteIndex={avatarPalette}
             size="lg"
-            active
             state={state}
           />
         </button>
@@ -118,7 +117,6 @@ export function PersonaAvatarLookPicker({
             shapeIndex={shapeIndex}
             paletteIndex={paletteIndex}
             size="lg"
-            active
             state={state}
           />
           <div className="flex w-full items-center justify-between gap-2">

--- a/mcpjam-inspector/client/src/components/swarms/persona-pixel-avatar.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/persona-pixel-avatar.tsx
@@ -438,9 +438,12 @@ export function PersonaPixelAvatar({
   /** Persisted look override (`personas.avatarPalette`) — mineral. */
   paletteIndex?: number | null;
   size?: "sm" | "md" | "lg";
-  /** Selected / focused — slightly peppier bob. */
+  /** Selected / focused in a list — ring only; does NOT mean a journey is running. */
   active?: boolean;
-  /** Activity language: light does the status work. */
+  /**
+   * Activity language. Peppy bob is reserved for `running` / `thinking` so
+   * motion answers "is a journey happening?" — not "is this row selected?".
+   */
   state?: PersonaPixelState;
   className?: string;
 }) {
@@ -457,14 +460,18 @@ export function PersonaPixelAvatar({
   const px = cellPx(size);
   const width = GRID_W * px;
   const height = GRID_H * px;
+  const isBusy = state === "running" || state === "thinking";
 
   return (
     <span
       className={cn(
-        "inline-flex shrink-0 items-end justify-center",
-        active
+        "inline-flex shrink-0 items-end justify-center rounded-sm",
+        // Peppy bob = journey in flight. Idle keeps a gentle bob so the
+        // character feels alive without shouting "working".
+        isBusy
           ? "animate-persona-pixel-bob-active"
           : "animate-persona-pixel-bob",
+        active && "ring-2 ring-ring/35 ring-offset-1 ring-offset-background",
         className,
       )}
       style={{ width, height: height + (size === "lg" ? 4 : 2) }}
@@ -473,6 +480,7 @@ export function PersonaPixelAvatar({
       data-shape={shapeIndex}
       data-palette={paletteIndex}
       data-state={state}
+      data-busy={isBusy ? "true" : "false"}
     >
       <svg
         width={width}

--- a/mcpjam-inspector/client/src/components/swarms/persona-pixel-avatar.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/persona-pixel-avatar.tsx
@@ -427,7 +427,6 @@ export function PersonaPixelAvatar({
   shapeIndex: shapeOverride,
   paletteIndex: paletteOverride,
   size = "md",
-  active = false,
   state = "idle",
   className,
 }: {
@@ -438,8 +437,6 @@ export function PersonaPixelAvatar({
   /** Persisted look override (`personas.avatarPalette`) — mineral. */
   paletteIndex?: number | null;
   size?: "sm" | "md" | "lg";
-  /** Selected / focused in a list — ring only; does NOT mean a journey is running. */
-  active?: boolean;
   /**
    * Activity language. Peppy bob is reserved for `running` / `thinking` so
    * motion answers "is a journey happening?" — not "is this row selected?".
@@ -471,7 +468,6 @@ export function PersonaPixelAvatar({
         isBusy
           ? "animate-persona-pixel-bob-active"
           : "animate-persona-pixel-bob",
-        active && "ring-2 ring-ring/35 ring-offset-1 ring-offset-background",
         className,
       )}
       style={{ width, height: height + (size === "lg" ? 4 : 2) }}

--- a/mcpjam-inspector/client/src/components/swarms/swarm-sessions-metric-strip.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/swarm-sessions-metric-strip.tsx
@@ -1,0 +1,170 @@
+/**
+ * Metric strip for the Swarms Sessions tab: tool error rate, tool calls /
+ * session, host latency P50/P95, and tokens / session across the current
+ * session scope (project-wide, or narrowed to a persona), with daily-bucket
+ * sparklines. Reuses the evals metric tiles; fed by the server-computed
+ * `journeyRuns:getSwarmSessionMetrics` aggregate so it never scans sessions
+ * client-side (and so it doesn't lie under pagination).
+ *
+ * Renders nothing while loading or when there are no sessions. Wrap in an
+ * ErrorBoundary at the mount site: `useQuery` on an undeployed backend query
+ * throws, and the strip must degrade to nothing rather than white-screen the tab.
+ */
+import { useMemo } from "react";
+import { useQuery } from "convex/react";
+import { cn } from "@/lib/utils";
+import { evalSurfaceCardClass } from "@/components/evals/eval-surface-chrome";
+import { LatencyTrendMetric, TrendMetric } from "@/components/evals/metric-strip";
+import { EvalSparkline } from "@/components/evals/eval-sparkline";
+import {
+  MIN_TREND_POINTS,
+  formatCompactNumber,
+} from "@/components/evals/metric-strip-data";
+import { SWARM_QUERIES, type SwarmSessionMetrics } from "@/lib/swarm-api";
+
+/** Short day label for sparkline points, e.g. "Jul 3". */
+function formatDay(ms: number): string {
+  return new Date(ms).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+/** One decimal below 10%, whole percent above. `rate` is a 0..1 fraction. */
+function formatPercent(rate: number): string {
+  const pct = rate * 100;
+  return `${pct >= 10 || pct === 0 ? Math.round(pct) : pct.toFixed(1)}%`;
+}
+
+export function SwarmSessionsMetricStrip({
+  projectId,
+  personaRefId,
+}: {
+  projectId: string;
+  personaRefId: string | null;
+}) {
+  const metrics = useQuery(
+    SWARM_QUERIES.getSwarmSessionMetrics as any,
+    (projectId
+      ? { projectId, ...(personaRefId ? { personaRefId } : {}) }
+      : "skip") as any,
+  ) as SwarmSessionMetrics | undefined;
+
+  const pointLabels = useMemo(
+    () => (metrics?.trend ?? []).map((p) => formatDay(p.dayStartMs)),
+    [metrics],
+  );
+  const series = useMemo(() => {
+    const trend = metrics?.trend ?? [];
+    return {
+      toolErrorPct: trend.map((p) => (p.toolErrorRate ?? 0) * 100),
+      latencyP50: trend.map((p) => p.latencyP50Ms ?? 0),
+      latencyP95: trend.map((p) => p.latencyP95Ms ?? 0),
+      toolCalls: trend.map((p) => p.avgToolCallsPerSession ?? 0),
+      tokens: trend.map((p) => p.avgTokensPerSession ?? 0),
+    };
+  }, [metrics]);
+
+  const showTrend = (metrics?.trend?.length ?? 0) >= MIN_TREND_POINTS;
+
+  if (!metrics || metrics.sessionCount === 0) return null;
+
+  const {
+    toolErrorRate,
+    toolCallCount,
+    toolErrorCount,
+    topFailingTool,
+    avgToolCallsPerSession,
+    latencyP50Ms,
+    latencyP95Ms,
+    avgTokensPerSession,
+    tokenSampleCount,
+    sessionCount,
+  } = metrics;
+
+  // Tokens come from write-time counters (independent of readiness analysis),
+  // so the backfill gap compares against ALL sessions in scope. Make a partial
+  // sample legible instead of silently averaging a subset.
+  const tokensSub =
+    avgTokensPerSession != null && tokenSampleCount < sessionCount
+      ? `${tokenSampleCount} of ${sessionCount} sessions`
+      : "per session";
+
+  return (
+    <div
+      className={cn(
+        evalSurfaceCardClass,
+        "grid grid-cols-2 overflow-hidden sm:grid-cols-4",
+      )}
+      data-testid="swarm-sessions-metric-strip"
+    >
+      <TrendMetric
+        divider={false}
+        label="Tool errors"
+        value={toolErrorRate != null ? formatPercent(toolErrorRate) : "—"}
+        sub={
+          topFailingTool
+            ? `top: ${topFailingTool.toolName} (${topFailingTool.errorCount})`
+            : `${toolErrorCount}/${toolCallCount} calls`
+        }
+        chart={
+          showTrend ? (
+            <EvalSparkline
+              points={series.toolErrorPct}
+              pointLabels={pointLabels}
+              formatValue={(v) => `${v.toFixed(1)}%`}
+              testId="swarm-metric-sparkline-tool-errors"
+            />
+          ) : undefined
+        }
+      />
+      <LatencyTrendMetric
+        p50={latencyP50Ms}
+        p95={latencyP95Ms}
+        p50Series={series.latencyP50}
+        p95Series={series.latencyP95}
+        pointLabels={pointLabels}
+        showTrend={showTrend}
+        subLabel="per session"
+      />
+      <TrendMetric
+        label="Tool calls"
+        value={
+          avgToolCallsPerSession != null
+            ? formatCompactNumber(avgToolCallsPerSession)
+            : "—"
+        }
+        sub="per session"
+        chart={
+          showTrend ? (
+            <EvalSparkline
+              points={series.toolCalls}
+              pointLabels={pointLabels}
+              formatValue={formatCompactNumber}
+              testId="swarm-metric-sparkline-tool-calls"
+            />
+          ) : undefined
+        }
+      />
+      <TrendMetric
+        label="Tokens"
+        value={
+          avgTokensPerSession != null
+            ? formatCompactNumber(avgTokensPerSession)
+            : "—"
+        }
+        sub={tokensSub}
+        chart={
+          showTrend && tokenSampleCount > 0 ? (
+            <EvalSparkline
+              points={series.tokens}
+              pointLabels={pointLabels}
+              formatValue={formatCompactNumber}
+              testId="swarm-metric-sparkline-tokens"
+            />
+          ) : undefined
+        }
+      />
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/swarms/use-journey-run-stream.ts
+++ b/mcpjam-inspector/client/src/components/swarms/use-journey-run-stream.ts
@@ -1,0 +1,217 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  initialEvalStreamState,
+  mergeStreamingTrace,
+  reduceEvalStreamEvent,
+  type EvalStreamState,
+} from "@/components/evals/eval-stream-reducer";
+import type { EvalStreamEvent } from "@/shared/eval-stream-events";
+import {
+  swarmEventToEvalPayload,
+  type SwarmAttemptStreamStatus,
+  type SwarmStreamEvent,
+} from "@/shared/swarm-stream-events";
+import { streamJourneyRun } from "@/lib/swarm-api";
+import type { TraceEnvelope } from "@/components/evals/trace-viewer-adapter";
+
+export type SwarmCellLiveStatus = SwarmAttemptStreamStatus | "pending";
+
+export type SwarmLiveSessionState = {
+  envelope: {
+    runId: string;
+    hostId: string;
+    chatSessionId: string;
+    sessionIndex: number;
+  };
+  attemptStatus: SwarmCellLiveStatus;
+  errorMessage?: string;
+  stream: EvalStreamState;
+};
+
+export type JourneyRunStreamState = {
+  sessions: Record<string, SwarmLiveSessionState>;
+  /** Coarse matrix key: `${hostId}:${sessionIndex}` → status */
+  cellStatus: Record<string, SwarmCellLiveStatus>;
+  runComplete: boolean;
+  connected: boolean;
+  error: string | null;
+};
+
+export function swarmCellKey(hostId: string, sessionIndex: number): string {
+  return `${hostId}:${sessionIndex}`;
+}
+
+function emptyRunStreamState(): JourneyRunStreamState {
+  return {
+    sessions: {},
+    cellStatus: {},
+    runComplete: false,
+    connected: false,
+    error: null,
+  };
+}
+
+function ensureSession(
+  state: JourneyRunStreamState,
+  event: SwarmStreamEvent,
+): SwarmLiveSessionState {
+  const existing = state.sessions[event.chatSessionId];
+  if (existing) return existing;
+  return {
+    envelope: {
+      runId: event.runId,
+      hostId: event.hostId,
+      chatSessionId: event.chatSessionId,
+      sessionIndex: event.sessionIndex,
+    },
+    attemptStatus: "pending",
+    stream: initialEvalStreamState,
+  };
+}
+
+/** Pure reducer for tests + the live hook. */
+export function reduceSwarmStreamEvent(
+  state: JourneyRunStreamState,
+  event: SwarmStreamEvent,
+): JourneyRunStreamState {
+  if (event.type === "run_complete") {
+    return { ...state, runComplete: true };
+  }
+
+  // Lifecycle-only events without a real session key (empty host/session).
+  if (!event.chatSessionId) {
+    return state;
+  }
+
+  const session = ensureSession(state, event);
+  const cellKey = swarmCellKey(event.hostId, event.sessionIndex);
+  let nextSession = session;
+  let nextCellStatus = state.cellStatus[cellKey] ?? "pending";
+
+  switch (event.type) {
+    case "attempt_status":
+    case "session_complete": {
+      const status =
+        event.type === "session_complete" ? event.status : event.status;
+      nextCellStatus = status;
+      nextSession = {
+        ...session,
+        attemptStatus: status,
+        ...(event.errorMessage ? { errorMessage: event.errorMessage } : {}),
+      };
+      break;
+    }
+    case "session_start": {
+      nextCellStatus = "running";
+      nextSession = { ...session, attemptStatus: "running" };
+      break;
+    }
+    default: {
+      const payload = swarmEventToEvalPayload(event);
+      if (payload) {
+        nextSession = {
+          ...session,
+          stream: reduceEvalStreamEvent(
+            session.stream,
+            payload as EvalStreamEvent,
+          ),
+        };
+      }
+      break;
+    }
+  }
+
+  return {
+    ...state,
+    sessions: {
+      ...state.sessions,
+      [event.chatSessionId]: nextSession,
+    },
+    cellStatus: {
+      ...state.cellStatus,
+      [cellKey]: nextCellStatus,
+    },
+  };
+}
+
+/**
+ * Auto-connects to the journey-run SSE while `enabled` (typically when the
+ * run detail is open and status is `running`). Aborts on unmount / disable /
+ * `run_complete`.
+ */
+export function useJourneyRunStream(
+  runId: string | null,
+  enabled: boolean,
+): JourneyRunStreamState {
+  const [state, setState] = useState<JourneyRunStreamState>(emptyRunStreamState);
+  const genRef = useRef(0);
+
+  useEffect(() => {
+    if (!runId || !enabled) {
+      setState(emptyRunStreamState());
+      return;
+    }
+
+    const gen = ++genRef.current;
+    const controller = new AbortController();
+    setState({
+      ...emptyRunStreamState(),
+      connected: true,
+    });
+
+    void streamJourneyRun(
+      runId,
+      (event) => {
+        if (genRef.current !== gen) return;
+        setState((prev) => reduceSwarmStreamEvent(prev, event));
+      },
+      controller.signal,
+    )
+      .catch((err) => {
+        if (genRef.current !== gen) return;
+        if (controller.signal.aborted) return;
+        setState((prev) => ({
+          ...prev,
+          connected: false,
+          error: err instanceof Error ? err.message : String(err),
+        }));
+      })
+      .finally(() => {
+        if (genRef.current !== gen) return;
+        setState((prev) => ({ ...prev, connected: false }));
+      });
+
+    return () => {
+      controller.abort();
+    };
+  }, [runId, enabled]);
+
+  return state;
+}
+
+export function liveSessionTrace(
+  session: SwarmLiveSessionState | undefined,
+): TraceEnvelope | null {
+  if (!session) return null;
+  return mergeStreamingTrace(session.stream.trace, session.stream.draftMessages);
+}
+
+export function useLiveSessionView(
+  stream: JourneyRunStreamState,
+  chatSessionId: string | null,
+): {
+  session: SwarmLiveSessionState | undefined;
+  fallbackTrace: TraceEnvelope | null;
+  toolCalls: EvalStreamState["actualToolCalls"];
+} {
+  return useMemo(() => {
+    const session = chatSessionId
+      ? stream.sessions[chatSessionId]
+      : undefined;
+    return {
+      session,
+      fallbackTrace: liveSessionTrace(session),
+      toolCalls: session?.stream.actualToolCalls ?? [],
+    };
+  }, [stream.sessions, chatSessionId]);
+}

--- a/mcpjam-inspector/client/src/components/swarms/use-persisted-session-trace.ts
+++ b/mcpjam-inspector/client/src/components/swarms/use-persisted-session-trace.ts
@@ -1,0 +1,150 @@
+import { useEffect, useState } from "react";
+import {
+  useSharedChatThread,
+  useSharedChatTurnTraces,
+  type SharedChatTurnTrace,
+} from "@/hooks/useSharedChatThreads";
+import type { TraceEnvelope } from "@/components/evals/trace-viewer-adapter";
+import type { EvalTraceSpan } from "@/shared/eval-trace";
+
+/**
+ * Fetch span blobs from turn trace URLs and flatten into a single span array.
+ * Same contract as ShareUsageThreadDetail's hydrateSpans.
+ */
+async function hydrateSpans(
+  traces: SharedChatTurnTrace[],
+): Promise<EvalTraceSpan[]> {
+  const results = await Promise.all(
+    traces.map(async (trace) => {
+      if (!trace.spansBlobUrl) return [];
+      try {
+        const response = await fetch(trace.spansBlobUrl);
+        if (!response.ok) return [];
+        const parsed = await response.json();
+        return Array.isArray(parsed) ? (parsed as EvalTraceSpan[]) : [];
+      } catch {
+        return [];
+      }
+    }),
+  );
+  return results.flat();
+}
+
+function extractMessages(data: unknown): unknown[] | null {
+  if (Array.isArray(data)) return data;
+  if (
+    data &&
+    typeof data === "object" &&
+    Array.isArray((data as { messages?: unknown }).messages)
+  ) {
+    return (data as { messages: unknown[] }).messages;
+  }
+  return null;
+}
+
+/**
+ * Load a completed swarm session's transcript + timing spans into a
+ * TraceEnvelope so Trace / Chat / Raw work after SSE has ended.
+ * Mirrors blob + turn-trace hydration in {@link ShareUsageThreadDetail}.
+ */
+export function usePersistedSessionTrace(threadId: string | null): {
+  trace: TraceEnvelope | null;
+  loading: boolean;
+  error: string | null;
+} {
+  const { thread } = useSharedChatThread({ threadId });
+  const { traces: turnTraces } = useSharedChatTurnTraces({ threadId });
+  const [messages, setMessages] = useState<unknown[] | null>(null);
+  const [spans, setSpans] = useState<EvalTraceSpan[]>([]);
+  const [loadingMessages, setLoadingMessages] = useState(false);
+  const [loadingSpans, setLoadingSpans] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!threadId || !thread?.messagesBlobUrl) {
+      setMessages(null);
+      setLoadingMessages(Boolean(threadId && thread === undefined));
+      setError(null);
+      return;
+    }
+
+    let active = true;
+    const controller = new AbortController();
+    setLoadingMessages(true);
+    setError(null);
+
+    void (async () => {
+      try {
+        const response = await fetch(thread.messagesBlobUrl!, {
+          signal: controller.signal,
+        });
+        if (!response.ok) {
+          throw new Error(`Failed to fetch messages: ${response.status}`);
+        }
+        const data = (await response.json()) as unknown;
+        if (!active) return;
+        const extracted = extractMessages(data);
+        if (!extracted) {
+          setMessages(null);
+          setError("Transcript blob had no messages");
+          return;
+        }
+        setMessages(extracted);
+      } catch (err) {
+        if (!active) return;
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        setMessages(null);
+        setError(
+          err instanceof Error ? err.message : "Failed to load transcript",
+        );
+      } finally {
+        if (active) setLoadingMessages(false);
+      }
+    })();
+
+    return () => {
+      active = false;
+      controller.abort();
+    };
+  }, [threadId, thread?.messagesBlobUrl, thread]);
+
+  useEffect(() => {
+    if (!threadId) {
+      setSpans([]);
+      setLoadingSpans(false);
+      return;
+    }
+    if (turnTraces === undefined) {
+      setLoadingSpans(true);
+      return;
+    }
+    if (turnTraces.length === 0) {
+      setSpans([]);
+      setLoadingSpans(false);
+      return;
+    }
+
+    let active = true;
+    setLoadingSpans(true);
+    void hydrateSpans(turnTraces).then((hydrated) => {
+      if (!active) return;
+      setSpans(hydrated);
+      setLoadingSpans(false);
+    });
+    return () => {
+      active = false;
+    };
+  }, [threadId, turnTraces]);
+
+  const loading = loadingMessages || loadingSpans;
+  const trace: TraceEnvelope | null =
+    messages == null
+      ? null
+      : {
+          traceVersion: 1,
+          messages: messages as TraceEnvelope["messages"],
+          ...(spans.length > 0 ? { spans } : {}),
+        };
+
+  return { trace, loading, error };
+}

--- a/mcpjam-inspector/client/src/lib/__tests__/swarm-api.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/swarm-api.test.ts
@@ -6,6 +6,7 @@ vi.mock("@/lib/session-token", () => ({
 }));
 
 import {
+  journeySessionRowToThread,
   launchJourneyRun,
   LaunchJourneyRunError,
 } from "@/lib/swarm-api";
@@ -165,24 +166,56 @@ describe("swarm rollup DTO contracts", () => {
     expect(rollup).not.toHaveProperty("totalRuns");
   });
 
-  it("JourneySessionRow (JourneySessionDto) is keyed by `id`, with no personaLabel/messageCount", () => {
+  it("JourneySessionRow (JourneySessionDto) is keyed by `id` and carries Sessions-tab list fields", () => {
     const row: JourneySessionRow = {
       id: "thread-1",
       chatSessionId: "synth_run_host_0",
       projectId: "proj-1",
       hostId: "host-1",
       personaRefId: "persona-1",
+      journeyRunId: "run-1",
+      journeyRefId: "journey-1",
       status: "completed",
       modelId: "anthropic/claude-haiku-4.5",
       startedAt: 1,
       lastActivityAt: 2,
+      messageCount: 4,
+      firstMessagePreview: "hello",
+      personaLabel: "Persona One",
+      visitorDisplayName: "Persona One",
+      synthetic: true,
       readiness: { status: "completed", verdict: "ready", issueCount: 0 },
     };
     // The identifier the viewer + deep-link consume is `id`.
     expect(row.id).toBe("thread-1");
     expect(row).not.toHaveProperty("_id");
-    expect(row).not.toHaveProperty("personaLabel");
-    expect(row).not.toHaveProperty("messageCount");
     expect(row).not.toHaveProperty("personaId");
+    expect(row.messageCount).toBe(4);
+    expect(row.personaLabel).toBe("Persona One");
+    expect(row.journeyRunId).toBe("run-1");
+  });
+
+  it("journeySessionRowToThread maps list rows into ShareUsageThreadList shape", () => {
+    const thread = journeySessionRowToThread(
+      {
+        id: "thread-1",
+        chatSessionId: "synth_1",
+        projectId: "proj-1",
+        hostId: "host-1",
+        personaRefId: "persona-1",
+        startedAt: 10,
+        messageCount: 3,
+        firstMessagePreview: "hi",
+      },
+      "Fallback Name",
+    );
+    expect(thread).toMatchObject({
+      _id: "thread-1",
+      sourceType: "swarm",
+      visitorDisplayName: "Fallback Name",
+      synthetic: true,
+      messageCount: 3,
+      personaLabel: "Fallback Name",
+    });
   });
 });

--- a/mcpjam-inspector/client/src/lib/swarm-api.ts
+++ b/mcpjam-inspector/client/src/lib/swarm-api.ts
@@ -12,6 +12,7 @@
  */
 
 import { authFetch } from "@/lib/session-token";
+import type { SharedChatThread } from "@/hooks/useSharedChatThreads";
 import type { SwarmStreamEvent } from "@/shared/swarm-stream-events";
 
 // ── Convex query names (string-keyed reads) ─────────────────────────────────
@@ -23,6 +24,10 @@ export const SWARM_QUERIES = {
   listHosts: "hosts:listHosts",
   listJourneyRuns: "journeyRuns:listJourneyRuns",
   listSessionsByJourneyRun: "journeyRuns:listSessionsByJourneyRun",
+  /** Flat Sessions-tab default: all swarm sessions in the project. */
+  listSessionsByProject: "journeyRuns:listSessionsByProject",
+  /** Sessions-tab persona filter (narrows the project feed). */
+  listSessionsByPersona: "journeyRuns:listSessionsByPersona",
   listRunningPersonaRefIds: "journeyRuns:listRunningPersonaRefIds",
 } as const;
 
@@ -96,9 +101,9 @@ export interface JourneyRun {
 /**
  * A single synthetic session row — the backend `JourneySessionDto` returned by
  * `journeyRuns:listSessionsBy*` page items. The row identifier is `id`
- * (`s._id` under the hood); there is NO `personaLabel` / `messageCount`.
- * `readiness` is the server-denormalized WIDE subset the readiness badge reads
- * (`session-readiness.tsx`).
+ * (`s._id` under the hood). List-card fields (`messageCount`, previews,
+ * persona labels) power the Swarms Sessions tab; `readiness` /
+ * `goalScore` are the server-denormalized subsets the badges read.
  */
 export interface JourneySessionRow {
   /** `s._id` — the id `ShareUsageThreadDetail` opens + the deep-link threadId. */
@@ -107,10 +112,18 @@ export interface JourneySessionRow {
   projectId: string;
   hostId: string;
   personaRefId?: string;
+  /** Parent journey run — required for `buildSwarmSessionPath` deep links. */
+  journeyRunId?: string;
+  journeyRefId?: string;
   status?: string;
   modelId?: string;
   startedAt: number;
   lastActivityAt?: number;
+  messageCount?: number;
+  firstMessagePreview?: string;
+  personaLabel?: string;
+  visitorDisplayName?: string;
+  synthetic?: boolean;
   /** Server-denormalized readiness subset (see `session-readiness.tsx`). */
   readiness?: {
     status?: string;
@@ -119,6 +132,38 @@ export interface JourneySessionRow {
   };
   /** Server-denormalized judge verdict subset (see `swarmJudge.ts` backend). */
   goalScore?: SessionGoalScore;
+}
+
+/**
+ * Map a journey session list row into the shape `ShareUsageThreadList` /
+ * chatbox Sessions cards expect. Swarm sessions are always synthetic for
+ * badge purposes even if an older row omitted the flag.
+ */
+export function journeySessionRowToThread(
+  row: JourneySessionRow,
+  fallbackPersonaName?: string,
+): SharedChatThread {
+  const displayName =
+    row.visitorDisplayName ??
+    row.personaLabel ??
+    fallbackPersonaName ??
+    "Swarm session";
+  return {
+    _id: row.id,
+    sourceType: "swarm",
+    chatSessionId: row.chatSessionId,
+    visitorDisplayName: displayName,
+    modelId: row.modelId,
+    messageCount: row.messageCount ?? 0,
+    firstMessagePreview: row.firstMessagePreview,
+    startedAt: row.startedAt,
+    lastActivityAt: row.lastActivityAt ?? row.startedAt,
+    synthetic: row.synthetic ?? true,
+    personaId: row.personaRefId,
+    personaLabel: row.personaLabel ?? fallbackPersonaName,
+    readiness: row.readiness as SharedChatThread["readiness"] | undefined,
+    goalScore: row.goalScore,
+  };
 }
 
 /**

--- a/mcpjam-inspector/client/src/lib/swarm-api.ts
+++ b/mcpjam-inspector/client/src/lib/swarm-api.ts
@@ -12,6 +12,7 @@
  */
 
 import { authFetch } from "@/lib/session-token";
+import type { SwarmStreamEvent } from "@/shared/swarm-stream-events";
 
 // ── Convex query names (string-keyed reads) ─────────────────────────────────
 export const SWARM_QUERIES = {
@@ -273,4 +274,90 @@ export async function launchJourneyRun(
     );
   }
   return { runId };
+}
+
+/**
+ * Subscribe to the multiplexed SSE stream for a journey run. Events are
+ * scoped by `chatSessionId` / `hostId` / `sessionIndex`. Resolves when the
+ * stream ends (`run_complete` or disconnect).
+ */
+export async function streamJourneyRun(
+  runId: string,
+  onEvent: (event: SwarmStreamEvent) => void,
+  signal?: AbortSignal,
+): Promise<void> {
+  const response = await authFetch(
+    `/api/web/swarm/runs/${encodeURIComponent(runId)}/stream`,
+    {
+      method: "GET",
+      headers: { Accept: "text/event-stream" },
+      signal,
+    },
+  );
+
+  if (!response.ok) {
+    let message = `Failed to stream journey run (${response.status})`;
+    try {
+      const body = (await response.json()) as { message?: string; error?: string };
+      if (typeof body.message === "string" && body.message.length > 0) {
+        message = body.message;
+      } else if (typeof body.error === "string" && body.error.length > 0) {
+        message = body.error;
+      }
+    } catch {
+      // ignore
+    }
+    throw new Error(message);
+  }
+
+  const reader = response.body?.getReader();
+  if (!reader) {
+    throw new Error("No response body for swarm run stream");
+  }
+
+  const decoder = new TextDecoder();
+  let buffer = "";
+  const emitSseLine = (line: string) => {
+    const trimmedLine = line.trim();
+    if (!trimmedLine.startsWith("data: ")) return;
+    const data = trimmedLine.slice(6).trim();
+    if (!data || data === "[DONE]") return;
+    try {
+      onEvent(JSON.parse(data) as SwarmStreamEvent);
+    } catch {
+      // ignore malformed lines
+    }
+  };
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split("\n");
+      buffer = lines.pop() || "";
+      for (const line of lines) {
+        emitSseLine(line);
+      }
+    }
+    buffer += decoder.decode();
+    for (const line of buffer.split("\n")) {
+      emitSseLine(line);
+    }
+  } finally {
+    try {
+      reader.releaseLock?.();
+    } catch {
+      // ignore
+    }
+  }
+}
+
+/** Deterministic attempt chatSessionId — matches the swarm runner claim key. */
+export function swarmAttemptChatSessionId(
+  runId: string,
+  hostId: string,
+  sessionIndex: number,
+): string {
+  return `synth_${runId}_${hostId}_${sessionIndex}`;
 }

--- a/mcpjam-inspector/client/src/lib/swarm-api.ts
+++ b/mcpjam-inspector/client/src/lib/swarm-api.ts
@@ -28,6 +28,8 @@ export const SWARM_QUERIES = {
   listSessionsByProject: "journeyRuns:listSessionsByProject",
   /** Sessions-tab persona filter (narrows the project feed). */
   listSessionsByPersona: "journeyRuns:listSessionsByPersona",
+  /** Sessions-tab metric strip aggregates (project-wide or persona-scoped). */
+  getSwarmSessionMetrics: "journeyRuns:getSwarmSessionMetrics",
   listRunningPersonaRefIds: "journeyRuns:listRunningPersonaRefIds",
 } as const;
 
@@ -132,6 +134,43 @@ export interface JourneySessionRow {
   };
   /** Server-denormalized judge verdict subset (see `swarmJudge.ts` backend). */
   goalScore?: SessionGoalScore;
+}
+
+/**
+ * One daily trend bucket for the Sessions metric strip sparklines. Mirrors
+ * `convex/lib/swarmSessionMetrics.ts` `SwarmSessionMetricsPoint` (hand-kept).
+ */
+export interface SwarmSessionMetricsPoint {
+  dayStartMs: number;
+  sessionCount: number;
+  toolErrorRate: number | null;
+  avgToolCallsPerSession: number | null;
+  latencyP50Ms: number | null;
+  latencyP95Ms: number | null;
+  avgTokensPerSession: number | null;
+}
+
+/**
+ * Aggregated Sessions-tab metrics returned by
+ * `journeyRuns:getSwarmSessionMetrics`. Mirrors the backend `SwarmSessionMetrics`
+ * (hand-kept, two-repo layout). Every average is null-safe: metrics with no
+ * sample come back `null` (rendered as "—"), never a misleading zero.
+ */
+export interface SwarmSessionMetrics {
+  sessionCount: number;
+  analyzedCount: number;
+  truncated: boolean;
+  toolCallCount: number;
+  toolErrorCount: number;
+  toolErrorRate: number | null;
+  sessionsWithToolErrors: number;
+  topFailingTool: { toolName: string; errorCount: number } | null;
+  avgToolCallsPerSession: number | null;
+  latencyP50Ms: number | null;
+  latencyP95Ms: number | null;
+  avgTokensPerSession: number | null;
+  tokenSampleCount: number;
+  trend: SwarmSessionMetricsPoint[];
 }
 
 /**

--- a/mcpjam-inspector/client/src/router.tsx
+++ b/mcpjam-inspector/client/src/router.tsx
@@ -100,9 +100,8 @@ const ROUTE_ELEMENTS: Record<
   // exercise the hosted-OAuth callback path via `/hosts` rather
   // than this route directly.
   chatboxes: { element: <ChatboxesRoute /> },
-  // `/swarms` — agent Swarm surface (Publish / Personas / Sessions) over
-  // the same host-backed chatbox as `/chatboxes`. Same billing feature +
-  // `sandboxes-enabled` flag.
+  // `/swarms` — project-scoped Persona → Journey → Run surface (`SwarmsTab`)
+  // with Journeys + Sessions views. Same billing feature as chatboxes.
   swarms: { element: <SwarmsRoute /> },
   playground: { element: <PlaygroundRoute /> },
   support: { element: <SupportRoute /> },

--- a/mcpjam-inspector/server/routes/web/swarm-runs.ts
+++ b/mcpjam-inspector/server/routes/web/swarm-runs.ts
@@ -19,10 +19,96 @@ import {
   SwarmAgentError,
   type PinnedHostExecutionSpec,
 } from "../../services/swarm-agent.js";
-import { startJourneyRun } from "../../services/sessionSimulation/swarm-runner.js";
+import {
+  getRunningJourneyStreamHub,
+  startJourneyRun,
+} from "../../services/sessionSimulation/swarm-runner.js";
+import type { SwarmStreamEvent } from "../../../shared/swarm-stream-events.js";
 import { logger } from "../../utils/logger.js";
+import { assertBearerToken } from "./errors.js";
 
 const swarmRuns = new Hono();
+
+const sseEncoder = new TextEncoder();
+
+function encodeSseEvent(event: SwarmStreamEvent): Uint8Array {
+  return sseEncoder.encode(`data: ${JSON.stringify(event)}\n\n`);
+}
+
+/**
+ * Multiplexed live stream for one journey run. Late joiners receive the
+ * in-memory ring buffer then live events until `run_complete`.
+ */
+swarmRuns.get("/runs/:runId/stream", async (c) => {
+  assertBearerToken(c);
+  const runId = c.req.param("runId");
+  if (!runId) {
+    throw new WebRouteError(
+      400,
+      ErrorCode.VALIDATION_ERROR,
+      "runId required"
+    );
+  }
+
+  const hub = getRunningJourneyStreamHub(runId);
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      if (!hub) {
+        // Run already finished (or never started on this process). Clients
+        // fall back to Convex + blobs for history.
+        try {
+          controller.enqueue(
+            encodeSseEvent({
+              type: "run_complete",
+              runId,
+              hostId: "",
+              chatSessionId: "",
+              sessionIndex: -1,
+            })
+          );
+          controller.close();
+        } catch {
+          // ignore
+        }
+        return;
+      }
+
+      let closed = false;
+      let unsubscribe: (() => void) | undefined;
+      const close = () => {
+        if (closed) return;
+        closed = true;
+        unsubscribe?.();
+        try {
+          controller.close();
+        } catch {
+          // ignore
+        }
+      };
+
+      unsubscribe = hub.subscribe((event) => {
+        if (closed) return;
+        try {
+          controller.enqueue(encodeSseEvent(event));
+          if (event.type === "run_complete") {
+            close();
+          }
+        } catch {
+          close();
+        }
+      });
+
+      c.req.raw.signal.addEventListener("abort", close, { once: true });
+    },
+  });
+
+  return c.body(stream as any, 200, {
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache",
+    Connection: "keep-alive",
+    "X-Accel-Buffering": "no",
+  });
+});
 
 function requireConvexHttpUrl(): string {
   const url = process.env.CONVEX_HTTP_URL;

--- a/mcpjam-inspector/server/services/sessionSimulation/__tests__/swarm-runner.test.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/__tests__/swarm-runner.test.ts
@@ -46,6 +46,7 @@ vi.mock("../runner.js", async () => {
 import {
   startJourneyRun,
   shutdownRunningJourneyRuns,
+  getRunningJourneyStreamHub,
   MAX_CONCURRENT_HOSTS,
 } from "../swarm-runner.js";
 
@@ -672,6 +673,52 @@ describe("swarm single-host runner — heartbeat", () => {
       expect(heartbeatJourneyRunMock.mock.calls.length).toBe(countAtFinish);
     } finally {
       vi.useRealTimers();
+    }
+  });
+});
+
+describe("swarm runner — live stream emit", () => {
+  it("publishes attempt_status, session payloads, and run_complete on the hub", async () => {
+    const seen: string[] = [];
+    let releaseSession!: () => void;
+    const sessionGate = new Promise<void>((resolve) => {
+      releaseSession = resolve;
+    });
+
+    runSyntheticHostSessionMock.mockImplementation(async (adapter: any) => {
+      expect(typeof adapter.emit).toBe("function");
+      adapter.emit({ type: "session_start" });
+      adapter.emit({ type: "text_delta", content: "hi" });
+      await sessionGate;
+      return { outcome: "succeeded" };
+    });
+
+    const runPromise = startJourneyRun(baseOpts({ sessionsPerHost: 1 }));
+
+    // Wait until the hub is registered and the attempt has been claimed.
+    let hub = getRunningJourneyStreamHub("run-1");
+    for (let i = 0; i < 50 && !hub; i++) {
+      await Promise.resolve();
+      hub = getRunningJourneyStreamHub("run-1");
+    }
+    expect(hub).toBeDefined();
+    hub!.subscribe((e) => seen.push(e.type));
+
+    releaseSession();
+    await runPromise;
+
+    expect(seen).toContain("attempt_status");
+    expect(seen).toContain("session_start");
+    expect(seen).toContain("text_delta");
+    expect(seen).toContain("run_complete");
+    expect(getRunningJourneyStreamHub("run-1")).toBeUndefined();
+  });
+
+  it("wires emit on the adapter for every session", async () => {
+    await startJourneyRun(baseOpts({ sessionsPerHost: 2 }));
+    expect(runSyntheticHostSessionMock).toHaveBeenCalledTimes(2);
+    for (const call of runSyntheticHostSessionMock.mock.calls) {
+      expect(typeof (call[0] as { emit?: unknown }).emit).toBe("function");
     }
   });
 });

--- a/mcpjam-inspector/server/services/sessionSimulation/__tests__/swarm-stream-hub.test.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/__tests__/swarm-stream-hub.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+import { JourneyRunStreamHub } from "../swarm-stream-hub.js";
+import type { SwarmStreamEvent } from "../../../../shared/swarm-stream-events.js";
+
+function event(
+  partial: Partial<SwarmStreamEvent> & Pick<SwarmStreamEvent, "type">,
+): SwarmStreamEvent {
+  return {
+    runId: "run_1",
+    hostId: "host_a",
+    chatSessionId: "synth_run_1_host_a_0",
+    sessionIndex: 0,
+    ...partial,
+  } as SwarmStreamEvent;
+}
+
+describe("JourneyRunStreamHub", () => {
+  it("fans out live events to subscribers", () => {
+    const hub = new JourneyRunStreamHub();
+    const seen: string[] = [];
+    hub.subscribe((e) => seen.push(e.type));
+    hub.emit(event({ type: "session_start" }));
+    hub.emit(event({ type: "text_delta", content: "hi" }));
+    expect(seen).toEqual(["session_start", "text_delta"]);
+  });
+
+  it("replays the ring buffer for late joiners", () => {
+    const hub = new JourneyRunStreamHub();
+    hub.emit(event({ type: "attempt_status", status: "running" }));
+    hub.emit(event({ type: "text_delta", content: "a" }));
+    const late: string[] = [];
+    hub.subscribe((e) => late.push(e.type));
+    expect(late).toEqual(["attempt_status", "text_delta"]);
+    hub.emit(event({ type: "turn_finish", turnIndex: 0 }));
+    expect(late).toEqual(["attempt_status", "text_delta", "turn_finish"]);
+  });
+
+  it("caps the ring buffer at 200 events", () => {
+    const hub = new JourneyRunStreamHub();
+    for (let i = 0; i < 250; i++) {
+      hub.emit(event({ type: "text_delta", content: String(i) }));
+    }
+    expect(hub.getBuffer()).toHaveLength(200);
+    const first = hub.getBuffer()[0] as { type: "text_delta"; content: string };
+    expect(first.content).toBe("50");
+  });
+
+  it("unsubscribe stops further delivery", () => {
+    const hub = new JourneyRunStreamHub();
+    const listener = vi.fn();
+    const unsub = hub.subscribe(listener);
+    hub.emit(event({ type: "session_start" }));
+    unsub();
+    hub.emit(event({ type: "session_complete", status: "succeeded" }));
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("subscriber errors do not break emit", () => {
+    const hub = new JourneyRunStreamHub();
+    hub.subscribe(() => {
+      throw new Error("boom");
+    });
+    const ok = vi.fn();
+    hub.subscribe(ok);
+    expect(() => hub.emit(event({ type: "session_start" }))).not.toThrow();
+    expect(ok).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mcpjam-inspector/server/services/sessionSimulation/runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/runner.ts
@@ -17,6 +17,8 @@ import {
   resolveLocalOrgMaxSteps,
   type RunLocalOrgChatTurnHeadlessOptions,
 } from "../../utils/org-model-stream-handler.js";
+import type { DirectChatTurnTraceEvents } from "../../utils/direct-chat-turn.js";
+import type { SwarmStreamPayload } from "../../../shared/swarm-stream-events.js";
 import { runUnifiedAssistantTurn } from "../../utils/turn-execution.js";
 import {
   resolveTurnRuntime,
@@ -586,6 +588,11 @@ export interface SyntheticHostSessionAdapter {
     connectedServerIds: string[];
     promptIndex: number;
   }): Promise<void>;
+  /**
+   * Optional live SSE emitter (swarm). Envelope (runId/hostId/chatSessionId/
+   * sessionIndex) is bound by the caller — this only receives payloads.
+   */
+  emit?(payload: SwarmStreamPayload): void;
 }
 
 export async function runSyntheticHostSession(
@@ -603,6 +610,7 @@ export async function runSyntheticHostSession(
     nextPersonaTurn,
     persist,
     onTurnPersisted,
+    emit,
   } = adapter;
   const {
     modelDefinition,
@@ -758,8 +766,17 @@ export async function runSyntheticHostSession(
       ? resolveWebAuthorizedHarnessStrategy()
       : undefined;
 
+    emit?.({ type: "session_start" });
+
     for (let turn = 0; turn < maxTurns; turn++) {
-      if (abortSignal?.aborted) return { outcome: "failed" };
+      if (abortSignal?.aborted) {
+        emit?.({
+          type: "session_complete",
+          status: "failed",
+          errorMessage: "aborted",
+        });
+        return { outcome: "failed" };
+      }
 
       const next = await nextPersonaTurn(lastTranscript);
 
@@ -777,6 +794,12 @@ export async function runSyntheticHostSession(
       // (same per-turn hygiene as the eval runners).
       browser.setActivePromptIndex(turn);
       await browser.dismissCarriedWidget();
+
+      emit?.({
+        type: "turn_start",
+        turnIndex: turn,
+        prompt: next.message,
+      });
 
       const {
         history: updatedHistory,
@@ -800,13 +823,75 @@ export async function runSyntheticHostSession(
         // prepareAdvertisedTools hook hides them until a widget is mounted.
         tools: { ...prepared.allTools, ...browser.computerWidgetTools },
         hooks: {
-          onToolCall: (event) => browser!.noteToolCallInput(event),
-          onToolResult: (event) => browser!.handleEngineToolResult(event),
+          onToolCall: (event) => {
+            browser!.noteToolCallInput(event);
+            const args =
+              event.input &&
+              typeof event.input === "object" &&
+              !Array.isArray(event.input)
+                ? (event.input as Record<string, unknown>)
+                : { value: event.input };
+            emit?.({
+              type: "tool_call",
+              toolName: event.toolName,
+              toolCallId: event.toolCallId,
+              args,
+            });
+          },
+          onToolResult: (event) => {
+            void browser!.handleEngineToolResult(event);
+            emit?.({
+              type: "tool_result",
+              toolCallId: event.toolCallId,
+              result: event.output,
+            });
+          },
           ...(browser.prepareAdvertisedTools
             ? { prepareAdvertisedTools: browser.prepareAdvertisedTools }
             : {}),
-          onToolResultChunk: (chunk) =>
-            browser!.handleDirectToolResultChunk(chunk),
+          onToolResultChunk: async (chunk) => {
+            await browser!.handleDirectToolResultChunk(chunk);
+            emit?.({
+              type: "tool_result",
+              toolCallId: chunk.toolCallId,
+              result: chunk.output,
+            });
+          },
+          onToolCallChunk: (chunk) => {
+            emit?.({
+              type: "tool_call",
+              toolName: chunk.toolName,
+              toolCallId: chunk.toolCallId,
+              args: chunk.input,
+            });
+          },
+          ...(emit
+            ? {
+                onLiveTextDelta: (content: string) => {
+                  emit({ type: "text_delta", content });
+                },
+                onStepFinish: (event: {
+                  stepIndex: number;
+                  turnUsage?: {
+                    inputTokens?: number;
+                    outputTokens?: number;
+                  };
+                }) => {
+                  emit({
+                    type: "step_finish",
+                    stepNumber: event.stepIndex,
+                    ...(event.turnUsage
+                      ? {
+                          usage: {
+                            inputTokens: event.turnUsage.inputTokens ?? 0,
+                            outputTokens: event.turnUsage.outputTokens ?? 0,
+                          },
+                        }
+                      : {}),
+                  });
+                },
+              }
+            : {}),
         },
         progressivePlan: prepared.progressivePlan,
         discoveryState: prepared.discoveryState,
@@ -842,6 +927,8 @@ export async function runSyntheticHostSession(
           ? { journeyRunId: persist.journeyRunId }
           : {}),
       });
+
+      emit?.({ type: "turn_finish", turnIndex: turn });
       // Track the first turn's modelSource for the per-session persist
       // calls. modelSource is stable across turns within a session because
       // chatbox modelId is pinned by `fetchChatboxRuntimeConfig` at start.
@@ -992,6 +1079,7 @@ export async function runSyntheticHostSession(
       });
     }
 
+    emit?.({ type: "session_complete", status: "succeeded" });
     return { outcome: "succeeded" };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -1002,6 +1090,11 @@ export async function runSyntheticHostSession(
     // breach (stop the WHOLE run). The chatbox runner ignores it for
     // rate-limited outcomes, so this is a safe additive change.
     if (classifyTurnFailure(message) === "rate_limited") {
+      emit?.({
+        type: "session_complete",
+        status: "rate_limited",
+        errorMessage: message,
+      });
       return { outcome: "rate_limited", errorMessage: message };
     }
     logger.warn("[sessionSimulation.runner] session failed", {
@@ -1009,6 +1102,11 @@ export async function runSyntheticHostSession(
       chatSessionId,
       personaId: persist.personaId,
       error: message,
+    });
+    emit?.({
+      type: "session_complete",
+      status: "failed",
+      errorMessage: message,
     });
     return { outcome: "failed", errorMessage: message };
   } finally {
@@ -1334,10 +1432,19 @@ export interface DrainAssistantTurnHooks {
   /** Engine branches (`/stream`, `/stream/org`): MCPJamHandlerOptions pass-throughs. */
   onToolCall?: MCPJamHandlerOptions["onToolCall"];
   onToolResult?: MCPJamHandlerOptions["onToolResult"];
+  /** Live text deltas (hosted + direct). Swarm SSE / eval sinks use this. */
+  onLiveTextDelta?: MCPJamHandlerOptions["onLiveTextDelta"];
+  /** Per-step settle (hosted + direct). Swarm SSE / eval sinks use this. */
+  onStepFinish?: MCPJamHandlerOptions["onStepFinish"];
   /** All branches: per-step advertised-tool narrowing. */
   prepareAdvertisedTools?: MCPJamHandlerOptions["prepareAdvertisedTools"];
   /** Local AI-SDK branch: awaited per-tool-result render hook. */
   onToolResultChunk?: RunLocalOrgChatTurnHeadlessOptions["onToolResultChunk"];
+  /**
+   * Local AI-SDK branch: tool-call chunk (via `traceEvents.onToolCallChunk`).
+   * Hosted engines use {@link onToolCall} instead.
+   */
+  onToolCallChunk?: DirectChatTurnTraceEvents["onToolCallChunk"];
 }
 
 /**
@@ -1510,6 +1617,13 @@ export async function drainAssistantTurn(
       ...(hooks?.onToolResultChunk
         ? { onToolResultChunk: hooks.onToolResultChunk }
         : {}),
+      ...(hooks?.onToolCallChunk
+        ? { onToolCallChunk: hooks.onToolCallChunk }
+        : {}),
+      ...(hooks?.onLiveTextDelta
+        ? { onLiveTextDelta: hooks.onLiveTextDelta }
+        : {}),
+      ...(hooks?.onStepFinish ? { onStepFinish: hooks.onStepFinish } : {}),
       onEngineError: captureEngineError,
     });
 
@@ -1616,6 +1730,10 @@ export async function drainAssistantTurn(
     ...(synthesisRunId ? { synthesisRunId } : {}),
     ...(hooks?.onToolCall ? { onToolCall: hooks.onToolCall } : {}),
     ...(hooks?.onToolResult ? { onToolResult: hooks.onToolResult } : {}),
+    ...(hooks?.onLiveTextDelta
+      ? { onLiveTextDelta: hooks.onLiveTextDelta }
+      : {}),
+    ...(hooks?.onStepFinish ? { onStepFinish: hooks.onStepFinish } : {}),
     ...(hooks?.prepareAdvertisedTools
       ? { prepareAdvertisedTools: hooks.prepareAdvertisedTools }
       : {}),

--- a/mcpjam-inspector/server/services/sessionSimulation/swarm-runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/swarm-runner.ts
@@ -13,6 +13,12 @@ import {
   type PinnedHostExecutionSpec,
   type SwarmAttemptStatus,
 } from "../swarm-agent.js";
+import { JourneyRunStreamHub } from "./swarm-stream-hub.js";
+import type {
+  SwarmStreamEnvelope,
+  SwarmStreamEvent,
+  SwarmStreamPayload,
+} from "../../../shared/swarm-stream-events.js";
 
 /**
  * Swarm (journey-execution) multi-host fan-out runner — PR 3d.
@@ -88,12 +94,21 @@ interface RunningJourneyHandle {
   abort: () => void;
   /** Resolves when the run loop's `finally` has cleared the registry. */
   done: Promise<void>;
+  /** Live SSE multiplex for this run (late-join buffer + subscribers). */
+  hub: JourneyRunStreamHub;
 }
 
 const runningJourneyRuns = new Map<string, RunningJourneyHandle>();
 
 export function getRunningJourneyRunCount(): number {
   return runningJourneyRuns.size;
+}
+
+/** Active run stream hub, if the runner is still in-process. */
+export function getRunningJourneyStreamHub(
+  runId: string
+): JourneyRunStreamHub | undefined {
+  return runningJourneyRuns.get(runId)?.hub;
 }
 
 /**
@@ -148,13 +163,23 @@ export async function startJourneyRun(
   const done = new Promise<void>((resolve) => {
     resolveDone = resolve;
   });
+  const hub = new JourneyRunStreamHub();
   runningJourneyRuns.set(opts.runId, {
     abort: () => controller.abort(),
     done,
+    hub,
   });
   try {
-    await runJourneyFanOut({ ...opts, abortSignal: composed });
+    await runJourneyFanOut({ ...opts, abortSignal: composed, hub });
   } finally {
+    // Terminal multiplex event before unregistering so late SSE clients see it.
+    hub.emit({
+      type: "run_complete",
+      runId: opts.runId,
+      hostId: "",
+      chatSessionId: "",
+      sessionIndex: -1,
+    });
     runningJourneyRuns.delete(opts.runId);
     resolveDone();
   }
@@ -219,8 +244,17 @@ function logEvent(
   logger.info(`[swarm.runner] ${event}`, fields);
 }
 
+function bindSessionEmit(
+  hub: JourneyRunStreamHub,
+  envelope: SwarmStreamEnvelope
+): (payload: SwarmStreamPayload) => void {
+  return (payload) => {
+    hub.emit({ ...envelope, ...payload } as SwarmStreamEvent);
+  };
+}
+
 async function runJourneyFanOut(
-  opts: StartJourneyRunOptions
+  opts: StartJourneyRunOptions & { hub: JourneyRunStreamHub }
 ): Promise<void> {
   const {
     runId,
@@ -234,6 +268,7 @@ async function runJourneyFanOut(
     authHeader,
     managerFactory,
     abortSignal,
+    hub,
   } = opts;
 
   const runStartedAt = Date.now();
@@ -355,6 +390,15 @@ async function runJourneyFanOut(
       const attemptStartedAt = Date.now();
       logEvent("attempt.start", { runId, hostId, sessionIdx, modelId });
 
+      const envelope: SwarmStreamEnvelope = {
+        runId,
+        hostId,
+        chatSessionId,
+        sessionIndex: sessionIdx,
+      };
+      const emit = bindSessionEmit(hub, envelope);
+      emit({ type: "attempt_status", status: "running" });
+
       // Execute the session via the shared core. It owns manager lifecycle +
       // dispose, per-turn persona→drain→persist, browser/widget capture, and
       // failure classification, and NEVER throws (returns a SessionResult).
@@ -407,6 +451,7 @@ async function runJourneyFanOut(
           personaId: personaSnapshot.personaId,
           personaLabel: personaSnapshot.name,
         },
+        emit,
         // No chatbox-scoped side-persistence on the swarm surface (widget /
         // browser-artifact rows are keyed by chatboxId, which swarm has none).
       });
@@ -441,6 +486,13 @@ async function runJourneyFanOut(
               : {}),
           }
         : terminalForOutcome(outcome, errorMessage);
+      emit({
+        type: "attempt_status",
+        status: terminal.status,
+        ...(terminal.errorMessage
+          ? { errorMessage: terminal.errorMessage }
+          : {}),
+      });
       try {
         await reportAttempt(convexHttpUrl, bearer, {
           projectId,

--- a/mcpjam-inspector/server/services/sessionSimulation/swarm-stream-hub.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/swarm-stream-hub.ts
@@ -1,0 +1,56 @@
+import type { SwarmStreamEvent } from "../../../shared/swarm-stream-events.js";
+
+const RING_BUFFER_SIZE = 200;
+
+export type SwarmStreamListener = (event: SwarmStreamEvent) => void;
+
+/**
+ * Per-run multiplex hub: ring-buffers recent events for late SSE joiners and
+ * fans out to live subscribers. One hub is owned by each active journey run
+ * in {@link runningJourneyRuns}.
+ */
+export class JourneyRunStreamHub {
+  private readonly buffer: SwarmStreamEvent[] = [];
+  private readonly listeners = new Set<SwarmStreamListener>();
+
+  emit(event: SwarmStreamEvent): void {
+    this.buffer.push(event);
+    if (this.buffer.length > RING_BUFFER_SIZE) {
+      this.buffer.splice(0, this.buffer.length - RING_BUFFER_SIZE);
+    }
+    for (const listener of this.listeners) {
+      try {
+        listener(event);
+      } catch {
+        // Subscriber errors must not break the runner.
+      }
+    }
+  }
+
+  /**
+   * Subscribe and immediately replay the ring buffer (late-join), then receive
+   * live events. Returns an unsubscribe function.
+   */
+  subscribe(listener: SwarmStreamListener): () => void {
+    this.listeners.add(listener);
+    for (const event of this.buffer) {
+      try {
+        listener(event);
+      } catch {
+        // ignore
+      }
+    }
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  /** Snapshot of the current ring buffer (tests / diagnostics). */
+  getBuffer(): readonly SwarmStreamEvent[] {
+    return this.buffer;
+  }
+
+  get listenerCount(): number {
+    return this.listeners.size;
+  }
+}

--- a/mcpjam-inspector/server/utils/turn-execution.ts
+++ b/mcpjam-inspector/server/utils/turn-execution.ts
@@ -104,6 +104,10 @@ export type DirectTurnOptions = {
   onToolResultChunk?: NonNullable<
     RunDirectChatTurnOptions["traceEvents"]
   >["onToolResultChunk"];
+  /** Direct engine tool-call chunk (swarm / eval SSE). */
+  onToolCallChunk?: NonNullable<
+    RunDirectChatTurnOptions["traceEvents"]
+  >["onToolCallChunk"];
   // TODO(PR 3 — local eval migration): local STREAMING eval still depends on the
   // direct engine's `traceEvents` (`onStepSnapshot`, `onToolResultChunk`) to emit
   // its SSE. Before PR 3 deletes `stream-adapter.ts`, expose normalized
@@ -200,8 +204,17 @@ export async function runUnifiedAssistantTurn(
     onEngineError: opts.onEngineError,
     // PR 3a: only forward `traceEvents` when the caller wired a chunk hook, so
     // callers that don't set it stay byte-identical (no traceEvents object).
-    ...(opts.onToolResultChunk
-      ? { traceEvents: { onToolResultChunk: opts.onToolResultChunk } }
+    ...(opts.onToolResultChunk || opts.onToolCallChunk
+      ? {
+          traceEvents: {
+            ...(opts.onToolCallChunk
+              ? { onToolCallChunk: opts.onToolCallChunk }
+              : {}),
+            ...(opts.onToolResultChunk
+              ? { onToolResultChunk: opts.onToolResultChunk }
+              : {}),
+          },
+        }
       : {}),
   });
   const headless = await consumeDirectChatTurnHeadless(handle);

--- a/mcpjam-inspector/shared/__tests__/swarm-stream-events.test.ts
+++ b/mcpjam-inspector/shared/__tests__/swarm-stream-events.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import {
+  swarmEventToEvalPayload,
+  type SwarmStreamEvent,
+} from "../swarm-stream-events";
+
+describe("swarm-stream-events", () => {
+  it("maps tool_call payloads without the envelope", () => {
+    const event: SwarmStreamEvent = {
+      type: "tool_call",
+      runId: "r",
+      hostId: "h",
+      chatSessionId: "c",
+      sessionIndex: 0,
+      toolName: "search",
+      toolCallId: "tc1",
+      args: { q: "dog" },
+    };
+    expect(swarmEventToEvalPayload(event)).toEqual({
+      type: "tool_call",
+      toolName: "search",
+      toolCallId: "tc1",
+      args: { q: "dog" },
+    });
+  });
+});

--- a/mcpjam-inspector/shared/swarm-stream-events.ts
+++ b/mcpjam-inspector/shared/swarm-stream-events.ts
@@ -1,0 +1,149 @@
+import type { EvalTraceBlobV1 } from "./eval-trace";
+
+/**
+ * Attempt / session terminal states reported on the swarm SSE multiplex.
+ * Mirrors journey-execution attempt statuses the fan-out runner already writes
+ * to Convex.
+ */
+export type SwarmAttemptStreamStatus =
+  | "pending"
+  | "running"
+  | "succeeded"
+  | "failed"
+  | "rate_limited";
+
+export type SwarmStreamToolCall = {
+  toolName: string;
+  arguments: Record<string, unknown>;
+};
+
+/**
+ * Scoping envelope on every swarm stream event. A single journey-run SSE
+ * multiplexes N concurrent host sessions; clients partition by `chatSessionId`.
+ */
+export type SwarmStreamEnvelope = {
+  runId: string;
+  hostId: string;
+  chatSessionId: string;
+  sessionIndex: number;
+};
+
+/** Eval-shaped per-turn / per-step payloads (no authored step_status). */
+export type SwarmStreamTurnPayload =
+  | { type: "turn_start"; turnIndex: number; prompt: string }
+  | { type: "text_delta"; content: string }
+  | {
+      type: "tool_call";
+      toolName: string;
+      toolCallId: string;
+      args: Record<string, unknown>;
+    }
+  | {
+      type: "tool_result";
+      toolCallId: string;
+      result: unknown;
+      isError?: boolean;
+    }
+  | {
+      type: "step_finish";
+      stepNumber: number;
+      usage?: { inputTokens: number; outputTokens: number };
+    }
+  | {
+      type: "trace_snapshot";
+      turnIndex: number;
+      stepIndex?: number;
+      snapshotKind: "step_finish" | "turn_finish" | "failure";
+      trace: EvalTraceBlobV1;
+      actualToolCalls: SwarmStreamToolCall[];
+      usage: {
+        inputTokens: number;
+        outputTokens: number;
+        totalTokens: number;
+      };
+    }
+  | { type: "turn_finish"; turnIndex: number }
+  | { type: "error"; message: string; details?: string };
+
+/** Swarm-only lifecycle events (no eval equivalent). */
+export type SwarmStreamLifecyclePayload =
+  | { type: "session_start" }
+  | {
+      type: "session_complete";
+      status: Exclude<SwarmAttemptStreamStatus, "pending" | "running">;
+      errorMessage?: string;
+    }
+  | {
+      type: "attempt_status";
+      status: SwarmAttemptStreamStatus;
+      errorMessage?: string;
+    }
+  | { type: "run_complete" };
+
+export type SwarmStreamPayload =
+  | SwarmStreamTurnPayload
+  | SwarmStreamLifecyclePayload;
+
+export type SwarmStreamEvent = SwarmStreamEnvelope & SwarmStreamPayload;
+
+/**
+ * Strip the swarm envelope so the leftover payload can be fed into the eval
+ * stream reducer (turn/text/tool events). Lifecycle events return null.
+ */
+export function swarmEventToEvalPayload(
+  event: SwarmStreamEvent,
+): SwarmStreamTurnPayload | null {
+  switch (event.type) {
+    case "turn_start":
+      return {
+        type: "turn_start",
+        turnIndex: event.turnIndex,
+        prompt: event.prompt,
+      };
+    case "text_delta":
+      return { type: "text_delta", content: event.content };
+    case "tool_call":
+      return {
+        type: "tool_call",
+        toolName: event.toolName,
+        toolCallId: event.toolCallId,
+        args: event.args,
+      };
+    case "tool_result":
+      return {
+        type: "tool_result",
+        toolCallId: event.toolCallId,
+        result: event.result,
+        isError: event.isError,
+      };
+    case "step_finish":
+      return {
+        type: "step_finish",
+        stepNumber: event.stepNumber,
+        usage: event.usage,
+      };
+    case "trace_snapshot":
+      return {
+        type: "trace_snapshot",
+        turnIndex: event.turnIndex,
+        stepIndex: event.stepIndex,
+        snapshotKind: event.snapshotKind,
+        trace: event.trace,
+        actualToolCalls: event.actualToolCalls,
+        usage: event.usage,
+      };
+    case "turn_finish":
+      return { type: "turn_finish", turnIndex: event.turnIndex };
+    case "error":
+      return {
+        type: "error",
+        message: event.message,
+        details: event.details,
+      };
+    case "session_start":
+    case "session_complete":
+    case "attempt_status":
+    case "run_complete":
+      return null;
+  }
+}


### PR DESCRIPTION
## Summary
Reworks the Swarms journey experience end-to-end: live streaming of journey runs, an evals-style results matrix, and a leaner journey creation/viewing UI.

- **Live SSE streaming** for journey runs via a new stream hub (`swarm-stream-hub.ts`), a shared event contract (`shared/swarm-stream-events.ts`), and a client hook (`use-journey-run-stream.ts`).
- **Evals-style matrix** and richer run results (`journey-run-results.tsx`, `journey-run-format.ts`) with a per-session metric strip (`swarm-sessions-metric-strip.tsx`).
- **Compact journey form** — pill dropdowns replacing the old verbose form; progressive/collapsible journey cards (`journey-list.tsx`).
- Surfaces previously-silent journey failures; keeps the client multi-select open while picking.
- Persisted session trace hook (`use-persisted-session-trace.ts`) plus host logo/avatar polish.

## Testing
New/updated tests cover the stream reducer, stream hub, journey list, metric strip, runner, and swarm-api wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large UI refactor plus new SSE streaming path and session outcome heuristics; behavior is heavily tested but depends on backend queries (`getSwarmSessionMetrics`, session list APIs) being deployed.
> 
> **Overview**
> **Swarms** gains a **Personas / Journeys** view switcher, a flat **Sessions** browser (`SwarmsSessionsPanel`) with persona and client filters, promote-to-eval, and an evals-style **metric strip** backed by `journeyRuns:getSwarmSessionMetrics`.
> 
> On **Personas**, journey UI is refactored into `JourneyList` with per-host outcome cells, run trend strips, and a **resizable run detail panel** that replaces inline expandable cards. Run detail shows a **sessions matrix**, **live SSE stream** (`GET /api/web/swarm/runs/:runId/stream` + in-memory hub), Trace/Chat/Raw via the eval stream reducer, persisted transcripts for completed sessions, and synthesis of **failed attempts without Convex rows**. Journey creation uses a **compact pill bar** (server group + multi-select clients popover).
> 
> Shared eval **metric tiles** are exported with optional `subLabel` / `divider` for swarm sessions. Persona avatars only **bob when running**, not when selected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7efb94255adac984e1fe0f20a88aa69896fdeb52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds live SSE streaming for swarm journey runs and an evals-style sessions×hosts matrix, plus a compact journey creation and browsing UI with a Sessions view and metrics. Improves clarity during runs, surfaces failures, and makes journeys easier to manage.

- New Features
  - Live SSE for journey runs with a per-run hub and late-join replay; client hook `use-journey-run-stream` consumes `shared/swarm-stream-events`.
  - Evals-style matrix with live status, per-cell outcomes, and a trace viewer; persisted-trace loader for completed sessions.
  - Sessions view with persona filter and a metric strip (tool error rate, tool calls/session, latency P50/P95, tokens/session).
  - Leaner journey UI: pill dropdowns, progressive journey cards, and host logos; multi-select stays open while toggling.

- Bug Fixes
  - Surfaces journey failures and rate limits in summaries and matrix cells.
  - Correct sessions-by-run wiring to use `journeyRunId` and the real `JourneySessionDto` (keyed by `id`).
  - Persona avatars animate only when a journey is running, not on selection.

<sup>Written for commit 7efb94255adac984e1fe0f20a88aa69896fdeb52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

