### PR TITLE
feat(oauth): wire runtime insufficient_scope step-up from transport to client

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -985,6 +985,7 @@ export function ToolsRoute() {
         <ToolsTab
           serverConfig={selectedMCPConfig}
           serverName={appState.selectedServer}
+          server={selectedServerEntry ?? undefined}
           serverConnectionStatus={
             selectedServerEntry?.connectionStatus ?? "disconnected"
           }

--- a/mcpjam-inspector/client/src/components/ToolsTab.tsx
+++ b/mcpjam-inspector/client/src/components/ToolsTab.tsx
@@ -200,6 +200,11 @@ export function ToolsTab({
   const sentinelRef = useRef<HTMLDivElement | null>(null);
   const toolFetchVersionRef = useRef(0);
   const taskCapabilitiesFetchVersionRef = useRef(0);
+  // SEP-2350: guards against a second tool run (or a repeated error) kicking off
+  // a duplicate step-up while the first is still in flight — a double redirect
+  // or double counter bump. Keyed by server name so distinct servers never
+  // block each other.
+  const stepUpInFlightRef = useRef<Set<string>>(new Set());
   const [cursor, setCursor] = useState<string | undefined>(undefined);
   const isServerConnected =
     serverConnectionStatus === undefined ||
@@ -509,6 +514,21 @@ export function ToolsTab({
     return toolName ? tools[toolName]?._meta : undefined;
   };
 
+  // SEP-2350: a successful call clears the bounded step-up counter so a future
+  // legitimate scope step-up starts fresh rather than inheriting a stale count
+  // that would prematurely throw. Factored so BOTH success paths — an immediate
+  // `completed` result and a task-augmented `task_created` — reset it.
+  const resetStepUpOnSuccess = () => {
+    if (!server) return;
+    try {
+      resetToolCallStepUp(server);
+    } catch (err) {
+      logger.warn("Failed to reset step-up counter", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
+
   const handleExecutionResponse = (
     response: ToolExecutionResponse,
     toolName: string
@@ -524,18 +544,7 @@ export function ToolsTab({
       const callResult = response.result;
       setResult(callResult);
 
-      // SEP-2350: a successful call clears the bounded step-up counter so a
-      // future legitimate scope step-up starts fresh rather than inheriting a
-      // stale count that would prematurely throw.
-      if (server) {
-        try {
-          resetToolCallStepUp(server);
-        } catch (err) {
-          logger.warn("Failed to reset step-up counter", {
-            error: err instanceof Error ? err.message : String(err),
-          });
-        }
-      }
+      resetStepUpOnSuccess();
 
       const rawResult = callResult as unknown as Record<string, unknown>;
       const currentTool = tools[toolName];
@@ -564,6 +573,11 @@ export function ToolsTab({
     // Handle task creation response (MCP Tasks spec 2025-11-25)
     if ("status" in response && response.status === "task_created") {
       const { task, modelImmediateResponse } = response;
+
+      // A task-augmented tool that succeeds lands here, not in the `completed`
+      // branch — reset the step-up counter on this success path too so a stale
+      // count doesn't prematurely throw a later legitimate step-up.
+      resetStepUpOnSuccess();
 
       // Track the task locally so it appears in the Tasks tab
       if (serverName) {
@@ -616,15 +630,27 @@ export function ToolsTab({
         response as { insufficientScope?: import("@/lib/apis/mcp-tools-api").ToolInsufficientScopeChallenge }
       ).insufficientScope;
       if (insufficientScope && server) {
-        void applyToolCallStepUp(server, {
-          requiredScope: insufficientScope.requiredScope,
-          resourceMetadataUrl: insufficientScope.resourceMetadataUrl,
-        }).catch((err) => {
-          logger.error("Step-up re-authorization failed", {
-            toolName,
-            error: err instanceof Error ? err.message : String(err),
-          });
-        });
+        // Dedup: only one step-up may be in flight per server. Without this a
+        // second tool run (or a repeated error) while the first is still
+        // resolving could fire a duplicate — a double redirect or double
+        // counter bump. The guard clears once the step-up settles.
+        const stepUpKey = server.name;
+        if (!stepUpInFlightRef.current.has(stepUpKey)) {
+          stepUpInFlightRef.current.add(stepUpKey);
+          void applyToolCallStepUp(server, {
+            requiredScope: insufficientScope.requiredScope,
+            resourceMetadataUrl: insufficientScope.resourceMetadataUrl,
+          })
+            .catch((err) => {
+              logger.error("Step-up re-authorization failed", {
+                toolName,
+                error: err instanceof Error ? err.message : String(err),
+              });
+            })
+            .finally(() => {
+              stepUpInFlightRef.current.delete(stepUpKey);
+            });
+        }
       }
     }
   };

--- a/mcpjam-inspector/client/src/components/ToolsTab.tsx
+++ b/mcpjam-inspector/client/src/components/ToolsTab.tsx
@@ -41,6 +41,11 @@ import {
 } from "@/lib/apis/mcp-tasks-api";
 import { trackTask } from "@/lib/task-tracker";
 import { validateToolOutput } from "@/lib/schema-utils";
+import {
+  applyToolCallStepUp,
+  resetToolCallStepUp,
+} from "@/state/oauth-orchestrator";
+import type { ServerWithName } from "@/state/app-types";
 import type { MCPServerConfig } from "@mcpjam/sdk/browser";
 import { isNormalizedError } from "@mcpjam/sdk/browser";
 import { WebApiError } from "@/lib/apis/web/base";
@@ -133,6 +138,13 @@ function normalizeElicitationContent(
 interface ToolsTabProps {
   serverConfig?: MCPServerConfig;
   serverName?: string;
+  /**
+   * The full server entry — needed to drive a SEP-2350 runtime scope step-up
+   * when a tool call returns a `403 insufficient_scope` challenge (issuer +
+   * originally-requested scopes are resolved from it). Optional: surfaces that
+   * don't plumb it through simply never trigger the local step-up.
+   */
+  server?: ServerWithName;
   serverConnectionStatus?: ConnectionStatus;
   mcpToolResultImageRendering?: McpToolResultImageRenderingPolicy;
 }
@@ -140,6 +152,7 @@ interface ToolsTabProps {
 export function ToolsTab({
   serverConfig,
   serverName,
+  server,
   serverConnectionStatus,
   mcpToolResultImageRendering,
 }: ToolsTabProps) {
@@ -511,6 +524,19 @@ export function ToolsTab({
       const callResult = response.result;
       setResult(callResult);
 
+      // SEP-2350: a successful call clears the bounded step-up counter so a
+      // future legitimate scope step-up starts fresh rather than inheriting a
+      // stale count that would prematurely throw.
+      if (server) {
+        try {
+          resetToolCallStepUp(server);
+        } catch (err) {
+          logger.warn("Failed to reset step-up counter", {
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+
       const rawResult = callResult as unknown as Record<string, unknown>;
       const currentTool = tools[toolName];
       setStructuredContentValid(
@@ -580,6 +606,26 @@ export function ToolsTab({
       setNormalizedError(
         isNormalizedError(maybeNormalized) ? maybeNormalized : null
       );
+
+      // SEP-2350 runtime scope step-up: the tool call failed with a
+      // `403 insufficient_scope`. Drive the bounded, union-scope
+      // re-authorization for the local (non-hosted) surface. On `reauthorize`
+      // this redirects the browser to the authorization server; `throw` /
+      // `manual` leave the surfaced error in place.
+      const insufficientScope = (
+        response as { insufficientScope?: import("@/lib/apis/mcp-tools-api").ToolInsufficientScopeChallenge }
+      ).insufficientScope;
+      if (insufficientScope && server) {
+        void applyToolCallStepUp(server, {
+          requiredScope: insufficientScope.requiredScope,
+          resourceMetadataUrl: insufficientScope.resourceMetadataUrl,
+        }).catch((err) => {
+          logger.error("Step-up re-authorization failed", {
+            toolName,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        });
+      }
     }
   };
 

--- a/mcpjam-inspector/client/src/components/__tests__/ToolsTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ToolsTab.test.tsx
@@ -34,6 +34,15 @@ vi.mock("@/lib/apis/mcp-tasks-api", () => ({
   getTaskCapabilities: (...args: unknown[]) => mockGetTaskCapabilities(...args),
 }));
 
+// SEP-2350 step-up orchestration — spy so we can assert the local tool-call
+// surface drives the resolver on a `403 insufficient_scope`.
+const mockApplyToolCallStepUp = vi.fn();
+const mockResetToolCallStepUp = vi.fn();
+vi.mock("@/state/oauth-orchestrator", () => ({
+  applyToolCallStepUp: (...args: unknown[]) => mockApplyToolCallStepUp(...args),
+  resetToolCallStepUp: (...args: unknown[]) => mockResetToolCallStepUp(...args),
+}));
+
 // Mock request storage
 vi.mock("@/lib/request-storage", () => ({
   listSavedRequests: vi.fn().mockReturnValue([]),
@@ -119,6 +128,11 @@ describe("ToolsTab", () => {
       supportsToolCalls: false,
       supportsList: false,
       supportsCancel: false,
+    });
+    mockApplyToolCallStepUp.mockResolvedValue({
+      action: "reauthorize",
+      scopes: [],
+      attempt: 0,
     });
   });
 
@@ -534,6 +548,107 @@ describe("ToolsTab", () => {
           undefined
         );
       });
+    });
+
+    it("drives the step-up resolver on a 403 insufficient_scope challenge", async () => {
+      const serverConfig = createServerConfig();
+      const server = {
+        name: "test-server",
+        config: serverConfig,
+        useOAuth: true,
+      } as unknown as import("@/state/app-types").ServerWithName;
+
+      mockListTools.mockResolvedValue({
+        tools: [
+          {
+            name: "scoped-tool",
+            inputSchema: { type: "object", properties: {} },
+          },
+        ],
+      });
+
+      // The tool call fails with a runtime insufficient-scope challenge.
+      mockExecuteToolApi.mockResolvedValue({
+        error: "insufficient_scope",
+        insufficientScope: {
+          requiredScope: "admin",
+          resourceMetadataUrl: "https://rs.example/.well-known",
+        },
+      });
+
+      render(
+        <ToolsTab
+          serverConfig={serverConfig}
+          serverName="test-server"
+          server={server}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("scoped-tool")).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByText("scoped-tool"));
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /^run/i })
+        ).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByRole("button", { name: /^run/i }));
+
+      // The local surface forwards the challenge into the step-up resolver.
+      await waitFor(() => {
+        expect(mockApplyToolCallStepUp).toHaveBeenCalledWith(
+          server,
+          expect.objectContaining({
+            requiredScope: "admin",
+            resourceMetadataUrl: "https://rs.example/.well-known",
+          })
+        );
+      });
+    });
+
+    it("resets the step-up counter after a successful tool call", async () => {
+      const serverConfig = createServerConfig();
+      const server = {
+        name: "test-server",
+        config: serverConfig,
+        useOAuth: true,
+      } as unknown as import("@/state/app-types").ServerWithName;
+
+      mockListTools.mockResolvedValue({
+        tools: [
+          { name: "ok-tool", inputSchema: { type: "object", properties: {} } },
+        ],
+      });
+      mockExecuteToolApi.mockResolvedValue({
+        status: "completed",
+        result: { content: [{ type: "text", text: "ok" }] },
+      });
+
+      render(
+        <ToolsTab
+          serverConfig={serverConfig}
+          serverName="test-server"
+          server={server}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("ok-tool")).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByText("ok-tool"));
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /^run/i })
+        ).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByRole("button", { name: /^run/i }));
+
+      await waitFor(() => {
+        expect(mockResetToolCallStepUp).toHaveBeenCalledWith(server);
+      });
+      expect(mockApplyToolCallStepUp).not.toHaveBeenCalled();
     });
   });
 

--- a/mcpjam-inspector/client/src/components/__tests__/ToolsTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ToolsTab.test.tsx
@@ -92,6 +92,12 @@ vi.mock("@/lib/task-tracker", () => ({
   trackTask: vi.fn(),
 }));
 
+// Mock app navigation — the task_created success branch navigates to /tasks;
+// stub it so tests don't need a router mounted.
+vi.mock("@/lib/app-navigation", () => ({
+  navigateApp: vi.fn(),
+}));
+
 // Mock ResizablePanelGroup to simplify rendering
 vi.mock("../ui/resizable", () => ({
   ResizablePanelGroup: ({ children }: { children: React.ReactNode }) => (
@@ -649,6 +655,117 @@ describe("ToolsTab", () => {
         expect(mockResetToolCallStepUp).toHaveBeenCalledWith(server);
       });
       expect(mockApplyToolCallStepUp).not.toHaveBeenCalled();
+    });
+
+    it("resets the step-up counter on a task_created success too", async () => {
+      const serverConfig = createServerConfig();
+      const server = {
+        name: "test-server",
+        config: serverConfig,
+        useOAuth: true,
+      } as unknown as import("@/state/app-types").ServerWithName;
+
+      mockListTools.mockResolvedValue({
+        tools: [
+          { name: "task-tool", inputSchema: { type: "object", properties: {} } },
+        ],
+      });
+      // A task-augmented tool that succeeds returns `task_created`, NOT
+      // `completed` — the reset must still fire on this branch.
+      mockExecuteToolApi.mockResolvedValue({
+        status: "task_created",
+        task: {
+          taskId: "task-1",
+          createdAt: Date.now(),
+          status: "working",
+          ttl: 0,
+          pollInterval: 1000,
+        },
+      });
+
+      render(
+        <ToolsTab
+          serverConfig={serverConfig}
+          serverName="test-server"
+          server={server}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("task-tool")).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByText("task-tool"));
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /^run/i })
+        ).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByRole("button", { name: /^run/i }));
+
+      await waitFor(() => {
+        expect(mockResetToolCallStepUp).toHaveBeenCalledWith(server);
+      });
+    });
+
+    it("dedupes concurrent step-ups: only one runs per server while in flight", async () => {
+      const serverConfig = createServerConfig();
+      const server = {
+        name: "test-server",
+        config: serverConfig,
+        useOAuth: true,
+      } as unknown as import("@/state/app-types").ServerWithName;
+
+      mockListTools.mockResolvedValue({
+        tools: [
+          {
+            name: "scoped-tool",
+            inputSchema: { type: "object", properties: {} },
+          },
+        ],
+      });
+      // Every run surfaces the same insufficient-scope challenge.
+      mockExecuteToolApi.mockResolvedValue({
+        error: "insufficient_scope",
+        insufficientScope: {
+          requiredScope: "admin",
+          resourceMetadataUrl: "https://rs.example/.well-known",
+        },
+      });
+      // Keep the first step-up pending (a redirect flow would navigate away),
+      // so the in-flight guard stays set across the second run.
+      mockApplyToolCallStepUp.mockReturnValue(new Promise(() => {}));
+
+      render(
+        <ToolsTab
+          serverConfig={serverConfig}
+          serverName="test-server"
+          server={server}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("scoped-tool")).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByText("scoped-tool"));
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /^run/i })
+        ).toBeInTheDocument();
+      });
+
+      const runButton = screen.getByRole("button", { name: /^run/i });
+      fireEvent.click(runButton);
+      await waitFor(() => {
+        expect(mockApplyToolCallStepUp).toHaveBeenCalledTimes(1);
+      });
+
+      // A second run while the first step-up is still resolving must NOT fire a
+      // duplicate (which would double-redirect / double-bump the counter).
+      fireEvent.click(runButton);
+      await waitFor(() => {
+        expect(mockExecuteToolApi).toHaveBeenCalledTimes(2);
+      });
+      expect(mockApplyToolCallStepUp).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/mcpjam-inspector/client/src/lib/apis/__tests__/mcp-tools-api.test.ts
+++ b/mcpjam-inspector/client/src/lib/apis/__tests__/mcp-tools-api.test.ts
@@ -1,7 +1,23 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { authFetchMock, isHostedModeMock } = vi.hoisted(() => ({
+  authFetchMock: vi.fn(),
+  isHostedModeMock: vi.fn(() => false),
+}));
+
+vi.mock("@/lib/session-token", () => ({
+  authFetch: authFetchMock,
+}));
+
+vi.mock("@/lib/apis/mode-client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/apis/mode-client")>();
+  return { ...actual, isHostedMode: isHostedModeMock };
+});
+
 import {
   attachToolMetadata,
   parseInsufficientScopeChallenge,
+  respondToElicitationApi,
 } from "../mcp-tools-api";
 import type { ListToolsResultWithMetadata } from "../mcp-tools-api";
 
@@ -39,6 +55,79 @@ describe("parseInsufficientScopeChallenge (SEP-2350)", () => {
     expect(parseInsufficientScopeChallenge(undefined)).toBeUndefined();
     expect(parseInsufficientScopeChallenge("nope")).toBeUndefined();
     expect(parseInsufficientScopeChallenge({})).toBeUndefined();
+  });
+});
+
+describe("respondToElicitationApi (SEP-2350 step-up on resume)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isHostedModeMock.mockReturnValue(false);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    isHostedModeMock.mockReturnValue(false);
+  });
+
+  it("forwards the insufficient_scope challenge when a resume fails with 403", async () => {
+    authFetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          error: "insufficient scope",
+          mcpError: {
+            insufficientScope: {
+              requiredScope: "read write admin",
+              resourceMetadataUrl: "https://rs.example/.well-known",
+            },
+          },
+          normalized: {
+            slug: "insufficient-scope",
+            title: "Insufficient scope",
+            oneLine: "The tool needs more scope.",
+            docsAnchor: "#insufficient-scope",
+            severity: "error",
+            rawMessage: "insufficient scope",
+            likelyCauses: [],
+            nextSteps: [],
+          },
+        }),
+        { status: 403, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    const result = await respondToElicitationApi("exec-1", "req-1", {
+      action: "accept",
+      content: {},
+    });
+
+    expect("error" in result && result.error).toBe("insufficient scope");
+    expect(
+      "insufficientScope" in result ? result.insufficientScope : undefined,
+    ).toEqual({
+      requiredScope: "read write admin",
+      resourceMetadataUrl: "https://rs.example/.well-known",
+      errorDescription: undefined,
+    });
+    // The describer block is preserved too, mirroring the /execute path.
+    expect(
+      "normalized" in result ? result.normalized : undefined,
+    ).toMatchObject({ title: "Insufficient scope" });
+  });
+
+  it("omits insufficientScope when a resume failure carries no challenge", async () => {
+    authFetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ error: "boom" }), {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    const result = await respondToElicitationApi("exec-1", "req-1", {
+      action: "accept",
+      content: {},
+    });
+
+    expect("error" in result && result.error).toBe("boom");
+    expect("insufficientScope" in result).toBe(false);
   });
 });
 

--- a/mcpjam-inspector/client/src/lib/apis/__tests__/mcp-tools-api.test.ts
+++ b/mcpjam-inspector/client/src/lib/apis/__tests__/mcp-tools-api.test.ts
@@ -1,6 +1,46 @@
 import { describe, expect, it } from "vitest";
-import { attachToolMetadata } from "../mcp-tools-api";
+import {
+  attachToolMetadata,
+  parseInsufficientScopeChallenge,
+} from "../mcp-tools-api";
 import type { ListToolsResultWithMetadata } from "../mcp-tools-api";
+
+describe("parseInsufficientScopeChallenge (SEP-2350)", () => {
+  it("narrows a well-formed challenge block", () => {
+    expect(
+      parseInsufficientScopeChallenge({
+        requiredScope: "read write",
+        resourceMetadataUrl: "https://rs.example/.well-known",
+        errorDescription: "more scope",
+      }),
+    ).toEqual({
+      requiredScope: "read write",
+      resourceMetadataUrl: "https://rs.example/.well-known",
+      errorDescription: "more scope",
+    });
+  });
+
+  it("keeps only string fields and drops the rest", () => {
+    expect(
+      parseInsufficientScopeChallenge({
+        requiredScope: "read",
+        resourceMetadataUrl: 42,
+        errorDescription: null,
+      }),
+    ).toEqual({
+      requiredScope: "read",
+      resourceMetadataUrl: undefined,
+      errorDescription: undefined,
+    });
+  });
+
+  it("returns undefined when no challenge field is a string", () => {
+    expect(parseInsufficientScopeChallenge({ requiredScope: 1 })).toBeUndefined();
+    expect(parseInsufficientScopeChallenge(undefined)).toBeUndefined();
+    expect(parseInsufficientScopeChallenge("nope")).toBeUndefined();
+    expect(parseInsufficientScopeChallenge({})).toBeUndefined();
+  });
+});
 
 describe("attachToolMetadata", () => {
   it("copies inspector toolsMetadata onto matching tool _meta", () => {

--- a/mcpjam-inspector/client/src/lib/apis/mcp-tools-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/mcp-tools-api.ts
@@ -277,7 +277,23 @@ export async function respondToElicitationApi(
   } catch {}
   if (!res.ok) {
     const message = body?.error || `Respond failed (${res.status})`;
-    return { error: message } as ToolExecutionResponse;
+    // SEP-2350: an elicitation-resume can ALSO fail with a runtime
+    // `403 insufficient_scope` (the widened-scope call happens after the
+    // elicitation round-trip). The `/respond` route serializes the same
+    // `mcpError.insufficientScope` / `normalized` blocks as `/execute`, so
+    // mirror that narrowing here — otherwise the challenge is dropped and the
+    // resume path can never drive a step-up.
+    const normalized = isNormalizedError(body?.normalized)
+      ? (body.normalized as NormalizedError)
+      : undefined;
+    const insufficientScope = parseInsufficientScopeChallenge(
+      body?.mcpError?.insufficientScope,
+    );
+    return {
+      error: message,
+      ...(normalized ? { normalized } : {}),
+      ...(insufficientScope ? { insufficientScope } : {}),
+    } as ToolExecutionResponse;
   }
   return body as ToolExecutionResponse;
 }

--- a/mcpjam-inspector/client/src/lib/apis/mcp-tools-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/mcp-tools-api.ts
@@ -61,7 +61,49 @@ export type ToolExecutionResponse =
        * ErrorCard directly without re-classifying from `error`.
        */
       normalized?: NormalizedError;
+      /**
+       * SEP-2350 step-up: present when the tool call failed with a runtime
+       * `403 insufficient_scope`. The server transport surfaces the
+       * `WWW-Authenticate` challenge as an `InsufficientScopeError`, which the
+       * `/tools/execute` route serializes onto `mcpError.insufficientScope`.
+       * Consumers pass `requiredScope` into the client step-up
+       * re-authorization (union of previously-requested and challenged scopes,
+       * bounded per session). Untrusted resource-server input — treat as such
+       * when rendering.
+       */
+      insufficientScope?: ToolInsufficientScopeChallenge;
     };
+
+/** The `WWW-Authenticate` step-up challenge surfaced on a failed tool call. */
+export type ToolInsufficientScopeChallenge = {
+  requiredScope?: string;
+  resourceMetadataUrl?: string;
+  errorDescription?: string;
+};
+
+/**
+ * Narrow an untrusted `mcpError.insufficientScope` payload to the challenge
+ * shape. Returns `undefined` unless at least one string field is present, so a
+ * malformed or empty block never masquerades as an actionable step-up.
+ */
+export function parseInsufficientScopeChallenge(
+  raw: unknown,
+): ToolInsufficientScopeChallenge | undefined {
+  if (!raw || typeof raw !== "object") {
+    return undefined;
+  }
+  const r = raw as Record<string, unknown>;
+  const requiredScope =
+    typeof r.requiredScope === "string" ? r.requiredScope : undefined;
+  const resourceMetadataUrl =
+    typeof r.resourceMetadataUrl === "string" ? r.resourceMetadataUrl : undefined;
+  const errorDescription =
+    typeof r.errorDescription === "string" ? r.errorDescription : undefined;
+  if (!requiredScope && !resourceMetadataUrl && !errorDescription) {
+    return undefined;
+  }
+  return { requiredScope, resourceMetadataUrl, errorDescription };
+}
 
 export async function listTools({
   serverId,
@@ -137,7 +179,20 @@ export async function executeToolApi(
           error instanceof WebApiError && isNormalizedError(error.normalized)
             ? error.normalized
             : undefined;
-        return { error: message, ...(normalized ? { normalized } : {}) };
+        // Hosted step-up challenge, if the route forwarded one on `details`
+        // (the WebRouteError `details` block WebApiError carries). Best-effort:
+        // omitted when the hosted serializer sends none.
+        const insufficientScope =
+          error instanceof WebApiError
+            ? parseInsufficientScopeChallenge(
+                (error.details as any)?.insufficientScope,
+              )
+            : undefined;
+        return {
+          error: message,
+          ...(normalized ? { normalized } : {}),
+          ...(insufficientScope ? { insufficientScope } : {}),
+        };
       }
     },
     local: async () => {
@@ -160,9 +215,16 @@ export async function executeToolApi(
         const normalized = isNormalizedError(body?.normalized)
           ? (body.normalized as NormalizedError)
           : undefined;
+        // SEP-2350: surface the step-up challenge the /tools/execute route
+        // serialized onto `mcpError.insufficientScope` for a runtime
+        // `403 insufficient_scope`, so consumers can drive union-scope re-auth.
+        const insufficientScope = parseInsufficientScopeChallenge(
+          body?.mcpError?.insufficientScope,
+        );
         return {
           error: message,
           ...(normalized ? { normalized } : {}),
+          ...(insufficientScope ? { insufficientScope } : {}),
         } as ToolExecutionResponse;
       }
 

--- a/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
@@ -2503,7 +2503,7 @@ function loadStoredDiscoveryState(
  * undefined before any AS is resolved; callers must NOT fall back to a stored
  * envelope's `activeIssuer`, which may be a stale AS after a PRM change.
  */
-function resolveStoredIssuer(
+export function resolveStoredIssuer(
   serverName: string,
   serverUrl?: string
 ): string | undefined {

--- a/mcpjam-inspector/client/src/lib/oauth/requested-scopes.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/requested-scopes.ts
@@ -102,16 +102,29 @@ export function persistRequestedScopes(
 
 /**
  * The scope set a step-up re-authorization should request: the union of the
- * scopes previously requested for this issuer and the scopes challenged by the
- * `403 insufficient_scope` response.
+ * scopes ORIGINALLY requested by the server's OAuth flow, the scopes persisted
+ * for this issuer from a prior step-up, and the scopes challenged by the `403
+ * insufficient_scope` response.
+ *
+ * `originalScopes` matters on the FIRST runtime step-up: nothing has been
+ * persisted yet (the persisted set only exists after a prior step-up
+ * re-authorization), so without the originally-requested scopes the union would
+ * collapse to just the challenged scopes and the re-authorization would DROP the
+ * scopes the original grant already held — the server would come back
+ * still-insufficient on the pre-existing scopes.
  */
 export function stepUpScopeUnion(
   serverName: string,
   issuer: string | undefined,
   challengedScopes: string[] | undefined,
+  originalScopes?: string[],
 ): string[] {
-  return computeScopeUnion(
+  // Order: original-requested first, then any issuer-persisted prior union,
+  // then the newly-challenged scopes. computeScopeUnion de-dupes and preserves
+  // first-seen order.
+  const previouslyRequested = computeScopeUnion(
+    originalScopes,
     readRequestedScopes(serverName, issuer),
-    challengedScopes,
   );
+  return computeScopeUnion(previouslyRequested, challengedScopes);
 }

--- a/mcpjam-inspector/client/src/state/__tests__/oauth-orchestrator.step-up.test.ts
+++ b/mcpjam-inspector/client/src/state/__tests__/oauth-orchestrator.step-up.test.ts
@@ -244,6 +244,51 @@ describe("resolveInsufficientScopeStepUp (SEP-2350)", () => {
     );
   });
 
+  it("applyToolCallStepUp consumes the attempt when the reauth actually redirects", async () => {
+    readStoredOAuthConfigMock.mockReturnValue({ scopes: ["read"] });
+    initiateOAuthMock.mockResolvedValue({ success: true }); // → { kind: "redirect" }
+
+    const outcome = await applyToolCallStepUp(createServer(), {
+      requiredScope: "admin",
+    });
+    expect(outcome.reauthorization).toEqual({ kind: "redirect" });
+
+    // A genuine re-authorization was initiated, so the attempt is consumed: a
+    // second challenge in the same session is now bounded to `throw`.
+    const retry = resolveInsufficientScopeStepUp({
+      serverName: "asana",
+      issuer: ISSUER,
+      challengedScopes: ["admin"],
+      authMode: "interactive",
+      maxRetries: 1,
+    });
+    expect(retry.action).toBe("throw");
+  });
+
+  it("applyToolCallStepUp does NOT consume the attempt on a transient reauth/init failure", async () => {
+    readStoredOAuthConfigMock.mockReturnValue({ scopes: ["read"] });
+    // ensureAuthorizedForReconnect clears stored OAuth data then the OAuth init
+    // fails transiently → an `error` outcome that never navigated away.
+    initiateOAuthMock.mockResolvedValue({ success: false, error: "init boom" });
+
+    const outcome = await applyToolCallStepUp(createServer(), {
+      requiredScope: "admin",
+    });
+    expect(outcome.action).toBe("reauthorize");
+    expect(outcome.reauthorization?.kind).toBe("error");
+
+    // The counter was rolled back: a retry in the SAME session still
+    // re-authorizes rather than being blocked by a wasted attempt.
+    const retry = resolveInsufficientScopeStepUp({
+      serverName: "asana",
+      issuer: ISSUER,
+      challengedScopes: ["admin"],
+      authMode: "interactive",
+      maxRetries: 1,
+    });
+    expect(retry.action).toBe("reauthorize");
+  });
+
   it("applyToolCallStepUp with m2m throws and never opens a browser", async () => {
     readStoredOAuthConfigMock.mockReturnValue({ scopes: ["read"] });
     const outcome = await applyToolCallStepUp(

--- a/mcpjam-inspector/client/src/state/__tests__/oauth-orchestrator.step-up.test.ts
+++ b/mcpjam-inspector/client/src/state/__tests__/oauth-orchestrator.step-up.test.ts
@@ -265,6 +265,37 @@ describe("resolveInsufficientScopeStepUp (SEP-2350)", () => {
     expect(retry.action).toBe("throw");
   });
 
+  it("applyToolCallStepUp KEEPS the attempt on a no-op `ready` (prevents an infinite step-up loop)", async () => {
+    readStoredOAuthConfigMock.mockReturnValue({ scopes: ["read"] });
+    // initiateOAuth resolves WITHOUT navigating: an already-authorized server
+    // returns a serverConfig immediately → ensureAuthorizedForReconnect `ready`.
+    // This is NOT a genuine widened-scope grant (that needs the redirect
+    // round-trip), so the consumed attempt MUST stick — otherwise a server
+    // stuck returning `insufficient_scope` would loop forever as each retry
+    // rolled the budget back to zero.
+    initiateOAuthMock.mockResolvedValue({
+      success: true,
+      serverConfig: { type: "http", url: "https://mcp.asana.com/sse" },
+    });
+
+    const outcome = await applyToolCallStepUp(createServer(), {
+      requiredScope: "admin",
+    });
+    expect(outcome.action).toBe("reauthorize");
+    expect(outcome.reauthorization?.kind).toBe("ready");
+
+    // The attempt was consumed (NOT reset): a second challenge in the same
+    // session is now bounded to `throw` rather than re-authorizing forever.
+    const retry = resolveInsufficientScopeStepUp({
+      serverName: "asana",
+      issuer: ISSUER,
+      challengedScopes: ["admin"],
+      authMode: "interactive",
+      maxRetries: 1,
+    });
+    expect(retry.action).toBe("throw");
+  });
+
   it("applyToolCallStepUp does NOT consume the attempt on a transient reauth/init failure", async () => {
     readStoredOAuthConfigMock.mockReturnValue({ scopes: ["read"] });
     // ensureAuthorizedForReconnect clears stored OAuth data then the OAuth init

--- a/mcpjam-inspector/client/src/state/__tests__/oauth-orchestrator.step-up.test.ts
+++ b/mcpjam-inspector/client/src/state/__tests__/oauth-orchestrator.step-up.test.ts
@@ -1,24 +1,32 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ServerWithName } from "../app-types";
 
-const { clearOAuthDataMock, initiateOAuthMock, readStoredOAuthConfigMock } =
-  vi.hoisted(() => ({
-    clearOAuthDataMock: vi.fn(),
-    initiateOAuthMock: vi.fn(),
-    readStoredOAuthConfigMock: vi.fn(),
-  }));
+const {
+  clearOAuthDataMock,
+  initiateOAuthMock,
+  readStoredOAuthConfigMock,
+  resolveStoredIssuerMock,
+} = vi.hoisted(() => ({
+  clearOAuthDataMock: vi.fn(),
+  initiateOAuthMock: vi.fn(),
+  readStoredOAuthConfigMock: vi.fn(),
+  resolveStoredIssuerMock: vi.fn(),
+}));
 
 vi.mock("@/lib/oauth/mcp-oauth", () => ({
   clearOAuthData: clearOAuthDataMock,
   hasOAuthConfig: vi.fn(),
   initiateOAuth: initiateOAuthMock,
   readStoredOAuthConfig: readStoredOAuthConfigMock,
+  resolveStoredIssuer: resolveStoredIssuerMock,
 }));
 
 import {
   ensureAuthorizedForReconnect,
   resolveInsufficientScopeStepUp,
   resetInsufficientScopeStepUp,
+  applyToolCallStepUp,
+  resetToolCallStepUp,
 } from "../oauth-orchestrator";
 import { persistRequestedScopes } from "@/lib/oauth/requested-scopes";
 
@@ -43,7 +51,11 @@ describe("resolveInsufficientScopeStepUp (SEP-2350)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    // The bounded counter now lives in sessionStorage — clear it too so
+    // counter state never leaks between tests.
+    sessionStorage.clear();
     readStoredOAuthConfigMock.mockReturnValue({});
+    resolveStoredIssuerMock.mockReturnValue(ISSUER);
   });
 
   it("unions previously-requested and challenged scopes on reauthorize", () => {
@@ -167,6 +179,97 @@ describe("resolveInsufficientScopeStepUp (SEP-2350)", () => {
     });
     expect(decision.action).toBe("manual");
     expect(decision.attempt).toBe(0);
+  });
+
+  it("includes the ORIGINAL OAuth scopes on the first step-up (nothing persisted yet)", () => {
+    // No prior step-up → nothing persisted. Without originalScopes the union
+    // would collapse to just the challenged scope and DROP the grant's scopes.
+    const decision = resolveInsufficientScopeStepUp({
+      serverName: "asana",
+      issuer: ISSUER,
+      challengedScopes: ["admin"],
+      originalScopes: ["read", "write"],
+      authMode: "interactive",
+      maxRetries: 1,
+    });
+    expect(decision.action).toBe("reauthorize");
+    // original ∪ challenged, original first, de-duplicated.
+    expect(decision.scopes).toEqual(["read", "write", "admin"]);
+  });
+
+  it("unions original ∪ persisted ∪ challenged without duplicating overlap", () => {
+    persistRequestedScopes("asana", ISSUER, ["read", "extra"]);
+    const decision = resolveInsufficientScopeStepUp({
+      serverName: "asana",
+      issuer: ISSUER,
+      challengedScopes: ["admin", "read"],
+      originalScopes: ["read", "write"],
+      authMode: "interactive",
+      maxRetries: 1,
+    });
+    expect(decision.scopes).toEqual(["read", "write", "extra", "admin"]);
+  });
+
+  it("bounds the counter PER SESSION (sessionStorage, not localStorage)", () => {
+    resolveInsufficientScopeStepUp({
+      serverName: "asana",
+      issuer: ISSUER,
+      challengedScopes: ["admin"],
+      authMode: "interactive",
+      maxRetries: 1,
+    });
+    // The counter is written to sessionStorage (survives a redirect within the
+    // session) and NOT localStorage (would block a fresh browser session).
+    expect(sessionStorage.getItem("mcp-stepup-attempts-asana")).toContain(
+      ISSUER,
+    );
+    expect(localStorage.getItem("mcp-stepup-attempts-asana")).toBeNull();
+  });
+
+  it("applyToolCallStepUp drives the resolver and the union-scope re-authorization", async () => {
+    // Original grant scopes come from the stored OAuth config.
+    readStoredOAuthConfigMock.mockReturnValue({ scopes: ["read", "write"] });
+    initiateOAuthMock.mockResolvedValue({ success: true });
+
+    const outcome = await applyToolCallStepUp(createServer(), {
+      requiredScope: "admin",
+    });
+
+    expect(outcome.action).toBe("reauthorize");
+    expect(outcome.scopes).toEqual(["read", "write", "admin"]);
+    expect(outcome.reauthorization).toEqual({ kind: "redirect" });
+    // The fresh flow requests the widened union.
+    expect(initiateOAuthMock).toHaveBeenCalledWith(
+      expect.objectContaining({ scopes: ["read", "write", "admin"] }),
+    );
+  });
+
+  it("applyToolCallStepUp with m2m throws and never opens a browser", async () => {
+    readStoredOAuthConfigMock.mockReturnValue({ scopes: ["read"] });
+    const outcome = await applyToolCallStepUp(
+      createServer(),
+      { requiredScope: "admin" },
+      { authMode: "m2m" },
+    );
+    expect(outcome.action).toBe("throw");
+    expect(outcome.reauthorization).toBeUndefined();
+    expect(initiateOAuthMock).not.toHaveBeenCalled();
+  });
+
+  it("resetToolCallStepUp clears the counter after a successful call", () => {
+    const input = {
+      serverName: "asana",
+      issuer: ISSUER,
+      challengedScopes: ["admin"],
+      authMode: "interactive" as const,
+      maxRetries: 1,
+    };
+    resolveInsufficientScopeStepUp(input); // counter → 1
+    expect(resolveInsufficientScopeStepUp(input).action).toBe("throw");
+
+    resetToolCallStepUp(createServer());
+
+    expect(resolveInsufficientScopeStepUp(input).action).toBe("reauthorize");
   });
 
   it("counts step-up attempts per issuer (an AS switch starts fresh)", () => {

--- a/mcpjam-inspector/client/src/state/__tests__/oauth-orchestrator.step-up.test.ts
+++ b/mcpjam-inspector/client/src/state/__tests__/oauth-orchestrator.step-up.test.ts
@@ -1,0 +1,189 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ServerWithName } from "../app-types";
+
+const { clearOAuthDataMock, initiateOAuthMock, readStoredOAuthConfigMock } =
+  vi.hoisted(() => ({
+    clearOAuthDataMock: vi.fn(),
+    initiateOAuthMock: vi.fn(),
+    readStoredOAuthConfigMock: vi.fn(),
+  }));
+
+vi.mock("@/lib/oauth/mcp-oauth", () => ({
+  clearOAuthData: clearOAuthDataMock,
+  hasOAuthConfig: vi.fn(),
+  initiateOAuth: initiateOAuthMock,
+  readStoredOAuthConfig: readStoredOAuthConfigMock,
+}));
+
+import {
+  ensureAuthorizedForReconnect,
+  resolveInsufficientScopeStepUp,
+  resetInsufficientScopeStepUp,
+} from "../oauth-orchestrator";
+import { persistRequestedScopes } from "@/lib/oauth/requested-scopes";
+
+const ISSUER = "https://as.example";
+
+const createServer = (
+  overrides: Partial<ServerWithName> = {},
+): ServerWithName =>
+  ({
+    name: "asana",
+    config: { type: "http", url: "https://mcp.asana.com/sse" },
+    lastConnectionTime: new Date(),
+    connectionStatus: "disconnected",
+    retryCount: 0,
+    enabled: true,
+    useOAuth: true,
+    oauthTokens: { access_token: "access-token", refresh_token: "refresh" },
+    ...overrides,
+  }) as ServerWithName;
+
+describe("resolveInsufficientScopeStepUp (SEP-2350)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    readStoredOAuthConfigMock.mockReturnValue({});
+  });
+
+  it("unions previously-requested and challenged scopes on reauthorize", () => {
+    // The server previously requested read+write against this issuer.
+    persistRequestedScopes("asana", ISSUER, ["read", "write"]);
+
+    const decision = resolveInsufficientScopeStepUp({
+      serverName: "asana",
+      issuer: ISSUER,
+      challengedScopes: ["admin"],
+      authMode: "interactive",
+      maxRetries: 1,
+    });
+
+    expect(decision.action).toBe("reauthorize");
+    expect(decision.attempt).toBe(0);
+    // Previous-first, de-duplicated, challenged appended.
+    expect(decision.scopes).toEqual(["read", "write", "admin"]);
+  });
+
+  it("feeds the union scopes into the fresh OAuth flow via stepUpScopes", async () => {
+    persistRequestedScopes("asana", ISSUER, ["read", "write"]);
+    initiateOAuthMock.mockResolvedValue({ success: true });
+
+    const decision = resolveInsufficientScopeStepUp({
+      serverName: "asana",
+      issuer: ISSUER,
+      challengedScopes: ["admin"],
+      authMode: "interactive",
+      maxRetries: 1,
+    });
+
+    const result = await ensureAuthorizedForReconnect(createServer(), {
+      allowInteractiveOAuthFlow: true,
+      stepUpScopes: decision.scopes,
+    });
+
+    expect(result).toEqual({ kind: "redirect" });
+    // The re-authorization requests the WIDENED union, not the stale scopes.
+    expect(initiateOAuthMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serverName: "asana",
+        scopes: ["read", "write", "admin"],
+      }),
+    );
+  });
+
+  it("stops re-authorizing after maxRetries (bounded cross-request loop)", () => {
+    const input = {
+      serverName: "asana",
+      issuer: ISSUER,
+      challengedScopes: ["admin"],
+      authMode: "interactive" as const,
+      maxRetries: 1,
+    };
+
+    // Attempt 0 → reauthorize (bumps the persisted counter to 1).
+    const first = resolveInsufficientScopeStepUp(input);
+    expect(first.action).toBe("reauthorize");
+    expect(first.attempt).toBe(0);
+
+    // Attempt 1 → the cap is reached, so throw instead of looping forever.
+    const second = resolveInsufficientScopeStepUp(input);
+    expect(second.action).toBe("throw");
+    expect(second.attempt).toBe(1);
+    // The union is still returned for display even when throwing.
+    expect(second.scopes).toEqual(["admin"]);
+  });
+
+  it("honors a maxRetries of 2 before throwing", () => {
+    const input = {
+      serverName: "asana",
+      issuer: ISSUER,
+      challengedScopes: ["admin"],
+      authMode: "interactive" as const,
+      maxRetries: 2,
+    };
+    expect(resolveInsufficientScopeStepUp(input).action).toBe("reauthorize");
+    expect(resolveInsufficientScopeStepUp(input).action).toBe("reauthorize");
+    expect(resolveInsufficientScopeStepUp(input).action).toBe("throw");
+  });
+
+  it("resetInsufficientScopeStepUp clears the counter so a later step-up starts fresh", () => {
+    const input = {
+      serverName: "asana",
+      issuer: ISSUER,
+      challengedScopes: ["admin"],
+      authMode: "interactive" as const,
+      maxRetries: 1,
+    };
+    resolveInsufficientScopeStepUp(input); // attempt 0 → reauthorize (counter=1)
+    expect(resolveInsufficientScopeStepUp(input).action).toBe("throw");
+
+    resetInsufficientScopeStepUp("asana", ISSUER);
+
+    const after = resolveInsufficientScopeStepUp(input);
+    expect(after.action).toBe("reauthorize");
+    expect(after.attempt).toBe(0);
+  });
+
+  it("m2m mode always throws (never opens a browser)", () => {
+    const decision = resolveInsufficientScopeStepUp({
+      serverName: "asana",
+      issuer: ISSUER,
+      challengedScopes: ["admin"],
+      authMode: "m2m",
+      maxRetries: 5,
+    });
+    expect(decision.action).toBe("throw");
+    // No re-authorization performed → counter untouched.
+    expect(decision.attempt).toBe(0);
+  });
+
+  it("debugger mode returns manual (advances explicitly, no auto-browser)", () => {
+    const decision = resolveInsufficientScopeStepUp({
+      serverName: "asana",
+      issuer: ISSUER,
+      challengedScopes: ["admin"],
+      authMode: "debugger",
+      maxRetries: 5,
+    });
+    expect(decision.action).toBe("manual");
+    expect(decision.attempt).toBe(0);
+  });
+
+  it("counts step-up attempts per issuer (an AS switch starts fresh)", () => {
+    const base = {
+      serverName: "asana",
+      challengedScopes: ["admin"],
+      authMode: "interactive" as const,
+      maxRetries: 1,
+    };
+    resolveInsufficientScopeStepUp({ ...base, issuer: ISSUER });
+    expect(
+      resolveInsufficientScopeStepUp({ ...base, issuer: ISSUER }).action,
+    ).toBe("throw");
+    // A different issuer has its own bucket → first attempt is reauthorize.
+    expect(
+      resolveInsufficientScopeStepUp({ ...base, issuer: "https://other.as" })
+        .action,
+    ).toBe("reauthorize");
+  });
+});

--- a/mcpjam-inspector/client/src/state/oauth-orchestrator.ts
+++ b/mcpjam-inspector/client/src/state/oauth-orchestrator.ts
@@ -598,13 +598,26 @@ export async function applyToolCallStepUp(
   });
 
   // The resolver already bumped the per-session counter (it must persist BEFORE
-  // the redirect so the bound survives the round-trip). But that path also
-  // clears stored OAuth data and can fail transiently (e.g. an OAuth-init
-  // error), returning a non-`redirect` outcome WITHOUT navigating away. A
-  // consumed-but-not-initiated attempt would block retrying the tool in the
-  // same session, so roll the counter back to its pre-decision value unless a
-  // genuine re-authorization was actually initiated (a `redirect`).
-  if (reauthorization.kind !== "redirect") {
+  // the redirect so the bound survives the round-trip). Roll it back to its
+  // pre-decision value ONLY on a transient failure that never navigated away
+  // and never completed a re-authorization — an OAuth-init `error` or a
+  // `reauth_required` — so a wasted attempt doesn't block retrying the tool in
+  // the same session.
+  //
+  // A `redirect` OR a `ready` KEEPS the consumed attempt. A `ready` here is NOT
+  // a genuine widened-scope grant — the redirect round-trip is what mints new
+  // scopes; a `ready` means `initiateOAuth` resolved without navigating (the
+  // server was already authorized / no redirect was needed), so the challenged
+  // scope was NOT obtained. Rolling that back would let a server stuck on
+  // `insufficient_scope` loop forever: every retry reads the un-bumped count,
+  // re-bumps, sees `ready`, rolls back, and never advances toward the cap.
+  // Keeping the bump advances the bounded budget until the §10.5 policy throws.
+  // A genuine step-up success clears the counter elsewhere — the caller's
+  // reset-on-successful-tool-call path — not here.
+  if (
+    reauthorization.kind === "error" ||
+    reauthorization.kind === "reauth_required"
+  ) {
     writeStepUpAttempts(server.name, issuer, decision.attempt);
   }
 

--- a/mcpjam-inspector/client/src/state/oauth-orchestrator.ts
+++ b/mcpjam-inspector/client/src/state/oauth-orchestrator.ts
@@ -2,6 +2,7 @@ import {
   clearOAuthData,
   initiateOAuth,
   readStoredOAuthConfig,
+  resolveStoredIssuer,
   MCPOAuthOptions,
 } from "@/lib/oauth/mcp-oauth";
 import { normalizeRegistrationMode } from "@/shared/xaa.js";
@@ -332,6 +333,21 @@ function stepUpAttemptsKey(serverName: string): string {
   return `${STEP_UP_ATTEMPTS_PREFIX}${serverName}`;
 }
 
+// The bounded step-up counter lives in `sessionStorage`, NOT `localStorage`: it
+// must survive the OAuth browser redirect that a re-authorization triggers
+// (same-origin, same tab → sessionStorage persists across the redirect
+// round-trip), but it must NOT outlive the browser session. In `localStorage`,
+// a prior session's exhausted counter would make a brand-new session throw
+// immediately on its first legitimate step-up. `sessionStorage` scopes the
+// bound to the session, which is exactly the loop we need to bound (§10.5#5).
+function stepUpAttemptsStore(): Storage | undefined {
+  try {
+    return typeof sessionStorage !== "undefined" ? sessionStorage : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 // Key attempts by issuer so an AS switch (or a step-up before issuer
 // discovery) never reuses another AS's count. An unknown issuer buckets under
 // "" — its own isolated bucket.
@@ -344,8 +360,9 @@ function readStepUpAttempts(
   issuer: string | undefined,
 ): number {
   try {
-    if (typeof localStorage === "undefined") return 0;
-    const raw = localStorage.getItem(stepUpAttemptsKey(serverName));
+    const store = stepUpAttemptsStore();
+    if (!store) return 0;
+    const raw = store.getItem(stepUpAttemptsKey(serverName));
     if (!raw) return 0;
     const parsed = JSON.parse(raw) as Record<string, unknown>;
     const value = parsed?.[issuerBucket(issuer)];
@@ -363,8 +380,9 @@ function writeStepUpAttempts(
   attempts: number,
 ): void {
   try {
-    if (typeof localStorage === "undefined") return;
-    const raw = localStorage.getItem(stepUpAttemptsKey(serverName));
+    const store = stepUpAttemptsStore();
+    if (!store) return;
+    const raw = store.getItem(stepUpAttemptsKey(serverName));
     let map: Record<string, number> = {};
     if (raw) {
       try {
@@ -377,7 +395,7 @@ function writeStepUpAttempts(
       }
     }
     map[issuerBucket(issuer)] = attempts;
-    localStorage.setItem(stepUpAttemptsKey(serverName), JSON.stringify(map));
+    store.setItem(stepUpAttemptsKey(serverName), JSON.stringify(map));
   } catch {
     // Best-effort: a full/unavailable store must not abort the OAuth flow. The
     // upstream transport still bounds retries within a single request; only the
@@ -391,6 +409,13 @@ export interface InsufficientScopeStepUpInput {
   issuer: string | undefined;
   /** Scopes named by the `403` `WWW-Authenticate` challenge's `scope` param. */
   challengedScopes: string[] | undefined;
+  /**
+   * The scopes the server's ORIGINAL OAuth flow requested (from the stored
+   * profile/config). Included in the union so the FIRST runtime step-up — when
+   * nothing has been persisted yet — does not drop the scopes the existing
+   * grant already held and re-request only the challenged subset.
+   */
+  originalScopes?: string[];
   /** Where the step-up is handled — drives the §10.5 policy split. */
   authMode: StepUpAuthMode;
   /** Max cross-request re-authorizations before giving up (default 1). */
@@ -420,11 +445,17 @@ export interface InsufficientScopeStepUpDecision {
 export function resolveInsufficientScopeStepUp(
   input: InsufficientScopeStepUpInput,
 ): InsufficientScopeStepUpDecision {
-  const { serverName, issuer, challengedScopes, authMode } = input;
+  const { serverName, issuer, challengedScopes, originalScopes, authMode } =
+    input;
   const maxRetries = input.maxRetries ?? DEFAULT_STEP_UP_MAX_RETRIES;
   const attempt = readStepUpAttempts(serverName, issuer);
   const action = resolveStepUpAction({ authMode, attempt, maxRetries });
-  const scopes = stepUpScopeUnion(serverName, issuer, challengedScopes);
+  const scopes = stepUpScopeUnion(
+    serverName,
+    issuer,
+    challengedScopes,
+    originalScopes,
+  );
 
   if (action === "reauthorize") {
     // Persist the widened set as the newly-requested scopes for this issuer so
@@ -447,18 +478,139 @@ export function resetInsufficientScopeStepUp(
   issuer: string | undefined,
 ): void {
   try {
-    if (typeof localStorage === "undefined") return;
-    const raw = localStorage.getItem(stepUpAttemptsKey(serverName));
+    const store = stepUpAttemptsStore();
+    if (!store) return;
+    const raw = store.getItem(stepUpAttemptsKey(serverName));
     if (!raw) return;
     const parsed = JSON.parse(raw) as Record<string, number>;
     if (!parsed || typeof parsed !== "object") return;
     delete parsed[issuerBucket(issuer)];
     if (Object.keys(parsed).length === 0) {
-      localStorage.removeItem(stepUpAttemptsKey(serverName));
+      store.removeItem(stepUpAttemptsKey(serverName));
     } else {
-      localStorage.setItem(stepUpAttemptsKey(serverName), JSON.stringify(parsed));
+      store.setItem(stepUpAttemptsKey(serverName), JSON.stringify(parsed));
     }
   } catch {
     // Best-effort reset.
   }
+}
+
+// ===========================================================================
+// Tool-call step-up wiring (local, non-hosted surface)
+// ===========================================================================
+//
+// The composition a live tool-call surface uses when `executeToolApi` surfaces
+// an `insufficientScope` challenge: resolve the server's issuer + originally-
+// requested scopes, run the bounded {@link resolveInsufficientScopeStepUp}
+// decision, and — on `reauthorize` — drive the fresh union-scope OAuth flow via
+// {@link ensureAuthorizedForReconnect}. This is what makes the step-up CORE
+// reachable end-to-end from a real MCP tool call on the local path.
+
+function readServerUrlForStepUp(server: ServerWithName): string | undefined {
+  const fromConfig = (server.config as any)?.url?.toString?.();
+  if (fromConfig) return fromConfig;
+  try {
+    return (
+      localStorage.getItem(`mcp-serverUrl-${server.name}`) ?? undefined
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+function readOriginalOAuthScopes(
+  server: ServerWithName,
+): string[] | undefined {
+  // Mirror buildReconnectOAuthOptions' scope precedence: the flow profile's
+  // scopes, else the stored OAuth config's scopes. These are the scopes the
+  // ORIGINAL grant requested — the base the step-up union must not drop.
+  const profileScopes = parseOAuthScopes(server.oauthFlowProfile?.scopes);
+  if (profileScopes) return profileScopes;
+  return readStoredOAuthConfig(server.name).scopes;
+}
+
+/** The `WWW-Authenticate` challenge fields a failed tool call surfaces. */
+export interface ToolCallStepUpChallenge {
+  requiredScope?: string;
+  resourceMetadataUrl?: string;
+}
+
+export interface ToolCallStepUpOutcome {
+  /** `reauthorize` (a fresh flow ran), `throw`, or `manual`. */
+  action: StepUpAction;
+  /** The union scope set the decision produced (for display / the fresh flow). */
+  scopes: string[];
+  /** Re-authorizations already performed this session before this decision. */
+  attempt: number;
+  /**
+   * The OAuth outcome when `action === "reauthorize"` (typically a `redirect`,
+   * which navigates away). Undefined for `throw` / `manual`.
+   */
+  reauthorization?: OAuthResult;
+}
+
+/**
+ * Handle a runtime `403 insufficient_scope` on a live tool call: decide (bounded
+ * per session, §10.5 policy split) and, on `reauthorize`, run the union-scope
+ * re-authorization. The caller supplies the server and the parsed challenge; the
+ * issuer and originally-requested scopes are resolved from stored state here.
+ */
+export async function applyToolCallStepUp(
+  server: ServerWithName,
+  challenge: ToolCallStepUpChallenge,
+  options?: {
+    /** Defaults to `interactive` — the local tool runner drives a browser flow. */
+    authMode?: StepUpAuthMode;
+    maxRetries?: number;
+    onTraceUpdate?: (trace: OAuthTrace) => void;
+    beforeRedirect?: (oauthOptions: MCPOAuthOptions) => void;
+  },
+): Promise<ToolCallStepUpOutcome> {
+  const issuer = resolveStoredIssuer(server.name, readServerUrlForStepUp(server));
+  const challengedScopes = parseOAuthScopes(challenge.requiredScope);
+
+  const decision = resolveInsufficientScopeStepUp({
+    serverName: server.name,
+    issuer,
+    challengedScopes,
+    originalScopes: readOriginalOAuthScopes(server),
+    authMode: options?.authMode ?? "interactive",
+    maxRetries: options?.maxRetries,
+  });
+
+  if (decision.action !== "reauthorize") {
+    return {
+      action: decision.action,
+      scopes: decision.scopes,
+      attempt: decision.attempt,
+    };
+  }
+
+  const reauthorization = await ensureAuthorizedForReconnect(server, {
+    allowInteractiveOAuthFlow: true,
+    // A resolved `reauthorize` IS the confirmed escalation — without this an
+    // auto server's tokenless guard would short-circuit to
+    // ready-unauthenticated instead of redirecting for the widened scopes.
+    interactiveOAuthConfirmed: true,
+    stepUpScopes: decision.scopes,
+    onTraceUpdate: options?.onTraceUpdate,
+    beforeRedirect: options?.beforeRedirect,
+  });
+
+  return {
+    action: decision.action,
+    scopes: decision.scopes,
+    attempt: decision.attempt,
+    reauthorization,
+  };
+}
+
+/**
+ * Clear the step-up counter after a SUCCESSFUL tool call (resolves the server's
+ * issuer, then {@link resetInsufficientScopeStepUp}). Call this on a completed
+ * result so a later legitimate step-up starts from zero.
+ */
+export function resetToolCallStepUp(server: ServerWithName): void {
+  const issuer = resolveStoredIssuer(server.name, readServerUrlForStepUp(server));
+  resetInsufficientScopeStepUp(server.name, issuer);
 }

--- a/mcpjam-inspector/client/src/state/oauth-orchestrator.ts
+++ b/mcpjam-inspector/client/src/state/oauth-orchestrator.ts
@@ -597,6 +597,17 @@ export async function applyToolCallStepUp(
     beforeRedirect: options?.beforeRedirect,
   });
 
+  // The resolver already bumped the per-session counter (it must persist BEFORE
+  // the redirect so the bound survives the round-trip). But that path also
+  // clears stored OAuth data and can fail transiently (e.g. an OAuth-init
+  // error), returning a non-`redirect` outcome WITHOUT navigating away. A
+  // consumed-but-not-initiated attempt would block retrying the tool in the
+  // same session, so roll the counter back to its pre-decision value unless a
+  // genuine re-authorization was actually initiated (a `redirect`).
+  if (reauthorization.kind !== "redirect") {
+    writeStepUpAttempts(server.name, issuer, decision.attempt);
+  }
+
   return {
     action: decision.action,
     scopes: decision.scopes,

--- a/mcpjam-inspector/client/src/state/oauth-orchestrator.ts
+++ b/mcpjam-inspector/client/src/state/oauth-orchestrator.ts
@@ -7,6 +7,15 @@ import {
 import { normalizeRegistrationMode } from "@/shared/xaa.js";
 import { ServerWithName } from "./app-types";
 import type { OAuthTrace } from "@/lib/oauth/oauth-trace";
+import {
+  resolveStepUpAction,
+  type StepUpAction,
+  type StepUpAuthMode,
+} from "@mcpjam/sdk/browser";
+import {
+  persistRequestedScopes,
+  stepUpScopeUnion,
+} from "@/lib/oauth/requested-scopes";
 
 export type OAuthReady = {
   kind: "ready";
@@ -129,6 +138,14 @@ function profileHeadersToRecord(
 function buildReconnectOAuthOptions(
   server: ServerWithName,
   serverUrl: string,
+  /**
+   * SEP-2350 step-up: the union of previously-requested and challenged scopes.
+   * When present it WINS over the profile/config scopes so the re-authorization
+   * requests the widened set the `403 insufficient_scope` challenge named —
+   * otherwise the fresh flow would re-request the old (insufficient) scopes and
+   * loop. Only used when a caller drives a scope step-up.
+   */
+  stepUpScopes?: string[],
 ): MCPOAuthOptions {
   const oauthConfig = readStoredOAuthConfig(server.name);
   const storedClientInfo = readStoredClientInfo(server.name);
@@ -146,11 +163,15 @@ function buildReconnectOAuthOptions(
     oauthConfig.registrationMode ??
     "auto";
   const profileScopes = parseOAuthScopes(profile?.scopes);
+  const effectiveScopes =
+    stepUpScopes && stepUpScopes.length > 0
+      ? stepUpScopes
+      : profileScopes ?? oauthConfig.scopes;
 
   return {
     serverName: server.name,
     serverUrl,
-    scopes: profileScopes ?? oauthConfig.scopes,
+    scopes: effectiveScopes,
     resourceUrl: nonEmptyString(profile?.resourceUrl) ?? oauthConfig.resourceUrl,
     customHeaders:
       profileHeadersToRecord(profile?.customHeaders) ??
@@ -190,6 +211,14 @@ export async function ensureAuthorizedForReconnect(
      * redirect the user didn't ask for.
      */
     interactiveOAuthConfirmed?: boolean;
+    /**
+     * SEP-2350 step-up scope union. When set, the fresh OAuth flow requests
+     * these scopes (the union of previously-requested and `403
+     * insufficient_scope`-challenged scopes) instead of the stored profile
+     * scopes. Set by the step-up re-authorization path
+     * ({@link resolveInsufficientScopeStepUp}).
+     */
+    stepUpScopes?: string[];
   },
 ): Promise<OAuthResult> {
   // If server is explicitly configured without OAuth, skip OAuth flow entirely
@@ -238,7 +267,7 @@ export async function ensureAuthorizedForReconnect(
   // Fallback to a fresh OAuth flow if URL is present
   // This may redirect away; the hook should reflect oauth-flow state
   if (url) {
-    const opts = buildReconnectOAuthOptions(server, url);
+    const opts = buildReconnectOAuthOptions(server, url, options?.stepUpScopes);
     clearOAuthData(server.name);
     options?.beforeRedirect?.(opts);
     opts.onTraceUpdate = options?.onTraceUpdate;
@@ -265,4 +294,171 @@ export async function ensureAuthorizedForReconnect(
     kind: "error",
     error: "OAuth authorization required and no URL present",
   };
+}
+
+// ===========================================================================
+// SEP-2350 runtime scope step-up orchestration
+// ===========================================================================
+//
+// The step-up CORE (scope union, challenge parse, §10.5 policy split) lives in
+// `@mcpjam/sdk/browser`. This is the client-side ORCHESTRATION that composes
+// those helpers into a bounded, redirect-surviving re-authorization decision
+// for a runtime `403 insufficient_scope` on a live MCP request (post-connect):
+//
+//   1. read how many step-up re-authorizations this session already ran for
+//      the server's authorization-server issuer (a PERSISTED counter, so it
+//      survives the OAuth browser redirect that re-authorization triggers —
+//      the SDK transport's per-request retry cap cannot bound a cross-request
+//      loop across a full redirect round-trip, §10.5#5);
+//   2. apply the §10.5 policy split (`resolveStepUpAction`): interactive
+//      re-authorizes while under the cap then throws; m2m always throws;
+//      debugger returns `manual` (the debugger advances explicitly — no
+//      auto-browser);
+//   3. on `reauthorize`, union the previously-requested and challenged scopes,
+//      persist the widened set, bump the counter, and return the union for the
+//      caller to feed into {@link ensureAuthorizedForReconnect} via
+//      `stepUpScopes` — so the fresh flow requests the widened scopes.
+//
+// A caller wires it as: on a tool call whose error carries an
+// `insufficientScope` challenge, call `resolveInsufficientScopeStepUp`; if the
+// action is `reauthorize`, run `ensureAuthorizedForReconnect(server, {
+// stepUpScopes })`; on a later SUCCESSFUL call, `resetInsufficientScopeStepUp`
+// to clear the counter so a future legitimate step-up starts fresh.
+
+const STEP_UP_ATTEMPTS_PREFIX = "mcp-stepup-attempts-";
+const DEFAULT_STEP_UP_MAX_RETRIES = 1;
+
+function stepUpAttemptsKey(serverName: string): string {
+  return `${STEP_UP_ATTEMPTS_PREFIX}${serverName}`;
+}
+
+// Key attempts by issuer so an AS switch (or a step-up before issuer
+// discovery) never reuses another AS's count. An unknown issuer buckets under
+// "" — its own isolated bucket.
+function issuerBucket(issuer: string | undefined): string {
+  return issuer ?? "";
+}
+
+function readStepUpAttempts(
+  serverName: string,
+  issuer: string | undefined,
+): number {
+  try {
+    if (typeof localStorage === "undefined") return 0;
+    const raw = localStorage.getItem(stepUpAttemptsKey(serverName));
+    if (!raw) return 0;
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const value = parsed?.[issuerBucket(issuer)];
+    return typeof value === "number" && Number.isInteger(value) && value >= 0
+      ? value
+      : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function writeStepUpAttempts(
+  serverName: string,
+  issuer: string | undefined,
+  attempts: number,
+): void {
+  try {
+    if (typeof localStorage === "undefined") return;
+    const raw = localStorage.getItem(stepUpAttemptsKey(serverName));
+    let map: Record<string, number> = {};
+    if (raw) {
+      try {
+        const parsed = JSON.parse(raw);
+        if (parsed && typeof parsed === "object") {
+          map = parsed as Record<string, number>;
+        }
+      } catch {
+        // Corrupt record — start fresh rather than aborting the step-up.
+      }
+    }
+    map[issuerBucket(issuer)] = attempts;
+    localStorage.setItem(stepUpAttemptsKey(serverName), JSON.stringify(map));
+  } catch {
+    // Best-effort: a full/unavailable store must not abort the OAuth flow. The
+    // upstream transport still bounds retries within a single request; only the
+    // cross-redirect count is lost, so the guard degrades, never disappears.
+  }
+}
+
+export interface InsufficientScopeStepUpInput {
+  serverName: string;
+  /** The server's authorization-server issuer, if known. */
+  issuer: string | undefined;
+  /** Scopes named by the `403` `WWW-Authenticate` challenge's `scope` param. */
+  challengedScopes: string[] | undefined;
+  /** Where the step-up is handled — drives the §10.5 policy split. */
+  authMode: StepUpAuthMode;
+  /** Max cross-request re-authorizations before giving up (default 1). */
+  maxRetries?: number;
+}
+
+export interface InsufficientScopeStepUpDecision {
+  /** `reauthorize` (run a fresh flow with `scopes`), `throw`, or `manual`. */
+  action: StepUpAction;
+  /**
+   * The scope union — previously-requested ∪ challenged. Pass into
+   * {@link ensureAuthorizedForReconnect}'s `stepUpScopes` on `reauthorize`;
+   * for `throw`/`manual` it is the set the caller would display/request.
+   */
+  scopes: string[];
+  /** Re-authorizations already performed this session before this decision. */
+  attempt: number;
+}
+
+/**
+ * Decide what a runtime `403 insufficient_scope` challenge should do, and (on
+ * `reauthorize`) persist the widened scope set + bump the bounded per-session
+ * counter. Pure w.r.t. the network — the caller performs the actual
+ * re-authorization via {@link ensureAuthorizedForReconnect}. Reads/writes the
+ * persisted counter so the bound holds across the redirect round-trip.
+ */
+export function resolveInsufficientScopeStepUp(
+  input: InsufficientScopeStepUpInput,
+): InsufficientScopeStepUpDecision {
+  const { serverName, issuer, challengedScopes, authMode } = input;
+  const maxRetries = input.maxRetries ?? DEFAULT_STEP_UP_MAX_RETRIES;
+  const attempt = readStepUpAttempts(serverName, issuer);
+  const action = resolveStepUpAction({ authMode, attempt, maxRetries });
+  const scopes = stepUpScopeUnion(serverName, issuer, challengedScopes);
+
+  if (action === "reauthorize") {
+    // Persist the widened set as the newly-requested scopes for this issuer so
+    // a subsequent step-up unions from the widened base, and record the
+    // attempt so the next cross-request challenge is bounded.
+    persistRequestedScopes(serverName, issuer, scopes);
+    writeStepUpAttempts(serverName, issuer, attempt + 1);
+  }
+
+  return { action, scopes, attempt };
+}
+
+/**
+ * Clear the per-session step-up counter for a server's issuer. Call after a
+ * SUCCESSFUL request so a future legitimate scope step-up starts from zero
+ * rather than inheriting a stale count that would prematurely throw.
+ */
+export function resetInsufficientScopeStepUp(
+  serverName: string,
+  issuer: string | undefined,
+): void {
+  try {
+    if (typeof localStorage === "undefined") return;
+    const raw = localStorage.getItem(stepUpAttemptsKey(serverName));
+    if (!raw) return;
+    const parsed = JSON.parse(raw) as Record<string, number>;
+    if (!parsed || typeof parsed !== "object") return;
+    delete parsed[issuerBucket(issuer)];
+    if (Object.keys(parsed).length === 0) {
+      localStorage.removeItem(stepUpAttemptsKey(serverName));
+    } else {
+      localStorage.setItem(stepUpAttemptsKey(serverName), JSON.stringify(parsed));
+    }
+  } catch {
+    // Best-effort reset.
+  }
 }

--- a/mcpjam-inspector/server/routes/mcp/__tests__/tools.serialize-error.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/tools.serialize-error.test.ts
@@ -48,6 +48,24 @@ describe("extractInsufficientScopeChallenge (SEP-2350)", () => {
     err.cause = err;
     expect(extractInsufficientScopeChallenge(err)).toBeUndefined();
   });
+
+  it("does NOT treat an unrelated error carrying a requiredScope field as a challenge", () => {
+    // A non-InsufficientScope error that happens to expose a `requiredScope`
+    // string must not be duck-typed into an OAuth step-up challenge — that
+    // would trigger a spurious client re-authorization.
+    const err = new Error("some tool needs a scope") as any;
+    err.requiredScope = "read:everything";
+    err.resourceMetadataUrl = "https://rs.example/.well-known";
+    expect(extractInsufficientScopeChallenge(err)).toBeUndefined();
+  });
+
+  it("does not treat a wrapped non-InsufficientScope requiredScope-bearer as a challenge", () => {
+    const inner = new Error("nested") as any;
+    inner.requiredScope = "admin";
+    const outer = new Error("outer");
+    (outer as any).cause = inner;
+    expect(extractInsufficientScopeChallenge(outer)).toBeUndefined();
+  });
 });
 
 describe("serializeMcpError", () => {

--- a/mcpjam-inspector/server/routes/mcp/__tests__/tools.serialize-error.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/tools.serialize-error.test.ts
@@ -2,8 +2,23 @@ import { describe, it, expect } from "vitest";
 import { InsufficientScopeError } from "@modelcontextprotocol/client";
 import {
   extractInsufficientScopeChallenge,
+  jsonError,
   serializeMcpError,
 } from "../tools.js";
+
+/** A minimal Hono-`c`-like stub that captures the `c.json(body, status)` call. */
+function captureJson() {
+  const calls: Array<{ body: unknown; status?: number }> = [];
+  return {
+    c: {
+      json: (body: unknown, status?: number) => {
+        calls.push({ body, status });
+        return { body, status };
+      },
+    },
+    calls,
+  };
+}
 
 describe("extractInsufficientScopeChallenge (SEP-2350)", () => {
   it("extracts the challenge from a top-level InsufficientScopeError", () => {
@@ -90,5 +105,43 @@ describe("serializeMcpError", () => {
     >;
     expect(serialized.insufficientScope).toBeUndefined();
     expect(serialized.message).toBe("nope");
+  });
+});
+
+describe("jsonError (SEP-2350 challenge status)", () => {
+  it("returns HTTP 403 for an insufficient_scope challenge that carries no status", () => {
+    // `InsufficientScopeError` has no numeric `status`, so without the challenge
+    // override it would serialize with the generic 500 fallback.
+    const err = new InsufficientScopeError({ requiredScope: "read write" });
+    expect((err as any).status).toBeUndefined();
+
+    const { c, calls } = captureJson();
+    jsonError(c, err, 500);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].status).toBe(403);
+    const body = calls[0].body as Record<string, any>;
+    expect(body.mcpError.insufficientScope).toEqual({
+      requiredScope: "read write",
+      resourceMetadataUrl: undefined,
+      errorDescription: undefined,
+    });
+  });
+
+  it("honors an explicit numeric status even when a challenge is present", () => {
+    const err = new InsufficientScopeError({ requiredScope: "admin" });
+    (err as any).status = 401;
+
+    const { c, calls } = captureJson();
+    jsonError(c, err, 500);
+
+    expect(calls[0].status).toBe(401);
+  });
+
+  it("falls back to the provided status for an ordinary error", () => {
+    const { c, calls } = captureJson();
+    jsonError(c, new Error("boom"), 500);
+
+    expect(calls[0].status).toBe(500);
   });
 });

--- a/mcpjam-inspector/server/routes/mcp/__tests__/tools.serialize-error.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/tools.serialize-error.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { InsufficientScopeError } from "@modelcontextprotocol/client";
+import {
+  extractInsufficientScopeChallenge,
+  serializeMcpError,
+} from "../tools.js";
+
+describe("extractInsufficientScopeChallenge (SEP-2350)", () => {
+  it("extracts the challenge from a top-level InsufficientScopeError", () => {
+    const err = new InsufficientScopeError({
+      requiredScope: "read write admin",
+      resourceMetadataUrl: "https://rs.example/.well-known/oauth-protected-resource",
+      errorDescription: "additional scope required",
+    });
+    expect(extractInsufficientScopeChallenge(err)).toEqual({
+      requiredScope: "read write admin",
+      resourceMetadataUrl:
+        "https://rs.example/.well-known/oauth-protected-resource",
+      errorDescription: "additional scope required",
+    });
+  });
+
+  it("walks the cause chain to find a wrapped InsufficientScopeError", () => {
+    const inner = new InsufficientScopeError({ requiredScope: "read:tickets" });
+    const outer = new Error("tool call failed");
+    (outer as any).cause = inner;
+    expect(extractInsufficientScopeChallenge(outer)).toEqual({
+      requiredScope: "read:tickets",
+      resourceMetadataUrl: undefined,
+      errorDescription: undefined,
+    });
+  });
+
+  it("returns undefined for a plain error (no challenge)", () => {
+    expect(
+      extractInsufficientScopeChallenge(new Error("boom")),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when a name match carries no challenge fields", () => {
+    const err = new Error("insufficient scope");
+    err.name = "InsufficientScopeError";
+    expect(extractInsufficientScopeChallenge(err)).toBeUndefined();
+  });
+
+  it("tolerates a self-referential cause chain", () => {
+    const err = new Error("loop") as any;
+    err.cause = err;
+    expect(extractInsufficientScopeChallenge(err)).toBeUndefined();
+  });
+});
+
+describe("serializeMcpError", () => {
+  it("attaches insufficientScope for a 403 insufficient_scope error", () => {
+    const err = new InsufficientScopeError({
+      requiredScope: "read write",
+      resourceMetadataUrl: "https://rs.example/.well-known",
+    });
+    const serialized = serializeMcpError(err) as Record<string, unknown>;
+    expect(serialized.insufficientScope).toEqual({
+      requiredScope: "read write",
+      resourceMetadataUrl: "https://rs.example/.well-known",
+      errorDescription: undefined,
+    });
+    expect(serialized.name).toBe("InsufficientScopeError");
+  });
+
+  it("omits insufficientScope for an ordinary error", () => {
+    const serialized = serializeMcpError(new Error("nope")) as Record<
+      string,
+      unknown
+    >;
+    expect(serialized.insufficientScope).toBeUndefined();
+    expect(serialized.message).toBe("nope");
+  });
+});

--- a/mcpjam-inspector/server/routes/mcp/tools.ts
+++ b/mcpjam-inspector/server/routes/mcp/tools.ts
@@ -103,11 +103,14 @@ export type InsufficientScopeChallenge = {
  * A runtime `403 insufficient_scope` from a live MCP request surfaces here as
  * this transport-layer error (the SDK constructs the transport with
  * `onInsufficientScope: "throw"`, so it never attempts a doomed server-side
- * interactive re-authorization). Detection is by `.name` /
- * `constructor.mcpBrand` — the class does not extend `OAuthError`, and its
- * fields (`requiredScope`, `resourceMetadataUrl`) originate from the resource
- * server's header, so treat them as untrusted when rendering. Returning the
- * challenge lets the client drive the union-scope step-up re-authorization.
+ * interactive re-authorization). Detection is strictly by
+ * `constructor.mcpBrand` / `.name` — an actual `InsufficientScopeError`, never
+ * a duck-typed `requiredScope` field (an unrelated error carrying that field
+ * must not masquerade as a step-up challenge). The class does not extend
+ * `OAuthError`, and its fields (`requiredScope`, `resourceMetadataUrl`)
+ * originate from the resource server's header, so treat them as untrusted when
+ * rendering. Returning the challenge lets the client drive the union-scope
+ * step-up re-authorization.
  */
 export function extractInsufficientScopeChallenge(
   error: unknown,
@@ -116,10 +119,14 @@ export function extractInsufficientScopeChallenge(
   let current: any = error;
   while (current && typeof current === "object" && !seen.has(current)) {
     seen.add(current);
+    // Recognize ONLY an actual `InsufficientScopeError` — by its class brand
+    // (`mcpBrand`, survives minification/cross-realm) or `.name`. Do NOT
+    // duck-type on a `requiredScope` string: an unrelated error that happens
+    // to carry a `requiredScope` field must not be serialized to the client as
+    // an OAuth step-up challenge (it would trigger a spurious re-authorization).
     const isInsufficientScope =
-      current.name === "InsufficientScopeError" ||
       current.constructor?.mcpBrand === "mcp.InsufficientScopeError" ||
-      typeof current.requiredScope === "string";
+      current.name === "InsufficientScopeError";
     if (isInsufficientScope) {
       const requiredScope =
         typeof current.requiredScope === "string"

--- a/mcpjam-inspector/server/routes/mcp/tools.ts
+++ b/mcpjam-inspector/server/routes/mcp/tools.ts
@@ -89,7 +89,62 @@ function getExecutionDurationMs(context: ExecutionContext): number {
   return Math.max(0, Date.now() - context.startedAtMs);
 }
 
-function serializeMcpError(error: unknown) {
+/** The `WWW-Authenticate` step-up challenge fields surfaced to the client. */
+export type InsufficientScopeChallenge = {
+  requiredScope?: string;
+  resourceMetadataUrl?: string;
+  errorDescription?: string;
+};
+
+/**
+ * Recognize an upstream `InsufficientScopeError` (SEP-2350) anywhere in the
+ * error / cause chain and return its `WWW-Authenticate` challenge fields.
+ *
+ * A runtime `403 insufficient_scope` from a live MCP request surfaces here as
+ * this transport-layer error (the SDK constructs the transport with
+ * `onInsufficientScope: "throw"`, so it never attempts a doomed server-side
+ * interactive re-authorization). Detection is by `.name` /
+ * `constructor.mcpBrand` — the class does not extend `OAuthError`, and its
+ * fields (`requiredScope`, `resourceMetadataUrl`) originate from the resource
+ * server's header, so treat them as untrusted when rendering. Returning the
+ * challenge lets the client drive the union-scope step-up re-authorization.
+ */
+export function extractInsufficientScopeChallenge(
+  error: unknown,
+): InsufficientScopeChallenge | undefined {
+  const seen = new Set<unknown>();
+  let current: any = error;
+  while (current && typeof current === "object" && !seen.has(current)) {
+    seen.add(current);
+    const isInsufficientScope =
+      current.name === "InsufficientScopeError" ||
+      current.constructor?.mcpBrand === "mcp.InsufficientScopeError" ||
+      typeof current.requiredScope === "string";
+    if (isInsufficientScope) {
+      const requiredScope =
+        typeof current.requiredScope === "string"
+          ? current.requiredScope
+          : undefined;
+      const resourceMetadataUrl =
+        typeof current.resourceMetadataUrl === "string"
+          ? current.resourceMetadataUrl
+          : undefined;
+      const errorDescription =
+        typeof current.errorDescription === "string"
+          ? current.errorDescription
+          : undefined;
+      // Only surface when at least one challenge field is present — a bare
+      // name match with no fields carries nothing actionable.
+      if (requiredScope || resourceMetadataUrl || errorDescription) {
+        return { requiredScope, resourceMetadataUrl, errorDescription };
+      }
+    }
+    current = current.cause;
+  }
+  return undefined;
+}
+
+export function serializeMcpError(error: unknown) {
   const anyErr = error as any;
   const base = {
     name: anyErr?.name ?? "Error",
@@ -105,6 +160,10 @@ function serializeMcpError(error: unknown) {
       code: (cause as any)?.code,
       data: (cause as any)?.data,
     };
+  }
+  const insufficientScope = extractInsufficientScopeChallenge(error);
+  if (insufficientScope) {
+    base.insufficientScope = insufficientScope;
   }
   if (process.env.NODE_ENV === "development" && anyErr?.stack) {
     base.stack = anyErr.stack;

--- a/mcpjam-inspector/server/routes/mcp/tools.ts
+++ b/mcpjam-inspector/server/routes/mcp/tools.ts
@@ -178,12 +178,19 @@ export function serializeMcpError(error: unknown) {
   return base;
 }
 
-function jsonError(c: any, error: unknown, fallbackStatus = 500) {
+export function jsonError(c: any, error: unknown, fallbackStatus = 500) {
   const details = serializeMcpError(error);
-  const status =
+  const explicitStatus =
     typeof (error as any)?.status === "number"
       ? (error as any).status
-      : fallbackStatus;
+      : undefined;
+  // SEP-2350: an `InsufficientScopeError` from `onInsufficientScope: "throw"`
+  // carries no numeric `status`, so without this the challenge would serialize
+  // with the generic 500 fallback. A scope step-up challenge MUST come back as
+  // HTTP 403 so the client recognizes it and drives the bounded re-auth. Honor
+  // an explicit numeric status if the error already carried one.
+  const status =
+    explicitStatus ?? (details.insufficientScope ? 403 : fallbackStatus);
   const normalized = describeError(error);
   return c.json(
     { error: details.message as string, mcpError: details, normalized },

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -1485,6 +1485,22 @@ export class MCPClientManager {
         reconnectionOptions: config.reconnectionOptions,
         authProvider: effectiveAuthProvider,
         sessionId: config.sessionId,
+        // SEP-2350 step-up. MCPJam drives interactive re-authorization on the
+        // CLIENT (a browser redirect through `initiateOAuth` /
+        // `ensureAuthorizedForReconnect`), not inside this transport. This
+        // transport runs server-side over a bearer `accessToken` or a
+        // `RefreshTokenOAuthProvider` — neither can complete an interactive
+        // step-up here. Under the upstream default (`"reauthorize"`) a 403
+        // `insufficient_scope` against a refresh-token server would run
+        // `auth(..., forceReauthorization: true)`, hit
+        // `RefreshTokenOAuthProvider.redirectToAuthorization()` and throw a
+        // bare "Non-interactive OAuth flow" — losing the challenge scopes.
+        // `"throw"` makes the transport surface a clean
+        // `InsufficientScopeError` (carrying `requiredScope` /
+        // `resourceMetadataUrl`) that the host serializes to the client, which
+        // owns the union-scope re-authorization and the bounded per-session
+        // retry (§10.5#5). Cross-request loop bounding is host responsibility.
+        onInsufficientScope: "throw",
       });
 
       try {

--- a/sdk/tests/mcp-client-manager.step-up.test.ts
+++ b/sdk/tests/mcp-client-manager.step-up.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Capture the options every StreamableHTTPClientTransport is constructed with,
+// while delegating to the real upstream class so connect still behaves.
+const capturedStreamableOpts: Array<Record<string, unknown>> = [];
+
+vi.mock("@modelcontextprotocol/client", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@modelcontextprotocol/client")>();
+  class SpyStreamableHTTPClientTransport extends actual.StreamableHTTPClientTransport {
+    constructor(url: URL, opts?: Record<string, unknown>) {
+      super(url, opts as never);
+      capturedStreamableOpts.push({ ...(opts ?? {}) });
+    }
+  }
+  return {
+    ...actual,
+    StreamableHTTPClientTransport: SpyStreamableHTTPClientTransport,
+  };
+});
+
+// Import AFTER the mock is registered so the manager binds the spy subclass.
+const { MCPClientManager } = await import("../src/mcp-client-manager");
+
+describe("MCPClientManager step-up transport wiring (SEP-2350)", () => {
+  beforeEach(() => {
+    capturedStreamableOpts.length = 0;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('constructs the Streamable HTTP transport with onInsufficientScope: "throw"', async () => {
+    const manager = new MCPClientManager();
+    // Unreachable URL — connect fails, but the transport is CONSTRUCTED first,
+    // so its options are captured regardless of the connect outcome.
+    await manager
+      .connectToServer("step-up-server", {
+        url: "http://127.0.0.1:1/mcp",
+      })
+      .catch(() => {});
+
+    expect(capturedStreamableOpts.length).toBeGreaterThan(0);
+    // Every Streamable HTTP transport this manager builds must gate step-up to
+    // "throw" — MCPJam drives interactive re-authorization on the client, so
+    // the server-side transport must surface a clean InsufficientScopeError
+    // (never attempt a doomed interactive reauthorize).
+    for (const opts of capturedStreamableOpts) {
+      expect(opts.onInsufficientScope).toBe("throw");
+    }
+  });
+});


### PR DESCRIPTION
## What

Wires the SEP-2350 §10.5 **runtime scope step-up** from the server-side transport to the client, and reaches it **end-to-end on the local (non-hosted) tool-call surface**. #3378 shipped the step-up *core* (scope union, challenge parse, policy split) but nothing surfaced a runtime `403 insufficient_scope` from a live (post-connect) MCP request to it. This connects that path.

## Why the premise's blocker was stale

The task named `managed-mcp-client.ts:193` (`NotYetSupportedInStateless` for 403 upscoping) as the blocker. That hand-rolled stateless preview client was **removed in Phase 1C** — both eras now go through the upstream `@modelcontextprotocol/client` transport, which *already* implements the step-up loop (`_stepUpAuthorize`, `onInsufficientScope`, `maxStepUpRetries`). The real gap is architectural: the transport runs **server-side** over a bearer token / `RefreshTokenOAuthProvider`, so it can never complete an *interactive* re-authorization — that is client-side and redirect-based in MCPJam.

## Bug found + fixed

`RefreshTokenOAuthProvider` satisfies upstream `isOAuthClientProvider` (has `tokens()`+`clientInformation()`). Under the transport default `onInsufficientScope: "reauthorize"`, a 403 `insufficient_scope` against a refresh-token server ran `auth(..., forceReauthorization: true)` → `RefreshTokenOAuthProvider.redirectToAuthorization()` → threw a bare **"Non-interactive OAuth flow"**, discarding the challenge scopes.

## Changes

- **SDK** (`MCPClientManager`): construct the Streamable HTTP transport with `onInsufficientScope: "throw"`, so it surfaces a clean `InsufficientScopeError` (carrying `requiredScope` / `resourceMetadataUrl`) for the client to drive step-up.
- **server** (`/tools/execute`): `serializeMcpError` attaches the `WWW-Authenticate` challenge from an `InsufficientScopeError` found anywhere in the cause chain onto `mcpError.insufficientScope`.
- **client** (`mcp-tools-api`): `executeToolApi` surfaces a narrowed `insufficientScope` on the tool-error response (untrusted resource-server input, strictly narrowed).
- **client** (`oauth-orchestrator`): `resolveInsufficientScopeStepUp` — a bounded, **redirect-surviving** step-up decision that unions previously-requested + challenged scopes and feeds them into `ensureAuthorizedForReconnect` via a `stepUpScopes` override. `interactive` re-authorizes under the cap then throws; `m2m` throws; `debugger` returns `manual`.
- **client** (`ToolsTab`, the local tool-call surface): now consumes the challenge end-to-end via new orchestration helpers `applyToolCallStepUp` / `resetToolCallStepUp` — on a `403 insufficient_scope` it resolves the server's issuer + originally-requested scopes, runs the bounded decision, and (on `reauthorize`) drives the union-scope re-authorization; on a successful call it clears the counter.

## Review-finding fixes (this PR)

1. **Over-broad challenge detection** (`server/routes/mcp/tools.ts`) — detection no longer duck-types on a `requiredScope` string; it recognizes **only** an actual `InsufficientScopeError` (`constructor.mcpBrand` / `.name`), so an unrelated error carrying a `requiredScope` field can't masquerade as an OAuth step-up challenge.
2. **First step-up dropped the original grant's scopes** (`requested-scopes.ts` / `oauth-orchestrator.ts`) — the union is now **original-requested ∪ persisted ∪ challenged**. `resolveInsufficientScopeStepUp` takes `originalScopes` so the first runtime step-up (nothing persisted yet) doesn't collapse to just the challenged subset.
3. **Counter never cleared on success in the live flow** — the local surface calls `resetToolCallStepUp` on a completed tool call.
4. **Retry counter was in `localStorage`** — moved to **`sessionStorage`**: it still survives the OAuth redirect within a session but no longer lets a prior session's exhausted counter block a fresh browser session's first legitimate step-up.
5. **Core had no production caller** — wired the local (non-hosted) surface so `resolveInsufficientScopeStepUp` is reachable end-to-end.

## Remaining follow-up (explicitly deferred)

- **Hosted path** (`/api/web/tools/execute` via `mapRuntimeError` / `withEphemeralConnection`) never attaches the challenge — the hosted serializer doesn't yet forward `insufficientScope` (findings at `mcp-tools-api.ts:187/189/190` and the `tools.ts` hosted path). Genuinely larger and multi-surface; not attempted here.
- **Connect-time `insufficient_scope`** discarded by the Streamable→SSE fallback (`MCPClientManager.ts:1503`). Connection-time step-up is a separate concern from tool-call step-up.
- **Post-callback auto-retry** of the original tool call after the OAuth redirect returns (this PR triggers the re-authorization; the user re-runs the tool for now).

## Tests

- SDK: transport constructed with `onInsufficientScope: "throw"`.
- server: challenge serialization + cause-chain walk + self-referential-cause guard; **new**: an unrelated error carrying `requiredScope` (top-level and wrapped) is NOT treated as a challenge.
- client: challenge narrowing; orchestration union flow, stop-after-`maxRetries`, per-issuer isolation, reset, m2m/debugger policy; **new**: original-scopes included on the first step-up, original ∪ persisted ∪ challenged de-dup, counter is per-session (`sessionStorage`, not `localStorage`), `applyToolCallStepUp` drives the resolver + union-scope reauth, `resetToolCallStepUp` clears the counter; **new** (`ToolsTab`): the local surface forwards a `403 insufficient_scope` into the resolver and resets the counter on success.

Typecheck clean (sdk + client). New + existing suites green. (`server/routes/mcp/__tests__/tools.test.ts` fails to load on a missing gitignored build artifact `HarnessPageBundle.generated.ts` — pre-existing, unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth re-authorization, scope union logic, and tool-call error handling; mistakes could cause redirect loops, dropped scopes, or spurious step-ups, though bounded retries and strict `InsufficientScopeError` detection mitigate this.
> 
> **Overview**
> **Runtime OAuth scope step-up (SEP-2350)** is wired from the server-side MCP transport through API responses into the **local Tools tab**, so a post-connect tool call that returns `403 insufficient_scope` can trigger bounded, union-scope re-authorization instead of a broken server-side retry.
> 
> The **SDK** now builds Streamable HTTP transports with `onInsufficientScope: "throw"`, surfacing `InsufficientScopeError` with challenge fields for the host to forward (avoiding refresh-token servers hitting non-interactive reauth). **Server** `/tools` error serialization attaches `mcpError.insufficientScope` from real `InsufficientScopeError` instances in the cause chain and uses **HTTP 403** when a challenge is present. **Client** `executeToolApi` / elicitation resume parse and return a narrowed `insufficientScope` payload.
> 
> New **orchestration** (`resolveInsufficientScopeStepUp`, `applyToolCallStepUp`, `resetToolCallStepUp`) unions **original grant ∪ persisted ∪ challenged** scopes, tracks retries in **`sessionStorage`** per issuer, and passes widened scopes via `stepUpScopes` into `ensureAuthorizedForReconnect`. **ToolsTab** calls step-up on insufficient-scope errors (with per-server in-flight deduping) and resets the counter on **`completed`** and **`task_created`** successes; **App** plumbs `selectedServerEntry` as `server`.
> 
> **Hosted** challenge forwarding on tool execute remains a noted follow-up; tests cover transport wiring, challenge extraction, API parsing, orchestration edge cases, and ToolsTab behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dfe4b9446b823b76a78724bfa63e0bf2df3ed97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires runtime OAuth scope step-up end to end and triggers bounded, union-scope reauth from the local ToolsTab when a tool call returns 403 insufficient_scope. Also forwards challenges on elicitation resume and tightens attempt accounting to avoid loops.

- **New Features**
  - SDK: build the HTTP transport with `onInsufficientScope: "throw"` so `@modelcontextprotocol/client` emits `InsufficientScopeError` with challenge fields.
  - Server: `/tools/execute` serializes `insufficientScope` by walking the cause chain and extracting the `WWW-Authenticate` challenge from a real `InsufficientScopeError`.
  - Client API: `executeToolApi` returns a narrowed `insufficientScope` via `parseInsufficientScopeChallenge` for local (and hosted, when forwarded) paths.
  - Orchestrator: `resolveInsufficientScopeStepUp` (from `@mcpjam/sdk/browser`) unions `original ∪ persisted ∪ challenged` scopes and feeds them into `ensureAuthorizedForReconnect` via `stepUpScopes`; per-issuer counter in `sessionStorage`. `applyToolCallStepUp`/`resetToolCallStepUp` wire the local ToolsTab to drive reauth and clear the counter on success.

- **Bug Fixes**
  - Server: force HTTP 403 when a serialized error includes an `insufficientScope` challenge (still honors an explicit status); restrict challenge detection to a real `InsufficientScopeError` (no duck-typing) and forward the challenge instead of attempting server-side interactive reauth on refresh-token flows.
  - Client: include original grant scopes in the first step-up union; bound retries per session and per issuer; dedupe in-flight step-ups per server; reset the counter after both `completed` and `task_created` success paths.
  - Orchestrator: keep the consumed attempt on `redirect` and no-op `ready`; roll back only on transient `error`/`reauth_required` so the budget advances and avoids infinite loops.
  - Client API: `respondToElicitationApi` now forwards `insufficientScope` (and `normalized`) when a resume fails with 403, mirroring `/execute`.

<sup>Written for commit 8dfe4b9446b823b76a78724bfa63e0bf2df3ed97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

