### PR TITLE
feat(computers): chat attachments land in the computer filesystem (COMP-14)

### DIFF
--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -113,6 +113,14 @@ import {
 } from "@/lib/client-config-v2";
 import { usePreviewedHostId } from "@/hooks/use-previewed-client-id";
 import { useHarnessBuiltinTools } from "@/hooks/useHarnessBuiltinTools";
+import { useComputersEnabled } from "@/hooks/useComputersEnabled";
+import { useComputerAttachmentUpload } from "@/hooks/useComputerAttachmentUpload";
+import { buildComputerAttachmentNote } from "@/lib/computer-attachments";
+import {
+  getBillingErrorMessage,
+  isComputerStartLimitError,
+} from "@/lib/billing-entitlements";
+import { useMCPJamLimitDialogStore } from "@/stores/mcpjam-limit-dialog-store";
 import { useAgentToolPromptBridge } from "@/stores/agent-tool-prompt-bridge";
 import { usePersistedHost } from "@/hooks/use-persisted-host";
 import { usePlaygroundHostSlots } from "@/hooks/use-playground-host-slots";
@@ -663,6 +671,20 @@ export function PlaygroundMain({
   // Hosted mode context (projectId, serverIds, OAuth tokens)
   const activeProject = appState.projects[appState.activeProjectId];
   const convexProjectId = activeProject?.sharedProjectId ?? null;
+
+  // COMP-14: when the previewed host attaches a personal computer, composer
+  // attachments are ALSO uploaded into the sandbox (reserve → mint → upload,
+  // the same primitives the Shell uses) and the outgoing message carries a
+  // system-visible note with the sandbox paths so the model's bash tool can
+  // reach them. Signed-in only — guests keep today's inline-only attachments
+  // (the backend rejects guest computer reservations for host-bound previews).
+  // The `computer` gate itself lives below, once the previewed host resolves.
+  const computersEnabled = useComputersEnabled();
+  const computerAttachmentUpload = useComputerAttachmentUpload({
+    projectId: convexProjectId,
+    isAuthenticated: isConvexAuthenticated,
+  });
+  const attachmentUploadInFlightRef = useRef(false);
   const hostedOrgModelConfig = useHostedOrgModelConfig({
     projectId: convexProjectId,
     organizationId: activeProject?.organizationId ?? null,
@@ -731,6 +753,14 @@ export function PlaygroundMain({
   // tab so a harness host's empty `tools` is annotated rather than confusing.
   const { tools: harnessBuiltinTools } =
     useHarnessBuiltinTools(previewedHostId);
+
+  // COMP-14 gate: composer attachments go into the sandbox only when the
+  // previewed host actually attaches a computer (honesty rule — no computer, no
+  // sandbox upload; attachments stay inline-only exactly as before).
+  const computerAttachmentsActive =
+    computersEnabled &&
+    isConvexAuthenticated &&
+    !!previewedHost?.config?.computer;
 
   // Use shared chat session hook
   const composerOnResetRef = useRef<() => void>(() => {});
@@ -3035,6 +3065,53 @@ export function PlaygroundMain({
       setIsFullscreenChatOpen(true);
     }
 
+    // COMP-14: computer-attached host → land the attachments in the sandbox
+    // (via the existing reserve → mint → upload path; the upload route enforces
+    // the COMP-8 quota) and append a system-visible note with the sandbox paths
+    // so the model can reference them. A failed upload ABORTS the send with the
+    // composer state intact — an honest error beats a message whose files
+    // silently never reached the box. Inline file parts are unchanged (vision
+    // et al. keep working).
+    let composerText = composer.input;
+    if (fileAttachments.length > 0 && computerAttachmentsActive) {
+      if (attachmentUploadInFlightRef.current) {
+        return false;
+      }
+      attachmentUploadInFlightRef.current = true;
+      try {
+        const entries = await computerAttachmentUpload.uploadAttachments(
+          fileAttachments.map((a) => a.file)
+        );
+        const note = buildComputerAttachmentNote(entries);
+        if (note) {
+          composerText =
+            composerText.trim().length > 0
+              ? `${composerText}\n\n${note}`
+              : note;
+        }
+        track("computer_chat_attachment_uploaded", {
+          file_count: entries.length,
+        });
+      } catch (err) {
+        if (isComputerStartLimitError(err)) {
+          track("computer_start_limit_hit", {
+            location: "playground_attachments",
+          });
+          useMCPJamLimitDialogStore.getState().notifyLimitHit();
+        } else {
+          toast.error(
+            getBillingErrorMessage(
+              err,
+              "Could not upload attachments to the computer."
+            )
+          );
+        }
+        return false;
+      } finally {
+        attachmentUploadInFlightRef.current = false;
+      }
+    }
+
     const files =
       fileAttachments.length > 0
         ? await attachmentsToFileUIParts(fileAttachments)
@@ -3042,7 +3119,7 @@ export function PlaygroundMain({
 
     if (isCompareMode) {
       queueBroadcastRequest({
-        text: composer.input,
+        text: composerText,
         files,
         prependMessages: [],
         widgetModelContext: modelContextQueue,
@@ -3051,14 +3128,14 @@ export function PlaygroundMain({
     } else {
       queueBroadcastRequest(
         {
-          text: composer.input,
+          text: composerText,
           files,
           prependMessages: [],
         },
         { single_model_send: true }
       );
       sendMessage({
-        text: composer.input,
+        text: composerText,
         files,
         metadata: outgoingSenderMetadata,
         widgetModelContext: modelContextQueue,
@@ -3086,6 +3163,8 @@ export function PlaygroundMain({
     sendMessage,
     outgoingSenderMetadata,
     onFirstMessageSent,
+    computerAttachmentsActive,
+    computerAttachmentUpload,
   ]);
 
   const onSubmit = async (event: FormEvent<HTMLFormElement>) => {

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.multi-host.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.multi-host.test.tsx
@@ -142,6 +142,9 @@ vi.mock("convex/react", () => ({
   useQuery: (_name: string, args: unknown) =>
     args === "skip" ? undefined : null,
   useMutation: () => () => Promise.resolve(),
+  // COMP-14: useComputerAttachmentUpload pulls in useMintTerminalToken (a
+  // Convex action). The flag mock keeps the flow inert; this keeps it mountable.
+  useAction: () => () => Promise.resolve({ token: "test-token" }),
 }));
 
 vi.mock("@/hooks/useViews", () => ({

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
@@ -170,6 +170,9 @@ vi.mock("convex/react", () => ({
   useQuery: (_name: string, args: unknown) =>
     args === "skip" ? undefined : null,
   useMutation: () => () => Promise.resolve(),
+  // COMP-14: useComputerAttachmentUpload pulls in useMintTerminalToken (a
+  // Convex action). The flag mock keeps the flow inert; this keeps it mountable.
+  useAction: () => () => Promise.resolve({ token: "test-token" }),
 }));
 
 // Mock useViews (useProjectServers)

--- a/mcpjam-inspector/client/src/hooks/useComputerAttachmentUpload.ts
+++ b/mcpjam-inspector/client/src/hooks/useComputerAttachmentUpload.ts
@@ -1,0 +1,74 @@
+import { useCallback } from "react";
+import {
+  useComputersDataPlaneConfig,
+  useMintTerminalToken,
+  useReserveComputer,
+} from "@/hooks/useProjectComputer";
+import { toTerminalWsBase } from "@/lib/computer-terminal-connection";
+import {
+  uploadAttachmentsToComputer,
+  type ComputerAttachmentNoteEntry,
+} from "@/lib/computer-attachments";
+
+/**
+ * React binding for the chat-attachment → computer-filesystem flow (COMP-14).
+ * Composes the SAME primitives the Shell uses — `getOrReserveComputer`,
+ * `mintTerminalToken`, and the data-plane resolution that decides whether the
+ * upload targets this server or a deployed remote data plane — so there is one
+ * reservation path and one upload route. Pure orchestration lives in
+ * `lib/computer-attachments.ts`.
+ *
+ * `available` is false until the data-plane config has resolved to a usable
+ * plane; callers should fall back to plain inline-only attachments (with a
+ * toast) rather than dropping the send silently.
+ */
+export function useComputerAttachmentUpload({
+  projectId,
+  isAuthenticated,
+}: {
+  projectId: string | null;
+  isAuthenticated: boolean;
+}) {
+  const effectiveProjectId = isAuthenticated ? projectId : null;
+  const reserve = useReserveComputer();
+  const mintToken = useMintTerminalToken();
+
+  // Mirror useComputerTerminal's plane resolution: local plane ⇒ page-origin
+  // upload; remote plane ⇒ convert its URL to the ws base the upload URL
+  // builder expects; neither ⇒ computers unusable from this inspector.
+  const dataPlane = useComputersDataPlaneConfig();
+  const remoteWsBase = dataPlane?.remoteDataPlaneUrl
+    ? toTerminalWsBase(dataPlane.remoteDataPlaneUrl)
+    : undefined;
+  const uploadBaseUrl =
+    dataPlane && !dataPlane.localConfigured ? remoteWsBase : undefined;
+  const available =
+    !!effectiveProjectId &&
+    dataPlane !== undefined &&
+    (dataPlane.localConfigured || !!remoteWsBase);
+
+  const uploadAttachments = useCallback(
+    async (files: File[]): Promise<ComputerAttachmentNoteEntry[]> => {
+      if (!effectiveProjectId) {
+        throw new Error("Sign in and select a project to use the computer.");
+      }
+      if (dataPlane === undefined) {
+        throw new Error("Computers are still loading — try again in a moment.");
+      }
+      if (!dataPlane.localConfigured && !remoteWsBase) {
+        throw new Error("Computers are not available on this server.");
+      }
+      return await uploadAttachmentsToComputer(
+        { reserve, mintToken },
+        {
+          projectId: effectiveProjectId,
+          files,
+          ...(uploadBaseUrl ? { uploadBaseUrl } : {}),
+        },
+      );
+    },
+    [effectiveProjectId, dataPlane, remoteWsBase, uploadBaseUrl, reserve, mintToken],
+  );
+
+  return { available, uploadAttachments };
+}

--- a/mcpjam-inspector/client/src/lib/__tests__/computer-attachments.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/computer-attachments.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  COMPUTER_ATTACHMENTS_DIR,
+  buildComputerAttachmentNote,
+  uploadAttachmentsToComputer,
+  zipAttachmentNoteEntries,
+} from "../computer-attachments";
+import type { UploadedComputerFile } from "../computer-terminal-connection";
+
+function makeFile(name: string): File {
+  return new File([new Uint8Array([1, 2, 3])], name, { type: "text/plain" });
+}
+
+describe("buildComputerAttachmentNote", () => {
+  it("returns an empty string for no entries (no stray note block)", () => {
+    expect(buildComputerAttachmentNote([])).toBe("");
+  });
+
+  it("renders one line per file with the original name and sandbox path", () => {
+    const note = buildComputerAttachmentNote([
+      { name: "report.csv", path: "/home/user/attachments/ab12cd34-report.csv" },
+      { name: "data.json", path: "/home/user/attachments/ef56gh78-data.json" },
+    ]);
+    expect(note).toBe(
+      [
+        "[Attachments uploaded to the computer — use the bash tool to read them]",
+        "- report.csv: /home/user/attachments/ab12cd34-report.csv",
+        "- data.json: /home/user/attachments/ef56gh78-data.json",
+      ].join("\n"),
+    );
+  });
+});
+
+describe("zipAttachmentNoteEntries", () => {
+  it("pairs original names with server paths in order", () => {
+    const uploaded: UploadedComputerFile[] = [
+      { name: "x1-report.csv", path: "/home/user/attachments/x1-report.csv", bytes: 3 },
+      { name: "x2-data.json", path: "/home/user/attachments/x2-data.json", bytes: 3 },
+    ];
+    expect(zipAttachmentNoteEntries(["report.csv", "data.json"], uploaded)).toEqual([
+      { name: "report.csv", path: "/home/user/attachments/x1-report.csv" },
+      { name: "data.json", path: "/home/user/attachments/x2-data.json" },
+    ]);
+  });
+
+  it("falls back to the server-reported name when the arrays disagree", () => {
+    const uploaded: UploadedComputerFile[] = [
+      { name: "x1-a.txt", path: "/home/user/attachments/x1-a.txt", bytes: 3 },
+    ];
+    expect(zipAttachmentNoteEntries([], uploaded)).toEqual([
+      { name: "x1-a.txt", path: "/home/user/attachments/x1-a.txt" },
+    ]);
+  });
+});
+
+describe("uploadAttachmentsToComputer", () => {
+  it("reserves BEFORE minting BEFORE uploading, targets the attachments dir, and returns note entries", async () => {
+    const calls: string[] = [];
+    const reserve = vi.fn(async () => {
+      calls.push("reserve");
+    });
+    const mintToken = vi.fn(async () => {
+      calls.push("mint");
+      return { token: "tok-1" };
+    });
+    const upload = vi.fn(async (args: { token: string; dir?: string }) => {
+      calls.push("upload");
+      expect(args.token).toBe("tok-1");
+      expect(args.dir).toBe(COMPUTER_ATTACHMENTS_DIR);
+      return [
+        {
+          name: "x1-report.csv",
+          path: "/home/user/attachments/x1-report.csv",
+          bytes: 3,
+        },
+      ];
+    });
+
+    const entries = await uploadAttachmentsToComputer(
+      { reserve, mintToken, upload: upload as never },
+      { projectId: "p1", files: [makeFile("report.csv")] },
+    );
+
+    expect(calls).toEqual(["reserve", "mint", "upload"]);
+    expect(reserve).toHaveBeenCalledWith({ projectId: "p1" });
+    expect(mintToken).toHaveBeenCalledWith({ projectId: "p1" });
+    expect(entries).toEqual([
+      { name: "report.csv", path: "/home/user/attachments/x1-report.csv" },
+    ]);
+  });
+
+  it("forwards the remote data-plane base URL to the upload client", async () => {
+    const upload = vi.fn(async (args: { baseUrl?: string }) => {
+      expect(args.baseUrl).toBe("wss://data-plane.example.com");
+      return [];
+    });
+    await uploadAttachmentsToComputer(
+      {
+        reserve: async () => {},
+        mintToken: async () => ({ token: "t" }),
+        upload: upload as never,
+      },
+      {
+        projectId: "p1",
+        files: [makeFile("a.txt")],
+        uploadBaseUrl: "wss://data-plane.example.com",
+      },
+    );
+    expect(upload).toHaveBeenCalledTimes(1);
+  });
+
+  it("no-ops (no reserve, no mint) when there are no files", async () => {
+    const reserve = vi.fn(async () => {});
+    const mintToken = vi.fn(async () => ({ token: "t" }));
+    const upload = vi.fn(async () => []);
+    const entries = await uploadAttachmentsToComputer(
+      { reserve, mintToken, upload: upload as never },
+      { projectId: "p1", files: [] },
+    );
+    expect(entries).toEqual([]);
+    expect(reserve).not.toHaveBeenCalled();
+    expect(mintToken).not.toHaveBeenCalled();
+    expect(upload).not.toHaveBeenCalled();
+  });
+
+  it("propagates a reserve failure without minting or uploading (abort-the-send contract)", async () => {
+    const mintToken = vi.fn(async () => ({ token: "t" }));
+    const upload = vi.fn(async () => []);
+    await expect(
+      uploadAttachmentsToComputer(
+        {
+          reserve: async () => {
+            throw new Error("Daily computer start limit reached.");
+          },
+          mintToken,
+          upload: upload as never,
+        },
+        { projectId: "p1", files: [makeFile("a.txt")] },
+      ),
+    ).rejects.toThrow(/start limit/i);
+    expect(mintToken).not.toHaveBeenCalled();
+    expect(upload).not.toHaveBeenCalled();
+  });
+
+  it("propagates the server's upload error message (e.g. quota / provisioning 503s)", async () => {
+    await expect(
+      uploadAttachmentsToComputer(
+        {
+          reserve: async () => {},
+          mintToken: async () => ({ token: "t" }),
+          upload: (async () => {
+            throw new Error(
+              "Upload would exceed this computer's storage quota.",
+            );
+          }) as never,
+        },
+        { projectId: "p1", files: [makeFile("a.txt")] },
+      ),
+    ).rejects.toThrow(/storage quota/i);
+  });
+});

--- a/mcpjam-inspector/client/src/lib/computer-attachments.ts
+++ b/mcpjam-inspector/client/src/lib/computer-attachments.ts
@@ -1,0 +1,115 @@
+/**
+ * Chat attachments → the attached computer's filesystem (COMP-14).
+ *
+ * When a host config attaches a personal computer, files the user attaches in
+ * the chat composer are ALSO uploaded into the sandbox (under
+ * `COMPUTER_ATTACHMENTS_DIR`) so the model's `bash` tool — and any MCP server
+ * running against the box — can actually reach them. Inline file parts alone
+ * are invisible to bash (they ride the prompt as data URLs), and the harness
+ * prompt channel is text-only, so the sandbox path note appended to the message
+ * text is the one channel that works on BOTH engines.
+ *
+ * This module is the pure core: the upload orchestration (reserve → mint →
+ * upload, deps injected for tests) and the model-visible note builder. React
+ * wiring lives in `hooks/useComputerAttachmentUpload.ts`.
+ *
+ * The upload rides the existing `POST /api/web/computers/upload` route, which
+ * already enforces the COMP-8 cumulative-upload quota (`reserveUploadBytes`
+ * server-side), the 30 MB request caps, and `/home/user` path confinement — no
+ * second writer path is introduced here.
+ */
+
+import {
+  uploadFilesToComputer,
+  type UploadedComputerFile,
+} from "./computer-terminal-connection";
+
+/** Predictable landing bucket for chat attachments — distinct from the Shell's
+ *  drag-drop default (`/home/user/uploads`) so "files I attached in chat" are
+ *  recognizable at a glance. The server confines it under `/home/user`. */
+export const COMPUTER_ATTACHMENTS_DIR = "/home/user/attachments";
+
+export interface ComputerAttachmentNoteEntry {
+  /** The user's original filename (what they'll recognize in the transcript). */
+  name: string;
+  /** Absolute sandbox path the server actually wrote (UUID-prefixed basename). */
+  path: string;
+}
+
+/**
+ * The system-visible note appended to the outgoing user message. Visible in the
+ * transcript AND model-visible on both engines (the harness collapses a turn to
+ * the last user message's TEXT, so a text suffix is the only cross-engine
+ * channel). Kept terse and line-oriented so the model can quote paths verbatim.
+ */
+export function buildComputerAttachmentNote(
+  entries: ComputerAttachmentNoteEntry[],
+): string {
+  if (entries.length === 0) return "";
+  const lines = entries.map((e) => `- ${e.name}: ${e.path}`);
+  return [
+    "[Attachments uploaded to the computer — use the bash tool to read them]",
+    ...lines,
+  ].join("\n");
+}
+
+/** Pair the user's original filenames with the server-written sandbox paths.
+ *  The upload route writes (and returns) files in request order; fall back to
+ *  the server-reported name if the arrays ever disagree in length. */
+export function zipAttachmentNoteEntries(
+  originalNames: string[],
+  uploaded: UploadedComputerFile[],
+): ComputerAttachmentNoteEntry[] {
+  return uploaded.map((file, i) => ({
+    name: originalNames[i] ?? file.name,
+    path: file.path,
+  }));
+}
+
+export interface ComputerAttachmentUploadDeps {
+  /** Convex `projectComputers:getOrReserveComputer` — provision-on-first-use /
+   *  wake. THE reservation path (COMP-14 explicitly forbids a second one). */
+  reserve: (args: { projectId: string }) => Promise<unknown>;
+  /** Convex `projectComputers:mintTerminalToken` — ~60s data-plane token. */
+  mintToken: (args: { projectId: string }) => Promise<{ token: string }>;
+  /** The shared upload client (injectable for tests). */
+  upload?: typeof uploadFilesToComputer;
+}
+
+/**
+ * Reserve/wake the caller's computer, mint a fresh terminal token, and upload
+ * the composer's files into `COMPUTER_ATTACHMENTS_DIR`. Ordering matters:
+ * reserve FIRST (creates the row on first use; wakes a hibernating box) so the
+ * mint has a computer to bind to; `Sandbox.connect` on the server side
+ * auto-resumes a paused box, so only a still-provisioning fresh machine can
+ * fail afterwards (surfaced as the route's friendly 503 message).
+ *
+ * Throws with a user-presentable message on any failure — callers abort the
+ * send and keep the composer state intact (no silent drop of the user's
+ * attachments or text).
+ */
+export async function uploadAttachmentsToComputer(
+  deps: ComputerAttachmentUploadDeps,
+  args: {
+    projectId: string;
+    files: File[];
+    /** ws(s):// base of the remote data plane, when this inspector doesn't
+     *  host the sandbox itself (same resolution the Shell uses). */
+    uploadBaseUrl?: string;
+  },
+): Promise<ComputerAttachmentNoteEntry[]> {
+  if (args.files.length === 0) return [];
+  await deps.reserve({ projectId: args.projectId });
+  const { token } = await deps.mintToken({ projectId: args.projectId });
+  const upload = deps.upload ?? uploadFilesToComputer;
+  const uploaded = await upload({
+    token,
+    files: args.files,
+    dir: COMPUTER_ATTACHMENTS_DIR,
+    ...(args.uploadBaseUrl ? { baseUrl: args.uploadBaseUrl } : {}),
+  });
+  return zipAttachmentNoteEntries(
+    args.files.map((f) => f.name),
+    uploaded,
+  );
+}

--- a/mcpjam-inspector/shared/analytics-events.ts
+++ b/mcpjam-inspector/shared/analytics-events.ts
@@ -90,6 +90,7 @@ export const ANALYTICS_EVENTS = {
   compare_run_tab_changed: { source: "client" },
   compare_run_view_opened: { source: "client" },
   compat_cta_clicked: { source: "client" },
+  computer_chat_attachment_uploaded: { source: "client" },
   computer_start_limit_hit: { source: "client" },
   computer_terminal_opened: { source: "client" },
   connect_host_overlay_opened: { source: "client" },


### PR DESCRIPTION
## COMP-14 — M0: bash on emulated clients + attachment upload into the computer filesystem

### Triage against current main (per the ticket: cross off what's already addressed)
| M0 item | Status |
|---|---|
| Attach flow on emulated-client host configs | **already on main** — `ComputerTab` switch is only locked for harness hosts; `computers-enabled` flag (fail-closed), org membership + per-org kill switch enforced backend-side |
| Bash advertisement + honesty rule | **already on main** — `resolveHostTools` gates on `builtInToolIds ∋ "bash"` + `computer` attached, with **no harness/emulated distinction**; no computer ⇒ skipped |
| Execution path (Convex `computerCommands` log, E2B data plane) | reused as-is |
| **Attachment upload into the filesystem + model told the path** | **the actual gap — implemented here** |

Composer attachments previously only rode the prompt as inline data URLs — invisible to the `bash` tool and to MCP servers running against the box.

### What this PR does
When the previewed host attaches a personal computer (and the user is signed in, flag on), submitting a message with attachments now:

1. **Reserves/wakes** via the existing `getOrReserveComputer` path (no second reservation path), mints a ~60s terminal token, and uploads through the **existing** `POST /api/web/computers/upload` route into **`/home/user/attachments/`** — inheriting the **COMP-8 quota chokepoint** (`reserveUploadBytes`), the 30 MB caps, and `/home/user` confinement for free (no new writer path).
2. Appends a **system-visible note** to the outgoing message text:
   ```
   [Attachments uploaded to the computer — use the bash tool to read them]
   - report.csv: /home/user/attachments/ab12cd34-report.csv
   ```
   Message text is the one channel that survives **both** engines (the harness prompt collapses to the last user message's text) and it shows the path in the conversation, per the ticket.
3. Keeps inline file parts unchanged (vision et al. keep working) and honors the honesty rule: no computer / guest / flag off ⇒ exactly today's inline-only behavior.
4. A failed upload **aborts the send with the composer state intact** (toast, or the start-limit dialog for the daily cap) — never a message whose files silently didn't land.

### Shape
- `lib/computer-attachments.ts` — pure core: reserve → mint → upload orchestration (injectable deps) + note builder.
- `hooks/useComputerAttachmentUpload.ts` — React binding mirroring the Shell's data-plane resolution (remote data planes work).
- `PlaygroundMain.tsx` — submit wiring + gate (`computers-enabled` && signed-in && `previewedHost.config.computer`).
- New analytics event `computer_chat_attachment_uploaded`; the two PlaygroundMain test mocks gain the `useAction` export the new hook pulls in.

### Verification
- 9 new lib tests (ordering, dir, remote base URL, no-files no-op, error propagation incl. quota/start-limit messages).
- `typecheck:client` clean; ui-playground suite 196/196; full client suite **5928 passed** — the 16 remaining failures are pre-existing on main (Windows locale/path-separator quirks in billing/evals tests, verified by running them on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Uploads chat attachments to the attached computer’s filesystem so the model and MCP servers can read them via bash. Fulfills COMP-14 by reserving the computer, minting a terminal token, writing files to /home/user/attachments, and appending a short, model-visible note with the paths.

- New Features
  - When a host has a computer attached and the user is signed in, attachments upload to /home/user/attachments via the existing route, inherit quotas and 30 MB caps, append a path note to the outgoing message, keep inline parts unchanged, and abort on upload failure with the composer intact. No computer or guest → inline-only behavior as before.
  - Added useComputerAttachmentUpload hook to run reserve → mint → upload and support local or remote data planes.
  - Implemented core orchestration and note builder in lib/computer-attachments.ts with tests.
  - Added analytics event computer_chat_attachment_uploaded.

<sup>Written for commit 83bfc3e72520131baed11333deb98b4f4cd41aff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

