### PR TITLE
feat(inspector): cursor pagination parity for prompts + resource-templates routes

### DIFF
--- a/cli/tests/pagination-route-parity.test.ts
+++ b/cli/tests/pagination-route-parity.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { MCPClientManager } from "@mcpjam/sdk";
+import { listPrompts } from "@mcpjam/sdk";
+
+// `mcpjam prompts list --cursor <cursor>` (cli/src/commands/prompts.ts) is a
+// DELIBERATE single-page escape hatch, not aggregation: it calls the SDK's
+// `listPrompts` operation with whatever cursor the operator passed and
+// returns exactly that one page. Auto-paging only happens when `--cursor` is
+// omitted (the official beta.4 client aggregates no-cursor list calls under
+// the hood). This test locks in the single-page contract at the layer the
+// CLI command itself calls, so nobody "fixes" `--cursor` into a full-drain
+// loop.
+function mockManagerWithPages(
+  pages: Record<string, { prompts: unknown[]; nextCursor?: string }>,
+): { manager: MCPClientManager; calls: Array<string | undefined> } {
+  const calls: Array<string | undefined> = [];
+  const manager = {
+    listPrompts: async (
+      _serverId: string,
+      params?: { cursor?: string },
+    ) => {
+      const cursor = params?.cursor;
+      calls.push(cursor);
+      const page = pages[cursor ?? "__first__"];
+      if (!page) {
+        throw new Error(`unexpected cursor ${cursor}`);
+      }
+      return page;
+    },
+  } as unknown as MCPClientManager;
+  return { manager, calls };
+}
+
+test("listPrompts with an explicit --cursor returns exactly one raw page (no auto-drain)", async () => {
+  const { manager, calls } = mockManagerWithPages({
+    __first__: { prompts: [{ name: "a" }], nextCursor: "page-2" },
+    "page-2": { prompts: [{ name: "b" }], nextCursor: "page-3" },
+    "page-3": { prompts: [{ name: "c" }] },
+  });
+
+  const result = await listPrompts(manager, {
+    serverId: "srv",
+    cursor: "page-2",
+  });
+
+  // Exactly one page back, with its own nextCursor surfaced for the caller
+  // to page forward manually — not aggregated into the full list.
+  assert.deepEqual(result.prompts, [{ name: "b" }]);
+  assert.equal(result.nextCursor, "page-3");
+
+  // The manager was called exactly once, with the cursor the operator
+  // passed — no loop.
+  assert.deepEqual(calls, ["page-2"]);
+});
+
+test("listPrompts without a cursor requests only the first page (raw passthrough, no client-side loop)", async () => {
+  const { manager, calls } = mockManagerWithPages({
+    __first__: { prompts: [{ name: "a" }], nextCursor: "page-2" },
+  });
+
+  const result = await listPrompts(manager, { serverId: "srv" });
+
+  assert.deepEqual(result.prompts, [{ name: "a" }]);
+  assert.equal(result.nextCursor, "page-2");
+  // Full-aggregate behavior (when the operator omits --cursor) comes from
+  // the official SDK client auto-paging inside `manager.listPrompts` itself,
+  // not from a loop in this operation — so the operation calls the manager
+  // exactly once regardless.
+  assert.deepEqual(calls, [undefined]);
+});

--- a/mcpjam-inspector/client/src/lib/apis/__tests__/mcp-prompts-api.hosted.test.ts
+++ b/mcpjam-inspector/client/src/lib/apis/__tests__/mcp-prompts-api.hosted.test.ts
@@ -20,11 +20,46 @@ vi.mock("@/lib/apis/web/context", () => ({
     resolveHostedServerIdMock(...args),
 }));
 
-import { listPromptsForServers } from "../mcp-prompts-api";
+import { listPromptsForServers, listPromptsPage } from "../mcp-prompts-api";
 
 describe("mcp-prompts-api hosted mode", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it("forwards cursor and maps nextCursor on the hosted page path", async () => {
+    listHostedPromptsMock.mockResolvedValueOnce({
+      prompts: [{ name: "draw" }],
+      nextCursor: "page-2",
+    });
+
+    const result = await listPromptsPage("Excalidraw (App)", {
+      cursor: "page-1",
+    });
+
+    expect(listHostedPromptsMock).toHaveBeenCalledWith({
+      serverNameOrId: "Excalidraw (App)",
+      cursor: "page-1",
+    });
+    expect(result).toEqual({
+      prompts: [{ name: "draw" }],
+      nextCursor: "page-2",
+    });
+  });
+
+  it("omits nextCursor when the hosted response has none", async () => {
+    listHostedPromptsMock.mockResolvedValueOnce({
+      prompts: [{ name: "draw" }],
+    });
+
+    const result = await listPromptsPage("Excalidraw (App)");
+
+    expect(listHostedPromptsMock).toHaveBeenCalledWith({
+      serverNameOrId: "Excalidraw (App)",
+      cursor: undefined,
+    });
+    expect(result).toEqual({ prompts: [{ name: "draw" }] });
+    expect("nextCursor" in result).toBe(false);
   });
 
   it("keeps the batch hosted path for hosted guests", async () => {

--- a/mcpjam-inspector/client/src/lib/apis/mcp-prompts-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/mcp-prompts-api.ts
@@ -36,11 +36,17 @@ export async function listPromptsPage(
   return runByMode({
     forceHosted: opts?.forceHosted,
     hosted: async () => {
-      const body = await listHostedPrompts({ serverNameOrId: serverId });
+      const body = await listHostedPrompts({
+        serverNameOrId: serverId,
+        cursor: opts?.cursor,
+      });
       return {
         prompts: Array.isArray(body?.prompts)
           ? (body.prompts as MCPPrompt[])
           : [],
+        ...(typeof body?.nextCursor === "string"
+          ? { nextCursor: body.nextCursor }
+          : {}),
       };
     },
     local: async () => {
@@ -67,8 +73,9 @@ export async function listPromptsPage(
         prompts: Array.isArray(body?.prompts)
           ? (body.prompts as MCPPrompt[])
           : [],
-        nextCursor:
-          typeof body?.nextCursor === "string" ? body.nextCursor : undefined,
+        ...(typeof body?.nextCursor === "string"
+          ? { nextCursor: body.nextCursor }
+          : {}),
       };
     },
   });

--- a/mcpjam-inspector/client/src/lib/apis/mcp-prompts-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/mcp-prompts-api.ts
@@ -19,19 +19,38 @@ export interface BatchPromptsResponse {
 
 export async function listPrompts(
   serverId: string,
-  opts?: { forceHosted?: boolean },
+  opts?: { forceHosted?: boolean; cursor?: string },
 ): Promise<MCPPrompt[]> {
+  const { prompts } = await listPromptsPage(serverId, opts);
+  return prompts;
+}
+
+// Cursor-aware variant of `listPrompts`, additive alongside it: omitting
+// `cursor` still returns the full aggregate (unchanged default behavior);
+// passing one returns exactly one raw page plus `nextCursor` when the server
+// has more. This is the plumbing a future paginated Prompts UI would call.
+export async function listPromptsPage(
+  serverId: string,
+  opts?: { forceHosted?: boolean; cursor?: string },
+): Promise<{ prompts: MCPPrompt[]; nextCursor?: string }> {
   return runByMode({
     forceHosted: opts?.forceHosted,
     hosted: async () => {
       const body = await listHostedPrompts({ serverNameOrId: serverId });
-      return Array.isArray(body?.prompts) ? (body.prompts as MCPPrompt[]) : [];
+      return {
+        prompts: Array.isArray(body?.prompts)
+          ? (body.prompts as MCPPrompt[])
+          : [],
+      };
     },
     local: async () => {
       const res = await authFetch("/api/mcp/prompts/list", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ serverId }),
+        body: JSON.stringify({
+          serverId,
+          ...(opts?.cursor ? { cursor: opts.cursor } : {}),
+        }),
       });
 
       let body: any = null;
@@ -44,7 +63,13 @@ export async function listPrompts(
         throw new Error(message);
       }
 
-      return Array.isArray(body?.prompts) ? (body.prompts as MCPPrompt[]) : [];
+      return {
+        prompts: Array.isArray(body?.prompts)
+          ? (body.prompts as MCPPrompt[])
+          : [],
+        nextCursor:
+          typeof body?.nextCursor === "string" ? body.nextCursor : undefined,
+      };
     },
   });
 }

--- a/mcpjam-inspector/client/src/lib/apis/mcp-resource-templates-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/mcp-resource-templates-api.ts
@@ -4,13 +4,33 @@ import { ensureLocalMode } from "@/lib/apis/mode-client";
 
 export async function listResourceTemplates(
   serverId: string,
+  opts?: { cursor?: string },
 ): Promise<MCPResourceTemplate[]> {
+  const { resourceTemplates } = await listResourceTemplatesPage(
+    serverId,
+    opts,
+  );
+  return resourceTemplates;
+}
+
+// Cursor-aware variant of `listResourceTemplates`, additive alongside it:
+// omitting `cursor` still returns the full aggregate (unchanged default
+// behavior); passing one returns exactly one raw page plus `nextCursor` when
+// the server has more. This is the plumbing a future paginated Resource
+// Templates UI would call.
+export async function listResourceTemplatesPage(
+  serverId: string,
+  opts?: { cursor?: string },
+): Promise<{ resourceTemplates: MCPResourceTemplate[]; nextCursor?: string }> {
   ensureLocalMode("Resource templates are not supported in hosted mode");
 
   const res = await authFetch("/api/mcp/resource-templates/list", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ serverId }),
+    body: JSON.stringify({
+      serverId,
+      ...(opts?.cursor ? { cursor: opts.cursor } : {}),
+    }),
   });
 
   let body: any = null;
@@ -24,7 +44,11 @@ export async function listResourceTemplates(
     throw new Error(message);
   }
 
-  return Array.isArray(body?.resourceTemplates)
-    ? (body.resourceTemplates as MCPResourceTemplate[])
-    : [];
+  return {
+    resourceTemplates: Array.isArray(body?.resourceTemplates)
+      ? (body.resourceTemplates as MCPResourceTemplate[])
+      : [],
+    nextCursor:
+      typeof body?.nextCursor === "string" ? body.nextCursor : undefined,
+  };
 }

--- a/mcpjam-inspector/client/src/lib/apis/mcp-resource-templates-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/mcp-resource-templates-api.ts
@@ -48,7 +48,8 @@ export async function listResourceTemplatesPage(
     resourceTemplates: Array.isArray(body?.resourceTemplates)
       ? (body.resourceTemplates as MCPResourceTemplate[])
       : [],
-    nextCursor:
-      typeof body?.nextCursor === "string" ? body.nextCursor : undefined,
+    ...(typeof body?.nextCursor === "string"
+      ? { nextCursor: body.nextCursor }
+      : {}),
   };
 }

--- a/mcpjam-inspector/server/routes/mcp/__tests__/prompts.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/prompts.test.ts
@@ -128,6 +128,105 @@ describe("POST /api/mcp/prompts/list", () => {
   });
 });
 
+describe("POST /api/mcp/prompts/list — cursor parity", () => {
+  // Small in-tree multi-page fixture: 5 prompts split into pages of 2, the
+  // way a real MCP server would paginate `prompts/list`. The route itself
+  // does no aggregation — it passes `cursor` straight through to the
+  // manager and returns exactly whatever page comes back (mirroring the
+  // already-shipped tools/resources routes). Default (no cursor) behavior
+  // is unchanged: the official beta.4 client aggregates no-cursor calls
+  // beneath the manager, so the manager mock here returns the complete set
+  // directly for that case.
+  const ALL_PROMPTS = Array.from({ length: 5 }, (_, i) => ({
+    name: `prompt-${i + 1}`,
+    description: `Prompt number ${i + 1}`,
+  }));
+  const PAGE_SIZE = 2;
+
+  function pageStartingAt(cursor?: string) {
+    const start = cursor ? Number(cursor) : 0;
+    const slice = ALL_PROMPTS.slice(start, start + PAGE_SIZE);
+    const next = start + PAGE_SIZE;
+    return {
+      prompts: slice,
+      nextCursor: next < ALL_PROMPTS.length ? String(next) : undefined,
+    };
+  }
+
+  let mcpClientManager: ReturnType<typeof createMockMcpClientManager>;
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mcpClientManager = createMockMcpClientManager({
+      // No cursor → the manager (standing in for the real MCP client, which
+      // auto-aggregates no-cursor calls) returns the COMPLETE set.
+      listPrompts: vi.fn().mockImplementation(async (_serverId, params) => {
+        if (!params?.cursor) {
+          return { prompts: ALL_PROMPTS, nextCursor: undefined };
+        }
+        return pageStartingAt(params.cursor);
+      }),
+    });
+    app = createApp(mcpClientManager);
+  });
+
+  it("returns the complete multi-page set by default (no cursor)", async () => {
+    const res = await app.request("/api/mcp/prompts/list", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ serverId: "test-server" }),
+    });
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.prompts).toHaveLength(5);
+    expect(data.prompts.map((p: { name: string }) => p.name)).toEqual(
+      ALL_PROMPTS.map((p) => p.name),
+    );
+    // Absence is semantic: no more pages, so nextCursor is omitted entirely.
+    expect("nextCursor" in data).toBe(false);
+    expect(mcpClientManager.listPrompts).toHaveBeenCalledWith(
+      "test-server",
+      undefined,
+    );
+  });
+
+  it("returns exactly one raw page plus nextCursor when a cursor is passed", async () => {
+    const res = await app.request("/api/mcp/prompts/list", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ serverId: "test-server", cursor: "2" }),
+    });
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.prompts).toHaveLength(2);
+    expect(data.prompts.map((p: { name: string }) => p.name)).toEqual([
+      "prompt-3",
+      "prompt-4",
+    ]);
+    expect(data.nextCursor).toBe("4");
+    expect(mcpClientManager.listPrompts).toHaveBeenCalledWith("test-server", {
+      cursor: "2",
+    });
+  });
+
+  it("omits nextCursor on the final page", async () => {
+    const res = await app.request("/api/mcp/prompts/list", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ serverId: "test-server", cursor: "4" }),
+    });
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.prompts).toHaveLength(1);
+    expect(data.prompts[0].name).toBe("prompt-5");
+    expect("nextCursor" in data).toBe(false);
+  });
+});
+
 describe("POST /api/mcp/prompts/list-multi", () => {
   let mcpClientManager: ReturnType<typeof createMockMcpClientManager>;
   let app: Hono;

--- a/mcpjam-inspector/server/routes/mcp/__tests__/resource-templates.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/resource-templates.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Hono } from "hono";
+import resourceTemplates from "../resource-templates.js";
+
+// Mock MCPClientManager
+const createMockMcpClientManager = (overrides: Record<string, any> = {}) => ({
+  listResourceTemplates: vi.fn().mockResolvedValue({
+    resourceTemplates: [
+      {
+        uriTemplate: "file:///{path}",
+        name: "file-template",
+        mimeType: "text/plain",
+      },
+      {
+        uriTemplate: "note://{id}",
+        name: "note-template",
+        mimeType: "text/plain",
+      },
+    ],
+  }),
+  ...overrides,
+});
+
+function createApp(
+  mcpClientManager: ReturnType<typeof createMockMcpClientManager>,
+) {
+  const app = new Hono();
+
+  // Middleware to inject mock mcpClientManager
+  app.use("*", async (c, next) => {
+    (c as any).mcpClientManager = mcpClientManager;
+    await next();
+  });
+
+  app.route("/api/mcp/resource-templates", resourceTemplates);
+  return app;
+}
+
+describe("POST /api/mcp/resource-templates/list", () => {
+  let mcpClientManager: ReturnType<typeof createMockMcpClientManager>;
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mcpClientManager = createMockMcpClientManager();
+    app = createApp(mcpClientManager);
+  });
+
+  describe("validation", () => {
+    it("returns 400 when serverId is missing", async () => {
+      const res = await app.request("/api/mcp/resource-templates/list", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.success).toBe(false);
+      expect(data.error).toBe("serverId is required");
+    });
+  });
+
+  describe("success cases", () => {
+    it("returns resource templates for connected server", async () => {
+      const res = await app.request("/api/mcp/resource-templates/list", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ serverId: "test-server" }),
+      });
+
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.resourceTemplates).toHaveLength(2);
+      expect(data.resourceTemplates[0].name).toBe("file-template");
+      expect("nextCursor" in data).toBe(false);
+      expect(mcpClientManager.listResourceTemplates).toHaveBeenCalledWith(
+        "test-server",
+        undefined,
+      );
+    });
+
+    it("passes cursor through and surfaces nextCursor", async () => {
+      mcpClientManager.listResourceTemplates.mockResolvedValue({
+        resourceTemplates: [
+          { uriTemplate: "page2://{id}", name: "page2-template" },
+        ],
+        nextCursor: "cursor-page-3",
+      });
+
+      const res = await app.request("/api/mcp/resource-templates/list", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          serverId: "test-server",
+          cursor: "cursor-page-2",
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.resourceTemplates).toHaveLength(1);
+      expect(data.nextCursor).toBe("cursor-page-3");
+      expect(mcpClientManager.listResourceTemplates).toHaveBeenCalledWith(
+        "test-server",
+        { cursor: "cursor-page-2" },
+      );
+    });
+  });
+
+  describe("error handling", () => {
+    it("returns 500 when listResourceTemplates fails", async () => {
+      mcpClientManager.listResourceTemplates.mockRejectedValue(
+        new Error("Server not responding"),
+      );
+
+      const res = await app.request("/api/mcp/resource-templates/list", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ serverId: "test-server" }),
+      });
+
+      expect(res.status).toBe(500);
+      const data = await res.json();
+      expect(data.success).toBe(false);
+      expect(data.error).toBe("Server not responding");
+    });
+  });
+});
+
+describe("POST /api/mcp/resource-templates/list — cursor parity", () => {
+  // Small in-tree multi-page fixture: 5 resource templates split into pages
+  // of 2, the way a real MCP server would paginate
+  // `resources/templates/list`. The route does no aggregation itself — it
+  // passes `cursor` straight through to the manager and returns exactly
+  // whatever page comes back (mirroring the already-shipped
+  // tools/resources routes). Default (no cursor) behavior is unchanged: the
+  // official beta.4 client aggregates no-cursor calls beneath the manager,
+  // so the manager mock here returns the complete set directly for that
+  // case.
+  const ALL_TEMPLATES = Array.from({ length: 5 }, (_, i) => ({
+    uriTemplate: `note://{id-${i + 1}}`,
+    name: `template-${i + 1}`,
+  }));
+  const PAGE_SIZE = 2;
+
+  function pageStartingAt(cursor?: string) {
+    const start = cursor ? Number(cursor) : 0;
+    const slice = ALL_TEMPLATES.slice(start, start + PAGE_SIZE);
+    const next = start + PAGE_SIZE;
+    return {
+      resourceTemplates: slice,
+      nextCursor: next < ALL_TEMPLATES.length ? String(next) : undefined,
+    };
+  }
+
+  let mcpClientManager: ReturnType<typeof createMockMcpClientManager>;
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mcpClientManager = createMockMcpClientManager({
+      listResourceTemplates: vi
+        .fn()
+        .mockImplementation(async (_serverId, params) => {
+          if (!params?.cursor) {
+            return { resourceTemplates: ALL_TEMPLATES, nextCursor: undefined };
+          }
+          return pageStartingAt(params.cursor);
+        }),
+    });
+    app = createApp(mcpClientManager);
+  });
+
+  it("returns the complete multi-page set by default (no cursor)", async () => {
+    const res = await app.request("/api/mcp/resource-templates/list", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ serverId: "test-server" }),
+    });
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.resourceTemplates).toHaveLength(5);
+    expect(
+      data.resourceTemplates.map((t: { name: string }) => t.name),
+    ).toEqual(ALL_TEMPLATES.map((t) => t.name));
+    expect("nextCursor" in data).toBe(false);
+  });
+
+  it("returns exactly one raw page plus nextCursor when a cursor is passed", async () => {
+    const res = await app.request("/api/mcp/resource-templates/list", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ serverId: "test-server", cursor: "2" }),
+    });
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.resourceTemplates).toHaveLength(2);
+    expect(
+      data.resourceTemplates.map((t: { name: string }) => t.name),
+    ).toEqual(["template-3", "template-4"]);
+    expect(data.nextCursor).toBe("4");
+  });
+
+  it("omits nextCursor on the final page", async () => {
+    const res = await app.request("/api/mcp/resource-templates/list", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ serverId: "test-server", cursor: "4" }),
+    });
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.resourceTemplates).toHaveLength(1);
+    expect(data.resourceTemplates[0].name).toBe("template-5");
+    expect("nextCursor" in data).toBe(false);
+  });
+});

--- a/mcpjam-inspector/server/routes/mcp/list-tools.ts
+++ b/mcpjam-inspector/server/routes/mcp/list-tools.ts
@@ -57,6 +57,13 @@ listTools.post("/", async (c) => {
       }
 
       try {
+        // No cursor here is deliberate, not a "only page 1" bug: the
+        // official beta.4 client auto-pages no-cursor `listTools` calls
+        // under the hood, so this already returns the server's COMPLETE
+        // tool list. Cursor plumbing exists elsewhere (MCPClientManager.
+        // listTools(serverId, { cursor }), the /api/mcp/prompts + resource
+        // templates routes) for callers that want one raw page — don't
+        // "fix" this call site into single-page behavior.
         const { tools } = await clientManager.listTools(serverId);
         const toolsMetadata = clientManager.getAllToolsMetadata(serverId);
         const serverTools = tools.map((tool: any) => {

--- a/mcpjam-inspector/server/routes/mcp/prompts.ts
+++ b/mcpjam-inspector/server/routes/mcp/prompts.ts
@@ -12,12 +12,22 @@ const prompts = new Hono();
 // List prompts endpoint
 prompts.post("/list", async (c) => {
   try {
-    const body = (await c.req.json()) as { serverId?: string };
+    const body = (await c.req.json()) as {
+      serverId?: string;
+      cursor?: string;
+    };
     if (!body.serverId) {
       return c.json({ success: false, error: "serverId is required" }, 400);
     }
+    // Cursor is optional — omitted, this returns the full aggregate (the
+    // official beta.4 client auto-pages no-cursor list calls). Passing a
+    // cursor returns exactly one raw page, matching the tools/resources
+    // routes' cursor parity.
     return c.json(
-      await listPrompts(c.mcpClientManager, body as { serverId: string }),
+      await listPrompts(c.mcpClientManager, {
+        serverId: body.serverId,
+        cursor: body.cursor,
+      }),
     );
   } catch (error) {
     logger.error("Error fetching prompts", error, { serverId: "unknown" });

--- a/mcpjam-inspector/server/routes/mcp/resource-templates.ts
+++ b/mcpjam-inspector/server/routes/mcp/resource-templates.ts
@@ -6,16 +6,31 @@ const resourceTemplates = new Hono();
 
 // List resource templates endpoint
 resourceTemplates.post("/list", async (c) => {
+  let serverId: string | undefined;
   try {
-    const { serverId } = (await c.req.json()) as { serverId?: string };
+    const body = (await c.req.json()) as {
+      serverId?: string;
+      cursor?: string;
+    };
+    serverId = body.serverId;
 
     if (!serverId) {
       return c.json({ success: false, error: "serverId is required" }, 400);
     }
     const mcpClientManager = c.mcpClientManager;
-    const { resourceTemplates: templates } =
-      await mcpClientManager.listResourceTemplates(serverId);
-    return c.json({ resourceTemplates: templates });
+    // Cursor is optional — omitted, this returns the full aggregate (the
+    // official beta.4 client auto-pages no-cursor list calls). Passing a
+    // cursor returns exactly one raw page, matching the tools/resources
+    // routes' cursor parity.
+    const { resourceTemplates: templates, nextCursor } =
+      await mcpClientManager.listResourceTemplates(
+        serverId,
+        body.cursor ? { cursor: body.cursor } : undefined,
+      );
+    return c.json({
+      resourceTemplates: templates,
+      ...(nextCursor ? { nextCursor } : {}),
+    });
   } catch (error) {
     logger.error("Error fetching resource templates", error, { serverId });
     return c.json(


### PR DESCRIPTION
## Summary

Phase 3 §11.1 — bring `prompts/list` and `resource-templates/list` up to cursor parity with the already-shipped `tools/list` and `resources/list` routes. **Default behavior is unchanged**: the official beta.4 MCP client auto-aggregates no-cursor list calls, so with no `cursor` these routes already return the COMPLETE set. This PR only adds the ability to opt into raw single-page requests, matching the pattern the tools/resources routes already have.

- `server/routes/mcp/prompts.ts` — accepts optional `cursor` in the request body, threads it into the SDK's `listPrompts` operation (which already supported `cursor`, `operations.ts:130-142`).
- `server/routes/mcp/resource-templates.ts` — accepts optional `cursor`, calls `mcpClientManager.listResourceTemplates(serverId, cursor ? { cursor } : undefined)`, surfaces `nextCursor` only when present (absence is semantic in MCP — no `nextCursor` key at all when there's no next page).
- `client/src/lib/apis/mcp-prompts-api.ts` / `mcp-resource-templates-api.ts` — additive `listPromptsPage` / `listResourceTemplatesPage` cursor-aware variants; existing `listPrompts` / `listResourceTemplates` callers are unaffected (same signature, same default behavior).
- `server/routes/mcp/list-tools.ts` — added a code comment on the aggregate `listTools` call explaining the beta.4 auto-aggregation contract, so nobody "fixes" it into a page-1-only call.
- CLI (`cli/src/commands/{tools,resources,prompts,compat}.ts`, `cli/src/lib/host-resolve.ts`) — no behavior changes; `--cursor` was already a deliberate single-page escape hatch. Added `cli/tests/pagination-route-parity.test.ts` locking in that `listPrompts(manager, { cursor })` returns exactly one raw page (no client-side aggregation loop).
- Tests: `server/routes/mcp/__tests__/prompts.test.ts` (new cursor-parity block) and new `server/routes/mcp/__tests__/resource-templates.test.ts`, each with a small in-tree 5-item/2-per-page mock fixture asserting (a) default returns the complete multi-page set with `nextCursor` omitted, (b) an explicit cursor returns exactly one page plus `nextCursor`, (c) the final page omits `nextCursor`.

## Decisions to review

- **Route-level tests mock at the `MCPClientManager` boundary** (matching the existing convention in this exact test directory — `prompts.test.ts` / `resources.test.ts` already do this) rather than standing up a real Hono/`createMcpHandler` MCP server. The manager mock simulates true multi-page pagination via an in-memory 5-item dataset. This validates the route's cursor passthrough + `nextCursor` omission (what actually changed) without pulling in heavier MCP-transport test machinery; real end-to-end auto-aggregation is the official SDK client's responsibility (out of scope per "don't import sdk test files across workspaces").
- **Client API additive design**: rather than changing `listPrompts`'/`listResourceTemplates`' return type (which would break existing callers expecting a plain array), added sibling `listPromptsPage` / `listResourceTemplatesPage` functions that return `{ items, nextCursor }`. `listPrompts`/`listResourceTemplates` now delegate to the `Page` variant and unwrap just the array — zero behavior change for existing callers, cursor-aware plumbing available for a future paginated UI.
- **Fixed a pre-existing bug** in `resource-templates.ts`: the `catch` block referenced `serverId`, but it was declared with `const` inside the `try` block (out of scope) — this would throw a `ReferenceError` on any error path, masking the real error, and was flagged by `tsc` (`TS18004`). Hoisted the declaration above the `try`. This is a small drive-by fix in a file this PR was already touching, not a scope-creep addition.
- **Deliberately did not** retrofit IntersectionObserver infinite-scroll into `PromptsTab`/`ResourceTemplatesTab` — they already render the complete aggregate by default; this PR is plumbing only, a follow-up UI PR can consume `listPromptsPage`/`listResourceTemplatesPage`.
- **Deliberately did not** change CLI `--cursor` behavior — confirmed it's already a correct single-page escape hatch and `host-resolve.ts`'s pagination loop (`assertToolVisibleToHost`, `:119-156`) is already correct under auto-aggregation.

## Verification

- `npx tsc --noEmit -p mcpjam-inspector/server/tsconfig.json`: baseline 115 pre-existing errors → 111 after (4 fewer: the `resource-templates.ts` scope bug fix, plus 3 transient generated-bundle errors unrelated to this change). **Zero new errors.**
- `npx tsc --noEmit -p mcpjam-inspector/client/tsconfig.typecheck.json`: 0 errors.
- `npm run typecheck` (root): fails identically before and after this change, at `cli` workspace (`Cannot find module '@modelcontextprotocol/server/stdio'` in `src/lib/mcp-server.ts`, `src/commands/mcp.ts`) — pre-existing, unrelated to any file this PR touches.
- Targeted vitest: `prompts.test.ts` + new `resource-templates.test.ts` → 25/25 passed.
- Full inspector `npm test`: 8584 passed / 2 failed / 6 skipped (8592 total tests); 75 failed test *files* out of 880, all pre-existing and unrelated — missing `@ai-sdk/harness/agent` module (env-level, same family as the documented known `HarnessPageBundle.generated.ts` issue) and `vitest-worker` fetch timeouts (this run shared a heavily disk/CPU-constrained overnight-agent host). The 2 failing individual tests are both in `computer-use-tool.test.ts` (`anthropic.tools.computer_20251124 is not a function`) — unrelated to prompts/resource-templates/list-tools.
- `npm run build:inspector`: exit 0, client + server + lib all built successfully.
- New CLI test: `npx tsx --test cli/tests/pagination-route-parity.test.ts` → 2/2 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API surface and passthrough pagination; default no-cursor behavior is unchanged. The resource-templates error-path fix only improves logging on failures.
> 
> **Overview**
> Adds **optional cursor pagination** to prompts and resource-templates list APIs so they match the existing tools/resources pattern: **no `cursor`** keeps today’s full-list behavior; **with `cursor`** returns a single page and includes **`nextCursor` only when there is another page**.
> 
> Server routes **`/api/mcp/prompts/list`** and **`/api/mcp/resource-templates/list`** now accept `cursor` in the JSON body, pass it through to the MCP client manager, and omit `nextCursor` on the last page. The resource-templates route also **fixes error logging** by hoisting `serverId` so the catch block no longer throws a `ReferenceError`.
> 
> Inspector client APIs gain additive **`listPromptsPage`** / **`listResourceTemplatesPage`** (hosted + local); existing **`listPrompts`** / **`listResourceTemplates`** delegate to them and still return plain arrays. A comment on **`list-tools`** documents that no-cursor `listTools` is intentionally aggregate via the SDK.
> 
> **Tests** cover route cursor passthrough (multi-page fixtures), hosted `listPromptsPage`, and a CLI/SDK test that **`--cursor`** stays a single-page escape hatch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e7b09a9d33ce3fb71ae83a8461fae7b6b38e6b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds cursor pagination to the prompts and resource-templates list routes, matching tools/resources. Default behavior is unchanged: no cursor returns the full list; passing a cursor returns one page and `nextCursor` when present.

- **New Features**
  - `/api/mcp/prompts/list` and `/api/mcp/resource-templates/list` accept optional `cursor`; omit it to get the full aggregate, include it to get one raw page with `nextCursor` when there’s more.
  - Client: added `listPromptsPage` and `listResourceTemplatesPage`; existing `listPrompts`/`listResourceTemplates` delegate and keep the same return type and behavior.
  - CLI: added a test to lock `--cursor` as a single-page escape hatch; no behavior changes.
  - Tests: added/updated route tests for default aggregate and cursor pages; hosted prompts tests verify cursor passthrough and `nextCursor` mapping.
  - Docs: added a comment in the tools route explaining the no-cursor auto-aggregation contract.

- **Bug Fixes**
  - Fixed `serverId` scope in `resource-templates` route error handling to prevent a `ReferenceError` masking real errors.
  - Hosted prompts page path now forwards `cursor` and maps `nextCursor`; responses omit `nextCursor` when absent across prompts and resource-templates.

<sup>Written for commit 1e7b09a9d33ce3fb71ae83a8461fae7b6b38e6b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

