### PR TITLE
feat(conformance): era-awareness so modern servers stop false-failing (Phase 3 §11.5)

### DIFF
--- a/sdk/src/mcp-client-manager/managed-mcp-client.ts
+++ b/sdk/src/mcp-client-manager/managed-mcp-client.ts
@@ -23,6 +23,8 @@
 
 import type {
   CallToolResult,
+  CompleteRequest,
+  CompleteResult,
   EmptyResult,
   GetPromptResult,
   Implementation,
@@ -157,6 +159,16 @@ export interface ManagedMcpClient {
     params: { name: string; arguments?: Record<string, string> },
     options?: RequestOptions
   ): Promise<GetPromptResult>;
+
+  // ---- Completions ----
+  // Used by the conformance suite's `completion-complete` check. Passthrough
+  // to upstream `Client.complete`; self-skips when the server does not
+  // advertise the optional completions capability, so this is never invoked
+  // against a server that lacks it.
+  complete(
+    params: CompleteRequest["params"],
+    options?: RequestOptions
+  ): Promise<CompleteResult>;
 
   // ---- Health ----
   ping(options?: RequestOptions): Promise<EmptyResult>;

--- a/sdk/src/mcp-client-manager/official-sdk-client-adapter.ts
+++ b/sdk/src/mcp-client-manager/official-sdk-client-adapter.ts
@@ -140,6 +140,14 @@ export class OfficialSdkClientAdapter implements ManagedMcpClient {
       ManagedMcpClient["getPrompt"]
     >;
   }
+  complete(
+    params: Parameters<Client["complete"]>[0],
+    options?: Parameters<Client["complete"]>[1],
+  ) {
+    return this.inner.complete(params, options) as ReturnType<
+      ManagedMcpClient["complete"]
+    >;
+  }
   ping(options?: Parameters<Client["ping"]>[0]) {
     return this.inner.ping(options) as ReturnType<ManagedMcpClient["ping"]>;
   }

--- a/sdk/src/mcp-conformance/checks/core.ts
+++ b/sdk/src/mcp-conformance/checks/core.ts
@@ -136,25 +136,14 @@ export const CORE_CHECKS: MCPClientCheckDefinition[] = [
       }
 
       try {
-        const result = await ctx.client.setLoggingLevel("info");
-        const isEmptyObject =
-          typeof result === "object" &&
-          result !== null &&
-          Object.keys(result).length === 0;
-
-        if (!isEmptyObject) {
-          return failedResult(
-            this,
-            Date.now() - startedAt,
-            "logging/setLevel did not return an empty object",
-            {
-              result: result as Record<string, unknown>,
-            },
-          );
-        }
+        // The managed client resolves `setLoggingLevel` to `void` (upstream
+        // returns an `EmptyResult` the manager discards). A clean resolve —
+        // no thrown JSON-RPC error — is the pass condition; there is no
+        // result body to inspect.
+        await ctx.client.setLoggingLevel("info");
 
         return passedResult(this, Date.now() - startedAt, {
-          result: result as Record<string, unknown>,
+          level: "info",
         });
       } catch (error) {
         return failedResult(

--- a/sdk/src/mcp-conformance/checks/helpers.ts
+++ b/sdk/src/mcp-conformance/checks/helpers.ts
@@ -1,4 +1,4 @@
-import type { MCPCheckResult } from "../types.js";
+import type { MCPCheckEra, MCPCheckResult } from "../types.js";
 
 type CheckMetadata = Pick<
   MCPCheckResult,
@@ -55,4 +55,17 @@ export function skippedResult(
 
 export function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Canonical skip reason for a check that does not apply to the run's era.
+ * Shared by the client-backed `eraGate` and the raw-HTTP runners so the
+ * message is identical across both tracks.
+ */
+export function eraSkipMessage(
+  era: MCPCheckEra,
+  protocolVersion: string | undefined,
+): string {
+  const pin = protocolVersion ?? "default";
+  return `Not applicable to the ${era} era (run pinned to ${pin})`;
 }

--- a/sdk/src/mcp-conformance/checks/protocol.ts
+++ b/sdk/src/mcp-conformance/checks/protocol.ts
@@ -21,6 +21,8 @@ const PROTOCOL_CHECK_METADATA = {
   Pick<MCPCheckResult, "id" | "category" | "title" | "description">
 >;
 
+const INVALID_METHOD = "nonexistent/method_that_does_not_exist";
+
 function buildBaseHeaders(ctx: RawHttpCheckContext): Record<string, string> {
   return {
     ...(ctx.config.customHeaders ?? {}),
@@ -30,6 +32,12 @@ function buildBaseHeaders(ctx: RawHttpCheckContext): Record<string, string> {
   };
 }
 
+/**
+ * Legacy prelude: run the `initialize` handshake and return the session id
+ * (if the server mints one). Modern (sessionless) runs skip this entirely.
+ * The protocol version pinned by the run drives the handshake; unset ⇒
+ * `"2025-11-25"`, byte-identical to the pre-era-awareness behavior.
+ */
 async function initializeAndGetSession(
   ctx: RawHttpCheckContext,
 ): Promise<string | undefined> {
@@ -45,7 +53,7 @@ async function initializeAndGetSession(
       id: 1,
       method: "initialize",
       params: {
-        protocolVersion: "2025-11-25",
+        protocolVersion: ctx.config.protocolVersion ?? "2025-11-25",
         capabilities: {},
         clientInfo: {
           name: "mcpjam-sdk-conformance",
@@ -56,6 +64,61 @@ async function initializeAndGetSession(
   });
 
   return response.headers.get("mcp-session-id") ?? undefined;
+}
+
+/**
+ * Send the invalid-method probe.
+ *
+ *   - Legacy: `initialize` first (to obtain a session for stateful servers),
+ *     then the bad-method POST carrying the session id.
+ *   - Modern (2026 era): no prelude. The 2026 era is sessionless, so the
+ *     bad-method POST stands alone, framed with the `MCP-Protocol-Version`
+ *     header and the per-request `_meta` protocol-version envelope the modern
+ *     wire requires (plus the SEP-2243 `mcp-method` mirror header).
+ */
+async function sendInvalidMethodProbe(
+  ctx: RawHttpCheckContext,
+): Promise<Response> {
+  if (ctx.config.era === "modern") {
+    const version = ctx.config.protocolVersion ?? "2025-11-25";
+    return await ctx.fetchFn(ctx.serverUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        "MCP-Protocol-Version": version,
+        "mcp-method": INVALID_METHOD,
+        ...buildBaseHeaders(ctx),
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 99,
+        method: INVALID_METHOD,
+        params: {
+          _meta: {
+            "io.modelcontextprotocol/protocolVersion": version,
+          },
+        },
+      }),
+    });
+  }
+
+  const sessionId = await initializeAndGetSession(ctx);
+  return await ctx.fetchFn(ctx.serverUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+      ...buildBaseHeaders(ctx),
+      ...(sessionId ? { "mcp-session-id": sessionId } : {}),
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 99,
+      method: INVALID_METHOD,
+      params: {},
+    }),
+  });
 }
 
 export async function runProtocolChecks(
@@ -70,23 +133,7 @@ export async function runProtocolChecks(
 
   const startedAt = Date.now();
   try {
-    const sessionId = await initializeAndGetSession(ctx);
-
-    const response = await ctx.fetchFn(ctx.serverUrl, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: "application/json, text/event-stream",
-        ...buildBaseHeaders(ctx),
-        ...(sessionId ? { "mcp-session-id": sessionId } : {}),
-      },
-      body: JSON.stringify({
-        jsonrpc: "2.0",
-        id: 99,
-        method: "nonexistent/method_that_does_not_exist",
-        params: {},
-      }),
-    });
+    const response = await sendInvalidMethodProbe(ctx);
 
     const contentType = response.headers.get("content-type") ?? "";
     let body: unknown;

--- a/sdk/src/mcp-conformance/checks/protocol.ts
+++ b/sdk/src/mcp-conformance/checks/protocol.ts
@@ -89,19 +89,24 @@ async function sendInvalidMethodProbe(
 ): Promise<Response> {
   if (ctx.config.era === "modern") {
     const version = ctx.config.protocolVersion ?? "2025-11-25";
+    // Build with a `Headers` instance so probe-owned fields win by
+    // case-insensitive NAME, not by object-key ordering. A plain object keeps
+    // `MCP-Method` and `mcp-method` as two distinct keys; Fetch then normalizes
+    // both to the canonical `mcp-method` and CONCATENATES their values
+    // ("tools/list, __invalid__"), so a caller's `customHeaders` case-variant
+    // would blend into the probe header and turn an honest probe into a false
+    // failure. `headers.set(...)` after the base spread REPLACES any such
+    // collision regardless of the caller's casing.
+    const headers = new Headers({
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+      ...buildBaseHeaders(ctx),
+    });
+    headers.set("MCP-Protocol-Version", version);
+    headers.set("mcp-method", INVALID_METHOD);
     return await ctx.fetchFn(ctx.serverUrl, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: "application/json, text/event-stream",
-        ...buildBaseHeaders(ctx),
-        // Probe-owned headers spread LAST so a caller's `customHeaders` can
-        // never overwrite the protocol-version pin or the SEP-2243 method
-        // mirror — otherwise a stray custom header turns an honest probe into
-        // a false failure unrelated to the server under test.
-        "MCP-Protocol-Version": version,
-        "mcp-method": INVALID_METHOD,
-      },
+      headers,
       body: JSON.stringify({
         jsonrpc: "2.0",
         id: 99,

--- a/sdk/src/mcp-conformance/checks/protocol.ts
+++ b/sdk/src/mcp-conformance/checks/protocol.ts
@@ -3,10 +3,18 @@ import type {
   MCPCheckResult,
   RawHttpCheckContext,
 } from "../types.js";
+import { CHECK_ERAS } from "../types.js";
 import {
+  eraSkipMessage,
   failedResult,
   passedResult,
+  skippedResult,
 } from "./helpers.js";
+
+// JSON-RPC "Method not found" — the only conforming error for an unrecognized
+// method name (JSON-RPC 2.0 §5.1). Accepting any numeric code would let a
+// server pass this check with an unrelated error (e.g. -32602 Invalid params).
+const METHOD_NOT_FOUND = -32601;
 
 const PROTOCOL_CHECK_METADATA = {
   "protocol-invalid-method-error": {
@@ -86,17 +94,32 @@ async function sendInvalidMethodProbe(
       headers: {
         "Content-Type": "application/json",
         Accept: "application/json, text/event-stream",
+        ...buildBaseHeaders(ctx),
+        // Probe-owned headers spread LAST so a caller's `customHeaders` can
+        // never overwrite the protocol-version pin or the SEP-2243 method
+        // mirror — otherwise a stray custom header turns an honest probe into
+        // a false failure unrelated to the server under test.
         "MCP-Protocol-Version": version,
         "mcp-method": INVALID_METHOD,
-        ...buildBaseHeaders(ctx),
       },
       body: JSON.stringify({
         jsonrpc: "2.0",
         id: 99,
         method: INVALID_METHOD,
         params: {
+          // The 2026-07-28 wire requires the FULL per-request `_meta` envelope
+          // (protocolVersion + clientInfo + clientCapabilities). Sending only
+          // the version makes a conforming server reject the request as a
+          // malformed envelope (-32602) BEFORE it ever dispatches the method,
+          // so the probe would never actually exercise unknown-method handling.
+          // clientInfo / clientCapabilities mirror the legacy `initialize`.
           _meta: {
             "io.modelcontextprotocol/protocolVersion": version,
+            "io.modelcontextprotocol/clientInfo": {
+              name: "mcpjam-sdk-conformance",
+              version: "1.0.0",
+            },
+            "io.modelcontextprotocol/clientCapabilities": {},
           },
         },
       }),
@@ -128,6 +151,22 @@ export async function runProtocolChecks(
   const results: MCPCheckResult[] = [];
 
   if (!selectedCheckIds.has("protocol-invalid-method-error")) {
+    return results;
+  }
+
+  // Era gate: route the raw protocol track through CHECK_ERAS, the single
+  // source of truth shared with the client / security / transport tracks. The
+  // invalid-method probe currently applies to both eras, so this is inert
+  // today — but keeping the runner on the map means a future reclassification
+  // (e.g. the Phase 3 safety valve downgrading it to legacy-only) becomes a
+  // safe era-skip instead of silently drifting into a false failure.
+  if (!CHECK_ERAS["protocol-invalid-method-error"].includes(ctx.config.era)) {
+    results.push(
+      skippedResult(
+        PROTOCOL_CHECK_METADATA["protocol-invalid-method-error"],
+        eraSkipMessage(ctx.config.era, ctx.config.protocolVersion),
+      ),
+    );
     return results;
   }
 
@@ -180,6 +219,21 @@ export async function runProtocolChecks(
           PROTOCOL_CHECK_METADATA["protocol-invalid-method-error"],
           Date.now() - startedAt,
           `JSON-RPC error is malformed: ${!hasCode ? "missing numeric code" : "missing message string"}`,
+          {
+            status: response.status,
+            error: rpcError,
+          },
+        ),
+      );
+      return results;
+    }
+
+    if (rpcError.code !== METHOD_NOT_FOUND) {
+      results.push(
+        failedResult(
+          PROTOCOL_CHECK_METADATA["protocol-invalid-method-error"],
+          Date.now() - startedAt,
+          `Expected JSON-RPC error code ${METHOD_NOT_FOUND} (Method not found) for an unrecognized method, got ${String(rpcError.code)}`,
           {
             status: response.status,
             error: rpcError,

--- a/sdk/src/mcp-conformance/checks/security.ts
+++ b/sdk/src/mcp-conformance/checks/security.ts
@@ -6,11 +6,18 @@ import type {
   MCPCheckResult,
   RawHttpCheckContext,
 } from "../types.js";
+import { CHECK_ERAS } from "../types.js";
 import {
+  eraSkipMessage,
   failedResult,
   skippedResult,
   passedResult,
 } from "./helpers.js";
+
+const LOCALHOST_SECURITY_CHECK_IDS = [
+  "localhost-host-rebinding-rejected",
+  "localhost-host-valid-accepted",
+] as const;
 
 type RawHttpResponse = {
   statusCode: number;
@@ -71,6 +78,7 @@ async function sendRequest(
   serverUrl: string,
   headers: Record<string, string>,
   timeoutMs: number,
+  protocolVersion: string,
 ): Promise<RawHttpResponse> {
   const target = new URL(serverUrl);
   const requestImpl = target.protocol === "https:" ? httpsRequest : httpRequest;
@@ -79,7 +87,7 @@ async function sendRequest(
     id: 1,
     method: "initialize",
     params: {
-      protocolVersion: "2025-11-25",
+      protocolVersion,
       capabilities: {},
       clientInfo: {
         name: "mcpjam-sdk-conformance",
@@ -149,12 +157,35 @@ export async function runSecurityChecks(
     return results;
   }
 
+  // Era gate (CHECK_ERAS is the single source of truth): the raw host-header
+  // probes are legacy-only, so on a modern run they surface as skips — never
+  // as a false failure — before any HTTP is attempted.
+  const applicable = new Set<MCPCheckId>();
+  for (const id of LOCALHOST_SECURITY_CHECK_IDS) {
+    if (!selectedCheckIds.has(id)) {
+      continue;
+    }
+    if (CHECK_ERAS[id].includes(ctx.config.era)) {
+      applicable.add(id);
+    } else {
+      results.push(
+        skippedResult(
+          SECURITY_CHECK_METADATA[id],
+          eraSkipMessage(ctx.config.era, ctx.config.protocolVersion),
+        ),
+      );
+    }
+  }
+
+  if (applicable.size === 0) {
+    return results;
+  }
+
+  const protocolVersion = ctx.config.protocolVersion ?? "2025-11-25";
+
   if (!isLocalhostUrl(ctx.serverUrl)) {
-    for (const id of [
-      "localhost-host-rebinding-rejected",
-      "localhost-host-valid-accepted",
-    ] as const) {
-      if (selectedCheckIds.has(id)) {
+    for (const id of LOCALHOST_SECURITY_CHECK_IDS) {
+      if (applicable.has(id)) {
         results.push(
           skippedResult(
             SECURITY_CHECK_METADATA[id],
@@ -173,7 +204,7 @@ export async function runSecurityChecks(
   const baseHeaders = buildBaseHeaders(ctx);
   const validHost = getHostFromUrl(ctx.serverUrl);
 
-  if (selectedCheckIds.has("localhost-host-rebinding-rejected")) {
+  if (applicable.has("localhost-host-rebinding-rejected")) {
     const startedAt = Date.now();
     try {
       const response = await sendRequest(
@@ -184,6 +215,7 @@ export async function runSecurityChecks(
           Origin: "http://evil.example.com",
         },
         ctx.config.checkTimeout,
+        protocolVersion,
       );
       const rejected =
         response.statusCode >= 400 && response.statusCode < 500;
@@ -220,7 +252,7 @@ export async function runSecurityChecks(
     }
   }
 
-  if (selectedCheckIds.has("localhost-host-valid-accepted")) {
+  if (applicable.has("localhost-host-valid-accepted")) {
     const startedAt = Date.now();
     try {
       const response = await sendRequest(
@@ -231,6 +263,7 @@ export async function runSecurityChecks(
           Origin: `http://${validHost}`,
         },
         ctx.config.checkTimeout,
+        protocolVersion,
       );
       const accepted =
         response.statusCode >= 200 && response.statusCode < 300;

--- a/sdk/src/mcp-conformance/checks/transport.ts
+++ b/sdk/src/mcp-conformance/checks/transport.ts
@@ -3,12 +3,16 @@ import type {
   MCPCheckResult,
   RawHttpCheckContext,
 } from "../types.js";
+import { CHECK_ERAS } from "../types.js";
 import {
   errorMessage,
+  eraSkipMessage,
   failedResult,
   skippedResult,
   passedResult,
 } from "./helpers.js";
+
+type TransportCheckId = keyof typeof TRANSPORT_CHECK_METADATA;
 
 const TRANSPORT_CHECK_METADATA = {
   "server-sse-polling-session": {
@@ -257,7 +261,7 @@ async function initializeSession(
         id: 1,
         method: "initialize",
         params: {
-          protocolVersion: "2025-11-25",
+          protocolVersion: ctx.config.protocolVersion ?? "2025-11-25",
           capabilities: {},
           clientInfo: {
             name: "mcpjam-sdk-conformance",
@@ -304,11 +308,35 @@ export async function runTransportChecks(
   selectedCheckIds: Set<MCPCheckId>,
 ): Promise<MCPCheckResult[]> {
   const results: MCPCheckResult[] = [];
-  const requestedTransportChecks = [...selectedCheckIds].filter((checkId) =>
-    checkId.startsWith("server-sse") || checkId === "server-accepts-multiple-post-streams",
+  const requestedTransportChecks = [...selectedCheckIds].filter(
+    (checkId): checkId is TransportCheckId =>
+      checkId.startsWith("server-sse") ||
+      checkId === "server-accepts-multiple-post-streams",
   );
 
   if (requestedTransportChecks.length === 0) {
+    return results;
+  }
+
+  // Era gate: every transport check asserts 2025-era stateful-session / SSE
+  // mechanics that do not exist in the sessionless 2026 era, so they are
+  // legacy-only. On a modern run they are skipped up front — the skips fire
+  // BEFORE `initializeSession` is ever called, so no handshake is attempted.
+  const applicableTransportChecks: TransportCheckId[] = [];
+  for (const id of requestedTransportChecks) {
+    if (CHECK_ERAS[id].includes(ctx.config.era)) {
+      applicableTransportChecks.push(id);
+    } else {
+      results.push(
+        skippedResult(
+          TRANSPORT_CHECK_METADATA[id],
+          eraSkipMessage(ctx.config.era, ctx.config.protocolVersion),
+        ),
+      );
+    }
+  }
+
+  if (applicableTransportChecks.length === 0) {
     return results;
   }
 
@@ -426,7 +454,8 @@ export async function runTransportChecks(
               headers: withSessionHeaders({
                 "Content-Type": "application/json",
                 Accept: "text/event-stream, application/json",
-                "mcp-protocol-version": "2025-11-25",
+                "mcp-protocol-version":
+                  ctx.config.protocolVersion ?? "2025-11-25",
                 ...buildBaseHeaders(ctx),
               }, activeSessionId),
               body: JSON.stringify({

--- a/sdk/src/mcp-conformance/index.ts
+++ b/sdk/src/mcp-conformance/index.ts
@@ -3,6 +3,7 @@ export { MCPConformanceSuite } from "./suite.js";
 
 export type {
   MCPCheckCategory,
+  MCPCheckEra,
   MCPCheckId,
   MCPCheckResult,
   MCPCheckStatus,
@@ -13,6 +14,7 @@ export type {
 } from "./types.js";
 
 export {
+  CHECK_ERAS,
   MCP_CHECK_CATEGORIES,
   MCP_CHECK_IDS,
 } from "./types.js";

--- a/sdk/src/mcp-conformance/runner.ts
+++ b/sdk/src/mcp-conformance/runner.ts
@@ -281,11 +281,30 @@ async function runClientChecks(
 
     return checks;
   } catch (error) {
-    const firstCheck = selectedClientChecks[0];
     const checks: MCPCheckResult[] = [];
 
+    // Era gate applies even when the connection could not be established: an
+    // era-inapplicable check is a deterministic era-skip, never a failure. On a
+    // modern run a connect error must NOT surface a legacy-only check (e.g.
+    // `server-initialize`) as failed, or `result.passed` goes false for a check
+    // that does not apply to the run's era. The surfaced connect failure is
+    // pinned to the first ERA-APPLICABLE check (in legacy that is
+    // `selectedClientChecks[0]`, byte-identical to the pre-era-awareness path).
+    const firstApplicableCheck = selectedClientChecks.find(
+      (check) => !eraGate(check, config.era, config.protocolVersion),
+    );
+
     for (const check of selectedClientChecks) {
-      if (check.id === "server-initialize" || check.id === firstCheck.id) {
+      const eraSkip = eraGate(check, config.era, config.protocolVersion);
+      if (eraSkip) {
+        checks.push(eraSkip);
+        continue;
+      }
+
+      if (
+        check.id === "server-initialize" ||
+        check.id === firstApplicableCheck?.id
+      ) {
         checks.push(
           failedResult(
             check,

--- a/sdk/src/mcp-conformance/runner.ts
+++ b/sdk/src/mcp-conformance/runner.ts
@@ -294,6 +294,27 @@ async function runClientChecks(
       (check) => !eraGate(check, config.era, config.protocolVersion),
     );
 
+    // Degenerate modern-era selection: EVERY selected client check is
+    // legacy-only, so there is no era-applicable check to pin the connect
+    // failure to (`firstApplicableCheck` is undefined). The normal loop below
+    // would era-skip all of them and the connection error would vanish — the
+    // run could report `passed` despite never connecting. Anchor the failure on
+    // the first selected check so a genuine connect failure ALWAYS surfaces as
+    // at least one failed result. This branch is unreachable in the legacy era
+    // (every check applies to `legacy`, so `firstApplicableCheck` is always
+    // defined), keeping the legacy path byte-identical to pre-era-awareness.
+    if (!firstApplicableCheck) {
+      return selectedClientChecks.map((check, index) =>
+        index === 0
+          ? failedResult(check, 0, errorMessage(error), undefined, error)
+          : (eraGate(check, config.era, config.protocolVersion) ??
+            skippedResult(
+              check,
+              "Skipping check because the MCP client session could not be established",
+            )),
+      );
+    }
+
     for (const check of selectedClientChecks) {
       const eraSkip = eraGate(check, config.era, config.protocolVersion);
       if (eraSkip) {

--- a/sdk/src/mcp-conformance/runner.ts
+++ b/sdk/src/mcp-conformance/runner.ts
@@ -14,19 +14,22 @@ import { TOOL_CHECKS } from "./checks/tools.js";
 import { PROMPT_CHECKS } from "./checks/prompts.js";
 import {
   errorMessage,
+  eraSkipMessage,
   failedResult,
   skippedResult,
 } from "./checks/helpers.js";
 import type {
   MCPCheckCategory,
+  MCPCheckEra,
   MCPCheckId,
   MCPCheckResult,
   MCPClientCheckContext,
+  MCPClientCheckDefinition,
   MCPConformanceConfig,
   MCPConformanceResult,
   NormalizedMCPConformanceConfig,
 } from "./types.js";
-import { MCP_CHECK_CATEGORIES } from "./types.js";
+import { CHECK_ERAS, MCP_CHECK_CATEGORIES } from "./types.js";
 import { normalizeMCPConformanceConfig } from "./validation.js";
 
 const CLIENT_CHECKS = [
@@ -107,7 +110,29 @@ function createServerConfig(
       ? { headers: config.customHeaders }
       : undefined,
     timeout: config.checkTimeout,
+    // Flows through `resolveVersionNegotiation`: a modern (stateless) pin
+    // makes the underlying Client negotiate the 2026 era so a modern-only
+    // server can connect at all. Absent ⇒ legacy negotiation, unchanged.
+    mcpProtocolVersion: config.protocolVersion,
   };
+}
+
+/**
+ * Era gate for a client-backed check. Returns a `skipped` result (never
+ * filtered out — the check still appears in the report) when the check does
+ * not apply to the run's era per {@link CHECK_ERAS}, else `undefined` so the
+ * check runs normally. Skipped checks never fail a run (the verdict is
+ * `checks.every(c => c.status !== "failed")`).
+ */
+function eraGate(
+  check: MCPClientCheckDefinition,
+  era: MCPCheckEra,
+  protocolVersion: string | undefined,
+): MCPCheckResult | undefined {
+  if (CHECK_ERAS[check.id].includes(era)) {
+    return undefined;
+  }
+  return skippedResult(check, eraSkipMessage(era, protocolVersion));
 }
 
 async function safeListResourceTemplates(
@@ -176,26 +201,14 @@ async function runClientChecks(
     const checks = await withEphemeralClient(
       createServerConfig(config),
       async (manager, serverId) => {
-        const client = manager.getClient(serverId);
+        // `getManagedClient()` works for every era — the modern pin and the
+        // legacy path both resolve to a `ManagedMcpClient` (the stateless
+        // preview adapter was removed in Phase 1C; both go through the
+        // official Client now). Absent only if connect failed to register a
+        // client, which is a genuine error.
+        const client = manager.getManagedClient(serverId);
         if (!client) {
-          // `getClient()` returns `undefined` for stateless-preview
-          // connections (no wrapped upstream `Client`). The client-check
-          // suite is written against the upstream `Client` surface, so
-          // it can't run against a stateless adapter yet — surface this
-          // as N/A for every selected client check rather than throwing
-          // a confusing "Underlying MCP client is unavailable" error.
-          // Wiring the suite through `getManagedClient()` is a separate
-          // follow-up.
-          const managed = manager.getManagedClient(serverId);
-          const reason = managed
-            ? "Client-side conformance checks are not yet wired through the 2026-07-28 stateless preview adapter."
-            : "Underlying MCP client is unavailable after connect";
-          if (managed) {
-            return selectedClientChecks.map((check) =>
-              skippedResult(check, reason),
-            );
-          }
-          throw new Error(reason);
+          throw new Error("Managed MCP client is unavailable after connect");
         }
 
         const initializationInfo = manager.getInitializationInfo(serverId);
@@ -223,6 +236,15 @@ async function runClientChecks(
         let connectionLost = false;
 
         for (const check of selectedClientChecks) {
+          // Era gate first: an era-inapplicable check is a deterministic skip
+          // that never runs `check.run`, so it neither observes nor affects
+          // the `connectionLost` sequencing below.
+          const eraSkip = eraGate(check, config.era, config.protocolVersion);
+          if (eraSkip) {
+            results.push(eraSkip);
+            continue;
+          }
+
           if (connectionLost) {
             results.push(
               skippedResult(

--- a/sdk/src/mcp-conformance/types.ts
+++ b/sdk/src/mcp-conformance/types.ts
@@ -1,5 +1,8 @@
-import type { Client } from "@modelcontextprotocol/client";
-import type { MCPClientManager } from "../mcp-client-manager/index.js";
+import type {
+  ManagedMcpClient,
+  MCPClientManager,
+} from "../mcp-client-manager/index.js";
+import type { McpProtocolVersion } from "../mcp-client-manager/mcp-protocol-version.js";
 
 export const MCP_CHECK_CATEGORIES = [
   "core",
@@ -35,6 +38,59 @@ export type MCPCheckId = (typeof MCP_CHECK_IDS)[number];
 
 export type MCPCheckStatus = "passed" | "failed" | "skipped";
 
+/**
+ * Protocol era a conformance run targets. Derived once in
+ * {@link NormalizedMCPConformanceConfig} from the pinned `protocolVersion`
+ * (via `isStatelessProtocolVersion`): a stateless/2026-era pin ⇒ `"modern"`,
+ * an absent or stateful pin ⇒ `"legacy"`. An absent pin therefore reproduces
+ * byte-identical legacy behavior.
+ */
+export type MCPCheckEra = "legacy" | "modern";
+
+/**
+ * Single source of truth mapping each check to the eras it applies to.
+ * Consumed by BOTH tracks — the client-backed checks (via `eraGate` in the
+ * runner) and the raw-HTTP checks (protocol/security/transport runners) —
+ * so era membership is never duplicated or allowed to drift between them.
+ * Phase 7 (modern MUST checks) reuses this map rather than re-deriving.
+ *
+ * Classification rationale:
+ *   - Legacy-only checks assert 2025-era wire mechanics that do not exist in
+ *     the sessionless 2026 era: the `initialize` handshake
+ *     (`server-initialize`), the stateful session id + concurrent POST/SSE
+ *     stream semantics (`server-sse-*`, `server-accepts-multiple-post-streams`),
+ *     and consistency/health probes (`capabilities-consistent`, `ping`) whose
+ *     modern equivalents are Phase 7 work.
+ *   - Both-era checks either self-skip on an unadvertised capability
+ *     (`logging-set-level`, `completion-complete`) or assert primitive
+ *     surface / generic JSON-RPC behavior that is era-agnostic
+ *     (`tools-list`, `tools-input-schemas-valid`, `prompts-list`,
+ *     `resources-list`, `protocol-invalid-method-error`).
+ *
+ * The two `localhost-host-*` security checks are deliberately legacy-only for
+ * now: their raw modern host-header probe could not be validated against the
+ * dual-era fixture (which leaves DNS-rebinding protection disabled), so per
+ * the Phase 3 safety valve they are downgraded to a safe skip on a modern run
+ * rather than shipped as a fragile probe. Promoting them is Phase 7 work.
+ */
+export const CHECK_ERAS: Record<MCPCheckId, readonly MCPCheckEra[]> = {
+  "server-initialize": ["legacy"],
+  ping: ["legacy"],
+  "capabilities-consistent": ["legacy"],
+  "server-sse-polling-session": ["legacy"],
+  "server-accepts-multiple-post-streams": ["legacy"],
+  "server-sse-streams-functional": ["legacy"],
+  "localhost-host-rebinding-rejected": ["legacy"],
+  "localhost-host-valid-accepted": ["legacy"],
+  "tools-list": ["legacy", "modern"],
+  "tools-input-schemas-valid": ["legacy", "modern"],
+  "prompts-list": ["legacy", "modern"],
+  "resources-list": ["legacy", "modern"],
+  "logging-set-level": ["legacy", "modern"],
+  "completion-complete": ["legacy", "modern"],
+  "protocol-invalid-method-error": ["legacy", "modern"],
+} as const satisfies Record<MCPCheckId, readonly MCPCheckEra[]>;
+
 export interface MCPCheckResult {
   id: MCPCheckId;
   category: MCPCheckCategory;
@@ -58,6 +114,14 @@ export interface MCPConformanceConfig {
   checkIds?: MCPCheckId[];
   fetchFn?: typeof fetch;
   clientName?: string;
+  /**
+   * Pinned MCP protocol version. Absent ⇒ legacy era, byte-identical to the
+   * pre-era-awareness behavior. A known stateless value (e.g. `"2026-07-28"`)
+   * selects the modern era: the client connects through the official Client's
+   * version negotiation and era-scoped checks apply per {@link CHECK_ERAS}.
+   * Validated at normalization via `isKnownProtocolVersion`.
+   */
+  protocolVersion?: McpProtocolVersion;
 }
 
 export interface NormalizedMCPConformanceConfig {
@@ -69,6 +133,10 @@ export interface NormalizedMCPConformanceConfig {
   checkIds?: MCPCheckId[];
   fetchFn: typeof fetch;
   clientName: string;
+  /** Validated protocol pin (see {@link MCPConformanceConfig.protocolVersion}). */
+  protocolVersion?: McpProtocolVersion;
+  /** Era derived from `protocolVersion`; absent pin ⇒ `"legacy"`. */
+  era: MCPCheckEra;
 }
 
 export interface MCPConformanceResult {
@@ -106,7 +174,7 @@ export interface MCPConformanceSuiteResult {
 
 export interface MCPClientCheckContext {
   manager: MCPClientManager;
-  client: Client;
+  client: ManagedMcpClient;
   serverId: string;
   config: NormalizedMCPConformanceConfig;
   initializationInfo: ReturnType<MCPClientManager["getInitializationInfo"]>;

--- a/sdk/src/mcp-conformance/validation.ts
+++ b/sdk/src/mcp-conformance/validation.ts
@@ -2,10 +2,16 @@ import {
   MCP_CHECK_CATEGORIES,
   MCP_CHECK_IDS,
   type MCPCheckCategory,
+  type MCPCheckEra,
   type MCPCheckId,
   type MCPConformanceConfig,
   type NormalizedMCPConformanceConfig,
 } from "./types.js";
+import {
+  isKnownProtocolVersion,
+  isStatelessProtocolVersion,
+  type McpProtocolVersion,
+} from "../mcp-client-manager/mcp-protocol-version.js";
 
 function normalizeCategories(
   categories: MCPConformanceConfig["categories"],
@@ -41,6 +47,26 @@ function normalizeCheckIds(
   return normalized;
 }
 
+function normalizeProtocolVersion(
+  protocolVersion: MCPConformanceConfig["protocolVersion"],
+): { protocolVersion?: McpProtocolVersion; era: MCPCheckEra } {
+  if (protocolVersion === undefined) {
+    // Unset ⇒ legacy era ⇒ byte-identical pre-era-awareness behavior.
+    return { era: "legacy" };
+  }
+
+  if (!isKnownProtocolVersion(protocolVersion)) {
+    throw new Error(
+      `Unknown MCP conformance protocolVersion: ${protocolVersion}`,
+    );
+  }
+
+  return {
+    protocolVersion,
+    era: isStatelessProtocolVersion(protocolVersion) ? "modern" : "legacy",
+  };
+}
+
 export function normalizeMCPConformanceConfig(
   config: MCPConformanceConfig,
 ): NormalizedMCPConformanceConfig {
@@ -57,6 +83,9 @@ export function normalizeMCPConformanceConfig(
 
   const categories = normalizeCategories(config.categories);
   const checkIds = normalizeCheckIds(config.checkIds);
+  const { protocolVersion, era } = normalizeProtocolVersion(
+    config.protocolVersion,
+  );
 
   return {
     serverUrl,
@@ -67,5 +96,7 @@ export function normalizeMCPConformanceConfig(
     checkIds,
     fetchFn: config.fetchFn ?? fetch,
     clientName: config.clientName?.trim() || "mcpjam-sdk-conformance",
+    protocolVersion,
+    era,
   };
 }

--- a/sdk/tests/mcp-conformance/checks.test.ts
+++ b/sdk/tests/mcp-conformance/checks.test.ts
@@ -59,6 +59,7 @@ function createTransportContext(fetchFn: typeof fetch) {
       categories: [],
       fetchFn,
       clientName: "mcpjam-sdk-conformance",
+      era: "legacy" as const,
     },
     serverUrl: "https://example.com/mcp",
     fetchFn,
@@ -97,6 +98,7 @@ describe("mcp conformance unit checks", () => {
         fn(
           {
             getClient: vi.fn().mockReturnValue({}),
+            getManagedClient: vi.fn().mockReturnValue({}),
             getInitializationInfo: vi.fn().mockReturnValue({
               protocolVersion: "2025-11-25",
               transport: "streamable-http",

--- a/sdk/tests/mcp-conformance/era.integration.test.ts
+++ b/sdk/tests/mcp-conformance/era.integration.test.ts
@@ -1,0 +1,165 @@
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { toNodeHandler } from "@modelcontextprotocol/node";
+import {
+  MCPConformanceTest,
+  type MCPCheckId,
+  type MCPCheckResult,
+} from "../../src/mcp-conformance/index.js";
+import { createFixtureHandler } from "../support/dual-era-fixture.js";
+
+/**
+ * Exit gate for Phase 3 §11.5 (conformance era-awareness): pointing the
+ * conformance suite at the modern (2026-07-28) dual-era fixture must produce
+ * ZERO false failures and no crash, and a legacy run must behave exactly as
+ * it did before era-awareness existed.
+ *
+ * The `serveFixtureOnPort` helper is vendored from
+ * `mcp-client-manager-fixture.integration.test.ts` (not cross-imported): the
+ * security host-header checks dial a real loopback socket, so the fixture
+ * must be served over an actual port rather than driven in-process.
+ */
+
+interface ServedFixture {
+  url: string;
+  close: () => Promise<void>;
+}
+
+async function serveFixtureOnPort(): Promise<ServedFixture> {
+  const handler = createFixtureHandler();
+  const httpServer = http.createServer(toNodeHandler(handler));
+  await new Promise<void>((resolve) =>
+    httpServer.listen(0, "127.0.0.1", resolve)
+  );
+  const address = httpServer.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${address.port}/mcp`,
+    close: () =>
+      new Promise<void>((resolve) => httpServer.close(() => resolve())),
+  };
+}
+
+function statusById(checks: MCPCheckResult[]): Record<string, string> {
+  return Object.fromEntries(checks.map((c) => [c.id, c.status]));
+}
+
+function byId(checks: MCPCheckResult[], id: MCPCheckId): MCPCheckResult {
+  const found = checks.find((c) => c.id === id);
+  if (!found) {
+    throw new Error(`check ${id} not found in results`);
+  }
+  return found;
+}
+
+const ERA_SKIP = /Not applicable to the .* era/;
+
+// Legacy-only checks — must be era-skipped on a modern run.
+const LEGACY_ONLY: MCPCheckId[] = [
+  "server-initialize",
+  "ping",
+  "capabilities-consistent",
+  "server-sse-polling-session",
+  "server-accepts-multiple-post-streams",
+  "server-sse-streams-functional",
+  "localhost-host-rebinding-rejected",
+  "localhost-host-valid-accepted",
+];
+
+// Neutral checks that carry real surface on the modern fixture — must pass.
+const MODERN_PASSING: MCPCheckId[] = [
+  "tools-list",
+  "tools-input-schemas-valid",
+  "prompts-list",
+  "resources-list",
+  "protocol-invalid-method-error",
+];
+
+describe("MCP conformance × era-awareness against the dual-era fixture", () => {
+  let served: ServedFixture;
+
+  beforeEach(async () => {
+    served = await serveFixtureOnPort();
+  });
+
+  afterEach(async () => {
+    await served.close();
+  });
+
+  it("modern run: zero failures, legacy-only checks era-skipped, neutral checks pass", async () => {
+    const result = await new MCPConformanceTest({
+      serverUrl: served.url,
+      protocolVersion: "2026-07-28",
+      checkTimeout: 10_000,
+    }).run();
+
+    // Exit gate: no false failures, no crash.
+    expect(result.checks.filter((c) => c.status === "failed")).toEqual([]);
+    expect(result.passed).toBe(true);
+
+    // Legacy-only checks appear (not filtered out) and are era-skipped.
+    for (const id of LEGACY_ONLY) {
+      const check = byId(result.checks, id);
+      expect(check.status).toBe("skipped");
+      expect(check.error?.message).toMatch(ERA_SKIP);
+    }
+
+    // Neutral checks with real surface pass on the modern era.
+    for (const id of MODERN_PASSING) {
+      expect(byId(result.checks, id).status).toBe("passed");
+    }
+
+    // The fixture advertises no logging/completions capability, so these
+    // both-era checks self-skip on capability (NOT the era gate).
+    for (const id of ["logging-set-level", "completion-complete"] as const) {
+      const check = byId(result.checks, id);
+      expect(check.status).toBe("skipped");
+      expect(check.error?.message).not.toMatch(ERA_SKIP);
+    }
+  });
+
+  it("legacy run (no protocolVersion): era gate is inert — every check runs", async () => {
+    const result = await new MCPConformanceTest({
+      serverUrl: served.url,
+      checkTimeout: 10_000,
+    }).run();
+
+    // No check is skipped for era reasons on a legacy run — this is the
+    // "byte-identical to today" guarantee. (We do not assert `passed`: the
+    // dual-era fixture leaves DNS-rebinding protection disabled, so
+    // `localhost-host-rebinding-rejected` fails here exactly as it did
+    // before this PR — a fixture property, not an era regression.)
+    for (const check of result.checks) {
+      expect(check.error?.message ?? "").not.toMatch(ERA_SKIP);
+    }
+
+    // The legacy-only checks actually execute rather than being skipped away.
+    expect(byId(result.checks, "server-initialize").status).toBe("passed");
+    expect(byId(result.checks, "ping").status).toBe("passed");
+    expect(byId(result.checks, "capabilities-consistent").status).toBe(
+      "passed"
+    );
+    for (const id of MODERN_PASSING) {
+      expect(byId(result.checks, id).status).toBe("passed");
+    }
+  });
+
+  it("legacy pin (2025-11-25): identical to the default legacy run", async () => {
+    const unpinned = await new MCPConformanceTest({
+      serverUrl: served.url,
+      checkTimeout: 10_000,
+    }).run();
+    const pinned = await new MCPConformanceTest({
+      serverUrl: served.url,
+      protocolVersion: "2025-11-25",
+      checkTimeout: 10_000,
+    }).run();
+
+    // Same set of checks, same statuses — the stateful pin routes through the
+    // identical legacy path.
+    expect(statusById(pinned.checks)).toEqual(statusById(unpinned.checks));
+    for (const check of pinned.checks) {
+      expect(check.error?.message ?? "").not.toMatch(ERA_SKIP);
+    }
+  });
+});

--- a/sdk/tests/mcp-conformance/era.unit.test.ts
+++ b/sdk/tests/mcp-conformance/era.unit.test.ts
@@ -195,9 +195,20 @@ describe("runProtocolChecks — era-aware invalid-method probe", () => {
     expect(headers["mcp-session-id"]).toBeUndefined();
     const body = JSON.parse(String(calls[0]?.body));
     expect(body.method).toBe("nonexistent/method_that_does_not_exist");
+    // Full 2026-07-28 per-request _meta envelope — a conforming modern server
+    // rejects an incomplete envelope (-32602) before dispatching the method,
+    // so all three keys must be present or the probe never reaches unknown-
+    // method handling.
     expect(body.params._meta["io.modelcontextprotocol/protocolVersion"]).toBe(
       "2026-07-28"
     );
+    expect(body.params._meta["io.modelcontextprotocol/clientInfo"]).toEqual({
+      name: "mcpjam-sdk-conformance",
+      version: "1.0.0",
+    });
+    expect(
+      body.params._meta["io.modelcontextprotocol/clientCapabilities"]
+    ).toEqual({});
   });
 });
 

--- a/sdk/tests/mcp-conformance/era.unit.test.ts
+++ b/sdk/tests/mcp-conformance/era.unit.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Unit coverage for conformance era-awareness (Phase 3 §11.5).
+ *
+ * These tests deliberately import from `types.js` / `validation.js` and the
+ * individual raw-check runners rather than the package `index.js`, so they
+ * do NOT pull in the MCP client/server packages — they run without a live
+ * server and without the beta.4 dual-era fixture. The end-to-end fixture
+ * assertions live in `era.integration.test.ts`.
+ */
+
+import {
+  CHECK_ERAS,
+  MCP_CHECK_IDS,
+  type MCPCheckId,
+  type NormalizedMCPConformanceConfig,
+} from "../../src/mcp-conformance/types.js";
+import { normalizeMCPConformanceConfig } from "../../src/mcp-conformance/validation.js";
+import { runProtocolChecks } from "../../src/mcp-conformance/checks/protocol.js";
+import { runSecurityChecks } from "../../src/mcp-conformance/checks/security.js";
+import { runTransportChecks } from "../../src/mcp-conformance/checks/transport.js";
+
+const SERVER_URL = "http://127.0.0.1:9/mcp";
+
+function jsonRpcErrorResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      id: 99,
+      error: { code: -32601, message: "Method not found" },
+    }),
+    { status: 200, headers: { "content-type": "application/json" } }
+  );
+}
+
+function initializeResponse(sessionId?: string): Response {
+  return new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result: {} }), {
+    status: 200,
+    headers: {
+      "content-type": "application/json",
+      ...(sessionId ? { "mcp-session-id": sessionId } : {}),
+    },
+  });
+}
+
+function normalize(
+  overrides: Partial<Parameters<typeof normalizeMCPConformanceConfig>[0]> = {}
+): NormalizedMCPConformanceConfig {
+  return normalizeMCPConformanceConfig({
+    serverUrl: SERVER_URL,
+    ...overrides,
+  });
+}
+
+describe("normalizeMCPConformanceConfig — protocolVersion → era", () => {
+  it("defaults to the legacy era with no protocolVersion", () => {
+    const config = normalize();
+    expect(config.era).toBe("legacy");
+    expect(config.protocolVersion).toBeUndefined();
+  });
+
+  it("classifies a stateful pin as legacy", () => {
+    const config = normalize({ protocolVersion: "2025-11-25" });
+    expect(config.era).toBe("legacy");
+    expect(config.protocolVersion).toBe("2025-11-25");
+  });
+
+  it("classifies the 2026 pin as modern", () => {
+    const config = normalize({ protocolVersion: "2026-07-28" });
+    expect(config.era).toBe("modern");
+    expect(config.protocolVersion).toBe("2026-07-28");
+  });
+
+  it("throws on an unknown protocolVersion (mirrors category/checkId errors)", () => {
+    expect(() =>
+      normalize({ protocolVersion: "DRAFT-2027-zzz" as never })
+    ).toThrow(/Unknown MCP conformance protocolVersion/);
+  });
+});
+
+describe("CHECK_ERAS map", () => {
+  it("is exhaustive over MCP_CHECK_IDS with no extra keys", () => {
+    const eraKeys = Object.keys(CHECK_ERAS).sort();
+    const ids = [...MCP_CHECK_IDS].sort();
+    expect(eraKeys).toEqual(ids);
+  });
+
+  it("every check applies to the legacy era (byte-identical legacy guarantee)", () => {
+    for (const id of MCP_CHECK_IDS) {
+      expect(CHECK_ERAS[id]).toContain("legacy");
+    }
+  });
+
+  it("classifies the era-specific and neutral checks as specified", () => {
+    const legacyOnly: MCPCheckId[] = [
+      "server-initialize",
+      "ping",
+      "capabilities-consistent",
+      "server-sse-polling-session",
+      "server-accepts-multiple-post-streams",
+      "server-sse-streams-functional",
+      "localhost-host-rebinding-rejected",
+      "localhost-host-valid-accepted",
+    ];
+    const bothEras: MCPCheckId[] = [
+      "tools-list",
+      "tools-input-schemas-valid",
+      "prompts-list",
+      "resources-list",
+      "logging-set-level",
+      "completion-complete",
+      "protocol-invalid-method-error",
+    ];
+
+    for (const id of legacyOnly) {
+      expect(CHECK_ERAS[id]).toEqual(["legacy"]);
+    }
+    for (const id of bothEras) {
+      expect([...CHECK_ERAS[id]].sort()).toEqual(["legacy", "modern"]);
+    }
+    // Sanity: the two partitions cover every id exactly once.
+    expect([...legacyOnly, ...bothEras].sort()).toEqual(
+      [...MCP_CHECK_IDS].sort()
+    );
+  });
+});
+
+describe("runProtocolChecks — era-aware invalid-method probe", () => {
+  const selected = new Set<MCPCheckId>(["protocol-invalid-method-error"]);
+
+  it("legacy: runs the initialize prelude then the bad-method POST", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const fetchFn = (async (url: unknown, init?: RequestInit) => {
+      calls.push({ url: String(url), init });
+      return calls.length === 1
+        ? initializeResponse("sess-1")
+        : jsonRpcErrorResponse();
+    }) as unknown as typeof fetch;
+
+    const config = normalize({ fetchFn });
+    const results = await runProtocolChecks(
+      { config, serverUrl: SERVER_URL, fetchFn: config.fetchFn },
+      selected
+    );
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.status).toBe("passed");
+    expect(calls).toHaveLength(2);
+    // Prelude is an initialize at the pinned (default) version.
+    const initBody = JSON.parse(String(calls[0]?.init?.body));
+    expect(initBody.method).toBe("initialize");
+    expect(initBody.params.protocolVersion).toBe("2025-11-25");
+    // The bad-method POST carries the session obtained from the prelude.
+    const badHeaders = calls[1]?.init?.headers as Record<string, string>;
+    expect(badHeaders["mcp-session-id"]).toBe("sess-1");
+  });
+
+  it("legacy: uses the pinned stateful version in the initialize prelude", async () => {
+    const calls: Array<RequestInit | undefined> = [];
+    const fetchFn = (async (_url: unknown, init?: RequestInit) => {
+      calls.push(init);
+      return calls.length === 1 ? initializeResponse() : jsonRpcErrorResponse();
+    }) as unknown as typeof fetch;
+
+    const config = normalize({ fetchFn, protocolVersion: "2025-06-18" });
+    await runProtocolChecks(
+      { config, serverUrl: SERVER_URL, fetchFn: config.fetchFn },
+      selected
+    );
+
+    const initBody = JSON.parse(String(calls[0]?.body));
+    expect(initBody.params.protocolVersion).toBe("2025-06-18");
+  });
+
+  it("modern: drops the prelude and frames the POST with the modern envelope", async () => {
+    const calls: Array<RequestInit | undefined> = [];
+    const fetchFn = (async (_url: unknown, init?: RequestInit) => {
+      calls.push(init);
+      return jsonRpcErrorResponse();
+    }) as unknown as typeof fetch;
+
+    const config = normalize({ fetchFn, protocolVersion: "2026-07-28" });
+    const results = await runProtocolChecks(
+      { config, serverUrl: SERVER_URL, fetchFn: config.fetchFn },
+      selected
+    );
+
+    expect(results[0]?.status).toBe("passed");
+    // No initialize prelude — a single sessionless POST.
+    expect(calls).toHaveLength(1);
+    const headers = calls[0]?.headers as Record<string, string>;
+    expect(headers["MCP-Protocol-Version"]).toBe("2026-07-28");
+    expect(headers["mcp-method"]).toBe(
+      "nonexistent/method_that_does_not_exist"
+    );
+    expect(headers["mcp-session-id"]).toBeUndefined();
+    const body = JSON.parse(String(calls[0]?.body));
+    expect(body.method).toBe("nonexistent/method_that_does_not_exist");
+    expect(body.params._meta["io.modelcontextprotocol/protocolVersion"]).toBe(
+      "2026-07-28"
+    );
+  });
+});
+
+describe("raw legacy-only checks are era-skipped on a modern run", () => {
+  it("transport checks skip before any HTTP is attempted", async () => {
+    let fetchCalled = false;
+    const fetchFn = (async () => {
+      fetchCalled = true;
+      return new Response("{}");
+    }) as unknown as typeof fetch;
+
+    const config = normalize({ fetchFn, protocolVersion: "2026-07-28" });
+    const selected = new Set<MCPCheckId>([
+      "server-sse-polling-session",
+      "server-accepts-multiple-post-streams",
+      "server-sse-streams-functional",
+    ]);
+    const results = await runTransportChecks(
+      { config, serverUrl: SERVER_URL, fetchFn: config.fetchFn },
+      selected
+    );
+
+    expect(fetchCalled).toBe(false);
+    expect(results).toHaveLength(3);
+    for (const result of results) {
+      expect(result.status).toBe("skipped");
+      expect(result.error?.message).toMatch(/Not applicable to the modern era/);
+    }
+  });
+
+  it("localhost security checks skip before any socket is opened", async () => {
+    const config = normalize({ protocolVersion: "2026-07-28" });
+    const selected = new Set<MCPCheckId>([
+      "localhost-host-rebinding-rejected",
+      "localhost-host-valid-accepted",
+    ]);
+    const results = await runSecurityChecks(
+      { config, serverUrl: SERVER_URL, fetchFn: config.fetchFn },
+      selected
+    );
+
+    expect(results).toHaveLength(2);
+    for (const result of results) {
+      expect(result.status).toBe("skipped");
+      expect(result.error?.message).toMatch(/Not applicable to the modern era/);
+    }
+  });
+});

--- a/sdk/tests/mcp-conformance/era.unit.test.ts
+++ b/sdk/tests/mcp-conformance/era.unit.test.ts
@@ -187,12 +187,12 @@ describe("runProtocolChecks — era-aware invalid-method probe", () => {
     expect(results[0]?.status).toBe("passed");
     // No initialize prelude — a single sessionless POST.
     expect(calls).toHaveLength(1);
-    const headers = calls[0]?.headers as Record<string, string>;
-    expect(headers["MCP-Protocol-Version"]).toBe("2026-07-28");
-    expect(headers["mcp-method"]).toBe(
+    const headers = new Headers(calls[0]?.headers as HeadersInit);
+    expect(headers.get("MCP-Protocol-Version")).toBe("2026-07-28");
+    expect(headers.get("mcp-method")).toBe(
       "nonexistent/method_that_does_not_exist"
     );
-    expect(headers["mcp-session-id"]).toBeUndefined();
+    expect(headers.has("mcp-session-id")).toBe(false);
     const body = JSON.parse(String(calls[0]?.body));
     expect(body.method).toBe("nonexistent/method_that_does_not_exist");
     // Full 2026-07-28 per-request _meta envelope — a conforming modern server
@@ -209,6 +209,37 @@ describe("runProtocolChecks — era-aware invalid-method probe", () => {
     expect(
       body.params._meta["io.modelcontextprotocol/clientCapabilities"]
     ).toEqual({});
+  });
+
+  it("modern: a customHeaders case-variant never blends into the probe pin", async () => {
+    const calls: Array<RequestInit | undefined> = [];
+    const fetchFn = (async (_url: unknown, init?: RequestInit) => {
+      calls.push(init);
+      return jsonRpcErrorResponse();
+    }) as unknown as typeof fetch;
+
+    // Case-variant collisions with the probe-owned pins. A plain object would
+    // keep these as distinct keys and Fetch would concatenate the canonical
+    // duplicates ("stale, __invalid__"); the Headers instance must REPLACE them.
+    const config = normalize({
+      fetchFn,
+      protocolVersion: "2026-07-28",
+      customHeaders: {
+        "MCP-Method": "tools/list",
+        "mcp-protocol-version": "1999-01-01",
+      },
+    });
+    await runProtocolChecks(
+      { config, serverUrl: SERVER_URL, fetchFn: config.fetchFn },
+      selected
+    );
+
+    const headers = new Headers(calls[0]?.headers as HeadersInit);
+    // No concatenation — the probe pin wins cleanly.
+    expect(headers.get("mcp-method")).toBe(
+      "nonexistent/method_that_does_not_exist"
+    );
+    expect(headers.get("MCP-Protocol-Version")).toBe("2026-07-28");
   });
 });
 

--- a/sdk/tests/mcp-conformance/runner.test.ts
+++ b/sdk/tests/mcp-conformance/runner.test.ts
@@ -68,6 +68,25 @@ describe("MCPConformanceTest", () => {
     }
   });
 
+  it("modern run + connect failure + all-legacy-only selection surfaces a failure, not a pass", async () => {
+    // Modern era, but the only selected client check (`ping`) is legacy-only,
+    // so it is era-skipped for this run. The server is unreachable, so
+    // `withEphemeralClient` throws. Without the connect-failure anchor, every
+    // check would be era-skipped and the run would silently report `passed`.
+    const test = new MCPConformanceTest({
+      serverUrl: "http://127.0.0.1:1/mcp",
+      protocolVersion: "2026-07-28",
+      checkTimeout: 3_000,
+      checkIds: ["ping"],
+    });
+
+    const result = await test.run();
+
+    expect(result.passed).toBe(false);
+    const failed = result.checks.filter((check) => check.status === "failed");
+    expect(failed.length).toBeGreaterThanOrEqual(1);
+  });
+
   it("treats stateless Streamable HTTP servers as supported transport variants", async () => {
     const mockServer = await startConformanceMockServer({
       statelessTransport: true,

--- a/sdk/tests/mcp-conformance/runner.test.ts
+++ b/sdk/tests/mcp-conformance/runner.test.ts
@@ -83,8 +83,17 @@ describe("MCPConformanceTest", () => {
     const result = await test.run();
 
     expect(result.passed).toBe(false);
+
+    // Assert the anchor itself, not just "something failed": the connect
+    // failure is pinned to the first selected check (`ping`). A bare
+    // `failed.length >= 1` would also pass if `ping` had failed for an
+    // unrelated reason or a different check failed, masking a missing anchor.
+    const ping = result.checks.find((check) => check.id === "ping");
+    expect(ping?.status).toBe("failed");
+    // And exactly the anchored check failed — no other check masks a missing
+    // anchor, and none is left era-skipped-into-a-silent-pass.
     const failed = result.checks.filter((check) => check.status === "failed");
-    expect(failed.length).toBeGreaterThanOrEqual(1);
+    expect(failed.map((check) => check.id)).toEqual(["ping"]);
   });
 
   it("treats stateless Streamable HTTP servers as supported transport variants", async () => {


### PR DESCRIPTION
Phase 3 §11.5. Teaches the MCP conformance suite about the **protocol era** so a conforming modern (2026-07-28) server stops false-failing on checks that only assert 2025-era wire mechanics. Scope is deliberately narrow — **no new modern MUST checks** (that is Phase 7). Legacy runs stay byte-identical.

## What changed

- **`CHECK_ERAS`** (new exported map in `types.ts`) is the single source of truth for which era each check applies to, consumed by BOTH the client-backed track (`eraGate` in the runner) and the raw-HTTP track (protocol/security/transport runners). Phase 7 reuses it.
- **`protocolVersion`** added to `MCPConformanceConfig`/normalized config (additive, optional). Validated via `isKnownProtocolVersion` (throws on unknown); `era` derived via `isStatelessProtocolVersion`. **Unset ⇒ legacy ⇒ byte-identical behavior.**
- Runner now passes `mcpProtocolVersion` into the server config (this is the line that lets a modern-only server connect via version negotiation), era-gates client checks as **skips** (never filtered out, so they still appear in the report), and reads the client through `getManagedClient()` — the dead stateless-preview `getClient()` skip block is gone (the preview client was removed in Phase 1C; `OfficialSdkClientAdapter` is the sole `ManagedMcpClient`).
- `complete()` added to `ManagedMcpClient` + adapter (additive) for the completion check; `logging-set-level` adjusted to the managed `void` return.
- Raw checks: the four hardcoded `"2025-11-25"` sites now use `config.protocolVersion ?? "2025-11-25"`; `protocol-invalid-method-error` gets a **sessionless modern probe** (drops the initialize prelude; sends the bad-method POST with the modern `_meta` protocol-version envelope + `MCP-Protocol-Version`/`mcp-method` headers).

## Decisions to review

- **CHECK_ERAS downgrade (safety valve):** the two `localhost-host-*` security checks are classified **legacy-only**, not both-era as the plan's first-pass classification suggested. Their raw modern host-header probe cannot be made reliably green against the dual-era fixture, which leaves `enableDnsRebindingProtection` **disabled** (verified in the server transport) — so `localhost-host-rebinding-rejected` cannot pass there in *any* era. Per the plan's explicit safety valve ("a skip is always safe; a false failure never is") they surface as era-skips on a modern run. Promoting them to both-era is Phase 7 work with a protecting fixture. All other checks match the plan's classification; `ping` is left legacy-only (not promoted) since it could not be verified on a 2026 pin.
- **`protocol-invalid-method-error` kept both-era** with a modern probe (canonical `METHOD_NOT_FOUND`). This is the one modern raw probe retained.
- **Verification gap (environmental):** the fixture-backed `era.integration.test.ts` (the exit gate) and every existing conformance runner/mock test **could not be executed in the overnight worktree** — `@modelcontextprotocol/server`/`node@2.0.0-beta.4` are not installed and the disk was full, so `npm install` fails (ENOSPC). What WAS verified locally: `sdk` `tsc --noEmit` clean; `era.unit.test.ts` (12 tests, incl. the modern probe framing via a stub fetch) + updated `checks.test.ts` green (17 total). The integration test type-checks (only the pre-existing missing-package error, identical to the existing fixture test). **The modern-run exit-gate assertions should be confirmed by CI**, where the beta.4 packages are present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches conformance verdict logic, protocol negotiation pins, and raw HTTP probes across legacy and modern eras; regressions could hide real failures or change default legacy runs if era mapping is wrong.
> 
> **Overview**
> Adds **protocol-era awareness** to the MCP conformance suite so pinning **2026-07-28** (modern/sessionless) skips checks that only assert 2025 stateful wire behavior instead of false-failing. Unset `protocolVersion` stays **legacy** and is intended to match prior behavior.
> 
> **`CHECK_ERAS`** maps each check to `legacy` / `modern` and drives **`eraGate`** on client checks plus raw HTTP runners (protocol, security, transport). Optional **`protocolVersion`** on config is validated and normalized to **`era`**; the runner passes **`mcpProtocolVersion`** into the ephemeral client for negotiation.
> 
> Client track uses **`getManagedClient()`** (drops the old stateless-preview skip path). **`complete()`** is added on **`ManagedMcpClient`** / adapter; **`logging-set-level`** passes on resolve only (void). Raw probes use the pinned version; **`protocol-invalid-method-error`** adds a sessionless modern POST (full `_meta`, headers via **`Headers.set`**) and requires JSON-RPC **-32601**. Connect failures on modern runs era-skip inapplicable checks and anchor failure so all-legacy-only selections cannot report **passed** without connecting.
> 
> Tests: **`era.unit.test.ts`**, **`era.integration.test.ts`**, runner edge case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e66f8e7424137f88df1d8ae8591e688b217c6e50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the MCP conformance suite era-aware so modern (2026) runs skip 2025-only checks instead of false-failing. Legacy runs remain unchanged; the invalid-method probe is hardened and connect failures are handled correctly.

- **New Features**
  - Added optional `protocolVersion` to config; derive `era` and validate via `isKnownProtocolVersion`.
  - Introduced `CHECK_ERAS` used by client and raw-HTTP tracks; inapplicable checks are reported as skipped with a consistent message.
  - Runner passes `mcpProtocolVersion`, uses `getManagedClient`, and era-gates client checks.
  - Added `complete()` to `ManagedMcpClient` and `OfficialSdkClientAdapter`; `logging-set-level` now resolves to `void`.
  - Modernized `protocol-invalid-method-error`: sessionless 2026 probe with full `_meta` envelope, requires JSON-RPC `-32601`, and honors `config.protocolVersion ?? "2025-11-25"`.
  - Classified `localhost-host-*` as legacy-only; they skip on modern runs.

- **Bug Fixes**
  - Applied era gating to connect-error paths and, when all selected checks are legacy-only on a modern run, anchored the connect failure to the first check so the run doesn’t report passed; added a regression test that asserts this exact anchor.
  - Built modern invalid-method probe headers with `Headers.set` to dedupe case-variant collisions with `customHeaders` so pins can’t be overridden.

<sup>Written for commit e66f8e7424137f88df1d8ae8591e688b217c6e50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

