### PR TITLE
fix(ci): bump smoke-test MCP v2 pin to 2.0.0-beta.4

### DIFF
--- a/.github/scripts/smoke-packed-npm-packages.mjs
+++ b/.github/scripts/smoke-packed-npm-packages.mjs
@@ -4,7 +4,7 @@ import path from "node:path";
 import { spawn, spawnSync } from "node:child_process";
 
 const rootDir = process.cwd();
-const expectedMcpV2PackageVersion = "2.0.0-alpha.2";
+const expectedMcpV2PackageVersion = "2.0.0-beta.4";
 const expectedMcpV2Packages = [
   "@modelcontextprotocol/client",
   "@modelcontextprotocol/node",


### PR DESCRIPTION
## What

The `Smoke packed npm packages` CI job hardcodes an exact expected version for the MCP v2 packages:

```js
// .github/scripts/smoke-packed-npm-packages.mjs
const expectedMcpV2PackageVersion = "2.0.0-alpha.2";
```

`readExpectedMcpV2Versions()` throws if any publishable package's pin for `@modelcontextprotocol/{client,node,server}` isn't *exactly* that string. The SDK/CLI/inspector deps were since bumped to `2.0.0-beta.4`, so the assertion fires on the first spec it reads:

```
Error: @mcpjam/sdk must pin @modelcontextprotocol/client to 2.0.0-alpha.2, got "2.0.0-beta.4".
```

## Fix

Bump the constant to `2.0.0-beta.4` to match the actual pins. Verified all three packages (`client`/`node`/`server`) across `sdk`, `cli`, and `mcpjam-inspector` resolve uniformly to `2.0.0-beta.4`.

## Note

This guard is deliberately strict (exact pin, lockstep across all packages), so every MCP v2 bump must also touch this constant. If bumps stay frequent, worth deriving the expected version from the SDK's `package.json` instead of hardcoding — left out of this fix to keep it minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant change in a CI smoke script; no runtime or production code paths affected.
> 
> **Overview**
> Updates the **Smoke packed npm packages** CI script so its hardcoded MCP v2 version matches the repo’s exact pins on `@modelcontextprotocol/client`, `node`, and `server`.
> 
> `expectedMcpV2PackageVersion` moves from `2.0.0-alpha.2` to **`2.0.0-beta.4`**, aligning with `sdk`, `cli`, and `mcpjam-inspector` and stopping `readExpectedMcpV2Versions()` from failing when it compares workspace `package.json` specs to the stale constant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fb213a817a514d5e8ad9ba3a4597307a1e189b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the smoke test’s expected MCP v2 version to 2.0.0-beta.4 (from 2.0.0-alpha.2) for `@modelcontextprotocol/{client,node,server}`, matching current pins in `sdk`, `cli`, and `mcpjam-inspector` and fixing the failing `Smoke packed npm packages` CI job.

<sup>Written for commit 3fb213a817a514d5e8ad9ba3a4597307a1e189b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

