### PR TITLE
test(sdk): pagination-parity evidence + modern wire invariants (Phase 3 §11.1)

### DIFF
--- a/sdk/src/operations.ts
+++ b/sdk/src/operations.ts
@@ -205,6 +205,28 @@ export async function listTools(
   };
 }
 
+/**
+ * `listAll*` (this one and its `listAllResources` / `listAllPrompts` /
+ * `listAllResourceTemplates` siblings below) manually walk pages via
+ * `drainPaginatedList`, including its own repeated-cursor guard and
+ * `MAX_PAGINATION_PAGES` cap. On beta.4 that manual walk is largely
+ * redundant for the common case: the underlying `@modelcontextprotocol/
+ * client` `Client.listTools()` (etc.) already auto-aggregates every page
+ * when called with no `cursor` — which is exactly how these helpers make
+ * their first `fetchPage(undefined)` call. `drainPaginatedList`'s loop only
+ * runs a second iteration if that first call still returns a `nextCursor`,
+ * which the client's own aggregate never does (see
+ * `pagination-parity.integration.test.ts` for the verified wire evidence,
+ * including the surprising case: a server that returns a repeated `nextCursor`
+ * makes the CLIENT's internal walk stop silently and return a partial
+ * aggregate — not throw — so `drainPaginatedList`'s repeated-cursor guard
+ * never even fires for that case either).
+ *
+ * Kept as public API regardless (no removals) — a `MCPClientManager` built
+ * without the official SDK's auto-aggregation (or a future client whose
+ * `listMaxPages` behavior differs) still needs this manual walk to be
+ * correct, and callers already depend on this exact function signature.
+ */
 export async function listAllTools(
   manager: MCPClientManager,
   params: ListAllToolsParams

--- a/sdk/tests/modern-evidence.integration.test.ts
+++ b/sdk/tests/modern-evidence.integration.test.ts
@@ -86,11 +86,22 @@ describe("modern-era (2026-07-28) wire evidence", () => {
       { signal: controller.signal }
     );
 
-    // Give the request time to actually reach the server before aborting.
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    // Deterministic proof the tools/call actually reached the fixture before
+    // we abort — a held-open call never lands in `exchanges` (its response
+    // never completes), so a fixed sleep here would let the test pass without
+    // ever dispatching the request. `waitForToolCall` resolves the instant the
+    // handler receives it.
+    await served!.waitForToolCall("slow-tool");
     controller.abort();
 
-    await expect(callPromise).rejects.toBeTruthy();
+    // The dispatched, held-open call must reject as a consequence of the abort
+    // (not resolve with `slow-tool finished`).
+    const outcome = await callPromise.then(
+      () => "resolved" as const,
+      (err) => err
+    );
+    expect(outcome).not.toBe("resolved");
+    expect(outcome).toBeTruthy();
 
     // The spec cancellation signal on modern is the aborted per-request
     // stream itself — there must be no explicit notifications/cancelled

--- a/sdk/tests/modern-evidence.integration.test.ts
+++ b/sdk/tests/modern-evidence.integration.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { MCPClientManager } from "../src/mcp-client-manager/index.js";
+import { serveMultiPageFixtureOnPort, type ServedMultiPageFixture } from "./support/multi-page-fixture.js";
+import { getWireField } from "./support/raw-capture.js";
+
+/**
+ * Phase 3 §11.1 — modern-era (2026-07-28) wire evidence, Node-side only
+ * (uses `node:http`, so this does not run in a browser/worker environment).
+ *
+ * Companion to `pagination-parity.integration.test.ts`: that suite proves
+ * pagination; this one proves the modern-era wire invariants MCPClientManager
+ * is supposed to preserve when pinned to `2026-07-28` — SEP-2243 standard
+ * headers, no session stickiness, correct negotiated-version reporting, and
+ * abort-as-cancellation (no `notifications/cancelled` POST).
+ */
+
+describe("modern-era (2026-07-28) wire evidence", () => {
+  let served: ServedMultiPageFixture | undefined;
+  let manager: MCPClientManager | undefined;
+
+  afterEach(async () => {
+    await manager?.disconnectAllServers().catch(() => {});
+    await served?.close();
+    served = undefined;
+    manager = undefined;
+  });
+
+  async function connectModern() {
+    served = await serveMultiPageFixtureOnPort();
+    manager = new MCPClientManager();
+    await manager.connectToServer("fixture", {
+      url: served.url,
+      mcpProtocolVersion: "2026-07-28",
+      timeout: 10_000,
+    });
+    return { served, manager };
+  }
+
+  function byMethod(method: string) {
+    return served!.exchanges.filter(
+      (e) => getWireField(e.request.json, "method") === method
+    );
+  }
+
+  it("negotiates 2026-07-28 and getInitializationInfo reports it", async () => {
+    const { manager } = await connectModern();
+    const info = manager.getInitializationInfo("fixture");
+    expect(info?.protocolVersion).toBe("2026-07-28");
+  });
+
+  it("tools/call carries Mcp-Method, Mcp-Name, and Mcp-Param-Message headers", async () => {
+    const { manager } = await connectModern();
+    // Populate the client's response cache with `tool-0`'s inputSchema (the
+    // x-mcp-header scan reads from a CACHED tools/list entry, not from the
+    // call itself).
+    await manager.listTools("fixture");
+    await manager.executeTool("fixture", "tool-0", { message: "hi" });
+
+    const calls = byMethod("tools/call");
+    expect(calls).toHaveLength(1);
+    const headers = calls[0]!.request.headers;
+    expect(headers["mcp-method"]).toBe("tools/call");
+    expect(headers["mcp-name"]).toBe("tool-0");
+    expect(headers["mcp-param-message"]).toBeDefined();
+  });
+
+  it("never retains or re-sends Mcp-Session-Id on modern requests", async () => {
+    const { manager } = await connectModern();
+    await manager.listTools("fixture");
+    await manager.listPrompts("fixture");
+    await manager.executeTool("fixture", "echo", { message: "hi" });
+
+    for (const exchange of served!.exchanges) {
+      expect(exchange.request.headers["mcp-session-id"]).toBeUndefined();
+      expect(exchange.response.headers["mcp-session-id"]).toBeUndefined();
+    }
+  });
+
+  it("aborting requestOptions.signal mid tools/call aborts the fetch and sends NO notifications/cancelled", async () => {
+    const { manager } = await connectModern();
+    const controller = new AbortController();
+    const callPromise = manager.executeTool(
+      "fixture",
+      "slow-tool",
+      { delayMs: 60_000 },
+      { signal: controller.signal }
+    );
+
+    // Give the request time to actually reach the server before aborting.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    controller.abort();
+
+    await expect(callPromise).rejects.toBeTruthy();
+
+    // The spec cancellation signal on modern is the aborted per-request
+    // stream itself — there must be no explicit notifications/cancelled
+    // POST alongside it.
+    expect(byMethod("notifications/cancelled")).toHaveLength(0);
+  });
+});

--- a/sdk/tests/pagination-parity.integration.test.ts
+++ b/sdk/tests/pagination-parity.integration.test.ts
@@ -1,0 +1,291 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { MCPClientManager } from "../src/mcp-client-manager/index.js";
+import {
+  listAllTools,
+  listAllPrompts,
+  listAllResources,
+  listAllResourceTemplates,
+} from "../src/operations.js";
+import {
+  FIXTURE_TOTAL_ITEMS,
+  serveMultiPageFixtureOnPort,
+  type ServedMultiPageFixture,
+} from "./support/multi-page-fixture.js";
+import { getWireField } from "./support/raw-capture.js";
+
+/**
+ * Phase 3 §11.1 pagination-parity evidence.
+ *
+ * KEY VERIFIED FACT (beta.4, `@modelcontextprotocol/client`): a no-cursor
+ * `client.listTools()` / `listPrompts()` / `listResources()` /
+ * `listResourceTemplates()` call does NOT return page 1 only — the client's
+ * internal `_listAllPages` walks every page and returns the complete
+ * aggregate, capped by `ClientOptions.listMaxPages` (default 64, which
+ * THROWS on overflow). So MCPClientManager callers built on the no-cursor
+ * path (`listTools`, `getTools`, `getToolsForAiSdk`, …) get every item
+ * without doing anything special — the "page-1-only truncation" failure
+ * mode this suite was commissioned to guard against does not exist for
+ * well-behaved servers. Section (f) below covers the one case this
+ * auto-aggregation does NOT protect against.
+ *
+ * This suite proves that aggregation with REAL wire evidence: pagination
+ * happens above the transport (inside the client), so
+ * `serveMultiPageFixtureOnPort`'s capture — taken at the `handler.fetch`
+ * seam behind a real loopback socket — sees one genuine `tools/list` (etc.)
+ * request per page, each with the correct `cursor`.
+ */
+
+describe("pagination parity — real wire evidence", () => {
+  let served: ServedMultiPageFixture | undefined;
+  let manager: MCPClientManager | undefined;
+
+  afterEach(async () => {
+    await manager?.disconnectAllServers().catch(() => {});
+    await served?.close();
+    served = undefined;
+    manager = undefined;
+  });
+
+  async function connect(options?: Parameters<typeof serveMultiPageFixtureOnPort>[0]) {
+    served = await serveMultiPageFixtureOnPort(options);
+    manager = new MCPClientManager();
+    await manager.connectToServer("fixture", { url: served.url, timeout: 10_000 });
+    return { served, manager };
+  }
+
+  function requestsFor(method: string): unknown[] {
+    return served!.exchanges
+      .filter((e) => getWireField(e.request.json, "method") === method)
+      .map((e) => e.request.json);
+  }
+
+  // ── (a)/(b): no-cursor calls return everything, wire shows one request
+  //     per page with the right cursors ──────────────────────────────────
+
+  it("listTools(): all 12 tools, one wire request per page with correct cursors", async () => {
+    const { manager } = await connect();
+    const result = await manager.listTools("fixture");
+    expect(result.tools.map((t) => t.name).sort()).toEqual(
+      Array.from({ length: FIXTURE_TOTAL_ITEMS }, (_, i) => `tool-${i}`).sort()
+    );
+
+    const reqs = requestsFor("tools/list") as { params?: { cursor?: string } }[];
+    expect(reqs).toHaveLength(3);
+    expect(reqs.map((r) => r.params?.cursor)).toEqual([undefined, "page-1", "page-2"]);
+  });
+
+  it("listPrompts(): all 12 prompts, one wire request per page with correct cursors", async () => {
+    const { manager } = await connect();
+    const result = await manager.listPrompts("fixture");
+    expect(result.prompts.map((p) => p.name).sort()).toEqual(
+      Array.from({ length: FIXTURE_TOTAL_ITEMS }, (_, i) => `prompt-${i}`).sort()
+    );
+
+    const reqs = requestsFor("prompts/list") as { params?: { cursor?: string } }[];
+    expect(reqs).toHaveLength(3);
+    expect(reqs.map((r) => r.params?.cursor)).toEqual([undefined, "page-1", "page-2"]);
+  });
+
+  it("listResources(): all 12 resources, one wire request per page with correct cursors", async () => {
+    const { manager } = await connect();
+    const result = await manager.listResources("fixture");
+    expect(result.resources.map((r) => r.uri).sort()).toEqual(
+      Array.from({ length: FIXTURE_TOTAL_ITEMS }, (_, i) => `test://resource/${i}`).sort()
+    );
+
+    const reqs = requestsFor("resources/list") as { params?: { cursor?: string } }[];
+    expect(reqs).toHaveLength(3);
+    expect(reqs.map((r) => r.params?.cursor)).toEqual([undefined, "page-1", "page-2"]);
+  });
+
+  it("listResourceTemplates(): all 12 templates, one wire request per page with correct cursors", async () => {
+    const { manager } = await connect();
+    const result = await manager.listResourceTemplates("fixture");
+    expect(result.resourceTemplates.map((t) => t.name).sort()).toEqual(
+      Array.from({ length: FIXTURE_TOTAL_ITEMS }, (_, i) => `template-${i}`).sort()
+    );
+
+    const reqs = requestsFor("resources/templates/list") as { params?: { cursor?: string } }[];
+    expect(reqs).toHaveLength(3);
+    expect(reqs.map((r) => r.params?.cursor)).toEqual([undefined, "page-1", "page-2"]);
+  });
+
+  // ── (c): an explicit { cursor } call returns exactly ONE raw page ──────
+
+  it("an explicit { cursor } call returns exactly one raw page with nextCursor intact", async () => {
+    const { manager } = await connect();
+    const page1 = await manager.listTools("fixture", { cursor: "page-1" });
+    expect(page1.tools.map((t) => t.name)).toEqual(["tool-4", "tool-5", "tool-6", "tool-7"]);
+    expect(page1.nextCursor).toBe("page-2");
+
+    // Exactly one wire request, carrying the explicit cursor — the
+    // single-page path does not silently walk further pages.
+    const reqs = requestsFor("tools/list") as { params?: { cursor?: string } }[];
+    expect(reqs).toHaveLength(1);
+    expect(reqs[0]?.params?.cursor).toBe("page-1");
+  });
+
+  // ── (d): getTools()/getToolsForAiSdk() surface every page ──────────────
+
+  it("getTools() surfaces every tool from every page", async () => {
+    const { manager } = await connect();
+    const tools = await manager.getTools(["fixture"]);
+    expect(tools.map((t) => t.name).sort()).toEqual(
+      Array.from({ length: FIXTURE_TOTAL_ITEMS }, (_, i) => `tool-${i}`).sort()
+    );
+  });
+
+  it("getToolsForAiSdk() surfaces every tool from every page", async () => {
+    const { manager } = await connect();
+    const aiTools = await manager.getToolsForAiSdk(["fixture"]);
+    expect(Object.keys(aiTools).sort()).toEqual(
+      Array.from({ length: FIXTURE_TOTAL_ITEMS }, (_, i) => `tool-${i}`).sort()
+    );
+  });
+
+  // ── (e): operations.ts listAll* helpers still return complete sets ─────
+
+  it("operations.listAllTools returns the complete set", async () => {
+    const { manager } = await connect();
+    const { tools } = await listAllTools(manager, { serverId: "fixture" });
+    expect(tools.map((t) => t.name).sort()).toEqual(
+      Array.from({ length: FIXTURE_TOTAL_ITEMS }, (_, i) => `tool-${i}`).sort()
+    );
+  });
+
+  it("operations.listAllPrompts returns the complete set", async () => {
+    const { manager } = await connect();
+    const { prompts } = await listAllPrompts(manager, { serverId: "fixture" });
+    expect(prompts.map((p) => p.name).sort()).toEqual(
+      Array.from({ length: FIXTURE_TOTAL_ITEMS }, (_, i) => `prompt-${i}`).sort()
+    );
+  });
+
+  it("operations.listAllResources returns the complete set", async () => {
+    const { manager } = await connect();
+    const { resources } = await listAllResources(manager, { serverId: "fixture" });
+    expect(resources.map((r) => r.uri).sort()).toEqual(
+      Array.from({ length: FIXTURE_TOTAL_ITEMS }, (_, i) => `test://resource/${i}`).sort()
+    );
+  });
+
+  it("operations.listAllResourceTemplates returns the complete set", async () => {
+    const { manager } = await connect();
+    const { resourceTemplates, unsupported } = await listAllResourceTemplates(manager, {
+      serverId: "fixture",
+    });
+    expect(unsupported).toBeUndefined();
+    expect(resourceTemplates.map((t) => t.name).sort()).toEqual(
+      Array.from({ length: FIXTURE_TOTAL_ITEMS }, (_, i) => `template-${i}`).sort()
+    );
+  });
+
+  // ── (f): a non-converging (repeated-cursor) server ──────────────────────
+  //
+  // VERIFIED BEHAVIOR (differs from the "guard throws" assumption this test
+  // was originally commissioned to prove): the vendor client's
+  // `_listAllPages` walk (`@modelcontextprotocol/client` dist/index.mjs,
+  // `while (cursor !== void 0 && !seen.has(cursor))`) treats a REPEATED
+  // `nextCursor` as "stop, return what we have" — silently, with no thrown
+  // error and no signal in the returned object that the aggregate is
+  // partial. Only `listMaxPages` overflow (a cursor sequence that never
+  // repeats but also never ends) throws
+  // `SdkErrorCode.ListPaginationExceeded`.
+  //
+  // `operations.ts`'s own `drainPaginatedList` DOES contain a
+  // repeated-cursor throw — but it never fires for `listAllTools` /
+  // `listAllPrompts` / `listAllResources` / `listAllResourceTemplates`,
+  // because their FIRST `fetchPage(undefined)` call already goes through
+  // the client's no-cursor auto-aggregate path, which exhausts (or, here,
+  // truncates) pagination internally before `drainPaginatedList` ever sees
+  // a `nextCursor` to walk. See the PR description for the full writeup —
+  // this is a real, verified gap, not a test artifact.
+  it("manager.listTools(): a repeated cursor silently truncates (matches the vendor client's documented behavior)", async () => {
+    const { manager } = await connect({ malformedCursor: true });
+    const result = await manager.listTools("fixture");
+    // Page 1 (4 items) + page 2 (4 items, whose nextCursor repeats "page-1")
+    // = 8, not the full 12. No error is thrown.
+    expect(result.tools).toHaveLength(8);
+    expect(result.nextCursor).toBeUndefined();
+
+    const reqs = requestsFor("tools/list") as { params?: { cursor?: string } }[];
+    expect(reqs).toHaveLength(2);
+    expect(reqs.map((r) => r.params?.cursor)).toEqual([undefined, "page-1"]);
+  });
+
+  it("operations.listAllTools(): the SAME repeated-cursor server also silently truncates (drainPaginatedList's guard never engages)", async () => {
+    const { manager } = await connect({ malformedCursor: true });
+    const { tools } = await listAllTools(manager, { serverId: "fixture" });
+    expect(tools).toHaveLength(8);
+
+    // Both wire requests happened INSIDE the single `fetchPage(undefined)`
+    // call `drainPaginatedList` made — the client's own internal walk sent
+    // them (cursor: undefined, then cursor: "page-1") and stopped itself on
+    // the repeat before returning. `drainPaginatedList` never sees a
+    // `nextCursor` to walk, so its own repeated-cursor guard (and its
+    // MAX_PAGINATION_PAGES cap) never engage — dead code for this call
+    // shape, confirmed here rather than asserted from reading alone.
+    const reqs = requestsFor("tools/list") as { params?: { cursor?: string } }[];
+    expect(reqs).toHaveLength(2);
+    expect(reqs.map((r) => r.params?.cursor)).toEqual([undefined, "page-1"]);
+  });
+
+  // Symmetric confirmation on prompts/resources/resourceTemplates — same
+  // silent-truncation shape, so this is not tools-specific.
+  it("manager.listPrompts()/listResources()/listResourceTemplates(): repeated cursor also silently truncates", async () => {
+    const { manager } = await connect({ malformedCursor: true });
+    const prompts = await manager.listPrompts("fixture");
+    const resources = await manager.listResources("fixture");
+    const templates = await manager.listResourceTemplates("fixture");
+    expect(prompts.prompts).toHaveLength(8);
+    expect(resources.resources).toHaveLength(8);
+    expect(templates.resourceTemplates).toHaveLength(8);
+  });
+
+  // ── table-driven: the FIVE §11.1 outcomes ───────────────────────────────
+
+  it("unsupported capability: listPrompts() returns empty with NO wire request when the server withholds the prompts capability", async () => {
+    const { manager } = await connect({ capabilities: { prompts: false } });
+    const result = await manager.listPrompts("fixture");
+    expect(result.prompts).toEqual([]);
+    expect(requestsFor("prompts/list")).toHaveLength(0);
+  });
+
+  it("empty result: capability present, server returns zero items (wire request DID happen)", async () => {
+    const { manager } = await connect({ emptyLists: true });
+    const result = await manager.listTools("fixture");
+    expect(result.tools).toEqual([]);
+    expect(requestsFor("tools/list")).toHaveLength(1);
+  });
+
+  it("protocol error: resources/templates/list throws a real JSON-RPC error, NOT classified as unsupported", async () => {
+    const { manager } = await connect({ resourceTemplatesProtocolError: true });
+    await expect(manager.listResourceTemplates("fixture")).rejects.toThrow(
+      /temporarily unavailable/
+    );
+    // operations.ts's listAllResourceTemplates must propagate this too — a
+    // real protocol error must not be swallowed into `unsupported: true`.
+    await expect(
+      listAllResourceTemplates(manager, { serverId: "fixture" })
+    ).rejects.toThrow(/temporarily unavailable/);
+  });
+
+  it("transport error: connecting to a closed port rejects instead of hanging or silently returning empty", async () => {
+    // Nothing is listening on this port (close it immediately after grabbing it).
+    const probe = await serveMultiPageFixtureOnPort();
+    const deadUrl = probe.url;
+    await probe.close();
+
+    const localManager = new MCPClientManager();
+    await expect(
+      localManager.connectToServer("dead", { url: deadUrl, timeout: 2_000 })
+    ).rejects.toThrow();
+    await localManager.disconnectAllServers().catch(() => {});
+  });
+
+  it("tool-execution error: fail-tool returns a spec-legal isError result, not a thrown exception", async () => {
+    const { manager } = await connect({ failingTool: true });
+    const result = await manager.executeTool("fixture", "fail-tool", {});
+    expect(result).toMatchObject({ isError: true });
+  });
+});

--- a/sdk/tests/support/multi-page-fixture.ts
+++ b/sdk/tests/support/multi-page-fixture.ts
@@ -1,0 +1,297 @@
+/**
+ * Multi-page beta.4 dual-era fixture for pagination-parity evidence
+ * (Phase 3 §11.1).
+ *
+ * Built on the LOW-LEVEL `Server` export (not `McpServer`) because the
+ * high-level builder has no page-size knob — hand-written `tools/list`,
+ * `prompts/list`, `resources/list`, and `resources/templates/list` handlers
+ * honor `params.cursor` and return `nextCursor` themselves. 3 pages of 4
+ * items each (12 total) per primitive, by default.
+ *
+ * `createMcpHandler(factory)` serves both the modern (2026-07-28) and
+ * legacy-stateless eras off the ONE factory, exactly like
+ * `dual-era-fixture.ts` — see that file's header for why a single factory
+ * matters (no cross-era drift).
+ *
+ * Modes (see {@link MultiPageFixtureOptions}):
+ *  - `capabilities`: omit a primitive's capability entirely to exercise the
+ *    "unsupported capability" outcome (the official client special-cases a
+ *    withheld capability and returns an empty list WITHOUT sending a wire
+ *    request — see `pagination-parity.integration.test.ts`).
+ *  - `emptyLists`: capability present, zero items, no `nextCursor` — the
+ *    "empty result" outcome.
+ *  - `malformedCursor`: page 2 (`cursor: "page-1"`) returns `nextCursor:
+ *    "page-1"` again instead of advancing to `"page-2"` — a
+ *    non-converging server. Proves how the client's list-walk ACTUALLY
+ *    behaves on a repeated cursor: per the doc comment on `_listAllPages` in
+ *    `@modelcontextprotocol/client`, it stops the walk silently and returns
+ *    a PARTIAL aggregate — it does NOT throw. `operations.ts`'s own
+ *    `drainPaginatedList` has a repeated-cursor throw, but (verified in
+ *    `pagination-parity.integration.test.ts`) it never fires for the
+ *    `listAll*` helpers, because their first no-cursor page request already
+ *    goes through this same silently-truncating client-side walk.
+ *  - `resourceTemplatesProtocolError`: `resources/templates/list` throws a
+ *    real JSON-RPC `InternalError`, distinct from "method not found" — the
+ *    "protocol error" outcome, which must NOT be mistaken for "unsupported"
+ *    by `isUnsupportedMethodError`/`isMethodUnavailableError`.
+ *  - `failingTool`: always registers a `fail-tool` that returns
+ *    `{ isError: true }` — the "tool-execution error" outcome (spec-legal
+ *    result, never a thrown protocol error).
+ */
+
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { toNodeHandler } from "@modelcontextprotocol/node";
+import {
+  createMcpHandler,
+  ProtocolError,
+  ProtocolErrorCode,
+  Server,
+} from "@modelcontextprotocol/server";
+import { createCapturingFetch, type RawExchange } from "./raw-capture.js";
+
+export const MULTI_PAGE_FIXTURE_SERVER_INFO = {
+  name: "mcpjam-multi-page-fixture",
+  version: "1.0.0",
+} as const;
+
+/** Items per page. 3 pages × this size = the fixture's total item count. */
+export const FIXTURE_PAGE_SIZE = 4;
+/** Total items served (no-cursor auto-aggregation must recover all of these). */
+export const FIXTURE_TOTAL_ITEMS = FIXTURE_PAGE_SIZE * 3;
+
+export interface MultiPageFixtureOptions {
+  /**
+   * Which capabilities to advertise. A key set to `false` is OMITTED from
+   * the server's declared capabilities entirely (not just emptied) — this
+   * is what makes the client take its "unsupported capability" short
+   * circuit instead of sending a wire request. Defaults to all `true`.
+   */
+  capabilities?: { tools?: boolean; resources?: boolean; prompts?: boolean };
+  /** Serve zero items (no `nextCursor`) from every paginated endpoint. */
+  emptyLists?: boolean;
+  /**
+   * After the first page, every subsequent page repeats the SAME
+   * `nextCursor` instead of advancing — simulates a non-converging server.
+   */
+  malformedCursor?: boolean;
+  /**
+   * `resources/templates/list` throws a real protocol-level `InternalError`
+   * instead of listing. Distinct from omitting the resources capability
+   * (which is "unsupported") or from an unregistered method (which reads as
+   * "method not found" / unsupported to MCPJam's error classifiers).
+   */
+  resourceTemplatesProtocolError?: boolean;
+  /**
+   * Register a `fail-tool` that always returns `{ isError: true }` — a
+   * spec-legal tool-execution failure, never a thrown JSON-RPC error.
+   */
+  failingTool?: boolean;
+}
+
+function paginatedPage<T>(
+  all: T[],
+  cursor: string | undefined,
+  opts: Pick<MultiPageFixtureOptions, "emptyLists" | "malformedCursor">
+): { items: T[]; nextCursor?: string } {
+  if (opts.emptyLists) return { items: [] };
+
+  const pageIndex = cursor === undefined ? 0 : parsePageCursor(cursor);
+  const start = pageIndex * FIXTURE_PAGE_SIZE;
+  const items = all.slice(start, start + FIXTURE_PAGE_SIZE);
+  const isLastPage = start + FIXTURE_PAGE_SIZE >= all.length;
+
+  if (opts.malformedCursor && pageIndex >= 1) {
+    // Non-converging server: keep pointing back at the same cursor forever
+    // instead of advancing (or terminating).
+    return { items, nextCursor: "page-1" };
+  }
+
+  return { items, nextCursor: isLastPage ? undefined : `page-${pageIndex + 1}` };
+}
+
+function parsePageCursor(cursor: string): number {
+  const match = /^page-(\d+)$/.exec(cursor);
+  return match ? Number(match[1]) : 0;
+}
+
+/** Build the fixture's fresh item lists (called once per server build). */
+function buildItems() {
+  const tools = Array.from({ length: FIXTURE_TOTAL_ITEMS }, (_, i) => ({
+    name: `tool-${i}`,
+    description: `Paginated tool ${i}`,
+    // `tool-0` declares a SEP-2243 `x-mcp-header` on its `message` property
+    // so a `tools/call` for it exercises the `Mcp-Param-Message` header path
+    // (the official client only mirrors `x-mcp-header` params it can read
+    // off a CACHED `tools/list` entry's `inputSchema` — see
+    // `modern-evidence.integration.test.ts`).
+    inputSchema:
+      i === 0
+        ? {
+            type: "object" as const,
+            properties: {
+              message: { type: "string" as const, "x-mcp-header": "Message" },
+            },
+          }
+        : { type: "object" as const, properties: {} },
+  }));
+  const prompts = Array.from({ length: FIXTURE_TOTAL_ITEMS }, (_, i) => ({
+    name: `prompt-${i}`,
+    description: `Paginated prompt ${i}`,
+  }));
+  const resources = Array.from({ length: FIXTURE_TOTAL_ITEMS }, (_, i) => ({
+    uri: `test://resource/${i}`,
+    name: `resource-${i}`,
+    mimeType: "text/plain",
+  }));
+  const resourceTemplates = Array.from({ length: FIXTURE_TOTAL_ITEMS }, (_, i) => ({
+    name: `template-${i}`,
+    uriTemplate: `test://template/${i}/{id}`,
+  }));
+  return { tools, prompts, resources, resourceTemplates };
+}
+
+/**
+ * Build a fresh low-level `Server` instance for the fixture.
+ * `createMcpHandler` calls this per request — keep it side-effect-free.
+ */
+export function buildMultiPageFixtureServer(
+  options: MultiPageFixtureOptions = {}
+): Server {
+  const caps = {
+    tools: options.capabilities?.tools ?? true,
+    resources: options.capabilities?.resources ?? true,
+    prompts: options.capabilities?.prompts ?? true,
+  };
+
+  const server = new Server(MULTI_PAGE_FIXTURE_SERVER_INFO, {
+    capabilities: {
+      ...(caps.tools ? { tools: {} } : {}),
+      ...(caps.resources ? { resources: {} } : {}),
+      ...(caps.prompts ? { prompts: {} } : {}),
+    },
+  });
+
+  const { tools, prompts, resources, resourceTemplates } = buildItems();
+
+  if (caps.tools) {
+    server.setRequestHandler("tools/list", (request: any) => {
+      const { items, nextCursor } = paginatedPage(tools, request?.params?.cursor, options);
+      return { tools: items, nextCursor };
+    });
+
+    server.setRequestHandler("tools/call", async (request: any, ctx: any) => {
+      const name = request.params.name as string;
+      if (name === "fail-tool") {
+        return {
+          content: [{ type: "text", text: "fail-tool always fails" }],
+          isError: true,
+        };
+      }
+      if (name === "slow-tool") {
+        // Held open for abort-mid-call evidence (modern-evidence.integration.test.ts):
+        // never resolves on its own within a test's timeout, so the test's
+        // `AbortSignal` is what ends the call.
+        const delayMs = Number(request.params.arguments?.delayMs ?? 60_000);
+        await new Promise((resolve, reject) => {
+          const timer = setTimeout(resolve, delayMs);
+          ctx?.signal?.addEventListener?.("abort", () => {
+            clearTimeout(timer);
+            reject(new Error("slow-tool aborted"));
+          });
+        });
+        return { content: [{ type: "text", text: "slow-tool finished" }] };
+      }
+      if (name === "echo" || name.startsWith("tool-")) {
+        return {
+          content: [
+            { type: "text", text: String(request.params.arguments?.message ?? `called ${name}`) },
+          ],
+        };
+      }
+      return { content: [{ type: "text", text: `called ${name}` }] };
+    });
+  }
+
+  if (caps.resources) {
+    server.setRequestHandler("resources/list", (request: any) => {
+      const { items, nextCursor } = paginatedPage(resources, request?.params?.cursor, options);
+      return { resources: items, nextCursor };
+    });
+
+    server.setRequestHandler("resources/templates/list", (request: any) => {
+      if (options.resourceTemplatesProtocolError) {
+        throw new ProtocolError(
+          ProtocolErrorCode.InternalError,
+          "resource template listing is temporarily unavailable"
+        );
+      }
+      const { items, nextCursor } = paginatedPage(
+        resourceTemplates,
+        request?.params?.cursor,
+        options
+      );
+      return { resourceTemplates: items, nextCursor };
+    });
+  }
+
+  if (caps.prompts) {
+    server.setRequestHandler("prompts/list", (request: any) => {
+      const { items, nextCursor } = paginatedPage(prompts, request?.params?.cursor, options);
+      return { prompts: items, nextCursor };
+    });
+  }
+
+  if (options.failingTool && !caps.tools) {
+    // failingTool implies a tools/call handler must exist even if the
+    // paginated tools/list surface itself is disabled for a test.
+    server.setRequestHandler("tools/call", async () => ({
+      content: [{ type: "text", text: "fail-tool always fails" }],
+      isError: true,
+    }));
+  }
+
+  return server;
+}
+
+/** A `createMcpHandler` bound to the fixture. Drive it with `handler.fetch(request)`. */
+export function createMultiPageFixtureHandler(options: MultiPageFixtureOptions = {}) {
+  return createMcpHandler(() => buildMultiPageFixtureServer(options));
+}
+
+export interface ServedMultiPageFixture {
+  url: string;
+  /** Every request/response the fixture handled, verbatim, in call order. */
+  exchanges: RawExchange[];
+  close: () => Promise<void>;
+}
+
+/**
+ * Serve the fixture over a REAL loopback HTTP port (mirrors
+ * `mcp-client-manager-fixture.integration.test.ts`'s `serveFixtureOnPort`),
+ * while also recording every exchange verbatim via `createCapturingFetch`.
+ *
+ * The capture point is `handler.fetch` — the same web-standard seam
+ * `toNodeHandler` calls internally — so this captures the true JSON-RPC
+ * request/response bodies MCPClientManager's real HTTP client produces,
+ * with a real socket in between. `exchanges` accumulates for the lifetime
+ * of the returned handle; read it any time.
+ */
+export async function serveMultiPageFixtureOnPort(
+  options: MultiPageFixtureOptions = {}
+): Promise<ServedMultiPageFixture> {
+  const handler = createMultiPageFixtureHandler(options);
+  const cap = createCapturingFetch((input, init) =>
+    (handler.fetch as any)(input, init)
+  );
+  const httpServer = http.createServer(
+    toNodeHandler({ fetch: cap.fetch } as any)
+  );
+  await new Promise<void>((resolve) => httpServer.listen(0, "127.0.0.1", resolve));
+  const address = httpServer.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${address.port}/mcp`,
+    exchanges: cap.exchanges,
+    close: () => new Promise<void>((resolve) => httpServer.close(() => resolve())),
+  };
+}

--- a/sdk/tests/support/multi-page-fixture.ts
+++ b/sdk/tests/support/multi-page-fixture.ts
@@ -87,6 +87,13 @@ export interface MultiPageFixtureOptions {
    * spec-legal tool-execution failure, never a thrown JSON-RPC error.
    */
   failingTool?: boolean;
+  /**
+   * Invoked with the tool name the instant a `tools/call` reaches the fixture
+   * handler, BEFORE any work. Used to build a deterministic "the request
+   * actually arrived" synchronization point (see `waitForToolCall` on
+   * {@link ServedMultiPageFixture}) instead of racing a fixed sleep.
+   */
+  onToolCall?: (name: string) => void;
 }
 
 function paginatedPage<T>(
@@ -182,7 +189,11 @@ export function buildMultiPageFixtureServer(
 
     server.setRequestHandler("tools/call", async (request: any, ctx: any) => {
       const name = request.params.name as string;
-      if (name === "fail-tool") {
+      options.onToolCall?.(name);
+      // `fail-tool` is opt-in: only the `failingTool` mode makes it fail, so a
+      // test that forgot to enable the mode can't silently get the failing
+      // outcome anyway.
+      if (name === "fail-tool" && options.failingTool) {
         return {
           content: [{ type: "text", text: "fail-tool always fails" }],
           isError: true,
@@ -193,9 +204,22 @@ export function buildMultiPageFixtureServer(
         // never resolves on its own within a test's timeout, so the test's
         // `AbortSignal` is what ends the call.
         const delayMs = Number(request.params.arguments?.delayMs ?? 60_000);
-        await new Promise((resolve, reject) => {
+        const signal: AbortSignal | undefined = ctx?.signal;
+        await new Promise<void>((resolve, reject) => {
+          // Already aborted before we could attach a listener — reject now so
+          // no timer is ever created for a doomed call.
+          if (signal?.aborted) {
+            reject(new Error("slow-tool aborted"));
+            return;
+          }
           const timer = setTimeout(resolve, delayMs);
-          ctx?.signal?.addEventListener?.("abort", () => {
+          // Never let this held-open timer keep the test process (or a
+          // wait-for-open-handles runner) alive for the full delay if the
+          // abort listener doesn't fire — e.g. the transport doesn't surface
+          // cancellation on `ctx.signal`. `unref` is enough on its own; the
+          // abort listener is the fast, deterministic path when it does fire.
+          (timer as unknown as { unref?: () => void }).unref?.();
+          signal?.addEventListener?.("abort", () => {
             clearTimeout(timer);
             reject(new Error("slow-tool aborted"));
           });
@@ -263,6 +287,14 @@ export interface ServedMultiPageFixture {
   url: string;
   /** Every request/response the fixture handled, verbatim, in call order. */
   exchanges: RawExchange[];
+  /**
+   * Resolves when a `tools/call` for `name` has actually reached the fixture
+   * handler (resolving immediately if one already has). A deterministic
+   * request-arrival signal for held-open calls (e.g. `slow-tool`), whose
+   * response never completes and so never lands in {@link exchanges} — making
+   * the exchange log useless as a "did it dispatch?" check.
+   */
+  waitForToolCall: (name: string) => Promise<void>;
   close: () => Promise<void>;
 }
 
@@ -280,7 +312,27 @@ export interface ServedMultiPageFixture {
 export async function serveMultiPageFixtureOnPort(
   options: MultiPageFixtureOptions = {}
 ): Promise<ServedMultiPageFixture> {
-  const handler = createMultiPageFixtureHandler(options);
+  // Track which tool calls have reached the handler so callers can await a
+  // real arrival signal (see `waitForToolCall`) rather than a racy sleep.
+  const seenToolCalls = new Set<string>();
+  const toolCallWaiters: Array<{ name: string; resolve: () => void }> = [];
+  const onToolCall = (name: string) => {
+    seenToolCalls.add(name);
+    for (let i = toolCallWaiters.length - 1; i >= 0; i--) {
+      if (toolCallWaiters[i]!.name === name) {
+        toolCallWaiters.splice(i, 1)[0]!.resolve();
+      }
+    }
+    options.onToolCall?.(name);
+  };
+  const waitForToolCall = (name: string): Promise<void> => {
+    if (seenToolCalls.has(name)) return Promise.resolve();
+    return new Promise<void>((resolve) => {
+      toolCallWaiters.push({ name, resolve });
+    });
+  };
+
+  const handler = createMultiPageFixtureHandler({ ...options, onToolCall });
   const cap = createCapturingFetch((input, init) =>
     (handler.fetch as any)(input, init)
   );
@@ -292,6 +344,7 @@ export async function serveMultiPageFixtureOnPort(
   return {
     url: `http://127.0.0.1:${address.port}/mcp`,
     exchanges: cap.exchanges,
+    waitForToolCall,
     close: () => new Promise<void>((resolve) => httpServer.close(() => resolve())),
   };
 }


### PR DESCRIPTION
## Decisions to review

**Branch renamed:** `test/pagination-parity-evidence` → `tests/pagination-parity-evidence`. The remote already has a branch literally named `test`, and git refs can't have both `refs/heads/test` and `refs/heads/test/...` (path/leaf conflict) — push was rejected with "directory file conflict" until renamed.

**Scope:** tests-only, plus one doc comment on `operations.ts`. No production code changed. All new tests pass; `npm run typecheck` (root) is clean.

### What this proves

Verified against the installed `@modelcontextprotocol/client@2.0.0-beta.4`: a no-cursor `listTools()`/`listPrompts()`/`listResources()`/`listResourceTemplates()` call on the official client auto-aggregates every page internally (`Client._listAllPages`), so `MCPClientManager.listTools()` (and `getTools()`/`getToolsForAiSdk()`, which build the chat model's toolset) and `operations.ts`'s `listAll*` helpers all recover every item from a well-behaved paginated server with no extra work. New fixture: `sdk/tests/support/multi-page-fixture.ts`, a hand-written low-level `Server`-based dual-era fixture (3 pages × 4 items, `createMcpHandler`) with a real-HTTP `serveMultiPageFixtureOnPort()` helper that captures every exchange verbatim at the `handler.fetch` seam (same technique as `createCapturingFetch`, but behind a real loopback socket) — so `pagination-parity.integration.test.ts` can assert BOTH the returned item counts AND that the wire genuinely shows one `tools/list`-style request per page with the correct `cursor`, not a single fabricated exchange.

`modern-evidence.integration.test.ts` covers the 2026-07-28-era wire invariants pinned separately: `Mcp-Method`/`Mcp-Name`/`Mcp-Param-*` request headers, no `Mcp-Session-Id` retention, `getInitializationInfo()` reporting the negotiated version, and abort-mid-`tools/call` producing no `notifications/cancelled` POST (modern's cancellation signal is the aborted per-request stream itself).

### Found gap (real, verified — not fixed in this PR)

The task brief for this PR assumed "the client's repeated-cursor guard throws — never silent partial." That assumption is **wrong**, verified with the `malformedCursor` fixture mode (a server whose `nextCursor` repeats instead of advancing or terminating):

- `@modelcontextprotocol/client`'s `Client._listAllPages` (`dist/index.mjs`) stops its internal page walk **silently** on a repeated cursor and returns whatever it has accumulated — no thrown error, and `nextCursor` is unconditionally deleted from the returned aggregate, so the caller has **no signal** the result is partial. (Only `listMaxPages` overflow — a cursor sequence that never repeats but also never terminates — throws `SdkErrorCode.ListPaginationExceeded`.)
- `MCPClientManager.listTools()` et al. inherit this directly: `manager.listTools(id)` against the malformed fixture returns **8 of 12** tools, no error.
- `operations.ts`'s `listAllTools`/`listAllPrompts`/`listAllResources`/`listAllResourceTemplates` DO have their own repeated-cursor throw inside `drainPaginatedList` — but it's **dead code** for their actual call pattern: each helper's first `fetchPage(undefined)` call already goes through the client's no-cursor auto-aggregate path above, which exhausts (or here, silently truncates) pagination internally *before* `drainPaginatedList` ever sees a `nextCursor` to walk a second time. Verified directly: `listAllTools()` against the malformed fixture also returns 8/12, with zero throw, and the wire shows exactly the same 2 requests the manager-level call made.

So the "never silent truncation" invariant this PR was commissioned to prove does not hold for a non-converging server — it just isn't the "page-1-only" failure mode originally suspected. All new tests assert the REAL (silently-truncating) behavior rather than the originally-assumed throwing behavior, with comments explaining the discrepancy.

**Proposed fix (not implemented here, scope: tests-only PR)**: this is fundamentally a vendor-SDK design tradeoff (`_listAllPages`'s doc comment describes the silent stop as deliberate non-converging-server defense), not something to patch by rewriting `@modelcontextprotocol/client`. Within MCPJam's own surface, the cleanest fix is likely one of:
1. Have `MCPClientManager`'s list methods detect this case (e.g. compare the vendor client's own page count against `listMaxPages`, or track cursors client-side before delegating) and surface a typed warning/error instead of a bare result.
2. Or, since `getTools()`/`getToolsForAiSdk()` are the highest-stakes consumers (they silently shrink the model's toolset), have those two specifically call through a path that re-validates completeness.

Left undone deliberately — this needs a design decision (surface as an error? a warning field? best-effort logging?) beyond what a tests-only PR should decide unilaterally.

## Verification

- `npm run typecheck` (root): exit 0, no errors (covers sdk/cli/design-system/chat-ui/widget-react/mcp workspaces — server package's pre-existing `resourceMetadataUrl` errors are out of this script's scope, unrelated to this change).
- `sdk` test suite (`npx vitest run` in `sdk/`): **141 test files, 2483 passed, 1 skipped, 0 failed** — exit 0.
- New files alone: `pagination-parity.integration.test.ts` (19 tests) + `modern-evidence.integration.test.ts` (4 tests), all passing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tests and documentation only; no production logic changes.
> 
> **Overview**
> Adds **Phase 3 §11.1** integration coverage: a multi-page HTTP fixture with real wire capture, plus suites that lock in pagination and modern-protocol behavior. **No runtime behavior changes** beyond a doc comment on `listAllTools` in `operations.ts`.
> 
> **Pagination parity** (`pagination-parity.integration.test.ts`): proves no-cursor `list*` / `getTools` / `getToolsForAiSdk` / `operations.listAll*` return full 12-item sets over 3 pages, with one wire request per page and correct cursors; explicit `{ cursor }` stays single-page. Also documents that **repeated `nextCursor` servers silently truncate** (vendor client behavior)—`drainPaginatedList`'s repeated-cursor guard does not run on the no-cursor path. Covers unsupported capability, empty lists, protocol/transport errors, and `isError` tool results.
> 
> **Modern wire** (`modern-evidence.integration.test.ts`): for `2026-07-28`, asserts negotiated version, SEP-2243 headers on `tools/call`, no `Mcp-Session-Id`, and abort cancellation without `notifications/cancelled`.
> 
> **Fixture** (`multi-page-fixture.ts`): low-level paginated server modes (`malformedCursor`, capability omission, etc.) and `waitForToolCall` for deterministic abort tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63ad27a68f2116a7440ca75ef684f31d50f7649e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add integration tests and a low-level multi-page fixture to prove pagination auto-aggregation in the official client and to capture modern (2026-07-28) wire invariants. No production code changes besides a doc comment.

- New Features
  - Multi-page dual-era HTTP fixture with real wire capture (`sdk/tests/support/multi-page-fixture.ts`), plus `waitForToolCall(name)` for deterministic arrival, a held-open `slow-tool` that short-circuits already-aborted calls and `unref`s its timer, and an opt-in `failingTool` mode; includes modes for omitted capabilities, empty lists, repeated-cursor, and a protocol error.
  - Pagination parity tests (`sdk/tests/pagination-parity.integration.test.ts`): verify no-cursor `list*` calls auto-aggregate via `@modelcontextprotocol/client@2.0.0-beta.4` (`Client._listAllPages`); `MCPClientManager.getTools()`/`getToolsForAiSdk()` and `operations.listAll*` return all items; explicit `{ cursor }` returns one raw page; also covers unsupported/empty/protocol/transport/tool-error outcomes; repeated `nextCursor` silently truncates and is inherited by `operations.listAll*`.
  - Modern wire tests (`sdk/tests/modern-evidence.integration.test.ts`): assert `Mcp-Method`/`Mcp-Name`/`Mcp-Param-*` headers, no `Mcp-Session-Id`, negotiated `2026-07-28`, and abort-as-cancellation with no `notifications/cancelled`; uses `waitForToolCall` and asserts the aborted `tools/call` rejects.
  - `sdk/src/operations.ts`: added a doc comment clarifying interaction with the client’s auto-aggregation and why `drainPaginatedList` may not run; evidence shows a repeated `nextCursor` silently truncates results in `@modelcontextprotocol/client` and is inherited by `operations.listAll*` (not changed here).

<sup>Written for commit 63ad27a68f2116a7440ca75ef684f31d50f7649e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

