### PR TITLE
feat(oauth): surface the 2026-07-28 OAuth machine (Phase 2, 2M-b)

### DIFF
--- a/cli/src/commands/oauth.ts
+++ b/cli/src/commands/oauth.ts
@@ -812,20 +812,30 @@ export function summarizeOAuthLoginCommandInput(
 export function buildOAuthLoginSnapshotConfig(
   config: Pick<
     OAuthLoginConfig,
-    "serverUrl" | "customHeaders" | "stepTimeout" | "client" | "auth"
+    | "serverUrl"
+    | "customHeaders"
+    | "stepTimeout"
+    | "client"
+    | "auth"
+    | "protocolVersion"
   >,
   result?: OAuthLoginResult,
 ): MCPServerConfig {
+  // Pin the sessionless 2026 wire era so the server-doctor snapshot probes via
+  // the stateless path, not the default 2025 initialize handshake. Prefer the
+  // negotiated version from the result, but fall back to the requested
+  // `--protocol-version` so a 2026 login that THROWS before returning a result
+  // (e.g. during initial 2026 discovery/probe) still records a 2026-pinned
+  // snapshot instead of a misleading 2025 probe.
+  const snapshotProtocolVersion =
+    result?.protocolVersion ?? config.protocolVersion;
   const baseConfig: MCPServerConfig = {
     url: config.serverUrl,
     ...(config.customHeaders
       ? { requestInit: { headers: config.customHeaders } }
       : {}),
     timeout: config.stepTimeout ?? 30_000,
-    // A 2026 login authenticated against a sessionless server; pin the wire
-    // era so the recorded server-doctor snapshot probes via the stateless
-    // path, not the default 2025 initialize handshake.
-    ...(result?.protocolVersion === "2026-07-28"
+    ...(snapshotProtocolVersion === "2026-07-28"
       ? { mcpProtocolVersion: "2026-07-28" as const }
       : {}),
   };

--- a/cli/src/commands/oauth.ts
+++ b/cli/src/commands/oauth.ts
@@ -822,6 +822,12 @@ export function buildOAuthLoginSnapshotConfig(
       ? { requestInit: { headers: config.customHeaders } }
       : {}),
     timeout: config.stepTimeout ?? 30_000,
+    // A 2026 login authenticated against a sessionless server; pin the wire
+    // era so the recorded server-doctor snapshot probes via the stateless
+    // path, not the default 2025 initialize handshake.
+    ...(result?.protocolVersion === "2026-07-28"
+      ? { mcpProtocolVersion: "2026-07-28" as const }
+      : {}),
   };
   if (!result) {
     return baseConfig;

--- a/cli/src/commands/oauth.ts
+++ b/cli/src/commands/oauth.ts
@@ -19,6 +19,7 @@ import {
 } from "../lib/server-config.js";
 import {
   VALID_PROTOCOL_VERSIONS,
+  CIMD_PROTOCOL_VERSIONS,
   VALID_REGISTRATION_STRATEGIES,
   VALID_AUTH_MODES,
 } from "../lib/oauth-enums.js";
@@ -122,7 +123,7 @@ export function buildOAuthLoginDebugOutcome(options: {
 
 export interface OAuthCommandOptions {
   url: string;
-  protocolVersion?: "2025-03-26" | "2025-06-18" | "2025-11-25";
+  protocolVersion?: "2025-03-26" | "2025-06-18" | "2025-11-25" | "2026-07-28";
   registration?: "cimd" | "dcr" | "preregistered";
   authMode?: "headless" | "interactive" | "client_credentials";
   clientId?: string;
@@ -157,7 +158,7 @@ export function registerOAuthCommands(program: Command): void {
     .requiredOption("--url <url>", "MCP server URL")
     .option(
       "--protocol-version <version>",
-      "OAuth protocol override: 2025-03-26, 2025-06-18, or 2025-11-25",
+      "OAuth protocol override: 2025-03-26, 2025-06-18, 2025-11-25, or 2026-07-28",
     )
     .option(
       "--registration <strategy>",
@@ -315,7 +316,7 @@ export function registerOAuthCommands(program: Command): void {
     .requiredOption("--url <url>", "MCP server URL")
     .requiredOption(
       "--protocol-version <version>",
-      "OAuth protocol version: 2025-03-26, 2025-06-18, or 2025-11-25",
+      "OAuth protocol version: 2025-03-26, 2025-06-18, 2025-11-25, or 2026-07-28",
     )
     .requiredOption(
       "--registration <strategy>",
@@ -563,7 +564,7 @@ export function buildOAuthConformanceConfig(
   }
 
   if (
-    protocolVersion !== "2025-11-25" &&
+    !CIMD_PROTOCOL_VERSIONS.has(protocolVersion) &&
     registrationStrategy === "cimd"
   ) {
     throw usageError(
@@ -689,7 +690,7 @@ export function buildOAuthLoginConfig(
   if (
     protocolVersion !== undefined &&
     registrationStrategy === "cimd" &&
-    protocolVersion !== "2025-11-25"
+    !CIMD_PROTOCOL_VERSIONS.has(protocolVersion)
   ) {
     throw usageError(
       `CIMD registration is not supported for protocol version ${protocolVersion}.`,
@@ -896,9 +897,9 @@ function assertValidUrl(value: string, label: string): void {
 
 function parseProtocolVersion(
   value: string,
-): "2025-03-26" | "2025-06-18" | "2025-11-25" {
+): "2025-03-26" | "2025-06-18" | "2025-11-25" | "2026-07-28" {
   if (VALID_PROTOCOL_VERSIONS.has(value)) {
-    return value as "2025-03-26" | "2025-06-18" | "2025-11-25";
+    return value as "2025-03-26" | "2025-06-18" | "2025-11-25" | "2026-07-28";
   }
 
   throw usageError(
@@ -908,7 +909,7 @@ function parseProtocolVersion(
 
 function parseRequiredProtocolVersion(
   value: string | undefined,
-): "2025-03-26" | "2025-06-18" | "2025-11-25" {
+): "2025-03-26" | "2025-06-18" | "2025-11-25" | "2026-07-28" {
   if (!value) {
     throw usageError(
       "--protocol-version is required for oauth conformance flows.",

--- a/cli/src/lib/oauth-enums.ts
+++ b/cli/src/lib/oauth-enums.ts
@@ -2,7 +2,11 @@ export const VALID_PROTOCOL_VERSIONS = new Set([
   "2025-03-26",
   "2025-06-18",
   "2025-11-25",
+  "2026-07-28",
 ]);
+
+// Protocol versions whose OAuth spec supports Client ID Metadata Documents.
+export const CIMD_PROTOCOL_VERSIONS = new Set(["2025-11-25", "2026-07-28"]);
 
 export const VALID_REGISTRATION_STRATEGIES = new Set([
   "cimd",

--- a/cli/tests/oauth.test.ts
+++ b/cli/tests/oauth.test.ts
@@ -286,6 +286,20 @@ test("buildOAuthLoginSnapshotConfig pins the 2026-07-28 stateless wire era", () 
   assert.equal((snapshotConfig as any).mcpProtocolVersion, "2026-07-28");
 });
 
+test("buildOAuthLoginSnapshotConfig falls back to the requested 2026 protocol when the login throws before a result", () => {
+  const config = buildOAuthConformanceConfig({
+    url: "https://example.com/mcp",
+    protocolVersion: "2026-07-28",
+    registration: "cimd",
+    authMode: "interactive",
+  });
+
+  // No result — mirrors `runOAuthLogin` throwing during 2026 discovery.
+  const snapshotConfig = buildOAuthLoginSnapshotConfig(config, undefined);
+
+  assert.equal((snapshotConfig as any).mcpProtocolVersion, "2026-07-28");
+});
+
 test("buildOAuthConformanceConfig accepts CIMD for the 2026-07-28 protocol", () => {
   const config = buildOAuthConformanceConfig({
     url: "https://example.com/mcp",

--- a/cli/tests/oauth.test.ts
+++ b/cli/tests/oauth.test.ts
@@ -260,6 +260,32 @@ test("buildOAuthConformanceConfig rejects unsupported combinations", () => {
   );
 });
 
+test("buildOAuthLoginSnapshotConfig pins the 2026-07-28 stateless wire era", () => {
+  const config = buildOAuthConformanceConfig({
+    url: "https://example.com/mcp",
+    protocolVersion: "2026-07-28",
+    registration: "cimd",
+    authMode: "interactive",
+  });
+
+  const snapshotConfig = buildOAuthLoginSnapshotConfig(config, {
+    completed: true,
+    serverUrl: "https://example.com/mcp",
+    protocolVersion: "2026-07-28",
+    registrationStrategy: "cimd",
+    protocolMode: "2026-07-28",
+    registrationMode: "cimd",
+    authMode: "interactive",
+    redirectUrl: "https://app.example.com/callback",
+    currentStep: "complete",
+    credentials: { accessToken: "access-token", clientId: "client-id" },
+    state: { currentStep: "complete", httpHistory: [], infoLogs: [] } as any,
+  } as any);
+
+  assert.equal("url" in snapshotConfig, true);
+  assert.equal((snapshotConfig as any).mcpProtocolVersion, "2026-07-28");
+});
+
 test("buildOAuthConformanceConfig accepts CIMD for the 2026-07-28 protocol", () => {
   const config = buildOAuthConformanceConfig({
     url: "https://example.com/mcp",

--- a/cli/tests/oauth.test.ts
+++ b/cli/tests/oauth.test.ts
@@ -260,6 +260,17 @@ test("buildOAuthConformanceConfig rejects unsupported combinations", () => {
   );
 });
 
+test("buildOAuthConformanceConfig accepts CIMD for the 2026-07-28 protocol", () => {
+  const config = buildOAuthConformanceConfig({
+    url: "https://example.com/mcp",
+    protocolVersion: "2026-07-28",
+    registration: "cimd",
+  });
+
+  assert.equal(config.registrationStrategy, "cimd");
+  assert.equal(config.auth?.mode, "interactive");
+});
+
 test("buildOAuthConformanceConfig rejects an invalid redirectUrl", () => {
   assert.throws(
     () =>

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -203,7 +203,10 @@ import {
   completeHostedOAuthCallback,
   handleOAuthCallback,
 } from "./lib/oauth/mcp-oauth";
-import { buildElectronMcpCallbackUrl } from "./hooks/use-server-state";
+import {
+  buildElectronMcpCallbackUrl,
+  resolveEffectiveWireProtocolVersion,
+} from "./hooks/use-server-state";
 import { disconnectAllRuntimeServers } from "./state/mcp-api";
 import { getEffectiveProjectClientCapabilities } from "./lib/client-config";
 import {
@@ -215,7 +218,6 @@ import {
 import {
   cloneHostTemplateInput,
   gateMcpToolResultImageRenderingByModelVisibility,
-  resolveEffectiveMcpProtocolVersion,
 } from "./lib/client-config-v2";
 import type { ProjectServerConfigDto } from "./lib/project-server-config";
 import { useHostList, useHostMutations } from "@/hooks/useClients";
@@ -2551,7 +2553,12 @@ export default function App() {
 
     const mcpProtocolVersionsByServerId: Record<string, McpProtocolVersion> =
       {};
-    for (const serverId of new Set(Object.values(hostedServerIdsByName))) {
+    const seenServerIds = new Set<string>();
+    for (const [serverName, serverId] of Object.entries(
+      hostedServerIdsByName
+    )) {
+      if (seenServerIds.has(serverId)) continue;
+      seenServerIds.add(serverId);
       // Project-server config is the control-plane source for per-server
       // protocol overrides. Host config mirrors it through Convex fan-out,
       // but hosted API calls should not fall back to the host default while
@@ -2566,10 +2573,18 @@ export default function App() {
         isKnownProtocolVersion(rawServerOverride)
           ? rawServerOverride
           : undefined;
-      const effective = resolveEffectiveMcpProtocolVersion(
+      // Share the client resolver's precedence so hosted chat/eval pick up the
+      // 2026 wire era a server carries via its OAuth profile / stamped config —
+      // not just explicit per-server overrides. Otherwise a modal-saved 2026
+      // OAuth server passes the immediate probe but hosted backend connects
+      // fall back to the 2025 initialize path. (`override → config pin →
+      // OAuth-profile 2026 → host default`.)
+      const effective = resolveEffectiveWireProtocolVersion({
+        serverConfig: undefined,
+        server: appState.servers[serverName],
         serverOverride,
-        hostPin
-      );
+        hostPin,
+      });
       if (!effective) continue;
       mcpProtocolVersionsByServerId[serverId] = effective;
     }

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -2611,6 +2611,10 @@ export default function App() {
     activeMcpProfile,
     hostedServerIdsByName,
     projectServerConfigDto?.overrides,
+    // The hosted protocol-version map now derives the OAuth-era pin from each
+    // server's config/OAuth profile, so it must recompute when server state
+    // changes (e.g. a modal-saved 2026 profile or a persisted config pin).
+    appState.servers,
   ]);
   useApiContext({
     projectId: convexProjectId,

--- a/mcpjam-inspector/client/src/components/connection/AddServerModal.tsx
+++ b/mcpjam-inspector/client/src/components/connection/AddServerModal.tsx
@@ -45,7 +45,8 @@ function normalizeOauthProtocolMode(
 ): ServerFormOAuthProtocolMode {
   return value === "2025-03-26" ||
     value === "2025-06-18" ||
-    value === "2025-11-25"
+    value === "2025-11-25" ||
+    value === "2026-07-28"
     ? value
     : "2025-11-25";
 }

--- a/mcpjam-inspector/client/src/components/connection/hooks/use-server-form.ts
+++ b/mcpjam-inspector/client/src/components/connection/hooks/use-server-form.ts
@@ -63,7 +63,8 @@ function normalizeOauthProtocolMode(
 ): ServerFormOAuthProtocolMode {
   return value === "2025-03-26" ||
     value === "2025-06-18" ||
-    value === "2025-11-25"
+    value === "2025-11-25" ||
+    value === "2026-07-28"
     ? value
     : DEFAULT_OAUTH_PROTOCOL_MODE;
 }

--- a/mcpjam-inspector/client/src/components/connection/shared/AuthenticationSection.tsx
+++ b/mcpjam-inspector/client/src/components/connection/shared/AuthenticationSection.tsx
@@ -106,6 +106,7 @@ const PROTOCOL_OPTIONS: Array<{
   value: ServerFormOAuthProtocolMode;
   label: string;
 }> = [
+  { value: "2026-07-28", label: "2026-07-28 (Draft)" },
   { value: "2025-11-25", label: "2025-11-25 (Latest)" },
   { value: "2025-06-18", label: "2025-06-18" },
   { value: "2025-03-26", label: "2025-03-26 (Legacy)" },

--- a/mcpjam-inspector/client/src/components/oauth/OAuthProfileModal.tsx
+++ b/mcpjam-inspector/client/src/components/oauth/OAuthProfileModal.tsx
@@ -198,6 +198,12 @@ export function OAuthProfileModal({
       url: validated.trimmedUrl,
       headers: Object.keys(headerMap).length ? headerMap : undefined,
       useOAuth: true,
+      // Carry the chosen OAuth protocol version onto the connection form so
+      // `toMCPConfig` stamps the sessionless 2026 wire era on the saved/synced
+      // server config. Without this, hosted chat/eval/backend connects — which
+      // forward host/per-server MCP pins, not the OAuth profile — fall back to
+      // the 2025 initialize path for a 2026-only server.
+      oauthProtocolMode: draft.protocolVersion,
       oauthScopes: scopesArray,
       clientId: validated.trimmedClientId || undefined,
       clientSecret: validated.trimmedClientSecret || undefined,

--- a/mcpjam-inspector/client/src/components/oauth/OAuthProfileModal.tsx
+++ b/mcpjam-inspector/client/src/components/oauth/OAuthProfileModal.tsx
@@ -354,6 +354,9 @@ export function OAuthProfileModal({
                       <SelectItem value="2025-11-25" className="text-xs">
                         2025-11-25 (Latest)
                       </SelectItem>
+                      <SelectItem value="2026-07-28" className="text-xs">
+                        2026-07-28 (Draft)
+                      </SelectItem>
                     </SelectContent>
                   </Select>
                 </div>

--- a/mcpjam-inspector/client/src/components/oauth/ProtocolVersionSelector.tsx
+++ b/mcpjam-inspector/client/src/components/oauth/ProtocolVersionSelector.tsx
@@ -213,10 +213,6 @@ export function ProtocolVersionSelector({
                         OIDC <code>application_type</code> sent on Dynamic Client
                         Registration (SEP-837)
                       </li>
-                      <li>
-                        RFC 9207 <code>iss</code> validation before code
-                        redemption
-                      </li>
                     </ul>
                   </div>
                 ) : value === "2025-11-25" ? (

--- a/mcpjam-inspector/client/src/components/oauth/ProtocolVersionSelector.tsx
+++ b/mcpjam-inspector/client/src/components/oauth/ProtocolVersionSelector.tsx
@@ -68,8 +68,13 @@ export function ProtocolVersionSelector({
               Choose between stable and draft specifications
             </CardDescription>
           </div>
-          {value === "2025-11-25" && (
+          {value === "2026-07-28" && (
             <Badge variant="default" className="ml-2">
+              Draft
+            </Badge>
+          )}
+          {value === "2025-11-25" && (
+            <Badge variant="secondary" className="ml-2">
               Latest
             </Badge>
           )}
@@ -101,6 +106,14 @@ export function ProtocolVersionSelector({
               <SelectItem value="2025-11-25">
                 <div className="flex items-center gap-2">
                   <span>2025-11-25</span>
+                  <Badge variant="secondary" className="text-xs">
+                    Latest
+                  </Badge>
+                </div>
+              </SelectItem>
+              <SelectItem value="2026-07-28">
+                <div className="flex items-center gap-2">
+                  <span>2026-07-28</span>
                   <Badge variant="default" className="text-xs">
                     Draft
                   </Badge>
@@ -189,7 +202,24 @@ export function ProtocolVersionSelector({
 
               {/* Key Differences */}
               <div className="text-xs text-muted-foreground mt-2 p-2 bg-muted/50 rounded">
-                {value === "2025-11-25" ? (
+                {value === "2026-07-28" ? (
+                  <div>
+                    <strong>New in 2026-07-28:</strong>
+                    <ul className="list-disc list-inside mt-1 space-y-0.5">
+                      <li>
+                        Inherits 2025-11-25 discovery, CIMD, and strict PKCE
+                      </li>
+                      <li>
+                        OIDC <code>application_type</code> sent on Dynamic Client
+                        Registration (SEP-837)
+                      </li>
+                      <li>
+                        RFC 9207 <code>iss</code> validation before code
+                        redemption
+                      </li>
+                    </ul>
+                  </div>
+                ) : value === "2025-11-25" ? (
                   <div>
                     <strong>New in 2025-11-25:</strong>
                     <ul className="list-disc list-inside mt-1 space-y-0.5">
@@ -245,9 +275,14 @@ export function ProtocolVersionBadge({
       title={currentInfo.description}
     >
       <span className="text-xs font-mono">{value}</span>
-      {value === "2025-11-25" && (
+      {value === "2026-07-28" && (
         <Badge variant="default" className="text-xs px-1.5 py-0">
           Draft
+        </Badge>
+      )}
+      {value === "2025-11-25" && (
+        <Badge variant="secondary" className="text-xs px-1.5 py-0">
+          Latest
         </Badge>
       )}
       {value === "2025-06-18" && (

--- a/mcpjam-inspector/client/src/components/oauth/__tests__/OAuthProfileModal.test.tsx
+++ b/mcpjam-inspector/client/src/components/oauth/__tests__/OAuthProfileModal.test.tsx
@@ -82,6 +82,32 @@ describe("OAuthProfileModal", () => {
     expect(onSave).toHaveBeenCalledTimes(1);
   });
 
+  it("carries the selected 2026 OAuth protocol version onto the saved form data", async () => {
+    // Without oauthProtocolMode on the saved form data, toMCPConfig cannot
+    // stamp the 2026 wire era and hosted chat/eval connects fall back to 2025.
+    const user = userEvent.setup();
+    const server = createServer("oauth-flow-target");
+    (server as any).oauthFlowProfile = {
+      serverUrl: "https://existing.example.com/mcp",
+      clientId: "",
+      clientSecret: "",
+      scopes: "",
+      customHeaders: [],
+      protocolVersion: "2026-07-28",
+    };
+    const { onSave } = renderModal({
+      server,
+      existingServerNames: ["oauth-flow-target"],
+    });
+
+    await user.click(screen.getByRole("button", { name: "Save configuration" }));
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    const payload = onSave.mock.calls[0][0];
+    expect(payload.formData.oauthProtocolMode).toBe("2026-07-28");
+    expect(payload.profile.protocolVersion).toBe("2026-07-28");
+  });
+
   it("blocks a second submit while the first save is still in flight", async () => {
     // Awaiting onSave keeps the modal open, which opened a resubmit window the
     // old fire-and-forget close never had.

--- a/mcpjam-inspector/client/src/components/oauth/__tests__/utils.test.ts
+++ b/mcpjam-inspector/client/src/components/oauth/__tests__/utils.test.ts
@@ -65,4 +65,36 @@ describe("deriveOAuthProfileFromServer stored-credential fallback", () => {
     expect(profile.clientId).toBe("");
     expect(profile.scopes).toBe("");
   });
+
+  it("defaults the OAuth profile to 2026-07-28 when the server is wire-pinned to it and no OAuth version is set", () => {
+    const profile = deriveOAuthProfileFromServer(
+      httpServer({
+        config: {
+          url: new URL("http://localhost:8787/mcp"),
+          mcpProtocolVersion: "2026-07-28",
+        } as ServerWithName["config"],
+      }),
+    );
+    expect(profile.protocolVersion).toBe("2026-07-28");
+  });
+
+  it("keeps an explicit OAuth profile version over the wire pin", () => {
+    const profile = deriveOAuthProfileFromServer(
+      httpServer({
+        config: {
+          url: new URL("http://localhost:8787/mcp"),
+          mcpProtocolVersion: "2026-07-28",
+        } as ServerWithName["config"],
+        oauthFlowProfile: {
+          serverUrl: "http://localhost:8787/mcp",
+          clientId: "",
+          clientSecret: "",
+          scopes: "",
+          customHeaders: [],
+          protocolVersion: "2025-11-25",
+        } as ServerWithName["oauthFlowProfile"],
+      }),
+    );
+    expect(profile.protocolVersion).toBe("2025-11-25");
+  });
 });

--- a/mcpjam-inspector/client/src/components/oauth/__tests__/utils.test.ts
+++ b/mcpjam-inspector/client/src/components/oauth/__tests__/utils.test.ts
@@ -66,35 +66,19 @@ describe("deriveOAuthProfileFromServer stored-credential fallback", () => {
     expect(profile.scopes).toBe("");
   });
 
-  it("defaults the OAuth profile to 2026-07-28 when the server is wire-pinned to it and no OAuth version is set", () => {
+  it("keeps an explicit 2026-07-28 OAuth profile version", () => {
     const profile = deriveOAuthProfileFromServer(
       httpServer({
-        config: {
-          url: new URL("http://localhost:8787/mcp"),
-          mcpProtocolVersion: "2026-07-28",
-        } as ServerWithName["config"],
-      }),
-    );
-    expect(profile.protocolVersion).toBe("2026-07-28");
-  });
-
-  it("keeps an explicit OAuth profile version over the wire pin", () => {
-    const profile = deriveOAuthProfileFromServer(
-      httpServer({
-        config: {
-          url: new URL("http://localhost:8787/mcp"),
-          mcpProtocolVersion: "2026-07-28",
-        } as ServerWithName["config"],
         oauthFlowProfile: {
           serverUrl: "http://localhost:8787/mcp",
           clientId: "",
           clientSecret: "",
           scopes: "",
           customHeaders: [],
-          protocolVersion: "2025-11-25",
+          protocolVersion: "2026-07-28",
         } as ServerWithName["oauthFlowProfile"],
       }),
     );
-    expect(profile.protocolVersion).toBe("2025-11-25");
+    expect(profile.protocolVersion).toBe("2026-07-28");
   });
 });

--- a/mcpjam-inspector/client/src/components/oauth/utils.ts
+++ b/mcpjam-inspector/client/src/components/oauth/utils.ts
@@ -90,23 +90,9 @@ export const deriveOAuthProfileFromServer = (
 
   const stored = readStoredOAuthCredentials(server.name);
 
-  // Bridge the two-union seam: the OAuth debugger tracks its own protocol
-  // version, separate from the wire `mcpProtocolVersion`. When a server is
-  // explicitly pinned to the 2026-07-28 wire era and the user has not chosen
-  // an OAuth profile version, default the OAuth flow to the 2026-07-28 machine
-  // so the debugger models the era the connection actually negotiates.
-  const explicitProfileVersion = server.oauthFlowProfile?.protocolVersion;
-  const protocolVersion =
-    !explicitProfileVersion &&
-    (httpConfig as { mcpProtocolVersion?: string }).mcpProtocolVersion ===
-      "2026-07-28"
-      ? "2026-07-28"
-      : baseProfile.protocolVersion;
-
   return {
     ...EMPTY_OAUTH_TEST_PROFILE,
     ...baseProfile,
-    protocolVersion,
     serverUrl: baseProfile.serverUrl || toUrlString(httpConfig.url),
     clientId: baseProfile.clientId || clientIdFromConfig || stored.clientId,
     clientSecret: baseProfile.clientSecret || clientSecretFromConfig,

--- a/mcpjam-inspector/client/src/components/oauth/utils.ts
+++ b/mcpjam-inspector/client/src/components/oauth/utils.ts
@@ -90,9 +90,23 @@ export const deriveOAuthProfileFromServer = (
 
   const stored = readStoredOAuthCredentials(server.name);
 
+  // Bridge the two-union seam: the OAuth debugger tracks its own protocol
+  // version, separate from the wire `mcpProtocolVersion`. When a server is
+  // explicitly pinned to the 2026-07-28 wire era and the user has not chosen
+  // an OAuth profile version, default the OAuth flow to the 2026-07-28 machine
+  // so the debugger models the era the connection actually negotiates.
+  const explicitProfileVersion = server.oauthFlowProfile?.protocolVersion;
+  const protocolVersion =
+    !explicitProfileVersion &&
+    (httpConfig as { mcpProtocolVersion?: string }).mcpProtocolVersion ===
+      "2026-07-28"
+      ? "2026-07-28"
+      : baseProfile.protocolVersion;
+
   return {
     ...EMPTY_OAUTH_TEST_PROFILE,
     ...baseProfile,
+    protocolVersion,
     serverUrl: baseProfile.serverUrl || toUrlString(httpConfig.url),
     clientId: baseProfile.clientId || clientIdFromConfig || stored.clientId,
     clientSecret: baseProfile.clientSecret || clientSecretFromConfig,

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
@@ -950,6 +950,52 @@ describe("useServerState OAuth callback failures", () => {
     );
   });
 
+  it("does not resurrect a stale 2026 pin when the form downgrades to 2025", async () => {
+    // Regression: switching an existing OAuth server from 2026 back to 2025
+    // must not recover the stale 2026 pin from the stored server.config /
+    // oauthFlowProfile. The authoritative pending form entry (unpinned 2025)
+    // wins over stored state.
+    const appState = createAppState();
+    for (const bucket of [appState.projects.default.servers, appState.servers]) {
+      bucket["demo-server"].config = {
+        type: "http",
+        url: "https://example.com/mcp",
+        mcpProtocolVersion: "2026-07-28",
+      } as any;
+      (bucket["demo-server"] as any).oauthFlowProfile = {
+        serverUrl: "https://example.com/mcp",
+        clientId: "",
+        clientSecret: "",
+        scopes: "",
+        customHeaders: [],
+        protocolVersion: "2026-07-28",
+      };
+    }
+
+    testConnectionMock.mockResolvedValueOnce({ success: true, initInfo: null });
+    const dispatch = vi.fn();
+    const { result } = renderUseServerState(dispatch, appState);
+
+    await act(async () => {
+      await result.current.handleConnect({
+        name: "demo-server",
+        type: "http",
+        url: "https://example.com/mcp",
+        useOAuth: true,
+        oauthProtocolMode: "2025-11-25",
+      } as any);
+    });
+
+    const probeArgs = testConnectionMock.mock.calls[0];
+    expect(probeArgs?.[2]?.connectionDefaults?.mcpProtocolVersion).not.toBe(
+      "2026-07-28",
+    );
+    const successCall = dispatch.mock.calls.find(
+      ([action]) => action?.type === "CONNECT_SUCCESS",
+    );
+    expect(successCall?.[0]?.config?.mcpProtocolVersion).not.toBe("2026-07-28");
+  });
+
   it("imports debugger-applied OAuth tokens before reconnecting in hosted mode", async () => {
     mockHostedMode.mockReturnValue(true);
     reconnectServerMock.mockResolvedValueOnce({

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
@@ -914,6 +914,42 @@ describe("useServerState OAuth callback failures", () => {
     expect(toastSuccess).toHaveBeenCalledWith("Connected to demo-server!");
   });
 
+  it("preserves the 2026 wire pin through the stored-credential probe and CONNECT_SUCCESS", async () => {
+    // Regression: handleConnect must not rebuild a URL-only config that drops
+    // the OAuth-derived 2026 pin, and CONNECT_SUCCESS must persist the pinned
+    // config (not a slim one) so later reconnects keep the wire era.
+    testConnectionMock.mockResolvedValueOnce({ success: true, initInfo: null });
+    const dispatch = vi.fn();
+    const { result } = renderUseServerState(dispatch);
+
+    await act(async () => {
+      await result.current.handleConnect({
+        name: "demo-server",
+        type: "http",
+        url: "https://example.com/mcp",
+        useOAuth: true,
+        oauthProtocolMode: "2026-07-28",
+      } as any);
+    });
+
+    // Blocker 1: the probe carries the 2026 wire era.
+    const probeArgs = testConnectionMock.mock.calls[0];
+    expect(probeArgs?.[0]).toEqual(
+      expect.objectContaining({ mcpProtocolVersion: "2026-07-28" }),
+    );
+    expect(probeArgs?.[2]?.connectionDefaults?.mcpProtocolVersion).toBe(
+      "2026-07-28",
+    );
+
+    // Blocker 2: CONNECT_SUCCESS persists the pinned canonical config.
+    const successCall = dispatch.mock.calls.find(
+      ([action]) => action?.type === "CONNECT_SUCCESS",
+    );
+    expect(successCall?.[0]?.config).toEqual(
+      expect.objectContaining({ mcpProtocolVersion: "2026-07-28" }),
+    );
+  });
+
   it("imports debugger-applied OAuth tokens before reconnecting in hosted mode", async () => {
     mockHostedMode.mockReturnValue(true);
     reconnectServerMock.mockResolvedValueOnce({

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
@@ -1027,6 +1027,11 @@ describe("useServerState OAuth callback failures", () => {
       ([action]) => action?.type === "CONNECT_SUCCESS",
     );
     expect(successCall?.[0]?.config?.mcpProtocolVersion).not.toBe("2026-07-28");
+    // The profile must also be refreshed so a later reconnect's OAuth-profile
+    // fallback doesn't revive 2026 from stale state.
+    expect(successCall?.[0]?.oauthFlowProfile?.protocolVersion).not.toBe(
+      "2026-07-28",
+    );
   });
 
   it("imports debugger-applied OAuth tokens before reconnecting in hosted mode", async () => {

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
@@ -854,6 +854,39 @@ describe("useServerState OAuth callback failures", () => {
     });
   });
 
+  it("persists the 2026 wire pin on a first-time OAuth completion with no prior config pin", async () => {
+    // Regression: applyTokensFromOAuthFlow must stamp the persisted config from
+    // the completed OAuth profile, or hosted connects (which read config pins,
+    // not the OAuth profile) keep using the 2025 initialize path.
+    reconnectServerMock.mockResolvedValueOnce({ success: true, initInfo: null });
+    const appState = createAppState();
+    for (const bucket of [appState.projects.default.servers, appState.servers]) {
+      (bucket["demo-server"] as any).oauthFlowProfile = {
+        serverUrl: "https://example.com/mcp",
+        clientId: "",
+        clientSecret: "",
+        scopes: "",
+        customHeaders: [],
+        protocolVersion: "2026-07-28",
+      };
+    }
+    const dispatch = vi.fn();
+    const { result } = renderUseServerState(dispatch, appState);
+
+    await act(async () => {
+      await result.current.handleConnectWithTokensFromOAuthFlow(
+        "demo-server",
+        { accessToken: "access-token", clientId: "client-id" },
+        "https://example.com/mcp",
+      );
+    });
+
+    const successCall = dispatch.mock.calls.find(
+      ([action]) => action?.type === "CONNECT_SUCCESS",
+    );
+    expect(successCall?.[0]?.config?.mcpProtocolVersion).toBe("2026-07-28");
+  });
+
   it("imports debugger-applied OAuth tokens before reconnecting a synced server", async () => {
     reconnectServerMock.mockResolvedValueOnce({
       success: true,

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -3604,8 +3604,24 @@ export function useServerState({
       });
       localStorage.removeItem(`mcp-tokens-${serverName}`);
 
+      // Preserve the existing server's wire protocol pin across the
+      // token-apply reconnect. Rebuilding as `{ url }` alone drops it, so a
+      // server pinned to the sessionless 2026 era (no initialize handshake)
+      // would be reconnected through the default stateful path and the fresh
+      // token would look unusable. Sourced from the wire config, not the OAuth
+      // profile version — the two are independent (the OAuth flow version does
+      // not dictate the MCP wire era).
+      const existingConfig = appStateServersRef.current[serverName]?.config;
+      const existingWireVersion =
+        existingConfig && "mcpProtocolVersion" in existingConfig
+          ? existingConfig.mcpProtocolVersion
+          : undefined;
+
       const serverConfig = {
         url: serverUrl,
+        ...(existingWireVersion
+          ? { mcpProtocolVersion: existingWireVersion }
+          : {}),
       } satisfies HttpServerConfig;
 
       dispatch({

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -779,8 +779,10 @@ function getConnectionTransport(serverConfig: MCPServerConfig): string {
  * revalidation effect so the "which version" answer can't drift between
  * "what we connect with" and "when we re-test".
  *
- * Precedence: explicit per-server override → explicit config pin → the 2026
- * era implied by the server's saved OAuth profile → host default.
+ * Precedence: explicit per-server override → explicit pin on the config being
+ * connected → explicit pin on the canonical stored `server.config` (recovers
+ * the pin when a caller passes a rebuilt URL-only config) → the 2026 era
+ * implied by the server's saved OAuth profile → host default.
  */
 function resolveEffectiveWireProtocolVersion(input: {
   serverConfig: MCPServerConfig | undefined;
@@ -789,20 +791,34 @@ function resolveEffectiveWireProtocolVersion(input: {
   hostPin: McpProtocolVersion | undefined;
 }): McpProtocolVersion | undefined {
   const { serverConfig, server, serverOverride, hostPin } = input;
-  const rawConfigPin =
-    serverConfig && "mcpProtocolVersion" in serverConfig
-      ? serverConfig.mcpProtocolVersion
+  const readConfigPin = (
+    config: MCPServerConfig | undefined
+  ): McpProtocolVersion | undefined => {
+    const raw =
+      config && "mcpProtocolVersion" in config
+        ? config.mcpProtocolVersion
+        : undefined;
+    return typeof raw === "string" && isKnownProtocolVersion(raw)
+      ? raw
       : undefined;
-  const configPin: McpProtocolVersion | undefined =
-    typeof rawConfigPin === "string" && isKnownProtocolVersion(rawConfigPin)
-      ? rawConfigPin
-      : undefined;
+  };
+  const configPin = readConfigPin(serverConfig);
+  // Fall back to the canonical stored config so a probe/reconnect that was
+  // handed a slim URL-only config (which drops the pin) still recovers the
+  // wire era the server was saved with.
+  const canonicalConfigPin = readConfigPin(server?.config);
   const oauthProfilePin: McpProtocolVersion | undefined =
     server?.useOAuth === true &&
     server.oauthFlowProfile?.protocolVersion === "2026-07-28"
       ? "2026-07-28"
       : undefined;
-  return serverOverride ?? configPin ?? oauthProfilePin ?? hostPin;
+  return (
+    serverOverride ??
+    configPin ??
+    canonicalConfigPin ??
+    oauthProfilePin ??
+    hostPin
+  );
 }
 
 function countRecordKeys(value: unknown): number {
@@ -3010,12 +3026,12 @@ export function useServerState({
             serverId: hostedServerId ?? null,
             serverName: formData.name,
           };
-          const serverConfig = {
-            url: formData.url,
-            ...(formData.headers && Object.keys(formData.headers).length > 0
-              ? { requestInit: { headers: formData.headers } }
-              : {}),
-          } satisfies HttpServerConfig;
+          // Reuse the canonical config from `toMCPConfig` (which carries the
+          // 2026 `mcpProtocolVersion` stamp) rather than rebuilding a URL-only
+          // config that drops the wire era — otherwise this first stored-cred
+          // probe runs the 2025 initialize handshake against a sessionless
+          // server and fails before OAuth can start.
+          const serverConfig: MCPServerConfig = mcpConfig;
           logger.info("Connecting with synced OAuth credentials", {
             serverName: formData.name,
           });

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -1410,10 +1410,33 @@ export function useServerState({
       assertClientConfigSynced();
       const resolved = tryResolveProjectServer(serverName);
       if (resolved) {
-        const configWithDefaults = withProjectConnectionDefaults(
+        const withDefaults = withProjectConnectionDefaults(
           serverConfig,
           resolved.serverId
         );
+        // Centralized OAuth wire-era derivation for every reconnect path
+        // (token-apply, OAuth completion, hosted callback, saved-profile
+        // reconnect). A server whose saved OAuth profile is 2026-07-28 speaks
+        // the sessionless 2026 transport, but `toMCPConfig` never copies the
+        // OAuth mode onto `config`, and hosted `readStoredOAuthConfig` is
+        // empty — so without this the resolver has no pin to honor and the
+        // reconnect falls back to the 2025 initialize handshake. Stamp it here
+        // (lowest precedence: an already-present config pin, or a per-server
+        // override / host default in the resolver, still wins).
+        const oauthServer = appStateServersRef.current[serverName];
+        const alreadyPinned =
+          "mcpProtocolVersion" in withDefaults &&
+          Boolean(withDefaults.mcpProtocolVersion);
+        const configWithDefaults: MCPServerConfig =
+          !alreadyPinned &&
+          "url" in withDefaults &&
+          oauthServer?.useOAuth === true &&
+          oauthServer.oauthFlowProfile?.protocolVersion === "2026-07-28"
+            ? ({
+                ...withDefaults,
+                mcpProtocolVersion: "2026-07-28",
+              } as HttpServerConfig)
+            : withDefaults;
         const connectionDefaults = buildResolverConnectionDefaults(
           configWithDefaults,
           activeMcpProfile,
@@ -3621,32 +3644,22 @@ export function useServerState({
       });
       localStorage.removeItem(`mcp-tokens-${serverName}`);
 
-      // Preserve the wire protocol era across the token-apply reconnect.
-      // Rebuilding as `{ url }` alone drops it, so a server on the sessionless
-      // 2026 era (no initialize handshake) would be reconnected through the
-      // default stateful path and the fresh token would look unusable.
-      //
-      // An explicit wire pin on the server config always wins. Absent one, a
-      // just-completed 2026 OAuth flow is sufficient evidence the server
-      // speaks the 2026 wire era — 2026 OAuth and the 2026 stateless transport
-      // ship together, and the flow only succeeds against such a server. This
-      // is NOT a general OAuth→wire coupling: only 2026 (non-default, coupled)
-      // fills in, and only when the connection carries no wire pin of its own.
-      const existingServer = appStateServersRef.current[serverName];
-      const existingConfig = existingServer?.config;
+      // Preserve an explicit wire protocol pin across the token-apply
+      // reconnect. Rebuilding as `{ url }` alone drops it. (The 2026 era
+      // derived from the OAuth profile is applied centrally in
+      // `guardedReconnectServer` for every reconnect path, so it is not
+      // repeated here — an explicit config pin still wins there.)
+      const existingConfig = appStateServersRef.current[serverName]?.config;
       const existingWireVersion =
         existingConfig && "mcpProtocolVersion" in existingConfig
           ? existingConfig.mcpProtocolVersion
           : undefined;
-      const oauthFlowWireVersion =
-        existingServer?.oauthFlowProfile?.protocolVersion === "2026-07-28"
-          ? ("2026-07-28" as const)
-          : undefined;
-      const wireVersion = existingWireVersion ?? oauthFlowWireVersion;
 
       const serverConfig = {
         url: serverUrl,
-        ...(wireVersion ? { mcpProtocolVersion: wireVersion } : {}),
+        ...(existingWireVersion
+          ? { mcpProtocolVersion: existingWireVersion }
+          : {}),
       } satisfies HttpServerConfig;
 
       dispatch({

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -1205,7 +1205,12 @@ export function useServerState({
       // reaches the connect payload — without this argument, the host
       // default wins and per-server overrides are silently dropped (the
       // bug PR #2257 review flagged).
-      serverId?: string
+      serverId?: string,
+      // Server name, used only to derive the sessionless 2026 wire era from
+      // the server's saved OAuth profile when nothing higher-precedence pins
+      // it. Every connect/probe/reconnect path funnels through this resolver,
+      // so deriving here covers them all in one place.
+      serverName?: string
     ) => {
       const defaults: ConnectionDefaults = {};
       if ("url" in serverConfig) {
@@ -1281,7 +1286,23 @@ export function useServerState({
         typeof rawConfigPin === "string" && isKnownProtocolVersion(rawConfigPin)
           ? rawConfigPin
           : undefined;
-      const resolvedProtocolVersion = effective ?? configPin;
+      // Lowest precedence of all: a server whose saved OAuth profile is
+      // 2026-07-28 speaks the sessionless 2026 transport, but `toMCPConfig`
+      // never copies the OAuth mode onto `config` and hosted
+      // `readStoredOAuthConfig` is empty — so without this the wire era is
+      // silently lost on the first OAuth connect/probe and every reconnect,
+      // and a 2026-only server falls back to the 2025 initialize handshake.
+      // Only 2026 (coupled + non-default) is derived; an explicit override,
+      // host default, or config pin above still wins.
+      const oauthServer = serverName
+        ? appStateServersRef.current[serverName]
+        : undefined;
+      const oauthProfilePin: McpProtocolVersion | undefined =
+        oauthServer?.useOAuth === true &&
+        oauthServer.oauthFlowProfile?.protocolVersion === "2026-07-28"
+          ? "2026-07-28"
+          : undefined;
+      const resolvedProtocolVersion = effective ?? configPin ?? oauthProfilePin;
       if (resolvedProtocolVersion !== undefined) {
         defaults.mcpProtocolVersion = resolvedProtocolVersion;
       }
@@ -1388,7 +1409,8 @@ export function useServerState({
           connectionDefaults: buildResolverConnectionDefaults(
             serverConfig,
             activeMcpProfile,
-            resolved.serverId
+            resolved.serverId,
+            serverName
           ),
         });
       }
@@ -1410,37 +1432,18 @@ export function useServerState({
       assertClientConfigSynced();
       const resolved = tryResolveProjectServer(serverName);
       if (resolved) {
-        const withDefaults = withProjectConnectionDefaults(
+        const configWithDefaults = withProjectConnectionDefaults(
           serverConfig,
           resolved.serverId
         );
-        // Centralized OAuth wire-era derivation for every reconnect path
-        // (token-apply, OAuth completion, hosted callback, saved-profile
-        // reconnect). A server whose saved OAuth profile is 2026-07-28 speaks
-        // the sessionless 2026 transport, but `toMCPConfig` never copies the
-        // OAuth mode onto `config`, and hosted `readStoredOAuthConfig` is
-        // empty — so without this the resolver has no pin to honor and the
-        // reconnect falls back to the 2025 initialize handshake. Stamp it here
-        // (lowest precedence: an already-present config pin, or a per-server
-        // override / host default in the resolver, still wins).
-        const oauthServer = appStateServersRef.current[serverName];
-        const alreadyPinned =
-          "mcpProtocolVersion" in withDefaults &&
-          Boolean(withDefaults.mcpProtocolVersion);
-        const configWithDefaults: MCPServerConfig =
-          !alreadyPinned &&
-          "url" in withDefaults &&
-          oauthServer?.useOAuth === true &&
-          oauthServer.oauthFlowProfile?.protocolVersion === "2026-07-28"
-            ? ({
-                ...withDefaults,
-                mcpProtocolVersion: "2026-07-28",
-              } as HttpServerConfig)
-            : withDefaults;
+        // The 2026 wire era (from the server's saved OAuth profile) is derived
+        // inside `buildResolverConnectionDefaults` via `serverName`, so it
+        // covers this reconnect path and the connect/probe paths uniformly.
         const connectionDefaults = buildResolverConnectionDefaults(
           configWithDefaults,
           activeMcpProfile,
-          resolved.serverId
+          resolved.serverId,
+          serverName
         );
         const effectiveProtocolVersion = connectionDefaults?.mcpProtocolVersion;
         const result = await reconnectServer(
@@ -3647,8 +3650,9 @@ export function useServerState({
       // Preserve an explicit wire protocol pin across the token-apply
       // reconnect. Rebuilding as `{ url }` alone drops it. (The 2026 era
       // derived from the OAuth profile is applied centrally in
-      // `guardedReconnectServer` for every reconnect path, so it is not
-      // repeated here — an explicit config pin still wins there.)
+      // `buildResolverConnectionDefaults`, which every connect/probe/reconnect
+      // path funnels through, so it is not repeated here — an explicit config
+      // pin still wins there.)
       const existingConfig = appStateServersRef.current[serverName]?.config;
       const existingWireVersion =
         existingConfig && "mcpProtocolVersion" in existingConfig

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -3604,24 +3604,32 @@ export function useServerState({
       });
       localStorage.removeItem(`mcp-tokens-${serverName}`);
 
-      // Preserve the existing server's wire protocol pin across the
-      // token-apply reconnect. Rebuilding as `{ url }` alone drops it, so a
-      // server pinned to the sessionless 2026 era (no initialize handshake)
-      // would be reconnected through the default stateful path and the fresh
-      // token would look unusable. Sourced from the wire config, not the OAuth
-      // profile version — the two are independent (the OAuth flow version does
-      // not dictate the MCP wire era).
-      const existingConfig = appStateServersRef.current[serverName]?.config;
+      // Preserve the wire protocol era across the token-apply reconnect.
+      // Rebuilding as `{ url }` alone drops it, so a server on the sessionless
+      // 2026 era (no initialize handshake) would be reconnected through the
+      // default stateful path and the fresh token would look unusable.
+      //
+      // An explicit wire pin on the server config always wins. Absent one, a
+      // just-completed 2026 OAuth flow is sufficient evidence the server
+      // speaks the 2026 wire era — 2026 OAuth and the 2026 stateless transport
+      // ship together, and the flow only succeeds against such a server. This
+      // is NOT a general OAuth→wire coupling: only 2026 (non-default, coupled)
+      // fills in, and only when the connection carries no wire pin of its own.
+      const existingServer = appStateServersRef.current[serverName];
+      const existingConfig = existingServer?.config;
       const existingWireVersion =
         existingConfig && "mcpProtocolVersion" in existingConfig
           ? existingConfig.mcpProtocolVersion
           : undefined;
+      const oauthFlowWireVersion =
+        existingServer?.oauthFlowProfile?.protocolVersion === "2026-07-28"
+          ? ("2026-07-28" as const)
+          : undefined;
+      const wireVersion = existingWireVersion ?? oauthFlowWireVersion;
 
       const serverConfig = {
         url: serverUrl,
-        ...(existingWireVersion
-          ? { mcpProtocolVersion: existingWireVersion }
-          : {}),
+        ...(wireVersion ? { mcpProtocolVersion: wireVersion } : {}),
       } satisfies HttpServerConfig;
 
       dispatch({

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -3065,6 +3065,7 @@ export function useServerState({
               config: serverConfig,
               tokens: undefined,
               useOAuth: true,
+              oauthFlowProfile: serverEntryForSave.oauthFlowProfile,
             });
             // An Auto server may have connected without credentials — don't
             // claim OAuth happened when it didn't.
@@ -3206,6 +3207,7 @@ export function useServerState({
                   tokens: undefined,
                   useOAuth: true,
                   oauthTrace: oauthResult.oauthTrace,
+                  oauthFlowProfile: serverEntryForSave.oauthFlowProfile,
                 });
                 toast.success("Connected successfully with OAuth!");
                 storeInitInfo(formData.name, connectionResult.initInfo).catch(
@@ -3274,6 +3276,7 @@ export function useServerState({
             name: formData.name,
             config: mcpConfig,
             useOAuth: formData.useOAuth ?? false,
+            oauthFlowProfile: serverEntryForSave.oauthFlowProfile,
           });
           // Env now persists on the Convex server doc via syncServerToConvex;
           // no localStorage write needed. The resolver returns env in the

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -87,7 +87,6 @@ import { resolveEffectiveClientCapabilities } from "@/lib/effective-client";
 import { EXCALIDRAW_SERVER_NAME } from "@/lib/excalidraw-quick-connect";
 import { readOnboardingState } from "@/lib/onboarding-state";
 import {
-  resolveEffectiveMcpProtocolVersion,
   type HostConfigDtoV2,
   type McpProtocolVersion,
 } from "@/lib/client-config-v2";
@@ -772,6 +771,40 @@ function getConnectionTransport(serverConfig: MCPServerConfig): string {
   return "unknown";
 }
 
+/**
+ * The single source of truth for a connection's effective wire protocol
+ * version. Every server-specific signal beats the broad host default; the
+ * host default is a blanket setting used only when nothing server-specific
+ * applies. Used by both the connect resolver and the connected-server
+ * revalidation effect so the "which version" answer can't drift between
+ * "what we connect with" and "when we re-test".
+ *
+ * Precedence: explicit per-server override → explicit config pin → the 2026
+ * era implied by the server's saved OAuth profile → host default.
+ */
+function resolveEffectiveWireProtocolVersion(input: {
+  serverConfig: MCPServerConfig | undefined;
+  server: ServerWithName | undefined;
+  serverOverride: McpProtocolVersion | undefined;
+  hostPin: McpProtocolVersion | undefined;
+}): McpProtocolVersion | undefined {
+  const { serverConfig, server, serverOverride, hostPin } = input;
+  const rawConfigPin =
+    serverConfig && "mcpProtocolVersion" in serverConfig
+      ? serverConfig.mcpProtocolVersion
+      : undefined;
+  const configPin: McpProtocolVersion | undefined =
+    typeof rawConfigPin === "string" && isKnownProtocolVersion(rawConfigPin)
+      ? rawConfigPin
+      : undefined;
+  const oauthProfilePin: McpProtocolVersion | undefined =
+    server?.useOAuth === true &&
+    server.oauthFlowProfile?.protocolVersion === "2026-07-28"
+      ? "2026-07-28"
+      : undefined;
+  return serverOverride ?? configPin ?? oauthProfilePin ?? hostPin;
+}
+
 function countRecordKeys(value: unknown): number {
   return value && typeof value === "object" && !Array.isArray(value)
     ? Object.keys(value).length
@@ -1266,39 +1299,14 @@ export function useServerState({
         typeof rawHostPin === "string" && isKnownProtocolVersion(rawHostPin)
           ? rawHostPin
           : undefined;
-      // A pin carried on the server config itself — e.g. the sessionless 2026
-      // wire era derived from a just-completed OAuth flow (see
-      // `createServerConfig` / `applyTokensFromOAuthFlow`). Server-specific.
-      const rawConfigPin =
-        "mcpProtocolVersion" in serverConfig
-          ? serverConfig.mcpProtocolVersion
-          : undefined;
-      const configPin: McpProtocolVersion | undefined =
-        typeof rawConfigPin === "string" && isKnownProtocolVersion(rawConfigPin)
-          ? rawConfigPin
-          : undefined;
-      // A server whose saved OAuth profile is 2026-07-28 speaks the sessionless
-      // 2026 transport, but `toMCPConfig` never copies the OAuth mode onto
-      // `config` and hosted `readStoredOAuthConfig` is empty — so without this
-      // the wire era is silently lost on the first OAuth connect/probe and
-      // every reconnect. Only 2026 (coupled + non-default) is derived.
-      const oauthServer = serverName
-        ? appStateServersRef.current[serverName]
-        : undefined;
-      const oauthProfilePin: McpProtocolVersion | undefined =
-        oauthServer?.useOAuth === true &&
-        oauthServer.oauthFlowProfile?.protocolVersion === "2026-07-28"
-          ? "2026-07-28"
-          : undefined;
-      // Precedence: every server-specific signal beats the broad host default.
-      // `serverOverride` (explicit per-server wire pin) and `configPin` (an
-      // explicit pin on the config) are the strongest; the OAuth-profile pin
-      // beats the host default too — otherwise a host default of 2025-11-25
-      // would override a server the user explicitly configured for 2026 OAuth
-      // and break the connect. `hostPin` is the weakest: a blanket default
-      // used only when nothing server-specific applies.
-      const resolvedProtocolVersion =
-        serverOverride ?? configPin ?? oauthProfilePin ?? hostPin;
+      const resolvedProtocolVersion = resolveEffectiveWireProtocolVersion({
+        serverConfig,
+        server: serverName
+          ? appStateServersRef.current[serverName]
+          : undefined,
+        serverOverride,
+        hostPin,
+      });
       if (resolvedProtocolVersion !== undefined) {
         defaults.mcpProtocolVersion = resolvedProtocolVersion;
       }
@@ -2268,12 +2276,16 @@ export function useServerState({
         typeof rawOverride === "string" && isKnownProtocolVersion(rawOverride)
           ? rawOverride
           : undefined;
-      const resolvedPin = resolveEffectiveMcpProtocolVersion(
+      // Same precedence as the connect resolver (shared helper) so the
+      // "did the effective version change?" decision matches what we would
+      // actually connect with — including the config pin and the 2026 era
+      // implied by the server's OAuth profile, not just override/host default.
+      const effective = resolveEffectiveWireProtocolVersion({
+        serverConfig: server.config,
+        server,
         serverOverride,
-        hostPin
-      );
-      // Gate removed — stateless-mcp-enabled goes permanent 2026-05-27.
-      const effective: McpProtocolVersion | undefined = resolvedPin;
+        hostPin,
+      });
 
       const seenBefore = lastAppliedProtocolVersionRef.current.has(name);
       const previous = lastAppliedProtocolVersionRef.current.get(name);

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -1265,8 +1265,25 @@ export function useServerState({
         serverOverride,
         hostPin
       );
-      if (effective !== undefined) {
-        defaults.mcpProtocolVersion = effective;
+      // Lowest-precedence fallback: a pin carried on the server config itself
+      // — e.g. the sessionless 2026 wire era derived from a just-completed
+      // OAuth flow (see `createServerConfig` / `applyTokensFromOAuthFlow`).
+      // Without this the resolver rebuilds `connectionDefaults` purely from
+      // host config and silently drops that pin, so a 2026-only server
+      // reconnects on the default 2025 initialize path. A per-server override
+      // or host default still wins, so an explicit wire pin is never clobbered
+      // by the OAuth-derived one.
+      const rawConfigPin =
+        "mcpProtocolVersion" in serverConfig
+          ? serverConfig.mcpProtocolVersion
+          : undefined;
+      const configPin: McpProtocolVersion | undefined =
+        typeof rawConfigPin === "string" && isKnownProtocolVersion(rawConfigPin)
+          ? rawConfigPin
+          : undefined;
+      const resolvedProtocolVersion = effective ?? configPin;
+      if (resolvedProtocolVersion !== undefined) {
+        defaults.mcpProtocolVersion = resolvedProtocolVersion;
       }
       // Enterprise-managed authorization policy from the active host's
       // mcpProfile. Sent only when validly ON; an `invalid` stored policy

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -1259,7 +1259,13 @@ export function useServerState({
       // the server's saved OAuth profile when nothing higher-precedence pins
       // it. Every connect/probe/reconnect path funnels through this resolver,
       // so deriving here covers them all in one place.
-      serverName?: string
+      serverName?: string,
+      // Authoritative pending server entry (a form save in flight). When
+      // supplied it REPLACES the stored app-state lookup for the config/profile
+      // fallbacks, so a form that downgrades 2026→2025 (an intentionally
+      // unpinned config) does not resurrect the stale stored 2026 pin/profile.
+      // Reconnects omit it and fall back to the stored entry as before.
+      authoritativeServerEntry?: ServerWithName
     ) => {
       const defaults: ConnectionDefaults = {};
       if ("url" in serverConfig) {
@@ -1317,9 +1323,11 @@ export function useServerState({
           : undefined;
       const resolvedProtocolVersion = resolveEffectiveWireProtocolVersion({
         serverConfig,
-        server: serverName
-          ? appStateServersRef.current[serverName]
-          : undefined,
+        // An in-flight authoritative form save wins over the stale stored
+        // entry, so a 2026→2025 downgrade doesn't recover the old pin/profile.
+        server:
+          authoritativeServerEntry ??
+          (serverName ? appStateServersRef.current[serverName] : undefined),
         serverOverride,
         hostPin,
       });
@@ -1410,7 +1418,14 @@ export function useServerState({
   );
 
   const guardedTestConnection = useCallback(
-    async (serverConfig: MCPServerConfig, serverName: string) => {
+    async (
+      serverConfig: MCPServerConfig,
+      serverName: string,
+      // The authoritative pending server entry when this probe is part of a
+      // form save (handleConnect). Threaded into the resolver so wire-era
+      // resolution reads the new config/profile, not the stale stored one.
+      authoritativeServerEntry?: ServerWithName
+    ) => {
       assertClientConfigSynced();
       // Opt into the resolver path when both projectId and a Convex serverId
       // are populated in the API context; otherwise fall back to legacy
@@ -1430,7 +1445,8 @@ export function useServerState({
             serverConfig,
             activeMcpProfile,
             resolved.serverId,
-            serverName
+            serverName,
+            authoritativeServerEntry
           ),
         });
       }
@@ -3037,7 +3053,8 @@ export function useServerState({
           });
           const storedCredentialResult = await guardedTestConnection(
             withProjectConnectionDefaults(serverConfig),
-            formData.name
+            formData.name,
+            serverEntryForSave
           );
           if (isStaleOp(formData.name, token)) return;
           if (storedCredentialResult.success) {
@@ -3176,7 +3193,8 @@ export function useServerState({
               );
               const connectionResult = await guardedTestConnection(
                 withProjectConnectionDefaults(oauthServerConfig),
-                formData.name
+                formData.name,
+                serverEntryForSave
               );
               if (isStaleOp(formData.name, token)) return;
               if (connectionResult.success) {
@@ -3246,7 +3264,8 @@ export function useServerState({
         const effectiveConfig = withProjectConnectionDefaults(mcpConfig);
         const result = await guardedTestConnection(
           effectiveConfig,
-          formData.name
+          formData.name,
+          serverEntryForSave
         );
         if (isStaleOp(formData.name, token)) return;
         if (result.success) {

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -1266,18 +1266,9 @@ export function useServerState({
         typeof rawHostPin === "string" && isKnownProtocolVersion(rawHostPin)
           ? rawHostPin
           : undefined;
-      const effective = resolveEffectiveMcpProtocolVersion(
-        serverOverride,
-        hostPin
-      );
-      // Lowest-precedence fallback: a pin carried on the server config itself
-      // — e.g. the sessionless 2026 wire era derived from a just-completed
-      // OAuth flow (see `createServerConfig` / `applyTokensFromOAuthFlow`).
-      // Without this the resolver rebuilds `connectionDefaults` purely from
-      // host config and silently drops that pin, so a 2026-only server
-      // reconnects on the default 2025 initialize path. A per-server override
-      // or host default still wins, so an explicit wire pin is never clobbered
-      // by the OAuth-derived one.
+      // A pin carried on the server config itself — e.g. the sessionless 2026
+      // wire era derived from a just-completed OAuth flow (see
+      // `createServerConfig` / `applyTokensFromOAuthFlow`). Server-specific.
       const rawConfigPin =
         "mcpProtocolVersion" in serverConfig
           ? serverConfig.mcpProtocolVersion
@@ -1286,14 +1277,11 @@ export function useServerState({
         typeof rawConfigPin === "string" && isKnownProtocolVersion(rawConfigPin)
           ? rawConfigPin
           : undefined;
-      // Lowest precedence of all: a server whose saved OAuth profile is
-      // 2026-07-28 speaks the sessionless 2026 transport, but `toMCPConfig`
-      // never copies the OAuth mode onto `config` and hosted
-      // `readStoredOAuthConfig` is empty — so without this the wire era is
-      // silently lost on the first OAuth connect/probe and every reconnect,
-      // and a 2026-only server falls back to the 2025 initialize handshake.
-      // Only 2026 (coupled + non-default) is derived; an explicit override,
-      // host default, or config pin above still wins.
+      // A server whose saved OAuth profile is 2026-07-28 speaks the sessionless
+      // 2026 transport, but `toMCPConfig` never copies the OAuth mode onto
+      // `config` and hosted `readStoredOAuthConfig` is empty — so without this
+      // the wire era is silently lost on the first OAuth connect/probe and
+      // every reconnect. Only 2026 (coupled + non-default) is derived.
       const oauthServer = serverName
         ? appStateServersRef.current[serverName]
         : undefined;
@@ -1302,7 +1290,15 @@ export function useServerState({
         oauthServer.oauthFlowProfile?.protocolVersion === "2026-07-28"
           ? "2026-07-28"
           : undefined;
-      const resolvedProtocolVersion = effective ?? configPin ?? oauthProfilePin;
+      // Precedence: every server-specific signal beats the broad host default.
+      // `serverOverride` (explicit per-server wire pin) and `configPin` (an
+      // explicit pin on the config) are the strongest; the OAuth-profile pin
+      // beats the host default too — otherwise a host default of 2025-11-25
+      // would override a server the user explicitly configured for 2026 OAuth
+      // and break the connect. `hostPin` is the weakest: a blanket default
+      // used only when nothing server-specific applies.
+      const resolvedProtocolVersion =
+        serverOverride ?? configPin ?? oauthProfilePin ?? hostPin;
       if (resolvedProtocolVersion !== undefined) {
         defaults.mcpProtocolVersion = resolvedProtocolVersion;
       }

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -784,7 +784,7 @@ function getConnectionTransport(serverConfig: MCPServerConfig): string {
  * the pin when a caller passes a rebuilt URL-only config) → the 2026 era
  * implied by the server's saved OAuth profile → host default.
  */
-function resolveEffectiveWireProtocolVersion(input: {
+export function resolveEffectiveWireProtocolVersion(input: {
   serverConfig: MCPServerConfig | undefined;
   server: ServerWithName | undefined;
   serverOverride: McpProtocolVersion | undefined;
@@ -3690,23 +3690,29 @@ export function useServerState({
       });
       localStorage.removeItem(`mcp-tokens-${serverName}`);
 
-      // Preserve an explicit wire protocol pin across the token-apply
-      // reconnect. Rebuilding as `{ url }` alone drops it. (The 2026 era
-      // derived from the OAuth profile is applied centrally in
-      // `buildResolverConnectionDefaults`, which every connect/probe/reconnect
-      // path funnels through, so it is not repeated here — an explicit config
-      // pin still wins there.)
-      const existingConfig = appStateServersRef.current[serverName]?.config;
+      // Stamp the wire era on the config PERSISTED by CONNECT_SUCCESS.
+      // `buildResolverConnectionDefaults` covers the immediate reconnect's wire
+      // negotiation, but the persisted config is what hosted chat/eval/backend
+      // read later (they don't consult the OAuth profile), so it must carry the
+      // pin itself. An explicit stored pin wins; otherwise a just-completed
+      // 2026 OAuth flow is authoritative evidence of the sessionless era (this
+      // is a flow completion, not a form save, so there is no downgrade
+      // ambiguity — the profile reflects the flow that just ran).
+      const existingServer = appStateServersRef.current[serverName];
+      const existingConfig = existingServer?.config;
       const existingWireVersion =
         existingConfig && "mcpProtocolVersion" in existingConfig
           ? existingConfig.mcpProtocolVersion
           : undefined;
+      const oauthFlowWireVersion =
+        existingServer?.oauthFlowProfile?.protocolVersion === "2026-07-28"
+          ? ("2026-07-28" as const)
+          : undefined;
+      const wireVersion = existingWireVersion ?? oauthFlowWireVersion;
 
       const serverConfig = {
         url: serverUrl,
-        ...(existingWireVersion
-          ? { mcpProtocolVersion: existingWireVersion }
-          : {}),
+        ...(wireVersion ? { mcpProtocolVersion: wireVersion } : {}),
       } satisfies HttpServerConfig;
 
       dispatch({

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
@@ -2582,3 +2582,29 @@ describe("mcp-oauth", () => {
     });
   });
 });
+
+describe("createServerConfig wire-era pin", () => {
+  it("pins mcpProtocolVersion for a 2026-07-28 OAuth flow", async () => {
+    const { createServerConfig } = await import("../mcp-oauth");
+    const config = createServerConfig(
+      "https://mcp.example.com",
+      { access_token: "tok" },
+      "2026-07-28",
+    );
+    expect((config as { mcpProtocolVersion?: string }).mcpProtocolVersion).toBe(
+      "2026-07-28",
+    );
+  });
+
+  it("leaves the wire era unset for older OAuth versions (legacy default)", async () => {
+    const { createServerConfig } = await import("../mcp-oauth");
+    const config = createServerConfig(
+      "https://mcp.example.com",
+      { access_token: "tok" },
+      "2025-11-25",
+    );
+    expect(
+      (config as { mcpProtocolVersion?: string }).mcpProtocolVersion,
+    ).toBeUndefined();
+  });
+});

--- a/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
@@ -2677,9 +2677,11 @@ export async function initiateOAuth(
       clearOAuthFlowSession(options.serverName);
       return {
         success: true,
-        serverConfig: createServerConfig(options.serverUrl, {
-          access_token: flowResult.state.accessToken,
-        }),
+        serverConfig: createServerConfig(
+          options.serverUrl,
+          { access_token: flowResult.state.accessToken },
+          protocolVersion
+        ),
         oauthTrace: trace,
       };
     }
@@ -3022,7 +3024,11 @@ export async function completeHostedOAuthCallback(
     return {
       success: true,
       serverName,
-      serverConfig: createServerConfig(serverUrl),
+      serverConfig: createServerConfig(
+        serverUrl,
+        undefined,
+        storedOAuthConfig.protocolVersion
+      ),
       expiresAt: result.expiresAt ?? null,
       oauthTrace: mergedTrace,
       oauthResourceUrl,
@@ -3226,9 +3232,11 @@ export async function handleOAuthCallback(
       localStorage.removeItem("mcp-oauth-pending");
       return {
         success: true,
-        serverConfig: createServerConfig(serverUrl, {
-          access_token: flowResult.state.accessToken,
-        }),
+        serverConfig: createServerConfig(
+          serverUrl,
+          { access_token: flowResult.state.accessToken },
+          storedSession?.protocolVersion
+        ),
         serverName,
         oauthTrace: mergedTrace,
         oauthResourceUrl,
@@ -3317,7 +3325,11 @@ export async function handleOAuthCallback(
     const mergedTrace = mergeOAuthTraces(previousTrace, callbackTrace);
     publishOAuthTraceUpdate(serverName, mergedTrace, options.onTraceUpdate);
 
-    const serverConfig = createServerConfig(serverUrl, tokens);
+    const serverConfig = createServerConfig(
+      serverUrl,
+      tokens,
+      oauthConfig.protocolVersion
+    );
     return {
       success: true,
       serverConfig,
@@ -3545,7 +3557,11 @@ export async function refreshOAuthTokens(
       message: "OAuth token refresh completed successfully.",
     });
     emitTrace();
-    const serverConfig = createServerConfig(serverUrl, tokens);
+    const serverConfig = createServerConfig(
+      serverUrl,
+      tokens,
+      oauthConfig.protocolVersion
+    );
     return {
       success: true,
       serverConfig,
@@ -3610,7 +3626,8 @@ export function clearOAuthData(serverName: string): void {
  */
 export function createServerConfig(
   serverUrl: string,
-  tokens?: { access_token?: string | null }
+  tokens?: { access_token?: string | null },
+  protocolVersion?: OAuthProtocolVersion
 ): HttpServerConfig {
   // Note: We don't include authProvider in the config because it can't be serialized
   // when sent to the backend via JSON. The backend will use the Authorization header instead.
@@ -3625,5 +3642,12 @@ export function createServerConfig(
           }
         : {},
     },
+    // Pin the sessionless 2026 wire era so the post-OAuth reconnect/test
+    // probes via the stateless path, not the default 2025 initialize. Only
+    // 2026 is coupled and non-default; older OAuth versions map to the legacy
+    // default (unset), so they stay exactly as before.
+    ...(protocolVersion === "2026-07-28"
+      ? { mcpProtocolVersion: "2026-07-28" as const }
+      : {}),
   };
 }

--- a/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
@@ -11,6 +11,7 @@ import {
   exchangeAuthorization,
   fetchToken,
   getBrowserDebugDynamicRegistrationMetadata,
+  getSupportedRegistrationStrategies,
   EMPTY_OAUTH_FLOW_STATE,
   projectOAuthTraceSnapshot,
   resolveAuthorizationPlan,
@@ -462,7 +463,8 @@ function loadOAuthFlowSession(
       !parsed.state ||
       (parsed.protocolVersion !== "2025-03-26" &&
         parsed.protocolVersion !== "2025-06-18" &&
-        parsed.protocolVersion !== "2025-11-25")
+        parsed.protocolVersion !== "2025-11-25" &&
+        parsed.protocolVersion !== "2026-07-28")
     ) {
       return undefined;
     }
@@ -883,7 +885,11 @@ function buildAutomaticAuthorizationDecisionReason(
         ? "The authorization server advertised client_id_metadata_document_supported, so automatic mode preferred CIMD over DCR."
         : "The authorization server advertised client_id_metadata_document_supported.";
     case "dcr":
-      if (plan.protocolVersion !== "2025-11-25") {
+      if (
+        !getSupportedRegistrationStrategies(plan.protocolVersion).includes(
+          "cimd"
+        )
+      ) {
         return `CIMD is not available for protocol version ${plan.protocolVersion}, so automatic mode used DCR.`;
       }
 
@@ -1014,13 +1020,15 @@ export function readStoredOAuthConfig(
         parsed?.protocolMode === "auto" ||
         parsed?.protocolMode === "2025-03-26" ||
         parsed?.protocolMode === "2025-06-18" ||
-        parsed?.protocolMode === "2025-11-25"
+        parsed?.protocolMode === "2025-11-25" ||
+        parsed?.protocolMode === "2026-07-28"
           ? parsed.protocolMode
           : undefined,
       protocolVersion:
         parsed?.protocolVersion === "2025-03-26" ||
         parsed?.protocolVersion === "2025-06-18" ||
-        parsed?.protocolVersion === "2025-11-25"
+        parsed?.protocolVersion === "2025-11-25" ||
+        parsed?.protocolVersion === "2026-07-28"
           ? parsed.protocolVersion
           : undefined,
       registrationMode:

--- a/mcpjam-inspector/client/src/lib/oauth/profile.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/profile.ts
@@ -3,12 +3,14 @@ import type {
   RegistrationStrategy2025_03_26,
   RegistrationStrategy2025_06_18,
   RegistrationStrategy2025_11_25,
+  RegistrationStrategy2026_07_28,
 } from "@mcpjam/sdk/browser";
 
 export type OAuthRegistrationStrategy =
   | RegistrationStrategy2025_03_26
   | RegistrationStrategy2025_06_18
-  | RegistrationStrategy2025_11_25;
+  | RegistrationStrategy2025_11_25
+  | RegistrationStrategy2026_07_28;
 
 export interface OAuthTestProfile {
   serverUrl: string;
@@ -36,6 +38,7 @@ const OAUTH_PROTOCOL_VERSIONS: readonly OAuthProtocolVersion[] = [
   "2025-03-26",
   "2025-06-18",
   "2025-11-25",
+  "2026-07-28",
 ];
 
 const OAUTH_REGISTRATION_STRATEGIES: readonly OAuthRegistrationStrategy[] = [

--- a/mcpjam-inspector/client/src/state/__tests__/server-helpers.test.ts
+++ b/mcpjam-inspector/client/src/state/__tests__/server-helpers.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { toMCPConfig } from "../server-helpers";
+import type { ServerFormData } from "@/shared/types.js";
+
+function httpForm(overrides: Partial<ServerFormData> = {}): ServerFormData {
+  return {
+    type: "http",
+    url: "https://example.com/mcp",
+    ...overrides,
+  } as ServerFormData;
+}
+
+describe("toMCPConfig OAuth wire-era stamp", () => {
+  it("stamps mcpProtocolVersion for a 2026-07-28 OAuth mode", () => {
+    const config = toMCPConfig(
+      httpForm({ oauthProtocolMode: "2026-07-28" }),
+    );
+    expect((config as { mcpProtocolVersion?: string }).mcpProtocolVersion).toBe(
+      "2026-07-28",
+    );
+  });
+
+  it("leaves the wire era unset for older OAuth modes and auto", () => {
+    for (const mode of ["auto", "2025-11-25", "2025-06-18"] as const) {
+      const config = toMCPConfig(httpForm({ oauthProtocolMode: mode }));
+      expect(
+        (config as { mcpProtocolVersion?: string }).mcpProtocolVersion,
+      ).toBeUndefined();
+    }
+  });
+});

--- a/mcpjam-inspector/client/src/state/app-reducer.ts
+++ b/mcpjam-inspector/client/src/state/app-reducer.ts
@@ -206,6 +206,12 @@ export function appReducer(state: AppState, action: AppAction): AppState {
         // Hosted project OAuth can succeed without browser-side tokens.
         // Preserve explicit auth mode when the dispatch provides it.
         useOAuth: shouldUseOAuth,
+        // Keep the OAuth profile consistent with the just-saved form so a
+        // 2026→2025 downgrade doesn't leave a stale 2026 profile that the
+        // wire-version resolver would revive on the next reconnect.
+        ...(action.oauthFlowProfile
+          ? { oauthFlowProfile: action.oauthFlowProfile }
+          : {}),
       });
       return {
         ...state,

--- a/mcpjam-inspector/client/src/state/app-types.ts
+++ b/mcpjam-inspector/client/src/state/app-types.ts
@@ -213,6 +213,10 @@ export type AppAction =
       tokens?: OauthTokens;
       useOAuth?: boolean;
       oauthTrace?: OAuthTrace;
+      // The just-saved OAuth debugger profile. When present it replaces the
+      // stored one so a form that downgrades 2026→2025 doesn't leave a stale
+      // 2026 `oauthFlowProfile` behind for the resolver to revive.
+      oauthFlowProfile?: OAuthTestProfile;
     }
   | {
       type: "CONNECT_FAILURE";

--- a/mcpjam-inspector/client/src/state/server-helpers.ts
+++ b/mcpjam-inspector/client/src/state/server-helpers.ts
@@ -24,6 +24,14 @@ export function toMCPConfig(formData: ServerFormData): MCPServerConfig {
           requestInit: { headers: formData.headers },
         }
       : {}),
+    // A 2026-07-28 OAuth mode implies the sessionless 2026 wire era (OAuth and
+    // transport ship together). Stamp it so the first connect/probe — which
+    // runs before the new server lands in app state — pins the wire era rather
+    // than falling back to the 2025 initialize handshake. An explicit
+    // per-server wire override still wins in the connection-defaults resolver.
+    ...(formData.oauthProtocolMode === "2026-07-28"
+      ? { mcpProtocolVersion: "2026-07-28" as const }
+      : {}),
   };
 
   return httpConfig;

--- a/mcpjam-inspector/shared/types.ts
+++ b/mcpjam-inspector/shared/types.ts
@@ -695,7 +695,8 @@ export type ServerFormOAuthProtocolMode =
   | "auto"
   | "2025-03-26"
   | "2025-06-18"
-  | "2025-11-25";
+  | "2025-11-25"
+  | "2026-07-28";
 
 /**
  * @deprecated Use {@link RegistrationMode} (re-exported from shared/xaa) — the

--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -300,6 +300,7 @@ export type {
   RegistrationStrategy2025_03_26,
   RegistrationStrategy2025_06_18,
   RegistrationStrategy2025_11_25,
+  RegistrationStrategy2026_07_28,
 } from "./oauth/state-machines/types.js";
 
 // MCP conformance transport support — pure predicate, safe for the browser.

--- a/sdk/src/oauth-conformance/checks/oauth-negative.ts
+++ b/sdk/src/oauth-conformance/checks/oauth-negative.ts
@@ -3,6 +3,7 @@ import { getConformanceAuthCodeDynamicRegistrationMetadata } from "../../oauth/c
 import type { OAuthFlowState } from "../../oauth/state-machines/types.js";
 import {
   buildInitializeRequestBody,
+  buildStatelessVerifyRequestBody,
   resolveInitializeProtocolVersion,
 } from "../../oauth/state-machines/shared/initialize.js";
 import { resolveRequestedScopeValue } from "../../oauth/state-machines/shared/challenges.js";
@@ -100,6 +101,27 @@ function buildInvalidTokenMcpRequest(
 
   if (input.config.protocolVersion !== "2025-03-26") {
     headers["MCP-Protocol-Version"] = input.config.protocolVersion;
+  }
+
+  // 2026-07-28 has no initialize handshake: the authenticated probe is a
+  // stateless `tools/list` carrying the protocol-version `_meta` envelope and
+  // the `Mcp-Method` header (mirrors the debug-oauth-2026-07-28 machine). An
+  // `initialize` body would be rejected by a spec-compliant modern server, so
+  // the invalid-token check would misread that rejection.
+  if (input.config.protocolVersion === "2026-07-28") {
+    headers["Mcp-Method"] = "tools/list";
+    return {
+      method: "POST",
+      url: input.config.serverUrl,
+      headers,
+      body: buildStatelessVerifyRequestBody({
+        protocolVersion: input.config.protocolVersion,
+        authMode: input.config.auth.mode,
+        clientName: "MCPJam SDK OAuth Conformance",
+        clientVersion: "1.0.0",
+        id: 999,
+      }),
+    };
   }
 
   return {

--- a/sdk/src/oauth-conformance/profile-schema.ts
+++ b/sdk/src/oauth-conformance/profile-schema.ts
@@ -12,7 +12,7 @@ import { z } from "zod";
 export const oauthConformanceProfileSchema = z.object({
   serverUrl: z.string().optional(),
   protocolVersion: z
-    .enum(["2025-03-26", "2025-06-18", "2025-11-25"])
+    .enum(["2025-03-26", "2025-06-18", "2025-11-25", "2026-07-28"])
     .optional(),
   registrationStrategy: z.enum(["cimd", "dcr", "preregistered"]).optional(),
   clientId: z.string().optional(),

--- a/sdk/src/oauth-conformance/runner.ts
+++ b/sdk/src/oauth-conformance/runner.ts
@@ -745,6 +745,12 @@ export class OAuthConformanceTest {
           ? { headers: this.config.customHeaders }
           : undefined,
         timeout: this.config.verification.timeout ?? 30_000,
+        // Post-auth verification must speak the negotiated wire era. For 2026
+        // the MCP endpoint is stateless (no initialize), so pin the transport;
+        // older OAuth flows keep the legacy default (unset).
+        ...(this.config.protocolVersion === "2026-07-28"
+          ? { mcpProtocolVersion: "2026-07-28" as const }
+          : {}),
       };
       try {
         await withEphemeralClient(

--- a/sdk/src/oauth-conformance/validation.ts
+++ b/sdk/src/oauth-conformance/validation.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_MCPJAM_CLIENT_ID_METADATA_URL } from "../oauth/client-identity.js";
+import { getSupportedRegistrationStrategies } from "../oauth/state-machines/factory.js";
 import type {
   NormalizedOAuthConformanceConfig,
   OAuthConformanceAuthConfig,
@@ -59,8 +60,8 @@ export function normalizeOAuthConformanceConfig(
   );
 
   if (
-    config.protocolVersion !== "2025-11-25" &&
-    config.registrationStrategy === "cimd"
+    config.registrationStrategy === "cimd" &&
+    !getSupportedRegistrationStrategies(config.protocolVersion).includes("cimd")
   ) {
     throw new Error(
       `CIMD registration is not supported for protocol version ${config.protocolVersion}`,

--- a/sdk/src/oauth-login.ts
+++ b/sdk/src/oauth-login.ts
@@ -289,6 +289,12 @@ async function runVerification(
       ? { headers: config.customHeaders }
       : undefined,
     timeout: verificationConfig.timeout ?? 30_000,
+    // Post-auth verification must speak the negotiated wire era. For 2026 the
+    // MCP endpoint is stateless (no initialize), so pin the transport; older
+    // OAuth flows keep the legacy default (unset) they used before.
+    ...(config.protocolVersion === "2026-07-28"
+      ? { mcpProtocolVersion: "2026-07-28" as const }
+      : {}),
   };
 
   try {

--- a/sdk/tests/oauth-conformance/checks.test.ts
+++ b/sdk/tests/oauth-conformance/checks.test.ts
@@ -146,6 +146,29 @@ describe("oauth conformance unit checks", () => {
     });
   });
 
+  it("probes 2026-07-28 with a stateless tools/list request, not initialize", async () => {
+    const trackedRequest = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      statusText: "Unauthorized",
+      body: { error: "invalid_token" },
+    });
+
+    await runInvalidTokenCheck({
+      ...(baseNegativeInput as any),
+      config: {
+        ...baseNegativeInput.config,
+        protocolVersion: "2026-07-28",
+      },
+      trackedRequest,
+    });
+
+    const request = trackedRequest.mock.calls[0][0];
+    expect(request.body.method).toBe("tools/list");
+    expect(request.headers["Mcp-Method"]).toBe("tools/list");
+    expect(request.headers["MCP-Protocol-Version"]).toBe("2026-07-28");
+  });
+
   it("passes when the authorization endpoint rejects a mismatched redirect_uri", async () => {
     const result = await runInvalidAuthorizeRedirectCheck({
       ...(baseNegativeInput as any),

--- a/sdk/tests/oauth-conformance/checks.test.ts
+++ b/sdk/tests/oauth-conformance/checks.test.ts
@@ -154,7 +154,7 @@ describe("oauth conformance unit checks", () => {
       body: { error: "invalid_token" },
     });
 
-    await runInvalidTokenCheck({
+    const result = await runInvalidTokenCheck({
       ...(baseNegativeInput as any),
       config: {
         ...baseNegativeInput.config,
@@ -167,6 +167,11 @@ describe("oauth conformance unit checks", () => {
     expect(request.body.method).toBe("tools/list");
     expect(request.headers["Mcp-Method"]).toBe("tools/list");
     expect(request.headers["MCP-Protocol-Version"]).toBe("2026-07-28");
+    // The 401 must still classify as a passing invalid-token check.
+    expect(result).toMatchObject({
+      step: "oauth_invalid_token",
+      status: "passed",
+    });
   });
 
   it("passes when the authorization endpoint rejects a mismatched redirect_uri", async () => {

--- a/sdk/tests/oauth-conformance/validation.test.ts
+++ b/sdk/tests/oauth-conformance/validation.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { normalizeOAuthConformanceConfig } from "../../src/oauth-conformance/validation.js";
+
+describe("normalizeOAuthConformanceConfig CIMD gate", () => {
+  it("accepts CIMD for 2026-07-28", () => {
+    const normalized = normalizeOAuthConformanceConfig({
+      serverUrl: "https://example.com/mcp",
+      protocolVersion: "2026-07-28",
+      registrationStrategy: "cimd",
+    });
+    expect(normalized.registrationStrategy).toBe("cimd");
+  });
+
+  it("accepts CIMD for 2025-11-25", () => {
+    const normalized = normalizeOAuthConformanceConfig({
+      serverUrl: "https://example.com/mcp",
+      protocolVersion: "2025-11-25",
+      registrationStrategy: "cimd",
+    });
+    expect(normalized.registrationStrategy).toBe("cimd");
+  });
+
+  it("rejects CIMD for versions whose spec has no CIMD (2025-06-18)", () => {
+    expect(() =>
+      normalizeOAuthConformanceConfig({
+        serverUrl: "https://example.com/mcp",
+        protocolVersion: "2025-06-18",
+        registrationStrategy: "cimd",
+      }),
+    ).toThrow(/CIMD registration is not supported/);
+  });
+});


### PR DESCRIPTION
## Phase 2 — 2M-b: surface/selectability of the 2026-07-28 OAuth machine

2M-a built the `debug-oauth-2026-07-28` state machine (spec-faithful, merged in #3321 + #3358) but it was **not user-reachable** — the protocol dropdowns excluded it and the client persistence layer silently dropped a stored 2026 version. This PR completes 2M-b: it makes the machine selectable across the client and CLI and correct across serialize/restore.

### Client
- Accept `2026-07-28` in the OAuth profile allow-list (`normalizeOAuthProtocolVersion`) and the registration-strategy union (`profile.ts`).
- Add `2026-07-28` to both protocol dropdowns: `ProtocolVersionSelector` (with a "Draft" badge + a 2026 "Key Differences" panel) and `OAuthProfileModal`.
- Stop `mcp-oauth.ts` from silently dropping a stored 2026 version: the flow-session deserializer and the stored-config parser (`protocolMode`/`protocolVersion`) now include `2026-07-28`. These are the "version-literal `if` twins" the 2M-a status flagged as invisible to `tsc` — found by grepping version literals, not the compiler.
- Fix the automatic-decision explainer to compute CIMD availability from `getSupportedRegistrationStrategies(...)` instead of a hardcoded `=== "2025-11-25"` (2026 supports CIMD).

### Two-union bridge
- `deriveOAuthProfileFromServer` defaults the OAuth profile to the 2026-07-28 machine when a server is **wire-pinned** (`config.mcpProtocolVersion`) to `2026-07-28` and no explicit OAuth profile version is set. An explicit profile version always wins.

### CLI
- Add `2026-07-28` to `VALID_PROTOCOL_VERSIONS`; widen the protocol-version type/help strings.
- Gate CIMD on a new `CIMD_PROTOCOL_VERSIONS` set (`2025-11-25` + `2026-07-28`) instead of `!== "2025-11-25"` in both `buildOAuthConformanceConfig` and the login path.

### SDK
- Re-export `RegistrationStrategy2026_07_28` from the browser barrel (additive, type-only).

### Tests
- CLI: `buildOAuthConformanceConfig` accepts CIMD on `2026-07-28`.
- Client: `deriveOAuthProfileFromServer` bridges from a 2026 wire pin and keeps an explicit profile version over it.

### Verification
- `sdk` typecheck clean; `cli` oauth tests 21/21; client `utils.test.ts` 5/5 and `project-serialization.test.ts` 27/27.
- Pre-existing unrelated errors on `main` (28 in `cli/src/lib/mcp-server.ts`, 3 in an in-progress `ServerDetailModal.tsx`) are not touched by this PR.

### Not in scope
- `client-registration.ts` (`ClientRegistrationService`) has no live callers (only a comment references it) — left untouched.
- Runtime security gates (`2R-iss`/`2R-store`/`2R-stepup`) and the shared SSRF/hardening pass remain separate Phase 2 packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth connect/resolver precedence and persisted `mcpProtocolVersion` across client and hosted paths; regressions could mis-route handshakes or revive stale protocol pins, though behavior is heavily test-covered.
> 
> **Overview**
> Adds **`2026-07-28 (Draft)`** as a selectable OAuth protocol across the CLI, inspector UI, and SDK, and threads the **sessionless 2026 MCP wire era** through connect, probe, verification, and hosted paths so 2026-only servers are not probed with the legacy 2025 `initialize` handshake.
> 
> **CLI & SDK:** `2026-07-28` joins valid protocol versions; CIMD is allowed for `2025-11-25` and `2026-07-28` via `CIMD_PROTOCOL_VERSIONS`. Login debug snapshots set `mcpProtocolVersion: "2026-07-28"` (including when login fails before a result). Conformance invalid-token checks use stateless `tools/list` for 2026; post-auth verification pins the 2026 transport in login and conformance runners.
> 
> **Inspector:** Protocol dropdowns and stored OAuth session/config parsing accept 2026. `toMCPConfig` and `createServerConfig` stamp `mcpProtocolVersion` when 2026 is chosen; OAuth profile save carries `oauthProtocolMode`. Shared **`resolveEffectiveWireProtocolVersion`** (override → config pins → OAuth-profile 2026 → host default) drives connect/probe/reconnect and hosted chat/eval; in-flight form saves win over stale stored pins on 2026→2025 downgrades. `CONNECT_SUCCESS` persists config and `oauthFlowProfile` consistently; stored-credential probes use the full `toMCPConfig` output instead of URL-only configs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdc87da4d31251ee9e40c159092a574756e3afb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the draft `2026-07-28` OAuth machine selectable across `client`, `cli`, and `sdk`, and routes connects, probes, verification, and reconnects over the stateless 2026 wire with clear server-first precedence. Hosted chat/eval use the same resolver and now recompute on server changes; first-time OAuth completions and saves persist a 2026 pin, and downgrades don’t revive stale pins.

- **New Features**
  - `client`: add `2026-07-28 (Draft)` to OAuth selectors; `toMCPConfig` stamps `mcpProtocolVersion: "2026-07-28"` when chosen so first probes use stateless MCP.
  - `cli`: accept `2026-07-28` in `VALID_PROTOCOL_VERSIONS`; gate CIMD via `CIMD_PROTOCOL_VERSIONS`; debug snapshots pin 2026 and fall back to the requested `--protocol-version` if no result returns.
  - `sdk`: re-export `RegistrationStrategy2026_07_28`; conformance profile schema accepts `2026-07-28`.

- **Bug Fixes**
  - Wire pinning and precedence: `createServerConfig` pins 2026 for all OAuth reconnect paths; token-apply preserves an existing pin; `CONNECT_SUCCESS` persists it and refreshes the saved `oauthFlowProfile` to avoid stale 2026 revivals on 2026→2025 downgrades; OAuthProfileModal saves `oauthProtocolMode` so `toMCPConfig` stamps the 2026 pin in synced configs. A shared `resolveEffectiveWireProtocolVersion` (override → config pin → OAuth-profile 2026 → host default) is used for connect/probe/reconnect and hosted chat/eval, and hosted maps now recompute when server state changes; an authoritative in-flight form prevents stale pins from resurfacing.
  - Verification and diagnostics: conformance invalid-token check uses a stateless `tools/list` probe with `Mcp-Method` and `_meta` for `2026-07-28`; post-auth verification pins the 2026 wire in both `oauth-login` and the conformance runner; CLI login debug snapshots pin 2026 even when the login throws before returning a result.
  - UI: removed an unenforced RFC 9207 `iss` validation claim from the 2026 “Key Differences” copy.

<sup>Written for commit fdc87da4d31251ee9e40c159092a574756e3afb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

