### PR TITLE
fix(playground): let the lead client be unchecked in the compare picker

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/__tests__/client-selector.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/__tests__/client-selector.test.tsx
@@ -126,6 +126,35 @@ describe("ClientSelector", () => {
     expect(screen.getByText("Global")).toBeInTheDocument();
   });
 
+  // The lead ("Global") row must be uncheckable like any other. The
+  // selector only reports the shorter line-up; promoting the new slot 0
+  // is `usePersistedHost`'s job — see its "drops the lead" tests.
+  it("removes the lead host when its row is unchecked while comparing", async () => {
+    const user = userEvent.setup();
+    const onSelectedHostIdsChange = vi.fn();
+    render(
+      <ClientSelector
+        hosts={hosts}
+        projectId="project-1"
+        currentHostId="host-0"
+        selectedHostIds={["host-0", "host-1", "host-3"]}
+        multiHostEnabled
+        onHostChange={vi.fn()}
+        onSelectedHostIdsChange={onSelectedHostIdsChange}
+        onMultiHostEnabledChange={vi.fn()}
+        onPromoteLead={vi.fn()}
+        enableMultiHost
+      />
+    );
+
+    await user.click(screen.getByTestId("client-selector-trigger"));
+    expect(screen.getByText("Global")).toBeInTheDocument();
+
+    await user.click(screen.getByTestId("client-row-host-0"));
+
+    expect(onSelectedHostIdsChange).toHaveBeenCalledWith(["host-1", "host-3"]);
+  });
+
   it("uses app-surface logo variants inside the modal", async () => {
     const user = userEvent.setup();
     renderClientSelector({

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-persisted-host.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-persisted-host.test.tsx
@@ -157,6 +157,60 @@ describe("usePersistedHost", () => {
     expect(loadPreviewedHostId(PROJECT)).toBe("a");
   });
 
+  // Removing the LEAD from the compare line-up is a legal picker gesture
+  // ("uncheck Claude"). The stored array no longer contains the lead, so
+  // the defensive derivation would otherwise resurrect it at slot 0 —
+  // destroying the host that legitimately moved up. Dropping the lead
+  // must instead promote the new slot 0.
+  it("promotes the new slot 0 when setSelectedHostIds drops the lead", () => {
+    saveSelectedHostIds(PROJECT, ["a", "b", "c"]);
+    savePreviewedHostId(PROJECT, "a");
+
+    const { result } = renderHook(() => usePersistedHost(PROJECT));
+    expect(result.current.selectedHostIds).toEqual(["a", "b", "c"]);
+
+    act(() => {
+      result.current.setSelectedHostIds(["b", "c"]);
+    });
+
+    expect(result.current.selectedHostIds).toEqual(["b", "c"]);
+    expect(loadSelectedHostIds(PROJECT)).toEqual(["b", "c"]);
+    expect(loadPreviewedHostId(PROJECT)).toBe("b");
+  });
+
+  // Same gesture, down to a single remaining host: dropping the lead from
+  // a two-host line-up leaves exactly the other host, still as the lead.
+  it("promotes the survivor when the lead is dropped from a two-host line-up", () => {
+    saveSelectedHostIds(PROJECT, ["a", "b"]);
+    savePreviewedHostId(PROJECT, "a");
+
+    const { result } = renderHook(() => usePersistedHost(PROJECT));
+
+    act(() => {
+      result.current.setSelectedHostIds(["b"]);
+    });
+
+    expect(result.current.selectedHostIds).toEqual(["b"]);
+    expect(loadPreviewedHostId(PROJECT)).toBe("b");
+  });
+
+  // Collapsing the array to empty (mutual-exclusion path in
+  // `PlaygroundMain.handleMultiModelEnabledChange`) is NOT a lead change —
+  // the lead has to survive so the single-host view still has a host.
+  it("leaves the lead alone when the array is cleared", () => {
+    saveSelectedHostIds(PROJECT, ["a", "b"]);
+    savePreviewedHostId(PROJECT, "a");
+
+    const { result } = renderHook(() => usePersistedHost(PROJECT));
+
+    act(() => {
+      result.current.setSelectedHostIds([]);
+    });
+
+    expect(loadPreviewedHostId(PROJECT)).toBe("a");
+    expect(result.current.selectedHostIds).toEqual(["a"]);
+  });
+
   it("preserves column count across a host switch via replaceLeadHostId", () => {
     saveSelectedHostIds(PROJECT, ["host-a", "extra"]);
     savePreviewedHostId(PROJECT, "host-a");

--- a/mcpjam-inspector/client/src/hooks/use-persisted-host.ts
+++ b/mcpjam-inspector/client/src/hooks/use-persisted-host.ts
@@ -132,7 +132,7 @@ export interface UsePersistedHostReturn {
 export function usePersistedHost(
   projectId: string | null,
 ): UsePersistedHostReturn {
-  const [previewedHostId] = usePreviewedHostId(projectId);
+  const [previewedHostId, setPreviewedHostId] = usePreviewedHostId(projectId);
   const [storedHostIds, setStoredHostIdsState] = useState<string[]>([]);
   const [multiHostEnabled, setMultiHostEnabledState] = useState(false);
   const [isInitialized, setIsInitialized] = useState(false);
@@ -207,17 +207,38 @@ export function usePersistedHost(
     [previewedHostId, storedHostIds],
   );
 
-  const setSelectedHostIds = useCallback((hostIds: string[]) => {
-    const normalized = normalizeSelectedHostIds(hostIds);
-    // React state is the source of truth for the compare-column line-up
-    // during in-app writes; the array-mirror effect above persists it.
-    // The lead (previewed host) is owned by `usePreviewedHostId` /
-    // `savePreviewedHostId`; this setter intentionally does NOT touch
-    // the lead — promotion goes through `replaceLeadHostId`. Mutating
-    // the lead from here would be the same anti-pattern that grew the
-    // model array on every host switch.
-    setStoredHostIdsState(normalized);
-  }, []);
+  const setSelectedHostIds = useCallback(
+    (hostIds: string[]) => {
+      const normalized = normalizeSelectedHostIds(hostIds);
+      // React state is the source of truth for the compare-column line-up
+      // during in-app writes; the array-mirror effect above persists it.
+      // The lead (previewed host) is owned by `usePreviewedHostId` /
+      // `savePreviewedHostId`; this setter does NOT promote a different
+      // lead — promotion goes through `replaceLeadHostId`. Mutating the
+      // lead from here would be the same anti-pattern that grew the model
+      // array on every host switch.
+      setStoredHostIdsState(normalized);
+
+      // ...with exactly one exception: an in-app write that DROPS the
+      // lead from a non-empty line-up. `deriveSelectedHostIds` cannot
+      // tell "the array dropped the lead" apart from "an external
+      // `savePreviewedHostId` moved the lead without rotating the array",
+      // so it would resurrect the dropped lead at slot 0 — clobbering the
+      // host that legitimately moved up and making the lead impossible to
+      // uncheck in the picker. An explicit array write is authoritative
+      // about the line-up, so the lead follows it to the new slot 0.
+      //
+      // Clearing the array to `[]` is deliberately NOT a lead change: the
+      // empty array means "fall back to the lead as the single implicit
+      // selection" (see `PlaygroundMain.handleMultiModelEnabledChange`),
+      // so the lead has to survive.
+      if (normalized.length === 0) return;
+      if (!previewedHostId) return;
+      if (normalized.includes(previewedHostId)) return;
+      setPreviewedHostId(normalized[0]);
+    },
+    [previewedHostId, setPreviewedHostId],
+  );
 
   const setMultiHostEnabled = useCallback((enabled: boolean) => {
     setMultiHostEnabledState(enabled);


### PR DESCRIPTION
## Problem

In the Playground client picker with **Multiple clients** on, the lead client — the one badged `GLOBAL` — cannot be unchecked. Clicking its row appears to do nothing, except that a *different* client silently disappears from the line-up. Clicking repeatedly eats one client per click until only the un-removable lead is left, which reads as "clicking it unchecked everything".

## Root cause

Not in the picker UI. The lead is stored apart from the compare line-up (`mcp-previewed-host-id` vs `mcp-inspector-selected-hosts:{projectId}`), and `usePersistedHost` re-derives the line-up on every read.

`deriveSelectedHostIds` has a deliberate defensive branch for external surfaces (global host bar, project setup) that move the lead *without* rotating the array: "lead not in array → replace slot 0 with it, never grow". It cannot tell that case apart from "the user just removed the lead from the array", so:

```
stored [claude, slackbot, chatgpt] + lead claude
  → uncheck claude → stored [slackbot, chatgpt]
  → derive re-inserts claude at slot 0 → [claude, chatgpt]   // slackbot destroyed
```

## Fix

`setSelectedHostIds` is an explicit in-app write, so it is authoritative about the line-up: when it drops the current lead from a non-empty array, the lead now follows to the new slot 0.

Clearing to `[]` deliberately stays a non-lead-change — that path (`PlaygroundMain.handleMultiModelEnabledChange`) means "fall back to the lead as the single implicit selection", so the lead has to survive it.

One change in the hook covers both surfaces: the chat-input `ClientSelector` and the header `MultiHostPicker` both route their writes through it. The count-preservation contract and the external-`savePreviewedHostId` derivation branches are untouched.

## Testing

- 3 new hook tests + 1 selector test. The two "drops the lead" tests fail on `main` exactly as described (`['a','c']` instead of `['b','c']`).
- Green: `use-persisted-host`, `MultiHostPicker`, `client-selector`, `PlaygroundMain.multi-host` — 59 tests.
- Verified in the running app with 4 clients: unchecking the lead removes it, promotes the next to `GLOBAL`, and leaves the third intact; unchecking again collapses cleanly to the survivor.

## Notes / not in scope

- The chip strip still renders no ✕ on the lead chip — that's an explicitly tested design decision (`MultiHostPicker.test.tsx:297`). The checkbox row is the removal path and now works; happy to make the two consistent if preferred.
- The `GLOBAL` badge just means "lead / slot 0" and reads as confusing. Renaming it to `Lead` is a one-line change plus a test — left out to keep this diff to the bug.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Playground compare picker so the `Global` lead can be unchecked without deleting other clients. Removing the lead from a non-empty lineup promotes the next client; clearing the list keeps the lead for single-host fallback.

- **Bug Fixes**
  - `setSelectedHostIds` now updates the lead to the new slot 0 when the current lead is dropped; clearing to `[]` preserves the lead.
  - Applies to both `ClientSelector` and `MultiHostPicker` via `usePersistedHost`.
  - Added tests: 3 for `usePersistedHost` and 1 for `ClientSelector`; affected suites are green.

<sup>Written for commit 3bc0282a09deb2fa6639ee50bb21c2ec9632af0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

