### PR TITLE
fix(agent): stop the in-app assistant inventing a "weather" server

### DIFF
--- a/mcpjam-inspector/server/routes/web/mcpjam-agent.ts
+++ b/mcpjam-inspector/server/routes/web/mcpjam-agent.ts
@@ -121,6 +121,7 @@ const AGENT_IDENTITY_PROMPT = [
   "When the user asks you to DO something (or where something is), drive the UI and take them there — prefer showing over describing.",
   "When the user asks a QUESTION about the product — how something works, how to do something, what a feature can do — search the MCPJam documentation first and answer from what it says; the screen atlas below tells you where things live, not how they behave, so don't answer product behavior from it alone. Then, if you can carry the answer out in the app, offer to — and wait for a yes before acting.",
   "Use web search for questions beyond MCPJam itself. You have no other way to act — when something isn't reachable through a `ui_*` tool, say so plainly rather than inventing a tool or claiming you did it.",
+  "When the user wants to add or try an MCP server but hasn't named one, ask which server they'd like to connect — never invent a placeholder server (there is no default \"weather\" server). If they just want a quick example to try, offer these real ones: `https://mcp.excalidraw.com/mcp` (streamable HTTP, no auth) or `https://mcp.mcpjam.com/mcp` (an OAuth example). Only add a server once you have a concrete name and URL from the user or from one of these examples.",
   "Keep replies short: lead with the answer in a few sentences, no filler, no restating the question. If the docs don't settle it, say you're not sure rather than guessing.",
   "",
   // The atlas: what screens exist and what they're for. Derived from the


### PR DESCRIPTION
## Problem

When a user asks the MCPJam in-app assistant to "add a server" without naming one, it offers to add a **weather** server. This confused a user — where did that come from?

I traced the full runtime prompt path (`AGENT_IDENTITY_PROMPT`, the app atlas, `buildUiToolsSystemPrompt`, and every `ui_*` tool description + input schema). **None of them mention "weather".** The only server-name example the agent is given is `Excalidraw` (add-server schema) and `Asana` (registry). So the weather server is the model's own **training prior** — a weather server is the canonical MCP quickstart across the official docs — not anything in our code.

## Fix

Add one line of guidance to `AGENT_IDENTITY_PROMPT` (`server/routes/web/mcpjam-agent.ts`): when the user wants to add a server but hasn't named one, **ask** rather than invent a placeholder, and if they just want an example to try, offer real ones:

- `https://mcp.excalidraw.com/mcp` — streamable HTTP, no auth (already our onboarding quick-connect example)
- `https://mcp.mcpjam.com/mcp` — an OAuth example

Static, cacheable prefix line — no per-turn cost.

## Note / open question

`https://mcp.mcpjam.com/mcp` is our platform MCP worker. I have **not** verified it completes an external OAuth connection end-to-end as a demo server. If it doesn't, we should swap the OAuth example for a known-good one (e.g. Asana/Linear). Flagging for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single static prompt line with no runtime or auth changes; only affects assistant wording when users add servers without specifying one.
> 
> **Overview**
> **Fixes the in-app assistant suggesting a fictional "weather" server** when users ask to add an MCP server without naming one.
> 
> Adds guidance to `AGENT_IDENTITY_PROMPT` in `mcpjam-agent.ts`: **ask** which server to connect, explicitly state there is no default weather server, and only offer **real** quick-try URLs (`mcp.excalidraw.com` and `mcp.mcpjam.com`) when the user wants an example. **Do not add a server** until the user picks a concrete name/URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e43c5ba2524da6ac7ab9e7c45629bd15d5c4680. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop the MCPJam in‑app assistant from inventing a fake “weather” server when users ask to add a server without naming one. The agent now asks which server to connect and offers real examples on request.

- **Bug Fixes**
  - Added guidance to `AGENT_IDENTITY_PROMPT` in `mcpjam-inspector/server/routes/web/mcpjam-agent.ts` to never invent a placeholder; ask for a server name/URL and only proceed with a concrete choice.
  - When an example is requested, suggest `https://mcp.excalidraw.com/mcp` (no auth, streamable HTTP) or `https://mcp.mcpjam.com/mcp` (OAuth; replace with a known‑good option if unreliable).

<sup>Written for commit 4e43c5ba2524da6ac7ab9e7c45629bd15d5c4680. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

