### PR TITLE
test(apps): regression-gate MCP Apps across protocol eras (2026-07-28)

### DIFF
--- a/cli/src/commands/apps.ts
+++ b/cli/src/commands/apps.ts
@@ -4,6 +4,7 @@ import {
   MCP_APPS_CHECK_IDS,
   MCPAppsConformanceSuite,
   MCPAppsConformanceTest,
+  isKnownProtocolVersion,
   type MCPAppsCheckCategory,
   type MCPAppsCheckId,
   type MCPAppsConformanceConfig,
@@ -64,6 +65,7 @@ const APPS_CHECK_IDS_BY_CATEGORY: Record<
 export interface AppsConformanceOptions extends SharedServerTargetOptions {
   category?: string[];
   checkId?: string[];
+  protocolVersion?: string;
 }
 
 export interface AppsRenderOptions extends SharedServerTargetOptions {
@@ -174,6 +176,10 @@ export function registerAppsCommands(program: Command): void {
       .option(
         "--reporter <reporter>",
         "Structured reporter output: json-summary or junit-xml",
+      )
+      .option(
+        "--protocol-version <version>",
+        "Pin the MCP protocol version for the conformance connection (e.g. 2026-07-28). HTTP targets only.",
       ),
   ).action(async (options, command) => {
     const reporter = parseReporterFormat(options.reporter as string | undefined);
@@ -592,8 +598,21 @@ export function buildAppsConformanceConfig(
         )
       : undefined;
 
+  const protocolVersion = options.protocolVersion?.trim();
+  if (protocolVersion) {
+    if (!isKnownProtocolVersion(protocolVersion)) {
+      throw usageError(`Unknown --protocol-version: ${protocolVersion}`);
+    }
+    if (!("url" in serverConfig) || !serverConfig.url) {
+      throw usageError(
+        "--protocol-version can only be used with an HTTP target (--url).",
+      );
+    }
+  }
+
   return {
     ...serverConfig,
+    ...(protocolVersion ? { mcpProtocolVersion: protocolVersion } : {}),
     ...(resolvedCheckIds && resolvedCheckIds.length > 0
       ? { checkIds: resolvedCheckIds as MCPAppsConformanceConfig["checkIds"] }
       : {}),

--- a/cli/src/commands/apps.ts
+++ b/cli/src/commands/apps.ts
@@ -8,6 +8,7 @@ import {
   type MCPAppsCheckCategory,
   type MCPAppsCheckId,
   type MCPAppsConformanceConfig,
+  type McpProtocolVersion,
 } from "@mcpjam/sdk";
 import { loadAppsSuiteConfig } from "../lib/config-file.js";
 import {
@@ -598,21 +599,23 @@ export function buildAppsConformanceConfig(
         )
       : undefined;
 
-  const protocolVersion = options.protocolVersion?.trim();
-  if (protocolVersion) {
-    if (!isKnownProtocolVersion(protocolVersion)) {
-      throw usageError(`Unknown --protocol-version: ${protocolVersion}`);
+  const trimmedProtocolVersion = options.protocolVersion?.trim();
+  let mcpProtocolVersion: McpProtocolVersion | undefined;
+  if (trimmedProtocolVersion) {
+    if (!isKnownProtocolVersion(trimmedProtocolVersion)) {
+      throw usageError(`Unknown --protocol-version: ${trimmedProtocolVersion}`);
     }
     if (!("url" in serverConfig) || !serverConfig.url) {
       throw usageError(
         "--protocol-version can only be used with an HTTP target (--url).",
       );
     }
+    mcpProtocolVersion = trimmedProtocolVersion;
   }
 
   return {
     ...serverConfig,
-    ...(protocolVersion ? { mcpProtocolVersion: protocolVersion } : {}),
+    ...(mcpProtocolVersion ? { mcpProtocolVersion } : {}),
     ...(resolvedCheckIds && resolvedCheckIds.length > 0
       ? { checkIds: resolvedCheckIds as MCPAppsConformanceConfig["checkIds"] }
       : {}),

--- a/cli/tests/apps-conformance.test.ts
+++ b/cli/tests/apps-conformance.test.ts
@@ -49,3 +49,42 @@ test("buildAppsConformanceConfig lets explicit check ids override categories", (
 
   assert.deepEqual(config.checkIds, ["ui-tools-present"]);
 });
+
+test("buildAppsConformanceConfig pins mcpProtocolVersion when --protocol-version is a known version", () => {
+  const config = buildAppsConformanceConfig({
+    url: "https://example.com/mcp",
+    protocolVersion: "2026-07-28",
+  });
+
+  assert.equal(
+    (config as { mcpProtocolVersion?: string }).mcpProtocolVersion,
+    "2026-07-28",
+  );
+});
+
+test("buildAppsConformanceConfig rejects an unknown --protocol-version", () => {
+  assert.throws(
+    () =>
+      buildAppsConformanceConfig({
+        url: "https://example.com/mcp",
+        protocolVersion: "not-a-real-version",
+      }),
+    (error) =>
+      error instanceof CliError &&
+      error.message.includes("Unknown --protocol-version"),
+  );
+});
+
+test("buildAppsConformanceConfig rejects --protocol-version against a stdio target", () => {
+  assert.throws(
+    () =>
+      buildAppsConformanceConfig({
+        command: "node",
+        args: ["server.js"],
+        protocolVersion: "2026-07-28",
+      }),
+    (error) =>
+      error instanceof CliError &&
+      error.message.includes("HTTP target"),
+  );
+});

--- a/sdk/tests/apps-conformance/runner-2026.integration.test.ts
+++ b/sdk/tests/apps-conformance/runner-2026.integration.test.ts
@@ -1,0 +1,82 @@
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { toNodeHandler } from "@modelcontextprotocol/node";
+import { MCPAppsConformanceTest } from "../../src/apps-conformance/index.js";
+import { createFixtureHandler } from "../support/dual-era-fixture.js";
+
+/**
+ * Phase 3 §11.4: MCPAppsConformanceConfig already accepts
+ * `mcpProtocolVersion` (it spreads `MCPServerConfig`, and
+ * `HttpServerConfig.mcpProtocolVersion` exists) — no sdk change is needed to
+ * run the apps-conformance suite against a modern (2026-07-28) connection.
+ * This is a REGRESSION GATE that a modern run produces the same check
+ * statuses as a legacy run against the same server.
+ */
+
+interface ServedFixture {
+  url: string;
+  close: () => Promise<void>;
+}
+
+async function serveFixtureOnPort(): Promise<ServedFixture> {
+  const handler = createFixtureHandler({ apps: true });
+  const httpServer = http.createServer(toNodeHandler(handler));
+  await new Promise<void>((resolve) =>
+    httpServer.listen(0, "127.0.0.1", resolve),
+  );
+  const address = httpServer.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${address.port}/mcp`,
+    close: () =>
+      new Promise<void>((resolve) => httpServer.close(() => resolve())),
+  };
+}
+
+describe("MCPAppsConformanceTest against the apps fixture — 2026-07-28", () => {
+  it("passes on a modern (2026-07-28) pin", async () => {
+    const served = await serveFixtureOnPort();
+    try {
+      const test = new MCPAppsConformanceTest({
+        url: served.url,
+        mcpProtocolVersion: "2026-07-28",
+        timeout: 10_000,
+      });
+
+      const result = await test.run();
+
+      expect(result.checks.length).toBeGreaterThan(0);
+      expect(
+        result.checks.every(
+          (check) => check.status === "passed" || check.status === "skipped",
+        ),
+      ).toBe(true);
+    } finally {
+      await served.close();
+    }
+  });
+
+  it("yields identical check statuses on legacy and modern runs", async () => {
+    const legacyServed = await serveFixtureOnPort();
+    const modernServed = await serveFixtureOnPort();
+    try {
+      const legacyResult = await new MCPAppsConformanceTest({
+        url: legacyServed.url,
+        timeout: 10_000,
+      }).run();
+      const modernResult = await new MCPAppsConformanceTest({
+        url: modernServed.url,
+        mcpProtocolVersion: "2026-07-28",
+        timeout: 10_000,
+      }).run();
+
+      const statuses = (checks: typeof legacyResult.checks) =>
+        Object.fromEntries(checks.map((c) => [c.id, c.status]));
+
+      expect(statuses(modernResult.checks)).toEqual(statuses(legacyResult.checks));
+      expect(modernResult.passed).toBe(legacyResult.passed);
+    } finally {
+      await legacyServed.close();
+      await modernServed.close();
+    }
+  });
+});

--- a/sdk/tests/support/apps-capability-carrier.integration.test.ts
+++ b/sdk/tests/support/apps-capability-carrier.integration.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Phase 3 §11.4 investigation: does the modern (2026-07-28) era carry the
+ * `io.modelcontextprotocol/ui` client-capability extension the same way the
+ * legacy era does?
+ *
+ * Legacy carries `capabilities.extensions` once, in the `initialize` request
+ * `params`. The 2026-07-28 wire moves client capabilities into the
+ * per-request `_meta["io.modelcontextprotocol/clientCapabilities"]` envelope
+ * (see `RequestMetaEnvelopeSchema` / `outboundEnvelope()` in
+ * `@modelcontextprotocol/client`'s 2026 codec) — declared per request rather
+ * than once at initialization. This test connects a REAL `MCPClientManager`
+ * (exercising the actual merge path: `MCPClientManager.ts` constructor ->
+ * `buildCapabilities` -> `ClientOptions.capabilities`) to the dual-era
+ * fixture over a raw-capture `fetch`, once per era, and asserts the wire
+ * carrier for each.
+ *
+ * `MCPClientManager` does not expose a `fetch` override in its server config
+ * (only `requestInit`), and the underlying `StreamableHTTPClientTransport`
+ * falls back to `globalThis.fetch` when none is supplied. So this test
+ * patches `globalThis.fetch` for the duration of a single connection — the
+ * capturing fetch still dials the real loopback HTTP server underneath, it
+ * just also records every exchange.
+ */
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { toNodeHandler } from "@modelcontextprotocol/node";
+import {
+  MCP_UI_EXTENSION_ID,
+  MCP_UI_RESOURCE_MIME_TYPE,
+  MCPClientManager,
+} from "../../src/mcp-client-manager/index.js";
+import { createFixtureHandler } from "./dual-era-fixture.js";
+import {
+  createCapturingFetch,
+  getWireField,
+  type CapturingFetch,
+  type RawExchange,
+} from "./raw-capture.js";
+
+interface ServedFixture {
+  url: string;
+  close: () => Promise<void>;
+}
+
+async function serveFixtureOnPort(): Promise<ServedFixture> {
+  const handler = createFixtureHandler();
+  const httpServer = http.createServer(toNodeHandler(handler));
+  await new Promise<void>((resolve) =>
+    httpServer.listen(0, "127.0.0.1", resolve),
+  );
+  const address = httpServer.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${address.port}/mcp`,
+    close: () =>
+      new Promise<void>((resolve) => httpServer.close(() => resolve())),
+  };
+}
+
+function byMethod(
+  exchanges: RawExchange[],
+  method: string,
+): RawExchange | undefined {
+  return exchanges.find((e) => getWireField(e.request.json, "method") === method);
+}
+
+/**
+ * Run `run` with `globalThis.fetch` swapped for a capturing fetch that still
+ * dials the real underlying fetch. Restores the original afterward even on
+ * throw.
+ */
+async function withCapturingFetch<T>(
+  run: (cap: CapturingFetch) => Promise<T>,
+): Promise<T> {
+  const originalFetch = globalThis.fetch;
+  const cap = createCapturingFetch(originalFetch.bind(globalThis));
+  globalThis.fetch = cap.fetch as typeof fetch;
+  try {
+    return await run(cap);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+describe("MCP Apps client-capability carrier — legacy vs 2026-07-28", () => {
+  let served: ServedFixture;
+  let manager: MCPClientManager;
+
+  beforeEach(async () => {
+    served = await serveFixtureOnPort();
+    manager = new MCPClientManager();
+  });
+
+  afterEach(async () => {
+    await manager.disconnectAllServers().catch(() => {});
+    await served.close();
+  });
+
+  it("legacy: advertises io.modelcontextprotocol/ui in the initialize request's params.capabilities.extensions", async () => {
+    const cap = await withCapturingFetch(async (cap) => {
+      await manager.connectToServer("fixture", {
+        url: served.url,
+        timeout: 10_000,
+      });
+      return cap;
+    });
+
+    const init = byMethod(cap.exchanges, "initialize");
+    expect(init, "initialize exchange captured").toBeDefined();
+    const extension = getWireField(init!.request.json, [
+      "params",
+      "capabilities",
+      "extensions",
+      MCP_UI_EXTENSION_ID,
+    ]) as { mimeTypes?: unknown } | undefined;
+    expect(extension?.mimeTypes).toContain(MCP_UI_RESOURCE_MIME_TYPE);
+  });
+
+  it("modern (2026-07-28): the empirical carrier for io.modelcontextprotocol/ui", async () => {
+    const cap = await withCapturingFetch(async (cap) => {
+      await manager.connectToServer("fixture", {
+        url: served.url,
+        mcpProtocolVersion: "2026-07-28",
+        timeout: 10_000,
+      });
+      // Exercise a second, ordinary request so we're not only looking at
+      // whatever server/discover or the negotiation probe carries.
+      await manager.listTools("fixture");
+      return cap;
+    });
+
+    const list = byMethod(cap.exchanges, "tools/list");
+    expect(list, "tools/list exchange captured").toBeDefined();
+
+    // The modern per-request `_meta` envelope carries the negotiated
+    // protocol version on every request (already covered by
+    // dual-era-fixture.test.ts) — confirm it's present alongside whatever we
+    // find for capabilities, so the two assertions are known to be looking
+    // at the same envelope.
+    expect(
+      getWireField(list!.request.json, [
+        "params",
+        "_meta",
+        "io.modelcontextprotocol/protocolVersion",
+      ]),
+    ).toBe("2026-07-28");
+
+    // EMPIRICAL: the 2026 codec's `outboundEnvelope()` places client
+    // capabilities under `_meta["io.modelcontextprotocol/clientCapabilities"]`
+    // on every outbound request (verified by reading
+    // `@modelcontextprotocol/client`'s installed beta.4 dist: `rev2026Codec
+    // .outboundEnvelope` in `src-CMjk3S93.mjs`, sourced from `this._capabilities`
+    // — the same `ClientOptions.capabilities` MCPClientManager.buildCapabilities
+    // constructs). This assertion is the wire-level confirmation of that
+    // reading, not a guess: if the installed SDK version ever stops emitting
+    // this carrier, this assertion is expected to fail loudly rather than
+    // silently pass.
+    const extension = getWireField(list!.request.json, [
+      "params",
+      "_meta",
+      "io.modelcontextprotocol/clientCapabilities",
+      "extensions",
+      MCP_UI_EXTENSION_ID,
+    ]) as { mimeTypes?: unknown } | undefined;
+    expect(extension?.mimeTypes).toContain(MCP_UI_RESOURCE_MIME_TYPE);
+  });
+});

--- a/sdk/tests/support/dual-era-fixture-apps.integration.test.ts
+++ b/sdk/tests/support/dual-era-fixture-apps.integration.test.ts
@@ -1,0 +1,236 @@
+/**
+ * MCP Apps preserved across protocol eras (Phase 3 §11.4 regression gate).
+ *
+ * The ui:// fetch and app-to-server tool calls already funnel through the
+ * shared MCPClientManager, so era negotiation (legacy vs 2026-07-28 pin) is
+ * inherited rather than special-cased — but nothing exercised Apps on a
+ * modern connection before this file. Parameterized over both eras against a
+ * real MCPClientManager talking to the dual-era fixture (apps: true) over a
+ * real loopback HTTP server.
+ */
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { toNodeHandler } from "@modelcontextprotocol/node";
+import type { CallToolResult } from "@modelcontextprotocol/client";
+import type { McpProtocolVersion } from "../../src/mcp-client-manager/mcp-protocol-version.js";
+import { MCPClientManager } from "../../src/mcp-client-manager/index.js";
+import { isMcpAppTool } from "../../src/mcp-client-manager/tool-converters.js";
+import {
+  createFixtureHandler,
+  FIXTURE_APP_MIME_TYPE,
+  FIXTURE_APP_WIDGET_OVERRIDE_URI,
+  FIXTURE_APP_WIDGET_URI,
+} from "./dual-era-fixture.js";
+import {
+  createCapturingFetch,
+  getWireField,
+  type CapturingFetch,
+  type RawExchange,
+} from "./raw-capture.js";
+
+interface ServedFixture {
+  url: string;
+  close: () => Promise<void>;
+}
+
+async function serveFixtureOnPort(): Promise<ServedFixture> {
+  const handler = createFixtureHandler({ apps: true });
+  const httpServer = http.createServer(toNodeHandler(handler));
+  await new Promise<void>((resolve) =>
+    httpServer.listen(0, "127.0.0.1", resolve),
+  );
+  const address = httpServer.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${address.port}/mcp`,
+    close: () =>
+      new Promise<void>((resolve) => httpServer.close(() => resolve())),
+  };
+}
+
+function byMethod(
+  exchanges: RawExchange[],
+  method: string,
+): RawExchange | undefined {
+  return exchanges.find((e) => getWireField(e.request.json, "method") === method);
+}
+
+/** Swap globalThis.fetch for a capturing fetch (still dials the real port). */
+async function withCapturingFetch<T>(
+  run: (cap: CapturingFetch) => Promise<T>,
+): Promise<T> {
+  const originalFetch = globalThis.fetch;
+  const cap = createCapturingFetch(originalFetch.bind(globalThis));
+  globalThis.fetch = cap.fetch as typeof fetch;
+  try {
+    return await run(cap);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+interface EraCase {
+  label: string;
+  mcpProtocolVersion?: McpProtocolVersion;
+}
+
+const ERAS: EraCase[] = [
+  { label: "legacy (no pin)" },
+  { label: "modern (2026-07-28)", mcpProtocolVersion: "2026-07-28" },
+];
+
+describe.each(ERAS)("MCP Apps on the $label era", ({ mcpProtocolVersion }) => {
+  let served: ServedFixture;
+  let manager: MCPClientManager;
+
+  beforeEach(async () => {
+    served = await serveFixtureOnPort();
+    manager = new MCPClientManager();
+  });
+
+  afterEach(async () => {
+    await manager.disconnectAllServers().catch(() => {});
+    await served.close();
+  });
+
+  it("detects both the nested and deprecated-flat MCP App tools via isMcpAppTool", async () => {
+    await manager.connectToServer("fixture", {
+      url: served.url,
+      mcpProtocolVersion,
+      timeout: 10_000,
+    });
+
+    const { tools } = await manager.listTools("fixture");
+    const byName = new Map(tools.map((t) => [t.name, t]));
+
+    const nested = byName.get("show-widget");
+    const flat = byName.get("show-widget-flat");
+    expect(nested, "show-widget listed").toBeDefined();
+    expect(flat, "show-widget-flat listed").toBeDefined();
+    expect(
+      isMcpAppTool(nested?._meta as Record<string, unknown> | undefined),
+    ).toBe(true);
+    expect(
+      isMcpAppTool(flat?._meta as Record<string, unknown> | undefined),
+    ).toBe(true);
+  });
+
+  it("reads the ui:// resource and gets back the mcp-app HTML", async () => {
+    await manager.connectToServer("fixture", {
+      url: served.url,
+      mcpProtocolVersion,
+      timeout: 10_000,
+    });
+
+    const result = await manager.readResource("fixture", {
+      uri: FIXTURE_APP_WIDGET_URI,
+    });
+    const contents = Array.isArray(result.contents) ? result.contents : [];
+    expect(contents).toHaveLength(1);
+    const content = contents[0] as {
+      mimeType?: string;
+      text?: string;
+    };
+    expect(content.mimeType).toBe(FIXTURE_APP_MIME_TYPE);
+    expect(content.text).toContain("fixture widget");
+  });
+
+  it("calls the app-to-server tool successfully", async () => {
+    await manager.connectToServer("fixture", {
+      url: served.url,
+      mcpProtocolVersion,
+      timeout: 10_000,
+    });
+
+    const result = (await manager.executeTool(
+      "fixture",
+      "show-widget",
+      {},
+    )) as CallToolResult;
+    expect(result.isError).not.toBe(true);
+    expect(Array.isArray(result.content) ? result.content.length : 0).toBeGreaterThan(0);
+  });
+
+  it("the call result's content-item _meta.ui.resourceUri takes precedence over the listing metadata", async () => {
+    await manager.connectToServer("fixture", {
+      url: served.url,
+      mcpProtocolVersion,
+      timeout: 10_000,
+    });
+
+    const { tools } = await manager.listTools("fixture");
+    const listed = tools.find((t) => t.name === "show-widget");
+    const listedMeta = listed?._meta as
+      | { ui?: { resourceUri?: unknown } }
+      | undefined;
+    // The tool-listing declaration points at the plain widget URI.
+    expect(listedMeta?.ui?.resourceUri).toBe(FIXTURE_APP_WIDGET_URI);
+
+    const result = (await manager.executeTool(
+      "fixture",
+      "show-widget",
+      {},
+    )) as CallToolResult;
+    const first = Array.isArray(result.content) ? result.content[0] : undefined;
+    const contentMeta = (first as { _meta?: { ui?: { resourceUri?: unknown } } })
+      ?._meta;
+    // The result's own content-item _meta carries a DIFFERENT resourceUri —
+    // that is the one a host must render for this specific call, taking
+    // precedence over the static tool-listing declaration.
+    expect(contentMeta?.ui?.resourceUri).toBe(FIXTURE_APP_WIDGET_OVERRIDE_URI);
+    expect(contentMeta?.ui?.resourceUri).not.toBe(listedMeta?.ui?.resourceUri);
+  });
+
+  it("carries the era-correct client-capability extension carrier alongside the negotiated protocol version", async () => {
+    const cap = await withCapturingFetch(async (cap) => {
+      await manager.connectToServer("fixture", {
+        url: served.url,
+        mcpProtocolVersion,
+        timeout: 10_000,
+      });
+      await manager.listTools("fixture");
+      return cap;
+    });
+
+    if (mcpProtocolVersion === "2026-07-28") {
+      const list = byMethod(cap.exchanges, "tools/list");
+      expect(list, "tools/list exchange captured").toBeDefined();
+      expect(
+        getWireField(list!.request.json, [
+          "params",
+          "_meta",
+          "io.modelcontextprotocol/protocolVersion",
+        ]),
+      ).toBe("2026-07-28");
+      const extension = getWireField(list!.request.json, [
+        "params",
+        "_meta",
+        "io.modelcontextprotocol/clientCapabilities",
+        "extensions",
+        "io.modelcontextprotocol/ui",
+      ]) as { mimeTypes?: unknown } | undefined;
+      expect(extension?.mimeTypes).toContain(FIXTURE_APP_MIME_TYPE);
+    } else {
+      const init = byMethod(cap.exchanges, "initialize");
+      expect(init, "initialize exchange captured").toBeDefined();
+      const extension = getWireField(init!.request.json, [
+        "params",
+        "capabilities",
+        "extensions",
+        "io.modelcontextprotocol/ui",
+      ]) as { mimeTypes?: unknown } | undefined;
+      expect(extension?.mimeTypes).toContain(FIXTURE_APP_MIME_TYPE);
+    }
+  });
+
+  it("the modern result stays a plain JSON boundary (JSON.parse(JSON.stringify(result)) deep-equals result)", async () => {
+    await manager.connectToServer("fixture", {
+      url: served.url,
+      mcpProtocolVersion,
+      timeout: 10_000,
+    });
+
+    const result = await manager.executeTool("fixture", "show-widget", {});
+    expect(JSON.parse(JSON.stringify(result))).toEqual(result);
+  });
+});

--- a/sdk/tests/support/dual-era-fixture.ts
+++ b/sdk/tests/support/dual-era-fixture.ts
@@ -25,11 +25,31 @@ export const FIXTURE_SERVER_INFO = {
 
 export const FIXTURE_GREETING_URI = "test://greeting";
 
+/** MCP Apps fixture surface (Phase 3 §11.4 dual-era regression gate). */
+export const FIXTURE_APP_WIDGET_URI = "ui://fixture/widget";
+export const FIXTURE_APP_WIDGET_OVERRIDE_URI = "ui://fixture/widget-override";
+export const FIXTURE_APP_MIME_TYPE = "text/html;profile=mcp-app";
+const FIXTURE_APP_WIDGET_HTML =
+  "<html><body><p>fixture widget</p></body></html>";
+
+export interface BuildFixtureServerOptions {
+  /**
+   * When true, additionally registers the MCP Apps surface: a `ui://`
+   * resource plus a nested-`_meta` tool (`show-widget`) and a
+   * deprecated-flat-`_meta` tool (`show-widget-flat`). Defaults to false so
+   * the default fixture surface stays byte-identical for tests that snapshot
+   * it (see `dual-era-fixture.test.ts`).
+   */
+  apps?: boolean;
+}
+
 /**
  * Build a fresh fixture server. `createMcpHandler` calls this per request, so
  * it must register the same surface every time; keep it side-effect-free.
  */
-export function buildFixtureServer(): McpServer {
+export function buildFixtureServer(
+  options: BuildFixtureServerOptions = {},
+): McpServer {
   const server = new McpServer(FIXTURE_SERVER_INFO, {
     capabilities: { tools: {}, resources: {}, prompts: {} },
   });
@@ -70,6 +90,61 @@ export function buildFixtureServer(): McpServer {
     }),
   );
 
+  if (options.apps) {
+    server.registerResource(
+      "fixture-widget",
+      FIXTURE_APP_WIDGET_URI,
+      {
+        description: "A static MCP Apps UI resource.",
+        mimeType: FIXTURE_APP_MIME_TYPE,
+      },
+      async () => ({
+        contents: [
+          {
+            uri: FIXTURE_APP_WIDGET_URI,
+            mimeType: FIXTURE_APP_MIME_TYPE,
+            text: FIXTURE_APP_WIDGET_HTML,
+          },
+        ],
+      }),
+    );
+
+    // Nested `_meta.ui.resourceUri` (preferred form, SEP-1865). The handler
+    // result's content-item `_meta.ui.resourceUri` intentionally differs from
+    // the tool-level declaration so precedence between the two is assertable.
+    server.registerTool(
+      "show-widget",
+      {
+        description: "Shows the fixture widget (nested _meta form).",
+        inputSchema: {},
+        _meta: { ui: { resourceUri: FIXTURE_APP_WIDGET_URI } },
+      },
+      async () => ({
+        content: [
+          {
+            type: "text" as const,
+            text: "widget shown",
+            _meta: { ui: { resourceUri: FIXTURE_APP_WIDGET_OVERRIDE_URI } },
+          },
+        ],
+      }),
+    );
+
+    // Deprecated flat `_meta["ui/resourceUri"]` form — legacy servers still
+    // emit this; `isMcpAppTool` must still detect it.
+    server.registerTool(
+      "show-widget-flat",
+      {
+        description: "Shows the fixture widget (deprecated flat _meta form).",
+        inputSchema: {},
+        _meta: { "ui/resourceUri": FIXTURE_APP_WIDGET_URI },
+      },
+      async () => ({
+        content: [{ type: "text" as const, text: "widget shown" }],
+      }),
+    );
+  }
+
   return server;
 }
 
@@ -77,6 +152,6 @@ export function buildFixtureServer(): McpServer {
  * A `createMcpHandler` bound to the fixture. Serves the modern era and, by
  * default, the legacy-stateless era. Drive it with `handler.fetch(request)`.
  */
-export function createFixtureHandler() {
-  return createMcpHandler(buildFixtureServer);
+export function createFixtureHandler(options: BuildFixtureServerOptions = {}) {
+  return createMcpHandler(() => buildFixtureServer(options));
 }


### PR DESCRIPTION
## Summary

Phase 3 §11.4: MCP Apps must be preserved across protocol eras. This is primarily a **test/regression-gate PR** — the `ui://` fetch and app-to-server tool calls already funnel through the shared `MCPClientManager`, so era negotiation (legacy vs. modern `2026-07-28` pin) is inherited rather than special-cased. Nothing exercised Apps on a modern connection before this PR; now it's covered end to end.

1. **Investigation** (`sdk/tests/support/apps-capability-carrier.integration.test.ts`): connects a real `MCPClientManager` to the dual-era fixture over a raw-capture `fetch`, once legacy and once pinned `2026-07-28`, and inspects the unnormalized wire frames for the `io.modelcontextprotocol/ui` client-capability extension.
2. **Fixture**: `dual-era-fixture.ts` gains an opt-in `{ apps?: boolean }` param (default `false`, existing default surface stays byte-identical) that registers a `ui://` resource plus a nested-`_meta` tool and a deprecated-flat-`_meta` tool.
3. **Regression gate** (`dual-era-fixture-apps.integration.test.ts`): parameterized over both eras against a real `MCPClientManager` over real loopback HTTP — tool detection, resource read, tool execution, result-vs-listing metadata precedence, capability-carrier assertions, and a plain-JSON boundary check. 12/12 pass on both eras.
4. **Apps-conformance on 2026** (`runner-2026.integration.test.ts`): `MCPAppsConformanceConfig` already accepts `mcpProtocolVersion` — no sdk change needed. A modern run passes and yields identical check statuses to a legacy run.
5. **Optional/severable**: `--protocol-version` on `mcpjam apps conformance` (CLI), validated via `isKnownProtocolVersion`, HTTP-only.

## Decisions to review

- **Empirical answer to the modern-extension-carrier question (the main open question in the plan): the carrier IS present.** The installed `@modelcontextprotocol/client` beta.4 does NOT drop `io.modelcontextprotocol/ui` on the 2026-07-28 era. Legacy puts client capabilities once, in the `initialize` request's `params.capabilities.extensions`. The 2026 codec instead moves the client's full capabilities (including `extensions`) into the **per-request** `_meta["io.modelcontextprotocol/clientCapabilities"]` envelope (see `RequestMetaEnvelopeSchema` / `rev2026Codec.outboundEnvelope()` in the installed dist), sourced from the same `ClientOptions.capabilities` that `MCPClientManager.buildCapabilities` constructs, and sent on **every** request rather than once at initialize. Since the carrier was present, no `it.fails(...)` / upstream issue was needed — everything merges green.
- I picked the **existing dual-era fixture (apps-enabled)** as "the apps fixture" for the 2026-conformance regression test (step 4), rather than the pre-existing `startConformanceMockServer` mock. That mock hand-rolls a legacy-only stateful `NodeStreamableHTTPServerTransport` session flow and cannot serve the modern era at all, so it can't be used to prove parity between eras.
- The new fixture tools deliberately declare **different** `resourceUri` values at the tool-listing level vs. the handler-result content-item level (`ui://fixture/widget` vs. `ui://fixture/widget-override`), specifically so the "result overrides listing" precedence is assertable — this mirrors a real-world scenario where a specific tool call renders a different widget than its static declaration.
- Branch name is `apps-dual-era-tests`, not `test/apps-dual-era` as originally planned — origin already has a branch literally named `test`, which conflicts with any `test/...` ref path (git refs can't have both a file and a directory at the same path segment).

## Test plan

- [x] `npm run typecheck -w @mcpjam/sdk` — clean (0 errors)
- [x] `npm run typecheck -w @mcpjam/cli` — clean on all touched files (`apps.ts`); pre-existing unrelated failures in `mcp-server.ts`/`mcp.ts` (missing `@modelcontextprotocol/server` resolution + implicit-any) reproduced identically on `main` — confirmed environmental/pre-existing, not introduced by this PR
- [x] `npx vitest run` in `sdk/` — 142/142 test files, 2476 passed, 1 skipped (pre-existing), exit 0
- [x] Existing `dual-era-fixture.test.ts` (default, non-apps surface) still passes unchanged — confirms the opt-in `apps` param didn't touch the default fixture surface
- [x] New CLI unit tests for `--protocol-version` validation (`cli/tests/apps-conformance.test.ts`) — 6/6 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Production behavior is unchanged except the new optional CLI flag; risk is limited to test maintenance and mis-pinning protocol version in conformance runs.
> 
> **Overview**
> Adds **Phase 3 §11.4 regression coverage** so MCP Apps behave the same on legacy connections and when pinned to **`2026-07-28`**, plus an optional CLI hook to run apps conformance against a specific protocol version.
> 
> The **dual-era test fixture** gains an opt-in `{ apps: true }` mode that registers a `ui://` resource, nested and flat `_meta` app tools, and a deliberate listing-vs-result `resourceUri` mismatch for precedence tests. New integration suites drive a real **`MCPClientManager`** over loopback HTTP: tool detection, resource read, tool calls, JSON-serializable results, wire-level **`io.modelcontextprotocol/ui`** capability placement (initialize `capabilities.extensions` vs per-request `_meta["io.modelcontextprotocol/clientCapabilities"]`), and **apps conformance parity** between legacy and modern pins.
> 
> **`mcpjam apps conformance`** accepts **`--protocol-version`** (known versions only, **HTTP `--url` targets only**), forwarding **`mcpProtocolVersion`** into the existing conformance config; CLI unit tests cover validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fc037e561028687add12111974611a37c2ab924. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a full regression gate to ensure MCP Apps work the same on legacy and modern (`2026-07-28`) protocol eras using a real `MCPClientManager` over loopback HTTP. Also adds `--protocol-version` to `mcpjam apps conformance` to pin the era for HTTP targets.

- **New Features**
  - `--protocol-version` for `mcpjam apps conformance` (HTTP only). Validates via `isKnownProtocolVersion` and sets `mcpProtocolVersion` in the config.

<sup>Written for commit 4fc037e561028687add12111974611a37c2ab924. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

