### PR TITLE
COMP-38: Enable cloud skill tools for guest users with a VM

### DIFF
--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -2,7 +2,10 @@ import { Hono } from "hono";
 import type { ChatV2Request } from "@/shared/chat-v2";
 import { getCanonicalModelId } from "@/shared/types";
 import { isHostedCatalogModel } from "../../services/hosted-model-catalog.js";
-import { shouldEnableCloudSkillTools } from "../../utils/computers/cloud-skill-tools.js";
+import {
+  resolveGuestCloudSkillScope,
+  shouldEnableCloudSkillTools,
+} from "../../utils/computers/cloud-skill-tools.js";
 import { isMCPAuthError, TaskCreatedSink } from "@mcpjam/sdk";
 import { isCompatibleHostedTasksVersion } from "@/shared/hosted-task-created";
 import { HostedTaskCreatedBridge } from "../../utils/hosted-task-created-bridge.js";
@@ -775,13 +778,14 @@ chatV2.post("/", async (c) => {
         | undefined
     )?.executionScope;
 
-    // COMP-38: the same scope, but for the cloud-skill READS, and only for a
-    // guest. A member's runtime config carries a scope too (`project_member`
-    // resolves one), and the scoped skills query is SHARED-ONLY — routing a
-    // member through it would silently drop their personal skills from the
-    // catalog. A guest has no membership to read by, so the scope is the only
-    // query they can pass.
-    const guestSkillScope = c.get("guestId") ? executionScope : undefined;
+    // COMP-38: the same scope, narrowed to the cloud-skill READS. One value
+    // feeds both the gate and the read context so they cannot disagree — see
+    // `resolveGuestCloudSkillScope` for why that matters, and why a member gets
+    // undefined here even though their config carries a scope.
+    const guestSkillScope = resolveGuestCloudSkillScope({
+      isGuest: Boolean(c.get("guestId")),
+      executionScope,
+    });
 
     // COMP-16: the host-configured computer working directory — the SAME
     // `computer.workdir` the bash tool runs in — threaded into the harness path

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -102,6 +102,7 @@ import {
 import { applyPluginVersionOverride } from "../../services/environments/plugin-override.js";
 import { resolveExecutionContext } from "../../utils/host-execution-context.js";
 import {
+  narrowHostComputer,
   resolveHostTools,
   type TrustedSandboxBinding,
 } from "../../utils/built-in-tools/registry.js";
@@ -787,7 +788,10 @@ chatV2.post("/", async (c) => {
     // Cloud skills are a Convex-backed PROJECT resource (no computer needed), so
     // the emulated chat path inlines the catalog and wires `loadSkill` (+ file
     // tools) for any signed-in member with a project that has skills. Gate only on:
-    //   - not a guest (a share-link/scenario guest gets no skill tools), and
+    //   - guests need a computer/VM attached (a plain share-link/chatbox guest
+    //     gets no skill tools, but a guest with a sandbox does — they can run
+    //     bash there, and cloud skills let them drive advanced automation too),
+    //     and
     //   - the turn will NOT run a real harness runtime — Claude Code delivers
     //     skills via the adapter `skills` param instead (Codex delivers none),
     //     so advertising the tools here would be a prompt/tool mismatch.
@@ -805,6 +809,14 @@ chatV2.post("/", async (c) => {
       !environmentServers &&
       shouldEnableCloudSkillTools({
         isGuest: Boolean(c.get("guestId")),
+        // A guest's VM access is the same signal that produces the bash tool: a
+        // `computer` resource on the server-resolved runtime config.
+        hasComputer:
+          narrowHostComputer(
+            hostRuntimeConfig
+              ? (hostRuntimeConfig as { computer?: unknown }).computer
+              : undefined,
+          ) != null,
         harness: resolvedExecution.harness,
         modelId: String(modelDefinition.id),
         // Provider is required so bare hosted ids canonicalize — without it a

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -102,7 +102,6 @@ import {
 import { applyPluginVersionOverride } from "../../services/environments/plugin-override.js";
 import { resolveExecutionContext } from "../../utils/host-execution-context.js";
 import {
-  narrowHostComputer,
   resolveHostTools,
   type TrustedSandboxBinding,
 } from "../../utils/built-in-tools/registry.js";
@@ -776,6 +775,14 @@ chatV2.post("/", async (c) => {
         | undefined
     )?.executionScope;
 
+    // COMP-38: the same scope, but for the cloud-skill READS, and only for a
+    // guest. A member's runtime config carries a scope too (`project_member`
+    // resolves one), and the scoped skills query is SHARED-ONLY — routing a
+    // member through it would silently drop their personal skills from the
+    // catalog. A guest has no membership to read by, so the scope is the only
+    // query they can pass.
+    const guestSkillScope = c.get("guestId") ? executionScope : undefined;
+
     // COMP-16: the host-configured computer working directory — the SAME
     // `computer.workdir` the bash tool runs in — threaded into the harness path
     // so its Shell roots under the same directory. Server-resolved config only.
@@ -788,10 +795,11 @@ chatV2.post("/", async (c) => {
     // Cloud skills are a Convex-backed PROJECT resource (no computer needed), so
     // the emulated chat path inlines the catalog and wires `loadSkill` (+ file
     // tools) for any signed-in member with a project that has skills. Gate only on:
-    //   - guests need a computer/VM attached (a plain share-link/chatbox guest
-    //     gets no skill tools, but a guest with a sandbox does — they can run
-    //     bash there, and cloud skills let them drive advanced automation too),
-    //     and
+    //   - a guest needs the turn's Phase-3 `executionScope` (COMP-38): a plain
+    //     share-link/chatbox guest gets no skill tools, but a guest whose grant
+    //     the backend serves a scope for does — the scoped skill queries are
+    //     what authorize the reads, so gating here on the scope gates on the
+    //     same authority that will answer them, and
     //   - the turn will NOT run a real harness runtime — Claude Code delivers
     //     skills via the adapter `skills` param instead (Codex delivers none),
     //     so advertising the tools here would be a prompt/tool mismatch.
@@ -809,14 +817,10 @@ chatV2.post("/", async (c) => {
       !environmentServers &&
       shouldEnableCloudSkillTools({
         isGuest: Boolean(c.get("guestId")),
-        // A guest's VM access is the same signal that produces the bash tool: a
-        // `computer` resource on the server-resolved runtime config.
-        hasComputer:
-          narrowHostComputer(
-            hostRuntimeConfig
-              ? (hostRuntimeConfig as { computer?: unknown }).computer
-              : undefined,
-          ) != null,
+        // NOT `computer`: the backend omits that field for guest actors, so
+        // probing it reads false exactly when a guest has a VM. The scope is the
+        // signal the skill reads are authorized against — see the helper's doc.
+        hasExecutionScope: guestSkillScope !== undefined,
         harness: resolvedExecution.harness,
         modelId: String(modelDefinition.id),
         // Provider is required so bare hosted ids canonicalize — without it a
@@ -1502,6 +1506,12 @@ chatV2.post("/", async (c) => {
                 cloudSkills: {
                   authHeader: `Bearer ${bearerToken}`,
                   projectId: hostedBody.projectId,
+                  // A guest's bearer can't read the project-wide catalog, so
+                  // their reads go through the scope-authorized queries. Unset
+                  // for a member, who keeps the project-wide ones.
+                  ...(guestSkillScope
+                    ? { executionScope: guestSkillScope }
+                    : {}),
                 },
               }
             : {}),

--- a/mcpjam-inspector/server/services/sessionSimulation/runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/runner.ts
@@ -654,9 +654,9 @@ export async function runSyntheticHostSession(
       Boolean(projectId) &&
       shouldEnableCloudSkillTools({
         isGuest: false,
-        // Member-initiated synthetic session — the guest/VM gate never applies,
-        // so this is moot; kept explicit for the required arg shape.
-        hasComputer: false,
+        // Member-initiated synthetic session, so the guest gate never applies
+        // and the scope it would consult is moot; explicit for the arg shape.
+        hasExecutionScope: false,
         harness,
         modelId: String(modelDefinition.id),
         provider: modelDefinition.provider,

--- a/mcpjam-inspector/server/services/sessionSimulation/runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/runner.ts
@@ -654,6 +654,9 @@ export async function runSyntheticHostSession(
       Boolean(projectId) &&
       shouldEnableCloudSkillTools({
         isGuest: false,
+        // Member-initiated synthetic session — the guest/VM gate never applies,
+        // so this is moot; kept explicit for the required arg shape.
+        hasComputer: false,
         harness,
         modelId: String(modelDefinition.id),
         provider: modelDefinition.provider,

--- a/mcpjam-inspector/server/utils/__tests__/chat-v2-orchestration.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/chat-v2-orchestration.test.ts
@@ -10,7 +10,7 @@ vi.mock("../computers/cloud-skills.js", async () => {
   >("../computers/cloud-skills.js");
   return {
     ...actual,
-    listCloudSkills: vi.fn(),
+    listCloudSkillsForActor: vi.fn(),
   };
 });
 
@@ -41,7 +41,7 @@ import {
 import { getSkillToolsAndPrompt } from "../skill-tools";
 import {
   CloudSkillsError,
-  listCloudSkills,
+  listCloudSkillsForActor,
 } from "../computers/cloud-skills";
 import { CLOUD_SKILLS_FETCH_TIMEOUT_MS } from "../computers/cloud-skill-tools";
 import {
@@ -68,7 +68,7 @@ beforeEach(() => {
     tools: {},
     systemPromptSection: "",
   });
-  vi.mocked(listCloudSkills).mockReset();
+  vi.mocked(listCloudSkillsForActor).mockReset();
 });
 
 describe("prepareChatV2", () => {
@@ -1397,7 +1397,7 @@ describe("prepareChatV2 — live cloud skills catalog", () => {
   const cloudSkills = { authHeader: "Bearer t", projectId: "proj-1" };
 
   it("inlines the catalog and advertises loadSkill, not listSkills", async () => {
-    vi.mocked(listCloudSkills).mockResolvedValue([
+    vi.mocked(listCloudSkillsForActor).mockResolvedValue([
       {
         skillId: "sk1",
         projectId: "proj-1",
@@ -1427,8 +1427,45 @@ describe("prepareChatV2 — live cloud skills catalog", () => {
     expect(result.skillsFetchFailed).toBeUndefined();
   });
 
+  it("forwards a guest turn's execution scope to the skill reads", async () => {
+    // COMP-38: the scope is how a non-member's reads are authorized, so it has
+    // to reach the read layer — a member turn still carries none.
+    const executionScope = {
+      kind: "swarm" as const,
+      swarmId: "swarm_1",
+      accessVersion: 1,
+      projectId: "proj-1",
+      workspaceId: "ws_1",
+    };
+    vi.mocked(listCloudSkillsForActor).mockResolvedValue([]);
+    await prepareChatV2({
+      mcpClientManager: mockManager({}),
+      selectedServers: [],
+      modelDefinition: { id: "gpt-4.1", provider: "openai" } as any,
+      systemPrompt: "Base prompt.",
+      cloudSkills: { ...cloudSkills, executionScope },
+    });
+    expect(listCloudSkillsForActor).toHaveBeenCalledWith(
+      expect.objectContaining({ executionScope })
+    );
+  });
+
+  it("omits the scope for a member turn", async () => {
+    vi.mocked(listCloudSkillsForActor).mockResolvedValue([]);
+    await prepareChatV2({
+      mcpClientManager: mockManager({}),
+      selectedServers: [],
+      modelDefinition: { id: "gpt-4.1", provider: "openai" } as any,
+      systemPrompt: "Base prompt.",
+      cloudSkills,
+    });
+    expect(listCloudSkillsForActor).toHaveBeenCalledWith(
+      expect.not.objectContaining({ executionScope: expect.anything() })
+    );
+  });
+
   it("advertises no skill tools or stanza when the project has zero skills", async () => {
-    vi.mocked(listCloudSkills).mockResolvedValue([]);
+    vi.mocked(listCloudSkillsForActor).mockResolvedValue([]);
     const result = await prepareChatV2({
       mcpClientManager: mockManager({}),
       selectedServers: [],
@@ -1443,7 +1480,7 @@ describe("prepareChatV2 — live cloud skills catalog", () => {
   });
 
   it("prepares the turn without skill tools when the catalog fetch throws", async () => {
-    vi.mocked(listCloudSkills).mockRejectedValue(
+    vi.mocked(listCloudSkillsForActor).mockRejectedValue(
       new CloudSkillsError("CONVEX_URL is not configured", 500)
     );
     const result = await prepareChatV2({
@@ -1463,7 +1500,7 @@ describe("prepareChatV2 — live cloud skills catalog", () => {
 
   it("prepares the turn without skill tools when the catalog fetch times out", async () => {
     vi.useFakeTimers();
-    vi.mocked(listCloudSkills).mockImplementation(
+    vi.mocked(listCloudSkillsForActor).mockImplementation(
       () => new Promise(() => {})
     );
     try {

--- a/mcpjam-inspector/server/utils/built-in-tools/registry.ts
+++ b/mcpjam-inspector/server/utils/built-in-tools/registry.ts
@@ -105,11 +105,14 @@ export interface BuiltInToolContext {
   /** Optional chat session, used by Convex for idempotency namespacing. */
   chatSessionId?: string;
   /**
-   * True when the acting identity is a guest. Computer-backed tools are not
-   * advertised to guests (the backend also omits `computer` from guest
-   * runtime configs, and rejects guests at reserve — this is the middle of
-   * three layers). Defaults to false for surfaces that pre-authenticate
-   * non-guest actors (eval runners, sessionSimulation).
+   * True when the acting identity is a guest (share-link / chatbox visitor
+   * rather than a project member). This gates the workspace (`mcpjam_*`) tools,
+   * which are NOT advertised to guests. It does NOT gate bash: bash keys off an
+   * attached `computer`, not guest status, so a guest WITH a computer attached
+   * still gets it — the backend accepts guest bearers on `/computers/reserve`
+   * and contains cost via the guest daily start cap and the idle-delete sweep
+   * (see the bash branch in `resolveHostTools`). Defaults to false for surfaces
+   * that pre-authenticate non-guest actors (eval runners, sessionSimulation).
    */
   isGuest?: boolean;
   /**

--- a/mcpjam-inspector/server/utils/built-in-tools/registry.ts
+++ b/mcpjam-inspector/server/utils/built-in-tools/registry.ts
@@ -106,13 +106,15 @@ export interface BuiltInToolContext {
   chatSessionId?: string;
   /**
    * True when the acting identity is a guest (share-link / chatbox visitor
-   * rather than a project member). This gates the workspace (`mcpjam_*`) tools,
-   * which are NOT advertised to guests. It does NOT gate bash: bash keys off an
-   * attached `computer`, not guest status, so a guest WITH a computer attached
-   * still gets it — the backend accepts guest bearers on `/computers/reserve`
-   * and contains cost via the guest daily start cap and the idle-delete sweep
-   * (see the bash branch in `resolveHostTools`). Defaults to false for surfaces
-   * that pre-authenticate non-guest actors (eval runners, sessionSimulation).
+   * rather than a project member). Workspace (`mcpjam_*`) tools are never
+   * advertised to a guest. Bash is advertised only on a host-funded swarm
+   * grant — `executionScope.kind === "swarm"` — because the backend rejects a
+   * guest reserve on the personal-project path (`assertNonGuestComputerActor`)
+   * and omits `computer` from guest runtime configs; a guest whose shell comes
+   * from an ephemeral sandbox reaches it through `sandboxBinding` instead, which
+   * is checked before any of these gates. See the bash branch in
+   * `resolveHostTools` for all three. Defaults to false for surfaces that
+   * pre-authenticate non-guest actors (eval runners, sessionSimulation).
    */
   isGuest?: boolean;
   /**

--- a/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
+++ b/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
@@ -49,6 +49,7 @@ import {
   withServerSkills,
 } from "./server-skill-tools.js";
 import type { EffectiveCapabilitySet } from "../services/environments/effective-capabilities.js";
+import type { ExecutionScope } from "./execution-scope.js";
 import type { PinnableSkill } from "../../shared/skill-types.js";
 import { logger } from "./logger.js";
 import { modelSupportsTemperature, type ModelDefinition } from "@/shared/types";
@@ -733,7 +734,17 @@ export interface PrepareChatV2Options {
    * callers whose host actually has a computer, so "advertise == enforce".
    * Takes precedence over the local/HOSTED_MODE skill branches.
    */
-  cloudSkills?: { authHeader: string; projectId: string };
+  cloudSkills?: {
+    authHeader: string;
+    projectId: string;
+    /**
+     * Phase-3 execution scope, set for a guest / swarm-grant turn (COMP-38).
+     * Forwarded so the catalog and `loadSkill` reads issue the scope-authorized
+     * queries the backend re-resolves — a non-member has no other authorization
+     * channel. Absent for a member, whose reads authorize by membership.
+     */
+    executionScope?: ExecutionScope;
+  };
   /**
    * Explicit skill source, ABOVE the cloud/HOSTED/local chain. Chat callers on
    * the legacy paths never set it → the existing precedence is byte-identical.
@@ -1113,6 +1124,9 @@ export async function prepareChatV2(
         {
           authHeader: cloudSkills.authHeader,
           projectId: cloudSkills.projectId,
+          ...(cloudSkills.executionScope
+            ? { executionScope: cloudSkills.executionScope }
+            : {}),
         },
         modelContextTokens
       )

--- a/mcpjam-inspector/server/utils/computers/__tests__/cloud-skill-tools-gate.test.ts
+++ b/mcpjam-inspector/server/utils/computers/__tests__/cloud-skill-tools-gate.test.ts
@@ -13,6 +13,7 @@ import { shouldEnableCloudSkillTools } from "../cloud-skill-tools";
 
 const base = {
   isGuest: false,
+  hasComputer: false,
   harness: undefined as string | undefined,
   modelId: "mcpjam/claude",
   hasProjectId: true,
@@ -30,8 +31,45 @@ describe("shouldEnableCloudSkillTools", () => {
     );
   });
 
-  it("disables for a guest", () => {
+  it("disables for a guest without a computer", () => {
     expect(shouldEnableCloudSkillTools({ ...base, isGuest: true })).toBe(false);
+  });
+
+  it("ENABLES for a guest WITH a computer/VM attached", () => {
+    // COMP-38: a guest with sandbox access gets cloud skills — they can run
+    // bash in the VM, so skills let them drive advanced automation there too.
+    expect(
+      shouldEnableCloudSkillTools({
+        ...base,
+        isGuest: true,
+        hasComputer: true,
+      })
+    ).toBe(true);
+  });
+
+  it("still disables a guest WITH a computer on a real harness turn", () => {
+    // VM access relaxes the guest gate, not the harness gate: a harness turn
+    // delivers skills via the adapter, so the emulated tools stay off.
+    expect(
+      shouldEnableCloudSkillTools({
+        ...base,
+        isGuest: true,
+        hasComputer: true,
+        harness: "claude-code",
+        modelId: "mcpjam/claude",
+      })
+    ).toBe(false);
+  });
+
+  it("still disables a guest WITH a computer but no project id", () => {
+    expect(
+      shouldEnableCloudSkillTools({
+        ...base,
+        isGuest: true,
+        hasComputer: true,
+        hasProjectId: false,
+      })
+    ).toBe(false);
   });
 
   it("disables without a project id", () => {

--- a/mcpjam-inspector/server/utils/computers/__tests__/cloud-skill-tools-gate.test.ts
+++ b/mcpjam-inspector/server/utils/computers/__tests__/cloud-skill-tools-gate.test.ts
@@ -9,7 +9,11 @@ vi.mock("../../../services/hosted-model-catalog.js", () => ({
     id.startsWith("mcpjam/") || (provider === "mcpjam" && !id.includes("/")),
 }));
 
-import { shouldEnableCloudSkillTools } from "../cloud-skill-tools";
+import {
+  resolveGuestCloudSkillScope,
+  shouldEnableCloudSkillTools,
+} from "../cloud-skill-tools";
+import type { ExecutionScope } from "../../execution-scope.js";
 
 const base = {
   isGuest: false,
@@ -121,6 +125,55 @@ describe("shouldEnableCloudSkillTools", () => {
         ...base,
         harness: "codex",
         modelId: "mcpjam/gpt-5",
+      })
+    ).toBe(false);
+  });
+});
+
+describe("resolveGuestCloudSkillScope", () => {
+  const scope: ExecutionScope = {
+    kind: "swarm",
+    swarmId: "swarm_1",
+    accessVersion: 2,
+    projectId: "proj_1",
+    workspaceId: "ws_1",
+  };
+
+  it("returns the scope for a guest turn that carries one", () => {
+    expect(
+      resolveGuestCloudSkillScope({ isGuest: true, executionScope: scope })
+    ).toBe(scope);
+  });
+
+  it("returns undefined for a member, scope or not", () => {
+    // A member's config carries a scope too, and the scoped query is
+    // shared-only — it would drop their personal skills.
+    expect(
+      resolveGuestCloudSkillScope({ isGuest: false, executionScope: scope })
+    ).toBeUndefined();
+    expect(
+      resolveGuestCloudSkillScope({ isGuest: false, executionScope: undefined })
+    ).toBeUndefined();
+  });
+
+  it("normalizes a null/omitted scope to undefined so the gate and the reads agree", () => {
+    // The gate reads `!== undefined`; a raw `null` from a malformed config would
+    // have opened it while the reads fell back to the membership-only query.
+    expect(
+      resolveGuestCloudSkillScope({ isGuest: true, executionScope: null })
+    ).toBeUndefined();
+    expect(
+      resolveGuestCloudSkillScope({ isGuest: true, executionScope: undefined })
+    ).toBeUndefined();
+    expect(
+      shouldEnableCloudSkillTools({
+        ...base,
+        isGuest: true,
+        hasExecutionScope:
+          resolveGuestCloudSkillScope({
+            isGuest: true,
+            executionScope: null,
+          }) !== undefined,
       })
     ).toBe(false);
   });

--- a/mcpjam-inspector/server/utils/computers/__tests__/cloud-skill-tools-gate.test.ts
+++ b/mcpjam-inspector/server/utils/computers/__tests__/cloud-skill-tools-gate.test.ts
@@ -13,7 +13,7 @@ import { shouldEnableCloudSkillTools } from "../cloud-skill-tools";
 
 const base = {
   isGuest: false,
-  hasComputer: false,
+  hasExecutionScope: false,
   harness: undefined as string | undefined,
   modelId: "mcpjam/claude",
   hasProjectId: true,
@@ -31,42 +31,42 @@ describe("shouldEnableCloudSkillTools", () => {
     );
   });
 
-  it("disables for a guest without a computer", () => {
+  it("disables for a guest whose turn carries no execution scope", () => {
     expect(shouldEnableCloudSkillTools({ ...base, isGuest: true })).toBe(false);
   });
 
-  it("ENABLES for a guest WITH a computer/VM attached", () => {
-    // COMP-38: a guest with sandbox access gets cloud skills — they can run
-    // bash in the VM, so skills let them drive advanced automation there too.
+  it("ENABLES for a guest whose turn carries an execution scope", () => {
+    // COMP-38: the scope is what authorizes the scoped skill reads, so a guest
+    // the backend granted one gets the tools those reads back.
     expect(
       shouldEnableCloudSkillTools({
         ...base,
         isGuest: true,
-        hasComputer: true,
+        hasExecutionScope: true,
       })
     ).toBe(true);
   });
 
-  it("still disables a guest WITH a computer on a real harness turn", () => {
-    // VM access relaxes the guest gate, not the harness gate: a harness turn
+  it("still disables a scoped guest on a real harness turn", () => {
+    // The scope relaxes the guest gate, not the harness gate: a harness turn
     // delivers skills via the adapter, so the emulated tools stay off.
     expect(
       shouldEnableCloudSkillTools({
         ...base,
         isGuest: true,
-        hasComputer: true,
+        hasExecutionScope: true,
         harness: "claude-code",
         modelId: "mcpjam/claude",
       })
     ).toBe(false);
   });
 
-  it("still disables a guest WITH a computer but no project id", () => {
+  it("still disables a scoped guest with no project id", () => {
     expect(
       shouldEnableCloudSkillTools({
         ...base,
         isGuest: true,
-        hasComputer: true,
+        hasExecutionScope: true,
         hasProjectId: false,
       })
     ).toBe(false);

--- a/mcpjam-inspector/server/utils/computers/__tests__/cloud-skills-actor-scope.test.ts
+++ b/mcpjam-inspector/server/utils/computers/__tests__/cloud-skills-actor-scope.test.ts
@@ -31,6 +31,7 @@ import {
 } from "../convex-skills-client.js";
 import {
   CloudSkillsError,
+  SKILL_FILE_MAX_READ_BYTES,
   getCloudSkillBodyForActor,
   listCloudSkillFilesForActor,
   listCloudSkillsForActor,
@@ -151,6 +152,45 @@ describe("readCloudSkillFileForActor", () => {
     await expect(
       readCloudSkillFileForActor(guest, "sk_1", "missing.md")
     ).rejects.toMatchObject({ status: 404 });
+  });
+
+  it("404s an entry the scoped listing minted no URL for", async () => {
+    vi.mocked(convexListSkillFilesForRuntimeExecution).mockResolvedValue([
+      { skillId: "sk_1", path: "notes.md", size: 5, url: null },
+    ]);
+    await expect(
+      readCloudSkillFileForActor(guest, "sk_1", "notes.md")
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  it("413s past the read cap, before fetching a single byte", async () => {
+    vi.mocked(convexListSkillFilesForRuntimeExecution).mockResolvedValue([
+      {
+        skillId: "sk_1",
+        path: "big.bin",
+        size: SKILL_FILE_MAX_READ_BYTES + 1,
+        url: "https://blob/big",
+      },
+    ]);
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    await expect(
+      readCloudSkillFileForActor(guest, "sk_1", "big.bin")
+    ).rejects.toMatchObject({ status: 413 });
+    expect(fetchMock).not.toHaveBeenCalled();
+    fetchMock.mockRestore();
+  });
+
+  it("502s a storage response that isn't ok", async () => {
+    vi.mocked(convexListSkillFilesForRuntimeExecution).mockResolvedValue([
+      { skillId: "sk_1", path: "notes.md", size: 5, url: "https://blob/1" },
+    ]);
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("nope", { status: 500 }));
+    await expect(
+      readCloudSkillFileForActor(guest, "sk_1", "notes.md")
+    ).rejects.toMatchObject({ status: 502 });
+    fetchMock.mockRestore();
   });
 
   it("keeps the member read on the member query", async () => {

--- a/mcpjam-inspector/server/utils/computers/__tests__/cloud-skills-actor-scope.test.ts
+++ b/mcpjam-inspector/server/utils/computers/__tests__/cloud-skills-actor-scope.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// COMP-38: the reads the chat skill tools make must follow the ACTOR. A member
+// keeps the project-wide queries; a guest / swarm grant goes through the
+// `*ForRuntimeExecution` pair, the only queries a non-member bearer can pass.
+vi.mock("../convex-skills-client.js", () => ({
+  convexListSkills: vi.fn(),
+  convexListSkillsForRuntimeExecution: vi.fn(),
+  convexGetSkillByName: vi.fn(),
+  convexListSkillFiles: vi.fn(),
+  convexListSkillFilesForRuntimeExecution: vi.fn(),
+  convexGetSkillFileUrl: vi.fn(),
+  // Unused by these reads, but the module namespace must resolve.
+  convexAttachSkillFiles: vi.fn(),
+  convexCreateSkill: vi.fn(),
+  convexDeleteSkill: vi.fn(),
+  convexGenerateSkillFileUploadUrl: vi.fn(),
+  convexGetSkill: vi.fn(),
+  convexPromoteSkill: vi.fn(),
+  convexRemoveSkillFile: vi.fn(),
+  convexUpdateSkill: vi.fn(),
+}));
+
+import {
+  convexGetSkillByName,
+  convexGetSkillFileUrl,
+  convexListSkillFiles,
+  convexListSkillFilesForRuntimeExecution,
+  convexListSkills,
+  convexListSkillsForRuntimeExecution,
+} from "../convex-skills-client.js";
+import {
+  CloudSkillsError,
+  getCloudSkillBodyForActor,
+  listCloudSkillFilesForActor,
+  listCloudSkillsForActor,
+  readCloudSkillFileForActor,
+  type CloudSkillsContext,
+} from "../cloud-skills";
+import type { ExecutionScope } from "../../execution-scope.js";
+
+const scope: ExecutionScope = {
+  kind: "swarm",
+  swarmId: "swarm_1",
+  accessVersion: 3,
+  projectId: "proj_1",
+  workspaceId: "ws_1",
+};
+
+const member: CloudSkillsContext = {
+  authHeader: "Bearer member",
+  projectId: "proj_1",
+};
+
+const guest: CloudSkillsContext = {
+  authHeader: "Bearer guest",
+  projectId: "proj_1",
+  executionScope: scope,
+};
+
+const scopedSkills = [
+  {
+    skillId: "sk_1",
+    name: "pdf-tools",
+    description: "Process PDFs",
+    content: "Step 1. Extract text.",
+    aggregateHash: "h1",
+  },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("listCloudSkillsForActor", () => {
+  it("uses the project-wide query for a member", async () => {
+    vi.mocked(convexListSkills).mockResolvedValue([]);
+    await listCloudSkillsForActor(member);
+    expect(convexListSkills).toHaveBeenCalledWith("Bearer member", "proj_1");
+    expect(convexListSkillsForRuntimeExecution).not.toHaveBeenCalled();
+  });
+
+  it("uses the scope-authorized query when the turn carries a scope", async () => {
+    vi.mocked(convexListSkillsForRuntimeExecution).mockResolvedValue(
+      scopedSkills
+    );
+    const catalog = await listCloudSkillsForActor(guest);
+    expect(convexListSkillsForRuntimeExecution).toHaveBeenCalledWith(
+      "Bearer guest",
+      scope
+    );
+    expect(convexListSkills).not.toHaveBeenCalled();
+    expect(catalog.map((entry) => entry.name)).toEqual(["pdf-tools"]);
+  });
+});
+
+describe("getCloudSkillBodyForActor", () => {
+  it("resolves a name off the scoped listing, never the member query", async () => {
+    vi.mocked(convexListSkillsForRuntimeExecution).mockResolvedValue(
+      scopedSkills
+    );
+    const skill = await getCloudSkillBodyForActor(guest, "pdf-tools");
+    expect(skill).toMatchObject({
+      skillId: "sk_1",
+      name: "pdf-tools",
+      content: "Step 1. Extract text.",
+    });
+    expect(convexGetSkillByName).not.toHaveBeenCalled();
+  });
+
+  it("returns null for a skill the grant does not expose", async () => {
+    vi.mocked(convexListSkillsForRuntimeExecution).mockResolvedValue(
+      scopedSkills
+    );
+    expect(await getCloudSkillBodyForActor(guest, "other")).toBeNull();
+  });
+});
+
+describe("listCloudSkillFilesForActor", () => {
+  it("narrows the scope's whole-grant file listing to the asked-for skill", async () => {
+    vi.mocked(convexListSkillFilesForRuntimeExecution).mockResolvedValue([
+      { skillId: "sk_1", path: "scripts/fill.py", size: 12, url: "u1" },
+      { skillId: "sk_2", path: "other.txt", size: 3, url: "u2" },
+    ]);
+    const files = await listCloudSkillFilesForActor(guest, "sk_1");
+    expect(files.map((file) => file.path)).toEqual(["scripts/fill.py"]);
+    expect(convexListSkillFiles).not.toHaveBeenCalled();
+  });
+});
+
+describe("readCloudSkillFileForActor", () => {
+  it("reads the bytes from the URL the scoped listing minted", async () => {
+    vi.mocked(convexListSkillFilesForRuntimeExecution).mockResolvedValue([
+      { skillId: "sk_1", path: "notes.md", size: 5, url: "https://blob/1" },
+    ]);
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("hello"));
+    const file = await readCloudSkillFileForActor(guest, "sk_1", "notes.md");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://blob/1",
+      expect.objectContaining({ signal: expect.anything() })
+    );
+    expect(file).toMatchObject({ path: "notes.md", isText: true });
+    expect(convexGetSkillFileUrl).not.toHaveBeenCalled();
+    fetchMock.mockRestore();
+  });
+
+  it("404s a path the grant does not expose", async () => {
+    vi.mocked(convexListSkillFilesForRuntimeExecution).mockResolvedValue([]);
+    await expect(
+      readCloudSkillFileForActor(guest, "sk_1", "missing.md")
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  it("keeps the member read on the member query", async () => {
+    vi.mocked(convexGetSkillFileUrl).mockResolvedValue({
+      url: null,
+      size: 0,
+    });
+    await expect(
+      readCloudSkillFileForActor(member, "sk_1", "notes.md")
+    ).rejects.toBeInstanceOf(CloudSkillsError);
+    expect(convexGetSkillFileUrl).toHaveBeenCalledWith(
+      "Bearer member",
+      "proj_1",
+      "sk_1",
+      "notes.md"
+    );
+    expect(convexListSkillFilesForRuntimeExecution).not.toHaveBeenCalled();
+  });
+});

--- a/mcpjam-inspector/server/utils/computers/cloud-skill-tools.ts
+++ b/mcpjam-inspector/server/utils/computers/cloud-skill-tools.ts
@@ -17,6 +17,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 import { isHostedCatalogModel } from "../../services/hosted-model-catalog.js";
+import type { ExecutionScope } from "../execution-scope.js";
 import type { PinnableSkill } from "../../../shared/skill-types.js";
 import { logger } from "../logger.js";
 import {
@@ -108,6 +109,30 @@ export function shouldEnableCloudSkillTools(args: {
   // members already read the project-wide catalog by membership.
   const actorAllowed = !args.isGuest || args.hasExecutionScope;
   return actorAllowed && !willRunHarness && args.hasProjectId;
+}
+
+/**
+ * The scope the cloud-skill READS should run under, or `undefined` for the
+ * membership-authorized queries.
+ *
+ * ONE value for two decisions — the gate above and the read context — because
+ * they must not be able to disagree. Deriving them separately let a config that
+ * carries `executionScope: null` open the gate (`null !== undefined`) while the
+ * reads fell back to the member query, which is precisely the guest-403 this
+ * change exists to prevent.
+ *
+ * Returns undefined for a member: their runtime config carries a scope too, and
+ * the scoped query is shared-only, so routing them through it would drop their
+ * personal skills. No structural validation of the scope itself — it is opaque
+ * and the backend re-resolves it (see `execution-scope.ts`); a malformed one is
+ * rejected there and the turn degrades to no skills.
+ */
+export function resolveGuestCloudSkillScope(args: {
+  isGuest: boolean;
+  executionScope: ExecutionScope | null | undefined;
+}): ExecutionScope | undefined {
+  if (!args.isGuest) return undefined;
+  return args.executionScope ?? undefined;
 }
 
 function errMessage(err: unknown): string {

--- a/mcpjam-inspector/server/utils/computers/cloud-skill-tools.ts
+++ b/mcpjam-inspector/server/utils/computers/cloud-skill-tools.ts
@@ -21,10 +21,10 @@ import type { PinnableSkill } from "../../../shared/skill-types.js";
 import { logger } from "../logger.js";
 import {
   CloudSkillsError,
-  getCloudSkillByName,
-  listCloudSkills,
-  listCloudSkillFiles,
-  readCloudSkillFile,
+  getCloudSkillBodyForActor,
+  listCloudSkillsForActor,
+  listCloudSkillFilesForActor,
+  readCloudSkillFileForActor,
   type CloudSkillsContext,
 } from "./cloud-skills.js";
 import {
@@ -61,10 +61,20 @@ export type SkillsFetchFailure = {
  * (or, for skills-incapable runtimes like Codex, not at all) — advertising the
  * emulated tools there would be a prompt/tool mismatch.
  *
- * Guests: a plain share-link/chatbox guest still gets no skill tools, but a
- * guest WITH a computer attached (`hasComputer`) does — they can already run
- * bash in the sandbox, so cloud skills let them drive advanced testing and
- * automation there too. A computer-less guest stays gated out.
+ * Guests (COMP-38): a plain share-link/chatbox guest still gets no skill tools,
+ * but a guest whose turn carries a Phase-3 `executionScope` does. That scope is
+ * the ONLY channel by which a non-member's skill read is authorized — the
+ * project-wide `projectSkills:listSkills` query requires membership, so the
+ * scoped `listSkillsForRuntimeExecution` is what the reads go through (see
+ * `cloud-skills.ts`) and the backend re-resolves the grant on every one of them.
+ * Gating on the scope therefore gates on the same authority that will decide
+ * whether the reads succeed, and a guest the backend declines gets an empty
+ * catalog (`skillsFetchFailed`) rather than tools that error on every call.
+ *
+ * NOT gated on an attached `computer`: the backend omits that field for guest
+ * actors (see `scenario-runtime-config.ts`), and guest `bash` comes either from
+ * an out-of-band ephemeral sandbox binding or from a scope-authorized reserve —
+ * so a computer probe here reads false exactly when a guest has a VM.
  *
  * Two footguns this check must not regress on:
  *  - `provider` is REQUIRED for the model check: bare hosted ids
@@ -80,7 +90,12 @@ export type SkillsFetchFailure = {
  */
 export function shouldEnableCloudSkillTools(args: {
   isGuest: boolean;
-  hasComputer: boolean;
+  /**
+   * Does this turn carry a Phase-3 `executionScope` the skill reads can be
+   * authorized against? Only consulted for a guest, who has no other
+   * authorization channel — a member reads by membership.
+   */
+  hasExecutionScope: boolean;
   harness: string | undefined;
   modelId: string;
   provider?: string;
@@ -89,9 +104,9 @@ export function shouldEnableCloudSkillTools(args: {
   const willRunHarness =
     args.harness !== undefined &&
     isHostedCatalogModel(args.modelId, args.provider);
-  // Guests are allowed only when they have a computer/VM attached (they can
-  // already run bash there); non-guest members are unaffected.
-  const actorAllowed = !args.isGuest || args.hasComputer;
+  // A guest needs the scope grant their reads will be authorized against;
+  // members already read the project-wide catalog by membership.
+  const actorAllowed = !args.isGuest || args.hasExecutionScope;
   return actorAllowed && !willRunHarness && args.hasProjectId;
 }
 
@@ -164,7 +179,7 @@ export function createCloudSkillTools(ctx: CloudSkillsContext) {
           return `Error: Invalid skill name format "${name}". Skill names contain only lowercase letters, numbers, and hyphens.`;
         }
         try {
-          const skill = await getCloudSkillByName(ctx, name);
+          const skill = await getCloudSkillBodyForActor(ctx, name);
           if (!skill) return `Error: Skill "${name}" not found.`;
           return `# Skill: ${skill.name}\n\n${skill.content}`;
         } catch (err) {
@@ -184,9 +199,9 @@ export function createCloudSkillTools(ctx: CloudSkillsContext) {
           return `Error: Invalid skill name format "${name}".`;
         }
         try {
-          const skill = await getCloudSkillByName(ctx, name);
+          const skill = await getCloudSkillBodyForActor(ctx, name);
           if (!skill) return `Error: Skill "${name}" not found.`;
-          const files = await listCloudSkillFiles(ctx, skill.skillId);
+          const files = await listCloudSkillFilesForActor(ctx, skill.skillId);
           if (files.length === 0) {
             return `Skill "${name}" has no supporting files.`;
           }
@@ -208,16 +223,22 @@ export function createCloudSkillTools(ctx: CloudSkillsContext) {
         name: z.string().describe("The skill name."),
         path: z
           .string()
-          .describe("Relative path within the skill (e.g., 'scripts/fill.py')."),
+          .describe(
+            "Relative path within the skill (e.g., 'scripts/fill.py')."
+          ),
       }),
       execute: async ({ name, path }) => {
         if (!NAME_RE.test(name)) {
           return `Error: Invalid skill name format "${name}".`;
         }
         try {
-          const skill = await getCloudSkillByName(ctx, name);
+          const skill = await getCloudSkillBodyForActor(ctx, name);
           if (!skill) return `Error: Skill "${name}" not found.`;
-          const file = await readCloudSkillFile(ctx, skill.skillId, path);
+          const file = await readCloudSkillFileForActor(
+            ctx,
+            skill.skillId,
+            path
+          );
           if (!file.isText) {
             return `File "${path}" is binary (${file.mimeType}, ${file.size} bytes) and can't be shown as text.`;
           }
@@ -250,9 +271,11 @@ function raceWithTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
   });
 }
 
-function skillsFailureFrom(err: unknown, latencyMs: number): SkillsFetchFailure {
-  const errorClass =
-    err instanceof Error ? err.constructor.name : typeof err;
+function skillsFailureFrom(
+  err: unknown,
+  latencyMs: number
+): SkillsFetchFailure {
+  const errorClass = err instanceof Error ? err.constructor.name : typeof err;
   const status = err instanceof CloudSkillsError ? err.status : undefined;
   return {
     errorClass,
@@ -282,7 +305,7 @@ export async function getCloudSkillToolsAndPrompt(
   const started = Date.now();
   try {
     const skills = await raceWithTimeout(
-      listCloudSkills(ctx),
+      listCloudSkillsForActor(ctx),
       CLOUD_SKILLS_FETCH_TIMEOUT_MS
     );
     const latencyMs = Date.now() - started;

--- a/mcpjam-inspector/server/utils/computers/cloud-skill-tools.ts
+++ b/mcpjam-inspector/server/utils/computers/cloud-skill-tools.ts
@@ -61,6 +61,11 @@ export type SkillsFetchFailure = {
  * (or, for skills-incapable runtimes like Codex, not at all) — advertising the
  * emulated tools there would be a prompt/tool mismatch.
  *
+ * Guests: a plain share-link/chatbox guest still gets no skill tools, but a
+ * guest WITH a computer attached (`hasComputer`) does — they can already run
+ * bash in the sandbox, so cloud skills let them drive advanced testing and
+ * automation there too. A computer-less guest stays gated out.
+ *
  * Two footguns this check must not regress on:
  *  - `provider` is REQUIRED for the model check: bare hosted ids
  *    (`gpt-5-nano` + `openai`) only canonicalize to their prefixed form with
@@ -75,6 +80,7 @@ export type SkillsFetchFailure = {
  */
 export function shouldEnableCloudSkillTools(args: {
   isGuest: boolean;
+  hasComputer: boolean;
   harness: string | undefined;
   modelId: string;
   provider?: string;
@@ -83,7 +89,10 @@ export function shouldEnableCloudSkillTools(args: {
   const willRunHarness =
     args.harness !== undefined &&
     isHostedCatalogModel(args.modelId, args.provider);
-  return !args.isGuest && !willRunHarness && args.hasProjectId;
+  // Guests are allowed only when they have a computer/VM attached (they can
+  // already run bash there); non-guest members are unaffected.
+  const actorAllowed = !args.isGuest || args.hasComputer;
+  return actorAllowed && !willRunHarness && args.hasProjectId;
 }
 
 function errMessage(err: unknown): string {

--- a/mcpjam-inspector/server/utils/computers/cloud-skills.ts
+++ b/mcpjam-inspector/server/utils/computers/cloud-skills.ts
@@ -26,7 +26,9 @@ import {
   convexGetSkillByName,
   convexGetSkillFileUrl,
   convexListSkillFiles,
+  convexListSkillFilesForRuntimeExecution,
   convexListSkills,
+  convexListSkillsForRuntimeExecution,
   convexPromoteSkill,
   convexRemoveSkillFile,
   convexUpdateSkill,
@@ -37,6 +39,7 @@ import {
   type SkillSharing,
 } from "./convex-skills-client.js";
 import { getMimeType, isTextMimeType } from "../skill-parser.js";
+import type { ExecutionScope } from "../execution-scope.js";
 import type { SkillFileContent } from "../../../shared/skill-types.js";
 
 /** Client-side preflight cap (the backend enforces the real one). */
@@ -60,6 +63,21 @@ export interface CloudSkillsContext {
   authHeader: string;
   projectId: string;
   signal?: AbortSignal;
+  /**
+   * Phase-3 execution scope from the server-resolved runtime config. It changes
+   * WHICH query the actor-scoped reads below issue: the `*ForRuntimeExecution`
+   * pair, which the backend re-resolves against the live grant, instead of the
+   * `projectId` queries that require membership.
+   *
+   * Set it ONLY for a non-member actor. A member's runtime config carries a
+   * scope as well, and the scoped query is shared-only — routing a member
+   * through it would drop their personal skills. Absent ⇒ the member queries,
+   * byte-identical to before.
+   *
+   * Only the actor-scoped reads honour it. The CRUD helpers stay member-only:
+   * they back the `/web/skills` routes, where the caller is always a member.
+   */
+  executionScope?: ExecutionScope;
 }
 
 export type { CloudSkillDetail, CloudSkillListItem, SkillSharing };
@@ -254,51 +272,175 @@ export function readCloudSkillFile(
       skillId,
       path
     );
-    if (!url) throw new CloudSkillsError("Skill file not found", 404);
-    // Guard on the server-verified size BEFORE fetching so a large blob can't
-    // force buffering the whole payload in memory. The backend caps files at
-    // 2MB, so anything above that is anomalous.
-    if (size > SKILL_FILE_MAX_READ_BYTES) {
-      throw new CloudSkillsError(
-        `Skill file too large to read (${size} bytes).`,
-        413
-      );
-    }
-    // Combine the caller's disconnect signal with an explicit timeout so a slow
-    // `_storage` response can't hold the worker indefinitely.
-    const timeout = AbortSignal.timeout(30_000);
-    const signal = ctx.signal
-      ? AbortSignal.any([ctx.signal, timeout])
-      : timeout;
-    const res = await fetch(url, { signal });
-    if (!res.ok) {
-      throw new CloudSkillsError(
-        `Failed to read skill file (${res.status})`,
-        502
-      );
-    }
-    const bytes = new Uint8Array(await res.arrayBuffer());
-    const mimeType = getMimeType(path);
-    const name = path.split("/").pop() ?? path;
-    const isText =
-      isTextMimeType(mimeType) && bytes.byteLength <= MAX_SKILL_FILE_TEXT_BYTES;
-    if (isText) {
-      return {
-        path,
-        name,
-        content: new TextDecoder().decode(bytes),
-        mimeType,
-        size: bytes.byteLength,
-        isText: true,
-      };
-    }
+    return await fetchSkillFileContent(ctx, { url, size, path });
+  });
+}
+
+/**
+ * Fetch one supporting file's bytes from an already-resolved `_storage` URL and
+ * shape them like the local FS reader. Shared by the member read above and the
+ * actor-scoped read below, which resolve the URL through different queries but
+ * must apply the same size guard, timeout and text/binary rule.
+ */
+async function fetchSkillFileContent(
+  ctx: CloudSkillsContext,
+  file: { url: string | null; size: number; path: string }
+): Promise<SkillFileContent> {
+  const { url, size, path } = file;
+  if (!url) throw new CloudSkillsError("Skill file not found", 404);
+  // Guard on the server-verified size BEFORE fetching so a large blob can't
+  // force buffering the whole payload in memory. The backend caps files at
+  // 2MB, so anything above that is anomalous.
+  if (size > SKILL_FILE_MAX_READ_BYTES) {
+    throw new CloudSkillsError(
+      `Skill file too large to read (${size} bytes).`,
+      413
+    );
+  }
+  // Combine the caller's disconnect signal with an explicit timeout so a slow
+  // `_storage` response can't hold the worker indefinitely.
+  const timeout = AbortSignal.timeout(30_000);
+  const signal = ctx.signal ? AbortSignal.any([ctx.signal, timeout]) : timeout;
+  const res = await fetch(url, { signal });
+  if (!res.ok) {
+    throw new CloudSkillsError(
+      `Failed to read skill file (${res.status})`,
+      502
+    );
+  }
+  const bytes = new Uint8Array(await res.arrayBuffer());
+  const mimeType = getMimeType(path);
+  const name = path.split("/").pop() ?? path;
+  const isText =
+    isTextMimeType(mimeType) && bytes.byteLength <= MAX_SKILL_FILE_TEXT_BYTES;
+  if (isText) {
     return {
       path,
       name,
-      base64: Buffer.from(bytes).toString("base64"),
+      content: new TextDecoder().decode(bytes),
       mimeType,
       size: bytes.byteLength,
-      isText: false,
+      isText: true,
     };
+  }
+  return {
+    path,
+    name,
+    base64: Buffer.from(bytes).toString("base64"),
+    mimeType,
+    size: bytes.byteLength,
+    isText: false,
+  };
+}
+
+// ── actor-scoped reads (the chat skill tools) ───────────────────────────────
+//
+// The four reads `createCloudSkillTools` makes, each authorized for whoever is
+// acting: a member through the project-wide queries, a guest / swarm grant
+// through the scope-authorized `*ForRuntimeExecution` pair. Same return shapes
+// either way, so the tools hold no branch of their own.
+//
+// The CRUD helpers above deliberately do NOT branch: a write is a member
+// operation, and a scoped write query does not exist to route to.
+
+/** What the prompt-inlined catalog needs from each visible skill. */
+export type CloudSkillCatalogEntry = { name: string; description: string };
+
+/** What `loadSkill` needs — the only fields the chat tools read off a skill. */
+export type CloudSkillBody = {
+  skillId: string;
+  name: string;
+  content: string;
+};
+
+/** One supporting file, as the file-listing tool renders it. */
+export type CloudSkillFileEntry = { path: string; size: number };
+
+export function listCloudSkillsForActor(
+  ctx: CloudSkillsContext
+): Promise<CloudSkillCatalogEntry[]> {
+  // The scoped listing is the runtime one, so it carries each skill's body as
+  // well as its metadata — there is no metadata-only scoped query to ask for
+  // instead. That makes a scoped catalog fetch heavier than a member's under
+  // the same `CLOUD_SKILLS_FETCH_TIMEOUT_MS`, which is why a timeout degrades
+  // to "no skills this turn" rather than failing it.
+  return run(async () =>
+    ctx.executionScope
+      ? await convexListSkillsForRuntimeExecution(
+          ctx.authHeader,
+          ctx.executionScope
+        )
+      : await convexListSkills(ctx.authHeader, ctx.projectId)
+  );
+}
+
+/**
+ * Resolve a skill by name for `loadSkill`.
+ *
+ * The scoped branch reads the name out of the scope's own listing rather than a
+ * by-name query: the backend serves no scoped `getSkillByName`, and the scoped
+ * listing already carries every visible skill's `content`. Resolving from it
+ * also means a guest can only ever name a skill the grant already exposes.
+ */
+export function getCloudSkillBodyForActor(
+  ctx: CloudSkillsContext,
+  name: string
+): Promise<CloudSkillBody | null> {
+  return run(async () => {
+    if (!ctx.executionScope) {
+      return await convexGetSkillByName(ctx.authHeader, ctx.projectId, name);
+    }
+    const skills = await convexListSkillsForRuntimeExecution(
+      ctx.authHeader,
+      ctx.executionScope
+    );
+    return skills.find((skill) => skill.name === name) ?? null;
+  });
+}
+
+export function listCloudSkillFilesForActor(
+  ctx: CloudSkillsContext,
+  skillId: string
+): Promise<CloudSkillFileEntry[]> {
+  return run(async () => {
+    if (!ctx.executionScope) {
+      return await convexListSkillFiles(ctx.authHeader, ctx.projectId, skillId);
+    }
+    // The scoped query returns every visible skill's files in one shot (it
+    // feeds harness materialization), so narrow to the one asked for.
+    const files = await convexListSkillFilesForRuntimeExecution(
+      ctx.authHeader,
+      ctx.executionScope
+    );
+    return files.filter((file) => file.skillId === skillId);
+  });
+}
+
+/**
+ * Read a supporting file's bytes for whoever is acting. The scoped branch takes
+ * the `_storage` URL off the scoped listing — which mints one per file — because
+ * `getSkillFileUrl` is a member query.
+ */
+export function readCloudSkillFileForActor(
+  ctx: CloudSkillsContext,
+  skillId: string,
+  path: string
+): Promise<SkillFileContent> {
+  const scope = ctx.executionScope;
+  if (!scope) return readCloudSkillFile(ctx, skillId, path);
+  return run(async () => {
+    const files = await convexListSkillFilesForRuntimeExecution(
+      ctx.authHeader,
+      scope
+    );
+    const match = files.find(
+      (file) => file.skillId === skillId && file.path === path
+    );
+    if (!match) throw new CloudSkillsError("Skill file not found", 404);
+    return await fetchSkillFileContent(ctx, {
+      url: match.url,
+      size: match.size,
+      path,
+    });
   });
 }

--- a/mcpjam-inspector/server/utils/web-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/web-chat-turn.ts
@@ -300,7 +300,16 @@ export interface WebChatTurnPrepareInputs {
    * rather than the local FS. Set by the hosted chat route only when the host
    * actually has a computer. See `chat-v2-orchestration.ts`.
    */
-  cloudSkills?: { authHeader: string; projectId: string };
+  cloudSkills?: {
+    authHeader: string;
+    projectId: string;
+    /**
+     * Phase-3 execution scope for a guest / swarm-grant turn (COMP-38), so the
+     * skill reads go through the scope-authorized queries. See the same field on
+     * `PrepareChatV2Options.cloudSkills`.
+     */
+    executionScope?: ExecutionScope;
+  };
   /**
    * Resolved Project-Environment skills for this turn (Phase 1.4), EMULATED
    * side. When set (even empty) they are the only skills the emulated engine


### PR DESCRIPTION
## Summary

Guest users with a VM/sandbox could not use cloud skill tools: `shouldEnableCloudSkillTools` blocked **all** guests unconditionally. This enables them, gated on the Phase-3 `executionScope` the backend serves for a non-member grant — and routes their skill reads through the queries that scope authorizes.

**Task:** [COMP-38](https://app.kestral.ai/workspace/yhNILB2/task/13cvFSvP) — requested by Marcelo Jimenez Rocabado in the QA Testing Cloud Skills thread.

## What changed

- **`cloud-skill-tools.ts`** — `shouldEnableCloudSkillTools` gains `hasExecutionScope`; the guest clause becomes `!isGuest || hasExecutionScope`. The harness and project gates are untouched.
- **`cloud-skills.ts`** — the four reads the chat tools make now follow the actor: `listCloudSkillsForActor`, `getCloudSkillBodyForActor`, `listCloudSkillFilesForActor`, `readCloudSkillFileForActor`. A member keeps the `projectId` queries; a scoped turn goes through `listSkillsForRuntimeExecution` / `listSkillFilesForRuntimeExecution`, which the backend re-resolves against the live grant. Without this half a guest that passed the gate would have hit "requires project member" on every call — `projectSkills:listSkills` requires membership.
- **`web/chat-v2.ts`** — derives `guestSkillScope` (the runtime config's `executionScope`, for a guest only) and passes it to both the gate and the reads.
- **`chat-v2-orchestration.ts` / `web-chat-turn.ts`** — `cloudSkills` carries the optional scope through to the read context.
- **`sessionSimulation/runner.ts`** — passes `hasExecutionScope: false`; synthetic sessions are member-initiated, so the guest gate never applies.
- **`built-in-tools/registry.ts`** — corrects the `isGuest` doc. It claimed the backend accepts guest bearers on `/computers/reserve`, which the bash branch below it contradicts: a guest gets bash on a host-funded swarm grant, or from an out-of-band `sandboxBinding`, and never from a personal-project reserve.

## Why not `computer`

The first revision keyed the gate on `narrowHostComputer(hostRuntimeConfig.computer)`. The backend omits `computer` for guest actors — documented on the field itself in `scenario-runtime-config.ts` — so that read was always `false` for the actor it targeted, and the change was a no-op in production. That is what cubic's P1 on this PR said; it is fixed here rather than resolved. Guest `bash` comes from an ephemeral `sandboxBinding` (out of band, provisioned ~400 lines after the gate) or a swarm-scoped reserve, so probing `config.computer` reads false precisely when a guest does have a VM.

## Members are unaffected

The scope is threaded for a guest only. A member's runtime config carries one too (`project_member` resolves a scope), and the scoped skills query is shared-only — routing a member through it would silently drop their personal skills from the catalog.

## Behavior

| Actor | Before | After |
|---|---|---|
| Member + project | ✅ | ✅ (unchanged, same queries) |
| Guest, no execution scope | ❌ | ❌ (unchanged) |
| Guest **with** an execution scope | ❌ | ✅ **(the fix)** |
| Guest with a scope, on a real harness turn | ❌ | ❌ (harness delivers skills itself) |
| Guest with a scope, no project | ❌ | ❌ (skills live in a project) |

A guest whose grant the backend declines gets an empty catalog and a `skillsFetchFailed` marker, not tools that error on every call.

## Testing

- `cloud-skill-tools-gate.test.ts` (11) — gate cases moved to the scope signal: scoped guest enables; scoped guest + harness and scoped guest without a project stay disabled.
- `cloud-skills-actor-scope.test.ts` (8, new) — which query each of the four reads issues for a member vs a scoped guest, that a scoped `loadSkill` resolves only names the grant exposes, and that a file outside the grant 404s.
- `chat-v2-orchestration.test.ts` — the scope reaches the read layer for a guest turn and is absent for a member turn.
- Full inspector suite locally: 17,798 passed / 4 failed, all four in files this branch does not touch (three pass in isolation; `plugin-vm-shim`'s idle-TTL assertion is wall-clock dependent and fails on this machine independent of the change).
- Not covered by a test: the two-line `guestSkillScope` derivation in `chat-v2.ts`, since the web route test harness has no guest-bearer path.

Rebased onto `main` — the branch was 127 commits behind and conflicting, and the cloud-skills mechanism was rewritten underneath it (`listSkills` removed, catalog inlined at prompt-build time).
