### PR TITLE
feat(oauth): runtime scope step-up core — union, challenge parse, policy split (2R-stepup)

### DIFF
--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/requested-scopes.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/requested-scopes.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  persistRequestedScopes,
+  readRequestedScopes,
+  stepUpScopeUnion,
+} from "../requested-scopes";
+
+const asA = "https://as-a.example.com";
+const asB = "https://as-b.example.com";
+const SERVER = "scoped-server";
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe("requested-scopes persistence (2R-stepup, §10.2#4)", () => {
+  it("persists and reads scopes for the exact issuer", () => {
+    persistRequestedScopes(SERVER, asA, ["read", "write"]);
+    expect(readRequestedScopes(SERVER, asA)).toEqual(["read", "write"]);
+  });
+
+  it("does not return AS A's scopes for AS B (SEP-2352)", () => {
+    persistRequestedScopes(SERVER, asA, ["read"]);
+    expect(readRequestedScopes(SERVER, asB)).toBeUndefined();
+  });
+
+  it("keeps each issuer's scopes in its own bucket", () => {
+    persistRequestedScopes(SERVER, asA, ["read"]);
+    persistRequestedScopes(SERVER, asB, ["admin"]);
+    expect(readRequestedScopes(SERVER, asA)).toEqual(["read"]);
+    expect(readRequestedScopes(SERVER, asB)).toEqual(["admin"]);
+  });
+
+  it("normalizes and de-duplicates on write", () => {
+    persistRequestedScopes(SERVER, asA, [" read ", "read", "write", ""]);
+    expect(readRequestedScopes(SERVER, asA)).toEqual(["read", "write"]);
+  });
+
+  it("no-ops for an unknown issuer or empty scopes", () => {
+    persistRequestedScopes(SERVER, undefined, ["read"]);
+    persistRequestedScopes(SERVER, asA, []);
+    expect(readRequestedScopes(SERVER, asA)).toBeUndefined();
+  });
+
+  it("unions persisted scopes with a 403 challenge for the step-up request", () => {
+    persistRequestedScopes(SERVER, asA, ["read", "write"]);
+    expect(stepUpScopeUnion(SERVER, asA, ["write", "admin"])).toEqual([
+      "read",
+      "write",
+      "admin",
+    ]);
+  });
+
+  it("unions only the challenged scopes when nothing was persisted for the issuer", () => {
+    persistRequestedScopes(SERVER, asA, ["read"]);
+    // A step-up against a different issuer must not fold in AS A's scopes.
+    expect(stepUpScopeUnion(SERVER, asB, ["admin"])).toEqual(["admin"]);
+  });
+});

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/requested-scopes.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/requested-scopes.test.ts
@@ -42,6 +42,20 @@ describe("requested-scopes persistence (2R-stepup, §10.2#4)", () => {
     expect(readRequestedScopes(SERVER, asA)).toBeUndefined();
   });
 
+  it("returns nothing when no issuer is supplied (no activeIssuer fallback)", () => {
+    persistRequestedScopes(SERVER, asA, ["read", "write"]);
+    // A read/step-up before issuer discovery must not reuse the active bucket.
+    expect(readRequestedScopes(SERVER, undefined)).toBeUndefined();
+    expect(stepUpScopeUnion(SERVER, undefined, ["admin"])).toEqual(["admin"]);
+  });
+
+  it("never reuses a legacy unkeyed scope record for any issuer", () => {
+    // A pre-migration record has no issuer binding; it must not be unioned in.
+    localStorage.setItem(`mcp-scopes-${SERVER}`, JSON.stringify(["legacy"]));
+    expect(readRequestedScopes(SERVER, asA)).toBeUndefined();
+    expect(stepUpScopeUnion(SERVER, asA, ["admin"])).toEqual(["admin"]);
+  });
+
   it("unions persisted scopes with a 403 challenge for the step-up request", () => {
     persistRequestedScopes(SERVER, asA, ["read", "write"]);
     expect(stepUpScopeUnion(SERVER, asA, ["write", "admin"])).toEqual([

--- a/mcpjam-inspector/client/src/lib/oauth/requested-scopes.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/requested-scopes.ts
@@ -49,15 +49,24 @@ export function readRequestedScopes(
   serverName: string,
   issuer: string | undefined,
 ): string[] | undefined {
+  // Never fall back to the envelope's `activeIssuer` (readIssuerKeyed's
+  // no-issuer default) or to a legacy unkeyed record here: a step-up before
+  // issuer discovery, or after an AS switch, must not union another AS's
+  // scopes into the re-authorization (SEP-2352). Only an exact issuer-bound
+  // record is reusable.
+  if (!issuer) {
+    return undefined;
+  }
   const store = getStore();
   if (!store) {
     return undefined;
   }
-  return readIssuerKeyed<string[]>(
+  const read = readIssuerKeyed<string[]>(
     store.getItem(storageKey(serverName)),
     issuer,
     parseLegacyScopes,
-  ).value;
+  );
+  return read.legacyUnbound ? undefined : read.value;
 }
 
 /**
@@ -78,12 +87,17 @@ export function persistRequestedScopes(
   if (normalized.length === 0) {
     return;
   }
-  const next = writeIssuerKeyed<string[]>(
-    store.getItem(storageKey(serverName)),
-    issuer,
-    normalized,
-  );
-  store.setItem(storageKey(serverName), JSON.stringify(next));
+  try {
+    const next = writeIssuerKeyed<string[]>(
+      store.getItem(storageKey(serverName)),
+      issuer,
+      normalized,
+    );
+    store.setItem(storageKey(serverName), JSON.stringify(next));
+  } catch {
+    // Best-effort persistence: a full/unavailable store (quota, private mode)
+    // must not abort the OAuth flow — the step-up simply unions less history.
+  }
 }
 
 /**

--- a/mcpjam-inspector/client/src/lib/oauth/requested-scopes.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/requested-scopes.ts
@@ -1,0 +1,103 @@
+/**
+ * 2R-stepup (SEP-2350, §10.2 item 4) — persisted requested scopes per issuer.
+ *
+ * A runtime scope step-up unions the scopes previously requested for a server's
+ * authorization-server issuer with the scopes a later `403 insufficient_scope`
+ * challenges. That union only exists if the previously-requested set survives
+ * across requests, so we persist it, keyed by exact issuer (reusing the 2R-store
+ * issuer-keyed store) — a scope set requested against AS A must never be unioned
+ * into a re-authorization against AS B.
+ */
+
+import { computeScopeUnion } from "@mcpjam/sdk/browser";
+import {
+  readIssuerKeyed,
+  writeIssuerKeyed,
+} from "./issuer-keyed-storage";
+
+const REQUESTED_SCOPES_PREFIX = "mcp-scopes-";
+
+function storageKey(serverName: string): string {
+  return `${REQUESTED_SCOPES_PREFIX}${serverName}`;
+}
+
+function getStore(): Storage | undefined {
+  try {
+    return typeof localStorage !== "undefined" ? localStorage : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Narrow a raw (pre-migration) parsed value to a scope array. */
+function parseLegacyScopes(parsed: unknown): string[] | undefined {
+  if (
+    Array.isArray(parsed) &&
+    parsed.every((scope) => typeof scope === "string")
+  ) {
+    return parsed as string[];
+  }
+  return undefined;
+}
+
+/**
+ * Read the scopes last requested for `serverName` against `issuer`. Returns
+ * `undefined` when nothing is stored for that exact issuer, so a step-up never
+ * unions another AS's scopes.
+ */
+export function readRequestedScopes(
+  serverName: string,
+  issuer: string | undefined,
+): string[] | undefined {
+  const store = getStore();
+  if (!store) {
+    return undefined;
+  }
+  return readIssuerKeyed<string[]>(
+    store.getItem(storageKey(serverName)),
+    issuer,
+    parseLegacyScopes,
+  ).value;
+}
+
+/**
+ * Persist the scopes requested for `serverName` against `issuer`. A known issuer
+ * promotes the record into the issuer-keyed store; an unknown issuer is a no-op
+ * (there is no binding to record yet — the next issuer-stamped save carries it).
+ */
+export function persistRequestedScopes(
+  serverName: string,
+  issuer: string | undefined,
+  scopes: string[] | undefined,
+): void {
+  const store = getStore();
+  if (!store || !issuer) {
+    return;
+  }
+  const normalized = computeScopeUnion(scopes);
+  if (normalized.length === 0) {
+    return;
+  }
+  const next = writeIssuerKeyed<string[]>(
+    store.getItem(storageKey(serverName)),
+    issuer,
+    normalized,
+  );
+  store.setItem(storageKey(serverName), JSON.stringify(next));
+}
+
+/**
+ * The scope set a step-up re-authorization should request: the union of the
+ * scopes previously requested for this issuer and the scopes challenged by the
+ * `403 insufficient_scope` response.
+ */
+export function stepUpScopeUnion(
+  serverName: string,
+  issuer: string | undefined,
+  challengedScopes: string[] | undefined,
+): string[] {
+  return computeScopeUnion(
+    readRequestedScopes(serverName, issuer),
+    challengedScopes,
+  );
+}

--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -176,6 +176,17 @@ export {
   validateAuthorizationResponseIssuer,
   type AuthorizationResponseIssuerCheck,
 } from "./oauth/state-machines/debug-oauth-2026-07-28.js";
+// SEP-2350 runtime scope step-up core (2R-stepup): scope union, insufficient-
+// scope challenge parsing, and the §10.5 interactive/M2M/debugger policy split.
+// Era-agnostic — the step-up decision lives at the runtime request boundary.
+export {
+  computeScopeUnion,
+  parseInsufficientScopeChallenge,
+  resolveStepUpAction,
+  type InsufficientScopeChallenge,
+  type StepUpAuthMode,
+  type StepUpAction,
+} from "./oauth/state-machines/shared/challenges.js";
 export type {
   OAuthAuthorizationRequestResult,
   OAuthStateMachineRunConfig,

--- a/sdk/src/oauth/state-machines/debug-oauth-2026-07-28.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2026-07-28.ts
@@ -41,6 +41,7 @@ import {
 } from "./shared/resource-indicator.js";
 import { buildStatelessVerifyRequestBody } from "./shared/initialize.js";
 import {
+  computeScopeUnion,
   parseBearerAuthenticateParameters,
   parseScopeString,
   resolveRequestedScopeValue,
@@ -88,7 +89,7 @@ function buildScopeUnionDetails(
     rows.push({ label: "requested scopes", value: requested.join(" ") });
   }
   if (challenged.length > 0) {
-    const union = Array.from(new Set([...requested, ...challenged]));
+    const union = computeScopeUnion(requested, challenged);
     rows.push({ label: "challenged scopes", value: challenged.join(" ") });
     rows.push({ label: "scope union", value: union.join(" ") });
   }

--- a/sdk/src/oauth/state-machines/shared/challenges.ts
+++ b/sdk/src/oauth/state-machines/shared/challenges.ts
@@ -33,6 +33,90 @@ export function parseScopeString(scopeValue?: string): string[] | undefined {
   return scopes.length > 0 ? Array.from(new Set(scopes)) : undefined;
 }
 
+/**
+ * SEP-2350 scope union. Returns the previously-requested scopes followed by any
+ * newly-challenged scopes not already present — order-preserving (previous
+ * first) and de-duplicated. This is the set a step-up re-authorization requests.
+ */
+export function computeScopeUnion(
+  previous?: string[],
+  challenged?: string[],
+): string[] {
+  const union: string[] = [];
+  const seen = new Set<string>();
+  for (const scope of [...(previous ?? []), ...(challenged ?? [])]) {
+    const trimmed = scope?.trim();
+    if (!trimmed || seen.has(trimmed)) {
+      continue;
+    }
+    seen.add(trimmed);
+    union.push(trimmed);
+  }
+  return union;
+}
+
+export interface InsufficientScopeChallenge {
+  /** True only when the `WWW-Authenticate` header carries `error="insufficient_scope"`. */
+  isInsufficientScope: boolean;
+  /** Scopes named by the challenge's `scope` parameter, if any. */
+  challengedScopes?: string[];
+  /** RFC 9728 `resource_metadata` pointer, if the challenge carried one. */
+  resourceMetadata?: string;
+}
+
+/**
+ * Parse a `403` `WWW-Authenticate: Bearer …` header for an insufficient-scope
+ * step-up challenge (RFC 6750 §3 / SEP-2350). Non-insufficient-scope challenges
+ * (e.g. `invalid_token`) return `isInsufficientScope: false` so callers do not
+ * mistake a plain 401 re-auth for a scope step-up.
+ */
+export function parseInsufficientScopeChallenge(
+  header?: string,
+): InsufficientScopeChallenge {
+  const params = parseBearerAuthenticateParameters(header);
+  const isInsufficientScope = params.error === "insufficient_scope";
+  return {
+    isInsufficientScope,
+    challengedScopes: parseScopeString(params.scope),
+    resourceMetadata: params.resource_metadata || undefined,
+  };
+}
+
+/** Where an insufficient-scope challenge is being handled — drives the policy split. */
+export type StepUpAuthMode = "interactive" | "m2m" | "debugger";
+
+/**
+ * What to do with an insufficient-scope challenge:
+ * - `reauthorize`: run a fresh authorization requesting the scope union;
+ * - `throw`: surface an `InsufficientScopeError` (no browser);
+ * - `manual`: let the user inspect and advance the step explicitly (debugger).
+ */
+export type StepUpAction = "reauthorize" | "throw" | "manual";
+
+/**
+ * §10.5 runtime step-up policy split with a bounded retry. `attempt` is the
+ * number of step-up re-authorizations ALREADY performed for this persisted
+ * client session (0 on the first challenge); once it reaches `maxRetries` the
+ * interactive path stops re-authorizing and throws, preventing an infinite
+ * cross-request loop (SDK per-request limits are not enough for a persisted
+ * session). M2M never opens a browser; the debugger advances by hand.
+ */
+export function resolveStepUpAction(input: {
+  authMode: StepUpAuthMode;
+  attempt: number;
+  maxRetries?: number;
+}): StepUpAction {
+  const maxRetries = input.maxRetries ?? 1;
+  switch (input.authMode) {
+    case "m2m":
+      return "throw";
+    case "debugger":
+      return "manual";
+    case "interactive":
+      return input.attempt < maxRetries ? "reauthorize" : "throw";
+  }
+}
+
 export function resolveRequestedScopeValue(input: {
   customScopes?: string;
   challengedScopes?: string[];

--- a/sdk/src/oauth/state-machines/shared/challenges.ts
+++ b/sdk/src/oauth/state-machines/shared/challenges.ts
@@ -79,12 +79,13 @@ export interface InsufficientScopeChallenge {
  * quote) into the Bearer parse. Tokenize quote-aware, group segments into
  * challenges (a segment that starts with `<scheme> <rest>` opens a new
  * challenge; a bare `key=value` segment continues the current one), and return
- * only the Bearer challenge's auth-params (last one wins), re-prefixed so the
- * delegated `Bearer …` parser reads exactly those.
+ * the parsed auth-params of EVERY Bearer challenge — the caller selects the
+ * applicable one (an `insufficient_scope` challenge must not be hidden by a
+ * later realm-only Bearer under last-challenge-wins).
  */
-function selectBearerChallenge(header?: string): string | undefined {
+function parseBearerChallenges(header?: string): Array<Record<string, string>> {
   if (!header) {
-    return undefined;
+    return [];
   }
 
   // Split on commas that are not inside a double-quoted string.
@@ -121,17 +122,21 @@ function selectBearerChallenge(header?: string): string | undefined {
     }
   }
 
-  // Last Bearer challenge wins (mirrors last-value-wins param parsing).
-  const bearer = challenges.filter((c) => c.scheme === "bearer").pop();
-  return bearer ? `Bearer ${bearer.params.join(", ")}` : undefined;
+  return challenges
+    .filter((c) => c.scheme === "bearer")
+    .map((c) => parseBearerAuthenticateParameters(`Bearer ${c.params.join(", ")}`));
 }
 
 export function parseInsufficientScopeChallenge(
   header?: string,
 ): InsufficientScopeChallenge {
-  const params = parseBearerAuthenticateParameters(
-    selectBearerChallenge(header),
-  );
+  const bearerChallenges = parseBearerChallenges(header);
+  // Select the insufficient_scope challenge among ALL Bearer challenges — a
+  // later realm-only Bearer must not hide an earlier insufficient_scope one.
+  const params =
+    bearerChallenges.find((p) => p.error === "insufficient_scope") ??
+    bearerChallenges[0] ??
+    {};
   const isInsufficientScope = params.error === "insufficient_scope";
   return {
     isInsufficientScope,

--- a/sdk/src/oauth/state-machines/shared/challenges.ts
+++ b/sdk/src/oauth/state-machines/shared/challenges.ts
@@ -70,10 +70,30 @@ export interface InsufficientScopeChallenge {
  * (e.g. `invalid_token`) return `isInsufficientScope: false` so callers do not
  * mistake a plain 401 re-auth for a scope step-up.
  */
+/**
+ * A `WWW-Authenticate` header may list several challenges (RFC 7235 §4.1), e.g.
+ * `Basic realm="x", Bearer error="insufficient_scope"`. The underlying parser
+ * only reads a header that STARTS with `Bearer`, so isolate the Bearer
+ * challenge first — from the last `Bearer ` token, whose auth-params run to the
+ * end of the header — before delegating.
+ */
+function selectBearerChallenge(header?: string): string | undefined {
+  if (!header) {
+    return undefined;
+  }
+  if (/^\s*Bearer\s/i.test(header)) {
+    return header;
+  }
+  const match = header.match(/(?:^|[,\s])(Bearer\s+.*)$/i);
+  return match ? match[1] : undefined;
+}
+
 export function parseInsufficientScopeChallenge(
   header?: string,
 ): InsufficientScopeChallenge {
-  const params = parseBearerAuthenticateParameters(header);
+  const params = parseBearerAuthenticateParameters(
+    selectBearerChallenge(header),
+  );
   const isInsufficientScope = params.error === "insufficient_scope";
   return {
     isInsufficientScope,
@@ -106,7 +126,13 @@ export function resolveStepUpAction(input: {
   attempt: number;
   maxRetries?: number;
 }): StepUpAction {
-  const maxRetries = input.maxRetries ?? 1;
+  // Guard the exported boundary against a non-finite/negative bound (e.g.
+  // Infinity), which would make `attempt < maxRetries` always true and defeat
+  // the loop protection. A non-integer or negative value falls back to 1.
+  const maxRetries =
+    Number.isInteger(input.maxRetries) && (input.maxRetries as number) >= 0
+      ? (input.maxRetries as number)
+      : 1;
   switch (input.authMode) {
     case "m2m":
       return "throw";

--- a/sdk/src/oauth/state-machines/shared/challenges.ts
+++ b/sdk/src/oauth/state-machines/shared/challenges.ts
@@ -72,20 +72,58 @@ export interface InsufficientScopeChallenge {
  */
 /**
  * A `WWW-Authenticate` header may list several challenges (RFC 7235 §4.1), e.g.
- * `Basic realm="x", Bearer error="insufficient_scope"`. The underlying parser
- * only reads a header that STARTS with `Bearer`, so isolate the Bearer
- * challenge first — from the last `Bearer ` token, whose auth-params run to the
- * end of the header — before delegating.
+ * `Basic realm="x", Bearer error="insufficient_scope", scope="a b"`. Both the
+ * challenge list AND each challenge's auth-params are comma-separated, and a
+ * quoted value may itself contain a comma — so a naive "slice from Bearer to
+ * end" would fold a LATER scheme's params (or a fabricated one hidden in a
+ * quote) into the Bearer parse. Tokenize quote-aware, group segments into
+ * challenges (a segment that starts with `<scheme> <rest>` opens a new
+ * challenge; a bare `key=value` segment continues the current one), and return
+ * only the Bearer challenge's auth-params (last one wins), re-prefixed so the
+ * delegated `Bearer …` parser reads exactly those.
  */
 function selectBearerChallenge(header?: string): string | undefined {
   if (!header) {
     return undefined;
   }
-  if (/^\s*Bearer\s/i.test(header)) {
-    return header;
+
+  // Split on commas that are not inside a double-quoted string.
+  const segments: string[] = [];
+  let buffer = "";
+  let inQuotes = false;
+  for (let i = 0; i < header.length; i++) {
+    const ch = header[i];
+    if (ch === '"') {
+      inQuotes = !inQuotes;
+      buffer += ch;
+    } else if (ch === "," && !inQuotes) {
+      segments.push(buffer);
+      buffer = "";
+    } else {
+      buffer += ch;
+    }
   }
-  const match = header.match(/(?:^|[,\s])(Bearer\s+.*)$/i);
-  return match ? match[1] : undefined;
+  segments.push(buffer);
+
+  // Group segments into challenges. A segment of the form `<scheme> <rest>`
+  // (a bare auth-scheme token followed by whitespace) opens a new challenge;
+  // an auth-param segment (`key=value`, no leading `<token> `) continues it.
+  const challenges: Array<{ scheme: string; params: string[] }> = [];
+  const CHALLENGE_START = /^([A-Za-z][A-Za-z0-9!#$%&'*+.^_`|~-]*)\s+(.+)$/s;
+  for (const raw of segments) {
+    const seg = raw.trim();
+    if (!seg) continue;
+    const start = CHALLENGE_START.exec(seg);
+    if (start) {
+      challenges.push({ scheme: start[1].toLowerCase(), params: [start[2]] });
+    } else if (challenges.length > 0) {
+      challenges[challenges.length - 1].params.push(seg);
+    }
+  }
+
+  // Last Bearer challenge wins (mirrors last-value-wins param parsing).
+  const bearer = challenges.filter((c) => c.scheme === "bearer").pop();
+  return bearer ? `Bearer ${bearer.params.join(", ")}` : undefined;
 }
 
 export function parseInsufficientScopeChallenge(

--- a/sdk/tests/oauth/scope-step-up.test.ts
+++ b/sdk/tests/oauth/scope-step-up.test.ts
@@ -44,6 +44,14 @@ describe("parseInsufficientScopeChallenge (RFC 6750 / SEP-2350)", () => {
     );
     expect(parseInsufficientScopeChallenge("").isInsufficientScope).toBe(false);
   });
+
+  it("finds the Bearer challenge when another scheme is listed first", () => {
+    const c = parseInsufficientScopeChallenge(
+      'Basic realm="x", Bearer error="insufficient_scope", scope="read write"',
+    );
+    expect(c.isInsufficientScope).toBe(true);
+    expect(c.challengedScopes).toEqual(["read", "write"]);
+  });
 });
 
 describe("resolveStepUpAction (§10.5 policy split, bounded retry)", () => {
@@ -64,6 +72,23 @@ describe("resolveStepUpAction (§10.5 policy split, bounded retry)", () => {
     expect(
       resolveStepUpAction({ authMode: "interactive", attempt: 2, maxRetries: 2 }),
     ).toBe("throw");
+  });
+
+  it("stays bounded when given a non-finite maxRetries (Infinity)", () => {
+    expect(
+      resolveStepUpAction({
+        authMode: "interactive",
+        attempt: 1,
+        maxRetries: Infinity,
+      }),
+    ).toBe("throw");
+    expect(
+      resolveStepUpAction({
+        authMode: "interactive",
+        attempt: 0,
+        maxRetries: Infinity,
+      }),
+    ).toBe("reauthorize");
   });
 
   it("never opens a browser for M2M", () => {

--- a/sdk/tests/oauth/scope-step-up.test.ts
+++ b/sdk/tests/oauth/scope-step-up.test.ts
@@ -52,6 +52,25 @@ describe("parseInsufficientScopeChallenge (RFC 6750 / SEP-2350)", () => {
     expect(c.isInsufficientScope).toBe(true);
     expect(c.challengedScopes).toEqual(["read", "write"]);
   });
+
+  it("does not let a LATER scheme's params bleed into the Bearer challenge", () => {
+    // The Basic challenge trailing Bearer carries error="insufficient_scope";
+    // it must NOT be attributed to Bearer (which here is a plain 401).
+    const c = parseInsufficientScopeChallenge(
+      'Bearer realm="mcp", Basic error="insufficient_scope", scope="admin"',
+    );
+    expect(c.isInsufficientScope).toBe(false);
+    expect(c.challengedScopes).toBeUndefined();
+  });
+
+  it("is not fooled by a fabricated challenge hidden inside a quoted value", () => {
+    // The quoted realm contains a comma and a fake `Bearer error=…`; quote-aware
+    // splitting keeps it as one Basic auth-param, so no insufficient_scope.
+    const c = parseInsufficientScopeChallenge(
+      'Basic realm="x, Bearer error=insufficient_scope"',
+    );
+    expect(c.isInsufficientScope).toBe(false);
+  });
 });
 
 describe("resolveStepUpAction (§10.5 policy split, bounded retry)", () => {

--- a/sdk/tests/oauth/scope-step-up.test.ts
+++ b/sdk/tests/oauth/scope-step-up.test.ts
@@ -63,6 +63,15 @@ describe("parseInsufficientScopeChallenge (RFC 6750 / SEP-2350)", () => {
     expect(c.challengedScopes).toBeUndefined();
   });
 
+  it("does not let a later realm-only Bearer hide an earlier insufficient_scope", () => {
+    // Reviewer repro: last-Bearer-wins would return isInsufficientScope=false.
+    const c = parseInsufficientScopeChallenge(
+      'Bearer error="insufficient_scope", scope="admin", Bearer realm="fallback"',
+    );
+    expect(c.isInsufficientScope).toBe(true);
+    expect(c.challengedScopes).toEqual(["admin"]);
+  });
+
   it("is not fooled by a fabricated challenge hidden inside a quoted value", () => {
     // The quoted realm contains a comma and a fake `Bearer error=…`; quote-aware
     // splitting keeps it as one Basic auth-param, so no insufficient_scope.

--- a/sdk/tests/oauth/scope-step-up.test.ts
+++ b/sdk/tests/oauth/scope-step-up.test.ts
@@ -1,0 +1,81 @@
+import {
+  computeScopeUnion,
+  parseInsufficientScopeChallenge,
+  resolveStepUpAction,
+} from "../../src/oauth/state-machines/shared/challenges.js";
+
+describe("computeScopeUnion (SEP-2350)", () => {
+  it("preserves previous-first order and de-duplicates", () => {
+    expect(computeScopeUnion(["a", "b"], ["b", "c"])).toEqual(["a", "b", "c"]);
+  });
+
+  it("handles missing sides", () => {
+    expect(computeScopeUnion(undefined, ["x"])).toEqual(["x"]);
+    expect(computeScopeUnion(["x"], undefined)).toEqual(["x"]);
+    expect(computeScopeUnion()).toEqual([]);
+  });
+
+  it("trims and drops blank scopes", () => {
+    expect(computeScopeUnion([" a ", ""], ["a", "  ", "b"])).toEqual(["a", "b"]);
+  });
+});
+
+describe("parseInsufficientScopeChallenge (RFC 6750 / SEP-2350)", () => {
+  it("extracts challenged scopes and resource metadata", () => {
+    const c = parseInsufficientScopeChallenge(
+      'Bearer error="insufficient_scope", scope="read write", resource_metadata="https://rs.example.com/.well-known/oauth-protected-resource"',
+    );
+    expect(c.isInsufficientScope).toBe(true);
+    expect(c.challengedScopes).toEqual(["read", "write"]);
+    expect(c.resourceMetadata).toBe(
+      "https://rs.example.com/.well-known/oauth-protected-resource",
+    );
+  });
+
+  it("does not treat a plain invalid_token 401 as a scope step-up", () => {
+    const c = parseInsufficientScopeChallenge('Bearer error="invalid_token"');
+    expect(c.isInsufficientScope).toBe(false);
+    expect(c.challengedScopes).toBeUndefined();
+  });
+
+  it("returns a benign result for a missing/blank header", () => {
+    expect(parseInsufficientScopeChallenge(undefined).isInsufficientScope).toBe(
+      false,
+    );
+    expect(parseInsufficientScopeChallenge("").isInsufficientScope).toBe(false);
+  });
+});
+
+describe("resolveStepUpAction (§10.5 policy split, bounded retry)", () => {
+  it("interactive reauthorizes up to maxRetries then throws", () => {
+    expect(
+      resolveStepUpAction({ authMode: "interactive", attempt: 0 }),
+    ).toBe("reauthorize");
+    // Default maxRetries is 1: after one re-authorization it must stop.
+    expect(
+      resolveStepUpAction({ authMode: "interactive", attempt: 1 }),
+    ).toBe("throw");
+  });
+
+  it("honors a higher maxRetries bound", () => {
+    expect(
+      resolveStepUpAction({ authMode: "interactive", attempt: 1, maxRetries: 2 }),
+    ).toBe("reauthorize");
+    expect(
+      resolveStepUpAction({ authMode: "interactive", attempt: 2, maxRetries: 2 }),
+    ).toBe("throw");
+  });
+
+  it("never opens a browser for M2M", () => {
+    expect(resolveStepUpAction({ authMode: "m2m", attempt: 0 })).toBe("throw");
+  });
+
+  it("lets the debugger advance manually", () => {
+    expect(resolveStepUpAction({ authMode: "debugger", attempt: 0 })).toBe(
+      "manual",
+    );
+    expect(resolveStepUpAction({ authMode: "debugger", attempt: 5 })).toBe(
+      "manual",
+    );
+  });
+});


### PR DESCRIPTION
**Phase 2 · 2R-stepup** — stacked on #3377 (2R-store) → #3375 (2R-iss). Review shows only this PR's diff; base retargets down the stack as each merges.

## What & why (§10.5 / SEP-2350)
On a `403 insufficient_scope`, a persisted OAuth client must (1) union the scopes it previously requested with the scopes the challenge names, and (2) decide whether to re-authorize — by auth mode, with a **bounded** retry so a persisted client session can't loop forever (§10.5#5 notes SDK per-request limits are not enough). Until now the machines only *visualized* a union; this lands the era-agnostic core the runtime boundary consumes.

## SDK (`shared/challenges.ts`, exported via `@mcpjam/sdk/browser`)
- **`computeScopeUnion(previous, challenged)`** — order-preserving (previous first), de-duplicated, trimmed. Replaces the 2026 machine's inline `new Set([...])` union (now calls the shared helper).
- **`parseInsufficientScopeChallenge(wwwAuthenticate)`** — detects `error="insufficient_scope"` (a plain `invalid_token` 401 is deliberately **not** a scope step-up) and extracts the challenged `scope` + RFC 9728 `resource_metadata`.
- **`resolveStepUpAction({ authMode, attempt, maxRetries })`** — the §10.5 policy split:
  - `interactive` → `reauthorize` up to `maxRetries` (default 1), then `throw` (bounded loop guard);
  - `m2m` → `throw` (never opens a browser);
  - `debugger` → `manual` (user inspects and advances).

## Client (`lib/oauth/requested-scopes.ts`)
- Persist requested scopes **per issuer** (§10.2#4) on the 2R-store issuer-keyed store, so the union has a "previous" set and scopes requested against AS **A** are never folded into a re-authorization against AS **B**. `stepUpScopeUnion()` reads the persisted set and unions it with a challenge.

## Tests
- 10 SDK unit tests: union order/dedup/trim; challenge parse including the non-step-up 401 and blank header; policy split including the exact bounded-retry boundary.
- 7 client tests: per-issuer persistence, cross-AS non-reuse, normalize-on-write, step-up union.
- SDK + client typecheck clean; 2026 machine suite (19) unchanged.

## Scope
The pure core + per-issuer scope persistence. Wiring the live transport's `onInsufficientScope` option and the reconnect orchestrator (`ensureAuthorizedForReconnect`) into this core is the immediate follow-on — the stateless preview still marks 403 upscoping `NotYetSupportedInStateless`, so faking that plumbing here would be dishonest. The seam is identified and the core it will call is tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth authorization behavior and `WWW-Authenticate` parsing where misclassification could trigger wrong re-auth vs throw; issuer-scoped storage reduces cross-AS scope leakage but persistence bugs could affect step-up requests once wired.
> 
> **Overview**
> Adds the **SEP-2350 / §10.5** building blocks for OAuth runtime scope step-up: shared scope union logic, `403 insufficient_scope` challenge parsing, a bounded re-authorize policy, and **per-issuer** persistence of previously requested scopes in the inspector client.
> 
> The SDK gains **`computeScopeUnion`**, **`parseInsufficientScopeChallenge`** (quote-aware multi-challenge `WWW-Authenticate` parsing; only `error="insufficient_scope"` counts as step-up), and **`resolveStepUpAction`** (interactive reauthorize up to `maxRetries`, M2M throw, debugger manual), exported from **`@mcpjam/sdk/browser`**. The 2026 OAuth debugger diagram now uses **`computeScopeUnion`** instead of an inline set union.
> 
> The client adds **`requested-scopes`**: persist/read scopes keyed by exact issuer via the 2R issuer-keyed store, with **`stepUpScopeUnion`** for re-auth scope sets—no `activeIssuer` fallback and legacy unkeyed records ignored (SEP-2352 isolation).
> 
> Unit tests cover union/order/dedup, challenge edge cases, policy retries, and client persistence. Live transport **`onInsufficientScope`** wiring is explicitly out of scope for this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6865feb69afd9eaa76cf803a773fa629467742d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the runtime OAuth scope step-up core: scope union, quote-aware `insufficient_scope` parsing across multi-challenge headers, and a bounded policy to decide re-authorization. Persists requested scopes per issuer so step-up requests use the right union without cross-issuer leaks.

- New Features
  - SDK (`@mcpjam/sdk/browser`): `computeScopeUnion`, `parseInsufficientScopeChallenge`, and `resolveStepUpAction` (interactive reauthorizes up to `maxRetries`, M2M throws, debugger manual). Non-`insufficient_scope` challenges are ignored; parses `resource_metadata`; RFC 7235–aware and quote-safe.
  - Client: per-issuer requested-scope persistence and `stepUpScopeUnion` to combine persisted and challenged scopes.
  - State machine now uses `computeScopeUnion` instead of an inline Set union.

- Bug Fixes
  - `WWW-Authenticate` parsing: quote-aware tokenizer; parses every Bearer challenge and selects the `insufficient_scope` one so a trailing realm-only Bearer can’t hide it; blocks later-scheme param bleed and quoted spoofing.
  - Issuer isolation on reads (no `activeIssuer` fallback; legacy unkeyed records ignored); non-finite `maxRetries` guarded; storage writes wrapped in try/catch.

<sup>Written for commit b6865feb69afd9eaa76cf803a773fa629467742d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

