### PR TITLE
fix(playground): stop guest first-run onboarding from hanging forever (#3352)

### DIFF
--- a/mcpjam-inspector/client/src/components/ui-playground/hooks/use-playground-state.ts
+++ b/mcpjam-inspector/client/src/components/ui-playground/hooks/use-playground-state.ts
@@ -75,6 +75,11 @@ import { PANEL_SIZES } from "../constants";
 
 const SERVER_SYNC_TIMEOUT_MS = 10000;
 const EXECUTION_INJECTION_TIMEOUT_MS = 5000;
+// Upper bound on the full-screen first-run skeleton. If onboarding connect /
+// remote provisioning never resolves (e.g. a guest whose Convex deployment
+// can't authenticate them, so no project is ever provisioned), fall through to
+// the usable Playground instead of spinning forever. See issue #3352.
+const FIRST_RUN_SKELETON_TIMEOUT_MS = 12000;
 
 export const PLAYGROUND_FIRST_RUN_PROMPT =
   "Draw me an MCP architecture diagram";
@@ -956,6 +961,30 @@ export function usePlaygroundState(options: UsePlaygroundStateOptions) {
     onboarding.isBootstrappingFirstRunConnection && !!onConnect;
   const isWaitingForServerSync =
     !serverConfig && isServerSyncing && !syncTimedOut;
+
+  // The full-screen first-run skeleton must never be a dead end. Track whether
+  // anything currently wants it, then time-bound it: if the underlying connect
+  // / provisioning never resolves the skeleton falls through to a usable
+  // Playground rather than hanging forever with no escape. See issue #3352.
+  const wantsFirstRunSkeleton =
+    isResolvingRemoteCompletion ||
+    isConnectingFirstRunExcalidraw ||
+    isBootstrappingFirstRunConnection ||
+    isWaitingForServerSync;
+  const [firstRunSkeletonTimedOut, setFirstRunSkeletonTimedOut] =
+    useState(false);
+  useEffect(() => {
+    if (!wantsFirstRunSkeleton) {
+      setFirstRunSkeletonTimedOut(false);
+      return;
+    }
+    const id = setTimeout(
+      () => setFirstRunSkeletonTimedOut(true),
+      FIRST_RUN_SKELETON_TIMEOUT_MS,
+    );
+    return () => clearTimeout(id);
+  }, [wantsFirstRunSkeleton]);
+
   const shouldMarkFirstRunNuxShown =
     firstRunComposerSeed &&
     onboarding.isGuidedPostConnect &&
@@ -971,10 +1000,7 @@ export function usePlaygroundState(options: UsePlaygroundStateOptions) {
   }, [onboarding.markOnboardingShown, shouldMarkFirstRunNuxShown]);
 
   const loadingState: PlaygroundLoadingState =
-    isResolvingRemoteCompletion ||
-    isConnectingFirstRunExcalidraw ||
-    isBootstrappingFirstRunConnection ||
-    isWaitingForServerSync
+    wantsFirstRunSkeleton && !firstRunSkeletonTimedOut
       ? { kind: "skeleton" }
       : !serverConfig && isServerSyncing && syncTimedOut
       ? { kind: "sync-timed-out" }

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-onboarding.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-onboarding.test.tsx
@@ -20,7 +20,20 @@ const mockState = vi.hoisted(() => ({
   markOnboardingShownMutation: vi.fn().mockResolvedValue(undefined),
   detectEnvironment: vi.fn(() => "test"),
   detectPlatform: vi.fn(() => "web"),
+  // Toggled per-test so the provisioning gate can be exercised in both hosted
+  // and local modes. Read live via the getter in the config mock below.
+  hostedMode: false,
 }));
+
+vi.mock("@/lib/config", async (importActual) => {
+  const actual = await importActual<typeof import("@/lib/config")>();
+  return {
+    ...actual,
+    get HOSTED_MODE() {
+      return mockState.hostedMode;
+    },
+  };
+});
 
 vi.mock("convex/react", () => ({
   useQuery: () => mockState.convexUser,
@@ -65,6 +78,7 @@ describe("useOnboarding", () => {
     vi.clearAllMocks();
     localStorage.clear();
     mockState.convexUser = undefined;
+    mockState.hostedMode = false;
   });
 
   it("auto-connects Excalidraw for a fresh first run", async () => {
@@ -86,7 +100,31 @@ describe("useOnboarding", () => {
     });
   });
 
-  it("waits for project provisioning before auto-connecting Excalidraw", async () => {
+  it("auto-connects Excalidraw in local mode even without a provisioned project", async () => {
+    // In local/non-hosted mode the active project is a local record and
+    // Excalidraw connects as a runtime server, so onboarding must not block on
+    // a Convex-synced project — otherwise guests on deployments that can't
+    // authenticate them hang on an infinite spinner. See issue #3352.
+    const onConnect = vi.fn();
+    renderHook(() =>
+      useOnboarding({
+        servers: {},
+        onConnect,
+        isSignedInWithWorkOs: false,
+        isWorkOsAuthLoading: false,
+        isProjectProvisioned: false,
+      })
+    );
+
+    await waitFor(() => {
+      expect(onConnect).toHaveBeenCalledWith(EXCALIDRAW_SERVER_CONFIG);
+    });
+  });
+
+  it("waits for project provisioning before auto-connecting Excalidraw in hosted mode", async () => {
+    // Hosted mode stores each server on the Convex project, so the first-run
+    // connect must wait for that project to provision.
+    mockState.hostedMode = true;
     const onConnect = vi.fn();
     const { rerender } = renderHook(
       ({ isProjectProvisioned }: { isProjectProvisioned: boolean }) =>

--- a/mcpjam-inspector/client/src/hooks/use-onboarding.ts
+++ b/mcpjam-inspector/client/src/hooks/use-onboarding.ts
@@ -14,6 +14,7 @@ import {
   EXCALIDRAW_SERVER_NAME,
 } from "@/lib/excalidraw-quick-connect";
 import { detectEnvironment, detectPlatform } from "@/lib/PosthogUtils";
+import { HOSTED_MODE } from "@/lib/config";
 import type { ServerFormData } from "@/shared/types.js";
 import type { ServerWithName } from "@/hooks/use-app-state";
 
@@ -196,7 +197,14 @@ export function useOnboarding({
   useEffect(() => {
     if (isWorkOsAuthLoading || isSignedInWithWorkOs) return;
     if (didAutoConnectRef.current) return;
-    if (!isProjectProvisioned) return;
+    // Hosted mode stores each server on the Convex project, so the first-run
+    // connect must wait for that project to provision. In local/non-hosted
+    // mode the active project is a local record and Excalidraw connects as a
+    // runtime server, so requiring a Convex-synced project here would strand
+    // first-run guests on an infinite spinner on any deployment that can't
+    // authenticate the guest (e.g. the open-source shared Convex deployment,
+    // where guest auth is never trusted). See issue #3352.
+    if (HOSTED_MODE && !isProjectProvisioned) return;
 
     if (hasRemoteOnboardingState) {
       if (hasSeenOnboarding) return;


### PR DESCRIPTION
## Summary

Fixes #3352. A first-time guest (no account) gets redirected to `/playground` and then stalls on a full-screen spinner forever — no error, no timeout, no escape.

## Root cause

The Playground renders a full-screen `LoadingScreen` (via `PlaygroundTab`'s `fixed inset-0 z-[100]` overlay) while first-run onboarding auto-connects the demo Excalidraw server. That auto-connect was gated on `isProjectProvisioned` — i.e. a Convex-synced `sharedProjectId`.

When a guest can't authenticate to Convex (e.g. a deployment that doesn't trust the guest JWT issuer, such as the open-source shared deployment, or a transient/slow provisioning), the project never gets a `sharedProjectId`. So:

1. `isConvexAuthenticated` stays `false` → no Convex identity → `sharedProjectId: null` → `isProjectProvisioned: false`.
2. `use-onboarding`'s auto-connect effect bails (`if (!isProjectProvisioned) return;`), leaving `phase` stuck at `connecting_excalidraw`.
3. `use-playground-state` reports `loadingState: "skeleton"` with **no timeout** → the overlay spins indefinitely.

This is the "local mode with Convex configured but auth failing" hybrid: `HOSTED_MODE=false` yet a Convex URL is set, so the app attempts cloud sync, it fails, and onboarding waits forever for a project that never comes.

## Changes

- **`use-onboarding.ts`** — only require a provisioned Convex project in **hosted** mode (`if (HOSTED_MODE && !isProjectProvisioned) return;`). In local/non-hosted mode the active project is a local record and Excalidraw connects as a runtime server, so onboarding proceeds without waiting on cloud sync.
- **`use-playground-state.ts`** — bound the first-run skeleton with a `FIRST_RUN_SKELETON_TIMEOUT_MS` (12s) safety net so it can never be a dead end; it falls through to a usable Playground on any deployment.
- **`use-onboarding.test.tsx`** — the one test that encoded the old "always wait for provisioning" contract now covers both real contracts: hosted waits, local proceeds (with a controllable `HOSTED_MODE` mock).

Together, a guest either completes onboarding or lands on a usable Playground (worst case a brief spinner then usable), matching the issue's expected behavior. On a properly configured deployment the Excalidraw connect succeeds and the guided first-run still works; where it can't, it fails gracefully (error toast with Retry) instead of hanging.

## Testing

- Reproduced end-to-end as a fresh guest against the open-source `energized-ant-201` deployment: confirmed the infinite full-screen spinner before, and a usable Playground after.
- `use-onboarding` tests: 17/17 pass.
- Client typecheck: clean.

## Scope note

This is a frontend robustness fix that protects every deployment. The separate question of why the shared open-source Convex deployment rejects the guest JWT (so guests there stay local-only) is intentionally out of scope for this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an infinite spinner for first-time guest visits to `/playground` by letting onboarding proceed in non-hosted mode and adding a 12s timeout so the loading screen always falls through to a usable Playground.

- **Bug Fixes**
  - `use-onboarding`: only wait for Convex project provisioning when `HOSTED_MODE` is true; in local/non-hosted mode, auto-connect Excalidraw without blocking.
  - `use-playground-state`: add `FIRST_RUN_SKELETON_TIMEOUT_MS` (12s) to bound the first-run skeleton and prevent dead-end spinners.
  - Tests updated to cover hosted (waits) vs local (proceeds) behavior.

<sup>Written for commit 60054d3cf5b4649b3b99eb2eb663cb4cbb617606. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

