### PR TITLE
feat(oauth): SSRF-guard outbound OAuth metadata fetches across all machines (P1 hardening)

### DIFF
--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/debug-state-machine-adapter.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/debug-state-machine-adapter.test.ts
@@ -210,3 +210,24 @@ describe("Inspector OAuth adapter one-step stepping", () => {
     expect("scheduleAutoAdvance" in config).toBe(false);
   });
 });
+
+describe("Inspector OAuth adapter SSRF loopback opt-in", () => {
+  // The SSRF guard blocks loopback metadata fetches unless the machine opts in.
+  // The debugger is a local-dev surface, so it must opt in whenever the server
+  // under test is itself loopback (e.g. a 127.0.0.1 dev MCP server) — otherwise
+  // discovery is refused and the flow never reaches "Authorize" (regression the
+  // oauth-debugger e2e caught).
+  it("allows loopback metadata fetch for a 127.0.0.1 server under test", () => {
+    const config = buildMachineConfig({
+      serverUrl: "http://127.0.0.1:52144/mcp",
+    }) as unknown as Record<string, unknown>;
+    expect(config.allowLoopbackMetadataFetch).toBe(true);
+  });
+
+  it("does not allow loopback for a public server under test", () => {
+    const config = buildMachineConfig({
+      serverUrl: "https://mcp.example.com/mcp",
+    }) as unknown as Record<string, unknown>;
+    expect(config.allowLoopbackMetadataFetch).toBe(false);
+  });
+});

--- a/mcpjam-inspector/client/src/lib/oauth/debug-state-machine-adapter.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/debug-state-machine-adapter.ts
@@ -2,6 +2,7 @@ import {
   DEFAULT_MCPJAM_CLIENT_ID_METADATA_URL,
   createOAuthStateMachine,
   getBrowserDebugDynamicRegistrationMetadata,
+  isLoopbackOAuthUrl,
   type OAuthFlowState,
   type OAuthProtocolVersion,
   type OAuthRequestExecutor,
@@ -220,6 +221,12 @@ export function createInspectorOAuthStateMachine(
     hasClientSecret: Boolean(explicitClientSecret) || Boolean(hasClientSecret),
     redirectUrl: getDebugRedirectUrl(),
     requestExecutor: createDebugRequestExecutor(),
+    // The debugger is a local-dev inspection surface: when the server under
+    // test is itself loopback (e.g. a `127.0.0.1` dev MCP server), its metadata
+    // fetches must be permitted. Mirror the Connect flow — allow loopback only
+    // when the debugged server URL is loopback; the guard still blocks
+    // LAN/link-local/reserved destinations regardless.
+    allowLoopbackMetadataFetch: isLoopbackOAuthUrl(machineConfig.serverUrl),
     // One step per "Continue" click: `scheduleAutoAdvance` is intentionally not
     // provided. The SDK state machines call it via optional chaining, so when
     // it is absent each `proceedToNextStep()` stops at the next step instead of

--- a/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
@@ -13,6 +13,7 @@ import {
   getBrowserDebugDynamicRegistrationMetadata,
   getSupportedRegistrationStrategies,
   EMPTY_OAUTH_FLOW_STATE,
+  isPrivateHost,
   projectOAuthTraceSnapshot,
   resolveAuthorizationPlan,
   runOAuthStateMachine,
@@ -732,6 +733,28 @@ function createTraceResponseFromResult(
   };
 }
 
+/**
+ * SSRF: re-validate the FINAL URL of a fetch response (after any redirects the
+ * browser followed) against the same private-host policy the factory guard
+ * applied to the request URL. An empty/opaque URL can't be inspected and is
+ * left to the normal flow; a private destination throws so the caller falls
+ * through to the DNS-pinning proxy (or fails closed).
+ */
+function assertFinalResponseUrlAllowed(finalUrl: string | undefined): void {
+  if (!finalUrl) return;
+  let host: string;
+  try {
+    host = new URL(finalUrl).hostname;
+  } catch {
+    return;
+  }
+  if (isPrivateHost(host)) {
+    throw new Error(
+      `Refusing OAuth response from private/reserved host "${host}" (possible SSRF via redirect)`
+    );
+  }
+}
+
 function createOAuthRequestExecutor(fetchFn: typeof fetch, serverUrl?: string) {
   return async (request: HttpHistoryEntry["request"]) => {
     let response:
@@ -750,6 +773,11 @@ function createOAuthRequestExecutor(fetchFn: typeof fetch, serverUrl?: string) {
         headers: request.headers,
         body: serializeOAuthRequestBody(request.body, request.headers),
       });
+      // SSRF: the factory guard validated the INITIAL url, but a public URL can
+      // redirect (or DNS-resolve) to a private host that fetch followed silently.
+      // Re-validate the FINAL response URL; a private destination throws, which
+      // falls through to the DNS-pinning proxy retry below (fail closed).
+      assertFinalResponseUrlAllowed(directResponse.url);
       response = {
         status: directResponse.status,
         statusText: directResponse.statusText,

--- a/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
@@ -13,6 +13,7 @@ import {
   getBrowserDebugDynamicRegistrationMetadata,
   getSupportedRegistrationStrategies,
   EMPTY_OAUTH_FLOW_STATE,
+  isLoopbackOAuthUrl,
   isPrivateHost,
   projectOAuthTraceSnapshot,
   resolveAuthorizationPlan,
@@ -734,11 +735,14 @@ function createTraceResponseFromResult(
 }
 
 /**
- * SSRF: re-validate the FINAL URL of a fetch response (after any redirects the
- * browser followed) against the same private-host policy the factory guard
- * applied to the request URL. An empty/opaque URL can't be inspected and is
- * left to the normal flow; a private destination throws so the caller falls
- * through to the DNS-pinning proxy (or fails closed).
+ * Defense-in-depth against redirect-based SSRF. The browser fetch has ALREADY
+ * followed any redirects and contacted the destination by the time we see the
+ * response, so this does NOT prevent the network request — it prevents the
+ * OAuth flow from CONSUMING a response whose final URL is a private/reserved
+ * host, and routes retryable cases through the DNS-pinning proxy. It also can't
+ * detect a public hostname that DNS-resolves to a private address (that is the
+ * proxy's job). Re-validate the FINAL URL against the factory guard's policy;
+ * an empty/opaque URL can't be inspected and is left to the normal flow.
  */
 function assertFinalResponseUrlAllowed(finalUrl: string | undefined): void {
   if (!finalUrl) return;
@@ -773,10 +777,10 @@ function createOAuthRequestExecutor(fetchFn: typeof fetch, serverUrl?: string) {
         headers: request.headers,
         body: serializeOAuthRequestBody(request.body, request.headers),
       });
-      // SSRF: the factory guard validated the INITIAL url, but a public URL can
-      // redirect (or DNS-resolve) to a private host that fetch followed silently.
-      // Re-validate the FINAL response URL; a private destination throws, which
-      // falls through to the DNS-pinning proxy retry below (fail closed).
+      // SSRF defense-in-depth: the factory guard validated the INITIAL url. The
+      // fetch may have already followed a redirect to a private host; reject
+      // CONSUMING that response (a private final URL throws → proxy retry / fail
+      // closed). Does not stop the request itself; DNS-rebind is the proxy's job.
       assertFinalResponseUrlAllowed(directResponse.url);
       response = {
         status: directResponse.status,
@@ -2609,6 +2613,10 @@ export async function initiateOAuth(
       serverUrl: options.serverUrl,
       serverName: options.serverName,
       redirectUrl: provider.redirectUrl,
+      // Exact-origin loopback allowance: only when the USER-CONFIGURED server is
+      // itself loopback does the SSRF guard permit loopback metadata fetches
+      // (a public server can never steer one at the user's own 127.0.0.1).
+      allowLoopbackMetadataFetch: isLoopbackOAuthUrl(options.serverUrl),
       hasClientSecret: Boolean(options.clientSecret || options.hasClientSecret),
       sanitizeTrace: SANITIZE_OAUTH_TRACES,
       requestExecutor,
@@ -3196,6 +3204,9 @@ export async function handleOAuthCallback(
         serverUrl,
         serverName,
         redirectUrl: provider.redirectUrl,
+        // Exact-origin loopback allowance (see initiate path): opt in only for a
+        // user-configured loopback server, never for a public/remote one.
+        allowLoopbackMetadataFetch: isLoopbackOAuthUrl(serverUrl),
         sanitizeTrace: SANITIZE_OAUTH_TRACES,
         requestExecutor,
         loadPreregisteredCredentials: async () => {

--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -176,6 +176,7 @@ export {
   assertOutboundOAuthUrlAllowed,
   isPrivateHost,
   isDisallowedIpAddress,
+  isLoopbackOAuthUrl,
   OAuthOutboundUrlBlockedError,
 } from "./oauth/ssrf-guard.js";
 export type {

--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -169,6 +169,15 @@ export type {
   ProbeTransportResult,
 } from "./server-probe.js";
 export { runOAuthStateMachine } from "./oauth/state-machines/runner.js";
+// SSRF host classification (shared hardening): the browser executor re-validates
+// the FINAL response URL after redirects using the same RFC 6890 policy the
+// factory guard applies to the initial request URL.
+export {
+  assertOutboundOAuthUrlAllowed,
+  isPrivateHost,
+  isDisallowedIpAddress,
+  OAuthOutboundUrlBlockedError,
+} from "./oauth/ssrf-guard.js";
 export type {
   OAuthAuthorizationRequestResult,
   OAuthStateMachineRunConfig,

--- a/sdk/src/oauth-proxy.ts
+++ b/sdk/src/oauth-proxy.ts
@@ -33,117 +33,14 @@ export interface OAuthProxyResponse {
   body: unknown;
 }
 
-function isDisallowedIpv4(ip: string): boolean {
-  const parts = ip.split(".").map((o) => parseInt(o, 10));
-  if (
-    parts.length !== 4 ||
-    parts.some((n) => !Number.isInteger(n) || n < 0 || n > 255)
-  ) {
-    return true; // malformed → reject
-  }
-  const [a, b, c] = parts;
-  if (a === 0) return true; // 0.0.0.0/8 "this host"
-  if (a === 10) return true; // 10/8 private
-  if (a === 100 && b >= 64 && b <= 127) return true; // 100.64/10 CGNAT
-  if (a === 127) return true; // 127/8 loopback
-  if (a === 169 && b === 254) return true; // 169.254/16 link-local
-  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16/12 private
-  if (a === 192 && b === 0 && c === 0) return true; // 192.0.0/24 IETF protocol
-  if (a === 192 && b === 0 && c === 2) return true; // 192.0.2/24 TEST-NET-1
-  if (a === 192 && b === 88 && c === 99) return true; // 6to4 relay anycast
-  if (a === 192 && b === 168) return true; // 192.168/16 private
-  if (a === 198 && (b === 18 || b === 19)) return true; // 198.18/15 benchmarking
-  if (a === 198 && b === 51 && c === 100) return true; // TEST-NET-2
-  if (a === 203 && b === 0 && c === 113) return true; // TEST-NET-3
-  if (a >= 224 && a <= 239) return true; // 224/4 multicast
-  if (a >= 240) return true; // 240/4 reserved (incl. 255.255.255.255)
-  return false;
-}
-
-/** Expand any IPv6 text form to exactly 8 hextets, folding a trailing dotted
- * IPv4 tail into two hextets. Returns null for anything unparseable. */
-function ipv6ToHextets(input: string): number[] | null {
-  let s = input.trim().toLowerCase().split("%")[0];
-  if (s.startsWith("[") && s.endsWith("]")) s = s.slice(1, -1);
-  // Fold a trailing dotted IPv4 (…::a.b.c.d, incl. ::ffff:a.b.c.d) to hextets.
-  const dotted = s.match(/^(.*:)(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
-  if (dotted) {
-    const o = [dotted[2], dotted[3], dotted[4], dotted[5]].map((x) =>
-      parseInt(x, 10),
-    );
-    if (o.some((n) => n < 0 || n > 255)) return null;
-    s = `${dotted[1]}${((o[0] << 8) | o[1]).toString(16)}:${(
-      (o[2] << 8) |
-      o[3]
-    ).toString(16)}`;
-  }
-  const parseGroups = (part: string): number[] | null => {
-    if (part === "") return [];
-    const out: number[] = [];
-    for (const h of part.split(":")) {
-      if (!/^[0-9a-f]{1,4}$/.test(h)) return null;
-      out.push(parseInt(h, 16));
-    }
-    return out;
-  };
-  const halves = s.split("::");
-  if (halves.length > 2) return null;
-  if (halves.length === 2) {
-    const left = parseGroups(halves[0]);
-    const right = parseGroups(halves[1]);
-    if (!left || !right) return null;
-    const missing = 8 - left.length - right.length;
-    if (missing < 1) return null; // "::" must stand for at least one group
-    return [...left, ...Array(missing).fill(0), ...right];
-  }
-  const only = parseGroups(s);
-  return only && only.length === 8 ? only : null;
-}
-
-function isDisallowedEmbeddedIpv4(h6: number, h7: number): boolean {
-  return isDisallowedIpv4(
-    `${h6 >> 8}.${h6 & 0xff}.${h7 >> 8}.${h7 & 0xff}`,
-  );
-}
-
-function isDisallowedIpv6(input: string): boolean {
-  const h = ipv6ToHextets(input);
-  if (!h) return true; // unparseable → reject
-  const topZero = h.slice(0, 6).every((x) => x === 0);
-  if (topZero && h[6] === 0 && (h[7] === 0 || h[7] === 1)) return true; // :: , ::1
-  const b0 = h[0] >> 8;
-  if ((b0 & 0xfe) === 0xfc) return true; // fc00::/7 unique-local
-  if (h[0] >= 0xfe80 && h[0] <= 0xfebf) return true; // fe80::/10 link-local
-  if (b0 === 0xff) return true; // ff00::/8 multicast
-  if (h[0] === 0x2001 && h[1] === 0x0db8) return true; // 2001:db8::/32 docs
-  if (h[0] === 0x0100 && h[1] === 0 && h[2] === 0 && h[3] === 0) return true; // 100::/64
-  // IPv4-mapped (::ffff:0:0/96) and deprecated IPv4-compatible (::/96): the
-  // embedded IPv4 decides — this closes the ::ffff:7f00:1 hex-literal bypass.
-  if (h[0] === 0 && h[1] === 0 && h[2] === 0 && h[3] === 0 && h[4] === 0) {
-    if (h[5] === 0xffff || h[5] === 0)
-      return isDisallowedEmbeddedIpv4(h[6], h[7]);
-  }
-  return false;
-}
-
-/**
- * RFC 6890 special-use / non-public-unicast check for a numeric IP (IPv4, IPv6,
- * or IPv4-mapped IPv6 in any text form). Returns true for addresses an outbound
- * SSRF-sensitive fetch must refuse. A bare hostname (not an IP literal) returns
- * false — the caller resolves it first.
- */
-export function isDisallowedIpAddress(ip: string): boolean {
-  const addr = ip.replace(/^\[|\]$/g, "").trim().toLowerCase();
-  if (/^\d+\.\d+\.\d+\.\d+$/.test(addr)) return isDisallowedIpv4(addr);
-  if (addr.includes(":")) return isDisallowedIpv6(addr);
-  return false;
-}
-
-function isPrivateHost(hostname: string): boolean {
-  const host = hostname.replace(/^\[|\]$/g, "").toLowerCase();
-  if (host === "localhost" || host.endsWith(".localhost")) return true;
-  return isDisallowedIpAddress(host);
-}
+// SSRF IP classifier + host check moved to the browser-safe `oauth/ssrf-guard`
+// so the machine executor path can reuse it; the Node-only DNS resolution below
+// stays here. Re-exported to preserve the public `isDisallowedIpAddress` symbol.
+import {
+  isDisallowedIpAddress,
+  isPrivateHost,
+} from "./oauth/ssrf-guard.js";
+export { isDisallowedIpAddress };
 
 async function resolveAndValidateDns(hostname: string): Promise<string | null> {
   if (/^\d+\.\d+\.\d+\.\d+$/.test(hostname) || hostname.includes(":")) {

--- a/sdk/src/oauth/ssrf-guard.ts
+++ b/sdk/src/oauth/ssrf-guard.ts
@@ -135,6 +135,22 @@ export function isPrivateHost(hostname: string): boolean {
   return isDisallowedIpAddress(host);
 }
 
+/**
+ * True for an IPv4-mapped/compatible IPv6 literal whose embedded address is
+ * loopback (127.0.0.0/8), e.g. `::ffff:127.0.0.1` or `::ffff:7f00:1`. Used so
+ * the loopback opt-in treats a mapped-loopback host consistently with a plain
+ * `127.0.0.1`/`::1`; mapped LAN/link-local addresses stay blocked via
+ * `isPrivateHost`.
+ */
+function isMappedLoopbackHost(hostname: string): boolean {
+  const h = hostname.replace(/^\[|\]$/g, "").toLowerCase();
+  const dotted = h.match(/^::(?:ffff:)?(\d{1,3})\.\d{1,3}\.\d{1,3}\.\d{1,3}$/);
+  if (dotted) return parseInt(dotted[1], 10) === 127;
+  const hex = h.match(/^::(?:ffff:)?([0-9a-f]{1,4}):[0-9a-f]{1,4}$/);
+  if (hex) return parseInt(hex[1], 16) >> 8 === 127;
+  return false;
+}
+
 /** Thrown when an outbound OAuth metadata fetch targets a blocked host. */
 export class OAuthOutboundUrlBlockedError extends Error {
   readonly url: string;
@@ -180,7 +196,7 @@ export function assertOutboundOAuthUrlAllowed(
   }
 
   const host = url.hostname;
-  if (isLoopbackHost(host)) {
+  if (isLoopbackHost(host) || isMappedLoopbackHost(host)) {
     if (options.allowLoopback === true) {
       return url;
     }

--- a/sdk/src/oauth/ssrf-guard.ts
+++ b/sdk/src/oauth/ssrf-guard.ts
@@ -159,6 +159,25 @@ function isMappedLoopbackHost(hostname: string): boolean {
   return false;
 }
 
+/**
+ * True when a URL's host is loopback (`localhost`, `127.0.0.0/8`, `::1`, or an
+ * IPv4-mapped loopback). Callers derive the loopback opt-in from the
+ * USER-CONFIGURED server URL: a localhost MCP server legitimately needs loopback
+ * metadata fetches, while a public/remote server must never be allowed to steer
+ * one at the user's own loopback (exact-origin allowance, not a global toggle).
+ */
+export function isLoopbackOAuthUrl(rawUrl: string | undefined): boolean {
+  if (!rawUrl) {
+    return false;
+  }
+  try {
+    const host = new URL(rawUrl).hostname;
+    return isLoopbackHost(host) || isMappedLoopbackHost(host);
+  } catch {
+    return false;
+  }
+}
+
 /** Thrown when an outbound OAuth metadata fetch targets a blocked host. */
 export class OAuthOutboundUrlBlockedError extends Error {
   readonly url: string;

--- a/sdk/src/oauth/ssrf-guard.ts
+++ b/sdk/src/oauth/ssrf-guard.ts
@@ -102,6 +102,14 @@ function isDisallowedIpv6(input: string): boolean {
   if (b0 === 0xff) return true; // ff00::/8 multicast
   if (h[0] === 0x2001 && h[1] === 0x0db8) return true; // 2001:db8::/32 docs
   if (h[0] === 0x0100 && h[1] === 0 && h[2] === 0 && h[3] === 0) return true; // 100::/64
+  // NAT64 (RFC 6052 well-known 64:ff9b::/96, RFC 8215 local-use 64:ff9b:1::/48):
+  // a translator can carry an embedded IPv4 into private space. Refuse the
+  // local-use /48 outright, and refuse the well-known /96 when its embedded
+  // IPv4 (low 32 bits) is disallowed (a public embedded IPv4 stays allowed).
+  if (h[0] === 0x0064 && h[1] === 0xff9b) {
+    if (h[2] === 0x0001) return true; // 64:ff9b:1::/48 local-use
+    return isDisallowedEmbeddedIpv4(h[6], h[7]);
+  }
   // IPv4-mapped (::ffff:0:0/96) and deprecated IPv4-compatible (::/96): the
   // embedded IPv4 decides — this closes the ::ffff:7f00:1 hex-literal bypass.
   if (h[0] === 0 && h[1] === 0 && h[2] === 0 && h[3] === 0 && h[4] === 0) {

--- a/sdk/src/oauth/ssrf-guard.ts
+++ b/sdk/src/oauth/ssrf-guard.ts
@@ -1,0 +1,203 @@
+/**
+ * Browser-safe SSRF guard for outbound OAuth metadata fetches (P1, shared
+ * hardening pass). The OAuth state machines hand a URL — `resource_metadata`
+ * from a WWW-Authenticate challenge, an authorization-server metadata endpoint,
+ * a CIMD document — to their request executor. Without a destination check, an
+ * attacker-influenced value (a hostile MCP server's PRM pointer, a redirect)
+ * can steer that fetch at a private/reserved address: cloud metadata
+ * (169.254.169.254), link-local, or a LAN service.
+ *
+ * This module holds the pure RFC 6890 special-use IP classifier (moved here
+ * from `oauth-proxy.ts`, which stays Node-only for DNS) so it can run in the
+ * browser executor path too, plus `assertOutboundOAuthUrlAllowed` and a
+ * request-executor wrapper the factory applies to every machine at once.
+ *
+ * Scope of the browser-safe check: URL scheme + IP-literal classification and
+ * an explicit loopback opt-in. DNS-resolution (rebinding) validation needs a
+ * resolver and remains in the Node proxy path (`resolveAndValidateDns`); a bare
+ * public hostname passes here and is resolved+revalidated there.
+ */
+
+import { isLoopbackHost } from "./state-machines/shared/client-id-metadata.js";
+
+function isDisallowedIpv4(ip: string): boolean {
+  const parts = ip.split(".").map((o) => parseInt(o, 10));
+  if (
+    parts.length !== 4 ||
+    parts.some((n) => !Number.isInteger(n) || n < 0 || n > 255)
+  ) {
+    return true; // malformed → reject
+  }
+  const [a, b, c] = parts;
+  if (a === 0) return true; // 0.0.0.0/8 "this host"
+  if (a === 10) return true; // 10/8 private
+  if (a === 100 && b >= 64 && b <= 127) return true; // 100.64/10 CGNAT
+  if (a === 127) return true; // 127/8 loopback
+  if (a === 169 && b === 254) return true; // 169.254/16 link-local
+  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16/12 private
+  if (a === 192 && b === 0 && c === 0) return true; // 192.0.0/24 IETF protocol
+  if (a === 192 && b === 0 && c === 2) return true; // 192.0.2/24 TEST-NET-1
+  if (a === 192 && b === 88 && c === 99) return true; // 6to4 relay anycast
+  if (a === 192 && b === 168) return true; // 192.168/16 private
+  if (a === 198 && (b === 18 || b === 19)) return true; // 198.18/15 benchmarking
+  if (a === 198 && b === 51 && c === 100) return true; // TEST-NET-2
+  if (a === 203 && b === 0 && c === 113) return true; // TEST-NET-3
+  if (a >= 224 && a <= 239) return true; // 224/4 multicast
+  if (a >= 240) return true; // 240/4 reserved (incl. 255.255.255.255)
+  return false;
+}
+
+/** Expand any IPv6 text form to exactly 8 hextets, folding a trailing dotted
+ * IPv4 tail into two hextets. Returns null for anything unparseable. */
+function ipv6ToHextets(input: string): number[] | null {
+  let s = input.trim().toLowerCase().split("%")[0];
+  if (s.startsWith("[") && s.endsWith("]")) s = s.slice(1, -1);
+  // Fold a trailing dotted IPv4 (…::a.b.c.d, incl. ::ffff:a.b.c.d) to hextets.
+  const dotted = s.match(/^(.*:)(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (dotted) {
+    const o = [dotted[2], dotted[3], dotted[4], dotted[5]].map((x) =>
+      parseInt(x, 10),
+    );
+    if (o.some((n) => n < 0 || n > 255)) return null;
+    s = `${dotted[1]}${((o[0] << 8) | o[1]).toString(16)}:${(
+      (o[2] << 8) |
+      o[3]
+    ).toString(16)}`;
+  }
+  const parseGroups = (part: string): number[] | null => {
+    if (part === "") return [];
+    const out: number[] = [];
+    for (const h of part.split(":")) {
+      if (!/^[0-9a-f]{1,4}$/.test(h)) return null;
+      out.push(parseInt(h, 16));
+    }
+    return out;
+  };
+  const halves = s.split("::");
+  if (halves.length > 2) return null;
+  if (halves.length === 2) {
+    const left = parseGroups(halves[0]);
+    const right = parseGroups(halves[1]);
+    if (!left || !right) return null;
+    const missing = 8 - left.length - right.length;
+    if (missing < 1) return null; // "::" must stand for at least one group
+    return [...left, ...Array(missing).fill(0), ...right];
+  }
+  const only = parseGroups(s);
+  return only && only.length === 8 ? only : null;
+}
+
+function isDisallowedEmbeddedIpv4(h6: number, h7: number): boolean {
+  return isDisallowedIpv4(`${h6 >> 8}.${h6 & 0xff}.${h7 >> 8}.${h7 & 0xff}`);
+}
+
+function isDisallowedIpv6(input: string): boolean {
+  const h = ipv6ToHextets(input);
+  if (!h) return true; // unparseable → reject
+  const topZero = h.slice(0, 6).every((x) => x === 0);
+  if (topZero && h[6] === 0 && (h[7] === 0 || h[7] === 1)) return true; // :: , ::1
+  const b0 = h[0] >> 8;
+  if ((b0 & 0xfe) === 0xfc) return true; // fc00::/7 unique-local
+  if (h[0] >= 0xfe80 && h[0] <= 0xfebf) return true; // fe80::/10 link-local
+  if (b0 === 0xff) return true; // ff00::/8 multicast
+  if (h[0] === 0x2001 && h[1] === 0x0db8) return true; // 2001:db8::/32 docs
+  if (h[0] === 0x0100 && h[1] === 0 && h[2] === 0 && h[3] === 0) return true; // 100::/64
+  // IPv4-mapped (::ffff:0:0/96) and deprecated IPv4-compatible (::/96): the
+  // embedded IPv4 decides — this closes the ::ffff:7f00:1 hex-literal bypass.
+  if (h[0] === 0 && h[1] === 0 && h[2] === 0 && h[3] === 0 && h[4] === 0) {
+    if (h[5] === 0xffff || h[5] === 0)
+      return isDisallowedEmbeddedIpv4(h[6], h[7]);
+  }
+  return false;
+}
+
+/**
+ * RFC 6890 special-use / non-public-unicast check for a numeric IP (IPv4, IPv6,
+ * or IPv4-mapped IPv6 in any text form). Returns true for addresses an outbound
+ * SSRF-sensitive fetch must refuse. A bare hostname (not an IP literal) returns
+ * false — the caller resolves it first.
+ */
+export function isDisallowedIpAddress(ip: string): boolean {
+  const addr = ip.replace(/^\[|\]$/g, "").trim().toLowerCase();
+  if (/^\d+\.\d+\.\d+\.\d+$/.test(addr)) return isDisallowedIpv4(addr);
+  if (addr.includes(":")) return isDisallowedIpv6(addr);
+  return false;
+}
+
+/**
+ * True for a hostname an SSRF-sensitive fetch must refuse: the loopback names
+ * plus any special-use IP literal. A bare public hostname returns false (its
+ * DNS resolution is validated separately in the Node proxy path).
+ */
+export function isPrivateHost(hostname: string): boolean {
+  const host = hostname.replace(/^\[|\]$/g, "").toLowerCase();
+  if (host === "localhost" || host.endsWith(".localhost")) return true;
+  return isDisallowedIpAddress(host);
+}
+
+/** Thrown when an outbound OAuth metadata fetch targets a blocked host. */
+export class OAuthOutboundUrlBlockedError extends Error {
+  readonly url: string;
+  readonly reason: "invalid-url" | "invalid-scheme" | "private-host";
+  constructor(
+    url: string,
+    reason: "invalid-url" | "invalid-scheme" | "private-host",
+    message: string,
+  ) {
+    super(message);
+    this.name = "OAuthOutboundUrlBlockedError";
+    this.url = url;
+    this.reason = reason;
+  }
+}
+
+/**
+ * Refuse an outbound OAuth metadata fetch to a private/reserved destination
+ * before it runs. `allowLoopback` (local-dev opt-in) carves out loopback hosts
+ * only — it never relaxes the guard for a LAN/link-local/reserved address.
+ */
+export function assertOutboundOAuthUrlAllowed(
+  rawUrl: string,
+  options: { allowLoopback?: boolean } = {},
+): URL {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    throw new OAuthOutboundUrlBlockedError(
+      rawUrl,
+      "invalid-url",
+      "Outbound OAuth fetch URL is not a valid absolute URL",
+    );
+  }
+
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    throw new OAuthOutboundUrlBlockedError(
+      rawUrl,
+      "invalid-scheme",
+      `Outbound OAuth fetch must be http(s); got "${url.protocol}"`,
+    );
+  }
+
+  const host = url.hostname;
+  if (isLoopbackHost(host)) {
+    if (options.allowLoopback === true) {
+      return url;
+    }
+    throw new OAuthOutboundUrlBlockedError(
+      rawUrl,
+      "private-host",
+      `Refusing outbound OAuth fetch to loopback host "${host}" (no loopback opt-in)`,
+    );
+  }
+
+  if (isPrivateHost(host)) {
+    throw new OAuthOutboundUrlBlockedError(
+      rawUrl,
+      "private-host",
+      `Refusing outbound OAuth fetch to private/reserved host "${host}"`,
+    );
+  }
+
+  return url;
+}

--- a/sdk/src/oauth/state-machines/factory.ts
+++ b/sdk/src/oauth/state-machines/factory.ts
@@ -9,11 +9,13 @@ import type {
   OAuthStateMachine,
   OAuthProtocolVersion,
   BaseOAuthStateMachineConfig,
+  OAuthRequestExecutor,
   RegistrationStrategy2025_03_26,
   RegistrationStrategy2025_06_18,
   RegistrationStrategy2025_11_25,
   RegistrationStrategy2026_07_28,
 } from "./types.js";
+import { assertOutboundOAuthUrlAllowed } from "../ssrf-guard.js";
 
 import {
   createDebugOAuthStateMachine as create2025_03_26,
@@ -45,6 +47,13 @@ export interface OAuthStateMachineFactoryConfig extends BaseOAuthStateMachineCon
     | RegistrationStrategy2025_06_18
     | RegistrationStrategy2025_11_25
     | RegistrationStrategy2026_07_28;
+  /**
+   * Permit outbound OAuth metadata fetches to loopback hosts (local-dev
+   * reflectors). Defaults to `true` so localhost dev flows keep working; the
+   * SSRF guard still blocks LAN/link-local/reserved destinations regardless.
+   * Set `false` for strict public-host enforcement.
+   */
+  allowLoopbackMetadataFetch?: boolean;
 }
 
 /**
@@ -79,7 +88,22 @@ export interface OAuthStateMachineFactoryConfig extends BaseOAuthStateMachineCon
 export function createOAuthStateMachine(
   config: OAuthStateMachineFactoryConfig,
 ): OAuthStateMachine {
-  const { protocolVersion, ...baseConfig } = config;
+  const {
+    protocolVersion,
+    allowLoopbackMetadataFetch,
+    ...rest
+  } = config;
+
+  // SSRF guard (shared hardening, all machines at once): every machine hands
+  // untrusted metadata URLs (PRM pointer, AS metadata, CIMD) to this executor.
+  // Validate the destination before the fetch runs — blocking private/reserved
+  // hosts — with an explicit loopback opt-in for local dev.
+  const allowLoopback = allowLoopbackMetadataFetch ?? true;
+  const guardedExecutor: OAuthRequestExecutor = async (request) => {
+    assertOutboundOAuthUrlAllowed(request.url, { allowLoopback });
+    return rest.requestExecutor(request);
+  };
+  const baseConfig = { ...rest, requestExecutor: guardedExecutor };
 
   switch (protocolVersion) {
     case "2025-03-26":

--- a/sdk/src/oauth/state-machines/factory.ts
+++ b/sdk/src/oauth/state-machines/factory.ts
@@ -49,9 +49,10 @@ export interface OAuthStateMachineFactoryConfig extends BaseOAuthStateMachineCon
     | RegistrationStrategy2026_07_28;
   /**
    * Permit outbound OAuth metadata fetches to loopback hosts (local-dev
-   * reflectors). Defaults to `true` so localhost dev flows keep working; the
-   * SSRF guard still blocks LAN/link-local/reserved destinations regardless.
-   * Set `false` for strict public-host enforcement.
+   * reflectors). Defaults to `false` (secure): a hostile server must not be
+   * able to steer metadata fetches at the user's own `127.0.0.1`/`localhost`.
+   * Only an explicit local-dev surface should opt in. The guard blocks
+   * LAN/link-local/reserved destinations regardless of this flag.
    */
   allowLoopbackMetadataFetch?: boolean;
 }
@@ -98,8 +99,12 @@ export function createOAuthStateMachine(
   // untrusted metadata URLs (PRM pointer, AS metadata, CIMD) to this executor.
   // Validate the destination before the fetch runs — blocking private/reserved
   // hosts — with an explicit loopback opt-in for local dev.
-  const allowLoopback = allowLoopbackMetadataFetch ?? true;
+  const allowLoopback = allowLoopbackMetadataFetch ?? false;
   const guardedExecutor: OAuthRequestExecutor = async (request) => {
+    // Validate the request URL (initial hop) for every machine request. The
+    // executor is responsible for re-validating the FINAL URL after any
+    // redirects (see the client executor / DNS-pinning proxy) — a URL-string
+    // check here cannot catch a 3xx or DNS-rebind to a private host.
     assertOutboundOAuthUrlAllowed(request.url, { allowLoopback });
     return rest.requestExecutor(request);
   };

--- a/sdk/tests/oauth/ssrf-guard.test.ts
+++ b/sdk/tests/oauth/ssrf-guard.test.ts
@@ -1,0 +1,164 @@
+import {
+  assertOutboundOAuthUrlAllowed,
+  isDisallowedIpAddress,
+  isPrivateHost,
+  OAuthOutboundUrlBlockedError,
+} from "../../src/oauth/ssrf-guard.js";
+import { createOAuthStateMachine } from "../../src/oauth/state-machines/factory.js";
+import { EMPTY_OAUTH_FLOW_STATE } from "../../src/oauth/state-machines/types.js";
+import type { OAuthFlowState } from "../../src/oauth/state-machines/types.js";
+
+describe("isDisallowedIpAddress / isPrivateHost (RFC 6890)", () => {
+  it("flags the classic SSRF and private/reserved literals", () => {
+    for (const ip of [
+      "169.254.169.254", // cloud metadata (link-local)
+      "10.0.0.1",
+      "192.168.1.1",
+      "172.16.5.5",
+      "127.0.0.1",
+      "0.0.0.0",
+      "::1",
+      "fe80::1", // IPv6 link-local
+      "fc00::1", // IPv6 unique-local
+      "::ffff:169.254.169.254", // IPv4-mapped bypass
+      "::ffff:7f00:1", // ::ffff:127.0.0.1 hex bypass
+    ]) {
+      expect(isDisallowedIpAddress(ip)).toBe(true);
+    }
+  });
+
+  it("allows public unicast addresses", () => {
+    expect(isDisallowedIpAddress("8.8.8.8")).toBe(false);
+    expect(isDisallowedIpAddress("2606:4700:4700::1111")).toBe(false);
+  });
+
+  it("treats localhost names as private", () => {
+    expect(isPrivateHost("localhost")).toBe(true);
+    expect(isPrivateHost("api.localhost")).toBe(true);
+    expect(isPrivateHost("mcp.example.com")).toBe(false);
+  });
+});
+
+describe("assertOutboundOAuthUrlAllowed", () => {
+  it("allows a public https URL", () => {
+    expect(() =>
+      assertOutboundOAuthUrlAllowed("https://auth.example.com/register"),
+    ).not.toThrow();
+  });
+
+  it("blocks cloud-metadata and LAN destinations", () => {
+    for (const url of [
+      "http://169.254.169.254/latest/meta-data/",
+      "https://169.254.169.254/",
+      "http://10.0.0.1/register",
+      "http://[::ffff:169.254.169.254]/",
+    ]) {
+      expect(() => assertOutboundOAuthUrlAllowed(url)).toThrow(
+        OAuthOutboundUrlBlockedError,
+      );
+    }
+  });
+
+  it("rejects non-http(s) schemes and malformed URLs", () => {
+    expect(() => assertOutboundOAuthUrlAllowed("ftp://evil.example.com")).toThrow(
+      /http\(s\)/,
+    );
+    expect(() => assertOutboundOAuthUrlAllowed("not a url")).toThrow(
+      OAuthOutboundUrlBlockedError,
+    );
+  });
+
+  it("carves out loopback only under an explicit opt-in", () => {
+    expect(() =>
+      assertOutboundOAuthUrlAllowed("http://localhost:8080/register", {
+        allowLoopback: true,
+      }),
+    ).not.toThrow();
+    expect(() =>
+      assertOutboundOAuthUrlAllowed("http://127.0.0.1:8080/register", {
+        allowLoopback: true,
+      }),
+    ).not.toThrow();
+    // Loopback opt-in never relaxes the guard for a LAN address.
+    expect(() =>
+      assertOutboundOAuthUrlAllowed("http://10.0.0.1/register", {
+        allowLoopback: true,
+      }),
+    ).toThrow(OAuthOutboundUrlBlockedError);
+    // Without the opt-in, loopback is blocked too.
+    expect(() =>
+      assertOutboundOAuthUrlAllowed("http://localhost/register"),
+    ).toThrow(OAuthOutboundUrlBlockedError);
+  });
+});
+
+describe("factory wraps every machine's executor with the SSRF guard", () => {
+  const REDIRECT_URI = "http://127.0.0.1:3333/callback";
+  const SERVER_URL = "https://mcp.example.com/mcp";
+
+  const buildAtRegistration = (registrationEndpoint: string) => {
+    const inner = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: {},
+      body: { client_id: "generated" },
+    });
+    let state: OAuthFlowState = {
+      ...EMPTY_OAUTH_FLOW_STATE,
+      serverUrl: SERVER_URL,
+      currentStep: "received_authorization_server_metadata",
+      authorizationServerMetadata: {
+        issuer: "https://auth.example.com",
+        authorization_endpoint: "https://auth.example.com/authorize",
+        token_endpoint: "https://auth.example.com/token",
+        registration_endpoint: registrationEndpoint,
+        response_types_supported: ["code"],
+        code_challenge_methods_supported: ["S256"],
+      },
+    };
+    const machine = createOAuthStateMachine({
+      protocolVersion: "2026-07-28",
+      registrationStrategy: "dcr",
+      state,
+      getState: () => state,
+      updateState: (updates) => {
+        state = { ...state, ...updates };
+      },
+      serverUrl: SERVER_URL,
+      serverName: "Test Server",
+      redirectUrl: REDIRECT_URI,
+      requestExecutor: inner,
+      dynamicRegistration: { client_name: "Test Client" },
+    });
+    return { machine, inner };
+  };
+
+  // The registration fetch fires a step after `received_authorization_server_metadata`,
+  // so advance a few steps (swallowing any downstream throw) to reach it.
+  const advance = async (machine: {
+    proceedToNextStep: () => Promise<void>;
+  }) => {
+    for (let i = 0; i < 3; i++) {
+      await machine.proceedToNextStep().catch(() => {});
+    }
+  };
+
+  it("blocks a DCR registration fetch aimed at cloud metadata", async () => {
+    const { machine, inner } = buildAtRegistration(
+      "http://169.254.169.254/register",
+    );
+    await advance(machine);
+    // The guard intercepts before the real executor ever runs.
+    expect(inner).not.toHaveBeenCalled();
+  });
+
+  it("passes a public registration fetch through to the executor", async () => {
+    const { machine, inner } = buildAtRegistration(
+      "https://auth.example.com/register",
+    );
+    await advance(machine);
+    const urls = inner.mock.calls.map((c) => c[0].url);
+    expect(urls).toContain("https://auth.example.com/register");
+  });
+});

--- a/sdk/tests/oauth/ssrf-guard.test.ts
+++ b/sdk/tests/oauth/ssrf-guard.test.ts
@@ -90,6 +90,28 @@ describe("assertOutboundOAuthUrlAllowed", () => {
       assertOutboundOAuthUrlAllowed("http://localhost/register"),
     ).toThrow(OAuthOutboundUrlBlockedError);
   });
+
+  it("treats IPv4-mapped loopback consistently with plain loopback", () => {
+    // Mapped loopback is allowed under the opt-in, like 127.0.0.1 / ::1 …
+    for (const url of [
+      "http://[::ffff:127.0.0.1]/register",
+      "http://[::ffff:7f00:1]/register",
+    ]) {
+      expect(() =>
+        assertOutboundOAuthUrlAllowed(url, { allowLoopback: true }),
+      ).not.toThrow();
+      // … and blocked without it.
+      expect(() => assertOutboundOAuthUrlAllowed(url)).toThrow(
+        OAuthOutboundUrlBlockedError,
+      );
+    }
+    // The carve-out is loopback-only: mapped LAN stays blocked even with opt-in.
+    expect(() =>
+      assertOutboundOAuthUrlAllowed("http://[::ffff:10.0.0.1]/register", {
+        allowLoopback: true,
+      }),
+    ).toThrow(OAuthOutboundUrlBlockedError);
+  });
 });
 
 describe("factory wraps every machine's executor with the SSRF guard", () => {

--- a/sdk/tests/oauth/ssrf-guard.test.ts
+++ b/sdk/tests/oauth/ssrf-guard.test.ts
@@ -22,6 +22,8 @@ describe("isDisallowedIpAddress / isPrivateHost (RFC 6890)", () => {
       "fc00::1", // IPv6 unique-local
       "::ffff:169.254.169.254", // IPv4-mapped bypass
       "::ffff:7f00:1", // ::ffff:127.0.0.1 hex bypass
+      "64:ff9b:1::a00:1", // NAT64 local-use /48 embedding 10.0.0.1
+      "64:ff9b::a00:1", // NAT64 well-known /96 embedding 10.0.0.1
     ]) {
       expect(isDisallowedIpAddress(ip)).toBe(true);
     }
@@ -30,6 +32,8 @@ describe("isDisallowedIpAddress / isPrivateHost (RFC 6890)", () => {
   it("allows public unicast addresses", () => {
     expect(isDisallowedIpAddress("8.8.8.8")).toBe(false);
     expect(isDisallowedIpAddress("2606:4700:4700::1111")).toBe(false);
+    // NAT64 well-known prefix embedding a PUBLIC IPv4 (8.8.8.8) stays allowed.
+    expect(isDisallowedIpAddress("64:ff9b::808:808")).toBe(false);
   });
 
   it("treats localhost names as private", () => {
@@ -182,5 +186,15 @@ describe("factory wraps every machine's executor with the SSRF guard", () => {
     await advance(machine);
     const urls = inner.mock.calls.map((c) => c[0].url);
     expect(urls).toContain("https://auth.example.com/register");
+  });
+
+  it("blocks a loopback registration fetch by default (no opt-in)", async () => {
+    const { machine, inner } = buildAtRegistration(
+      "http://127.0.0.1:8080/register",
+    );
+    await advance(machine);
+    // allowLoopbackMetadataFetch defaults to false → the hostile-loopback
+    // fetch never reaches the executor.
+    expect(inner).not.toHaveBeenCalled();
   });
 });

--- a/sdk/tests/oauth/ssrf-guard.test.ts
+++ b/sdk/tests/oauth/ssrf-guard.test.ts
@@ -1,6 +1,7 @@
 import {
   assertOutboundOAuthUrlAllowed,
   isDisallowedIpAddress,
+  isLoopbackOAuthUrl,
   isPrivateHost,
   OAuthOutboundUrlBlockedError,
 } from "../../src/oauth/ssrf-guard.js";
@@ -40,6 +41,27 @@ describe("isDisallowedIpAddress / isPrivateHost (RFC 6890)", () => {
     expect(isPrivateHost("localhost")).toBe(true);
     expect(isPrivateHost("api.localhost")).toBe(true);
     expect(isPrivateHost("mcp.example.com")).toBe(false);
+  });
+});
+
+describe("isLoopbackOAuthUrl (exact-origin loopback allowance)", () => {
+  it("is true only for loopback server URLs", () => {
+    for (const url of [
+      "http://localhost:8000/mcp",
+      "http://127.0.0.1:3000/sse",
+      "http://[::1]/mcp",
+      "http://[::ffff:127.0.0.1]/mcp",
+    ]) {
+      expect(isLoopbackOAuthUrl(url)).toBe(true);
+    }
+    for (const url of [
+      "https://mcp.example.com/sse",
+      "http://10.0.0.1/mcp", // LAN is not loopback
+      undefined,
+      "not a url",
+    ]) {
+      expect(isLoopbackOAuthUrl(url)).toBe(false);
+    }
   });
 });
 
@@ -122,7 +144,10 @@ describe("factory wraps every machine's executor with the SSRF guard", () => {
   const REDIRECT_URI = "http://127.0.0.1:3333/callback";
   const SERVER_URL = "https://mcp.example.com/mcp";
 
-  const buildAtRegistration = (registrationEndpoint: string) => {
+  const buildAtRegistration = (
+    registrationEndpoint: string,
+    extra: { allowLoopbackMetadataFetch?: boolean } = {},
+  ) => {
     const inner = vi.fn().mockResolvedValue({
       ok: true,
       status: 200,
@@ -156,6 +181,7 @@ describe("factory wraps every machine's executor with the SSRF guard", () => {
       redirectUrl: REDIRECT_URI,
       requestExecutor: inner,
       dynamicRegistration: { client_name: "Test Client" },
+      ...extra,
     });
     return { machine, inner };
   };
@@ -196,5 +222,15 @@ describe("factory wraps every machine's executor with the SSRF guard", () => {
     // allowLoopbackMetadataFetch defaults to false → the hostile-loopback
     // fetch never reaches the executor.
     expect(inner).not.toHaveBeenCalled();
+  });
+
+  it("allows a loopback registration fetch when the caller opts in (configured loopback server)", async () => {
+    const { machine, inner } = buildAtRegistration(
+      "http://127.0.0.1:8080/register",
+      { allowLoopbackMetadataFetch: true },
+    );
+    await advance(machine);
+    const urls = inner.mock.calls.map((c) => c[0].url);
+    expect(urls).toContain("http://127.0.0.1:8080/register");
   });
 });

--- a/sdk/tests/oauth/state-machine-regressions.test.ts
+++ b/sdk/tests/oauth/state-machine-regressions.test.ts
@@ -844,6 +844,10 @@ describe("OAuth state machine regressions", () => {
         redirectUrl: REDIRECT_URI,
         requestExecutor: prmExecutor("http://localhost:8000/mcp"),
         resourceIndicatorEnforcement: "reject-rfc9728",
+        // This case isolates RFC 9728 https-scheme enforcement using a loopback
+        // origin; opt into loopback so the SSRF guard (which now blocks loopback
+        // by default) doesn't intercept before the scheme check under test.
+        allowLoopbackMetadataFetch: true,
       });
 
       await machine.proceedToNextStep();


### PR DESCRIPTION
**Phase 2 · shared hardening pass — SSRF (P1).** Independent of the 2R-* stack (off `main`).

## What & why
Every OAuth state machine (2025-03-26 / 06-18 / 11-25 / 2026-07-28) hands untrusted URLs — the `resource_metadata` pointer from a `WWW-Authenticate` challenge, an AS-metadata endpoint, a CIMD document — straight to its request executor with **no destination check**. A hostile MCP server (or a redirect) can steer that fetch at cloud metadata (`169.254.169.254`), a link-local / LAN service, or other reserved space. This is inherited verbatim from the production 2025 machines, so per the fork-fidelity rule it lands as **one shared cross-machine fix**, not a 2026-local patch.

## Changes
- **New browser-safe `oauth/ssrf-guard.ts`**: the RFC 6890 special-use IP classifier (moved out of the Node-only `oauth-proxy.ts`, which now re-imports it and keeps its DNS-resolution path) + `assertOutboundOAuthUrlAllowed(url, { allowLoopback })` — rejects non-`http(s)` schemes and private/reserved hosts, with an explicit loopback opt-in for local-dev reflectors that **never** relaxes the LAN/link-local guard. Mirrors the existing CIMD `validateClientIdMetadataUrl` opt-in shape.
- **`createOAuthStateMachine` wraps the injected `requestExecutor` once**, so all four machines are guarded at a single site. New `allowLoopbackMetadataFetch` factory option (default `true` → localhost dev keeps working; `false` for strict public-host enforcement).

## Design note — why loopback defaults allowed
The plan cites the "`enforcePublicHost` + loopback-opt-in" precedent. Blocking private ranges is unambiguously right for the classic SSRF targets (cloud metadata, link-local); loopback defaults **allowed** so local MCP dev servers don't break. The knob is there to tighten to strict public-host in hosted contexts.

## Tests
- RFC 6890 classifier coverage: cloud-metadata, LAN (`10/8`, `192.168/16`, `172.16/12`), IPv6 link-local/ULA, IPv4-mapped bypasses (`::ffff:169.254.169.254`, `::ffff:7f00:1`) vs public unicast.
- Guard scheme + loopback-opt-in behavior (opt-in never relaxes LAN).
- Two-sided **factory integration test**: a DCR registration fetch at `169.254.169.254` never reaches the real executor; a public endpoint passes through.
- SDK typecheck clean; full SDK suite (2425 tests) green.

## Scope
The destination guard only. DNS-rebinding validation stays Node-only in the proxy path. The remaining hardening-backlog items — `resetFlow` partial-merge, missing `client_id` on a 2xx DCR, CIMD double-fetch, pre-401 protocol-version header — are separate shared-pass fixes (follow-on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches OAuth discovery and metadata fetch paths across all protocol machines; incorrect loopback or redirect validation could break local dev or leave SSRF gaps, though defaults are fail-closed with explicit opt-in.
> 
> **Overview**
> **Hardens outbound OAuth metadata fetches** against attacker-controlled URLs (PRM pointers, AS metadata, CIMD, redirects) by validating destinations before state machines call the request executor.
> 
> Introduces browser-safe **`oauth/ssrf-guard.ts`**: RFC 6890 private/reserved IP classification (moved from **`oauth-proxy.ts`**, which now imports it), **`assertOutboundOAuthUrlAllowed`**, **`isLoopbackOAuthUrl`**, and related helpers exported from **`@mcpjam/sdk/browser`**. IPv6 coverage adds NAT64 (`64:ff9b::/96`, local-use `/48`) and mapped-loopback handling.
> 
> **`createOAuthStateMachine`** wraps every machine’s **`requestExecutor`** once with the guard. New **`allowLoopbackMetadataFetch`** defaults to **`false`**; loopback is allowed only when explicitly opted in and never relaxes LAN/link-local/reserved blocks.
> 
> **Inspector** sets **`allowLoopbackMetadataFetch: isLoopbackOAuthUrl(serverUrl)`** on connect, callback, and OAuth debugger paths so local **`127.0.0.1`** dev servers work without letting a public server steer fetches at the user’s loopback.
> 
> **Connect flow** in **`mcp-oauth.ts`** re-validates the **final** response URL after browser redirects via **`isPrivateHost`** (defense-in-depth; DNS rebind stays on the Node proxy).
> 
> Tests cover the classifier, loopback opt-in, factory integration (cloud metadata blocked; loopback gated), and inspector adapter behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 029a8a76a2a951ff9ff49d22b901ce8ffaa359fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an SSRF guard to all outbound OAuth metadata fetches, blocking non-http(s) schemes and private/reserved hosts across all machines. Loopback is blocked by default; the client and debugger now opt into loopback only when the user-configured server URL is itself loopback, and the browser path also re-validates the final URL after redirects.

- **New Features**
  - New `sdk/src/oauth/ssrf-guard.ts` with RFC 6890 classifier and `assertOutboundOAuthUrlAllowed(url, { allowLoopback })`; `sdk/src/oauth-proxy.ts` reuses it (DNS validation stays in the proxy). `sdk/src/browser.ts` exports `assertOutboundOAuthUrlAllowed`, `isPrivateHost`, `isDisallowedIpAddress`, `isLoopbackOAuthUrl`, and the error.
  - Factory wraps the injected request executor once to guard all machines. New `allowLoopbackMetadataFetch` option defaults to false; loopback (including IPv4‑mapped) is allowed only when true. LAN/link-local/reserved hosts are always blocked. NAT64 hardening rejects `64:ff9b:1::/48` and `64:ff9b::/96` with private embedded IPv4.
  - Exact-origin allowance: both the Connect flow and the Inspector debugger set `allowLoopbackMetadataFetch` only when `isLoopbackOAuthUrl(serverUrl)` is true, so public servers cannot steer fetches to a user’s loopback. The browser executor also rejects consuming responses whose final URL (after redirects) resolves to a private host.

- **Migration**
  - Direct SDK users intentionally hitting `localhost`/`127.0.0.1` should pass `allowLoopbackMetadataFetch: true` to `createOAuthStateMachine`. No changes are needed for hosted/remote flows.

<sup>Written for commit 029a8a76a2a951ff9ff49d22b901ce8ffaa359fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

