### PR TITLE
feat(computers): configurable working directory for the bash tool (COMP-16)

### DIFF
--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ComputerTab.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ComputerTab.tsx
@@ -1,10 +1,15 @@
+import { useEffect, useState } from "react";
 import { Switch } from "@mcpjam/design-system/switch";
+import { Input } from "@mcpjam/design-system/input";
 import type { HostConfigInputV2 } from "@/lib/client-config-v2";
 import { FieldRow, FocusBlock } from "./primitives";
 import { useBuiltInToolCatalog } from "@/hooks/useBuiltInToolCatalog";
 import {
   attachComputerPatch,
   detachComputerPatch,
+  setComputerWorkdirPatch,
+  validateComputerWorkdir,
+  DEFAULT_COMPUTER_WORKDIR,
 } from "@/lib/host-config-computer";
 
 interface ComputerTabProps {
@@ -43,6 +48,22 @@ export function ComputerTab({
   const lockedByHarness =
     draft.harness !== undefined && draft.computer !== undefined;
 
+  // Working directory (COMP-16). Locally-buffered text so keystrokes don't
+  // re-hash the whole host config; committed on blur. The stored value clears to
+  // undefined at the default, so the placeholder shows the effective default.
+  const attached = draft.computer !== undefined;
+  const storedWorkdir = draft.computer?.workdir ?? "";
+  const [workdirText, setWorkdirText] = useState(storedWorkdir);
+  useEffect(() => {
+    // Re-sync when the draft changes underneath us (host switch, external edit).
+    setWorkdirText(storedWorkdir);
+  }, [storedWorkdir]);
+  const workdirError = validateComputerWorkdir(workdirText);
+  const commitWorkdir = () => {
+    if (workdirError) return; // keep the invalid text visible for correction
+    update(setComputerWorkdirPatch(draft, workdirText));
+  };
+
   return (
     <div className="flex flex-col gap-4">
       <FocusBlock title="Computer">
@@ -68,6 +89,43 @@ export function ComputerTab({
             />
           }
         />
+        {attached && (
+          <FieldRow
+            label="Working directory"
+            description={
+              "Where the bash tool runs and the terminal opens (the harness " +
+              "Shell runs in a per-session folder beneath it). Must be under " +
+              "/home/user; chat attachments land in /home/user/attachments, so " +
+              "the default keeps relative paths working."
+            }
+            control={
+              <div className="flex flex-col items-end gap-1">
+                <Input
+                  value={workdirText}
+                  onChange={(e) => setWorkdirText(e.target.value)}
+                  onBlur={commitWorkdir}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      e.preventDefault();
+                      commitWorkdir();
+                    }
+                  }}
+                  placeholder={DEFAULT_COMPUTER_WORKDIR}
+                  spellCheck={false}
+                  autoCapitalize="off"
+                  autoCorrect="off"
+                  aria-label="Working directory"
+                  aria-invalid={workdirError ? true : undefined}
+                  disabled={readOnly}
+                  className="w-64 font-mono text-xs"
+                />
+                {workdirError && (
+                  <span className="text-xs text-red-500">{workdirError}</span>
+                )}
+              </div>
+            }
+          />
+        )}
       </FocusBlock>
     </div>
   );

--- a/mcpjam-inspector/client/src/components/playground/PlaygroundRightRail.tsx
+++ b/mcpjam-inspector/client/src/components/playground/PlaygroundRightRail.tsx
@@ -85,7 +85,13 @@ function RightRailTabbed({
   // Read with the SAME key the chat stream writes (previewedHostId), not
   // hostConfig.id — those are different identifiers and would never match.
   const streamedWorkdir = useHarnessWorkdir(projectId, hostId);
-  const harnessCwd = isHarnessHost ? streamedWorkdir : undefined;
+  // COMP-16: open the terminal in the configured working directory. For a
+  // harness host use the streamed per-session dir; for a plain computer host
+  // fall back to the host-configured `computer.workdir` (the same dir the bash
+  // tool runs in) so the Shell opens where the model works.
+  const harnessCwd = isHarnessHost
+    ? streamedWorkdir
+    : hostConfig?.computer?.workdir;
   // Only offer "Open terminal" once the data-plane config has resolved to a
   // usable plane — opening while it's still loading mounts the terminal at the
   // page origin; opening with no plane reserves a computer it can't reach.

--- a/mcpjam-inspector/client/src/lib/__tests__/host-config-computer.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/host-config-computer.test.ts
@@ -5,8 +5,11 @@ import {
   computerBackedToolIds,
   detachComputerPatch,
   sanitizeHostConfigForEvalSuite,
+  setComputerWorkdirPatch,
   shouldShowComputerToggle,
+  validateComputerWorkdir,
   visibleBuiltInToolCatalog,
+  DEFAULT_COMPUTER_WORKDIR,
 } from "../host-config-computer";
 import { emptyHostConfigInputV2 } from "../client-config-v2";
 import type { BuiltInToolCatalogEntry } from "@/hooks/useBuiltInToolCatalog";
@@ -42,6 +45,46 @@ describe("host-config-computer helpers", () => {
 
   it("attachComputerPatch attaches the resource shape", () => {
     expect(attachComputerPatch()).toEqual({ computer: { kind: "personal" } });
+  });
+
+  describe("working directory (COMP-16)", () => {
+    it("accepts blank and paths under /home/user; rejects escapes", () => {
+      expect(validateComputerWorkdir("")).toBeNull();
+      expect(validateComputerWorkdir("/home/user")).toBeNull();
+      expect(validateComputerWorkdir("/home/user/myproject")).toBeNull();
+      expect(validateComputerWorkdir("relative")).toBeTruthy();
+      expect(validateComputerWorkdir("/etc")).toBeTruthy();
+      expect(validateComputerWorkdir("/home/user/../etc")).toBeTruthy();
+      expect(validateComputerWorkdir("/home/user2")).toBeTruthy();
+    });
+
+    it("sets a non-default workdir on the attached computer", () => {
+      const value = emptyHostConfigInputV2({ computer: { kind: "personal" } });
+      expect(setComputerWorkdirPatch(value, "/home/user/myproject")).toEqual({
+        computer: { kind: "personal", workdir: "/home/user/myproject" },
+      });
+    });
+
+    it("clears workdir at the default or blank (hashes identically to unset)", () => {
+      const value = emptyHostConfigInputV2({
+        computer: { kind: "personal", workdir: "/home/user/old" },
+      });
+      expect(setComputerWorkdirPatch(value, DEFAULT_COMPUTER_WORKDIR)).toEqual({
+        computer: { kind: "personal", workdir: undefined },
+      });
+      expect(setComputerWorkdirPatch(value, "   ")).toEqual({
+        computer: { kind: "personal", workdir: undefined },
+      });
+      // Trailing slash normalizes to the default → cleared.
+      expect(setComputerWorkdirPatch(value, "/home/user/")).toEqual({
+        computer: { kind: "personal", workdir: undefined },
+      });
+    });
+
+    it("is a no-op when no computer is attached", () => {
+      const value = emptyHostConfigInputV2({});
+      expect(setComputerWorkdirPatch(value, "/home/user/x")).toEqual({});
+    });
   });
 
   it("detachComputerPatch clears the computer AND strips computer-backed ids", () => {

--- a/mcpjam-inspector/client/src/lib/host-config-computer.ts
+++ b/mcpjam-inspector/client/src/lib/host-config-computer.ts
@@ -80,6 +80,62 @@ export function attachComputerPatch(): Partial<HostConfigInputV2> {
 }
 
 /**
+ * The box home — the default working directory when `computer.workdir` is unset.
+ * Chosen so COMP-14 chat attachments (which land in `/home/user/attachments`)
+ * are reachable by a plain relative path from the default cwd. Mirrors the
+ * server's `HOME_ROOT` (`server/utils/computers/path-confine.ts`).
+ */
+export const DEFAULT_COMPUTER_WORKDIR = "/home/user";
+
+/**
+ * Client-side mirror of the server's `resolveWorkingDirectory` confinement
+ * (COMP-16), for inline field validation only — the server check is
+ * authoritative. Returns an error string, or `null` when acceptable (a blank
+ * value is acceptable and means "use the default"). Keep in lockstep with
+ * `server/utils/computers/path-confine.ts`.
+ */
+export function validateComputerWorkdir(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (trimmed === "") return null; // blank ⇒ default /home/user
+  if (!trimmed.startsWith("/")) {
+    return "Use an absolute path under /home/user.";
+  }
+  const normalized = trimmed.replace(/\/+$/, "");
+  if (
+    normalized !== DEFAULT_COMPUTER_WORKDIR &&
+    !normalized.startsWith(`${DEFAULT_COMPUTER_WORKDIR}/`)
+  ) {
+    return "Must resolve under /home/user.";
+  }
+  if (normalized.split("/").includes("..")) {
+    return 'No ".." segments.';
+  }
+  return null;
+}
+
+/**
+ * Patch that sets (or clears) the computer's working directory (COMP-16). A
+ * blank value OR the default `/home/user` CLEARS `workdir`, so the default
+ * hashes identically to "never set" (content-addressed host configs: the box
+ * default is `/home/user` either way, so storing it would only fork the row).
+ * No-op when no computer is attached.
+ */
+export function setComputerWorkdirPatch(
+  value: HostConfigInputV2,
+  workdir: string
+): Partial<HostConfigInputV2> {
+  if (value.computer === undefined) return {};
+  const trimmed = workdir.trim().replace(/\/+$/, "");
+  const keep = trimmed !== "" && trimmed !== DEFAULT_COMPUTER_WORKDIR;
+  return {
+    computer: {
+      ...value.computer,
+      workdir: keep ? trimmed : undefined,
+    },
+  };
+}
+
+/**
  * Whether the editor should render the personal-computer toggle. Shown when
  * the catalog exposes a computer-backed tool (so the `bash` row stays hidden
  * until launch) OR when a computer is already attached — so an existing

--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -705,6 +705,15 @@ chatV2.post("/", async (c) => {
         : null,
     );
 
+    // COMP-16: the host-configured computer working directory — the SAME
+    // `computer.workdir` the bash tool runs in — threaded into the harness path
+    // so its Shell roots under the same directory. Server-resolved config only.
+    const computerWorkdir = (
+      hostRuntimeConfig as { computer?: { workdir?: unknown } } | undefined
+    )?.computer?.workdir;
+    const harnessComputerWorkdir =
+      typeof computerWorkdir === "string" ? computerWorkdir : undefined;
+
     let prepared;
     try {
       prepared = await prepareChatV2({
@@ -857,6 +866,10 @@ chatV2.post("/", async (c) => {
         // Server-executed built-ins forwarded separately so the harness path
         // can hand them to HarnessAgent (MCP-server tools arrive via .mcp.json).
         ...(builtInTools ? { builtInTools } : {}),
+        // COMP-16: root the harness Shell at the configured working directory.
+        ...(harnessComputerWorkdir
+          ? { computerWorkdir: harnessComputerWorkdir }
+          : {}),
         projectId: body.projectId,
         // Phase 3: thread the runtime-config execution scope into the harness
         // path (sandbox reserve, skills, broker, session-state, commit).

--- a/mcpjam-inspector/server/routes/web/__tests__/computers.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/computers.test.ts
@@ -144,7 +144,7 @@ describe("POST /api/web/computers/exec", () => {
       projectId: "proj_1",
       command: "echo hello",
       commandId: "call_7",
-      workdir: "/workspace",
+      workdir: "/home/user/workspace",
       timeoutSeconds: 30,
     });
 
@@ -158,7 +158,7 @@ describe("POST /api/web/computers/exec", () => {
       expect.objectContaining({
         sandboxId: "sbx_42",
         command: "echo hello",
-        workdir: "/workspace",
+        workdir: "/home/user/workspace",
         timeoutMs: 30_000,
       })
     );

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -395,6 +395,15 @@ chatV2.post("/", async (c) => {
       },
     );
 
+    // COMP-16: the host-configured computer working directory — the SAME
+    // `computer.workdir` the bash tool runs in — threaded into the harness path
+    // so its Shell roots under the same directory. Server-resolved config only.
+    const rawComputerWorkdir = (
+      hostRuntimeConfig as { computer?: { workdir?: unknown } } | undefined
+    )?.computer?.workdir;
+    const harnessComputerWorkdir =
+      typeof rawComputerWorkdir === "string" ? rawComputerWorkdir : undefined;
+
     // Cloud skills are a Convex-backed PROJECT resource (no computer needed), so
     // the emulated chat path wires the listSkills/loadSkill tools for any
     // signed-in member with a project. Gate only on:
@@ -567,6 +576,11 @@ chatV2.post("/", async (c) => {
           appTools: validatedAppTools,
           widgetModelContext: validatedWidgetModelContext,
           ...(builtInTools ? { builtInTools } : {}),
+          // COMP-16: root the harness Shell at the host-configured working
+          // directory — the same `computer.workdir` the bash tool runs in.
+          ...(harnessComputerWorkdir
+            ? { computerWorkdir: harnessComputerWorkdir }
+            : {}),
           ...(cloudSkillsEnabled
             ? {
                 cloudSkills: {

--- a/mcpjam-inspector/server/utils/__tests__/computers-bash-tool.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/computers-bash-tool.test.ts
@@ -65,7 +65,8 @@ function happyControlPlane() {
 const toolOpts = {
   authHeader: "Bearer user-token",
   projectId: "proj_1",
-  workdir: "/workspace",
+  // COMP-16: the working directory is confined under /home/user at exec time.
+  workdir: "/home/user/workspace",
 };
 
 function execTool(
@@ -110,7 +111,7 @@ describe(`${BASH_TOOL_NAME} tool`, () => {
       expect.objectContaining({
         sandboxId: "sbx_42",
         command: "echo hello",
-        workdir: "/workspace",
+        workdir: "/home/user/workspace",
         timeoutMs: 120_000,
       })
     );
@@ -131,6 +132,18 @@ describe(`${BASH_TOOL_NAME} tool`, () => {
       status: "completed",
       exitCode: 0,
     });
+  });
+
+  it("rejects a working directory that escapes /home/user with a clear error, before running (COMP-16)", async () => {
+    happyControlPlane();
+    const runner = vi.fn(async () => ({ stdout: "", stderr: "", exitCode: 0 }));
+    const tool = buildBashTool({ ...toolOpts, workdir: "/etc" }, runner);
+
+    const result = await execTool(tool, { command: "cat passwd" });
+    expect(result).toMatchObject({ error: expect.stringContaining("/home/user") });
+    expect((result as { error: string }).error).toContain("/etc");
+    // The escape is caught before the vendor exec — the runner never runs.
+    expect(runner).not.toHaveBeenCalled();
   });
 
   it("polls reserve until ready and surfaces waking → ready", async () => {

--- a/mcpjam-inspector/server/utils/computers/__tests__/path-confine.test.ts
+++ b/mcpjam-inspector/server/utils/computers/__tests__/path-confine.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { confineToHome, HOME_ROOT } from "../path-confine.js";
+import {
+  confineToHome,
+  resolveWorkingDirectory,
+  HOME_ROOT,
+} from "../path-confine.js";
 
 describe("confineToHome", () => {
   it("accepts the home root itself", () => {
@@ -52,5 +56,44 @@ describe("confineToHome", () => {
 
   it("exposes the home root constant", () => {
     expect(HOME_ROOT).toBe("/home/user");
+  });
+});
+
+describe("resolveWorkingDirectory (COMP-16 workdir contract)", () => {
+  it("treats absent/blank as the box default (undefined, no error)", () => {
+    expect(resolveWorkingDirectory(undefined)).toEqual({ workdir: undefined });
+    expect(resolveWorkingDirectory("")).toEqual({ workdir: undefined });
+    expect(resolveWorkingDirectory("   ")).toEqual({ workdir: undefined });
+  });
+
+  it("accepts and normalizes a directory under the home root", () => {
+    expect(resolveWorkingDirectory("/home/user")).toEqual({
+      workdir: "/home/user",
+    });
+    expect(resolveWorkingDirectory("/home/user/myproject/")).toEqual({
+      workdir: "/home/user/myproject",
+    });
+    // The COMP-14 attachments bucket is a valid workdir (relative paths "just work").
+    expect(resolveWorkingDirectory("/home/user/attachments")).toEqual({
+      workdir: "/home/user/attachments",
+    });
+  });
+
+  it("rejects traversal and absolute escapes with a clear, path-bearing error", () => {
+    for (const bad of [
+      "/etc",
+      "/etc/passwd",
+      "/home/user/../etc",
+      "/home/user/../../root",
+      "/home/user2/secret",
+      "relative/path",
+    ]) {
+      const result = resolveWorkingDirectory(bad);
+      expect("error" in result, bad).toBe(true);
+      if ("error" in result) {
+        expect(result.error).toContain("/home/user");
+        expect(result.error).toContain(bad);
+      }
+    }
   });
 });

--- a/mcpjam-inspector/server/utils/computers/path-confine.ts
+++ b/mcpjam-inspector/server/utils/computers/path-confine.ts
@@ -43,3 +43,38 @@ export function confineToHome(
   if (normalized.split("/").includes("..")) return null;
   return normalized;
 }
+
+/**
+ * The single working-directory contract for a computer (COMP-16). One
+ * `hostConfig.computer.workdir` governs WHERE commands run on the box —
+ * honored identically by the chat `bash` tool, the harness Shell, and the web
+ * terminal PTY, rather than three competing settings.
+ *
+ * Resolution:
+ *   - absent / blank ⇒ `{ workdir: undefined }` — use the box default (`$HOME`,
+ *     i.e. `/home/user`); callers that need an explicit path use `?? HOME_ROOT`.
+ *   - present ⇒ must `confineToHome`; a value that escapes (`..`, `/etc`, a
+ *     sibling like `/home/user2`) returns `{ error }` with a clear message the
+ *     caller surfaces, instead of silently running somewhere unexpected.
+ *
+ * This is the server-side confinement the COMP-16 acceptance criteria require;
+ * the host-config UI validates the same rule for immediate feedback, but the
+ * exec-time check here is the authoritative one (a value can reach exec from an
+ * older client, the API, or a hand-edited host config).
+ */
+export function resolveWorkingDirectory(
+  raw: string | undefined
+): { workdir: string | undefined } | { error: string } {
+  if (raw === undefined || raw.trim() === "") {
+    return { workdir: undefined };
+  }
+  const confined = confineToHome(raw);
+  if (!confined) {
+    return {
+      error:
+        `Working directory "${raw}" must resolve under ${HOME_ROOT} ` +
+        `(no "..", absolute escapes like /etc, or sibling prefixes).`,
+    };
+  }
+  return { workdir: confined };
+}

--- a/mcpjam-inspector/server/utils/computers/run-command.ts
+++ b/mcpjam-inspector/server/utils/computers/run-command.ts
@@ -20,6 +20,7 @@ import {
   recordComputerCommand,
 } from "./control-plane-client.js";
 import { detectAuthUrls } from "./auth-urls.js";
+import { resolveWorkingDirectory } from "./path-confine.js";
 import { logger } from "../logger.js";
 import { type ExecutionScope } from "../execution-scope.js";
 
@@ -61,6 +62,15 @@ export const e2bRunner: BashRunner = async ({
 }) => {
   const sandbox = await Sandbox.connect(sandboxId);
   try {
+    // Create-on-first-use (COMP-16): a freshly-configured workdir may not exist
+    // yet; `commands.run` with a missing cwd errors. `makeDir` is idempotent and
+    // best-effort — a failure here surfaces as the command's own cwd error, and
+    // the path is already confined under /home/user by the caller.
+    if (workdir) {
+      try {
+        await sandbox.files.makeDir(workdir);
+      } catch {}
+    }
     const result = await sandbox.commands.run(command, {
       ...(workdir ? { cwd: workdir } : {}),
       timeoutMs,
@@ -140,6 +150,15 @@ export async function runComputerCommand(
     };
   }
 
+  // COMP-16: confine the host-configured working directory under /home/user.
+  // Absent ⇒ the box default ($HOME). An escaping value fails CLOSED with a
+  // clear error rather than running somewhere unexpected — the authoritative
+  // server-side check behind the host-config UI's validation.
+  const resolvedWorkdir = resolveWorkingDirectory(args.workdir);
+  if ("error" in resolvedWorkdir) {
+    return { error: resolvedWorkdir.error };
+  }
+
   const timeoutMs =
     Math.min(
       Math.max(args.timeoutSeconds ?? DEFAULT_COMMAND_TIMEOUT_S, 1),
@@ -151,7 +170,7 @@ export async function runComputerCommand(
     result = await runner({
       sandboxId: info.value.providerComputerId,
       command: args.command,
-      workdir: args.workdir,
+      workdir: resolvedWorkdir.workdir,
       timeoutMs,
       signal: args.signal,
     });

--- a/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
+++ b/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
@@ -72,6 +72,10 @@ import type { EvalTraceSpan } from "@/shared/eval-trace";
 import { createOffsetInterval } from "@/shared/eval-trace";
 import { getCanonicalModelId } from "@/shared/types";
 import { createE2BHarnessSandboxProvider } from "./e2b-sandbox-provider.js";
+import {
+  resolveWorkingDirectory,
+  HOME_ROOT,
+} from "../computers/path-confine.js";
 import { resolveHarnessSandbox } from "./resolve-sandbox.js";
 import {
   fetchRuntimeSkills,
@@ -330,6 +334,7 @@ export async function runHarnessTurn(
     harness,
     harnessMcpProxy,
     builtInTools,
+    computerWorkdir,
     executionScope,
   } = options;
   // Canonicalize the model id up front (bare hosted ids like `gpt-5-nano` →
@@ -779,8 +784,23 @@ export async function runHarnessTurn(
       const auth = buildBrokerDummyAuth(harnessAdapter.id, broker.proxyBaseUrl);
       tBroker = Date.now();
 
-      // 4. Assemble the harness over the host's E2B computer.
-      const sandbox = createE2BHarnessSandboxProvider({ sandboxId });
+      // 4. Assemble the harness over the host's E2B computer. Root the Shell at
+      // the host-configured working directory (COMP-16) — the same
+      // `computer.workdir` the chat bash tool honors — confined under
+      // /home/user, defaulting to the box home. The harness framework nests a
+      // per-session `<workdir>/claude-code-<sessionId>` dir beneath it, so both
+      // planes share one configured root even though the Shell gets its own
+      // session subdir. An escaping value falls back to the default rather than
+      // failing the turn (the UI + bash path already reject escapes loudly).
+      const resolvedHarnessWorkdir = resolveWorkingDirectory(computerWorkdir);
+      const defaultWorkingDirectory =
+        "error" in resolvedHarnessWorkdir
+          ? HOME_ROOT
+          : resolvedHarnessWorkdir.workdir ?? HOME_ROOT;
+      const sandbox = createE2BHarnessSandboxProvider({
+        sandboxId,
+        defaultWorkingDirectory,
+      });
       // (permissionMode was computed above, before the runtime fingerprint.)
 
       // The adapter maps the host modelId to the harness's native model and

--- a/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
@@ -412,6 +412,15 @@ export interface MCPJamHandlerOptions {
    * browser-fulfilled) and skills (the harness has its own).
    */
   builtInTools?: ToolSet;
+  /**
+   * The host's configured computer working directory (`hostConfig.computer
+   * .workdir`), COMP-16. Single source of truth for WHERE commands run on the
+   * box: the chat `bash` tool already reads it via `builtInTools`; the harness
+   * path needs it separately here to root its Shell under the same directory
+   * (the harness framework then nests a per-session `<workdir>/claude-code-<id>`
+   * subdir). Absent ⇒ the box default (`/home/user`). Confined server-side.
+   */
+  computerWorkdir?: string;
   authHeader?: string;
   chatboxId?: string;
   accessVersion?: number;

--- a/mcpjam-inspector/server/utils/web-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/web-chat-turn.ts
@@ -177,6 +177,9 @@ export interface WebChatTurnPrepareInputs {
   uiTools?: UiToolEntry[];
   /** Server-side built-in tools (e.g. web_search) to merge into the tool set. */
   builtInTools?: ToolSet;
+  /** Host-configured computer working directory (COMP-16); roots the harness
+   *  Shell under the same dir the bash tool runs in. */
+  computerWorkdir?: string;
   widgetModelContext?: WidgetModelContextEntry[];
   /**
    * When set, skills are sourced from the caller's Computer (E2B sandbox)
@@ -681,6 +684,11 @@ export async function streamWebChatTurn(
     // (web_search) to HarnessAgent without the MCP-server tools, which the
     // harness gets via .mcp.json.
     ...(prepare.builtInTools ? { builtInTools: prepare.builtInTools } : {}),
+    // COMP-16: root the harness Shell at the host-configured working directory
+    // (same source as the bash tool's cwd).
+    ...(prepare.computerWorkdir
+      ? { computerWorkdir: prepare.computerWorkdir }
+      : {}),
     abortSignal: runtime.abortSignal,
     onConversationComplete,
     onStreamComplete: async () => {


### PR DESCRIPTION
## COMP-16 — M0: Configurable working directory for the bash tool

Let the host control WHERE on the computer's filesystem the bash tool runs, so MCP servers under test and COMP-14 uploaded attachments share a predictable cwd.

## ⚠️ The harness-vs-bash workdir contract (design decision, written down as the ticket requires)

There were two features wanting to own "working directory" on the same box: this one (chat bash cwd) and the Claude Code harness Shell workdir (PR #2996). **Decision: ONE field owns it.**

**`hostConfig.computer.workdir` is the single working-directory setting, honored by BOTH the chat bash tool and the harness Shell.** Details of the shared contract:

- **Chat bash tool** runs each command *directly* in `computer.workdir`.
- **Harness Shell** roots there too, but the harness framework (`@ai-sdk/harness`) structurally nests a **per-session subdir** — `<workdir>/claude-code-<sessionId>` — for session isolation. So the harness Shell runs in a child of the configured dir, not the bare dir. Both planes therefore share one configured **root**; forcing the harness into the bare dir would require patching the framework (it always appends `/<harnessId>-<sessionId>`), which is out of scope.
- **Default `/home/user`** — chosen so COMP-14 attachments (which land in `/home/user/attachments`) are reachable by a plain relative path from the default cwd.

## What changed

Most of the pipe already existed (the SDK canonicalizes `computer.workdir`; the bash tool already threaded it to E2B `cwd`). This PR adds the missing pieces:

- **Server confinement (authoritative).** New `resolveWorkingDirectory` (in `path-confine.ts`, reusing the upload route's `confineToHome`) confines the workdir under `/home/user` at the bash exec chokepoint (`run-command.ts`) and at the harness provider construction. An escape (`..`, `/etc`, `/home/user2`) **fails closed with a clear, path-bearing error** instead of running somewhere unexpected. `e2bRunner` `makeDir`s the cwd first (**create-on-first-use**).
- **Harness Shell honors the field.** Threaded `computer.workdir` from both chat routes → `MCPJamHandlerOptions.computerWorkdir` → `runHarnessTurn` → `createE2BHarnessSandboxProvider({ defaultWorkingDirectory })` (confined, default `/home/user`). Previously the harness ignored the field and hardcoded `/home/user`.
- **UI.** A "Working directory" input on the Computer attachment tab (default `/home/user`, inline validation mirroring the server rule). Clears at the default/blank so it **hashes identically to "unset"** (content-addressed host configs — no fork for the default).
- **Terminal PTY** opens in the configured dir: a plain computer host now sources the terminal cwd from `computer.workdir` (harness hosts keep their streamed per-session dir).

## Acceptance criteria

- [x] `workdir = /home/user/myproject` → bash `pwd` returns it; commands read/write there (workdir threaded to E2B `cwd` + `makeDir` on first use).
- [x] Escapes (`../`, `/etc`) rejected with a clear error, **covered by tests** (`resolveWorkingDirectory` unit tests + an exec-level bash-tool rejection test + client-side `validateComputerWorkdir`).
- [x] **Field verified to persist and round-trip through the REAL backend** (not just local types): the backend's *installed* `@mcpjam/sdk` **1.29.0** (including the `/host-config/internal` entry it imports) canonicalizes `workdir` (`COMPUTER_KEYS = ["kind","toolset","workdir"]`), and the Convex `hostConfigs.computer` column stores `workdir: v.optional(v.string())`. So the field already round-trips — **no SDK bump or backend change needed**. Locked by the SDK canonicalize test (preserve + trim + blank-collapse).
- [x] The harness-vs-bash workdir contract decision is written down (above).

## Note on the process gate

The ticket asks for a one-pager + Marcelo's thumbs-up before building; per direction I proceeded on the **recommended** contract (one shared `workdir`). The contract section above is that write-up — flagging it here for explicit sign-off.

## Verification
`typecheck:client` clean; server `tsc` unchanged from baseline; affected suites green — harness + computers + chat routes (291), SDK canonicalize (61), ComputerTab + helpers (29), path-confine + bash-tool (46).

🤖 Generated with [Claude Code](https://claude.com/claude-code)