### PR TITLE
chat: stop shipping MCPJam ui_* tools from generic chat surfaces

### DIFF
--- a/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.hosted.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.hosted.test.tsx
@@ -24,6 +24,10 @@ const mockState = vi.hoisted(() => ({
   setSelectedModelId: vi.fn(),
   useSharedChatWidgetCapture: vi.fn(),
   latestOnData: undefined as ((part: unknown) => void) | undefined,
+  latestOnToolCall: undefined as
+    | ((options: { toolCall: unknown }) => Promise<void> | void)
+    | undefined,
+  addToolOutput: vi.fn(),
   convexAuth: {
     isAuthenticated: true,
     isLoading: false,
@@ -228,16 +232,21 @@ vi.mock("@ai-sdk/react", async () => {
         id,
         transport,
         onData,
+        onToolCall,
       }: {
         id: string;
         transport: {
           sendMessages: (options: any) => Promise<unknown>;
         };
         onData?: (part: unknown) => void;
+        onToolCall?: (options: {
+          toolCall: unknown;
+        }) => Promise<void> | void;
       }) => {
         const latchedIdRef = React.useRef(id);
         const latchedTransportRef = React.useRef(transport);
         mockState.latestOnData = onData;
+        mockState.latestOnToolCall = onToolCall;
 
         if (latchedIdRef.current !== id) {
           latchedIdRef.current = id;
@@ -272,6 +281,7 @@ vi.mock("@ai-sdk/react", async () => {
           error: undefined,
           setMessages: mockState.setMessages,
           addToolApprovalResponse: mockState.addToolApprovalResponse,
+          addToolOutput: mockState.addToolOutput,
         };
       }
     ),
@@ -323,6 +333,8 @@ describe("useChatSession hosted mode", () => {
     mockState.getGuestBearerToken.mockResolvedValue("guest-token");
     mockState.selectedModelId = "anthropic/claude-haiku-4.5";
     mockState.latestOnData = undefined;
+    mockState.latestOnToolCall = undefined;
+    mockState.addToolOutput.mockReset();
     vi.mocked(generateId).mockReset();
     vi.mocked(generateId).mockReturnValue("chat-session-id");
     useTrafficLogStore.getState().clear();
@@ -429,7 +441,11 @@ describe("useChatSession hosted mode", () => {
     unmount();
   });
 
-  it("ships WebMCP ui_* tools on direct chats but never on chatbox sessions", async () => {
+  it("never ships WebMCP ui_* tools from the generic hook", async () => {
+    // MCPJam UI tools are agent-surface-only: even with a non-empty internal
+    // registry, the generic chat body must not carry a `uiTools` field on any
+    // surface. The only sender is agent-chat-instances.ts
+    // (/api/web/mcpjam-agent).
     const unregister = useUiToolsRegistry.getState().registerUiTool({
       name: "ui_navigate",
       description: "Navigate the MCPJam inspector",
@@ -439,7 +455,7 @@ describe("useChatSession hosted mode", () => {
       }),
     });
     try {
-      // Direct hosted chat (no chatbox scope): the snapshot ships.
+      // Direct hosted chat: no uiTools field.
       const direct = renderHook(() =>
         useChatSession({
           selectedServers: ["server-1"],
@@ -449,14 +465,11 @@ describe("useChatSession hosted mode", () => {
           },
         })
       );
-      expect(lastTransportOptions.body().uiTools).toEqual([
-        expect.objectContaining({ name: "ui_navigate" }),
-      ]);
+      expect(lastTransportOptions.body()).not.toHaveProperty("uiTools");
       direct.unmount();
 
-      // Chatbox session (published/share-link or owner preview): the turn
-      // renders the end-user chatbox surface — inspector-driving tools are
-      // omitted entirely, not sent as an empty list.
+      // Chatbox session (published/share-link or owner preview): same —
+      // the field is absent entirely, not sent as an empty list.
       const chatbox = renderHook(() =>
         useChatSession({
           selectedServers: ["server-1"],
@@ -470,6 +483,51 @@ describe("useChatSession hosted mode", () => {
       );
       expect(lastTransportOptions.body()).not.toHaveProperty("uiTools");
       chatbox.unmount();
+    } finally {
+      unregister();
+    }
+  });
+
+  it("does not claim a server-origin ui_* tool call in the generic hook", async () => {
+    // Provenance boundary regression: an MCP server may legitimately expose a
+    // tool named `ui_server_action`. Even when the internal MCPJam UI registry
+    // holds a same-named entry, the generic hook's onToolCall must NOT execute
+    // it in the browser or synthesize a tool output — the call falls through
+    // to the server's execute path like any other MCP tool.
+    const uiExecute = vi.fn(async () => ({
+      content: [{ type: "text" as const, text: "{}" }],
+    }));
+    const unregister = useUiToolsRegistry.getState().registerUiTool({
+      name: "ui_server_action",
+      description: "Registry twin that must not claim the server call",
+      readOnly: false,
+      execute: uiExecute,
+    });
+    try {
+      const { unmount } = renderHook(() =>
+        useChatSession({
+          selectedServers: ["server-1"],
+          hostedContext: {
+            projectId: "project-1",
+            selectedServerIds: ["server-id-1"],
+          },
+        })
+      );
+      expect(mockState.latestOnToolCall).toBeDefined();
+
+      await act(async () => {
+        await mockState.latestOnToolCall?.({
+          toolCall: {
+            toolName: "ui_server_action",
+            toolCallId: "tool-call-ui-1",
+            input: {},
+          },
+        });
+      });
+
+      expect(uiExecute).not.toHaveBeenCalled();
+      expect(mockState.addToolOutput).not.toHaveBeenCalled();
+      unmount();
     } finally {
       unregister();
     }

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -37,12 +37,6 @@ import {
   recordAppToolInvocation,
 } from "@/components/chat-v2/thread/mcp-apps/app-tools-registry";
 import { scrubAppToolResultForModel } from "@/components/chat-v2/thread/mcp-apps/app-tools-sanitizer";
-import { useUiToolsRegistry } from "@/lib/webmcp/ui-tools-registry";
-import { handleUiToolCall } from "@/lib/webmcp/ui-tool-executor";
-import {
-  createUiAwareApprovalResponseHandler,
-  fulfillOrphanedDeferredUiToolCalls,
-} from "@/lib/webmcp/ui-tool-approval";
 import { useAuth } from "@workos-inc/authkit-react";
 import { useConvex, useConvexAuth } from "convex/react";
 import { ModelDefinition, type ModelProvider } from "@/shared/types";
@@ -1860,14 +1854,8 @@ export function useChatSession(
           appTools: useAppToolsRegistry
             .getState()
             .snapshotForChatBody(chatSessionIdRef.current),
-          // WebMCP UI tools snapshot — same drain-fresh contract as appTools;
-          // the server defends the boundary again in `validateUiToolEntries`.
-          // Omitted for chatbox sessions (published/share-link AND owner
-          // preview): those turns render the end-user chatbox surface, which
-          // must not advertise inspector-driving ui_* tools to the model.
-          ...(hostedChatboxId
-            ? {}
-            : { uiTools: useUiToolsRegistry.getState().snapshotForChatBody() }),
+          // MCPJam UI tools are agent-surface-only; the only uiTools sender
+          // is agent-chat-instances.ts (/api/web/mcpjam-agent).
           ...(widgetModelContext && widgetModelContext.length > 0
             ? { widgetModelContext }
             : {}),
@@ -1939,26 +1927,6 @@ export function useChatSession(
     // app aliases land here.
     onToolCall: async ({ toolCall }) => {
       const toolName = (toolCall as { toolName: string }).toolName;
-      // WebMCP UI tools run first: `handleUiToolCall` only claims calls the
-      // UI registry knows (or shipped this session) and supplies the output
-      // itself; everything else falls through to the app-alias path below.
-      if (
-        await handleUiToolCall({
-          toolName,
-          toolCallId: (toolCall as { toolCallId: string }).toolCallId,
-          input: (toolCall as { input: unknown }).input,
-          addToolOutput: addToolOutput as Parameters<
-            typeof handleUiToolCall
-          >[0]["addToolOutput"],
-          // Defers mutating UI tools to the approval pill when the toggle is
-          // on — must mirror the server's gate (shared predicate).
-          requireToolApproval: requireToolApprovalRef.current,
-          // Duplicate detection is per chat session, not per module.
-          telemetryScope: chatSessionIdRef.current,
-        })
-      ) {
-        return;
-      }
       const entry = useAppToolsRegistry
         .getState()
         .resolve(toolName, chatSessionIdRef.current);
@@ -2117,41 +2085,6 @@ export function useChatSession(
   });
   const messagesRef = useRef(messages);
   messagesRef.current = messages;
-
-  // UI-tool-aware approval responses: Approve on a `ui_*` part executes the
-  // tool in the browser and ships the result (the server can't execute a
-  // no-execute tool, and a bare approval response would strand the turn);
-  // Deny and every non-UI tool use the plain approval response unchanged.
-  const uiAwareAddToolApprovalResponse = useMemo(
-    () =>
-      createUiAwareApprovalResponseHandler({
-        getMessages: () => messagesRef.current,
-        addToolApprovalResponse,
-        addToolOutput: addToolOutput as Parameters<
-          typeof createUiAwareApprovalResponseHandler
-        >[0]["addToolOutput"],
-        // Keeps reload-approved calls in this session's duplicate ring.
-        telemetryScope: chatSessionId,
-      }),
-    [addToolApprovalResponse, addToolOutput, chatSessionId]
-  );
-
-  // Orphaned-defer fallback: a UI tool call deferred for approval whose
-  // approval request never arrived (client/server flag disagreement for one
-  // turn, e.g. the toggle flipped mid-stream) executes once the stream
-  // settles so the turn can't hang.
-  const prevStatusForDeferredUiRef = useRef(status);
-  useEffect(() => {
-    const prev = prevStatusForDeferredUiRef.current;
-    prevStatusForDeferredUiRef.current = status;
-    if (prev === status || status !== "ready") return;
-    fulfillOrphanedDeferredUiToolCalls({
-      messages: messagesRef.current,
-      addToolOutput: addToolOutput as Parameters<
-        typeof fulfillOrphanedDeferredUiToolCalls
-      >[0]["addToolOutput"],
-    });
-  }, [addToolOutput, status]);
 
   const queueSessionHydration = useCallback(
     (hydration: PendingSessionHydration) => {
@@ -3115,7 +3048,7 @@ export function useChatSession(
     // Tool approval
     requireToolApproval,
     setRequireToolApproval,
-    addToolApprovalResponse: uiAwareAddToolApprovalResponse,
+    addToolApprovalResponse,
 
     // Actions
     resetChat,

--- a/mcpjam-inspector/client/src/lib/webmcp/ui-tools-registry.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/ui-tools-registry.ts
@@ -25,7 +25,7 @@
 import { create } from "zustand";
 import { isUiToolName } from "@/shared/client-fulfilled-tools.js";
 import type { UiToolAnnotations } from "@/shared/client-fulfilled-tools.js";
-import type { UiToolSnapshotEntry } from "@/shared/chat-v2.js";
+import type { UiToolSnapshotEntry } from "@/shared/mcpjam-ui-tools.js";
 import { mirrorUiToolToNative } from "./native-mirror";
 
 export interface UiToolResult {

--- a/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
+++ b/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
@@ -78,11 +78,12 @@ export type AppToolEntry = import("@/shared/chat-v2").AppToolSnapshotEntry;
 /**
  * WebMCP-shaped MCPJam UI tool descriptor as accepted by `prepareChatV2`,
  * already sanitized by {@link validateUiToolEntries}. Mirrors
- * `UiToolSnapshotEntry` in `shared/chat-v2.ts`. Unlike app tools there is no
- * alias indirection: `name` (reserved `ui_` prefix) is the model-facing tool
- * name, fulfilled client-side by `useChat.onToolCall`.
+ * `UiToolSnapshotEntry` in `shared/mcpjam-ui-tools.ts`. Unlike app tools
+ * there is no alias indirection: `name` (reserved `ui_` prefix) is the
+ * model-facing tool name, fulfilled client-side in the browser.
  */
-export type UiToolEntry = import("@/shared/chat-v2").UiToolSnapshotEntry;
+export type UiToolEntry =
+  import("@/shared/mcpjam-ui-tools").UiToolSnapshotEntry;
 export type WidgetModelContextEntry =
   import("@/shared/chat-v2").WidgetModelContextEntry;
 

--- a/mcpjam-inspector/shared/chat-v2.ts
+++ b/mcpjam-inspector/shared/chat-v2.ts
@@ -1,6 +1,5 @@
 import { UIMessage } from "ai";
 import type { ModelDefinition } from "./types";
-import type { UiToolAnnotations } from "./client-fulfilled-tools";
 import type {
   McpToolResultImageRenderingPolicy,
   ModelVisibleMcpToolResults,
@@ -106,17 +105,6 @@ export interface ChatV2Request {
    */
   appTools?: AppToolSnapshotEntry[];
   /**
-   * WebMCP-shaped MCPJam UI tools snapshot — per chat POST.
-   *
-   * Registered by the client catalog into the UI tools registry
-   * (`client/src/lib/webmcp/ui-tools-registry.ts`) and snapshotted fresh at
-   * POST time, exactly like `appTools`. The server defends the boundary in
-   * `validateUiToolEntries` (caps, `ui_` name regex, schema size) and
-   * registers them as no-execute AI SDK tools; `useChat.onToolCall` fulfills
-   * them in-page.
-   */
-  uiTools?: UiToolSnapshotEntry[];
-  /**
    * SEP-1865 `ui/update-model-context` snapshots for the next model turn.
    *
    * These are per-request, ephemeral model context: the server appends them
@@ -146,28 +134,6 @@ export interface AppToolSnapshotEntry {
   description?: string;
   inputSchema?: Record<string, unknown>;
   readOnly: boolean;
-}
-
-/**
- * WebMCP-shaped MCPJam UI tool snapshot entry. Mirrors `UiToolEntry` in
- * `server/utils/chat-v2-orchestration.ts` so the client snapshotter and the
- * server validator share a single shape.
- *
- * Unlike app tools, UI tools are first-party and curated: `name` is the
- * model-facing tool name directly (reserved `ui_` prefix, validated at the
- * boundary), with no alias indirection.
- *
- * `annotations` carries the MCP `ToolAnnotations` hints and is what drives
- * approval policy (`uiToolCallNeedsApproval`). `readOnly` predates it and is
- * retained for wire compatibility: an old client ships only `readOnly`, and
- * the validator rejects a snapshot whose `readOnlyHint` contradicts it.
- */
-export interface UiToolSnapshotEntry {
-  name: string;
-  description: string;
-  inputSchema?: Record<string, unknown>;
-  readOnly: boolean;
-  annotations?: UiToolAnnotations;
 }
 
 export interface WidgetModelContextEntry {

--- a/mcpjam-inspector/shared/mcpjam-ui-tools.ts
+++ b/mcpjam-inspector/shared/mcpjam-ui-tools.ts
@@ -1,0 +1,26 @@
+import type { UiToolAnnotations } from "./client-fulfilled-tools";
+
+/**
+ * WebMCP-shaped MCPJam UI tool snapshot entry — the `uiTools` wire shape of
+ * `POST /api/web/mcpjam-agent`, the only route that accepts the first-party
+ * UI catalog. Mirrors `UiToolEntry` in
+ * `server/utils/chat-v2-orchestration.ts` so the client snapshotter and the
+ * server validator share a single shape. Deliberately NOT part of the
+ * chat-v2 request body: generic chat surfaces never ship MCPJam UI tools.
+ *
+ * Unlike app tools, UI tools are first-party and curated: `name` is the
+ * model-facing tool name directly (reserved `ui_` prefix, validated at the
+ * boundary), with no alias indirection.
+ *
+ * `annotations` carries the MCP `ToolAnnotations` hints and is what drives
+ * approval policy (`uiToolCallNeedsApproval`). `readOnly` predates it and is
+ * retained for wire compatibility: an old client ships only `readOnly`, and
+ * the validator rejects a snapshot whose `readOnlyHint` contradicts it.
+ */
+export interface UiToolSnapshotEntry {
+  name: string;
+  description: string;
+  inputSchema?: Record<string, unknown>;
+  readOnly: boolean;
+  annotations?: UiToolAnnotations;
+}


### PR DESCRIPTION
## What

Client slice of the "MCPJam UI tools are agent-surface-only" plan. Only the Ask MCPJam agent surfaces (side panel + Home "Ask anything", via `agent-chat-instances.ts` → `POST /api/web/mcpjam-agent`) advertise the first-party `ui_*` UI catalog.

- `use-chat-session.ts` (generic hook, every chat-v2 surface) no longer sends the `uiTools` snapshot — on direct hosted chats *or* chatbox sessions — and no longer fulfills MCPJam UI tool calls: the `handleUiToolCall` branch, the UI-aware approval-response wrapper, and the orphaned-defer effect are gone. The plain `addToolApprovalResponse` is returned. The SEP-1865 app-alias (`app_<8hex>`) path is byte-identical.
- No `ui_*` name filtering was added anywhere: a server-origin MCP tool named `ui_navigate`/`ui_server_action` falls through `onToolCall` like any other MCP tool and executes server-side. This is a provenance boundary, not a name ban.
- Wire type moved out of chat-v2: `uiTools?: UiToolSnapshotEntry[]` is removed from `ChatV2Request`, and `UiToolSnapshotEntry` now lives in the focused `shared/mcpjam-ui-tools.ts` (documented as the `/api/web/mcpjam-agent` snapshot type). Reintroducing the field into chat-v2 is now an explicit architectural change, not an easy reuse of a nearby type. Importers (`ui-tools-registry.ts`, `chat-v2-orchestration.ts`) got import-path-only updates.

## Mixed-version safety

Cached pre-cutover clients may still POST `uiTools` on chat-v2; the companion server slice makes both chat-v2 routes ignore (not reject) the field. New clients simply omit it, which existing validators already accept.

## Tests

- `use-chat-session.hosted.test.tsx`: the old "ships on direct, never on chatbox" test is flipped to "never ships" — with `ui_navigate` registered in the internal registry, the body has no `uiTools` property on both direct-hosted and chatbox renders.
- New regression: a streamed tool call named `ui_server_action` with a same-named registry twin is not claimed by the MCPJam UI executor — its `execute` never runs and no browser-synthesized `addToolOutput` occurs.
- Still green: `use-mcpjam-agent-session.uitools.test.tsx` (agent path still ships/fulfills), `webmcp-approval-sdk-ordering.test.tsx`, all of `client/src/lib/webmcp/__tests__/`, `chat-v2-orchestration.test.ts`, `mcpjam-agent.uitools.test.ts` (21 files / 268 tests, exit 0). `typecheck:client` clean.

Note for the companion server PR: the two `body.uiTools` reads in `server/routes/web/chat-v2.ts:510` and `server/routes/mcp/chat-v2.ts:625` reference the removed field (server routes are esbuild-bundled and `server/tsconfig.json` is not a CI gate); the server slice deletes exactly those reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes tool-call routing and approval behavior on all non-agent chat surfaces; wrong assumptions could strand turns or let inspector UI tools leak into chatbox/end-user contexts.
> 
> **Overview**
> **MCPJam `ui_*` tools are no longer advertised or fulfilled on generic chat-v2 surfaces** (hosted direct chat, chatbox preview/share, playground via `useChatSession`). Only the Ask MCPJam agent path (`agent-chat-instances` → `/api/web/mcpjam-agent`) is intended to ship and run the first-party UI catalog.
> 
> `use-chat-session.ts` drops the `uiTools` POST snapshot (including the old chatbox-only omission), removes `handleUiToolCall` from `onToolCall`, and deletes UI-specific approval handling (the UI-aware `addToolApprovalResponse` wrapper and orphaned-defer effect). Consumers get plain `addToolApprovalResponse` again; SEP-1865 **app** alias fulfillment is unchanged.
> 
> **Provenance, not a name ban:** a server MCP tool named `ui_*` is not intercepted in the generic hook—it falls through like any other server tool even if the local registry has a same-named entry.
> 
> `UiToolSnapshotEntry` and `uiTools` are removed from `ChatV2Request` in `shared/chat-v2.ts` and moved to `shared/mcpjam-ui-tools.ts`, documented as the mcpjam-agent wire type. Import paths in `ui-tools-registry.ts` and `chat-v2-orchestration.ts` follow.
> 
> Tests in `use-chat-session.hosted.test.tsx` assert `uiTools` is absent on all surfaces and that `ui_server_action` does not run registry `execute` or call `addToolOutput`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f7752ac6810f87c4e1c42929f3d4c466411a2d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops sending and handling MCPJam `ui_*` tools from generic chat surfaces. Only the Ask MCPJam agent (`agent-chat-instances.ts` → `POST /api/web/mcpjam-agent`) now advertises and fulfills the UI tool catalog.

- **Refactors**
  - Removed `uiTools` snapshot and all UI tool handling from `use-chat-session` (no `handleUiToolCall`, no UI-aware approval wrapper; returns plain `addToolApprovalResponse`).
  - Server-origin `ui_*` tool calls now fall through `onToolCall` like any other MCP tool and execute server-side.
  - Deleted `uiTools` from `ChatV2Request`; moved `UiToolSnapshotEntry` to `shared/mcpjam-ui-tools.ts` and updated imports.
  - Mixed-version safe: older clients may still POST `uiTools`; server ignores it.

<sup>Written for commit 8f7752ac6810f87c4e1c42929f3d4c466411a2d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

