### PR TITLE
feat(oauth): issuer-key local OAuth token reads (2R-store follow-up)

### DIFF
--- a/mcpjam-inspector/client/src/components/AuthTab.tsx
+++ b/mcpjam-inspector/client/src/components/AuthTab.tsx
@@ -140,7 +140,7 @@ export const AuthTab = ({
       const serverUrl = serverConfig.url.toString();
 
       // Check for existing tokens using the real OAuth system
-      const existingTokens = getStoredTokens(serverName);
+      const existingTokens = getStoredTokens(serverName, serverUrl);
 
       updateAuthSettings({
         serverUrl,
@@ -193,7 +193,10 @@ export const AuthTab = ({
 
       if (result.success) {
         // Check for updated tokens
-        const updatedTokens = getStoredTokens(serverName);
+        const updatedTokens = getStoredTokens(
+          serverName,
+          authSettings.serverUrl
+        );
 
         updateAuthSettings({
           tokens: updatedTokens,
@@ -273,7 +276,10 @@ export const AuthTab = ({
 
       if (result.success) {
         // Check for updated tokens
-        const updatedTokens = getStoredTokens(serverName);
+        const updatedTokens = getStoredTokens(
+          serverName,
+          authSettings.serverUrl
+        );
 
         updateAuthSettings({
           tokens: updatedTokens,
@@ -357,10 +363,15 @@ export const AuthTab = ({
     updateOAuthFlowState(EMPTY_OAUTH_FLOW_STATE);
     // Refresh tokens after guided flow completion
     if (serverName) {
-      const updatedTokens = getStoredTokens(serverName);
+      const updatedTokens = getStoredTokens(serverName, authSettings.serverUrl);
       updateAuthSettings({ tokens: updatedTokens });
     }
-  }, [serverName, updateAuthSettings, updateOAuthFlowState]);
+  }, [
+    serverName,
+    authSettings.serverUrl,
+    updateAuthSettings,
+    updateOAuthFlowState,
+  ]);
 
   const handleClearTokens = useCallback(() => {
     if (serverConfig && authSettings.serverUrl && serverName) {
@@ -401,7 +412,9 @@ export const AuthTab = ({
       ));
   // Check if OAuth is currently configured/in-use. Stored OAuth tokens can be
   // stale, so don't let them mask explicit bearer metadata.
-  const storedOAuthTokens = serverName ? getStoredTokens(serverName) : null;
+  const storedOAuthTokens = serverName
+    ? getStoredTokens(serverName, authSettings.serverUrl)
+    : null;
   const hasOAuthConfigured = Boolean(
     serverName &&
       serverEntry?.useOAuth !== false &&

--- a/mcpjam-inspector/client/src/components/connection/ServerInfoContent.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerInfoContent.tsx
@@ -42,9 +42,11 @@ export function ServerInfoContent({
   const [hostedTokenError, setHostedTokenError] = useState<string | null>(null);
   const hostedRevealRequestIdRef = useRef(0);
 
+  const serverUrl =
+    "url" in server.config ? server.config.url?.toString() : undefined;
   const storedTokensState = server.oauthTokens
     ? { tokens: undefined, isInvalid: false }
-    : getStoredTokensState(server.name);
+    : getStoredTokensState(server.name, serverUrl);
   const oauthTokens = server.oauthTokens ?? storedTokensState.tokens;
   const hasInvalidStoredAuthData =
     server.oauthTokens == null && storedTokensState.isInvalid;

--- a/mcpjam-inspector/client/src/components/connection/hooks/use-server-form.ts
+++ b/mcpjam-inspector/client/src/components/connection/hooks/use-server-form.ts
@@ -247,7 +247,10 @@ export function useServerForm(
         // 1. Check if server has oauth tokens
         // 2. Check if there's stored OAuth data
         const hasOAuthTokens = server.oauthTokens != null;
-        const hasStoredOAuthConfig = hasOAuthConfig(server.name);
+        // Bind stored-credential reads to the exact server URL so a reused
+        // server name can't surface a previous authorization server's data.
+        const httpServerUrl = config.url ? config.url.toString() : undefined;
+        const hasStoredOAuthConfig = hasOAuthConfig(server.name, httpServerUrl);
         hasServerOAuth =
           server.useOAuth === true ||
           hasOAuthTokens ||
@@ -260,7 +263,7 @@ export function useServerForm(
         const storedClientInfo = localStorage.getItem(
           `mcp-client-${server.name}`
         );
-        const storedTokens = getStoredTokens(server.name);
+        const storedTokens = getStoredTokens(server.name, httpServerUrl);
 
         const clientInfo = storedClientInfo ? JSON.parse(storedClientInfo) : {};
         const oauthConfig = storedOAuthConfig

--- a/mcpjam-inspector/client/src/components/oauth/utils.ts
+++ b/mcpjam-inspector/client/src/components/oauth/utils.ts
@@ -13,10 +13,11 @@ import { getStoredTokens } from "@/lib/oauth/mcp-oauth";
 // those fields blank for a server the Connect page clearly knows about.
 const readStoredOAuthCredentials = (
   serverName?: string,
+  serverUrl?: string,
 ): { clientId: string; scopes: string } => {
   if (!serverName) return { clientId: "", scopes: "" };
   try {
-    const storedTokens = getStoredTokens(serverName);
+    const storedTokens = getStoredTokens(serverName, serverUrl);
     const clientInfo = JSON.parse(
       localStorage.getItem(`mcp-client-${serverName}`) || "{}",
     );
@@ -88,7 +89,10 @@ export const deriveOAuthProfileFromServer = (
       ? (httpConfig as any).clientSecret
       : "";
 
-  const stored = readStoredOAuthCredentials(server.name);
+  const stored = readStoredOAuthCredentials(
+    server.name,
+    toUrlString(httpConfig.url) || undefined,
+  );
 
   return {
     ...EMPTY_OAUTH_TEST_PROFILE,

--- a/mcpjam-inspector/client/src/hooks/hosted/use-hosted-oauth-gate.ts
+++ b/mcpjam-inspector/client/src/hooks/hosted/use-hosted-oauth-gate.ts
@@ -70,7 +70,8 @@ function buildHostedOAuthStateMap(
     const existing = previous[server.serverId];
     const hasToken = isVaultBacked
       ? false
-      : !!getStoredTokens(server.serverName)?.access_token;
+      : !!getStoredTokens(server.serverName, server.serverUrl ?? undefined)
+          ?.access_token;
     const matchesResume =
       resumeMarker != null &&
       matchesHostedOAuthServerIdentity(
@@ -144,10 +145,11 @@ function setStoredOAuthTokenState(
 
 async function waitForStoredAccessToken(
   serverName: string,
-  attempts: number
+  attempts: number,
+  serverUrl?: string
 ): Promise<string | null> {
   for (let attempt = 0; attempt < attempts; attempt++) {
-    const accessToken = getStoredTokens(serverName)?.access_token;
+    const accessToken = getStoredTokens(serverName, serverUrl)?.access_token;
     if (typeof accessToken === "string" && accessToken.trim()) {
       return accessToken;
     }
@@ -281,9 +283,11 @@ export function useHostedOAuthGate({
           : isResume
           ? await waitForStoredAccessToken(
               server.serverName,
-              RESUME_TOKEN_POLL_ATTEMPTS
+              RESUME_TOKEN_POLL_ATTEMPTS,
+              server.serverUrl ?? undefined
             )
-          : getStoredTokens(server.serverName)?.access_token ?? null;
+          : getStoredTokens(server.serverName, server.serverUrl ?? undefined)
+              ?.access_token ?? null;
 
         if (isUnmountedRef.current) return;
 

--- a/mcpjam-inspector/client/src/hooks/hosted/use-hosted-oauth-gate.ts
+++ b/mcpjam-inspector/client/src/hooks/hosted/use-hosted-oauth-gate.ts
@@ -485,7 +485,8 @@ export function useHostedOAuthGate({
         ? null
         : await waitForStoredAccessToken(
             server.serverName,
-            INLINE_TOKEN_POLL_ATTEMPTS
+            INLINE_TOKEN_POLL_ATTEMPTS,
+            server.serverUrl ?? undefined
           );
 
       if (accessToken) {

--- a/mcpjam-inspector/client/src/lib/debugger-header-servers.ts
+++ b/mcpjam-inspector/client/src/lib/debugger-header-servers.ts
@@ -7,10 +7,13 @@ export function isOAuthDebuggerHeaderServer(server: ServerWithName): boolean {
   if (server.useXaa === true) return false;
   if (server.useOAuth === false) return false;
 
+  const serverUrl = server.config.url
+    ? server.config.url.toString()
+    : undefined;
   return Boolean(
     server.useOAuth === true ||
       server.oauthTokens ||
-      hasOAuthConfig(server.name) ||
+      hasOAuthConfig(server.name, serverUrl) ||
       server.connectionStatus === "oauth-flow"
   );
 }

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/issuer-keyed-storage.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/issuer-keyed-storage.test.ts
@@ -26,6 +26,23 @@ describe("issuer-keyed-storage", () => {
     expect(isIssuerKeyedStore(rec)).toBe(true);
   });
 
+  it("rejects a v2 record whose byIssuer is missing, null, or an array", () => {
+    // A valid map still passes.
+    expect(
+      isIssuerKeyedStore({ v: 2, byIssuer: { [asA]: { client_id: "a" } } })
+    ).toBe(true);
+    // Malformed byIssuer shapes are NOT issuer-keyed stores — callers classify
+    // these as corrupt v2 envelopes rather than empty keyed stores.
+    expect(isIssuerKeyedStore({ v: 2 })).toBe(false);
+    expect(isIssuerKeyedStore({ v: 2, byIssuer: null })).toBe(false);
+    expect(isIssuerKeyedStore({ v: 2, byIssuer: "x" })).toBe(false);
+    // An array passes `typeof === "object"` but must be rejected.
+    expect(isIssuerKeyedStore({ v: 2, byIssuer: [] })).toBe(false);
+    expect(
+      isIssuerKeyedStore({ v: 2, byIssuer: [{ client_id: "a" }] })
+    ).toBe(false);
+  });
+
   it("returns the bucket for the exact issuer and nothing for another (SEP-2352)", () => {
     const raw = JSON.stringify(writeIssuerKeyed<Cred>(null, asA, { client_id: "a" }));
     expect(readIssuerKeyed<Cred>(raw, asA, parseLegacy).value).toEqual({

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
@@ -1967,6 +1967,131 @@ describe("mcp-oauth", () => {
       expect(raw.activeIssuer).toBe("https://as-b.example.com");
     });
 
+    it("does not present AS-A tokens after discovery resolves to AS-B (SEP-2352)", async () => {
+      const { MCPOAuthProvider, getStoredTokens, getStoredTokensState } =
+        await import("../mcp-oauth");
+      // Seed a v2 token envelope with buckets for two authorization servers.
+      // (No app path writes keyed token records today — Convex is the token
+      // source of truth — so we seed the envelope directly to exercise the
+      // issuer-gated READ, exactly as the client-id F4/F5 test does.)
+      localStorage.setItem(
+        "mcp-tokens-issuer-tokens",
+        JSON.stringify({
+          v: 2,
+          activeIssuer: "https://as-a.example.com",
+          byIssuer: {
+            "https://as-a.example.com": {
+              access_token: "token-for-as-a",
+              token_type: "Bearer",
+            },
+            "https://as-b.example.com": {
+              access_token: "token-for-as-b",
+              token_type: "Bearer",
+            },
+          },
+        })
+      );
+      const provider = new MCPOAuthProvider(
+        "issuer-tokens",
+        "https://mcp.example.com/sse"
+      );
+
+      // Discovery points at AS A → AS A's token is returned.
+      await provider.saveDiscoveryState({
+        ...createDiscoveryState(),
+        authorizationServerUrl: "https://as-a.example.com",
+        authorizationServerMetadata: { issuer: "https://as-a.example.com" },
+      } as any);
+      expect(provider.tokens()?.access_token).toBe("token-for-as-a");
+      expect(getStoredTokens("issuer-tokens")?.access_token).toBe(
+        "token-for-as-a"
+      );
+
+      // Protected-resource metadata now resolves to AS B → AS B's token, and
+      // AS A's token is NEVER surfaced for AS B.
+      await provider.saveDiscoveryState({
+        ...createDiscoveryState(),
+        authorizationServerUrl: "https://as-b.example.com",
+        authorizationServerMetadata: { issuer: "https://as-b.example.com" },
+      } as any);
+      expect(provider.tokens()?.access_token).toBe("token-for-as-b");
+      expect(getStoredTokens("issuer-tokens")?.access_token).toBe(
+        "token-for-as-b"
+      );
+      expect(getStoredTokensState("issuer-tokens").isInvalid).toBe(false);
+
+      // Both buckets remain intact (a multi-issuer server keeps each AS's row).
+      const raw = localStorage.getItem("mcp-tokens-issuer-tokens") ?? "";
+      expect(raw).toContain("token-for-as-a");
+      expect(raw).toContain("token-for-as-b");
+    });
+
+    it("returns a legacy unkeyed token record as unbound compat (lazy migration)", async () => {
+      const { MCPOAuthProvider, getStoredTokens } = await import(
+        "../mcp-oauth"
+      );
+      // Pre-migration records are raw (unversioned) token bags with no issuer
+      // binding. They stay readable so existing local logins and the refresh
+      // path keep working (parity with the client-id read).
+      localStorage.setItem(
+        "mcp-tokens-legacy-tokens",
+        JSON.stringify({
+          access_token: "legacy-access",
+          refresh_token: "legacy-refresh",
+          token_type: "Bearer",
+        })
+      );
+      const provider = new MCPOAuthProvider(
+        "legacy-tokens",
+        "https://mcp.example.com/sse"
+      );
+      // Even with an issuer resolved, an UNBOUND legacy record is returned —
+      // we cannot know which AS it was granted by.
+      await provider.saveDiscoveryState({
+        ...createDiscoveryState(),
+        authorizationServerUrl: "https://as-a.example.com",
+        authorizationServerMetadata: { issuer: "https://as-a.example.com" },
+      } as any);
+      expect(provider.tokens()?.access_token).toBe("legacy-access");
+      expect(provider.tokens()?.refresh_token).toBe("legacy-refresh");
+      expect(getStoredTokens("legacy-tokens")?.access_token).toBe(
+        "legacy-access"
+      );
+    });
+
+    it("treats a v2 token envelope with no bucket for the resolved issuer as absent", async () => {
+      const { MCPOAuthProvider, getStoredTokens, getStoredTokensState } =
+        await import("../mcp-oauth");
+      localStorage.setItem(
+        "mcp-tokens-no-bucket",
+        JSON.stringify({
+          v: 2,
+          activeIssuer: "https://as-a.example.com",
+          byIssuer: {
+            "https://as-a.example.com": { access_token: "token-for-as-a" },
+          },
+        })
+      );
+      const provider = new MCPOAuthProvider(
+        "no-bucket",
+        "https://mcp.example.com/sse"
+      );
+      await provider.saveDiscoveryState({
+        ...createDiscoveryState(),
+        authorizationServerUrl: "https://as-b.example.com",
+        authorizationServerMetadata: { issuer: "https://as-b.example.com" },
+      } as any);
+
+      // No AS-B bucket → treat as absent (re-authorize), not corrupt.
+      expect(provider.tokens()).toBeUndefined();
+      expect(getStoredTokens("no-bucket")).toBeUndefined();
+      expect(getStoredTokensState("no-bucket").isInvalid).toBe(false);
+      // AS-A's bucket is left intact for when discovery points back at it.
+      expect(localStorage.getItem("mcp-tokens-no-bucket") ?? "").toContain(
+        "token-for-as-a"
+      );
+    });
+
     it("preserves the original callback error and verifier when registry token exchange fails", async () => {
       authFetch.mockImplementationOnce(async (input: RequestInfo | URL) => {
         const url =

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
@@ -2193,6 +2193,91 @@ describe("mcp-oauth", () => {
       });
     });
 
+    it("classifies a v2-shaped but corrupt envelope as invalid, not valid tokens", async () => {
+      const { getStoredTokens, getStoredTokensState } = await import(
+        "../mcp-oauth"
+      );
+      // `byIssuer` is a string, not an object: the record carries the v2
+      // version marker but fails the full issuer-keyed shape check. Without the
+      // corrupt-v2 guard, parseLegacyStoredTokens accepts the raw `{ v: 2, ... }`
+      // object as an unbound legacy token bag and surfaces it as VALID tokens.
+      localStorage.setItem(
+        "mcp-tokens-corrupt-v2",
+        JSON.stringify({ v: 2, byIssuer: "not-an-object" })
+      );
+      expect(getStoredTokens("corrupt-v2")).toBeUndefined();
+      expect(getStoredTokensState("corrupt-v2")).toEqual({
+        tokens: undefined,
+        isInvalid: true,
+      });
+
+      // `byIssuer` missing entirely is likewise a corrupt v2 envelope.
+      localStorage.setItem(
+        "mcp-tokens-corrupt-v2-missing",
+        JSON.stringify({ v: 2, activeIssuer: "https://as.example.com" })
+      );
+      expect(getStoredTokensState("corrupt-v2-missing")).toEqual({
+        tokens: undefined,
+        isInvalid: true,
+      });
+
+      // `byIssuer` null is corrupt too (typeof null === "object" but rejected).
+      localStorage.setItem(
+        "mcp-tokens-corrupt-v2-null",
+        JSON.stringify({ v: 2, byIssuer: null })
+      );
+      expect(getStoredTokensState("corrupt-v2-null")).toEqual({
+        tokens: undefined,
+        isInvalid: true,
+      });
+    });
+
+    it("getStoredTokens does not surface a PREVIOUS serverUrl's token bucket when the name is reused (SEP-2352)", async () => {
+      const { MCPOAuthProvider, getStoredTokens } = await import(
+        "../mcp-oauth"
+      );
+      // v2 token envelope + discovery bound to the ORIGINAL serverUrl (AS A).
+      localStorage.setItem(
+        "mcp-tokens-reused-gst",
+        JSON.stringify({
+          v: 2,
+          activeIssuer: "https://as-a.example.com",
+          byIssuer: {
+            "https://as-a.example.com": {
+              access_token: "token-for-as-a",
+              token_type: "Bearer",
+            },
+          },
+        })
+      );
+      const originalProvider = new MCPOAuthProvider(
+        "reused-gst",
+        "https://old.example.com/sse"
+      );
+      await originalProvider.saveDiscoveryState({
+        ...createDiscoveryState(),
+        authorizationServerUrl: "https://as-a.example.com",
+        authorizationServerMetadata: { issuer: "https://as-a.example.com" },
+      } as any);
+
+      // Reading with the ORIGINAL serverUrl still resolves AS A → token present.
+      expect(getStoredTokens("reused-gst", "https://old.example.com/sse")
+        ?.access_token).toBe("token-for-as-a");
+
+      // Reused with a DIFFERENT URL: the stale discovery must NOT resolve an
+      // issuer, so AS A's token bucket is NOT surfaced through getStoredTokens.
+      expect(
+        getStoredTokens("reused-gst", "https://new.example.com/sse")
+      ).toBeUndefined();
+
+      // The security-critical regression: calling WITHOUT a serverUrl falls back
+      // to persisted discovery, which still points at AS A. Passing the new URL
+      // (as every caller now does) is what prevents the stale-bucket read.
+      expect(getStoredTokens("reused-gst")?.access_token).toBe(
+        "token-for-as-a"
+      );
+    });
+
     it("preserves the original callback error and verifier when registry token exchange fails", async () => {
       authFetch.mockImplementationOnce(async (input: RequestInfo | URL) => {
         const url =

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
@@ -2230,6 +2230,44 @@ describe("mcp-oauth", () => {
         tokens: undefined,
         isInvalid: true,
       });
+
+      // `byIssuer` an ARRAY passes `typeof === "object"` but is not a valid
+      // issuer→record map: still a corrupt v2 envelope, not an empty keyed store
+      // that reads as absent.
+      localStorage.setItem(
+        "mcp-tokens-corrupt-v2-array",
+        JSON.stringify({ v: 2, byIssuer: [] })
+      );
+      expect(getStoredTokens("corrupt-v2-array")).toBeUndefined();
+      expect(getStoredTokensState("corrupt-v2-array")).toEqual({
+        tokens: undefined,
+        isInvalid: true,
+      });
+    });
+
+    it("provider.tokens() returns undefined for a v2-marked but malformed envelope", async () => {
+      const { MCPOAuthProvider } = await import("../mcp-oauth");
+      // A record carrying the v2 marker but failing the issuer-keyed shape check
+      // must NOT be handed to parseLegacyStoredTokens (which would accept the raw
+      // `{ v: 2, ... }` object as an unbound legacy token bag and surface it as
+      // valid). tokens() has no isInvalid channel, so it returns undefined.
+      const provider = new MCPOAuthProvider(
+        "corrupt-v2-provider",
+        "https://mcp.example.com/sse"
+      );
+
+      for (const bad of [
+        { v: 2, byIssuer: "not-an-object" },
+        { v: 2, activeIssuer: "https://as.example.com" },
+        { v: 2, byIssuer: null },
+        { v: 2, byIssuer: [] },
+      ]) {
+        localStorage.setItem(
+          "mcp-tokens-corrupt-v2-provider",
+          JSON.stringify(bad)
+        );
+        expect(provider.tokens()).toBeUndefined();
+      }
     });
 
     it("getStoredTokens does not surface a PREVIOUS serverUrl's token bucket when the name is reused (SEP-2352)", async () => {

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
@@ -2092,6 +2092,107 @@ describe("mcp-oauth", () => {
       );
     });
 
+    it("does not surface the activeIssuer token bucket before any AS resolves (SEP-2352)", async () => {
+      const { MCPOAuthProvider, getStoredTokens, getStoredTokensState } =
+        await import("../mcp-oauth");
+      // A v2 envelope exists but NO discovery/session has resolved an issuer for
+      // this server. The read must NOT fall back to the envelope's activeIssuer
+      // bucket — that AS binding is unverified for the current serverUrl.
+      localStorage.setItem(
+        "mcp-tokens-unresolved",
+        JSON.stringify({
+          v: 2,
+          activeIssuer: "https://as-a.example.com",
+          byIssuer: {
+            "https://as-a.example.com": {
+              access_token: "token-for-as-a",
+              token_type: "Bearer",
+            },
+          },
+        })
+      );
+      const provider = new MCPOAuthProvider(
+        "unresolved",
+        "https://mcp.example.com/sse"
+      );
+
+      // No discovery state saved → currentIssuer() is undefined → absent.
+      expect(provider.tokens()).toBeUndefined();
+      expect(getStoredTokens("unresolved")).toBeUndefined();
+      expect(getStoredTokensState("unresolved").isInvalid).toBe(false);
+      // The bucket is preserved for when discovery later resolves to AS A.
+      expect(localStorage.getItem("mcp-tokens-unresolved") ?? "").toContain(
+        "token-for-as-a"
+      );
+    });
+
+    it("does not surface a token bucket bound via a PREVIOUS serverUrl when the name is reused (SEP-2352)", async () => {
+      const { MCPOAuthProvider, getStoredTokensState } = await import(
+        "../mcp-oauth"
+      );
+      // Seed a v2 token envelope and discovery bound to the ORIGINAL serverUrl.
+      localStorage.setItem(
+        "mcp-tokens-reused-name",
+        JSON.stringify({
+          v: 2,
+          activeIssuer: "https://as-a.example.com",
+          byIssuer: {
+            "https://as-a.example.com": {
+              access_token: "token-for-as-a",
+              token_type: "Bearer",
+            },
+          },
+        })
+      );
+      const originalProvider = new MCPOAuthProvider(
+        "reused-name",
+        "https://old.example.com/sse"
+      );
+      await originalProvider.saveDiscoveryState({
+        ...createDiscoveryState(),
+        authorizationServerUrl: "https://as-a.example.com",
+        authorizationServerMetadata: { issuer: "https://as-a.example.com" },
+      } as any);
+
+      // Reading with the ORIGINAL serverUrl still resolves AS A → token present.
+      expect(
+        getStoredTokensState("reused-name", "https://old.example.com/sse")
+          .tokens?.access_token
+      ).toBe("token-for-as-a");
+
+      // The server name is now reused with a DIFFERENT URL. The stale discovery
+      // (for the old URL) must NOT resolve an issuer, so the AS-A token bucket is
+      // NOT surfaced for the new server.
+      const reused = getStoredTokensState(
+        "reused-name",
+        "https://new.example.com/sse"
+      );
+      expect(reused.tokens).toBeUndefined();
+      expect(reused.isInvalid).toBe(false);
+    });
+
+    it("classifies a present-but-malformed token record (null) as invalid, not absent", async () => {
+      const { getStoredTokens, getStoredTokensState } = await import(
+        "../mcp-oauth"
+      );
+      // Valid JSON but not a usable token object. Pre-2R this classified as
+      // invalid (the client_id merge threw); the issuer-keyed read must preserve
+      // that classification rather than silently reporting "no tokens".
+      localStorage.setItem("mcp-tokens-malformed-null", "null");
+      expect(getStoredTokens("malformed-null")).toBeUndefined();
+      expect(getStoredTokensState("malformed-null")).toEqual({
+        tokens: undefined,
+        isInvalid: true,
+      });
+
+      // A JSON array is likewise a malformed-but-present record.
+      localStorage.setItem("mcp-tokens-malformed-array", "[]");
+      expect(getStoredTokensState("malformed-array")).toEqual({
+        tokens: undefined,
+        isInvalid: true,
+      });
+    });
+
     it("preserves the original callback error and verifier when registry token exchange fails", async () => {
       authFetch.mockImplementationOnce(async (input: RequestInfo | URL) => {
         const url =

--- a/mcpjam-inspector/client/src/lib/oauth/issuer-keyed-storage.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/issuer-keyed-storage.ts
@@ -39,6 +39,22 @@ export function isIssuerKeyedStore<T>(
   );
 }
 
+/**
+ * True when `value` carries the v2 version marker (`v === 2`) regardless of
+ * whether the rest of the issuer-keyed shape is valid. A record that is
+ * version-marked but fails `isIssuerKeyedStore` (e.g. `byIssuer` missing, null,
+ * or not an object) is a CORRUPT v2 envelope — NOT a legacy unkeyed record.
+ * Callers use this to classify such a record as invalid instead of accepting
+ * the raw `{ v: 2, ... }` object as an unbound legacy credential bag.
+ */
+export function hasIssuerKeyedVersionMarker(value: unknown): boolean {
+  return (
+    !!value &&
+    typeof value === "object" &&
+    (value as { v?: unknown }).v === ISSUER_KEYED_STORAGE_VERSION
+  );
+}
+
 export interface IssuerKeyedRead<T> {
   value: T | undefined;
   /**

--- a/mcpjam-inspector/client/src/lib/oauth/issuer-keyed-storage.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/issuer-keyed-storage.ts
@@ -35,7 +35,12 @@ export function isIssuerKeyedStore<T>(
     typeof value === "object" &&
     (value as { v?: unknown }).v === ISSUER_KEYED_STORAGE_VERSION &&
     typeof (value as { byIssuer?: unknown }).byIssuer === "object" &&
-    (value as { byIssuer?: unknown }).byIssuer !== null
+    (value as { byIssuer?: unknown }).byIssuer !== null &&
+    // An array `byIssuer` passes `typeof === "object"` but is NOT a valid
+    // issuer→record map. Reject it so a `{ v: 2, byIssuer: [] }` record is
+    // classified as a CORRUPT v2 envelope (via hasIssuerKeyedVersionMarker)
+    // rather than an empty keyed store that silently reads as absent.
+    !Array.isArray((value as { byIssuer?: unknown }).byIssuer)
   );
 }
 

--- a/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
@@ -2156,6 +2156,26 @@ export class MCPOAuthProvider implements OAuthClientProvider {
     // being the token source of truth — are returned as UNBOUND compat so
     // existing local logins and the refresh path keep working.
     const raw = localStorage.getItem(`mcp-tokens-${this.serverName}`);
+    // A record carrying the v2 version marker but FAILING the full issuer-keyed
+    // shape check (e.g. `byIssuer` missing, null, an array, or not an object) is
+    // a CORRUPT v2 envelope. Without this guard `parseLegacyStoredTokens`
+    // accepts the raw `{ v: 2, ... }` object as an unbound legacy token bag and
+    // it is surfaced as VALID tokens. `tokens()` has no isInvalid contract, so
+    // return undefined — parity with the corrupt-v2 classification in
+    // getStoredTokensState.
+    if (raw) {
+      try {
+        const parsedRaw = JSON.parse(raw);
+        if (
+          !isIssuerKeyedStore(parsedRaw) &&
+          hasIssuerKeyedVersionMarker(parsedRaw)
+        ) {
+          return undefined;
+        }
+      } catch {
+        // Unparseable raw is handled below by readIssuerKeyed (returns absent).
+      }
+    }
     const issuer = this.currentIssuer();
     const { value, legacyUnbound } = readIssuerKeyed<any>(
       raw,

--- a/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
@@ -88,6 +88,19 @@ interface StoredOAuthClientInformation {
   client_secret?: string;
 }
 
+/**
+ * Narrows a raw (pre-migration) parsed `mcp-tokens-*` record to a usable token
+ * object. Any non-null, non-array object is accepted as an unbound legacy token
+ * bag; anything else (string, number, array, null) is rejected. Used by the
+ * issuer-keyed token reads so a legacy unkeyed record is returned as UNBOUND
+ * compat while a v2 envelope is gated to the exact resolved issuer (SEP-2352).
+ */
+function parseLegacyStoredTokens(parsed: unknown): any {
+  return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+    ? parsed
+    : undefined;
+}
+
 type OAuthRegistrationStrategy =
   | RegistrationStrategy2025_03_26
   | RegistrationStrategy2025_06_18
@@ -2129,15 +2142,21 @@ export class MCPOAuthProvider implements OAuthClientProvider {
   }
 
   tokens() {
-    const stored = localStorage.getItem(`mcp-tokens-${this.serverName}`);
-    if (!stored) {
-      return undefined;
-    }
-    try {
-      return JSON.parse(stored);
-    } catch {
-      return undefined;
-    }
+    // SEP-2352: return only the token bucket bound to the EXACT resolved issuer.
+    // A v2-keyed envelope for AS A yields nothing once discovery resolves to
+    // AS B, so AS A's tokens are never presented to AS B (mirrors the client-id
+    // read). Legacy unkeyed records — the only shape written today; see the
+    // `saveTokens` note on Convex being the token source of truth — are returned
+    // as UNBOUND compat so existing local logins and the refresh path keep
+    // working. Before any AS is resolved, `readIssuerKeyed` falls back to the
+    // envelope's active bucket (or the legacy value), preserving refresh.
+    const raw = localStorage.getItem(`mcp-tokens-${this.serverName}`);
+    const { value } = readIssuerKeyed<any>(
+      raw,
+      this.currentIssuer(),
+      parseLegacyStoredTokens
+    );
+    return value;
   }
 
   async saveTokens(tokens: any) {
@@ -3649,28 +3668,42 @@ export function getStoredTokensState(serverName: string): StoredTokensState {
   if (HOSTED_MODE) {
     return { tokens: undefined, isInvalid: false };
   }
-  const tokens = localStorage.getItem(`mcp-tokens-${serverName}`);
+  const raw = localStorage.getItem(`mcp-tokens-${serverName}`);
   // TODO: Maybe we should move clientID away from the token info? Not sure if clientID is bonded to token
-  if (!tokens) return { tokens: undefined, isInvalid: false };
+  if (!raw) return { tokens: undefined, isInvalid: false };
 
+  // A present-but-unparseable record is corrupt (isInvalid), distinct from an
+  // absent one — detect that up front so the issuer gating below doesn't
+  // silently reclassify malformed data as "no tokens".
   try {
-    const tokensJson = JSON.parse(tokens);
-    const clientJson = readStoredClientInformation(serverName);
-
-    // Merge tokens with client_id from client information
-    return {
-      tokens: {
-        ...tokensJson,
-        client_id: clientJson.client_id || tokensJson.client_id,
-      },
-      isInvalid: false,
-    };
+    JSON.parse(raw);
   } catch {
-    return {
-      tokens: undefined,
-      isInvalid: true,
-    };
+    return { tokens: undefined, isInvalid: true };
   }
+
+  // SEP-2352: gate the record by the exact resolved issuer so a v2-keyed AS-A
+  // token bucket is never surfaced after PRM resolves to AS B. Legacy unkeyed
+  // records stay readable as UNBOUND compat (parity with the client-id read).
+  const issuer = resolveStoredIssuer(serverName);
+  const { value: tokensJson } = readIssuerKeyed<any>(
+    raw,
+    issuer,
+    parseLegacyStoredTokens
+  );
+  if (!tokensJson) {
+    // A v2 envelope with no bucket for the resolved issuer: not corrupt, just
+    // not this AS's tokens — treat as absent so the flow re-authorizes.
+    return { tokens: undefined, isInvalid: false };
+  }
+
+  const clientJson = readStoredClientInformation(serverName);
+  return {
+    tokens: {
+      ...tokensJson,
+      client_id: clientJson.client_id || tokensJson.client_id,
+    },
+    isInvalid: false,
+  };
 }
 
 export function getStoredTokens(serverName: string): any {

--- a/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
@@ -39,6 +39,7 @@ import type {
 import type { HttpServerConfig } from "@mcpjam/sdk/browser";
 import { generateRandomString } from "./pkce";
 import {
+  hasIssuerKeyedVersionMarker,
   isIssuerKeyedStore,
   readIssuerKeyed,
   writeIssuerKeyed,
@@ -3698,6 +3699,16 @@ export function getStoredTokensState(
   }
   const isKeyedEnvelope = isIssuerKeyedStore(parsed);
 
+  // A record carrying the v2 version marker but FAILING the full issuer-keyed
+  // shape check (e.g. `byIssuer` missing, null, or not an object) is a CORRUPT
+  // v2 envelope. Without this guard `parseLegacyStoredTokens` accepts the raw
+  // `{ v: 2, ... }` object as an unbound legacy token bag and the record is
+  // surfaced as valid tokens. Classify it as INVALID here, for parity with the
+  // legacy-malformed handling below.
+  if (!isKeyedEnvelope && hasIssuerKeyedVersionMarker(parsed)) {
+    return { tokens: undefined, isInvalid: true };
+  }
+
   // SEP-2352: gate the record by the exact resolved issuer so a v2-keyed AS-A
   // token bucket is never surfaced after PRM resolves to AS B. Bind the exact
   // serverUrl (as the provider's `tokens()` read does via `currentIssuer()`) so
@@ -3740,14 +3751,18 @@ export function getStoredTokensState(
   };
 }
 
-export function getStoredTokens(serverName: string): any {
-  return getStoredTokensState(serverName).tokens;
+// `serverUrl` binds the issuer-keyed token read to the EXACT server URL so a
+// reused server name can't surface a previous authorization server's tokens
+// (SEP-2352). Callers should pass `server.config.url`; omitting it falls back
+// to the persisted discovery/session issuer (legacy behavior).
+export function getStoredTokens(serverName: string, serverUrl?: string): any {
+  return getStoredTokensState(serverName, serverUrl).tokens;
 }
 
 /**
  * Checks if OAuth is configured for a server by looking at multiple sources
  */
-export function hasOAuthConfig(serverName: string): boolean {
+export function hasOAuthConfig(serverName: string, serverUrl?: string): boolean {
   if (HOSTED_MODE) {
     return false;
   }
@@ -3756,7 +3771,7 @@ export function hasOAuthConfig(serverName: string): boolean {
   const storedOAuthConfig = localStorage.getItem(
     `mcp-oauth-config-${serverName}`
   );
-  const storedTokens = getStoredTokens(serverName);
+  const storedTokens = getStoredTokens(serverName, serverUrl);
 
   return (
     storedServerUrl != null ||
@@ -3771,12 +3786,13 @@ export function hasOAuthConfig(serverName: string): boolean {
  */
 export async function waitForTokens(
   serverName: string,
-  timeoutMs: number = 5000
+  timeoutMs: number = 5000,
+  serverUrl?: string
 ): Promise<any> {
   const startTime = Date.now();
 
   while (Date.now() - startTime < timeoutMs) {
-    const tokens = getStoredTokens(serverName);
+    const tokens = getStoredTokens(serverName, serverUrl);
     if (tokens?.access_token) {
       return tokens;
     }

--- a/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
@@ -38,7 +38,11 @@ import type {
 } from "@mcpjam/sdk/browser";
 import type { HttpServerConfig } from "@mcpjam/sdk/browser";
 import { generateRandomString } from "./pkce";
-import { readIssuerKeyed, writeIssuerKeyed } from "./issuer-keyed-storage";
+import {
+  isIssuerKeyedStore,
+  readIssuerKeyed,
+  writeIssuerKeyed,
+} from "./issuer-keyed-storage";
 import { authFetch } from "@/lib/session-token";
 import { HOSTED_MODE, SANITIZE_OAUTH_TRACES } from "@/lib/config";
 import {
@@ -2143,19 +2147,27 @@ export class MCPOAuthProvider implements OAuthClientProvider {
 
   tokens() {
     // SEP-2352: return only the token bucket bound to the EXACT resolved issuer.
-    // A v2-keyed envelope for AS A yields nothing once discovery resolves to
-    // AS B, so AS A's tokens are never presented to AS B (mirrors the client-id
-    // read). Legacy unkeyed records — the only shape written today; see the
-    // `saveTokens` note on Convex being the token source of truth — are returned
-    // as UNBOUND compat so existing local logins and the refresh path keep
-    // working. Before any AS is resolved, `readIssuerKeyed` falls back to the
-    // envelope's active bucket (or the legacy value), preserving refresh.
+    // `currentIssuer()` binds the provider's serverUrl, so a discovery entry for
+    // a DIFFERENT serverUrl can't resolve an issuer here. A v2-keyed envelope for
+    // AS A yields nothing once discovery resolves to AS B, so AS A's tokens are
+    // never presented to AS B (mirrors the client-id read). Legacy unkeyed
+    // records — the only shape written today; see the `saveTokens` note on Convex
+    // being the token source of truth — are returned as UNBOUND compat so
+    // existing local logins and the refresh path keep working.
     const raw = localStorage.getItem(`mcp-tokens-${this.serverName}`);
-    const { value } = readIssuerKeyed<any>(
+    const issuer = this.currentIssuer();
+    const { value, legacyUnbound } = readIssuerKeyed<any>(
       raw,
-      this.currentIssuer(),
+      issuer,
       parseLegacyStoredTokens
     );
+    // When no issuer resolves (e.g. serverUrl changed so persisted discovery no
+    // longer matches), a v2 envelope must NOT surface its `activeIssuer` bucket —
+    // that could be a stale AS's tokens after a PRM/serverUrl change (SEP-2352).
+    // Only legacy unkeyed records are returned as UNBOUND compat.
+    if (!issuer && !legacyUnbound) {
+      return undefined;
+    }
     return value;
   }
 
@@ -3664,7 +3676,10 @@ export interface StoredTokensState {
   isInvalid: boolean;
 }
 
-export function getStoredTokensState(serverName: string): StoredTokensState {
+export function getStoredTokensState(
+  serverName: string,
+  serverUrl?: string
+): StoredTokensState {
   if (HOSTED_MODE) {
     return { tokens: undefined, isInvalid: false };
   }
@@ -3675,28 +3690,47 @@ export function getStoredTokensState(serverName: string): StoredTokensState {
   // A present-but-unparseable record is corrupt (isInvalid), distinct from an
   // absent one — detect that up front so the issuer gating below doesn't
   // silently reclassify malformed data as "no tokens".
+  let parsed: unknown;
   try {
-    JSON.parse(raw);
+    parsed = JSON.parse(raw);
   } catch {
     return { tokens: undefined, isInvalid: true };
   }
+  const isKeyedEnvelope = isIssuerKeyedStore(parsed);
 
   // SEP-2352: gate the record by the exact resolved issuer so a v2-keyed AS-A
-  // token bucket is never surfaced after PRM resolves to AS B. Legacy unkeyed
-  // records stay readable as UNBOUND compat (parity with the client-id read).
-  const issuer = resolveStoredIssuer(serverName);
-  const { value: tokensJson } = readIssuerKeyed<any>(
+  // token bucket is never surfaced after PRM resolves to AS B. Bind the exact
+  // serverUrl (as the provider's `tokens()` read does via `currentIssuer()`) so
+  // a discovery entry for a PREVIOUS serverUrl — when a server name is reused —
+  // can't resolve a stale issuer here. Legacy unkeyed records stay readable as
+  // UNBOUND compat (parity with the client-id read).
+  const issuer = resolveStoredIssuer(serverName, serverUrl);
+  const { value: tokensJson, legacyUnbound } = readIssuerKeyed<any>(
     raw,
     issuer,
     parseLegacyStoredTokens
   );
   if (!tokensJson) {
-    // A v2 envelope with no bucket for the resolved issuer: not corrupt, just
-    // not this AS's tokens — treat as absent so the flow re-authorizes.
+    if (isKeyedEnvelope) {
+      // A v2 envelope with no bucket for the resolved issuer (or none resolved):
+      // not corrupt, just not this AS's tokens — treat as absent so the flow
+      // re-authorizes.
+      return { tokens: undefined, isInvalid: false };
+    }
+    // A present, valid-JSON but malformed legacy record (e.g. `null`, an array,
+    // or a scalar) is INVALID, not absent — preserve the pre-2R classification
+    // so the UI surfaces "invalid stored auth data" rather than silently
+    // dropping it.
+    return { tokens: undefined, isInvalid: true };
+  }
+  // When no issuer resolves, a v2 envelope must NOT surface its `activeIssuer`
+  // bucket (a stale AS after a serverUrl/PRM change, SEP-2352). Only legacy
+  // unkeyed records are returned as UNBOUND compat.
+  if (!issuer && !legacyUnbound) {
     return { tokens: undefined, isInvalid: false };
   }
 
-  const clientJson = readStoredClientInformation(serverName);
+  const clientJson = readStoredClientInformation(serverName, serverUrl);
   return {
     tokens: {
       ...tokensJson,


### PR DESCRIPTION
## Summary

Follow-up to 2R-store (SEP-2352, #3377), which issuer-keyed OAuth **client-info** and explicitly deferred tokens, discovery state, and the Convex binding. This PR extends the same issuer-keyed pattern (`issuer-keyed-storage.ts` + `resolveStoredIssuer`, exact-issuer reads, lazy migration) to the storage that was deferred — keying where correct and documenting where keying does **not** fit rather than forcing it.

**SEP-2352 invariant:** a credential/token bound to authorization-server issuer A must never be reused after protected-resource metadata resolves to issuer B.

## Decision per target

### Tokens — KEYED ✅ (reads)
`MCPOAuthProvider.tokens()` and `getStoredTokensState()` now resolve the exact AS issuer via `resolveStoredIssuer` and read only that issuer's bucket via `readIssuerKeyed`. A v2-keyed AS-A token record is never presented once discovery resolves to AS-B (mirrors the client-id read).

- Legacy unkeyed records stay readable as **unbound compat** (parity with the client-id read) so existing local logins and the token-refresh path keep working.
- A v2 envelope with **no bucket** for the resolved issuer reads as **absent** (re-authorize), not corrupt.
- The malformed-record → `isInvalid: true` semantics are preserved.

**No new localStorage token writer is added — and that's deliberate.** Verified there is **no** `setItem("mcp-tokens-*")` anywhere in production code: `saveTokens` imports tokens to Convex and clears localStorage in local mode, and returns early in hosted mode. **Convex is the token source of truth in both modes**, so hosted behavior is unchanged and the local token localStorage path is read-only legacy/migration compat. Keying the reads therefore hardens the read side (v2-envelope isolation + parity with client-info) without reintroducing browser token persistence — which would contradict the "stop keeping secrets in browser storage" direction (#2758/#2866). Keyed token envelopes are exercised in tests via direct seeding (as the client-id F4/F5 test does).

### Discovery state — SKIPPED (by design) 🟡
`mcp-discovery-*` is the single mutable **current-AS pointer** that *defines* the issuer — `resolveStoredIssuer` reads it to determine the issuer for everything else. Keying it by issuer would be circular (you'd need the issuer to read the thing that yields the issuer) and would break issuer resolution. Its overwrite on a PRM change is exactly what *triggers* the issuer-keyed isolation of client-info and tokens. Correct as-is.

### Convex binding — SKIPPED (by design) 🟡
`mcp-oauth-binding-*` (`projectId`/`serverId`) is a per-server **routing pointer** to the Convex `hostedOAuthCredentials` row, not an AS-bound credential. It is invariant across AS changes and the Convex row is the source of truth for the credential, so issuer-keying it would fragment token-import routing and could drop the import after an AS change. Per-server-not-per-issuer by design.

## Tests
New tests mirror the client-id SEP-2352 integration test:
- AS-A tokens not returned for AS-B (both `tokens()` and `getStoredTokens`/`getStoredTokensState`); both buckets preserved (multi-issuer server).
- Legacy unkeyed record returned as unbound compat (lazy migration).
- v2 envelope with no bucket for the resolved issuer → absent, not corrupt; other bucket left intact.

## Verification
- Client typecheck: `tsc -p client/tsconfig.typecheck.json` → 0 errors.
- `vitest run client/src/lib/oauth/__tests__/` → 170 passed (13 files); mcp-oauth.test.ts 66 → 69.
- Token-seeding suites unaffected: local-state-migration + ServerDetailModal → 43 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes how stored OAuth tokens are resolved and classified (issuer + serverUrl gating), which can change whether connections appear authenticated or prompt re-auth; security-sensitive but read-path only with no new token writers.
> 
> **Overview**
> Extends **SEP-2352** issuer-keyed localStorage reads from client-info to **OAuth tokens**: `MCPOAuthProvider.tokens()` and `getStoredTokensState` resolve the authorization server via `resolveStoredIssuer` and return only that issuer’s bucket through `readIssuerKeyed`, without falling back to a v2 envelope’s `activeIssuer` when no issuer is bound.
> 
> Adds optional **`serverUrl`** on `getStoredTokens`, `hasOAuthConfig`, and `waitForTokens` so discovery tied to a previous URL cannot surface stale tokens when a server name is reused; UI call sites (`AuthTab`, connect form, hosted OAuth gate, debugger headers, OAuth profile utils) pass the current HTTP URL.
> 
> Tightens **v2 envelope validation**: `isIssuerKeyedStore` rejects array `byIssuer`; new `hasIssuerKeyedVersionMarker` treats version-marked but malformed records as **corrupt** (`isInvalid: true` / `tokens()` returns undefined) instead of legacy unbound tokens. Broad **mcp-oauth** and **issuer-keyed-storage** tests cover cross-issuer isolation, legacy compat, missing buckets, and reused names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab21f4cfac1bdbd6c1b14120e3cc3be97bf60d0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Issuer-keyed OAuth token reads now bind to the resolved issuer and exact `serverUrl`, and reject malformed v2 envelopes to prevent stale or corrupt tokens from being surfaced.

- **New Features**
  - `MCPOAuthProvider.tokens()` and `getStoredTokensState(serverName, serverUrl)` resolve the issuer and read only that issuer’s bucket via `readIssuerKeyed`. Legacy unkeyed records read as unbound; v2 envelopes without a bucket read as absent; no new localStorage writers (Convex remains the source of truth).
  - Added `hasIssuerKeyedVersionMarker` and tightened `isIssuerKeyedStore` (rejects missing/null/array `byIssuer`) to classify version-marked but shape-invalid records correctly.

- **Bug Fixes**
  - `tokens()` now returns undefined for v2-marked but malformed envelopes; `getStoredTokensState` classifies these as `isInvalid` (not valid tokens). No fallback to a v2 envelope’s `activeIssuer` when no issuer resolves.
  - Issuer-keyed reads now bind to the exact `serverUrl` across all callers, including `AuthTab`, `use-server-form`, `oauth/utils`, `use-hosted-oauth-gate` (immediate post-authorize poll), `ServerInfoContent`, and `debugger-header-servers`, preventing reused names from surfacing a previous URL/issuer’s tokens.

<sup>Written for commit ab21f4cfac1bdbd6c1b14120e3cc3be97bf60d0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

