### PR TITLE
feat(connection): allow pinning MCP protocol version when adding a server

### DIFF
--- a/mcpjam-inspector/client/src/components/ServersTab.tsx
+++ b/mcpjam-inspector/client/src/components/ServersTab.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useContext, useEffect, useMemo, useState } from "react";
+import {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { createPortal } from "react-dom";
 import { AnimatePresence, motion } from "framer-motion";
 import { Card } from "@mcpjam/design-system/card";
@@ -79,10 +86,12 @@ import { Skeleton } from "@mcpjam/design-system/skeleton";
 import { ServersLoadingSkeleton } from "@mcpjam/design-system/servers-loading-skeleton";
 import { useConvexAuth, useMutation, useQuery } from "convex/react";
 import { useAuth } from "@workos-inc/authkit-react";
-import type {
-  ProjectServerConfigDto,
-  ProjectServerConfigInput,
+import {
+  applyMcpProtocolVersionOverride,
+  type ProjectServerConfigDto,
+  type ProjectServerConfigInput,
 } from "@/lib/project-server-config";
+import type { McpProtocolVersion } from "@/lib/client-config-v2";
 import {
   resetAutoConnectAttempts,
   useAutoConnectProjectServers,
@@ -1306,6 +1315,68 @@ export function ServersTab({
     [focusLoggerOnServer, onReconnect, isAppBootstrapping, appReadyMessage]
   );
 
+  // Protocol pin chosen in the Add Server modal. The pin is persisted on
+  // the project layer (`projectServerConfig` overrides) keyed by the hosted
+  // server row's `_id` — which doesn't exist until the add flow's Convex
+  // sync lands. Stash the (name, version) pair here and let the effect
+  // below apply it once the hosted row appears in `remoteServersByName`,
+  // then reconnect so the pin actually takes effect on the wire (mirrors
+  // the edit flow's save→reconnect behavior in `ServerDetailModal`).
+  const [pendingAddProtocolPin, setPendingAddProtocolPin] = useState<{
+    serverName: string;
+    version: McpProtocolVersion;
+  } | null>(null);
+  // Guards double-fire while the async apply is in flight (the effect
+  // re-runs on every reactive update of the DTO / server list).
+  const isApplyingAddProtocolPinRef = useRef(false);
+  useEffect(() => {
+    if (!pendingAddProtocolPin) return;
+    if (isApplyingAddProtocolPinRef.current) return;
+    if (!sharedProjectIdForHostScope) return;
+    // Wait for BOTH the hosted server row and the config DTO to hydrate —
+    // `applyMcpProtocolVersionOverride` replaces the whole (serverIds,
+    // overrides) pair, so writing against a still-loading DTO would wipe
+    // other servers' overrides. `null` (no row yet) is a valid baseline.
+    if (projectServerConfigDto === undefined) return;
+    const serverId = remoteServersByName[pendingAddProtocolPin.serverName]?._id;
+    if (!serverId) return;
+    const { serverName, version } = pendingAddProtocolPin;
+    isApplyingAddProtocolPinRef.current = true;
+    void (async () => {
+      try {
+        await applyMcpProtocolVersionOverride({
+          projectId: sharedProjectIdForHostScope,
+          serverId,
+          current: projectServerConfigDto,
+          next: version,
+          setConfig: setProjectServerConfigMutation,
+        });
+        // Reconnect so the just-saved pin governs the live connection.
+        // Non-interactive on purpose: the add flow may already be running
+        // an OAuth escalation; don't stack a second interactive flow.
+        await handleReconnectServer(serverName, {
+          allowInteractiveOAuthFlow: false,
+        });
+      } catch (err) {
+        toast.error(
+          err instanceof Error
+            ? `Server added, but saving its protocol version failed: ${err.message}`
+            : "Server added, but saving its protocol version failed."
+        );
+      } finally {
+        isApplyingAddProtocolPinRef.current = false;
+        setPendingAddProtocolPin(null);
+      }
+    })();
+  }, [
+    pendingAddProtocolPin,
+    sharedProjectIdForHostScope,
+    projectServerConfigDto,
+    remoteServersByName,
+    setProjectServerConfigMutation,
+    handleReconnectServer,
+  ]);
+
   const clearPendingQuickConnectIfMatches = useCallback(
     (serverName: string) => {
       if (pendingQuickConnect?.serverName !== serverName) {
@@ -2008,6 +2079,15 @@ export function ServersTab({
           track("connecting_server", {
             location: "servers_tab",
           });
+          // The wire-version pin can't be written until the hosted server
+          // row exists — stash it and let the watcher effect apply it once
+          // the Convex sync surfaces the row, then reconnect with the pin.
+          if (formData.mcpProtocolVersionOverride) {
+            setPendingAddProtocolPin({
+              serverName: formData.name,
+              version: formData.mcpProtocolVersionOverride,
+            });
+          }
           handleConnectServer(formData);
         }}
         projectClientConfig={selectedProject?.clientConfig}
@@ -2016,6 +2096,7 @@ export function ServersTab({
         projectXaaDefaultIdentity={
           selectedProject?.xaaTestDefaults?.defaultIdentity ?? null
         }
+        projectId={sharedProjectIdForHostScope}
       />
 
       {/* JSON Import Modal */}

--- a/mcpjam-inspector/client/src/components/connection/AddServerModal.tsx
+++ b/mcpjam-inspector/client/src/components/connection/AddServerModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useAuth } from "@workos-inc/authkit-react";
 import { toast } from "@/lib/toast";
 import { normalizeRegistrationMode } from "@/shared/xaa.js";
@@ -38,6 +38,15 @@ interface AddServerModalProps {
   isSignedIn?: boolean;
   /** Project default XAA test identity — shown as override placeholders. */
   projectXaaDefaultIdentity?: { subject: string; email: string } | null;
+  /**
+   * Shared (hosted) project id. When present, the Connection-overrides
+   * section shows the per-server MCP protocol-version picker; the chosen
+   * pin rides `ServerFormData.mcpProtocolVersionOverride` and the caller
+   * persists it on the project layer once the hosted server row exists.
+   * Absent (local-only / CLI contexts) the picker stays hidden — there is
+   * no project row to bind the override to.
+   */
+  projectId?: string | null;
 }
 
 function normalizeOauthProtocolMode(
@@ -115,6 +124,7 @@ export function AddServerModal({
   organizationId,
   isSignedIn,
   projectXaaDefaultIdentity = null,
+  projectId = null,
 }: AddServerModalProps) {
   const appState = useOptionalSharedAppState();
   const activeProject = findProjectByAnyId(
@@ -136,6 +146,15 @@ export function AddServerModal({
     organizationId: resolvedConfidentialCimdContext.organizationId,
     isSignedIn: resolvedConfidentialCimdContext.isSignedIn,
   });
+  // Per-server MCP wire-version pin. Lives OUTSIDE `useServerForm` on
+  // purpose: the edit flow persists this on the project layer via
+  // `projectServerConfig:setConfig` (see `ServerDetailModal`), never through
+  // the server-save payload, so the shared form hook must not start
+  // emitting it. Here it rides the one-shot `ServerFormData` and the add
+  // path applies it once the hosted server row exists.
+  const [mcpProtocolVersionOverride, setMcpProtocolVersionOverride] = useState<
+    ServerFormData["mcpProtocolVersionOverride"]
+  >(undefined);
   const hostedUrlPlaceholder = "https://example.com/mcp";
   const appReady = useAppReady();
   const appReadyMessage = useAppReadyMessage();
@@ -281,6 +300,7 @@ export function AddServerModal({
 
   const handleClose = () => {
     formState.resetForm();
+    setMcpProtocolVersionOverride(undefined);
     onClose();
   };
 
@@ -322,9 +342,15 @@ export function AddServerModal({
       return;
     }
 
-    const finalFormData = formState.buildFormData();
+    const finalFormData: ServerFormData = {
+      ...formState.buildFormData(),
+      ...(mcpProtocolVersionOverride !== undefined
+        ? { mcpProtocolVersionOverride }
+        : {}),
+    };
     onSubmit(finalFormData);
     formState.resetForm();
+    setMcpProtocolVersionOverride(undefined);
     onClose();
   };
 
@@ -566,6 +592,10 @@ export function AddServerModal({
             clientCapabilitiesOverrideError={
               formState.clientCapabilitiesOverrideError
             }
+            showMcpProtocolVersionOverride={Boolean(projectId)}
+            mcpProtocolVersionOverride={mcpProtocolVersionOverride}
+            onMcpProtocolVersionOverrideChange={setMcpProtocolVersionOverride}
+            transportKind={formState.type === "http" ? "http" : "stdio"}
             {...(formState.type === "http"
               ? {
                   customHeaders: formState.customHeaders,

--- a/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
@@ -40,10 +40,11 @@ import { ServerHistoryContent } from "./ServerHistoryContent";
 import { ServerHistoryDriftChip } from "./ServerHistoryDriftChip";
 import { HostCompatContent } from "@/components/compat/HostCompatContent";
 import type { McpProtocolVersion } from "@/lib/client-config-v2";
-import type {
-  ProjectServerConfigDto,
-  ProjectServerConfigInput,
-  ProjectServerOverrideEntry,
+import {
+  applyMcpProtocolVersionOverride,
+  type ProjectServerConfigDto,
+  type ProjectServerConfigInput,
+  type ProtocolOverrideAutoEnrollRecord,
 } from "@/lib/project-server-config";
 import { EffectiveProtocolVersionChip } from "./shared/EffectiveProtocolVersionChip";
 import { fetchServerSecrets } from "@/lib/apis/server-secrets-api";
@@ -93,73 +94,6 @@ interface ServerDetailModalProps {
   /** Project default XAA test identity — shown as override placeholders. */
   projectXaaDefaultIdentity?: { subject: string; email: string } | null;
 }
-
-type ProtocolOverrideAutoEnrollRecord = {
-  previousServerIds: string[];
-};
-
-const PROTOCOL_OVERRIDE_AUTO_ENROLL_STORAGE_PREFIX =
-  "mcpjam:protocol-override-auto-enroll";
-
-const getProtocolOverrideAutoEnrollKey = (
-  projectId: string,
-  serverId: string
-) => `${PROTOCOL_OVERRIDE_AUTO_ENROLL_STORAGE_PREFIX}:${projectId}:${serverId}`;
-
-const readProtocolOverrideAutoEnrollRecord = (
-  key: string
-): ProtocolOverrideAutoEnrollRecord | undefined => {
-  if (typeof window === "undefined") return undefined;
-  try {
-    const raw = window.sessionStorage.getItem(key);
-    if (!raw) return undefined;
-    const parsed = JSON.parse(raw) as Partial<ProtocolOverrideAutoEnrollRecord>;
-    if (!Array.isArray(parsed.previousServerIds)) return undefined;
-    return {
-      previousServerIds: parsed.previousServerIds.filter(
-        (id): id is string => typeof id === "string"
-      ),
-    };
-  } catch {
-    return undefined;
-  }
-};
-
-const writeProtocolOverrideAutoEnrollRecord = (
-  key: string,
-  record: ProtocolOverrideAutoEnrollRecord
-) => {
-  if (typeof window === "undefined") return;
-  try {
-    window.sessionStorage.setItem(key, JSON.stringify(record));
-  } catch {
-    // Losing this marker only affects cleanup of an implicit enrollment.
-  }
-};
-
-const removeProtocolOverrideAutoEnrollRecord = (key: string) => {
-  if (typeof window === "undefined") return;
-  try {
-    window.sessionStorage.removeItem(key);
-  } catch {
-    // Best-effort cleanup only.
-  }
-};
-
-const matchesImplicitAutoEnrollment = (
-  currentServerIds: string[],
-  serverId: string,
-  previousServerIds: string[]
-) => {
-  const previousServerIdSet = new Set(previousServerIds);
-  if (previousServerIdSet.has(serverId)) return false;
-  if (!currentServerIds.includes(serverId)) return false;
-  if (currentServerIds.length !== previousServerIdSet.size + 1) return false;
-  return currentServerIds.every(
-    (currentServerId) =>
-      currentServerId === serverId || previousServerIdSet.has(currentServerId)
-  );
-};
 
 export function ServerDetailModal({
   isOpen,
@@ -295,78 +229,18 @@ export function ServerDetailModal({
       );
       return;
     }
-    // setConfig replaces the entire (serverIds, overrides) pair — read
-    // current (now guaranteed non-undefined), splice in the new
-    // override, write back. Preserve every other server's overrides
-    // verbatim. `projectServerConfigDto` may still be `null` (no row
-    // yet for this project) — that case is genuinely the empty
-    // baseline.
-    const currentServerIds = projectServerConfigDto?.serverIds ?? [];
-    const currentOverrides = projectServerConfigDto?.overrides ?? {};
-    const existingEntry = currentOverrides[serverId] ?? {};
-    const updatedEntry: ProjectServerOverrideEntry = {
-      ...existingEntry,
-      mcpProtocolVersionOverride: next,
-    };
-    // Drop entry when it collapses to nothing (no headers, no timeout,
-    // no wire-mode). Mirrors `normalizeOverrideEntry` on the backend so
-    // the canonicalizer doesn't see an empty entry.
-    const hasContent =
-      (updatedEntry.headersOverride &&
-        Object.keys(updatedEntry.headersOverride).length > 0) ||
-      updatedEntry.requestTimeoutOverride !== undefined ||
-      updatedEntry.mcpProtocolVersionOverride !== undefined;
-    const nextOverrides: Record<string, ProjectServerOverrideEntry> = {
-      ...currentOverrides,
-    };
-    if (hasContent) nextOverrides[serverId] = updatedEntry;
-    else delete nextOverrides[serverId];
-    // Backend validation requires override keys to be members of `serverIds`.
-    // If this control enrolls the server only to save the protocol pin, remember
-    // that provenance so clearing the pin can undo the implicit enrollment
-    // without removing servers that were already explicitly auto-connected.
-    const autoEnrollKey = getProtocolOverrideAutoEnrollKey(projectId, serverId);
-    const autoEnrollRecord =
-      protocolOverrideAutoEnrolledRef.current.get(autoEnrollKey) ??
-      readProtocolOverrideAutoEnrollRecord(autoEnrollKey);
-    const shouldAutoEnrollForOverride =
-      hasContent && !currentServerIds.includes(serverId);
-    const shouldUndoAutoEnroll =
-      !hasContent &&
-      autoEnrollRecord !== undefined &&
-      matchesImplicitAutoEnrollment(
-        currentServerIds,
-        serverId,
-        autoEnrollRecord.previousServerIds
-      );
-    const nextServerIds = shouldAutoEnrollForOverride
-      ? [...currentServerIds, serverId]
-      : shouldUndoAutoEnroll
-      ? currentServerIds.filter(
-          (currentServerId) => currentServerId !== serverId
-        )
-      : currentServerIds;
     try {
-      await setProjectServerConfigMutation({
+      // Shared splice + implicit-enrollment bookkeeping — same helper the
+      // Add Server flow uses (`applyMcpProtocolVersionOverride`). The
+      // `null` case is genuinely the empty baseline (no row yet).
+      await applyMcpProtocolVersionOverride({
         projectId,
-        input: { serverIds: nextServerIds, overrides: nextOverrides },
+        serverId,
+        current: projectServerConfigDto ?? null,
+        next,
+        setConfig: setProjectServerConfigMutation,
+        autoEnrollCache: protocolOverrideAutoEnrolledRef.current,
       });
-      if (shouldAutoEnrollForOverride) {
-        const nextAutoEnrollRecord = {
-          previousServerIds: [...currentServerIds],
-        };
-        protocolOverrideAutoEnrolledRef.current.set(
-          autoEnrollKey,
-          nextAutoEnrollRecord
-        );
-        writeProtocolOverrideAutoEnrollRecord(
-          autoEnrollKey,
-          nextAutoEnrollRecord
-        );
-      } else if (!hasContent && autoEnrollRecord !== undefined) {
-        protocolOverrideAutoEnrolledRef.current.delete(autoEnrollKey);
-        removeProtocolOverrideAutoEnrollRecord(autoEnrollKey);
-      }
       // Reconnect-after-save race: `onReconnect` ultimately reads from
       // `activeHostConfig.serverConnectionOverrides` to compute the new
       // wire mode. That value is a derivation of the same Convex row we

--- a/mcpjam-inspector/client/src/components/connection/shared/AdvancedConnectionSettingsSection.tsx
+++ b/mcpjam-inspector/client/src/components/connection/shared/AdvancedConnectionSettingsSection.tsx
@@ -63,9 +63,11 @@ interface AdvancedConnectionSettingsSectionProps {
   /**
    * Visibility for the protocol-version override row. Edit-server contexts
    * (where the per-server override can be persisted on the project layer)
-   * pass true; the Add Server modal leaves it off since no project server
-   * ref exists yet. Defaults to false. Host-default JSON keeps working
-   * regardless — just no per-server affordance.
+   * pass true; the Add Server modal passes true only when a shared project
+   * id exists (the pin rides the form payload and is applied to the project
+   * layer once the hosted server row is created). Defaults to false.
+   * Host-default JSON keeps working regardless — just no per-server
+   * affordance.
    */
   showMcpProtocolVersionOverride?: boolean;
   /**

--- a/mcpjam-inspector/client/src/lib/__tests__/project-server-config.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/project-server-config.test.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  applyMcpProtocolVersionOverride,
+  getProtocolOverrideAutoEnrollKey,
+  readProtocolOverrideAutoEnrollRecord,
+  type ProjectServerConfigDto,
+} from "../project-server-config";
+
+const PROJECT_ID = "proj_1";
+const SERVER_ID = "srv_new";
+
+const dto = (
+  overrides: Partial<ProjectServerConfigDto> = {},
+): ProjectServerConfigDto => ({
+  projectId: PROJECT_ID,
+  serverIds: [],
+  overrides: {},
+  ...overrides,
+});
+
+describe("applyMcpProtocolVersionOverride", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it("enrolls an un-enrolled server and records provenance (add-flow shape)", async () => {
+    const setConfig = vi.fn().mockResolvedValue(undefined);
+    await applyMcpProtocolVersionOverride({
+      projectId: PROJECT_ID,
+      serverId: SERVER_ID,
+      current: dto({ serverIds: ["srv_other"] }),
+      next: "2026-07-28",
+      setConfig,
+    });
+    expect(setConfig).toHaveBeenCalledWith({
+      projectId: PROJECT_ID,
+      input: {
+        serverIds: ["srv_other", SERVER_ID],
+        overrides: {
+          [SERVER_ID]: { mcpProtocolVersionOverride: "2026-07-28" },
+        },
+      },
+    });
+    expect(
+      readProtocolOverrideAutoEnrollRecord(
+        getProtocolOverrideAutoEnrollKey(PROJECT_ID, SERVER_ID),
+      ),
+    ).toEqual({ previousServerIds: ["srv_other"] });
+  });
+
+  it("treats a null DTO as the empty baseline (no row yet)", async () => {
+    const setConfig = vi.fn().mockResolvedValue(undefined);
+    await applyMcpProtocolVersionOverride({
+      projectId: PROJECT_ID,
+      serverId: SERVER_ID,
+      current: null,
+      next: "2025-11-25",
+      setConfig,
+    });
+    expect(setConfig).toHaveBeenCalledWith({
+      projectId: PROJECT_ID,
+      input: {
+        serverIds: [SERVER_ID],
+        overrides: {
+          [SERVER_ID]: { mcpProtocolVersionOverride: "2025-11-25" },
+        },
+      },
+    });
+  });
+
+  it("preserves other servers' overrides verbatim", async () => {
+    const setConfig = vi.fn().mockResolvedValue(undefined);
+    await applyMcpProtocolVersionOverride({
+      projectId: PROJECT_ID,
+      serverId: SERVER_ID,
+      current: dto({
+        serverIds: ["srv_other", SERVER_ID],
+        overrides: {
+          srv_other: { requestTimeoutOverride: 5000 },
+        },
+      }),
+      next: "2026-07-28",
+      setConfig,
+    });
+    expect(setConfig.mock.calls[0][0].input.overrides).toEqual({
+      srv_other: { requestTimeoutOverride: 5000 },
+      [SERVER_ID]: { mcpProtocolVersionOverride: "2026-07-28" },
+    });
+    expect(setConfig.mock.calls[0][0].input.serverIds).toEqual([
+      "srv_other",
+      SERVER_ID,
+    ]);
+  });
+
+  it("clearing the pin drops the empty entry and undoes an implicit enrollment", async () => {
+    const setConfig = vi.fn().mockResolvedValue(undefined);
+    // First: implicit enrollment via pin.
+    await applyMcpProtocolVersionOverride({
+      projectId: PROJECT_ID,
+      serverId: SERVER_ID,
+      current: dto({ serverIds: ["srv_other"] }),
+      next: "2026-07-28",
+      setConfig,
+    });
+    // Then: clear it against the post-write state.
+    await applyMcpProtocolVersionOverride({
+      projectId: PROJECT_ID,
+      serverId: SERVER_ID,
+      current: dto({
+        serverIds: ["srv_other", SERVER_ID],
+        overrides: {
+          [SERVER_ID]: { mcpProtocolVersionOverride: "2026-07-28" },
+        },
+      }),
+      next: undefined,
+      setConfig,
+    });
+    expect(setConfig.mock.calls[1][0].input).toEqual({
+      serverIds: ["srv_other"],
+      overrides: {},
+    });
+    expect(
+      readProtocolOverrideAutoEnrollRecord(
+        getProtocolOverrideAutoEnrollKey(PROJECT_ID, SERVER_ID),
+      ),
+    ).toBeUndefined();
+  });
+
+  it("clearing the pin keeps an explicitly enrolled server enrolled", async () => {
+    const setConfig = vi.fn().mockResolvedValue(undefined);
+    // No provenance record exists — the server was enrolled by the user.
+    await applyMcpProtocolVersionOverride({
+      projectId: PROJECT_ID,
+      serverId: SERVER_ID,
+      current: dto({
+        serverIds: [SERVER_ID],
+        overrides: {
+          [SERVER_ID]: { mcpProtocolVersionOverride: "2026-07-28" },
+        },
+      }),
+      next: undefined,
+      setConfig,
+    });
+    expect(setConfig.mock.calls[0][0].input).toEqual({
+      serverIds: [SERVER_ID],
+      overrides: {},
+    });
+  });
+
+  it("keeps the entry when other overrides remain after clearing the pin", async () => {
+    const setConfig = vi.fn().mockResolvedValue(undefined);
+    await applyMcpProtocolVersionOverride({
+      projectId: PROJECT_ID,
+      serverId: SERVER_ID,
+      current: dto({
+        serverIds: [SERVER_ID],
+        overrides: {
+          [SERVER_ID]: {
+            requestTimeoutOverride: 8000,
+            mcpProtocolVersionOverride: "2026-07-28",
+          },
+        },
+      }),
+      next: undefined,
+      setConfig,
+    });
+    expect(setConfig.mock.calls[0][0].input.overrides).toEqual({
+      [SERVER_ID]: { requestTimeoutOverride: 8000 },
+    });
+    expect(setConfig.mock.calls[0][0].input.serverIds).toEqual([SERVER_ID]);
+  });
+});

--- a/mcpjam-inspector/client/src/lib/project-server-config.ts
+++ b/mcpjam-inspector/client/src/lib/project-server-config.ts
@@ -61,3 +61,163 @@ export const emptyProjectServerConfigInput = (): ProjectServerConfigInput => ({
   serverIds: [],
   overrides: {},
 });
+
+/**
+ * Provenance marker for a server that was enrolled in `serverIds` ONLY so a
+ * `mcpProtocolVersionOverride` could be saved (backend validation requires
+ * override keys to be members of `serverIds`). Remembered so clearing the
+ * pin can undo the implicit enrollment without removing servers that were
+ * already explicitly auto-connected.
+ */
+export type ProtocolOverrideAutoEnrollRecord = {
+  previousServerIds: string[];
+};
+
+const PROTOCOL_OVERRIDE_AUTO_ENROLL_STORAGE_PREFIX =
+  "mcpjam:protocol-override-auto-enroll";
+
+export const getProtocolOverrideAutoEnrollKey = (
+  projectId: string,
+  serverId: string,
+) => `${PROTOCOL_OVERRIDE_AUTO_ENROLL_STORAGE_PREFIX}:${projectId}:${serverId}`;
+
+export const readProtocolOverrideAutoEnrollRecord = (
+  key: string,
+): ProtocolOverrideAutoEnrollRecord | undefined => {
+  if (typeof window === "undefined") return undefined;
+  try {
+    const raw = window.sessionStorage.getItem(key);
+    if (!raw) return undefined;
+    const parsed = JSON.parse(raw) as Partial<ProtocolOverrideAutoEnrollRecord>;
+    if (!Array.isArray(parsed.previousServerIds)) return undefined;
+    return {
+      previousServerIds: parsed.previousServerIds.filter(
+        (id): id is string => typeof id === "string",
+      ),
+    };
+  } catch {
+    return undefined;
+  }
+};
+
+export const writeProtocolOverrideAutoEnrollRecord = (
+  key: string,
+  record: ProtocolOverrideAutoEnrollRecord,
+) => {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.setItem(key, JSON.stringify(record));
+  } catch {
+    // Losing this marker only affects cleanup of an implicit enrollment.
+  }
+};
+
+export const removeProtocolOverrideAutoEnrollRecord = (key: string) => {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.removeItem(key);
+  } catch {
+    // Best-effort cleanup only.
+  }
+};
+
+export const matchesImplicitAutoEnrollment = (
+  currentServerIds: string[],
+  serverId: string,
+  previousServerIds: string[],
+) => {
+  const previousServerIdSet = new Set(previousServerIds);
+  if (previousServerIdSet.has(serverId)) return false;
+  if (!currentServerIds.includes(serverId)) return false;
+  if (currentServerIds.length !== previousServerIdSet.size + 1) return false;
+  return currentServerIds.every(
+    (currentServerId) =>
+      currentServerId === serverId || previousServerIdSet.has(currentServerId),
+  );
+};
+
+/**
+ * Splice one server's `mcpProtocolVersionOverride` into the project's
+ * `(serverIds, overrides)` pair and write it back through `setConfig`.
+ *
+ * `setConfig` REPLACES the whole pair on the backend, so callers must pass
+ * the current hydrated DTO (`null` is the genuine "no row yet" baseline;
+ * a still-loading `undefined` must be handled by the caller BEFORE calling
+ * this — defaulting it here would wipe the project's membership list and
+ * every other server's overrides). Every other server's overrides are
+ * preserved verbatim, an entry that collapses to nothing is dropped
+ * (mirrors backend `normalizeOverrideEntry`), and implicit enrollment /
+ * un-enrollment provenance is tracked via sessionStorage plus the optional
+ * in-memory `autoEnrollCache`.
+ */
+export async function applyMcpProtocolVersionOverride({
+  projectId,
+  serverId,
+  current,
+  next,
+  setConfig,
+  autoEnrollCache,
+}: {
+  projectId: string;
+  serverId: string;
+  current: ProjectServerConfigDto | null;
+  next: McpProtocolVersion | undefined;
+  setConfig: (args: {
+    projectId: string;
+    input: ProjectServerConfigInput;
+  }) => Promise<unknown>;
+  autoEnrollCache?: Map<string, ProtocolOverrideAutoEnrollRecord>;
+}): Promise<void> {
+  const currentServerIds = current?.serverIds ?? [];
+  const currentOverrides = current?.overrides ?? {};
+  const existingEntry = currentOverrides[serverId] ?? {};
+  const updatedEntry: ProjectServerOverrideEntry = {
+    ...existingEntry,
+    mcpProtocolVersionOverride: next,
+  };
+  const hasContent =
+    (updatedEntry.headersOverride &&
+      Object.keys(updatedEntry.headersOverride).length > 0) ||
+    updatedEntry.requestTimeoutOverride !== undefined ||
+    updatedEntry.mcpProtocolVersionOverride !== undefined;
+  const nextOverrides: Record<string, ProjectServerOverrideEntry> = {
+    ...currentOverrides,
+  };
+  if (hasContent) nextOverrides[serverId] = updatedEntry;
+  else delete nextOverrides[serverId];
+  const autoEnrollKey = getProtocolOverrideAutoEnrollKey(projectId, serverId);
+  const autoEnrollRecord =
+    autoEnrollCache?.get(autoEnrollKey) ??
+    readProtocolOverrideAutoEnrollRecord(autoEnrollKey);
+  const shouldAutoEnrollForOverride =
+    hasContent && !currentServerIds.includes(serverId);
+  const shouldUndoAutoEnroll =
+    !hasContent &&
+    autoEnrollRecord !== undefined &&
+    matchesImplicitAutoEnrollment(
+      currentServerIds,
+      serverId,
+      autoEnrollRecord.previousServerIds,
+    );
+  const nextServerIds = shouldAutoEnrollForOverride
+    ? [...currentServerIds, serverId]
+    : shouldUndoAutoEnroll
+      ? currentServerIds.filter(
+          (currentServerId) => currentServerId !== serverId,
+        )
+      : currentServerIds;
+  await setConfig({
+    projectId,
+    input: { serverIds: nextServerIds, overrides: nextOverrides },
+  });
+  if (shouldAutoEnrollForOverride) {
+    const nextAutoEnrollRecord = {
+      previousServerIds: [...currentServerIds],
+    };
+    autoEnrollCache?.set(autoEnrollKey, nextAutoEnrollRecord);
+    writeProtocolOverrideAutoEnrollRecord(autoEnrollKey, nextAutoEnrollRecord);
+  } else if (!hasContent && autoEnrollRecord !== undefined) {
+    autoEnrollCache?.delete(autoEnrollKey);
+    removeProtocolOverrideAutoEnrollRecord(autoEnrollKey);
+  }
+}

--- a/mcpjam-inspector/shared/types.ts
+++ b/mcpjam-inspector/shared/types.ts
@@ -746,6 +746,15 @@ export interface ServerFormData {
   clearXaaConfig?: boolean;
   oauthProtocolMode?: ServerFormOAuthProtocolMode;
   /**
+   * Per-server MCP wire-version pin chosen at ADD time (the edit flow writes
+   * it directly through `projectServerConfig:setConfig` instead of the form
+   * payload). Persisted on the project layer
+   * (`projectServerRefs.mcpProtocolVersionOverride`), NOT on the server's own
+   * config blob — the add flow applies it once the hosted server row exists,
+   * then reconnects. Undefined = inherit host default / SDK default.
+   */
+  mcpProtocolVersionOverride?: import("@mcpjam/sdk/browser").McpProtocolVersion;
+  /**
    * Unified client-registration mode (Client↔AS leg) shared by the OAuth
    * flows and the XAA debugger: how this server's client establishes its
    * identity at the authorization server. "auto" resolves to a concrete


### PR DESCRIPTION
## What

The per-server MCP **wire-version** pin (Client default / Latest `2025-11-25` / 2026 RC `2026-07-28`) was **edit-only** — the picker sat under **Connection overrides** in the Server detail/edit modal but was hidden in the **Add Server** modal. This adds it to the Add flow.

## Why it was edit-only

The pin persists on the **project layer** (`projectServerRefs.mcpProtocolVersionOverride`), keyed by the hosted server row's `_id`. At add time no row exists yet, so there was nothing to bind the override to.

## How

- **New one-shot field** `ServerFormData.mcpProtocolVersionOverride` carries the pin out of the modal. It's held in local `AddServerModal` state, deliberately **not** in `useServerForm` — that hook's save payload must never emit a project-layer field.
- **`AddServerModal`** shows the existing tri-state picker under Connection overrides, but only when a shared (hosted) `projectId` is passed. Local-only / CLI contexts keep it hidden (no project row to bind to). The RC option stays HTTP-only via `transportKind`.
- **`ServersTab`** stashes the `(serverName, version)` pair on submit; a watcher effect applies it once **both** the hosted server row and the project config DTO have hydrated (writing against a still-loading DTO would wipe other servers' overrides — `setConfig` replaces the whole `(serverIds, overrides)` pair), then reconnects **non-interactively** so the pin governs the live connection. This mirrors the edit flow's save→reconnect in `ServerDetailModal`.
- **Shared write path**: the splice + implicit-enrollment bookkeeping is extracted out of `ServerDetailModal` into `applyMcpProtocolVersionOverride` in `project-server-config.ts`. Add and edit now use one helper. Unit-tested (6 cases).

## Product note

Add-time is now the second entry point for the launch-posture rule *"modern reachable via explicit per-server pin"* (see the 2026-07-28 migration plan). This is the **wire**-version pin only; the connect-form OAuth-flow version dropdown is separate work (plan WP 2M-c).

## Known limits (v1)

- Only the ServersTab add path is wired. The other three `AddServerModal` mount points (chat input, active-server selector, host builder) don't pass `projectId`, so they're unchanged.
- First connect briefly uses the default wire mode before the pin-reconnect lands.
- One pending pin tracked at a time.

## Test plan

- `tsc --noEmit -p client/tsconfig.typecheck.json` — clean.
- `vitest run` connection + ServersTab suites + new helper test — **169 passed** (6 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Writes replace the full project `(serverIds, overrides)` pair; the add flow guards hydration, but a brief default wire mode before reconnect remains, and only ServersTab wires persistence today.
> 
> **Overview**
> **Adds per-server MCP wire-version pinning to the Add Server flow**, matching what was already available when editing a server.
> 
> The **Add Server** modal now shows the protocol version picker under Connection overrides when a shared `projectId` is passed (hidden for local-only contexts). The choice is kept in modal state—not `useServerForm`—and submitted as `ServerFormData.mcpProtocolVersionOverride`.
> 
> **ServersTab** queues the pin on submit, then an effect waits for the hosted Convex server row and hydrated project config before calling **`applyMcpProtocolVersionOverride`** and doing a **non-interactive reconnect** so the pin applies on the wire without racing a still-loading DTO (which would wipe other overrides).
> 
> Protocol override logic is **extracted** from `ServerDetailModal` into shared **`applyMcpProtocolVersionOverride`** in `project-server-config.ts` (implicit `serverIds` enrollment + sessionStorage provenance); add and edit paths share it. **Six unit tests** cover the helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59e17c27395e9f0108cc28f1e4d93173d5da42e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable pinning the MCP wire protocol version when adding a server. The pin is saved on the project layer and applied after the server is created, then the app reconnects so the pin takes effect.

- **New Features**
  - Show the protocol picker in Add Server when `projectId` is present.
  - Carry the pin via `ServerFormData.mcpProtocolVersionOverride`; apply it once the hosted row and config hydrate, then reconnect non‑interactively.
  - RC (`2026-07-28`) remains `http`-only via `transportKind`.

- **Refactors**
  - Add `applyMcpProtocolVersionOverride` to update `(serverIds, overrides)`, preserve other overrides, and track implicit auto‑enrollment.
  - Adopt the helper in both add and edit flows; unit tests added.

<sup>Written for commit 59e17c27395e9f0108cc28f1e4d93173d5da42e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3365?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

