### PR TITLE
feat(learning): guided tours ride the system prompt and pace one step per turn

### DIFF
--- a/mcpjam-inspector/client/src/components/__tests__/LearningTab.tours.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/LearningTab.tours.test.tsx
@@ -47,21 +47,29 @@ describe("LearningTab — guided tour dispatch", () => {
 });
 
 describe("guided tour content invariants", () => {
-  it("every tour is a guided module with a usable prompt", () => {
+  it("every tour is a guided module with a usable system prompt", () => {
     expect(GUIDED_TOURS.length).toBeGreaterThan(0);
     for (const tour of GUIDED_TOURS) {
       expect(tour.kind).toBe("guided");
-      expect(tour.agentPrompt.trim().length).toBeGreaterThan(0);
+      expect(tour.agentSystemPrompt.trim().length).toBeGreaterThan(0);
     }
   });
 
   it("every tour prompt encodes the never-submit and mark-complete rules", () => {
     for (const tour of GUIDED_TOURS) {
-      const prompt = tour.agentPrompt.toLowerCase();
+      const prompt = tour.agentSystemPrompt.toLowerCase();
       // never click the final submit for the user
       expect(prompt).toContain("never click the final");
       // close by pointing back to the Learning tab
       expect(prompt).toContain("complete");
+    }
+  });
+
+  it("every tour prompt encodes the one-step-per-turn pacing gate", () => {
+    for (const tour of GUIDED_TOURS) {
+      const prompt = tour.agentSystemPrompt.toLowerCase();
+      expect(prompt).toContain("one numbered step per turn");
+      expect(prompt).toContain("never continue to the next numbered step");
     }
   });
 

--- a/mcpjam-inspector/client/src/components/lifecycle/guided-tour-lessons.ts
+++ b/mcpjam-inspector/client/src/components/lifecycle/guided-tour-lessons.ts
@@ -9,11 +9,13 @@ import type { GuidedTourConcept, LearningGroup } from "./learning-concepts";
 
 /**
  * Guided tours. Unlike the reading modules, selecting one of these does not
- * open an in-tab article — it launches the MCPJam agent in the side panel,
- * seeded with the tour's `agentPrompt` as the user's first message. The agent
- * then teaches by driving the real inspector UI (navigate, narrate, prefill
- * forms) through the existing `ui_*` tool catalog, handing the final,
- * consequential click back to the user.
+ * open an in-tab article — it launches the MCPJam agent in the side panel with
+ * the tour's `agentSystemPrompt` riding in the request system prompt (stashed
+ * per-session by `tour-session-prompt.ts`, sent on every POST by the agent
+ * transport) and a short visible first message ("Start the tour: …")
+ * autosubmitted on the user's behalf. The agent then teaches by driving the
+ * real inspector UI (navigate, narrate, prefill forms) through the existing
+ * `ui_*` tool catalog, handing every consequential click back to the user.
  *
  * The teaching quality lives entirely in these prompts. They are natural
  * language and deliberately do NOT name `ui_*` tools — the agent already knows
@@ -23,21 +25,23 @@ import type { GuidedTourConcept, LearningGroup } from "./learning-concepts";
  */
 
 /**
- * Appended to every tour prompt. Encodes the safety and pedagogy invariants the
- * agent must hold regardless of which tour is running: narrate before acting,
- * adapt to the user's real state, prefill but never submit, never spend
- * money/quota without asking, and close by pointing the user back to mark the
- * tour complete.
+ * Appended to every tour system prompt. Encodes the safety and pedagogy
+ * invariants the agent must hold regardless of which tour is running: narrate
+ * before acting, adapt to the user's real state, prefill but never submit,
+ * never spend money/quota without asking, ONE numbered step per turn with an
+ * explicit check-in before the next, and close by pointing the user back to
+ * mark the tour complete.
  */
 const TOUR_GROUND_RULES = `
 Ground rules for this tour — follow all of them:
 1. Before you act on any screen, explain in 1-2 sentences what that screen or control is for. Keep narration short; this is a tour, not a lecture.
-2. Start by taking a snapshot of the app so the tour matches my real state. If something you need is already set up, say so and skip ahead instead of redoing it.
-3. If the tour needs a connected MCP server and I don't have one, detour first: help me connect one (a public demo server is fine), then continue.
-4. Prefill any forms for me and explain each field, but never click the final submit / create / run button yourself — hand that click back to me and tell me exactly what to press.
-5. Never start anything that spends money, tokens, or run quota (model calls, eval runs, swarm runs) without asking me first.
-6. Move one step at a time and check in briefly so I can follow along.
-7. When we're done, recap what I learned in 2-3 bullets and remind me to go back to the Learning tab and check this tour off as complete.
+2. Start by taking a snapshot of the app so the tour matches the user's real state. If something you need is already set up, say so and skip ahead instead of redoing it.
+3. If the tour needs a connected MCP server and the user doesn't have one, detour first: help them connect one (a public demo server is fine), then continue.
+4. Prefill any forms for the user and explain each field, but never click the final submit / create / run button yourself — hand that click back to them and say exactly what to press.
+5. Never start anything that spends money, tokens, or run quota (model calls, eval runs, swarm runs) without asking the user first.
+6. Do exactly ONE numbered step per turn. After finishing a step, stop and end your turn with a short check-in question (for example, "Ready for the next step?"). Never continue to the next numbered step in the same turn, even if you are confident the user is ready.
+7. A short reply like "next", "yes", or "ok" is confirmation — do the next single step, then stop and check in again.
+8. When the tour is done, recap what the user learned in 2-3 bullets and remind them to go back to the Learning tab and check this tour off as complete.
 `.trim();
 
 function withGroundRules(body: string): string {
@@ -54,16 +58,16 @@ export const GUIDED_TOURS: GuidedTourConcept[] = [
     icon: Cable,
     category: "Guided tour",
     estimatedMinutes: 3,
-    agentPrompt: withGroundRules(`
-Give me a hands-on guided tour of connecting my first MCP server in the MCPJam inspector (about 3 minutes). I'm brand new — assume I've never connected one.
+    agentSystemPrompt: withGroundRules(`
+You are running the guided tour "Connect your first MCP server" (about 3 minutes) for a user who just started it from the Learning tab. Assume they are brand new and have never connected an MCP server.
 
-Walk me through, in order:
-1. In a sentence, what an MCP server connection is and why I'd add one here.
-2. Take a snapshot to see whether I already have a server connected. If I do, point it out and offer to show me its tools instead of adding another.
-3. Open the form to add a new server and explain the transport choice — a remote HTTP URL versus a local command (STDIO) — so I know which to pick.
-4. Prefill the form with a reputable public demo MCP server over HTTP so I can try it without any setup. Explain what each field is.
-5. Stop and hand me the Connect button — tell me exactly what to click.
-6. Once it's connected, show me where the server's tools (and resources, if any) appear, so I know the connection worked.
+Walk the user through, in order:
+1. In a sentence, what an MCP server connection is and why they'd add one here.
+2. Take a snapshot to see whether they already have a server connected. If they do, point it out and offer to show its tools instead of adding another.
+3. Open the form to add a new server and explain the transport choice — a remote HTTP URL versus a local command (STDIO) — so they know which to pick.
+4. Prefill the form with a reputable public demo MCP server over HTTP so they can try it without any setup. Explain what each field is.
+5. Stop and hand them the Connect button — say exactly what to click.
+6. Once it's connected, show them where the server's tools (and resources, if any) appear, so they know the connection worked.
 `),
   },
   {
@@ -75,17 +79,17 @@ Walk me through, in order:
     icon: Gamepad2,
     category: "Guided tour",
     estimatedMinutes: 4,
-    agentPrompt: withGroundRules(`
-Give me a hands-on guided tour of the Playground in the MCPJam inspector (about 4 minutes). I want to see a model actually call one of my MCP server's tools.
+    agentSystemPrompt: withGroundRules(`
+You are running the guided tour "Run a tool in the Playground" (about 4 minutes) for a user who just started it from the Learning tab. The goal is for them to see a model actually call one of their MCP server's tools.
 
-Walk me through, in order:
-1. In a sentence or two, what the Playground is — a chat where a model can use my connected server's tools.
-2. Snapshot my state. I need a connected server with at least one tool; if I don't have one, detour and help me connect one first.
-3. Take me to the Playground and explain what I'm looking at.
-4. Explain the model picker and that every message sends a real, billable model call. Help me pick an inexpensive model.
-5. Draft a chat message that should make the model call a specific tool my server exposes, and tell me which tool you expect it to use and why.
-6. Stop before sending — ask me to hit send myself (this spends a model call).
-7. After it runs, walk me through the result: where the tool call shows up, the arguments the model chose, and what the tool returned.
+Walk the user through, in order:
+1. In a sentence or two, what the Playground is — a chat where a model can use their connected server's tools.
+2. Snapshot their state. They need a connected server with at least one tool; if they don't have one, detour and help them connect one first.
+3. Take them to the Playground and explain what they're looking at.
+4. Explain the model picker and that every message sends a real, billable model call. Help them pick an inexpensive model.
+5. Draft a chat message that should make the model call a specific tool their server exposes, and say which tool you expect it to use and why.
+6. Stop before sending — ask them to hit send themselves (this spends a model call).
+7. After it runs, walk them through the result: where the tool call shows up, the arguments the model chose, and what the tool returned.
 `),
   },
   {
@@ -97,17 +101,17 @@ Walk me through, in order:
     icon: FlaskConical,
     category: "Guided tour",
     estimatedMinutes: 5,
-    agentPrompt: withGroundRules(`
-Give me a hands-on guided tour of evals in the MCPJam inspector (about 5 minutes). I want to learn how to create an eval suite for an MCP server and run it.
+    agentSystemPrompt: withGroundRules(`
+You are running the guided tour "Create and run an eval suite" (about 5 minutes) for a user who just started it from the Learning tab. The goal is for them to learn how to create an eval suite for an MCP server and run it.
 
-Walk me through, in order:
-1. In a couple of sentences, what evals are for in MCPJam — testing that a model uses my MCP server's tools correctly.
-2. Check my current state. I need a connected MCP server to eval against; if I don't have one, help me connect one first.
-3. Take me to the evals area and explain what I'm looking at.
-4. Open the create-suite dialog and prefill the suite name for me. The test prompts and expected tool calls are mine to fill in — walk me through a good first test case based on the tools my server actually exposes (a prompt a real user might ask, and the tool you'd expect the model to call), and explain how expected tool calls are judged.
+Walk the user through, in order:
+1. In a couple of sentences, what evals are for in MCPJam — testing that a model uses their MCP server's tools correctly.
+2. Check their current state. They need a connected MCP server to eval against; if they don't have one, help them connect one first.
+3. Take them to the evals area and explain what they're looking at.
+4. Open the create-suite dialog and prefill the suite name. The test prompts and expected tool calls are theirs to fill in — walk them through a good first test case based on the tools their server actually exposes (a prompt a real user might ask, and the tool you'd expect the model to call), and explain how expected tool calls are judged.
 5. If there's a way to generate test cases automatically, mention it and what it costs before suggesting it.
-6. Stop before running anything. Tell me exactly which button to press to save and run the suite, warn me that running it calls a real model, and let me decide.
-7. If I choose to run it, explain how to read the results — what a pass and a fail look like, and what I'd change to fix a failing test.
+6. Stop before running anything. Say exactly which button to press to save and run the suite, warn them that running it calls a real model, and let them decide.
+7. If they choose to run it, explain how to read the results — what a pass and a fail look like, and what they'd change to fix a failing test.
 `),
   },
   {
@@ -119,16 +123,16 @@ Walk me through, in order:
     icon: Users,
     category: "Guided tour",
     estimatedMinutes: 5,
-    agentPrompt: withGroundRules(`
-Give me a hands-on guided tour of Swarms in the MCPJam inspector (about 5 minutes). I want to simulate real users exercising my MCP server.
+    agentSystemPrompt: withGroundRules(`
+You are running the guided tour "Simulate users with Swarms" (about 5 minutes) for a user who just started it from the Learning tab. The goal is for them to learn how to simulate real users exercising their MCP server.
 
-Walk me through, in order:
-1. In a couple of sentences, what Swarms are — synthetic user personas that run through journeys against my server — and why that's useful.
-2. Snapshot my state. Swarms need a connected server; if I don't have one, detour and help me connect one first.
-3. Take me to Swarms and explain the pieces: personas and journeys.
-4. Explain what a persona is and suggest a good starter persona for my server — a name, a role, and a note or two. Creating it is a quick form; tell me exactly what to enter rather than creating it for me.
-5. Explain what a journey is, then open the new-journey form and prefill the goal text for a task this persona would plausibly attempt with my server's tools. Picking the host and how many sessions is mine to choose — walk me through those.
-6. Explain that launching a swarm run consumes run quota and model calls. Stop before launching — hand me the launch button and let me decide.
+Walk the user through, in order:
+1. In a couple of sentences, what Swarms are — synthetic user personas that run through journeys against their server — and why that's useful.
+2. Snapshot their state. Swarms need a connected server; if they don't have one, detour and help them connect one first.
+3. Take them to Swarms and explain the pieces: personas and journeys.
+4. Explain what a persona is and suggest a good starter persona for their server — a name, a role, and a note or two. Creating it is a quick form; say exactly what to enter rather than creating it for them.
+5. Explain what a journey is, then open the new-journey form and prefill the goal text for a task this persona would plausibly attempt with their server's tools. Picking the host and how many sessions is theirs to choose — walk them through those.
+6. Explain that launching a swarm run consumes run quota and model calls. Stop before launching — hand them the launch button and let them decide.
 `),
   },
   {
@@ -140,16 +144,16 @@ Walk me through, in order:
     icon: Package,
     category: "Guided tour",
     estimatedMinutes: 4,
-    agentPrompt: withGroundRules(`
-Give me a hands-on guided tour of Hosts in the MCPJam inspector (about 4 minutes). I want to package my servers into a reusable Host.
+    agentSystemPrompt: withGroundRules(`
+You are running the guided tour "Package servers into a Host" (about 4 minutes) for a user who just started it from the Learning tab. The goal is for them to learn how to package their servers into a reusable Host.
 
-Walk me through, in order:
-1. In a couple of sentences, what a Host is — a named bundle of MCP servers exposed together to a client — and when I'd want one.
-2. Snapshot my state so we can use my actual connected server(s). If I have none, detour and help me connect one first.
-3. Take me to Hosts and explain what I'm looking at.
-4. Walk me through creating a host: suggest a clear name and tell me exactly what to click to create it (creating the host, and later attaching servers, are commits I'll make myself — describe the values to use rather than doing it for me).
-5. Once the host exists, open its editor and show me where I'd adjust its config — model, system prompt, and behavior. Then explain that servers are selected project-wide (not inside this editor): take me to the Servers tab and show me how to include my connected server(s) so the host can use them.
-6. Recap what the Host lets me do and what I'd change next.
+Walk the user through, in order:
+1. In a couple of sentences, what a Host is — a named bundle of MCP servers exposed together to a client — and when they'd want one.
+2. Snapshot their state so the tour can use their actual connected server(s). If they have none, detour and help them connect one first.
+3. Take them to Hosts and explain what they're looking at.
+4. Walk them through creating a host: suggest a clear name and say exactly what to click to create it (creating the host, and later attaching servers, are commits they'll make themselves — describe the values to use rather than doing it for them).
+5. Once the host exists, open its editor and show them where they'd adjust its config — model, system prompt, and behavior. Then explain that servers are selected project-wide (not inside this editor): take them to the Servers tab and show them how to include their connected server(s) so the host can use them.
+6. Recap what the Host lets them do and what they'd change next.
 `),
   },
 ];

--- a/mcpjam-inspector/client/src/components/lifecycle/learning-concepts.ts
+++ b/mcpjam-inspector/client/src/components/lifecycle/learning-concepts.ts
@@ -33,13 +33,14 @@ export interface LearningConcept extends LearningModuleBase {
 
 /**
  * A guided tour — selecting it launches the MCPJam agent in the side panel
- * seeded with `agentPrompt`, rather than opening an in-tab article. Has no
+ * with `agentSystemPrompt` riding in the request system prompt (plus a short
+ * autosubmitted first message), rather than opening an in-tab article. Has no
  * `totalSteps` (the tour isn't a fixed step sequence); the union makes that
  * absence explicit instead of a lying `0`. See `guided-tour-lessons.ts`.
  */
 export interface GuidedTourConcept extends LearningModuleBase {
   kind: "guided";
-  agentPrompt: string;
+  agentSystemPrompt: string;
 }
 
 export type LearningModule = LearningConcept | GuidedTourConcept;

--- a/mcpjam-inspector/client/src/lib/mcpjam-agent/__tests__/agent-chat-instances.test.ts
+++ b/mcpjam-inspector/client/src/lib/mcpjam-agent/__tests__/agent-chat-instances.test.ts
@@ -58,6 +58,10 @@ import {
   markAgentTurnStarted,
   claimAgentTurnCompletion,
 } from "../agent-chat-instances";
+import {
+  __resetTourSystemPromptsForTests,
+  writeTourSystemPrompt,
+} from "../tour-session-prompt";
 import { __resetUiToolExecutorForTests } from "@/lib/webmcp/ui-tool-executor";
 import {
   AGENT_PANEL_STORAGE_KEY,
@@ -90,6 +94,7 @@ describe("agent-chat-instances", () => {
     mockState.lastTransportOptions = null;
     __resetAgentChatInstancesForTests();
     __resetUiToolExecutorForTests();
+    __resetTourSystemPromptsForTests();
     window.localStorage.removeItem(AGENT_PANEL_STORAGE_KEY);
     useAgentPanelStore.setState({
       isOpen: false,
@@ -123,6 +128,23 @@ describe("agent-chat-instances", () => {
     });
     config.projectId = "p2";
     expect(mockState.lastTransportOptions.body().projectId).toBe("p2");
+  });
+
+  it("body carries the tour system prompt for tour sessions only", () => {
+    writeTourSystemPrompt("tour-sess", {
+      tourId: "tour-a",
+      systemPrompt: "You are running tour A.",
+    });
+
+    getOrCreateAgentChat("tour-sess");
+    expect(mockState.lastTransportOptions.body().systemPrompt).toBe(
+      "You are running tour A.",
+    );
+
+    // Non-tour sessions must not grow a systemPrompt field — the route treats
+    // its absence as "identity prompt only".
+    getOrCreateAgentChat("plain-sess");
+    expect(mockState.lastTransportOptions.body().systemPrompt).toBeUndefined();
   });
 
   it("evicts only idle, detached instances beyond the cap", () => {

--- a/mcpjam-inspector/client/src/lib/mcpjam-agent/__tests__/launch-lesson.test.ts
+++ b/mcpjam-inspector/client/src/lib/mcpjam-agent/__tests__/launch-lesson.test.ts
@@ -22,6 +22,10 @@ import {
   launchLessonSession,
 } from "../launch-lesson";
 import { pendingAgentPromptKey } from "../pending-prompt";
+import {
+  __resetTourSystemPromptsForTests,
+  readTourSystemPrompt,
+} from "../tour-session-prompt";
 import { useAgentPanelStore } from "@/stores/agent-panel/agent-panel-store";
 import { loadRecentMcpjamAgentSessions } from "@/components/mcpjam-agent/recent-sessions";
 
@@ -33,11 +37,15 @@ const TOUR: GuidedTourConcept = {
   icon: Cable,
   category: "Guided tour",
   estimatedMinutes: 5,
-  agentPrompt: "Give me a tour of evals.",
+  agentSystemPrompt: "You are running the evals tour.",
 };
+
+// What the launch autosubmits as the visible first message.
+const STARTER_TEXT = `Start the tour: ${TOUR.title}`;
 
 beforeEach(() => {
   __resetLaunchLessonForTests();
+  __resetTourSystemPromptsForTests();
   idCounter.n = 0;
   generateIdMock.mockClear();
   window.sessionStorage.clear();
@@ -60,9 +68,13 @@ describe("launchLessonSession", () => {
 
     const raw = window.sessionStorage.getItem(pendingAgentPromptKey("sess-1"));
     expect(JSON.parse(raw as string)).toEqual({
-      text: TOUR.agentPrompt,
+      text: STARTER_TEXT,
       fresh: true,
     });
+
+    // The tour instructions ride in the per-session system prompt, not the
+    // visible message.
+    expect(readTourSystemPrompt("sess-1")).toBe(TOUR.agentSystemPrompt);
 
     const state = useAgentPanelStore.getState();
     expect(state.activeSessionId).toBe("sess-1");
@@ -104,7 +116,7 @@ describe("launchLessonSession", () => {
     expect(pendingAtActivation).not.toBeNull();
     expect(pendingAtActivation).not.toBe("UNSET");
     expect(JSON.parse(pendingAtActivation as string)).toEqual({
-      text: TOUR.agentPrompt,
+      text: STARTER_TEXT,
       fresh: true,
     });
   });

--- a/mcpjam-inspector/client/src/lib/mcpjam-agent/__tests__/tour-session-prompt.test.ts
+++ b/mcpjam-inspector/client/src/lib/mcpjam-agent/__tests__/tour-session-prompt.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __resetTourSystemPromptsForTests,
+  readTourSystemPrompt,
+  writeTourSystemPrompt,
+} from "../tour-session-prompt";
+
+const STORAGE_KEY = "mcpjam:agent-tour-system-prompts:v1";
+
+beforeEach(() => {
+  __resetTourSystemPromptsForTests();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("tour-session-prompt", () => {
+  it("roundtrips a system prompt by session id", () => {
+    writeTourSystemPrompt("sess-1", {
+      tourId: "tour-a",
+      systemPrompt: "You are running tour A.",
+    });
+    expect(readTourSystemPrompt("sess-1")).toBe("You are running tour A.");
+    expect(readTourSystemPrompt("sess-other")).toBeNull();
+  });
+
+  it("re-writing the same session replaces rather than duplicates", () => {
+    writeTourSystemPrompt("sess-1", { tourId: "tour-a", systemPrompt: "v1" });
+    writeTourSystemPrompt("sess-1", { tourId: "tour-a", systemPrompt: "v2" });
+    expect(readTourSystemPrompt("sess-1")).toBe("v2");
+    const stored = JSON.parse(
+      window.localStorage.getItem(STORAGE_KEY) as string,
+    ) as unknown[];
+    expect(stored).toHaveLength(1);
+  });
+
+  it("caps the registry MRU-style, evicting the oldest entry", () => {
+    for (let i = 1; i <= 13; i++) {
+      writeTourSystemPrompt(`sess-${i}`, {
+        tourId: "tour-a",
+        systemPrompt: `prompt ${i}`,
+      });
+    }
+    // Oldest launch evicted; the 12 most recent survive.
+    expect(readTourSystemPrompt("sess-1")).toBeNull();
+    expect(readTourSystemPrompt("sess-2")).toBe("prompt 2");
+    expect(readTourSystemPrompt("sess-13")).toBe("prompt 13");
+  });
+
+  it("returns null (not a throw) on corrupt stored JSON", () => {
+    window.localStorage.setItem(STORAGE_KEY, "{not json");
+    expect(readTourSystemPrompt("sess-1")).toBeNull();
+    // And a write on top of corruption recovers cleanly.
+    writeTourSystemPrompt("sess-1", { tourId: "tour-a", systemPrompt: "ok" });
+    expect(readTourSystemPrompt("sess-1")).toBe("ok");
+  });
+
+  it("filters malformed entries instead of trusting the array shape", () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify([
+        { sessionId: "sess-bad" }, // missing fields
+        {
+          sessionId: "sess-1",
+          tourId: "tour-a",
+          systemPrompt: "kept",
+          ts: 1,
+        },
+      ]),
+    );
+    expect(readTourSystemPrompt("sess-bad")).toBeNull();
+    expect(readTourSystemPrompt("sess-1")).toBe("kept");
+  });
+
+  // jsdom's window.localStorage does not route through Storage.prototype, so
+  // spy the instance (same note as launch-lesson.test.ts).
+
+  it("swallows setItem failures (quota/disabled storage)", () => {
+    vi.spyOn(window.localStorage, "setItem").mockImplementation(() => {
+      throw new Error("quota");
+    });
+    expect(() =>
+      writeTourSystemPrompt("sess-1", {
+        tourId: "tour-a",
+        systemPrompt: "p",
+      }),
+    ).not.toThrow();
+  });
+
+  it("swallows getItem failures and reads as empty", () => {
+    vi.spyOn(window.localStorage, "getItem").mockImplementation(() => {
+      throw new Error("denied");
+    });
+    expect(readTourSystemPrompt("sess-1")).toBeNull();
+  });
+});

--- a/mcpjam-inspector/client/src/lib/mcpjam-agent/__tests__/tour-session-prompt.test.ts
+++ b/mcpjam-inspector/client/src/lib/mcpjam-agent/__tests__/tour-session-prompt.test.ts
@@ -48,6 +48,31 @@ describe("tour-session-prompt", () => {
     expect(readTourSystemPrompt("sess-13")).toBe("prompt 13");
   });
 
+  it("promotes an entry on read so an active session survives eviction", () => {
+    for (let i = 1; i <= 12; i++) {
+      writeTourSystemPrompt(`sess-${i}`, {
+        tourId: "tour-a",
+        systemPrompt: `prompt ${i}`,
+      });
+    }
+    // sess-1 is oldest; a POST-time read promotes it to the front...
+    expect(readTourSystemPrompt("sess-1")).toBe("prompt 1");
+    // ...so the next launch evicts sess-2 instead.
+    writeTourSystemPrompt("sess-13", {
+      tourId: "tour-a",
+      systemPrompt: "prompt 13",
+    });
+    expect(readTourSystemPrompt("sess-1")).toBe("prompt 1");
+    expect(readTourSystemPrompt("sess-2")).toBeNull();
+  });
+
+  it("does not rewrite storage when the entry is already at the front", () => {
+    writeTourSystemPrompt("sess-1", { tourId: "tour-a", systemPrompt: "p" });
+    const setItem = vi.spyOn(window.localStorage, "setItem");
+    expect(readTourSystemPrompt("sess-1")).toBe("p");
+    expect(setItem).not.toHaveBeenCalled();
+  });
+
   it("returns null (not a throw) on corrupt stored JSON", () => {
     window.localStorage.setItem(STORAGE_KEY, "{not json");
     expect(readTourSystemPrompt("sess-1")).toBeNull();

--- a/mcpjam-inspector/client/src/lib/mcpjam-agent/agent-chat-instances.ts
+++ b/mcpjam-inspector/client/src/lib/mcpjam-agent/agent-chat-instances.ts
@@ -28,6 +28,7 @@ import { useUiToolsRegistry } from "@/lib/webmcp/ui-tools-registry";
 import { handleUiToolCall } from "@/lib/webmcp/ui-tool-executor";
 import { createUiAwareApprovalResponseHandler } from "@/lib/webmcp/ui-tool-approval";
 import { useAgentPanelStore } from "@/stores/agent-panel/agent-panel-store";
+import { readTourSystemPrompt } from "./tour-session-prompt";
 import type { ModelDefinition } from "@/shared/types";
 
 const AGENT_API_PATH = "/api/web/mcpjam-agent";
@@ -260,6 +261,13 @@ export function getOrCreateAgentChat(chatSessionId: string): AgentChatEntry {
         // contract as `useChatSession`). The server validates again in
         // `validateUiToolEntries`.
         uiTools: useUiToolsRegistry.getState().snapshotForChatBody(),
+        // Guided-tour instructions for this session, if any (the route
+        // prepends body.systemPrompt to the agent identity prompt). Read at
+        // POST time so the tour context survives reloads and Recent Chats
+        // resume. Constant per session, so the system-prompt prefix stays
+        // cache-stable; `undefined` is dropped at serialization, leaving
+        // non-tour bodies unchanged.
+        systemPrompt: readTourSystemPrompt(chatSessionId) ?? undefined,
       }),
     }),
     // WebMCP UI tools are no-execute server-side; the stream pauses until

--- a/mcpjam-inspector/client/src/lib/mcpjam-agent/launch-lesson.ts
+++ b/mcpjam-inspector/client/src/lib/mcpjam-agent/launch-lesson.ts
@@ -4,12 +4,14 @@ import { appendRecentMcpjamAgentSession } from "@/components/mcpjam-agent/recent
 import { useAgentPanelStore } from "@/stores/agent-panel/agent-panel-store";
 import { track } from "@/lib/analytics";
 import { writePendingAgentPrompt } from "./pending-prompt";
+import { writeTourSystemPrompt } from "./tour-session-prompt";
 
 /**
- * Launches a Learning-tab guided tour: mints a fresh agent chat session seeded
- * with the tour's prompt and opens the always-mounted agent side panel to it.
- * `McpjamAgentThread` consumes the seeded prompt and autosubmits it on mount,
- * so the agent begins the tour on its own.
+ * Launches a Learning-tab guided tour: mints a fresh agent chat session, stows
+ * the tour's instructions in the per-session system-prompt registry, seeds a
+ * short "Start the tour: …" first message, and opens the always-mounted agent
+ * side panel to it. `McpjamAgentThread` consumes the seeded message and
+ * autosubmits it on mount, so the agent begins the tour on its own.
  *
  * This deliberately replicates the side panel's own session-start
  * (`AgentSidePanel.handleSessionStart`) and the home→panel handoff
@@ -149,11 +151,19 @@ export function launchLessonSession({
 
   const sessionId = generateId();
 
+  // The tour's instructions ride in the request system prompt (the agent
+  // transport's body() re-reads this registry on every POST of the session);
+  // the visible, autosubmitted first message stays short and natural.
+  writeTourSystemPrompt(sessionId, {
+    tourId: tour.id,
+    systemPrompt: tour.agentSystemPrompt,
+  });
+
   // Order matters: write the pending prompt BEFORE setActiveSession (which
   // mounts the thread) so the thread's synchronous optimistic-bubble peek sees
   // it, then setActiveSession before setOpen to match the handoff and avoid a
   // one-frame hero flash in the opening panel.
-  writePendingAgentPrompt(sessionId, tour.agentPrompt);
+  writePendingAgentPrompt(sessionId, `Start the tour: ${tour.title}`);
 
   // Pre-seed the recents title so the Recent Chats pill reads "Tour: <title>"
   // instead of the first 50 chars of the lesson prompt (the thread's submit
@@ -178,7 +188,7 @@ export function launchLessonSession({
     tour_id: tour.id,
     session_id: sessionId,
     estimated_minutes: tour.estimatedMinutes,
-    prompt_length: tour.agentPrompt.length,
+    prompt_length: tour.agentSystemPrompt.length,
   });
 
   writeLastLaunch({ tourId: tour.id, sessionId, projectId: resolvedProjectId });

--- a/mcpjam-inspector/client/src/lib/mcpjam-agent/tour-session-prompt.ts
+++ b/mcpjam-inspector/client/src/lib/mcpjam-agent/tour-session-prompt.ts
@@ -1,0 +1,91 @@
+/**
+ * Durable per-session system prompts for Learning-tab guided tours.
+ *
+ * When `launchLessonSession` mints a tour session, the tour's instructions
+ * (walk + ground rules) ride in the request `systemPrompt` rather than the
+ * visible first user message. The agent transport's `body()` re-reads this
+ * registry on EVERY POST of the session, so the tour context survives later
+ * turns, reloads, and Recent Chats resume — which is why this is localStorage,
+ * unlike the one-shot sessionStorage handoff in `pending-prompt.ts`.
+ *
+ * Entries are an MRU stack capped at `MAX_ENTRIES` (matching
+ * `recent-sessions.ts`): a tour session evicted `MAX_ENTRIES` launches later
+ * simply degrades to a normal agent chat, the same lifetime as its Recent
+ * Chats pill. Storage failures are swallowed everywhere — the tour still runs,
+ * it just loses tour-awareness after a reload.
+ */
+
+const STORAGE_KEY = "mcpjam:agent-tour-system-prompts:v1";
+const MAX_ENTRIES = 12;
+
+interface TourSystemPromptEntry {
+  sessionId: string;
+  tourId: string;
+  systemPrompt: string;
+  /** Unix ms of the launch, for debuggability; ordering is array position. */
+  ts: number;
+}
+
+function safeParse(raw: string | null): TourSystemPromptEntry[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (entry): entry is TourSystemPromptEntry =>
+        typeof entry === "object" &&
+        entry !== null &&
+        typeof (entry as TourSystemPromptEntry).sessionId === "string" &&
+        typeof (entry as TourSystemPromptEntry).tourId === "string" &&
+        typeof (entry as TourSystemPromptEntry).systemPrompt === "string" &&
+        typeof (entry as TourSystemPromptEntry).ts === "number",
+    );
+  } catch {
+    return [];
+  }
+}
+
+function load(): TourSystemPromptEntry[] {
+  if (typeof window === "undefined") return [];
+  try {
+    return safeParse(window.localStorage.getItem(STORAGE_KEY));
+  } catch {
+    return [];
+  }
+}
+
+export function writeTourSystemPrompt(
+  sessionId: string,
+  { tourId, systemPrompt }: { tourId: string; systemPrompt: string },
+): void {
+  if (typeof window === "undefined") return;
+  try {
+    const next: TourSystemPromptEntry[] = [
+      { sessionId, tourId, systemPrompt, ts: Date.now() },
+      ...load().filter((entry) => entry.sessionId !== sessionId),
+    ].slice(0, MAX_ENTRIES);
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+  } catch {
+    // Quota/disabled storage — the launch proceeds; the session just isn't
+    // tour-aware on the server side. See doc comment above.
+  }
+}
+
+/**
+ * The system prompt for a tour session, or null for any non-tour session.
+ * Called from the agent transport's `body()` on every POST.
+ */
+export function readTourSystemPrompt(sessionId: string): string | null {
+  const entry = load().find((e) => e.sessionId === sessionId);
+  return entry ? entry.systemPrompt : null;
+}
+
+/** Test-only: clears the registry between cases. */
+export function __resetTourSystemPromptsForTests(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+}

--- a/mcpjam-inspector/client/src/lib/mcpjam-agent/tour-session-prompt.ts
+++ b/mcpjam-inspector/client/src/lib/mcpjam-agent/tour-session-prompt.ts
@@ -74,10 +74,28 @@ export function writeTourSystemPrompt(
 /**
  * The system prompt for a tour session, or null for any non-tour session.
  * Called from the agent transport's `body()` on every POST.
+ *
+ * Reading promotes the entry to the front so an actively posting session
+ * can't be evicted by `MAX_ENTRIES` newer launches (true MRU, not FIFO).
+ * Guarded so the common case — already at the front — costs no write.
  */
 export function readTourSystemPrompt(sessionId: string): string | null {
-  const entry = load().find((e) => e.sessionId === sessionId);
-  return entry ? entry.systemPrompt : null;
+  const entries = load();
+  const index = entries.findIndex((e) => e.sessionId === sessionId);
+  if (index < 0) return null;
+  const entry = entries[index];
+  if (index > 0 && typeof window !== "undefined") {
+    try {
+      entries.splice(index, 1);
+      window.localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify([entry, ...entries]),
+      );
+    } catch {
+      // Promotion is best-effort; returning the prompt is still correct.
+    }
+  }
+  return entry.systemPrompt;
 }
 
 /** Test-only: clears the registry between cases. */


### PR DESCRIPTION
## What

Two UX fixes for the Learning-tab guided tours (#3334):

1. **Tour instructions move to the system prompt.** The full tour prompt (numbered walk + 7 ground rules) used to be autosubmitted as a giant visible user bubble. Now it rides in the request `systemPrompt` — a field `/api/web/mcpjam-agent` already accepted, prepended to the identity prompt, and persisted, but which no client ever sent. The visible first message is now just `Start the tour: <title>`.
2. **One step per turn.** The ground rules are rewritten in system voice with a hard pacing gate: do exactly one numbered step, end the turn with a short check-in question ("Ready for the next step?"), never continue in the same turn; "next"/"yes" counts as confirmation. The user drives the tour instead of watching the agent barrel through it.

## How

- New `client/src/lib/mcpjam-agent/tour-session-prompt.ts`: a per-session localStorage MRU registry (cap 12, matching `recent-sessions.ts`) of `{ sessionId, tourId, systemPrompt }`. `launchLessonSession` writes it at launch; the agent transport's `body()` reads it at POST time, so tour context survives later turns, reloads, and Recent Chats resume. Storage failures degrade to a normal chat, never block the launch.
- `agent-chat-instances.ts` `body()` gains one field: `systemPrompt: readTourSystemPrompt(chatSessionId) ?? undefined` — `undefined` is dropped at serialization, so non-tour sessions send a byte-identical body. The value is constant per session, keeping the system-prompt prefix cache-stable.
- `GuidedTourConcept.agentPrompt` → `agentSystemPrompt`; all 5 tour prompts reframed from first-person user voice to system voice.
- **Zero server changes.** Note for reviewers: `effectiveSystemPrompt` order is `[body.systemPrompt, AGENT_IDENTITY_PROMPT, ambientContextPrompt]`, so tour rules land first; the route already persists `body.systemPrompt`, so hosted transcripts record tour context for free.

## Tests

- New `tour-session-prompt.test.ts`: roundtrip, MRU dedupe/eviction, corrupt-JSON and disabled-storage resilience.
- `launch-lesson.test.ts`: starter message + system-prompt registry assertions.
- `agent-chat-instances.test.ts`: `body()` carries the tour system prompt for tour sessions only.
- `LearningTab.tours.test.tsx`: new invariant — every tour prompt encodes the one-step-per-turn gate.

Full client project: 606 files / 5944 tests pass; `npm run typecheck:client` clean.

## Deliberately out of scope

A "Next step" quick-reply chip under assistant turns. The seam exists (`McpjamAgentThread` owns both `handleSubmit` and the session id), but every tour turn now ends in an explicit question and typing "next" is natural — evaluate the prompt-only pacing first, add the chip as a small follow-up if turns still feel unprompted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only learning/agent UX and prompt plumbing; no server changes. Worst case is degraded tour context after storage eviction or quota failures, not security or data corruption.
> 
> **Overview**
> **Guided tours** no longer autosubmit the full walk + ground rules as the first user bubble. Tour copy is stored per session in a new **localStorage MRU registry** (`tour-session-prompt.ts`, cap 12), written at launch and read on every agent POST via `systemPrompt` on the transport body; non-tour chats still omit that field. The visible starter is **`Start the tour: <title>`**.
> 
> **`GuidedTourConcept.agentPrompt`** is renamed to **`agentSystemPrompt`**, with all five tours reframed in system voice. **Ground rules** add a hard **one numbered step per turn** gate (check-in after each step; short replies like "next" advance).
> 
> Tests cover the registry, launch wiring, transport body behavior, and content invariants for pacing and safety rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96b7a152d2f376637e501c54b0a9559fcff83388. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves guided tour instructions into the request `systemPrompt` and adds a one-step-per-turn pacing gate. This cleans up the first message and makes tours user-driven, with zero server changes to `/api/web/mcpjam-agent`.

- **New Features**
  - Tour instructions ride in `systemPrompt` instead of a long visible message; the first message is now “Start the tour: <title>”.
  - Per-session localStorage MRU registry (`tour-session-prompt.ts`, cap 12) persists tour context across turns, reloads, and Recent Chats; read on every POST.
  - Pacing: exactly one numbered step per turn; end with a short check-in question; “next/yes/ok” advances.
  - Agent transport adds `systemPrompt` only for tour sessions; non-tour bodies remain unchanged.
  - Renamed `GuidedTourConcept.agentPrompt` to `agentSystemPrompt` and rewrote prompts in system voice.

- **Bug Fixes**
  - Promote tour system prompt on read (true MRU) so active sessions aren’t evicted; guarded to avoid unnecessary writes.

<sup>Written for commit 96b7a152d2f376637e501c54b0a9559fcff83388. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

