### PR TITLE
feat(oauth): route 2026-07-28 through the connect-form OAuth protocol leg (2M-c)

### DIFF
--- a/mcpjam-inspector/client/src/components/connection/AddServerModal.tsx
+++ b/mcpjam-inspector/client/src/components/connection/AddServerModal.tsx
@@ -26,6 +26,7 @@ import { EnvVarsSection } from "./shared/EnvVarsSection";
 import { HostedConnectionTypeControl } from "./shared/HostedConnectionTypeControl";
 import { findProjectByAnyId, type Project } from "@/state/app-types";
 import { useOptionalSharedAppState } from "@/state/app-state-context";
+import { useActiveMcpProfile } from "@/contexts/active-mcp-profile-context";
 
 interface AddServerModalProps {
   isOpen: boolean;
@@ -120,6 +121,11 @@ export function AddServerModal({
   projectId = null,
 }: AddServerModalProps) {
   const appState = useOptionalSharedAppState();
+  // Active host's mcpProfile — the host-level wire pin that "auto" OAuth
+  // falls back to when no per-server override is set (see handleSubmit and
+  // AuthenticationSection's serverMcpProtocolVersion prop). Provided by the
+  // Servers tab's ActiveMcpProfileProvider; undefined in local/CLI contexts.
+  const activeMcpProfile = useActiveMcpProfile();
   const activeProject = findProjectByAnyId(
     appState?.projects,
     appState?.activeProjectId,
@@ -341,10 +347,13 @@ export function AddServerModal({
 
     const finalFormData: ServerFormData = {
       ...formState.buildFormData({
-        // Resolve a default ("auto") OAuth protocol against the wire pin so a
-        // 2026-07-28-pinned server submits the 2026 OAuth flow, not the 2025
-        // default. An explicit dropdown selection still wins.
-        wireProtocolVersionOverride: mcpProtocolVersionOverride,
+        // Resolve a default ("auto") OAuth protocol against the effective wire
+        // pin so a 2026-07-28-pinned server submits the 2026 OAuth flow, not
+        // the 2025 default. Precedence mirrors AuthenticationSection's preview:
+        // the per-server pin wins, else the active host's mcpProfile pin. An
+        // explicit dropdown selection still wins over both.
+        wireProtocolVersionOverride:
+          mcpProtocolVersionOverride ?? activeMcpProfile?.mcpProtocolVersion,
       }),
       ...(mcpProtocolVersionOverride !== undefined
         ? { mcpProtocolVersionOverride }

--- a/mcpjam-inspector/client/src/components/connection/AddServerModal.tsx
+++ b/mcpjam-inspector/client/src/components/connection/AddServerModal.tsx
@@ -156,6 +156,10 @@ export function AddServerModal({
   // Initialize form with initial data if provided
   useEffect(() => {
     if (initialData && isOpen) {
+      // Hydrate the per-server wire pin from the prefill so the OAuth-protocol
+      // "auto" bridge sees it: a 2026-07-28-pinned prefill must resolve to the
+      // 2026 OAuth flow and round-trip its pin, not silently drop to 2025.
+      setMcpProtocolVersionOverride(initialData.mcpProtocolVersionOverride);
       if (initialData.name) {
         formState.setName(initialData.name);
       }
@@ -336,7 +340,12 @@ export function AddServerModal({
     }
 
     const finalFormData: ServerFormData = {
-      ...formState.buildFormData(),
+      ...formState.buildFormData({
+        // Resolve a default ("auto") OAuth protocol against the wire pin so a
+        // 2026-07-28-pinned server submits the 2026 OAuth flow, not the 2025
+        // default. An explicit dropdown selection still wins.
+        wireProtocolVersionOverride: mcpProtocolVersionOverride,
+      }),
       ...(mcpProtocolVersionOverride !== undefined
         ? { mcpProtocolVersionOverride }
         : {}),

--- a/mcpjam-inspector/client/src/components/connection/AddServerModal.tsx
+++ b/mcpjam-inspector/client/src/components/connection/AddServerModal.tsx
@@ -14,7 +14,7 @@ import {
 } from "@mcpjam/design-system/select";
 import {
   ServerFormData,
-  type ServerFormOAuthProtocolMode,
+  normalizeOauthProtocolMode,
 } from "@/shared/types.js";
 import { track } from "@/lib/analytics";
 import { HOSTED_MODE } from "@/lib/config";
@@ -49,16 +49,8 @@ interface AddServerModalProps {
   projectId?: string | null;
 }
 
-function normalizeOauthProtocolMode(
-  value?: ServerFormData["oauthProtocolMode"],
-): ServerFormOAuthProtocolMode {
-  return value === "2025-03-26" ||
-    value === "2025-06-18" ||
-    value === "2025-11-25" ||
-    value === "2026-07-28"
-    ? value
-    : "2025-11-25";
-}
+// normalizeOauthProtocolMode / ServerFormOAuthProtocolMode are single-sourced
+// in shared/types (the normalizer preserves the 2026-07-28 draft era).
 
 // Single-sourced in the SDK's registration vocabulary (accepts the legacy
 // pre_registered alias; unknown → undefined so callers apply defaults).
@@ -501,6 +493,7 @@ export function AddServerModal({
               onOauthScopesChange={formState.setOauthScopesInput}
               oauthProtocolMode={formState.oauthProtocolMode}
               onOauthProtocolModeChange={formState.setOauthProtocolMode}
+              serverMcpProtocolVersion={mcpProtocolVersionOverride}
               registrationMode={formState.registrationMode}
               onOauthRegistrationModeChange={
                 formState.setOauthRegistrationMode

--- a/mcpjam-inspector/client/src/components/connection/EditServerFormContent.tsx
+++ b/mcpjam-inspector/client/src/components/connection/EditServerFormContent.tsx
@@ -32,6 +32,15 @@ interface EditServerFormContentProps {
   onMcpProtocolVersionOverrideChange?: (
     mode: McpProtocolVersion | undefined
   ) => void;
+  /**
+   * The active host's default MCP wire pin, resolved PROP-FIRST by the modal
+   * (`hostDefaultMcpProtocolVersion ?? useActiveMcpProfile()`). Forwarded to
+   * AuthenticationSection so the "auto" OAuth plan preview resolves against the
+   * SAME host fallback the submit path bakes with — otherwise the preview
+   * (context) and the saved era (host default) could disagree when the modal
+   * renders outside an ActiveMcpProfileProvider.
+   */
+  hostDefaultMcpProtocolVersion?: McpProtocolVersion;
   /** Project default XAA test identity — shown as override placeholders. */
   projectXaaDefaultIdentity?: { subject: string; email: string } | null;
 }
@@ -43,6 +52,7 @@ export function EditServerFormContent({
   hostedServerId = null,
   mcpProtocolVersionOverride,
   onMcpProtocolVersionOverrideChange,
+  hostDefaultMcpProtocolVersion,
   projectXaaDefaultIdentity = null,
 }: EditServerFormContentProps) {
   const hostedUrlPlaceholder = "https://example.com/mcp";
@@ -230,6 +240,7 @@ export function EditServerFormContent({
             oauthProtocolMode={formState.oauthProtocolMode}
             onOauthProtocolModeChange={formState.setOauthProtocolMode}
             serverMcpProtocolVersion={mcpProtocolVersionOverride}
+            hostDefaultMcpProtocolVersion={hostDefaultMcpProtocolVersion}
             registrationMode={formState.registrationMode}
             onOauthRegistrationModeChange={formState.setOauthRegistrationMode}
             xaaClientAuth={formState.xaaClientAuth}

--- a/mcpjam-inspector/client/src/components/connection/EditServerFormContent.tsx
+++ b/mcpjam-inspector/client/src/components/connection/EditServerFormContent.tsx
@@ -229,6 +229,7 @@ export function EditServerFormContent({
             onOauthScopesChange={formState.setOauthScopesInput}
             oauthProtocolMode={formState.oauthProtocolMode}
             onOauthProtocolModeChange={formState.setOauthProtocolMode}
+            serverMcpProtocolVersion={mcpProtocolVersionOverride}
             registrationMode={formState.registrationMode}
             onOauthRegistrationModeChange={formState.setOauthRegistrationMode}
             xaaClientAuth={formState.xaaClientAuth}

--- a/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
@@ -418,14 +418,17 @@ export function ServerDetailModal({
         ...(revealedHeaders ? { revealedHeaders } : {}),
         // Resolve a deferred "auto" OAuth protocol against the effective wire
         // pin. Precedence mirrors AuthenticationSection's preview: the
-        // per-server pin wins, else the active host's mcpProfile pin (so an
+        // per-server pin wins, else the PROP-FIRST resolved host default (so an
         // edited OAuth server with no stored protocol under a 2026-pinned host
         // bakes the 2026 flow). An edit-loaded concrete mode passes through
-        // unchanged. Reads the same context source as the display bridge so
-        // the saved profile and the preview cannot disagree.
+        // unchanged. Uses `resolvedHostDefaultMcpProtocolVersion` — the same
+        // authoritative host pin the chip attributes and the preview now
+        // resolves against — rather than the raw context read, so the saved
+        // era matches the preview even when this modal renders without an
+        // ActiveMcpProfileProvider (or one whose value differs from the prop).
         wireProtocolVersionOverride:
           currentMcpProtocolVersionOverride ??
-          activeMcpProfile?.mcpProtocolVersion,
+          resolvedHostDefaultMcpProtocolVersion,
       });
       await onSubmit(finalFormData, server.name);
     } finally {
@@ -641,6 +644,9 @@ export function ServerDetailModal({
                     projectXaaDefaultIdentity={projectXaaDefaultIdentity}
                     mcpProtocolVersionOverride={
                       currentMcpProtocolVersionOverride
+                    }
+                    hostDefaultMcpProtocolVersion={
+                      resolvedHostDefaultMcpProtocolVersion
                     }
                     onMcpProtocolVersionOverrideChange={
                       canEditMcpProtocolVersionOverride

--- a/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
@@ -416,10 +416,16 @@ export function ServerDetailModal({
 
       const finalFormData = formState.buildFormData({
         ...(revealedHeaders ? { revealedHeaders } : {}),
-        // Resolve a deferred "auto" OAuth protocol against the server's wire
-        // pin (edit-loaded modes are concrete, so this is a no-op for them —
-        // it just keeps the Add and Edit save paths on one resolver).
-        wireProtocolVersionOverride: currentMcpProtocolVersionOverride,
+        // Resolve a deferred "auto" OAuth protocol against the effective wire
+        // pin. Precedence mirrors AuthenticationSection's preview: the
+        // per-server pin wins, else the active host's mcpProfile pin (so an
+        // edited OAuth server with no stored protocol under a 2026-pinned host
+        // bakes the 2026 flow). An edit-loaded concrete mode passes through
+        // unchanged. Reads the same context source as the display bridge so
+        // the saved profile and the preview cannot disagree.
+        wireProtocolVersionOverride:
+          currentMcpProtocolVersionOverride ??
+          activeMcpProfile?.mcpProtocolVersion,
       });
       await onSubmit(finalFormData, server.name);
     } finally {

--- a/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
@@ -414,9 +414,13 @@ export function ServerDetailModal({
         }
       }
 
-      const finalFormData = formState.buildFormData(
-        revealedHeaders ? { revealedHeaders } : undefined
-      );
+      const finalFormData = formState.buildFormData({
+        ...(revealedHeaders ? { revealedHeaders } : {}),
+        // Resolve a deferred "auto" OAuth protocol against the server's wire
+        // pin (edit-loaded modes are concrete, so this is a no-op for them —
+        // it just keeps the Add and Edit save paths on one resolver).
+        wireProtocolVersionOverride: currentMcpProtocolVersionOverride,
+      });
       await onSubmit(finalFormData, server.name);
     } finally {
       setIsSaving(false);

--- a/mcpjam-inspector/client/src/components/connection/__tests__/AddServerModal.protocol-bridge.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/AddServerModal.protocol-bridge.test.tsx
@@ -1,0 +1,54 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { ServerFormData } from "@/shared/types.js";
+import { AddServerModal } from "../AddServerModal";
+
+// AddServerModal reaches for auth, app-readiness and analytics at render time;
+// stub them so the modal mounts standalone. HOSTED_MODE stays false (the test
+// default), which keeps useServerForm's confidential-CIMD probe off the network.
+vi.mock("@workos-inc/authkit-react", () => ({
+  useAuth: () => ({ user: null }),
+}));
+vi.mock("@/hooks/use-app-ready", () => ({
+  useAppReady: () => ({ status: "ready" }),
+  useAppReadyMessage: () => null,
+}));
+vi.mock("@/lib/analytics", () => ({ track: vi.fn() }));
+
+function submitAddServer(): ServerFormData {
+  const onSubmit = vi.fn();
+  render(
+    <AddServerModal
+      isOpen
+      onClose={vi.fn()}
+      onSubmit={onSubmit}
+      // A prefilled OAuth server already pinned to the 2026 wire era, with the
+      // Protocol dropdown left at its default (no explicit oauthProtocolMode).
+      initialData={{
+        name: "draft-2026",
+        type: "http",
+        url: "https://example.test/mcp",
+        useOAuth: true,
+        mcpProtocolVersionOverride: "2026-07-28",
+      }}
+      projectId="proj-1"
+    />
+  );
+
+  fireEvent.click(screen.getByRole("button", { name: /add server/i }));
+  expect(onSubmit).toHaveBeenCalledTimes(1);
+  return onSubmit.mock.calls[0][0] as ServerFormData;
+}
+
+describe("AddServerModal — default-OAuth × 2026 wire-pin bridge (end to end)", () => {
+  it("submits the 2026 OAuth flow and round-trips the wire pin", () => {
+    const submitted = submitAddServer();
+
+    // The crux: default OAuth (dropdown untouched) + a 2026-07-28 wire pin
+    // resolves to the 2026 OAuth flow rather than silently degrading to 2025.
+    expect(submitted.oauthProtocolMode).toBe("2026-07-28");
+    // The prefilled pin survives the round-trip — the server stays 2026-pinned.
+    expect(submitted.mcpProtocolVersionOverride).toBe("2026-07-28");
+    expect(submitted.useOAuth).toBe(true);
+  });
+});

--- a/mcpjam-inspector/client/src/components/connection/__tests__/AddServerModal.protocol-bridge.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/AddServerModal.protocol-bridge.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ServerFormData } from "@/shared/types.js";
+import type { McpProtocolVersion } from "@mcpjam/sdk/browser";
 import { AddServerModal } from "../AddServerModal";
 
 // AddServerModal reaches for auth, app-readiness and analytics at render time;
@@ -15,24 +16,35 @@ vi.mock("@/hooks/use-app-ready", () => ({
 }));
 vi.mock("@/lib/analytics", () => ({ track: vi.fn() }));
 
-function submitAddServer(): ServerFormData {
+// The active host's mcpProfile normally arrives via ActiveMcpProfileProvider
+// (the Servers tab). Stub the context so the test can pin the host-level wire
+// version and prove the "auto" OAuth bridge falls back to it. Authentication
+// Section reads the same hook, so display and submit share this source.
+let mockActiveMcpProfile:
+  | { profileVersion: 1; mcpProtocolVersion?: McpProtocolVersion }
+  | undefined;
+vi.mock("@/contexts/active-mcp-profile-context", () => ({
+  useActiveMcpProfile: () => mockActiveMcpProfile,
+  ActiveMcpProfileProvider: ({ children }: { children: React.ReactNode }) =>
+    children,
+}));
+
+afterEach(() => {
+  mockActiveMcpProfile = undefined;
+});
+
+function submitAddServer(
+  initialData: Partial<ServerFormData>,
+): ServerFormData {
   const onSubmit = vi.fn();
   render(
     <AddServerModal
       isOpen
       onClose={vi.fn()}
       onSubmit={onSubmit}
-      // A prefilled OAuth server already pinned to the 2026 wire era, with the
-      // Protocol dropdown left at its default (no explicit oauthProtocolMode).
-      initialData={{
-        name: "draft-2026",
-        type: "http",
-        url: "https://example.test/mcp",
-        useOAuth: true,
-        mcpProtocolVersionOverride: "2026-07-28",
-      }}
+      initialData={initialData}
       projectId="proj-1"
-    />
+    />,
   );
 
   fireEvent.click(screen.getByRole("button", { name: /add server/i }));
@@ -41,8 +53,16 @@ function submitAddServer(): ServerFormData {
 }
 
 describe("AddServerModal — default-OAuth × 2026 wire-pin bridge (end to end)", () => {
-  it("submits the 2026 OAuth flow and round-trips the wire pin", () => {
-    const submitted = submitAddServer();
+  it("submits the 2026 OAuth flow and round-trips a per-server wire pin", () => {
+    // A prefilled OAuth server pinned to the 2026 wire era, Protocol dropdown
+    // left at its default (no explicit oauthProtocolMode).
+    const submitted = submitAddServer({
+      name: "draft-2026",
+      type: "http",
+      url: "https://example.test/mcp",
+      useOAuth: true,
+      mcpProtocolVersionOverride: "2026-07-28",
+    });
 
     // The crux: default OAuth (dropdown untouched) + a 2026-07-28 wire pin
     // resolves to the 2026 OAuth flow rather than silently degrading to 2025.
@@ -50,5 +70,56 @@ describe("AddServerModal — default-OAuth × 2026 wire-pin bridge (end to end)"
     // The prefilled pin survives the round-trip — the server stays 2026-pinned.
     expect(submitted.mcpProtocolVersionOverride).toBe("2026-07-28");
     expect(submitted.useOAuth).toBe(true);
+  });
+
+  it("preserves an explicit 'auto' prefill and resolves it under the wire pin", () => {
+    // Round-2 regression: an "auto" prefill was coerced to 2025-11-25 during
+    // hydration (normalizeOauthProtocolMode), dropping the sentinel so the
+    // bridge no longer fired. It must survive and resolve against the pin.
+    const submitted = submitAddServer({
+      name: "auto-prefill-2026",
+      type: "http",
+      url: "https://example.test/mcp",
+      useOAuth: true,
+      oauthProtocolMode: "auto",
+      mcpProtocolVersionOverride: "2026-07-28",
+    });
+
+    expect(submitted.oauthProtocolMode).toBe("2026-07-28");
+    expect(submitted.mcpProtocolVersionOverride).toBe("2026-07-28");
+  });
+
+  it("falls back to the active host's 2026 wire pin when no per-server override is set", () => {
+    // Round-2 P2: with the per-server picker at "Client default"
+    // (mcpProtocolVersionOverride undefined), "auto" OAuth must consult the
+    // active host's mcpProfile.mcpProtocolVersion before the 2025 default.
+    mockActiveMcpProfile = {
+      profileVersion: 1,
+      mcpProtocolVersion: "2026-07-28",
+    };
+
+    const submitted = submitAddServer({
+      name: "host-pinned-2026",
+      type: "http",
+      url: "https://example.test/mcp",
+      useOAuth: true,
+      // No mcpProtocolVersionOverride, no explicit oauthProtocolMode.
+    });
+
+    expect(submitted.oauthProtocolMode).toBe("2026-07-28");
+    // The per-server override stays unset — only the host default is inherited.
+    expect(submitted.mcpProtocolVersionOverride).toBeUndefined();
+  });
+
+  it("stays on the 2025 default when neither a per-server nor host pin is 2026", () => {
+    const submitted = submitAddServer({
+      name: "unpinned",
+      type: "http",
+      url: "https://example.test/mcp",
+      useOAuth: true,
+    });
+
+    expect(submitted.oauthProtocolMode).toBe("2025-11-25");
+    expect(submitted.mcpProtocolVersionOverride).toBeUndefined();
   });
 });

--- a/mcpjam-inspector/client/src/components/connection/__tests__/AuthenticationSection.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/AuthenticationSection.test.tsx
@@ -774,4 +774,91 @@ describe("AuthenticationSection", () => {
     ).not.toBeInTheDocument();
     expect(screen.getByText(/A client secret is saved/i)).toBeInTheDocument();
   });
+
+  describe("Protocol dropdown + auto → wire-pin bridge", () => {
+    const protocolBaseProps = {
+      serverUrl: "https://example.com/mcp",
+      authType: "oauth" as const,
+      onAuthTypeChange: vi.fn(),
+      showAuthSettings: true,
+      bearerToken: "",
+      onBearerTokenChange: vi.fn(),
+      oauthScopesInput: "",
+      onOauthScopesChange: vi.fn(),
+      onOauthProtocolModeChange: vi.fn(),
+      registrationMode: "auto" as const,
+      onOauthRegistrationModeChange: vi.fn(),
+      useCustomClientId: false,
+      onUseCustomClientIdChange: vi.fn(),
+      clientId: "",
+      onClientIdChange: vi.fn(),
+      clientSecret: "",
+      onClientSecretChange: vi.fn(),
+      clientIdError: null,
+      clientSecretError: null,
+    };
+
+    const openAdvanced = () =>
+      fireEvent.click(
+        screen.getByRole("button", { name: /advanced settings/i })
+      );
+
+    it("offers the 2026-07-28 (Draft) option in the Protocol dropdown", () => {
+      render(
+        <AuthenticationSection
+          {...protocolBaseProps}
+          oauthProtocolMode="2026-07-28"
+        />
+      );
+      openAdvanced();
+      // Radix Select renders the selected item's label in the trigger; the
+      // 2026 draft option resolving to a label proves it is in PROTOCOL_OPTIONS.
+      expect(screen.getByText("2026-07-28 (Draft)")).toBeInTheDocument();
+    });
+
+    it("resolves 'auto' to the 2026 flow when the wire pin is 2026-07-28", () => {
+      render(
+        <AuthenticationSection
+          {...protocolBaseProps}
+          oauthProtocolMode="auto"
+          serverMcpProtocolVersion="2026-07-28"
+        />
+      );
+      openAdvanced();
+      expect(screen.getByText("2026-07-28 (Draft)")).toBeInTheDocument();
+      expect(
+        screen.queryByText("2025-11-25 (Latest)")
+      ).not.toBeInTheDocument();
+    });
+
+    it("resolves 'auto' to the 2025-11-25 default when no 2026 wire pin", () => {
+      render(
+        <AuthenticationSection
+          {...protocolBaseProps}
+          oauthProtocolMode="auto"
+          serverMcpProtocolVersion="2025-11-25"
+        />
+      );
+      openAdvanced();
+      expect(screen.getByText("2025-11-25 (Latest)")).toBeInTheDocument();
+      expect(
+        screen.queryByText("2026-07-28 (Draft)")
+      ).not.toBeInTheDocument();
+    });
+
+    it("lets an explicit protocol selection win over a 2026 wire pin", () => {
+      render(
+        <AuthenticationSection
+          {...protocolBaseProps}
+          oauthProtocolMode="2025-06-18"
+          serverMcpProtocolVersion="2026-07-28"
+        />
+      );
+      openAdvanced();
+      expect(screen.getByText("2025-06-18")).toBeInTheDocument();
+      expect(
+        screen.queryByText("2026-07-28 (Draft)")
+      ).not.toBeInTheDocument();
+    });
+  });
 });

--- a/mcpjam-inspector/client/src/components/connection/__tests__/AuthenticationSection.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/AuthenticationSection.test.tsx
@@ -846,6 +846,39 @@ describe("AuthenticationSection", () => {
       ).not.toBeInTheDocument();
     });
 
+    it("resolves 'auto' against the host-default pin when no per-server override is set", () => {
+      // Mirrors the submit path: with no per-server pin, the preview must
+      // resolve against the PROP-FIRST host default (the same value the modal
+      // bakes with), even with no ActiveMcpProfileProvider in the tree.
+      render(
+        <AuthenticationSection
+          {...protocolBaseProps}
+          oauthProtocolMode="auto"
+          serverMcpProtocolVersion={undefined}
+          hostDefaultMcpProtocolVersion="2026-07-28"
+        />
+      );
+      openAdvanced();
+      expect(screen.getByText("2026-07-28 (Draft)")).toBeInTheDocument();
+      expect(
+        screen.queryByText("2025-11-25 (Latest)")
+      ).not.toBeInTheDocument();
+    });
+
+    it("lets a per-server override win over the host-default pin for 'auto'", () => {
+      render(
+        <AuthenticationSection
+          {...protocolBaseProps}
+          oauthProtocolMode="auto"
+          serverMcpProtocolVersion="2026-07-28"
+          hostDefaultMcpProtocolVersion="2025-06-18"
+        />
+      );
+      openAdvanced();
+      expect(screen.getByText("2026-07-28 (Draft)")).toBeInTheDocument();
+      expect(screen.queryByText("2025-06-18")).not.toBeInTheDocument();
+    });
+
     it("lets an explicit protocol selection win over a 2026 wire pin", () => {
       render(
         <AuthenticationSection

--- a/mcpjam-inspector/client/src/components/connection/__tests__/ServerDetailModal.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/ServerDetailModal.test.tsx
@@ -690,4 +690,118 @@ describe("ServerDetailModal", () => {
 
     expect(onKeyDown).not.toHaveBeenCalled();
   });
+
+  // Regression: an "Auto" OAuth server with no stored protocol era must bake
+  // the SAME era the plan preview showed. The submit path resolves "auto"
+  // against the PROP-FIRST resolved host default (the value the chip and the
+  // preview use), NOT the raw ActiveMcpProfile context — otherwise a modal
+  // rendered without an ActiveMcpProfileProvider (context undefined) would
+  // save the 2025 default while the chip/host advertise 2026.
+  describe("bakes the Auto OAuth era against the effective wire pin at save", () => {
+    const renameAndSave = async (name = "test-server-renamed") => {
+      const nameInput = screen.getByDisplayValue("test-server");
+      fireEvent.change(nameInput, { target: { value: name } });
+      const form = screen
+        .getByRole("button", { name: "Save Changes" })
+        .closest("form");
+      expect(form).not.toBeNull();
+      fireEvent.submit(form!);
+    };
+
+    it("saves the 2026 era from the host default when no per-server pin is set", async () => {
+      const onSubmit = vi.fn().mockResolvedValue({
+        ok: true,
+        serverName: "test-server",
+      });
+
+      render(
+        <ServerDetailModal
+          {...defaultProps}
+          server={createServer({ authMethod: "auto" })}
+          onSubmit={onSubmit}
+          hostDefaultMcpProtocolVersion="2026-07-28"
+        />
+      );
+
+      await renameAndSave();
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledWith(
+          expect.objectContaining({
+            authMethod: "auto",
+            useOAuth: true,
+            oauthProtocolMode: "2026-07-28",
+          }),
+          "test-server"
+        );
+      });
+    });
+
+    it("saves the current default era when the host is not 2026-pinned", async () => {
+      const onSubmit = vi.fn().mockResolvedValue({
+        ok: true,
+        serverName: "test-server",
+      });
+
+      render(
+        <ServerDetailModal
+          {...defaultProps}
+          server={createServer({ authMethod: "auto" })}
+          onSubmit={onSubmit}
+        />
+      );
+
+      await renameAndSave();
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledWith(
+          expect.objectContaining({
+            authMethod: "auto",
+            useOAuth: true,
+            oauthProtocolMode: "2025-11-25",
+          }),
+          "test-server"
+        );
+      });
+    });
+
+    it("re-resolves to the 2026 era from a per-server override even when the host default is not 2026", async () => {
+      const onSubmit = vi.fn().mockResolvedValue({
+        ok: true,
+        serverName: "test-server",
+      });
+      // Per-server wire pin (project-layer override) is 2026 while the host
+      // default is unset — the override must win and bake the 2026 era.
+      mockUseQuery.mockReturnValue({
+        projectId: "project_123",
+        serverIds: ["server_123"],
+        overrides: {
+          server_123: { mcpProtocolVersionOverride: "2026-07-28" },
+        },
+      });
+
+      render(
+        <ServerDetailModal
+          {...defaultProps}
+          server={createServer({ authMethod: "auto" })}
+          onSubmit={onSubmit}
+          projectId="project_123"
+          hostedServerId="server_123"
+        />
+      );
+
+      await renameAndSave();
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledWith(
+          expect.objectContaining({
+            authMethod: "auto",
+            useOAuth: true,
+            oauthProtocolMode: "2026-07-28",
+          }),
+          "test-server"
+        );
+      });
+    });
+  });
 });

--- a/mcpjam-inspector/client/src/components/connection/hooks/__tests__/use-server-form.test.ts
+++ b/mcpjam-inspector/client/src/components/connection/hooks/__tests__/use-server-form.test.ts
@@ -18,10 +18,72 @@ describe("useServerForm", () => {
     vi.mocked(hasOAuthConfig).mockReturnValue(false);
   });
 
-  it("defaults OAuth protocol mode to explicit latest", () => {
+  it("defaults OAuth protocol mode to the deferred 'auto' sentinel", () => {
+    // "auto" (not a concrete era) is what makes the wire-pin bridge reachable:
+    // a fresh form defers its OAuth era to the server's MCP wire pin instead of
+    // hard-pinning 2025-11-25 and stranding a 2026-pinned server on the 2025
+    // flow. The submit path bakes it into a concrete era (see below).
     const { result } = renderHook(() => useServerForm());
 
-    expect(result.current.oauthProtocolMode).toBe("2025-11-25");
+    expect(result.current.oauthProtocolMode).toBe("auto");
+  });
+
+  describe("default OAuth protocol 'auto' → wire-pin submit bridge", () => {
+    const startDefaultOAuthAdd = (result: {
+      current: ReturnType<typeof useServerForm>;
+    }) => {
+      act(() => {
+        result.current.setName("Draft server");
+        result.current.setUrl("https://example.com/mcp");
+        result.current.setAuthType("oauth");
+        result.current.setShowAuthSettings(true);
+        // Note: oauthProtocolMode is left at its "auto" default — the user
+        // never touched the Protocol dropdown.
+      });
+    };
+
+    it("bakes the 2026 OAuth flow when adding with a 2026-07-28 wire pin", () => {
+      const { result } = renderHook(() => useServerForm());
+      startDefaultOAuthAdd(result);
+
+      expect(
+        result.current.buildFormData({
+          wireProtocolVersionOverride: "2026-07-28",
+        })
+      ).toMatchObject({
+        useOAuth: true,
+        oauthProtocolMode: "2026-07-28",
+      });
+    });
+
+    it("keeps the 2025-11-25 default when there is no 2026 wire pin", () => {
+      const { result } = renderHook(() => useServerForm());
+      startDefaultOAuthAdd(result);
+
+      expect(result.current.buildFormData()).toMatchObject({
+        useOAuth: true,
+        oauthProtocolMode: "2025-11-25",
+      });
+      expect(
+        result.current.buildFormData({
+          wireProtocolVersionOverride: "2025-11-25",
+        }).oauthProtocolMode
+      ).toBe("2025-11-25");
+    });
+
+    it("lets an explicit protocol selection win over a 2026 wire pin", () => {
+      const { result } = renderHook(() => useServerForm());
+      startDefaultOAuthAdd(result);
+      act(() => {
+        result.current.setOauthProtocolMode("2025-06-18");
+      });
+
+      expect(
+        result.current.buildFormData({
+          wireProtocolVersionOverride: "2026-07-28",
+        }).oauthProtocolMode
+      ).toBe("2025-06-18");
+    });
   });
 
   it("rejects malformed HTTP URLs even when HTTPS is optional", () => {

--- a/mcpjam-inspector/client/src/components/connection/hooks/__tests__/use-server-form.test.ts
+++ b/mcpjam-inspector/client/src/components/connection/hooks/__tests__/use-server-form.test.ts
@@ -1001,7 +1001,7 @@ describe("useServerForm", () => {
     });
   });
 
-  it("normalizes legacy automatic OAuth protocol mode to explicit latest for existing servers", async () => {
+  it("preserves a stored 'auto' OAuth protocol mode so the wire-pin bridge still applies on edit", async () => {
     const server = {
       name: "Existing OAuth server",
       config: {
@@ -1023,11 +1023,59 @@ describe("useServerForm", () => {
 
     const { result } = renderHook(() => useServerForm(server));
 
+    // Round-2: a stored "auto" is NOT coerced to a concrete era during
+    // hydration — the deferred sentinel survives so the submit-time bridge can
+    // route a 2026-pinned server through the 2026 OAuth flow.
     await waitFor(() => {
-      expect(result.current.oauthProtocolMode).toBe("2025-11-25");
+      expect(result.current.oauthProtocolMode).toBe("auto");
     });
 
+    // Under a 2026 wire pin the preserved "auto" bakes the 2026 flow…
+    expect(
+      result.current.buildFormData({
+        wireProtocolVersionOverride: "2026-07-28",
+      }).oauthProtocolMode
+    ).toBe("2026-07-28");
+    // …and without a pin it lands on the 2025 default, as before.
+    expect(result.current.buildFormData().oauthProtocolMode).toBe("2025-11-25");
+
     localStorage.removeItem("mcp-oauth-config-Existing OAuth server");
+  });
+
+  it("keeps 'auto' when editing an OAuth server with no stored protocol so the wire-pin bridge applies", async () => {
+    // Round-2: the edit initializer called normalizeOauthProtocolMode(undefined)
+    // → a concrete 2025-11-25, stranding an edited OAuth server (no stored
+    // protocol) on the 2025 flow even under a 2026 wire pin. With no stored
+    // protocol the deferred "auto" default must survive.
+    const server = {
+      name: "OAuth server without stored protocol",
+      config: {
+        url: "https://example.com/mcp",
+      },
+      useOAuth: true,
+      lastConnectionTime: new Date(),
+      connectionStatus: "disconnected",
+      retryCount: 0,
+      enabled: true,
+    } as any;
+
+    const { result } = renderHook(() => useServerForm(server));
+
+    await waitFor(() => {
+      expect(result.current.authType).toBe("oauth");
+    });
+    expect(result.current.oauthProtocolMode).toBe("auto");
+    // The preserved sentinel is a no-op change (initial snapshot is "auto" too).
+    expect(result.current.hasChanges).toBe(false);
+
+    // The submit path resolves it against the wire pin: 2026 under a 2026 pin…
+    expect(
+      result.current.buildFormData({
+        wireProtocolVersionOverride: "2026-07-28",
+      }).oauthProtocolMode
+    ).toBe("2026-07-28");
+    // …and the 2025 default otherwise.
+    expect(result.current.buildFormData().oauthProtocolMode).toBe("2025-11-25");
   });
 
   it("normalizes invalid stored OAuth registration strategies back to auto", async () => {

--- a/mcpjam-inspector/client/src/components/connection/hooks/use-server-form.ts
+++ b/mcpjam-inspector/client/src/components/connection/hooks/use-server-form.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import {
   ServerFormData,
+  normalizeOauthProtocolMode,
   type ServerFormAuthType,
   type ServerFormOAuthProtocolMode,
 } from "@/shared/types.js";
@@ -58,16 +59,8 @@ interface HeaderEntry {
   value: string;
 }
 
-function normalizeOauthProtocolMode(
-  value?: string
-): ServerFormOAuthProtocolMode {
-  return value === "2025-03-26" ||
-    value === "2025-06-18" ||
-    value === "2025-11-25" ||
-    value === "2026-07-28"
-    ? value
-    : DEFAULT_OAUTH_PROTOCOL_MODE;
-}
+// normalizeOauthProtocolMode is single-sourced in shared/types (preserves the
+// 2026-07-28 draft era; unknown/"auto" → 2025-11-25 default).
 
 // Single-sourced in the SDK's registration vocabulary (accepts the legacy
 // pre_registered alias; unknown → undefined so callers apply defaults).

--- a/mcpjam-inspector/client/src/components/connection/hooks/use-server-form.ts
+++ b/mcpjam-inspector/client/src/components/connection/hooks/use-server-form.ts
@@ -290,15 +290,24 @@ export function useServerForm(
         clientIdValue = storedTokens?.client_id || savedClientId;
         clientSecretValue = hasStoredClientSecretValue ? "" : savedClientSecret;
 
-        protocolModeValue = normalizeOauthProtocolMode(
+        // A server with a stored OAuth protocol loads that (concrete) era. A
+        // server with NONE stored keeps the deferred "auto" default so the
+        // wire-pin bridge still applies on edit — normalizing `undefined`
+        // would bake a concrete 2025-11-25 and make the bridge unreachable for
+        // an edited server pinned to the 2026 wire era. (normalizeOauthProtocol
+        // Mode also preserves a stored "auto" should one ever be persisted.)
+        const storedProtocolMode =
           typeof oauthConfig.protocolMode === "string"
             ? oauthConfig.protocolMode
             : typeof server.oauthFlowProfile?.protocolVersion === "string"
             ? server.oauthFlowProfile.protocolVersion
             : typeof oauthConfig.protocolVersion === "string"
             ? oauthConfig.protocolVersion
-            : undefined
-        );
+            : undefined;
+        protocolModeValue =
+          storedProtocolMode != null
+            ? normalizeOauthProtocolMode(storedProtocolMode)
+            : DEFAULT_OAUTH_PROTOCOL_MODE;
 
         // The CANONICAL per-server registrationMode wins — it can be "auto",
         // while the legacy profile/localStorage values are rollback-compat

--- a/mcpjam-inspector/client/src/components/connection/hooks/use-server-form.ts
+++ b/mcpjam-inspector/client/src/components/connection/hooks/use-server-form.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from "react";
 import {
   ServerFormData,
   normalizeOauthProtocolMode,
+  resolveEffectiveOauthProtocolMode,
   type ServerFormAuthType,
   type ServerFormOAuthProtocolMode,
 } from "@/shared/types.js";
@@ -50,7 +51,13 @@ interface InitialFormValues {
   xaaEmail: string;
 }
 
-const DEFAULT_OAUTH_PROTOCOL_MODE: ServerFormOAuthProtocolMode = "2025-11-25";
+// New connect forms default to the deferred "auto" sentinel, NOT a concrete
+// era: "auto" lets AuthenticationSection's wire-pin bridge (and the submit-time
+// resolver below) route a 2026-07-28-pinned server through the 2026 OAuth flow.
+// A concrete default would make that bridge unreachable — the user would have
+// to hand-pick 2026 even on a server already pinned to the 2026 wire era. Edit
+// mode overwrites this from the server's stored (always concrete) protocol.
+const DEFAULT_OAUTH_PROTOCOL_MODE: ServerFormOAuthProtocolMode = "auto";
 const DEFAULT_OAUTH_REGISTRATION_MODE: RegistrationMode = "auto";
 
 interface HeaderEntry {
@@ -791,6 +798,15 @@ export function useServerForm(
      * change without wiping the headers the form can't see.
      */
     revealedHeaders?: Record<string, string>;
+    /**
+     * The server's per-server MCP wire-version pin. Only used to resolve the
+     * deferred "auto" OAuth protocol mode into a concrete era at save time so
+     * the persisted OAuth profile / localStorage config carry the 2026-07-28
+     * flow when the wire is pinned to 2026 (OAuth + transport ship together).
+     * The pin itself is NOT emitted from this hook — the Add/Edit shells own
+     * that on the project layer.
+     */
+    wireProtocolVersionOverride?: string;
   }): ServerFormData => {
     const parsedTimeout = Number.parseInt(requestTimeout.trim(), 10);
     const reqTimeout = Number.isFinite(parsedTimeout)
@@ -937,7 +953,17 @@ export function useServerForm(
           : useXaa
           ? server?.authServerMode
           : undefined,
-      oauthProtocolMode: useOAuth ? oauthProtocolMode : undefined,
+      // Bake the deferred "auto" sentinel into a concrete era before it is
+      // persisted: "auto" + a 2026-07-28 wire pin submits the 2026 OAuth flow,
+      // otherwise the current default. An explicit selection passes through.
+      // Same resolver the AuthenticationSection preview uses, so the saved
+      // profile matches what the form showed.
+      oauthProtocolMode: useOAuth
+        ? resolveEffectiveOauthProtocolMode(
+            oauthProtocolMode,
+            buildOptions?.wireProtocolVersionOverride
+          )
+        : undefined,
       // The unified registration mode rides with every authorization flow —
       // the XAA debugger reads the same per-server field the OAuth flow does.
       registrationMode:

--- a/mcpjam-inspector/client/src/components/connection/shared/AuthenticationSection.tsx
+++ b/mcpjam-inspector/client/src/components/connection/shared/AuthenticationSection.tsx
@@ -26,9 +26,10 @@ import {
 import { useActiveMcpProfile } from "@/contexts/active-mcp-profile-context";
 import type { RegistrationMode, XaaClientAuthMethod } from "@/shared/xaa.js";
 import type { ConfidentialCimdCapabilityStatus } from "@/hooks/use-confidential-cimd-capability";
-import type {
-  ServerFormAuthType,
-  ServerFormOAuthProtocolMode,
+import {
+  resolveEffectiveOauthProtocolMode,
+  type ServerFormAuthType,
+  type ServerFormOAuthProtocolMode,
 } from "@/shared/types.js";
 import { REGISTRATION_MODE_OPTIONS } from "@/lib/registration-strategy";
 import { fetchOAuthClientSecret } from "@/lib/apis/hosted-oauth-client-secret-api";
@@ -334,13 +335,12 @@ export function AuthenticationSection({
   // sessionless transport ship together, so a 2026-07-28 wire pin makes "auto"
   // resolve to the 2026 OAuth flow (mirror of server-helpers' oauth-mode → wire
   // stamp). An explicit protocol selection is passed straight through — it
-  // always wins over the bridge.
-  const effectiveOauthProtocolMode: Exclude<ServerFormOAuthProtocolMode, "auto"> =
-    oauthProtocolMode === "auto"
-      ? serverMcpProtocolVersion === "2026-07-28"
-        ? "2026-07-28"
-        : "2025-11-25"
-      : oauthProtocolMode;
+  // always wins over the bridge. Single-sourced with the submit path via the
+  // shared resolver so the plan preview and the saved profile cannot disagree.
+  const effectiveOauthProtocolMode = resolveEffectiveOauthProtocolMode(
+    oauthProtocolMode,
+    serverMcpProtocolVersion
+  );
   const oauthPlan =
     authType === "oauth" || authType === "auto"
       ? resolveAuthorizationPlan({

--- a/mcpjam-inspector/client/src/components/connection/shared/AuthenticationSection.tsx
+++ b/mcpjam-inspector/client/src/components/connection/shared/AuthenticationSection.tsx
@@ -60,8 +60,9 @@ interface AuthenticationSectionProps {
    * era, so when the wire pin is 2026-07-28 an "auto" protocol mode resolves
    * to the 2026 OAuth flow rather than the 2025 default. The mirror of
    * server-helpers' oauth-mode → wire stamp (#3363). An EXPLICIT protocol
-   * selection always wins over this bridge. Undefined = inherit host/SDK
-   * default → "auto" stays on the 2025-11-25 flow.
+   * selection always wins over this bridge. Undefined ("Client default") falls
+   * back to the active host's `mcpProfile.mcpProtocolVersion` before the SDK
+   * default, so a 2026-pinned host still routes "auto" through the 2026 flow.
    */
   serverMcpProtocolVersion?: McpProtocolVersion;
   registrationMode: RegistrationMode;
@@ -190,8 +191,9 @@ export function AuthenticationSection({
   // method here overrides — the helper copy under the select says which.
   // `invalid` renders as off here; the connect path surfaces the config
   // error, this component only shapes helper text.
+  const activeMcpProfile = useActiveMcpProfile();
   const hostPolicyEnterpriseManaged =
-    readXaaEnterprisePolicy(useActiveMcpProfile()).kind === "on";
+    readXaaEnterprisePolicy(activeMcpProfile).kind === "on";
   const [revealedClientSecret, setRevealedClientSecret] = useState<
     string | null
   >(null);
@@ -331,15 +333,20 @@ export function AuthenticationSection({
     effectiveXaaRegistrationMode === "preregistered";
   const showXaaClientAuthPicker =
     confidentialCimdStatus === "ready" || xaaClientAuth === "private_key_jwt";
-  // "auto" defers the protocol era to the server's wire pin: OAuth and the
+  // "auto" defers the protocol era to the effective wire pin: OAuth and the
   // sessionless transport ship together, so a 2026-07-28 wire pin makes "auto"
   // resolve to the 2026 OAuth flow (mirror of server-helpers' oauth-mode → wire
-  // stamp). An explicit protocol selection is passed straight through — it
-  // always wins over the bridge. Single-sourced with the submit path via the
-  // shared resolver so the plan preview and the saved profile cannot disagree.
+  // stamp). Precedence: the per-server pin wins, else the ACTIVE HOST's
+  // mcpProfile.mcpProtocolVersion (so "Client default" on a 2026-pinned host
+  // still routes through 2026), else the 2025 default. An explicit protocol
+  // selection is passed straight through — it always wins over the bridge.
+  // Single-sourced with the submit path via the shared resolver so the plan
+  // preview and the saved profile cannot disagree.
+  const effectiveWireProtocolVersion =
+    serverMcpProtocolVersion ?? activeMcpProfile?.mcpProtocolVersion;
   const effectiveOauthProtocolMode = resolveEffectiveOauthProtocolMode(
     oauthProtocolMode,
-    serverMcpProtocolVersion
+    effectiveWireProtocolVersion
   );
   const oauthPlan =
     authType === "oauth" || authType === "auto"

--- a/mcpjam-inspector/client/src/components/connection/shared/AuthenticationSection.tsx
+++ b/mcpjam-inspector/client/src/components/connection/shared/AuthenticationSection.tsx
@@ -65,6 +65,19 @@ interface AuthenticationSectionProps {
    * default, so a 2026-pinned host still routes "auto" through the 2026 flow.
    */
   serverMcpProtocolVersion?: McpProtocolVersion;
+  /**
+   * The active host's default MCP wire pin, resolved PROP-FIRST by the
+   * surrounding shell (ServerDetailModal:
+   * `hostDefaultMcpProtocolVersion ?? useActiveMcpProfile()`). The "auto"
+   * OAuth bridge falls back to this when no per-server pin is set — it is the
+   * SAME value the submit path bakes the era with, so the plan preview and the
+   * persisted era cannot disagree even when the modal renders without an
+   * `ActiveMcpProfileProvider` (or with one whose value differs from the
+   * prop). Undefined → the component's own `useActiveMcpProfile()` read below
+   * is the final fallback, which is exactly the Add path's context-only
+   * behavior (the Add modal passes no host-default prop).
+   */
+  hostDefaultMcpProtocolVersion?: McpProtocolVersion;
   registrationMode: RegistrationMode;
   onOauthRegistrationModeChange: (value: RegistrationMode) => void;
   xaaClientAuth?: XaaClientAuthMethod;
@@ -146,6 +159,7 @@ export function AuthenticationSection({
   oauthProtocolMode,
   onOauthProtocolModeChange,
   serverMcpProtocolVersion,
+  hostDefaultMcpProtocolVersion,
   registrationMode,
   onOauthRegistrationModeChange,
   xaaClientAuth = "none",
@@ -341,9 +355,16 @@ export function AuthenticationSection({
   // still routes through 2026), else the 2025 default. An explicit protocol
   // selection is passed straight through — it always wins over the bridge.
   // Single-sourced with the submit path via the shared resolver so the plan
-  // preview and the saved profile cannot disagree.
+  // preview and the saved profile cannot disagree. The host fallback prefers
+  // the prop-first `hostDefaultMcpProtocolVersion` (the authoritative host pin
+  // the submit path also bakes with — see ServerDetailModal) so preview and
+  // persisted era stay identical even when this component is mounted outside an
+  // `ActiveMcpProfileProvider`; the local context read is only the last resort
+  // for callers (the Add modal) that pass no host-default prop.
   const effectiveWireProtocolVersion =
-    serverMcpProtocolVersion ?? activeMcpProfile?.mcpProtocolVersion;
+    serverMcpProtocolVersion ??
+    hostDefaultMcpProtocolVersion ??
+    activeMcpProfile?.mcpProtocolVersion;
   const effectiveOauthProtocolMode = resolveEffectiveOauthProtocolMode(
     oauthProtocolMode,
     effectiveWireProtocolVersion

--- a/mcpjam-inspector/client/src/components/connection/shared/AuthenticationSection.tsx
+++ b/mcpjam-inspector/client/src/components/connection/shared/AuthenticationSection.tsx
@@ -21,6 +21,7 @@ import {
 import {
   readXaaEnterprisePolicy,
   resolveAuthorizationPlan,
+  type McpProtocolVersion,
 } from "@mcpjam/sdk/browser";
 import { useActiveMcpProfile } from "@/contexts/active-mcp-profile-context";
 import type { RegistrationMode, XaaClientAuthMethod } from "@/shared/xaa.js";
@@ -51,6 +52,17 @@ interface AuthenticationSectionProps {
   onOauthScopesChange: (value: string) => void;
   oauthProtocolMode: ServerFormOAuthProtocolMode;
   onOauthProtocolModeChange: (value: ServerFormOAuthProtocolMode) => void;
+  /**
+   * The server's per-server MCP wire-version pin (from the Connection
+   * overrides picker / project server config). Drives the "auto" OAuth-mode
+   * bridge: OAuth and the sessionless transport ship together in the 2026
+   * era, so when the wire pin is 2026-07-28 an "auto" protocol mode resolves
+   * to the 2026 OAuth flow rather than the 2025 default. The mirror of
+   * server-helpers' oauth-mode → wire stamp (#3363). An EXPLICIT protocol
+   * selection always wins over this bridge. Undefined = inherit host/SDK
+   * default → "auto" stays on the 2025-11-25 flow.
+   */
+  serverMcpProtocolVersion?: McpProtocolVersion;
   registrationMode: RegistrationMode;
   onOauthRegistrationModeChange: (value: RegistrationMode) => void;
   xaaClientAuth?: XaaClientAuthMethod;
@@ -131,6 +143,7 @@ export function AuthenticationSection({
   onOauthScopesChange,
   oauthProtocolMode,
   onOauthProtocolModeChange,
+  serverMcpProtocolVersion,
   registrationMode,
   onOauthRegistrationModeChange,
   xaaClientAuth = "none",
@@ -317,8 +330,17 @@ export function AuthenticationSection({
     effectiveXaaRegistrationMode === "preregistered";
   const showXaaClientAuthPicker =
     confidentialCimdStatus === "ready" || xaaClientAuth === "private_key_jwt";
-  const effectiveOauthProtocolMode =
-    oauthProtocolMode === "auto" ? "2025-11-25" : oauthProtocolMode;
+  // "auto" defers the protocol era to the server's wire pin: OAuth and the
+  // sessionless transport ship together, so a 2026-07-28 wire pin makes "auto"
+  // resolve to the 2026 OAuth flow (mirror of server-helpers' oauth-mode → wire
+  // stamp). An explicit protocol selection is passed straight through — it
+  // always wins over the bridge.
+  const effectiveOauthProtocolMode: Exclude<ServerFormOAuthProtocolMode, "auto"> =
+    oauthProtocolMode === "auto"
+      ? serverMcpProtocolVersion === "2026-07-28"
+        ? "2026-07-28"
+        : "2025-11-25"
+      : oauthProtocolMode;
   const oauthPlan =
     authType === "oauth" || authType === "auto"
       ? resolveAuthorizationPlan({

--- a/mcpjam-inspector/client/src/lib/__tests__/project-serialization.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/project-serialization.test.ts
@@ -510,6 +510,24 @@ describe("OAuth test-profile round-trip (protocol version + registration strateg
     expect(profile.clientId).toBe("client_abc");
   });
 
+  it("survives a 2026-07-28 draft-era protocol version through the round-trip", () => {
+    const servers = deserializeServersFromConvex([
+      {
+        name: "draft-2026",
+        enabled: true,
+        useOAuth: true,
+        url: "https://example.test/mcp",
+        clientId: "client_abc",
+        oauthProtocolVersion: "2026-07-28",
+        oauthRegistrationStrategy: "dcr",
+      },
+    ]);
+
+    const profile = servers["draft-2026"].oauthFlowProfile!;
+    expect(profile.protocolVersion).toBe("2026-07-28");
+    expect(profile.registrationStrategy).toBe("dcr");
+  });
+
   it("builds a profile even when only the strategy columns are present", () => {
     const servers = deserializeServersFromConvex([
       {

--- a/mcpjam-inspector/shared/__tests__/types.test.ts
+++ b/mcpjam-inspector/shared/__tests__/types.test.ts
@@ -7,6 +7,7 @@ import {
   isMCPJamGuestAllowedModel,
   isMCPJamProvidedModel,
   isModelSupported,
+  normalizeOauthProtocolMode,
   SUPPORTED_MODELS,
 } from "../types.js";
 
@@ -119,5 +120,26 @@ describe("MCPJam-provided model classification", () => {
     expect(hosted.every((m) => m.hosted === true)).toBe(true);
     // Every hosted snapshot model is guest-allowed now (guests un-curated).
     expect(hosted.every((m) => m.guestAllowed === true)).toBe(true);
+  });
+});
+
+describe("normalizeOauthProtocolMode (connect-form OAuth protocol)", () => {
+  // Single source for the Add and Edit connect forms — both previously kept
+  // private copies that had to preserve 2026-07-28 in lockstep.
+  it("preserves every concrete protocol era, including the 2026-07-28 draft", () => {
+    expect(normalizeOauthProtocolMode("2025-03-26")).toBe("2025-03-26");
+    expect(normalizeOauthProtocolMode("2025-06-18")).toBe("2025-06-18");
+    expect(normalizeOauthProtocolMode("2025-11-25")).toBe("2025-11-25");
+    expect(normalizeOauthProtocolMode("2026-07-28")).toBe("2026-07-28");
+  });
+
+  it("does not silently degrade a stored 2026-07-28 pin to 2025-11-25", () => {
+    expect(normalizeOauthProtocolMode("2026-07-28")).not.toBe("2025-11-25");
+  });
+
+  it("falls back to 2025-11-25 for the deferred 'auto' sentinel and unknowns", () => {
+    expect(normalizeOauthProtocolMode("auto")).toBe("2025-11-25");
+    expect(normalizeOauthProtocolMode(undefined)).toBe("2025-11-25");
+    expect(normalizeOauthProtocolMode("garbage")).toBe("2025-11-25");
   });
 });

--- a/mcpjam-inspector/shared/__tests__/types.test.ts
+++ b/mcpjam-inspector/shared/__tests__/types.test.ts
@@ -8,6 +8,8 @@ import {
   isMCPJamProvidedModel,
   isModelSupported,
   normalizeOauthProtocolMode,
+  resolveEffectiveOauthProtocolMode,
+  SERVER_FORM_OAUTH_PROTOCOL_MODES,
   SUPPORTED_MODELS,
 } from "../types.js";
 
@@ -141,5 +143,39 @@ describe("normalizeOauthProtocolMode (connect-form OAuth protocol)", () => {
     expect(normalizeOauthProtocolMode("auto")).toBe("2025-11-25");
     expect(normalizeOauthProtocolMode(undefined)).toBe("2025-11-25");
     expect(normalizeOauthProtocolMode("garbage")).toBe("2025-11-25");
+  });
+
+  it("derives its accepted set from the single-source tuple", () => {
+    // Every concrete era normalizes to itself; the tuple IS the source the
+    // union and the membership check share, so this guards against drift.
+    for (const era of SERVER_FORM_OAUTH_PROTOCOL_MODES) {
+      expect(normalizeOauthProtocolMode(era)).toBe(era);
+    }
+  });
+});
+
+describe("resolveEffectiveOauthProtocolMode (auto → wire-pin bridge)", () => {
+  it("resolves 'auto' to the 2026 flow only under a 2026-07-28 wire pin", () => {
+    expect(resolveEffectiveOauthProtocolMode("auto", "2026-07-28")).toBe(
+      "2026-07-28"
+    );
+  });
+
+  it("resolves 'auto' to the 2025-11-25 default without a 2026 wire pin", () => {
+    expect(resolveEffectiveOauthProtocolMode("auto", "2025-11-25")).toBe(
+      "2025-11-25"
+    );
+    expect(resolveEffectiveOauthProtocolMode("auto", undefined)).toBe(
+      "2025-11-25"
+    );
+  });
+
+  it("passes an explicit selection straight through — it always wins", () => {
+    expect(resolveEffectiveOauthProtocolMode("2025-06-18", "2026-07-28")).toBe(
+      "2025-06-18"
+    );
+    expect(resolveEffectiveOauthProtocolMode("2026-07-28", undefined)).toBe(
+      "2026-07-28"
+    );
   });
 });

--- a/mcpjam-inspector/shared/__tests__/types.test.ts
+++ b/mcpjam-inspector/shared/__tests__/types.test.ts
@@ -139,8 +139,14 @@ describe("normalizeOauthProtocolMode (connect-form OAuth protocol)", () => {
     expect(normalizeOauthProtocolMode("2026-07-28")).not.toBe("2025-11-25");
   });
 
-  it("falls back to 2025-11-25 for the deferred 'auto' sentinel and unknowns", () => {
-    expect(normalizeOauthProtocolMode("auto")).toBe("2025-11-25");
+  it("preserves the deferred 'auto' sentinel through hydration", () => {
+    // "auto" is a valid mode the wire-pin bridge resolves later; coercing it
+    // to a concrete era here would drop the sentinel and make the bridge
+    // unreachable for prefilled/edited servers.
+    expect(normalizeOauthProtocolMode("auto")).toBe("auto");
+  });
+
+  it("falls back to 2025-11-25 for unknowns and undefined", () => {
     expect(normalizeOauthProtocolMode(undefined)).toBe("2025-11-25");
     expect(normalizeOauthProtocolMode("garbage")).toBe("2025-11-25");
   });

--- a/mcpjam-inspector/shared/types.ts
+++ b/mcpjam-inspector/shared/types.ts
@@ -691,12 +691,40 @@ export const isBedrockModelId = (modelId: string): boolean => {
   );
 };
 
+/**
+ * The concrete connect-form OAuth protocol eras, in dropdown order (newest
+ * first). SINGLE SOURCE OF TRUTH: both the {@link ServerFormOAuthProtocolMode}
+ * union and {@link normalizeOauthProtocolMode}'s membership check derive from
+ * this tuple, so a new era is added in exactly one place and the two can no
+ * longer drift on which values survive a stored/prefilled pin.
+ */
+export const SERVER_FORM_OAUTH_PROTOCOL_MODES = [
+  "2025-03-26",
+  "2025-06-18",
+  "2025-11-25",
+  "2026-07-28",
+] as const;
+
+/** A resolved connect-form OAuth protocol era (never the "auto" sentinel). */
+export type ServerFormOAuthProtocolConcreteMode =
+  (typeof SERVER_FORM_OAUTH_PROTOCOL_MODES)[number];
+
 export type ServerFormOAuthProtocolMode =
   | "auto"
-  | "2025-03-26"
-  | "2025-06-18"
-  | "2025-11-25"
-  | "2026-07-28";
+  | ServerFormOAuthProtocolConcreteMode;
+
+/**
+ * The default concrete era used when nothing is stored and "auto" cannot be
+ * biased by a wire pin (the current "Latest" release).
+ */
+export const DEFAULT_OAUTH_PROTOCOL_CONCRETE_MODE: ServerFormOAuthProtocolConcreteMode =
+  "2025-11-25";
+
+function isConcreteOauthProtocolMode(
+  value: string
+): value is ServerFormOAuthProtocolConcreteMode {
+  return (SERVER_FORM_OAUTH_PROTOCOL_MODES as readonly string[]).includes(value);
+}
 
 /**
  * Coerce an arbitrary stored/prefilled protocol string to a concrete
@@ -711,12 +739,32 @@ export type ServerFormOAuthProtocolMode =
 export function normalizeOauthProtocolMode(
   value?: string
 ): ServerFormOAuthProtocolMode {
-  return value === "2025-03-26" ||
-    value === "2025-06-18" ||
-    value === "2025-11-25" ||
-    value === "2026-07-28"
+  return value != null && isConcreteOauthProtocolMode(value)
     ? value
-    : "2025-11-25";
+    : DEFAULT_OAUTH_PROTOCOL_CONCRETE_MODE;
+}
+
+/**
+ * Resolve a connect-form OAuth protocol mode to the concrete era the flow will
+ * actually run. An explicit era passes straight through — it always wins. The
+ * deferred "auto" sentinel defers to the server's per-server MCP wire-version
+ * pin: OAuth and the sessionless transport ship together, so a 2026-07-28 wire
+ * pin makes "auto" resolve to the 2026 OAuth flow (the mirror of
+ * server-helpers' oauth-mode → wire stamp, #3363); otherwise "auto" resolves
+ * to the current default. Single-sourced so the display bridge (which drives
+ * the OAuth plan preview) and the submit path (which bakes the era into the
+ * saved profile) cannot disagree on where "auto" lands.
+ */
+export function resolveEffectiveOauthProtocolMode(
+  mode: ServerFormOAuthProtocolMode,
+  wireProtocolVersion?: string
+): ServerFormOAuthProtocolConcreteMode {
+  if (mode !== "auto") {
+    return mode;
+  }
+  return wireProtocolVersion === "2026-07-28"
+    ? "2026-07-28"
+    : DEFAULT_OAUTH_PROTOCOL_CONCRETE_MODE;
 }
 
 /**

--- a/mcpjam-inspector/shared/types.ts
+++ b/mcpjam-inspector/shared/types.ts
@@ -699,6 +699,27 @@ export type ServerFormOAuthProtocolMode =
   | "2026-07-28";
 
 /**
+ * Coerce an arbitrary stored/prefilled protocol string to a concrete
+ * connect-form OAuth protocol mode, preserving the 2026-07-28 draft era.
+ * Unknown values — and the deferred "auto" sentinel, which callers resolve
+ * separately once the wire pin is known — fall back to the current default
+ * (2025-11-25). Single-sourced here so the Add and Edit connect-form paths
+ * cannot drift: they previously kept private, hand-maintained copies that
+ * both had to be patched in lockstep to avoid silently degrading a stored
+ * 2026-07-28 pin down to 2025-11-25.
+ */
+export function normalizeOauthProtocolMode(
+  value?: string
+): ServerFormOAuthProtocolMode {
+  return value === "2025-03-26" ||
+    value === "2025-06-18" ||
+    value === "2025-11-25" ||
+    value === "2026-07-28"
+    ? value
+    : "2025-11-25";
+}
+
+/**
  * @deprecated Use {@link RegistrationMode} (re-exported from shared/xaa) — the
  * unified client-registration vocabulary shared by the OAuth flows and the
  * XAA debugger. Structurally identical; kept as an alias for older imports.

--- a/mcpjam-inspector/shared/types.ts
+++ b/mcpjam-inspector/shared/types.ts
@@ -692,11 +692,13 @@ export const isBedrockModelId = (modelId: string): boolean => {
 };
 
 /**
- * The concrete connect-form OAuth protocol eras, in dropdown order (newest
- * first). SINGLE SOURCE OF TRUTH: both the {@link ServerFormOAuthProtocolMode}
- * union and {@link normalizeOauthProtocolMode}'s membership check derive from
- * this tuple, so a new era is added in exactly one place and the two can no
- * longer drift on which values survive a stored/prefilled pin.
+ * The concrete connect-form OAuth protocol eras, in chronological order
+ * (oldest first). The dropdown (AuthenticationSection's PROTOCOL_OPTIONS)
+ * renders newest-first separately; this tuple's order is not the UI order.
+ * SINGLE SOURCE OF TRUTH: both the {@link ServerFormOAuthProtocolMode} union
+ * and {@link normalizeOauthProtocolMode}'s membership check derive from this
+ * tuple, so a new era is added in exactly one place and the two can no longer
+ * drift on which values survive a stored/prefilled pin.
  */
 export const SERVER_FORM_OAUTH_PROTOCOL_MODES = [
   "2025-03-26",
@@ -727,18 +729,23 @@ function isConcreteOauthProtocolMode(
 }
 
 /**
- * Coerce an arbitrary stored/prefilled protocol string to a concrete
- * connect-form OAuth protocol mode, preserving the 2026-07-28 draft era.
- * Unknown values — and the deferred "auto" sentinel, which callers resolve
- * separately once the wire pin is known — fall back to the current default
- * (2025-11-25). Single-sourced here so the Add and Edit connect-form paths
- * cannot drift: they previously kept private, hand-maintained copies that
- * both had to be patched in lockstep to avoid silently degrading a stored
- * 2026-07-28 pin down to 2025-11-25.
+ * Coerce an arbitrary stored/prefilled protocol string to a connect-form OAuth
+ * protocol mode, preserving both the 2026-07-28 draft era AND the deferred
+ * "auto" sentinel. "auto" is a valid {@link ServerFormOAuthProtocolMode} that
+ * the wire-pin bridge resolves later, so it MUST survive hydration — coercing
+ * it to a concrete era here drops the sentinel and makes the bridge unreachable
+ * for prefilled/edited servers. Only unknown values and `undefined` fall back
+ * to the current concrete default (2025-11-25). Single-sourced here so the Add
+ * and Edit connect-form paths cannot drift: they previously kept private,
+ * hand-maintained copies that both had to be patched in lockstep to avoid
+ * silently degrading a stored 2026-07-28 pin down to 2025-11-25.
  */
 export function normalizeOauthProtocolMode(
   value?: string
 ): ServerFormOAuthProtocolMode {
+  if (value === "auto") {
+    return "auto";
+  }
   return value != null && isConcreteOauthProtocolMode(value)
     ? value
     : DEFAULT_OAUTH_PROTOCOL_CONCRETE_MODE;


### PR DESCRIPTION
## What

Makes the **Server Add/Edit form's own OAuth "Protocol" dropdown** (Authentication → Advanced) — the connect path the **Auto auth ladder** runs through when a normally-added server 401s — offer, preserve, and route the **2026-07-28** draft era end to end. This is the third version-plumbing surface after the debugger/CLI (2M-a) and wire-pinning (2M-b, #3363).

## Changes

- **Consolidate the duplicated normalizer.** `normalizeOauthProtocolMode` was a hand-maintained private copy in both `use-server-form.ts` and `AddServerModal.tsx`; either could silently degrade a stored/prefilled `2026-07-28` pin to `2025-11-25` if the other was patched out of lockstep. Now a single exported helper in `shared/types.ts` (colocated with the `ServerFormOAuthProtocolMode` union); both former copies import it.
- **`effectiveOauthProtocolMode` wire-pin bridge.** Previously `"auto"` hard-resolved to `2025-11-25` before `resolveAuthorizationPlan`. It now resolves to the **2026 OAuth flow when the server's per-server MCP wire pin is `2026-07-28`** (OAuth and the sessionless transport ship together) — the connect-path mirror of the `oauth-mode → wire` stamp `server-helpers.ts` gained in #3363. An **explicit** protocol selection always wins; an absent/non-2026 wire pin keeps `"auto"` on the 2025-11-25 flow. The wire pin is threaded into `AuthenticationSection` from both the Add and Edit forms.

The dropdown option, the type union, the persistence normalizers, and `buildOAuthProfileFromFormData` already carried 2026 (landed in #3363); this PR fills the two remaining connect-form gaps.

## Tests

- Shared `normalizeOauthProtocolMode`: preserves all four concrete eras incl. `2026-07-28`; `auto`/unknown → `2025-11-25`.
- Protocol dropdown offers `2026-07-28 (Draft)`.
- `"auto"` resolves to 2026 only under a 2026 wire pin; default stays 2025-11-25; **explicit selection wins** over a 2026 wire pin.
- A `2026-07-28` value survives the Convex serialization round-trip.

Affected suites green (217 tests across connection/oauth/server-helpers/serialization/use-server-state). Client typecheck clean (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OAuth protocol defaults and persistence for connect flows; mistakes could mis-route auth for 2026-pinned servers, but scope is form/UI with shared resolver and broad test coverage.
> 
> **Overview**
> Routes the **2026-07-28** draft OAuth era through Add/Edit server connect forms by tying the deferred **"auto"** protocol mode to the effective MCP wire pin (per-server override → host default → 2025 fallback), so OAuth and transport stay aligned.
> 
> **Centralizes** `normalizeOauthProtocolMode` and adds `resolveEffectiveOauthProtocolMode` in `shared/types.ts` (with `SERVER_FORM_OAUTH_PROTOCOL_MODES`), replacing duplicate normalizers that could drop `2026-07-28` or coerce `"auto"` to `2025-11-25`. New OAuth forms default protocol to `"auto"` instead of a hard-coded latest; edit hydration keeps `"auto"` when no stored protocol exists.
> 
> **AuthenticationSection** resolves `"auto"` for the OAuth plan preview via the same resolver; Add/Edit pass `serverMcpProtocolVersion` and `hostDefaultMcpProtocolVersion`. **Submit** paths in `useServerForm.buildFormData`, `AddServerModal`, and `ServerDetailModal` bake `"auto"` into a concrete era using the matching wire pin.
> 
> Regression tests cover end-to-end add/save, preview precedence, and serialization of `2026-07-28`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa4b6fcf4f7b7678d211b23fc323434c423275ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes the 2026-07-28 OAuth draft through the Add/Edit connect form with an “auto” default that resolves via the MCP wire pin. Edit save now resolves “auto” against the prop-first host pin to keep the preview and persisted era in sync.

- **New Features**
  - Protocol dropdown includes `2026-07-28 (Draft)` and preserves it through form state and serialization.
  - “Auto” protocol resolves using shared helpers with precedence: per‑server wire pin; else host default; else 2025. Explicit selections always win. Authorization preview and saves use the same resolver with `@mcpjam/sdk/browser`.

- **Bug Fixes**
  - `useServerForm` defaults OAuth mode to `"auto"` and preserves `"auto"` on hydration so the wire‑pin bridge is reachable for prefilled/edited servers.
  - Save path bakes `"auto"` into a concrete era with the shared resolver and the effective wire pin. Add threads `initialData.mcpProtocolVersionOverride`; Edit resolves against a prop‑first `hostDefaultMcpProtocolVersion` (not just context) so preview and persisted era cannot disagree.

<sup>Written for commit fa4b6fcf4f7b7678d211b23fc323434c423275ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3388?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

