### PR TITLE
feat(oauth-conformance): server-side spec-obligation checks (HP-17 3/4/5)

### DIFF
--- a/.changeset/hp-45-oauth-server-obligation-checks.md
+++ b/.changeset/hp-45-oauth-server-obligation-checks.md
@@ -19,3 +19,8 @@ checks:
 
 These are hard failures against normative spec text, distinct from the
 host-capability readiness matrix.
+
+`StepResult` gains an optional `warnings` array for non-fatal evidence on a
+passing step (e.g. a stale session rejected with 400 instead of the
+spec-preferred 404). Warnings surface in conformance report details and render
+distinctly from errors in the inspector UI.

--- a/.changeset/hp-45-oauth-server-obligation-checks.md
+++ b/.changeset/hp-45-oauth-server-obligation-checks.md
@@ -1,0 +1,21 @@
+---
+"@mcpjam/sdk": minor
+---
+
+feat(oauth-conformance): add three server-side spec-obligation checks (HP-17 findings 3/4/5)
+
+The OAuth conformance suite now verifies obligations the MCP server owes every
+client, gated behind `oauthConformanceChecks` alongside the existing negative
+checks:
+
+- `oauth_unauthenticated_challenge` — an unauthenticated request must be
+  answered with HTTP 401 and a `WWW-Authenticate: Bearer` challenge, never a
+  500 (RFC 6750 §3).
+- `oauth_resource_metadata_challenge` — the Bearer challenge must advertise an
+  absolute `resource_metadata` URL (RFC 9728 §5.1).
+- `oauth_stale_session_rejection` — a request carrying an unknown
+  `Mcp-Session-Id` must be rejected with a 4xx (404 preferred), never a 500
+  (Streamable HTTP transport). Skipped on the stateless 2026-07-28 wire.
+
+These are hard failures against normative spec text, distinct from the
+host-capability readiness matrix.

--- a/.changeset/hp-45-oauth-server-obligation-checks.md
+++ b/.changeset/hp-45-oauth-server-obligation-checks.md
@@ -10,9 +10,11 @@ checks:
 
 - `oauth_unauthenticated_challenge` — an unauthenticated request must be
   answered with HTTP 401 and a `WWW-Authenticate: Bearer` challenge, never a
-  500 (RFC 6750 §3).
+  500 (RFC 6750 §3). A 2xx skips as unverifiable — anonymous `initialize` with
+  authorization enforced on later requests is spec-legal.
 - `oauth_resource_metadata_challenge` — the Bearer challenge must advertise an
-  absolute `resource_metadata` URL (RFC 9728 §5.1).
+  absolute `resource_metadata` URL (RFC 9728 §5.1). Skipped on 2025-03-26,
+  which predates RFC 9728 in the MCP authorization spec.
 - `oauth_stale_session_rejection` — a request carrying an unknown
   `Mcp-Session-Id` must be rejected with a 4xx (404 preferred), never a 500
   (Streamable HTTP transport). Skipped on the stateless 2026-07-28 wire.

--- a/mcpjam-inspector/client/src/components/conformance/ConformancePanel.tsx
+++ b/mcpjam-inspector/client/src/components/conformance/ConformancePanel.tsx
@@ -240,6 +240,20 @@ function OAuthStepRow({ step }: { step: OAuthConformanceStepResult }) {
             </div>
           )}
 
+          {step.warnings && step.warnings.length > 0 && (
+            <div className="rounded-sm bg-muted/20 px-2 py-1.5 text-xs text-muted-foreground">
+              <div className="mb-1 flex items-center gap-1 font-medium text-foreground/70">
+                <AlertTriangle className="h-3 w-3" />
+                Warnings
+              </div>
+              <ul className="space-y-1 pl-4 list-disc">
+                {step.warnings.map((warning) => (
+                  <li key={warning}>{warning}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+
           {step.error && (
             <div className="rounded-sm border border-red-500/20 bg-red-500/5 px-2 py-1.5 text-xs text-red-400 whitespace-pre-wrap break-words">
               {step.error.message}

--- a/mcpjam-inspector/client/src/components/conformance/__tests__/ConformancePanel.test.tsx
+++ b/mcpjam-inspector/client/src/components/conformance/__tests__/ConformancePanel.test.tsx
@@ -366,6 +366,41 @@ describe("ConformanceTab", () => {
     ).not.toBeNull();
   });
 
+  it("renders warnings on a passed OAuth step without an error banner", async () => {
+    setupSuccessfulRunMocks({
+      oauth: createOAuthResult({
+        steps: [
+          {
+            step: "oauth_stale_session_rejection",
+            title: "OAuth Check: Stale Session Rejection",
+            summary: "Reject unknown session ids with a 4xx.",
+            status: "passed",
+            durationMs: 9,
+            logs: [],
+            httpAttempts: [],
+            warnings: [
+              "Rejected with HTTP 400 (the transport spec prefers 404)",
+            ],
+          },
+        ],
+      }),
+    });
+
+    render(<ConformanceTab server={createHttpServer()} />);
+
+    fireEvent.click(screen.getByText("Run available checks"));
+    await screen.findByText("OAuth summary");
+
+    clickRow("OAuth Check: Stale Session Rejection");
+    const warning = screen.getByText(
+      "Rejected with HTTP 400 (the transport spec prefers 404)",
+    );
+    expect(warning).not.toBeNull();
+    expect(screen.queryByText("Warnings")).not.toBeNull();
+    // Warnings render in the muted style, never the red error treatment.
+    expect(warning.closest("div")?.className).not.toContain("red");
+  });
+
   it("collapses expanded rows when conformance is rerun", async () => {
     setupSuccessfulRunMocks({
       protocol: createProtocolResult({

--- a/sdk/src/conformance-reporting.ts
+++ b/sdk/src/conformance-reporting.ts
@@ -180,10 +180,13 @@ function reportCaseFromOAuthStep(
     durationMs: step.durationMs,
     description: step.summary,
     ...(step.error?.message ? { error: step.error.message } : {}),
-    ...(step.error?.details !== undefined || step.teachableMoments?.length
+    ...(step.error?.details !== undefined ||
+    step.warnings?.length ||
+    step.teachableMoments?.length
       ? {
           details: buildDetailPayload({
             errorDetails: step.error?.details,
+            warnings: step.warnings,
             teachableMoments: step.teachableMoments,
           }),
         }

--- a/sdk/src/oauth-conformance/checks/oauth-server-obligations.ts
+++ b/sdk/src/oauth-conformance/checks/oauth-server-obligations.ts
@@ -40,6 +40,7 @@ export interface OAuthServerObligationOutcome {
   status: StepResult["status"];
   durationMs: number;
   error?: StepResult["error"];
+  warnings?: StepResult["warnings"];
 }
 
 interface OAuthServerObligationInput {
@@ -117,10 +118,12 @@ function challengeOffersBearer(wwwAuthenticate: string): boolean {
 }
 
 /** Extract the `resource_metadata` auth-param value from a WWW-Authenticate
- * challenge. RFC 7235 allows the value quoted or as a bare token; accept both. */
+ * challenge. RFC 7235 allows the value quoted or as a bare token; accept both.
+ * The left boundary keeps a hypothetical `x_resource_metadata` param from
+ * matching. */
 function extractResourceMetadata(wwwAuthenticate: string): string | undefined {
   const match = wwwAuthenticate.match(
-    /resource_metadata\s*=\s*(?:"([^"]*)"|([^",\s]+))/i,
+    /(?:^|[\s,])resource_metadata\s*=\s*(?:"([^"]*)"|([^",\s]+))/i,
   );
   if (!match) {
     return undefined;
@@ -144,9 +147,7 @@ function bodyIsParseable(body: unknown): boolean {
   if (typeof body === "string") {
     return body.trim().length > 0;
   }
-  if (typeof body === "object") {
-    return Object.keys(body as Record<string, unknown>).length > 0;
-  }
+  // Any object (including {}) got here by parsing successfully.
   return true;
 }
 
@@ -165,6 +166,15 @@ function buildUnauthenticatedMcpRequest(
     "Content-Type": "application/json",
     Accept: "application/json, text/event-stream",
   };
+
+  // customHeaders may carry credentials (e.g. a gateway bypass token). If any
+  // Authorization variant survives the spread, the probe is silently
+  // authenticated and the check false-fails on the resulting 2xx.
+  for (const key of Object.keys(headers)) {
+    if (key.toLowerCase() === "authorization") {
+      delete headers[key];
+    }
+  }
 
   if (config.protocolVersion !== "2025-03-26") {
     headers["MCP-Protocol-Version"] = config.protocolVersion;
@@ -312,6 +322,22 @@ export async function runResourceMetadataChallengeCheck(
     };
   }
 
+  // A non-Bearer challenge (e.g. Basic) already fails
+  // oauth_unauthenticated_challenge; failing here too would report the same
+  // root cause twice. RFC 9728 only obligates resource_metadata on Bearer.
+  if (!challengeOffersBearer(wwwAuthenticate)) {
+    return {
+      step: "oauth_resource_metadata_challenge",
+      status: "skipped",
+      durationMs,
+      error: {
+        message:
+          "The WWW-Authenticate challenge does not offer a Bearer scheme, so resource_metadata does not apply; the missing Bearer challenge is reported by the unauthenticated-challenge check",
+        details: { wwwAuthenticate },
+      },
+    };
+  }
+
   const resourceMetadata = extractResourceMetadata(wwwAuthenticate);
 
   if (!resourceMetadata) {
@@ -346,6 +372,11 @@ export async function runResourceMetadataChallengeCheck(
   };
 }
 
+// Unlike every other check, this request carries the REAL access token, and a
+// transport failure embeds it in error.details.request.headers. That is safe
+// in reports only because renderConformanceReportJson (conformance-reporting.ts)
+// deep-redacts authorization keys via redaction.ts before serializing — any
+// consumer of raw StepResults bypasses that redaction.
 function buildStaleSessionMcpRequest(
   config: NormalizedOAuthConformanceConfig,
   accessToken: string,
@@ -454,28 +485,26 @@ export async function runStaleSessionRejectionCheck(
   }
 
   if (response.status >= 400) {
-    const parseableBody = bodyIsParseable(response.body);
+    // Evidence only — 404 is spec-preferred and a parseable body is nice to
+    // have, but neither is mandated, so they never downgrade a passing 4xx.
+    // Recorded as warnings, not error: the UI renders error as a failure
+    // banner regardless of status.
+    const warnings: string[] = [];
+    if (response.status !== 404) {
+      warnings.push(
+        `Rejected with HTTP ${response.status} (the transport spec prefers 404)`,
+      );
+    }
+    if (!bodyIsParseable(response.body)) {
+      warnings.push(
+        `Rejected with ${response.status} but the response body was empty or unparseable`,
+      );
+    }
     return {
       step: "oauth_stale_session_rejection",
       status: "passed",
       durationMs,
-      // Evidence only — 404 is spec-preferred and a parseable body is nice to
-      // have, but neither is mandated, so they never downgrade a passing 4xx.
-      ...(response.status !== 404 || !parseableBody
-        ? {
-            error: {
-              message:
-                response.status !== 404
-                  ? `Rejected with HTTP ${response.status} (the transport spec prefers 404)`
-                  : "Rejected with 404 but the response body was empty or unparseable",
-              details: {
-                status: response.status,
-                statusText: response.statusText,
-                parseableBody,
-              },
-            },
-          }
-        : {}),
+      ...(warnings.length ? { warnings } : {}),
     };
   }
 

--- a/sdk/src/oauth-conformance/checks/oauth-server-obligations.ts
+++ b/sdk/src/oauth-conformance/checks/oauth-server-obligations.ts
@@ -1,0 +1,497 @@
+import type { OAuthFlowState } from "../../oauth/state-machines/types.js";
+import {
+  buildInitializeRequestBody,
+  resolveInitializeProtocolVersion,
+} from "../../oauth/state-machines/shared/initialize.js";
+import type {
+  NormalizedOAuthConformanceConfig,
+  OAuthConformanceCheckId,
+  StepResult,
+  TrackedRequestFn,
+} from "../types.js";
+
+// ── Server-side spec obligations (HP-17 findings 3/4/5) ────────────────
+//
+// These three checks encode server conformance requirements that Composio's
+// cross-client feedback surfaced (validated in HP-17, 2026-07-21). Unlike the
+// host-capability matrix — which records how real *clients* behave — these are
+// obligations the MCP *server* owes every client, so they belong here in the
+// conformance suite where a violation is a hard FAIL against normative spec
+// text, not a readiness warning.
+//
+//   Finding 3 — the `WWW-Authenticate` challenge must carry an absolute
+//     `resource_metadata` URL (RFC 9728 §5.1).
+//   Finding 4 — an unauthenticated request must be answered with 401 + a Bearer
+//     challenge, never a 500 (RFC 6750 §3 / MCP authorization).
+//   Finding 5 — a stale `Mcp-Session-Id` must be rejected with a 4xx, never a
+//     500 (MCP Streamable HTTP transport). Per HP-17 the spec prefers 404 and
+//     does NOT mandate a parseable body, so only the 5xx crash is a failure;
+//     the status specificity and body shape are reported as evidence only.
+
+type OAuthServerObligationStep = Extract<
+  OAuthConformanceCheckId,
+  | "oauth_unauthenticated_challenge"
+  | "oauth_resource_metadata_challenge"
+  | "oauth_stale_session_rejection"
+>;
+
+export interface OAuthServerObligationOutcome {
+  step: OAuthServerObligationStep;
+  status: StepResult["status"];
+  durationMs: number;
+  error?: StepResult["error"];
+}
+
+interface OAuthServerObligationInput {
+  config: NormalizedOAuthConformanceConfig;
+  state: OAuthFlowState;
+  trackedRequest: TrackedRequestFn;
+}
+
+// A syntactically valid (visible-ASCII) session id that the server never
+// issued — the "stale session" the transport spec says must be rejected.
+const STALE_SESSION_ID = "00000000-0000-0000-0000-000000000000";
+
+function errorDetails(error: unknown) {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+      stack: error.stack,
+    };
+  }
+
+  return error;
+}
+
+function buildTransportFailure(
+  step: OAuthServerObligationStep,
+  startedAt: number,
+  request: {
+    method: string;
+    url: string;
+    headers: Record<string, string>;
+    body?: Record<string, unknown>;
+  },
+  error: unknown,
+  messagePrefix: string,
+): OAuthServerObligationOutcome {
+  return {
+    step,
+    status: "failed",
+    durationMs: Date.now() - startedAt,
+    error: {
+      message: `${messagePrefix}: ${error instanceof Error ? error.message : String(error)}`,
+      details: {
+        request,
+        error: errorDetails(error),
+      },
+    },
+  };
+}
+
+/** Headers are lowercased by the runner, but read case-insensitively anyway so
+ * these checks stay correct against a custom fetch that does not normalize. */
+function getHeaderValue(
+  headers: Record<string, string> | undefined,
+  name: string,
+): string | undefined {
+  if (!headers) {
+    return undefined;
+  }
+  const lower = name.toLowerCase();
+  const direct = headers[lower];
+  if (typeof direct === "string") {
+    return direct;
+  }
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() === lower) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function challengeOffersBearer(wwwAuthenticate: string): boolean {
+  return /\bBearer\b/i.test(wwwAuthenticate);
+}
+
+/** Extract the `resource_metadata` auth-param value from a WWW-Authenticate
+ * challenge. RFC 7235 allows the value quoted or as a bare token; accept both. */
+function extractResourceMetadata(wwwAuthenticate: string): string | undefined {
+  const match = wwwAuthenticate.match(
+    /resource_metadata\s*=\s*(?:"([^"]*)"|([^",\s]+))/i,
+  );
+  if (!match) {
+    return undefined;
+  }
+  return match[1] ?? match[2];
+}
+
+function isAbsoluteHttpUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function bodyIsParseable(body: unknown): boolean {
+  if (body === undefined || body === null) {
+    return false;
+  }
+  if (typeof body === "string") {
+    return body.trim().length > 0;
+  }
+  if (typeof body === "object") {
+    return Object.keys(body as Record<string, unknown>).length > 0;
+  }
+  return true;
+}
+
+function buildUnauthenticatedMcpRequest(
+  config: NormalizedOAuthConformanceConfig,
+): {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+  body: Record<string, unknown>;
+} {
+  // Deliberately no Authorization header — this is the unauthenticated probe.
+  // Mirrors buildInvalidTokenMcpRequest (oauth-negative.ts) minus the bearer.
+  const headers: Record<string, string> = {
+    ...(config.customHeaders ?? {}),
+    "Content-Type": "application/json",
+    Accept: "application/json, text/event-stream",
+  };
+
+  if (config.protocolVersion !== "2025-03-26") {
+    headers["MCP-Protocol-Version"] = config.protocolVersion;
+  }
+
+  return {
+    method: "POST",
+    url: config.serverUrl,
+    headers,
+    body: buildInitializeRequestBody({
+      protocolVersion: resolveInitializeProtocolVersion(config.protocolVersion),
+      authMode: config.auth.mode,
+      clientName: "MCPJam SDK OAuth Conformance",
+      clientVersion: "1.0.0",
+      id: 1001,
+    }),
+  };
+}
+
+/**
+ * Finding 4: an unauthenticated request to a protected MCP server must be
+ * answered with `401` and a `Bearer` challenge — never a `500`, and never
+ * silently accepted.
+ */
+export async function runUnauthenticatedChallengeCheck(
+  input: OAuthServerObligationInput,
+): Promise<OAuthServerObligationOutcome> {
+  const startedAt = Date.now();
+  const request = buildUnauthenticatedMcpRequest(input.config);
+  let response: Awaited<ReturnType<TrackedRequestFn>>;
+
+  try {
+    response = await input.trackedRequest(request);
+  } catch (error) {
+    return buildTransportFailure(
+      "oauth_unauthenticated_challenge",
+      startedAt,
+      request,
+      error,
+      "Unauthenticated MCP request failed",
+    );
+  }
+
+  const durationMs = Date.now() - startedAt;
+  const wwwAuthenticate = getHeaderValue(response.headers, "www-authenticate");
+
+  if (response.status >= 500) {
+    return {
+      step: "oauth_unauthenticated_challenge",
+      status: "failed",
+      durationMs,
+      error: {
+        message: `MCP server returned HTTP ${response.status} for an unauthenticated request instead of 401`,
+        details: {
+          status: response.status,
+          statusText: response.statusText,
+          response: response.body,
+        },
+      },
+    };
+  }
+
+  if (response.status !== 401) {
+    return {
+      step: "oauth_unauthenticated_challenge",
+      status: "failed",
+      durationMs,
+      error: {
+        message: `MCP server did not challenge an unauthenticated request (expected HTTP 401, received ${response.status})`,
+        details: {
+          status: response.status,
+          statusText: response.statusText,
+          response: response.body,
+        },
+      },
+    };
+  }
+
+  if (!wwwAuthenticate || !challengeOffersBearer(wwwAuthenticate)) {
+    return {
+      step: "oauth_unauthenticated_challenge",
+      status: "failed",
+      durationMs,
+      error: {
+        message: wwwAuthenticate
+          ? "MCP server returned 401 with a WWW-Authenticate header that does not offer a Bearer challenge"
+          : "MCP server returned 401 without a WWW-Authenticate Bearer challenge (RFC 6750 §3)",
+        details: {
+          status: response.status,
+          wwwAuthenticate,
+        },
+      },
+    };
+  }
+
+  return {
+    step: "oauth_unauthenticated_challenge",
+    status: "passed",
+    durationMs,
+  };
+}
+
+/**
+ * Finding 3: the Bearer challenge on an unauthenticated request must include an
+ * absolute `resource_metadata` URL (RFC 9728 §5.1) so the client can discover
+ * the protected-resource metadata document.
+ */
+export async function runResourceMetadataChallengeCheck(
+  input: OAuthServerObligationInput,
+): Promise<OAuthServerObligationOutcome> {
+  const startedAt = Date.now();
+  const request = buildUnauthenticatedMcpRequest(input.config);
+  let response: Awaited<ReturnType<TrackedRequestFn>>;
+
+  try {
+    response = await input.trackedRequest(request);
+  } catch (error) {
+    return buildTransportFailure(
+      "oauth_resource_metadata_challenge",
+      startedAt,
+      request,
+      error,
+      "Unauthenticated MCP request failed",
+    );
+  }
+
+  const durationMs = Date.now() - startedAt;
+  const wwwAuthenticate = getHeaderValue(response.headers, "www-authenticate");
+
+  // No challenge to inspect — the missing/!401 challenge is a distinct
+  // obligation owned by oauth_unauthenticated_challenge; don't double-report it.
+  if (!wwwAuthenticate) {
+    return {
+      step: "oauth_resource_metadata_challenge",
+      status: "skipped",
+      durationMs,
+      error: {
+        message:
+          "No WWW-Authenticate challenge was returned, so resource_metadata could not be isolated",
+        details: {
+          status: response.status,
+          statusText: response.statusText,
+        },
+      },
+    };
+  }
+
+  const resourceMetadata = extractResourceMetadata(wwwAuthenticate);
+
+  if (!resourceMetadata) {
+    return {
+      step: "oauth_resource_metadata_challenge",
+      status: "failed",
+      durationMs,
+      error: {
+        message:
+          "WWW-Authenticate Bearer challenge omitted the resource_metadata parameter (RFC 9728 §5.1)",
+        details: { wwwAuthenticate },
+      },
+    };
+  }
+
+  if (!isAbsoluteHttpUrl(resourceMetadata)) {
+    return {
+      step: "oauth_resource_metadata_challenge",
+      status: "failed",
+      durationMs,
+      error: {
+        message: `resource_metadata must be an absolute http(s) URL (RFC 9728 §5.1); received "${resourceMetadata}"`,
+        details: { wwwAuthenticate, resourceMetadata },
+      },
+    };
+  }
+
+  return {
+    step: "oauth_resource_metadata_challenge",
+    status: "passed",
+    durationMs,
+  };
+}
+
+function buildStaleSessionMcpRequest(
+  config: NormalizedOAuthConformanceConfig,
+  accessToken: string,
+): {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+  body: Record<string, unknown>;
+} {
+  const headers: Record<string, string> = {
+    ...(config.customHeaders ?? {}),
+    Authorization: `Bearer ${accessToken}`,
+    "Content-Type": "application/json",
+    Accept: "application/json, text/event-stream",
+    "Mcp-Session-Id": STALE_SESSION_ID,
+  };
+
+  if (config.protocolVersion !== "2025-03-26") {
+    headers["MCP-Protocol-Version"] = config.protocolVersion;
+  }
+
+  // A non-initialize method: `initialize` creates sessions, so a stale session
+  // id is only meaningful on a subsequent request. `tools/list` needs a live
+  // session, so an unknown session id is exactly the stale-session scenario.
+  return {
+    method: "POST",
+    url: config.serverUrl,
+    headers,
+    body: {
+      jsonrpc: "2.0",
+      method: "tools/list",
+      params: {},
+      id: 1002,
+    },
+  };
+}
+
+/**
+ * Finding 5: a request carrying a stale/unknown `Mcp-Session-Id` must be
+ * rejected with a 4xx (the transport spec prefers 404) — never a 500. Per
+ * HP-17 the spec does NOT mandate a parseable body, so a non-parseable body is
+ * reported as evidence but does not fail the check; only a 5xx crash does.
+ */
+export async function runStaleSessionRejectionCheck(
+  input: OAuthServerObligationInput,
+): Promise<OAuthServerObligationOutcome> {
+  const startedAt = Date.now();
+
+  // The 2026-07-28 wire is stateless — there is no Mcp-Session-Id to go stale.
+  if (input.config.protocolVersion === "2026-07-28") {
+    return {
+      step: "oauth_stale_session_rejection",
+      status: "skipped",
+      durationMs: 0,
+      error: {
+        message:
+          "The 2026-07-28 transport is stateless; there is no session id to invalidate",
+      },
+    };
+  }
+
+  const accessToken = input.state.accessToken;
+  if (!accessToken) {
+    return {
+      step: "oauth_stale_session_rejection",
+      status: "skipped",
+      durationMs: 0,
+      error: {
+        message:
+          "No access token is available to isolate stale-session handling from authentication",
+      },
+    };
+  }
+
+  const request = buildStaleSessionMcpRequest(input.config, accessToken);
+  let response: Awaited<ReturnType<TrackedRequestFn>>;
+
+  try {
+    response = await input.trackedRequest(request);
+  } catch (error) {
+    return buildTransportFailure(
+      "oauth_stale_session_rejection",
+      startedAt,
+      request,
+      error,
+      "Stale-session MCP request failed",
+    );
+  }
+
+  const durationMs = Date.now() - startedAt;
+
+  if (response.status >= 500) {
+    return {
+      step: "oauth_stale_session_rejection",
+      status: "failed",
+      durationMs,
+      error: {
+        message: `MCP server returned HTTP ${response.status} for a stale Mcp-Session-Id instead of a 4xx rejection`,
+        details: {
+          status: response.status,
+          statusText: response.statusText,
+          response: response.body,
+        },
+      },
+    };
+  }
+
+  if (response.status >= 400) {
+    const parseableBody = bodyIsParseable(response.body);
+    return {
+      step: "oauth_stale_session_rejection",
+      status: "passed",
+      durationMs,
+      // Evidence only — 404 is spec-preferred and a parseable body is nice to
+      // have, but neither is mandated, so they never downgrade a passing 4xx.
+      ...(response.status !== 404 || !parseableBody
+        ? {
+            error: {
+              message:
+                response.status !== 404
+                  ? `Rejected with HTTP ${response.status} (the transport spec prefers 404)`
+                  : "Rejected with 404 but the response body was empty or unparseable",
+              details: {
+                status: response.status,
+                statusText: response.statusText,
+                parseableBody,
+              },
+            },
+          }
+        : {}),
+    };
+  }
+
+  // 2xx: the server ignored an unknown session id. A stateless/non-session
+  // server legitimately does this, so it is not a violation — just unverifiable.
+  return {
+    step: "oauth_stale_session_rejection",
+    status: "skipped",
+    durationMs,
+    error: {
+      message:
+        "MCP server accepted a request with an unknown Mcp-Session-Id; it does not appear to enforce session state",
+      details: {
+        status: response.status,
+        statusText: response.statusText,
+      },
+    },
+  };
+}

--- a/sdk/src/oauth-conformance/checks/oauth-server-obligations.ts
+++ b/sdk/src/oauth-conformance/checks/oauth-server-obligations.ts
@@ -20,9 +20,12 @@ import type {
 // text, not a readiness warning.
 //
 //   Finding 3 — the `WWW-Authenticate` challenge must carry an absolute
-//     `resource_metadata` URL (RFC 9728 §5.1).
+//     `resource_metadata` URL (RFC 9728 §5.1). RFC 9728 entered the MCP spec
+//     at 2025-06-18, so this check skips on a 2025-03-26 target.
 //   Finding 4 — an unauthenticated request must be answered with 401 + a Bearer
-//     challenge, never a 500 (RFC 6750 §3 / MCP authorization).
+//     challenge, never a 500 (RFC 6750 §3 / MCP authorization). A 2xx is not a
+//     violation — the spec permits anonymous `initialize` with authorization
+//     enforced on later requests — so it skips as unverifiable.
 //   Finding 5 — a stale `Mcp-Session-Id` must be rejected with a 4xx, never a
 //     500 (MCP Streamable HTTP transport). Per HP-17 the spec prefers 404 and
 //     does NOT mandate a parseable body, so only the 5xx crash is a failure;
@@ -65,6 +68,23 @@ function errorDetails(error: unknown) {
   return error;
 }
 
+/** Strip credential-bearing headers before a request is embedded in error
+ * details. Raw StepResults reach consumers (the inspector panel, persisted
+ * runs) that never pass through the report-level redaction in
+ * conformance-reporting.ts, and no consumer needs the token. */
+function redactRequestForDetails(request: {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+  body?: Record<string, unknown>;
+}) {
+  const headers: Record<string, string> = {};
+  for (const [key, value] of Object.entries(request.headers)) {
+    headers[key] = key.toLowerCase() === "authorization" ? "[REDACTED]" : value;
+  }
+  return { ...request, headers };
+}
+
 function buildTransportFailure(
   step: OAuthServerObligationStep,
   startedAt: number,
@@ -84,7 +104,7 @@ function buildTransportFailure(
     error: {
       message: `${messagePrefix}: ${error instanceof Error ? error.message : String(error)}`,
       details: {
-        request,
+        request: redactRequestForDetails(request),
         error: errorDetails(error),
       },
     },
@@ -237,6 +257,26 @@ export async function runUnauthenticatedChallengeCheck(
     };
   }
 
+  // 2xx: the server served an anonymous `initialize`. The spec does not
+  // require every request to be authenticated — authorization may only be
+  // enforced on later requests (e.g. tools/call) — so, as with the
+  // stale-session 2xx path, this is unverifiable rather than a violation.
+  if (response.status >= 200 && response.status < 300) {
+    return {
+      step: "oauth_unauthenticated_challenge",
+      status: "skipped",
+      durationMs,
+      error: {
+        message:
+          "MCP server accepted an unauthenticated initialize; authorization may only be enforced on later requests, so the 401 challenge could not be observed",
+        details: {
+          status: response.status,
+          statusText: response.statusText,
+        },
+      },
+    };
+  }
+
   if (response.status !== 401) {
     return {
       step: "oauth_unauthenticated_challenge",
@@ -285,6 +325,21 @@ export async function runUnauthenticatedChallengeCheck(
 export async function runResourceMetadataChallengeCheck(
   input: OAuthServerObligationInput,
 ): Promise<OAuthServerObligationOutcome> {
+  // RFC 9728 protected-resource metadata entered the MCP authorization spec at
+  // 2025-06-18; a 2025-03-26 server owes no resource_metadata parameter, so
+  // there is nothing to probe.
+  if (input.config.protocolVersion === "2025-03-26") {
+    return {
+      step: "oauth_resource_metadata_challenge",
+      status: "skipped",
+      durationMs: 0,
+      error: {
+        message:
+          "The 2025-03-26 authorization spec predates RFC 9728 protected-resource metadata; resource_metadata is not required on this protocol version",
+      },
+    };
+  }
+
   const startedAt = Date.now();
   const request = buildUnauthenticatedMcpRequest(input.config);
   let response: Awaited<ReturnType<TrackedRequestFn>>;
@@ -372,11 +427,10 @@ export async function runResourceMetadataChallengeCheck(
   };
 }
 
-// Unlike every other check, this request carries the REAL access token, and a
-// transport failure embeds it in error.details.request.headers. That is safe
-// in reports only because renderConformanceReportJson (conformance-reporting.ts)
-// deep-redacts authorization keys via redaction.ts before serializing — any
-// consumer of raw StepResults bypasses that redaction.
+// Unlike every other check, this request carries the REAL access token.
+// buildTransportFailure redacts the Authorization header before embedding the
+// request in error details, so the token never enters a StepResult regardless
+// of whether the consumer applies the report-level redaction.
 function buildStaleSessionMcpRequest(
   config: NormalizedOAuthConformanceConfig,
   accessToken: string,

--- a/sdk/src/oauth-conformance/runner.ts
+++ b/sdk/src/oauth-conformance/runner.ts
@@ -175,6 +175,7 @@ function buildStepResult(
   logs: StepResult["logs"],
   httpAttempts: StepResult["httpAttempts"],
   error?: StepResult["error"],
+  warnings?: StepResult["warnings"],
 ): StepResult {
   const metadata = resolveStepInfo(step);
   return {
@@ -187,6 +188,7 @@ function buildStepResult(
     http: httpAttempts[httpAttempts.length - 1],
     httpAttempts,
     error,
+    ...(warnings?.length ? { warnings } : {}),
     teachableMoments: metadata.teachableMoments,
   };
 }
@@ -288,6 +290,7 @@ export class OAuthConformanceTest {
         status: StepResult["status"];
         durationMs: number;
         error?: StepResult["error"];
+        warnings?: StepResult["warnings"];
       }>,
     ) => {
       const beforeHistory = state.httpHistory?.length ?? 0;
@@ -304,6 +307,7 @@ export class OAuthConformanceTest {
             [],
             attempts,
             outcome.error,
+            outcome.warnings,
           ),
         );
       } catch (error) {

--- a/sdk/src/oauth-conformance/runner.ts
+++ b/sdk/src/oauth-conformance/runner.ts
@@ -30,6 +30,11 @@ import {
   runInvalidRedirectCheck,
 } from "./checks/oauth-negative.js";
 import { runTokenFormatCheck } from "./checks/oauth-token-format.js";
+import {
+  runUnauthenticatedChallengeCheck,
+  runResourceMetadataChallengeCheck,
+  runStaleSessionRejectionCheck,
+} from "./checks/oauth-server-obligations.js";
 import type { HttpServerConfig } from "../mcp-client-manager/index.js";
 import { withEphemeralClient, listTools } from "../operations.js";
 import {
@@ -706,6 +711,31 @@ export class OAuthConformanceTest {
         } else {
           steps.push(buildSkippedStepResult("oauth_invalid_redirect"));
         }
+
+        // Server-side spec obligations (HP-17 findings 3/4/5). These probe the
+        // server independently of the client-capability matrix; a violation is
+        // a hard failure against normative spec text.
+        await recordOAuthCheck("oauth_unauthenticated_challenge", () =>
+          runUnauthenticatedChallengeCheck({
+            config: this.config,
+            state,
+            trackedRequest,
+          }),
+        );
+        await recordOAuthCheck("oauth_resource_metadata_challenge", () =>
+          runResourceMetadataChallengeCheck({
+            config: this.config,
+            state,
+            trackedRequest,
+          }),
+        );
+        await recordOAuthCheck("oauth_stale_session_rejection", () =>
+          runStaleSessionRejectionCheck({
+            config: this.config,
+            state,
+            trackedRequest,
+          }),
+        );
 
         const tokenRequestStep = [...steps]
           .reverse()

--- a/sdk/src/oauth-conformance/types.ts
+++ b/sdk/src/oauth-conformance/types.ts
@@ -22,7 +22,11 @@ export type OAuthConformanceCheckId =
   | "oauth_invalid_authorize_redirect"
   | "oauth_invalid_token"
   | "oauth_invalid_redirect"
-  | "oauth_token_format";
+  | "oauth_token_format"
+  // Server-side spec obligations (HP-17 findings 3/4/5).
+  | "oauth_unauthenticated_challenge"
+  | "oauth_resource_metadata_challenge"
+  | "oauth_stale_session_rejection";
 
 /** A step in a conformance result: either a real flow step or a post-flow check. */
 export type ConformanceStepId = OAuthFlowStep | OAuthConformanceCheckId;
@@ -77,6 +81,30 @@ export const CONFORMANCE_CHECK_METADATA: Record<
       "Validate that the successful token response includes the expected access token fields.",
     teachableMoments: [
       "Token responses should include a usable bearer token, token type, and expiration metadata.",
+    ],
+  },
+  oauth_unauthenticated_challenge: {
+    title: "OAuth Check: Unauthenticated Request Challenge",
+    summary:
+      "Send an unauthenticated MCP request and confirm the server answers with HTTP 401 and a WWW-Authenticate Bearer challenge, never a 500.",
+    teachableMoments: [
+      "A protected resource must reject unauthenticated requests with 401 and a Bearer challenge (RFC 6750 §3), not a server error.",
+    ],
+  },
+  oauth_resource_metadata_challenge: {
+    title: "OAuth Check: Resource Metadata URL in Challenge",
+    summary:
+      "Confirm the WWW-Authenticate Bearer challenge advertises an absolute resource_metadata URL so clients can discover protected-resource metadata.",
+    teachableMoments: [
+      "RFC 9728 §5.1 requires the Bearer challenge to carry an absolute resource_metadata URL; a relative or missing value breaks discovery.",
+    ],
+  },
+  oauth_stale_session_rejection: {
+    title: "OAuth Check: Stale Session Rejection",
+    summary:
+      "Send an authenticated request carrying an unknown Mcp-Session-Id and confirm the server rejects it with a 4xx, never a 500.",
+    teachableMoments: [
+      "The Streamable HTTP transport requires a stale or unknown session id to fail with a clean 4xx (404 preferred), not crash the server with a 500.",
     ],
   },
 };

--- a/sdk/src/oauth-conformance/types.ts
+++ b/sdk/src/oauth-conformance/types.ts
@@ -169,6 +169,10 @@ export interface StepResult {
     message: string;
     details?: unknown;
   };
+  /** Non-fatal evidence recorded on a passing step (e.g. a spec-preferred but
+   * not mandated behavior was missed). Never present on a failed step —
+   * failures use `error`. */
+  warnings?: string[];
   teachableMoments?: string[];
 }
 

--- a/sdk/tests/oauth-conformance/checks.test.ts
+++ b/sdk/tests/oauth-conformance/checks.test.ts
@@ -450,6 +450,40 @@ describe("oauth server obligation checks", () => {
       });
     });
 
+    it("strips Authorization variants supplied via customHeaders", async () => {
+      const trackedRequest = jest.fn().mockImplementation(async (request) => {
+        const authKeys = Object.keys(request.headers).filter(
+          (key: string) => key.toLowerCase() === "authorization",
+        );
+        expect(authKeys).toEqual([]);
+        expect(request.headers["X-Gateway"]).toBe("bypass");
+        return {
+          ok: false,
+          status: 401,
+          statusText: "Unauthorized",
+          headers: { "www-authenticate": BEARER_WITH_METADATA },
+          body: { error: "unauthorized" },
+        };
+      });
+
+      const result = await runUnauthenticatedChallengeCheck({
+        ...(baseObligationInput as any),
+        config: {
+          ...baseObligationInput.config,
+          customHeaders: {
+            authorization: "Bearer gateway-bypass-token",
+            "X-Gateway": "bypass",
+          },
+        },
+        trackedRequest,
+      });
+
+      expect(result).toMatchObject({
+        step: "oauth_unauthenticated_challenge",
+        status: "passed",
+      });
+    });
+
     it("fails when the server returns 500 instead of 401", async () => {
       const result = await runUnauthenticatedChallengeCheck({
         ...(baseObligationInput as any),
@@ -485,6 +519,27 @@ describe("oauth server obligation checks", () => {
         step: "oauth_unauthenticated_challenge",
         status: "failed",
         error: { message: expect.stringContaining("without a WWW-Authenticate Bearer challenge") },
+      });
+    });
+
+    it("fails when a 401 challenge does not offer a Bearer scheme", async () => {
+      const result = await runUnauthenticatedChallengeCheck({
+        ...(baseObligationInput as any),
+        trackedRequest: jest.fn().mockResolvedValue({
+          ok: false,
+          status: 401,
+          statusText: "Unauthorized",
+          headers: { "www-authenticate": 'Basic realm="mcp"' },
+          body: { error: "unauthorized" },
+        }),
+      });
+
+      expect(result).toMatchObject({
+        step: "oauth_unauthenticated_challenge",
+        status: "failed",
+        error: {
+          message: expect.stringContaining("does not offer a Bearer challenge"),
+        },
       });
     });
 
@@ -582,6 +637,53 @@ describe("oauth server obligation checks", () => {
       });
     });
 
+    it("skips when the challenge does not offer a Bearer scheme", async () => {
+      const result = await runResourceMetadataChallengeCheck({
+        ...(baseObligationInput as any),
+        trackedRequest: jest.fn().mockResolvedValue({
+          ok: false,
+          status: 401,
+          statusText: "Unauthorized",
+          headers: { "www-authenticate": 'Basic realm="mcp"' },
+          body: undefined,
+        }),
+      });
+
+      expect(result).toMatchObject({
+        step: "oauth_resource_metadata_challenge",
+        status: "skipped",
+        error: {
+          message: expect.stringContaining("does not offer a Bearer scheme"),
+        },
+      });
+    });
+
+    it("does not accept a lookalike parameter name for resource_metadata", async () => {
+      const result = await runResourceMetadataChallengeCheck({
+        ...(baseObligationInput as any),
+        trackedRequest: jest.fn().mockResolvedValue({
+          ok: false,
+          status: 401,
+          statusText: "Unauthorized",
+          headers: {
+            "www-authenticate":
+              'Bearer x_resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource"',
+          },
+          body: undefined,
+        }),
+      });
+
+      expect(result).toMatchObject({
+        step: "oauth_resource_metadata_challenge",
+        status: "failed",
+        error: {
+          message: expect.stringContaining(
+            "omitted the resource_metadata parameter",
+          ),
+        },
+      });
+    });
+
     it("skips when there is no challenge to inspect", async () => {
       const result = await runResourceMetadataChallengeCheck({
         ...(baseObligationInput as any),
@@ -648,7 +750,7 @@ describe("oauth server obligation checks", () => {
       });
     });
 
-    it("passes a non-404 4xx but records it as evidence only", async () => {
+    it("passes a non-404 4xx and records it as a warning, not an error", async () => {
       const result = await runStaleSessionRejectionCheck({
         ...(baseObligationInput as any),
         trackedRequest: jest.fn().mockResolvedValue({
@@ -663,8 +765,49 @@ describe("oauth server obligation checks", () => {
       expect(result).toMatchObject({
         step: "oauth_stale_session_rejection",
         status: "passed",
-        error: { message: expect.stringContaining("prefers 404") },
+        warnings: [expect.stringContaining("prefers 404")],
       });
+      expect(result.error).toBeUndefined();
+    });
+
+    it("treats a 404 with an empty JSON object body as parseable", async () => {
+      const result = await runStaleSessionRejectionCheck({
+        ...(baseObligationInput as any),
+        trackedRequest: jest.fn().mockResolvedValue({
+          ok: false,
+          status: 404,
+          statusText: "Not Found",
+          headers: {},
+          body: {},
+        }),
+      });
+
+      expect(result).toMatchObject({
+        step: "oauth_stale_session_rejection",
+        status: "passed",
+      });
+      expect(result.warnings).toBeUndefined();
+      expect(result.error).toBeUndefined();
+    });
+
+    it("warns when a 404 rejection has an empty body", async () => {
+      const result = await runStaleSessionRejectionCheck({
+        ...(baseObligationInput as any),
+        trackedRequest: jest.fn().mockResolvedValue({
+          ok: false,
+          status: 404,
+          statusText: "Not Found",
+          headers: {},
+          body: "",
+        }),
+      });
+
+      expect(result).toMatchObject({
+        step: "oauth_stale_session_rejection",
+        status: "passed",
+        warnings: [expect.stringContaining("empty or unparseable")],
+      });
+      expect(result.error).toBeUndefined();
     });
 
     it("skips when the server accepts an unknown session id", async () => {

--- a/sdk/tests/oauth-conformance/checks.test.ts
+++ b/sdk/tests/oauth-conformance/checks.test.ts
@@ -6,6 +6,11 @@ import {
   runInvalidRedirectCheck,
 } from "../../src/oauth-conformance/checks/oauth-negative.js";
 import { runTokenFormatCheck } from "../../src/oauth-conformance/checks/oauth-token-format.js";
+import {
+  runResourceMetadataChallengeCheck,
+  runStaleSessionRejectionCheck,
+  runUnauthenticatedChallengeCheck,
+} from "../../src/oauth-conformance/checks/oauth-server-obligations.js";
 
 const baseNegativeInput = {
   config: {
@@ -397,6 +402,323 @@ describe("oauth conformance unit checks", () => {
       error: {
         message: expect.stringContaining("expires_in"),
       },
+    });
+  });
+});
+
+// ── Server-side spec obligations (HP-17 findings 3/4/5) ────────────────
+
+const baseObligationInput = {
+  config: {
+    serverUrl: "https://mcp.example.com",
+    protocolVersion: "2025-11-25",
+    auth: { mode: "headless" },
+  },
+  state: {
+    accessToken: "valid-access-token",
+  },
+};
+
+const BEARER_WITH_METADATA =
+  'Bearer resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource"';
+
+describe("oauth server obligation checks", () => {
+  // Finding 4 — unauthenticated request → 401 + Bearer challenge, never 500.
+  describe("unauthenticated challenge", () => {
+    it("sends no Authorization header on the probe", async () => {
+      const trackedRequest = jest.fn().mockImplementation(async (request) => {
+        expect(request.headers.Authorization).toBeUndefined();
+        expect(request.method).toBe("POST");
+        expect(request.url).toBe("https://mcp.example.com");
+        return {
+          ok: false,
+          status: 401,
+          statusText: "Unauthorized",
+          headers: { "www-authenticate": BEARER_WITH_METADATA },
+          body: { error: "unauthorized" },
+        };
+      });
+
+      const result = await runUnauthenticatedChallengeCheck({
+        ...(baseObligationInput as any),
+        trackedRequest,
+      });
+
+      expect(result).toMatchObject({
+        step: "oauth_unauthenticated_challenge",
+        status: "passed",
+      });
+    });
+
+    it("fails when the server returns 500 instead of 401", async () => {
+      const result = await runUnauthenticatedChallengeCheck({
+        ...(baseObligationInput as any),
+        trackedRequest: jest.fn().mockResolvedValue({
+          ok: false,
+          status: 500,
+          statusText: "Internal Server Error",
+          headers: {},
+          body: "boom",
+        }),
+      });
+
+      expect(result).toMatchObject({
+        step: "oauth_unauthenticated_challenge",
+        status: "failed",
+        error: { message: expect.stringContaining("instead of 401") },
+      });
+    });
+
+    it("fails when a 401 omits the Bearer challenge", async () => {
+      const result = await runUnauthenticatedChallengeCheck({
+        ...(baseObligationInput as any),
+        trackedRequest: jest.fn().mockResolvedValue({
+          ok: false,
+          status: 401,
+          statusText: "Unauthorized",
+          headers: {},
+          body: { error: "unauthorized" },
+        }),
+      });
+
+      expect(result).toMatchObject({
+        step: "oauth_unauthenticated_challenge",
+        status: "failed",
+        error: { message: expect.stringContaining("without a WWW-Authenticate Bearer challenge") },
+      });
+    });
+
+    it("fails when the server accepts an unauthenticated request", async () => {
+      const result = await runUnauthenticatedChallengeCheck({
+        ...(baseObligationInput as any),
+        trackedRequest: jest.fn().mockResolvedValue({
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          body: { jsonrpc: "2.0", result: {} },
+        }),
+      });
+
+      expect(result).toMatchObject({
+        step: "oauth_unauthenticated_challenge",
+        status: "failed",
+        error: { message: expect.stringContaining("expected HTTP 401, received 200") },
+      });
+    });
+
+    it("turns transport errors into failed checks", async () => {
+      const result = await runUnauthenticatedChallengeCheck({
+        ...(baseObligationInput as any),
+        trackedRequest: jest.fn().mockRejectedValue(new Error("timeout")),
+      });
+
+      expect(result).toMatchObject({
+        step: "oauth_unauthenticated_challenge",
+        status: "failed",
+        error: { message: "Unauthenticated MCP request failed: timeout" },
+      });
+    });
+  });
+
+  // Finding 3 — Bearer challenge must carry an absolute resource_metadata URL.
+  describe("resource metadata challenge", () => {
+    it("passes when the challenge advertises an absolute resource_metadata URL", async () => {
+      const result = await runResourceMetadataChallengeCheck({
+        ...(baseObligationInput as any),
+        trackedRequest: jest.fn().mockResolvedValue({
+          ok: false,
+          status: 401,
+          statusText: "Unauthorized",
+          headers: { "www-authenticate": BEARER_WITH_METADATA },
+          body: undefined,
+        }),
+      });
+
+      expect(result).toMatchObject({
+        step: "oauth_resource_metadata_challenge",
+        status: "passed",
+      });
+    });
+
+    it("fails when the challenge omits resource_metadata", async () => {
+      const result = await runResourceMetadataChallengeCheck({
+        ...(baseObligationInput as any),
+        trackedRequest: jest.fn().mockResolvedValue({
+          ok: false,
+          status: 401,
+          statusText: "Unauthorized",
+          headers: { "www-authenticate": 'Bearer error="invalid_token"' },
+          body: undefined,
+        }),
+      });
+
+      expect(result).toMatchObject({
+        step: "oauth_resource_metadata_challenge",
+        status: "failed",
+        error: { message: expect.stringContaining("omitted the resource_metadata parameter") },
+      });
+    });
+
+    it("fails when resource_metadata is a relative URL", async () => {
+      const result = await runResourceMetadataChallengeCheck({
+        ...(baseObligationInput as any),
+        trackedRequest: jest.fn().mockResolvedValue({
+          ok: false,
+          status: 401,
+          statusText: "Unauthorized",
+          headers: {
+            "www-authenticate":
+              'Bearer resource_metadata="/.well-known/oauth-protected-resource"',
+          },
+          body: undefined,
+        }),
+      });
+
+      expect(result).toMatchObject({
+        step: "oauth_resource_metadata_challenge",
+        status: "failed",
+        error: { message: expect.stringContaining("must be an absolute http(s) URL") },
+      });
+    });
+
+    it("skips when there is no challenge to inspect", async () => {
+      const result = await runResourceMetadataChallengeCheck({
+        ...(baseObligationInput as any),
+        trackedRequest: jest.fn().mockResolvedValue({
+          ok: false,
+          status: 401,
+          statusText: "Unauthorized",
+          headers: {},
+          body: undefined,
+        }),
+      });
+
+      expect(result).toMatchObject({
+        step: "oauth_resource_metadata_challenge",
+        status: "skipped",
+      });
+    });
+  });
+
+  // Finding 5 — stale Mcp-Session-Id → 4xx (404 preferred), never 500.
+  describe("stale session rejection", () => {
+    it("sends a valid bearer token with an unknown Mcp-Session-Id", async () => {
+      const trackedRequest = jest.fn().mockImplementation(async (request) => {
+        expect(request.headers.Authorization).toBe("Bearer valid-access-token");
+        expect(request.headers["Mcp-Session-Id"]).toBeDefined();
+        expect(request.body).toMatchObject({ method: "tools/list" });
+        return {
+          ok: false,
+          status: 404,
+          statusText: "Not Found",
+          headers: {},
+          body: { error: "session not found" },
+        };
+      });
+
+      const result = await runStaleSessionRejectionCheck({
+        ...(baseObligationInput as any),
+        trackedRequest,
+      });
+
+      expect(result).toMatchObject({
+        step: "oauth_stale_session_rejection",
+        status: "passed",
+      });
+      expect(result.error).toBeUndefined();
+    });
+
+    it("fails when the server crashes with a 500 on a stale session", async () => {
+      const result = await runStaleSessionRejectionCheck({
+        ...(baseObligationInput as any),
+        trackedRequest: jest.fn().mockResolvedValue({
+          ok: false,
+          status: 500,
+          statusText: "Internal Server Error",
+          headers: {},
+          body: "stack trace",
+        }),
+      });
+
+      expect(result).toMatchObject({
+        step: "oauth_stale_session_rejection",
+        status: "failed",
+        error: { message: expect.stringContaining("instead of a 4xx") },
+      });
+    });
+
+    it("passes a non-404 4xx but records it as evidence only", async () => {
+      const result = await runStaleSessionRejectionCheck({
+        ...(baseObligationInput as any),
+        trackedRequest: jest.fn().mockResolvedValue({
+          ok: false,
+          status: 400,
+          statusText: "Bad Request",
+          headers: {},
+          body: { error: "bad session" },
+        }),
+      });
+
+      expect(result).toMatchObject({
+        step: "oauth_stale_session_rejection",
+        status: "passed",
+        error: { message: expect.stringContaining("prefers 404") },
+      });
+    });
+
+    it("skips when the server accepts an unknown session id", async () => {
+      const result = await runStaleSessionRejectionCheck({
+        ...(baseObligationInput as any),
+        trackedRequest: jest.fn().mockResolvedValue({
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          body: { jsonrpc: "2.0", result: { tools: [] } },
+        }),
+      });
+
+      expect(result).toMatchObject({
+        step: "oauth_stale_session_rejection",
+        status: "skipped",
+        error: { message: expect.stringContaining("does not appear to enforce session state") },
+      });
+    });
+
+    it("skips on the stateless 2026-07-28 transport", async () => {
+      const trackedRequest = jest.fn();
+      const result = await runStaleSessionRejectionCheck({
+        ...(baseObligationInput as any),
+        config: {
+          ...baseObligationInput.config,
+          protocolVersion: "2026-07-28",
+        },
+        trackedRequest,
+      });
+
+      expect(result).toMatchObject({
+        step: "oauth_stale_session_rejection",
+        status: "skipped",
+        error: { message: expect.stringContaining("stateless") },
+      });
+      expect(trackedRequest).not.toHaveBeenCalled();
+    });
+
+    it("skips when no access token is available", async () => {
+      const trackedRequest = jest.fn();
+      const result = await runStaleSessionRejectionCheck({
+        ...(baseObligationInput as any),
+        state: {},
+        trackedRequest,
+      });
+
+      expect(result).toMatchObject({
+        step: "oauth_stale_session_rejection",
+        status: "skipped",
+        error: { message: expect.stringContaining("No access token") },
+      });
+      expect(trackedRequest).not.toHaveBeenCalled();
     });
   });
 });

--- a/sdk/tests/oauth-conformance/checks.test.ts
+++ b/sdk/tests/oauth-conformance/checks.test.ts
@@ -543,7 +543,10 @@ describe("oauth server obligation checks", () => {
       });
     });
 
-    it("fails when the server accepts an unauthenticated request", async () => {
+    it("skips when the server accepts an unauthenticated initialize", async () => {
+      // Anonymous initialize is spec-legal (authorization may be enforced on
+      // later requests), so a 2xx is unverifiable, not a violation — mirrors
+      // the stale-session 2xx handling.
       const result = await runUnauthenticatedChallengeCheck({
         ...(baseObligationInput as any),
         trackedRequest: jest.fn().mockResolvedValue({
@@ -557,8 +560,31 @@ describe("oauth server obligation checks", () => {
 
       expect(result).toMatchObject({
         step: "oauth_unauthenticated_challenge",
+        status: "skipped",
+        error: {
+          message: expect.stringContaining(
+            "accepted an unauthenticated initialize",
+          ),
+        },
+      });
+    });
+
+    it("still fails a non-401 rejection such as 403", async () => {
+      const result = await runUnauthenticatedChallengeCheck({
+        ...(baseObligationInput as any),
+        trackedRequest: jest.fn().mockResolvedValue({
+          ok: false,
+          status: 403,
+          statusText: "Forbidden",
+          headers: {},
+          body: { error: "forbidden" },
+        }),
+      });
+
+      expect(result).toMatchObject({
+        step: "oauth_unauthenticated_challenge",
         status: "failed",
-        error: { message: expect.stringContaining("expected HTTP 401, received 200") },
+        error: { message: expect.stringContaining("expected HTTP 401, received 403") },
       });
     });
 
@@ -682,6 +708,25 @@ describe("oauth server obligation checks", () => {
           ),
         },
       });
+    });
+
+    it("skips on 2025-03-26, which predates RFC 9728, without probing", async () => {
+      const trackedRequest = jest.fn();
+      const result = await runResourceMetadataChallengeCheck({
+        ...(baseObligationInput as any),
+        config: {
+          ...baseObligationInput.config,
+          protocolVersion: "2025-03-26",
+        },
+        trackedRequest,
+      });
+
+      expect(result).toMatchObject({
+        step: "oauth_resource_metadata_challenge",
+        status: "skipped",
+        error: { message: expect.stringContaining("predates RFC 9728") },
+      });
+      expect(trackedRequest).not.toHaveBeenCalled();
     });
 
     it("skips when there is no challenge to inspect", async () => {
@@ -846,6 +891,24 @@ describe("oauth server obligation checks", () => {
         error: { message: expect.stringContaining("stateless") },
       });
       expect(trackedRequest).not.toHaveBeenCalled();
+    });
+
+    it("redacts the access token from transport-failure details", async () => {
+      const result = await runStaleSessionRejectionCheck({
+        ...(baseObligationInput as any),
+        trackedRequest: jest.fn().mockRejectedValue(new Error("timeout")),
+      });
+
+      expect(result).toMatchObject({
+        step: "oauth_stale_session_rejection",
+        status: "failed",
+        error: { message: "Stale-session MCP request failed: timeout" },
+      });
+      const details = result.error?.details as {
+        request: { headers: Record<string, string> };
+      };
+      expect(details.request.headers.Authorization).toBe("[REDACTED]");
+      expect(JSON.stringify(details)).not.toContain("valid-access-token");
     });
 
     it("skips when no access token is available", async () => {


### PR DESCRIPTION
## What

Adds three OAuth **conformance** checks encoding server-side spec obligations that Composio's cross-client feedback surfaced, validated in **HP-17** (2026-07-21). These are obligations the MCP *server* owes every client — distinct from the host-capability readiness matrix — so a violation is a hard FAIL against normative spec text.

Gated behind `oauthConformanceChecks`, running after a completed flow alongside the existing negative checks.

| Check | HP-17 finding | Spec | Fails when |
|---|---|---|---|
| `oauth_unauthenticated_challenge` | 4 | RFC 6750 §3 | 5xx, non-401, or 2xx (accepts unauthenticated) |
| `oauth_resource_metadata_challenge` | 3 | RFC 9728 §5.1 | `resource_metadata` missing / relative / non-http |
| `oauth_stale_session_rejection` | 5 | Streamable HTTP | 5xx on a stale `Mcp-Session-Id` |

## Notes for review

- **Finding 5 follows HP-17's stricter reading, not the ticket wording.** HP-45 says "4xx *with parseable body*", but HP-17 established the body is **not** spec-mandated. So only a `5xx` crash fails; a non-404 status or empty body is attached as *evidence* on an otherwise-passing result. The check also **skips** on the stateless `2026-07-28` wire (no sessions) and when no access token is available to isolate session handling from auth.
- **Findings 3 & 4 each send their own unauthenticated probe**, matching the one-check-one-request idiom in `oauth-negative.ts`. Costs one extra request; keeps each check self-contained.
- Findings 3/4/5 that go to the **conformance suite** are the ones HP-17 routed there; the refuted findings (6/8/9) and the host-profile fields (1/2/7/bonus) are handled in the HP-3/HP-45-fields and HP-43 branches, not here.

## Scope

First of the HP-43/44/45 branch series (the unblocked half of HP-45). No dependency on the `HostConfigOAuthProfileV1` work.

## Test

- `tsc --noEmit` clean · `npm run build` clean
- **315/315** oauth + oauth-conformance tests pass, including **15 new** unit tests in `checks.test.ts` covering pass / fail / skip / transport-error paths for each check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds three server-side OAuth conformance checks for MCP server spec obligations, gated by `oauthConformanceChecks`. Implements HP-17 findings 3/4/5 for HP-45, with clear skips where the spec or protocol version makes a check inapplicable.

- New Features
  - `oauth_unauthenticated_challenge` (HP-17/4, RFC 6750 §3): unauthenticated request must return 401 with a `WWW-Authenticate: Bearer` challenge; never 5xx. A 2xx is skipped as unverifiable (anonymous initialize can be spec-legal).
  - `oauth_resource_metadata_challenge` (HP-17/3, RFC 9728 §5.1): Bearer challenge must include an absolute `resource_metadata` URL; skipped on protocol `2025-03-26` (predates RFC 9728).
  - `oauth_stale_session_rejection` (HP-17/5, Streamable HTTP): unknown `Mcp-Session-Id` must be 4xx (404 preferred); only 5xx fails. Skips on protocol `2026-07-28` and when no access token is available. Records non-fatal evidence as `warnings`.
  - `StepResult.warnings` flow into reports and render in the inspector with a muted “Warnings” block.

- Bug Fixes
  - Redact `Authorization` in transport-failure details to avoid leaking tokens in raw `StepResult`s.
  - Strip any case-variant `Authorization` from `customHeaders` in the unauthenticated probe to prevent silent auth.
  - Skip the resource-metadata check when the challenge lacks Bearer to avoid double-reporting.
  - Tightened parsing: add a left boundary in the `resource_metadata` regex; treat `{}` as a parseable rejection body.

<sup>Written for commit a5c84ee12d06b9d4e4f7230329c83faa98c1ae5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

