### PR TITLE
Surface and configure the Swarm goal-completion judge

### DIFF
--- a/.changeset/swarm-journey-judge.md
+++ b/.changeset/swarm-journey-judge.md
@@ -1,0 +1,9 @@
+---
+"@mcpjam/inspector": minor
+---
+
+Surface and configure the Swarm goal-completion judge.
+
+- The per-session judge badge (`SessionGoalScoreBadge`) moves to the shared `session-quality` module (reusing the eval `ScoreBadge`) and now renders in the Sessions list and run matrix cells; `SwarmJudgeSection` is reachable even for sessions with no transcript.
+- The judge config type/defaults are extracted to a shared `GoalJudgeConfig` (evals re-export the historical `EvalJudgeConfig` names), so the eval `JudgesSection` is reusable.
+- New journeys expose an **Advanced → Judge** disclosure that reuses `JudgesSection` to set the judge model and auto-grade toggle (`journeys:createJourney` carries the config). Pairs with the backend `judgeConfig` snapshot + config-driven auto-run.

--- a/mcpjam-inspector/client/src/components/connection/share-usage/ShareUsageThreadDetail.tsx
+++ b/mcpjam-inspector/client/src/components/connection/share-usage/ShareUsageThreadDetail.tsx
@@ -398,6 +398,25 @@ export function ShareUsageThreadDetail({
   }
 
   if (!adaptedTrace || adaptedTrace.messages.length === 0) {
+    // A swarm session with no persisted transcript (a failed or empty attempt)
+    // must still expose the on-demand judge entry point — the verdict grades
+    // the journey goal, not the transcript. Render a minimal shell with the
+    // judge section instead of a dead-end "No messages" message.
+    if (thread.sourceType === "swarm") {
+      return (
+        <div className="flex h-full flex-col">
+          {thread.synthetic === true && thread.readiness ? (
+            <SessionInsightBar readiness={thread.readiness} />
+          ) : null}
+          <SwarmJudgeSection threadId={threadId} goalScore={thread.goalScore} />
+          <div className="flex flex-1 items-center justify-center">
+            <p className="text-sm text-muted-foreground">
+              No messages in this session
+            </p>
+          </div>
+        </div>
+      );
+    }
     return (
       <div className="flex h-full items-center justify-center">
         <p className="text-sm text-muted-foreground">No messages in thread</p>

--- a/mcpjam-inspector/client/src/components/connection/share-usage/ShareUsageThreadList.tsx
+++ b/mcpjam-inspector/client/src/components/connection/share-usage/ShareUsageThreadList.tsx
@@ -14,6 +14,7 @@ import {
   type SharedChatThread,
 } from "@/hooks/useSharedChatThreads";
 import { SessionReadinessBadge } from "@/components/chatboxes/session-readiness";
+import { SessionGoalScoreBadge } from "@/components/shared/session-quality/session-goal-score-badge";
 
 interface ShareUsageThreadListProps {
   /** Optional: when `threads` is provided (chatbox Usage panel) these are unused. */
@@ -193,6 +194,9 @@ function ThreadCard({
         {thread.synthetic === true ? (
           <SessionReadinessBadge readiness={thread.readiness} />
         ) : null}
+        {/* Judge verdict — only when a goalScore exists; absence = ungraded,
+            not "broken". readiness = "ran cleanly"; judge = "hit the goal". */}
+        <SessionGoalScoreBadge goalScore={thread.goalScore} />
       </div>
       {thread.firstMessagePreview ? (
         <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">

--- a/mcpjam-inspector/client/src/components/evals/goal-completion-card.tsx
+++ b/mcpjam-inspector/client/src/components/evals/goal-completion-card.tsx
@@ -21,12 +21,10 @@ import {
   judgeDisagreesWithVerdict,
 } from "./goal-completion-presentation";
 import { groupRunIterationsByTestCase } from "./run-case-groups";
-
-/** Managed default judge model (mirrors GOAL_COMPLETION_MODEL in the backend). */
-const DEFAULT_JUDGE_MODEL = "openai/gpt-5.4-mini";
-// A reasonable starting cutoff only — LLM-as-judge scores aren't comparable
-// across domains, so teams should recalibrate this against a labeled set.
-const DEFAULT_THRESHOLD = 0.7;
+import {
+  MANAGED_DEFAULT_JUDGE_MODEL as DEFAULT_JUDGE_MODEL,
+  DEFAULT_JUDGE_THRESHOLD as DEFAULT_THRESHOLD,
+} from "@/components/shared/session-quality/judge-config";
 
 export interface GoalCompletionCardProps {
   run: EvalSuiteRun;

--- a/mcpjam-inspector/client/src/components/evals/judges-section.tsx
+++ b/mcpjam-inspector/client/src/components/evals/judges-section.tsx
@@ -9,7 +9,10 @@ import {
 } from "@mcpjam/design-system/select";
 import { Switch } from "@mcpjam/design-system/switch";
 import type { ModelDefinition } from "@/shared/types";
-import type { EvalJudgeConfig } from "./types";
+import {
+  MANAGED_DEFAULT_JUDGE_MODEL,
+  type GoalJudgeConfig as EvalJudgeConfig,
+} from "@/components/shared/session-quality/judge-config";
 
 /**
  * Suite-level authoritative judge config. Mirrors the `ValidatorsSection`
@@ -23,8 +26,6 @@ import type { EvalJudgeConfig } from "./types";
  * `run.configSnapshot.judgeConfig` and displays it read-only; this is the
  * one place a user can change the suite contract.
  */
-
-const MANAGED_DEFAULT_JUDGE_MODEL = "openai/gpt-5.4-mini";
 
 interface JudgesSectionProps {
   value: EvalJudgeConfig | undefined;

--- a/mcpjam-inspector/client/src/components/evals/judges-section.tsx
+++ b/mcpjam-inspector/client/src/components/evals/judges-section.tsx
@@ -40,6 +40,14 @@ interface JudgesSectionProps {
    * (e.g. the suite settings sheet).
    */
   chrome?: "panel" | "bare";
+  /**
+   * Bare-chrome auto-grade row copy. Defaults to the eval-suite phrasing
+   * ("every run / each case's objective"); other products pass their own so
+   * the one shared control reads correctly in context (Swarm journeys grade
+   * "every session against the journey goal"). Ignored in panel chrome.
+   */
+  bareAutoGradeBlurb?: string;
+  bareAutoGradeAriaLabel?: string;
 }
 
 function pruneEmpty(value: EvalJudgeConfig): EvalJudgeConfig | undefined {
@@ -61,6 +69,8 @@ export function JudgesSection({
   title = "LLM as Judge",
   description = "Advisory grading of run results against rubric anchors. Calibrate per suite — scores aren't comparable across domains.",
   chrome = "panel",
+  bareAutoGradeBlurb = "Grade every run automatically against each case’s objective. Uses credits.",
+  bareAutoGradeAriaLabel = "Auto-grade every run with LLM as Judge",
 }: JudgesSectionProps) {
   const isBare = chrome === "bare";
   const gc = value?.goalCompletion;
@@ -132,8 +142,7 @@ export function JudgesSection({
             // repeat the section header. In `panel` chrome there's no outer
             // label, so we keep the sub-heading + description.
             <p className="text-[12px] text-muted-foreground">
-              Grade every run automatically against each case&apos;s
-              objective. Uses credits.
+              {bareAutoGradeBlurb}
             </p>
           ) : (
             <>
@@ -150,9 +159,7 @@ export function JudgesSection({
           checked={sectionOn}
           onCheckedChange={handleMainToggle}
           aria-label={
-            isBare
-              ? "Auto-grade every run with LLM as Judge"
-              : "Enable LLM as Judge for this suite"
+            isBare ? bareAutoGradeAriaLabel : "Enable LLM as Judge for this suite"
           }
         />
       </div>

--- a/mcpjam-inspector/client/src/components/evals/types.ts
+++ b/mcpjam-inspector/client/src/components/evals/types.ts
@@ -9,6 +9,15 @@ import type {
 } from "@/shared/eval-matching";
 import type { TraceEnvelope, TraceMessage } from "./trace-viewer-adapter";
 import type { EvalStepStatusEntry } from "./eval-stream-reducer";
+// The judge config envelope is product-neutral and shared with Swarms; the
+// canonical definition lives in the shared session-quality module. Aliased +
+// re-exported under the historical Eval* names so eval call sites are unchanged.
+import type {
+  GoalJudgeConfig as EvalJudgeConfig,
+  GoalJudgeConfigOverride as EvalJudgeConfigOverride,
+  GoalJudgeRunOverride as EvalJudgeRunOverride,
+} from "@/components/shared/session-quality/judge-config";
+export type { EvalJudgeConfig, EvalJudgeConfigOverride, EvalJudgeRunOverride };
 
 /**
  * Host identity an eval run executed against. Hand-mirrored from the Convex
@@ -265,41 +274,6 @@ export type EvalCase = {
   _creationTime?: number; // Convex auto field
 };
 
-/**
- * Suite-level judge config envelope. Currently carries goalCompletion only;
- * the envelope shape is forward-compatible with additional judges (refusal
- * judge, future serverQuality move-here, etc.) without a second pass on
- * the type surface.
- */
-export type EvalJudgeConfig = {
-  goalCompletion?: {
-    enabled?: boolean;
-    judgeModel?: string;
-    threshold?: number;
-    /**
-     * When true, the judge fires automatically as each run completes
-     * (matches the dominant industry pattern — most eval platforms run
-     * scorers inline with the eval rather than on-demand). Default off
-     * so suites preserve the cost-conscious V1 behavior until they opt in.
-     */
-    autoRun?: boolean;
-  };
-};
-
-/** Per-case judge override. Opt-out only in V1. */
-export type EvalJudgeConfigOverride = {
-  goalCompletion?: {
-    enabled?: boolean;
-  };
-};
-
-/** Per-run exploration override; persists on the run for transparency. */
-export type EvalJudgeRunOverride = {
-  goalCompletion?: {
-    judgeModel?: string;
-    threshold?: number;
-  };
-};
 
 export type EvalIteration = {
   _id: string;

--- a/mcpjam-inspector/client/src/components/shared/session-quality/judge-config.ts
+++ b/mcpjam-inspector/client/src/components/shared/session-quality/judge-config.ts
@@ -1,0 +1,46 @@
+/**
+ * Product-neutral goal-completion judge config — the client mirror of the
+ * backend `judgeConfigValidator` (mcpjam-backend `convex/lib/judgeConfig.ts`).
+ * Shared by Evals (suite-level) and Swarms (journey-level) so both surfaces
+ * drive the same `JudgesSection` UI and the same backend grader. Kept in sync
+ * with the backend validator by hand, per the two-repo layout.
+ *
+ * The envelope currently carries `goalCompletion` only, but is forward-
+ * compatible with additional judges (refusal judge, etc.) without a second
+ * pass on the type surface.
+ */
+export type GoalJudgeConfig = {
+  goalCompletion?: {
+    enabled?: boolean;
+    judgeModel?: string;
+    threshold?: number;
+    /**
+     * When true, the judge fires automatically as each run completes. Default
+     * off so surfaces preserve cost-conscious behavior until they opt in.
+     */
+    autoRun?: boolean;
+  };
+};
+
+/** Per-item judge override (per-case in Evals). Opt-out only in V1. */
+export type GoalJudgeConfigOverride = {
+  goalCompletion?: {
+    enabled?: boolean;
+  };
+};
+
+/** Per-run exploration override; persists on the run for transparency. */
+export type GoalJudgeRunOverride = {
+  goalCompletion?: {
+    judgeModel?: string;
+    threshold?: number;
+  };
+};
+
+/**
+ * Defaults mirror the backend `GOAL_COMPLETION_DEFAULTS`. The backend is the
+ * authority; these exist so the UI can render the managed default without a
+ * round-trip and select it explicitly.
+ */
+export const MANAGED_DEFAULT_JUDGE_MODEL = "openai/gpt-5.4-mini";
+export const DEFAULT_JUDGE_THRESHOLD = 0.7;

--- a/mcpjam-inspector/client/src/components/shared/session-quality/session-goal-score-badge.tsx
+++ b/mcpjam-inspector/client/src/components/shared/session-quality/session-goal-score-badge.tsx
@@ -1,0 +1,87 @@
+import { formatScore, ScoreBadge } from "./judge-presentation";
+
+/**
+ * Per-session goal-completion judge badge, shared by the Swarms sessions list,
+ * the run matrix, and the shared-chat thread list. Lives here (not in
+ * SwarmsTab) so surfaces rendered *inside* SwarmsTab's subtree can import it
+ * without an import cycle.
+ *
+ * States: completed → "82% + meets/below" (reusing the shared ScoreBadge);
+ * running → "judging…"; failed → "judge unavailable" (never silently hidden —
+ * the session viewer offers Retry); absent/malformed → nothing.
+ */
+
+// The backend denormalizes a WIDE `goalScore` subset onto sessions/threads.
+// Both `JourneySessionRow["goalScore"]` (swarm-api) and
+// `SharedChatThread["goalScore"]` (useSharedChatThreads) are structurally this.
+export type SessionGoalScoreLike = {
+  status?: string;
+  score?: number;
+  passed?: boolean;
+  threshold?: number;
+  reason?: string;
+  error?: string;
+};
+
+const GOAL_SCORE_STATUSES = ["running", "completed", "failed"] as const;
+export type GoalScoreStatus = (typeof GOAL_SCORE_STATUSES)[number];
+
+/**
+ * Validate the status enum + score before rendering so a malformed record
+ * degrades to "no badge" instead of a corrupt verdict.
+ */
+export function toSessionGoalScore(
+  raw: SessionGoalScoreLike | undefined,
+): (SessionGoalScoreLike & { status: GoalScoreStatus }) | undefined {
+  if (!raw) return undefined;
+  if (!(GOAL_SCORE_STATUSES as readonly string[]).includes(raw.status ?? "")) {
+    return undefined;
+  }
+  const status = raw.status as GoalScoreStatus;
+  // A completed verdict must carry BOTH a finite score and a boolean passed —
+  // a malformed `passed` must not silently render as "below threshold".
+  if (
+    status === "completed" &&
+    (!Number.isFinite(raw.score) || typeof raw.passed !== "boolean")
+  ) {
+    return undefined;
+  }
+  return { ...raw, status };
+}
+
+export function SessionGoalScoreBadge({
+  goalScore,
+}: {
+  goalScore: SessionGoalScoreLike | undefined;
+}) {
+  const gs = toSessionGoalScore(goalScore);
+  if (!gs) return null;
+  if (gs.status === "running") {
+    return (
+      <span className="rounded-sm bg-muted/60 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide text-muted-foreground">
+        judging…
+      </span>
+    );
+  }
+  if (gs.status === "failed") {
+    return (
+      <span
+        className="rounded-sm bg-muted/60 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide text-muted-foreground"
+        title={gs.error ?? "Judge run failed — open the session to retry"}
+      >
+        judge unavailable
+      </span>
+    );
+  }
+  // completed: reuse the shared ScoreBadge so the pass/fail chrome stays
+  // identical to the evals verdict, prefixed with the compact score.
+  return (
+    <span
+      className="inline-flex items-center gap-1 font-mono text-[10px] tabular-nums text-muted-foreground"
+      title={gs.reason ?? undefined}
+    >
+      {formatScore(gs.score ?? NaN)}
+      <ScoreBadge passed={gs.passed ?? false} />
+    </span>
+  );
+}

--- a/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
@@ -1746,8 +1746,8 @@ function NewJourneyButton({
               value={judgeConfig}
               onChange={setJudgeConfig}
               availableModels={availableModels}
-              title="Judge"
-              description="Grade each session against this journey's goal."
+              bareAutoGradeBlurb="Grade every session automatically against this journey's goal. Uses credits. You can also judge any session on demand from its detail view."
+              bareAutoGradeAriaLabel="Auto-grade every session with LLM as Judge"
             />
           </div>
         ) : null}

--- a/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
@@ -70,10 +70,18 @@ import {
   type JourneyRollup,
   type JourneySessionRow,
   type PersonaTrackRecord,
-  type SessionGoalScore,
 } from "@/lib/swarm-api";
-import { formatScore } from "@/components/shared/session-quality/judge-presentation";
+// The badge + wide-shape guard live in the shared session-quality module so
+// surfaces rendered inside this subtree can use them without an import cycle.
+// Re-exported here because the goal-score unit test imports from `../SwarmsTab`.
+export {
+  SessionGoalScoreBadge,
+  toSessionGoalScore,
+} from "@/components/shared/session-quality/session-goal-score-badge";
 import { ShareUsageThreadDetail } from "@/components/connection/share-usage/ShareUsageThreadDetail";
+import { JudgesSection } from "@/components/evals/judges-section";
+import { useAvailableModels } from "@/hooks/use-available-models";
+import type { GoalJudgeConfig } from "@/components/shared/session-quality/judge-config";
 import {
   buildEvalsPath,
   buildSwarmSessionPath,
@@ -127,73 +135,6 @@ import type {
 const AGENT_SNAPSHOT_MAX_PERSONAS = 30;
 const AGENT_SNAPSHOT_MAX_JOURNEYS = 30;
 
-// Judge-verdict guard: the backend denormalizes a WIDE `goalScore` subset;
-// validate the status enum + score before rendering so a malformed record
-// degrades to "no badge".
-const GOAL_SCORE_STATUSES = ["running", "completed", "failed"] as const;
-type GoalScoreStatus = (typeof GOAL_SCORE_STATUSES)[number];
-
-export function toSessionGoalScore(raw: JourneySessionRow["goalScore"]):
-  | (SessionGoalScore & { status: GoalScoreStatus })
-  | undefined {
-  if (!raw) return undefined;
-  if (!(GOAL_SCORE_STATUSES as readonly string[]).includes(raw.status ?? "")) {
-    return undefined;
-  }
-  const status = raw.status as GoalScoreStatus;
-  // A completed verdict must carry BOTH a finite score and a boolean passed —
-  // a malformed `passed` must not silently render as "below threshold".
-  if (
-    status === "completed" &&
-    (!Number.isFinite(raw.score) || typeof raw.passed !== "boolean")
-  ) {
-    return undefined;
-  }
-  return { ...raw, status };
-}
-
-/**
- * Per-session judge score badge, rendered next to the readiness badge.
- * completed → "82% · meets goal"; running → "judging…"; failed → "judge
- * unavailable" (never silently hidden — the viewer offers Retry); absent →
- * nothing.
- */
-export function SessionGoalScoreBadge({
-  goalScore,
-}: {
-  goalScore: JourneySessionRow["goalScore"];
-}) {
-  const gs = toSessionGoalScore(goalScore);
-  if (!gs) return null;
-  if (gs.status === "running") {
-    return (
-      <span className="rounded-sm bg-muted/60 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide text-muted-foreground">
-        judging…
-      </span>
-    );
-  }
-  if (gs.status === "failed") {
-    return (
-      <span
-        className="rounded-sm bg-muted/60 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide text-muted-foreground"
-        title={gs.error ?? "Judge run failed — open the session to retry"}
-      >
-        judge unavailable
-      </span>
-    );
-  }
-  return (
-    <span
-      className={`rounded-sm px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide ${
-        gs.passed ? "bg-success/50 text-foreground" : "bg-warning/50 text-foreground"
-      }`}
-      title={gs.reason ?? undefined}
-    >
-      {formatScore(gs.score ?? NaN)} · {gs.passed ? "meets goal" : "below threshold"}
-    </span>
-  );
-}
-
 type Persona = {
   _id: string;
   personaId: string;
@@ -213,6 +154,8 @@ type Journey = {
   /** Standalone server group shared across all hosts at launch (suite-like). */
   serverAttachmentId?: string | null;
   config: { sessionsPerHost: number; maxTurns: number };
+  /** Per-journey goal-completion judge config (shared envelope with suites). */
+  judgeConfig?: GoalJudgeConfig;
 };
 type HostItem = {
   hostId: string;
@@ -1526,6 +1469,7 @@ function NewJourneyButton({
     hostIds: string[];
     serverAttachmentId: string;
     config: { sessionsPerHost: number; maxTurns: number };
+    judgeConfig?: GoalJudgeConfig;
   }) => Promise<void>;
   // Controlled by SwarmsTab so `ui_open_journey_form` can open + prefill it.
   open: boolean;
@@ -1541,10 +1485,21 @@ function NewJourneyButton({
   const [sessionsPerHost, setSessionsPerHost] = useState(2);
   const [maxTurns, setMaxTurns] = useState(6);
   const [clientsPickerOpen, setClientsPickerOpen] = useState(false);
+  // Judge config is hidden behind "Advanced" — progressive discovery. Default
+  // undefined = managed defaults (auto-grade off) until the user opts in.
+  const [judgeConfig, setJudgeConfig] = useState<GoalJudgeConfig | undefined>(
+    undefined,
+  );
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+  const { availableModels } = useAvailableModels({ projectId });
   // Seed the goal from the agent prefill (or reset to "") whenever the form
   // transitions open. Manual "+ New journey" opens pass goalSeed="".
   useEffect(() => {
-    if (open) setGoal(goalSeed);
+    if (open) {
+      setGoal(goalSeed);
+      setJudgeConfig(undefined);
+      setAdvancedOpen(false);
+    }
   }, [open, goalSeed]);
   const setOpen = onOpenChange;
   // A journey may target ANY project host, including chatbox/suite-owned ones
@@ -1767,6 +1722,37 @@ function NewJourneyButton({
         </div>
       </div>
 
+      {/* Advanced → Judge. Hidden by default (progressive discovery); the
+          JudgesSection is the same control the eval suite settings use. */}
+      <div className="mb-2.5 border-t border-border/40 pt-2">
+        <button
+          type="button"
+          onClick={() => setAdvancedOpen((v) => !v)}
+          className="flex items-center gap-1 text-[11px] font-medium text-muted-foreground hover:text-foreground"
+          aria-expanded={advancedOpen}
+        >
+          <ChevronDown
+            className={cn(
+              "size-3 transition-transform",
+              advancedOpen && "rotate-180",
+            )}
+          />
+          Advanced
+        </button>
+        {advancedOpen ? (
+          <div className="mt-2">
+            <JudgesSection
+              chrome="bare"
+              value={judgeConfig}
+              onChange={setJudgeConfig}
+              availableModels={availableModels}
+              title="Judge"
+              description="Grade each session against this journey's goal."
+            />
+          </div>
+        ) : null}
+      </div>
+
       <div className="flex justify-end gap-2">
         <Button type="button" size="sm" variant="ghost" onClick={() => setOpen(false)}>
           Cancel
@@ -1792,11 +1778,13 @@ function NewJourneyButton({
               hostIds,
               serverAttachmentId,
               config: { sessionsPerHost, maxTurns },
+              ...(judgeConfig ? { judgeConfig } : {}),
             });
             setOpen(false);
             setGoal("");
             setHostIds([]);
             setServerAttachmentId(null);
+            setJudgeConfig(undefined);
           }}
         >
           Create journey

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.agent.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.agent.test.tsx
@@ -10,6 +10,13 @@
  */
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// NewJourneyButton's Advanced → Judge section pulls the model catalog via
+// useAvailableModels (AppStateProvider-coupled); these tests render SwarmsTab
+// without providers, so stub it to an empty catalog.
+vi.mock("@/hooks/use-available-models", () => ({
+  useAvailableModels: () => ({ availableModels: [] }),
+}));
 import { executeInspectorCommand } from "@/lib/inspector-command-handlers";
 import { readSurfaceSnapshot } from "@/lib/webmcp/surface-snapshot-registry";
 import type {

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.journeyForm.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.journeyForm.test.tsx
@@ -4,6 +4,13 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+// NewJourneyButton's Advanced → Judge section pulls the model catalog via
+// useAvailableModels (AppStateProvider-coupled); these tests render SwarmsTab
+// without providers, so stub it to an empty catalog.
+vi.mock("@/hooks/use-available-models", () => ({
+  useAvailableModels: () => ({ availableModels: [] }),
+}));
+
 const persona = {
   _id: "persona-1",
   personaId: "p1",

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.launch.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.launch.test.tsx
@@ -1,6 +1,13 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+// NewJourneyButton's Advanced → Judge section pulls the model catalog via
+// useAvailableModels (AppStateProvider-coupled); these tests render SwarmsTab
+// without providers, so stub it to an empty catalog.
+vi.mock("@/hooks/use-available-models", () => ({
+  useAvailableModels: () => ({ availableModels: [] }),
+}));
+
 const persona = {
   _id: "persona-1",
   personaId: "p1",

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.personas.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.personas.test.tsx
@@ -4,6 +4,13 @@
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+// NewJourneyButton's Advanced → Judge section pulls the model catalog via
+// useAvailableModels (AppStateProvider-coupled); these tests render SwarmsTab
+// without providers, so stub it to an empty catalog.
+vi.mock("@/hooks/use-available-models", () => ({
+  useAvailableModels: () => ({ availableModels: [] }),
+}));
+
 const persona = {
   _id: "persona-1",
   personaId: "p1",

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.sessions.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.sessions.test.tsx
@@ -1,6 +1,13 @@
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+// NewJourneyButton's Advanced → Judge section pulls the model catalog via
+// useAvailableModels (AppStateProvider-coupled); these tests render SwarmsTab
+// without providers, so stub it to an empty catalog.
+vi.mock("@/hooks/use-available-models", () => ({
+  useAvailableModels: () => ({ availableModels: [] }),
+}));
+
 /**
  * CONTRACT (finding 4): the sessions-by-run view must call the backend query
  * `journeyRuns:listSessionsByJourneyRun` with the arg name `journeyRunId` (NOT

--- a/mcpjam-inspector/client/src/components/swarms/journey-run-results.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/journey-run-results.tsx
@@ -6,7 +6,7 @@ import {
   type JourneySessionRow,
   type SessionGoalScore,
 } from "@/lib/swarm-api";
-import { formatScore } from "@/components/shared/session-quality/judge-presentation";
+import { SessionGoalScoreBadge } from "@/components/shared/session-quality/session-goal-score-badge";
 import { TraceViewer } from "@/components/evals/trace-viewer";
 import {
   TraceViewModeTabs,
@@ -89,16 +89,6 @@ export function resolveSwarmCellOutcome(args: {
   return "pending";
 }
 
-function GoalScoreHint({ score }: { score?: SessionGoalScore }) {
-  if (score?.score == null) return null;
-  return (
-    <span className="text-[10px] tabular-nums text-muted-foreground">
-      {formatScore(score.score)}
-      {score.passed != null ? (score.passed ? " · pass" : " · miss") : ""}
-    </span>
-  );
-}
-
 /**
  * One session chip: `<host> #<n> · <outcome>`. Kept `data-testid`
  * "swarm-host-cell" from the old grid so outcome assertions carry over.
@@ -140,7 +130,7 @@ export function SwarmHostCell({
       </span>
       <span className={cn("size-1.5 rounded-full", meta.dot)} />
       <span className={cn("font-semibold", meta.text)}>{meta.label}</span>
-      <GoalScoreHint score={goalScore} />
+      <SessionGoalScoreBadge goalScore={goalScore} />
     </button>
   );
 }


### PR DESCRIPTION
## What

Makes the Swarm goal-completion judge **visible** and **configurable per journey**, reusing the eval judge stack instead of building a parallel one — a journey is the Swarm analog of an eval suite.

## Why

Judging was backend-complete but nearly invisible: `SessionGoalScoreBadge` was built and tested yet **never rendered**, auto-grade was a deployment env flag, and the only entry point was buried in session detail behind an empty-messages guard. There was also no per-journey judge config.

## Changes

**Visibility**
- `SessionGoalScoreBadge` + the wide-shape guard move to shared `components/shared/session-quality/session-goal-score-badge.tsx` (so surfaces rendered inside SwarmsTab's subtree can use them without an import cycle). The completed state now reuses the shared `ScoreBadge`. `SwarmsTab` re-exports for its unit test.
- Rendered in the **Sessions list** (`ShareUsageThreadList`) and **run matrix cells** (`journey-run-results.tsx`, replacing the score-only `GoalScoreHint`) — shown only when a `goalScore` exists (absence = ungraded, not broken).
- `SwarmJudgeSection` is reachable for a swarm session with **no transcript** (past the empty-messages early return in `ShareUsageThreadDetail`), so failed/empty sessions can still be judged.

**Shared config type**
- Extracted `GoalJudgeConfig` + `MANAGED_DEFAULT_JUDGE_MODEL` / `DEFAULT_JUDGE_THRESHOLD` into `session-quality/judge-config.ts` (the client mirror of the backend `judgeConfigValidator`). `evals/types.ts` re-exports the historical `EvalJudgeConfig` names; `JudgesSection` / `goal-completion-card` re-point. No eval behavior change.

**Journey settings UI**
- The new-journey form (`NewJourneyButton`) gains a collapsed **Advanced → Judge** disclosure reusing the eval `JudgesSection` (`chrome="bare"`) — progressive discovery: hidden until opened, auto-grade off by default. `judgeConfig` flows through the existing `createJourney` call.
- The 5 SwarmsTab test files stub `useAvailableModels` (it is `AppStateProvider`-coupled and those tests render without providers).

## Tests

`typecheck:client` clean; swarms + share-usage + evals suites pass. The badge's completed/running/failed/absent states are covered via the shared implementation (through the SwarmsTab re-export).

## Dependency

Pairs with **MCPJam/mcpjam-backend#749** (journey `judgeConfig` schema + run snapshot + config-driven auto-run). This client PR is safe to merge independently — the visibility wiring works today; the settings UI is inert until the backend accepts `judgeConfig`.

## Known follow-up

No journey **edit** UI yet — journeys are create-only in the client, so a journey created without judge config can't enable it later. The backend `updateJourney` already accepts `judgeConfig`; a minimal edit affordance reusing `JudgesSection` is the natural next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly UI wiring and shared types with eval parity; optional `judgeConfig` on create is inert until the paired backend PR ships.
> 
> **Overview**
> Surfaces the **Swarm goal-completion judge** in the UI and adds **per-journey judge settings**, reusing the eval judge stack instead of a parallel implementation.
> 
> **Visibility:** `SessionGoalScoreBadge` moves to shared `session-quality/` (completed state uses eval `ScoreBadge`) and is shown in the shared **Sessions list** and **run matrix** when `goalScore` exists. **Empty swarm sessions** still render `SwarmJudgeSection` in `ShareUsageThreadDetail` instead of a dead-end “no messages” view.
> 
> **Shared config:** `GoalJudgeConfig` and default model/threshold constants live in `session-quality/judge-config.ts`; evals keep `EvalJudgeConfig` re-exports. `JudgesSection` gains optional **bare-chrome** copy props for Swarm wording.
> 
> **Journey create:** **Advanced → Judge** on the new-journey form reuses `JudgesSection` and passes optional `judgeConfig` into `createJourney` (active once backend #749 lands). Five SwarmsTab tests stub `useAvailableModels`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b5bd383aa2d02728b7a18308ccff9a9d8ebc844. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surface the Swarm goal-completion judge in the UI and add per-journey judge settings using the shared judge stack. Journeys can opt into auto-grade with a chosen model and threshold; pairs with `MCPJam/mcpjam-backend#749`.

- **New Features**
  - Show `SessionGoalScoreBadge` in Sessions list and run matrix; renders running/completed/failed and hides when ungraded.
  - Make `SwarmJudgeSection` available for swarm sessions with no transcript.
  - Add Advanced → Judge to New Journey using `JudgesSection`; `judgeConfig` flows through `createJourney`. Journey-specific copy for the auto-grade toggle clarifies it grades sessions against the journey goal and that on-demand judging remains available.

- **Refactors**
  - Extract shared `GoalJudgeConfig` and defaults to `session-quality/judge-config`; evals re-export historical `EvalJudge*` types, and `goal-completion-card` uses the shared defaults.
  - Move `SessionGoalScoreBadge` to `session-quality/` and reuse the shared `ScoreBadge`; add a safe wide-shape validator.
  - Stub `useAvailableModels` in SwarmsTab tests.

<sup>Written for commit 6b5bd383aa2d02728b7a18308ccff9a9d8ebc844. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

