### PR TITLE
feat(harness): cross-instance RPC log fan-in via the Convex sink (COMP-21, inspector)

### DIFF
--- a/mcpjam-inspector/server/routes/web/__tests__/harness-mcp.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/harness-mcp.test.ts
@@ -27,7 +27,7 @@ vi.mock("../auth", () => ({
   createAuthorizedManager: vi.fn().mockResolvedValue({ manager: mockManager }),
   withManager: async (
     mp: Promise<any>,
-    fn: (m: any) => Promise<any>,
+    fn: (m: any) => Promise<any>
   ): Promise<any> => {
     const r = await mp;
     return fn(r.manager ?? r);
@@ -36,9 +36,11 @@ vi.mock("../auth", () => ({
 
 import { harnessMcp } from "../harness-mcp.js";
 import { signTestProxyToken } from "../../../utils/harness/__tests__/sign-test-token.js";
+import { __resetHarnessRpcLogSinkForTest } from "../../../utils/harness/harness-rpc-log-sink.js";
 
 beforeAll(() => {
-  process.env.COMPUTERS_TERMINAL_TOKEN_SECRET = "test-harness-proxy-secret-32-chars";
+  process.env.COMPUTERS_TERMINAL_TOKEN_SECRET =
+    "test-harness-proxy-secret-32-chars";
 });
 
 const app = new Hono();
@@ -70,18 +72,25 @@ describe("/api/web/harness-mcp", () => {
   });
 
   it("401s a token missing the delegated identity (externalId)", async () => {
-    const noIdentity = signTestProxyToken({ serverId: "srv-a", externalId: "" });
+    const noIdentity = signTestProxyToken({
+      serverId: "srv-a",
+      externalId: "",
+    });
     const res = await post("srv-a", { "X-MCPJam-Proxy-Token": noIdentity });
     expect(res.status).toBe(401);
   });
 
   it("401s a token minted for a different server", async () => {
-    const res = await post("srv-a", { "X-MCPJam-Proxy-Token": webToken("srv-b") });
+    const res = await post("srv-a", {
+      "X-MCPJam-Proxy-Token": webToken("srv-b"),
+    });
     expect(res.status).toBe(401);
   });
 
   it("200s and forwards tools/list through the bridge with a valid web token", async () => {
-    const res = await post("srv-a", { "X-MCPJam-Proxy-Token": webToken("srv-a") });
+    const res = await post("srv-a", {
+      "X-MCPJam-Proxy-Token": webToken("srv-a"),
+    });
     expect(res.status).toBe(200);
     const data = await res.json();
     expect(data.jsonrpc).toBe("2.0");
@@ -132,7 +141,7 @@ describe("/api/web/harness-mcp", () => {
   // message (MCP 2025-06-18 removed batching; the bridge handles one request).
   it("returns -32600 with id null for a JSON-RPC batch array (NOT 202)", async () => {
     const res = await postRaw(
-      JSON.stringify([{ jsonrpc: "2.0", id: 1, method: "tools/list" }]),
+      JSON.stringify([{ jsonrpc: "2.0", id: 1, method: "tools/list" }])
     );
     expect(res.status).toBe(400);
     const data = await res.json();
@@ -143,7 +152,7 @@ describe("/api/web/harness-mcp", () => {
   // #3041 review: a PRESENT but wrong `jsonrpc` version is malformed → -32600.
   it("returns -32600 for a present but invalid `jsonrpc` version", async () => {
     const res = await postRaw(
-      JSON.stringify({ jsonrpc: "1.0", id: 5, method: "tools/list" }),
+      JSON.stringify({ jsonrpc: "1.0", id: 5, method: "tools/list" })
     );
     expect(res.status).toBe(400);
     const data = await res.json();
@@ -155,7 +164,7 @@ describe("/api/web/harness-mcp", () => {
   // a valid method still forwards through the bridge, it is NOT rejected.
   it("tolerates an absent `jsonrpc` when the method is valid (forwards, no -32600)", async () => {
     const res = await postRaw(
-      JSON.stringify({ id: 8, method: "tools/list", params: {} }),
+      JSON.stringify({ id: 8, method: "tools/list", params: {} })
     );
     expect(res.status).toBe(200);
     const data = await res.json();
@@ -166,7 +175,7 @@ describe("/api/web/harness-mcp", () => {
   // the error response so it stays valid JSON-RPC the client can parse.
   it("normalizes a non-scalar id to null in the error response", async () => {
     const res = await postRaw(
-      JSON.stringify({ jsonrpc: "2.0", id: { bad: 1 }, params: {} }),
+      JSON.stringify({ jsonrpc: "2.0", id: { bad: 1 }, params: {} })
     );
     expect(res.status).toBe(400);
     const data = await res.json();
@@ -179,7 +188,7 @@ describe("/api/web/harness-mcp", () => {
   // into a SUCCESS response, emitting an invalid JSON-RPC id.
   it("rejects a non-scalar id even when the method is valid (NOT a 200)", async () => {
     const res = await postRaw(
-      JSON.stringify({ jsonrpc: "2.0", id: {}, method: "tools/list" }),
+      JSON.stringify({ jsonrpc: "2.0", id: {}, method: "tools/list" })
     );
     expect(res.status).toBe(400);
     const data = await res.json();
@@ -190,7 +199,7 @@ describe("/api/web/harness-mcp", () => {
   // #3041 re-review: non-structured `params` (a scalar) is invalid per JSON-RPC.
   it("rejects non-structured params (scalar) even with a valid method", async () => {
     const res = await postRaw(
-      JSON.stringify({ jsonrpc: "2.0", id: 3, method: "tools/list", params: 5 }),
+      JSON.stringify({ jsonrpc: "2.0", id: 3, method: "tools/list", params: 5 })
     );
     expect(res.status).toBe(400);
     const data = await res.json();
@@ -200,7 +209,7 @@ describe("/api/web/harness-mcp", () => {
 
   it("still 202s a real notification (method present, no id)", async () => {
     const res = await postRaw(
-      JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }),
+      JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" })
     );
     expect(res.status).toBe(202);
   });
@@ -210,7 +219,9 @@ describe("/api/web/harness-mcp", () => {
     const { rpcLogBus } = await import("../../../services/rpc-log-bus.js");
     (createAuthorizedManager as ReturnType<typeof vi.fn>).mockClear();
 
-    const res = await post("srv-a", { "X-MCPJam-Proxy-Token": webToken("srv-a") });
+    const res = await post("srv-a", {
+      "X-MCPJam-Proxy-Token": webToken("srv-a"),
+    });
     expect(res.status).toBe(200);
 
     // 8th arg = options; the route must hand the manager a logger that lands
@@ -233,5 +244,28 @@ describe("/api/web/harness-mcp", () => {
     }
     expect(seen).toHaveLength(1);
     expect(seen[0]).toMatchObject({ serverId: "srv-a", direction: "send" });
+  });
+
+  // COMP-21: the cross-instance Convex sink is observation-only — a failing sink
+  // must NEVER slow or fail the proxy request. With the sink configured but every
+  // Convex write rejecting, the tool call still succeeds.
+  it("still succeeds when the cross-instance log sink write fails", async () => {
+    vi.stubEnv("CONVEX_HTTP_URL", "https://convex.example.com");
+    vi.stubEnv("INSPECTOR_SERVICE_TOKEN", "svc-token");
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValue(new Error("convex down"));
+    try {
+      const res = await post("srv-a", {
+        "X-MCPJam-Proxy-Token": webToken("srv-a"),
+      });
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.jsonrpc).toBe("2.0");
+    } finally {
+      fetchSpy.mockRestore();
+      vi.unstubAllEnvs();
+      __resetHarnessRpcLogSinkForTest();
+    }
   });
 });

--- a/mcpjam-inspector/server/routes/web/__tests__/hosted-rpc-logs-cross-instance.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/hosted-rpc-logs-cross-instance.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// COMP-21: the cross-instance poller reads the shared sink; drive it with a
+// controlled `readCrossInstanceRpcLogs` and assert the frames another instance
+// produced reach the turn's collector (with dedup on the sink row id).
+const readMock = vi.fn();
+vi.mock("../../../utils/harness/harness-rpc-log-sink", () => ({
+  isRpcLogSinkConfigured: () => true,
+  readCrossInstanceRpcLogs: (...args: unknown[]) => readMock(...args),
+}));
+
+import {
+  createHostedRpcLogCollector,
+  startCrossInstanceRpcLogPoll,
+} from "../hosted-rpc-logs";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  readMock.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function entry(
+  id: string,
+  serverId: string,
+  createdAt: number,
+  extra?: Partial<{ direction: "send" | "receive"; message: unknown }>
+) {
+  return {
+    id,
+    serverId,
+    direction: extra?.direction ?? ("send" as const),
+    loggedAt: "t",
+    message: extra?.message ?? { id },
+    createdAt,
+  };
+}
+
+describe("startCrossInstanceRpcLogPoll", () => {
+  it("delivers frames another instance produced into the collector", async () => {
+    readMock.mockResolvedValueOnce([
+      entry("a", "srv-1", 10, { message: { m: "from-B" } }),
+      entry("b", "srv-1", 10, {
+        direction: "receive",
+        message: { m: "from-B-2" },
+      }),
+    ]);
+    const collector = createHostedRpcLogCollector({});
+    const stop = startCrossInstanceRpcLogPoll(["srv-1"], collector);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    stop();
+
+    expect(collector.logs.map((l) => (l.message as { m: string }).m)).toEqual([
+      "from-B",
+      "from-B-2",
+    ]);
+    // The first poll uses the turn-start cursor; it asks for our servers.
+    expect(readMock).toHaveBeenCalledWith(
+      expect.objectContaining({ serverIds: ["srv-1"] })
+    );
+  });
+
+  it("dedups on sink row id across overlapping polls (same-ms batch can't double-deliver)", async () => {
+    // A batch write stamps one createdAt; the cursor advances by createdAt with
+    // `>=`, so the next poll re-sees id "a" — it must NOT be delivered twice.
+    readMock
+      .mockResolvedValueOnce([entry("a", "srv-1", 10)])
+      .mockResolvedValueOnce([
+        entry("a", "srv-1", 10),
+        entry("c", "srv-1", 10),
+      ]);
+    const collector = createHostedRpcLogCollector({});
+    const stop = startCrossInstanceRpcLogPoll(["srv-1"], collector);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    await vi.advanceTimersByTimeAsync(1000);
+    stop();
+
+    expect(collector.logs.map((l) => (l.message as { id: string }).id)).toEqual(
+      ["a", "c"]
+    );
+  });
+
+  it("stops polling after teardown", async () => {
+    readMock.mockResolvedValue([]);
+    const collector = createHostedRpcLogCollector({});
+    const stop = startCrossInstanceRpcLogPoll(["srv-1"], collector);
+    await vi.advanceTimersByTimeAsync(1000);
+    const callsBefore = readMock.mock.calls.length;
+    stop();
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(readMock.mock.calls.length).toBe(callsBefore);
+  });
+
+  it("no-ops with no servers (nothing to fan in)", async () => {
+    const collector = createHostedRpcLogCollector({});
+    const stop = startCrossInstanceRpcLogPoll([], collector);
+    await vi.advanceTimersByTimeAsync(3000);
+    stop();
+    expect(readMock).not.toHaveBeenCalled();
+  });
+});

--- a/mcpjam-inspector/server/routes/web/__tests__/hosted-rpc-logs-cross-instance.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/hosted-rpc-logs-cross-instance.test.ts
@@ -41,13 +41,16 @@ function entry(
 
 describe("startCrossInstanceRpcLogPoll", () => {
   it("delivers frames another instance produced into the collector", async () => {
-    readMock.mockResolvedValueOnce([
-      entry("a", "srv-1", 10, { message: { m: "from-B" } }),
-      entry("b", "srv-1", 10, {
-        direction: "receive",
-        message: { m: "from-B-2" },
-      }),
-    ]);
+    readMock.mockResolvedValueOnce({
+      entries: [
+        entry("a", "srv-1", 10, { message: { m: "from-B" } }),
+        entry("b", "srv-1", 10, {
+          direction: "receive",
+          message: { m: "from-B-2" },
+        }),
+      ],
+      cursors: [{ serverId: "srv-1", sinceMs: 10 }],
+    });
     const collector = createHostedRpcLogCollector({});
     const stop = startCrossInstanceRpcLogPoll(["srv-1"], collector);
 
@@ -58,9 +61,11 @@ describe("startCrossInstanceRpcLogPoll", () => {
       "from-B",
       "from-B-2",
     ]);
-    // The first poll uses the turn-start cursor; it asks for our servers.
+    // The first poll uses a per-server turn-start cursor.
     expect(readMock).toHaveBeenCalledWith(
-      expect.objectContaining({ serverIds: ["srv-1"] })
+      expect.objectContaining({
+        servers: [{ serverId: "srv-1", sinceMs: expect.any(Number) }],
+      })
     );
   });
 
@@ -68,11 +73,14 @@ describe("startCrossInstanceRpcLogPoll", () => {
     // A batch write stamps one createdAt; the cursor advances by createdAt with
     // `>=`, so the next poll re-sees id "a" — it must NOT be delivered twice.
     readMock
-      .mockResolvedValueOnce([entry("a", "srv-1", 10)])
-      .mockResolvedValueOnce([
-        entry("a", "srv-1", 10),
-        entry("c", "srv-1", 10),
-      ]);
+      .mockResolvedValueOnce({
+        entries: [entry("a", "srv-1", 10)],
+        cursors: [{ serverId: "srv-1", sinceMs: 10 }],
+      })
+      .mockResolvedValueOnce({
+        entries: [entry("a", "srv-1", 10), entry("c", "srv-1", 10)],
+        cursors: [{ serverId: "srv-1", sinceMs: 10 }],
+      });
     const collector = createHostedRpcLogCollector({});
     const stop = startCrossInstanceRpcLogPoll(["srv-1"], collector);
 
@@ -85,8 +93,58 @@ describe("startCrossInstanceRpcLogPoll", () => {
     );
   });
 
+  it("adopts the sink's per-server cursors instead of deriving them from delivered frames", async () => {
+    // The starvation case: a server whose scan window is full of OUR OWN
+    // instance's rows delivers nothing, but the sink still advanced its cursor.
+    // If the poller derived the cursor from delivered frames it would re-ask
+    // from the turn-start cursor forever and never reach the frame behind them.
+    readMock
+      .mockResolvedValueOnce({
+        entries: [],
+        cursors: [{ serverId: "srv-1", sinceMs: 5000 }],
+      })
+      .mockResolvedValueOnce({
+        entries: [entry("late", "srv-1", 6000, { message: { m: "from-B" } })],
+        cursors: [{ serverId: "srv-1", sinceMs: 6000 }],
+      });
+    const collector = createHostedRpcLogCollector({});
+    const stop = startCrossInstanceRpcLogPoll(["srv-1"], collector);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    // The second poll must carry the ADVANCED cursor, not the turn-start one.
+    await vi.advanceTimersByTimeAsync(1000);
+    stop();
+
+    expect(readMock).toHaveBeenNthCalledWith(2, {
+      servers: [{ serverId: "srv-1", sinceMs: 5000 }],
+    });
+    expect(collector.logs.map((l) => (l.message as { m: string }).m)).toEqual([
+      "from-B",
+    ]);
+  });
+
+  it("holds cursors when a poll fails, so frames are re-read rather than skipped", async () => {
+    readMock
+      .mockResolvedValueOnce({
+        entries: [],
+        cursors: [{ serverId: "srv-1", sinceMs: 5000 }],
+      })
+      .mockRejectedValueOnce(new Error("convex down"))
+      .mockResolvedValueOnce({ entries: [], cursors: [] });
+    const collector = createHostedRpcLogCollector({});
+    const stop = startCrossInstanceRpcLogPoll(["srv-1"], collector);
+
+    await vi.advanceTimersByTimeAsync(3000);
+    stop();
+
+    // The poll after the failure re-asks from the last GOOD cursor.
+    expect(readMock).toHaveBeenNthCalledWith(3, {
+      servers: [{ serverId: "srv-1", sinceMs: 5000 }],
+    });
+  });
+
   it("stops polling after teardown", async () => {
-    readMock.mockResolvedValue([]);
+    readMock.mockResolvedValue({ entries: [], cursors: [] });
     const collector = createHostedRpcLogCollector({});
     const stop = startCrossInstanceRpcLogPoll(["srv-1"], collector);
     await vi.advanceTimersByTimeAsync(1000);

--- a/mcpjam-inspector/server/routes/web/harness-mcp.ts
+++ b/mcpjam-inspector/server/routes/web/harness-mcp.ts
@@ -31,6 +31,7 @@ import {
 } from "./auth";
 import { verifyHarnessProxyToken } from "../../utils/harness/harness-proxy-token";
 import { rpcLogBus } from "../../services/rpc-log-bus";
+import { enqueueHarnessRpcLog } from "../../utils/harness/harness-rpc-log-sink";
 import { logger } from "../../utils/logger";
 import { resolveXaaIssuer } from "../../services/xaa-mint.js";
 import { HOSTED_MODE } from "../../config.js";
@@ -52,7 +53,8 @@ function rateLimited(key: string): boolean {
   if (!bucket || now >= bucket.resetAt) {
     // Opportunistic prune so the map can't grow unbounded.
     if (rateBuckets.size > 5000) {
-      for (const [k, b] of rateBuckets) if (now >= b.resetAt) rateBuckets.delete(k);
+      for (const [k, b] of rateBuckets)
+        if (now >= b.resetAt) rateBuckets.delete(k);
     }
     rateBuckets.set(key, { count: 1, resetAt: now + RATE_WINDOW_MS });
     return false;
@@ -178,27 +180,41 @@ async function handle(c: any) {
           // the local-mode Logs SSE/buffer sees it too. Observation-only —
           // never affects the proxy result: the bus isolates subscribers, and
           // this guard is the belt-and-suspenders so no logging failure can
-          // reach the RPC try/catch below. Cross-instance hosted delivery
-          // needs a shared sink (follow-up issue).
+          // reach the RPC try/catch below.
+          //
+          // COMP-21: ALSO enqueue the frame to the shared Convex sink (batched,
+          // best-effort) so a turn streaming from ANOTHER instance can pull it —
+          // cross-instance fan-in on the scaled hosted plane. The enqueue never
+          // throws to here (own try/catch inside), and the sink no-ops when
+          // Convex isn't configured (single-instance / self-hosted).
           rpcLogger: ({ direction, message, serverId: sid }) => {
+            const timestamp = new Date().toISOString();
             try {
               rpcLogBus.publish({
                 serverId: sid,
                 direction,
-                timestamp: new Date().toISOString(),
+                timestamp,
                 message,
               });
             } catch (error) {
               logger.warn(
                 `[harness-mcp] rpc log publish failed serverId=${sid}: ${
                   error instanceof Error ? error.message : error
-                }`,
+                }`
               );
             }
+            enqueueHarnessRpcLog({
+              serverId: sid,
+              projectId: claims.projectId,
+              organizationId: claims.orgId,
+              direction,
+              loggedAt: timestamp,
+              message,
+            });
           },
-        },
+        }
       ),
-      (manager) => handleJsonRpc(serverId, body, manager, "adapter"),
+      (manager) => handleJsonRpc(serverId, body, manager, "adapter")
     );
     // Notification (no id) → 202 Accepted, no body.
     if (!response) return c.body("Accepted", 202);
@@ -207,7 +223,7 @@ async function handle(c: any) {
     // Log the real cause server-side, but NEVER leak internal exception text to
     // the sandbox — return a generic JSON-RPC error so the client can recover.
     logger.error(
-      `[harness-mcp] proxy error serverId=${serverId}: ${e?.message ?? e}`,
+      `[harness-mcp] proxy error serverId=${serverId}: ${e?.message ?? e}`
     );
     return c.json(
       {
@@ -215,7 +231,7 @@ async function handle(c: any) {
         id: body?.id ?? null,
         error: { code: -32000, message: "harness proxy error" },
       },
-      200,
+      200
     );
   }
 }

--- a/mcpjam-inspector/server/routes/web/hosted-rpc-logs.ts
+++ b/mcpjam-inspector/server/routes/web/hosted-rpc-logs.ts
@@ -2,6 +2,10 @@ import type { UIMessageChunk } from "ai";
 import type { RpcLogger } from "@mcpjam/sdk";
 import { rpcLogBus } from "../../services/rpc-log-bus.js";
 import { logger } from "../../utils/logger.js";
+import {
+  isRpcLogSinkConfigured,
+  readCrossInstanceRpcLogs,
+} from "../../utils/harness/harness-rpc-log-sink.js";
 import type {
   HostedRpcLogEvent,
   HostedRpcLogsEnvelope,
@@ -13,7 +17,7 @@ type HostedRpcChunkWriter = {
 
 function normalizeServerName(
   serverId: string,
-  serverNamesById: Record<string, string>,
+  serverNamesById: Record<string, string>
 ): string {
   const resolved = serverNamesById[serverId];
   return typeof resolved === "string" && resolved.trim().length > 0
@@ -23,7 +27,7 @@ function normalizeServerName(
 
 function writeHostedRpcLogDataPart(
   writer: HostedRpcChunkWriter,
-  event: HostedRpcLogEvent,
+  event: HostedRpcLogEvent
 ): void {
   writer.write({
     type: "data-rpc-log",
@@ -34,7 +38,7 @@ function writeHostedRpcLogDataPart(
 
 function readOptionalString(
   value: unknown,
-  fallback?: string,
+  fallback?: string
 ): string | undefined {
   return typeof value === "string" && value.trim().length > 0
     ? value
@@ -43,7 +47,7 @@ function readOptionalString(
 
 function mapAlignedServerNames(
   serverIds: unknown,
-  serverNames: unknown,
+  serverNames: unknown
 ): Record<string, string> {
   if (!Array.isArray(serverIds) || serverIds.length === 0) {
     return {};
@@ -64,7 +68,7 @@ function mapAlignedServerNames(
 }
 
 function extractServerNamesById(
-  body: Record<string, unknown> | null | undefined,
+  body: Record<string, unknown> | null | undefined
 ): Record<string, string> {
   if (!body) {
     return {};
@@ -79,11 +83,11 @@ function extractServerNamesById(
 
   Object.assign(
     resolved,
-    mapAlignedServerNames(body.serverIds, body.serverNames),
+    mapAlignedServerNames(body.serverIds, body.serverNames)
   );
   Object.assign(
     resolved,
-    mapAlignedServerNames(body.selectedServerIds, body.selectedServerNames),
+    mapAlignedServerNames(body.selectedServerIds, body.selectedServerNames)
   );
 
   return resolved;
@@ -138,7 +142,7 @@ export class HostedRpcLogCollector {
       } catch (error) {
         logger.warn(
           "Hosted RPC log stream write failed; falling back to envelope delivery",
-          { error },
+          { error }
         );
         this.writer = null;
         return;
@@ -148,7 +152,7 @@ export class HostedRpcLogCollector {
 }
 
 export function createHostedRpcLogCollector(
-  body: Record<string, unknown> | null | undefined,
+  body: Record<string, unknown> | null | undefined
 ): HostedRpcLogCollector {
   return new HostedRpcLogCollector(extractServerNamesById(body));
 }
@@ -164,10 +168,11 @@ export function createHostedRpcLogCollector(
  * emulated engine uses (`data-rpc-log` stream parts / response envelope), so
  * the Playground Logs panel fills for harness turns with zero client changes.
  *
- * SINGLE-INSTANCE by design: the bus is per-process, so this covers local dev
- * and self-hosted. In the horizontally-scaled hosted plane a harness-mcp
- * request may land on another instance and its entries won't reach this turn —
- * cross-instance fan-in needs a shared sink (tracked as a follow-up issue).
+ * Covers the SAME-INSTANCE case: the bus is per-process, so this alone handles
+ * local dev and self-hosted. On the horizontally-scaled hosted plane a
+ * harness-mcp request may land on another instance; those frames are pulled from
+ * the shared Convex sink by `startCrossInstanceRpcLogPoll` (COMP-21), which pairs
+ * with this bridge — start both, tear both down.
  *
  * Scoped by serverId only (the proxy token carries no turn id), so a
  * concurrent turn against the same server on this instance would also see the
@@ -178,7 +183,7 @@ export function createHostedRpcLogCollector(
  */
 export function bridgeHarnessRpcLogsToCollector(
   serverIds: string[],
-  collector: HostedRpcLogCollector,
+  collector: HostedRpcLogCollector
 ): () => void {
   // An empty filter would subscribe to EVERY server's traffic (bus semantics);
   // a harness turn with no MCP servers has nothing to bridge.
@@ -192,9 +197,69 @@ export function bridgeHarnessRpcLogsToCollector(
   });
 }
 
+/** How often a live turn polls the shared sink for other instances' frames. */
+const CROSS_INSTANCE_POLL_MS = 1000;
+
+/**
+ * COMP-21: the cross-instance half of the bridge. `bridgeHarnessRpcLogsToCollector`
+ * only sees frames the LOCAL process produced; this polls the shared Convex sink
+ * for frames OTHER instances wrote and feeds them into the SAME collector, so the
+ * Logs panel completes even when a harness-mcp request lands on a different
+ * instance than the chat stream.
+ *
+ * The sink read EXCLUDES this process's own instance, so a frame the bus already
+ * delivered is never pulled again — the two paths never double-deliver. Dedups
+ * on the sink row id (a batch write stamps one `createdAt`, so the cursor
+ * advances by `createdAt` with `>=` while the id set prevents re-delivery).
+ *
+ * No-op when the sink isn't configured (single-instance / self-hosted) or the
+ * turn has no servers. Best-effort throughout — a slow or erroring sink never
+ * blocks the stream. Returns a stop fn callers MUST run on stream completion.
+ */
+export function startCrossInstanceRpcLogPoll(
+  serverIds: string[],
+  collector: HostedRpcLogCollector
+): () => void {
+  if (serverIds.length === 0 || !isRpcLogSinkConfigured()) return () => {};
+  let stopped = false;
+  let sinceMs = Date.now(); // only frames from this turn onward
+  const seen = new Set<string>(); // sink row ids already delivered
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  const tick = async () => {
+    if (stopped) return;
+    try {
+      const entries = await readCrossInstanceRpcLogs({ serverIds, sinceMs });
+      for (const e of entries) {
+        if (seen.has(e.id)) continue;
+        seen.add(e.id);
+        collector.rpcLogger({
+          direction: e.direction,
+          message: e.message,
+          serverId: e.serverId,
+        });
+        if (e.createdAt > sinceMs) sinceMs = e.createdAt;
+      }
+    } catch {
+      // best-effort; observation-only
+    }
+    if (!stopped) {
+      timer = setTimeout(tick, CROSS_INSTANCE_POLL_MS);
+      timer.unref?.();
+    }
+  };
+  timer = setTimeout(tick, CROSS_INSTANCE_POLL_MS);
+  timer.unref?.();
+
+  return () => {
+    stopped = true;
+    if (timer) clearTimeout(timer);
+  };
+}
+
 export function attachHostedRpcLogs<T>(
   payload: T,
-  collector?: HostedRpcLogCollector,
+  collector?: HostedRpcLogCollector
 ): T | (T & HostedRpcLogsEnvelope) {
   if (
     !collector?.hasLogs() ||

--- a/mcpjam-inspector/server/routes/web/hosted-rpc-logs.ts
+++ b/mcpjam-inspector/server/routes/web/hosted-rpc-logs.ts
@@ -209,8 +209,16 @@ const CROSS_INSTANCE_POLL_MS = 1000;
  *
  * The sink read EXCLUDES this process's own instance, so a frame the bus already
  * delivered is never pulled again — the two paths never double-deliver. Dedups
- * on the sink row id (a batch write stamps one `createdAt`, so the cursor
- * advances by `createdAt` with `>=` while the id set prevents re-delivery).
+ * on the sink row id (a batch write stamps one `createdAt`, so cursors are
+ * inclusive and the id set prevents re-delivery of the boundary rows).
+ *
+ * Cursors are PER-SERVER and come from the sink's response — never derived from
+ * the frames we received. Two reasons, both silent-data-loss bugs otherwise:
+ * own-instance rows are filtered server-side AFTER the index scan, so a busy
+ * server can yield zero frames while the scan still advanced (deriving the
+ * cursor from delivered frames would stall that server for the rest of the
+ * turn); and a single global cursor would let a busy server drag a quiet one
+ * past rows it hasn't flushed yet.
  *
  * No-op when the sink isn't configured (single-instance / self-hosted) or the
  * turn has no servers. Best-effort throughout — a slow or erroring sink never
@@ -222,15 +230,19 @@ export function startCrossInstanceRpcLogPoll(
 ): () => void {
   if (serverIds.length === 0 || !isRpcLogSinkConfigured()) return () => {};
   let stopped = false;
-  let sinceMs = Date.now(); // only frames from this turn onward
+  const startedAt = Date.now(); // only frames from this turn onward
+  let cursors = [...new Set(serverIds)].map((serverId) => ({
+    serverId,
+    sinceMs: startedAt,
+  }));
   const seen = new Set<string>(); // sink row ids already delivered
   let timer: ReturnType<typeof setTimeout> | undefined;
 
   const tick = async () => {
     if (stopped) return;
     try {
-      const entries = await readCrossInstanceRpcLogs({ serverIds, sinceMs });
-      for (const e of entries) {
+      const page = await readCrossInstanceRpcLogs({ servers: cursors });
+      for (const e of page.entries) {
         if (seen.has(e.id)) continue;
         seen.add(e.id);
         collector.rpcLogger({
@@ -238,10 +250,11 @@ export function startCrossInstanceRpcLogPoll(
           message: e.message,
           serverId: e.serverId,
         });
-        if (e.createdAt > sinceMs) sinceMs = e.createdAt;
       }
+      cursors = page.cursors;
     } catch {
-      // best-effort; observation-only
+      // Best-effort; observation-only. Cursors stay put, so a failed tick
+      // re-reads rather than skipping frames.
     }
     if (!stopped) {
       timer = setTimeout(tick, CROSS_INSTANCE_POLL_MS);

--- a/mcpjam-inspector/server/utils/harness/__tests__/harness-rpc-log-sink.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/harness-rpc-log-sink.test.ts
@@ -131,40 +131,70 @@ describe("readCrossInstanceRpcLogs", () => {
         createdAt: 5,
       },
     ];
+    const cursors = [{ serverId: "srv-a", sinceMs: 5 }];
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({ entries }),
+      json: async () => ({ entries, cursors }),
     });
     vi.stubGlobal("fetch", fetchMock);
 
     const got = await readCrossInstanceRpcLogs({
-      serverIds: ["srv-a"],
-      sinceMs: 0,
+      servers: [{ serverId: "srv-a", sinceMs: 0 }],
     });
-    expect(got).toEqual(entries);
+    expect(got).toEqual({ entries, cursors });
     const body = lastFetchBody(fetchMock);
     expect(body.excludeInstanceId).toBe(getInspectorInstanceId());
-    expect(body).toMatchObject({ serverIds: ["srv-a"], sinceMs: 0 });
+    expect(body).toMatchObject({
+      servers: [{ serverId: "srv-a", sinceMs: 0 }],
+    });
   });
 
-  it("returns [] on a sink error (never blocks the turn)", async () => {
+  it("keeps the caller's cursors when the sink omits them (never rewinds or skips)", async () => {
     configure();
+    const servers = [{ serverId: "srv-a", sinceMs: 42 }];
+    // Malformed/absent cursors must not silently reset progress to 0.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) })
+    );
+    expect(await readCrossInstanceRpcLogs({ servers })).toEqual({
+      entries: [],
+      cursors: servers,
+    });
+  });
+
+  it("returns unchanged cursors on a non-ok response", async () => {
+    configure();
+    const servers = [{ serverId: "srv-a", sinceMs: 42 }];
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false }));
+    expect(await readCrossInstanceRpcLogs({ servers })).toEqual({
+      entries: [],
+      cursors: servers,
+    });
+  });
+
+  it("returns no entries on a sink error (never blocks the turn)", async () => {
+    configure();
+    const servers = [{ serverId: "srv-a", sinceMs: 0 }];
     vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("boom")));
-    expect(
-      await readCrossInstanceRpcLogs({ serverIds: ["srv-a"], sinceMs: 0 })
-    ).toEqual([]);
+    expect(await readCrossInstanceRpcLogs({ servers })).toEqual({
+      entries: [],
+      cursors: servers,
+    });
   });
 
   it("no-ops with no servers or when unconfigured", async () => {
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
-    expect(
-      await readCrossInstanceRpcLogs({ serverIds: [], sinceMs: 0 })
-    ).toEqual([]);
+    expect(await readCrossInstanceRpcLogs({ servers: [] })).toEqual({
+      entries: [],
+      cursors: [],
+    });
     configure();
-    expect(
-      await readCrossInstanceRpcLogs({ serverIds: [], sinceMs: 0 })
-    ).toEqual([]);
+    expect(await readCrossInstanceRpcLogs({ servers: [] })).toEqual({
+      entries: [],
+      cursors: [],
+    });
     expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/mcpjam-inspector/server/utils/harness/__tests__/harness-rpc-log-sink.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/harness-rpc-log-sink.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  enqueueHarnessRpcLog,
+  flushHarnessRpcLogs,
+  getInspectorInstanceId,
+  isRpcLogSinkConfigured,
+  readCrossInstanceRpcLogs,
+  __resetHarnessRpcLogSinkForTest,
+} from "../harness-rpc-log-sink";
+
+const CONVEX = "https://convex.example.com";
+
+function configure() {
+  vi.stubEnv("CONVEX_HTTP_URL", CONVEX);
+  vi.stubEnv("INSPECTOR_SERVICE_TOKEN", "svc-token");
+}
+
+function lastFetchBody(fetchMock: ReturnType<typeof vi.fn>): any {
+  const call = fetchMock.mock.calls.at(-1)!;
+  return JSON.parse((call[1] as RequestInit).body as string);
+}
+
+beforeEach(() => {
+  __resetHarnessRpcLogSinkForTest();
+});
+
+afterEach(() => {
+  __resetHarnessRpcLogSinkForTest();
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("config gate", () => {
+  it("no-ops (no fetch) when Convex/service-token are absent — single-instance path", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    expect(isRpcLogSinkConfigured()).toBe(false);
+    enqueueHarnessRpcLog({
+      serverId: "srv-a",
+      direction: "send",
+      loggedAt: "t",
+      message: { m: 1 },
+    });
+    await flushHarnessRpcLogs();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("enqueue + batched flush", () => {
+  it("flushes buffered frames to /write tagged with this instance id", async () => {
+    configure();
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+
+    enqueueHarnessRpcLog({
+      serverId: "srv-a",
+      projectId: "p1",
+      organizationId: "o1",
+      direction: "send",
+      loggedAt: "t1",
+      message: { a: 1 },
+    });
+    enqueueHarnessRpcLog({
+      serverId: "srv-a",
+      direction: "receive",
+      loggedAt: "t2",
+      message: { b: 2 },
+    });
+    await flushHarnessRpcLogs();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toBe(`${CONVEX}/harness/rpc-logs/write`);
+    expect((init as RequestInit).headers).toMatchObject({
+      "x-inspector-service-token": "svc-token",
+    });
+    const body = lastFetchBody(fetchMock);
+    expect(body.entries).toHaveLength(2);
+    expect(
+      body.entries.every((e: any) => e.instanceId === getInspectorInstanceId())
+    ).toBe(true);
+    expect(body.entries[0]).toMatchObject({
+      serverId: "srv-a",
+      projectId: "p1",
+    });
+  });
+
+  it("replaces an oversized message with a truncation marker (bounded on write)", async () => {
+    configure();
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+
+    enqueueHarnessRpcLog({
+      serverId: "srv-a",
+      direction: "send",
+      loggedAt: "t",
+      message: { big: "x".repeat(20_000) },
+    });
+    await flushHarnessRpcLogs();
+
+    const body = lastFetchBody(fetchMock);
+    expect(body.entries[0].message).toMatchObject({ _truncated: true });
+    expect(body.entries[0].message.big).toBeUndefined();
+  });
+
+  it("swallows a failing flush — never throws to the caller (observation-only)", async () => {
+    configure();
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("convex down")));
+    enqueueHarnessRpcLog({
+      serverId: "srv-a",
+      direction: "send",
+      loggedAt: "t",
+      message: { a: 1 },
+    });
+    // Must resolve, not reject.
+    await expect(flushHarnessRpcLogs()).resolves.toBeUndefined();
+  });
+});
+
+describe("readCrossInstanceRpcLogs", () => {
+  it("excludes this instance and returns the sink's entries", async () => {
+    configure();
+    const entries = [
+      {
+        id: "1",
+        serverId: "srv-a",
+        direction: "send",
+        loggedAt: "t",
+        message: {},
+        createdAt: 5,
+      },
+    ];
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ entries }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const got = await readCrossInstanceRpcLogs({
+      serverIds: ["srv-a"],
+      sinceMs: 0,
+    });
+    expect(got).toEqual(entries);
+    const body = lastFetchBody(fetchMock);
+    expect(body.excludeInstanceId).toBe(getInspectorInstanceId());
+    expect(body).toMatchObject({ serverIds: ["srv-a"], sinceMs: 0 });
+  });
+
+  it("returns [] on a sink error (never blocks the turn)", async () => {
+    configure();
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("boom")));
+    expect(
+      await readCrossInstanceRpcLogs({ serverIds: ["srv-a"], sinceMs: 0 })
+    ).toEqual([]);
+  });
+
+  it("no-ops with no servers or when unconfigured", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    expect(
+      await readCrossInstanceRpcLogs({ serverIds: [], sinceMs: 0 })
+    ).toEqual([]);
+    configure();
+    expect(
+      await readCrossInstanceRpcLogs({ serverIds: [], sinceMs: 0 })
+    ).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/mcpjam-inspector/server/utils/harness/harness-rpc-log-sink.ts
+++ b/mcpjam-inspector/server/utils/harness/harness-rpc-log-sink.ts
@@ -152,19 +152,37 @@ export async function flushHarnessRpcLogs(): Promise<void> {
   }
 }
 
+export type RpcLogCursor = { serverId: string; sinceMs: number };
+
+export type CrossInstanceRpcLogPage = {
+  entries: CrossInstanceRpcLogEntry[];
+  /** Per-server cursors for the NEXT read. Adopt these verbatim — see below. */
+  cursors: RpcLogCursor[];
+};
+
 /**
- * Read frames OTHER instances wrote for these servers since a cursor. Excludes
- * this instance (its frames arrived via the bus). Best-effort: any failure
- * yields `[]` so a slow/erroring sink never blocks a turn's stream.
+ * Read frames OTHER instances wrote for these servers since a PER-SERVER cursor.
+ * Excludes this instance (its frames arrived via the bus). Best-effort: any
+ * failure yields no entries and UNCHANGED cursors, so a slow/erroring sink never
+ * blocks a turn's stream and never silently skips frames.
+ *
+ * The caller must adopt the returned `cursors` rather than deriving them from
+ * `entries`. Own-instance rows are filtered server-side AFTER the index scan, so
+ * a window full of them yields zero entries while the scan still made progress —
+ * a cursor derived from delivered rows would never advance and that server would
+ * go blind for the rest of the turn.
  */
 export async function readCrossInstanceRpcLogs(args: {
-  serverIds: string[];
-  sinceMs: number;
+  servers: RpcLogCursor[];
   limit?: number;
-}): Promise<CrossInstanceRpcLogEntry[]> {
+}): Promise<CrossInstanceRpcLogPage> {
+  const unchanged: CrossInstanceRpcLogPage = {
+    entries: [],
+    cursors: args.servers,
+  };
   const base = convexBase();
   const token = serviceToken();
-  if (!base || !token || args.serverIds.length === 0) return [];
+  if (!base || !token || args.servers.length === 0) return unchanged;
   try {
     const res = await fetch(new URL("/harness/rpc-logs/read", base), {
       method: "POST",
@@ -173,17 +191,32 @@ export async function readCrossInstanceRpcLogs(args: {
         "x-inspector-service-token": token,
       },
       body: JSON.stringify({
-        serverIds: args.serverIds,
-        sinceMs: args.sinceMs,
+        servers: args.servers,
         excludeInstanceId: INSTANCE_ID,
         ...(args.limit !== undefined ? { limit: args.limit } : {}),
       }),
     });
-    if (!res.ok) return [];
-    const body = (await res.json()) as { entries?: CrossInstanceRpcLogEntry[] };
-    return Array.isArray(body.entries) ? body.entries : [];
+    if (!res.ok) return unchanged;
+    const body = (await res.json()) as {
+      entries?: CrossInstanceRpcLogEntry[];
+      cursors?: RpcLogCursor[];
+    };
+    const cursors = Array.isArray(body.cursors)
+      ? body.cursors.filter(
+          (c): c is RpcLogCursor =>
+            !!c &&
+            typeof c.serverId === "string" &&
+            typeof c.sinceMs === "number" &&
+            Number.isFinite(c.sinceMs)
+        )
+      : [];
+    return {
+      entries: Array.isArray(body.entries) ? body.entries : [],
+      // A response without usable cursors must not rewind or drop progress.
+      cursors: cursors.length > 0 ? cursors : args.servers,
+    };
   } catch {
-    return [];
+    return unchanged;
   }
 }
 

--- a/mcpjam-inspector/server/utils/harness/harness-rpc-log-sink.ts
+++ b/mcpjam-inspector/server/utils/harness/harness-rpc-log-sink.ts
@@ -1,0 +1,198 @@
+// Cross-instance harness RPC-log sink — inspector side (COMP-21).
+//
+// A harness's MCP tool calls arrive as separate `/api/web/harness-mcp/:serverId`
+// requests FROM the sandbox; on the scaled hosted plane one can land on a
+// different instance than the one streaming the chat turn. Same-instance frames
+// ride the in-process `rpcLogBus`; this module ALSO writes each frame to a shared
+// Convex sink (batched) and lets a streaming turn PULL the frames OTHER instances
+// wrote — completing the Logs panel across instances.
+//
+// Hard rules (observation-only): a sink failure must NEVER slow or fail a proxy
+// request — every path here is best-effort and swallowed. Never token material,
+// only the JSON-RPC payloads. Bounded on write (per-message size cap here; TTL
+// reaper on the backend).
+
+import { randomUUID } from "node:crypto";
+import { logger } from "../logger.js";
+
+/** Stable per-PROCESS id. The reader excludes its own instance so bus-delivered
+ *  (same-instance) frames aren't also pulled from Convex — the dedup that lets
+ *  both delivery paths coexist. */
+const INSTANCE_ID = randomUUID();
+export function getInspectorInstanceId(): string {
+  return INSTANCE_ID;
+}
+
+const FLUSH_INTERVAL_MS = 1000;
+const MAX_BUFFER_ENTRIES = 50;
+const MAX_BUFFER_BYTES = 256 * 1024;
+/** Per-frame cap. An oversized frame becomes a marker — never dropped, never
+ *  allowed to blow the Convex document limit. */
+const MESSAGE_CAP_BYTES = 16 * 1024;
+
+export type HarnessRpcLogEntry = {
+  serverId: string;
+  projectId?: string;
+  organizationId?: string;
+  direction: "send" | "receive";
+  loggedAt: string; // ISO
+  message: unknown;
+};
+
+export type CrossInstanceRpcLogEntry = {
+  id: string;
+  serverId: string;
+  direction: "send" | "receive";
+  loggedAt: string;
+  message: unknown;
+  createdAt: number;
+};
+
+function convexBase(): string | null {
+  return process.env.CONVEX_HTTP_URL?.trim() || null;
+}
+function serviceToken(): string | null {
+  return process.env.INSPECTOR_SERVICE_TOKEN?.trim() || null;
+}
+
+/** The sink only operates when this inspector can reach Convex with the service
+ *  token. Absent ⇒ single-instance / self-hosted: the in-process bus is the only
+ *  (and sufficient) delivery path, exactly as before COMP-21. */
+export function isRpcLogSinkConfigured(): boolean {
+  return Boolean(convexBase() && serviceToken());
+}
+
+function capMessage(message: unknown): unknown {
+  try {
+    const s = JSON.stringify(message);
+    if (s.length > MESSAGE_CAP_BYTES) {
+      return { _truncated: true, bytes: s.length };
+    }
+    return message;
+  } catch {
+    return { _truncated: true, reason: "unserializable" };
+  }
+}
+
+let buffer: HarnessRpcLogEntry[] = [];
+let bufferBytes = 0;
+let flushTimer: ReturnType<typeof setTimeout> | undefined;
+
+/**
+ * Buffer one frame for the shared sink. Flushes when the buffer hits a count or
+ * byte threshold, else on a ~1s timer — NEVER one Convex write per frame.
+ * Best-effort: any failure is swallowed so the proxy request is untouched.
+ */
+export function enqueueHarnessRpcLog(entry: HarnessRpcLogEntry): void {
+  if (!isRpcLogSinkConfigured()) return;
+  try {
+    const capped: HarnessRpcLogEntry = {
+      ...entry,
+      message: capMessage(entry.message),
+    };
+    buffer.push(capped);
+    try {
+      bufferBytes += JSON.stringify(capped).length;
+    } catch {
+      bufferBytes += MESSAGE_CAP_BYTES;
+    }
+    if (
+      buffer.length >= MAX_BUFFER_ENTRIES ||
+      bufferBytes >= MAX_BUFFER_BYTES
+    ) {
+      void flushHarnessRpcLogs();
+    } else if (!flushTimer) {
+      flushTimer = setTimeout(
+        () => void flushHarnessRpcLogs(),
+        FLUSH_INTERVAL_MS
+      );
+      // Don't keep the process alive for a pending log flush.
+      flushTimer.unref?.();
+    }
+  } catch (err) {
+    logger.warn(
+      `[harness-rpc-log-sink] enqueue failed: ${
+        err instanceof Error ? err.message : err
+      }`
+    );
+  }
+}
+
+/** Flush the buffer to Convex now. Best-effort; a failed flush drops the batch
+ *  (observation-only) rather than retrying and risking unbounded growth. */
+export async function flushHarnessRpcLogs(): Promise<void> {
+  if (flushTimer) {
+    clearTimeout(flushTimer);
+    flushTimer = undefined;
+  }
+  if (buffer.length === 0) return;
+  const base = convexBase();
+  const token = serviceToken();
+  const entries = buffer;
+  buffer = [];
+  bufferBytes = 0;
+  if (!base || !token) return;
+  try {
+    await fetch(new URL("/harness/rpc-logs/write", base), {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-inspector-service-token": token,
+      },
+      body: JSON.stringify({
+        entries: entries.map((e) => ({ ...e, instanceId: INSTANCE_ID })),
+      }),
+    });
+  } catch (err) {
+    logger.warn(
+      `[harness-rpc-log-sink] flush failed (${
+        entries.length
+      } entries dropped): ${err instanceof Error ? err.message : err}`
+    );
+  }
+}
+
+/**
+ * Read frames OTHER instances wrote for these servers since a cursor. Excludes
+ * this instance (its frames arrived via the bus). Best-effort: any failure
+ * yields `[]` so a slow/erroring sink never blocks a turn's stream.
+ */
+export async function readCrossInstanceRpcLogs(args: {
+  serverIds: string[];
+  sinceMs: number;
+  limit?: number;
+}): Promise<CrossInstanceRpcLogEntry[]> {
+  const base = convexBase();
+  const token = serviceToken();
+  if (!base || !token || args.serverIds.length === 0) return [];
+  try {
+    const res = await fetch(new URL("/harness/rpc-logs/read", base), {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-inspector-service-token": token,
+      },
+      body: JSON.stringify({
+        serverIds: args.serverIds,
+        sinceMs: args.sinceMs,
+        excludeInstanceId: INSTANCE_ID,
+        ...(args.limit !== undefined ? { limit: args.limit } : {}),
+      }),
+    });
+    if (!res.ok) return [];
+    const body = (await res.json()) as { entries?: CrossInstanceRpcLogEntry[] };
+    return Array.isArray(body.entries) ? body.entries : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Test-only: drop buffered state + pending timer between cases. */
+export function __resetHarnessRpcLogSinkForTest(): void {
+  if (flushTimer) {
+    clearTimeout(flushTimer);
+    flushTimer = undefined;
+  }
+  buffer = [];
+  bufferBytes = 0;
+}

--- a/mcpjam-inspector/server/utils/web-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/web-chat-turn.ts
@@ -75,7 +75,10 @@ import {
 import { isRenderedUiContextText } from "@/shared/ui-context";
 import type { createHostedRpcLogCollector } from "./../routes/web/hosted-rpc-logs.js";
 import type { HostedElicitationBridge } from "./../routes/web/hosted-elicitation.js";
-import { bridgeHarnessRpcLogsToCollector } from "./../routes/web/hosted-rpc-logs.js";
+import {
+  bridgeHarnessRpcLogsToCollector,
+  startCrossInstanceRpcLogPoll,
+} from "./../routes/web/hosted-rpc-logs.js";
 import type { CustomProviderConfig } from "./chat-helpers.js";
 import { getClientIp } from "./client-ip.js";
 import { convertToMcpjamModelMessages } from "./mcp-tool-result-model-output.js";
@@ -225,7 +228,7 @@ export interface StreamWebChatTurnArgs {
  * types the marker into chat keeps their message intact.
  */
 export function stripUiContextModelParts(
-  messages: ModelMessage[],
+  messages: ModelMessage[]
 ): ModelMessage[] {
   let changed = false;
   const out = messages.map((message) => {
@@ -239,7 +242,7 @@ export function stripUiContextModelParts(
           typeof part === "object" &&
           (part as { type?: unknown }).type === "text" &&
           isRenderedUiContextText((part as { text?: unknown }).text)
-        ),
+        )
     );
     if (content.length === message.content.length) return message;
     changed = true;
@@ -273,7 +276,7 @@ function uiToolApprovalsFrom(
  * path and mapping the error to a `webError(...)` response.
  */
 export async function streamWebChatTurn(
-  args: StreamWebChatTurnArgs,
+  args: StreamWebChatTurnArgs
 ): Promise<Response> {
   const { manager, prepare, persist, runtime } = args;
   const { c } = runtime;
@@ -283,7 +286,7 @@ export async function streamWebChatTurn(
     throw new WebRouteError(
       500,
       ErrorCode.INTERNAL_ERROR,
-      "Server missing CONVEX_HTTP_URL configuration",
+      "Server missing CONVEX_HTTP_URL configuration"
     );
   }
 
@@ -298,7 +301,7 @@ export async function streamWebChatTurn(
       // trigger new linked resource reads. Fresh server-side tool execution
       // resolves resource_link results through trusted tool-origin metadata.
       abortSignal: c.req.raw.signal as AbortSignal | undefined,
-    },
+    }
   );
 
   let prepared;
@@ -388,7 +391,7 @@ export async function streamWebChatTurn(
     : preparedTools;
 
   const widgetModelContextSystemPrompt = buildWidgetModelContextSystemPrompt(
-    prepare.widgetModelContext ?? [],
+    prepare.widgetModelContext ?? []
   );
   const effectiveEnhancedSystemPrompt = [
     enhancedSystemPrompt,
@@ -417,7 +420,7 @@ export async function streamWebChatTurn(
     Boolean(prepare.modelDefinition.id) &&
     isHostedCatalogModel(
       String(prepare.modelDefinition.id),
-      prepare.modelDefinition.provider,
+      prepare.modelDefinition.provider
     );
 
   // Resolve the host config now that `resolvedTemperature` is known.
@@ -425,21 +428,21 @@ export async function streamWebChatTurn(
   // callers preserve that by passing a closure here.
   const resolvedHostConfig: DirectHostConfig | null =
     typeof persist.hostConfig === "function"
-      ? (persist.hostConfig({ resolvedTemperature }) ?? null)
-      : (persist.hostConfig ?? null);
+      ? persist.hostConfig({ resolvedTemperature }) ?? null
+      : persist.hostConfig ?? null;
 
   // Build the persist callback once — it's a closure over a lot of context
   // and is identical between MCPJam-free and org-BYOK other than the modelId
   // + modelSource.
   const buildOnConversationComplete = (
     modelId: string,
-    modelSource: "mcpjam" | "byok" | "local_byok",
+    modelSource: "mcpjam" | "byok" | "local_byok"
   ) => {
     if (!hostedChatSessionId) return undefined;
     return async (
       fullHistory: ModelMessage[],
       turnTrace: PersistedTurnTrace,
-      harnessSessionCommit?: HarnessSessionCommitPayload,
+      harnessSessionCommit?: HarnessSessionCommitPayload
     ) => {
       const isDirectChat = !isChatboxSession;
       // Capture the live tool catalog. Failures must never block the persist.
@@ -457,7 +460,7 @@ export async function streamWebChatTurn(
               await exportConnectedServerToolSnapshotForEvalAuthoring(
                 manager,
                 knownIds,
-                { logPrefix: "chat-v2.persist" },
+                { logPrefix: "chat-v2.persist" }
               );
           }
         } catch {
@@ -481,7 +484,7 @@ export async function streamWebChatTurn(
         sessionMessages: stampSenderUserIdsOnSessionMessages(
           stripUiContextModelParts(fullHistory),
           persist.originalMessages as unknown[],
-          { authenticatedUserId: persist.authenticatedUserId },
+          { authenticatedUserId: persist.authenticatedUserId }
         ),
         startedAt: sessionStartedAt,
         lastActivityAt: Date.now(),
@@ -518,13 +521,13 @@ export async function streamWebChatTurn(
 
   if (!isMCPJam) {
     const providerKeyResult = deriveOrgProviderKeyResult(
-      prepare.modelDefinition,
+      prepare.modelDefinition
     );
     if (!providerKeyResult.ok) {
       throw new WebRouteError(
         400,
         ErrorCode.VALIDATION_ERROR,
-        providerKeyResult.error,
+        providerKeyResult.error
       );
     }
     const providerKey = providerKeyResult.key;
@@ -544,13 +547,13 @@ export async function streamWebChatTurn(
             chatboxId: persist.chatboxId,
             accessVersion: persist.accessVersion,
             serverIds: persist.selectedServerIds,
-          },
+          }
         )
       : { runtimeLocation: "cloud", providerKey };
 
     const onConversationComplete = buildOnConversationComplete(
       modelId,
-      orgRuntime.runtimeLocation === "local" ? "local_byok" : "byok",
+      orgRuntime.runtimeLocation === "local" ? "local_byok" : "byok"
     );
 
     warnIfChatAbortSignalMissing(runtime.abortSignal, "web/chat-v2");
@@ -623,7 +626,7 @@ export async function streamWebChatTurn(
   const mcpjamModelId = String(prepare.modelDefinition.id);
   const onConversationComplete = buildOnConversationComplete(
     mcpjamModelId,
-    "mcpjam",
+    "mcpjam"
   );
   warnIfChatAbortSignalMissing(runtime.abortSignal, "web/chat-v2");
 
@@ -644,6 +647,9 @@ export async function streamWebChatTurn(
   // Subscribed at stream start (not before — a pre-stream failure must not
   // leave a live subscription) and torn down with the stream.
   let stopHarnessRpcLogBridge: (() => void) | undefined;
+  // COMP-21: cross-instance half of the harness log bridge (polls the shared
+  // Convex sink for frames other instances produced). Paired with the bus bridge.
+  let stopCrossInstanceRpcLogPoll: (() => void) | undefined;
 
   return handleMCPJamFreeChatModel({
     messages: modelMessages,
@@ -670,9 +676,9 @@ export async function streamWebChatTurn(
     selectedServers: persist.selectedServerIds,
     requireToolApproval: persist.requireToolApproval,
     uiToolApprovals: uiToolApprovalsFrom(
-        effectiveUiTools,
-        persist.requireToolApproval
-      ),
+      effectiveUiTools,
+      persist.requireToolApproval
+    ),
     modelVisibleMcpToolResults: prepare.modelVisibleMcpToolResults,
     ...(persist.harness ? { harness: persist.harness } : {}),
     ...(harnessMcpProxy ? { harnessMcpProxy } : {}),
@@ -686,6 +692,8 @@ export async function streamWebChatTurn(
     onStreamComplete: async () => {
       stopHarnessRpcLogBridge?.();
       stopHarnessRpcLogBridge = undefined;
+      stopCrossInstanceRpcLogPoll?.();
+      stopCrossInstanceRpcLogPoll = undefined;
       await cleanupStream();
     },
     onStreamWriterReady: (writer) => {
@@ -697,6 +705,12 @@ export async function streamWebChatTurn(
       runtime.elicitationBridge?.attachStreamWriter(writer);
       if (persist.harness && runtime.rpcCollector && !stopHarnessRpcLogBridge) {
         stopHarnessRpcLogBridge = bridgeHarnessRpcLogsToCollector(
+          persist.selectedServerIds,
+          runtime.rpcCollector
+        );
+        // COMP-21: cross-instance frames (harness-mcp landed on another
+        // instance) arrive via the shared Convex sink. No-op single-instance.
+        stopCrossInstanceRpcLogPoll = startCrossInstanceRpcLogPoll(
           persist.selectedServerIds,
           runtime.rpcCollector
         );


### PR DESCRIPTION
## COMP-21 — inspector half (pairs with backend PR MCPJam/mcpjam-backend#765)

Completes the Playground Logs panel for harness turns on the scaled hosted plane: today a harness-mcp request that lands on a **different** instance than the chat stream never reaches the turn's in-process `rpcLogBus`, so the panel under-reports with no error (issue #2999, option A). Fix = a shared Convex sink; delivery stays on the chat stream, so **zero client changes**.

- **`harness-rpc-log-sink.ts`** — a per-process **`instanceId`** + a **batched, best-effort** writer to `/harness/rpc-logs/write` (flush every ~1s / 50 entries / 256 KB — never one write per frame; per-frame 16 KB cap → truncation marker) and a reader of `/harness/rpc-logs/read`. **No-ops when Convex isn't configured** (single-instance / self-hosted keep the bus-only path). Every path swallows errors — a slow/erroring sink can't touch a proxy request.
- **`harness-mcp.ts` `rpcLogger`** — ALSO enqueues each frame to the sink (tagged with projectId/orgId), alongside the existing bus publish. Own try/catch; never reaches the RPC try/catch.
- **`hosted-rpc-logs.ts` `startCrossInstanceRpcLogPoll`** — polls the sink (~1s) for frames OTHER instances wrote and feeds the turn's collector → same `data-rpc-log` delivery the emulated engine uses. The read **excludes our own `instanceId`** (a bus-delivered frame is never pulled again) and **dedups on the sink row id** (a batch write shares one `createdAt`). Paired with the bus bridge in `web-chat-turn.ts` — start together, tear down together.

**Acceptance criteria**
- [x] A turn's Logs panel shows entries produced by the OTHER instance → the cross-instance poller (test: frames from another instance reach the collector).
- [x] A Convex outage/slow sink doesn't slow or fail harness tool calls → sink is best-effort/batched/swallowed; **test: the harness-mcp route still 200s when the sink write rejects**, plus flush/read swallow errors.
- [x] Retention verified → backend TTL reaper test (deletes old, keeps fresh, self-drains).
- [x] Existing single-instance behavior unchanged → `rpc-logs.test.ts` + `harness-mcp.test.ts` still green (bus path untouched).

**Verification:** server `tsc` clean for touched files; `server/routes/web` + `server/utils/harness` suites green (559).

🤖 Generated with [Claude Code](https://claude.com/claude-code)