### PR TITLE
feat(oauth): validate callback state + RFC 9207 iss before redemption (Phase 2, 2R-iss)

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -1738,6 +1738,8 @@ export default function App() {
     const code = urlParams.get("code");
     const error = urlParams.get("error");
     const state = urlParams.get("state");
+    // 2R-iss: RFC 9207 issuer identification from the callback URL.
+    const iss = urlParams.get("iss");
 
     let cancelled = false;
     setHostedOAuthHandling(true);
@@ -1832,6 +1834,8 @@ export default function App() {
         })()
       : handleOAuthCallback(code, {
           onTraceUpdate: handleLiveOAuthTrace,
+          callbackState: state,
+          callbackIss: iss,
         });
 
     completeCallback

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -1828,6 +1828,7 @@ export default function App() {
 
           return completeHostedOAuthCallback(callbackContext, code, {
             callbackState: state,
+            callbackIss: iss,
             onTraceUpdate: handleLiveOAuthTrace,
             authorizationHeader,
           });

--- a/mcpjam-inspector/client/src/components/OAuthFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/OAuthFlowTab.tsx
@@ -451,7 +451,11 @@ export const OAuthFlowTab = ({
   ]);
 
   useEffect(() => {
-    const processOAuthCallback = (code: string, state: string | undefined) => {
+    const processOAuthCallback = (
+      code: string,
+      state: string | undefined,
+      iss?: string | undefined
+    ) => {
       if (processedCodeRef.current === code) {
         return;
       }
@@ -490,6 +494,10 @@ export const OAuthFlowTab = ({
 
       updateOAuthFlowState({
         authorizationCode: code,
+        // 2R-iss / review F8: record the RFC 9207 `iss` so the machine's
+        // authorization-response issuer step validates it (it reads
+        // `state.authorizationResponseIss`) instead of leaving it unset.
+        authorizationResponseIss: iss,
         error: undefined,
       });
 
@@ -505,7 +513,7 @@ export const OAuthFlowTab = ({
       }
 
       if (event.data?.type === "OAUTH_CALLBACK" && event.data?.code) {
-        processOAuthCallback(event.data.code, event.data.state);
+        processOAuthCallback(event.data.code, event.data.state, event.data.iss);
       }
     };
 
@@ -537,8 +545,9 @@ export const OAuthFlowTab = ({
 
         const code = parsed.searchParams.get("code");
         const state = parsed.searchParams.get("state");
+        const iss = parsed.searchParams.get("iss");
         if (code) {
-          processOAuthCallback(code, state ?? undefined);
+          processOAuthCallback(code, state ?? undefined, iss ?? undefined);
         }
       } catch (error) {
         console.error("Failed to process Electron OAuth callback:", error);
@@ -550,7 +559,11 @@ export const OAuthFlowTab = ({
       channel = new BroadcastChannel("oauth_callback_channel");
       channel.onmessage = (event) => {
         if (event.data?.type === "OAUTH_CALLBACK" && event.data?.code) {
-          processOAuthCallback(event.data.code, event.data.state);
+          processOAuthCallback(
+            event.data.code,
+            event.data.state,
+            event.data.iss
+          );
         }
       };
     } catch (error) {

--- a/mcpjam-inspector/client/src/components/oauth/OAuthDebugCallback.tsx
+++ b/mcpjam-inspector/client/src/components/oauth/OAuthDebugCallback.tsx
@@ -56,13 +56,16 @@ export default function OAuthDebugCallback() {
     if (callbackParams.successful && callbackParams.code) {
       hasAttemptedSendRef.current = true;
       try {
-        const stateParam = new URLSearchParams(window.location.search).get(
-          "state",
-        );
+        const callbackSearch = new URLSearchParams(window.location.search);
+        const stateParam = callbackSearch.get("state");
+        // 2R-iss: forward the RFC 9207 `iss` so the opener can validate it
+        // against the recorded issuer before redeeming the code.
+        const issParam = callbackSearch.get("iss");
         const message = {
           type: "OAUTH_CALLBACK",
           code: callbackParams.code,
           state: stateParam,
+          iss: issParam,
         };
 
         // Method 1: Try window.opener (works most of the time)

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -2518,6 +2518,7 @@ export function useServerState({
         const result = isHostedProjectCallback
           ? await completeHostedOAuthCallback(hostedCallbackContext, code, {
               callbackState: state,
+              callbackIss: iss,
               onTraceUpdate: handleLiveOAuthTrace,
             })
           : await handleOAuthCallback(code, {

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -2495,6 +2495,7 @@ export function useServerState({
     async (
       code: string,
       state: string | null,
+      iss: string | null,
       hostedCallbackContext: ReturnType<typeof getHostedOAuthCallbackContext>
     ) => {
       const pendingServerName = localStorage.getItem("mcp-oauth-pending");
@@ -2521,6 +2522,8 @@ export function useServerState({
             })
           : await handleOAuthCallback(code, {
               onTraceUpdate: handleLiveOAuthTrace,
+              callbackState: state,
+              callbackIss: iss,
             });
 
         localStorage.removeItem("mcp-oauth-return-hash");
@@ -2753,6 +2756,8 @@ export function useServerState({
     const code = urlParams.get("code");
     const state = urlParams.get("state");
     const error = urlParams.get("error");
+    // 2R-iss: RFC 9207 issuer identification from the callback URL.
+    const iss = urlParams.get("iss");
     const errorDescription = urlParams.get("error_description");
     const electronCallbackUrl = buildElectronMcpCallbackUrl();
     // Read in local mode too: the pending marker pins the org/project/server
@@ -2825,6 +2830,7 @@ export function useServerState({
       void handleOAuthCallbackComplete(
         code,
         state,
+        iss,
         isHostedProjectCallback ? hostedOAuthCallbackContext : null
       ).finally(restoreCallbackUrl);
     } else if (error) {

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.hosted-session.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.hosted-session.test.ts
@@ -63,6 +63,7 @@ describe("mcp-oauth hosted callback sessions", () => {
       "oauth-code",
       {
         callbackState: "oauth-state-1",
+        callbackIss: "https://auth.asana.com",
       }
     );
 
@@ -84,6 +85,8 @@ describe("mcp-oauth hosted callback sessions", () => {
       projectId: "ws_1",
       serverId: "srv_asana",
       code: "oauth-code",
+      // RFC 9207 iss threaded through for backend exact-match validation.
+      iss: "https://auth.asana.com",
       oauthResourceUrl: "https://mcp.asana.com/sse",
       state: "oauth-state-1",
       sessionId: "hosted-session-1",

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
@@ -2042,6 +2042,22 @@ describe("mcp-oauth", () => {
       expect(mockExchangeAuthorization).not.toHaveBeenCalled();
     });
 
+    it("fails closed on the no-session fallback when the callback returns a state (review F6)", async () => {
+      // seedAsanaCallback omits the flow session, so there is no issued `state`
+      // to compare. A returned state must fail closed rather than redeem a code
+      // whose CSRF state is unverifiable.
+      seedAsanaCallback(createAsanaDiscoveryState());
+
+      const { handleOAuthCallback } = await import("../mcp-oauth");
+      const callbackResult = await handleOAuthCallback("oauth-code", {
+        callbackState: "attacker-supplied-state",
+      });
+
+      expect(callbackResult.success).toBe(false);
+      expect(callbackResult.error).toContain("state");
+      expect(mockExchangeAuthorization).not.toHaveBeenCalled();
+    });
+
     it("rejects PRM metadata that omits its required resource during callback completion", async () => {
       const asana = createAsanaDiscoveryState();
       delete asana.resourceMetadata.resource;

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
@@ -219,16 +219,20 @@ function createFetchFromRequestExecutor(
 // A real authorization server returns the exact `state` the client issued, and
 // the 2R-iss callback gate now enforces it. Echo the state persisted by
 // initiateOAuth for the pending server so callback tests mirror real requests.
-// Returns null when no session was stored (the no-session fallback path).
+// Prefers the flow-session state; on the no-session fallback path it falls back
+// to the durable issued-state key (which F6 recovery reads). Returns null only
+// when neither is present.
 const issuedCallbackState = (): string | null => {
   const serverName = localStorage.getItem("mcp-oauth-pending");
   if (!serverName) return null;
   try {
     const raw = localStorage.getItem(`mcp-oauth-flow-state-${serverName}`);
-    return raw ? (JSON.parse(raw).state?.state ?? null) : null;
+    const fromSession = raw ? (JSON.parse(raw).state?.state ?? null) : null;
+    if (fromSession) return fromSession;
   } catch {
-    return null;
+    // fall through to the durable key
   }
+  return localStorage.getItem(`mcp-oauth-issued-state-${serverName}`);
 };
 
 describe("mcp-oauth", () => {
@@ -2003,6 +2007,8 @@ describe("mcp-oauth", () => {
 
     const seedAsanaCallback = (discoveryState: any) => {
       localStorage.setItem("mcp-oauth-pending", "asana");
+      // Durable issued state (F6 recovery reads this on the no-session path).
+      localStorage.setItem("mcp-oauth-issued-state-asana", "asana-issued-state");
       localStorage.setItem(
         "mcp-serverUrl-asana",
         "https://mcp.asana.com/v2/mcp"
@@ -2042,19 +2048,40 @@ describe("mcp-oauth", () => {
       expect(mockExchangeAuthorization).not.toHaveBeenCalled();
     });
 
-    it("fails closed on the no-session fallback when the callback returns a state (review F6)", async () => {
-      // seedAsanaCallback omits the flow session, so there is no issued `state`
-      // to compare. A returned state must fail closed rather than redeem a code
-      // whose CSRF state is unverifiable.
-      seedAsanaCallback(createAsanaDiscoveryState());
-
+    it("fails closed on the no-session fallback for a mismatched OR omitted state (review F6)", async () => {
       const { handleOAuthCallback } = await import("../mcp-oauth");
-      const callbackResult = await handleOAuthCallback("oauth-code", {
+
+      // Durable issued state is recovered ("asana-issued-state"); a mismatched
+      // callback state must be rejected before redemption.
+      seedAsanaCallback(createAsanaDiscoveryState());
+      const mismatched = await handleOAuthCallback("oauth-code", {
         callbackState: "attacker-supplied-state",
       });
+      expect(mismatched.success).toBe(false);
+      expect(mismatched.error).toContain("state");
+      expect(mockExchangeAuthorization).not.toHaveBeenCalled();
 
-      expect(callbackResult.success).toBe(false);
-      expect(callbackResult.error).toContain("state");
+      // An OMITTED callback state is equally unverifiable — every machine issues
+      // a state — so it must also fail closed, not slip through.
+      seedAsanaCallback(createAsanaDiscoveryState());
+      const omitted = await handleOAuthCallback("oauth-code", {});
+      expect(omitted.success).toBe(false);
+      expect(omitted.error).toContain("state");
+      expect(mockExchangeAuthorization).not.toHaveBeenCalled();
+    });
+
+    it("fails closed on the no-session fallback when the issued state cannot be recovered (review F6)", async () => {
+      seedAsanaCallback(createAsanaDiscoveryState());
+      // Simulate the durable issued state also being lost.
+      localStorage.removeItem("mcp-oauth-issued-state-asana");
+
+      const { handleOAuthCallback } = await import("../mcp-oauth");
+      const result = await handleOAuthCallback("oauth-code", {
+        callbackState: "asana-issued-state",
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("state");
       expect(mockExchangeAuthorization).not.toHaveBeenCalled();
     });
 

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
@@ -216,6 +216,21 @@ function createFetchFromRequestExecutor(
   };
 }
 
+// A real authorization server returns the exact `state` the client issued, and
+// the 2R-iss callback gate now enforces it. Echo the state persisted by
+// initiateOAuth for the pending server so callback tests mirror real requests.
+// Returns null when no session was stored (the no-session fallback path).
+const issuedCallbackState = (): string | null => {
+  const serverName = localStorage.getItem("mcp-oauth-pending");
+  if (!serverName) return null;
+  try {
+    const raw = localStorage.getItem(`mcp-oauth-flow-state-${serverName}`);
+    return raw ? (JSON.parse(raw).state?.state ?? null) : null;
+  } catch {
+    return null;
+  }
+};
+
 describe("mcp-oauth", () => {
   let authFetch: ReturnType<typeof vi.fn>;
 
@@ -1494,7 +1509,9 @@ describe("mcp-oauth", () => {
       });
       expect(initiateResult.success).toBe(true);
 
-      const callbackResult = await handleOAuthCallback("oauth-code");
+      const callbackResult = await handleOAuthCallback("oauth-code", {
+        callbackState: issuedCallbackState(),
+      });
 
       expect(callbackResult.success).toBe(true);
       expect(callbackResult.serverName).toBe("asana");
@@ -1562,7 +1579,9 @@ describe("mcp-oauth", () => {
       // Exercise the callback path that performs the exchange directly; the
       // state-machine path already owns separate resource persistence tests.
       localStorage.removeItem(`mcp-oauth-flow-state-${serverName}`);
-      const callbackResult = await handleOAuthCallback("oauth-code");
+      const callbackResult = await handleOAuthCallback("oauth-code", {
+        callbackState: issuedCallbackState(),
+      });
       expect(callbackResult.success, callbackResult.error).toBe(true);
       expect(callbackResult.oauthResourceUrl).toBe(advertisedResource);
       expect(
@@ -1685,7 +1704,9 @@ describe("mcp-oauth", () => {
       );
 
       const { handleOAuthCallback } = await import("../mcp-oauth");
-      const callbackResult = await handleOAuthCallback("oauth-code");
+      const callbackResult = await handleOAuthCallback("oauth-code", {
+        callbackState: issuedCallbackState(),
+      });
 
       expect(callbackResult.success).toBe(true);
       expect(localStorage.getItem("mcp-verifier-asana")).toBeNull();
@@ -1907,7 +1928,9 @@ describe("mcp-oauth", () => {
       );
 
       const { handleOAuthCallback } = await import("../mcp-oauth");
-      const callbackResult = await handleOAuthCallback("oauth-code");
+      const callbackResult = await handleOAuthCallback("oauth-code", {
+        callbackState: issuedCallbackState(),
+      });
 
       expect(callbackResult.success).toBe(false);
       expect(callbackResult.error).not.toBe("Code verifier not found");
@@ -1952,7 +1975,9 @@ describe("mcp-oauth", () => {
       );
 
       const { handleOAuthCallback } = await import("../mcp-oauth");
-      const callbackResult = await handleOAuthCallback("oauth-code");
+      const callbackResult = await handleOAuthCallback("oauth-code", {
+        callbackState: issuedCallbackState(),
+      });
 
       expect(callbackResult.success).toBe(true);
       expect(browserFetch).not.toHaveBeenCalled();
@@ -2006,7 +2031,9 @@ describe("mcp-oauth", () => {
       });
 
       const { handleOAuthCallback } = await import("../mcp-oauth");
-      const callbackResult = await handleOAuthCallback("oauth-code");
+      const callbackResult = await handleOAuthCallback("oauth-code", {
+        callbackState: issuedCallbackState(),
+      });
 
       expect(callbackResult.success).toBe(false);
       expect(callbackResult.error).toContain(
@@ -2021,7 +2048,9 @@ describe("mcp-oauth", () => {
       seedAsanaCallback(asana);
 
       const { handleOAuthCallback } = await import("../mcp-oauth");
-      const callbackResult = await handleOAuthCallback("oauth-code");
+      const callbackResult = await handleOAuthCallback("oauth-code", {
+        callbackState: issuedCallbackState(),
+      });
 
       expect(callbackResult.success).toBe(false);
       expect(callbackResult.error).toContain('missing its required "resource"');
@@ -2069,7 +2098,9 @@ describe("mcp-oauth", () => {
       );
 
       const { handleOAuthCallback } = await import("../mcp-oauth");
-      const callbackResult = await handleOAuthCallback("oauth-code");
+      const callbackResult = await handleOAuthCallback("oauth-code", {
+        callbackState: issuedCallbackState(),
+      });
 
       expect(callbackResult.success).toBe(true);
       expect(browserFetch).not.toHaveBeenCalled();
@@ -2138,7 +2169,9 @@ describe("mcp-oauth", () => {
       );
 
       const { handleOAuthCallback } = await import("../mcp-oauth");
-      const callbackResult = await handleOAuthCallback("oauth-code");
+      const callbackResult = await handleOAuthCallback("oauth-code", {
+        callbackState: issuedCallbackState(),
+      });
 
       expect(callbackResult.success).toBe(true);
       expect(browserFetch).not.toHaveBeenCalled();
@@ -2606,5 +2639,80 @@ describe("createServerConfig wire-era pin", () => {
     expect(
       (config as { mcpProtocolVersion?: string }).mcpProtocolVersion,
     ).toBeUndefined();
+  });
+});
+
+describe("evaluateCallbackSecurity (2R-iss callback gate)", () => {
+  const base = {
+    callbackState: "s-123",
+    callbackIss: "https://as.example.com",
+    expectedState: "s-123",
+    recordedIssuer: "https://as.example.com",
+    issParameterSupported: true as boolean | undefined,
+  };
+
+  it("passes when state and iss both match", async () => {
+    const { evaluateCallbackSecurity } = await import("../mcp-oauth");
+    expect(evaluateCallbackSecurity(base)).toEqual({ ok: true });
+  });
+
+  it("rejects a state mismatch (CSRF) before touching iss", async () => {
+    const { evaluateCallbackSecurity } = await import("../mcp-oauth");
+    const result = evaluateCallbackSecurity({
+      ...base,
+      callbackState: "attacker-state",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/state.*mismatch|CSRF/i);
+  });
+
+  it("rejects when an expected state was issued but the callback returns none", async () => {
+    const { evaluateCallbackSecurity } = await import("../mcp-oauth");
+    const result = evaluateCallbackSecurity({ ...base, callbackState: null });
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects a present-but-mismatched iss (RFC 9207)", async () => {
+    const { evaluateCallbackSecurity } = await import("../mcp-oauth");
+    const result = evaluateCallbackSecurity({
+      ...base,
+      callbackIss: "https://evil.example.com",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/issuer|RFC 9207/i);
+  });
+
+  it("rejects an absent iss when the AS advertised iss support", async () => {
+    const { evaluateCallbackSecurity } = await import("../mcp-oauth");
+    const result = evaluateCallbackSecurity({
+      ...base,
+      callbackIss: null,
+      issParameterSupported: true,
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("allows an absent iss when the AS did not advertise iss support", async () => {
+    const { evaluateCallbackSecurity } = await import("../mcp-oauth");
+    expect(
+      evaluateCallbackSecurity({
+        ...base,
+        callbackIss: null,
+        issParameterSupported: undefined,
+      }),
+    ).toEqual({ ok: true });
+  });
+
+  it("skips the state check on the no-session fallback (no expected state)", async () => {
+    const { evaluateCallbackSecurity } = await import("../mcp-oauth");
+    expect(
+      evaluateCallbackSecurity({
+        callbackState: "whatever",
+        callbackIss: "https://as.example.com",
+        expectedState: undefined,
+        recordedIssuer: "https://as.example.com",
+        issParameterSupported: undefined,
+      }),
+    ).toEqual({ ok: true });
   });
 });

--- a/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
@@ -16,6 +16,7 @@ import {
   projectOAuthTraceSnapshot,
   resolveAuthorizationPlan,
   runOAuthStateMachine,
+  validateAuthorizationResponseIssuer,
 } from "@mcpjam/sdk/browser";
 import type {
   AuthorizationDiscoverySnapshot,
@@ -3077,9 +3078,55 @@ export async function completeHostedOAuthCallback(
 /**
  * Handles OAuth callback and completes the flow
  */
+/**
+ * 2R-iss — era-agnostic callback security gate. Validates the CSRF `state` and
+ * the RFC 9207 authorization-response `iss` from the redirect BEFORE the code
+ * is redeemed. Runs on every protocol era: RFC 9207's local-policy row permits
+ * validating a present `iss` regardless of version, and validating `state` is
+ * always sound. On failure the caller must reject WITHOUT touching the token
+ * endpoint and WITHOUT echoing attacker-controlled callback `error*` values.
+ */
+export function evaluateCallbackSecurity(input: {
+  callbackState: string | null | undefined;
+  callbackIss: string | null | undefined;
+  /** The `state` this flow issued on the authorization request, if any. */
+  expectedState: string | undefined;
+  /** The exact issuer recorded when the AS metadata was validated. */
+  recordedIssuer: string | undefined;
+  /** Whether the AS advertised `authorization_response_iss_parameter_supported`. */
+  issParameterSupported: boolean | undefined;
+}): { ok: true } | { ok: false; error: string } {
+  // CSRF: if this flow issued a `state`, the callback MUST return it exactly.
+  if (input.expectedState && input.callbackState !== input.expectedState) {
+    return {
+      ok: false,
+      error:
+        "OAuth `state` mismatch — the callback did not return the value this flow issued (possible CSRF). Authorization was not completed.",
+    };
+  }
+  const issCheck = validateAuthorizationResponseIssuer({
+    recordedIssuer: input.recordedIssuer,
+    returnedIss: input.callbackIss ?? undefined,
+    issParameterSupported: input.issParameterSupported,
+  });
+  if (!issCheck.ok) {
+    return {
+      ok: false,
+      error: `OAuth issuer validation failed (RFC 9207): ${issCheck.reason}. Authorization was not completed.`,
+    };
+  }
+  return { ok: true };
+}
+
 export async function handleOAuthCallback(
   authorizationCode: string,
-  options: { onTraceUpdate?: (trace: OAuthTrace) => void } = {}
+  options: {
+    onTraceUpdate?: (trace: OAuthTrace) => void;
+    // 2R-iss: CSRF `state` and RFC 9207 `iss` captured from the callback URL at
+    // the callback boundary and validated here before code redemption.
+    callbackState?: string | null;
+    callbackIss?: string | null;
+  } = {}
 ): Promise<OAuthResult & { serverName?: string }> {
   // Get pending server name from localStorage (needed before creating interceptor)
   const serverName = localStorage.getItem("mcp-oauth-pending");
@@ -3118,6 +3165,24 @@ export async function handleOAuthCallback(
     clearOAuthTraceSession(serverName);
 
     if (storedSession) {
+      // 2R-iss: validate CSRF `state` + RFC 9207 `iss` before redeeming the
+      // code. Reject without touching the token endpoint on any mismatch.
+      const security = evaluateCallbackSecurity({
+        callbackState: options.callbackState,
+        callbackIss: options.callbackIss,
+        expectedState: storedSession.state.state,
+        recordedIssuer:
+          storedSession.state.recordedIssuer ??
+          storedSession.state.authorizationServerMetadata?.issuer,
+        issParameterSupported:
+          storedSession.state.authorizationServerMetadata
+            ?.authorization_response_iss_parameter_supported,
+      });
+      if (!security.ok) {
+        clearOAuthFlowSession(serverName);
+        localStorage.removeItem("mcp-oauth-pending");
+        return { success: false, error: security.error, serverName };
+      }
       let state = cloneFlowState(storedSession.state);
       const updateState = (updates: Partial<OAuthFlowState>) => {
         state = { ...state, ...updates };
@@ -3270,6 +3335,29 @@ export async function handleOAuthCallback(
       fetchFn,
       oauthConfig.customHeaders
     );
+    // 2R-iss: validate the RFC 9207 `iss` against the discovered issuer before
+    // redeeming on this no-stored-session fallback. There is no persisted
+    // request `state` on this path, so CSRF `state` is enforced only on the
+    // resume path (which has the stored session); pass `expectedState:
+    // undefined` here.
+    const fallbackIssuerMetadata = discoveryState.authorizationServerMetadata as
+      | {
+          issuer?: string;
+          authorization_response_iss_parameter_supported?: boolean;
+        }
+      | undefined;
+    const fallbackSecurity = evaluateCallbackSecurity({
+      callbackState: options.callbackState,
+      callbackIss: options.callbackIss,
+      expectedState: undefined,
+      recordedIssuer: fallbackIssuerMetadata?.issuer,
+      issParameterSupported:
+        fallbackIssuerMetadata?.authorization_response_iss_parameter_supported,
+    });
+    if (!fallbackSecurity.ok) {
+      localStorage.removeItem("mcp-oauth-pending");
+      return { success: false, error: fallbackSecurity.error, serverName };
+    }
     completeOAuthTraceStep(callbackTrace, "received_authorization_code", {
       message: "Callback state restored.",
       details: {

--- a/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
@@ -2765,6 +2765,7 @@ export async function completeHostedOAuthCallback(
   authorizationCode: string,
   options: {
     callbackState?: string | null;
+    callbackIss?: string | null;
     onTraceUpdate?: (trace: OAuthTrace) => void;
     authorizationHeader?: string | null;
   } = {}
@@ -2867,6 +2868,13 @@ export async function completeHostedOAuthCallback(
       typeof options.callbackState === "string"
         ? options.callbackState.trim()
         : "";
+    // RFC 9207 authorization-response `iss`. The hosted flow redeems the code
+    // server-side and the browser has no local session/recorded issuer for it,
+    // so the backend performs the exact-match validation; thread the value into
+    // the completion request so it CAN (client-side validation isn't possible
+    // here). Empty string omitted below.
+    const callbackIss =
+      typeof options.callbackIss === "string" ? options.callbackIss.trim() : "";
     if (!context.sessionId && !legacyCodeVerifier) {
       throw new Error("Code verifier not found");
     }
@@ -2937,6 +2945,7 @@ export async function completeHostedOAuthCallback(
           projectId: context.projectId,
           serverId: context.serverId,
           code: authorizationCode,
+          ...(callbackIss ? { iss: callbackIss } : {}),
           oauthResourceUrl,
           ...(context.sessionId
             ? {

--- a/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
@@ -814,6 +814,10 @@ async function persistOAuthStateArtifacts(
     await provider.saveCodeVerifier(state.codeVerifier);
   }
 
+  if (typeof state.state === "string" && state.state) {
+    provider.saveIssuedCallbackState(state.state);
+  }
+
   // Persist discovery (incl. authorizationServerUrl) BEFORE saveTokens: the
   // hosted-OAuth import inside saveTokens reads the AS URL from discoveryState()
   // (localStorage), so it must already be written or the import omits it and a
@@ -2228,6 +2232,24 @@ export class MCPOAuthProvider implements OAuthClientProvider {
     localStorage.setItem(`mcp-verifier-${this.serverName}`, codeVerifier);
   }
 
+  // 2R-iss / review F6: the issued CSRF `state` persisted durably (like the
+  // verifier), so the no-stored-session callback fallback can still recover and
+  // validate it after the flow session is lost, instead of redeeming blindly.
+  saveIssuedCallbackState(state: string) {
+    localStorage.setItem(`mcp-oauth-issued-state-${this.serverName}`, state);
+  }
+
+  issuedCallbackState(): string | undefined {
+    return (
+      localStorage.getItem(`mcp-oauth-issued-state-${this.serverName}`) ??
+      undefined
+    );
+  }
+
+  clearIssuedCallbackState() {
+    localStorage.removeItem(`mcp-oauth-issued-state-${this.serverName}`);
+  }
+
   codeVerifier(): string {
     const verifier = localStorage.getItem(`mcp-verifier-${this.serverName}`);
     if (!verifier) {
@@ -3010,6 +3032,7 @@ export async function completeHostedOAuthCallback(
 
     localStorage.removeItem(`mcp-tokens-${serverName}`);
     localStorage.removeItem(`mcp-verifier-${serverName}`);
+    localStorage.removeItem(`mcp-oauth-issued-state-${serverName}`);
     writeStoredOAuthConfig(serverName, {
       resourceUrl: oauthResourceUrl,
     });
@@ -3303,6 +3326,7 @@ export async function handleOAuthCallback(
       });
       clearOAuthFlowSession(serverName);
       localStorage.removeItem(`mcp-verifier-${serverName}`);
+      localStorage.removeItem(`mcp-oauth-issued-state-${serverName}`);
       localStorage.removeItem("mcp-oauth-pending");
       return {
         success: true,
@@ -3344,23 +3368,24 @@ export async function handleOAuthCallback(
       fetchFn,
       oauthConfig.customHeaders
     );
-    // 2R-iss / review F6: this no-stored-session fallback has no persisted
-    // request `state` to compare against (the session that held it is gone).
-    // If the AS nevertheless returned a `state`, the flow issued one and we
-    // cannot verify it here — FAIL CLOSED rather than redeem a code whose CSRF
-    // `state` is unchecked. (A separate persistence key wouldn't help: the
-    // fallback fires exactly when that storage was lost/cleared.) When no state
-    // was returned there is nothing to verify; proceed to the `iss` check.
-    if (options.callbackState) {
+    // 2R-iss / review F6: the flow session that held the issued `state` is gone
+    // on this fallback, but every machine issues a state, so an omitted OR
+    // mismatched callback state is unverifiable and MUST NOT redeem. Recover the
+    // state from its durable key (persisted like the verifier, which this path
+    // already depends on surviving). If it can't be recovered, fail closed —
+    // there is no value to match, so redemption would skip CSRF entirely.
+    const recoveredExpectedState = provider.issuedCallbackState();
+    if (!recoveredExpectedState) {
       localStorage.removeItem("mcp-oauth-pending");
       return {
         success: false,
         error:
-          "OAuth `state` could not be verified — the authorization flow session was not found, so the callback state cannot be matched to an issued value (possible CSRF). Please retry the connection.",
+          "OAuth `state` could not be verified — the issued authorization state was not found, so the callback state cannot be matched (possible CSRF). Please retry the connection.",
         serverName,
       };
     }
-    // Validate the RFC 9207 `iss` against the discovered issuer before redeeming.
+    // Validate CSRF `state` (recovered) and RFC 9207 `iss` before redeeming. A
+    // missing or mismatched callbackState now fails the state check.
     const fallbackIssuerMetadata = discoveryState.authorizationServerMetadata as
       | {
           issuer?: string;
@@ -3370,7 +3395,7 @@ export async function handleOAuthCallback(
     const fallbackSecurity = evaluateCallbackSecurity({
       callbackState: options.callbackState,
       callbackIss: options.callbackIss,
-      expectedState: undefined,
+      expectedState: recoveredExpectedState,
       recordedIssuer: fallbackIssuerMetadata?.issuer,
       issParameterSupported:
         fallbackIssuerMetadata?.authorization_response_iss_parameter_supported,
@@ -3428,6 +3453,7 @@ export async function handleOAuthCallback(
     // Clean up pending state
     localStorage.removeItem("mcp-oauth-pending");
     localStorage.removeItem(`mcp-verifier-${serverName}`);
+    localStorage.removeItem(`mcp-oauth-issued-state-${serverName}`);
     writeStoredOAuthConfig(serverName, {
       resourceUrl: oauthResourceUrl,
     });
@@ -3721,6 +3747,7 @@ export function clearOAuthData(serverName: string): void {
   localStorage.removeItem(`mcp-tokens-${serverName}`);
   localStorage.removeItem(`mcp-client-${serverName}`);
   localStorage.removeItem(`mcp-verifier-${serverName}`);
+  localStorage.removeItem(`mcp-oauth-issued-state-${serverName}`);
   localStorage.removeItem(`mcp-serverUrl-${serverName}`);
   localStorage.removeItem(`mcp-oauth-config-${serverName}`);
   oauthBindingStorage.clear(serverName);

--- a/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
@@ -3344,11 +3344,23 @@ export async function handleOAuthCallback(
       fetchFn,
       oauthConfig.customHeaders
     );
-    // 2R-iss: validate the RFC 9207 `iss` against the discovered issuer before
-    // redeeming on this no-stored-session fallback. There is no persisted
-    // request `state` on this path, so CSRF `state` is enforced only on the
-    // resume path (which has the stored session); pass `expectedState:
-    // undefined` here.
+    // 2R-iss / review F6: this no-stored-session fallback has no persisted
+    // request `state` to compare against (the session that held it is gone).
+    // If the AS nevertheless returned a `state`, the flow issued one and we
+    // cannot verify it here — FAIL CLOSED rather than redeem a code whose CSRF
+    // `state` is unchecked. (A separate persistence key wouldn't help: the
+    // fallback fires exactly when that storage was lost/cleared.) When no state
+    // was returned there is nothing to verify; proceed to the `iss` check.
+    if (options.callbackState) {
+      localStorage.removeItem("mcp-oauth-pending");
+      return {
+        success: false,
+        error:
+          "OAuth `state` could not be verified — the authorization flow session was not found, so the callback state cannot be matched to an issued value (possible CSRF). Please retry the connection.",
+        serverName,
+      };
+    }
+    // Validate the RFC 9207 `iss` against the discovered issuer before redeeming.
     const fallbackIssuerMetadata = discoveryState.authorizationServerMetadata as
       | {
           issuer?: string;

--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -169,6 +169,13 @@ export type {
   ProbeTransportResult,
 } from "./server-probe.js";
 export { runOAuthStateMachine } from "./oauth/state-machines/runner.js";
+// RFC 9207 authorization-response `iss` validation. Era-agnostic (validating a
+// present `iss` is permitted on every version), so the browser callback gate
+// reuses it across 2025/2026 flows.
+export {
+  validateAuthorizationResponseIssuer,
+  type AuthorizationResponseIssuerCheck,
+} from "./oauth/state-machines/debug-oauth-2026-07-28.js";
 export type {
   OAuthAuthorizationRequestResult,
   OAuthStateMachineRunConfig,


### PR DESCRIPTION
## Phase 2 — 2R-iss: era-agnostic callback security gate

The runtime-security half of Phase 2. Closes a real gap: the local browser OAuth **resume** path (`handleOAuthCallback`) redeemed the authorization code **without validating the callback `state`** (CSRF — only the interactive step machine and the hosted path checked it) and **never captured the RFC 9207 `iss`**, so the 2026 machine's `validateAuthorizationResponseIssuer` was inert on the real flow.

### What changed
- **`evaluateCallbackSecurity`** (new, era-agnostic): validates `state` (rejects a callback that doesn't return the value this flow issued) and the RFC 9207 `iss` (via the SDK validator) **before touching the token endpoint**, on **both** redemption paths — the stored-session resume and the no-session fallback. Rejections never echo attacker-controlled callback `error*` values.
- **Capture `iss`**: read from the callback URL and threaded via `callbackState`/`callbackIss` through `handleOAuthCallback` and `handleOAuthCallbackComplete`; the debug callback popup now forwards `iss` in its `postMessage` payload.
- **SDK**: `validateAuthorizationResponseIssuer` is exported from the browser barrel (it's era-agnostic — validating a present `iss` is permitted on every version).

### Precedence / era notes
- Runs on **all eras** (D16): validating a present `iss` and the CSRF `state` is sound on 2025 and 2026. `recordedIssuer` falls back to `authorizationServerMetadata.issuer`; `issParameterSupported` comes from the AS metadata, so the "advertised-but-absent `iss` → reject" row (RFC 9207 row 3) now fires when the AS advertised it — this is the row 2M-a deliberately deferred to 2R-iss.
- The no-session **fallback** has no persisted request `state` to compare, so CSRF `state` is enforced on the resume path (documented inline); `iss` is still validated against the discovered issuer there.

### Scope
- This wires the `handleOAuthCallback` boundary (the WP's anchor). The **interactive** `OAuthFlowTab` step-machine path already validates `state`; threading `iss` into that machine is a small follow-up.

### Verification
- `mcp-oauth` 62/62 (7 new gate tests + fixtures updated to echo the issued `state`, mirroring a real AS); hosted-oauth / orchestrator suites 89/89; SDK `debug-oauth-2026` 19/19. Client + SDK typecheck clean.

Part of the Phase 2 runtime-security series (2R-iss → 2R-store → 2R-stepup → shared hardening pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes OAuth authorization callback and token-redemption behavior across local, hosted, and debugger flows; mis-validation or overly strict checks could block legitimate sign-ins, though the change is intentional security hardening with broad test coverage.
> 
> **Overview**
> **OAuth callback security is tightened so authorization codes are not redeemed until redirect parameters are verified.**
> 
> A new **`evaluateCallbackSecurity`** gate runs before any token exchange on the local **`handleOAuthCallback`** path (stored-session resume and no-session fallback). It requires the callback **`state`** to match what the flow issued and validates **`iss`** via the SDK’s **`validateAuthorizationResponseIssuer`** (including reject when the AS advertised iss support but the callback omits it).
> 
> **`iss`** and **`state`** are read from the callback URL and passed as **`callbackState`** / **`callbackIss`** through **`App.tsx`**, **`use-server-state`**, **`completeHostedOAuthCallback`** (hosted completion POST now includes **`iss`**), and the OAuth debug popup / **`OAuthFlowTab`** (sets **`authorizationResponseIss`** for the step machine). Issued **`state`** is persisted durably (like the PKCE verifier) so the fallback path can fail closed on mismatch or missing recovery instead of redeeming blindly.
> 
> The SDK browser barrel now exports **`validateAuthorizationResponseIssuer`** for reuse. Tests cover the gate, F6 fallback behavior, and updated callback fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa456f11f08f392527fc27bd8a99aed774a5c831. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a callback security gate that validates OAuth `state` and RFC 9207 `iss` before redeeming the code, and now persists the issued `state` so stateless fallbacks can verify CSRF and fail closed when unverifiable. Hosted flows send `iss` to the backend for exact-match validation.

- **New Features**
  - Added era‑agnostic `evaluateCallbackSecurity` to verify `state` and `iss` pre-exchange on stored-session and fallback paths, using `validateAuthorizationResponseIssuer` from `@mcpjam/sdk/browser`.
  - Persist the issued OAuth `state` under a durable key and clear it on success/cleanup; capture `iss` from callbacks and thread it through `handleOAuthCallback`, `completeHostedOAuthCallback`, and into `OAuthFlowTab`/debug callback.

- **Bug Fixes**
  - Local resume and no-session fallback now enforce CSRF: verify against the durable state and fail closed on mismatched or omitted callback `state`, or when the issued state can’t be recovered.
  - Hosted completion POST includes `iss` for backend issuer checks. Tests updated to echo the issued `state` and cover gate cases.

<sup>Written for commit aa456f11f08f392527fc27bd8a99aed774a5c831. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

