### PR TITLE
chat-v2: ignore client uiTools; server tools win ui_* name collisions

### DIFF
--- a/mcpjam-inspector/server/routes/mcp/__tests__/chat-v2.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/chat-v2.test.ts
@@ -861,6 +861,77 @@ describe("POST /api/mcp/chat-v2", () => {
     });
   });
 
+  describe("uiTools boundary (agent-route-only)", () => {
+    it("ignores a client uiTools snapshot: 200, no ui_* entry advertised, no UI prompt section", async () => {
+      const { streamText } = await import("ai");
+      manager.getToolsForAiSdk.mockResolvedValue({
+        legit_tool: { description: "Server tool", execute: vi.fn() },
+      });
+
+      const res = await postJson(app, "/api/mcp/chat-v2", {
+        messages: [{ role: "user", content: "Hello" }],
+        model: { id: "gpt-4", provider: "openai" },
+        apiKey: "test-key",
+        // Stale snapshot a cached pre-cutover client may still send. The
+        // route must ignore it (never 400) for mixed-version safety.
+        uiTools: [
+          { name: "ui_navigate", description: "Navigate", readOnly: false },
+        ],
+      });
+
+      expect(res.status).toBe(200);
+      const options = vi.mocked(streamText).mock.calls.at(-1)![0] as {
+        tools: Record<string, unknown>;
+        system?: string;
+      };
+      expect(
+        Object.keys(options.tools).filter((name) => /^ui_/.test(name))
+      ).toEqual([]);
+      expect(options.system ?? "").not.toContain("MCPJam UI tools");
+    });
+
+    it("a server tool named ui_navigate stays executable with ordinary approval — never claimed by a stale UI snapshot", async () => {
+      const { streamText } = await import("ai");
+      const serverExecute = vi.fn();
+      manager.getToolsForAiSdk.mockResolvedValue({
+        ui_navigate: {
+          description: "Server-executed tool that uses the ui_ prefix",
+          execute: serverExecute,
+        },
+      });
+
+      const res = await postJson(app, "/api/mcp/chat-v2", {
+        messages: [{ role: "user", content: "Hello" }],
+        model: { id: "gpt-4", provider: "openai" },
+        apiKey: "test-key",
+        requireToolApproval: true,
+        uiTools: [
+          { name: "ui_navigate", description: "Stale twin", readOnly: false },
+        ],
+      });
+
+      expect(res.status).toBe(200);
+      const options = vi.mocked(streamText).mock.calls.at(-1)![0] as {
+        tools: Record<string, { execute?: unknown; needsApproval?: unknown }>;
+        system?: string;
+      };
+      // Provenance decides: the manager-origin tool stays executable — it
+      // was never replaced by a no-execute client-fulfilled entry. (The
+      // engine wraps execute for error surfacing, so assert executability
+      // rather than reference identity.)
+      expect(typeof options.tools["ui_navigate"]?.execute).toBe("function");
+      // No MCPJam UI system-prompt section and no UI approval
+      // classification: the tool follows the normal requireToolApproval
+      // flag, which the route threads into the manager's SDK conversion.
+      expect(options.system ?? "").not.toContain("MCPJam UI tools");
+      expect(manager.getToolsForAiSdk).toHaveBeenCalledWith(
+        undefined,
+        expect.objectContaining({ needsApproval: true })
+      );
+      expect(options.tools["ui_navigate"]?.needsApproval).toBeUndefined();
+    });
+  });
+
   describe("error handling", () => {
     it("returns 500 when getToolsForAiSdk fails", async () => {
       manager.getToolsForAiSdk.mockRejectedValue(

--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -43,12 +43,9 @@ import {
   prepareChatV2,
   validateAppToolEntries,
   AppToolValidationError,
-  validateUiToolEntries,
-  UiToolValidationError,
   validateWidgetModelContextEntries,
   WidgetModelContextValidationError,
 } from "../../utils/chat-v2-orchestration";
-import { classifyUiToolApprovals } from "@/shared/client-fulfilled-tools";
 import {
   formatProviderOverloadError,
   isProviderOverloadError,
@@ -614,32 +611,12 @@ chatV2.post("/", async (c) => {
       throw error;
     }
 
-    // WebMCP UI tools: same boundary treatment as appTools. Chatbox-bound
-    // turns (owner preview persists as `sourceType: "chatbox"`) never accept
-    // them — ui_* tools drive the inspector UI, which is not part of the
-    // chatbox surface, so a stale or tampered client snapshot must not
-    // re-advertise them here.
-    let validatedUiTools;
-    if (!isChatboxSession) {
-      try {
-        validatedUiTools = validateUiToolEntries(body.uiTools);
-      } catch (error) {
-        if (error instanceof UiToolValidationError) {
-          return c.json({ error: error.message }, 400);
-        }
-        throw error;
-      }
-    }
-
-    // Per-tool `ui_*` approval policy for this turn. The BYOK `streamText`
-    // path reads it off each tool's `needsApproval` (set by `buildUiTools`);
-    // the MCPJam/org loops re-implement approval on top of a proxied stream,
-    // so they need the classification passed explicitly or destructive UI
-    // tools would execute unconfirmed whenever `requireToolApproval` is off.
-    const uiToolApprovals = classifyUiToolApprovals(
-      validatedUiTools,
-      requireToolApproval === true,
-    );
+    // `body.uiTools` is intentionally ignored here, not rejected: MCPJam UI
+    // tools are agent-route-only (server/routes/web/mcpjam-agent.ts), but
+    // cached pre-cutover clients may still send the field. Without a
+    // validated snapshot no MCPJam UI approval/free-name classification
+    // exists on this route — an MCP server tool named `ui_*` is a normal
+    // executable tool with ordinary approval semantics.
 
     let validatedWidgetModelContext;
     try {
@@ -755,7 +732,6 @@ chatV2.post("/", async (c) => {
             }
           : {}),
         appTools: validatedAppTools,
-        uiTools: validatedUiTools,
       });
     } catch (error) {
       // prepareChatV2 throws on Anthropic validation errors — return 400.
@@ -858,7 +834,6 @@ chatV2.post("/", async (c) => {
         mcpClientManager,
         selectedServers,
         requireToolApproval,
-        uiToolApprovals,
         modelVisibleMcpToolResults,
         ...(resolvedExecution.harness
           ? {
@@ -1077,7 +1052,6 @@ chatV2.post("/", async (c) => {
         selectedServers,
         serverIds: hostConfigServerIds,
         requireToolApproval,
-        uiToolApprovals,
         modelVisibleMcpToolResults,
         abortSignal: inboundAbortSignalOrg,
         onConversationComplete,

--- a/mcpjam-inspector/server/routes/web/__tests__/chat-v2.hosted.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chat-v2.hosted.test.ts
@@ -295,8 +295,9 @@ describe("web routes — chat-v2 hosted mode", () => {
     expect(persistArgs.hostConfig).toBeUndefined();
   });
 
-  it("validates uiTools on direct turns but strips them from chatbox-bound turns", async () => {
+  it("ignores a client uiTools snapshot on direct AND chatbox turns (agent-route-only, never rejected)", async () => {
     const { app, token } = createWebTestApp();
+    // Non-empty/stale snapshot a cached pre-cutover client may still send.
     const uiTools = [
       { name: "ui_navigate", description: "Navigate", readOnly: false },
     ];
@@ -309,20 +310,18 @@ describe("web routes — chat-v2 hosted mode", () => {
       uiTools,
     };
 
-    // Direct hosted chat: the snapshot crosses the validation boundary and
-    // reaches prepareChatV2.
+    // Direct hosted chat: the field is dropped at the boundary — never
+    // validated (a malformed snapshot must not 400 the turn) and never
+    // forwarded into prepareChatV2.
     const direct = await postJson(app, "/api/web/chat-v2", baseBody, token);
     expect(direct.status).toBe(200);
-    expect(validateUiToolEntriesMock).toHaveBeenCalledWith(uiTools);
-    // The route forwards the validator's return value (the mock yields []).
-    expect(prepareChatV2Mock).toHaveBeenLastCalledWith(
-      expect.objectContaining({ uiTools: [] })
-    );
-    const directValidateCalls = validateUiToolEntriesMock.mock.calls.length;
+    expect(validateUiToolEntriesMock).not.toHaveBeenCalled();
+    // streamWebChatTurn's uiTools plumbing stays (the agent route uses it),
+    // so the key exists — but this route never populates the snapshot.
+    let prepareArgs = prepareChatV2Mock.mock.calls.at(-1)![0];
+    expect(prepareArgs.uiTools).toBeUndefined();
 
-    // Chatbox-bound turn: ui_* tools drive the inspector UI, which is not
-    // part of the chatbox surface — the snapshot is ignored wholesale (not
-    // even validated), so a stale/tampered client can't re-advertise them.
+    // Chatbox-bound turn: same silent-ignore treatment.
     const chatbox = await postJson(
       app,
       "/api/web/chat-v2",
@@ -330,12 +329,9 @@ describe("web routes — chat-v2 hosted mode", () => {
       token
     );
     expect(chatbox.status).toBe(200);
-    expect(validateUiToolEntriesMock.mock.calls.length).toBe(
-      directValidateCalls
-    );
-    expect(prepareChatV2Mock).toHaveBeenLastCalledWith(
-      expect.objectContaining({ uiTools: undefined })
-    );
+    expect(validateUiToolEntriesMock).not.toHaveBeenCalled();
+    prepareArgs = prepareChatV2Mock.mock.calls.at(-1)![0];
+    expect(prepareArgs.uiTools).toBeUndefined();
   });
 
   // PR3: host-bound direct session (Playground previewing a saved host).

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -18,8 +18,6 @@ import { getConvexBearerForRequest } from "../../utils/v1-convex-token.js";
 import {
   validateAppToolEntries,
   AppToolValidationError,
-  validateUiToolEntries,
-  UiToolValidationError,
   validateWidgetModelContextEntries,
   WidgetModelContextValidationError,
 } from "../../utils/chat-v2-orchestration.js";
@@ -500,25 +498,11 @@ chatV2.post("/", async (c) => {
       throw error;
     }
 
-    // WebMCP UI tools: same boundary treatment as appTools. Chatbox-bound
-    // turns never accept them — ui_* tools drive the inspector UI, which is
-    // not part of the published/preview chatbox surface, so a stale or
-    // tampered client snapshot must not re-advertise them here.
-    let validatedUiTools;
-    if (!isChatboxSession) {
-      try {
-        validatedUiTools = validateUiToolEntries(body.uiTools);
-      } catch (error) {
-        if (error instanceof UiToolValidationError) {
-          throw new WebRouteError(
-            400,
-            ErrorCode.VALIDATION_ERROR,
-            error.message
-          );
-        }
-        throw error;
-      }
-    }
+    // `body.uiTools` is intentionally ignored here, not rejected: MCPJam UI
+    // tools are agent-route-only (server/routes/web/mcpjam-agent.ts), but
+    // cached pre-cutover clients may still send the field. MCP server tools
+    // whose names happen to match `ui_*` come from MCPClientManager and stay
+    // ordinary executable tools.
 
     let validatedWidgetModelContext;
     try {
@@ -581,7 +565,6 @@ chatV2.post("/", async (c) => {
               }
             : {}),
           appTools: validatedAppTools,
-          uiTools: validatedUiTools,
           widgetModelContext: validatedWidgetModelContext,
           ...(builtInTools ? { builtInTools } : {}),
           ...(cloudSkillsEnabled

--- a/mcpjam-inspector/server/utils/__tests__/chat-v2-orchestration.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/chat-v2-orchestration.test.ts
@@ -1002,12 +1002,13 @@ describe("prepareChatV2 — WebMCP UI tools", () => {
     expect(entry.description).toContain("Navigate the MCPJam inspector");
   });
 
-  it("drops a same-named MCP server tool with a warn (UI tool wins)", async () => {
+  it("keeps a same-named MCP server tool executable (server tool wins) and omits the UI twin", async () => {
+    const serverExecute = vi.fn();
     const manager = mockManager({
       ui_navigate: {
-        description: "Sneaky third-party tool squatting the ui_ prefix",
+        description: "Server tool that legitimately uses the ui_ prefix",
         _serverId: "server-x",
-        execute: vi.fn(),
+        execute: serverExecute,
       },
       legit_tool: {
         description: "Unrelated server tool",
@@ -1023,10 +1024,69 @@ describe("prepareChatV2 — WebMCP UI tools", () => {
       uiTools,
     });
 
+    // The server's executable tool survives untouched — a connected server
+    // never loses a capability over MCPJam's guessable catalog name.
     const entry = result.allTools["ui_navigate"] as { execute?: unknown };
-    // The UI (no-execute) twin won; the MCP tool's execute is gone.
-    expect(entry.execute).toBeUndefined();
+    expect(entry.execute).toBe(serverExecute);
     expect(result.allTools["legit_tool"]).toBeDefined();
+    // The client-fulfilled twin is gone from the effective set (and thus
+    // from approval classification); the non-colliding UI tool remains.
+    expect(result.effectiveUiTools.map((t) => t.name)).toEqual([
+      "ui_snapshot_app",
+    ]);
+    // The effective UI prompt never mentions the discarded UI tool.
+    expect(result.enhancedSystemPrompt).toContain("MCPJam UI tools");
+    expect(result.enhancedSystemPrompt).toContain("ui_snapshot_app");
+    expect(result.enhancedSystemPrompt).not.toContain("Navigate the MCPJam");
+  });
+
+  it("a non-colliding server ui_* tool coexists with the UI catalog and keeps execute", async () => {
+    const serverExecute = vi.fn();
+    const manager = mockManager({
+      ui_render: {
+        description: "Server-side renderer",
+        _serverId: "server-x",
+        execute: serverExecute,
+      },
+    });
+
+    const result = await prepareChatV2({
+      mcpClientManager: manager,
+      selectedServers: ["server-x"],
+      modelDefinition: { id: "gpt-4.1", provider: "openai" } as any,
+      systemPrompt: "Base prompt.",
+      uiTools,
+    });
+
+    expect(
+      (result.allTools["ui_render"] as { execute?: unknown }).execute
+    ).toBe(serverExecute);
+    // Both UI entries survive: provenance, not the ui_ prefix, decides.
+    expect(result.effectiveUiTools.map((t) => t.name).sort()).toEqual([
+      "ui_navigate",
+      "ui_snapshot_app",
+    ]);
+    expect(
+      (result.allTools["ui_navigate"] as { execute?: unknown }).execute
+    ).toBeUndefined();
+  });
+
+  it("emits no UI prompt section when every UI entry loses its collision", async () => {
+    const manager = mockManager({
+      ui_navigate: { description: "srv", _serverId: "s", execute: vi.fn() },
+      ui_snapshot_app: { description: "srv", _serverId: "s", execute: vi.fn() },
+    });
+
+    const result = await prepareChatV2({
+      mcpClientManager: manager,
+      selectedServers: ["s"],
+      modelDefinition: { id: "gpt-4.1", provider: "openai" } as any,
+      systemPrompt: "Base prompt.",
+      uiTools,
+    });
+
+    expect(result.effectiveUiTools).toEqual([]);
+    expect(result.enhancedSystemPrompt).toBe("Base prompt.");
   });
 
   it("fails closed when a built-in collides with a UI tool", async () => {
@@ -1097,7 +1157,11 @@ describe("prepareChatV2 — WebMCP UI tools", () => {
       uiTools,
     });
     expect(withUiTools.enhancedSystemPrompt).toContain("MCPJam UI tools");
-    expect(withUiTools.enhancedSystemPrompt).toContain("ui_execute_tool");
+    // Guidance only names tools actually in the effective set — the fixture
+    // has ui_snapshot_app but not ui_execute_tool, so the playground
+    // walkthrough sentence must be absent.
+    expect(withUiTools.enhancedSystemPrompt).toContain("ui_snapshot_app");
+    expect(withUiTools.enhancedSystemPrompt).not.toContain("ui_execute_tool");
 
     const withoutUiTools = await prepareChatV2({
       mcpClientManager: manager,

--- a/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
+++ b/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
@@ -775,21 +775,38 @@ export function buildUiTools(
 
 /**
  * System-prompt section advertising the UI tools. Empty when none were
- * snapshotted, so surfaces without UI tools keep a byte-identical prompt.
+ * snapshotted — or when none survived collision resolution — so surfaces
+ * without UI tools keep a byte-identical prompt. Callers must pass the
+ * EFFECTIVE entry set for the turn: each sentence naming specific catalog
+ * tools is gated on every tool it mentions being present, so the prompt
+ * never tells the model to call a UI tool that isn't advertised.
  */
 export function buildUiToolsSystemPrompt(
   uiTools: UiToolEntry[] | undefined,
   opts?: { requireToolApproval?: boolean }
 ): string {
   if (!uiTools || uiTools.length === 0) return "";
-  return [
+  const names = new Set(uiTools.map((t) => t.name));
+  const has = (...toolNames: string[]) => toolNames.every((n) => names.has(n));
+  const lines = [
     "## MCPJam UI tools",
     "You can drive the MCPJam inspector itself with the `ui_*` tools. Every action happens in the user's open app and is immediately visible to them.",
-    "Prefer `ui_open_playground` before `ui_select_tool` / `ui_execute_tool`. `ui_execute_tool` REALLY runs a tool against the user's connected MCP server — treat it as side-effectful; when the user hasn't clearly asked to run a tool, prefill it with `ui_select_tool` instead.",
-    "`ui_snapshot_app` is read-only and works from anywhere — use it to see where the user is and what is selected before acting, rather than assuming.",
+  ];
+  if (has("ui_open_playground", "ui_select_tool", "ui_execute_tool")) {
+    lines.push(
+      "Prefer `ui_open_playground` before `ui_select_tool` / `ui_execute_tool`. `ui_execute_tool` REALLY runs a tool against the user's connected MCP server — treat it as side-effectful; when the user hasn't clearly asked to run a tool, prefill it with `ui_select_tool` instead."
+    );
+  }
+  if (has("ui_snapshot_app")) {
+    lines.push(
+      "`ui_snapshot_app` is read-only and works from anywhere — use it to see where the user is and what is selected before acting, rather than assuming."
+    );
+  }
+  lines.push(
     "When a `ui_*` tool returns an error, relay the reason instead of retrying blindly.",
-    approvalGuidance(uiTools, opts?.requireToolApproval === true),
-  ].join("\n");
+    approvalGuidance(uiTools, opts?.requireToolApproval === true)
+  );
+  return lines.join("\n");
 }
 
 /**
@@ -826,6 +843,14 @@ export interface PrepareChatV2Result {
    */
   progressivePlan: ProgressiveToolPlan;
   discoveryState: ToolDiscoveryState;
+  /**
+   * MCPJam UI tool entries that survived collision resolution against the
+   * loaded MCP tools (server tool wins an exact `ui_*` name collision).
+   * Approval classification for client-fulfilled UI calls must use THIS set,
+   * never the raw snapshot — a server-executed tool named `ui_navigate` must
+   * not inherit MCPJam UI approval semantics from a discarded client entry.
+   */
+  effectiveUiTools: UiToolEntry[];
 }
 
 /**
@@ -949,21 +974,26 @@ export async function prepareChatV2(
   // `app_<8hex>` namespace is opaque and disjoint from both).
   const appToolEntries = buildAppTools(appTools);
   // WebMCP UI tools — client-fulfilled like app tools, but with curated
-  // `ui_*` names instead of opaque aliases.
-  const uiToolEntries = buildUiTools(uiTools, { requireToolApproval });
-  const builtInToolEntries = builtInTools ?? {};
-  // UI tools are host-curated like built-ins, but `ui_` is a guessable
-  // prefix any third-party MCP server could ship — failing closed would let
-  // such a server brick every chat turn for the user. Same policy as
-  // built-ins: the UI tool wins and the MCP twin is dropped with a warn.
-  for (const name of Object.keys(uiToolEntries)) {
-    if (Object.prototype.hasOwnProperty.call(mcpTools, name)) {
-      logger.warn(
-        `[chat-v2] UI tool '${name}' shadows an MCP tool with the same name; using the UI tool`,
-      );
-      delete mcpTools[name];
+  // `ui_*` names instead of opaque aliases. `ui_` is a guessable prefix any
+  // MCP server may legitimately ship, so on an exact name collision the
+  // genuine server tool wins: the MCPJam UI entry is omitted for this turn
+  // (with a warn) and the server tool keeps its execute + ordinary approval
+  // semantics. A connected server must never lose a capability because
+  // MCPJam's first-party catalog picked the same name. Everything UI-scoped
+  // downstream — ToolSet entries, system prompt, discovery exemption,
+  // approval classification — derives from this effective set, never the
+  // raw snapshot.
+  const effectiveUiTools = (uiTools ?? []).filter((entry) => {
+    if (!Object.prototype.hasOwnProperty.call(mcpTools, entry.name)) {
+      return true;
     }
-  }
+    logger.warn(
+      `[chat-v2] MCP server tool '${entry.name}' collides with the MCPJam UI tool of the same name; keeping the server tool and omitting the UI entry for this turn`,
+    );
+    return false;
+  });
+  const uiToolEntries = buildUiTools(effectiveUiTools, { requireToolApproval });
+  const builtInToolEntries = builtInTools ?? {};
   // Collision policy, per origin:
   //  - MCP tools: the built-in wins and the server tool is dropped with a
   //    warn. Built-ins are the host's explicit catalog choice, and the
@@ -1093,7 +1123,7 @@ export async function prepareChatV2(
   const enhancedSystemPrompt = [
     systemPrompt,
     skillsPromptSection,
-    buildUiToolsSystemPrompt(uiTools, { requireToolApproval }),
+    buildUiToolsSystemPrompt(effectiveUiTools, { requireToolApproval }),
   ]
     .filter((section): section is string => Boolean(section?.trim()))
     .map((section) => section.trim())
@@ -1123,5 +1153,6 @@ export async function prepareChatV2(
     scrubMessages,
     progressivePlan,
     discoveryState,
+    effectiveUiTools,
   };
 }

--- a/mcpjam-inspector/server/utils/web-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/web-chat-turn.ts
@@ -251,10 +251,12 @@ export function stripUiContextModelParts(
 /**
  * Per-tool approval policy for this turn's `ui_*` tools, from the VALIDATED
  * snapshot's MCP annotations — never from the raw name, which a third-party
- * server could spoof. Consumed by the MCPJam loop's approval gate (see
- * `toolCallNeedsApproval` in mcpjam-stream-handler); the BYOK `streamText`
- * path gets the same policy baked into each tool's `needsApproval` by
- * `buildUiTools`.
+ * server could spoof. Must be fed prepareChatV2's `effectiveUiTools` (the
+ * post-collision set), not the raw snapshot: a server-executed `ui_*` tool
+ * that won its name collision follows ordinary approval semantics. Consumed
+ * by the MCPJam loop's approval gate (see `toolCallNeedsApproval` in
+ * mcpjam-stream-handler); the BYOK `streamText` path gets the same policy
+ * baked into each tool's `needsApproval` by `buildUiTools`.
  */
 function uiToolApprovalsFrom(
   uiTools: UiToolEntry[] | undefined,
@@ -336,6 +338,7 @@ export async function streamWebChatTurn(
     scrubMessages,
     progressivePlan,
     discoveryState,
+    effectiveUiTools,
   } = prepared;
 
   /**
@@ -602,7 +605,7 @@ export async function streamWebChatTurn(
       serverIds: persist.selectedServerIds,
       requireToolApproval: persist.requireToolApproval,
       uiToolApprovals: uiToolApprovalsFrom(
-        prepare.uiTools,
+        effectiveUiTools,
         persist.requireToolApproval
       ),
       modelVisibleMcpToolResults: prepare.modelVisibleMcpToolResults,
@@ -667,7 +670,7 @@ export async function streamWebChatTurn(
     selectedServers: persist.selectedServerIds,
     requireToolApproval: persist.requireToolApproval,
     uiToolApprovals: uiToolApprovalsFrom(
-        prepare.uiTools,
+        effectiveUiTools,
         persist.requireToolApproval
       ),
     modelVisibleMcpToolResults: prepare.modelVisibleMcpToolResults,


### PR DESCRIPTION
## What

Server slice of restricting MCPJam's WebMCP UI tools to the "Ask MCPJam" agent surfaces.

- **MCPJam UI tools are agent-route-only.** The only route that accepts and validates the client `uiTools` snapshot is `POST /api/web/mcpjam-agent`. Both chat-v2 routes (`/api/web/chat-v2`, `/api/mcp/chat-v2`) now drop the field at the boundary.
- **Ignored, not rejected.** For mixed-version safety, a stale/cached pre-cutover client that still sends `uiTools` gets a normal 200 turn — the field is never validated and never 400s the request. The MCP route also stops computing/forwarding `uiToolApprovals` (the handler options were already optional).
- **Collision policy reversed: the server tool wins.** `prepareChatV2` used to delete a same-named MCP server tool in favor of the client-fulfilled UI entry. `ui_` is a guessable prefix any server may legitimately use, so a connected server must never lose a capability to MCPJam's catalog naming. Now the executable server tool stays and the colliding MCPJam UI entry is omitted for the turn with a structured warn.
- **`effectiveUiTools` on `PrepareChatV2Result`.** The post-collision set drives the no-execute ToolSet entries, the UI system-prompt section (now truthful: guidance sentences only name tools actually present; no section at all when none survive), the progressive-discovery exemption, and the approval classification at both `streamWebChatTurn` handler call sites — so a server-executed `ui_navigate` never inherits MCPJam UI approval semantics from a discarded client entry.
- **Provenance, not prefix, is the invariant.** Client-fulfilled status is established by a validated snapshot entry materialized as a no-execute ToolSet entry, never by the `ui_*` name shape alone. An MCP server tool named `ui_*` is a normal executable tool on every surface.

## Tests

- Web hosted route: non-empty `uiTools` on direct AND chatbox bodies → 200, validator never called, prepare input has no snapshot.
- MCP route: bypass test (no `ui_*` advertised, no UI prompt marker) + collision test (server `ui_navigate` stays executable with ordinary `requireToolApproval`, no UI prompt/classification).
- Orchestration: server-preserving collision tests (coexisting `ui_render`, exact-collision `ui_navigate`, all-collide → empty prompt section) replacing the old UI-wins tests; truthful-prompt assertions.
- All 8 focused server/shared suites green (273 tests); server tsc error set byte-identical to the origin/main baseline; `typecheck:client` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes tool advertisement, approval semantics, and collision behavior on core chat paths; mixed-version clients are handled gracefully but agent vs playground behavior shifts.
> 
> **Overview**
> Restricts **MCPJam WebMCP `ui_*` tools** to the agent route (`mcpjam-agent`); **both chat-v2 routes** (`/api/web/chat-v2`, `/api/mcp/chat-v2`) now **drop `body.uiTools`** instead of validating or forwarding it. Stale clients still sending the field get **200** (no 400), and the MCP route no longer passes **`uiToolApprovals`**.
> 
> **`prepareChatV2`** reverses name-collision policy: on an exact **`ui_*` clash**, the **MCP server tool stays executable** and the client UI catalog entry is omitted for the turn. It exposes **`effectiveUiTools`** so prompts, tool registration, and approval classification only reflect tools that survived collision—**`web-chat-turn`** uses that set instead of the raw snapshot. **`buildUiToolsSystemPrompt`** only mentions catalog tools actually in the effective set.
> 
> Tests cover route boundaries, server `ui_navigate` vs stale snapshots, and orchestration collision/prompt behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70af0c544d33807cf115589605326107e3d2d305. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts MCPJam UI tools to the agent route and makes server tools win any `ui_*` name collisions, so server capabilities are never shadowed. chat-v2 routes now ignore client `uiTools` snapshots, and prompt/approval logic derives from the post-collision `effectiveUiTools`.

- **Refactors**
  - `/api/web/chat-v2` and `/api/mcp/chat-v2` drop `uiTools` at the boundary — ignored, not rejected (mixed-version safe).
  - Collision policy reversed in `prepareChatV2`: a server tool keeps execute on exact `ui_*` name matches; the UI twin is omitted with a warn.
  - `effectiveUiTools` added to `PrepareChatV2Result` and used for UI ToolSet entries, the system prompt, discovery exemptions, and approval gating (replacing route-level `uiToolApprovals` plumbing).
  - UI prompt lines are gated by the effective set; the section is omitted when none survive.

<sup>Written for commit 70af0c544d33807cf115589605326107e3d2d305. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

