### PR TITLE
feat(agent): docs-first answers for product questions, offer before acting

### DIFF
--- a/mcpjam-inspector/server/routes/web/__tests__/mcpjam-agent.ui-only.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/mcpjam-agent.ui-only.test.ts
@@ -90,6 +90,16 @@ describe("web routes — mcpjam-agent is UI-only", () => {
     expect(args.prepare.systemPrompt).toContain("`ui_*` tools");
   });
 
+  it("steers product questions to docs-first, then offer-before-acting", async () => {
+    const args = await postAgentTurn();
+    expect(args.prepare.systemPrompt).toContain(
+      "search the MCPJam documentation first",
+    );
+    expect(args.prepare.systemPrompt).toContain("wait for a yes before acting");
+    // Brevity + honesty rails for the same answer path.
+    expect(args.prepare.systemPrompt).toContain("lead with the answer");
+  });
+
   it("ships the app atlas so the model knows what screens exist", async () => {
     const args = await postAgentTurn();
     expect(args.prepare.systemPrompt).toContain("screen by screen");

--- a/mcpjam-inspector/server/routes/web/mcpjam-agent.ts
+++ b/mcpjam-inspector/server/routes/web/mcpjam-agent.ts
@@ -118,8 +118,10 @@ function agentPlatformToolsEnabled(): boolean {
 const AGENT_IDENTITY_PROMPT = [
   "## You are the MCPJam in-app assistant",
   "You are embedded in the MCPJam inspector, sitting next to the user's own screen. You act by DRIVING THAT UI with the `ui_*` tools: every action you take lands in the app the user is looking at, and they watch it happen.",
-  "Prefer navigating and showing over describing. If the user asks where something is or how to do it, take them there instead of narrating the click path.",
-  "Use the documentation and web search tools to answer knowledge questions; use the `ui_*` tools to actually do things. You have no other way to act — when something isn't reachable through a `ui_*` tool, say so plainly rather than inventing a tool or claiming you did it.",
+  "When the user asks you to DO something (or where something is), drive the UI and take them there — prefer showing over describing.",
+  "When the user asks a QUESTION about the product — how something works, how to do something, what a feature can do — search the MCPJam documentation first and answer from what it says; the screen atlas below tells you where things live, not how they behave, so don't answer product behavior from it alone. Then, if you can carry the answer out in the app, offer to — and wait for a yes before acting.",
+  "Use web search for questions beyond MCPJam itself. You have no other way to act — when something isn't reachable through a `ui_*` tool, say so plainly rather than inventing a tool or claiming you did it.",
+  "Keep replies short: lead with the answer in a few sentences, no filler, no restating the question. If the docs don't settle it, say you're not sure rather than guessing.",
   "",
   // The atlas: what screens exist and what they're for. Derived from the
   // surface manifests, so a new screen joins the agent's map by existing


### PR DESCRIPTION
## What

The in-app agent answers product questions ("how do I add another client in playground") from the app atlas + its own memory instead of the connected `mcpjam-docs` server — and embellishes (it claimed the playground tests "a single server at a time", which the atlas itself contradicts). It also acts, or offers to navigate, before the user asked for action.

## How

Rewrites the steering lines of `AGENT_IDENTITY_PROMPT` (server/routes/web/mcpjam-agent.ts):

- **DO requests** ("do X", "take me to X") — unchanged: drive the UI, prefer showing over describing.
- **Product QUESTIONS** (how something works / how to do it / what a feature can do) — search the MCPJam documentation first and answer from it; the atlas is explicitly framed as "where things live, not how they behave". Then offer to carry the answer out in-app and **wait for a yes before acting**.
- **Brevity + honesty rails** — lead with the answer in a few sentences, no filler; if docs don't settle it, say "not sure" rather than guessing.

The prompt remains static per build, so the cacheable-prefix property is untouched. No tool/wiring changes — the docs server was already connected and preflighted every turn.

## Tests

New assertion block in `mcpjam-agent.ui-only.test.ts` pinning the docs-first, offer-before-acting, and brevity phrases; all 11 route tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-only behavior change with regression tests; no auth, data, or tool wiring changes.
> 
> **Overview**
> **Rewrites** the in-app agent’s `AGENT_IDENTITY_PROMPT` so **DO** requests still mean drive the UI and show rather than describe, while **product questions** must **search MCPJam docs first**, treat the screen atlas as navigation-only (not behavior), then **offer** in-app help and **wait for confirmation** before acting.
> 
> Adds **brevity and honesty** rails (lead with the answer; admit uncertainty when docs don’t cover it) and scopes **web search** to non-MCPJam topics. **No** MCP/tool wiring changes—the prompt stays static per build for cacheable prefixes.
> 
> **Tests** add assertions that the prepared system prompt includes the docs-first, offer-before-acting, and brevity phrases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9dbb5934f918ef28e59da5834ce8bb3c7c5c4a48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route product questions to the docs: the in-app agent now searches `mcpjam-docs` first and answers from it, not the screen atlas. It still drives the UI for DO requests, then offers to execute and waits for a yes; replies are brief and avoid guessing.

<sup>Written for commit 9dbb5934f918ef28e59da5834ce8bb3c7c5c4a48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

