### PR TITLE
feat(sdk): dual-era logging core — one concept, era-specific delivery

### DIFF
--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -75,6 +75,7 @@ import { RefreshTokenOAuthProvider } from "./refresh-token-auth-provider.js";
 import {
   NotificationManager,
   applyProgressHandler,
+  LoggingMessageNotificationMethod,
   PromptListChangedNotificationMethod,
   ResourceListChangedNotificationMethod,
   ResourceUpdatedNotificationMethod,
@@ -147,6 +148,14 @@ export class MCPClientManager {
     string,
     Promise<string>
   >();
+  /**
+   * Per-server modern per-request log level. A present entry means "inject
+   * `LOG_LEVEL_META_KEY` into every request's `_meta` on the modern era";
+   * an ABSENT entry means opt-out (no `_meta` key). Read live by each
+   * server's `LogLevelMetaClient` decorator via the provider closure wired
+   * at connect, so `setPerRequestLogLevel` takes effect without reconnect.
+   */
+  private readonly perRequestLogLevels = new Map<string, LoggingLevel>();
 
   // Managers for specific features
   private readonly notificationManager = new NotificationManager();
@@ -443,6 +452,7 @@ export class MCPClientManager {
     this.toolsMetadataCache.delete(serverId);
     this.notificationManager.clearServer(serverId);
     this.elicitationManager.clearServer(serverId);
+    this.perRequestLogLevels.delete(serverId);
   }
 
   /**
@@ -875,6 +885,52 @@ export class MCPClientManager {
   }
 
   /**
+   * Modern (2026-07-28) per-request logging opt-in. One user-facing concept
+   * ("set a level for this server"), era-specific delivery: on the modern era
+   * the level rides on every request as `_meta[LOG_LEVEL_META_KEY]` (injected
+   * by the server's `LogLevelMetaClient` decorator); on the legacy era this is
+   * inert — use {@link setLoggingLevel} there.
+   *
+   * Passing `undefined` opts out: the key becomes ABSENT on the wire (absence
+   * is semantic — we never send an empty/null level). Takes effect on the next
+   * request without a reconnect. No-op-safe before connect: the level is
+   * stored and read live once the client exists.
+   */
+  setPerRequestLogLevel(
+    serverId: string,
+    level: LoggingLevel | undefined
+  ): void {
+    if (level === undefined) {
+      this.perRequestLogLevels.delete(serverId);
+    } else {
+      this.perRequestLogLevels.set(serverId, level);
+    }
+  }
+
+  /**
+   * Which logging mechanism is live for a server, for UI selection:
+   *   - `"per-request-meta"` — modern era + server advertises `logging`; set a
+   *     level with {@link setPerRequestLogLevel}.
+   *   - `"setLevel"` — legacy era + server advertises `logging`; set a level
+   *     with {@link setLoggingLevel}.
+   *   - `"none"` — no live client, or the server does not advertise `logging`.
+   */
+  getLoggingMechanism(
+    serverId: string
+  ): "setLevel" | "per-request-meta" | "none" {
+    const client = this.liveClientStates.get(serverId)?.client;
+    if (!client) {
+      return "none";
+    }
+    if (!client.getServerCapabilities?.()?.logging) {
+      return "none";
+    }
+    return client.getProtocolEra?.() === "modern"
+      ? "per-request-meta"
+      : "setLevel";
+  }
+
+  /**
    * Gets the session ID for a Streamable HTTP server.
    */
   getSessionIdByServer(serverId: string): string | undefined {
@@ -953,6 +1009,23 @@ export class MCPClientManager {
     this.addNotificationHandler(
       serverId,
       TaskStatusNotificationMethod,
+      handler
+    );
+  }
+
+  /**
+   * Registers a handler for server→client log records
+   * (`notifications/message`). Works on BOTH eras: legacy servers stream
+   * these after `logging/setLevel`; modern servers stream them inline within
+   * the originating request's response. Follows the same
+   * `NotificationManager.addHandler` + `applyToClient` path as the
+   * `list_changed` registrations, so a handler registered before connect is
+   * re-applied when the client is (re)built.
+   */
+  onLogMessage(serverId: string, handler: NotificationHandler): void {
+    this.addNotificationHandler(
+      serverId,
+      LoggingMessageNotificationMethod,
       handler
     );
   }
@@ -1284,7 +1357,13 @@ export class MCPClientManager {
         resolvedClientInfo as { name: string; version: string },
         clientOptions
       );
-      const managedClient: ManagedMcpClient = wrapLegacyClient(upstreamClient);
+      // Wire the modern per-request logging opt-in. The provider reads the
+      // per-server level live, so `setPerRequestLogLevel` takes effect with no
+      // reconnect; the decorator itself only injects on the modern era.
+      const managedClient: ManagedMcpClient = wrapLegacyClient(
+        upstreamClient,
+        () => this.perRequestLogLevels.get(serverId),
+      );
       client = managedClient;
 
       // Apply handlers (no-ops for the stateless stub; rewired after

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -315,11 +315,25 @@ export class MCPClientManager {
   getClient(serverId: string): Client | undefined {
     const managed = this.liveClientStates.get(serverId)?.client;
     if (!managed) return undefined;
-    // `OfficialSdkClientAdapter` exposes the wrapped Client via `.inner`;
-    // structural check keeps this independent of an instanceof tree-
-    // shaken across the SDK boundary.
-    const inner = (managed as { inner?: Client }).inner;
-    return inner;
+    // Peel the `ManagedMcpClient` wrapper chain down to the raw upstream
+    // `Client`. Each wrapper exposes the next layer via `.inner`:
+    // `LogLevelMetaClient` (present on every connection, wrapping) →
+    // `OfficialSdkClientAdapter` → upstream `Client`. The upstream `Client`
+    // does NOT expose `.inner`, so unwrap until `.inner` is absent. A single
+    // `.inner` hop would stop at the adapter (a `ManagedMcpClient` lacking
+    // `complete`/`setLoggingLevel`-with-result), which is what external
+    // consumers of this deprecated API — and the conformance runner — expect
+    // to be the raw `Client`. Structural check keeps this independent of an
+    // instanceof tree shaken across the SDK boundary.
+    let current: unknown = managed;
+    while (
+      current &&
+      typeof current === "object" &&
+      (current as { inner?: unknown }).inner
+    ) {
+      current = (current as { inner?: unknown }).inner;
+    }
+    return current as Client;
   }
 
   /**

--- a/sdk/src/mcp-client-manager/index.ts
+++ b/sdk/src/mcp-client-manager/index.ts
@@ -147,6 +147,7 @@ export {
   ResourceListChangedNotificationMethod,
   ResourceUpdatedNotificationMethod,
   PromptListChangedNotificationMethod,
+  LoggingMessageNotificationMethod,
 } from "./notification-handlers.js";
 
 // ManagedMcpClient: interface + adapters + factory for 2026-07-28
@@ -168,6 +169,10 @@ export {
   PaginatedToolHeaderDiscoveryUnsupported,
 } from "./managed-mcp-client.js";
 export { OfficialSdkClientAdapter } from "./official-sdk-client-adapter.js";
+export {
+  LogLevelMetaClient,
+  type LogLevelProvider,
+} from "./log-level-meta-client.js";
 export {
   DialectAwareJsonSchemaValidator,
   type DialectAwareJsonSchemaValidatorOptions,

--- a/sdk/src/mcp-client-manager/log-level-meta-client.ts
+++ b/sdk/src/mcp-client-manager/log-level-meta-client.ts
@@ -1,0 +1,219 @@
+/**
+ * `LogLevelMetaClient` — a `ManagedMcpClient` decorator that injects the
+ * modern per-request logging opt-in into outbound requests.
+ *
+ * MCPJam keeps ONE user-facing logging concept ("set a level for this
+ * server") with era-specific delivery:
+ *
+ *   - **Legacy (2025-era):** the level is delivered once via
+ *     `logging/setLevel` on connect (the manager's existing
+ *     `setLoggingLevel` + auto-`debug` gate). This decorator is inert.
+ *
+ *   - **Modern (2026-07-28):** there is no session to carry a level, so the
+ *     level rides along on EVERY request as a `_meta` key
+ *     (`LOG_LEVEL_META_KEY = "io.modelcontextprotocol/logLevel"`). Upstream
+ *     `Client` exports the key but its outbound-meta envelope never supplies
+ *     a value, so this decorator merges it into `params._meta`.
+ *
+ * The injection is applied ONLY WHEN both hold:
+ *   (a) a level is currently set for this server (`getLevel()` is defined), and
+ *   (b) the negotiated connection era is `"modern"`.
+ *
+ * When no level is set the `_meta` key is ABSENT — absence is semantic here
+ * (opt-out), so we never send an empty/null key. Caller-supplied `_meta` keys
+ * always win: the level is spread first and the caller's `_meta` spread on top.
+ */
+
+import {
+  LOG_LEVEL_META_KEY,
+  type LoggingLevel,
+  type ProtocolEra,
+  type Request,
+  type RequestOptions,
+} from "@modelcontextprotocol/client";
+import type {
+  ManagedMcpClient,
+  ManagedMcpClientConnectOptions,
+  ManagedMcpClientNotificationHandler,
+  ManagedMcpClientNotificationMethod,
+  ManagedMcpClientRequestHandler,
+  ManagedMcpClientRequestMethod,
+} from "./managed-mcp-client.js";
+
+/**
+ * Live accessor for the per-server request log level. Returning `undefined`
+ * means "opt-out": no `_meta` key is injected. Read fresh on every call so a
+ * `setPerRequestLogLevel` change takes effect immediately without reconnect.
+ */
+export type LogLevelProvider = () => LoggingLevel | undefined;
+
+export class LogLevelMetaClient implements ManagedMcpClient {
+  constructor(
+    readonly inner: ManagedMcpClient,
+    private readonly getLevel: LogLevelProvider,
+  ) {}
+
+  /**
+   * The level to inject on this call, or `undefined` to inject nothing.
+   * `undefined` when no level is set (opt-out) OR the era is not modern
+   * (legacy delivers via `logging/setLevel`, so injecting `_meta` would be a
+   * second, redundant channel).
+   */
+  private activeLevel(): LoggingLevel | undefined {
+    const level = this.getLevel();
+    if (level === undefined) {
+      return undefined;
+    }
+    if (this.inner.getProtocolEra?.() !== "modern") {
+      return undefined;
+    }
+    return level;
+  }
+
+  /**
+   * Merge the active level into `params._meta` under `LOG_LEVEL_META_KEY`.
+   * Caller `_meta` keys win (spread last). Returns `params` untouched when
+   * there is nothing to inject.
+   */
+  private inject<T extends Record<string, unknown> | undefined>(params: T): T {
+    const level = this.activeLevel();
+    if (level === undefined) {
+      return params;
+    }
+    const callerMeta = (params as { _meta?: Record<string, unknown> } | undefined)
+      ?._meta;
+    return {
+      ...(params ?? {}),
+      _meta: { [LOG_LEVEL_META_KEY]: level, ...(callerMeta ?? {}) },
+    } as unknown as T;
+  }
+
+  // ---- Lifecycle (pass-through) ----
+  connect(
+    transport: Parameters<ManagedMcpClient["connect"]>[0],
+    options?: ManagedMcpClientConnectOptions,
+  ): Promise<void> {
+    return this.inner.connect(transport, options);
+  }
+  close(): Promise<void> {
+    return this.inner.close();
+  }
+  get onerror(): ((error: Error) => void) | undefined {
+    return this.inner.onerror;
+  }
+  set onerror(handler: ((error: Error) => void) | undefined) {
+    this.inner.onerror = handler;
+  }
+  get onclose(): (() => void) | undefined {
+    return this.inner.onclose;
+  }
+  set onclose(handler: (() => void) | undefined) {
+    this.inner.onclose = handler;
+  }
+
+  // ---- Capability / identity getters (pass-through) ----
+  getServerCapabilities() {
+    return this.inner.getServerCapabilities();
+  }
+  getServerVersion() {
+    return this.inner.getServerVersion();
+  }
+  getInstructions() {
+    return this.inner.getInstructions();
+  }
+  getProtocolEra(): ProtocolEra | undefined {
+    return this.inner.getProtocolEra?.();
+  }
+
+  // ---- Request-bearing methods (inject `_meta` when modern + level set) ----
+  listTools(
+    params?: Parameters<ManagedMcpClient["listTools"]>[0],
+    options?: RequestOptions,
+  ) {
+    return this.inner.listTools(this.inject(params), options);
+  }
+  callTool(
+    params: Parameters<ManagedMcpClient["callTool"]>[0],
+    options?: RequestOptions,
+  ) {
+    return this.inner.callTool(this.inject(params), options);
+  }
+  request<T = unknown>(req: Request, options?: RequestOptions): Promise<T> {
+    const level = this.activeLevel();
+    if (level === undefined) {
+      return this.inner.request<T>(req, options);
+    }
+    const params = this.inject(
+      req.params as Record<string, unknown> | undefined,
+    );
+    return this.inner.request<T>({ ...req, params } as Request, options);
+  }
+  listResources(
+    params?: Parameters<ManagedMcpClient["listResources"]>[0],
+    options?: RequestOptions,
+  ) {
+    return this.inner.listResources(this.inject(params), options);
+  }
+  readResource(
+    params: Parameters<ManagedMcpClient["readResource"]>[0],
+    options?: RequestOptions,
+  ) {
+    return this.inner.readResource(this.inject(params), options);
+  }
+  listResourceTemplates(
+    params?: Parameters<ManagedMcpClient["listResourceTemplates"]>[0],
+    options?: RequestOptions,
+  ) {
+    return this.inner.listResourceTemplates(this.inject(params), options);
+  }
+  listPrompts(
+    params?: Parameters<ManagedMcpClient["listPrompts"]>[0],
+    options?: RequestOptions,
+  ) {
+    return this.inner.listPrompts(this.inject(params), options);
+  }
+  getPrompt(
+    params: Parameters<ManagedMcpClient["getPrompt"]>[0],
+    options?: RequestOptions,
+  ) {
+    return this.inner.getPrompt(this.inject(params), options);
+  }
+  subscribeResource(
+    params: Parameters<ManagedMcpClient["subscribeResource"]>[0],
+    options?: RequestOptions,
+  ) {
+    return this.inner.subscribeResource(this.inject(params), options);
+  }
+  unsubscribeResource(
+    params: Parameters<ManagedMcpClient["unsubscribeResource"]>[0],
+    options?: RequestOptions,
+  ) {
+    return this.inner.unsubscribeResource(this.inject(params), options);
+  }
+
+  // ---- No-params / non-injected methods (pass-through) ----
+  ping(options?: RequestOptions) {
+    return this.inner.ping(options);
+  }
+  setLoggingLevel(level: LoggingLevel, options?: RequestOptions): Promise<void> {
+    // Legacy delivery channel — always forwarded verbatim, never gated.
+    return this.inner.setLoggingLevel(level, options);
+  }
+
+  // ---- Handler registration (pass-through) ----
+  setNotificationHandler(
+    method: ManagedMcpClientNotificationMethod,
+    handler: ManagedMcpClientNotificationHandler,
+  ): void {
+    this.inner.setNotificationHandler(method, handler);
+  }
+  setRequestHandler(
+    method: ManagedMcpClientRequestMethod,
+    handler: ManagedMcpClientRequestHandler,
+  ): void {
+    this.inner.setRequestHandler(method, handler);
+  }
+  removeRequestHandler(method: ManagedMcpClientRequestMethod): void {
+    this.inner.removeRequestHandler(method);
+  }
+}

--- a/sdk/src/mcp-client-manager/managed-mcp-client-factory.ts
+++ b/sdk/src/mcp-client-manager/managed-mcp-client-factory.ts
@@ -18,8 +18,28 @@ import {
 import { type ManagedMcpClient } from "./managed-mcp-client.js";
 import { DialectAwareJsonSchemaValidator } from "./dialect-aware-json-schema-validator.js";
 import { OfficialSdkClientAdapter } from "./official-sdk-client-adapter.js";
+import {
+  LogLevelMetaClient,
+  type LogLevelProvider,
+} from "./log-level-meta-client.js";
 import type { McpProtocolVersion } from "./mcp-protocol-version.js";
 import type { RpcLogger } from "./types.js";
+
+export type { LogLevelProvider };
+
+/**
+ * Wrap an adapter in the `LogLevelMetaClient` decorator when a
+ * `logLevelProvider` is supplied, else return the adapter untouched. Keeping
+ * this here means both factory entry points get the decorator identically.
+ */
+function withLogLevelMeta(
+  adapter: ManagedMcpClient,
+  logLevelProvider?: LogLevelProvider,
+): ManagedMcpClient {
+  return logLevelProvider
+    ? new LogLevelMetaClient(adapter, logLevelProvider)
+    : adapter;
+}
 
 // Re-export so consumers can `import { McpProtocolVersion } from "@mcpjam/sdk"`
 // rather than reaching into the protocol-version module.
@@ -29,6 +49,13 @@ export type { McpProtocolVersion };
 export interface CreateManagedMcpClientArgs {
   clientInfo: Implementation;
   clientOptions?: ClientOptions;
+  /**
+   * Optional live accessor for this server's per-request log level. When
+   * provided, the returned client is wrapped in `LogLevelMetaClient`, which
+   * injects `LOG_LEVEL_META_KEY` into `params._meta` on the modern era only
+   * (legacy uses `logging/setLevel`). Omit to opt a connection out entirely.
+   */
+  logLevelProvider?: LogLevelProvider;
 }
 
 /**
@@ -54,15 +81,25 @@ export function createManagedMcpClient(
       args.clientOptions.jsonSchemaValidator ??
       new DialectAwareJsonSchemaValidator(),
   });
-  return new OfficialSdkClientAdapter(inner);
+  return withLogLevelMeta(
+    new OfficialSdkClientAdapter(inner),
+    args.logLevelProvider,
+  );
 }
 
 /**
  * Helper for callers that already have an upstream `Client`. Wraps without
- * re-constructing.
+ * re-constructing. Pass `logLevelProvider` to layer on the modern
+ * per-request logging opt-in (see {@link CreateManagedMcpClientArgs}).
  */
-export function wrapLegacyClient(client: Client): ManagedMcpClient {
-  return new OfficialSdkClientAdapter(client);
+export function wrapLegacyClient(
+  client: Client,
+  logLevelProvider?: LogLevelProvider,
+): ManagedMcpClient {
+  return withLogLevelMeta(
+    new OfficialSdkClientAdapter(client),
+    logLevelProvider,
+  );
 }
 
 export type { RpcLogger };

--- a/sdk/src/mcp-client-manager/managed-mcp-client.ts
+++ b/sdk/src/mcp-client-manager/managed-mcp-client.ts
@@ -31,6 +31,7 @@ import type {
   ListResourceTemplatesResult,
   ListToolsResult,
   LoggingLevel,
+  ProtocolEra,
   ReadResourceResult,
   Request,
   RequestOptions,
@@ -116,6 +117,15 @@ export interface ManagedMcpClient {
   getServerCapabilities(): ServerCapabilities | undefined;
   getServerVersion(): Implementation | undefined;
   getInstructions(): string | undefined;
+  /**
+   * The negotiated protocol era (`"legacy"` | `"modern"`), or `undefined`
+   * before `initialize` completes. OPTIONAL because not every adapter can
+   * report it — only the `OfficialSdkClientAdapter` passes it through from
+   * upstream `Client.getProtocolEra()`. Consumers (the `LogLevelMetaClient`
+   * decorator, the `getLoggingMechanism` helper) MUST treat an absent method
+   * or `undefined` as "era unknown — do not apply modern-only behavior".
+   */
+  getProtocolEra?(): ProtocolEra | undefined;
 
   // ---- Tool calls ----
   listTools(

--- a/sdk/src/mcp-client-manager/notification-handlers.ts
+++ b/sdk/src/mcp-client-manager/notification-handlers.ts
@@ -16,6 +16,15 @@ export const ResourceUpdatedNotificationMethod =
 export const PromptListChangedNotificationMethod =
   "notifications/prompts/list_changed" as const;
 export const ProgressNotificationMethod = "notifications/progress" as const;
+/**
+ * `notifications/message` — server→client log records (RFC 5424 severities).
+ * Present on BOTH eras: legacy servers emit it after `logging/setLevel`;
+ * modern servers emit it inline within the originating request's response
+ * stream (there is no separate session channel). The manager surfaces it via
+ * `MCPClientManager.onLogMessage`.
+ */
+export const LoggingMessageNotificationMethod =
+  "notifications/message" as const;
 
 // Type aliases for notification handling (the manager's method-string form).
 type NotificationMethodName = ManagedMcpClientNotificationMethod;

--- a/sdk/src/mcp-client-manager/official-sdk-client-adapter.ts
+++ b/sdk/src/mcp-client-manager/official-sdk-client-adapter.ts
@@ -75,6 +75,11 @@ export class OfficialSdkClientAdapter implements ManagedMcpClient {
   getInstructions() {
     return this.inner.getInstructions();
   }
+  getProtocolEra() {
+    // Upstream `Client.getProtocolEra()` returns the negotiated era once
+    // `initialize` completes (`undefined` before). Pure pass-through.
+    return this.inner.getProtocolEra();
+  }
 
   // ---- RPC ----
   listTools(

--- a/sdk/tests/logging-dual-era.integration.test.ts
+++ b/sdk/tests/logging-dual-era.integration.test.ts
@@ -1,0 +1,302 @@
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { toNodeHandler } from "@modelcontextprotocol/node";
+import { LOG_LEVEL_META_KEY } from "@modelcontextprotocol/client";
+import { MCPClientManager } from "../src/mcp-client-manager/index.js";
+import { LogLevelMetaClient } from "../src/mcp-client-manager/log-level-meta-client.js";
+import type {
+  ManagedMcpClient,
+  ManagedMcpClientNotification,
+} from "../src/mcp-client-manager/managed-mcp-client.js";
+import type { RpcLogEvent } from "../src/mcp-client-manager/types.js";
+import {
+  createLoggingFixtureHandler,
+  EMIT_LOG_TOOL_NAME,
+} from "./support/logging-fixture.js";
+import {
+  createCapturingFetch,
+  getWireField,
+  hasWireField,
+  type RawExchange,
+} from "./support/raw-capture.js";
+
+/**
+ * Dual-era logging integration for MCPJam's one-concept, two-delivery model:
+ *
+ *   - MODERN (2026-07-28): per-request opt-in rides `_meta[LOG_LEVEL_META_KEY]`
+ *     on every request, injected by `LogLevelMetaClient`. Opt-out ⇒ the key is
+ *     absent (absence is semantic).
+ *   - LEGACY (2025-era): the level is delivered once via `logging/setLevel` on
+ *     connect; the `_meta` key never rides the wire.
+ *
+ * The manager transport uses the global `fetch`, so we tee it through
+ * `createCapturingFetch` to inspect raw frames BEFORE SDK normalization (the
+ * client hides the `_meta` envelope), and serve the fixture over a real
+ * loopback port (`serveLoggingFixtureOnPort`).
+ */
+
+interface ServedFixture {
+  url: string;
+  close: () => Promise<void>;
+}
+
+async function serveLoggingFixtureOnPort(): Promise<ServedFixture> {
+  const handler = createLoggingFixtureHandler();
+  const httpServer = http.createServer(toNodeHandler(handler));
+  await new Promise<void>((resolve) =>
+    httpServer.listen(0, "127.0.0.1", resolve),
+  );
+  const address = httpServer.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${address.port}/mcp`,
+    close: () =>
+      new Promise<void>((resolve) => httpServer.close(() => resolve())),
+  };
+}
+
+/** Client→server JSON-RPC REQUESTS (have both `method` and `id`) in a window. */
+function requestExchanges(
+  exchanges: RawExchange[],
+  from = 0,
+): RawExchange[] {
+  return exchanges.slice(from).filter((e) => {
+    const json = e.request.json as
+      | { method?: unknown; id?: unknown }
+      | undefined;
+    return (
+      json != null &&
+      typeof json.method === "string" &&
+      json.id !== undefined
+    );
+  });
+}
+
+function requestsWithMethod(
+  exchanges: RawExchange[],
+  method: string,
+): RawExchange[] {
+  return exchanges.filter(
+    (e) => getWireField(e.request.json, "method") === method,
+  );
+}
+
+describe("logging — dual-era delivery", () => {
+  let served: ServedFixture;
+  let manager: MCPClientManager;
+  let cap: ReturnType<typeof createCapturingFetch>;
+  let realFetch: typeof fetch;
+
+  beforeEach(async () => {
+    served = await serveLoggingFixtureOnPort();
+    realFetch = globalThis.fetch;
+    cap = createCapturingFetch(realFetch);
+    // The manager's transport dials the global `fetch`; tee it.
+    globalThis.fetch = cap.fetch as typeof fetch;
+    manager = new MCPClientManager();
+  });
+
+  afterEach(async () => {
+    globalThis.fetch = realFetch;
+    await manager.disconnectAllServers().catch(() => {});
+    await served.close();
+  });
+
+  it("MODERN + opt-in injects the level on every request; opt-out drops the key", async () => {
+    manager.setPerRequestLogLevel("srv", "warning");
+    await manager.connectToServer("srv", {
+      url: served.url,
+      mcpProtocolVersion: "2026-07-28",
+      timeout: 10_000,
+    });
+    expect(manager.getLoggingMechanism("srv")).toBe("per-request-meta");
+
+    // --- opt-in window: level is set, so every routed request carries it ---
+    const optInStart = cap.exchanges.length;
+    await manager.listTools("srv");
+    await manager.executeTool("srv", EMIT_LOG_TOOL_NAME, {});
+
+    const optIn = requestExchanges(cap.exchanges, optInStart);
+    expect(optIn.length).toBeGreaterThan(0);
+    for (const ex of optIn) {
+      expect(
+        getWireField(ex.request.json, ["params", "_meta", LOG_LEVEL_META_KEY]),
+        `${getWireField(ex.request.json, "method")} carries the opt-in level`,
+      ).toBe("warning");
+    }
+
+    // The modern log records ride the ORIGINATING request's response stream:
+    // assert on the single tools/call fetch — no separate GET channel.
+    const [call] = requestsWithMethod(optIn, "tools/call");
+    expect(call, "tools/call captured").toBeDefined();
+    const streamed = (call!.response.sse ?? []).some(
+      (frame) => getWireField(frame.json, "method") === "notifications/message",
+    );
+    expect(streamed, "notifications/message in the tools/call response stream").toBe(
+      true,
+    );
+
+    // --- opt-out window: absence is semantic — the key must be ABSENT ---
+    manager.setPerRequestLogLevel("srv", undefined);
+    const optOutStart = cap.exchanges.length;
+    await manager.listTools("srv");
+    await manager.executeTool("srv", EMIT_LOG_TOOL_NAME, {});
+
+    const optOut = requestExchanges(cap.exchanges, optOutStart);
+    expect(optOut.length).toBeGreaterThan(0);
+    for (const ex of optOut) {
+      expect(
+        hasWireField(ex.request.json, ["params", "_meta", LOG_LEVEL_META_KEY]),
+        `${getWireField(ex.request.json, "method")} omits the key when opted out`,
+      ).toBe(false);
+    }
+  });
+
+  it("LEGACY sends logging/setLevel once on connect and never the _meta key", async () => {
+    // A per-request level is set, but the legacy era must ignore it for wire
+    // injection (delivery is via logging/setLevel instead).
+    manager.setPerRequestLogLevel("srv", "warning");
+    await manager.connectToServer("srv", {
+      url: served.url,
+      timeout: 10_000,
+    });
+    expect(manager.getLoggingMechanism("srv")).toBe("setLevel");
+
+    await manager.listTools("srv");
+    await manager.executeTool("srv", EMIT_LOG_TOOL_NAME, {});
+
+    // Auto-`setLoggingLevel("debug")` fired once on connect (capability-gated).
+    const setLevel = requestsWithMethod(
+      requestExchanges(cap.exchanges),
+      "logging/setLevel",
+    );
+    expect(setLevel.length).toBe(1);
+    expect(getWireField(setLevel[0].request.json, "params.level")).toBe("debug");
+
+    // The modern per-request key never appears on the legacy wire.
+    for (const ex of requestExchanges(cap.exchanges)) {
+      expect(
+        hasWireField(ex.request.json, ["params", "_meta", LOG_LEVEL_META_KEY]),
+      ).toBe(false);
+    }
+  });
+
+  it("onLogMessage receives notifications on BOTH eras", async () => {
+    // Modern.
+    manager.setPerRequestLogLevel("modern", "debug");
+    await manager.connectToServer("modern", {
+      url: served.url,
+      mcpProtocolVersion: "2026-07-28",
+      timeout: 10_000,
+    });
+    const modernLogs: ManagedMcpClientNotification[] = [];
+    manager.onLogMessage("modern", (n) => modernLogs.push(n));
+    await manager.executeTool("modern", EMIT_LOG_TOOL_NAME, {});
+    expect(modernLogs.length).toBeGreaterThan(0);
+    expect(modernLogs.every((n) => n.method === "notifications/message")).toBe(
+      true,
+    );
+
+    // Legacy.
+    await manager.connectToServer("legacy", {
+      url: served.url,
+      timeout: 10_000,
+    });
+    const legacyLogs: ManagedMcpClientNotification[] = [];
+    manager.onLogMessage("legacy", (n) => legacyLogs.push(n));
+    await manager.executeTool("legacy", EMIT_LOG_TOOL_NAME, {});
+    expect(legacyLogs.length).toBeGreaterThan(0);
+    expect(legacyLogs.every((n) => n.method === "notifications/message")).toBe(
+      true,
+    );
+  });
+
+  it("the rpcLogger tee records the raw notifications/message frames", async () => {
+    const events: RpcLogEvent[] = [];
+    await manager.connectToServer("srv", {
+      url: served.url,
+      mcpProtocolVersion: "2026-07-28",
+      timeout: 10_000,
+      rpcLogger: (e) => events.push(e),
+    });
+    manager.setPerRequestLogLevel("srv", "debug");
+    await manager.executeTool("srv", EMIT_LOG_TOOL_NAME, {});
+
+    const logRecords = events.filter(
+      (e) =>
+        e.direction === "receive" &&
+        typeof e.message === "object" &&
+        e.message != null &&
+        (e.message as { method?: unknown }).method === "notifications/message",
+    );
+    expect(logRecords.length).toBeGreaterThan(0);
+  });
+});
+
+/**
+ * Focused decorator semantics — merge precedence and era gating — exercised
+ * directly, since the manager's tool-call surface does not expose a
+ * caller-supplied `_meta` seam to thread through.
+ */
+describe("LogLevelMetaClient — merge precedence and era gating", () => {
+  function stubInner(era: "legacy" | "modern" | undefined) {
+    const calls: Array<Record<string, unknown> | undefined> = [];
+    const inner = {
+      getProtocolEra: () => era,
+      callTool: async (params: Record<string, unknown>) => {
+        calls.push(params);
+        return { content: [] };
+      },
+    } as unknown as ManagedMcpClient;
+    return { inner, calls };
+  }
+
+  it("injects on modern and lets caller _meta keys win", async () => {
+    const { inner, calls } = stubInner("modern");
+    const client = new LogLevelMetaClient(inner, () => "warning");
+
+    await client.callTool({
+      name: "x",
+      arguments: {},
+      // Caller supplies its OWN value for the same key + an unrelated key.
+      _meta: {
+        [LOG_LEVEL_META_KEY]: "error",
+        "caller.custom": "keep-me",
+      },
+    } as Parameters<ManagedMcpClient["callTool"]>[0]);
+
+    const meta = (calls[0]?._meta ?? {}) as Record<string, unknown>;
+    // Caller wins over the injected level.
+    expect(meta[LOG_LEVEL_META_KEY]).toBe("error");
+    // Caller's unrelated key is preserved.
+    expect(meta["caller.custom"]).toBe("keep-me");
+  });
+
+  it("injects the manager level when the caller supplies no _meta", async () => {
+    const { inner, calls } = stubInner("modern");
+    const client = new LogLevelMetaClient(inner, () => "info");
+
+    await client.callTool({ name: "x", arguments: {} });
+
+    const meta = (calls[0]?._meta ?? {}) as Record<string, unknown>;
+    expect(meta[LOG_LEVEL_META_KEY]).toBe("info");
+  });
+
+  it("does NOT inject on the legacy era", async () => {
+    const { inner, calls } = stubInner("legacy");
+    const client = new LogLevelMetaClient(inner, () => "warning");
+
+    await client.callTool({ name: "x", arguments: {} });
+
+    expect(calls[0]?._meta).toBeUndefined();
+  });
+
+  it("does NOT inject when no level is set (opt-out)", async () => {
+    const { inner, calls } = stubInner("modern");
+    const client = new LogLevelMetaClient(inner, () => undefined);
+
+    await client.callTool({ name: "x", arguments: {} });
+
+    expect(calls[0]?._meta).toBeUndefined();
+  });
+});

--- a/sdk/tests/support/logging-fixture.ts
+++ b/sdk/tests/support/logging-fixture.ts
@@ -1,0 +1,140 @@
+/**
+ * Dual-era logging fixture.
+ *
+ * Extends the base dual-era idea (`dual-era-fixture.ts`) with a single
+ * `emit-log` tool that streams `notifications/message` records at several
+ * severities. It is the server-side counterpart to MCPJam's one-concept,
+ * two-delivery logging model:
+ *
+ *   - **Modern (2026-07-28):** there is no session to carry a level, so the
+ *     client rides its opt-in on every request as `_meta[LOG_LEVEL_META_KEY]`.
+ *     The SDK lifts that reserved key into `ctx.mcpReq.envelope`, keyed by the
+ *     full `LOG_LEVEL_META_KEY` string. When present, the handler filters the
+ *     records it emits to that level and above — proving the injected level
+ *     actually reached the server. Records are streamed via `ctx.mcpReq.notify`
+ *     so they ride the ORIGINATING request's response stream (no session, no
+ *     separate GET channel).
+ *
+ *   - **Legacy (2025-era):** requests carry no `_meta` envelope, so
+ *     `ctx.mcpReq.envelope` is absent. The handler streams every severity via
+ *     the same `notify` seam (the level was set once on connect via
+ *     `logging/setLevel`; this fixture does not re-filter it server-side).
+ *
+ * Every era emits at least one record, so `MCPClientManager.onLogMessage`
+ * receives notifications on both.
+ */
+
+import { createMcpHandler, McpServer } from "@modelcontextprotocol/server";
+import {
+  LOG_LEVEL_META_KEY,
+  type LoggingLevel,
+} from "@modelcontextprotocol/server";
+
+export const LOGGING_FIXTURE_SERVER_INFO = {
+  name: "mcpjam-logging-fixture",
+  version: "1.0.0",
+} as const;
+
+export const EMIT_LOG_TOOL_NAME = "emit-log";
+
+/**
+ * The severities the `emit-log` tool walks, low→high. A modern opt-in level of
+ * `warning` therefore drops `debug`/`info` and keeps `warning`/`error`.
+ */
+export const EMITTED_SEVERITIES: readonly LoggingLevel[] = [
+  "debug",
+  "info",
+  "warning",
+  "error",
+] as const;
+
+/** RFC 5424 severity ranking (lower = less severe), per MCP `LoggingLevel`. */
+const SEVERITY_RANK: Record<LoggingLevel, number> = {
+  debug: 0,
+  info: 1,
+  notice: 2,
+  warning: 3,
+  error: 4,
+  critical: 5,
+  alert: 6,
+  emergency: 7,
+};
+
+/** Whether `level` is at least as severe as `threshold`. */
+function atLeast(level: LoggingLevel, threshold: LoggingLevel): boolean {
+  return SEVERITY_RANK[level] >= SEVERITY_RANK[threshold];
+}
+
+/**
+ * Build a fresh logging fixture server. `createMcpHandler` calls this per
+ * request, so it must be side-effect-free and register the same surface each
+ * time.
+ */
+export function buildLoggingFixtureServer(): McpServer {
+  const server = new McpServer(LOGGING_FIXTURE_SERVER_INFO, {
+    // `logging` is what the manager's auto-`setLoggingLevel("debug")` gate keys
+    // on; advertise it so the legacy path fires `logging/setLevel` on connect.
+    capabilities: { tools: {}, logging: {} },
+  });
+
+  server.registerTool(
+    EMIT_LOG_TOOL_NAME,
+    {
+      description:
+        "Streams notifications/message records at several severities. On the " +
+        "modern era, filters to the request's opt-in log level when present.",
+      inputSchema: {},
+    },
+    async (_args, ctx) => {
+      // The reserved `_meta` envelope only exists on the modern era; the SDK
+      // lifts `LOG_LEVEL_META_KEY` into it keyed by the full string.
+      const envelope = ctx.mcpReq.envelope as
+        | Record<string, unknown>
+        | undefined;
+      const requested = envelope?.[LOG_LEVEL_META_KEY] as
+        | LoggingLevel
+        | undefined;
+
+      for (const level of EMITTED_SEVERITIES) {
+        // Modern opt-in: emit only records at or above the requested level.
+        // Absent opt-in (modern opt-out or legacy): emit every severity.
+        if (requested !== undefined && !atLeast(level, requested)) {
+          continue;
+        }
+        // `notify` ties the notification to the current request so it rides the
+        // originating response stream — no session channel required.
+        await ctx.mcpReq.notify({
+          method: "notifications/message",
+          params: {
+            level,
+            logger: EMIT_LOG_TOOL_NAME,
+            data: { text: `log:${level}` },
+          },
+        });
+      }
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: requested
+              ? `emitted (filtered ≥ ${requested})`
+              : "emitted (all)",
+          },
+        ],
+      };
+    },
+  );
+
+  return server;
+}
+
+/**
+ * A `createMcpHandler` bound to the logging fixture. Serves the modern era
+ * and, by default, the legacy-stateless era. Drive it with
+ * `handler.fetch(request)` in-process, or over a loopback port via
+ * `toNodeHandler`.
+ */
+export function createLoggingFixtureHandler() {
+  return createMcpHandler(buildLoggingFixtureServer);
+}


### PR DESCRIPTION
Keep ONE user-facing logging concept ("set a level for this server") with era-specific delivery. Legacy (2025-era) delivers the level once via `logging/setLevel` on connect; modern (2026-07-28) rides a per-request opt-in as `_meta[LOG_LEVEL_META_KEY]` because there is no session to carry it. All SDK-only, additive.

## What changed

- **`notifications/message` handling (was absent).** New `LoggingMessageNotificationMethod` const and a public `MCPClientManager.onLogMessage(serverId, handler)` that follows the existing `list_changed` registration path (`NotificationManager.addHandler` + `applyToClient`). Works on both eras.
- **Modern per-request opt-in.** `MCPClientManager.setPerRequestLogLevel(serverId, level | undefined)` (undefined = opt-out = **absent** `_meta` key — absence is semantic, we never send an empty/null key). A new `LogLevelMetaClient` decorator (`log-level-meta-client.ts`) merges `params._meta = { [LOG_LEVEL_META_KEY]: level, ...callerMeta }` (**caller keys win**) into every request-bearing method, **only when** (a) a level is set AND (b) the negotiated era is `modern`. Era is read via a new **optional** `getProtocolEra()` passthrough added to the `ManagedMcpClient` interface and `OfficialSdkClientAdapter` (upstream `Client.getProtocolEra()` exists). The decorator is wrapped in `managed-mcp-client-factory.ts` (`createManagedMcpClient` / `wrapLegacyClient`), wired at connect with a live provider closure so `setPerRequestLogLevel` takes effect without reconnect.
- **Legacy path unchanged.** Existing `setLoggingLevel` and the auto-`debug` connect gate are untouched. New `getLoggingMechanism(serverId): "setLevel" | "per-request-meta" | "none"` helper for UIs.
- **Tests.** `tests/support/logging-fixture.ts` (dual-era `emit-log` tool that streams `notifications/message` at several severities and, on modern, filters by the request envelope's lifted `LOG_LEVEL_META_KEY`). `tests/logging-dual-era.integration.test.ts` covers: modern opt-in ⇒ every routed request carries the key / opt-out ⇒ key absent; caller-wins + era gating (focused decorator unit); legacy ⇒ one `logging/setLevel` on connect and the key never on the wire; `onLogMessage` delivery on both eras with the modern record arriving inside the originating `tools/call` response stream (single-fetch capture); and the `rpcLogger` tee recording the raw `notifications/message`.

## Verification

- `tsc --noEmit` on `@mcpjam/sdk` (src + tests): clean.
- `npm run build -w @mcpjam/sdk`: exit 0.
- New suite: 8/8 pass. Regression: `MCPClientManager*` + factory + fixture suites 129 + 8 pass.
- Known pre-existing failures (unrelated, not touched): two `mcpjam-inspector/server` `resourceMetadataUrl` string-vs-URL tsc errors; gitignored `HarnessPageBundle.generated.ts` test-load failure.

## Decisions to review

- **Caller-wins tested at the decorator, not through the manager.** `MCPClientManager.executeTool`/`listTools` do not expose a caller-supplied `_meta` seam, so the "caller keys win" precedence is asserted directly against `LogLevelMetaClient` with a stub inner client. The wire presence/absence assertions still go through the real manager over a loopback port.
- **`getProtocolEra()` is OPTIONAL on `ManagedMcpClient`.** Only `OfficialSdkClientAdapter` implements it; the decorator and `getLoggingMechanism` treat an absent method / `undefined` as "era unknown — do not apply modern-only behavior".
- **Auto-`setLoggingLevel("debug")` still fires on the modern era too** (it is capability-gated, not era-gated, and I left it as-is per the task). On modern this puts a deprecated-but-functional `logging/setLevel` on the wire in addition to the per-request `_meta`; assertions scope to post-connect tool requests to avoid coupling to that. Flagging in case we want to era-gate that auto-call in a follow-up.
- **`getLoggingMechanism` returns `"none"` when the server does not advertise the `logging` capability**, mirroring the connect-time auto-`debug` gate. If we want modern per-request logging to be offered even for servers that omit the (2026-deprecated) `logging` capability, this predicate would need to loosen.
- **Provider closure over `serverId`.** The per-server level lives in a `Map` on the manager and is read live by each connection's decorator; `removeServer` clears it. No level state is persisted across a full server removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive SDK surface and decorator on outbound RPC params; legacy `setLoggingLevel` path unchanged. Main caveat is broader `getClient()` unwrapping behavior for wrapped clients.
> 
> **Overview**
> Adds **dual-era MCP logging** to the SDK: one user-facing “set level per server” idea with **legacy** delivery via existing `logging/setLevel` and **modern (2026-07-28)** delivery via `_meta[LOG_LEVEL_META_KEY]` on every outbound request.
> 
> **Manager API:** `setPerRequestLogLevel` (live map, no reconnect), `getLoggingMechanism` for UI, and `onLogMessage` for `notifications/message` on both eras. Per-request state is cleared on `removeServer`.
> 
> **Wire behavior:** New `LogLevelMetaClient` decorator injects the meta key only when a level is set and `getProtocolEra()` is `"modern"`; opt-out omits the key entirely; caller `_meta` wins on merge. Wired through `wrapLegacyClient` / `createManagedMcpClient` with a live `logLevelProvider`. Optional `getProtocolEra()` is added on `ManagedMcpClient` and passed through `OfficialSdkClientAdapter`.
> 
> **Compatibility:** Deprecated `getClient()` now unwraps the full `.inner` chain so consumers still see the raw upstream `Client` through `LogLevelMetaClient`.
> 
> **Tests:** Dual-era integration (wire capture, legacy `logging/setLevel`, `onLogMessage`, rpcLogger) plus decorator unit tests and a logging fixture server.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a9d7ca6ce54e23c5c3332ca7281d18899faf2b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps one logging concept with era-specific delivery; modern adds per-request `_meta` opt-in and legacy keeps `logging/setLevel` on connect. Also fixes `getClient()` to always return the raw upstream `Client` by unwrapping decorators.

- **New Features**
  - `MCPClientManager.setPerRequestLogLevel(serverId, level | undefined)` adds modern per-request logging; injects `_meta[LOG_LEVEL_META_KEY]` only on modern era; updates take effect without reconnect; `undefined` removes the key.
  - `MCPClientManager.onLogMessage(serverId, handler)` registers for `notifications/message` on both eras.
  - `MCPClientManager.getLoggingMechanism(serverId)` returns `"per-request-meta" | "setLevel" | "none"` for UI logic.
  - `LogLevelMetaClient` decorator injects the meta key for request-bearing methods when modern and a level is set; caller `_meta` keys win; absence is semantic (no empty/null key).
  - `ManagedMcpClient.getProtocolEra()` added as optional; passed through by `OfficialSdkClientAdapter`.
  - Factory wiring: `createManagedMcpClient`/`wrapLegacyClient` wrap clients with `LogLevelMetaClient` via a live provider.
  - Legacy path unchanged, including the existing auto-`debug` connect gate.

- **Bug Fixes**
  - `MCPClientManager.getClient()` now fully unwraps the `.inner` chain (e.g., `LogLevelMetaClient` → `OfficialSdkClientAdapter`) to return the raw upstream `Client`.

<sup>Written for commit 5a9d7ca6ce54e23c5c3332ca7281d18899faf2b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

