### PR TITLE
chore(changesets): add unreleased SDK v2 / inspector batch / CLI+widget entries

### DIFF
--- a/.changeset/cli-widget-sdk-v2-alignment.md
+++ b/.changeset/cli-widget-sdk-v2-alignment.md
@@ -1,0 +1,6 @@
+---
+"@mcpjam/cli": patch
+"@mcpjam/widget-react": patch
+---
+
+Align with the `@mcpjam/sdk` v2 (`@modelcontextprotocol` beta.4) migration.

--- a/.changeset/inspector-unreleased-batch.md
+++ b/.changeset/inspector-unreleased-batch.md
@@ -1,0 +1,12 @@
+---
+"@mcpjam/inspector": minor
+---
+
+Inspector feature batch since the last release:
+
+- WebMCP agent tool surfaces: hosts, computer, chatboxes, swarms, evals, registry, primitives (resources/prompts/tools), playground, plus surface tool-group foundation and outcome telemetry.
+- The in-app agent acts only through the UI: app map from surface manifests, per-turn location, cross-screen observation, and annotation-gated `ui_*` approval.
+- Swarm journeys: live SSE streaming, evals-style matrix, journey-scoped server groups, persona avatars, and anonymous personal-org access.
+- Dynamic model catalog served in hosted mode and to the client, with guests un-gated.
+- Hosted elicitation: form dialog, URL consent, gating, and `-32042` surfacing, plus the client-capability toggle.
+- User-facing "Hosts" → "Clients" rename and assorted fixes (sidebar sign-in in local/npx, Connect nav overlap, tri-selector active state, logger copy button, upload-quota enforcement).

--- a/.changeset/sdk-v2-beta4-migration.md
+++ b/.changeset/sdk-v2-beta4-migration.md
@@ -1,0 +1,11 @@
+---
+"@mcpjam/sdk": major
+---
+
+Migrate to `@modelcontextprotocol` v2 (beta.4) and route modern connections through the official Client (Phase 1A/1B/1C).
+
+BREAKING:
+- Modern (non-legacy) connections now go through the upstream official `Client` rather than the in-house preview path.
+- The stateless preview client has been removed.
+- Version negotiation is resolved via `resolveVersionNegotiation` (pin → versionNegotiation).
+- MCP error codes are centralized, including the renumbered 2026-07-28 codes.


### PR DESCRIPTION
Adds three changeset entries documenting already-landed work, so the next release-please/changesets version bump is correct. No source changes.

## Changesets
- **`@mcpjam/sdk` (major)** — v2 (`@modelcontextprotocol` beta.4) migration; modern connections routed through the official `Client`; stateless preview client removed; centralized MCP error codes (2026-07-28 renumbering).
- **`@mcpjam/inspector` (minor)** — WebMCP agent tool surfaces, UI-only agent, swarm journeys (live SSE + matrix), dynamic model catalog, hosted elicitation, Hosts→Clients rename + fixes.
- **`@mcpjam/cli` + `@mcpjam/widget-react` (patch)** — align with the SDK v2 migration.

## Notes
- Changeset-only PR — no code touched.
- Bump levels reflect the nature of each package's shipped work (SDK breaking → major; inspector features → minor; CLI/widget alignment → patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata only; no runtime or behavioral changes in this diff.
> 
> **Overview**
> Adds **three changeset entries** so the next release-please/changesets run picks up version bumps for work that already shipped—**no application code** in this PR.
> 
> **`@mcpjam/sdk` (major)** records the v2 `@modelcontextprotocol` beta.4 migration: modern connections via the official `Client`, removal of the stateless preview client, `resolveVersionNegotiation`, and centralized MCP error codes (2026-07-28 renumbering).
> 
> **`@mcpjam/inspector` (minor)** batches WebMCP surfaces, UI-only agent behavior, swarm journeys, dynamic model catalog, hosted elicitation, Hosts→Clients rename, and related fixes.
> 
> **`@mcpjam/cli` and `@mcpjam/widget-react` (patch)** note alignment with the SDK v2 migration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 314b08e0820cd05e4ba166c95c4b44411c7061c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds changeset entries so the next release captures the SDK v2 migration, inspector feature batch, and CLI/widget alignment. No source changes.

- **Changesets**
  - `@mcpjam/sdk` (major): migrate to `@modelcontextprotocol` v2 (beta.4); route modern connections via official `Client`; remove stateless preview client; centralize MCP error codes.
  - `@mcpjam/inspector` (minor): WebMCP surfaces; UI-only in-app agent; swarm journeys (live SSE + matrix); dynamic model catalog; hosted elicitation; rename "Hosts" → "Clients" with fixes.
  - `@mcpjam/cli` and `@mcpjam/widget-react` (patch): align with SDK v2.

<sup>Written for commit 314b08e0820cd05e4ba166c95c4b44411c7061c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

