### PR TITLE
fix(computers): stop advertising bash to guests off the swarm path

### DIFF
--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -697,6 +697,12 @@ chatV2.post("/", async (c) => {
         ? {
             authHeader: builtInAuthHeader,
             projectId: body.projectId,
+            // A request with no user-supplied Authorization is an anonymous
+            // guest (the route mints a production guest bearer for it), so the
+            // resolver withholds bash on the personal-project path — matching
+            // web/chat-v2's `isGuest: Boolean(c.get("guestId"))`. Bash is kept
+            // only for a host-funded swarm executionScope.
+            isGuest: !requestAuthHeader,
             ...(executionScope ? { executionScope } : {}),
             ...(body.chatSessionId
               ? { chatSessionId: body.chatSessionId }

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -324,7 +324,9 @@ chatV2.post("/", async (c) => {
     // built-in-tools/registry.ts). `computer` comes exclusively from the
     // server-resolved runtime config — never the request body — so a
     // tampered client can't attach a shell the host didn't authorize; the
-    // resolver also skips computer-backed tools for guest actors.
+    // resolver skips bash for anonymous guests unless the turn carries a
+    // host-funded swarm executionScope (personal-project guest reserves are
+    // rejected backend-side).
     // Harness preflight: a host-bound turn whose resolved host runs a harness
     // (claude-code | codex) must fail closed with a clear message when the
     // runtime isn't available on this server — never silently degrade to the

--- a/mcpjam-inspector/server/utils/__tests__/built-in-tools-registry.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/built-in-tools-registry.test.ts
@@ -101,12 +101,42 @@ describe("resolveHostTools — computer-backed bash", () => {
     expect(Object.keys(tools ?? {})).toEqual([WEB_SEARCH_TOOL_NAME]);
   });
 
-  it("advertises bash to guest actors too (cost is contained backend-side)", () => {
+  it("skips bash for an anonymous guest on the personal-project path (backend rejects the reserve)", () => {
     const tools = resolveHostTools(
       { builtInToolIds: [BASH_TOOL_NAME, WEB_SEARCH_TOOL_NAME], computer },
       { ...ctx, isGuest: true }
     );
+    expect(Object.keys(tools ?? {})).toEqual([WEB_SEARCH_TOOL_NAME]);
+  });
+
+  it("advertises bash to a guest ONLY on a host-funded swarm executionScope", () => {
+    const tools = resolveHostTools(
+      { builtInToolIds: [BASH_TOOL_NAME, WEB_SEARCH_TOOL_NAME], computer },
+      {
+        ...ctx,
+        isGuest: true,
+        executionScope: {
+          kind: "swarm",
+          swarmId: "swarm-1",
+          accessVersion: 1,
+          projectId: "project-1",
+          workspaceId: "ws-1",
+        },
+      }
+    );
     expect(Object.keys(tools ?? {})).toContain(BASH_TOOL_NAME);
+  });
+
+  it("skips bash for a guest on a project-scoped executionScope (not host-funded)", () => {
+    const tools = resolveHostTools(
+      { builtInToolIds: [BASH_TOOL_NAME, WEB_SEARCH_TOOL_NAME], computer },
+      {
+        ...ctx,
+        isGuest: true,
+        executionScope: { kind: "project", projectId: "project-1" },
+      }
+    );
+    expect(Object.keys(tools ?? {})).toEqual([WEB_SEARCH_TOOL_NAME]);
   });
 
   it("does NOT advertise bash off the computer alone — the id must be granted", () => {

--- a/mcpjam-inspector/server/utils/built-in-tools/registry.ts
+++ b/mcpjam-inspector/server/utils/built-in-tools/registry.ts
@@ -179,9 +179,19 @@ export function resolveHostTools(
         );
         continue;
       }
-      // Guests get bash too: the backend accepts guest bearers on
-      // /computers/reserve and contains cost via the guest daily start cap
-      // and the idle-delete sweep.
+      // Anonymous guests get bash ONLY on a host-funded swarm grant
+      // (executionScope.kind === "swarm"), where a member host opted in and
+      // pays under per-swarm caps. On the legacy/personal-project path the
+      // backend now rejects guest reserves (projectComputers
+      // `assertNonGuestComputerActor`, mirroring inspector #3132), so
+      // advertising bash there would only produce a tool that errors — skip it.
+      if (ctx.isGuest && ctx.executionScope?.kind !== "swarm") {
+        logger.debug(
+          "[built-in-tools] bash not advertised to guest actor without a host-funded swarm scope; skipping",
+          { projectId: ctx.projectId }
+        );
+        continue;
+      }
       out[BASH_TOOL_NAME] = buildBashTool({
         authHeader,
         projectId: ctx.projectId,


### PR DESCRIPTION
Stop advertising the bash tool to anonymous guests on the personal-project path, and fix a stale comment claiming the resolver already did this. Companion to backend PR MCPJam/mcpjam-backend#759 and follow-up to #3132.

resolveHostTools granted bash to any guest whenever a computer was in the resolved config. Meanwhile chat-v2.ts asserted the resolver 'skips computer-backed tools for guest actors' — it did not. With the backend now rejecting anonymous-guest reserves on the personal-project path, advertising bash there only produces a tool that errors on first call.

Change: skip bash for anonymous guests unless the turn carries a host-funded swarm executionScope (kind === swarm), where a member host opted in and pays under per-swarm caps. Correct the misleading chat-v2 comment; update resolver tests (30/30 pass).

Not a security control — the backend gate is authoritative. This just stops the client advertising a tool the backend will now reject.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tool-listing UX alignment only; backend reserve rejection remains authoritative. Small, well-tested change in built-in tool resolution and chat route context wiring.
> 
> **Overview**
> **`resolveHostTools` no longer exposes `bash` to anonymous guests on the personal-project path**, aligning tool advertisement with backend guest computer reserves (companion to backend #759 / inspector #3132). Guests still get **`bash` only when the turn has a host-funded swarm `executionScope`** (`kind === "swarm"`); project-scoped scopes are treated like the legacy path.
> 
> The **MCP `chat-v2` route** now passes **`isGuest: !requestAuthHeader`** into the resolver (minted guest bearer without a user `Authorization`), matching web chat’s guest detection. Comments on both chat routes were updated to describe the real behavior. **Resolver tests** cover guest without scope, guest with swarm scope, and guest with project scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da5e534ae18f22bc5a9a74769d9cb7154749b1b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop advertising the `bash` tool to anonymous guests on the personal-project path. Guests now only see `bash` when the turn has a host-funded swarm `executionScope` (`kind: "swarm"`), and this is enforced in both the resolver and `/api/mcp/chat-v2`.

- **Bug Fixes**
  - Gate `bash` in `resolveHostTools` for guests to only allow when `executionScope.kind === "swarm"`.
  - Thread guest state into `mcp/chat-v2` by passing `isGuest: !requestAuthHeader` so the gate applies on that route.
  - Update resolver tests to cover guest without scope, guest with swarm scope, and guest with project scope.

<sup>Written for commit da5e534ae18f22bc5a9a74769d9cb7154749b1b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

