### PR TITLE
feat(plugins): MCP JSON compatibility + plugin import client (INS-1)

### DIFF
--- a/.changeset/ins-1-plugin-import-client.md
+++ b/.changeset/ins-1-plugin-import-client.md
@@ -1,0 +1,12 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Plugin import client foundations (INS-1): the JSON server-import parser now
+accepts the OpenAI `mcp_servers` wrapper and a direct server map in addition to
+the existing `mcpServers` wrapper (all three import identically), sharing the
+three-shape unwrap contract with `@mcpjam/sdk/plugin-bundle`. Adds a typed
+plugin-import client and upload helpers over the backend import endpoints, a
+zero-dependency folder-to-ZIP helper for local/Electron mode (folder and ZIP
+sources produce the same content-addressed bundle hash), and reactive import
+progress hooks. No user-facing plugin UI yet.

--- a/mcpjam-inspector/client/src/hooks/__tests__/usePluginImport.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/usePluginImport.test.ts
@@ -1,0 +1,67 @@
+import { renderHook } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { PluginImportRecord } from "@/lib/plugins/plugin-import-types";
+
+const mockUseQuery = vi.fn();
+vi.mock("convex/react", () => ({
+  useQuery: (...args: unknown[]) => mockUseQuery(...args),
+  useConvex: () => ({}),
+}));
+
+import { usePluginImport } from "../usePluginImport";
+
+function record(status: PluginImportRecord["status"]): PluginImportRecord {
+  return {
+    importId: "import_1",
+    projectId: "proj_1",
+    status,
+    createdAt: 0,
+    updatedAt: 0,
+    expiresAt: 0,
+  };
+}
+
+describe("usePluginImport", () => {
+  beforeEach(() => mockUseQuery.mockReset());
+
+  it("skips the subscription when importId is nullish", () => {
+    mockUseQuery.mockReturnValue(undefined);
+    const { result } = renderHook(() => usePluginImport(null));
+    // Second arg to useQuery must be the "skip" sentinel.
+    expect(mockUseQuery.mock.calls[0][1]).toBe("skip");
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.record).toBeUndefined();
+  });
+
+  it("reports loading while the row is undefined", () => {
+    mockUseQuery.mockReturnValue(undefined);
+    const { result } = renderHook(() => usePluginImport("import_1"));
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("derives phase flags from the row status", () => {
+    mockUseQuery.mockReturnValue(record("preview_ready"));
+    const { result } = renderHook(() => usePluginImport("import_1"));
+    expect(result.current.isPreviewReady).toBe(true);
+    expect(result.current.isTerminal).toBe(false);
+    expect(result.current.isFailed).toBe(false);
+  });
+
+  it("marks completed and failed as terminal", () => {
+    mockUseQuery.mockReturnValue(record("failed"));
+    const failed = renderHook(() => usePluginImport("import_1"));
+    expect(failed.result.current.isTerminal).toBe(true);
+    expect(failed.result.current.isFailed).toBe(true);
+
+    mockUseQuery.mockReturnValue(record("completed"));
+    const done = renderHook(() => usePluginImport("import_1"));
+    expect(done.result.current.isTerminal).toBe(true);
+  });
+
+  it("treats uploaded and inspecting as in-progress inspection", () => {
+    mockUseQuery.mockReturnValue(record("inspecting"));
+    const { result } = renderHook(() => usePluginImport("import_1"));
+    expect(result.current.isInspecting).toBe(true);
+    expect(result.current.isTerminal).toBe(false);
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/__tests__/usePluginImport.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/usePluginImport.test.ts
@@ -59,9 +59,11 @@ describe("usePluginImport", () => {
   });
 
   it("treats uploaded and inspecting as in-progress inspection", () => {
-    mockUseQuery.mockReturnValue(record("inspecting"));
-    const { result } = renderHook(() => usePluginImport("import_1"));
-    expect(result.current.isInspecting).toBe(true);
-    expect(result.current.isTerminal).toBe(false);
+    for (const status of ["uploaded", "inspecting"] as const) {
+      mockUseQuery.mockReturnValue(record(status));
+      const { result } = renderHook(() => usePluginImport("import_1"));
+      expect(result.current.isInspecting).toBe(true);
+      expect(result.current.isTerminal).toBe(false);
+    }
   });
 });

--- a/mcpjam-inspector/client/src/hooks/__tests__/usePluginImportRunner.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/usePluginImportRunner.test.ts
@@ -55,13 +55,17 @@ describe("usePluginImportRunner", () => {
     expect(result.current.phase).toBe("uploading");
 
     // The runner threads an onPhase callback into the orchestrator; driving it
-    // moves the runner into the (otherwise unobservable) inspecting phase.
+    // moves the runner into the (otherwise unobservable) inspecting phase AND
+    // must expose the staged importId so usePluginImport(importId) can subscribe
+    // to server-side progress while inspection runs (not null until done).
     const onPhase = mockStartFromZip.mock.calls[0][1].onPhase as (
       p: "uploading" | "inspecting",
+      importId?: string,
     ) => void;
     expect(typeof onPhase).toBe("function");
-    act(() => onPhase("inspecting"));
+    act(() => onPhase("inspecting", "i1"));
     expect(result.current.phase).toBe("inspecting");
+    expect(result.current.importId).toBe("i1");
 
     await act(async () => {
       d.resolve(okResult("i1"));

--- a/mcpjam-inspector/client/src/hooks/__tests__/usePluginImportRunner.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/usePluginImportRunner.test.ts
@@ -1,0 +1,121 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { StartPluginImportResult } from "@/lib/plugins/plugin-import-client";
+
+const { mockStartFromZip } = vi.hoisted(() => ({
+  mockStartFromZip: vi.fn(),
+}));
+
+vi.mock("convex/react", () => ({
+  useConvex: () => ({}),
+  useQuery: () => undefined,
+}));
+
+vi.mock("@/lib/plugins/plugin-import-client", async (importActual) => {
+  const actual =
+    await importActual<typeof import("@/lib/plugins/plugin-import-client")>();
+  return { ...actual, startPluginImportFromZip: mockStartFromZip };
+});
+
+import { usePluginImportRunner } from "../usePluginImport";
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+}
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+const okResult = (importId: string): StartPluginImportResult => ({
+  importId,
+  bundleStorageId: "st",
+  inspect: { importId, status: "preview_ready" },
+});
+
+describe("usePluginImportRunner", () => {
+  beforeEach(() => mockStartFromZip.mockReset());
+
+  it("advances uploading → inspecting → done and exposes importId", async () => {
+    const d = deferred<StartPluginImportResult>();
+    mockStartFromZip.mockReturnValue(d.promise);
+
+    const { result } = renderHook(() => usePluginImportRunner());
+    let call!: Promise<StartPluginImportResult>;
+    act(() => {
+      call = result.current.startFromZip({
+        projectId: "p",
+        bundle: new Blob([]),
+      });
+    });
+    expect(result.current.phase).toBe("uploading");
+
+    // The runner threads an onPhase callback into the orchestrator; driving it
+    // moves the runner into the (otherwise unobservable) inspecting phase.
+    const onPhase = mockStartFromZip.mock.calls[0][1].onPhase as (
+      p: "uploading" | "inspecting",
+    ) => void;
+    expect(typeof onPhase).toBe("function");
+    act(() => onPhase("inspecting"));
+    expect(result.current.phase).toBe("inspecting");
+
+    await act(async () => {
+      d.resolve(okResult("i1"));
+      await call;
+    });
+    expect(result.current.phase).toBe("done");
+    expect(result.current.importId).toBe("i1");
+  });
+
+  it("moves to the error phase (with importId) on a failed inspect", async () => {
+    // A failed inspect resolves (does not throw); the runner records the error
+    // phase AND keeps the importId so the UI can still surface the row.
+    // (The throw-path importId preservation is covered in plugin-import-client
+    // via PluginImportError.importId.)
+    mockStartFromZip.mockResolvedValue({
+      importId: "i_failed",
+      bundleStorageId: "st",
+      inspect: { importId: "i_failed", status: "failed", failureCode: "X" },
+    });
+    const { result } = renderHook(() => usePluginImportRunner());
+    await act(async () => {
+      await result.current.startFromZip({
+        projectId: "p",
+        bundle: new Blob([]),
+      });
+    });
+    expect(result.current.phase).toBe("error");
+    expect(result.current.importId).toBe("i_failed");
+    expect(result.current.error?.message).toContain("X");
+  });
+
+  it("a stale run cannot stomp a newer reset()", async () => {
+    const d = deferred<StartPluginImportResult>();
+    mockStartFromZip.mockReturnValue(d.promise);
+
+    const { result } = renderHook(() => usePluginImportRunner());
+    let call!: Promise<StartPluginImportResult>;
+    act(() => {
+      call = result.current.startFromZip({
+        projectId: "p",
+        bundle: new Blob([]),
+      });
+    });
+    // Reset while the run is still in flight, then let the stale run resolve.
+    act(() => result.current.reset());
+    expect(result.current.phase).toBe("idle");
+
+    await act(async () => {
+      d.resolve(okResult("late"));
+      await call;
+    });
+    // The late resolution must NOT revive state past the reset.
+    expect(result.current.phase).toBe("idle");
+    expect(result.current.importId).toBeNull();
+    await waitFor(() => expect(result.current.phase).toBe("idle"));
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/usePluginImport.ts
+++ b/mcpjam-inspector/client/src/hooks/usePluginImport.ts
@@ -118,7 +118,10 @@ export function usePluginImportRunner(): UsePluginImportRunner {
   const run = useCallback(
     async (
       exec: (
-        onPhase: (phase: "uploading" | "inspecting") => void,
+        onPhase: (
+          phase: "uploading" | "inspecting",
+          importId?: string,
+        ) => void,
       ) => Promise<StartPluginImportResult>,
     ): Promise<StartPluginImportResult> => {
       const attempt = ++attemptRef.current;
@@ -129,12 +132,15 @@ export function usePluginImportRunner(): UsePluginImportRunner {
 
       commit({ phase: "uploading", importId: null, error: null });
       try {
-        const result = await exec((phase) => {
+        const result = await exec((phase, importId) => {
           // The orchestrator reports `inspecting` once the row is staged; that
           // is the only phase the runner cannot infer on its own (uploading is
-          // set up-front, done/error from the outcome).
+          // set up-front, done/error from the outcome). It hands over the staged
+          // importId here so `usePluginImport(importId)` can subscribe to
+          // server-side progress WHILE inspection runs — committing null would
+          // defeat the purpose of surfacing the inspecting phase at all.
           if (phase === "inspecting") {
-            commit({ phase: "inspecting", importId: null, error: null });
+            commit({ phase: "inspecting", importId: importId ?? null, error: null });
           }
         });
         commit({

--- a/mcpjam-inspector/client/src/hooks/usePluginImport.ts
+++ b/mcpjam-inspector/client/src/hooks/usePluginImport.ts
@@ -14,9 +14,10 @@
  * that consumes these.
  */
 
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { useConvex, useQuery } from "convex/react";
 import {
+  PluginImportError,
   startPluginImportFromFolder,
   startPluginImportFromZip,
   type StartPluginImportResult,
@@ -109,19 +110,34 @@ export function usePluginImportRunner(): UsePluginImportRunner {
     importId: null,
     error: null,
   });
+  // Attempt generation. Every run() and reset() bumps it; a run may only commit
+  // state while it is still the latest attempt, so a slow run that resolves
+  // after a reset() or a newer run cannot stomp the fresher state.
+  const attemptRef = useRef(0);
 
   const run = useCallback(
     async (
-      exec: () => Promise<StartPluginImportResult>,
+      exec: (
+        onPhase: (phase: "uploading" | "inspecting") => void,
+      ) => Promise<StartPluginImportResult>,
     ): Promise<StartPluginImportResult> => {
-      setState({ phase: "uploading", importId: null, error: null });
+      const attempt = ++attemptRef.current;
+      const isCurrent = () => attemptRef.current === attempt;
+      const commit = (next: UsePluginImportRunnerState) => {
+        if (isCurrent()) setState(next);
+      };
+
+      commit({ phase: "uploading", importId: null, error: null });
       try {
-        // `startPluginImportFrom*` performs upload → createImport → inspect in
-        // sequence; we cannot observe the importId until it resolves, so the
-        // runner reports `uploading` across upload+stage, then the result
-        // carries the id and the terminal inspect status.
-        const result = await exec();
-        setState({
+        const result = await exec((phase) => {
+          // The orchestrator reports `inspecting` once the row is staged; that
+          // is the only phase the runner cannot infer on its own (uploading is
+          // set up-front, done/error from the outcome).
+          if (phase === "inspecting") {
+            commit({ phase: "inspecting", importId: null, error: null });
+          }
+        });
+        commit({
           phase: result.inspect.status === "failed" ? "error" : "done",
           importId: result.importId,
           error:
@@ -136,7 +152,11 @@ export function usePluginImportRunner(): UsePluginImportRunner {
         return result;
       } catch (err) {
         const error = err instanceof Error ? err : new Error(String(err));
-        setState({ phase: "error", importId: null, error });
+        // Preserve the staged importId when inspect throws after staging, so the
+        // UI can still subscribe to / recover the row instead of stranding it.
+        const importId =
+          err instanceof PluginImportError ? err.importId : null;
+        commit({ phase: "error", importId, error });
         throw error;
       }
     },
@@ -144,16 +164,23 @@ export function usePluginImportRunner(): UsePluginImportRunner {
   );
 
   const startFromZip = useCallback<UsePluginImportRunner["startFromZip"]>(
-    (args) => run(() => startPluginImportFromZip(convex, args)),
+    (args) =>
+      run((onPhase) => startPluginImportFromZip(convex, { ...args, onPhase })),
     [convex, run],
   );
 
   const startFromFolder = useCallback<UsePluginImportRunner["startFromFolder"]>(
-    (args) => run(() => startPluginImportFromFolder(convex, args)),
+    (args) =>
+      run((onPhase) =>
+        startPluginImportFromFolder(convex, { ...args, onPhase }),
+      ),
     [convex, run],
   );
 
   const reset = useCallback(() => {
+    // Invalidate any in-flight attempt so its late resolution cannot revive
+    // state after the reset.
+    attemptRef.current++;
     setState({ phase: "idle", importId: null, error: null });
   }, []);
 

--- a/mcpjam-inspector/client/src/hooks/usePluginImport.ts
+++ b/mcpjam-inspector/client/src/hooks/usePluginImport.ts
@@ -1,0 +1,161 @@
+/**
+ * Plugin import progress hooks.
+ *
+ * `usePluginImport` subscribes to a `pluginImports` row via Convex `useQuery`
+ * (reactive — no manual polling loop; the row pushes on every state
+ * transition) and returns the typed record plus derived phase flags.
+ *
+ * `usePluginImportRunner` drives the imperative upload → stage → inspect flow
+ * (`plugin-import-client.ts`) and tracks the pre-row local phase (`uploading`)
+ * that no server subscription can report yet, then hands off to the reactive
+ * subscription once an `importId` exists.
+ *
+ * INS-1 provides the data/runner surface only; INS-2 owns the Add-plugin UI
+ * that consumes these.
+ */
+
+import { useCallback, useState } from "react";
+import { useConvex, useQuery } from "convex/react";
+import {
+  startPluginImportFromFolder,
+  startPluginImportFromZip,
+  type StartPluginImportResult,
+} from "@/lib/plugins/plugin-import-client";
+import type { PluginFolderFiles } from "@/lib/plugins/plugin-file-source";
+import {
+  isTerminalImportStatus,
+  type PluginImportRecord,
+} from "@/lib/plugins/plugin-import-types";
+
+const GET_PLUGIN_IMPORT_FN = "plugins:getPluginImport";
+
+export interface UsePluginImportResult {
+  /** The import row, `undefined` while loading, `null` if not found/skipped. */
+  record: PluginImportRecord | null | undefined;
+  isLoading: boolean;
+  /** True once the import reached a terminal state (completed/failed). */
+  isTerminal: boolean;
+  isInspecting: boolean;
+  isPreviewReady: boolean;
+  isFailed: boolean;
+}
+
+/**
+ * Reactively subscribe to an import's progress. Pass `null`/`undefined` for
+ * `importId` to skip the subscription (Convex "skip" sentinel) before an
+ * import exists.
+ */
+export function usePluginImport(
+  importId: string | null | undefined,
+): UsePluginImportResult {
+  const record = useQuery(
+    GET_PLUGIN_IMPORT_FN as any,
+    importId ? ({ importId } as any) : "skip",
+  ) as PluginImportRecord | null | undefined;
+
+  const status = record?.status;
+  return {
+    record,
+    isLoading: importId != null && record === undefined,
+    isTerminal: status !== undefined && isTerminalImportStatus(status),
+    isInspecting: status === "inspecting" || status === "uploaded",
+    isPreviewReady: status === "preview_ready",
+    isFailed: status === "failed",
+  };
+}
+
+/** Local phase of the imperative runner before/around the server subscription. */
+export type PluginImportRunnerPhase =
+  | "idle"
+  | "uploading"
+  | "inspecting"
+  | "done"
+  | "error";
+
+export interface UsePluginImportRunnerState {
+  phase: PluginImportRunnerPhase;
+  importId: string | null;
+  error: Error | null;
+}
+
+export interface UsePluginImportRunner extends UsePluginImportRunnerState {
+  /** Upload + stage + inspect a prebuilt ZIP bundle (hosted or local). */
+  startFromZip: (args: {
+    projectId: string;
+    bundle: Blob;
+    sourceLabel?: string;
+  }) => Promise<StartPluginImportResult>;
+  /** Zip a selected folder, then run the same flow (local/Electron mode). */
+  startFromFolder: (args: {
+    projectId: string;
+    files: PluginFolderFiles;
+    sourceLabel?: string;
+  }) => Promise<StartPluginImportResult>;
+  /** Reset back to idle (e.g. when the modal closes or a retry starts). */
+  reset: () => void;
+}
+
+/**
+ * Imperative driver for a single import attempt. Pair the returned `importId`
+ * with `usePluginImport(importId)` to render live progress once staging
+ * succeeds. The runner surfaces the `uploading` phase (before an import row
+ * exists) and the `inspecting` phase (while the Node action runs) so the UI can
+ * show progress across the whole flow, not just the server-visible part.
+ */
+export function usePluginImportRunner(): UsePluginImportRunner {
+  const convex = useConvex();
+  const [state, setState] = useState<UsePluginImportRunnerState>({
+    phase: "idle",
+    importId: null,
+    error: null,
+  });
+
+  const run = useCallback(
+    async (
+      exec: () => Promise<StartPluginImportResult>,
+    ): Promise<StartPluginImportResult> => {
+      setState({ phase: "uploading", importId: null, error: null });
+      try {
+        // `startPluginImportFrom*` performs upload → createImport → inspect in
+        // sequence; we cannot observe the importId until it resolves, so the
+        // runner reports `uploading` across upload+stage, then the result
+        // carries the id and the terminal inspect status.
+        const result = await exec();
+        setState({
+          phase: result.inspect.status === "failed" ? "error" : "done",
+          importId: result.importId,
+          error:
+            result.inspect.status === "failed"
+              ? new Error(
+                  result.inspect.failureCode
+                    ? `Inspection failed: ${result.inspect.failureCode}`
+                    : "Inspection failed",
+                )
+              : null,
+        });
+        return result;
+      } catch (err) {
+        const error = err instanceof Error ? err : new Error(String(err));
+        setState({ phase: "error", importId: null, error });
+        throw error;
+      }
+    },
+    [],
+  );
+
+  const startFromZip = useCallback<UsePluginImportRunner["startFromZip"]>(
+    (args) => run(() => startPluginImportFromZip(convex, args)),
+    [convex, run],
+  );
+
+  const startFromFolder = useCallback<UsePluginImportRunner["startFromFolder"]>(
+    (args) => run(() => startPluginImportFromFolder(convex, args)),
+    [convex, run],
+  );
+
+  const reset = useCallback(() => {
+    setState({ phase: "idle", importId: null, error: null });
+  }, []);
+
+  return { ...state, startFromZip, startFromFolder, reset };
+}

--- a/mcpjam-inspector/client/src/lib/__tests__/json-config-parser.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/json-config-parser.test.ts
@@ -234,6 +234,27 @@ describe("parseJsonConfig", () => {
       // And it is not imported as an empty, unusable server.
       expect(parseJsonConfig(json)).toHaveLength(0);
     });
+
+    it("imports a stdio entry that carries an empty url as stdio (not skipped)", () => {
+      // A present-but-empty `url: ""` must NOT route a command entry to HTTP and
+      // get it skipped for a missing URL. validate must accept it AND parse must
+      // import exactly one stdio server (never a validated-but-imports-nothing
+      // config).
+      const json = JSON.stringify({
+        mcp_servers: {
+          local: { command: "node", args: ["server.js"], url: "" },
+        },
+      });
+      expect(validateJsonConfig(json).success).toBe(true);
+      const servers = parseJsonConfig(json);
+      expect(servers).toHaveLength(1);
+      expect(servers[0]).toMatchObject({
+        name: "local",
+        type: "stdio",
+        command: "node",
+        args: ["server.js"],
+      });
+    });
   });
 
   describe("error handling", () => {

--- a/mcpjam-inspector/client/src/lib/__tests__/json-config-parser.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/json-config-parser.test.ts
@@ -128,6 +128,78 @@ describe("parseJsonConfig", () => {
     });
   });
 
+  describe("compatible config shapes (mcp_servers / direct)", () => {
+    // The three shapes must import IDENTICALLY (acceptance criterion of INS-1):
+    // an OpenAI `mcp_servers` wrapper, a direct server map, and the legacy
+    // `mcpServers` wrapper all produce the same ServerFormData.
+    const expected = [
+      {
+        name: "svr",
+        type: "stdio" as const,
+        command: "node",
+        args: ["server.js"],
+        env: {},
+      },
+    ];
+
+    it("parses the mcpServers wrapper (legacy)", () => {
+      const json = JSON.stringify({
+        mcpServers: { svr: { command: "node", args: ["server.js"] } },
+      });
+      expect(parseJsonConfig(json)).toEqual(expected);
+    });
+
+    it("parses the mcp_servers wrapper identically", () => {
+      const json = JSON.stringify({
+        mcp_servers: { svr: { command: "node", args: ["server.js"] } },
+      });
+      expect(parseJsonConfig(json)).toEqual(expected);
+    });
+
+    it("parses a direct server map identically", () => {
+      const json = JSON.stringify({
+        svr: { command: "node", args: ["server.js"] },
+      });
+      expect(parseJsonConfig(json)).toEqual(expected);
+    });
+
+    it("preserves env values across all three shapes", () => {
+      const server = { command: "python", env: { API_KEY: "secret123" } };
+      const direct = parseJsonConfig(JSON.stringify({ s: server }));
+      const snake = parseJsonConfig(JSON.stringify({ mcp_servers: { s: server } }));
+      const camel = parseJsonConfig(JSON.stringify({ mcpServers: { s: server } }));
+      expect(direct).toEqual(snake);
+      expect(snake).toEqual(camel);
+      expect(direct[0].env).toEqual({ API_KEY: "secret123" });
+    });
+
+    it("validates mcp_servers and direct shapes as success", () => {
+      expect(
+        validateJsonConfig(
+          JSON.stringify({ mcp_servers: { s: { command: "node" } } }),
+        ).success,
+      ).toBe(true);
+      expect(
+        validateJsonConfig(
+          JSON.stringify({ s: { url: "https://x/mcp" } }),
+        ).success,
+      ).toBe(true);
+    });
+
+    it("rejects declaring both wrappers", () => {
+      const json = JSON.stringify({
+        mcp_servers: { a: { command: "x" } },
+        mcpServers: { b: { command: "y" } },
+      });
+      expect(() => parseJsonConfig(json)).toThrow(
+        'cannot declare both "mcp_servers" and "mcpServers"',
+      );
+      expect(validateJsonConfig(json).error).toContain(
+        'Cannot declare both "mcp_servers" and "mcpServers"',
+      );
+    });
+  });
+
   describe("error handling", () => {
     it("throws error for invalid JSON", () => {
       expect(() => parseJsonConfig("not valid json")).toThrow(

--- a/mcpjam-inspector/client/src/lib/__tests__/json-config-parser.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/json-config-parser.test.ts
@@ -198,6 +198,42 @@ describe("parseJsonConfig", () => {
         'Cannot declare both "mcp_servers" and "mcpServers"',
       );
     });
+
+    it("carries HTTP headers through on the new shapes (credentials)", () => {
+      const server = {
+        url: "https://mcp.example.com/mcp",
+        headers: { Authorization: "Bearer tok", "X-Api-Key": "abc" },
+      };
+      const snake = parseJsonConfig(
+        JSON.stringify({ mcp_servers: { s: server } }),
+      );
+      const direct = parseJsonConfig(JSON.stringify({ s: server }));
+      expect(snake[0].headers).toEqual({
+        Authorization: "Bearer tok",
+        "X-Api-Key": "abc",
+      });
+      expect(direct[0].headers).toEqual(snake[0].headers);
+    });
+
+    it("tolerates non-object sibling keys in a direct map", () => {
+      const json = JSON.stringify({
+        version: "1.0",
+        s: { command: "node" },
+      });
+      expect(validateJsonConfig(json).success).toBe(true);
+      const servers = parseJsonConfig(json);
+      expect(servers).toHaveLength(1);
+      expect(servers[0].name).toBe("s");
+    });
+
+    it("rejects an SSE/HTTP entry with no URL", () => {
+      const json = JSON.stringify({ mcp_servers: { s: { type: "sse" } } });
+      const result = validateJsonConfig(json);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('must have a non-empty "url"');
+      // And it is not imported as an empty, unusable server.
+      expect(parseJsonConfig(json)).toHaveLength(0);
+    });
   });
 
   describe("error handling", () => {

--- a/mcpjam-inspector/client/src/lib/json-config-parser.ts
+++ b/mcpjam-inspector/client/src/lib/json-config-parser.ts
@@ -1,5 +1,9 @@
 import { ServerFormData } from "@/shared/types.js";
 import { ServerWithName } from "@/state/app-types";
+import {
+  unwrapMcpServerMap,
+  type UnwrapFailureReason,
+} from "@/lib/plugins/mcp-config-shape";
 
 export interface JsonServerConfig {
   command?: string;
@@ -11,6 +15,27 @@ export interface JsonServerConfig {
 
 export interface JsonConfig {
   mcpServers: Record<string, JsonServerConfig>;
+}
+
+/**
+ * Map an unwrap failure to the legacy user-facing message. The wording is kept
+ * byte-identical to the pre-refactor parser so existing callers/tests and the
+ * import modal copy are unchanged; only the set of ACCEPTED shapes widened (a
+ * bare `mcp_servers` wrapper and a direct server map now parse identically to
+ * `mcpServers`).
+ */
+function unwrapErrorMessage(reason: UnwrapFailureReason): string {
+  if (reason === "both-wrappers") {
+    return 'Invalid JSON config: cannot declare both "mcp_servers" and "mcpServers"';
+  }
+  return 'Invalid JSON config: missing or invalid "mcpServers" property';
+}
+
+function validateErrorMessage(reason: UnwrapFailureReason): string {
+  if (reason === "both-wrappers") {
+    return 'Cannot declare both "mcp_servers" and "mcpServers"';
+  }
+  return 'Missing or invalid "mcpServers" property';
 }
 
 /**
@@ -59,19 +84,18 @@ export function formatJsonConfig(
  */
 export function parseJsonConfig(jsonContent: string): ServerFormData[] {
   try {
-    const config: JsonConfig = JSON.parse(jsonContent);
+    const config: unknown = JSON.parse(jsonContent);
 
-    if (!config.mcpServers || typeof config.mcpServers !== "object") {
-      throw new Error(
-        'Invalid JSON config: missing or invalid "mcpServers" property',
-      );
+    const unwrapped = unwrapMcpServerMap(config);
+    if (!unwrapped.ok) {
+      throw new Error(unwrapErrorMessage(unwrapped.reason));
     }
 
     const servers: ServerFormData[] = [];
 
     for (const [serverName, serverConfig] of Object.entries(
-      config.mcpServers,
-    )) {
+      unwrapped.servers,
+    ) as Array<[string, JsonServerConfig]>) {
       if (!serverConfig || typeof serverConfig !== "object") {
         console.warn(`Skipping invalid server config for "${serverName}"`);
         continue;
@@ -124,16 +148,17 @@ export function validateJsonConfig(jsonContent: string): {
   error?: string;
 } {
   try {
-    const config = JSON.parse(jsonContent);
+    const config: unknown = JSON.parse(jsonContent);
 
-    if (!config.mcpServers || typeof config.mcpServers !== "object") {
+    const unwrapped = unwrapMcpServerMap(config);
+    if (!unwrapped.ok) {
       return {
         success: false,
-        error: 'Missing or invalid "mcpServers" property',
+        error: validateErrorMessage(unwrapped.reason),
       };
     }
 
-    const serverNames = Object.keys(config.mcpServers);
+    const serverNames = Object.keys(unwrapped.servers);
     if (serverNames.length === 0) {
       return {
         success: false,
@@ -143,8 +168,8 @@ export function validateJsonConfig(jsonContent: string): {
 
     // Validate each server config
     for (const [serverName, serverConfig] of Object.entries(
-      config.mcpServers,
-    )) {
+      unwrapped.servers,
+    ) as Array<[string, JsonServerConfig]>) {
       if (!serverConfig || typeof serverConfig !== "object") {
         return {
           success: false,

--- a/mcpjam-inspector/client/src/lib/json-config-parser.ts
+++ b/mcpjam-inspector/client/src/lib/json-config-parser.ts
@@ -9,8 +9,20 @@ export interface JsonServerConfig {
   command?: string;
   args?: string[];
   env?: Record<string, string>;
-  type?: "sse";
+  headers?: Record<string, string>;
+  type?: string;
+  transport?: string;
   url?: string;
+}
+
+/** Transport `type`/`transport` values that denote an HTTP/SSE server. */
+function isHttpTypeToken(token: unknown): boolean {
+  return (
+    token === "sse" ||
+    token === "http" ||
+    token === "streamable-http" ||
+    token === "streamableHttp"
+  );
 }
 
 export interface JsonConfig {
@@ -102,14 +114,29 @@ export function parseJsonConfig(jsonContent: string): ServerFormData[] {
       }
 
       // Determine server type based on config
-      if (serverConfig.type === "sse" || serverConfig.url) {
-        // HTTP/SSE server
+      const httpToken = serverConfig.type ?? serverConfig.transport;
+      const isHttpish =
+        isHttpTypeToken(httpToken) || typeof serverConfig.url === "string";
+      const hasUrl =
+        typeof serverConfig.url === "string" && serverConfig.url.length > 0;
+      if (isHttpish) {
+        // HTTP/SSE server. Require a non-empty URL — a `{type:"sse"}` entry with
+        // no URL would otherwise import an unusable empty server.
+        if (!hasUrl) {
+          console.warn(
+            `Skipping server "${serverName}": HTTP/SSE server missing "url"`,
+          );
+          continue;
+        }
+        // Carry headers (and env) through for ALL accepted shapes — the
+        // OpenAI mcp_servers/direct configs put credentials like Authorization
+        // in `headers`, and dropping them silently loses the connection's auth.
         servers.push({
           name: serverName,
           type: "http",
-          url: serverConfig.url || "",
-          headers: {},
-          env: {},
+          url: serverConfig.url as string,
+          headers: serverConfig.headers || {},
+          env: serverConfig.env || {},
           useOAuth: false,
         });
       } else if (serverConfig.command) {
@@ -171,6 +198,11 @@ export function validateJsonConfig(jsonContent: string): {
       unwrapped.servers,
     ) as Array<[string, JsonServerConfig]>) {
       if (!serverConfig || typeof serverConfig !== "object") {
+        // A direct server map may carry non-object sibling keys (e.g. a
+        // top-level `version: "1.0"`); tolerate them like the wrapped shapes do
+        // (the parse loop skips them). Inside an explicit wrapper, a non-object
+        // value is a malformed server and stays an error.
+        if (unwrapped.wrapper === "direct") continue;
         return {
           success: false,
           error: `Invalid server config for "${serverName}"`,
@@ -179,21 +211,31 @@ export function validateJsonConfig(jsonContent: string): {
 
       const configObj = serverConfig as JsonServerConfig;
       const hasCommand =
-        configObj.command && typeof configObj.command === "string";
-      const hasUrl = configObj.url && typeof configObj.url === "string";
-      const isSse = configObj.type === "sse";
-
-      if (!hasCommand && !hasUrl && !isSse) {
-        return {
-          success: false,
-          error: `Server "${serverName}" must have either "command" or "url" property`,
-        };
-      }
+        typeof configObj.command === "string" && configObj.command.length > 0;
+      const hasUrl =
+        typeof configObj.url === "string" && configObj.url.length > 0;
+      const isHttpType = isHttpTypeToken(configObj.type ?? configObj.transport);
 
       if (hasCommand && hasUrl) {
         return {
           success: false,
           error: `Server "${serverName}" cannot have both "command" and "url" properties`,
+        };
+      }
+
+      if (isHttpType || hasUrl) {
+        // HTTP/SSE server must carry a usable URL — reject `{type:"sse"}` with
+        // no URL rather than importing an empty, unusable server.
+        if (!hasUrl) {
+          return {
+            success: false,
+            error: `Server "${serverName}" must have a non-empty "url" property`,
+          };
+        }
+      } else if (!hasCommand) {
+        return {
+          success: false,
+          error: `Server "${serverName}" must have either "command" or "url" property`,
         };
       }
     }

--- a/mcpjam-inspector/client/src/lib/json-config-parser.ts
+++ b/mcpjam-inspector/client/src/lib/json-config-parser.ts
@@ -113,12 +113,15 @@ export function parseJsonConfig(jsonContent: string): ServerFormData[] {
         continue;
       }
 
-      // Determine server type based on config
+      // Determine server type based on config. Route on a GENUINE non-empty URL
+      // (or an explicit http/sse type token) — a present-but-empty `url: ""` is
+      // NOT http-ish, so a stdio entry that also carries `url: ""` stays stdio
+      // instead of being routed to HTTP and skipped for a missing URL. This
+      // mirrors validateJsonConfig so a validated config never imports nothing.
       const httpToken = serverConfig.type ?? serverConfig.transport;
-      const isHttpish =
-        isHttpTypeToken(httpToken) || typeof serverConfig.url === "string";
       const hasUrl =
         typeof serverConfig.url === "string" && serverConfig.url.length > 0;
+      const isHttpish = isHttpTypeToken(httpToken) || hasUrl;
       if (isHttpish) {
         // HTTP/SSE server. Require a non-empty URL — a `{type:"sse"}` entry with
         // no URL would otherwise import an unusable empty server.

--- a/mcpjam-inspector/client/src/lib/plugins/__tests__/folder-to-zip.test.ts
+++ b/mcpjam-inspector/client/src/lib/plugins/__tests__/folder-to-zip.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from "vitest";
+import { unzipSync } from "fflate";
+import { parsePluginBundle } from "@mcpjam/sdk/plugin-bundle";
+import { folderToZip, folderToZipBlob } from "../folder-to-zip.js";
+import {
+  createFolderPluginSource,
+  readBrowserFolderSelection,
+  type PluginFolderFiles,
+} from "../plugin-file-source.js";
+
+const encoder = new TextEncoder();
+const enc = (text: string): Uint8Array => encoder.encode(text);
+
+/** A valid combined bundle: manifest + one skill + a `.mcp.json` (mcp_servers). */
+function combinedBundle(): Map<string, Uint8Array> {
+  return new Map<string, Uint8Array>([
+    [
+      ".codex-plugin/plugin.json",
+      enc(
+        JSON.stringify({
+          name: "demo-plugin",
+          version: "1.2.3",
+          description: "A demo plugin for INS-1 parity tests.",
+        }),
+      ),
+    ],
+    [
+      "skills/demo-skill/SKILL.md",
+      enc(
+        "---\nname: demo-skill\ndescription: Does demo things for tests.\n---\n\nInstructions.\n",
+      ),
+    ],
+    [
+      ".mcp.json",
+      enc(
+        JSON.stringify({
+          mcp_servers: {
+            "local-server": {
+              command: "node",
+              args: ["${PLUGIN_ROOT}/server/index.js"],
+              env: { DEMO_API_KEY: "${DEMO_API_KEY}" },
+            },
+          },
+        }),
+      ),
+    ],
+  ]);
+}
+
+describe("folderToZip", () => {
+  it("produces a ZIP a standard unzipper can read back byte-for-byte", () => {
+    const files = combinedBundle();
+    const zip = folderToZip(files);
+    const recovered = unzipSync(zip);
+
+    expect(Object.keys(recovered).sort()).toEqual([...files.keys()].sort());
+    for (const [path, bytes] of files) {
+      // fflate may return a subarray view (differing byteOffset/buffer); compare
+      // by content, not by typed-array identity/structure.
+      expect(Array.from(recovered[path])).toEqual(Array.from(bytes));
+    }
+  });
+
+  it("is deterministic for identical input", () => {
+    const a = folderToZip(combinedBundle());
+    const b = folderToZip(combinedBundle());
+    expect(a).toEqual(b);
+  });
+
+  it("wraps output as an application/zip Blob", () => {
+    const blob = folderToZipBlob(combinedBundle());
+    expect(blob.type).toBe("application/zip");
+    expect(blob.size).toBeGreaterThan(0);
+  });
+
+  it("handles an empty folder (valid empty archive)", () => {
+    const zip = folderToZip(new Map());
+    expect(unzipSync(zip)).toEqual({});
+  });
+});
+
+describe("folder vs ZIP bundle-hash parity", () => {
+  // INS-1 acceptance: folder and ZIP sources produce the SAME bundle hash for
+  // identical contents. The SDK bundle hash is content-addressed, so parsing a
+  // folder source and parsing the same folder round-tripped through
+  // folderToZip → unzip must yield the identical bundleHash.
+  it("folder source and zipped-then-unzipped source hash identically", async () => {
+    const files = combinedBundle();
+
+    const fromFolder = await parsePluginBundle(createFolderPluginSource(files));
+
+    const roundTripped = unzipSync(folderToZip(files));
+    const rebuilt: PluginFolderFiles = new Map(Object.entries(roundTripped));
+    const fromZip = await parsePluginBundle(createFolderPluginSource(rebuilt));
+
+    expect(fromFolder.bundleHash).toBe(fromZip.bundleHash);
+    expect(fromFolder.manifestHash).toBe(fromZip.manifestHash);
+    // Sanity: the bundle actually parsed its components (not an empty match).
+    expect(fromFolder.skills).toHaveLength(1);
+    expect(fromFolder.mcpServers).toHaveLength(1);
+  });
+});
+
+describe("createFolderPluginSource", () => {
+  it("enforces maxBytes by throwing rather than truncating", async () => {
+    const source = createFolderPluginSource(
+      new Map([["big.bin", new Uint8Array(100)]]),
+    );
+    await expect(source.readBytes("big.bin", 10)).rejects.toThrow(/exceeds/);
+  });
+
+  it("lists entries with sizes and reads text", async () => {
+    const source = createFolderPluginSource(
+      new Map([["a.txt", enc("hello")]]),
+    );
+    const entries = await source.list();
+    expect(entries).toEqual([{ path: "a.txt", size: 5, kind: "file" }]);
+    expect(await source.readText?.("a.txt", 100)).toBe("hello");
+  });
+});
+
+describe("readBrowserFolderSelection", () => {
+  // jsdom's File lacks arrayBuffer(); build a minimal browser-File-shaped stub
+  // exposing exactly what readBrowserFolderSelection reads.
+  function fakeFile(relativePath: string, content: string): File {
+    const bytes = enc(content);
+    return {
+      name: relativePath.split("/").pop() ?? "f",
+      webkitRelativePath: relativePath,
+      arrayBuffer: async () => bytes.buffer,
+    } as unknown as File;
+  }
+
+  it("strips the selected root directory segment so keys are bundle-relative", async () => {
+    const files = await readBrowserFolderSelection([
+      fakeFile("my-plugin/.codex-plugin/plugin.json", "{}"),
+      fakeFile("my-plugin/skills/s/SKILL.md", "x"),
+    ]);
+    expect([...files.keys()].sort()).toEqual([
+      ".codex-plugin/plugin.json",
+      "skills/s/SKILL.md",
+    ]);
+  });
+});

--- a/mcpjam-inspector/client/src/lib/plugins/__tests__/folder-to-zip.test.ts
+++ b/mcpjam-inspector/client/src/lib/plugins/__tests__/folder-to-zip.test.ts
@@ -1,38 +1,45 @@
 import { describe, it, expect } from "vitest";
 import { unzipSync } from "fflate";
-import { parsePluginBundle } from "@mcpjam/sdk/plugin-bundle";
-import { folderToZip, folderToZipBlob } from "../folder-to-zip.js";
+import { parsePluginBundle, PluginBundleError } from "@mcpjam/sdk/plugin-bundle";
+import {
+  assertFolderWithinLimits,
+  folderToZip,
+  folderToZipBlob,
+  PluginFolderTooLargeError,
+} from "../folder-to-zip.js";
 import {
   createFolderPluginSource,
   readBrowserFolderSelection,
+  type PluginFolderFile,
   type PluginFolderFiles,
 } from "../plugin-file-source.js";
 
 const encoder = new TextEncoder();
 const enc = (text: string): Uint8Array => encoder.encode(text);
+const pathsOf = (files: PluginFolderFiles): string[] =>
+  files.map((f) => f.path);
+
+const MANIFEST = enc(
+  JSON.stringify({
+    name: "demo-plugin",
+    version: "1.2.3",
+    description: "A demo plugin for INS-1 parity tests.",
+  }),
+);
 
 /** A valid combined bundle: manifest + one skill + a `.mcp.json` (mcp_servers). */
-function combinedBundle(): Map<string, Uint8Array> {
-  return new Map<string, Uint8Array>([
-    [
-      ".codex-plugin/plugin.json",
-      enc(
-        JSON.stringify({
-          name: "demo-plugin",
-          version: "1.2.3",
-          description: "A demo plugin for INS-1 parity tests.",
-        }),
-      ),
-    ],
-    [
-      "skills/demo-skill/SKILL.md",
-      enc(
+function combinedBundle(): PluginFolderFile[] {
+  return [
+    { path: ".codex-plugin/plugin.json", bytes: MANIFEST },
+    {
+      path: "skills/demo-skill/SKILL.md",
+      bytes: enc(
         "---\nname: demo-skill\ndescription: Does demo things for tests.\n---\n\nInstructions.\n",
       ),
-    ],
-    [
-      ".mcp.json",
-      enc(
+    },
+    {
+      path: ".mcp.json",
+      bytes: enc(
         JSON.stringify({
           mcp_servers: {
             "local-server": {
@@ -43,18 +50,17 @@ function combinedBundle(): Map<string, Uint8Array> {
           },
         }),
       ),
-    ],
-  ]);
+    },
+  ];
 }
 
 describe("folderToZip", () => {
   it("produces a ZIP a standard unzipper can read back byte-for-byte", () => {
     const files = combinedBundle();
-    const zip = folderToZip(files);
-    const recovered = unzipSync(zip);
+    const recovered = unzipSync(folderToZip(files));
 
-    expect(Object.keys(recovered).sort()).toEqual([...files.keys()].sort());
-    for (const [path, bytes] of files) {
+    expect(Object.keys(recovered).sort()).toEqual(pathsOf(files).sort());
+    for (const { path, bytes } of files) {
       // fflate may return a subarray view (differing byteOffset/buffer); compare
       // by content, not by typed-array identity/structure.
       expect(Array.from(recovered[path])).toEqual(Array.from(bytes));
@@ -62,9 +68,9 @@ describe("folderToZip", () => {
   });
 
   it("is deterministic for identical input", () => {
-    const a = folderToZip(combinedBundle());
-    const b = folderToZip(combinedBundle());
-    expect(a).toEqual(b);
+    expect(folderToZip(combinedBundle())).toEqual(
+      folderToZip(combinedBundle()),
+    );
   });
 
   it("wraps output as an application/zip Blob", () => {
@@ -74,8 +80,64 @@ describe("folderToZip", () => {
   });
 
   it("handles an empty folder (valid empty archive)", () => {
-    const zip = folderToZip(new Map());
-    expect(unzipSync(zip)).toEqual({});
+    expect(unzipSync(folderToZip([]))).toEqual({});
+  });
+
+  it("preflights against the DEFAULT SDK limits before materializing", () => {
+    // A single file above the 10 MB default per-file cap must fail fast rather
+    // than materialize the archive.
+    const oversized = [
+      { path: "big.bin", bytes: new Uint8Array(10 * 1024 * 1024 + 1) },
+    ];
+    expect(() => folderToZip(oversized)).toThrow(PluginFolderTooLargeError);
+  });
+});
+
+describe("assertFolderWithinLimits", () => {
+  const limits = {
+    maxEntries: 2,
+    maxTotalBytes: 50,
+    maxFileBytes: 30,
+    maxPathBytes: 512,
+    maxPathDepth: 20,
+    maxSkills: 20,
+    maxMcpServers: 20,
+  };
+
+  it("rejects too many entries", () => {
+    const files = [
+      { path: "a", bytes: enc("x") },
+      { path: "b", bytes: enc("y") },
+      { path: "c", bytes: enc("z") },
+    ];
+    expect(() => assertFolderWithinLimits(files, limits)).toThrow(/files/);
+  });
+
+  it("rejects an oversized single file", () => {
+    expect(() =>
+      assertFolderWithinLimits(
+        [{ path: "a", bytes: new Uint8Array(40) }],
+        limits,
+      ),
+    ).toThrow(/per-file limit/);
+  });
+
+  it("rejects an oversized total", () => {
+    expect(() =>
+      assertFolderWithinLimits(
+        [
+          { path: "a", bytes: new Uint8Array(30) },
+          { path: "b", bytes: new Uint8Array(30) },
+        ],
+        limits,
+      ),
+    ).toThrow(/uncompressed limit/);
+  });
+
+  it("accepts a folder within limits", () => {
+    expect(() =>
+      assertFolderWithinLimits([{ path: "a", bytes: enc("x") }], limits),
+    ).not.toThrow();
   });
 });
 
@@ -90,7 +152,9 @@ describe("folder vs ZIP bundle-hash parity", () => {
     const fromFolder = await parsePluginBundle(createFolderPluginSource(files));
 
     const roundTripped = unzipSync(folderToZip(files));
-    const rebuilt: PluginFolderFiles = new Map(Object.entries(roundTripped));
+    const rebuilt: PluginFolderFiles = Object.entries(roundTripped).map(
+      ([path, bytes]) => ({ path, bytes }),
+    );
     const fromZip = await parsePluginBundle(createFolderPluginSource(rebuilt));
 
     expect(fromFolder.bundleHash).toBe(fromZip.bundleHash);
@@ -101,44 +165,83 @@ describe("folder vs ZIP bundle-hash parity", () => {
   });
 });
 
-describe("createFolderPluginSource", () => {
+describe("createFolderPluginSource — SDK path validators are not bypassed", () => {
   it("enforces maxBytes by throwing rather than truncating", async () => {
-    const source = createFolderPluginSource(
-      new Map([["big.bin", new Uint8Array(100)]]),
-    );
+    const source = createFolderPluginSource([
+      { path: "big.bin", bytes: new Uint8Array(100) },
+    ]);
     await expect(source.readBytes("big.bin", 10)).rejects.toThrow(/exceeds/);
   });
 
   it("lists entries with sizes and reads text", async () => {
-    const source = createFolderPluginSource(
-      new Map([["a.txt", enc("hello")]]),
-    );
-    const entries = await source.list();
-    expect(entries).toEqual([{ path: "a.txt", size: 5, kind: "file" }]);
+    const source = createFolderPluginSource([
+      { path: "a.txt", bytes: enc("hello") },
+    ]);
+    expect(await source.list()).toEqual([
+      { path: "a.txt", size: 5, kind: "file" },
+    ]);
     expect(await source.readText?.("a.txt", 100)).toBe("hello");
+  });
+
+  it("surfaces an absolute path so the parser fires PATH_ABSOLUTE", async () => {
+    const source = createFolderPluginSource([
+      { path: ".codex-plugin/plugin.json", bytes: MANIFEST },
+      { path: "/etc/passwd", bytes: enc("root:x:0:0") },
+    ]);
+    const err = await parsePluginBundle(source).catch((e) => e);
+    expect(err).toBeInstanceOf(PluginBundleError);
+    expect((err as PluginBundleError).issues.map((i) => i.code)).toContain(
+      "PATH_ABSOLUTE",
+    );
+  });
+
+  it("surfaces duplicate paths so the parser fires PATH_DUPLICATE", async () => {
+    const source = createFolderPluginSource([
+      { path: ".codex-plugin/plugin.json", bytes: MANIFEST },
+      { path: "dup.txt", bytes: enc("a") },
+      { path: "dup.txt", bytes: enc("b") },
+    ]);
+    const err = await parsePluginBundle(source).catch((e) => e);
+    expect(err).toBeInstanceOf(PluginBundleError);
+    expect((err as PluginBundleError).issues.map((i) => i.code)).toContain(
+      "PATH_DUPLICATE",
+    );
   });
 });
 
 describe("readBrowserFolderSelection", () => {
   // jsdom's File lacks arrayBuffer(); build a minimal browser-File-shaped stub
-  // exposing exactly what readBrowserFolderSelection reads.
-  function fakeFile(relativePath: string, content: string): File {
+  // exposing exactly what readBrowserFolderSelection reads. An undefined
+  // `relativePath` models a drag-and-drop file with no webkitRelativePath.
+  function fakeFile(
+    name: string,
+    content: string,
+    relativePath?: string,
+  ): File {
     const bytes = enc(content);
     return {
-      name: relativePath.split("/").pop() ?? "f",
-      webkitRelativePath: relativePath,
+      name,
+      webkitRelativePath: relativePath ?? "",
       arrayBuffer: async () => bytes.buffer,
     } as unknown as File;
   }
 
   it("strips the selected root directory segment so keys are bundle-relative", async () => {
     const files = await readBrowserFolderSelection([
-      fakeFile("my-plugin/.codex-plugin/plugin.json", "{}"),
-      fakeFile("my-plugin/skills/s/SKILL.md", "x"),
+      fakeFile("plugin.json", "{}", "my-plugin/.codex-plugin/plugin.json"),
+      fakeFile("SKILL.md", "x", "my-plugin/skills/s/SKILL.md"),
     ]);
-    expect([...files.keys()].sort()).toEqual([
+    expect(pathsOf(files).sort()).toEqual([
       ".codex-plugin/plugin.json",
       "skills/s/SKILL.md",
     ]);
+  });
+
+  it("falls back to file.name when webkitRelativePath is absent (drag-drop)", async () => {
+    const files = await readBrowserFolderSelection([
+      fakeFile("plugin.json", "{}"),
+    ]);
+    expect(pathsOf(files)).toEqual(["plugin.json"]);
+    expect(files).toHaveLength(1);
   });
 });

--- a/mcpjam-inspector/client/src/lib/plugins/__tests__/mcp-config-shape.test.ts
+++ b/mcpjam-inspector/client/src/lib/plugins/__tests__/mcp-config-shape.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { unwrapMcpServerMap } from "../mcp-config-shape.js";
+
+describe("unwrapMcpServerMap", () => {
+  it("unwraps the mcpServers wrapper (MCPJam/Claude style)", () => {
+    const result = unwrapMcpServerMap({
+      mcpServers: { svr: { command: "node" } },
+    });
+    expect(result).toEqual({
+      ok: true,
+      wrapper: "mcpServers",
+      servers: { svr: { command: "node" } },
+    });
+  });
+
+  it("unwraps the mcp_servers wrapper (OpenAI plugin docs)", () => {
+    const result = unwrapMcpServerMap({
+      mcp_servers: { svr: { url: "https://x/mcp" } },
+    });
+    expect(result).toEqual({
+      ok: true,
+      wrapper: "mcp_servers",
+      servers: { svr: { url: "https://x/mcp" } },
+    });
+  });
+
+  it("accepts a direct server map (OpenAI direct)", () => {
+    const result = unwrapMcpServerMap({
+      svr: { command: "node", args: ["x.js"] },
+    });
+    expect(result).toEqual({
+      ok: true,
+      wrapper: "direct",
+      servers: { svr: { command: "node", args: ["x.js"] } },
+    });
+  });
+
+  it("rejects declaring both wrappers", () => {
+    const result = unwrapMcpServerMap({
+      mcp_servers: { a: { command: "x" } },
+      mcpServers: { b: { command: "y" } },
+    });
+    expect(result).toEqual({ ok: false, reason: "both-wrappers" });
+  });
+
+  it("rejects a wrapper whose value is not an object", () => {
+    expect(unwrapMcpServerMap({ mcpServers: "nope" })).toEqual({
+      ok: false,
+      reason: "wrapper-not-object",
+    });
+  });
+
+  it("rejects a non-object top-level value", () => {
+    expect(unwrapMcpServerMap([1, 2, 3])).toEqual({
+      ok: false,
+      reason: "not-object",
+    });
+    expect(unwrapMcpServerMap("string")).toEqual({
+      ok: false,
+      reason: "not-object",
+    });
+  });
+
+  it("rejects a bare single server config (not a map)", () => {
+    // Top-level string command means one server config, not a server MAP.
+    expect(unwrapMcpServerMap({ command: "node", args: ["x"] })).toEqual({
+      ok: false,
+      reason: "no-server-map",
+    });
+    expect(unwrapMcpServerMap({ url: "https://x/mcp" })).toEqual({
+      ok: false,
+      reason: "no-server-map",
+    });
+  });
+
+  it("does not misread arbitrary JSON as a direct server map", () => {
+    // `{ servers: {} }` — the value has no command/url/type, so it is not a
+    // server entry and the object is not a server map (preserves the legacy
+    // 'missing mcpServers' error for such input).
+    expect(unwrapMcpServerMap({ servers: {} })).toEqual({
+      ok: false,
+      reason: "no-server-map",
+    });
+    expect(unwrapMcpServerMap({})).toEqual({
+      ok: false,
+      reason: "no-server-map",
+    });
+  });
+
+  it("treats a direct map with a type-only entry as a server map", () => {
+    const result = unwrapMcpServerMap({ svr: { type: "sse", url: "https://x" } });
+    expect(result.ok).toBe(true);
+  });
+});

--- a/mcpjam-inspector/client/src/lib/plugins/__tests__/mcp-config-shape.test.ts
+++ b/mcpjam-inspector/client/src/lib/plugins/__tests__/mcp-config-shape.test.ts
@@ -88,7 +88,22 @@ describe("unwrapMcpServerMap", () => {
   });
 
   it("treats a direct map with a type-only entry as a server map", () => {
-    const result = unwrapMcpServerMap({ svr: { type: "sse", url: "https://x" } });
+    // No `url`/`command` — proves the `type`-only branch of server detection.
+    const result = unwrapMcpServerMap({ svr: { type: "sse" } });
     expect(result.ok).toBe(true);
+  });
+
+  it("tolerates non-object sibling keys in a direct map", () => {
+    // A top-level `version` alongside real servers must not defeat direct-map
+    // detection (parity with the wrapped shapes).
+    const result = unwrapMcpServerMap({
+      version: "1.0",
+      svr: { command: "node" },
+    });
+    expect(result).toEqual({
+      ok: true,
+      wrapper: "direct",
+      servers: { version: "1.0", svr: { command: "node" } },
+    });
   });
 });

--- a/mcpjam-inspector/client/src/lib/plugins/__tests__/plugin-import-client.test.ts
+++ b/mcpjam-inspector/client/src/lib/plugins/__tests__/plugin-import-client.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   commitImport,
   PLUGIN_COMMIT_NOT_AVAILABLE,
+  PluginImportError,
   startPluginImportFromFolder,
   startPluginImportFromZip,
   uploadBundleToStorage,
@@ -113,6 +114,32 @@ describe("startPluginImportFromZip", () => {
     });
     expect(result.inspect.status).toBe("failed");
   });
+
+  it("fires onPhase uploading then inspecting", async () => {
+    const { convex } = makeConvex();
+    const phases: string[] = [];
+    await startPluginImportFromZip(convex, {
+      projectId: "proj_1",
+      bundle: new Blob([]),
+      onPhase: (p) => phases.push(p),
+    });
+    expect(phases).toEqual(["uploading", "inspecting"]);
+  });
+
+  it("preserves the staged importId when inspect throws", async () => {
+    const { convex, action } = makeConvex({ importId: "import_kept" });
+    // Make the inspect action reject AFTER createImport staged the row.
+    (action as unknown as { mockRejectedValueOnce: (e: Error) => void }).mockRejectedValueOnce(
+      new Error("inspect boom"),
+    );
+    const err = await startPluginImportFromZip(convex, {
+      projectId: "proj_1",
+      bundle: new Blob([]),
+    }).catch((e) => e);
+    expect(err).toBeInstanceOf(PluginImportError);
+    expect((err as PluginImportError).importId).toBe("import_kept");
+    expect((err as PluginImportError).bundleStorageId).toBe("st_from_zip");
+  });
 });
 
 describe("startPluginImportFromFolder", () => {
@@ -126,9 +153,12 @@ describe("startPluginImportFromFolder", () => {
 
   it("zips the folder then runs the same flow", async () => {
     const { convex } = makeConvex({ importId: "import_folder" });
-    const files = new Map([
-      [".codex-plugin/plugin.json", new TextEncoder().encode("{}")],
-    ]);
+    const files = [
+      {
+        path: ".codex-plugin/plugin.json",
+        bytes: new TextEncoder().encode("{}"),
+      },
+    ];
     const result = await startPluginImportFromFolder(convex, {
       projectId: "proj_1",
       files,

--- a/mcpjam-inspector/client/src/lib/plugins/__tests__/plugin-import-client.test.ts
+++ b/mcpjam-inspector/client/src/lib/plugins/__tests__/plugin-import-client.test.ts
@@ -115,15 +115,20 @@ describe("startPluginImportFromZip", () => {
     expect(result.inspect.status).toBe("failed");
   });
 
-  it("fires onPhase uploading then inspecting", async () => {
-    const { convex } = makeConvex();
-    const phases: string[] = [];
+  it("fires onPhase uploading then inspecting, carrying the staged importId", async () => {
+    const { convex } = makeConvex({ importId: "import_live" });
+    const calls: Array<[string, string | undefined]> = [];
     await startPluginImportFromZip(convex, {
       projectId: "proj_1",
       bundle: new Blob([]),
-      onPhase: (p) => phases.push(p),
+      onPhase: (p, importId) => calls.push([p, importId]),
     });
-    expect(phases).toEqual(["uploading", "inspecting"]);
+    // `inspecting` must carry the id createImport already returned, so a
+    // subscriber can attach WHILE inspection runs (not only after it finishes).
+    expect(calls).toEqual([
+      ["uploading", undefined],
+      ["inspecting", "import_live"],
+    ]);
   });
 
   it("preserves the staged importId when inspect throws", async () => {

--- a/mcpjam-inspector/client/src/lib/plugins/__tests__/plugin-import-client.test.ts
+++ b/mcpjam-inspector/client/src/lib/plugins/__tests__/plugin-import-client.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  commitImport,
+  PLUGIN_COMMIT_NOT_AVAILABLE,
+  startPluginImportFromFolder,
+  startPluginImportFromZip,
+  uploadBundleToStorage,
+  type PluginConvexClient,
+} from "../plugin-import-client.js";
+
+function makeConvex(overrides?: {
+  uploadUrl?: string;
+  importId?: string;
+  inspectStatus?: "preview_ready" | "failed";
+}) {
+  const uploadUrl = overrides?.uploadUrl ?? "https://storage.example/upload";
+  const importId = overrides?.importId ?? "import_1";
+  const mutation = vi.fn(async (name: string) => {
+    if (String(name).includes("generateBundleUploadUrl")) return uploadUrl;
+    if (String(name).includes("createImport")) return { importId };
+    throw new Error(`unexpected mutation ${name}`);
+  });
+  const action = vi.fn(async () => ({
+    importId,
+    status: overrides?.inspectStatus ?? "preview_ready",
+  }));
+  const query = vi.fn(async () => null);
+  const convex = { mutation, query, action } as unknown as PluginConvexClient;
+  return { convex, mutation, action, query, uploadUrl, importId };
+}
+
+describe("uploadBundleToStorage", () => {
+  const realFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  it("POSTs the blob and returns the storageId", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ storageId: "st_123" }),
+    })) as unknown as typeof fetch;
+    globalThis.fetch = fetchMock;
+
+    const id = await uploadBundleToStorage(
+      "https://storage.example/upload",
+      new Blob([new Uint8Array([1, 2, 3])], { type: "application/zip" }),
+    );
+    expect(id).toBe("st_123");
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("throws on a non-ok upload response", async () => {
+    globalThis.fetch = vi.fn(async () => ({
+      ok: false,
+      status: 500,
+      statusText: "Server Error",
+    })) as unknown as typeof fetch;
+    await expect(
+      uploadBundleToStorage("https://x", new Blob([])),
+    ).rejects.toThrow(/Failed to upload plugin bundle/);
+  });
+
+  it("throws when the response omits a storageId", async () => {
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({}),
+    })) as unknown as typeof fetch;
+    await expect(
+      uploadBundleToStorage("https://x", new Blob([])),
+    ).rejects.toThrow(/storageId/);
+  });
+});
+
+describe("startPluginImportFromZip", () => {
+  beforeEach(() => {
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ storageId: "st_from_zip" }),
+    })) as unknown as typeof fetch;
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it("runs upload → createImport → inspect and returns the result", async () => {
+    const { convex, mutation, action } = makeConvex();
+    const result = await startPluginImportFromZip(convex, {
+      projectId: "proj_1",
+      bundle: new Blob([new Uint8Array([1])], { type: "application/zip" }),
+      sourceLabel: "demo.zip",
+    });
+
+    expect(result.importId).toBe("import_1");
+    expect(result.bundleStorageId).toBe("st_from_zip");
+    expect(result.inspect.status).toBe("preview_ready");
+
+    // createImport received the uploaded storage id + sanitizable label.
+    const createCall = mutation.mock.calls.find((c) =>
+      String(c[0]).includes("createImport"),
+    );
+    expect(createCall?.[1]).toMatchObject({
+      projectId: "proj_1",
+      bundleStorageId: "st_from_zip",
+      sourceLabel: "demo.zip",
+    });
+    expect(action).toHaveBeenCalledOnce();
+  });
+
+  it("surfaces a failed inspect status", async () => {
+    const { convex } = makeConvex({ inspectStatus: "failed" });
+    const result = await startPluginImportFromZip(convex, {
+      projectId: "proj_1",
+      bundle: new Blob([]),
+    });
+    expect(result.inspect.status).toBe("failed");
+  });
+});
+
+describe("startPluginImportFromFolder", () => {
+  beforeEach(() => {
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ storageId: "st_folder" }),
+    })) as unknown as typeof fetch;
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it("zips the folder then runs the same flow", async () => {
+    const { convex } = makeConvex({ importId: "import_folder" });
+    const files = new Map([
+      [".codex-plugin/plugin.json", new TextEncoder().encode("{}")],
+    ]);
+    const result = await startPluginImportFromFolder(convex, {
+      projectId: "proj_1",
+      files,
+    });
+    expect(result.importId).toBe("import_folder");
+    expect(result.bundleStorageId).toBe("st_folder");
+  });
+});
+
+describe("commitImport stub (backend BE-4 not merged)", () => {
+  it("throws a stable not-available error", async () => {
+    const { convex } = makeConvex();
+    await expect(
+      commitImport(convex, { importId: "import_1" }),
+    ).rejects.toThrow(PLUGIN_COMMIT_NOT_AVAILABLE);
+  });
+});

--- a/mcpjam-inspector/client/src/lib/plugins/folder-to-zip.ts
+++ b/mcpjam-inspector/client/src/lib/plugins/folder-to-zip.ts
@@ -1,0 +1,159 @@
+/**
+ * Deterministic, dependency-free folder → ZIP for local/Electron plugin import.
+ *
+ * In desktop/local mode the client zips a selected plugin folder before upload
+ * so the backend receives the SAME canonical input as a hosted ZIP upload
+ * (scope decision in docs/plans/openai-plugin-import-cross-repo.md, "V1 import
+ * sources"). The plugin bundle hash is content-addressed by the SDK parser
+ * (SHA-256 over sorted `path NUL contentHash` framing — see
+ * sdk/src/plugin-bundle/hashes.ts), so it depends only on the set of
+ * {path, bytes} the archive yields, never on the container's bytes, ordering,
+ * or compression. A folder and a ZIP of identical contents therefore produce
+ * an identical bundle hash regardless of how this writer lays the ZIP out.
+ *
+ * The writer uses the STORE method (no compression): a plugin bundle is capped
+ * at 25 MB compressed / 100 MB uncompressed and is inspected once, so the
+ * simplicity and zero-dependency footprint outweigh compression. Entries are
+ * emitted in sorted path order so the produced bytes are deterministic for a
+ * given input (useful for tests and content caching). Browser-safe: no Node
+ * APIs, only typed arrays and TextEncoder.
+ */
+
+import type { PluginFolderFiles } from "./plugin-file-source";
+
+const LOCAL_FILE_HEADER_SIG = 0x04034b50;
+const CENTRAL_DIR_HEADER_SIG = 0x02014b50;
+const END_OF_CENTRAL_DIR_SIG = 0x06054b50;
+/** General-purpose bit 11: filename/comment are UTF-8. */
+const UTF8_FLAG = 0x0800;
+/** Method 0 = stored (no compression). */
+const METHOD_STORE = 0;
+/** Fixed DOS timestamp (1980-01-01 00:00:00) for reproducible archives. */
+const DOS_TIME = 0;
+const DOS_DATE = 0x0021;
+
+const CRC32_TABLE = buildCrc32Table();
+
+function buildCrc32Table(): Uint32Array {
+  const table = new Uint32Array(256);
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let k = 0; k < 8; k++) {
+      c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    }
+    table[n] = c >>> 0;
+  }
+  return table;
+}
+
+function crc32(bytes: Uint8Array): number {
+  let crc = 0xffffffff;
+  for (let i = 0; i < bytes.length; i++) {
+    crc = CRC32_TABLE[(crc ^ bytes[i]) & 0xff] ^ (crc >>> 8);
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+interface StagedEntry {
+  nameBytes: Uint8Array;
+  data: Uint8Array;
+  crc: number;
+  localHeaderOffset: number;
+}
+
+/**
+ * Zip a plugin folder map (bundle-relative POSIX path → bytes) into a single
+ * ZIP byte array. Directory entries are implied by file paths and are not
+ * written; the SDK parser derives structure from file paths.
+ */
+export function folderToZip(files: PluginFolderFiles): Uint8Array {
+  const encoder = new TextEncoder();
+  // Sorted for deterministic output; the bundle hash is order-independent but
+  // stable bytes make the archive itself reproducible.
+  const paths = [...files.keys()].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+
+  const staged: StagedEntry[] = [];
+  const chunks: Uint8Array[] = [];
+  let offset = 0;
+
+  for (const path of paths) {
+    const data = files.get(path)!;
+    const nameBytes = encoder.encode(path);
+    const crc = crc32(data);
+
+    const header = new Uint8Array(30 + nameBytes.length);
+    const view = new DataView(header.buffer);
+    view.setUint32(0, LOCAL_FILE_HEADER_SIG, true);
+    view.setUint16(4, 20, true); // version needed
+    view.setUint16(6, UTF8_FLAG, true);
+    view.setUint16(8, METHOD_STORE, true);
+    view.setUint16(10, DOS_TIME, true);
+    view.setUint16(12, DOS_DATE, true);
+    view.setUint32(14, crc, true);
+    view.setUint32(18, data.length, true); // compressed size (== uncompressed)
+    view.setUint32(22, data.length, true); // uncompressed size
+    view.setUint16(26, nameBytes.length, true);
+    view.setUint16(28, 0, true); // extra field length
+    header.set(nameBytes, 30);
+
+    staged.push({ nameBytes, data, crc, localHeaderOffset: offset });
+    chunks.push(header);
+    chunks.push(data);
+    offset += header.length + data.length;
+  }
+
+  const centralDirStart = offset;
+  for (const entry of staged) {
+    const record = new Uint8Array(46 + entry.nameBytes.length);
+    const view = new DataView(record.buffer);
+    view.setUint32(0, CENTRAL_DIR_HEADER_SIG, true);
+    view.setUint16(4, 20, true); // version made by
+    view.setUint16(6, 20, true); // version needed
+    view.setUint16(8, UTF8_FLAG, true);
+    view.setUint16(10, METHOD_STORE, true);
+    view.setUint16(12, DOS_TIME, true);
+    view.setUint16(14, DOS_DATE, true);
+    view.setUint32(16, entry.crc, true);
+    view.setUint32(20, entry.data.length, true); // compressed size
+    view.setUint32(24, entry.data.length, true); // uncompressed size
+    view.setUint16(28, entry.nameBytes.length, true);
+    view.setUint16(30, 0, true); // extra field length
+    view.setUint16(32, 0, true); // comment length
+    view.setUint16(34, 0, true); // disk number start
+    view.setUint16(36, 0, true); // internal attributes
+    view.setUint32(38, 0, true); // external attributes
+    view.setUint32(42, entry.localHeaderOffset, true);
+    record.set(entry.nameBytes, 46);
+    chunks.push(record);
+    offset += record.length;
+  }
+  const centralDirSize = offset - centralDirStart;
+
+  const end = new Uint8Array(22);
+  const endView = new DataView(end.buffer);
+  endView.setUint32(0, END_OF_CENTRAL_DIR_SIG, true);
+  endView.setUint16(4, 0, true); // disk number
+  endView.setUint16(6, 0, true); // central dir start disk
+  endView.setUint16(8, staged.length, true); // entries on this disk
+  endView.setUint16(10, staged.length, true); // total entries
+  endView.setUint32(12, centralDirSize, true);
+  endView.setUint32(16, centralDirStart, true);
+  endView.setUint16(20, 0, true); // comment length
+  chunks.push(end);
+  offset += end.length;
+
+  const out = new Uint8Array(offset);
+  let cursor = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, cursor);
+    cursor += chunk.length;
+  }
+  return out;
+}
+
+/** Convenience: zip a folder and wrap it as a `Blob` ready for upload. */
+export function folderToZipBlob(files: PluginFolderFiles): Blob {
+  const bytes = folderToZip(files);
+  // Copy into a fresh ArrayBuffer so Blob never sees a shared/pooled buffer.
+  return new Blob([bytes.slice().buffer], { type: "application/zip" });
+}

--- a/mcpjam-inspector/client/src/lib/plugins/folder-to-zip.ts
+++ b/mcpjam-inspector/client/src/lib/plugins/folder-to-zip.ts
@@ -17,9 +17,66 @@
  * emitted in sorted path order so the produced bytes are deterministic for a
  * given input (useful for tests and content caching). Browser-safe: no Node
  * APIs, only typed arrays and TextEncoder.
+ *
+ * TRADEOFF (deflate is intentionally out of scope for INS-1): because STORE
+ * does not compress, `folderToZip` first runs `assertFolderWithinLimits` — a
+ * preflight against the SDK's uncompressed bundle limits — so an oversized
+ * folder fails fast with a clear error instead of blowing up memory while
+ * materializing the archive. STORE also adds ~per-entry header overhead, so a
+ * folder whose CONTENT is just under the backend's 25 MB *compressed* cap can
+ * still be rejected on upload; the backend remains the authority on the
+ * compressed cap. If large real-world plugins hit this, add deflate here.
  */
 
+import {
+  DEFAULT_PLUGIN_BUNDLE_LIMITS,
+  type PluginBundleLimits,
+} from "@mcpjam/sdk/plugin-bundle";
 import type { PluginFolderFiles } from "./plugin-file-source";
+
+/** Stable error code thrown when a folder exceeds the SDK bundle limits. */
+export const PLUGIN_FOLDER_TOO_LARGE = "PLUGIN_FOLDER_TOO_LARGE";
+
+export class PluginFolderTooLargeError extends Error {
+  readonly code = PLUGIN_FOLDER_TOO_LARGE;
+  constructor(message: string) {
+    super(message);
+    this.name = "PluginFolderTooLargeError";
+  }
+}
+
+/**
+ * Preflight a folder against the SDK's uncompressed bundle limits (entry count,
+ * per-file size, total size) BEFORE materializing the archive in memory. Mirror
+ * of the archive-level caps the parser/backend enforce, applied early so an
+ * oversized selection cannot OOM the STORE writer. Throws
+ * `PluginFolderTooLargeError`; the parser still enforces the same caps on the
+ * uploaded archive as the authoritative check.
+ */
+export function assertFolderWithinLimits(
+  files: PluginFolderFiles,
+  limits: PluginBundleLimits = DEFAULT_PLUGIN_BUNDLE_LIMITS,
+): void {
+  if (files.length > limits.maxEntries) {
+    throw new PluginFolderTooLargeError(
+      `plugin folder has ${files.length} files; the limit is ${limits.maxEntries}`,
+    );
+  }
+  let total = 0;
+  for (const file of files) {
+    if (file.bytes.byteLength > limits.maxFileBytes) {
+      throw new PluginFolderTooLargeError(
+        `plugin file "${file.path}" is ${file.bytes.byteLength} bytes; the per-file limit is ${limits.maxFileBytes}`,
+      );
+    }
+    total += file.bytes.byteLength;
+    if (total > limits.maxTotalBytes) {
+      throw new PluginFolderTooLargeError(
+        `plugin folder exceeds the ${limits.maxTotalBytes}-byte uncompressed limit`,
+      );
+    }
+  }
+}
 
 const LOCAL_FILE_HEADER_SIG = 0x04034b50;
 const CENTRAL_DIR_HEADER_SIG = 0x02014b50;
@@ -62,22 +119,28 @@ interface StagedEntry {
 }
 
 /**
- * Zip a plugin folder map (bundle-relative POSIX path → bytes) into a single
- * ZIP byte array. Directory entries are implied by file paths and are not
- * written; the SDK parser derives structure from file paths.
+ * Zip a plugin folder (array of bundle-relative path → bytes) into a single ZIP
+ * byte array. Directory entries are implied by file paths and are not written;
+ * the SDK parser derives structure from file paths. Duplicate paths are written
+ * verbatim (the parser rejects them). Throws `PluginFolderTooLargeError` when
+ * the folder exceeds the SDK's uncompressed limits.
  */
-export function folderToZip(files: PluginFolderFiles): Uint8Array {
+export function folderToZip(files: PluginFolderFiles): Uint8Array<ArrayBuffer> {
+  assertFolderWithinLimits(files);
+
   const encoder = new TextEncoder();
-  // Sorted for deterministic output; the bundle hash is order-independent but
-  // stable bytes make the archive itself reproducible.
-  const paths = [...files.keys()].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+  // Sorted by path for deterministic output; the bundle hash is
+  // order-independent but stable bytes make the archive itself reproducible.
+  // A stable sort preserves the relative order of any duplicate paths.
+  const ordered = [...files].sort((a, b) =>
+    a.path < b.path ? -1 : a.path > b.path ? 1 : 0,
+  );
 
   const staged: StagedEntry[] = [];
   const chunks: Uint8Array[] = [];
   let offset = 0;
 
-  for (const path of paths) {
-    const data = files.get(path)!;
+  for (const { path, bytes: data } of ordered) {
     const nameBytes = encoder.encode(path);
     const crc = crc32(data);
 
@@ -153,7 +216,7 @@ export function folderToZip(files: PluginFolderFiles): Uint8Array {
 
 /** Convenience: zip a folder and wrap it as a `Blob` ready for upload. */
 export function folderToZipBlob(files: PluginFolderFiles): Blob {
-  const bytes = folderToZip(files);
-  // Copy into a fresh ArrayBuffer so Blob never sees a shared/pooled buffer.
-  return new Blob([bytes.slice().buffer], { type: "application/zip" });
+  // `folderToZip` returns a Uint8Array backed by its own freshly-allocated
+  // buffer, so Blob can take it directly.
+  return new Blob([folderToZip(files)], { type: "application/zip" });
 }

--- a/mcpjam-inspector/client/src/lib/plugins/mcp-config-shape.ts
+++ b/mcpjam-inspector/client/src/lib/plugins/mcp-config-shape.ts
@@ -68,14 +68,15 @@ function looksLikeServerEntry(value: unknown): boolean {
 }
 
 /**
- * Detect whether a wrapper-less object is a direct server map: every value
- * must be an object and at least one must look like a server entry.
+ * Detect whether a wrapper-less object is a direct server map: at least one
+ * value must look like a server entry. Non-object sibling keys (e.g. a
+ * top-level `version: "1.0"` alongside real servers) are TOLERATED — the
+ * wrapped shapes don't reject such siblings either, and the per-server loop
+ * skips non-object values — so a direct map imports the same servers a
+ * `mcp_servers` wrapper would.
  */
 function looksLikeServerMap(record: Record<string, unknown>): boolean {
-  const values = Object.values(record);
-  if (values.length === 0) return false;
-  if (!values.every(isPlainObject)) return false;
-  return values.some(looksLikeServerEntry);
+  return Object.values(record).some(looksLikeServerEntry);
 }
 
 /**

--- a/mcpjam-inspector/client/src/lib/plugins/mcp-config-shape.ts
+++ b/mcpjam-inspector/client/src/lib/plugins/mcp-config-shape.ts
@@ -1,0 +1,125 @@
+/**
+ * MCP configuration shape detection — the three compatible source shapes.
+ *
+ * MCPJam ingests MCP server configuration in three interchangeable shapes
+ * (locked architecture decision 7 of
+ * docs/plans/openai-plugin-import-cross-repo.md):
+ *
+ *   1. a direct server map            `{ "svr": { command } }`
+ *   2. an `mcp_servers` wrapper        `{ "mcp_servers": { "svr": { command } } }`
+ *      (current OpenAI plugin docs)
+ *   3. an `mcpServers` wrapper         `{ "mcpServers": { "svr": { command } } }`
+ *      (existing MCPJam / Claude-style configs)
+ *
+ * The SDK's `@mcpjam/sdk/plugin-bundle` parser owns this same wrapper contract
+ * for the plugin-bundle path (`normalizePluginMcpConfig`), but that normalizer
+ * is (a) not part of the SDK's exported public surface and (b) deliberately
+ * VALUE-STRIPPING — it stores requirement NAMES only, never resolved
+ * command/env/header VALUES, because a plugin bundle must not persist secrets.
+ * The JSON-import surface here is value-PRESERVING: a user pasting their own
+ * `mcpServers` config expects a working server with its real command/env/url,
+ * so it cannot consume the value-stripping normalizer verbatim. This module
+ * therefore shares the wrapper/transport CONTRACT with the SDK while keeping
+ * the value-preserving mapping local. Keep the two in sync: the accepted
+ * shapes and the duplicate-wrapper / bare-server rejections mirror the SDK's
+ * `normalizePluginMcpConfig` exactly.
+ */
+
+export type McpConfigWrapper = "mcp_servers" | "mcpServers" | "direct";
+
+export type UnwrapMcpServerMapResult =
+  | { ok: true; wrapper: McpConfigWrapper; servers: Record<string, unknown> }
+  | { ok: false; reason: UnwrapFailureReason };
+
+/**
+ * Why a config could not be resolved to a server map. Callers map these to
+ * their own (legacy-compatible) user-facing messages.
+ */
+export type UnwrapFailureReason =
+  /** Top-level value was not a JSON object (array/null/scalar). */
+  | "not-object"
+  /** Declared both `mcp_servers` and `mcpServers` — ambiguous. */
+  | "both-wrappers"
+  /** A wrapper key was present but its value was not an object. */
+  | "wrapper-not-object"
+  /** No wrapper key and the object does not look like a direct server map. */
+  | "no-server-map";
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * A value "looks like" a server entry when it is an object carrying at least
+ * one recognized transport signal (`command`, `url`, or an explicit
+ * `type`/`transport`). Used only to decide whether a wrapper-less object is a
+ * direct server MAP: requiring a strong per-entry signal keeps arbitrary JSON
+ * (e.g. `{ "servers": {} }`) from being silently misread as a server map,
+ * preserving the legacy "missing mcpServers" error for such input.
+ */
+function looksLikeServerEntry(value: unknown): boolean {
+  if (!isPlainObject(value)) return false;
+  return (
+    typeof value.command === "string" ||
+    typeof value.url === "string" ||
+    value.type !== undefined ||
+    value.transport !== undefined
+  );
+}
+
+/**
+ * Detect whether a wrapper-less object is a direct server map: every value
+ * must be an object and at least one must look like a server entry.
+ */
+function looksLikeServerMap(record: Record<string, unknown>): boolean {
+  const values = Object.values(record);
+  if (values.length === 0) return false;
+  if (!values.every(isPlainObject)) return false;
+  return values.some(looksLikeServerEntry);
+}
+
+/**
+ * Resolve any of the three accepted MCP config shapes to a `{ name: config }`
+ * server map WITHOUT stripping values. Mirrors the SDK's wrapper contract:
+ * both wrappers present is rejected as ambiguous; a bare single-server object
+ * is not a server map.
+ */
+export function unwrapMcpServerMap(config: unknown): UnwrapMcpServerMapResult {
+  if (!isPlainObject(config)) {
+    return { ok: false, reason: "not-object" };
+  }
+
+  const hasSnake = Object.prototype.hasOwnProperty.call(config, "mcp_servers");
+  const hasCamel = Object.prototype.hasOwnProperty.call(config, "mcpServers");
+
+  if (hasSnake && hasCamel) {
+    return { ok: false, reason: "both-wrappers" };
+  }
+
+  if (hasCamel) {
+    const servers = config.mcpServers;
+    if (!isPlainObject(servers)) {
+      return { ok: false, reason: "wrapper-not-object" };
+    }
+    return { ok: true, wrapper: "mcpServers", servers };
+  }
+
+  if (hasSnake) {
+    const servers = config.mcp_servers;
+    if (!isPlainObject(servers)) {
+      return { ok: false, reason: "wrapper-not-object" };
+    }
+    return { ok: true, wrapper: "mcp_servers", servers };
+  }
+
+  // No wrapper key: accept a direct server map only when the object plausibly
+  // IS one. A bare single server config (top-level string `command`/`url`) is
+  // not a map — this matches the SDK, which rejects that shape.
+  if (typeof config.command === "string" || typeof config.url === "string") {
+    return { ok: false, reason: "no-server-map" };
+  }
+  if (looksLikeServerMap(config)) {
+    return { ok: true, wrapper: "direct", servers: config };
+  }
+  return { ok: false, reason: "no-server-map" };
+}

--- a/mcpjam-inspector/client/src/lib/plugins/plugin-file-source.ts
+++ b/mcpjam-inspector/client/src/lib/plugins/plugin-file-source.ts
@@ -1,0 +1,124 @@
+/**
+ * Browser-safe folder adapters for the SDK plugin-bundle parser.
+ *
+ * The `@mcpjam/sdk/plugin-bundle` parser is pure — it consumes an abstract
+ * `PluginFileSource` and never touches a filesystem or archive library. This
+ * module provides an in-memory folder source so local/Electron mode can parse
+ * and preview a selected plugin folder with the SAME normalization, validation,
+ * and deterministic hashing the backend applies to an uploaded ZIP (locked
+ * decision 3 of docs/plans/openai-plugin-import-cross-repo.md).
+ *
+ * The map key is the bundle-relative POSIX path exactly as it should appear in
+ * the archive (e.g. `.codex-plugin/plugin.json`, `skills/foo/SKILL.md`). The
+ * parser owns path validation; this adapter only surfaces entries and bytes.
+ */
+
+import type {
+  PluginFileEntry,
+  PluginFileSource,
+} from "@mcpjam/sdk/plugin-bundle";
+
+/** A plugin folder flattened to bundle-relative path → exact file bytes. */
+export type PluginFolderFiles = ReadonlyMap<string, Uint8Array>;
+
+/** One selected file plus its bundle-relative path. */
+export interface PluginFolderFile {
+  /** Bundle-relative POSIX path (no leading slash, no `..`). */
+  path: string;
+  bytes: Uint8Array;
+}
+
+/**
+ * Build a `PluginFileSource` over an in-memory file map. Paths are surfaced
+ * verbatim; the parser rejects anything unsafe. `readBytes` enforces `maxBytes`
+ * by throwing (never truncating) so hashes are computed over full content.
+ */
+export function createFolderPluginSource(
+  files: PluginFolderFiles,
+): PluginFileSource {
+  const entries: PluginFileEntry[] = [...files.entries()].map(
+    ([path, bytes]) => ({ path, size: bytes.byteLength, kind: "file" }),
+  );
+
+  return {
+    async list(): Promise<PluginFileEntry[]> {
+      return entries;
+    },
+    async readBytes(path: string, maxBytes: number): Promise<Uint8Array> {
+      const bytes = files.get(path);
+      if (bytes === undefined) {
+        throw new Error(`plugin file not found: ${path}`);
+      }
+      if (bytes.byteLength > maxBytes) {
+        throw new Error(
+          `plugin file exceeds ${maxBytes} bytes: ${path} (${bytes.byteLength})`,
+        );
+      }
+      return bytes;
+    },
+    async readText(path: string, maxBytes: number): Promise<string> {
+      const bytes = await this.readBytes(path, maxBytes);
+      return new TextDecoder("utf-8", { fatal: false }).decode(bytes);
+    },
+  };
+}
+
+/**
+ * Normalize a browser directory selection (an `<input type="file"
+ * webkitdirectory>` FileList, or drag-and-drop entries the caller has already
+ * flattened) into a `PluginFolderFiles` map.
+ *
+ * `webkitRelativePath` includes the chosen root directory as its first segment
+ * (`my-plugin/.codex-plugin/plugin.json`); we strip that single leading segment
+ * so the map keys are bundle-relative, matching what a ZIP of the folder's
+ * CONTENTS would contain. This keeps the folder bundle hash identical to a ZIP
+ * built from the same contents.
+ */
+export async function readBrowserFolderSelection(
+  fileList: ArrayLike<File>,
+): Promise<PluginFolderFiles> {
+  const files = new Map<string, Uint8Array>();
+  const list = Array.from(fileList);
+  for (const file of list) {
+    const relative = (file as File & { webkitRelativePath?: string })
+      .webkitRelativePath;
+    const rawPath = relative && relative.length > 0 ? relative : file.name;
+    const path = stripLeadingDirectory(rawPath);
+    if (path.length === 0) continue;
+    const bytes = new Uint8Array(await file.arrayBuffer());
+    files.set(path, bytes);
+  }
+  return files;
+}
+
+/**
+ * Build a `PluginFolderFiles` map from explicit path/bytes pairs (e.g. an
+ * Electron main-process directory walk that already produced bundle-relative
+ * POSIX paths).
+ */
+export function toPluginFolderFiles(
+  files: Iterable<PluginFolderFile>,
+): PluginFolderFiles {
+  const map = new Map<string, Uint8Array>();
+  for (const { path, bytes } of files) {
+    const normalized = normalizePosixPath(path);
+    if (normalized.length === 0) continue;
+    map.set(normalized, bytes);
+  }
+  return map;
+}
+
+/** Strip the first path segment (the selected root directory name). */
+function stripLeadingDirectory(rawPath: string): string {
+  const posix = normalizePosixPath(rawPath);
+  const slash = posix.indexOf("/");
+  return slash === -1 ? "" : posix.slice(slash + 1);
+}
+
+/** Normalize separators and trim leading `./` and `/`. */
+function normalizePosixPath(rawPath: string): string {
+  let posix = rawPath.replace(/\\/g, "/");
+  while (posix.startsWith("./")) posix = posix.slice(2);
+  while (posix.startsWith("/")) posix = posix.slice(1);
+  return posix;
+}

--- a/mcpjam-inspector/client/src/lib/plugins/plugin-file-source.ts
+++ b/mcpjam-inspector/client/src/lib/plugins/plugin-file-source.ts
@@ -8,9 +8,13 @@
  * and deterministic hashing the backend applies to an uploaded ZIP (locked
  * decision 3 of docs/plans/openai-plugin-import-cross-repo.md).
  *
- * The map key is the bundle-relative POSIX path exactly as it should appear in
- * the archive (e.g. `.codex-plugin/plugin.json`, `skills/foo/SKILL.md`). The
- * parser owns path validation; this adapter only surfaces entries and bytes.
+ * SECURITY: this adapter surfaces entry paths VERBATIM and does NOT collapse
+ * duplicates. The SDK parser owns archive-safety validation — absolute paths,
+ * `..` traversal, duplicate normalized paths, case-fold collisions, etc. A Map
+ * keyed by path (which silently de-duplicates and demands pre-normalized keys)
+ * would hide `PATH_ABSOLUTE` / `PATH_DUPLICATE` from the parser on the folder
+ * path, reopening the exact gap the parser exists to close — so files are held
+ * as an ARRAY and paths reach the parser unmodified.
  */
 
 import type {
@@ -18,34 +22,44 @@ import type {
   PluginFileSource,
 } from "@mcpjam/sdk/plugin-bundle";
 
-/** A plugin folder flattened to bundle-relative path → exact file bytes. */
-export type PluginFolderFiles = ReadonlyMap<string, Uint8Array>;
-
-/** One selected file plus its bundle-relative path. */
+/** One selected file plus its bundle-relative path (verbatim, unvalidated). */
 export interface PluginFolderFile {
-  /** Bundle-relative POSIX path (no leading slash, no `..`). */
+  /** Bundle-relative path as selected; validated by the SDK parser, not here. */
   path: string;
   bytes: Uint8Array;
 }
 
 /**
- * Build a `PluginFileSource` over an in-memory file map. Paths are surfaced
- * verbatim; the parser rejects anything unsafe. `readBytes` enforces `maxBytes`
- * by throwing (never truncating) so hashes are computed over full content.
+ * A plugin folder flattened to (path, bytes) entries. An ARRAY, not a Map, so
+ * duplicate and absolute paths survive to the parser instead of being silently
+ * merged or normalized away.
+ */
+export type PluginFolderFiles = ReadonlyArray<PluginFolderFile>;
+
+/**
+ * Build a `PluginFileSource` over an in-memory folder. Entries (including
+ * duplicates) and their paths are surfaced exactly as given; the parser
+ * rejects anything unsafe. `readBytes` enforces `maxBytes` by throwing (never
+ * truncating) so hashes are computed over full content.
  */
 export function createFolderPluginSource(
   files: PluginFolderFiles,
 ): PluginFileSource {
-  const entries: PluginFileEntry[] = [...files.entries()].map(
-    ([path, bytes]) => ({ path, size: bytes.byteLength, kind: "file" }),
-  );
+  const entries: PluginFileEntry[] = files.map((file) => ({
+    path: file.path,
+    size: file.bytes.byteLength,
+    kind: "file",
+  }));
+
+  const findFirst = (path: string): Uint8Array | undefined =>
+    files.find((file) => file.path === path)?.bytes;
 
   return {
     async list(): Promise<PluginFileEntry[]> {
       return entries;
     },
     async readBytes(path: string, maxBytes: number): Promise<Uint8Array> {
-      const bytes = files.get(path);
+      const bytes = findFirst(path);
       if (bytes === undefined) {
         throw new Error(`plugin file not found: ${path}`);
       }
@@ -65,60 +79,48 @@ export function createFolderPluginSource(
 
 /**
  * Normalize a browser directory selection (an `<input type="file"
- * webkitdirectory>` FileList, or drag-and-drop entries the caller has already
- * flattened) into a `PluginFolderFiles` map.
+ * webkitdirectory>` FileList, or drag-and-drop files) into `PluginFolderFiles`.
  *
- * `webkitRelativePath` includes the chosen root directory as its first segment
+ * `webkitRelativePath` prefixes the chosen root directory as its first segment
  * (`my-plugin/.codex-plugin/plugin.json`); we strip that single leading segment
- * so the map keys are bundle-relative, matching what a ZIP of the folder's
- * CONTENTS would contain. This keeps the folder bundle hash identical to a ZIP
- * built from the same contents.
+ * so paths are bundle-relative, matching a ZIP of the folder's CONTENTS. When
+ * `webkitRelativePath` is absent (drag-and-drop / fallback), the file's `name`
+ * is used as-is — otherwise the whole import would come back empty. Everything
+ * after the root segment is preserved verbatim (leading `/`, `..`, duplicates)
+ * for the SDK parser to validate.
  */
 export async function readBrowserFolderSelection(
   fileList: ArrayLike<File>,
 ): Promise<PluginFolderFiles> {
-  const files = new Map<string, Uint8Array>();
-  const list = Array.from(fileList);
-  for (const file of list) {
+  const files: PluginFolderFile[] = [];
+  for (const file of Array.from(fileList)) {
     const relative = (file as File & { webkitRelativePath?: string })
       .webkitRelativePath;
-    const rawPath = relative && relative.length > 0 ? relative : file.name;
-    const path = stripLeadingDirectory(rawPath);
+    const path =
+      relative && relative.length > 0
+        ? stripFirstSegment(relative)
+        : file.name;
     if (path.length === 0) continue;
     const bytes = new Uint8Array(await file.arrayBuffer());
-    files.set(path, bytes);
+    files.push({ path, bytes });
   }
   return files;
 }
 
 /**
- * Build a `PluginFolderFiles` map from explicit path/bytes pairs (e.g. an
- * Electron main-process directory walk that already produced bundle-relative
- * POSIX paths).
+ * Build `PluginFolderFiles` from explicit path/bytes pairs (e.g. an Electron
+ * main-process directory walk). Paths are preserved EXACTLY — no stripping, no
+ * de-duplication — so the SDK parser can reject absolute/duplicate/traversal
+ * paths a walker might surface.
  */
 export function toPluginFolderFiles(
   files: Iterable<PluginFolderFile>,
 ): PluginFolderFiles {
-  const map = new Map<string, Uint8Array>();
-  for (const { path, bytes } of files) {
-    const normalized = normalizePosixPath(path);
-    if (normalized.length === 0) continue;
-    map.set(normalized, bytes);
-  }
-  return map;
+  return [...files];
 }
 
-/** Strip the first path segment (the selected root directory name). */
-function stripLeadingDirectory(rawPath: string): string {
-  const posix = normalizePosixPath(rawPath);
-  const slash = posix.indexOf("/");
-  return slash === -1 ? "" : posix.slice(slash + 1);
-}
-
-/** Normalize separators and trim leading `./` and `/`. */
-function normalizePosixPath(rawPath: string): string {
-  let posix = rawPath.replace(/\\/g, "/");
-  while (posix.startsWith("./")) posix = posix.slice(2);
-  while (posix.startsWith("/")) posix = posix.slice(1);
-  return posix;
+/** Strip only the first `/`-delimited segment (the selected root directory). */
+function stripFirstSegment(path: string): string {
+  const slash = path.indexOf("/");
+  return slash === -1 ? path : path.slice(slash + 1);
 }

--- a/mcpjam-inspector/client/src/lib/plugins/plugin-import-client.ts
+++ b/mcpjam-inspector/client/src/lib/plugins/plugin-import-client.ts
@@ -164,9 +164,11 @@ export interface StartPluginImportArgs {
   /**
    * Progress callback. Fires `uploading` before the upload and `inspecting`
    * after the import row is staged (so the runner can surface the inspect phase
-   * instead of jumping straight from uploading to done).
+   * instead of jumping straight from uploading to done). The `inspecting` call
+   * carries the staged `importId` so a subscriber can attach to server-side
+   * progress WHILE inspection runs, not only after it finishes.
    */
-  onPhase?: (phase: StartPluginImportPhase) => void;
+  onPhase?: (phase: StartPluginImportPhase, importId?: string) => void;
 }
 
 export interface StartPluginImportResult {
@@ -219,8 +221,9 @@ export async function startPluginImportFromZip(
     bundleStorageId,
     sourceLabel: args.sourceLabel,
   });
-  // The row now exists; a later failure must not lose its id.
-  args.onPhase?.("inspecting");
+  // The row now exists; a later failure must not lose its id. Hand the id to the
+  // progress callback so a subscriber can attach during inspection, not after.
+  args.onPhase?.("inspecting", importId);
   try {
     const inspect = await inspectImport(convex, { importId });
     return { importId, bundleStorageId, inspect };
@@ -237,7 +240,7 @@ export interface StartPluginImportFromFolderArgs {
   /** Selected folder CONTENTS (path/bytes entries, paths validated by the SDK). */
   files: PluginFolderFiles;
   sourceLabel?: string;
-  onPhase?: (phase: StartPluginImportPhase) => void;
+  onPhase?: (phase: StartPluginImportPhase, importId?: string) => void;
 }
 
 /**

--- a/mcpjam-inspector/client/src/lib/plugins/plugin-import-client.ts
+++ b/mcpjam-inspector/client/src/lib/plugins/plugin-import-client.ts
@@ -152,12 +152,21 @@ export async function uploadBundleToStorage(
   return body.storageId;
 }
 
+/** Phases the orchestrator passes to an optional progress callback. */
+export type StartPluginImportPhase = "uploading" | "inspecting";
+
 export interface StartPluginImportArgs {
   projectId: string;
   /** ZIP bytes of the plugin bundle (hosted ZIP upload or folderToZip output). */
   bundle: Blob;
   /** Optional display label (backend sanitizes; a local path is never stored). */
   sourceLabel?: string;
+  /**
+   * Progress callback. Fires `uploading` before the upload and `inspecting`
+   * after the import row is staged (so the runner can surface the inspect phase
+   * instead of jumping straight from uploading to done).
+   */
+  onPhase?: (phase: StartPluginImportPhase) => void;
 }
 
 export interface StartPluginImportResult {
@@ -168,15 +177,39 @@ export interface StartPluginImportResult {
 }
 
 /**
+ * Error thrown when the flow fails AFTER a `pluginImports` row was staged (e.g.
+ * `inspectImport` rejects). It carries the staged `importId` so the caller can
+ * still subscribe to / recover the row instead of stranding it — a bare rethrow
+ * loses the id.
+ */
+export class PluginImportError extends Error {
+  readonly importId: string;
+  readonly bundleStorageId: string;
+  constructor(
+    message: string,
+    context: { importId: string; bundleStorageId: string; cause?: unknown },
+  ) {
+    super(message, { cause: context.cause });
+    this.name = "PluginImportError";
+    this.importId = context.importId;
+    this.bundleStorageId = context.bundleStorageId;
+  }
+}
+
+/**
  * Full upload → stage → inspect for a ZIP bundle. `createImport` does not
  * trigger inspection on the backend, so we schedule `inspectImport` here and
  * await its terminal preview_ready / failed result. Callers then read the
  * sanitized preview via `getPluginImport` (or the `usePluginImport` hook).
+ *
+ * If `inspectImport` throws after staging, the staged `importId` is preserved
+ * on a thrown `PluginImportError` so the caller keeps a handle to the row.
  */
 export async function startPluginImportFromZip(
   convex: PluginConvexClient,
   args: StartPluginImportArgs,
 ): Promise<StartPluginImportResult> {
+  args.onPhase?.("uploading");
   const uploadUrl = await generateBundleUploadUrl(convex, {
     projectId: args.projectId,
   });
@@ -186,15 +219,25 @@ export async function startPluginImportFromZip(
     bundleStorageId,
     sourceLabel: args.sourceLabel,
   });
-  const inspect = await inspectImport(convex, { importId });
-  return { importId, bundleStorageId, inspect };
+  // The row now exists; a later failure must not lose its id.
+  args.onPhase?.("inspecting");
+  try {
+    const inspect = await inspectImport(convex, { importId });
+    return { importId, bundleStorageId, inspect };
+  } catch (cause) {
+    throw new PluginImportError(
+      cause instanceof Error ? cause.message : "Plugin inspect failed",
+      { importId, bundleStorageId, cause },
+    );
+  }
 }
 
 export interface StartPluginImportFromFolderArgs {
   projectId: string;
-  /** Bundle-relative path → bytes for the selected folder's CONTENTS. */
+  /** Selected folder CONTENTS (path/bytes entries, paths validated by the SDK). */
   files: PluginFolderFiles;
   sourceLabel?: string;
+  onPhase?: (phase: StartPluginImportPhase) => void;
 }
 
 /**
@@ -212,6 +255,7 @@ export async function startPluginImportFromFolder(
     projectId: args.projectId,
     bundle,
     sourceLabel: args.sourceLabel,
+    onPhase: args.onPhase,
   });
 }
 

--- a/mcpjam-inspector/client/src/lib/plugins/plugin-import-client.ts
+++ b/mcpjam-inspector/client/src/lib/plugins/plugin-import-client.ts
@@ -1,0 +1,229 @@
+/**
+ * Typed client + upload helpers for the OpenAI plugin import backend surface.
+ *
+ * The inspector calls Convex functions by string name (the backend is a
+ * separate repo with no shared generated `api`), so this module is the single
+ * typed seam over the plugin import functions in `mcpjam-backend`
+ * `convex/plugins.ts` / `convex/pluginsNode.ts`. Callers pass a
+ * `ConvexReactClient` (from `useConvex()`), matching the imperative pattern in
+ * `client/src/lib/apis/*` and `use-playground-project-executions.ts`.
+ *
+ * Upload flow (backend BE-3 "Upload"):
+ *   1. `generateBundleUploadUrl` — mint a Convex `_storage` upload URL.
+ *   2. POST the ZIP bytes to that URL → `{ storageId }`.
+ *   3. `createImport` — stage a `pluginImports` row referencing the blob.
+ *   4. `inspectImport` (Node action) — parse + validate → preview_ready/failed.
+ *
+ * `commitImport` (backend BE-4) is a TYPED STUB: the commit action is not yet
+ * merged, so calling it throws a clear error. Wire the real call the moment
+ * BE-4 lands (see `PLUGIN_COMMIT_NOT_AVAILABLE`).
+ */
+
+import type { ConvexReactClient } from "convex/react";
+import type { ParsedPluginBundle } from "@mcpjam/sdk/plugin-bundle";
+import { parsePluginBundle } from "@mcpjam/sdk/plugin-bundle";
+import {
+  createFolderPluginSource,
+  type PluginFolderFiles,
+} from "./plugin-file-source";
+import { folderToZipBlob } from "./folder-to-zip";
+import type {
+  CommitImportOptions,
+  CommitImportResult,
+  InspectImportResult,
+  PluginImportRecord,
+} from "./plugin-import-types";
+
+// Convex function references. Kept as named constants so a backend rename is a
+// one-line change and every call site is greppable.
+const FN = {
+  generateBundleUploadUrl: "plugins:generateBundleUploadUrl",
+  createImport: "plugins:createImport",
+  getPluginImport: "plugins:getPluginImport",
+  inspectImport: "pluginsNode:inspectImport",
+  // BE-4 — not merged yet; only referenced by the stub below.
+  commitImport: "pluginsNode:commitImport",
+} as const;
+
+/**
+ * The `useConvex()` client exposes `query`/`mutation`/`action`. We accept the
+ * broad `ConvexReactClient` type but only touch those three methods, each
+ * called by string name (mirrored, not generated, so the args/returns are cast
+ * to the hand-written DTOs above).
+ */
+export type PluginConvexClient = Pick<
+  ConvexReactClient,
+  "query" | "mutation" | "action"
+>;
+
+// ---------------------------------------------------------------------------
+// Thin typed wrappers over the backend functions.
+// ---------------------------------------------------------------------------
+
+/** Mint a Convex `_storage` upload URL (project-admin gated on the backend). */
+export async function generateBundleUploadUrl(
+  convex: PluginConvexClient,
+  args: { projectId: string },
+): Promise<string> {
+  return (await convex.mutation(
+    FN.generateBundleUploadUrl as any,
+    args as any,
+  )) as string;
+}
+
+/** Stage a `pluginImports` row for an already-uploaded bundle blob. */
+export async function createImport(
+  convex: PluginConvexClient,
+  args: { projectId: string; bundleStorageId: string; sourceLabel?: string },
+): Promise<{ importId: string }> {
+  return (await convex.mutation(FN.createImport as any, args as any)) as {
+    importId: string;
+  };
+}
+
+/** Read an import's status/preview/failure (backend member-gated). */
+export async function getPluginImport(
+  convex: PluginConvexClient,
+  args: { importId: string },
+): Promise<PluginImportRecord | null> {
+  return (await convex.query(
+    FN.getPluginImport as any,
+    args as any,
+  )) as PluginImportRecord | null;
+}
+
+/** Run the Node inspect action → preview_ready / failed. */
+export async function inspectImport(
+  convex: PluginConvexClient,
+  args: { importId: string },
+): Promise<InspectImportResult> {
+  return (await convex.action(
+    FN.inspectImport as any,
+    args as any,
+  )) as InspectImportResult;
+}
+
+/** Stable error code thrown by the commit stub until BE-4 is merged. */
+export const PLUGIN_COMMIT_NOT_AVAILABLE = "PLUGIN_COMMIT_NOT_AVAILABLE";
+
+/**
+ * TYPED STUB for `pluginsNode.commitImport` (backend BE-4, not merged).
+ *
+ * The commit action — which materializes plugin components and flips the
+ * version to `ready` — does not exist in the deployed backend yet, so this
+ * intentionally throws rather than calling a nonexistent function. The typed
+ * surface (args + return) is defined so INS-2 can build the confirm step
+ * against a stable signature; replace the throw with
+ * `convex.action(FN.commitImport, ...)` when BE-4 lands and reconcile
+ * `CommitImportOptions` / `CommitImportResult` with the merged validators.
+ */
+export async function commitImport(
+  _convex: PluginConvexClient,
+  _args: { importId: string; options?: CommitImportOptions },
+): Promise<CommitImportResult> {
+  throw new Error(
+    `${PLUGIN_COMMIT_NOT_AVAILABLE}: plugin import commit (backend BE-4) is not available yet`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Upload orchestration.
+// ---------------------------------------------------------------------------
+
+/** POST bundle bytes to a Convex storage upload URL → the new storage id. */
+export async function uploadBundleToStorage(
+  uploadUrl: string,
+  bundle: Blob,
+): Promise<string> {
+  const response = await fetch(uploadUrl, {
+    method: "POST",
+    headers: { "Content-Type": bundle.type || "application/zip" },
+    body: bundle,
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Failed to upload plugin bundle (${response.status} ${response.statusText})`,
+    );
+  }
+  const body = (await response.json()) as { storageId?: string };
+  if (!body.storageId) {
+    throw new Error("Upload response did not include a storageId");
+  }
+  return body.storageId;
+}
+
+export interface StartPluginImportArgs {
+  projectId: string;
+  /** ZIP bytes of the plugin bundle (hosted ZIP upload or folderToZip output). */
+  bundle: Blob;
+  /** Optional display label (backend sanitizes; a local path is never stored). */
+  sourceLabel?: string;
+}
+
+export interface StartPluginImportResult {
+  importId: string;
+  bundleStorageId: string;
+  /** Result of the inspect pass (preview_ready / failed). */
+  inspect: InspectImportResult;
+}
+
+/**
+ * Full upload → stage → inspect for a ZIP bundle. `createImport` does not
+ * trigger inspection on the backend, so we schedule `inspectImport` here and
+ * await its terminal preview_ready / failed result. Callers then read the
+ * sanitized preview via `getPluginImport` (or the `usePluginImport` hook).
+ */
+export async function startPluginImportFromZip(
+  convex: PluginConvexClient,
+  args: StartPluginImportArgs,
+): Promise<StartPluginImportResult> {
+  const uploadUrl = await generateBundleUploadUrl(convex, {
+    projectId: args.projectId,
+  });
+  const bundleStorageId = await uploadBundleToStorage(uploadUrl, args.bundle);
+  const { importId } = await createImport(convex, {
+    projectId: args.projectId,
+    bundleStorageId,
+    sourceLabel: args.sourceLabel,
+  });
+  const inspect = await inspectImport(convex, { importId });
+  return { importId, bundleStorageId, inspect };
+}
+
+export interface StartPluginImportFromFolderArgs {
+  projectId: string;
+  /** Bundle-relative path → bytes for the selected folder's CONTENTS. */
+  files: PluginFolderFiles;
+  sourceLabel?: string;
+}
+
+/**
+ * Local/Electron entry point: zip the selected folder, then run the same
+ * upload → stage → inspect path as a hosted ZIP. Because the SDK bundle hash is
+ * content-addressed, a folder and a ZIP of identical contents yield the same
+ * ready version (import-source parity).
+ */
+export async function startPluginImportFromFolder(
+  convex: PluginConvexClient,
+  args: StartPluginImportFromFolderArgs,
+): Promise<StartPluginImportResult> {
+  const bundle = folderToZipBlob(args.files);
+  return startPluginImportFromZip(convex, {
+    projectId: args.projectId,
+    bundle,
+    sourceLabel: args.sourceLabel,
+  });
+}
+
+/**
+ * Parse a selected plugin folder locally with the SHARED SDK parser (reusing
+ * its manifest / MCP-config / skill normalization and deterministic hashing),
+ * without uploading. Lets local mode show an instant preview and compute the
+ * bundle hash the backend will assign to the uploaded ZIP. Throws
+ * `PluginBundleError` on validation failure — callers render `error.issues`.
+ */
+export async function previewPluginFolderLocally(
+  files: PluginFolderFiles,
+): Promise<ParsedPluginBundle> {
+  return parsePluginBundle(createFolderPluginSource(files));
+}

--- a/mcpjam-inspector/client/src/lib/plugins/plugin-import-types.ts
+++ b/mcpjam-inspector/client/src/lib/plugins/plugin-import-types.ts
@@ -1,0 +1,156 @@
+/**
+ * Typed DTOs for the OpenAI plugin import backend surface.
+ *
+ * The inspector references Convex functions by string name (the backend is a
+ * separate repository with no generated `api` object shared here), so these
+ * types are hand-mirrored from `mcpjam-backend` `convex/plugins.ts`,
+ * `convex/pluginsNode.ts`, and `convex/lib/pluginPreview.ts` (PRs BE-3/BE-4 of
+ * docs/plans/openai-plugin-import-cross-repo.md). They are the client's typed
+ * contract for `plugin-import-client.ts`; keep them in sync with the backend.
+ *
+ * The preview carries METADATA ONLY — the backend never puts resolved
+ * env/header VALUES or secrets here; requirement NAMES only.
+ */
+
+import type { PluginSetupRequirement } from "@mcpjam/sdk/plugin-bundle";
+
+/** `pluginImports.status` — the import state machine (backend BE-3). */
+export type PluginImportStatus =
+  | "uploaded"
+  | "inspecting"
+  | "preview_ready"
+  | "committing"
+  | "completed"
+  | "failed";
+
+/** States from which no further progress is possible. */
+export const TERMINAL_IMPORT_STATUSES: readonly PluginImportStatus[] = [
+  "completed",
+  "failed",
+];
+
+export function isTerminalImportStatus(status: PluginImportStatus): boolean {
+  return TERMINAL_IMPORT_STATUSES.includes(status);
+}
+
+export interface PluginImportPreviewSkill {
+  modelRef: string;
+  name: string;
+  description: string;
+  supportingFileCount: number;
+  mcpToolDependencyCount: number;
+  hasOpenaiMetadata: boolean;
+  allowImplicitInvocation?: boolean;
+}
+
+export interface PluginImportPreviewServer {
+  key: string;
+  transport: "stdio" | "http";
+  /** Requested env var NAMES only (stdio). Never values. */
+  envRequirements?: Array<{ name: string; required: boolean }>;
+  /** Requested header NAMES only (http). Never values. */
+  headerRequirements?: Array<{ name: string; secret: boolean }>;
+  oauth?: { timing?: "on_install" | "on_use"; scopes?: string[] };
+  /** Presence only — never the (possibly path-bearing) working-dir string. */
+  hasWorkingDirectory?: boolean;
+}
+
+export interface PluginImportPreviewApp {
+  appId: string;
+  binding: string;
+  status: string;
+  serverKey?: string;
+}
+
+export interface PluginImportPreviewAsset {
+  kind: string;
+  contentType: string;
+  size: number;
+}
+
+export interface PluginImportPreviewUnsupported {
+  kind: string;
+  key: string;
+  reason: string;
+  pathCount: number;
+}
+
+export interface PluginImportPreviewWarning {
+  code: string;
+  severity: string;
+  componentKey?: string;
+  message: string;
+}
+
+/** Sanitized, metadata-only import preview (backend `buildImportPreview`). */
+export interface PluginImportPreview {
+  identity: {
+    name: string;
+    displayName?: string;
+    version?: string;
+    description?: string;
+  };
+  bundleHash: string;
+  manifestHash: string;
+  counts: {
+    skills: number;
+    servers: number;
+    apps: number;
+    assets: number;
+    unsupported: number;
+    warnings: number;
+  };
+  skills: PluginImportPreviewSkill[];
+  servers: PluginImportPreviewServer[];
+  apps: PluginImportPreviewApp[];
+  assets: PluginImportPreviewAsset[];
+  /** Requirement NAMES only — the SDK never puts values here. */
+  setupRequirements: PluginSetupRequirement[];
+  unsupported: PluginImportPreviewUnsupported[];
+  warnings: PluginImportPreviewWarning[];
+}
+
+/** Stable sanitized failure ({code, message}) persisted on a failed import. */
+export interface PluginImportFailure {
+  code: string;
+  message: string;
+}
+
+/** `plugins.getPluginImport` return shape. */
+export interface PluginImportRecord {
+  importId: string;
+  projectId: string;
+  status: PluginImportStatus;
+  sourceLabel?: string;
+  preview?: PluginImportPreview;
+  failure?: PluginImportFailure;
+  pluginId?: string;
+  pluginVersionId?: string;
+  createdAt: number;
+  updatedAt: number;
+  expiresAt: number;
+}
+
+/** `pluginsNode.inspectImport` return shape. */
+export interface InspectImportResult {
+  importId: string;
+  status: "preview_ready" | "failed";
+  failureCode?: string;
+}
+
+/**
+ * `pluginsNode.commitImport` options (backend BE-4). Typed ahead of the merged
+ * contract; see the STUB note in `plugin-import-client.ts`. Shape is provisional
+ * until BE-4 lands and MUST be reconciled then.
+ */
+export interface CommitImportOptions {
+  /** Set the committed version as the plugin's active version. */
+  activate?: boolean;
+}
+
+/** Provisional `pluginsNode.commitImport` return shape (backend BE-4). */
+export interface CommitImportResult {
+  pluginId: string;
+  pluginVersionId: string;
+  bundleHash: string;
+}

--- a/mcpjam-inspector/client/vite.config.ts
+++ b/mcpjam-inspector/client/vite.config.ts
@@ -41,6 +41,14 @@ const sdkWidgetRuntimeEntry = path.resolve(
   rootDir,
   "../sdk/src/widget-runtime/index.ts",
 );
+// @mcpjam/sdk/plugin-bundle resolves to dist via package exports; alias it to
+// source so build:client resolves it without a prior `npm run build -w
+// @mcpjam/sdk` (mirrors the SDK subpath aliases above). The exported parser is
+// pure/browser-safe (no Node imports), so aliasing to source is safe.
+const sdkPluginBundleEntry = path.resolve(
+  rootDir,
+  "../sdk/src/plugin-bundle/index.ts",
+);
 // @mcpjam/chat-ui publishes from dist, but a clean checkout has no
 // chat-ui/dist until it is built. Resolve the package from source so the
 // inspector's dev/build/typecheck/test never depend on a chat-ui build.
@@ -106,6 +114,7 @@ export default defineConfig(({ mode }) => {
         "@mcpjam/chat-ui/trace": chatUiTraceEntry,
         "@mcpjam/chat-ui": chatUiEntry,
         "@mcpjam/widget-react": widgetReactEntry,
+        "@mcpjam/sdk/plugin-bundle": sdkPluginBundleEntry,
         "@mcpjam/sdk/browser": sdkBrowserEntry,
         "@mcpjam/sdk/widget-runtime": sdkWidgetRuntimeEntry,
         "@mcpjam/sdk/host-compat": sdkHostCompatEntry,

--- a/mcpjam-inspector/client/vitest.config.ts
+++ b/mcpjam-inspector/client/vitest.config.ts
@@ -36,6 +36,13 @@ const sdkWidgetRuntimeEntry = path.resolve(
   rootDir,
   "../sdk/src/widget-runtime/index.ts",
 );
+// @mcpjam/sdk/plugin-bundle advertises ./dist via package exports; alias to
+// source so inspector vitest resolves it without a prior SDK build (mirrors the
+// SDK subpath aliases above). The exported parser is pure/browser-safe.
+const sdkPluginBundleEntry = path.resolve(
+  rootDir,
+  "../sdk/src/plugin-bundle/index.ts",
+);
 // Resolve @mcpjam/chat-ui from source (its published exports point at dist,
 // which a clean checkout hasn't built). Mirrors the SDK source aliases above.
 const chatUiEntry = path.resolve(rootDir, "../chat-ui/src/index.ts");
@@ -133,6 +140,10 @@ export default defineConfig({
       {
         find: "@mcpjam/sdk/skill-reference",
         replacement: sdkSkillReferenceEntry,
+      },
+      {
+        find: "@mcpjam/sdk/plugin-bundle",
+        replacement: sdkPluginBundleEntry,
       },
       { find: "@mcpjam/sdk/browser", replacement: sdkBrowserEntry },
       { find: "@mcpjam/sdk/matchers", replacement: sdkMatchersEntry },


### PR DESCRIPTION
## PR INS-1 — MCP JSON compatibility and plugin client API

Foundations for OpenAI plugin import in the `mcpjam-inspector` package (PR INS-1 of `docs/plans/openai-plugin-import-cross-repo.md`). Inspector-only; no backend or SDK changes. Hosts stay plugin-blind per the SDK-2 pivot — **no `pluginVersionIds` HostConfig field is introduced.** No user-facing plugin UI yet (that is INS-2).

### What's in scope

**1. JSON config parser — three compatible MCP shapes**
`client/src/lib/json-config-parser.ts` now unwraps all three shapes via a shared contract (`client/src/lib/plugins/mcp-config-shape.ts`):
- `mcpServers` wrapper (legacy MCPJam/Claude) — unchanged behavior
- `mcp_servers` wrapper (current OpenAI plugin docs) — new
- direct server map (OpenAI direct) — new

All three import **identically**. Legacy error messages and per-server mapping are preserved (value-preserving: real `command`/`args`/`env`/`url` are kept so imported servers actually connect).

> Design note: the SDK's `normalizePluginMcpConfig` is (a) **not exported** from `@mcpjam/sdk/plugin-bundle` 2.0.0 and (b) deliberately **value-stripping** (stores requirement names, never resolved secret values). It therefore cannot be reused verbatim for a value-preserving paste/import. This PR shares the **wrapper/transport contract** (duplicate-wrapper rejection, bare-server rejection, direct-map acceptance) with the SDK while keeping the value-preserving mapping local. The genuine SDK-parser reuse for the plugin path is `previewPluginFolderLocally`, which runs `parsePluginBundle` over a folder source.

**2. Typed plugin import client + upload helpers** (`client/src/lib/plugins/plugin-import-client.ts`, `plugin-import-types.ts`)
Thin typed wrappers over the backend BE-3 endpoints, called by string name (backend is a separate repo, no shared generated `api`):
- `generateBundleUploadUrl`, `createImport`, `getPluginImport`, `inspectImport`
- `startPluginImportFromZip` / `startPluginImportFromFolder` orchestrators (upload → stage → inspect)
- `previewPluginFolderLocally` (local SDK-parser preview, no upload)
- **`commitImport` is a typed STUB** — the backend commit action (BE-4) is not merged yet, so it throws `PLUGIN_COMMIT_NOT_AVAILABLE`. Wire the real call when BE-4 lands (see the TODO in the file).

**3. Folder-to-ZIP helper for Electron/local mode** (`client/src/lib/plugins/folder-to-zip.ts`, `plugin-file-source.ts`)
Zero-dependency, deterministic STORE-method ZIP writer plus a browser-safe folder `PluginFileSource` adapter, so local/Electron mode uploads the same canonical input as a hosted ZIP. Because the SDK bundle hash is content-addressed, **folder and ZIP of identical contents produce the same bundle hash** (asserted in tests by parsing both a folder source and the ZIP round-tripped through `fflate`).

**4. Import progress hooks** (`client/src/hooks/usePluginImport.ts`)
`usePluginImport` (reactive Convex subscription + derived phase flags) and `usePluginImportRunner` (imperative upload→stage→inspect driver with local `uploading`/`inspecting` phases).

### Acceptance criteria
- ✅ Existing `mcpServers` imports still work (regression tests pass unchanged).
- ✅ OpenAI direct and `mcp_servers` shapes import identically (dedicated parity tests).
- ✅ Folder and ZIP sources produce the same bundle hash for identical contents (dedicated parity test via the SDK parser).

### Verification
- `tsc --noEmit -p client/tsconfig.typecheck.json` — **clean (exit 0)**, covers all new client TypeScript.
- Renderer Tier-B import guard — **clean**.
- `npm run test -w @mcpjam/sdk` — **2444 passed, 1 skipped** (unaffected; sanity).
- Full inspector vitest suite (`npx vitest run`, all projects) — **9501 passed, 6 skipped (880 files), exit 0**. Includes the new suites: `mcp-config-shape` (9), `json-config-parser` (32, incl. new shapes), `folder-to-zip` (8, incl. hash parity), `plugin-import-client` (7), `usePluginImport` (5).

### Residual / not-yet-confirmed
- **`npm run build:inspector` not run** in this session (full clean rebuild of SDK + client + server; deferred to CI). Client typecheck (`tsc --noEmit`) + Tier-B guard cover the client-only TypeScript this PR touches.
- Note: the `npm run test -w @mcpjam/inspector` *workspace wrapper* produced a spurious `exit 1` with zero captured output (likely OOM/wrapper artifact); the authoritative direct `vitest run` above is green.
- **`commitImport` is stubbed** pending backend BE-4 (`pluginsNode.commitImport`); the client surface is typed but throws until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches connection JSON import (credentials in headers/env) and new upload/orchestration code, but changes are well-tested, inspector-scoped, and commit remains stubbed until BE-4.
> 
> **Overview**
> **INS-1** lays inspector-only foundations for OpenAI plugin import: broader MCP JSON paste/import, a Convex-backed import pipeline, and hooks for a future Add-plugin UI.
> 
> The **JSON server import** path now accepts `mcp_servers` and direct server maps as well as legacy `mcpServers`, via shared `unwrapMcpServerMap` detection. Parsing stays value-preserving (`command`, `env`, `headers`, `url`) while tightening HTTP routing (non-empty URLs, `headers` on HTTP servers, stdio not misclassified when `url` is empty) and aligning `validateJsonConfig` with `parseJsonConfig`.
> 
> A new **plugin import stack** wires BE-3: typed DTOs, `plugin-import-client` (upload URL → storage POST → `createImport` → `inspectImport`), folder `PluginFileSource`, deterministic STORE `folderToZip`, and `previewPluginFolderLocally` via `@mcpjam/sdk/plugin-bundle`. `commitImport` is a typed stub until BE-4. **`usePluginImport`** subscribes to import rows; **`usePluginImportRunner`** drives zip/folder upload with local phases, staged `importId` during inspect, and stale-run protection.
> 
> Vite/Vitest gain a `@mcpjam/sdk/plugin-bundle` source alias so dev/tests work without a prior SDK build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b2f5ec8848c92455bb710fb5688817bd345fa46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds MCP JSON compatibility and a typed plugin import client in `@mcpjam/inspector`, laying the groundwork for OpenAI plugin import (INS-1). Inspector-only; hosts remain plugin-blind per SDK-2; no user-facing UI yet.

- **New Features**
  - JSON parser accepts `mcpServers`, `mcp_servers`, or a direct server map; preserves `command`/`args`/`env`/`headers`/`url`.
  - Typed client for backend BE-3: `generateBundleUploadUrl`, `createImport`, `getPluginImport`, `inspectImport`; orchestrators `startPluginImportFromZip`/`startPluginImportFromFolder`; `commitImport` stub throws `PLUGIN_COMMIT_NOT_AVAILABLE`.
  - Deterministic STORE ZIP helper and browser-safe folder `PluginFileSource`; folder and ZIP of identical contents produce the same content-addressed bundle hash.
  - Import progress hooks: `usePluginImport` (Convex subscription) and `usePluginImportRunner` (upload → stage → inspect).

- **Bug Fixes**
  - Folder adapter no longer bypasses SDK validators (keeps duplicates/absolute paths); drag‑and‑drop falls back to file name; HTTP/SSE entries must have a non-empty `url`; direct maps tolerate non-object siblings.
  - HTTP `headers` (e.g., Authorization) are preserved for `mcp_servers` and direct-map inputs.
  - Stdio entries with `url: ""` are no longer misrouted to HTTP; validate and parse now agree.
  - Post‑staging inspect failures keep the staged `importId` via `PluginImportError`; runner exposes `inspecting` via `onPhase` and now preserves the staged `importId` during that phase; guards against stale runs.
  - Preflights folder size against SDK limits before zipping; adds `@mcpjam/sdk/plugin-bundle` source alias in Vite/Vitest for clean dev/test.

<sup>Written for commit 2b2f5ec8848c92455bb710fb5688817bd345fa46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

