### PR TITLE
fix(oauth): shared hardening pass across the four debug OAuth machines

### DIFF
--- a/sdk/src/oauth/state-machines/debug-oauth-2025-03-26.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-03-26.ts
@@ -10,7 +10,7 @@
  */
 
 import { decodeJWT, formatJWTTimestamp } from "./shared/jwt.js";
-import { EMPTY_OAUTH_FLOW_STATE } from "./types.js";
+import { EMPTY_OAUTH_FLOW_STATE, buildResetFlowState } from "./types.js";
 import type {
   BaseOAuthStateMachineConfig,
   OAuthFlowStep,
@@ -489,6 +489,7 @@ export const createDebugOAuthStateMachine = (
                 headers: mergeHeaders(customHeaders, {
                   "Content-Type": "application/json",
                   Accept: "application/json, text/event-stream",
+                  "MCP-Protocol-Version": "2025-03-26",
                 }),
                 body: JSON.stringify(
                   buildInitializeRequestBody({
@@ -930,7 +931,11 @@ export const createDebugOAuthStateMachine = (
                 break;
               }
 
-              if (strictConformance && dcr.missingClientId) {
+              // RFC 7591: a successful (2xx) registration response MUST carry a
+              // client_id. Without one there is no client identity to proceed
+              // with, so reject regardless of strictConformance — accepting it
+              // would carry an undefined clientId into the authorization leg.
+              if (dcr.missingClientId) {
                 updateState({
                   lastResponse: dcr.response,
                   httpHistory: dcr.httpHistory,
@@ -1788,20 +1793,10 @@ export const createDebugOAuthStateMachine = (
     },
 
     resetFlow: () => {
-      updateState({
-        ...EMPTY_OAUTH_FLOW_STATE,
-        lastRequest: undefined,
-        lastResponse: undefined,
-        httpHistory: [],
-        infoLogs: [],
-        authorizationCode: undefined,
-        authorizationUrl: undefined,
-        accessToken: undefined,
-        refreshToken: undefined,
-        codeVerifier: undefined,
-        codeChallenge: undefined,
-        error: undefined,
-      });
+      // Reset to a fully-cleared flow. updateState MERGES, so every field must
+      // be explicitly cleared — buildResetFlowState enumerates them all so no
+      // stored client, token, discovery result, or recorded issuer survives.
+      updateState(buildResetFlowState());
     },
   };
 

--- a/sdk/src/oauth/state-machines/debug-oauth-2025-06-18.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-06-18.ts
@@ -9,7 +9,7 @@
  */
 
 import { decodeJWT, formatJWTTimestamp } from "./shared/jwt.js";
-import { EMPTY_OAUTH_FLOW_STATE } from "./types.js";
+import { EMPTY_OAUTH_FLOW_STATE, buildResetFlowState } from "./types.js";
 import type {
   BaseOAuthStateMachineConfig,
   OAuthFlowStep,
@@ -536,6 +536,7 @@ export const createDebugOAuthStateMachine = (
             const initialRequestHeaders = mergeHeaders(customHeaders, {
               "Content-Type": "application/json",
               Accept: "application/json, text/event-stream",
+              "MCP-Protocol-Version": "2025-06-18",
             });
             const initializeRequestBody = buildInitializeRequestBody({
               protocolVersion: initializeProtocolVersion,
@@ -587,6 +588,7 @@ export const createDebugOAuthStateMachine = (
                 headers: mergeHeaders(customHeaders, {
                   "Content-Type": "application/json",
                   Accept: "application/json, text/event-stream",
+                  "MCP-Protocol-Version": "2025-06-18",
                 }),
                 body: JSON.stringify(
                   buildInitializeRequestBody({
@@ -1287,8 +1289,12 @@ export const createDebugOAuthStateMachine = (
               break;
             }
 
-            // Registration successful
-            if (strictConformance && dcr.missingClientId) {
+            // Registration successful.
+            // RFC 7591: a successful (2xx) registration response MUST carry a
+            // client_id. Without one there is no client identity to proceed
+            // with, so reject regardless of strictConformance — accepting it
+            // would carry an undefined clientId into the authorization leg.
+            if (dcr.missingClientId) {
               updateState({
                 lastResponse: dcr.response,
                 httpHistory: dcr.httpHistory,
@@ -2095,20 +2101,10 @@ export const createDebugOAuthStateMachine = (
 
     // Reset the flow to initial state
     resetFlow: () => {
-      updateState({
-        ...EMPTY_OAUTH_FLOW_STATE,
-        lastRequest: undefined,
-        lastResponse: undefined,
-        httpHistory: [],
-        infoLogs: [],
-        authorizationCode: undefined,
-        authorizationUrl: undefined,
-        accessToken: undefined,
-        refreshToken: undefined,
-        codeVerifier: undefined,
-        codeChallenge: undefined,
-        error: undefined,
-      });
+      // Reset to a fully-cleared flow. updateState MERGES, so every field must
+      // be explicitly cleared — buildResetFlowState enumerates them all so no
+      // stored client, token, discovery result, or recorded issuer survives.
+      updateState(buildResetFlowState());
     },
   };
 

--- a/sdk/src/oauth/state-machines/debug-oauth-2025-11-25.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-11-25.ts
@@ -1513,6 +1513,10 @@ export const createDebugOAuthStateMachine = (
                 url: cimdClientId,
                 headers: normalizeHeaders(undefined),
               };
+              // Capture request start BEFORE issuing the fetch so the trace
+              // entry's timestamp reflects request start and carries the
+              // round-trip duration, matching every other fetch step.
+              const cimdRequestStart = Date.now();
               const cimdResponse = await executeRequest(cimdClientId, {
                 method: "GET",
               });
@@ -1539,7 +1543,8 @@ export const createDebugOAuthStateMachine = (
                   ...(state.httpHistory || []),
                   {
                     step: "cimd_fetch_request",
-                    timestamp: Date.now(),
+                    timestamp: cimdRequestStart,
+                    duration: Date.now() - cimdRequestStart,
                     request: cimdRequest,
                     response: cimdResponseData,
                   },

--- a/sdk/src/oauth/state-machines/debug-oauth-2025-11-25.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-11-25.ts
@@ -9,7 +9,7 @@
  */
 
 import { decodeJWT, formatJWTTimestamp } from "./shared/jwt.js";
-import { EMPTY_OAUTH_FLOW_STATE } from "./types.js";
+import { EMPTY_OAUTH_FLOW_STATE, buildResetFlowState } from "./types.js";
 import type {
   BaseOAuthStateMachineConfig,
   OAuthFlowStep,
@@ -654,6 +654,7 @@ export const createDebugOAuthStateMachine = (
             const initialRequestHeaders = mergeHeaders(customHeaders, {
               "Content-Type": "application/json",
               Accept: "application/json, text/event-stream",
+              "MCP-Protocol-Version": "2025-11-25",
             });
             const initializeRequestBody = buildInitializeRequestBody({
               protocolVersion: initializeProtocolVersion,
@@ -705,6 +706,7 @@ export const createDebugOAuthStateMachine = (
                 headers: mergeHeaders(customHeaders, {
                   "Content-Type": "application/json",
                   Accept: "application/json, text/event-stream",
+                  "MCP-Protocol-Version": "2025-11-25",
                 }),
                 body: JSON.stringify(
                   buildInitializeRequestBody({
@@ -1449,8 +1451,12 @@ export const createDebugOAuthStateMachine = (
                 break;
               }
 
-              // Registration successful
-              if (strictConformance && dcr.missingClientId) {
+              // Registration successful.
+              // RFC 7591: a successful (2xx) registration response MUST carry a
+              // client_id. Without one there is no client identity to proceed
+              // with, so reject regardless of strictConformance — accepting it
+              // would carry an undefined clientId into the authorization leg.
+              if (dcr.missingClientId) {
                 updateState({
                   lastResponse: dcr.response,
                   httpHistory: dcr.httpHistory,
@@ -1497,9 +1503,16 @@ export const createDebugOAuthStateMachine = (
             return;
 
           case "cimd_fetch_request":
-            // CIMD Step 3: Fetch and validate the CIMD document
+            // CIMD Step 3: Fetch the CIMD document ONCE and record it as the
+            // response shown in the trace. The validation step reads this exact
+            // recorded document rather than re-fetching, so the AS cannot serve
+            // one document here and a different one at validation time.
             try {
-              // Fetch the CIMD document (simulating what the auth server does)
+              const cimdRequest = {
+                method: "GET",
+                url: cimdClientId,
+                headers: normalizeHeaders(undefined),
+              };
               const cimdResponse = await executeRequest(cimdClientId, {
                 method: "GET",
               });
@@ -1510,9 +1523,27 @@ export const createDebugOAuthStateMachine = (
                 );
               }
 
-              // Store metadata for next step
+              // Record the fetched document as lastResponse + a history entry so
+              // the validation step (and the trace) reads exactly these bytes.
+              const cimdResponseData = {
+                status: cimdResponse.status,
+                statusText: cimdResponse.statusText,
+                headers: cimdResponse.headers,
+                body: cimdResponse.body,
+              };
               updateState({
                 currentStep: "cimd_metadata_response",
+                lastRequest: cimdRequest,
+                lastResponse: cimdResponseData,
+                httpHistory: [
+                  ...(state.httpHistory || []),
+                  {
+                    step: "cimd_fetch_request",
+                    timestamp: Date.now(),
+                    request: cimdRequest,
+                    response: cimdResponseData,
+                  },
+                ],
                 isInitiatingAuth: false,
               });
 
@@ -1530,20 +1561,14 @@ export const createDebugOAuthStateMachine = (
             }
 
           case "cimd_metadata_response":
-            // CIMD Step 4: Validate the fetched metadata and complete registration
+            // CIMD Step 4: Validate the metadata fetched in the previous step
+            // (no re-fetch) and complete registration.
             try {
-              // Re-fetch to validate
-              const cimdResponse = await executeRequest(cimdClientId, {
-                method: "GET",
-              });
+              const cimdDoc = state.lastResponse?.body;
 
-              if (!cimdResponse.ok) {
-                throw new Error(
-                  `CIMD endpoint returned HTTP ${cimdResponse.status}`
-                );
+              if (!cimdDoc || typeof cimdDoc !== "object") {
+                throw new Error("CIMD metadata document was not available");
               }
-
-              const cimdDoc = cimdResponse.body;
 
               // Validate CIMD document
               if (cimdDoc.client_id !== cimdClientId) {
@@ -2343,20 +2368,10 @@ export const createDebugOAuthStateMachine = (
 
     // Reset the flow to initial state
     resetFlow: () => {
-      updateState({
-        ...EMPTY_OAUTH_FLOW_STATE,
-        lastRequest: undefined,
-        lastResponse: undefined,
-        httpHistory: [],
-        infoLogs: [],
-        authorizationCode: undefined,
-        authorizationUrl: undefined,
-        accessToken: undefined,
-        refreshToken: undefined,
-        codeVerifier: undefined,
-        codeChallenge: undefined,
-        error: undefined,
-      });
+      // Reset to a fully-cleared flow. updateState MERGES, so every field must
+      // be explicitly cleared — buildResetFlowState enumerates them all so no
+      // stored client, token, discovery result, or recorded issuer survives.
+      updateState(buildResetFlowState());
     },
   };
 

--- a/sdk/src/oauth/state-machines/debug-oauth-2026-07-28.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2026-07-28.ts
@@ -1666,6 +1666,10 @@ export const createDebugOAuthStateMachine = (
                 url: cimdClientId,
                 headers: normalizeHeaders(undefined),
               };
+              // Capture request start BEFORE issuing the fetch so the trace
+              // entry's timestamp reflects request start and carries the
+              // round-trip duration, matching every other fetch step.
+              const cimdRequestStart = Date.now();
               const cimdResponse = await executeRequest(cimdClientId, {
                 method: "GET",
               });
@@ -1692,7 +1696,8 @@ export const createDebugOAuthStateMachine = (
                   ...(state.httpHistory || []),
                   {
                     step: "cimd_fetch_request",
-                    timestamp: Date.now(),
+                    timestamp: cimdRequestStart,
+                    duration: Date.now() - cimdRequestStart,
                     request: cimdRequest,
                     response: cimdResponseData,
                   },

--- a/sdk/src/oauth/state-machines/debug-oauth-2026-07-28.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2026-07-28.ts
@@ -9,7 +9,7 @@
  */
 
 import { decodeJWT, formatJWTTimestamp } from "./shared/jwt.js";
-import { EMPTY_OAUTH_FLOW_STATE } from "./types.js";
+import { EMPTY_OAUTH_FLOW_STATE, buildResetFlowState } from "./types.js";
 import type {
   BaseOAuthStateMachineConfig,
   OAuthFlowStep,
@@ -1604,8 +1604,12 @@ export const createDebugOAuthStateMachine = (
                 break;
               }
 
-              // Registration successful
-              if (strictConformance && dcr.missingClientId) {
+              // Registration successful.
+              // RFC 7591: a successful (2xx) registration response MUST carry a
+              // client_id. Without one there is no client identity to proceed
+              // with, so reject regardless of strictConformance — accepting it
+              // would carry an undefined clientId into the authorization leg.
+              if (dcr.missingClientId) {
                 updateState({
                   lastResponse: dcr.response,
                   httpHistory: dcr.httpHistory,
@@ -1652,9 +1656,16 @@ export const createDebugOAuthStateMachine = (
             return;
 
           case "cimd_fetch_request":
-            // CIMD Step 3: Fetch and validate the CIMD document
+            // CIMD Step 3: Fetch the CIMD document ONCE and record it as the
+            // response shown in the trace. The validation step reads this exact
+            // recorded document rather than re-fetching, so the AS cannot serve
+            // one document here and a different one at validation time.
             try {
-              // Fetch the CIMD document (simulating what the auth server does)
+              const cimdRequest = {
+                method: "GET",
+                url: cimdClientId,
+                headers: normalizeHeaders(undefined),
+              };
               const cimdResponse = await executeRequest(cimdClientId, {
                 method: "GET",
               });
@@ -1665,9 +1676,27 @@ export const createDebugOAuthStateMachine = (
                 );
               }
 
-              // Store metadata for next step
+              // Record the fetched document as lastResponse + a history entry so
+              // the validation step (and the trace) reads exactly these bytes.
+              const cimdResponseData = {
+                status: cimdResponse.status,
+                statusText: cimdResponse.statusText,
+                headers: cimdResponse.headers,
+                body: cimdResponse.body,
+              };
               updateState({
                 currentStep: "cimd_metadata_response",
+                lastRequest: cimdRequest,
+                lastResponse: cimdResponseData,
+                httpHistory: [
+                  ...(state.httpHistory || []),
+                  {
+                    step: "cimd_fetch_request",
+                    timestamp: Date.now(),
+                    request: cimdRequest,
+                    response: cimdResponseData,
+                  },
+                ],
                 isInitiatingAuth: false,
               });
 
@@ -1685,20 +1714,14 @@ export const createDebugOAuthStateMachine = (
             }
 
           case "cimd_metadata_response":
-            // CIMD Step 4: Validate the fetched metadata and complete registration
+            // CIMD Step 4: Validate the metadata fetched in the previous step
+            // (no re-fetch) and complete registration.
             try {
-              // Re-fetch to validate
-              const cimdResponse = await executeRequest(cimdClientId, {
-                method: "GET",
-              });
+              const cimdDoc = state.lastResponse?.body;
 
-              if (!cimdResponse.ok) {
-                throw new Error(
-                  `CIMD endpoint returned HTTP ${cimdResponse.status}`
-                );
+              if (!cimdDoc || typeof cimdDoc !== "object") {
+                throw new Error("CIMD metadata document was not available");
               }
-
-              const cimdDoc = cimdResponse.body;
 
               // Validate CIMD document
               if (cimdDoc.client_id !== cimdClientId) {
@@ -2565,20 +2588,10 @@ export const createDebugOAuthStateMachine = (
 
     // Reset the flow to initial state
     resetFlow: () => {
-      updateState({
-        ...EMPTY_OAUTH_FLOW_STATE,
-        lastRequest: undefined,
-        lastResponse: undefined,
-        httpHistory: [],
-        infoLogs: [],
-        authorizationCode: undefined,
-        authorizationUrl: undefined,
-        accessToken: undefined,
-        refreshToken: undefined,
-        codeVerifier: undefined,
-        codeChallenge: undefined,
-        error: undefined,
-      });
+      // Reset to a fully-cleared flow. updateState MERGES, so every field must
+      // be explicitly cleared — buildResetFlowState enumerates them all so no
+      // stored client, token, discovery result, or recorded issuer survives.
+      updateState(buildResetFlowState());
     },
   };
 

--- a/sdk/src/oauth/state-machines/types.ts
+++ b/sdk/src/oauth/state-machines/types.ts
@@ -221,6 +221,65 @@ export const EMPTY_OAUTH_FLOW_STATE: OAuthFlowState = {
   tokenEndpointAuthMethod: undefined,
 };
 
+/**
+ * Builds a fully-cleared flow state for `resetFlow`. State updates MERGE over
+ * the prior state (see runner.ts `updateState`), so a reset that only spreads
+ * `EMPTY_OAUTH_FLOW_STATE` (whose optional fields are absent, not `undefined`)
+ * leaves every prior credential, token, discovery result, and recorded issuer
+ * in place. This helper enumerates EVERY optional `OAuthFlowState` field as an
+ * explicit `undefined` so the merge overwrites — nothing leaks across a reset —
+ * and returns fresh empty arrays so no history/log array is shared. Add new
+ * fields here whenever `OAuthFlowState` grows.
+ */
+export function buildResetFlowState(): OAuthFlowState {
+  return {
+    isInitiatingAuth: false,
+    currentStep: "idle",
+
+    // Discovery / challenge
+    serverUrl: undefined,
+    wwwAuthenticateHeader: undefined,
+    challengedScopes: undefined,
+    resourceMetadataUrl: undefined,
+    resourceMetadata: undefined,
+    resourceIndicator: undefined,
+    authorizationServerUrl: undefined,
+    authorizationServerMetadata: undefined,
+
+    // Client registration
+    clientId: undefined,
+    clientSecret: undefined,
+    tokenEndpointAuthMethod: undefined,
+
+    // PKCE
+    codeVerifier: undefined,
+    codeChallenge: undefined,
+    codeChallengeMethod: undefined,
+
+    // Authorization
+    authorizationUrl: undefined,
+    authorizationCode: undefined,
+    state: undefined,
+    recordedIssuer: undefined,
+    authorizationResponseIss: undefined,
+    requestedScopes: undefined,
+
+    // Tokens
+    accessToken: undefined,
+    refreshToken: undefined,
+    tokenType: undefined,
+    expiresIn: undefined,
+
+    // Raw request/response + history
+    lastRequest: undefined,
+    lastResponse: undefined,
+    httpHistory: [],
+    infoLogs: [],
+
+    error: undefined,
+  };
+}
+
 // State machine interface
 export interface OAuthStateMachine {
   state: OAuthFlowState;

--- a/sdk/tests/oauth/hardening-shared-pass.test.ts
+++ b/sdk/tests/oauth/hardening-shared-pass.test.ts
@@ -1,0 +1,405 @@
+import { createOAuthStateMachine } from "../../src/oauth/state-machines/factory.js";
+import {
+  EMPTY_OAUTH_FLOW_STATE,
+  buildResetFlowState,
+} from "../../src/oauth/state-machines/types.js";
+import type {
+  OAuthFlowState,
+  OAuthProtocolVersion,
+} from "../../src/oauth/state-machines/types.js";
+
+const REDIRECT_URI = "http://127.0.0.1:3333/callback";
+const SERVER_URL = "https://mcp.example.com/mcp";
+const REGISTRATION_ENDPOINT = "https://auth.example.com/register";
+
+const ALL_VERSIONS: OAuthProtocolVersion[] = [
+  "2025-03-26",
+  "2025-06-18",
+  "2025-11-25",
+  "2026-07-28",
+];
+
+// A registration strategy that reaches the DCR path for every version.
+const DCR_STRATEGY = "dcr" as const;
+
+function makeMachine(
+  protocolVersion: OAuthProtocolVersion,
+  seed: Partial<OAuthFlowState>,
+  extra: Record<string, unknown> = {},
+) {
+  let state: OAuthFlowState = {
+    ...EMPTY_OAUTH_FLOW_STATE,
+    ...seed,
+  };
+  const machine = createOAuthStateMachine({
+    protocolVersion,
+    registrationStrategy: DCR_STRATEGY,
+    state,
+    getState: () => state,
+    updateState: (updates) => {
+      state = { ...state, ...updates };
+    },
+    serverUrl: SERVER_URL,
+    serverName: "Test Server",
+    redirectUrl: REDIRECT_URI,
+    requestExecutor: jest.fn(),
+    dynamicRegistration: { client_name: "Test Client" },
+    ...(extra as any),
+  });
+  return { machine, getState: () => state };
+}
+
+// -----------------------------------------------------------------------------
+// Defect 1: resetFlow must fully clear state (updateState MERGES, so a partial
+// reset leaves stale credentials/tokens/discovery/recorded issuer behind).
+// -----------------------------------------------------------------------------
+describe("resetFlow clears all prior flow state", () => {
+  // buildResetFlowState is the shared source of truth; verify it names every
+  // optional field so future OAuthFlowState growth can't silently leak.
+  it("buildResetFlowState clears every optional OAuthFlowState field", () => {
+    const reset = buildResetFlowState();
+    // Sample the full set of carry-over fields.
+    for (const key of [
+      "serverUrl",
+      "wwwAuthenticateHeader",
+      "challengedScopes",
+      "resourceMetadataUrl",
+      "resourceMetadata",
+      "resourceIndicator",
+      "authorizationServerUrl",
+      "authorizationServerMetadata",
+      "clientId",
+      "clientSecret",
+      "tokenEndpointAuthMethod",
+      "codeVerifier",
+      "codeChallenge",
+      "codeChallengeMethod",
+      "authorizationUrl",
+      "authorizationCode",
+      "state",
+      "recordedIssuer",
+      "authorizationResponseIss",
+      "requestedScopes",
+      "accessToken",
+      "refreshToken",
+      "tokenType",
+      "expiresIn",
+      "lastRequest",
+      "lastResponse",
+      "error",
+    ] as const) {
+      expect(reset).toHaveProperty(key);
+      expect((reset as Record<string, unknown>)[key]).toBeUndefined();
+    }
+    expect(reset.currentStep).toBe("idle");
+    expect(reset.isInitiatingAuth).toBe(false);
+    expect(reset.httpHistory).toEqual([]);
+    expect(reset.infoLogs).toEqual([]);
+    // Fresh array instances, not shared references.
+    expect(reset.httpHistory).not.toBe(buildResetFlowState().httpHistory);
+  });
+
+  it.each(ALL_VERSIONS)(
+    "resetFlow wipes stored client, tokens, discovery, and recorded issuer (%s)",
+    (version) => {
+      const stale: Partial<OAuthFlowState> = {
+        currentStep: "complete",
+        isInitiatingAuth: true,
+        serverUrl: SERVER_URL,
+        wwwAuthenticateHeader: 'Bearer realm="x"',
+        challengedScopes: ["files:read"],
+        resourceMetadataUrl: "https://mcp.example.com/.well-known/x",
+        resourceMetadata: { resource: SERVER_URL },
+        authorizationServerUrl: "https://auth.example.com",
+        authorizationServerMetadata: {
+          issuer: "https://auth.example.com",
+          authorization_endpoint: "https://auth.example.com/authorize",
+          token_endpoint: "https://auth.example.com/token",
+          response_types_supported: ["code"],
+        },
+        clientId: "stale-client-id",
+        clientSecret: "stale-secret",
+        tokenEndpointAuthMethod: "client_secret_basic",
+        codeVerifier: "stale-verifier",
+        codeChallenge: "stale-challenge",
+        authorizationUrl: "https://auth.example.com/authorize?x=1",
+        authorizationCode: "stale-code",
+        state: "stale-state",
+        recordedIssuer: "https://auth.example.com",
+        authorizationResponseIss: "https://auth.example.com",
+        requestedScopes: ["files:read"],
+        accessToken: "stale-access-token",
+        refreshToken: "stale-refresh-token",
+        tokenType: "Bearer",
+        expiresIn: 3600,
+        lastRequest: {
+          method: "POST",
+          url: SERVER_URL,
+          headers: {},
+          body: {},
+        },
+        lastResponse: {
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          body: {},
+        },
+        httpHistory: [
+          {
+            step: "complete",
+            timestamp: Date.now(),
+            request: { method: "GET", url: SERVER_URL, headers: {} },
+          },
+        ],
+        infoLogs: [
+          {
+            id: "1",
+            step: "complete",
+            label: "x",
+            data: {},
+            timestamp: Date.now(),
+            level: "info",
+          },
+        ],
+        error: "stale error",
+      };
+
+      const { machine, getState } = makeMachine(version, stale);
+      machine.resetFlow();
+      const s = getState();
+
+      expect(s.currentStep).toBe("idle");
+      expect(s.isInitiatingAuth).toBe(false);
+      expect(s.httpHistory).toEqual([]);
+      expect(s.infoLogs).toEqual([]);
+
+      // None of the stale fields survive the reset.
+      expect(s.serverUrl).toBeUndefined();
+      expect(s.wwwAuthenticateHeader).toBeUndefined();
+      expect(s.challengedScopes).toBeUndefined();
+      expect(s.resourceMetadataUrl).toBeUndefined();
+      expect(s.resourceMetadata).toBeUndefined();
+      expect(s.authorizationServerUrl).toBeUndefined();
+      expect(s.authorizationServerMetadata).toBeUndefined();
+      expect(s.clientId).toBeUndefined();
+      expect(s.clientSecret).toBeUndefined();
+      expect(s.tokenEndpointAuthMethod).toBeUndefined();
+      expect(s.codeVerifier).toBeUndefined();
+      expect(s.codeChallenge).toBeUndefined();
+      expect(s.authorizationUrl).toBeUndefined();
+      expect(s.authorizationCode).toBeUndefined();
+      expect(s.state).toBeUndefined();
+      expect(s.recordedIssuer).toBeUndefined();
+      expect(s.authorizationResponseIss).toBeUndefined();
+      expect(s.requestedScopes).toBeUndefined();
+      expect(s.accessToken).toBeUndefined();
+      expect(s.refreshToken).toBeUndefined();
+      expect(s.tokenType).toBeUndefined();
+      expect(s.expiresIn).toBeUndefined();
+      expect(s.lastRequest).toBeUndefined();
+      expect(s.lastResponse).toBeUndefined();
+      expect(s.error).toBeUndefined();
+    },
+  );
+});
+
+// -----------------------------------------------------------------------------
+// Defect 2: a 2xx DCR response missing client_id must be rejected even in
+// non-strict mode (RFC 7591 requires client_id on a successful registration).
+// -----------------------------------------------------------------------------
+describe("DCR success without client_id is rejected", () => {
+  it.each(ALL_VERSIONS)(
+    "rejects a 201 registration response that omits client_id in non-strict mode (%s)",
+    async (version) => {
+      const seed: Partial<OAuthFlowState> = {
+        currentStep: "request_client_registration",
+        authorizationServerMetadata: {
+          issuer: "https://auth.example.com",
+          authorization_endpoint: "https://auth.example.com/authorize",
+          token_endpoint: "https://auth.example.com/token",
+          registration_endpoint: REGISTRATION_ENDPOINT,
+          response_types_supported: ["code"],
+        },
+        lastRequest: {
+          method: "POST",
+          url: REGISTRATION_ENDPOINT,
+          headers: {},
+          body: { client_name: "Test Client" },
+        },
+        httpHistory: [
+          {
+            step: "request_client_registration",
+            timestamp: Date.now(),
+            request: {
+              method: "POST",
+              url: REGISTRATION_ENDPOINT,
+              headers: {},
+              body: { client_name: "Test Client" },
+            },
+          },
+        ],
+        isInitiatingAuth: true,
+      };
+
+      // A 2xx registration response that is a valid JSON object but has NO
+      // client_id. strictConformance intentionally left false/omitted.
+      const requestExecutor = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 201,
+        statusText: "Created",
+        headers: {},
+        body: {
+          client_name: "Test Client",
+          token_endpoint_auth_method: "none",
+          // client_id deliberately absent
+        },
+      });
+
+      const { machine, getState } = makeMachine(version, seed, {
+        requestExecutor,
+      });
+
+      await machine.proceedToNextStep();
+      const s = getState();
+
+      expect(s.error).toBe(
+        "Dynamic Client Registration response is missing a client_id.",
+      );
+      expect(s.clientId).toBeUndefined();
+      expect(s.currentStep).not.toBe("received_client_credentials");
+      expect(s.isInitiatingAuth).toBe(false);
+    },
+  );
+});
+
+// -----------------------------------------------------------------------------
+// Defect 3: CIMD document must be fetched ONCE and the exact fetched (and
+// displayed) document validated — not re-fetched at validation time.
+// -----------------------------------------------------------------------------
+describe("CIMD document is fetched once and the shown document is validated", () => {
+  const CIMD_URL = "https://client.example.com/.well-known/client-metadata.json";
+
+  it.each(["2025-11-25", "2026-07-28"] as OAuthProtocolVersion[])(
+    "validates the single fetched document, never a second fetch (%s)",
+    async (version) => {
+      const goodDoc = {
+        client_id: CIMD_URL,
+        client_name: "Honest Client",
+        redirect_uris: [REDIRECT_URI],
+        token_endpoint_auth_method: "none",
+      };
+      // A second fetch — if it happened — would return a mismatched document
+      // that fails validation, so a passing flow proves only one fetch occurred.
+      const swappedDoc = {
+        client_id: "https://evil.example.com/metadata.json",
+        client_name: "Swapped Client",
+      };
+
+      const requestExecutor = jest
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          headers: { "content-type": "application/json" },
+          body: goodDoc,
+        })
+        .mockResolvedValue({
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          headers: { "content-type": "application/json" },
+          body: swappedDoc,
+        });
+
+      let state: OAuthFlowState = {
+        ...EMPTY_OAUTH_FLOW_STATE,
+        currentStep: "cimd_fetch_request",
+        serverUrl: SERVER_URL,
+      };
+      const machine = createOAuthStateMachine({
+        protocolVersion: version,
+        registrationStrategy: "cimd",
+        state,
+        getState: () => state,
+        updateState: (updates) => {
+          state = { ...state, ...updates };
+        },
+        serverUrl: SERVER_URL,
+        serverName: "Test Server",
+        redirectUrl: REDIRECT_URI,
+        requestExecutor,
+        clientIdMetadataUrl: CIMD_URL,
+        dynamicRegistration: { client_name: "Test Client" },
+      });
+
+      // Step 1: fetch the CIMD document.
+      await machine.proceedToNextStep();
+      expect(state.currentStep).toBe("cimd_metadata_response");
+      // The fetched document is recorded as the shown response.
+      expect(state.lastResponse?.body).toEqual(goodDoc);
+
+      // Step 2: validate — must NOT issue a second fetch.
+      await machine.proceedToNextStep();
+
+      expect(requestExecutor).toHaveBeenCalledTimes(1);
+      expect(state.error).toBeUndefined();
+      expect(state.currentStep).toBe("received_client_credentials");
+      expect(state.clientId).toBe(CIMD_URL);
+    },
+  );
+});
+
+// -----------------------------------------------------------------------------
+// Defect 4: the unauthenticated pre-401 probe must carry MCP-Protocol-Version,
+// like every other request the machine issues.
+// -----------------------------------------------------------------------------
+describe("pre-401 probe carries the MCP-Protocol-Version header", () => {
+  const PROBE_VERSIONS: Array<[OAuthProtocolVersion, string]> = [
+    ["2025-03-26", "2025-03-26"],
+    ["2025-06-18", "2025-06-18"],
+    ["2025-11-25", "2025-11-25"],
+    ["2026-07-28", "2026-07-28"],
+  ];
+
+  it.each(PROBE_VERSIONS)(
+    "the executed probe request includes MCP-Protocol-Version (%s)",
+    async (version, expectedHeaderValue) => {
+      const requestExecutor = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        statusText: "Unauthorized",
+        headers: { "www-authenticate": "Bearer" },
+        body: null,
+      });
+
+      const seed: Partial<OAuthFlowState> = {
+        currentStep: "request_without_token",
+        serverUrl: SERVER_URL,
+        httpHistory: [
+          {
+            step: "request_without_token",
+            timestamp: Date.now(),
+            request: {
+              method: "POST",
+              url: SERVER_URL,
+              headers: {},
+              body: {},
+            },
+          },
+        ],
+      };
+
+      const { machine } = makeMachine(version, seed, { requestExecutor });
+      await machine.proceedToNextStep();
+
+      expect(requestExecutor).toHaveBeenCalledTimes(1);
+      const probe = requestExecutor.mock.calls[0][0];
+      const headerEntry = Object.entries(probe.headers ?? {}).find(
+        ([k]) => k.toLowerCase() === "mcp-protocol-version",
+      );
+      expect(headerEntry).toBeDefined();
+      expect(headerEntry?.[1]).toBe(expectedHeaderValue);
+    },
+  );
+});

--- a/sdk/tests/oauth/hardening-shared-pass.test.ts
+++ b/sdk/tests/oauth/hardening-shared-pass.test.ts
@@ -339,6 +339,17 @@ describe("CIMD document is fetched once and the shown document is validated", ()
       // The fetched document is recorded as the shown response.
       expect(state.lastResponse?.body).toEqual(goodDoc);
 
+      // The CIMD trace step is timed like every other fetch: its timestamp
+      // marks request start (before the fetch) and it carries a round-trip
+      // duration, rather than being stamped after the fetch with no duration.
+      const cimdEntry = (state.httpHistory ?? []).find(
+        (e) => e.step === "cimd_fetch_request",
+      );
+      expect(cimdEntry).toBeDefined();
+      expect(typeof cimdEntry?.timestamp).toBe("number");
+      expect(typeof cimdEntry?.duration).toBe("number");
+      expect(cimdEntry?.duration).toBeGreaterThanOrEqual(0);
+
       // Step 2: validate — must NOT issue a second fetch.
       await machine.proceedToNextStep();
 


### PR DESCRIPTION
## Summary
A shared hardening pass over the production OAuth debug engine — the four state machines in `sdk/src/oauth/state-machines/` (`debug-oauth-2025-03-26`, `-2025-06-18`, `-2025-11-25`, `-2026-07-28`). Each defect was inherited verbatim across forks, so the fix lives in shared code where possible.

## Defects fixed & how each is tested

**1. `resetFlow` merged partial state → stale credentials/tokens/discovery survived a reset.**
`updateState` MERGES over prior state (see `runner.ts`), and `resetFlow` only spread `EMPTY_OAUTH_FLOW_STATE` (whose optional fields are absent, not `undefined`) plus a few explicit clears. Fields like `clientId`, `clientSecret`, `accessToken`, `tokenType`, `expiresIn`, discovery metadata, and `recordedIssuer` were never cleared. Added a shared `buildResetFlowState()` in `types.ts` that enumerates **every** optional `OAuthFlowState` field as an explicit `undefined` (fresh empty arrays); all four machines reset through it.
*Test:* seeds every carry-over field stale, calls `resetFlow()`, asserts all cleared (all 4 versions) + a unit test that `buildResetFlowState()` names every field.

**2. DCR 2xx response missing `client_id` accepted in non-strict mode.**
The reject was gated on `strictConformance && dcr.missingClientId`; in non-strict mode a successful registration without `client_id` proceeded with `clientId: undefined`. RFC 7591 requires `client_id` on a successful registration, so the reject is now **unconditional** in all four machines.
*Test:* drives DCR with a 201 body that omits `client_id`, `strictConformance` off; asserts the flow errors and does not reach `received_client_credentials` (all 4 versions).

**3. CIMD document double-fetch (`2025-11-25` / `2026-07-28`).**
The `cimd_metadata_response` step **re-fetched** the client metadata document ("Re-fetch to validate"), so the AS could serve one document to the displayed fetch step and a different one to validation. Now the document is fetched **once** in `cimd_fetch_request`, recorded as the shown response (`lastResponse` + an `httpHistory` entry), and the validation step reads that exact document — no second fetch.
*Test:* executor returns a valid document first and a mismatched one on any second call; asserts the executor is called exactly once and the flow validates/completes on the shown document (both CIMD versions).

**4. Pre-401 probe omitted `MCP-Protocol-Version`.**
The unauthenticated probe issued before the 401 lacked the header every other request carries. Added it to the probe (displayed + executed) in the three 2025 machines. The `2026-07-28` probe already carried it (no change there).
*Test:* drives the probe and asserts the executed request carries `MCP-Protocol-Version` with the machine's version literal (all 4 versions, incl. 2026 as the already-correct control).

## Validation
- New `sdk/tests/oauth/hardening-shared-pass.test.ts` — 15 cases, all green.
- Full `tests/oauth` suite green: **347 passed** (332 baseline + 15 new).
- `npm run typecheck` clean in `sdk/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth registration, CIMD validation, and state reset paths across all debug machines; stricter DCR and reset behavior could surface previously hidden server bugs or change inspector UX after reset.
> 
> **Overview**
> Hardens the four MCP OAuth **debug** state machines (`2025-03-26` through `2026-07-28`) with shared fixes and regression tests.
> 
> **`resetFlow`:** Because `updateState` merges, resets that only spread `EMPTY_OAUTH_FLOW_STATE` left tokens, client IDs, discovery metadata, and issuers in place. All machines now call new **`buildResetFlowState()`** in `types.ts`, which sets every optional field to `undefined` and fresh empty history/log arrays.
> 
> **DCR:** Missing `client_id` on a 2xx registration is rejected **always** (RFC 7591), not only when `strictConformance` is on—previously non-strict mode could continue with `clientId: undefined`.
> 
> **CIMD (`2025-11-25`, `2026-07-28`):** Metadata is fetched once, stored on `lastResponse` and `httpHistory` (with proper trace timing); validation reads that snapshot instead of re-fetching.
> 
> **Probes:** Unauthenticated initialize probes now send **`MCP-Protocol-Version`** matching each machine’s spec (added for 2025 variants where it was missing).
> 
> Adds **`hardening-shared-pass.test.ts`** (15 cases) covering reset, DCR, CIMD single-fetch, and probe headers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 377a391af6cad8cb7a140294eb6a2bab214bb1c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the OAuth debug engines across all protocol versions by fixing reset-state leaks, enforcing DCR client_id, removing a CIMD double-fetch, sending MCP-Protocol-Version on the pre-401 probe, and correcting CIMD trace timing. Adds a shared reset helper and tests; behavior is stricter and traces are consistent.

- **Bug Fixes**
  - Reset now fully clears state via buildResetFlowState(); no stale client, tokens, discovery, or issuer survive.
  - DCR: reject any 2xx registration that omits client_id (RFC 7591), even when strictConformance is off.
  - CIMD (2025-11-25, 2026-07-28): fetch once, record to lastResponse + httpHistory, and validate that exact document; the cimd_fetch_request trace now timestamps request start and includes duration.
  - Pre-401 probe: include MCP-Protocol-Version in 2025-03-26, 2025-06-18, 2025-11-25 (2026-07-28 already correct).
  - Tests: added 15 targeted cases (incl. CIMD timing assertion); full suite green and typecheck clean.

<sup>Written for commit 377a391af6cad8cb7a140294eb6a2bab214bb1c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

