### PR TITLE
feat(sdk): 2026-07-28 OAuth machine spec steps (Phase 2, 2M-a remainder)

### DIFF
--- a/sdk/src/oauth/state-machines/debug-oauth-2026-07-28.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2026-07-28.ts
@@ -39,10 +39,7 @@ import {
   resolveDiscoveryResourceIndicator,
   resolveFlowResourceValue,
 } from "./shared/resource-indicator.js";
-import {
-  buildInitializeRequestBody,
-  resolveInitializeProtocolVersion,
-} from "./shared/initialize.js";
+import { buildStatelessVerifyRequestBody } from "./shared/initialize.js";
 import {
   parseBearerAuthenticateParameters,
   parseScopeString,
@@ -77,6 +74,40 @@ const previewResourceValue = (
   flowState: OAuthFlowState,
 ): string | undefined => resolveFlowResourceValue(flowState);
 
+// SEP-2350 (display half): the authorization step shows the scopes requested,
+// any scopes challenged by a later 403 insufficient_scope, and their union —
+// the set a step-up re-authorization would request. The runtime step-up loop
+// itself is a separate track (2R-stepup); this only visualizes the union.
+function buildScopeUnionDetails(
+  flowState: OAuthFlowState,
+): Array<{ label: string; value: any }> {
+  const requested = flowState.requestedScopes ?? [];
+  const challenged = flowState.challengedScopes ?? [];
+  const rows: Array<{ label: string; value: any }> = [];
+  if (requested.length > 0) {
+    rows.push({ label: "requested scopes", value: requested.join(" ") });
+  }
+  if (challenged.length > 0) {
+    const union = Array.from(new Set([...requested, ...challenged]));
+    rows.push({ label: "challenged scopes", value: challenged.join(" ") });
+    rows.push({ label: "scope union", value: union.join(" ") });
+  }
+  return rows;
+}
+
+// SEP-2352 (display half): show the exact issuer the client credentials are
+// bound to (the issuer recorded at discovery, which the RFC 8414 §3.3 check
+// proved equals the AS URL). The storage-write half — keying persisted
+// credentials by issuer and refusing cross-issuer reuse — is a separate track
+// (2R-store).
+function buildIssuerBindingDetails(
+  flowState: OAuthFlowState,
+): Array<{ label: string; value: any }> {
+  const issuer =
+    flowState.recordedIssuer ?? flowState.authorizationServerMetadata?.issuer;
+  return issuer ? [{ label: "bound to issuer", value: issuer }] : [];
+}
+
 /**
  * Build the sequence of actions for the 2026-07-28 OAuth flow
  * This function creates the visual representation of the OAuth flow steps
@@ -96,7 +127,7 @@ export function buildActions_2026_07_28(
       details: flowState.serverUrl
         ? [
             { label: "POST", value: flowState.serverUrl },
-            { label: "method", value: "initialize" },
+            { label: "method", value: "tools/list" },
           ]
         : undefined,
     },
@@ -275,6 +306,13 @@ export function buildActions_2026_07_28(
                   label: "Note",
                   value: "Dynamic client registration (DCR)",
                 },
+                {
+                  label: "Deprecated",
+                  value:
+                    "DCR is deprecated in 2026-07-28 (PR #2858). Prefer CIMD " +
+                    "or a pre-registered client; DCR remains a compatibility " +
+                    "fallback for authorization servers without CIMD support.",
+                },
               ],
             },
             {
@@ -290,6 +328,7 @@ export function buildActions_2026_07_28(
                       label: "client_id",
                       value: flowState.clientId.substring(0, 20) + "...",
                     },
+                    ...buildIssuerBindingDetails(flowState),
                   ]
                 : undefined,
             },
@@ -312,6 +351,7 @@ export function buildActions_2026_07_28(
                       label: "Note",
                       value: "Pre-registered (no DCR needed)",
                     },
+                    ...buildIssuerBindingDetails(flowState),
                   ]
                 : [
                     {
@@ -364,6 +404,7 @@ export function buildActions_2026_07_28(
               label: "resource",
               value: previewResourceValue(flowState) || "",
             },
+            ...buildScopeUnionDetails(flowState),
           ]
         : undefined,
     },
@@ -517,6 +558,57 @@ function buildAuthServerMetadataUrls(authServerUrl: string): string[] {
   return urls;
 }
 
+export type AuthorizationResponseIssuerCheck =
+  | { ok: true }
+  | { ok: false; reason: string };
+
+/**
+ * RFC 9207 authorization-response `iss` validation — a 2026-07-28 requirement.
+ * Four rows:
+ *   1. `iss` present and equals the recorded issuer            → ok
+ *   2. `iss` present and differs                               → reject
+ *   3. `iss` absent but the AS advertised
+ *      `authorization_response_iss_parameter_supported: true`  → reject
+ *   4. `iss` absent and not advertised                         → ok
+ * A present-but-not-advertised `iss` is still validated (rows 1/2): if the AS
+ * sends one, it must be correct. Comparison is exact — no normalization, same
+ * discipline as the RFC 8414 §3.3 issuer check. On a mismatch the caller emits
+ * a fixed diagnostic and MUST NOT surface any server-supplied `error*` callback
+ * parameters.
+ */
+export function validateAuthorizationResponseIssuer(input: {
+  recordedIssuer: string | undefined;
+  returnedIss: string | undefined;
+  issParameterSupported: boolean | undefined;
+}): AuthorizationResponseIssuerCheck {
+  const { recordedIssuer, returnedIss, issParameterSupported } = input;
+
+  if (returnedIss !== undefined && returnedIss !== "") {
+    if (recordedIssuer !== undefined && returnedIss !== recordedIssuer) {
+      return {
+        ok: false,
+        reason:
+          "Authorization response `iss` does not match the issuer this flow " +
+          "started with. Refusing to exchange the authorization code; not " +
+          "displaying any server-supplied error parameters (RFC 9207).",
+      };
+    }
+    return { ok: true };
+  }
+
+  if (issParameterSupported === true) {
+    return {
+      ok: false,
+      reason:
+        "Authorization server advertised " +
+        "`authorization_response_iss_parameter_supported: true` but the " +
+        "callback did not include an `iss` parameter (RFC 9207 requires it).",
+    };
+  }
+
+  return { ok: true };
+}
+
 // Factory function to create the 2026-07-28 state machine
 export const createDebugOAuthStateMachine = (
   config: DebugOAuthStateMachineConfig
@@ -543,11 +635,11 @@ export const createDebugOAuthStateMachine = (
   } = config;
 
   const redirectUri = redirectUrl;
-  // TODO(2026 delta): 2026-07-28 is stateless — no `initialize` handshake. The
-  // idle + authenticated verify steps below still send `initialize` (forked
-  // from 2025-11-25); they should become stateless requests. See the note in
-  // resolveInitializeProtocolVersion. Deferred; behavior is otherwise inherited.
-  const initializeProtocolVersion = resolveInitializeProtocolVersion("2026-07-28");
+  // 2026-07-28 is stateless: there is no `initialize` handshake. The probe and
+  // token-verification steps issue a stateless `tools/list`
+  // (buildStatelessVerifyRequestBody) carrying the `_meta` envelope; this
+  // literal is only the `MCP-Protocol-Version` header value for those requests.
+  const statelessProtocolVersion = "2026-07-28";
   const dynamicRegistrationDefaults = dynamicRegistration ?? {};
   let cimdClientId = clientIdMetadataUrl ?? "";
 
@@ -659,9 +751,13 @@ export const createDebugOAuthStateMachine = (
             const initialRequestHeaders = mergeHeaders(customHeaders, {
               "Content-Type": "application/json",
               Accept: "application/json, text/event-stream",
+              // 2026-07-28 stateless probe headers — no initialize handshake.
+              // Mcp-Name is omitted: tools/list takes no name argument.
+              "MCP-Protocol-Version": statelessProtocolVersion,
+              "Mcp-Method": "tools/list",
             });
-            const initializeRequestBody = buildInitializeRequestBody({
-              protocolVersion: initializeProtocolVersion,
+            const probeRequestBody = buildStatelessVerifyRequestBody({
+              protocolVersion: statelessProtocolVersion,
               authMode,
               clientName: "MCPJam Inspector",
               clientVersion: "1.0.0",
@@ -672,7 +768,7 @@ export const createDebugOAuthStateMachine = (
               method: "POST",
               url: serverUrl,
               headers: initialRequestHeaders,
-              body: initializeRequestBody,
+              body: probeRequestBody,
             };
 
             // Update state with the request
@@ -710,10 +806,12 @@ export const createDebugOAuthStateMachine = (
                 headers: mergeHeaders(customHeaders, {
                   "Content-Type": "application/json",
                   Accept: "application/json, text/event-stream",
+                  "MCP-Protocol-Version": statelessProtocolVersion,
+                  "Mcp-Method": "tools/list",
                 }),
                 body: JSON.stringify(
-                  buildInitializeRequestBody({
-                    protocolVersion: initializeProtocolVersion,
+                  buildStatelessVerifyRequestBody({
+                    protocolVersion: statelessProtocolVersion,
                     authMode,
                     clientName: "MCPJam Inspector",
                     clientVersion: "1.0.0",
@@ -1131,6 +1229,24 @@ export const createDebugOAuthStateMachine = (
                 "Authorization server metadata missing required 'issuer' field"
               );
             }
+
+            // RFC 8414 §3.3 (a 2026-07-28 MUST): the returned `issuer` MUST be
+            // identical to the issuer identifier into which the well-known
+            // string was inserted to build the metadata URL — i.e. the AS URL
+            // the flow started discovery from. Exact string comparison, NO
+            // normalization (a trailing-slash or case difference is a real
+            // finding, not something to paper over). This binds the metadata
+            // document to the issuer and is the anchor every later issuer check
+            // (record_issuer, callback `iss`) trusts.
+            if (authServerMetadata.issuer !== state.authorizationServerUrl) {
+              throw new Error(
+                "Authorization server metadata `issuer` does not match the " +
+                  "authorization server URL it was discovered from " +
+                  `(expected "${state.authorizationServerUrl}", got ` +
+                  `"${authServerMetadata.issuer}"). RFC 8414 §3.3 requires an ` +
+                  "exact match; refusing to continue."
+              );
+            }
             if (!authServerMetadata.authorization_endpoint) {
               throw new Error(
                 "Authorization server metadata missing 'authorization_endpoint'"
@@ -1355,11 +1471,30 @@ export const createDebugOAuthStateMachine = (
                 customHeaders,
               });
 
+              // 2026-07-28 deprecates DCR as a registration mechanism
+              // (PR #2858); surface a warning while still performing it, since
+              // it stays a supported compatibility fallback.
+              const dcrDeprecationLogs = addInfoLog(
+                getCurrentState(),
+                "request_client_registration",
+                "dcr-deprecated",
+                "DCR is deprecated in 2026-07-28",
+                {
+                  Note:
+                    "Dynamic Client Registration (RFC 7591) is deprecated as a " +
+                    "registration mechanism in 2026-07-28 (PR #2858). It remains " +
+                    "a compatibility fallback; prefer CIMD or a pre-registered " +
+                    "client where the authorization server supports it.",
+                },
+                { level: "warning" }
+              );
+
               // Update state with the request
               updateState({
                 currentStep: "request_client_registration",
                 lastRequest: registrationRequest,
                 lastResponse: undefined,
+                infoLogs: dcrDeprecationLogs,
                 httpHistory: [
                   ...(state.httpHistory || []),
                   {
@@ -1645,6 +1780,13 @@ export const createDebugOAuthStateMachine = (
               codeChallenge,
               codeChallengeMethod: "S256",
               state: generateRandomString(16),
+              // RFC 9207: record the issuer the flow is anchored to at the same
+              // moment we mint the PKCE verifier/state. The exact-match check at
+              // discovery already proved `issuer === authorizationServerUrl`, so
+              // recording the metadata `issuer` binds the returned `iss` to the
+              // exact string the flow began with.
+              recordedIssuer: getCurrentState().authorizationServerMetadata
+                ?.issuer,
               infoLogs: pkceInfoLogs,
               isInitiatingAuth: false,
             });
@@ -1703,6 +1845,11 @@ export const createDebugOAuthStateMachine = (
               refreshToken: undefined,
               tokenType: undefined,
               expiresIn: undefined,
+              // Retain the requested scope set (SEP-2350 display half) so a later
+              // step-up challenge can be shown as prior ∪ challenged scopes.
+              requestedScopes: requestedScopeValue
+                ? requestedScopeValue.split(/\s+/).filter(Boolean)
+                : undefined,
               infoLogs: authUrlInfoLogs,
               isInitiatingAuth: false,
             });
@@ -1735,6 +1882,32 @@ export const createDebugOAuthStateMachine = (
 
             if (!state.authorizationServerMetadata?.token_endpoint) {
               throw new Error("Missing token endpoint");
+            }
+
+            // RFC 9207 (2026-07-28): validate the authorization-response issuer
+            // BEFORE touching the token endpoint. On failure, stop the flow with
+            // a fixed diagnostic — never echo attacker-controlled callback
+            // `error*` parameters (the machine deliberately does not read them).
+            //
+            // Scope seam: `issParameterSupported` is deliberately NOT passed
+            // here. That flag drives the "advertised-but-absent iss → reject"
+            // row, which can only be enforced safely once the callback boundary
+            // actually captures `iss` (the 2R-iss track threads it into
+            // `authorizationResponseIss`). Until then, a genuinely-absent `iss`
+            // is indistinguishable from an un-captured one, so enforcing that
+            // row now would hard-fail every AS that advertises iss support.
+            // What IS safe today: reject a PRESENT-but-mismatched `iss`.
+            const issCheck = validateAuthorizationResponseIssuer({
+              recordedIssuer: state.recordedIssuer,
+              returnedIss: state.authorizationResponseIss,
+              issParameterSupported: undefined,
+            });
+            if (!issCheck.ok) {
+              updateState({
+                error: issCheck.reason,
+                isInitiatingAuth: false,
+              });
+              return;
             }
 
             // Build the token request body as an object (will be shown in HTTP history)
@@ -2066,7 +2239,9 @@ export const createDebugOAuthStateMachine = (
             break;
 
           case "received_access_token":
-            // Step 12: Make authenticated MCP request (initialize to establish session)
+            // Step 12: Make an authenticated stateless MCP request to verify the
+            // token. 2026-07-28 has no `initialize`/session handshake, so this is
+            // a plain `tools/list` carrying the `_meta` envelope + bearer token.
             if (!state.serverUrl || !state.accessToken) {
               throw new Error("Missing server URL or access token");
             }
@@ -2078,10 +2253,11 @@ export const createDebugOAuthStateMachine = (
                 Authorization: `Bearer ${state.accessToken}`,
                 "Content-Type": "application/json",
                 Accept: "application/json, text/event-stream",
-                "MCP-Protocol-Version": "2026-07-28",
+                "MCP-Protocol-Version": statelessProtocolVersion,
+                "Mcp-Method": "tools/list",
               },
-              body: buildInitializeRequestBody({
-                protocolVersion: initializeProtocolVersion,
+              body: buildStatelessVerifyRequestBody({
+                protocolVersion: statelessProtocolVersion,
                 authMode,
                 clientName: "MCPJam Inspector",
                 clientVersion: "1.0.0",
@@ -2089,14 +2265,14 @@ export const createDebugOAuthStateMachine = (
               }),
             };
 
-            // Add info log for authenticated initialize request
+            // Add info log for the authenticated stateless verify request
             const authenticatedRequestInfoLogs = addInfoLog(
               getCurrentState(),
               "authenticated_mcp_request",
-              "authenticated-init",
-              "Authenticated MCP Initialize Request",
+              "authenticated-verify",
+              "Authenticated MCP Verify Request (tools/list)",
               {
-                Request: "MCP initialize with OAuth bearer token",
+                Request: "Stateless tools/list with OAuth bearer token",
                 "Protocol Version": "2026-07-28",
                 Client: "MCPJam Inspector v1.0.0",
                 Endpoint: state.serverUrl,
@@ -2125,7 +2301,8 @@ export const createDebugOAuthStateMachine = (
             return;
 
           case "authenticated_mcp_request":
-            // Step 13: Make actual authenticated request to verify token (initialize with auth)
+            // Step 13: Execute the authenticated stateless verify request
+            // (tools/list with the bearer token). No initialize/session step.
             if (!state.serverUrl || !state.accessToken) {
               throw new Error("Missing server URL or access token");
             }
@@ -2137,10 +2314,12 @@ export const createDebugOAuthStateMachine = (
                   Authorization: `Bearer ${state.accessToken}`,
                   "Content-Type": "application/json",
                   Accept: "application/json, text/event-stream",
+                  "MCP-Protocol-Version": statelessProtocolVersion,
+                  "Mcp-Method": "tools/list",
                 }),
                 body: JSON.stringify(
-                  buildInitializeRequestBody({
-                    protocolVersion: initializeProtocolVersion,
+                  buildStatelessVerifyRequestBody({
+                    protocolVersion: statelessProtocolVersion,
                     authMode,
                     clientName: "MCPJam Inspector",
                     clientVersion: "1.0.0",
@@ -2234,7 +2413,7 @@ export const createDebugOAuthStateMachine = (
                     Transport: "Streamable HTTP",
                     "Response Format": "Server-Sent Events (streaming)",
                     "Content-Type": contentType,
-                    Note: "Server returned streaming response. Initialize response delivered via SSE stream.",
+                    Note: "Server returned streaming response. tools/list verify response delivered via SSE stream.",
                     Events: response.body?.events
                       ? `${response.body.events.length} events parsed`
                       : "No events parsed",

--- a/sdk/src/oauth/state-machines/debug-oauth-2026-07-28.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2026-07-28.ts
@@ -2448,6 +2448,29 @@ export const createDebugOAuthStateMachine = (
                   "MCP Server Information",
                   protocolInfo
                 );
+              } else if (mcpResponse?.result) {
+                // 2026-07-28 stateless verify: the request is `tools/list`, so a
+                // successful result has no `initialize` protocolVersion/serverInfo
+                // to report — it simply proves the bearer token is accepted.
+                // Surface that (with a tool count when present) instead of
+                // logging nothing.
+                const toolCount = Array.isArray(mcpResponse.result.tools)
+                  ? mcpResponse.result.tools.length
+                  : undefined;
+                mcpInfoLogs = addInfoLog(
+                  getCurrentState(),
+                  "authenticated_mcp_request",
+                  "mcp-token-verified",
+                  "Access token verified (tools/list)",
+                  {
+                    Transport: "Streamable HTTP",
+                    "Response Format": "JSON",
+                    Result: "Bearer token accepted; tools/list succeeded",
+                    ...(toolCount !== undefined
+                      ? { "Tools listed": toolCount }
+                      : {}),
+                  }
+                );
               }
 
               updateState({

--- a/sdk/src/oauth/state-machines/shared/initialize.ts
+++ b/sdk/src/oauth/state-machines/shared/initialize.ts
@@ -3,6 +3,14 @@ import type { OAuthAuthMode, OAuthProtocolVersion } from "../types.js";
 export const MCP_OAUTH_CLIENT_CREDENTIALS_EXTENSION =
   "io.modelcontextprotocol/oauth-client-credentials";
 
+// 2026-07-28 stateless `_meta` envelope keys. Every stateless request
+// self-describes with these instead of a prior `initialize` handshake.
+export const MCP_PROTOCOL_VERSION_META_KEY =
+  "io.modelcontextprotocol/protocolVersion";
+export const MCP_CLIENT_CAPABILITIES_META_KEY =
+  "io.modelcontextprotocol/clientCapabilities";
+export const MCP_CLIENT_INFO_META_KEY = "io.modelcontextprotocol/clientInfo";
+
 export function resolveInitializeProtocolVersion(
   protocolVersion: OAuthProtocolVersion,
 ): string {
@@ -10,12 +18,10 @@ export function resolveInitializeProtocolVersion(
     case "2025-11-25":
       return "2025-11-25";
     case "2026-07-28":
-      // TODO(2026 machine delta): the 2026-07-28 wire is stateless — there is
-      // no `initialize` handshake. The OAuth flow's final token-verification
-      // step (forked verbatim from 2025-11-25) still sends `initialize` with
-      // this header; it should instead issue a stateless request (e.g.
-      // `tools/list` carrying the `_meta` envelope). Deferred to the larger
-      // 2026 delta; this returns the correct header value for now.
+      // The 2026-07-28 wire is stateless — no `initialize` handshake. The OAuth
+      // machine's probe/verify steps now issue a stateless `tools/list` via
+      // buildStatelessVerifyRequestBody; this value is only the
+      // `MCP-Protocol-Version` header literal for that request.
       return "2026-07-28";
     case "2025-06-18":
     case "2025-03-26":
@@ -55,6 +61,41 @@ export function buildInitializeRequestBody(input: {
       clientInfo: {
         name: input.clientName,
         version: input.clientVersion,
+      },
+    },
+    id: input.id,
+  };
+}
+
+/**
+ * Build a stateless 2026-07-28 request body for the OAuth flow's connectivity
+ * probe and post-token verification. The stateless era has no `initialize`
+ * handshake; every request self-describes through a `_meta` envelope carrying
+ * the protocol version, client capabilities, and client identity. The OAuth
+ * machine uses `tools/list` purely as a lightweight probe — unauthenticated it
+ * elicits the `401` that starts discovery, and with a bearer token it confirms
+ * the token works — so it never depends on the tool list itself.
+ */
+export function buildStatelessVerifyRequestBody(input: {
+  protocolVersion: string;
+  authMode?: OAuthAuthMode;
+  clientName: string;
+  clientVersion: string;
+  id: number;
+}): Record<string, unknown> {
+  return {
+    jsonrpc: "2.0",
+    method: "tools/list",
+    params: {
+      _meta: {
+        [MCP_PROTOCOL_VERSION_META_KEY]: input.protocolVersion,
+        [MCP_CLIENT_CAPABILITIES_META_KEY]: buildInitializeCapabilities(
+          input.authMode,
+        ),
+        [MCP_CLIENT_INFO_META_KEY]: {
+          name: input.clientName,
+          version: input.clientVersion,
+        },
       },
     },
     id: input.id,

--- a/sdk/src/oauth/state-machines/types.ts
+++ b/sdk/src/oauth/state-machines/types.ts
@@ -71,6 +71,10 @@ export interface OAuthFlowState {
     code_challenge_methods_supported?: string[];
     // 2025-11-25 additions
     client_id_metadata_document_supported?: boolean;
+    // 2026-07-28 / RFC 9207: when true, the AS promises to return `iss` on the
+    // authorization response, so a missing `iss` on the callback is a hard
+    // failure rather than a not-supported no-op.
+    authorization_response_iss_parameter_supported?: boolean;
   };
 
   // Client Registration
@@ -87,6 +91,17 @@ export interface OAuthFlowState {
   authorizationUrl?: string;
   authorizationCode?: string;
   state?: string;
+  // 2026-07-28 (RFC 9207): the AS issuer recorded at discovery time, stamped
+  // alongside the PKCE verifier so the callback leg can validate the returned
+  // `iss` against the exact issuer the flow began with (no re-derivation).
+  recordedIssuer?: string;
+  // The `iss` value returned on the authorization callback, if any. Populated
+  // by the callback boundary; the machine validates it against recordedIssuer.
+  authorizationResponseIss?: string;
+  // The scope set requested when the authorization request was built. Retained
+  // so a step-up challenge can be displayed as the union of prior-requested and
+  // challenged scopes (SEP-2350, display half).
+  requestedScopes?: string[];
 
   // Tokens
   accessToken?: string;

--- a/sdk/tests/oauth/debug-oauth-2026.test.ts
+++ b/sdk/tests/oauth/debug-oauth-2026.test.ts
@@ -1,7 +1,11 @@
 import { createOAuthStateMachine } from "../../src/oauth/state-machines/factory.js";
+import { validateAuthorizationResponseIssuer } from "../../src/oauth/state-machines/debug-oauth-2026-07-28.js";
 import { deriveApplicationType } from "../../src/oauth/state-machines/shared/dynamic-client-registration.js";
 import { EMPTY_OAUTH_FLOW_STATE } from "../../src/oauth/state-machines/types.js";
-import type { OAuthFlowState } from "../../src/oauth/state-machines/types.js";
+import type {
+  OAuthFlowState,
+  OAuthRequestExecutor,
+} from "../../src/oauth/state-machines/types.js";
 
 const REDIRECT_URI = "http://127.0.0.1:3333/callback";
 const SERVER_URL = "https://mcp.example.com/mcp";
@@ -142,5 +146,212 @@ describe("debug-oauth-2026-07-28 machine", () => {
       "https://hosted.example.com/callback",
     ]);
     expect(req?.body?.application_type).toBe("web");
+  });
+});
+
+describe("validateAuthorizationResponseIssuer (RFC 9207)", () => {
+  const ISS = "https://auth.example.com";
+
+  it("row 1: present and matching → ok", () => {
+    expect(
+      validateAuthorizationResponseIssuer({
+        recordedIssuer: ISS,
+        returnedIss: ISS,
+        issParameterSupported: true,
+      }),
+    ).toEqual({ ok: true });
+  });
+
+  it("row 2: present and mismatched → reject (no error params surfaced)", () => {
+    const result = validateAuthorizationResponseIssuer({
+      recordedIssuer: ISS,
+      returnedIss: "https://evil.example.com",
+      issParameterSupported: true,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/RFC 9207/);
+  });
+
+  it("row 3: absent but advertised supported → reject (missing required iss)", () => {
+    const result = validateAuthorizationResponseIssuer({
+      recordedIssuer: ISS,
+      returnedIss: undefined,
+      issParameterSupported: true,
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("row 4: absent and not advertised → ok (nothing to validate)", () => {
+    expect(
+      validateAuthorizationResponseIssuer({
+        recordedIssuer: ISS,
+        returnedIss: undefined,
+        issParameterSupported: undefined,
+      }),
+    ).toEqual({ ok: true });
+  });
+
+  it("present-but-not-advertised is still validated: match → ok, mismatch → reject", () => {
+    expect(
+      validateAuthorizationResponseIssuer({
+        recordedIssuer: ISS,
+        returnedIss: ISS,
+        issParameterSupported: false,
+      }),
+    ).toEqual({ ok: true });
+    expect(
+      validateAuthorizationResponseIssuer({
+        recordedIssuer: ISS,
+        returnedIss: "https://evil.example.com",
+        issParameterSupported: false,
+      }).ok,
+    ).toBe(false);
+  });
+
+  it("treats an empty-string iss as absent", () => {
+    expect(
+      validateAuthorizationResponseIssuer({
+        recordedIssuer: ISS,
+        returnedIss: "",
+        issParameterSupported: undefined,
+      }),
+    ).toEqual({ ok: true });
+  });
+});
+
+describe("debug-oauth-2026-07-28 machine — 2M-a spec steps", () => {
+  const AS_URL = "https://auth.example.com";
+
+  // Build a machine seeded at a given step with a custom request executor, run
+  // one step, and return the resulting state.
+  const driveOnce = async (
+    overrides: Partial<OAuthFlowState>,
+    executor: OAuthRequestExecutor,
+  ) => {
+    let state: OAuthFlowState = {
+      ...EMPTY_OAUTH_FLOW_STATE,
+      serverUrl: SERVER_URL,
+      ...overrides,
+    };
+    const machine = createOAuthStateMachine({
+      protocolVersion: "2026-07-28",
+      registrationStrategy: "dcr",
+      state,
+      getState: () => state,
+      updateState: (updates) => {
+        state = { ...state, ...updates };
+      },
+      serverUrl: SERVER_URL,
+      serverName: "Test Server",
+      redirectUrl: REDIRECT_URI,
+      requestExecutor: executor,
+      dynamicRegistration: { client_name: "Test Client" },
+    });
+    await machine.proceedToNextStep();
+    return () => state;
+  };
+
+  const metadata = (issuer: string) => ({
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    headers: {},
+    body: {
+      issuer,
+      authorization_endpoint: `${AS_URL}/authorize`,
+      token_endpoint: `${AS_URL}/token`,
+      registration_endpoint: `${AS_URL}/register`,
+      response_types_supported: ["code"],
+      code_challenge_methods_supported: ["S256"],
+    },
+  });
+
+  it("rejects AS metadata whose issuer ≠ the discovery URL (RFC 8414 §3.3)", async () => {
+    const getState = await driveOnce(
+      {
+        currentStep: "request_authorization_server_metadata",
+        authorizationServerUrl: AS_URL,
+      },
+      jest.fn().mockResolvedValue(metadata("https://evil.example.com")),
+    );
+    expect(getState().error).toMatch(/RFC 8414/);
+  });
+
+  it("accepts AS metadata whose issuer matches the discovery URL exactly", async () => {
+    const getState = await driveOnce(
+      {
+        currentStep: "request_authorization_server_metadata",
+        authorizationServerUrl: AS_URL,
+      },
+      jest.fn().mockResolvedValue(metadata(AS_URL)),
+    );
+    expect(getState().error).toBeUndefined();
+    expect(getState().currentStep).toBe("received_authorization_server_metadata");
+  });
+
+  it("records the issuer alongside the PKCE parameters", async () => {
+    const getState = await driveOnce(
+      {
+        currentStep: "received_client_credentials",
+        clientId: "client-123",
+        authorizationServerMetadata: metadata(AS_URL).body,
+      },
+      jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        body: {},
+      }),
+    );
+    expect(getState().codeVerifier).toBeTruthy();
+    expect(getState().recordedIssuer).toBe(AS_URL);
+  });
+
+  it("blocks the token exchange when the callback iss mismatches (RFC 9207)", async () => {
+    const getState = await driveOnce(
+      {
+        currentStep: "received_authorization_code",
+        authorizationCode: "auth-code-abc",
+        recordedIssuer: AS_URL,
+        authorizationResponseIss: "https://evil.example.com",
+        authorizationServerMetadata: metadata(AS_URL).body,
+      },
+      jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        body: {},
+      }),
+    );
+    // Stopped before building/sending the token request.
+    expect(getState().currentStep).toBe("received_authorization_code");
+    expect(getState().error).toMatch(/RFC 9207/);
+  });
+
+  it("post-token verification is a stateless tools/list, never initialize", async () => {
+    const getState = await driveOnce(
+      {
+        currentStep: "received_access_token",
+        accessToken: "test-access-token",
+      },
+      jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        body: {},
+      }),
+    );
+    const req = getState().lastRequest;
+    expect(req?.body?.method).toBe("tools/list");
+    expect(JSON.stringify(req?.body)).not.toContain("initialize");
+    expect(req?.headers?.["MCP-Protocol-Version"]).toBe("2026-07-28");
+    expect(req?.headers?.["Mcp-Method"]).toBe("tools/list");
+    // The stateless `_meta` envelope carries the protocol version.
+    expect(
+      req?.body?.params?._meta?.["io.modelcontextprotocol/protocolVersion"],
+    ).toBe("2026-07-28");
   });
 });

--- a/sdk/tests/oauth/debug-oauth-2026.test.ts
+++ b/sdk/tests/oauth/debug-oauth-2026.test.ts
@@ -330,6 +330,32 @@ describe("debug-oauth-2026-07-28 machine — 2M-a spec steps", () => {
     expect(getState().error).toMatch(/RFC 9207/);
   });
 
+  it("logs a token-verified info entry for a tools/list verify result", async () => {
+    const getState = await driveOnce(
+      {
+        currentStep: "authenticated_mcp_request",
+        accessToken: "test-access-token",
+      },
+      jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/json" },
+        body: {
+          jsonrpc: "2.0",
+          id: 2,
+          result: { tools: [{ name: "a" }, { name: "b" }] },
+        },
+      }),
+    );
+    expect(getState().currentStep).toBe("complete");
+    const verified = (getState().infoLogs ?? []).find(
+      (l) => l.id === "mcp-token-verified",
+    );
+    expect(verified).toBeDefined();
+    expect(verified?.data?.["Tools listed"]).toBe(2);
+  });
+
   it("post-token verification is a stateless tools/list, never initialize", async () => {
     const getState = await driveOnce(
       {


### PR DESCRIPTION
Finishes the **2M-a** slice begun in #3321. The forked `debug-oauth-2026-07-28` machine was "11-25 semantics + `application_type` wearing a 2026 label" until now; this lands the five in-machine spec-delta steps plus the stateless verify reshape so the machine is actually 2026-faithful.

## What changed
| Step | Change |
|---|---|
| **DCR deprecation** | Warning info-log on the DCR path + a "Deprecated" diagram row (PR #2858). |
| **AS-metadata issuer exact-match** | RFC 8414 §3.3: reject metadata whose `issuer` ≠ the discovery URL (`authorizationServerUrl`), exact, no normalization. |
| **record_issuer + RFC 9207** | Stamp `recordedIssuer` alongside the PKCE verifier; validate the callback `iss` before the token endpoint; fixed diagnostic on mismatch (never echoes callback `error*`). |
| **AS-binding (display half)** | "bound to issuer" row on the client-credentials step (SEP-2352; storage-write half stays 2R-store). |
| **Scope-union (display half)** | requested / challenged / union rows on the authorization step (SEP-2350; step-up loop stays 2R-stepup). |
| **Stateless verify reshape** | All four `initialize` sites → stateless `tools/list` with the `io.modelcontextprotocol/protocolVersion` `_meta` envelope + `MCP-Protocol-Version`/`Mcp-Method` headers. `TODO(2026 delta)` markers removed; new `buildStatelessVerifyRequestBody` helper. |

## Key decision — cross-track safety seam
The machine's `iss` check **defers the "advertised-but-absent iss → reject" row** to the **2R-iss** track (which owns callback capture at the App.tsx boundary). Nothing populates `authorizationResponseIss` in production yet, so enforcing that row now would hard-fail every AS that advertises iss support the moment someone pins 2026. What ships today: reject a **present-but-mismatched** `iss`. `validateAuthorizationResponseIssuer` still encodes the full RFC 9207 4-row table and is unit-tested independently.

## Deliberately deferred (separate tracks per the plan)
2R-iss (callback capture + `state` CSRF gate), 2R-store (issuer-keyed storage), 2R-stepup (403 loop), and the shared SSRF hardening pass.

## Verification
- `tsc --noEmit` → 0 errors
- `vitest run tests/oauth` → **298 passed** (12 new in `debug-oauth-2026.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OAuth discovery and token-exchange gates and wire format for 2026-07-28 probes; misconfigured AS metadata or servers expecting initialize may fail until aligned, but scope is the debug state machine with tests.
> 
> **Overview**
> Brings the **2026-07-28** debug OAuth state machine in line with the spec delta: connectivity probe and post-token checks no longer use **`initialize`**; they send stateless **`tools/list`** with the **`_meta`** envelope (`buildStatelessVerifyRequestBody`) plus **`MCP-Protocol-Version`** / **`Mcp-Method`** headers.
> 
> **Issuer and security checks:** After AS metadata discovery, **`issuer`** must exactly match the discovery URL (RFC 8414 §3.3). The flow stamps **`recordedIssuer`** with PKCE, validates callback **`iss`** via **`validateAuthorizationResponseIssuer`** before token exchange (present mismatch → fixed RFC 9207 error, no callback **`error*`** echo). The “advertised-but-missing **`iss`**” case stays deferred until callback capture lands.
> 
> **UX / diagram only:** DCR path gets a deprecation warning and diagram note; client-credentials steps show **bound to issuer**; authorization shows requested / challenged / **scope union** when applicable.
> 
> New **`OAuthFlowState`** fields and tests cover issuer validation, metadata rejection, **`iss`** blocking, and stateless verify behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 936e1815ad54f6d2a71942112b6fec3772ce489a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes the `2026-07-28` OAuth state machine (Phase 2, 2M‑a): verify is stateless, issuer checks are strict, UI shows issuer/scope details, and successful `tools/list` verify now logs a clear “token verified” message.

- **New Features**
  - Stateless verify: replaced `initialize` with `tools/list` carrying `_meta` (`io.modelcontextprotocol/protocolVersion`, client info/capabilities) and headers `MCP-Protocol-Version`/`Mcp-Method`; added `buildStatelessVerifyRequestBody`.
  - RFC 8414 §3.3: reject AS metadata when `issuer` ≠ discovery URL (exact match, no normalization).
  - RFC 9207: stamp `recordedIssuer` and validate callback `iss` before token exchange; present-but-mismatched `iss` rejects with a fixed diagnostic. The advertised‑but‑absent `iss` row is deferred to the callback track.
  - Display-only: show "bound to issuer" on client credentials; show requested/challenged/union scopes on authorization.
  - DCR path: logs a deprecation warning and marks it as deprecated in the diagram.
  - Post-verify logging: on successful `tools/list`, add “Access token verified” with tool count when present.
  - Tests: added coverage for issuer checks, RFC 9207 validator, and stateless verify.

- **Migration**
  - Ensure your AS metadata `issuer` exactly matches the discovery URL.
  - Servers must accept stateless `tools/list` with the `_meta` envelope and `MCP-Protocol-Version`/`Mcp-Method` headers under `2026-07-28`.

<sup>Written for commit 936e1815ad54f6d2a71942112b6fec3772ce489a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

