### PR TITLE
feat(sdk): thread SEP-2549 cacheMode + cache-serve provenance (§11.2)

### DIFF
--- a/.changeset/cache-policy-core.md
+++ b/.changeset/cache-policy-core.md
@@ -1,0 +1,10 @@
+---
+"@mcpjam/sdk": minor
+---
+
+Thread the SEP-2549 response-cache disposition (`cacheMode`) through the manager's cacheable read verbs and add a local cache-serve provenance channel.
+
+- `ClientRequestOptions` now carries an optional `cacheMode` (`"use" | "refresh" | "bypass"`); the type is re-exported as `CacheMode` (plus `CacheScope`). `listTools` / `listResources` / `listResourceTemplates` / `listPrompts` / `readResource` (and the `operations.ts` params) forward it to the underlying client.
+- New `MCPClientManagerOptions.cacheEventLogger` reports fresh cache serves (`{ serverId, method, params, ageMs, scope }`) via a new `ObservableResponseCache` store wrapper. This is a channel DISTINCT from `rpcLogger`: a cache hit never touches the wire and is never a wire-log entry.
+- Raw-evidence surfaces (`server-snapshot`, `server-doctor`, `mcp-conformance` list/read checks) pass `cacheMode: "bypass"` so they always exercise the live wire.
+- `defaultCacheTtlMs` is left at its `0` default: a result without a server-sent `ttlMs` is stored but never served. Persisted-discovery (`prior` DiscoverResult) reconnect is explicitly deferred.

--- a/mcpjam-inspector/server/routes/mcp/__tests__/resources.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/resources.test.ts
@@ -105,6 +105,7 @@ describe("POST /api/mcp/resources/list", () => {
       expect(mcpClientManager.listResources).toHaveBeenCalledWith(
         "test-server",
         { cursor: "cursor-page-2" },
+        undefined,
       );
     });
 
@@ -118,6 +119,7 @@ describe("POST /api/mcp/resources/list", () => {
       expect(res.status).toBe(200);
       expect(mcpClientManager.listResources).toHaveBeenCalledWith(
         "test-server",
+        undefined,
         undefined,
       );
     });
@@ -201,6 +203,7 @@ describe("POST /api/mcp/resources/read", () => {
         {
           uri: "file:///test.txt",
         },
+        undefined,
       );
     });
 

--- a/mcpjam-inspector/server/routes/mcp/__tests__/tools.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/tools.test.ts
@@ -69,7 +69,11 @@ describe("POST /api/mcp/tools/list", () => {
       });
 
       expect(res.status).toBe(200);
-      expect(manager.listTools).toHaveBeenCalledWith("Test-Server", undefined);
+      expect(manager.listTools).toHaveBeenCalledWith(
+        "Test-Server",
+        undefined,
+        undefined,
+      );
     });
   });
 

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -102,6 +102,18 @@ export {
   type McpProtocolVersion,
 } from "./mcp-client-manager/index.js";
 
+// Response cache (SEP-2549) — per-call disposition + serve provenance
+export type {
+  CacheMode,
+  CacheScope,
+  CacheHitEvent,
+  CacheEventLogger,
+} from "./mcp-client-manager/index.js";
+export {
+  ObservableResponseCache,
+  type ObservableResponseCacheOptions,
+} from "./mcp-client-manager/index.js";
+
 // Error classes
 export {
   MCPError,

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -6,6 +6,7 @@ import {
   type CallToolResult,
   Client,
   type ClientOptions,
+  InMemoryResponseCacheStore,
   type LoggingLevel,
   SSEClientTransport,
   type ServerCapabilities,
@@ -44,6 +45,7 @@ import type {
   ElicitResult,
   ProgressHandler,
   RpcLogger,
+  CacheEventLogger,
   Tool,
   AiSdkTool,
 } from "./types.js";
@@ -107,6 +109,7 @@ import {
 } from "./capabilities.js";
 import { assertCallToolResult, isCreateTaskResult } from "./result-guards.js";
 import { wrapLegacyClient } from "./managed-mcp-client-factory.js";
+import { ObservableResponseCache } from "./observable-response-cache.js";
 import { resolveVersionNegotiation } from "./version-negotiation.js";
 import { DialectAwareJsonSchemaValidator } from "./dialect-aware-json-schema-validator.js";
 import { isStatelessProtocolVersion } from "./mcp-protocol-version.js";
@@ -175,6 +178,7 @@ export class MCPClientManager {
   private readonly defaultLogJsonRpc: boolean;
   private readonly defaultRpcLogger?: RpcLogger;
   private readonly defaultProgressHandler?: ProgressHandler;
+  private readonly cacheEventLogger?: CacheEventLogger;
   private readonly defaultRetryPolicy: RetryPolicy;
   private readonly lazyConnect: boolean;
   private readonly elicitationTimeoutExtensionMs: number;
@@ -206,6 +210,7 @@ export class MCPClientManager {
     this.defaultLogJsonRpc = options.defaultLogJsonRpc ?? false;
     this.defaultRpcLogger = options.rpcLogger;
     this.defaultProgressHandler = options.progressHandler;
+    this.cacheEventLogger = options.cacheEventLogger;
     this.defaultRetryPolicy = normalizeRetryPolicy(options.retryPolicy);
     this.lazyConnect = options.lazyConnect ?? false;
     this.elicitationTimeoutExtensionMs = Math.max(
@@ -1273,6 +1278,21 @@ export class MCPClientManager {
           ? { supportedProtocolVersions }
           : {}),
         ...(versionNegotiation ? { versionNegotiation } : {}),
+        // Cache-serve provenance. Only when a `cacheEventLogger` is wired do we
+        // supply our own store; otherwise the client allocates its default
+        // `InMemoryResponseCacheStore` and behavior is byte-identical. We wrap
+        // a FRESH in-memory store per connection (the upstream default) so
+        // freshness/scope semantics are unchanged — the wrapper only observes.
+        // `defaultCacheTtlMs` is intentionally left at its `0` default: a
+        // result without a server `ttlMs` is stored but never served.
+        ...(this.cacheEventLogger
+          ? {
+              responseCacheStore: new ObservableResponseCache(
+                new InMemoryResponseCacheStore(),
+                { serverId, onHit: this.cacheEventLogger }
+              ),
+            }
+          : {}),
       };
 
       // Both eras go through the official upstream `Client`, constructed
@@ -1898,20 +1918,22 @@ export class MCPClientManager {
 
   private withTimeout(
     serverId: string,
-    options?: RequestOptions
-  ): RequestOptions {
+    options?: ClientRequestOptions
+  ): ClientRequestOptions {
     const state = this.registeredServers.get(serverId);
     const timeout = state?.timeout ?? this.defaultTimeout;
 
     if (!options) return { timeout };
+    // Spread preserves any `cacheMode` the caller threaded so it survives into
+    // the underlying cacheable-verb call.
     if (options.timeout === undefined) return { ...options, timeout };
     return options;
   }
 
   private withProgressHandler(
     serverId: string,
-    options?: RequestOptions
-  ): RequestOptions {
+    options?: ClientRequestOptions
+  ): ClientRequestOptions {
     const mergedOptions = this.withTimeout(serverId, options);
 
     if (!mergedOptions.onprogress && this.defaultProgressHandler) {

--- a/sdk/src/mcp-client-manager/index.ts
+++ b/sdk/src/mcp-client-manager/index.ts
@@ -58,6 +58,18 @@ export type {
   ClientCapabilityOptions,
 } from "./types.js";
 
+// Types - Response cache (SEP-2549) provenance
+export type {
+  CacheMode,
+  CacheScope,
+  CacheHitEvent,
+  CacheEventLogger,
+} from "./types.js";
+export {
+  ObservableResponseCache,
+  type ObservableResponseCacheOptions,
+} from "./observable-response-cache.js";
+
 // Types - MCP result aliases
 export type {
   MCPPromptListResult,

--- a/sdk/src/mcp-client-manager/managed-mcp-client.ts
+++ b/sdk/src/mcp-client-manager/managed-mcp-client.ts
@@ -22,6 +22,7 @@
  */
 
 import type {
+  CacheableRequestOptions,
   CallToolResult,
   EmptyResult,
   GetPromptResult,
@@ -118,9 +119,13 @@ export interface ManagedMcpClient {
   getInstructions(): string | undefined;
 
   // ---- Tool calls ----
+  // The five cacheable verbs (SEP-2549) widen their options to
+  // `CacheableRequestOptions` so a caller can thread `cacheMode` through to
+  // the underlying client. The upstream `Client` methods already accept this
+  // shape; `OfficialSdkClientAdapter` forwards verbatim.
   listTools(
     params?: { cursor?: string },
-    options?: RequestOptions
+    options?: CacheableRequestOptions
   ): Promise<ListToolsResult>;
   callTool(
     params: { name: string; arguments?: Record<string, unknown> },
@@ -137,21 +142,21 @@ export interface ManagedMcpClient {
   // ---- Resources ----
   listResources(
     params?: { cursor?: string },
-    options?: RequestOptions
+    options?: CacheableRequestOptions
   ): Promise<ListResourcesResult>;
   readResource(
     params: { uri: string },
-    options?: RequestOptions
+    options?: CacheableRequestOptions
   ): Promise<ReadResourceResult>;
   listResourceTemplates(
     params?: { cursor?: string },
-    options?: RequestOptions
+    options?: CacheableRequestOptions
   ): Promise<ListResourceTemplatesResult>;
 
   // ---- Prompts ----
   listPrompts(
     params?: { cursor?: string },
-    options?: RequestOptions
+    options?: CacheableRequestOptions
   ): Promise<ListPromptsResult>;
   getPrompt(
     params: { name: string; arguments?: Record<string, string> },

--- a/sdk/src/mcp-client-manager/observable-response-cache.ts
+++ b/sdk/src/mcp-client-manager/observable-response-cache.ts
@@ -57,6 +57,39 @@ function serializeKey(key: CacheKey): string {
 }
 
 /**
+ * Whether `value` is a document the upstream client would actually SERVE.
+ * The client's read path (`ClientResponseCache.read`) freshly parses every hit
+ * and, if the body does not `JSON.parse` to a non-null, non-array object,
+ * reports it, DELETES it, and treats the read as a miss (a wire request goes
+ * out). Mirroring that exact gate here keeps a fresh-but-corrupt entry from
+ * emitting a provenance hit for a serve that never happens.
+ */
+function isServeableDocument(value: string): boolean {
+  try {
+    const parsed = JSON.parse(value);
+    return (
+      typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Hard bound on the `storedAt` side table. The narrow {@link ResponseCacheStore}
+ * interface exposes no eviction callback, so the inner store's own size-cap and
+ * TTL evictions are invisible to this wrapper; without a bound, a long-lived
+ * manager reading an unbounded stream of distinct `resources/read` URIs would
+ * grow `storedAt` forever. The inner default caps `resources/read` at 512 and
+ * exempts the handful of list singletons, so this ceiling leaves ample headroom
+ * for the default store while still guaranteeing an upper bound for any inner
+ * store. Losing an old timestamp only degrades that entry's `ageMs` to `0` —
+ * the same best-effort fallback already used for entries this wrapper never
+ * stored.
+ */
+const MAX_STORED_AT_ENTRIES = 1024;
+
+/**
  * Wrap a {@link ResponseCacheStore} (default: a fresh in-memory store) so fresh
  * `get` hits are reported to {@link ObservableResponseCacheOptions.onHit}. All
  * mutation/read semantics are delegated verbatim to the wrapped store — the
@@ -83,24 +116,41 @@ export class ObservableResponseCache implements ResponseCacheStore {
 
   async get(key: CacheKey): Promise<CacheEntry | undefined> {
     const entry = await this.inner.get(key);
+    const skey = serializeKey(key);
     // Report only FRESH hits: a stored-but-stale entry (no `expiresAt`, or one
     // in the past) is never served, so it is not provenance-worthy. This
     // mirrors the client's own freshness gate (`expiresAt > now`).
-    if (entry?.expiresAt !== undefined && entry.expiresAt > this.now()) {
-      const stored = this.storedAt.get(serializeKey(key));
-      const ageMs = stored !== undefined ? Math.max(0, this.now() - stored) : 0;
-      try {
-        this.onHit({
-          serverId: this.serverId,
-          method: key.method,
-          params: key.params ?? "",
-          ageMs,
-          scope: entry.scope,
-        });
-      } catch {
-        // Provenance is observational — a throwing sink must never cost the
-        // caller a result the cache already holds.
-      }
+    const fresh = entry?.expiresAt !== undefined && entry.expiresAt > this.now();
+    if (!fresh) {
+      // Miss or stale: the inner store either evicted this key (its own
+      // size-cap / TTL policy, which this wrapper is never told about) or is
+      // holding an expired entry the client will refetch. Either way the paired
+      // timestamp is dead weight, so drop it lazily here — this, together with
+      // the `set()` size cap, keeps `storedAt` from outliving the entries it
+      // annotates in a long-lived manager.
+      this.storedAt.delete(skey);
+      return entry;
+    }
+    // Fresh — but only a value the client can actually SERVE is provenance-
+    // worthy. A fresh-but-corrupt entry is rejected, deleted, and refetched by
+    // the client (its `delete()` prunes `storedAt`), so emitting a hit for it
+    // would claim a local serve that never happened.
+    if (!isServeableDocument(entry.value)) {
+      return entry;
+    }
+    const stored = this.storedAt.get(skey);
+    const ageMs = stored !== undefined ? Math.max(0, this.now() - stored) : 0;
+    try {
+      this.onHit({
+        serverId: this.serverId,
+        method: key.method,
+        params: key.params ?? "",
+        ageMs,
+        scope: entry.scope,
+      });
+    } catch {
+      // Provenance is observational — a throwing sink must never cost the
+      // caller a result the cache already holds.
     }
     return entry;
   }
@@ -110,6 +160,14 @@ export class ObservableResponseCache implements ResponseCacheStore {
     entry: { value: string; expiresAt?: number; scope?: CacheEntry["scope"] }
   ): MaybePromise<number> {
     this.storedAt.set(serializeKey(key), this.now());
+    // Bound the side table independently of the inner store's eviction policy,
+    // which this wrapper cannot observe through the store interface. `Map`
+    // preserves insertion order, so the oldest timestamp is pruned first.
+    while (this.storedAt.size > MAX_STORED_AT_ENTRIES) {
+      const oldest = this.storedAt.keys().next().value;
+      if (oldest === undefined) break;
+      this.storedAt.delete(oldest);
+    }
     return this.inner.set(key, entry);
   }
 

--- a/sdk/src/mcp-client-manager/observable-response-cache.ts
+++ b/sdk/src/mcp-client-manager/observable-response-cache.ts
@@ -1,0 +1,136 @@
+/**
+ * `ObservableResponseCache` — a `ResponseCacheStore` decorator that surfaces
+ * PROVENANCE for the SEP-2549 response cache.
+ *
+ * ## Why this exists
+ *
+ * The upstream client (`@modelcontextprotocol/client`) serves a cacheable verb
+ * from cache — with ZERO wire exchange — whenever a still-fresh entry exists
+ * under `cacheMode: "use"` (the default). Freshness requires the server to have
+ * sent `ttlMs > 0` (`defaultCacheTtlMs` stays `0`, so a hint-less result is
+ * stored but never served). A debugger MUST NOT let such an invisible serve
+ * look like a real request: MCPJam surfaces the serve (and its age) so the
+ * operator can tell "the server answered this" from "the cache answered this".
+ *
+ * This wrapper reports each fresh `get` hit to a {@link CacheEventLogger}. That
+ * is a channel wholly SEPARATE from the rpc/wire logger: a cache hit is exactly
+ * the case where no JSON-RPC request left the process, so it must never be
+ * injected into the wire log.
+ *
+ * ## Known imprecision of the "fresh get ⇒ served" heuristic
+ *
+ * The store cannot see the caller's `cacheMode`. The upstream client only calls
+ * `store.get` on the READ path, which it takes ONLY under `cacheMode: "use"`
+ * (verified: `'refresh'`/`'bypass'` short-circuit before consulting the store).
+ * So a fresh `get` observed here corresponds to a real serve under `"use"`.
+ * The one caveat: the client also probes `tools/list` internally to back
+ * `callTool` output-validation / header mirroring, so a fresh `get` for
+ * `tools/list` can be an internal derived-view read rather than a user-facing
+ * list serve. We report both and accept that over-count — an extra provenance
+ * signal is safe; a missed one (an invisible serve shown as a wire request)
+ * is not. `ageMs` is best-effort: it is `now − storeTime` for entries THIS
+ * wrapper stored; a hit on an entry written by a different wrapper instance
+ * (e.g. a shared store) reports `ageMs: 0`.
+ */
+
+import {
+  InMemoryResponseCacheStore,
+  type CacheEntry,
+  type CacheKey,
+  type MaybePromise,
+  type ResponseCacheStore,
+} from "@modelcontextprotocol/client";
+import type { CacheEventLogger } from "./types.js";
+
+export interface ObservableResponseCacheOptions {
+  /** Server whose connection this store backs (stamped onto every event). */
+  serverId: string;
+  /** Provenance sink for fresh serves. */
+  onHit: CacheEventLogger;
+  /** Clock injection point (tests). Defaults to `Date.now`. */
+  now?: () => number;
+}
+
+/** Stable string form of a {@link CacheKey} for the store-time side table. */
+function serializeKey(key: CacheKey): string {
+  return JSON.stringify([key.method, key.params ?? "", key.partition ?? ""]);
+}
+
+/**
+ * Wrap a {@link ResponseCacheStore} (default: a fresh in-memory store) so fresh
+ * `get` hits are reported to {@link ObservableResponseCacheOptions.onHit}. All
+ * mutation/read semantics are delegated verbatim to the wrapped store — the
+ * only added behavior is the out-of-band provenance emission and a store-time
+ * side table used to compute `ageMs`.
+ */
+export class ObservableResponseCache implements ResponseCacheStore {
+  private readonly inner: ResponseCacheStore;
+  private readonly serverId: string;
+  private readonly onHit: CacheEventLogger;
+  private readonly now: () => number;
+  /** key → wall-clock ms at which THIS wrapper last stored the entry. */
+  private readonly storedAt = new Map<string, number>();
+
+  constructor(
+    inner: ResponseCacheStore = new InMemoryResponseCacheStore(),
+    options: ObservableResponseCacheOptions
+  ) {
+    this.inner = inner;
+    this.serverId = options.serverId;
+    this.onHit = options.onHit;
+    this.now = options.now ?? Date.now;
+  }
+
+  async get(key: CacheKey): Promise<CacheEntry | undefined> {
+    const entry = await this.inner.get(key);
+    // Report only FRESH hits: a stored-but-stale entry (no `expiresAt`, or one
+    // in the past) is never served, so it is not provenance-worthy. This
+    // mirrors the client's own freshness gate (`expiresAt > now`).
+    if (entry?.expiresAt !== undefined && entry.expiresAt > this.now()) {
+      const stored = this.storedAt.get(serializeKey(key));
+      const ageMs = stored !== undefined ? Math.max(0, this.now() - stored) : 0;
+      try {
+        this.onHit({
+          serverId: this.serverId,
+          method: key.method,
+          params: key.params ?? "",
+          ageMs,
+          scope: entry.scope,
+        });
+      } catch {
+        // Provenance is observational — a throwing sink must never cost the
+        // caller a result the cache already holds.
+      }
+    }
+    return entry;
+  }
+
+  set(
+    key: CacheKey,
+    entry: { value: string; expiresAt?: number; scope?: CacheEntry["scope"] }
+  ): MaybePromise<number> {
+    this.storedAt.set(serializeKey(key), this.now());
+    return this.inner.set(key, entry);
+  }
+
+  delete(key: CacheKey): MaybePromise<void> {
+    this.storedAt.delete(serializeKey(key));
+    return this.inner.delete(key);
+  }
+
+  evict(method: string): MaybePromise<void> {
+    for (const k of [...this.storedAt.keys()]) {
+      try {
+        if ((JSON.parse(k) as [string])[0] === method) this.storedAt.delete(k);
+      } catch {
+        // Best-effort side-table cleanup; a stale entry only affects ageMs.
+      }
+    }
+    return this.inner.evict(method);
+  }
+
+  clear(): MaybePromise<void> {
+    this.storedAt.clear();
+    return this.inner.clear();
+  }
+}

--- a/sdk/src/mcp-client-manager/types.ts
+++ b/sdk/src/mcp-client-manager/types.ts
@@ -3,6 +3,8 @@
  */
 
 import type {
+  CacheMode,
+  CacheScope,
   CallToolResult,
   Client,
   ClientOptions,
@@ -24,6 +26,103 @@ import type { ToolSet } from "ai";
 
 // Re-export ElicitResult for convenience
 export type { ElicitResult };
+
+/**
+ * The per-call cache disposition for the SEP-2549 cacheable verbs
+ * (`listTools` / `listPrompts` / `listResources` / `listResourceTemplates` /
+ * `readResource`). Re-exported verbatim from the upstream client so callers
+ * can `import { CacheMode } from "@mcpjam/sdk"`.
+ *
+ *   - `"use"` (upstream default) serves a still-fresh cached entry — a hit
+ *     costs ZERO wire exchange. A result is "fresh" only when the server sent
+ *     `ttlMs > 0` (SEP-2549) AND that ttl has not elapsed; `defaultCacheTtlMs`
+ *     stays `0`, so a result WITHOUT a server `ttlMs` is stored but never
+ *     served (every call refetches).
+ *   - `"refresh"` always fetches and re-stores (the "Refresh" affordance).
+ *   - `"bypass"` fetches without consulting OR writing the cache — the raw /
+ *     conformance evidence disposition.
+ *
+ * NOTE: only the 2026-07-28 wire codec emits `ttlMs`/`cacheScope`; a 2025-era
+ * connection never carries them, so an invisible cache serve is a modern-era
+ * phenomenon. The cache engine itself is era-blind (it reads `ttlMs` off the
+ * decoded body), but the body only has `ttlMs` when the modern codec put it
+ * there.
+ */
+export type { CacheMode, CacheScope };
+
+/**
+ * A single local cache-serve event, reported by `ObservableResponseCache` to
+ * {@link CacheEventLogger} when a cacheable verb is answered from a still-fresh
+ * cached entry (a `get` whose `expiresAt > now`).
+ *
+ * This is a LOCAL event with no wire counterpart — it MUST NOT be conflated
+ * with {@link RpcLogger} traffic. A cache hit is precisely the case where NO
+ * JSON-RPC request left the process, so injecting it into the rpc/wire log
+ * would make an invisible serve masquerade as a real request.
+ */
+export interface CacheHitEvent {
+  /** The server whose connection served the entry. */
+  serverId: string;
+  /** The cacheable method (`"tools/list"`, `"resources/read"`, …). */
+  method: string;
+  /** Canonical params key (`""` for the list verbs, the `uri` for reads). */
+  params?: string;
+  /**
+   * Age of the served entry in milliseconds (now − store time). Best-effort;
+   * see `ObservableResponseCache` for the heuristic's known imprecision.
+   */
+  ageMs: number;
+  /** Server-reported cache scope (`"public"` / `"private"`), if present. */
+  scope?: CacheScope;
+}
+
+/**
+ * Callback invoked for each fresh cache-serve. Distinct channel from
+ * {@link RpcLogger}: cache hits never appear on the wire, so they surface
+ * here — never as rpc log entries. Absence of an emission is NOT proof a call
+ * hit the wire; see `ObservableResponseCache`.
+ */
+export type CacheEventLogger = (event: CacheHitEvent) => void;
+
+/**
+ * MCPJam response-cache POLICY (SEP-2549). This is the single source of truth
+ * for how the debugger disposes of the client's response cache; the code above
+ * and the raw-evidence surfaces (`server-snapshot`, `server-doctor`,
+ * `mcp-conformance`) implement it.
+ *
+ * 1. **Default UI reads use `"use"`.** A default read MAY be served from cache
+ *    — but ONLY when (a) the server sent `ttlMs > 0` (so the entry is fresh)
+ *    AND (b) MCPJam surfaces the serve's provenance and age to the operator
+ *    (via {@link CacheEventLogger}). A serve the operator cannot see is
+ *    indistinguishable from a fabricated wire response and is forbidden.
+ * 2. **`defaultCacheTtlMs` stays `0`.** A result WITHOUT a server `ttlMs` is
+ *    stored (so the client's `tools/list`-derived index keeps working) but is
+ *    NEVER served. Invisible serving therefore happens EXACTLY when a server
+ *    opts in with `ttlMs > 0`.
+ * 3. **"Refresh" ⇒ `cacheMode: "refresh"`.** The refresh affordance always
+ *    fetches and re-stores.
+ * 4. **Raw / conformance ⇒ `cacheMode: "bypass"`.** Evidence surfaces neither
+ *    consult nor write the cache.
+ *
+ * ### Explicitly DEFERRED: persisted-discovery (`prior`) reconnect
+ *
+ * The upstream client supports a zero-round-trip reconnect by adopting a prior
+ * {@link import("@modelcontextprotocol/client").DiscoverResult} on `connect`
+ * (`ConnectOptions.prior`). MCPJam does NOT implement this here — it is
+ * deferred pending owner sign-off on how to display the provenance of an
+ * adopted-without-a-handshake connection. When implemented, the persisted
+ * `DiscoverResult` MUST be keyed by the full authorization/negotiation context
+ * so a cached discovery is never reused across a different principal or a
+ * different negotiated shape. The intended key spec is:
+ *
+ *   - server ORIGIN (scheme + host + port of the MCP endpoint),
+ *   - AUTH / TENANT context (the same identity that scopes the response cache
+ *     partition — e.g. the auth subject / `cachePartition`), and
+ *   - NEGOTIATION INPUTS (proposed protocol-version accept-list + advertised
+ *     client capabilities) that produced the `DiscoverResult`.
+ *
+ * Do NOT reuse a `prior` across any change in those inputs.
+ */
 
 /**
  * Client capability options extracted from MCP SDK ClientOptions
@@ -332,6 +431,19 @@ export interface MCPClientManagerOptions {
   rpcLogger?: RpcLogger;
   /** Global progress handler */
   progressHandler?: ProgressHandler;
+  /**
+   * Optional provenance sink for LOCAL cache serves. When set, every managed
+   * connection is given an `ObservableResponseCache` (wrapping a fresh
+   * in-memory store) and this callback fires whenever a cacheable verb is
+   * answered from a still-fresh cached entry — a serve that costs ZERO wire
+   * exchange. This is a DISTINCT channel from `rpcLogger`: cache hits never
+   * touch the wire, so they must never be injected into the rpc/wire log
+   * (that would make an invisible serve look like a real request).
+   *
+   * When unset, connections use the upstream default store and behavior is
+   * byte-identical to not wiring a cache observer.
+   */
+  cacheEventLogger?: CacheEventLogger;
   /** Default retry policy for retryable manager operations */
   retryPolicy?: RetryPolicy;
   /**
@@ -460,7 +572,13 @@ export type MCPListTasksResult = BaseListTasksResult;
 // Client Method Parameter Types
 // ============================================================================
 
-export type ClientRequestOptions = RequestOptions;
+/**
+ * Request options accepted by the manager's read verbs. Extends the upstream
+ * `RequestOptions` with the SEP-2549 `cacheMode` so a caller can pick the
+ * per-call cache disposition; ignored by verbs that are not cacheable (e.g.
+ * `callTool`). See {@link CacheMode}.
+ */
+export type ClientRequestOptions = RequestOptions & { cacheMode?: CacheMode };
 export type CallToolOptions = RequestOptions;
 export type ListResourcesParams = Parameters<Client["listResources"]>[0];
 export type ListResourceTemplatesParams = Parameters<

--- a/sdk/src/mcp-conformance/checks/prompts.ts
+++ b/sdk/src/mcp-conformance/checks/prompts.ts
@@ -14,7 +14,7 @@ export const PROMPT_CHECKS: MCPClientCheckDefinition[] = [
     async run(ctx) {
       const startedAt = Date.now();
       try {
-        const result = await ctx.manager.listPrompts(ctx.serverId);
+        const result = await ctx.manager.listPrompts(ctx.serverId, undefined, { cacheMode: "bypass" });
         const invalidPrompts = (result.prompts ?? [])
           .map((prompt, index) => ({ prompt, index }))
           .filter(({ prompt }) => !prompt.name)

--- a/sdk/src/mcp-conformance/checks/resources.ts
+++ b/sdk/src/mcp-conformance/checks/resources.ts
@@ -14,7 +14,7 @@ export const RESOURCE_CHECKS: MCPClientCheckDefinition[] = [
     async run(ctx) {
       const startedAt = Date.now();
       try {
-        const result = await ctx.manager.listResources(ctx.serverId);
+        const result = await ctx.manager.listResources(ctx.serverId, undefined, { cacheMode: "bypass" });
         const invalidResources = (result.resources ?? [])
           .map((resource, index) => ({ resource, index }))
           .filter(({ resource }) => !resource.uri || !resource.name)

--- a/sdk/src/mcp-conformance/checks/tools.ts
+++ b/sdk/src/mcp-conformance/checks/tools.ts
@@ -14,7 +14,7 @@ export const TOOL_CHECKS: MCPClientCheckDefinition[] = [
     async run(ctx) {
       const startedAt = Date.now();
       try {
-        const result = await ctx.manager.listTools(ctx.serverId);
+        const result = await ctx.manager.listTools(ctx.serverId, undefined, { cacheMode: "bypass" });
         const invalidTools = (result.tools ?? [])
           .map((tool, index) => ({ tool, index }))
           .filter(({ tool }) => !tool.name || !tool.inputSchema)
@@ -55,7 +55,7 @@ export const TOOL_CHECKS: MCPClientCheckDefinition[] = [
     async run(ctx) {
       const startedAt = Date.now();
       try {
-        const result = await ctx.manager.listTools(ctx.serverId);
+        const result = await ctx.manager.listTools(ctx.serverId, undefined, { cacheMode: "bypass" });
         const tools = result.tools ?? [];
 
         if (tools.length === 0) {

--- a/sdk/src/mcp-conformance/runner.ts
+++ b/sdk/src/mcp-conformance/runner.ts
@@ -114,7 +114,13 @@ async function safeListResourceTemplates(
   ctx: Pick<MCPClientCheckContext, "manager" | "serverId">,
 ): Promise<string[]> {
   try {
-    const result = await ctx.manager.listResourceTemplates(ctx.serverId);
+    // Conformance is a raw-evidence surface: bypass the SEP-2549 response
+    // cache so the check always exercises the live wire.
+    const result = await ctx.manager.listResourceTemplates(
+      ctx.serverId,
+      undefined,
+      { cacheMode: "bypass" },
+    );
     return (result.resourceTemplates ?? []).map((template) => template.uriTemplate);
   } catch {
     return [];

--- a/sdk/src/operations.ts
+++ b/sdk/src/operations.ts
@@ -8,6 +8,7 @@
 
 import { MCPClientManager } from "./mcp-client-manager/index.js";
 import type {
+  CacheMode,
   ListToolsResult,
   MCPPrompt,
   MCPResource,
@@ -18,19 +19,32 @@ import type {
 } from "./mcp-client-manager/index.js";
 import { isMethodUnavailableError } from "./mcp-client-manager/index.js";
 
+/**
+ * Per-call cache disposition threaded to the underlying cacheable verbs
+ * (SEP-2549). Absent ⇒ upstream default `"use"`. Raw-evidence callers
+ * (snapshot/doctor/conformance) pass `"bypass"` so their reads never resolve
+ * from a cached body. See {@link CacheMode}.
+ */
+type WithCacheMode = { cacheMode?: CacheMode };
+
+/** Build the read options object, omitting it entirely when no cacheMode is set. */
+function cacheOptions(cacheMode?: CacheMode): { cacheMode: CacheMode } | undefined {
+  return cacheMode ? { cacheMode } : undefined;
+}
+
 // ── Param types ─────────────────────────────────────────────────────
 
-export interface ListResourcesParams {
+export interface ListResourcesParams extends WithCacheMode {
   serverId: string;
   cursor?: string;
 }
 
-export interface ReadResourceParams {
+export interface ReadResourceParams extends WithCacheMode {
   serverId: string;
   uri: string;
 }
 
-export interface ListPromptsParams {
+export interface ListPromptsParams extends WithCacheMode {
   serverId: string;
   cursor?: string;
 }
@@ -45,12 +59,12 @@ export interface GetPromptParams {
   arguments?: Record<string, unknown>;
 }
 
-export interface ListToolsParams {
+export interface ListToolsParams extends WithCacheMode {
   serverId: string;
   cursor?: string;
 }
 
-export interface ListAllToolsParams {
+export interface ListAllToolsParams extends WithCacheMode {
   serverId: string;
 }
 
@@ -59,7 +73,7 @@ export interface ListAllToolsResult {
   toolsMetadata: Record<string, unknown>;
 }
 
-export interface ListAllResourcesParams {
+export interface ListAllResourcesParams extends WithCacheMode {
   serverId: string;
 }
 
@@ -67,7 +81,7 @@ export interface ListAllResourcesResult {
   resources: MCPResource[];
 }
 
-export interface ListAllPromptsParams {
+export interface ListAllPromptsParams extends WithCacheMode {
   serverId: string;
 }
 
@@ -75,7 +89,7 @@ export interface ListAllPromptsResult {
   prompts: MCPPrompt[];
 }
 
-export interface ListAllResourceTemplatesParams {
+export interface ListAllResourceTemplatesParams extends WithCacheMode {
   serverId: string;
 }
 
@@ -107,7 +121,8 @@ export async function listResources(
 ) {
   const result = await manager.listResources(
     params.serverId,
-    params.cursor ? { cursor: params.cursor } : undefined
+    params.cursor ? { cursor: params.cursor } : undefined,
+    cacheOptions(params.cacheMode)
   );
   return {
     resources: result.resources ?? [],
@@ -119,9 +134,11 @@ export async function readResource(
   manager: MCPClientManager,
   params: ReadResourceParams
 ) {
-  const content = await manager.readResource(params.serverId, {
-    uri: params.uri,
-  });
+  const content = await manager.readResource(
+    params.serverId,
+    { uri: params.uri },
+    cacheOptions(params.cacheMode)
+  );
   return { content };
 }
 
@@ -133,7 +150,8 @@ export async function listPrompts(
 ) {
   const result = await manager.listPrompts(
     params.serverId,
-    params.cursor ? { cursor: params.cursor } : undefined
+    params.cursor ? { cursor: params.cursor } : undefined,
+    cacheOptions(params.cacheMode)
   );
   return {
     prompts: result.prompts ?? [],
@@ -197,7 +215,8 @@ export async function listTools(
 ) {
   const result = await manager.listTools(
     params.serverId,
-    params.cursor ? { cursor: params.cursor } : undefined
+    params.cursor ? { cursor: params.cursor } : undefined,
+    cacheOptions(params.cacheMode)
   );
   return {
     tools: result.tools ?? [],
@@ -213,7 +232,12 @@ export async function listAllTools(
     Awaited<ReturnType<typeof listTools>>["tools"][number],
     Awaited<ReturnType<typeof listTools>>
   >(
-    async (cursor) => listTools(manager, { serverId: params.serverId, cursor }),
+    async (cursor) =>
+      listTools(manager, {
+        serverId: params.serverId,
+        cursor,
+        cacheMode: params.cacheMode,
+      }),
     "tools/list",
     (page) => page.tools ?? []
   );
@@ -238,7 +262,11 @@ export async function listAllResources(
     Awaited<ReturnType<typeof listResources>>
   >(
     async (cursor) =>
-      listResources(manager, { serverId: params.serverId, cursor }),
+      listResources(manager, {
+        serverId: params.serverId,
+        cursor,
+        cacheMode: params.cacheMode,
+      }),
     "resources/list",
     (page) => page.resources ?? []
   );
@@ -255,7 +283,11 @@ export async function listAllPrompts(
     Awaited<ReturnType<typeof listPrompts>>
   >(
     async (cursor) =>
-      listPrompts(manager, { serverId: params.serverId, cursor }),
+      listPrompts(manager, {
+        serverId: params.serverId,
+        cursor,
+        cacheMode: params.cacheMode,
+      }),
     "prompts/list",
     (page) => page.prompts ?? []
   );
@@ -280,7 +312,8 @@ export async function listAllResourceTemplates(
       try {
         result = await manager.listResourceTemplates(
           params.serverId,
-          cursor ? { cursor } : undefined
+          cursor ? { cursor } : undefined,
+          cacheOptions(params.cacheMode)
         );
       } catch (error) {
         if (

--- a/sdk/src/server-doctor.ts
+++ b/sdk/src/server-doctor.ts
@@ -203,7 +203,9 @@ async function collectTools(
   serverId: string
 ): Promise<DoctorToolsCollectionResult> {
   try {
-    const result = await listAllTools(manager, { serverId });
+    // Raw-evidence surface: bypass the SEP-2549 response cache so the doctor
+    // reports the server's live surface, never a cached body.
+    const result = await listAllTools(manager, { serverId, cacheMode: "bypass" });
     const tools =
       result.tools?.map((tool) => {
         const { _meta: _ignoredMeta, ...toolWithoutMeta } = tool;
@@ -230,7 +232,10 @@ async function collectResources(
   serverId: string
 ): Promise<DoctorResourcesCollectionResult> {
   try {
-    const result = await listAllResources(manager, { serverId });
+    const result = await listAllResources(manager, {
+      serverId,
+      cacheMode: "bypass",
+    });
     const resources = result.resources ?? [];
     return {
       resources,
@@ -251,7 +256,10 @@ async function collectPrompts(
   serverId: string
 ): Promise<DoctorPromptsCollectionResult> {
   try {
-    const result = await listAllPrompts(manager, { serverId });
+    const result = await listAllPrompts(manager, {
+      serverId,
+      cacheMode: "bypass",
+    });
     const prompts = result.prompts ?? [];
     return {
       prompts,
@@ -272,7 +280,10 @@ async function collectResourceTemplates(
   serverId: string
 ): Promise<DoctorResourceTemplatesCollectionResult> {
   try {
-    const result = await listAllResourceTemplates(manager, { serverId });
+    const result = await listAllResourceTemplates(manager, {
+      serverId,
+      cacheMode: "bypass",
+    });
     const resourceTemplates = result.resourceTemplates ?? [];
     if (result.unsupported) {
       return {

--- a/sdk/src/server-snapshot.ts
+++ b/sdk/src/server-snapshot.ts
@@ -163,12 +163,15 @@ export async function collectConnectedServerSnapshot<TTarget = unknown>(
   dependencies: Pick<ServerSnapshotDependencies, "now"> = {}
 ): Promise<CollectedServerSnapshot<TTarget>> {
   const now = dependencies.now ?? (() => new Date());
+  // Raw-evidence surface: a snapshot must reflect what the server sends NOW, so
+  // every list bypasses the SEP-2549 response cache (`cacheMode: "bypass"`) —
+  // it neither consults nor writes a cached body.
   const [toolsResult, resourcesResult, resourceTemplatesResult, promptsResult] =
     await Promise.all([
-      listAllTools(manager, { serverId }),
-      listAllResources(manager, { serverId }),
-      listAllResourceTemplates(manager, { serverId }),
-      listAllPrompts(manager, { serverId }),
+      listAllTools(manager, { serverId, cacheMode: "bypass" }),
+      listAllResources(manager, { serverId, cacheMode: "bypass" }),
+      listAllResourceTemplates(manager, { serverId, cacheMode: "bypass" }),
+      listAllPrompts(manager, { serverId, cacheMode: "bypass" }),
     ]);
 
   return {

--- a/sdk/tests/cache-policy.integration.test.ts
+++ b/sdk/tests/cache-policy.integration.test.ts
@@ -1,0 +1,198 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { MCPClientManager } from "../src/mcp-client-manager/index.js";
+import type { CacheHitEvent } from "../src/mcp-client-manager/index.js";
+import { collectConnectedServerSnapshot } from "../src/server-snapshot.js";
+import {
+  createCacheFixtureHandler,
+  createNoTtlFixtureHandler,
+  serveCountingFixtureOnPort,
+  type ServedCountingFixture,
+} from "./support/cache-fixture.js";
+
+/**
+ * End-to-end policy proof for the SEP-2549 response cache, driven through the
+ * real `MCPClientManager` against the dual-era cache fixture over a loopback
+ * port. Wire hits are counted at the server (the manager exposes no injectable
+ * `fetch`), so a cache serve — which never leaves the client — is exactly the
+ * case where the `tools/list` count does NOT advance.
+ *
+ * ## Era asymmetry (load-bearing)
+ *
+ * Only the 2026-07-28 wire codec emits `ttlMs`/`cacheScope`. So an invisible
+ * cache serve is a MODERN-era phenomenon: on a `2026-07-28` pin the ttl fixture
+ * serves a still-fresh `tools/list` with zero wire exchange, while the SAME
+ * fixture on a 2025-era pin carries no `ttlMs` and refetches every time. The
+ * cache engine itself is era-blind (it reads `ttlMs` off the decoded body); the
+ * body only has `ttlMs` when the modern codec put it there. Both eras are
+ * exercised below.
+ */
+
+const MODERN = "2026-07-28" as const;
+const LEGACY = "2025-06-18" as const;
+const TIMEOUT = 10_000;
+
+function connectConfig(url: string, pin: string) {
+  return { url, timeout: TIMEOUT, mcpProtocolVersion: pin };
+}
+
+// ── Modern era: the ttl fixture actually serves from cache ──────────────────
+
+describe("cache policy · ttl fixture · modern (2026-07-28)", () => {
+  let served: ServedCountingFixture;
+  let manager: MCPClientManager;
+  const cacheEvents: CacheHitEvent[] = [];
+
+  beforeEach(async () => {
+    served = await serveCountingFixtureOnPort(createCacheFixtureHandler());
+    manager = new MCPClientManager(
+      {},
+      { cacheEventLogger: (e) => cacheEvents.push(e) },
+    );
+    await manager.connectToServer("fixture", connectConfig(served.url, MODERN));
+    cacheEvents.length = 0;
+  });
+
+  afterEach(async () => {
+    await manager.disconnectAllServers().catch(() => {});
+    await served.close();
+  });
+
+  it("(a) a second no-cursor listTools serves from cache: ZERO new wire + provenance event", async () => {
+    // First call populates the cache (one wire tools/list).
+    const first = await manager.listTools("fixture");
+    expect(first.tools.map((t) => t.name)).toContain("echo");
+    const afterFirst = served.count("tools/list");
+    expect(afterFirst).toBeGreaterThanOrEqual(1);
+    cacheEvents.length = 0;
+
+    // Second call is answered from cache — no new wire request.
+    const second = await manager.listTools("fixture");
+    expect(second.tools.map((t) => t.name)).toContain("echo");
+    expect(served.count("tools/list")).toBe(afterFirst);
+
+    // …and the invisible serve is surfaced with an age (proving it is real).
+    const event = cacheEvents.find((e) => e.method === "tools/list");
+    expect(event, "expected a tools/list cache-serve event").toBeDefined();
+    expect(event!.serverId).toBe("fixture");
+    expect(typeof event!.ageMs).toBe("number");
+    expect(event!.ageMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("(b) cacheMode 'refresh' always hits the wire", async () => {
+    await manager.listTools("fixture");
+    const before = served.count("tools/list");
+    cacheEvents.length = 0;
+
+    await manager.listTools("fixture", undefined, { cacheMode: "refresh" });
+
+    expect(served.count("tools/list")).toBe(before + 1);
+    // A refresh fetches; it never serves, so no serve event fired.
+    expect(cacheEvents.filter((e) => e.method === "tools/list")).toHaveLength(0);
+  });
+
+  it("(c) cacheMode 'bypass' hits the wire and leaves the stored entry intact", async () => {
+    await manager.listTools("fixture"); // populate a fresh entry
+    const beforeBypass = served.count("tools/list");
+
+    await manager.listTools("fixture", undefined, { cacheMode: "bypass" });
+    expect(served.count("tools/list")).toBe(beforeBypass + 1); // bypass fetched
+
+    // The bypass did NOT overwrite the cache: a subsequent default read still
+    // serves the original fresh entry with zero new wire exchange.
+    const afterBypass = served.count("tools/list");
+    cacheEvents.length = 0;
+    await manager.listTools("fixture");
+    expect(served.count("tools/list")).toBe(afterBypass);
+    expect(cacheEvents.some((e) => e.method === "tools/list")).toBe(true);
+  });
+
+  it("(e) snapshot list ops always hit the wire (they bypass the cache)", async () => {
+    await manager.listTools("fixture"); // populate a fresh entry
+    const before = served.count("tools/list");
+    cacheEvents.length = 0;
+
+    await collectConnectedServerSnapshot(manager, "fixture", null);
+
+    // The snapshot re-fetched despite a fresh cached entry, and never served.
+    expect(served.count("tools/list")).toBe(before + 1);
+    expect(cacheEvents.filter((e) => e.method === "tools/list")).toHaveLength(0);
+  });
+});
+
+// ── Legacy era: the SAME ttl fixture never serves (no wire ttlMs) ────────────
+
+describe("cache policy · ttl fixture · legacy (2025-06-18)", () => {
+  let served: ServedCountingFixture;
+  let manager: MCPClientManager;
+  const cacheEvents: CacheHitEvent[] = [];
+
+  beforeEach(async () => {
+    served = await serveCountingFixtureOnPort(createCacheFixtureHandler());
+    manager = new MCPClientManager(
+      {},
+      { cacheEventLogger: (e) => cacheEvents.push(e) },
+    );
+    await manager.connectToServer("fixture", connectConfig(served.url, LEGACY));
+    cacheEvents.length = 0;
+  });
+
+  afterEach(async () => {
+    await manager.disconnectAllServers().catch(() => {});
+    await served.close();
+  });
+
+  it("refetches on every listTools — the 2025 wire never carries ttlMs", async () => {
+    await manager.listTools("fixture");
+    const before = served.count("tools/list");
+    cacheEvents.length = 0;
+
+    const second = await manager.listTools("fixture");
+    expect(second.tools.map((t) => t.name)).toContain("echo");
+
+    expect(served.count("tools/list")).toBe(before + 1);
+    expect(cacheEvents).toHaveLength(0);
+  });
+});
+
+// ── (d) no-ttl fixture: guards against an upstream defaultCacheTtlMs change ──
+
+for (const era of [
+  { name: "modern (2026-07-28)", pin: MODERN },
+  { name: "legacy (2025-06-18)", pin: LEGACY },
+]) {
+  describe(`cache policy · no-ttl fixture · ${era.name}`, () => {
+    let served: ServedCountingFixture;
+    let manager: MCPClientManager;
+    const cacheEvents: CacheHitEvent[] = [];
+
+    beforeEach(async () => {
+      served = await serveCountingFixtureOnPort(createNoTtlFixtureHandler());
+      manager = new MCPClientManager(
+        {},
+        { cacheEventLogger: (e) => cacheEvents.push(e) },
+      );
+      await manager.connectToServer(
+        "fixture",
+        connectConfig(served.url, era.pin),
+      );
+      cacheEvents.length = 0;
+    });
+
+    afterEach(async () => {
+      await manager.disconnectAllServers().catch(() => {});
+      await served.close();
+    });
+
+    it("(d) refetches on every listTools — a hint-less result is stored but never served", async () => {
+      await manager.listTools("fixture");
+      const before = served.count("tools/list");
+      cacheEvents.length = 0;
+
+      await manager.listTools("fixture");
+
+      // defaultCacheTtlMs stays 0, so even the modern era never serves here.
+      expect(served.count("tools/list")).toBe(before + 1);
+      expect(cacheEvents).toHaveLength(0);
+    });
+  });
+}

--- a/sdk/tests/observable-response-cache.test.ts
+++ b/sdk/tests/observable-response-cache.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+import type {
+  CacheEntry,
+  CacheKey,
+  MaybePromise,
+  ResponseCacheStore,
+} from "@modelcontextprotocol/client";
+import { ObservableResponseCache } from "../src/mcp-client-manager/observable-response-cache.js";
+import type { CacheHitEvent } from "../src/mcp-client-manager/types.js";
+
+/**
+ * Direct unit coverage for the provenance wrapper's two false-hit / leak fixes:
+ *  - a fresh entry only emits once it is a value the client would actually
+ *    serve (a corrupt document is rejected+refetched, so it must not emit);
+ *  - the `storedAt` side table stays bounded even though the inner store's own
+ *    evictions are invisible through the `ResponseCacheStore` interface.
+ */
+
+function keyOf(key: CacheKey): string {
+  return JSON.stringify([key.method, key.params ?? "", key.partition ?? ""]);
+}
+
+/** Uncapped in-memory store so the wrapper's OWN bound is what's under test. */
+class FakeStore implements ResponseCacheStore {
+  readonly map = new Map<string, CacheEntry>();
+  private stamp = 0;
+  get(key: CacheKey): MaybePromise<CacheEntry | undefined> {
+    return this.map.get(keyOf(key));
+  }
+  set(
+    key: CacheKey,
+    entry: { value: string; expiresAt?: number; scope?: CacheEntry["scope"] },
+  ): MaybePromise<number> {
+    const stamp = ++this.stamp;
+    this.map.set(keyOf(key), {
+      value: entry.value,
+      stamp,
+      expiresAt: entry.expiresAt,
+      scope: entry.scope,
+    });
+    return stamp;
+  }
+  delete(key: CacheKey): MaybePromise<void> {
+    this.map.delete(keyOf(key));
+  }
+  evict(method: string): MaybePromise<void> {
+    for (const k of [...this.map.keys()]) {
+      if ((JSON.parse(k) as [string])[0] === method) this.map.delete(k);
+    }
+  }
+  clear(): MaybePromise<void> {
+    this.map.clear();
+  }
+}
+
+function wrap(inner: ResponseCacheStore, now: () => number) {
+  const events: CacheHitEvent[] = [];
+  const cache = new ObservableResponseCache(inner, {
+    serverId: "srv",
+    onHit: (e) => events.push(e),
+    now,
+  });
+  return { cache, events };
+}
+
+const FUTURE = 1_000_000;
+
+describe("ObservableResponseCache · serve-gated provenance", () => {
+  it("emits a hit for a fresh, serveable document with age + scope", async () => {
+    const inner = new FakeStore();
+    let clock = 100;
+    const { cache, events } = wrap(inner, () => clock);
+
+    await cache.set(
+      { method: "tools/list", params: "" },
+      { value: JSON.stringify({ tools: [] }), expiresAt: FUTURE, scope: "public" },
+    );
+    clock = 150;
+    await cache.get({ method: "tools/list", params: "" });
+
+    expect(events).toHaveLength(1);
+    expect(events[0].method).toBe("tools/list");
+    expect(events[0].scope).toBe("public");
+    expect(events[0].ageMs).toBe(50);
+  });
+
+  it("does NOT emit for a fresh but non-object document (client rejects+refetches)", async () => {
+    const inner = new FakeStore();
+    const { cache, events } = wrap(inner, () => 100);
+
+    for (const bad of ['"a bare string"', "[1,2,3]", "not-json", "null"]) {
+      const key = { method: "resources/read", params: bad };
+      await cache.set(key, { value: bad, expiresAt: FUTURE, scope: "private" });
+      await cache.get(key);
+    }
+    expect(events).toHaveLength(0);
+  });
+
+  it("does NOT emit for a stale entry and prunes its side-table timestamp", async () => {
+    const inner = new FakeStore();
+    let clock = 100;
+    const { cache, events } = wrap(inner, () => clock);
+    const key = { method: "resources/read", params: "u" };
+
+    await cache.set(key, {
+      value: JSON.stringify({ ok: 1 }),
+      expiresAt: 200,
+      scope: "private",
+    });
+    clock = 500; // now past expiresAt
+    await cache.get(key);
+    expect(events).toHaveLength(0);
+
+    // Re-store fresh but WITHOUT going through set()'s timestamp (simulate a
+    // different writer): a subsequent fresh serve reports ageMs 0, proving the
+    // stale read pruned the old timestamp rather than leaving it to skew age.
+    inner.map.set(keyOf(key), {
+      value: JSON.stringify({ ok: 1 }),
+      stamp: 99,
+      expiresAt: FUTURE,
+      scope: "private",
+    });
+    await cache.get(key);
+    expect(events).toHaveLength(1);
+    expect(events[0].ageMs).toBe(0);
+  });
+});
+
+describe("ObservableResponseCache · bounded side table", () => {
+  it("keeps storedAt bounded past the cap; evicted timestamps degrade to ageMs 0", async () => {
+    const inner = new FakeStore();
+    let clock = 0;
+    const { cache, events } = wrap(inner, () => clock);
+
+    // Insert well past the 1024 cap under distinct resources/read URIs.
+    for (let i = 0; i < 2000; i++) {
+      clock = i + 1;
+      await cache.set(
+        { method: "resources/read", params: `u${i}` },
+        { value: JSON.stringify({ i }), expiresAt: FUTURE, scope: "private" },
+      );
+    }
+
+    // The oldest key's timestamp must have been evicted from the side table:
+    // its still-fresh inner entry serves with ageMs 0 (best-effort fallback),
+    // while a recent key retains a real, positive age.
+    clock = 5000;
+    await cache.get({ method: "resources/read", params: "u0" });
+    await cache.get({ method: "resources/read", params: "u1999" });
+
+    const oldHit = events.find((e) => e.params === "u0");
+    const recentHit = events.find((e) => e.params === "u1999");
+    expect(oldHit?.ageMs).toBe(0);
+    expect(recentHit?.ageMs).toBeGreaterThan(0);
+  });
+});

--- a/sdk/tests/operations.test.ts
+++ b/sdk/tests/operations.test.ts
@@ -49,9 +49,11 @@ describe("listResources", () => {
       cursor: "cur",
     });
 
-    expect(manager.listResources).toHaveBeenCalledWith("srv", {
-      cursor: "cur",
-    });
+    expect(manager.listResources).toHaveBeenCalledWith(
+      "srv",
+      { cursor: "cur" },
+      undefined,
+    );
     expect(result.resources).toHaveLength(1);
     expect(result.nextCursor).toBe("next");
   });
@@ -60,7 +62,11 @@ describe("listResources", () => {
     const manager = createMockManager();
     await listResources(manager, { serverId: "srv" });
 
-    expect(manager.listResources).toHaveBeenCalledWith("srv", undefined);
+    expect(manager.listResources).toHaveBeenCalledWith(
+      "srv",
+      undefined,
+      undefined,
+    );
   });
 
   it("defaults resources to empty array when undefined", async () => {
@@ -89,9 +95,11 @@ describe("readResource", () => {
       uri: "file:///test.txt",
     });
 
-    expect(manager.readResource).toHaveBeenCalledWith("srv", {
-      uri: "file:///test.txt",
-    });
+    expect(manager.readResource).toHaveBeenCalledWith(
+      "srv",
+      { uri: "file:///test.txt" },
+      undefined,
+    );
     expect(result.content).toEqual(content);
   });
 });
@@ -212,7 +220,11 @@ describe("listTools", () => {
 
     await listTools(manager, { serverId: "srv", cursor: "cur" });
 
-    expect(manager.listTools).toHaveBeenCalledWith("srv", { cursor: "cur" });
+    expect(manager.listTools).toHaveBeenCalledWith(
+      "srv",
+      { cursor: "cur" },
+      undefined,
+    );
   });
 
   it("defaults tools to empty array when undefined", async () => {
@@ -276,10 +288,18 @@ describe("pagination guards", () => {
       echo: { executionCount: 1 },
       draw: { title: "Draw" },
     });
-    expect(manager.listTools).toHaveBeenNthCalledWith(1, "srv", undefined);
-    expect(manager.listTools).toHaveBeenNthCalledWith(2, "srv", {
-      cursor: "cursor-1",
-    });
+    expect(manager.listTools).toHaveBeenNthCalledWith(
+      1,
+      "srv",
+      undefined,
+      undefined,
+    );
+    expect(manager.listTools).toHaveBeenNthCalledWith(
+      2,
+      "srv",
+      { cursor: "cursor-1" },
+      undefined,
+    );
   });
 });
 

--- a/sdk/tests/support/cache-fixture.ts
+++ b/sdk/tests/support/cache-fixture.ts
@@ -1,0 +1,172 @@
+/**
+ * SEP-2549 cache test fixture (dual-era).
+ *
+ * `buildCacheFixtureServer` registers the same primitive surface as the base
+ * dual-era fixture but attaches a server-level `cacheHints` entry so its
+ * `tools/list` result carries `ttlMs: 60_000` (+ `cacheScope: 'public'`). On a
+ * 2026-07-28 connection the modern wire codec emits those fields, so a still-
+ * fresh cached `tools/list` is SERVED without a round trip under
+ * `cacheMode: 'use'` (the default) — the invisible serve this PR makes
+ * observable. The 2025-era codec has no cache path, so a legacy connection
+ * never carries `ttlMs`: the same fixture refetches every time (the cache
+ * engine is era-blind, but the wire body only has `ttlMs` when the modern
+ * codec put it there).
+ *
+ * `serveCountingFixtureOnPort` serves any handler over a loopback port while
+ * counting JSON-RPC request methods that actually reach the server — the wire
+ * evidence a debugger needs to prove "the cache answered, not the server".
+ * (The `MCPClientManager` transport takes no injectable `fetch`, so wire
+ * counting is done at the server handler rather than with `createCapturingFetch`.)
+ */
+
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { createMcpHandler, McpServer } from "@modelcontextprotocol/server";
+import type { McpHttpHandler } from "@modelcontextprotocol/server";
+import { toNodeHandler } from "@modelcontextprotocol/node";
+import { z } from "zod";
+
+export const CACHE_FIXTURE_SERVER_INFO = {
+  name: "mcpjam-cache-fixture",
+  version: "1.0.0",
+} as const;
+
+/** The server-declared cache lifetime for `tools/list` in the ttl fixture. */
+export const CACHE_FIXTURE_TTL_MS = 60_000;
+
+export const CACHE_FIXTURE_GREETING_URI = "test://greeting";
+
+function registerSurface(server: McpServer): void {
+  server.registerTool(
+    "echo",
+    {
+      description: "Echoes the provided message back as text.",
+      inputSchema: { message: z.string() },
+    },
+    async (args) => ({
+      content: [{ type: "text" as const, text: String(args.message) }],
+    }),
+  );
+  server.registerResource(
+    "greeting",
+    CACHE_FIXTURE_GREETING_URI,
+    { description: "A static greeting resource.", mimeType: "text/plain" },
+    async () => ({
+      contents: [
+        {
+          uri: CACHE_FIXTURE_GREETING_URI,
+          mimeType: "text/plain",
+          text: "hello from the cache fixture",
+        },
+      ],
+    }),
+  );
+  server.registerPrompt(
+    "welcome",
+    { description: "A trivial welcome prompt." },
+    async () => ({
+      messages: [
+        {
+          role: "user" as const,
+          content: { type: "text" as const, text: "welcome" },
+        },
+      ],
+    }),
+  );
+}
+
+/**
+ * Fixture whose `tools/list` carries `ttlMs: 60_000` on the modern era. The
+ * hint is server configuration (era-blind); only the 2026 codec emits it.
+ */
+export function buildCacheFixtureServer(): McpServer {
+  const server = new McpServer(CACHE_FIXTURE_SERVER_INFO, {
+    capabilities: { tools: {}, resources: {}, prompts: {} },
+    cacheHints: {
+      "tools/list": { ttlMs: CACHE_FIXTURE_TTL_MS, cacheScope: "public" },
+    },
+  });
+  registerSurface(server);
+  return server;
+}
+
+/**
+ * Same surface WITHOUT any cache hint: `tools/list` never carries `ttlMs`, so
+ * even on the modern era the client's `defaultCacheTtlMs` (0) makes every
+ * result "immediately stale" — a guard against an upstream default change.
+ */
+export function buildNoTtlFixtureServer(): McpServer {
+  const server = new McpServer(CACHE_FIXTURE_SERVER_INFO, {
+    capabilities: { tools: {}, resources: {}, prompts: {} },
+  });
+  registerSurface(server);
+  return server;
+}
+
+export function createCacheFixtureHandler(): McpHttpHandler {
+  return createMcpHandler(buildCacheFixtureServer);
+}
+
+export function createNoTtlFixtureHandler(): McpHttpHandler {
+  return createMcpHandler(buildNoTtlFixtureServer);
+}
+
+export interface ServedCountingFixture {
+  url: string;
+  /** JSON-RPC method → number of requests that reached the server. */
+  methodCounts: Map<string, number>;
+  /** Count for a single method (0 when unseen). */
+  count: (method: string) => number;
+  close: () => Promise<void>;
+}
+
+function recordMethods(bodyText: string, counts: Map<string, number>): void {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(bodyText);
+  } catch {
+    return;
+  }
+  const messages = Array.isArray(parsed) ? parsed : [parsed];
+  for (const message of messages) {
+    const method = (message as { method?: unknown })?.method;
+    if (typeof method === "string") {
+      counts.set(method, (counts.get(method) ?? 0) + 1);
+    }
+  }
+}
+
+/**
+ * Serve `handler` over a loopback port, counting every JSON-RPC request method
+ * that reaches it. The count is taken at the web-standard `fetch` seam (before
+ * the handler runs), so a cache serve — which never leaves the client — is
+ * exactly the case where the count does NOT advance.
+ */
+export async function serveCountingFixtureOnPort(
+  handler: McpHttpHandler,
+): Promise<ServedCountingFixture> {
+  const methodCounts = new Map<string, number>();
+  const countingHandler = {
+    fetch: async (request: Request, options?: unknown) => {
+      // Clone before reading so the real handler still sees the body.
+      const text = await request
+        .clone()
+        .text()
+        .catch(() => "");
+      recordMethods(text, methodCounts);
+      return handler.fetch(request, options as never);
+    },
+  };
+  const httpServer = http.createServer(toNodeHandler(countingHandler));
+  await new Promise<void>((resolve) =>
+    httpServer.listen(0, "127.0.0.1", resolve),
+  );
+  const address = httpServer.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${address.port}/mcp`,
+    methodCounts,
+    count: (method: string) => methodCounts.get(method) ?? 0,
+    close: () =>
+      new Promise<void>((resolve) => httpServer.close(() => resolve())),
+  };
+}


### PR DESCRIPTION
## What

Phase 3 §11.2 (SDK). The installed `@modelcontextprotocol/client` beta.4 has a real SEP-2549 response cache (`CacheMode = 'use' | 'refresh' | 'bypass'`, default `'use'` for the five cacheable verbs). `defaultCacheTtlMs` defaults to `0`, so a result WITHOUT a server-sent `ttlMs` is stored but never served — an invisible cache serve happens EXACTLY when a server sends `ttlMs > 0`. A debugger must never let such a serve look like a wire request. This PR threads `cacheMode` and adds a provenance channel.

- **`cacheMode` on the read verbs.** `ClientRequestOptions` gains an optional `cacheMode`; upstream `CacheMode`/`CacheScope` are re-exported. The five cacheable verbs on `ManagedMcpClient` widen to `CacheableRequestOptions`, and `MCPClientManager` + `operations.ts` params thread `cacheMode` into the underlying client calls. `withTimeout`/`withProgressHandler` now type-preserve it.
- **Provenance channel (distinct from `rpcLogger`).** New `observable-response-cache.ts` wraps the default in-memory store and reports fresh `get` hits (`entry.expiresAt > now`) to a new optional `MCPClientManagerOptions.cacheEventLogger` (`{ serverId, method, params, ageMs, scope }`). Cache hits are LOCAL events — they are never injected into the wire/rpc log. Wired only when a logger is supplied, so default behavior is byte-identical to the upstream default store.
- **Raw/conformance bypass.** `server-snapshot`, `server-doctor` list ops, and the `mcp-conformance` list/read checks pass `cacheMode: "bypass"` so they always exercise the live wire and never overwrite a cached entry.
- **Policy doc.** JSDoc states: default UI reads may serve cache only when the server sent `ttlMs` AND MCPJam surfaces provenance+age; Refresh ⇒ `'refresh'`; raw/conformance ⇒ `'bypass'`; `defaultCacheTtlMs` stays `0`. The `prior` DiscoverResult reconnect is EXPLICITLY DEFERRED (intended key spec written: server origin + auth/tenant + negotiation inputs) — not implemented here.
- **Tests.** `tests/support/cache-fixture.ts` (dual-era, `tools/list` carries `ttlMs: 60_000` via the server SDK's `cacheHints`) + `tests/cache-policy.integration.test.ts` prove: (a) a second no-cursor `listTools` performs ZERO new wire requests AND `cacheEventLogger` fires with an age; (b) `'refresh'` hits the wire; (c) `'bypass'` hits the wire without overwriting the stored entry; (d) a no-`ttlMs` fixture refetches every call; (e) snapshot list ops always hit the wire.

## Decisions to review

- **Era asymmetry is load-bearing.** Only the 2026-07-28 wire codec emits `ttlMs`/`cacheScope`, so the invisible serve is a MODERN-era phenomenon; the same ttl fixture on a 2025-era pin (`2025-06-18`) carries no `ttlMs` and refetches every call. The test exercises both eras and asserts the era-appropriate outcome (modern serves; legacy refetches) rather than pretending legacy can serve. Flagging in case the plan intended a single "both eras serve" assertion — that is not physically possible against a conformant server.
- **Wire counting is server-side, not `createCapturingFetch`.** The plan named `createCapturingFetch`, but `MCPClientManager`'s transport exposes no injectable `fetch`, so wire hits are counted at the server handler's `fetch` seam (`serveCountingFixtureOnPort`). This is stronger evidence anyway: a serve is exactly the case where the server never sees the request.
- **`cacheEventLogger` provenance is best-effort.** A fresh `get` under `'use'` ⇒ served; `'refresh'`/`'bypass'` never call `store.get` (verified in the compiled client), so the heuristic only over-counts on the client's internal `tools/list` derived-view probe during `callTool`. `ageMs` is `now − storeTime` for entries this wrapper stored (0 for entries from a different wrapper instance). Documented in the file.
- **Conformance bypass call sites overlap a sibling PR.** Another overnight PR is rewriting `mcp-conformance/runner.ts`. I added `cacheMode: "bypass"` to the clear list/read checks in `checks/{tools,resources,prompts}.ts` and to the single `runner.ts` `listResourceTemplates` call. Whichever of the two PRs merges second should rebase — the bypass belongs on whatever list/read calls remain.
- **`ObservableResponseCache` is exported** (additive public API) alongside the `CacheMode`/`CacheScope`/`CacheHitEvent`/`CacheEventLogger` types; a `minor` changeset is included.

## Verification

- `npm run typecheck -w @mcpjam/sdk` → exit 0; SDK build → exit 0.
- Full SDK vitest suite → exit 0 (2467 passed, 1 skipped). Includes the new `cache-policy.integration.test.ts` (7 tests) and updated `operations.test.ts` call-arg assertions (new 3rd cache-options arg).
- Downstream workspaces `@mcpjam/{design-system,chat-ui,widget-react,mcp}` typecheck → exit 0.
- The root `npm run typecheck` still stops at a PRE-EXISTING `@mcpjam/cli` failure (29 × TS7031 in `cli/src/lib/mcp-server.ts` on zod tool-handler params). Confirmed identical with a pristine SDK build (stash + rebuild), so it is not introduced by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core MCP read paths and caching semantics; mistakes could hide stale data in the debugger or mis-report wire vs cache, though defaults and bypass on evidence surfaces limit blast radius.
> 
> **Overview**
> Adds **SEP-2549 response-cache control** to `@mcpjam/sdk`: read paths can pass **`cacheMode`** (`use` | `refresh` | `bypass`) on `ClientRequestOptions`, through `MCPClientManager`, `operations.ts`, and the five cacheable verbs on `ManagedMcpClient`. **`CacheMode` / `CacheScope`** and related types are re-exported from the package entry.
> 
> When **`MCPClientManagerOptions.cacheEventLogger`** is set, each connection uses **`ObservableResponseCache`** around a per-connection in-memory store so **fresh local cache serves** emit `{ serverId, method, params, ageMs, scope }` without touching **`rpcLogger`** (cache hits never hit the wire). With no logger, behavior stays the same as the upstream default store. **`defaultCacheTtlMs` remains 0**, so entries without server `ttlMs` are stored but not served.
> 
> **Raw-evidence** flows (`server-snapshot`, `server-doctor`, `mcp-conformance` list/read checks) now pass **`cacheMode: "bypass"`** so they always use the live server. Inspector route tests expect the new third options argument on manager mocks. New **integration/unit tests** and a dual-era cache fixture document modern vs legacy `ttlMs` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0bdecdebc1f9ad871918871d1a6d14391c79fe1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SEP-2549 response-cache control to SDK read calls with per-call `cacheMode` and a local provenance channel for cache serves. Raw-evidence surfaces bypass the cache. No breaking changes; defaults stay the same.

- **New Features**
  - Added `cacheMode` to `ClientRequestOptions` and threaded it through the five cacheable read verbs and `operations.ts`; widened client method options to accept it.
  - Exported `CacheMode`, `CacheScope`, `ObservableResponseCache`, `CacheHitEvent`, and `CacheEventLogger` from the SDK.
  - New `MCPClientManagerOptions.cacheEventLogger` enables `ObservableResponseCache` (wrapping `InMemoryResponseCacheStore`) to emit cache-hit events; default `defaultCacheTtlMs` remains `0`.
  - `server-snapshot`, `server-doctor`, and `mcp-conformance` list/read checks now pass `cacheMode: "bypass"`.

- **Bug Fixes**
  - `ObservableResponseCache` only emits hits for fresh, serveable documents (corrupt or non-object values no longer emit).
  - Bounded the internal timestamp map used for `ageMs` (lazy pruning on stale/miss plus a hard size cap) to prevent unbounded growth.

<sup>Written for commit f0bdecdebc1f9ad871918871d1a6d14391c79fe1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

