### PR TITLE
feat: Project Environments — Inspector UI (management, suites, journeys, runner)

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -29,7 +29,12 @@ import { CiEvalsTab } from "./components/CiEvalsTab";
 import { ChatboxesTab } from "./components/ChatboxesTab";
 import { SwarmsTab } from "./components/swarms/SwarmsTab";
 import { EmptyState } from "./components/ui/empty-state";
-import { canViewSwarms, useViewerProjectRole } from "./hooks/useProjects";
+import {
+  canManageHosts,
+  canViewSwarms,
+  useViewerProjectRole,
+} from "./hooks/useProjects";
+import { ProjectEnvironmentsRoute } from "./components/project-environments/ProjectEnvironmentsRoute";
 import { SettingsTab } from "./components/SettingsTab";
 import { ApiKeysRoute } from "./components/settings/ApiKeysRoute";
 import { ProjectSettingsTab } from "./components/ProjectSettingsTab";
@@ -516,6 +521,8 @@ function NoRouterRouteBody({ activeTab }: { activeTab: string }) {
       return <ChatboxesRoute />;
     case "swarms":
       return <SwarmsRoute />;
+    case "environments":
+      return <EnvironmentsRoute />;
     case "playground":
       return <PlaygroundRoute />;
     case "support":
@@ -1200,6 +1207,29 @@ export function SwarmsRoute() {
       key={convexProjectId ?? "no-project"}
       projectId={convexProjectId}
       isAuthenticated={isAuthenticated}
+    />
+  );
+}
+
+export function EnvironmentsRoute() {
+  // Project environments (host + server group + skills bundles). The page
+  // component itself enforces the `project-environments-enabled` flag —
+  // rendering the standard redirect when off — so a direct `/environments`
+  // URL cannot bypass the sidebar gate. Writes are project-admin only
+  // (`canManageHosts` mirrors the backend's admin gate); everyone else
+  // browses read-only.
+  const { convexProjectId, isAuthenticated } = useAppRouteContext();
+  const { user, isLoading: isWorkOsLoading } = useAuth();
+  const { role } = useViewerProjectRole({
+    isAuthenticated,
+    projectId: convexProjectId,
+    viewerEmail: user?.email,
+    identityLoading: isWorkOsLoading,
+  });
+  return (
+    <ProjectEnvironmentsRoute
+      projectId={convexProjectId ?? null}
+      canManage={canManageHosts(role)}
     />
   );
 }

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -30,7 +30,7 @@ import { ChatboxesTab } from "./components/ChatboxesTab";
 import { SwarmsTab } from "./components/swarms/SwarmsTab";
 import { EmptyState } from "./components/ui/empty-state";
 import {
-  canManageHosts,
+  canManageAsOwnerOrAdmin,
   canViewSwarms,
   useViewerProjectRole,
 } from "./hooks/useProjects";
@@ -996,12 +996,10 @@ export function ToolsRoute() {
           serverConnectionStatus={
             selectedServerEntry?.connectionStatus ?? "disconnected"
           }
-          mcpToolResultImageRendering={
-            gateMcpToolResultImageRenderingByModelVisibility(
-              activeHost?.config?.mcpToolResultImageRendering,
-              activeHost?.config?.modelVisibleMcpToolResults
-            )
-          }
+          mcpToolResultImageRendering={gateMcpToolResultImageRenderingByModelVisibility(
+            activeHost?.config?.mcpToolResultImageRendering,
+            activeHost?.config?.modelVisibleMcpToolResults
+          )}
         />
       </div>
     </ActiveHostCapsResolverScope>
@@ -1227,15 +1225,16 @@ export function EnvironmentsRoute() {
     viewerEmail: user?.email,
     identityLoading: isWorkOsLoading,
   });
-  // Anonymous Convex owners never get a WorkOS email, so `role` stays
-  // undefined — but they own their personal-org default project and clear the
-  // backend admin gate (`requireAdminAccess` → owner) via userId. Mirror
-  // SwarmsTab: WorkOS-signed-in viewers go through the role-based admin gate;
-  // a settled anonymous owner (authenticated, not signed in, WorkOS hydrated)
-  // gets management. Fail-closed while WorkOS is still resolving.
-  const canManage = isWorkOsSignedIn
-    ? canManageHosts(role)
-    : isAuthenticated && !!convexProjectId && !isWorkOsLoading;
+  // Shared with SwarmsTab and unit-tested in `useProjects.test.ts`: WorkOS
+  // viewers take the role-based admin gate; a SETTLED anonymous Convex owner
+  // gets management (they never receive a role); fail-closed while hydrating.
+  const canManage = canManageAsOwnerOrAdmin({
+    isWorkOsSignedIn,
+    role,
+    isAuthenticated,
+    hasProject: !!convexProjectId,
+    identityLoading: isWorkOsLoading,
+  });
   return (
     <ProjectEnvironmentsRoute
       projectId={convexProjectId ?? null}
@@ -1663,8 +1662,8 @@ export default function App() {
     activeTab === "oauth-flow"
       ? "oauth"
       : activeTab === "xaa-flow" && xaaEnabled === true
-        ? "xaa"
-        : null;
+      ? "xaa"
+      : null;
   const { hidden: hiddenHeaderServers, hide: hideHeaderServer } =
     useHiddenHeaderServers(headerHiddenSurface);
 
@@ -2147,8 +2146,8 @@ export default function App() {
     const names = appState.selectedMultipleServers.length
       ? appState.selectedMultipleServers
       : appState.selectedServer && appState.selectedServer !== "none"
-        ? [appState.selectedServer]
-        : [];
+      ? [appState.selectedServer]
+      : [];
     publishSelectedServerNames(names);
   }, [appState.selectedMultipleServers, appState.selectedServer]);
   const persistRuntimeServerToProjectRef = useRef(
@@ -2899,7 +2898,9 @@ export default function App() {
         if (hasSurfaceKey && !isAppSurfaceId(requested)) {
           throw createInspectorCommandClientError(
             "invalid_request",
-            `Invalid surface ${JSON.stringify(requested)}. Omit it to snapshot the whole app, or pass a known screen id.`
+            `Invalid surface ${JSON.stringify(
+              requested
+            )}. Omit it to snapshot the whole app, or pass a known screen id.`
           );
         }
 
@@ -2933,8 +2934,8 @@ export default function App() {
         const selectedServers = appState.selectedMultipleServers?.length
           ? appState.selectedMultipleServers
           : focused
-            ? [focused]
-            : [];
+          ? [focused]
+          : [];
         return {
           path: pathname,
           activeTab: pathnameToActiveTab(pathname),

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -1220,16 +1220,26 @@ export function EnvironmentsRoute() {
   // browses read-only.
   const { convexProjectId, isAuthenticated } = useAppRouteContext();
   const { user, isLoading: isWorkOsLoading } = useAuth();
+  const isWorkOsSignedIn = !!user;
   const { role } = useViewerProjectRole({
     isAuthenticated,
     projectId: convexProjectId,
     viewerEmail: user?.email,
     identityLoading: isWorkOsLoading,
   });
+  // Anonymous Convex owners never get a WorkOS email, so `role` stays
+  // undefined — but they own their personal-org default project and clear the
+  // backend admin gate (`requireAdminAccess` → owner) via userId. Mirror
+  // SwarmsTab: WorkOS-signed-in viewers go through the role-based admin gate;
+  // a settled anonymous owner (authenticated, not signed in, WorkOS hydrated)
+  // gets management. Fail-closed while WorkOS is still resolving.
+  const canManage = isWorkOsSignedIn
+    ? canManageHosts(role)
+    : isAuthenticated && !!convexProjectId && !isWorkOsLoading;
   return (
     <ProjectEnvironmentsRoute
       projectId={convexProjectId ?? null}
-      canManage={canManageHosts(role)}
+      canManage={canManage}
     />
   );
 }

--- a/mcpjam-inspector/client/src/components/computer/EnvironmentsDrawer.tsx
+++ b/mcpjam-inspector/client/src/components/computer/EnvironmentsDrawer.tsx
@@ -29,6 +29,7 @@ import {
   type EnvironmentView,
 } from "@/hooks/useComputerEnvironments";
 import { EnvironmentBuildBadge } from "./EnvironmentBuildBadge";
+import { convexErrMessage } from "@/lib/convex-error";
 
 // Ships a real, buildable default so "Create → Build" works out of the box.
 // The base must be an allowlisted official image (debian, ubuntu, node,
@@ -40,25 +41,9 @@ FROM debian:bookworm-slim@sha256:60eac759739651111db372c07be67863818726f754804b8
 RUN echo "customize me"
 `;
 
-function errMessage(err: unknown, fallback: string): string {
-  // Convex `ConvexError` payloads land on `err.data` (a string, or a record
-  // with `message`) — e.g. the backend's DockerfileValidationError. Prefer that
-  // over `err.message`, which for an application error is the redacted
-  // "Server Error"/Request-ID string.
-  if (err && typeof err === "object" && "data" in err) {
-    const data = (err as { data: unknown }).data;
-    if (typeof data === "string" && data.trim()) return data.slice(0, 400);
-    if (data && typeof data === "object" && "message" in data) {
-      const msg = (data as { message: unknown }).message;
-      if (typeof msg === "string" && msg.trim()) return msg.slice(0, 400);
-    }
-  }
-  if (err instanceof Error && err.message) {
-    // Fallback: strip the noisy server prefix from a plain thrown message.
-    return err.message.replace(/^\[.*?\]\s*/, "").slice(0, 400) || fallback;
-  }
-  return fallback;
-}
+// Convex error shaping (e.g. the backend's DockerfileValidationError) lives
+// in the shared util now that project environments reuse the same pattern.
+const errMessage = convexErrMessage;
 
 /**
  * Manage the project's Computer environments and which one this computer boots
@@ -105,7 +90,9 @@ export function EnvironmentsDrawer({
         className="flex w-full flex-col gap-0 sm:max-w-xl"
       >
         <SheetHeader className="border-b px-4 py-3">
-          <SheetTitle>Environments</SheetTitle>
+          {/* "Sandbox images", not "Environments" — Project environments own
+              the word "Environments" in UI now (naming decision 2026-07-24). */}
+          <SheetTitle>Sandbox images</SheetTitle>
           <SheetDescription>
             A custom Docker image your computer boots from. Changing the image
             rebuilds the computer — all files on it will be deleted.

--- a/mcpjam-inspector/client/src/components/evals/__tests__/build-suite-run-plans.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/build-suite-run-plans.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import { buildSuiteRunPlans } from "../helpers";
+
+const hostAttachment = (namedHostId: string, servers: string[]) => ({
+  namedHostId,
+  enabledOptionalServerIds: [],
+  hostName: `host-${namedHostId}`,
+  resolvedServerNames: servers,
+});
+
+describe("buildSuiteRunPlans", () => {
+  it("replaces the host axis with the environment axis when environmentIds is set", () => {
+    const plans = buildSuiteRunPlans(
+      {
+        environment: { servers: ["flat-1"] },
+        hostAttachments: [hostAttachment("h1", ["srv-a"])],
+        environmentIds: ["env-1", "env-2"],
+      },
+      [
+        { environmentId: "env-2", name: "Beta" },
+        { environmentId: "env-1", name: "Alpha" },
+      ],
+      ["flat-1"]
+    );
+    expect(plans).toHaveLength(2);
+    expect(plans.map((p) => p.environmentId)).toEqual(["env-1", "env-2"]);
+    expect(plans.map((p) => p.environmentName)).toEqual(["Alpha", "Beta"]);
+    // Environment plans never carry host pointers.
+    expect(plans.every((p) => p.namedHostId === undefined)).toBe(true);
+  });
+
+  it("preserves the suite's attach order, not the environments list order", () => {
+    const plans = buildSuiteRunPlans({ environmentIds: ["env-b", "env-a"] }, [
+      { environmentId: "env-a", name: "A" },
+      { environmentId: "env-b", name: "B" },
+    ]);
+    expect(plans.map((p) => p.environmentId)).toEqual(["env-b", "env-a"]);
+  });
+
+  it("never guesses server ids for environment plans", () => {
+    const plans = buildSuiteRunPlans(
+      {
+        environment: { servers: ["flat-1", "flat-2"] },
+        serverAttachment: {
+          _id: "sa-1",
+          name: "group",
+          serverIds: ["s1"],
+          resolvedServerNames: ["srv-standalone"],
+        },
+        environmentIds: ["env-1"],
+      },
+      [{ environmentId: "env-1", name: "Solo" }],
+      ["flat-1", "flat-2"]
+    );
+    expect(plans).toHaveLength(1);
+    expect(plans[0].serverIds).toEqual([]);
+  });
+
+  it("carries an explicit environmentId even for a single-env suite", () => {
+    const plans = buildSuiteRunPlans({ environmentIds: ["env-only"] }, []);
+    expect(plans).toEqual([
+      {
+        namedHostId: undefined,
+        hostName: null,
+        serverIds: [],
+        environmentId: "env-only",
+        environmentName: "env-only",
+      },
+    ]);
+  });
+
+  it("falls back to id when the environment list has no matching name", () => {
+    const plans = buildSuiteRunPlans({ environmentIds: ["env-x"] }, undefined);
+    expect(plans[0].environmentName).toBe("env-x");
+  });
+
+  it("delegates to host plans when the suite has no environments", () => {
+    const plans = buildSuiteRunPlans(
+      {
+        environment: { servers: ["flat-1"] },
+        hostAttachments: [
+          hostAttachment("h1", ["srv-a"]),
+          hostAttachment("h2", ["srv-b"]),
+        ],
+      },
+      [],
+      ["flat-1"]
+    );
+    expect(plans).toHaveLength(2);
+    expect(plans.map((p) => p.namedHostId)).toEqual(["h1", "h2"]);
+    expect(plans[0].serverIds).toEqual(["srv-a"]);
+    expect(plans.every((p) => p.environmentId === undefined)).toBe(true);
+  });
+
+  it("treats an empty environmentIds array as legacy (host/flat) fan-out", () => {
+    const plans = buildSuiteRunPlans(
+      { environment: { servers: ["flat-1"] }, environmentIds: [] },
+      [],
+      ["flat-1"]
+    );
+    expect(plans).toEqual([
+      { namedHostId: undefined, hostName: null, serverIds: ["flat-1"] },
+    ]);
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/__tests__/schedule-editor-environment.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/schedule-editor-environment.test.tsx
@@ -19,6 +19,11 @@ vi.mock("@/hooks/useProjectEnvironments", () => ({
     projectId ? mockUseProjectEnvironments() : undefined,
 }));
 
+// The environment pin is flag-gated; these cases exercise the enabled path.
+vi.mock("@/hooks/useProjectEnvironmentsEnabled", () => ({
+  useProjectEnvironmentsEnabled: () => true,
+}));
+
 vi.mock("@/lib/toast", () => ({
   toast: { success: vi.fn(), error: vi.fn() },
 }));

--- a/mcpjam-inspector/client/src/components/evals/__tests__/schedule-editor-environment.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/schedule-editor-environment.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
+
+const { mockSetSuiteSchedule, mockUseProjectEnvironments } = vi.hoisted(() => ({
+  mockSetSuiteSchedule: vi.fn(async () => ({})),
+  mockUseProjectEnvironments: vi.fn(() => [
+    { environmentId: "env-a", name: "Alpha" },
+    { environmentId: "env-b", name: "Beta" },
+  ]),
+}));
+
+vi.mock("convex/react", () => ({
+  useMutation: () => mockSetSuiteSchedule,
+}));
+
+vi.mock("@/hooks/useProjectEnvironments", () => ({
+  useProjectEnvironments: (projectId: string | null) =>
+    projectId ? mockUseProjectEnvironments() : undefined,
+}));
+
+vi.mock("@/lib/toast", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import { ScheduleEditor } from "../schedule-editor";
+
+describe("ScheduleEditor environment pin", () => {
+  beforeEach(() => {
+    mockSetSuiteSchedule.mockClear();
+  });
+
+  it("renders a required environment select for a multi-env suite and pins on enable", async () => {
+    const user = userEvent.setup();
+    render(
+      <ScheduleEditor
+        suiteId="suite-1"
+        schedule={undefined}
+        projectId="proj-1"
+        environmentIds={["env-b", "env-a"]}
+      />
+    );
+
+    expect(
+      screen.getByText("Scheduled runs use environment")
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("switch"));
+
+    expect(mockSetSuiteSchedule).toHaveBeenCalledTimes(1);
+    expect(mockSetSuiteSchedule).toHaveBeenCalledWith(
+      expect.objectContaining({
+        suiteId: "suite-1",
+        enabled: true,
+        // Defaults to the FIRST attached env (suite attach order), not the
+        // environments list order.
+        environmentId: "env-b",
+      })
+    );
+  });
+
+  it("uses the persisted pin over the attach-order default", async () => {
+    const user = userEvent.setup();
+    render(
+      <ScheduleEditor
+        suiteId="suite-1"
+        schedule={{
+          intervalMinutes: 60,
+          enabled: false,
+          state: "active",
+          environmentId: "env-a",
+        }}
+        projectId="proj-1"
+        environmentIds={["env-b", "env-a"]}
+      />
+    );
+
+    await user.click(screen.getByRole("switch"));
+
+    expect(mockSetSuiteSchedule).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: true, environmentId: "env-a" })
+    );
+  });
+
+  it("omits the pin (and the select) for single-env and legacy suites", async () => {
+    const user = userEvent.setup();
+    render(
+      <ScheduleEditor
+        suiteId="suite-1"
+        schedule={undefined}
+        projectId="proj-1"
+        environmentIds={["env-a"]}
+      />
+    );
+
+    expect(
+      screen.queryByText("Scheduled runs use environment")
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("switch"));
+
+    expect(mockSetSuiteSchedule).toHaveBeenCalledTimes(1);
+    const args = mockSetSuiteSchedule.mock.calls[0][0] as Record<
+      string,
+      unknown
+    >;
+    expect(args).not.toHaveProperty("environmentId");
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/__tests__/use-eval-handlers.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/use-eval-handlers.test.ts
@@ -55,6 +55,10 @@ vi.mock("convex/react", () => ({
   }),
   useMutation: () => vi.fn().mockResolvedValue(undefined),
   useAction: () => vi.fn().mockResolvedValue(undefined),
+  // Pulled in via useProjectEnvironments (env-suite fan-out labels); the
+  // handlers under test never enable that query (flag off ⇒ "skip").
+  useQuery: () => undefined,
+  useConvexAuth: () => ({ isAuthenticated: false, isLoading: false }),
 }));
 
 // Mock useAiProviderKeys (mutable for replay-without-keys coverage)

--- a/mcpjam-inspector/client/src/components/evals/helpers.ts
+++ b/mcpjam-inspector/client/src/components/evals/helpers.ts
@@ -107,6 +107,49 @@ export function buildSuiteHostRunPlans(
   );
 }
 
+export type SuiteRunPlan = SuiteHostRunPlan & {
+  /** Set on environment plans; forwarded on the run request wire. */
+  environmentId?: string;
+  /** Display-only (toasts/labels); the server re-resolves authoritatively. */
+  environmentName?: string;
+};
+
+/**
+ * Run-all fan-out plans. When the suite has attached project environments,
+ * the ENVIRONMENT axis replaces the host axis: one plan per environment, in
+ * attach order, carrying `{environmentId, environmentName}` ONLY —
+ * `serverIds` stays EMPTY because `listEnvironments` intentionally returns
+ * pointers, not a closed execution set. The Inspector server performs the
+ * authoritative resolution (P0.1 `resolveEnvironmentForLaunch`) and returns
+ * a readable auth/connection error for that exact closed set; any browser
+ * readiness check is advisory only. Suites without environments delegate to
+ * {@link buildSuiteHostRunPlans} unchanged.
+ */
+export function buildSuiteRunPlans(
+  suite: {
+    environment?: { servers?: string[] } | undefined;
+    hostAttachments?: EvalSuite["hostAttachments"];
+    serverAttachment?: EvalSuite["serverAttachment"];
+    environmentIds?: string[];
+  },
+  environments?: Array<{ environmentId: string; name: string }>,
+  fallbackServerIds?: string[],
+): SuiteRunPlan[] {
+  const envIds = suite.environmentIds ?? [];
+  if (envIds.length > 0) {
+    return envIds.map((environmentId) => ({
+      namedHostId: undefined,
+      hostName: null,
+      serverIds: [],
+      environmentId,
+      environmentName:
+        environments?.find((e) => e.environmentId === environmentId)?.name ??
+        environmentId,
+    }));
+  }
+  return buildSuiteHostRunPlans(suite, fallbackServerIds);
+}
+
 export function getSelectedSuiteHostRunPlan(
   suite: {
     environment?: { servers?: string[] } | undefined;

--- a/mcpjam-inspector/client/src/components/evals/run-detail-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-detail-view.tsx
@@ -434,6 +434,11 @@ export function RunDetailView({
     ? runEnvironments?.find((e) => e.environmentId === runComputerEnvId)
         ?.name ?? runComputerEnvId
     : null;
+  // Project-environment provenance frozen at run start (name + revision) —
+  // renders the "Environment" chip. Distinct from the sandbox-image pin
+  // above, whose chip reads "Sandbox image".
+  const runProjectEnvironmentRef =
+    selectedRunDetails.configSnapshot?.environmentRef ?? null;
   const {
     result: goalCompletionResult,
     pending: goalCompletionPending,
@@ -707,9 +712,28 @@ export function RunDetailView({
         </div>
       ) : null}
 
-      {runComputerEnvId ? (
+      {runProjectEnvironmentRef ? (
         <div className="mb-4 flex flex-wrap items-center gap-2">
           <span className={runDetailMetaLabelClass}>Environment</span>
+          <span
+            className="inline-flex items-center gap-1.5 rounded-md border border-border/60 px-2 py-0.5 text-xs"
+            title={runProjectEnvironmentRef.environmentId}
+          >
+            <span className="text-foreground">
+              {runProjectEnvironmentRef.name}
+            </span>
+            <span className="font-mono text-[10px] text-muted-foreground">
+              rev {runProjectEnvironmentRef.revision}
+            </span>
+          </span>
+        </div>
+      ) : null}
+
+      {runComputerEnvId ? (
+        <div className="mb-4 flex flex-wrap items-center gap-2">
+          {/* "Sandbox image", not "Environment" — project environments own
+              that word now (naming decision 2026-07-24). */}
+          <span className={runDetailMetaLabelClass}>Sandbox image</span>
           <span
             className="inline-flex items-center gap-1.5 rounded-md border border-border/60 px-2 py-0.5 text-xs"
             title={

--- a/mcpjam-inspector/client/src/components/evals/run-detail-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-detail-view.tsx
@@ -49,6 +49,7 @@ import {
 } from "./run-insight-rail";
 import { runDetailMetaLabelClass } from "./run-detail-typography";
 import { useEnvironments } from "@/hooks/useComputerEnvironments";
+import { useProjectEnvironmentsEnabled } from "@/hooks/useProjectEnvironmentsEnabled";
 import {
   ResizableHandle,
   ResizablePanel,
@@ -436,9 +437,12 @@ export function RunDetailView({
     : null;
   // Project-environment provenance frozen at run start (name + revision) —
   // renders the "Environment" chip. Distinct from the sandbox-image pin
-  // above, whose chip reads "Sandbox image".
-  const runProjectEnvironmentRef =
-    selectedRunDetails.configSnapshot?.environmentRef ?? null;
+  // above, whose chip reads "Sandbox image". Flag-gated so the rollback
+  // kill-switch hides env names/revisions on retained historical runs too.
+  const projectEnvironmentsEnabled = useProjectEnvironmentsEnabled();
+  const runProjectEnvironmentRef = projectEnvironmentsEnabled
+    ? (selectedRunDetails.configSnapshot?.environmentRef ?? null)
+    : null;
   const {
     result: goalCompletionResult,
     pending: goalCompletionPending,

--- a/mcpjam-inspector/client/src/components/evals/schedule-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/schedule-editor.tsx
@@ -8,7 +8,7 @@
  * resume; resume resets the failure counter and the clock.
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useMutation } from "convex/react";
 import { toast } from "@/lib/toast";
 import { Button } from "@mcpjam/design-system/button";
@@ -20,6 +20,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@mcpjam/design-system/select";
+import { useProjectEnvironments } from "@/hooks/useProjectEnvironments";
 
 const INTERVAL_OPTIONS: Array<{ minutes: number; label: string }> = [
   { minutes: 5, label: "Every 5 minutes" },
@@ -35,6 +36,12 @@ export type SuiteSchedule = {
   enabled: boolean;
   state: "active" | "paused_quota" | "paused_auth" | "paused_failures";
   consecutiveFailures?: number;
+  /**
+   * The pinned project environment scheduled runs launch with. Required by
+   * `setSuiteSchedule` when the suite attaches ≥2 environments; single-env
+   * suites may omit it (the run-start default applies).
+   */
+  environmentId?: string;
 };
 
 const PAUSE_COPY: Record<Exclude<SuiteSchedule["state"], "active">, string> = {
@@ -49,9 +56,15 @@ const PAUSE_COPY: Record<Exclude<SuiteSchedule["state"], "active">, string> = {
 export function ScheduleEditor({
   suiteId,
   schedule,
+  projectId = null,
+  environmentIds,
 }: {
   suiteId: string;
   schedule: SuiteSchedule | undefined;
+  /** Needed only to label the environment pin (multi-env suites). */
+  projectId?: string | null;
+  /** The suite's attach-ordered project environments (absent ⇒ legacy). */
+  environmentIds?: string[];
 }) {
   const setSuiteSchedule = useMutation(
     "testSuites:setSuiteSchedule" as any,
@@ -59,6 +72,7 @@ export function ScheduleEditor({
     suiteId: string;
     enabled: boolean;
     intervalMinutes?: number;
+    environmentId?: string;
   }) => Promise<unknown>;
   const [isSaving, setIsSaving] = useState(false);
 
@@ -73,15 +87,53 @@ export function ScheduleEditor({
   useEffect(() => {
     setDraftIntervalMinutes(persistedIntervalMinutes);
   }, [persistedIntervalMinutes]);
-  const pausedState =
-    enabled && schedule && schedule.state !== "active"
-      ? schedule.state
-      : null;
+
+  // Environment pin: REQUIRED when the suite attaches ≥2 environments.
+  // Draft mirrors the interval pattern — persisted pin (or first attached
+  // env) seeds it, and every enabled write carries it.
+  const attachedEnvironmentIds = useMemo(
+    () => environmentIds ?? [],
+    [environmentIds],
+  );
+  const requiresEnvironmentPin = attachedEnvironmentIds.length >= 2;
+  const persistedEnvironmentId = schedule?.environmentId;
+  const [draftEnvironmentId, setDraftEnvironmentId] = useState<
+    string | undefined
+  >(persistedEnvironmentId ?? attachedEnvironmentIds[0]);
+  useEffect(() => {
+    setDraftEnvironmentId(persistedEnvironmentId ?? attachedEnvironmentIds[0]);
+  }, [persistedEnvironmentId, attachedEnvironmentIds]);
+  const environments = useProjectEnvironments(
+    requiresEnvironmentPin ? projectId : null,
+  );
+  // Defensive: a persisted pin whose environment was detached from the
+  // suite still renders (marked) so the user sees why a re-pin is needed.
+  const pinDetached =
+    !!draftEnvironmentId &&
+    attachedEnvironmentIds.length > 0 &&
+    !attachedEnvironmentIds.includes(draftEnvironmentId);
+
+  const environmentLabel = (id: string) =>
+    environments?.find((e) => e.environmentId === id)?.name ?? id;
 
   const apply = async (args: { enabled: boolean; intervalMinutes?: number }) => {
+    if (args.enabled && requiresEnvironmentPin && !draftEnvironmentId) {
+      toast.error(
+        "Pick which environment scheduled runs should use before enabling.",
+      );
+      return;
+    }
     setIsSaving(true);
     try {
-      await setSuiteSchedule({ suiteId, ...args });
+      await setSuiteSchedule({
+        suiteId,
+        ...args,
+        // Every enabled write carries the pin so a backend-side default can
+        // never drift from what this editor shows.
+        ...(args.enabled && requiresEnvironmentPin && draftEnvironmentId
+          ? { environmentId: draftEnvironmentId }
+          : {}),
+      });
       toast.success(
         args.enabled ? "Schedule updated" : "Schedule disabled",
       );
@@ -93,6 +145,11 @@ export function ScheduleEditor({
       setIsSaving(false);
     }
   };
+
+  const pausedState =
+    enabled && schedule && schedule.state !== "active"
+      ? schedule.state
+      : null;
 
   return (
     <div className="space-y-3">
@@ -143,6 +200,56 @@ export function ScheduleEditor({
           </SelectContent>
         </Select>
       </div>
+      {requiresEnvironmentPin ? (
+        <div className="flex items-center justify-between gap-3">
+          <span className="text-xs text-muted-foreground">
+            Scheduled runs use environment
+          </span>
+          <Select
+            value={draftEnvironmentId ?? ""}
+            disabled={isSaving}
+            onValueChange={(next) => {
+              if (!next) return;
+              setDraftEnvironmentId(next);
+              if (enabled) {
+                void setSuiteSchedule({
+                  suiteId,
+                  enabled: true,
+                  intervalMinutes: draftIntervalMinutes,
+                  environmentId: next,
+                })
+                  .then(() => toast.success("Schedule updated"))
+                  .catch((error) =>
+                    toast.error(
+                      error instanceof Error
+                        ? error.message
+                        : "Failed to update schedule",
+                    ),
+                  );
+              }
+            }}
+          >
+            <SelectTrigger className="h-8 w-44 text-xs">
+              <SelectValue placeholder="Pick an environment" />
+            </SelectTrigger>
+            <SelectContent>
+              {attachedEnvironmentIds.map((id) => (
+                <SelectItem key={id} value={id} className="text-xs">
+                  {environmentLabel(id)}
+                </SelectItem>
+              ))}
+              {pinDetached && draftEnvironmentId ? (
+                <SelectItem
+                  value={draftEnvironmentId}
+                  className="text-xs"
+                >
+                  {environmentLabel(draftEnvironmentId)} (no longer attached)
+                </SelectItem>
+              ) : null}
+            </SelectContent>
+          </Select>
+        </div>
+      ) : null}
       {pausedState ? (
         <div className="flex items-start justify-between gap-3 rounded-md border border-warning/50 bg-warning/10 p-3">
           <p className="text-xs text-foreground">{PAUSE_COPY[pausedState]}</p>

--- a/mcpjam-inspector/client/src/components/evals/schedule-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/schedule-editor.tsx
@@ -21,6 +21,7 @@ import {
   SelectValue,
 } from "@mcpjam/design-system/select";
 import { useProjectEnvironments } from "@/hooks/useProjectEnvironments";
+import { useProjectEnvironmentsEnabled } from "@/hooks/useProjectEnvironmentsEnabled";
 
 const INTERVAL_OPTIONS: Array<{ minutes: number; label: string }> = [
   { minutes: 5, label: "Every 5 minutes" },
@@ -95,7 +96,12 @@ export function ScheduleEditor({
     () => environmentIds ?? [],
     [environmentIds],
   );
-  const requiresEnvironmentPin = attachedEnvironmentIds.length >= 2;
+  // Flag-gated: with the kill-switch off, the environment pin control, its
+  // query, and its write are all suppressed even for a suite that already has
+  // ≥2 attached environments.
+  const projectEnvironmentsEnabled = useProjectEnvironmentsEnabled();
+  const requiresEnvironmentPin =
+    projectEnvironmentsEnabled && attachedEnvironmentIds.length >= 2;
   const persistedEnvironmentId = schedule?.environmentId;
   const [draftEnvironmentId, setDraftEnvironmentId] = useState<
     string | undefined
@@ -116,8 +122,15 @@ export function ScheduleEditor({
   const environmentLabel = (id: string) =>
     environments?.find((e) => e.environmentId === id)?.name ?? id;
 
-  const apply = async (args: { enabled: boolean; intervalMinutes?: number }) => {
-    if (args.enabled && requiresEnvironmentPin && !draftEnvironmentId) {
+  const apply = async (args: {
+    enabled: boolean;
+    intervalMinutes?: number;
+    /** New pin to persist this write (env-change path); defaults to the draft
+     * pin. Passed explicitly because a just-set draft isn't visible yet. */
+    environmentId?: string;
+  }) => {
+    const effectiveEnvironmentId = args.environmentId ?? draftEnvironmentId;
+    if (args.enabled && requiresEnvironmentPin && !effectiveEnvironmentId) {
       toast.error(
         "Pick which environment scheduled runs should use before enabling.",
       );
@@ -127,11 +140,14 @@ export function ScheduleEditor({
     try {
       await setSuiteSchedule({
         suiteId,
-        ...args,
+        enabled: args.enabled,
+        ...(args.intervalMinutes !== undefined
+          ? { intervalMinutes: args.intervalMinutes }
+          : {}),
         // Every enabled write carries the pin so a backend-side default can
         // never drift from what this editor shows.
-        ...(args.enabled && requiresEnvironmentPin && draftEnvironmentId
-          ? { environmentId: draftEnvironmentId }
+        ...(args.enabled && requiresEnvironmentPin && effectiveEnvironmentId
+          ? { environmentId: effectiveEnvironmentId }
           : {}),
       });
       toast.success(
@@ -211,21 +227,15 @@ export function ScheduleEditor({
             onValueChange={(next) => {
               if (!next) return;
               setDraftEnvironmentId(next);
+              // Route through apply() so this write serializes on `isSaving`
+              // with the switch/interval writes — a quick disable or interval
+              // change can no longer race and persist an unintended state.
               if (enabled) {
-                void setSuiteSchedule({
-                  suiteId,
+                void apply({
                   enabled: true,
                   intervalMinutes: draftIntervalMinutes,
                   environmentId: next,
-                })
-                  .then(() => toast.success("Schedule updated"))
-                  .catch((error) =>
-                    toast.error(
-                      error instanceof Error
-                        ? error.message
-                        : "Failed to update schedule",
-                    ),
-                  );
+                });
               }
             }}
           >

--- a/mcpjam-inspector/client/src/components/evals/schedule-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/schedule-editor.tsx
@@ -68,7 +68,7 @@ export function ScheduleEditor({
   environmentIds?: string[];
 }) {
   const setSuiteSchedule = useMutation(
-    "testSuites:setSuiteSchedule" as any,
+    "testSuites:setSuiteSchedule" as any
   ) as unknown as (args: {
     suiteId: string;
     enabled: boolean;
@@ -83,7 +83,7 @@ export function ScheduleEditor({
   // until the next enable (the server only stores intervals on enabled
   // writes). Re-seeds when the persisted value changes from elsewhere.
   const [draftIntervalMinutes, setDraftIntervalMinutes] = useState(
-    persistedIntervalMinutes,
+    persistedIntervalMinutes
   );
   useEffect(() => {
     setDraftIntervalMinutes(persistedIntervalMinutes);
@@ -92,9 +92,17 @@ export function ScheduleEditor({
   // Environment pin: REQUIRED when the suite attaches ≥2 environments.
   // Draft mirrors the interval pattern — persisted pin (or first attached
   // env) seeds it, and every enabled write carries it.
+  // Memoized on CONTENT, not on the array reference: `environmentIds` comes
+  // from a live Convex subscription and is a fresh array on every parent
+  // re-render even when the ids are identical. Keying on the reference made the
+  // seeding effect below re-run on any unrelated suite update, silently
+  // discarding a pin the user had picked but not yet saved. Convex ids never
+  // contain a comma, so the joined key is unambiguous.
+  const attachedEnvironmentIdsKey = (environmentIds ?? []).join(",");
   const attachedEnvironmentIds = useMemo(
-    () => environmentIds ?? [],
-    [environmentIds],
+    () =>
+      attachedEnvironmentIdsKey ? attachedEnvironmentIdsKey.split(",") : [],
+    [attachedEnvironmentIdsKey]
   );
   // Flag-gated: with the kill-switch off, the environment pin control, its
   // query, and its write are all suppressed even for a suite that already has
@@ -110,7 +118,7 @@ export function ScheduleEditor({
     setDraftEnvironmentId(persistedEnvironmentId ?? attachedEnvironmentIds[0]);
   }, [persistedEnvironmentId, attachedEnvironmentIds]);
   const environments = useProjectEnvironments(
-    requiresEnvironmentPin ? projectId : null,
+    requiresEnvironmentPin ? projectId : null
   );
   // Defensive: a persisted pin whose environment was detached from the
   // suite still renders (marked) so the user sees why a re-pin is needed.
@@ -132,7 +140,7 @@ export function ScheduleEditor({
     const effectiveEnvironmentId = args.environmentId ?? draftEnvironmentId;
     if (args.enabled && requiresEnvironmentPin && !effectiveEnvironmentId) {
       toast.error(
-        "Pick which environment scheduled runs should use before enabling.",
+        "Pick which environment scheduled runs should use before enabling."
       );
       return;
     }
@@ -150,12 +158,10 @@ export function ScheduleEditor({
           ? { environmentId: effectiveEnvironmentId }
           : {}),
       });
-      toast.success(
-        args.enabled ? "Schedule updated" : "Schedule disabled",
-      );
+      toast.success(args.enabled ? "Schedule updated" : "Schedule disabled");
     } catch (error) {
       toast.error(
-        error instanceof Error ? error.message : "Failed to update schedule",
+        error instanceof Error ? error.message : "Failed to update schedule"
       );
     } finally {
       setIsSaving(false);
@@ -163,9 +169,7 @@ export function ScheduleEditor({
   };
 
   const pausedState =
-    enabled && schedule && schedule.state !== "active"
-      ? schedule.state
-      : null;
+    enabled && schedule && schedule.state !== "active" ? schedule.state : null;
 
   return (
     <div className="space-y-3">
@@ -249,10 +253,7 @@ export function ScheduleEditor({
                 </SelectItem>
               ))}
               {pinDetached && draftEnvironmentId ? (
-                <SelectItem
-                  value={draftEnvironmentId}
-                  className="text-xs"
-                >
+                <SelectItem value={draftEnvironmentId} className="text-xs">
                   {environmentLabel(draftEnvironmentId)} (no longer attached)
                 </SelectItem>
               ) : null}
@@ -282,8 +283,8 @@ export function ScheduleEditor({
       ) : null}
       <p className="text-[11px] text-muted-foreground">
         Runs the whole suite — render checks and prompt tests — under your
-        identity. Prompt tests use the organization&apos;s model
-        configuration; failed scheduled runs raise an in-app notification.
+        identity. Prompt tests use the organization&apos;s model configuration;
+        failed scheduled runs raise an in-app notification.
       </p>
     </div>
   );

--- a/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
@@ -4,6 +4,8 @@ import { useFeatureFlagEnabled } from "posthog-js/react";
 import { useHostList } from "@/hooks/useClients";
 import { useComputersEnabled } from "@/hooks/useComputersEnabled";
 import { useEnvironments } from "@/hooks/useComputerEnvironments";
+import { useProjectEnvironmentsEnabled } from "@/hooks/useProjectEnvironmentsEnabled";
+import { SuiteProjectEnvironmentsPicker } from "./suite-project-environments-picker";
 import { toast } from "sonner";
 import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
 import {
@@ -389,6 +391,7 @@ export function SuiteIterationsView({
   // Reproducible-evals env picker (gated by the computers feature flag). Only
   // fetch the project's environments when the flag is on and we have a project.
   const computersEnabled = useComputersEnabled();
+  const projectEnvironmentsEnabled = useProjectEnvironmentsEnabled();
   const computerEnvironments = useEnvironments(
     computersEnabled && projectId ? projectId : null
   );
@@ -1436,6 +1439,32 @@ export function SuiteIterationsView({
                 </SettingsSection>
               ) : null}
 
+              {/* ── Environments (project environments, flag-gated) ────
+                  Attach-ordered bundles of one client + optional server
+                  group + pinned skills. Run all fires one run per attached
+                  environment; the backend resolves each at launch. */}
+              {projectEnvironmentsEnabled && projectId ? (
+                <SettingsSection
+                  label="Environments"
+                  layout="inline"
+                  inlineSlot={
+                    <SuiteProjectEnvironmentsPicker
+                      suiteId={suite._id}
+                      projectId={projectId}
+                      environmentIds={suite.environmentIds}
+                    />
+                  }
+                >
+                  <p className="text-[11px] text-muted-foreground/60">
+                    Run all fires one run per environment, in this order. An
+                    environment bundles one client, an optional server group,
+                    and pinned skills, resolved at launch. The client&apos;s
+                    own skills always apply on top; a suite skills
+                    &quot;exclude&quot; override wins over both.
+                  </p>
+                </SettingsSection>
+              ) : null}
+
               {/* ── Tool calls ───────────────────────────────────────── */}
               <SettingsSection
                 label="Tool calls"
@@ -1513,6 +1542,8 @@ export function SuiteIterationsView({
                   <ScheduleEditor
                     suiteId={suite._id}
                     schedule={suite.schedule}
+                    projectId={projectId}
+                    environmentIds={suite.environmentIds}
                   />
                 </SettingsSection>
               ) : null}

--- a/mcpjam-inspector/client/src/components/evals/suite-project-environments-picker.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-project-environments-picker.tsx
@@ -1,0 +1,184 @@
+import { useMemo, useState } from "react";
+import { useMutation } from "convex/react";
+import { ChevronDown, ExternalLink, Layers, Loader2 } from "lucide-react";
+import { toast } from "@/lib/toast";
+import { Checkbox } from "@mcpjam/design-system/checkbox";
+import { Label } from "@mcpjam/design-system/label";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@mcpjam/design-system/popover";
+import { cn } from "@/lib/utils";
+import { navigateApp, routePaths } from "@/lib/app-navigation";
+import { convexErrMessage } from "@/lib/convex-error";
+import { useProjectEnvironments } from "@/hooks/useProjectEnvironments";
+
+/** Backend cap on `suite.environmentIds`. */
+export const MAX_SUITE_ENVIRONMENTS = 10;
+
+/**
+ * Ordered multi-select of project environments for a suite. Selection order
+ * IS attach order (ordinal badges) — Run all fans out one run per
+ * environment in this order. Commits through
+ * `testSuites:setSuiteEnvironments`; backend rejections (dupes, cap,
+ * schedule-pin conflicts) surface verbatim.
+ */
+export function SuiteProjectEnvironmentsPicker({
+  suiteId,
+  projectId,
+  environmentIds,
+}: {
+  suiteId: string;
+  projectId: string;
+  /** The suite's persisted attach-ordered environment ids. */
+  environmentIds: string[] | undefined;
+}) {
+  const environments = useProjectEnvironments(projectId);
+  const setSuiteEnvironments = useMutation(
+    "testSuites:setSuiteEnvironments" as any
+  ) as unknown as (args: {
+    suiteId: string;
+    environmentIds: string[] | null;
+  }) => Promise<unknown>;
+
+  const [open, setOpen] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  const selected = environmentIds ?? [];
+  const environmentsById = useMemo(
+    () => new Map((environments ?? []).map((e) => [e.environmentId, e])),
+    [environments]
+  );
+
+  const commit = async (next: string[]) => {
+    setSaving(true);
+    try {
+      await setSuiteEnvironments({
+        suiteId,
+        environmentIds: next.length > 0 ? next : null,
+      });
+    } catch (err) {
+      // Includes the backend's schedule-pin conflict rejection — surface it
+      // verbatim so the user sees which enabled schedule blocks the change.
+      toast.error(convexErrMessage(err, "Failed to update environments"));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const toggle = (environmentId: string, checked: boolean) => {
+    if (checked) {
+      if (selected.length >= MAX_SUITE_ENVIRONMENTS) return;
+      void commit([...selected, environmentId]);
+    } else {
+      void commit(selected.filter((id) => id !== environmentId));
+    }
+  };
+
+  const triggerLabel =
+    selected.length === 0
+      ? "No environments · pick some"
+      : selected.map((id) => environmentsById.get(id)?.name ?? "…").join(", ");
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            "flex h-8 max-w-[280px] items-center gap-1 rounded-full border px-2 text-foreground",
+            "outline-none transition-colors",
+            selected.length === 0
+              ? "border-dashed border-border/60 bg-muted/30 hover:bg-muted/45"
+              : "border-border/60 bg-muted/40 hover:bg-muted/60"
+          )}
+        >
+          <Layers className="size-3.5 shrink-0 text-muted-foreground" />
+          <span className="min-w-0 flex-1 truncate text-xs font-medium">
+            {triggerLabel}
+          </span>
+          {selected.length > 0 ? (
+            <span className="text-[10px] text-muted-foreground">
+              · {selected.length}
+            </span>
+          ) : null}
+          {saving ? (
+            <Loader2 className="size-3.5 animate-spin text-muted-foreground" />
+          ) : (
+            <ChevronDown className="size-3 shrink-0 text-muted-foreground" />
+          )}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent className="w-72 p-1" align="start" sideOffset={4}>
+        <div className="px-2 pb-1 pt-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+          Environments · run order
+        </div>
+        {environments === undefined ? (
+          <div className="flex items-center gap-2 px-2 py-2 text-xs text-muted-foreground">
+            <Loader2 className="size-3.5 animate-spin" /> Loading…
+          </div>
+        ) : environments.length === 0 ? (
+          <p className="px-2 py-1.5 text-xs text-muted-foreground">
+            No environments in this project yet.
+          </p>
+        ) : (
+          <div className="max-h-64 space-y-0.5 overflow-y-auto">
+            {environments.map((env) => {
+              const ordinal = selected.indexOf(env.environmentId);
+              const checked = ordinal !== -1;
+              const capBlocked =
+                !checked && selected.length >= MAX_SUITE_ENVIRONMENTS;
+              return (
+                <Label
+                  key={env.environmentId}
+                  className={cn(
+                    "flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-sm hover:bg-accent/30",
+                    (capBlocked || saving) &&
+                      "cursor-not-allowed opacity-60 hover:bg-transparent"
+                  )}
+                >
+                  <Checkbox
+                    checked={checked}
+                    onCheckedChange={(next) =>
+                      toggle(env.environmentId, next === true)
+                    }
+                    disabled={capBlocked || saving}
+                    aria-label={env.name}
+                  />
+                  <span className="min-w-0 flex-1 truncate font-normal">
+                    {env.name}
+                  </span>
+                  {checked ? (
+                    <span className="shrink-0 rounded-full bg-muted px-1.5 font-mono text-[10px] text-muted-foreground">
+                      {ordinal + 1}
+                    </span>
+                  ) : null}
+                </Label>
+              );
+            })}
+          </div>
+        )}
+        {selected.length >= MAX_SUITE_ENVIRONMENTS ? (
+          <p className="px-2 py-1 text-[11px] text-muted-foreground">
+            Cap reached — a suite can attach at most {MAX_SUITE_ENVIRONMENTS}{" "}
+            environments.
+          </p>
+        ) : null}
+        <div className="mt-0.5 border-t pt-0.5">
+          <button
+            type="button"
+            onClick={() => {
+              setOpen(false);
+              navigateApp(routePaths.environments);
+            }}
+            className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-xs text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+          >
+            <ExternalLink className="size-3.5 shrink-0" />
+            Manage environments →
+          </button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/mcpjam-inspector/client/src/components/evals/suite-project-environments-picker.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-project-environments-picker.tsx
@@ -70,6 +70,20 @@ export function SuiteProjectEnvironmentsPicker({
         ),
     [selected, environmentsById]
   );
+  // An attached id the query doesn't return AT ALL (hard-deleted, or no longer
+  // in this project). `archivedSelected` cannot surface these — it resolves
+  // through `environmentsById`, so a missing id filters away silently and the
+  // suite stays stuck referencing something with no row and no way to detach
+  // it. Render them as detach-only rows, same as archived. Gated on the query
+  // having settled so a loading list doesn't flash every attached id as an
+  // orphan.
+  const orphanSelectedIds = useMemo(
+    () =>
+      environments === undefined
+        ? []
+        : selected.filter((id) => !environmentsById.has(id)),
+    [environments, selected, environmentsById]
+  );
 
   const commit = async (next: string[]) => {
     setSaving(true);
@@ -138,7 +152,9 @@ export function SuiteProjectEnvironmentsPicker({
           <div className="flex items-center gap-2 px-2 py-2 text-xs text-muted-foreground">
             <Loader2 className="size-3.5 animate-spin" /> Loading…
           </div>
-        ) : liveEnvironments.length === 0 && archivedSelected.length === 0 ? (
+        ) : liveEnvironments.length === 0 &&
+          archivedSelected.length === 0 &&
+          orphanSelectedIds.length === 0 ? (
           <p className="px-2 py-1.5 text-xs text-muted-foreground">
             No environments in this project yet.
           </p>
@@ -199,6 +215,37 @@ export function SuiteProjectEnvironmentsPicker({
                     {env.name}
                     <span className="ml-1 text-[10px] text-muted-foreground">
                       (archived)
+                    </span>
+                  </span>
+                  <span className="shrink-0 rounded-full bg-muted px-1.5 font-mono text-[10px] text-muted-foreground">
+                    {ordinal + 1}
+                  </span>
+                </Label>
+              );
+            })}
+            {orphanSelectedIds.map((environmentId) => {
+              const ordinal = selected.indexOf(environmentId);
+              return (
+                <Label
+                  key={environmentId}
+                  className={cn(
+                    "flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-sm hover:bg-accent/30",
+                    saving &&
+                      "cursor-not-allowed opacity-60 hover:bg-transparent"
+                  )}
+                >
+                  {/* Unresolvable: uncheck to detach only. There is no name to
+                      show — the row exists purely so the id is removable. */}
+                  <Checkbox
+                    checked
+                    onCheckedChange={() => toggle(environmentId, false)}
+                    disabled={saving}
+                    aria-label={`Unavailable environment ${environmentId} (detach)`}
+                  />
+                  <span className="min-w-0 flex-1 truncate font-normal text-muted-foreground">
+                    Unavailable environment
+                    <span className="ml-1 font-mono text-[10px]">
+                      {environmentId.slice(0, 8)}
                     </span>
                   </span>
                   <span className="shrink-0 rounded-full bg-muted px-1.5 font-mono text-[10px] text-muted-foreground">

--- a/mcpjam-inspector/client/src/components/evals/suite-project-environments-picker.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-project-environments-picker.tsx
@@ -34,7 +34,12 @@ export function SuiteProjectEnvironmentsPicker({
   /** The suite's persisted attach-ordered environment ids. */
   environmentIds: string[] | undefined;
 }) {
-  const environments = useProjectEnvironments(projectId);
+  // Include archived so a suite whose attached environment was later archived
+  // can still surface (and DETACH) that row — a live-only list would drop it,
+  // leaving the id stuck with only a "…" label and no way to remove it.
+  const environments = useProjectEnvironments(projectId, {
+    includeArchived: true,
+  });
   const setSuiteEnvironments = useMutation(
     "testSuites:setSuiteEnvironments" as any
   ) as unknown as (args: {
@@ -49,6 +54,21 @@ export function SuiteProjectEnvironmentsPicker({
   const environmentsById = useMemo(
     () => new Map((environments ?? []).map((e) => [e.environmentId, e])),
     [environments]
+  );
+  // Live envs are attachable; archived envs that are STILL attached to this
+  // suite render as detach-only rows (never offered for new selection).
+  const liveEnvironments = useMemo(
+    () => (environments ?? []).filter((e) => !e.archivedAt),
+    [environments]
+  );
+  const archivedSelected = useMemo(
+    () =>
+      selected
+        .map((id) => environmentsById.get(id))
+        .filter(
+          (e): e is NonNullable<typeof e> => !!e && e.archivedAt !== undefined
+        ),
+    [selected, environmentsById]
   );
 
   const commit = async (next: string[]) => {
@@ -118,13 +138,13 @@ export function SuiteProjectEnvironmentsPicker({
           <div className="flex items-center gap-2 px-2 py-2 text-xs text-muted-foreground">
             <Loader2 className="size-3.5 animate-spin" /> Loading…
           </div>
-        ) : environments.length === 0 ? (
+        ) : liveEnvironments.length === 0 && archivedSelected.length === 0 ? (
           <p className="px-2 py-1.5 text-xs text-muted-foreground">
             No environments in this project yet.
           </p>
         ) : (
           <div className="max-h-64 space-y-0.5 overflow-y-auto">
-            {environments.map((env) => {
+            {liveEnvironments.map((env) => {
               const ordinal = selected.indexOf(env.environmentId);
               const checked = ordinal !== -1;
               const capBlocked =
@@ -154,6 +174,36 @@ export function SuiteProjectEnvironmentsPicker({
                       {ordinal + 1}
                     </span>
                   ) : null}
+                </Label>
+              );
+            })}
+            {archivedSelected.map((env) => {
+              const ordinal = selected.indexOf(env.environmentId);
+              return (
+                <Label
+                  key={env.environmentId}
+                  className={cn(
+                    "flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-sm hover:bg-accent/30",
+                    saving &&
+                      "cursor-not-allowed opacity-60 hover:bg-transparent"
+                  )}
+                >
+                  {/* Archived: uncheck to detach only — never re-attachable. */}
+                  <Checkbox
+                    checked
+                    onCheckedChange={() => toggle(env.environmentId, false)}
+                    disabled={saving}
+                    aria-label={`${env.name} (archived)`}
+                  />
+                  <span className="min-w-0 flex-1 truncate font-normal">
+                    {env.name}
+                    <span className="ml-1 text-[10px] text-muted-foreground">
+                      (archived)
+                    </span>
+                  </span>
+                  <span className="shrink-0 rounded-full bg-muted px-1.5 font-mono text-[10px] text-muted-foreground">
+                    {ordinal + 1}
+                  </span>
                 </Label>
               );
             })}

--- a/mcpjam-inspector/client/src/components/evals/types.ts
+++ b/mcpjam-inspector/client/src/components/evals/types.ts
@@ -200,12 +200,26 @@ export type EvalSuite = {
   serverAttachmentId?: string;
   /** Hydrated by the backend resolver when serverAttachmentId is set. */
   serverAttachment?: EvalServerAttachment;
+  /**
+   * Attach-ordered project environments (`projectEnvironments` docs). When
+   * non-empty, Run all fans out ONE run per environment (replacing
+   * hostAttachments as the fan-out axis — env pointers win over the legacy
+   * host/server pointers above). The backend resolves each environment at
+   * run start; the client never derives servers from these ids.
+   */
+  environmentIds?: string[];
   /** Synthetic-monitor schedule; absent ⇒ never scheduled. */
   schedule?: {
     intervalMinutes: number;
     enabled: boolean;
     state: "active" | "paused_quota" | "paused_auth" | "paused_failures";
     consecutiveFailures?: number;
+    /**
+     * Multi-environment suites pin the schedule to ONE member environment
+     * (required by `setSuiteSchedule`); single-env suites may omit it and
+     * the run-start default applies.
+     */
+    environmentId?: string;
   };
 };
 
@@ -488,6 +502,19 @@ export type EvalSuiteRun = {
       baseImageDigests: string[];
       provider: "e2b" | "stub";
     };
+    /**
+     * Project-environment provenance: the environment this run resolved at
+     * start, frozen with the revision it resolved. Drives the run-detail
+     * "Environment" chip (name + rev). Distinct from `computerEnvironment`
+     * above, which is the sandbox-image pin ("Sandbox image" chip).
+     */
+    environmentRef?: {
+      environmentId: string;
+      name: string;
+      revision: number;
+    };
+    /** The environment's standalone server-group pointer at resolve time. */
+    environmentServerAttachmentId?: string;
     /**
      * Suite-level judge config snapshotted at run-create. The run-detail
      * card reads `modelUsed` / `threshold` from here when displaying the

--- a/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
@@ -17,10 +17,12 @@ import type {
 } from "./types";
 import { getSuiteReplayEligibility } from "./replay-eligibility";
 import {
-  buildSuiteHostRunPlans,
+  buildSuiteRunPlans,
   getEffectiveSuiteServers,
   getSelectedSuiteHostRunPlan,
 } from "./helpers";
+import { useProjectEnvironments } from "@/hooks/useProjectEnvironments";
+import { useProjectEnvironmentsEnabled } from "@/hooks/useProjectEnvironmentsEnabled";
 import { draftTestCaseId } from "./draft-test-case";
 import { isModelFree, promptTurnsToSteps } from "@/shared/steps";
 import type { useEvalMutations } from "./use-eval-mutations";
@@ -230,6 +232,14 @@ export function useEvalHandlers({
   // Resolves the WorkOS token for signed-in users and the guest bearer for
   // guests (project-owning guests included). See use-convex-access-token.
   const getAccessToken = useConvexAccessToken();
+  // Environment names for env-suite fan-out toasts/labels only — env plans
+  // never derive servers from this list (the server resolves them at launch).
+  // Queried only when the feature flag is on; a flag-off env suite still
+  // fans out correctly with ids as display fallbacks.
+  const projectEnvironmentsEnabled = useProjectEnvironmentsEnabled();
+  const projectEnvironments = useProjectEnvironments(
+    projectEnvironmentsEnabled ? projectId : null,
+  );
 
   // Action states
   const [rerunningSuiteId, setRerunningSuiteId] = useState<string | null>(null);
@@ -572,6 +582,13 @@ export function useEvalHandlers({
     ) => {
       if (rerunningSuiteId) return;
 
+      // Environment suites launch through the server's authoritative
+      // resolution (P0.1): the browser never knows the environment's closed
+      // server set, so the legacy server-readiness gates below are skipped —
+      // the server returns a readable auth/connection error for the exact
+      // resolved set instead.
+      const isEnvironmentSuite = (suite.environmentIds?.length ?? 0) > 0;
+
       // Effective servers = flat env.servers ∪ resolved servers across all
       // host attachments. Without this union, a host-only suite would fail
       // the "no servers configured" gate even though the runner can derive
@@ -590,7 +607,7 @@ export function useEvalHandlers({
         latestRun,
       });
 
-      if (suiteServers.length === 0) {
+      if (!isEnvironmentSuite && suiteServers.length === 0) {
         if (rerunEligibility.replayableLatestRun?._id) {
           await handleReplayRun(suite, rerunEligibility.replayableLatestRun);
           return;
@@ -599,7 +616,7 @@ export function useEvalHandlers({
         return;
       }
 
-      if (rerunEligibility.missingServers.length > 0) {
+      if (!isEnvironmentSuite && rerunEligibility.missingServers.length > 0) {
         if (ensureServersReady != null) {
           const readiness = await ensureServersReady(suiteServers);
           if (!hasUnavailableServers(readiness)) {
@@ -635,26 +652,31 @@ export function useEvalHandlers({
 
       setRerunningSuiteId(suite._id);
 
-      // Host-bound fan-out: when the suite has hostAttachments we fire one
-      // run request per host so each gets its own snapshot. Otherwise we
-      // run the suite's flat server list once as before.
-      const runPlans = buildSuiteHostRunPlans(
+      // Fan-out axis: attached project environments (one run per env, in
+      // attach order) win over hostAttachments; otherwise one run request
+      // per host so each gets its own snapshot, else the suite's flat
+      // server list once as before. Env plans carry NO serverIds — the
+      // server resolves the environment's closed set at launch.
+      const runPlans = buildSuiteRunPlans(
         suite,
+        projectEnvironments,
         executionContext.suiteServers,
       );
 
       // Generate a shared group id ONLY when the rerun fans out to more
-      // than one host. The inspector route threads this through the Zod
-      // schema → recorder → Convex mutation; every sibling run carries
-      // the same id so the UI can collapse them into a single parent
-      // row. Single-host launches stay ungrouped so legacy + single-host
-      // rows render identically.
+      // than one host/environment. The inspector route threads this through
+      // the Zod schema → recorder → Convex mutation; every sibling run
+      // carries the same id so the UI can collapse them into a single
+      // parent row. Single-plan launches stay ungrouped so legacy +
+      // single-host rows render identically.
       const runGroupId = runPlans.length > 1 ? crypto.randomUUID() : undefined;
 
       // Show toast immediately when user clicks rerun
       toast.success(
         runPlans.length > 1
-          ? `Starting ${runPlans.length} runs across hosts…`
+          ? `Starting ${runPlans.length} runs across ${
+              isEnvironmentSuite ? "environments" : "hosts"
+            }…`
           : "Run started successfully! Results will appear shortly.",
       );
 
@@ -721,6 +743,11 @@ export function useEvalHandlers({
               matchOptionsOverride: options?.matchOptionsOverride,
               refreshSnapshot: options?.refreshSnapshot,
               ...(plan.namedHostId ? { namedHostId: plan.namedHostId } : {}),
+              // Always sent explicitly on env plans — even single-env
+              // suites — so the server's authoritative resolution runs.
+              ...(plan.environmentId
+                ? { environmentId: plan.environmentId }
+                : {}),
               ...(runGroupId ? { runGroupId } : {}),
             }),
           ),
@@ -799,7 +826,12 @@ export function useEvalHandlers({
           }
         } else if (failures.length < runPlans.length) {
           const failedHostNames = failures
-            .map((failure) => failure.plan.hostName ?? "(unnamed client)")
+            .map(
+              (failure) =>
+                failure.plan.environmentName ??
+                failure.plan.hostName ??
+                "(unnamed client)",
+            )
             .join(", ");
           toast.error(
             `${failures.length} of ${runPlans.length} client runs failed: ${failedHostNames}`,
@@ -827,6 +859,7 @@ export function useEvalHandlers({
       getAccessToken,
       projectId,
       projectServers,
+      projectEnvironments,
       getSuiteExecutionContext,
       handleReplayRun,
       evalsNavigationContext,

--- a/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
@@ -48,7 +48,7 @@ import type { EnsureServersReadyResult } from "@/hooks/use-app-state";
 
 function navigateEvalRoute(route: EvalRoute, context: "evals" | "ci-evals") {
   navigateApp(
-    context === "ci-evals" ? buildCiEvalsPath(route) : buildEvalsPath(route),
+    context === "ci-evals" ? buildCiEvalsPath(route) : buildEvalsPath(route)
   );
 }
 import type { RemoteServer } from "@/hooks/useProjects";
@@ -59,7 +59,7 @@ import {
 } from "@/lib/mcp-server-display-name";
 
 function getConfiguredTestCaseModelValues(
-  testCase: Pick<EvalCase, "models">,
+  testCase: Pick<EvalCase, "models">
 ): string[] {
   const modelValues = new Set<string>();
 
@@ -86,7 +86,7 @@ export function hasUnavailableServers(result: EnsureServersReadyResult) {
 export function formatEnsureServersReadyError(
   result: EnsureServersReadyResult,
   actionLabel: string,
-  projectServers: RemoteServer[] | undefined,
+  projectServers: RemoteServer[] | undefined
 ) {
   if (result.missingServerNames.length > 0) {
     // Never list server names/ids in this toast: refs may be legacy Convex
@@ -114,7 +114,7 @@ export function formatEnsureServersReadyError(
     }
     return `Re-authenticate with ${formatMcpServerRefsForError(
       names,
-      opts,
+      opts
     )} to ${actionLabel}.`;
   }
 
@@ -129,7 +129,7 @@ export function formatEnsureServersReadyError(
     }
     return `We couldn't connect to ${formatMcpServerRefsForError(
       names,
-      opts,
+      opts
     )}. Try again to ${actionLabel}.`;
   }
 
@@ -137,12 +137,12 @@ export function formatEnsureServersReadyError(
 }
 
 export function normalizeSuiteServerRefs(
-  serverNamesOrIds: readonly string[] | undefined,
+  serverNamesOrIds: readonly string[] | undefined
 ): string[] {
   const rawServerRefs = (serverNamesOrIds ?? []).flatMap((serverRef) =>
     typeof serverRef === "string" && serverRef.trim().length > 0
       ? [serverRef.trim()]
-      : [],
+      : []
   );
 
   if (rawServerRefs.length === 0) {
@@ -195,7 +195,7 @@ interface UseEvalHandlersProps {
   projectId?: string | null;
   connectedServerNames?: Set<string>;
   ensureServersReady?: (
-    serverNames: string[],
+    serverNames: string[]
   ) => Promise<EnsureServersReadyResult>;
   latestRunBySuiteId?: Map<string, EvalSuiteRun | null>;
   /**
@@ -238,25 +238,25 @@ export function useEvalHandlers({
   // fans out correctly with ids as display fallbacks.
   const projectEnvironmentsEnabled = useProjectEnvironmentsEnabled();
   const projectEnvironments = useProjectEnvironments(
-    projectEnvironmentsEnabled ? projectId : null,
+    projectEnvironmentsEnabled ? projectId : null
   );
 
   // Action states
   const [rerunningSuiteId, setRerunningSuiteId] = useState<string | null>(null);
   const [runningTestCaseId, setRunningTestCaseId] = useState<string | null>(
-    null,
+    null
   );
   const [replayingRunId, setReplayingRunId] = useState<string | null>(null);
   const [cancellingRunId, setCancellingRunId] = useState<string | null>(null);
   const [deletingSuiteId, setDeletingSuiteId] = useState<string | null>(null);
   const [suiteToDelete, setSuiteToDelete] = useState<EvalSuite | null>(null);
   const [duplicatingSuiteId, setDuplicatingSuiteId] = useState<string | null>(
-    null,
+    null
   );
   const [deletingRunId, setDeletingRunId] = useState<string | null>(null);
   const [runToDelete, setRunToDelete] = useState<string | null>(null);
   const [deletingTestCaseId, setDeletingTestCaseId] = useState<string | null>(
-    null,
+    null
   );
   const [duplicatingTestCaseId, setDuplicatingTestCaseId] = useState<
     string | null
@@ -276,11 +276,11 @@ export function useEvalHandlers({
             type: "suite-overview";
             suiteId: string;
             view?: SuiteOverviewView;
-          },
+          }
     ) => {
       navigateEvalRoute(route as EvalRoute, evalsNavigationContext);
     },
-    [evalsNavigationContext],
+    [evalsNavigationContext]
   );
 
   // Query to get test cases for a suite
@@ -289,7 +289,7 @@ export function useEvalHandlers({
       try {
         const testCases = await convex.query(
           "testSuites:listTestCases" as any,
-          { suiteId },
+          { suiteId }
         );
         return testCases;
       } catch (error) {
@@ -297,7 +297,7 @@ export function useEvalHandlers({
         return [];
       }
     },
-    [convex],
+    [convex]
   );
 
   const getSuiteExecutionContext = useCallback(
@@ -319,7 +319,7 @@ export function useEvalHandlers({
             (m) =>
               String(m.id) === suite.defaultConfig!.modelId &&
               (!suite.defaultConfig!.provider ||
-                m.provider === suite.defaultConfig!.provider),
+                m.provider === suite.defaultConfig!.provider)
           )
         : undefined;
       // Distinguish "no default set" from "default set but unresolvable"
@@ -346,7 +346,7 @@ export function useEvalHandlers({
         const caseSteps = Array.isArray(testCase.steps)
           ? testCase.steps
           : promptTurnsToSteps(
-              Array.isArray(testCase.promptTurns) ? testCase.promptTurns : [],
+              Array.isArray(testCase.promptTurns) ? testCase.promptTurns : []
             );
         if (isModelFree(caseSteps)) {
           if (caseSteps.length === 0) {
@@ -410,13 +410,13 @@ export function useEvalHandlers({
             ? `${suite.defaultConfig.modelId} (${suite.defaultConfig.provider})`
             : suite.defaultConfig?.modelId;
           toast.error(
-            `Suite default model ${label} is not available. Re-select it in the suite's default execution config, or add per-case models.`,
+            `Suite default model ${label} is not available. Re-select it in the suite's default execution config, or add per-case models.`
           );
         } else if (probesSkippedMissingConfig > 0) {
           // Probe-only suites land here when every probe was skipped above;
           // "add models" would be the wrong prescription for them.
           toast.error(
-            "No tests to run. The suite's render checks are missing their configuration.",
+            "No tests to run. The suite's render checks are missing their configuration."
           );
         } else {
           toast.error("No tests to run. Please add models to your test cases.");
@@ -443,20 +443,20 @@ export function useEvalHandlers({
         providersNeeded,
       };
     },
-    [getTestCasesForRerun, availableModels],
+    [getTestCasesForRerun, availableModels]
   );
 
   const handleReplayRun = useCallback(
     async (
       suite: EvalSuite,
       run: Pick<EvalSuiteRun, "_id" | "hasServerReplayConfig" | "passCriteria">,
-      options?: { minimumPassRate?: number },
+      options?: { minimumPassRate?: number }
     ) => {
       if (rerunningSuiteId || replayingRunId) return;
 
       if (!run.hasServerReplayConfig) {
         toast.error(
-          "This CI run can't be replayed because it doesn't have stored replay config.",
+          "This CI run can't be replayed because it doesn't have stored replay config."
         );
         return;
       }
@@ -527,7 +527,7 @@ export function useEvalHandlers({
               runId: result.runId,
               insightsFocus: true,
             },
-            "ci-evals",
+            "ci-evals"
           );
         }
 
@@ -540,7 +540,7 @@ export function useEvalHandlers({
           getBillingErrorMessage(error, "Failed to replay eval run"),
           {
             id: replayToastId,
-          },
+          }
         );
       } finally {
         setReplayingRunId(null);
@@ -552,7 +552,7 @@ export function useEvalHandlers({
       selectedSuiteEntry,
       getSuiteExecutionContext,
       getAccessToken,
-    ],
+    ]
   );
 
   // Rerun handler
@@ -578,7 +578,7 @@ export function useEvalHandlers({
          * existing suites.
          */
         refreshSnapshot?: boolean;
-      },
+      }
     ) => {
       if (rerunningSuiteId) return;
 
@@ -594,7 +594,7 @@ export function useEvalHandlers({
       // the "no servers configured" gate even though the runner can derive
       // servers from each attachment's snapshot at fan-out time.
       const suiteServers = normalizeSuiteServerRefs(
-        getEffectiveSuiteServers(suite),
+        getEffectiveSuiteServers(suite)
       );
       const latestRun =
         latestRunBySuiteId?.get(suite._id) ??
@@ -629,8 +629,8 @@ export function useEvalHandlers({
               formatEnsureServersReadyError(
                 readiness,
                 "run this suite",
-                projectServers,
-              ),
+                projectServers
+              )
             );
             return;
           }
@@ -639,7 +639,7 @@ export function useEvalHandlers({
             formatMcpConnectServerPrompt(rerunEligibility.missingServers, {
               remoteServers: projectServers,
               kind: "suite",
-            }),
+            })
           );
           return;
         }
@@ -660,7 +660,7 @@ export function useEvalHandlers({
       const runPlans = buildSuiteRunPlans(
         suite,
         projectEnvironments,
-        executionContext.suiteServers,
+        executionContext.suiteServers
       );
 
       // Generate a shared group id ONLY when the rerun fans out to more
@@ -677,7 +677,7 @@ export function useEvalHandlers({
           ? `Starting ${runPlans.length} runs across ${
               isEnvironmentSuite ? "environments" : "hosts"
             }…`
-          : "Run started successfully! Results will appear shortly.",
+          : "Run started successfully! Results will appear shortly."
       );
 
       const suiteRunStartedAt = Date.now();
@@ -749,25 +749,34 @@ export function useEvalHandlers({
                 ? { environmentId: plan.environmentId }
                 : {}),
               ...(runGroupId ? { runGroupId } : {}),
-            }),
-          ),
+            })
+          )
         );
 
         const failures = settled
           .map((result, index) =>
             result.status === "rejected"
               ? { plan: runPlans[index], reason: result.reason }
-              : null,
+              : null
           )
           .filter(
             (
-              entry,
+              entry
             ): entry is { plan: (typeof runPlans)[number]; reason: unknown } =>
-              entry !== null,
+              entry !== null
           );
 
-        // Track suite run started (once per fan-out batch; per-host
+        // Track suite run started (once per fan-out batch; per-target
         // multiplicity is captured in the iteration data).
+        //
+        // `num_hosts` counts PLANS and is kept verbatim for dashboard
+        // compatibility — but for an environment suite a plan is an
+        // ENVIRONMENT, and two environments sharing one host would land in
+        // host analytics as two hosts. `fan_out_axis` + `num_environments`
+        // make the axis explicit so host metrics can exclude env fan-outs
+        // instead of silently absorbing (and double-counting) them.
+        const fanOutAxis = isEnvironmentSuite ? "environment" : "host";
+        const numEnvironments = isEnvironmentSuite ? runPlans.length : 0;
         track("eval_suite_run_started", {
           location: "evals_tab",
           suite_id: suite._id,
@@ -776,6 +785,8 @@ export function useEvalHandlers({
           num_models: executionContext.providersNeeded.size,
           minimum_pass_rate: minimumPassRate,
           num_hosts: runPlans.length,
+          fan_out_axis: fanOutAxis,
+          num_environments: numEnvironments,
         });
 
         track("eval_suite_run_start_requests_completed", {
@@ -788,13 +799,19 @@ export function useEvalHandlers({
           num_failed_hosts: failures.length,
           all_succeeded: failures.length === 0,
           duration_ms: Date.now() - suiteRunStartedAt,
+          fan_out_axis: fanOutAxis,
+          num_environments: numEnvironments,
         });
 
+        // "client" vs "environment": a fan-out plan is one environment for an
+        // environment suite and one client otherwise — the toasts must name
+        // the axis the user actually selected.
+        const targetNoun = isEnvironmentSuite ? "environment" : "client";
         if (failures.length === 0) {
           toast.success(
             runPlans.length > 1
-              ? `All ${runPlans.length} client runs started.`
-              : "Eval run started!",
+              ? `All ${runPlans.length} ${targetNoun} runs started.`
+              : "Eval run started!"
           );
 
           // Drop the user on the new run's detail page so they can see
@@ -815,13 +832,13 @@ export function useEvalHandlers({
                   suiteId: suite._id,
                   runId: newRunId,
                 },
-                evalsNavigationContext,
+                evalsNavigationContext
               );
             }
           } else {
             navigateEvalRoute(
               { type: "suite-overview", suiteId: suite._id, view: "runs" },
-              evalsNavigationContext,
+              evalsNavigationContext
             );
           }
         } else if (failures.length < runPlans.length) {
@@ -830,18 +847,18 @@ export function useEvalHandlers({
               (failure) =>
                 failure.plan.environmentName ??
                 failure.plan.hostName ??
-                "(unnamed client)",
+                "(unnamed client)"
             )
             .join(", ");
           toast.error(
-            `${failures.length} of ${runPlans.length} client runs failed: ${failedHostNames}`,
+            `${failures.length} of ${runPlans.length} ${targetNoun} runs failed: ${failedHostNames}`
           );
         } else {
           // All failed — surface the first error for actionable detail.
           const firstError = failures[0]?.reason;
           throw firstError instanceof Error
             ? firstError
-            : new Error(String(firstError ?? "All client runs failed"));
+            : new Error(String(firstError ?? `All ${targetNoun} runs failed`));
         }
       } catch (error) {
         console.error("Failed to rerun evals:", error);
@@ -863,7 +880,7 @@ export function useEvalHandlers({
       getSuiteExecutionContext,
       handleReplayRun,
       evalsNavigationContext,
-    ],
+    ]
   );
 
   const handleRunTestCase = useCallback(
@@ -882,7 +899,7 @@ export function useEvalHandlers({
          */
         iterationOverride?: number;
         namedHostId?: string;
-      },
+      }
     ) => {
       if (runningTestCaseId || rerunningSuiteId || replayingRunId) {
         return null;
@@ -895,7 +912,7 @@ export function useEvalHandlers({
       // to Run all instead of silently running against the wrong servers.
       if ((suite.environmentIds?.length ?? 0) > 0) {
         toast.info(
-          "Run environment suites with Run all — single-case quick-run doesn't resolve environments yet.",
+          "Run environment suites with Run all — single-case quick-run doesn't resolve environments yet."
         );
         return null;
       }
@@ -925,7 +942,7 @@ export function useEvalHandlers({
       const runPlan = getSelectedSuiteHostRunPlan(suite, options?.namedHostId);
       const suiteServers = normalizeSuiteServerRefs(runPlan.serverIds);
       const disconnectedSuiteServers = suiteServers.filter(
-        (serverName) => !connectedServerNames?.has(serverName),
+        (serverName) => !connectedServerNames?.has(serverName)
       );
 
       if (suiteServers.length === 0) {
@@ -941,8 +958,8 @@ export function useEvalHandlers({
               formatEnsureServersReadyError(
                 readiness,
                 "run this test case",
-                projectServers,
-              ),
+                projectServers
+              )
             );
             return null;
           }
@@ -951,7 +968,7 @@ export function useEvalHandlers({
             formatMcpConnectServerPrompt(disconnectedSuiteServers, {
               remoteServers: projectServers,
               kind: "test-case",
-            }),
+            })
           );
           return null;
         }
@@ -978,11 +995,11 @@ export function useEvalHandlers({
                 options?.iterationOverride !== undefined
                   ? { runs: options.iterationOverride }
                   : undefined,
-            }),
-          ),
+            })
+          )
         );
         const preparedRuns = preparedResults.flatMap((result) =>
-          result.status === "fulfilled" ? [result.value] : [],
+          result.status === "fulfilled" ? [result.value] : []
         );
         const preparationFailures = preparedResults.flatMap((result, index) =>
           result.status === "rejected"
@@ -992,13 +1009,13 @@ export function useEvalHandlers({
                   error: result.reason,
                 },
               ]
-            : [],
+            : []
         );
 
         for (const failure of preparationFailures) {
           console.error(
             `Failed to prepare test case for model ${failure.modelValue}:`,
-            failure.error,
+            failure.error
           );
         }
 
@@ -1006,8 +1023,8 @@ export function useEvalHandlers({
           toast.error(
             getBillingErrorMessage(
               preparationFailures[0]?.error,
-              "Failed to run test case",
-            ),
+              "Failed to run test case"
+            )
           );
           return null;
         }
@@ -1054,7 +1071,7 @@ export function useEvalHandlers({
             } catch (error) {
               console.error(
                 `Failed to run test case for model ${preparedRun.modelValue}:`,
-                error,
+                error
               );
               return {
                 ok: false as const,
@@ -1062,26 +1079,26 @@ export function useEvalHandlers({
                 error,
               };
             }
-          }),
+          })
         );
 
         const successfulRuns = runResults.filter(
           (
-            result,
+            result
           ): result is {
             ok: true;
             modelValue: string;
             data: any;
-          } => result.ok,
+          } => result.ok
         );
         const failedRuns = runResults.filter(
           (
-            result,
+            result
           ): result is {
             ok: false;
             modelValue: string;
             error: unknown;
-          } => !result.ok,
+          } => !result.ok
         );
         const totalModelsRequested = modelValuesToRun.length;
         const totalFailedRuns = [
@@ -1098,28 +1115,28 @@ export function useEvalHandlers({
             toast.success(
               isMultiModelRun
                 ? `Test completed across ${totalModelsRequested} models!`
-                : "Test completed successfully!",
+                : "Test completed successfully!"
             );
           } else if (successfulRuns.length > 0) {
             toast.error(
               `${successfulRuns.length}/${totalModelsRequested} model${
                 totalModelsRequested === 1 ? "" : "s"
-              } completed successfully.`,
+              } completed successfully.`
             );
           } else {
             toast.error(
               getBillingErrorMessage(
                 totalFailedRuns[0]?.error,
-                "Failed to run test case",
-              ),
+                "Failed to run test case"
+              )
             );
           }
         } else if (successfulRuns.length === 0) {
           toast.error(
             getBillingErrorMessage(
               totalFailedRuns[0]?.error,
-              "Failed to run test case",
-            ),
+              "Failed to run test case"
+            )
           );
         }
 
@@ -1154,7 +1171,7 @@ export function useEvalHandlers({
       ensureServersReady,
       projectServers,
       isDirectGuest,
-    ],
+    ]
   );
 
   // Delete handler - opens confirmation modal
@@ -1163,7 +1180,7 @@ export function useEvalHandlers({
       if (deletingSuiteId) return;
       setSuiteToDelete(suite);
     },
-    [deletingSuiteId],
+    [deletingSuiteId]
   );
 
   // Confirm deletion - actually performs the deletion
@@ -1228,19 +1245,19 @@ export function useEvalHandlers({
               type: "suite-overview",
               suiteId: newSuite._id,
             },
-            "evals",
+            "evals"
           );
         }
       } catch (error) {
         console.error("Failed to duplicate suite:", error);
         toast.error(
-          getBillingErrorMessage(error, "Failed to duplicate test suite"),
+          getBillingErrorMessage(error, "Failed to duplicate test suite")
         );
       } finally {
         setDuplicatingSuiteId(null);
       }
     },
-    [duplicatingSuiteId, mutations.duplicateSuiteMutation],
+    [duplicatingSuiteId, mutations.duplicateSuiteMutation]
   );
 
   // Cancel handler
@@ -1260,7 +1277,7 @@ export function useEvalHandlers({
         setCancellingRunId(null);
       }
     },
-    [cancellingRunId, mutations.cancelRunMutation],
+    [cancellingRunId, mutations.cancelRunMutation]
   );
 
   // Delete run handler - opens confirmation modal (for single run from detail view)
@@ -1269,7 +1286,7 @@ export function useEvalHandlers({
       if (deletingRunId) return;
       setRunToDelete(runId);
     },
-    [deletingRunId],
+    [deletingRunId]
   );
 
   // Direct delete function - actually performs the deletion (for batch delete)
@@ -1282,7 +1299,7 @@ export function useEvalHandlers({
         throw error;
       }
     },
-    [mutations.deleteRunMutation],
+    [mutations.deleteRunMutation]
   );
 
   // Confirm run deletion - actually performs the deletion
@@ -1316,7 +1333,7 @@ export function useEvalHandlers({
         testId: draftTestCaseId("prompt"),
       });
     },
-    [navigateAfterTestCaseMutation],
+    [navigateAfterTestCaseMutation]
   );
 
   // Handle delete test case - opens confirmation modal
@@ -1325,7 +1342,7 @@ export function useEvalHandlers({
       if (deletingTestCaseId) return;
       setTestCaseToDelete({ id: testCaseId, title: testCaseTitle });
     },
-    [deletingTestCaseId],
+    [deletingTestCaseId]
   );
 
   /** Perform deletion only (no modal). Used for playground batch delete. */
@@ -1338,7 +1355,7 @@ export function useEvalHandlers({
         test_case_id: testCaseId,
       });
     },
-    [mutations.deleteTestCaseMutation, selectedSuiteId],
+    [mutations.deleteTestCaseMutation, selectedSuiteId]
   );
 
   // Confirm test case deletion
@@ -1370,7 +1387,7 @@ export function useEvalHandlers({
             : {
                 type: "suite-overview",
                 suiteId: selectedSuiteId,
-              },
+              }
         );
       }
 
@@ -1427,7 +1444,7 @@ export function useEvalHandlers({
       } catch (error) {
         console.error("Failed to duplicate test case:", error);
         toast.error(
-          getBillingErrorMessage(error, "Failed to duplicate test case"),
+          getBillingErrorMessage(error, "Failed to duplicate test case")
         );
         return null;
       } finally {
@@ -1438,7 +1455,7 @@ export function useEvalHandlers({
       duplicatingTestCaseId,
       mutations.duplicateTestCaseMutation,
       navigateAfterTestCaseMutation,
-    ],
+    ]
   );
 
   // Generate tests handler - calls API and creates test cases
@@ -1446,14 +1463,14 @@ export function useEvalHandlers({
     async (
       suiteId: string,
       serverIds: string[],
-      postOptions?: HandleGenerateEvalTestsOptions,
+      postOptions?: HandleGenerateEvalTestsOptions
     ) => {
       if (isGeneratingTests) return;
 
       const suiteServers = normalizeSuiteServerRefs(serverIds);
       if (suiteServers.length === 0) {
         toast.error(
-          "Add at least one server to this suite before generating cases.",
+          "Add at least one server to this suite before generating cases."
         );
         return;
       }
@@ -1462,7 +1479,7 @@ export function useEvalHandlers({
 
       try {
         const disconnected = suiteServers.filter(
-          (name) => !connectedServerNames?.has(name),
+          (name) => !connectedServerNames?.has(name)
         );
         if (disconnected.length > 0) {
           if (ensureServersReady != null) {
@@ -1472,8 +1489,8 @@ export function useEvalHandlers({
                 formatEnsureServersReadyError(
                   readiness,
                   "generate test cases",
-                  projectServers,
-                ),
+                  projectServers
+                )
               );
               return;
             }
@@ -1482,7 +1499,7 @@ export function useEvalHandlers({
               formatMcpConnectServerPrompt(disconnected, {
                 remoteServers: projectServers,
                 kind: "suite",
-              }),
+              })
             );
             return;
           }
@@ -1495,7 +1512,7 @@ export function useEvalHandlers({
           suiteId,
           serverIds,
           createTestCase: mutations.createTestCaseMutation as (
-            input: any,
+            input: any
           ) => Promise<unknown>,
           skipIfExistingCases: false,
           isDirectGuest,
@@ -1533,7 +1550,7 @@ export function useEvalHandlers({
             suite_id: suiteId,
             generated_count: outcome.createdCount,
             auto_ran: Boolean(
-              shouldAutoRun && outcome.createdTestCaseIds.length > 0,
+              shouldAutoRun && outcome.createdTestCaseIds.length > 0
             ),
           });
         }
@@ -1544,7 +1561,7 @@ export function useEvalHandlers({
           generated_count: outcome.createdCount,
           api_returned_tests: outcome.apiReturnedTests,
           auto_ran: Boolean(
-            shouldAutoRun && outcome.createdTestCaseIds.length > 0,
+            shouldAutoRun && outcome.createdTestCaseIds.length > 0
           ),
           success: true,
         });
@@ -1557,7 +1574,7 @@ export function useEvalHandlers({
           const suite = postOptions!.suite!;
           const allCases = (await getTestCasesForRerun(suiteId)) as EvalCase[];
           const byId = new Map<string, EvalCase>(
-            allCases.map((c) => [c._id, c]),
+            allCases.map((c) => [c._id, c])
           );
           const toRun: EvalCase[] = [];
           for (const id of outcome.createdTestCaseIds) {
@@ -1576,7 +1593,7 @@ export function useEvalHandlers({
             toast.success(
               `Generated ${outcome.createdCount} test case${
                 outcome.createdCount > 1 ? "s" : ""
-              }. Open the list to run them when they appear.`,
+              }. Open the list to run them when they appear.`
             );
           } else if (toRun.length === 1) {
             toast.success("Generated 1 new case and ran it.");
@@ -1587,7 +1604,7 @@ export function useEvalHandlers({
           toast.success(
             `Generated ${outcome.createdCount} test case${
               outcome.createdCount > 1 ? "s" : ""
-            }`,
+            }`
           );
         }
       } catch (error) {
@@ -1605,7 +1622,7 @@ export function useEvalHandlers({
           error_message: rawMessage.slice(0, 200),
         });
         toast.error(
-          getBillingErrorMessage(error, "Failed to generate test cases"),
+          getBillingErrorMessage(error, "Failed to generate test cases")
         );
       } finally {
         setIsGeneratingTests(false);
@@ -1623,7 +1640,7 @@ export function useEvalHandlers({
       isDirectGuest,
       getTestCasesForRerun,
       handleRunTestCase,
-    ],
+    ]
   );
 
   return {

--- a/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
@@ -888,6 +888,18 @@ export function useEvalHandlers({
         return null;
       }
 
+      // Environment suites resolve their closed server set server-side (P0.1)
+      // at Run-all fan-out; the single-case quick-run path below still derives
+      // servers from host/flat plans and can't send `environmentId`, so it
+      // would mis-launch (or trip the "attach a client" gate). Route env suites
+      // to Run all instead of silently running against the wrong servers.
+      if ((suite.environmentIds?.length ?? 0) > 0) {
+        toast.info(
+          "Run environment suites with Run all — single-case quick-run doesn't resolve environments yet.",
+        );
+        return null;
+      }
+
       // Widget probes have no single-case quick-run path yet: the
       // run-test-case endpoints only execute model-driven cases, and probes
       // intentionally carry no models. Without this branch the model guard

--- a/mcpjam-inspector/client/src/components/hosts/HostPicker.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/HostPicker.tsx
@@ -32,7 +32,8 @@ export type HostPickerLocation =
   | "chat_tab"
   | "chatbox_builder"
   | "eval_runner"
-  | "project_settings";
+  | "project_settings"
+  | "project_environments";
 
 interface HostPickerProps {
   projectId: string | null;

--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -21,6 +21,7 @@ import {
   UserPlus,
   ShieldCheck,
   Loader2,
+  Layers,
 } from "lucide-react";
 import { useFeatureFlagEnabled } from "posthog-js/react";
 import { track } from "@/lib/analytics";
@@ -226,6 +227,12 @@ const navigationSections: NavSection[] = [
         icon: FlaskConical,
         billingFeature: "evals",
         evalsSubnav: true,
+      },
+      {
+        title: "Environments",
+        url: "/environments",
+        icon: Layers,
+        featureFlag: "project-environments-enabled",
       },
     ],
   },
@@ -607,6 +614,9 @@ export function MCPSidebar({
   // Hosted Cloud Skills nav is gated until QA completes; fail-closed (absent /
   // loading flag ⇒ hidden). See `useSkillsEnabled`.
   const skillsEnabled = useFeatureFlagEnabled("skills-enabled");
+  const projectEnvironmentsEnabled = useFeatureFlagEnabled(
+    "project-environments-enabled"
+  );
   const { isAuthenticated, isLoading: isConvexAuthLoading } = useConvexAuth();
   const { user, isLoading: isWorkOsAuthLoading } = useAuth();
   // Until WorkOS + Convex resolve the session we don't yet know guest-vs-authed
@@ -681,6 +691,8 @@ export function MCPSidebar({
       "hosts-enabled": isAuthenticated,
       "home-page-enabled": isAuthenticated,
       xaa: xaaEnabled === true,
+      "project-environments-enabled":
+        projectEnvironmentsEnabled === true && isAuthenticated,
     }),
     [
       learningEnabled,
@@ -689,6 +701,7 @@ export function MCPSidebar({
       conformanceEnabled,
       compatibilityEnabled,
       xaaEnabled,
+      projectEnvironmentsEnabled,
       isAuthenticated,
     ]
   );

--- a/mcpjam-inspector/client/src/components/project-environments/ProjectEnvironmentEditor.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/ProjectEnvironmentEditor.tsx
@@ -1,0 +1,405 @@
+import { useCallback, useState } from "react";
+import { Loader2, TriangleAlert, X } from "lucide-react";
+import { toast } from "@/lib/toast";
+import { Button } from "@mcpjam/design-system/button";
+import { Label } from "@mcpjam/design-system/label";
+import { HostPicker } from "@/components/hosts/HostPicker";
+import { ServerGroupPicker } from "@/components/hosts/ServerGroupPicker";
+import { convexErrMessage } from "@/lib/convex-error";
+import {
+  isRevisionConflictError,
+  useCreateProjectEnvironment,
+  useUpdateProjectEnvironment,
+  type ProjectEnvironmentSkillSelection,
+  type ProjectEnvironmentView,
+} from "@/hooks/useProjectEnvironments";
+import { ProjectEnvironmentSkillsPicker } from "./ProjectEnvironmentSkillsPicker";
+
+type EnvironmentDraft = {
+  name: string;
+  description: string;
+  hostId: string | null;
+  serverAttachmentId: string | null;
+  skillSelection: ProjectEnvironmentSkillSelection | null;
+};
+
+function draftFromEnvironment(env: ProjectEnvironmentView): EnvironmentDraft {
+  return {
+    name: env.name,
+    description: env.description ?? "",
+    hostId: env.hostId,
+    serverAttachmentId: env.serverAttachmentId ?? null,
+    skillSelection: env.skillSelection ?? null,
+  };
+}
+
+function sameSkillSelection(
+  a: ProjectEnvironmentSkillSelection | null,
+  b: ProjectEnvironmentSkillSelection | null
+): boolean {
+  if (a === null || b === null) return a === b;
+  return (
+    a.skillIds.length === b.skillIds.length &&
+    a.skillIds.every((id, i) => id === b.skillIds[i])
+  );
+}
+
+/**
+ * Create/edit form for one project environment.
+ *
+ * expectedRevision pattern (the repo's optimistic-concurrency convention,
+ * defined here): `baseRevision` is captured when the draft is
+ * initialized/reset and THAT value is sent on update — never the newest
+ * reactive row revision at submit time, which would let a stale draft
+ * overwrite a concurrent edit. When reactivity observes a newer revision
+ * while the form is dirty, the draft is marked stale; a mutation conflict
+ * toasts, offers an explicit reload, and never auto-retries.
+ */
+export function ProjectEnvironmentEditor({
+  projectId,
+  environment,
+  canManage,
+  onCreated,
+  onCancelCreate,
+}: {
+  projectId: string;
+  /** null ⇒ create mode. */
+  environment: ProjectEnvironmentView | null;
+  /** Admin-gated writes; members get a read-only form. */
+  canManage: boolean;
+  onCreated?: (env: ProjectEnvironmentView) => void;
+  onCancelCreate?: () => void;
+}) {
+  const createEnvironment = useCreateProjectEnvironment();
+  const updateEnvironment = useUpdateProjectEnvironment();
+
+  const [draft, setDraft] = useState<EnvironmentDraft>(() =>
+    environment
+      ? draftFromEnvironment(environment)
+      : {
+          name: "",
+          description: "",
+          hostId: null,
+          serverAttachmentId: null,
+          skillSelection: null,
+        }
+  );
+  // Captured at draft init/reset — the ONLY revision update may send.
+  const [baseRevision, setBaseRevision] = useState<number | null>(
+    environment?.revision ?? null
+  );
+  const [saving, setSaving] = useState(false);
+  // Set on a rejected stale write; cleared only by an explicit reload.
+  const [conflicted, setConflicted] = useState(false);
+
+  const readOnly = !canManage;
+  const trimmedName = draft.name.trim();
+  const trimmedDescription = draft.description.trim();
+
+  const dirty = environment
+    ? trimmedName !== environment.name ||
+      trimmedDescription !== (environment.description ?? "") ||
+      draft.hostId !== environment.hostId ||
+      draft.serverAttachmentId !== (environment.serverAttachmentId ?? null) ||
+      !sameSkillSelection(
+        draft.skillSelection,
+        environment.skillSelection ?? null
+      )
+    : trimmedName.length > 0 ||
+      trimmedDescription.length > 0 ||
+      draft.hostId !== null ||
+      draft.serverAttachmentId !== null ||
+      draft.skillSelection !== null;
+
+  // Reactivity observed someone else's edit while this draft diverged.
+  const stale =
+    environment !== null &&
+    baseRevision !== null &&
+    environment.revision !== baseRevision;
+
+  const resetDraft = useCallback(() => {
+    if (!environment) return;
+    setDraft(draftFromEnvironment(environment));
+    setBaseRevision(environment.revision);
+    setConflicted(false);
+  }, [environment]);
+
+  const save = async () => {
+    if (!trimmedName) {
+      toast.error("Give the environment a name.");
+      return;
+    }
+    if (!draft.hostId) {
+      toast.error("Pick a client for this environment.");
+      return;
+    }
+    setSaving(true);
+    try {
+      if (!environment) {
+        const created = await createEnvironment({
+          projectId,
+          name: trimmedName,
+          ...(trimmedDescription ? { description: trimmedDescription } : {}),
+          hostId: draft.hostId,
+          ...(draft.serverAttachmentId
+            ? { serverAttachmentId: draft.serverAttachmentId }
+            : {}),
+          ...(draft.skillSelection
+            ? { skillSelection: draft.skillSelection }
+            : {}),
+        });
+        toast.success(`Created “${created.name}”.`);
+        onCreated?.(created);
+        return;
+      }
+      if (baseRevision === null) return;
+      const updated = await updateEnvironment({
+        environmentId: environment.environmentId,
+        // The revision captured at draft init — NOT environment.revision,
+        // which may have moved under a dirty draft.
+        expectedRevision: baseRevision,
+        ...(trimmedName !== environment.name ? { name: trimmedName } : {}),
+        ...(trimmedDescription !== (environment.description ?? "")
+          ? { description: trimmedDescription || null }
+          : {}),
+        ...(draft.hostId !== environment.hostId
+          ? { hostId: draft.hostId }
+          : {}),
+        ...(draft.serverAttachmentId !==
+        (environment.serverAttachmentId ?? null)
+          ? { serverAttachmentId: draft.serverAttachmentId }
+          : {}),
+        ...(!sameSkillSelection(
+          draft.skillSelection,
+          environment.skillSelection ?? null
+        )
+          ? { skillSelection: draft.skillSelection }
+          : {}),
+      });
+      setDraft(draftFromEnvironment(updated));
+      setBaseRevision(updated.revision);
+      setConflicted(false);
+      toast.success("Saved.");
+    } catch (err) {
+      if (environment && isRevisionConflictError(err)) {
+        // Never auto-retry a stale patch — surface it and let the user
+        // review the refreshed values explicitly.
+        setConflicted(true);
+        toast.error(
+          "This environment was changed by someone else — review the refreshed values before saving again."
+        );
+      } else {
+        toast.error(
+          convexErrMessage(
+            err,
+            environment
+              ? "Could not save the environment."
+              : "Could not create the environment."
+          )
+        );
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-4">
+      {(stale || conflicted) && environment ? (
+        <ConflictBanner
+          conflicted={conflicted}
+          dirty={dirty}
+          onReload={resetDraft}
+        />
+      ) : null}
+
+      <div className="space-y-1.5">
+        <Label htmlFor="project-environment-name" className="text-xs">
+          Name
+        </Label>
+        <input
+          id="project-environment-name"
+          value={draft.name}
+          disabled={readOnly}
+          onChange={(e) => setDraft((d) => ({ ...d, name: e.target.value }))}
+          placeholder="e.g. Staging on Claude"
+          className="w-full rounded-md border bg-background px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-ring disabled:opacity-60"
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="project-environment-description" className="text-xs">
+          Description
+        </Label>
+        <textarea
+          id="project-environment-description"
+          value={draft.description}
+          disabled={readOnly}
+          onChange={(e) =>
+            setDraft((d) => ({ ...d, description: e.target.value }))
+          }
+          placeholder="What this environment is for (optional)"
+          rows={2}
+          className="w-full resize-y rounded-md border bg-background px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-ring disabled:opacity-60"
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <Label className="text-xs">Client</Label>
+        <HostPicker
+          projectId={projectId}
+          value={draft.hostId}
+          onChange={(hostId) => setDraft((d) => ({ ...d, hostId }))}
+          location="project_environments"
+          placeholder="Select a client"
+          includeNone={false}
+          disabled={readOnly}
+        />
+        <p className="text-[11px] text-muted-foreground">
+          Every environment runs on exactly one client. The client&apos;s own
+          skills always apply on top of this environment&apos;s selection.
+        </p>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label className="text-xs">Server group</Label>
+        <div className="flex items-center gap-2">
+          <ServerGroupPicker
+            projectId={projectId}
+            value={draft.serverAttachmentId}
+            onChange={(serverAttachmentId) =>
+              setDraft((d) => ({ ...d, serverAttachmentId }))
+            }
+            disabled={readOnly}
+            emptyTriggerLabel="Client default · pick a group"
+            infoText="Optional: a named set of MCP servers this environment runs against. Without one, the client's own server picks apply."
+            onClearSelection={() =>
+              setDraft((d) => ({ ...d, serverAttachmentId: null }))
+            }
+          />
+          {draft.serverAttachmentId && !readOnly ? (
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              className="h-8 px-2 text-xs"
+              onClick={() =>
+                setDraft((d) => ({ ...d, serverAttachmentId: null }))
+              }
+            >
+              <X className="mr-1 size-3" /> Clear
+            </Button>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label className="text-xs">Skills</Label>
+        <ProjectEnvironmentSkillsPicker
+          projectId={projectId}
+          value={draft.skillSelection}
+          onChange={(skillSelection) =>
+            setDraft((d) => ({ ...d, skillSelection }))
+          }
+          disabled={readOnly}
+        />
+      </div>
+
+      {readOnly ? (
+        <p className="text-[11px] text-muted-foreground">
+          Only project admins can edit environments.
+        </p>
+      ) : (
+        <div className="flex items-center justify-end gap-2">
+          {onCancelCreate ? (
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              onClick={onCancelCreate}
+              disabled={saving}
+            >
+              Cancel
+            </Button>
+          ) : null}
+          <Button
+            type="button"
+            size="sm"
+            onClick={() => void save()}
+            disabled={saving || (environment !== null && !dirty)}
+          >
+            {saving ? (
+              <Loader2 className="mr-1.5 size-3.5 animate-spin" />
+            ) : null}
+            {environment ? "Save" : "Create"}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ConflictBanner({
+  conflicted,
+  dirty,
+  onReload,
+}: {
+  conflicted: boolean;
+  dirty: boolean;
+  onReload: () => void;
+}) {
+  const [confirming, setConfirming] = useState(false);
+  return (
+    <div className="flex items-start justify-between gap-3 rounded-md border border-warning/50 bg-warning/10 p-3">
+      <p className="flex items-start gap-2 text-xs text-foreground">
+        <TriangleAlert className="mt-0.5 size-3.5 shrink-0 text-warning" />
+        <span>
+          {conflicted
+            ? "Your save was rejected — this environment was changed by someone else."
+            : "This environment was changed by someone else while you were editing."}{" "}
+          Reloading discards your unsaved edits.
+        </span>
+      </p>
+      {confirming && dirty ? (
+        <span className="flex shrink-0 items-center gap-2">
+          <Button
+            type="button"
+            size="sm"
+            variant="destructive"
+            className="h-7 text-xs"
+            onClick={() => {
+              setConfirming(false);
+              onReload();
+            }}
+          >
+            Discard &amp; reload
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            className="h-7 text-xs"
+            onClick={() => setConfirming(false)}
+          >
+            Keep editing
+          </Button>
+        </span>
+      ) : (
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          className="h-7 shrink-0 text-xs"
+          onClick={() => {
+            // A clean draft has nothing to lose — reload directly. A dirty
+            // one requires the explicit discard confirmation.
+            if (dirty) setConfirming(true);
+            else onReload();
+          }}
+        >
+          Load latest
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/project-environments/ProjectEnvironmentEditor.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/ProjectEnvironmentEditor.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Loader2, TriangleAlert, X } from "lucide-react";
 import { toast } from "@/lib/toast";
 import { Button } from "@mcpjam/design-system/button";
@@ -123,6 +123,33 @@ export function ProjectEnvironmentEditor({
     setBaseRevision(environment.revision);
     setConflicted(false);
   }, [environment]);
+
+  // Project switched while the form is open: drop any draft that referenced the
+  // previous project's host/server-group/skills so it can't be submitted to the
+  // newly selected project. (Skips the initial mount — state already seeded.)
+  const didMountRef = useRef(false);
+  useEffect(() => {
+    if (!didMountRef.current) {
+      didMountRef.current = true;
+      return;
+    }
+    setDraft(
+      environment
+        ? draftFromEnvironment(environment)
+        : {
+            name: "",
+            description: "",
+            hostId: null,
+            serverAttachmentId: null,
+            skillSelection: null,
+          }
+    );
+    setBaseRevision(environment?.revision ?? null);
+    setConflicted(false);
+    // Reset is keyed on the project boundary only; `environment` changes are
+    // handled by the list⇄detail remount and the explicit reload path.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [projectId]);
 
   const save = async () => {
     if (!trimmedName) {

--- a/mcpjam-inspector/client/src/components/project-environments/ProjectEnvironmentSkillsPicker.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/ProjectEnvironmentSkillsPicker.tsx
@@ -115,7 +115,11 @@ export function ProjectEnvironmentSkillsPicker({
           const ineligible =
             skill.pinnability !== undefined && skill.pinnability.ok === false;
           const capBlocked = !checked && atCap;
-          const rowDisabled = disabled || ineligible || capBlocked;
+          // Ineligibility (and the cap) block NEW selections only — a skill that
+          // was pinned and later became ineligible must stay uncheckable so the
+          // user can repair the selection.
+          const rowDisabled =
+            disabled || capBlocked || (ineligible && !checked);
           const row = (
             <Label
               key={skillId}

--- a/mcpjam-inspector/client/src/components/project-environments/ProjectEnvironmentSkillsPicker.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/ProjectEnvironmentSkillsPicker.tsx
@@ -64,6 +64,20 @@ export function ProjectEnvironmentSkillsPicker({
 
   const selectedIds = useMemo(() => new Set(value?.skillIds ?? []), [value]);
   const atCap = selectedIds.size >= MAX_ENVIRONMENT_SKILLS;
+  // Pinned ids the shared-skills list doesn't return: the skill was unshared,
+  // deleted, or moved out of the project. Without a row they are invisible AND
+  // unremovable, yet they still count toward the footer and still ship on
+  // save. Surface them as detach-only rows. Gated on `skills` having loaded so
+  // the loading state doesn't flash every pin as an orphan.
+  const orphanSelectedIds = useMemo(
+    () =>
+      skills === null
+        ? []
+        : Array.from(selectedIds).filter(
+            (id) => !skills.some((s) => s.skillId === id)
+          ),
+    [skills, selectedIds]
+  );
 
   const toggle = (skillId: string, checked: boolean) => {
     const next = new Set(selectedIds);
@@ -93,7 +107,10 @@ export function ProjectEnvironmentSkillsPicker({
       </div>
     );
   }
-  if (skills.length === 0) {
+  // Only the truly-empty case short-circuits. With orphaned pins we MUST fall
+  // through to the list so they get detach-only rows — otherwise the pins are
+  // invisible, unremovable, and still sent on save.
+  if (skills.length === 0 && orphanSelectedIds.length === 0) {
     return (
       <p className="py-1 text-xs italic text-muted-foreground">
         No shared skills in this project yet. Share a skill with the project to
@@ -163,6 +180,37 @@ export function ProjectEnvironmentSkillsPicker({
             </Tooltip>
           );
         })}
+        {orphanSelectedIds.map((skillId) => (
+          <Label
+            key={skillId}
+            className={cn(
+              "flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent/30",
+              disabled && "cursor-not-allowed opacity-60 hover:bg-transparent"
+            )}
+          >
+            {/* Unresolvable pin: uncheck to remove only — never re-selectable.
+                There is no name to show; the row exists so the id is
+                removable rather than a silent passenger on every save. */}
+            <Checkbox
+              checked
+              onCheckedChange={() => toggle(skillId, false)}
+              disabled={disabled}
+              aria-label={`Unavailable skill ${skillId} (remove)`}
+            />
+            <SquareSlash className="size-3.5 shrink-0 text-muted-foreground" />
+            <span className="flex min-w-0 flex-col">
+              <span className="truncate font-normal text-muted-foreground">
+                Unavailable skill
+                <span className="ml-1 font-mono text-[10px]">
+                  {skillId.slice(0, 8)}
+                </span>
+              </span>
+              <span className="truncate text-[11px] text-muted-foreground">
+                No longer shared with this project — remove it to save.
+              </span>
+            </span>
+          </Label>
+        ))}
       </div>
       <p className="text-[11px] text-muted-foreground">
         {selectedIds.size}/{MAX_ENVIRONMENT_SKILLS} skills selected

--- a/mcpjam-inspector/client/src/components/project-environments/ProjectEnvironmentSkillsPicker.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/ProjectEnvironmentSkillsPicker.tsx
@@ -1,0 +1,169 @@
+import { useEffect, useMemo, useState } from "react";
+import { Loader2, SquareSlash } from "lucide-react";
+import { Checkbox } from "@mcpjam/design-system/checkbox";
+import { Label } from "@mcpjam/design-system/label";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@mcpjam/design-system/tooltip";
+import { cn } from "@/lib/utils";
+import { listSkills } from "@/lib/apis/mcp-skills-api";
+import type { SkillListItem } from "@/shared/skill-types";
+import type { ProjectEnvironmentSkillSelection } from "@/hooks/useProjectEnvironments";
+
+/** Backend cap on `skillSelection.skillIds`. */
+export const MAX_ENVIRONMENT_SKILLS = 20;
+
+/**
+ * Shared-skill multi-select for a project environment's `skillSelection`.
+ *
+ * Only SHARED (`sharing === 'project'`) skills are selectable — the backend
+ * rejects personal skills. Rows the backend flags as non-pinnable (P0.3
+ * `pinnability` metadata: plugin_component skills, supporting files, extra
+ * frontmatter) render disabled with the backend-aligned reason, so users
+ * never pick a skill only to discover the restriction at save time.
+ *
+ * Emits `{ mode: 'explicit', skillIds }` or `null` — never an empty array
+ * (the backend rejects `[]`; clearing means `null`).
+ */
+export function ProjectEnvironmentSkillsPicker({
+  projectId,
+  value,
+  onChange,
+  disabled = false,
+}: {
+  projectId: string;
+  value: ProjectEnvironmentSkillSelection | null | undefined;
+  onChange: (next: ProjectEnvironmentSkillSelection | null) => void;
+  disabled?: boolean;
+}) {
+  const [skills, setSkills] = useState<SkillListItem[] | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    setSkills(null);
+    setLoadError(null);
+    (async () => {
+      try {
+        const list = await listSkills({ kind: "cloud", projectId });
+        if (!active) return;
+        setSkills(list.filter((s) => s.sharing === "project" && s.skillId));
+      } catch (err) {
+        if (!active) return;
+        setLoadError(
+          err instanceof Error ? err.message : "Failed to load skills"
+        );
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, [projectId]);
+
+  const selectedIds = useMemo(() => new Set(value?.skillIds ?? []), [value]);
+  const atCap = selectedIds.size >= MAX_ENVIRONMENT_SKILLS;
+
+  const toggle = (skillId: string, checked: boolean) => {
+    const next = new Set(selectedIds);
+    if (checked) {
+      if (next.size >= MAX_ENVIRONMENT_SKILLS) return;
+      next.add(skillId);
+    } else {
+      next.delete(skillId);
+    }
+    // Never emit an empty explicit selection — clearing means null.
+    onChange(
+      next.size === 0 ? null : { mode: "explicit", skillIds: Array.from(next) }
+    );
+  };
+
+  if (loadError) {
+    return (
+      <p className="text-xs text-destructive">
+        Couldn&apos;t load project skills: {loadError}
+      </p>
+    );
+  }
+  if (skills === null) {
+    return (
+      <div className="flex items-center gap-2 py-1 text-xs text-muted-foreground">
+        <Loader2 className="size-3.5 animate-spin" /> Loading skills…
+      </div>
+    );
+  }
+  if (skills.length === 0) {
+    return (
+      <p className="py-1 text-xs italic text-muted-foreground">
+        No shared skills in this project yet. Share a skill with the project to
+        pin it here.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-1">
+      <div
+        role="group"
+        aria-label="Environment skills"
+        className="flex max-h-56 flex-col gap-1 overflow-y-auto pr-1"
+      >
+        {skills.map((skill) => {
+          const skillId = skill.skillId!;
+          const checked = selectedIds.has(skillId);
+          const ineligible =
+            skill.pinnability !== undefined && skill.pinnability.ok === false;
+          const capBlocked = !checked && atCap;
+          const rowDisabled = disabled || ineligible || capBlocked;
+          const row = (
+            <Label
+              key={skillId}
+              className={cn(
+                "flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent/30",
+                rowDisabled &&
+                  "cursor-not-allowed opacity-60 hover:bg-transparent"
+              )}
+            >
+              <Checkbox
+                checked={checked}
+                onCheckedChange={(next) => toggle(skillId, next === true)}
+                disabled={rowDisabled}
+                aria-label={skill.name}
+              />
+              <SquareSlash className="size-3.5 shrink-0 text-muted-foreground" />
+              <span className="flex min-w-0 flex-col">
+                <span className="truncate font-normal">{skill.name}</span>
+                {skill.description ? (
+                  <span className="truncate text-[11px] text-muted-foreground">
+                    {skill.description}
+                  </span>
+                ) : null}
+              </span>
+            </Label>
+          );
+          if (!ineligible) return row;
+          return (
+            <Tooltip key={skillId}>
+              <TooltipTrigger asChild>
+                {/* span keeps the tooltip alive over the disabled row */}
+                <span>{row}</span>
+              </TooltipTrigger>
+              <TooltipContent side="right" className="max-w-[260px]">
+                <p className="text-xs leading-snug">
+                  {skill.pinnability && !skill.pinnability.ok
+                    ? skill.pinnability.reason
+                    : "This skill can't be pinned to an environment."}
+                </p>
+              </TooltipContent>
+            </Tooltip>
+          );
+        })}
+      </div>
+      <p className="text-[11px] text-muted-foreground">
+        {selectedIds.size}/{MAX_ENVIRONMENT_SKILLS} skills selected
+        {atCap ? " — cap reached" : ""}. Shared skills only.
+      </p>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/project-environments/ProjectEnvironmentsRoute.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/ProjectEnvironmentsRoute.tsx
@@ -51,6 +51,24 @@ export function ProjectEnvironmentsRoute({
     null
   );
 
+  // The route is NOT keyed on projectId (router.tsx renders a bare
+  // <EnvironmentsRoute />), so switching the active project re-runs this
+  // component with a new `projectId` but every piece of selection state
+  // intact. Reset all three:
+  //   - `creating` is the harmful one — the editor would stay open holding the
+  //     PREVIOUS project's host / server group / skill picks while bound to the
+  //     new projectId. (The backend re-validates project scope, so a save
+  //     fails rather than corrupting — but the form is broken and confusing.)
+  //   - `selectedId` mostly self-heals once the new list arrives and no id
+  //     matches, but clearing it avoids a flash of the wrong detail.
+  //   - `justCreated` holds a raw env object from the OLD project that
+  //     `selected` would otherwise return for up to 3s.
+  useEffect(() => {
+    setSelectedId(null);
+    setCreating(false);
+    setJustCreated(null);
+  }, [projectId]);
+
   useEffect(() => {
     if (!justCreated) return;
     if (

--- a/mcpjam-inspector/client/src/components/project-environments/ProjectEnvironmentsRoute.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/ProjectEnvironmentsRoute.tsx
@@ -1,0 +1,406 @@
+import { useEffect, useMemo, useState } from "react";
+import { Navigate } from "react-router";
+import {
+  Archive,
+  ArchiveRestore,
+  ChevronLeft,
+  Layers,
+  Loader2,
+  Plus,
+} from "lucide-react";
+import { toast } from "@/lib/toast";
+import { Button } from "@mcpjam/design-system/button";
+import { Badge } from "@mcpjam/design-system/badge";
+import { routePaths } from "@/lib/app-navigation";
+import { convexErrMessage } from "@/lib/convex-error";
+import { useProjectEnvironmentsEnabledState } from "@/hooks/useProjectEnvironmentsEnabled";
+import {
+  useArchiveProjectEnvironment,
+  useProjectEnvironments,
+  useRestoreProjectEnvironment,
+  type ProjectEnvironmentView,
+} from "@/hooks/useProjectEnvironments";
+import { ProjectEnvironmentEditor } from "./ProjectEnvironmentEditor";
+import { useProjectEnvironmentConsumers } from "./use-project-environment-consumers";
+
+/**
+ * Full-page list⇄detail management screen for Project environments — named
+ * host + server group + pinned-skills bundles that suites and journeys run
+ * against. Flag-gated INSIDE the component so a direct `/environments` URL
+ * cannot bypass the sidebar gate.
+ */
+export function ProjectEnvironmentsRoute({
+  projectId,
+  canManage,
+}: {
+  projectId: string | null;
+  /** Admin-gated writes; members browse read-only. */
+  canManage: boolean;
+}) {
+  const flagEnabled = useProjectEnvironmentsEnabledState();
+
+  const environments = useProjectEnvironments(
+    flagEnabled === true ? projectId : null,
+    { includeArchived: true }
+  );
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+  // A just-created env, kept until the reactive list query includes it — so
+  // we land on its detail immediately instead of bouncing back to the list.
+  const [justCreated, setJustCreated] = useState<ProjectEnvironmentView | null>(
+    null
+  );
+
+  useEffect(() => {
+    if (!justCreated) return;
+    if (
+      environments?.some((e) => e.environmentId === justCreated.environmentId)
+    ) {
+      setJustCreated(null);
+      return;
+    }
+    const t = setTimeout(() => setJustCreated(null), 3000);
+    return () => clearTimeout(t);
+  }, [justCreated, environments]);
+
+  const selected = useMemo(
+    () =>
+      environments?.find((e) => e.environmentId === selectedId) ??
+      (justCreated?.environmentId === selectedId ? justCreated : null),
+    [environments, selectedId, justCreated]
+  );
+
+  // Only redirect on an explicit `false`. While PostHog hydrates the flag is
+  // `undefined`; bouncing then would strand a flagged-in user who cold-loads
+  // /environments directly. Render nothing until it settles.
+  if (flagEnabled === false) {
+    return <Navigate to={routePaths.servers} replace />;
+  }
+  if (flagEnabled === undefined) {
+    return null;
+  }
+
+  if (!projectId) {
+    return (
+      <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+        Select a project to manage its environments.
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full overflow-y-auto">
+      <div className="mx-auto max-w-2xl px-6 py-8">
+        {creating ? (
+          <div className="space-y-4">
+            <BackLink
+              label="All environments"
+              onClick={() => setCreating(false)}
+            />
+            <h1 className="text-lg font-semibold text-foreground">
+              New environment
+            </h1>
+            <ProjectEnvironmentEditor
+              projectId={projectId}
+              environment={null}
+              canManage={canManage}
+              onCreated={(env) => {
+                setCreating(false);
+                setJustCreated(env);
+                setSelectedId(env.environmentId);
+              }}
+              onCancelCreate={() => setCreating(false)}
+            />
+          </div>
+        ) : selected ? (
+          <EnvironmentDetail
+            key={`${selected.environmentId}:${selected.archivedAt ?? "live"}`}
+            projectId={projectId}
+            environment={selected}
+            canManage={canManage}
+            onBack={() => setSelectedId(null)}
+          />
+        ) : (
+          <EnvironmentList
+            environments={environments}
+            canManage={canManage}
+            onSelect={setSelectedId}
+            onNew={() => setCreating(true)}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function BackLink({ label, onClick }: { label: string; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex w-fit items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+    >
+      <ChevronLeft className="size-3.5" /> {label}
+    </button>
+  );
+}
+
+function EnvironmentList({
+  environments,
+  canManage,
+  onSelect,
+  onNew,
+}: {
+  environments: ProjectEnvironmentView[] | undefined;
+  canManage: boolean;
+  onSelect: (id: string) => void;
+  onNew: () => void;
+}) {
+  if (environments === undefined) {
+    return (
+      <div className="flex items-center justify-center py-16 text-sm text-muted-foreground">
+        <Loader2 className="mr-2 size-4 animate-spin" /> Loading environments…
+      </div>
+    );
+  }
+  const live = environments.filter((e) => !e.archivedAt);
+  const archived = environments.filter((e) => !!e.archivedAt);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h1 className="text-lg font-semibold text-foreground">
+            Environments
+          </h1>
+          <p className="mt-1 text-xs text-muted-foreground">
+            A named bundle of one client, an optional server group, and optional
+            pinned skills. Suites and journeys run against environments and
+            resolve them at launch.
+          </p>
+        </div>
+        {canManage ? (
+          <Button size="sm" onClick={onNew}>
+            <Plus className="mr-1.5 size-3.5" /> New environment
+          </Button>
+        ) : null}
+      </div>
+
+      {live.length === 0 ? (
+        <div className="rounded-md border border-dashed px-4 py-10 text-center text-sm text-muted-foreground">
+          <Layers className="mx-auto mb-2 size-5" />
+          No environments yet
+          {canManage ? " — create one to get started." : "."}
+        </div>
+      ) : (
+        <div className="divide-y divide-border/60 rounded-md border">
+          {live.map((env) => (
+            <EnvironmentRow
+              key={env.environmentId}
+              env={env}
+              onSelect={onSelect}
+            />
+          ))}
+        </div>
+      )}
+
+      {archived.length > 0 ? (
+        <div className="space-y-2">
+          <h2 className="text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground/80">
+            Archived
+          </h2>
+          <div className="divide-y divide-border/60 rounded-md border">
+            {archived.map((env) => (
+              <EnvironmentRow
+                key={env.environmentId}
+                env={env}
+                onSelect={onSelect}
+              />
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function EnvironmentRow({
+  env,
+  onSelect,
+}: {
+  env: ProjectEnvironmentView;
+  onSelect: (id: string) => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(env.environmentId)}
+      className="flex w-full items-center justify-between gap-3 px-3 py-2.5 text-left text-sm hover:bg-muted/50"
+    >
+      <span className="flex min-w-0 flex-col">
+        <span className="truncate font-medium text-foreground">{env.name}</span>
+        {env.description ? (
+          <span className="truncate text-xs text-muted-foreground">
+            {env.description}
+          </span>
+        ) : null}
+      </span>
+      <span className="flex shrink-0 items-center gap-2">
+        {env.archivedAt ? <Badge variant="outline">Archived</Badge> : null}
+        <span className="font-mono text-[10px] text-muted-foreground">
+          rev {env.revision}
+        </span>
+      </span>
+    </button>
+  );
+}
+
+function EnvironmentDetail({
+  projectId,
+  environment,
+  canManage,
+  onBack,
+}: {
+  projectId: string;
+  environment: ProjectEnvironmentView;
+  canManage: boolean;
+  onBack: () => void;
+}) {
+  const archiveEnvironment = useArchiveProjectEnvironment();
+  const restoreEnvironment = useRestoreProjectEnvironment();
+  const [confirmingArchive, setConfirmingArchive] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const { suiteCount } = useProjectEnvironmentConsumers(
+    projectId,
+    confirmingArchive ? environment.environmentId : null
+  );
+
+  const isArchived = !!environment.archivedAt;
+
+  const onArchive = async () => {
+    setBusy(true);
+    try {
+      // Archive is actioned on the row as currently shown (no draft), so the
+      // reactive revision IS the base revision here.
+      await archiveEnvironment({
+        environmentId: environment.environmentId,
+        expectedRevision: environment.revision,
+      });
+      toast.success(`Archived “${environment.name}”.`);
+      setConfirmingArchive(false);
+    } catch (err) {
+      toast.error(convexErrMessage(err, "Could not archive the environment."));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onRestore = async () => {
+    setBusy(true);
+    try {
+      await restoreEnvironment({
+        environmentId: environment.environmentId,
+        expectedRevision: environment.revision,
+      });
+      toast.success(`Restored “${environment.name}”.`);
+    } catch (err) {
+      toast.error(convexErrMessage(err, "Could not restore the environment."));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between gap-3">
+        <BackLink label="All environments" onClick={onBack} />
+        <span className="flex items-center gap-2">
+          {isArchived ? <Badge variant="outline">Archived</Badge> : null}
+          <span className="font-mono text-[10px] text-muted-foreground">
+            rev {environment.revision}
+          </span>
+        </span>
+      </div>
+
+      {isArchived ? (
+        <div className="flex items-center justify-between gap-3 rounded-md border bg-muted/30 p-3">
+          <p className="text-xs text-muted-foreground">
+            Archived — hidden from pickers; suites and journeys still
+            referencing it fail fast at their next launch.
+          </p>
+          {canManage ? (
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              className="h-7 shrink-0 text-xs"
+              disabled={busy}
+              onClick={() => void onRestore()}
+            >
+              <ArchiveRestore className="mr-1.5 size-3.5" /> Restore
+            </Button>
+          ) : null}
+        </div>
+      ) : null}
+
+      <ProjectEnvironmentEditor
+        projectId={projectId}
+        environment={environment}
+        canManage={canManage && !isArchived}
+      />
+
+      {canManage && !isArchived ? (
+        <div className="flex items-center justify-between border-t pt-4">
+          {confirmingArchive ? (
+            <span className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+              <span>
+                Archive “{environment.name}”?{" "}
+                {suiteCount === null
+                  ? "Checking references…"
+                  : suiteCount > 0
+                  ? `${suiteCount} suite${
+                      suiteCount === 1 ? "" : "s"
+                    } reference it (count may be incomplete — journeys aren't scanned).`
+                  : "No referencing suites found (count may be incomplete — journeys aren't scanned)."}{" "}
+                Referencing runs fail fast at their next launch.
+              </span>
+              <Button
+                type="button"
+                size="sm"
+                variant="destructive"
+                className="h-7 text-xs"
+                disabled={busy}
+                onClick={() => void onArchive()}
+              >
+                {busy ? (
+                  <Loader2 className="mr-1.5 size-3.5 animate-spin" />
+                ) : null}
+                Archive
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant="ghost"
+                className="h-7 text-xs"
+                disabled={busy}
+                onClick={() => setConfirmingArchive(false)}
+              >
+                Cancel
+              </Button>
+            </span>
+          ) : (
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              className="text-destructive hover:text-destructive"
+              onClick={() => setConfirmingArchive(true)}
+            >
+              <Archive className="mr-1.5 size-3.5" /> Archive
+            </Button>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/project-environments/__tests__/orphan-selections.test.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/__tests__/orphan-selections.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * Orphaned-selection rows for both environment pickers.
+ *
+ * Both surfaces persist a list of ids and render rows from a LIVE query. An id
+ * the query doesn't return — hard-deleted, unshared, or moved out of the
+ * project — otherwise renders no row at all: invisible, unremovable, and still
+ * shipped on every save. Each picker must surface those ids as detach-only
+ * rows. (The archived-but-present case was already handled; this covers the
+ * genuinely-missing case.)
+ */
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockEnvironments, mockSetSuiteEnvironments, mockListSkills } =
+  vi.hoisted(() => ({
+    mockEnvironments: { value: [] as unknown[] },
+    mockSetSuiteEnvironments: vi.fn(),
+    mockListSkills: vi.fn(),
+  }));
+
+vi.mock("convex/react", () => ({
+  useMutation: () => mockSetSuiteEnvironments,
+}));
+vi.mock("@/hooks/useProjectEnvironments", () => ({
+  useProjectEnvironments: () => mockEnvironments.value,
+}));
+vi.mock("@/lib/apis/mcp-skills-api", () => ({
+  listSkills: (...args: unknown[]) => mockListSkills(...args),
+}));
+vi.mock("@/lib/toast", () => ({ toast: { error: vi.fn() } }));
+vi.mock("@/lib/app-navigation", () => ({
+  navigateApp: vi.fn(),
+  routePaths: { environments: "/environments" },
+}));
+
+import { SuiteProjectEnvironmentsPicker } from "@/components/evals/suite-project-environments-picker";
+import { ProjectEnvironmentSkillsPicker } from "../ProjectEnvironmentSkillsPicker";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSetSuiteEnvironments.mockResolvedValue(undefined);
+});
+
+describe("SuiteProjectEnvironmentsPicker — unresolvable attached ids", () => {
+  it("renders a detach-only row for an attached id the query never returns", async () => {
+    // "env-live" resolves; "env-gone" was hard-deleted.
+    mockEnvironments.value = [
+      { environmentId: "env-live", name: "Prod-like", revision: 1 },
+    ];
+
+    render(
+      <SuiteProjectEnvironmentsPicker
+        suiteId="suite-1"
+        projectId="proj-1"
+        environmentIds={["env-live", "env-gone"]}
+      />
+    );
+
+    // The popover trigger is the only button rendered before it opens; its
+    // label is the joined environment names, so match it positionally.
+    fireEvent.click(screen.getAllByRole("button")[0]!);
+
+    const orphanRow = await screen.findByLabelText(
+      /Unavailable environment env-gone \(detach\)/i
+    );
+    expect(orphanRow).toBeInTheDocument();
+
+    // Unchecking it must commit the remaining ids — i.e. it is REMOVABLE.
+    fireEvent.click(orphanRow);
+    await waitFor(() => {
+      expect(mockSetSuiteEnvironments).toHaveBeenCalledWith({
+        suiteId: "suite-1",
+        environmentIds: ["env-live"],
+      });
+    });
+  });
+
+  it("shows no orphan rows while the query is still loading", () => {
+    mockEnvironments.value = undefined as unknown as unknown[];
+    render(
+      <SuiteProjectEnvironmentsPicker
+        suiteId="suite-1"
+        projectId="proj-1"
+        environmentIds={["env-a", "env-b"]}
+      />
+    );
+    // The popover trigger is the only button rendered before it opens; its
+    // label is the joined environment names, so match it positionally.
+    fireEvent.click(screen.getAllByRole("button")[0]!);
+    // A loading list must not flash every attached id as an orphan.
+    expect(
+      screen.queryByLabelText(/Unavailable environment/i)
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("ProjectEnvironmentSkillsPicker — unresolvable pinned ids", () => {
+  it("renders a removable row for a pinned skill missing from the shared list", async () => {
+    mockListSkills.mockResolvedValue([
+      { skillId: "sk-live", name: "Live skill", description: "d" },
+    ]);
+    const onChange = vi.fn();
+
+    render(
+      <ProjectEnvironmentSkillsPicker
+        projectId="proj-1"
+        value={{ mode: "explicit", skillIds: ["sk-live", "sk-gone"] }}
+        onChange={onChange}
+      />
+    );
+
+    const orphanRow = await screen.findByLabelText(
+      /Unavailable skill sk-gone \(remove\)/i
+    );
+    fireEvent.click(orphanRow);
+    expect(onChange).toHaveBeenCalledWith({
+      mode: "explicit",
+      skillIds: ["sk-live"],
+    });
+  });
+
+  it("still surfaces orphaned pins when the project has NO shared skills", async () => {
+    // The empty-list early return would otherwise swallow the pins entirely,
+    // leaving them invisible AND unremovable while still counted + saved.
+    mockListSkills.mockResolvedValue([]);
+    const onChange = vi.fn();
+
+    render(
+      <ProjectEnvironmentSkillsPicker
+        projectId="proj-1"
+        value={{ mode: "explicit", skillIds: ["sk-gone"] }}
+        onChange={onChange}
+      />
+    );
+
+    const orphanRow = await screen.findByLabelText(
+      /Unavailable skill sk-gone \(remove\)/i
+    );
+    expect(
+      screen.queryByText(/No shared skills in this project yet/i)
+    ).not.toBeInTheDocument();
+
+    // Clearing the last pin emits null, never an empty array.
+    fireEvent.click(orphanRow);
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+});

--- a/mcpjam-inspector/client/src/components/project-environments/__tests__/project-environments-route.flag-gate.test.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/__tests__/project-environments-route.flag-gate.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockFlagValue, mockListEnvironments } = vi.hoisted(() => ({
+  mockFlagValue: { value: undefined as boolean | undefined },
+  mockListEnvironments: vi.fn(() => [] as unknown[]),
+}));
+
+vi.mock("posthog-js/react", () => ({
+  useFeatureFlagEnabled: () => mockFlagValue.value,
+}));
+
+// The flag gate is the unit under test; the data hooks and the (heavy)
+// editor subtree are stubbed out.
+vi.mock("@/hooks/useProjectEnvironments", () => ({
+  useProjectEnvironments: (projectId: string | null) =>
+    projectId ? mockListEnvironments() : undefined,
+  useArchiveProjectEnvironment: () => vi.fn(),
+  useRestoreProjectEnvironment: () => vi.fn(),
+}));
+vi.mock("../ProjectEnvironmentEditor", () => ({
+  ProjectEnvironmentEditor: () => <div>Environment Editor</div>,
+}));
+vi.mock("../use-project-environment-consumers", () => ({
+  useProjectEnvironmentConsumers: () => ({ suiteCount: null }),
+}));
+
+import { ProjectEnvironmentsRoute } from "../ProjectEnvironmentsRoute";
+
+function renderAtEnvironments() {
+  return render(
+    <MemoryRouter initialEntries={["/environments"]}>
+      <Routes>
+        <Route
+          path="/environments"
+          element={<ProjectEnvironmentsRoute projectId="proj-1" canManage />}
+        />
+        <Route path="/servers" element={<div>Servers Screen</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe("ProjectEnvironmentsRoute flag gate", () => {
+  beforeEach(() => {
+    mockFlagValue.value = undefined;
+    mockListEnvironments.mockClear();
+  });
+
+  it("redirects a direct /environments visit to /servers when the flag is OFF", () => {
+    mockFlagValue.value = false;
+    renderAtEnvironments();
+    expect(screen.getByText("Servers Screen")).toBeInTheDocument();
+    expect(screen.queryByText("Environments")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing (no redirect, no content) while the flag is loading", () => {
+    mockFlagValue.value = undefined;
+    renderAtEnvironments();
+    expect(screen.queryByText("Servers Screen")).not.toBeInTheDocument();
+    expect(screen.queryByText("Environments")).not.toBeInTheDocument();
+  });
+
+  it("renders the management screen when the flag is ON", () => {
+    mockFlagValue.value = true;
+    renderAtEnvironments();
+    expect(
+      screen.getByRole("heading", { name: "Environments" })
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Servers Screen")).not.toBeInTheDocument();
+  });
+
+  it("never fires the environments query while the flag is off", () => {
+    mockFlagValue.value = false;
+    renderAtEnvironments();
+    expect(mockListEnvironments).not.toHaveBeenCalled();
+  });
+});

--- a/mcpjam-inspector/client/src/components/project-environments/__tests__/project-environments-route.flag-gate.test.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/__tests__/project-environments-route.flag-gate.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -28,13 +28,13 @@ vi.mock("../use-project-environment-consumers", () => ({
 
 import { ProjectEnvironmentsRoute } from "../ProjectEnvironmentsRoute";
 
-function renderAtEnvironments() {
+function renderAtEnvironments(projectId = "proj-1") {
   return render(
     <MemoryRouter initialEntries={["/environments"]}>
       <Routes>
         <Route
           path="/environments"
-          element={<ProjectEnvironmentsRoute projectId="proj-1" canManage />}
+          element={<ProjectEnvironmentsRoute projectId={projectId} canManage />}
         />
         <Route path="/servers" element={<div>Servers Screen</div>} />
       </Routes>
@@ -75,5 +75,38 @@ describe("ProjectEnvironmentsRoute flag gate", () => {
     mockFlagValue.value = false;
     renderAtEnvironments();
     expect(mockListEnvironments).not.toHaveBeenCalled();
+  });
+});
+
+describe("ProjectEnvironmentsRoute project switch", () => {
+  beforeEach(() => {
+    mockFlagValue.value = true;
+    mockListEnvironments.mockClear().mockReturnValue([]);
+  });
+
+  it("closes an open create form when the active project changes", () => {
+    // The route is not keyed on projectId, so without an explicit reset the
+    // editor would stay open holding the PREVIOUS project's picks while bound
+    // to the new projectId.
+    const { rerender } = renderAtEnvironments("proj-1");
+    fireEvent.click(screen.getByRole("button", { name: /new environment/i }));
+    expect(screen.getByText("Environment Editor")).toBeInTheDocument();
+
+    rerender(
+      <MemoryRouter initialEntries={["/environments"]}>
+        <Routes>
+          <Route
+            path="/environments"
+            element={<ProjectEnvironmentsRoute projectId="proj-2" canManage />}
+          />
+          <Route path="/servers" element={<div>Servers Screen</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByText("Environment Editor")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Environments" })
+    ).toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/components/project-environments/use-project-environment-consumers.ts
+++ b/mcpjam-inspector/client/src/components/project-environments/use-project-environment-consumers.ts
@@ -1,0 +1,40 @@
+import { useMemo } from "react";
+import { useQuery, useConvexAuth } from "convex/react";
+import { useDbUserReady } from "@/contexts/db-user-ready-context";
+import { shouldQueryProjectId } from "@/hooks/useProjects";
+
+/**
+ * ADVISORY count of consumers referencing an environment, for the
+ * archive-confirm dialog. No reverse index exists backend-side, so this is a
+ * client scan of the suites the viewer can already see; journeys are not
+ * scanned (their list query is persona-keyed). The dialog copy must say the
+ * count "may be incomplete" — archiving while referenced is allowed by
+ * design (consumers fail fast at their next launch).
+ */
+export function useProjectEnvironmentConsumers(
+  projectId: string | null,
+  environmentId: string | null
+): { suiteCount: number | null } {
+  const { isAuthenticated } = useConvexAuth();
+  const isUserReady = useDbUserReady();
+  const enableQuery =
+    isAuthenticated &&
+    isUserReady &&
+    shouldQueryProjectId(projectId) &&
+    !!environmentId;
+
+  const overview = useQuery(
+    "testSuites:getTestSuitesOverview" as any,
+    enableQuery ? ({ projectId } as any) : "skip"
+  ) as Array<{ suite?: { environmentIds?: string[] } }> | undefined;
+
+  return useMemo(() => {
+    if (!environmentId || overview === undefined) {
+      return { suiteCount: null };
+    }
+    const suiteCount = overview.filter((entry) =>
+      (entry.suite?.environmentIds ?? []).includes(environmentId)
+    ).length;
+    return { suiteCount };
+  }, [overview, environmentId]);
+}

--- a/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
@@ -79,6 +79,7 @@ import {
 } from "@/components/swarms/swarm-targets";
 import { buildEnvJourneyPayload } from "@/components/swarms/journey-environments";
 import { useProjectEnvironmentsEnabled } from "@/hooks/useProjectEnvironmentsEnabled";
+import { shouldQueryProjectId } from "@/hooks/useProjects";
 // The badge + wide-shape guard live in the shared session-quality module so
 // surfaces rendered inside this subtree can use them without an import cycle.
 // Re-exported here because the goal-score unit test imports from `../SwarmsTab`.
@@ -206,7 +207,12 @@ function useProjectHosts(projectId: string | null) {
 function useProjectEnvironmentsList(projectId: string | null, enabled: boolean) {
   return useQuery(
     SWARM_QUERIES.listEnvironments as any,
-    enabled && projectId ? ({ projectId } as any) : "skip",
+    // `shouldQueryProjectId` (not a bare truthiness check): a local/placeholder
+    // or UUID project id during a project transition would 500 the Convex arg
+    // validator, so skip until the id is a real queryable project.
+    enabled && shouldQueryProjectId(projectId)
+      ? ({ projectId } as any)
+      : "skip",
   ) as EnvironmentView[] | undefined;
 }
 function usePersonaTrackRecord(personaRefId: string | null) {

--- a/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
@@ -29,7 +29,15 @@
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQuery, useMutation, usePaginatedQuery } from "convex/react";
-import { Check, ChevronDown, Info, Loader2, Plus, Users, X } from "lucide-react";
+import {
+  Check,
+  ChevronDown,
+  Info,
+  Loader2,
+  Plus,
+  Users,
+  X,
+} from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
 import {
   Dialog,
@@ -204,15 +212,16 @@ function useProjectHosts(projectId: string | null) {
 }
 /** Live project environments — subscribed ONLY while the feature flag is on
  * (every client exposure of Project Environments is flag-gated). */
-function useProjectEnvironmentsList(projectId: string | null, enabled: boolean) {
+function useProjectEnvironmentsList(
+  projectId: string | null,
+  enabled: boolean
+) {
   return useQuery(
     SWARM_QUERIES.listEnvironments as any,
     // `shouldQueryProjectId` (not a bare truthiness check): a local/placeholder
     // or UUID project id during a project transition would 500 the Convex arg
     // validator, so skip until the id is a real queryable project.
-    enabled && shouldQueryProjectId(projectId)
-      ? ({ projectId } as any)
-      : "skip",
+    enabled && shouldQueryProjectId(projectId) ? ({ projectId } as any) : "skip"
   ) as EnvironmentView[] | undefined;
 }
 function usePersonaTrackRecord(personaRefId: string | null) {
@@ -236,7 +245,7 @@ function RunningPersonasSubscriber({
 }) {
   const ids = useQuery(
     SWARM_QUERIES.listRunningPersonaRefIds as any,
-    projectId ? ({ projectId } as any) : "skip",
+    projectId ? ({ projectId } as any) : "skip"
   ) as string[] | undefined;
 
   useEffect(() => {
@@ -246,10 +255,7 @@ function RunningPersonasSubscriber({
   return null;
 }
 
-export function SwarmsTab({
-  projectId,
-  isAuthenticated,
-}: SwarmsTabProps) {
+export function SwarmsTab({ projectId, isAuthenticated }: SwarmsTabProps) {
   // Don't subscribe to project-scoped Convex reads until auth is ready — a
   // signed-out/loading mount with a persisted project would otherwise surface
   // authorization errors instead of holding the screen.
@@ -259,12 +265,12 @@ export function SwarmsTab({
   const environmentsEnabled = useProjectEnvironmentsEnabled();
   const environments = useProjectEnvironmentsList(
     effectiveProjectId,
-    environmentsEnabled,
+    environmentsEnabled
   );
   const [runningPersonaIds, setRunningPersonaIds] = useState<string[]>([]);
   const runningSet = useMemo(
     () => new Set(runningPersonaIds),
-    [runningPersonaIds],
+    [runningPersonaIds]
   );
   const onRunningPersonasChange = useCallback((ids: string[]) => {
     setRunningPersonaIds(ids);
@@ -273,7 +279,7 @@ export function SwarmsTab({
   // Parse ONCE on mount so later user navigation isn't clobbered by the URL.
   const deepLink = useMemo(
     () => parseSwarmSessionParams(window.location.search),
-    [],
+    []
   );
   type SwarmViewMode = "journeys" | "sessions";
   const SWARM_VIEW_OPTIONS = [
@@ -283,10 +289,10 @@ export function SwarmsTab({
   // Session deep-links open the flat Sessions browser; run-only links stay on
   // Journeys so the matrix / live stream can restore.
   const [viewMode, setViewMode] = useState<SwarmViewMode>(() =>
-    deepLink.threadId ? "sessions" : "journeys",
+    deepLink.threadId ? "sessions" : "journeys"
   );
   const [selectedPersonaId, setSelectedPersonaId] = useState<string | null>(
-    () => deepLink.personaRefId ?? null,
+    () => deepLink.personaRefId ?? null
   );
   const journeys = useJourneys(selectedPersonaId);
   // Lifted for the agent snapshot (one subscription).
@@ -305,18 +311,18 @@ export function SwarmsTab({
         notes?: string;
         avatarShape?: number;
         avatarPalette?: number;
-      },
+      }
     ) => {
       try {
         await updatePersona({ personaRefId, ...patch } as any);
       } catch (error) {
         toast.error(
-          error instanceof Error ? error.message : "Failed to update persona",
+          error instanceof Error ? error.message : "Failed to update persona"
         );
         throw error;
       }
     },
-    [updatePersona],
+    [updatePersona]
   );
 
   const selectedPersona = useMemo(
@@ -328,7 +334,7 @@ export function SwarmsTab({
   // must not subscribe getPersonaTrackRecord before the allowed persona list
   // has loaded and matched — that surfaces backend authorization errors.
   const trackRecord = usePersonaTrackRecord(
-    selectedPersona ? selectedPersonaId : null,
+    selectedPersona ? selectedPersonaId : null
   );
 
   // New-journey form, lifted so `ui_open_journey_form` can open it (the
@@ -347,7 +353,7 @@ export function SwarmsTab({
     (
       journey: JourneyListJourney,
       run: JourneyRun,
-      targetKey: string | null,
+      targetKey: string | null
     ) => {
       setRunDetail({
         journeyId: journey._id,
@@ -356,7 +362,7 @@ export function SwarmsTab({
         runSnapshot: run,
       });
     },
-    [],
+    []
   );
   const closeRunDetail = useCallback(() => setRunDetail(null), []);
   // Close the panel when the persona changes or its journey disappears.
@@ -373,7 +379,7 @@ export function SwarmsTab({
     }
   }, [journeys, runDetail]);
   const detailJourney = runDetail
-    ? (journeys?.find((j) => j._id === runDetail.journeyId) ?? null)
+    ? journeys?.find((j) => j._id === runDetail.journeyId) ?? null
     : null;
 
   // ── Agent bridge ──────────────────────────────────────────────────────────
@@ -388,7 +394,7 @@ export function SwarmsTab({
     if (!agentOperable) {
       throw createInspectorCommandClientError(
         "unsupported_in_mode",
-        "Swarms is locked here — sign in and select a project before using the swarm tools.",
+        "Swarms is locked here — sign in and select a project before using the swarm tools."
       );
     }
   };
@@ -409,10 +415,9 @@ export function SwarmsTab({
   // ANY failure and dropped only after a confirmed 2xx.
   const launchJourney = useCallback(
     async (
-      journeyId: string,
+      journeyId: string
     ): Promise<
-      | { status: "launched"; runId?: string }
-      | { status: "already_launching" }
+      { status: "launched"; runId?: string } | { status: "already_launching" }
     > => {
       if (!projectId) {
         throw new LaunchJourneyRunError(0, "No project is selected.");
@@ -440,7 +445,7 @@ export function SwarmsTab({
         launchingRef.current.delete(journeyId);
       }
     },
-    [projectId],
+    [projectId]
   );
 
   // Exact (case-insensitive) resolution against the loaded lists — unknown or
@@ -449,24 +454,24 @@ export function SwarmsTab({
     if (typeof raw !== "string" || raw.trim().length === 0) {
       throw createInspectorCommandClientError(
         "invalid_request",
-        "Missing required 'persona' string (a persona name or id).",
+        "Missing required 'persona' string (a persona name or id)."
       );
     }
     const wanted = raw.trim();
     const wantedLower = wanted.toLowerCase();
     const matches = (personas ?? []).filter(
-      (p) => p._id === wanted || p.name.toLowerCase() === wantedLower,
+      (p) => p._id === wanted || p.name.toLowerCase() === wantedLower
     );
     if (matches.length === 1) return matches[0];
     if (matches.length === 0) {
       throw createInspectorCommandClientError(
         "invalid_request",
-        `No persona matches "${wanted}". Use a persona name or id from this screen (list them with ui_snapshot_app).`,
+        `No persona matches "${wanted}". Use a persona name or id from this screen (list them with ui_snapshot_app).`
       );
     }
     throw createInspectorCommandClientError(
       "invalid_request",
-      `${matches.length} personas match "${wanted}" — pass the persona id instead (ids are in ui_snapshot_app).`,
+      `${matches.length} personas match "${wanted}" — pass the persona id instead (ids are in ui_snapshot_app).`
     );
   };
 
@@ -474,13 +479,13 @@ export function SwarmsTab({
     if (typeof raw !== "string" || raw.trim().length === 0) {
       throw createInspectorCommandClientError(
         "invalid_request",
-        "Missing required 'journey' string (a goal or journey id).",
+        "Missing required 'journey' string (a goal or journey id)."
       );
     }
     if (!selectedPersona) {
       throw createInspectorCommandClientError(
         "invalid_request",
-        "Select a persona first — journeys are listed per persona (see ui_snapshot_app).",
+        "Select a persona first — journeys are listed per persona (see ui_snapshot_app)."
       );
     }
     const wanted = raw.trim();
@@ -489,18 +494,18 @@ export function SwarmsTab({
       (j) =>
         j._id === wanted ||
         j.goal.toLowerCase() === wantedLower ||
-        (j.name ?? "").toLowerCase() === wantedLower,
+        (j.name ?? "").toLowerCase() === wantedLower
     );
     if (matches.length === 1) return matches[0];
     if (matches.length === 0) {
       throw createInspectorCommandClientError(
         "invalid_request",
-        `No journey matches "${wanted}" for persona "${selectedPersona.name}". Use a journey goal or id from this screen; if the journey belongs to another persona, select that persona first.`,
+        `No journey matches "${wanted}" for persona "${selectedPersona.name}". Use a journey goal or id from this screen; if the journey belongs to another persona, select that persona first.`
       );
     }
     throw createInspectorCommandClientError(
       "invalid_request",
-      `${matches.length} journeys match "${wanted}" — pass the journey id instead (ids are in ui_snapshot_app).`,
+      `${matches.length} journeys match "${wanted}" — pass the journey id instead (ids are in ui_snapshot_app).`
     );
   };
 
@@ -516,7 +521,7 @@ export function SwarmsTab({
         if (!pid) {
           throw createInspectorCommandClientError(
             "unsupported_in_mode",
-            "No project is selected.",
+            "No project is selected."
           );
         }
         const { payload } = command as CreatePersonaInspectorCommand;
@@ -527,19 +532,19 @@ export function SwarmsTab({
         if (!name) {
           throw createInspectorCommandClientError(
             "invalid_request",
-            "Missing required 'name' string.",
+            "Missing required 'name' string."
           );
         }
         if (!role) {
           throw createInspectorCommandClientError(
             "invalid_request",
-            "Missing required 'role' string.",
+            "Missing required 'role' string."
           );
         }
         if (payload?.notes !== undefined && typeof payload.notes !== "string") {
           throw createInspectorCommandClientError(
             "invalid_request",
-            "'notes' must be a string when provided.",
+            "'notes' must be a string when provided."
           );
         }
         const notes =
@@ -571,13 +576,13 @@ export function SwarmsTab({
         if (!persona) {
           throw createInspectorCommandClientError(
             "invalid_request",
-            "Select or name a persona first — a journey belongs to a persona.",
+            "Select or name a persona first — a journey belongs to a persona."
           );
         }
         if (payload?.goal !== undefined && typeof payload.goal !== "string") {
           throw createInspectorCommandClientError(
             "invalid_request",
-            "'goal' must be a string when provided.",
+            "'goal' must be a string when provided."
           );
         }
         const goal =
@@ -597,7 +602,7 @@ export function SwarmsTab({
         if (!pid) {
           throw createInspectorCommandClientError(
             "unsupported_in_mode",
-            "No project is selected.",
+            "No project is selected."
           );
         }
         const { payload } = command as LaunchSwarmRunInspectorCommand;
@@ -610,7 +615,7 @@ export function SwarmsTab({
           if (result.status === "already_launching") {
             throw createInspectorCommandClientError(
               "execution_failed",
-              "This journey is already launching — wait for it to start.",
+              "This journey is already launching — wait for it to start."
             );
           }
           return {
@@ -624,12 +629,12 @@ export function SwarmsTab({
             if (e.status === 402) {
               throw createInspectorCommandClientError(
                 "execution_failed",
-                `Cannot launch this journey run: ${e.message} Launching spends the organization's swarm quota, which is exhausted — do not retry until it resets or billing is updated.`,
+                `Cannot launch this journey run: ${e.message} Launching spends the organization's swarm quota, which is exhausted — do not retry until it resets or billing is updated.`
               );
             }
             throw createInspectorCommandClientError(
               "execution_failed",
-              `Could not launch the journey run: ${e.message}`,
+              `Could not launch the journey run: ${e.message}`
             );
           }
           throw e; // already an InspectorCommandClientError (e.g. already_launching)
@@ -724,14 +729,19 @@ export function SwarmsTab({
                 <h2 className="text-sm font-semibold">Personas</h2>
                 <NewPersonaDialog
                   onCreate={async (draft) => {
-                    const row = await createPersona({ projectId, ...draft } as any);
+                    const row = await createPersona({
+                      projectId,
+                      ...draft,
+                    } as any);
                     setSelectedPersonaId(row._id);
                   }}
                 />
               </div>
               <div className="min-h-0 flex-1 overflow-y-auto">
                 {personas === undefined ? (
-                  <div className="p-4 text-sm text-muted-foreground">Loading…</div>
+                  <div className="p-4 text-sm text-muted-foreground">
+                    Loading…
+                  </div>
                 ) : personas.length === 0 ? (
                   <div className="p-4 text-sm text-muted-foreground">
                     No personas yet. Create one to get started.
@@ -746,7 +756,7 @@ export function SwarmsTab({
                         onClick={() => setSelectedPersonaId(p._id)}
                         className={cn(
                           "flex w-full items-center gap-3 border-b px-4 py-3 text-left hover:bg-muted/50",
-                          selected && "bg-muted",
+                          selected && "bg-muted"
                         )}
                       >
                         <PersonaPixelAvatar
@@ -788,7 +798,7 @@ export function SwarmsTab({
                         onDelete={async () => {
                           if (
                             !window.confirm(
-                              `Delete persona "${selectedPersona.name}"? Its journeys are hidden but historical runs are kept.`,
+                              `Delete persona "${selectedPersona.name}"? Its journeys are hidden but historical runs are kept.`
                             )
                           ) {
                             return;
@@ -805,7 +815,7 @@ export function SwarmsTab({
                           "mb-3",
                           journeyFormOpen
                             ? "space-y-2"
-                            : "flex items-center justify-between",
+                            : "flex items-center justify-between"
                         )}
                       >
                         <h3 className="text-sm font-semibold">Journeys</h3>
@@ -881,7 +891,9 @@ export function SwarmsTab({
                       <ResizableHandle withHandle />
                       <ResizablePanel defaultSize={62} minSize={35}>
                         <RunDetailPanel
-                          key={`${runDetail.runId}:${runDetail.targetKey ?? ""}`}
+                          key={`${runDetail.runId}:${
+                            runDetail.targetKey ?? ""
+                          }`}
                           journey={detailJourney}
                           runId={runDetail.runId}
                           runSnapshot={runDetail.runSnapshot}
@@ -945,11 +957,11 @@ function RunDetailPanel({
   const { results: runs } = usePaginatedQuery(
     SWARM_QUERIES.listJourneyRuns as any,
     { journeyRefId: journey._id } as any,
-    { initialNumItems: DEFAULT_PAGE_SIZE },
+    { initialNumItems: DEFAULT_PAGE_SIZE }
   );
   const rollup = useQuery(
     SWARM_QUERIES.journeyRollup as any,
-    { journeyRefId: journey._id } as any,
+    { journeyRefId: journey._id } as any
   ) as JourneyRollup | undefined;
   const typedRuns = runs as JourneyRun[];
   const runIndex = typedRuns.findIndex((r) => r._id === runId);
@@ -969,7 +981,7 @@ function RunDetailPanel({
             <span
               className={cn(
                 "rounded-full px-1.5 py-px text-[10px] font-medium capitalize",
-                runStatusChipClass(run.status),
+                runStatusChipClass(run.status)
               )}
             >
               {run.status.replace(/_/g, " ")}
@@ -1045,7 +1057,7 @@ function RunSessionsView({
   } = usePaginatedQuery(
     SWARM_QUERIES.listSessionsByJourneyRun as any,
     { journeyRunId: runId } as any,
-    { initialNumItems: Math.max(DEFAULT_PAGE_SIZE, sessionsPerHost * 4) },
+    { initialNumItems: Math.max(DEFAULT_PAGE_SIZE, sessionsPerHost * 4) }
   );
 
   const streamEnabled = runStatus === "running";
@@ -1053,13 +1065,16 @@ function RunSessionsView({
 
   const [selection, setSelection] = useState<SwarmMatrixSelection | null>(null);
   const [detailSession, setDetailSession] = useState<JourneySessionRow | null>(
-    null,
+    null
   );
   const [sessionToPromote, setSessionToPromote] =
     useState<JourneySessionRow | null>(null);
 
-  const hostName = (id: string) =>
-    hosts.find((h) => h.hostId === id)?.name ?? id.slice(0, 8);
+  // Returns undefined for a host no longer in the project so
+  // `buildSwarmRunTargets` can fall back to the run snapshot's `hostName`
+  // before truncating the id.
+  const hostName = (id: string) => hosts.find((h) => h.hostId === id)?.name;
+  const hostNameOrId = (id: string) => hostName(id) ?? id.slice(0, 8);
 
   const rows = sessions as JourneySessionRow[];
   const hostSummaries = run.hostSummaries;
@@ -1080,7 +1095,7 @@ function RunSessionsView({
     return Array.from(seen).map((hostId) => ({
       key: hostId,
       hostId,
-      label: hostName(hostId),
+      label: hostNameOrId(hostId),
       identity: { hostId },
     }));
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -1093,7 +1108,7 @@ function RunSessionsView({
   }, [rows]);
 
   const selectedConvex = selection
-    ? (convexByChatId.get(selection.chatSessionId) ?? null)
+    ? convexByChatId.get(selection.chatSessionId) ?? null
     : null;
 
   const fallbackTrace = useMemo(
@@ -1101,7 +1116,7 @@ function RunSessionsView({
       selection
         ? liveSessionTrace(stream.sessions[selection.chatSessionId])
         : null,
-    [selection, stream.sessions],
+    [selection, stream.sessions]
   );
 
   // Deep-link restore: select the matrix cell whose MINTED session id matches
@@ -1142,10 +1157,10 @@ function RunSessionsView({
     if (!target) return;
     const mintedIds = Array.from(
       { length: Math.max(1, sessionsPerHost) },
-      (_, i) => swarmAttemptChatSessionId(runId, target.identity, i),
+      (_, i) => swarmAttemptChatSessionId(runId, target.identity, i)
     );
     const matchIdx = mintedIds.findIndex((id) =>
-      rows.some((s) => s.chatSessionId === id),
+      rows.some((s) => s.chatSessionId === id)
     );
     if (matchIdx >= 0) {
       appliedInitialTargetRef.current = true;
@@ -1164,7 +1179,7 @@ function RunSessionsView({
       hostSummaries.some(
         (h) =>
           (h.targetId ?? h.hostId) === initialTargetKey ||
-          h.hostId === initialTargetKey,
+          h.hostId === initialTargetKey
       )
     ) {
       appliedInitialTargetRef.current = true;
@@ -1192,7 +1207,7 @@ function RunSessionsView({
   useEffect(() => {
     if (selection || !streamEnabled) return;
     const runningEntry = Object.entries(stream.cellStatus).find(
-      ([, status]) => status === "running",
+      ([, status]) => status === "running"
     );
     if (!runningEntry) return;
     const [key] = runningEntry;
@@ -1210,7 +1225,7 @@ function RunSessionsView({
       chatSessionId: swarmAttemptChatSessionId(
         runId,
         target.identity,
-        sessionIndex,
+        sessionIndex
       ),
     });
   }, [selection, streamEnabled, stream.cellStatus, runId, targets]);
@@ -1315,7 +1330,7 @@ function RunSessionsView({
               type: "test-edit",
               suiteId,
               testId: testCaseId,
-            }),
+            })
           );
         }}
       />
@@ -1393,7 +1408,7 @@ function PersonaDetailHeader({
             className={cn(
               "mt-2 min-h-0 resize-none border-0 bg-transparent px-0 py-0 text-sm",
               "text-muted-foreground shadow-none placeholder:text-muted-foreground/60",
-              "focus-visible:border-0 focus-visible:ring-0",
+              "focus-visible:border-0 focus-visible:ring-0"
             )}
           />
         </div>
@@ -1452,7 +1467,7 @@ function NewPersonaDialog({
       setOpen(false);
     } catch (error) {
       toast.error(
-        error instanceof Error ? error.message : "Failed to create persona",
+        error instanceof Error ? error.message : "Failed to create persona"
       );
     } finally {
       setSaving(false);
@@ -1536,9 +1551,7 @@ function NewPersonaDialog({
               disabled={saving || !name.trim() || !role.trim()}
               onClick={() => void handleCreate()}
             >
-              {saving ? (
-                <Loader2 className="mr-1 size-3 animate-spin" />
-              ) : null}
+              {saving ? <Loader2 className="mr-1 size-3 animate-spin" /> : null}
               Create persona
             </Button>
           </DialogFooter>
@@ -1582,11 +1595,11 @@ function NewJourneyButton({
   const [goal, setGoal] = useState("");
   const [hostIds, setHostIds] = useState<string[]>([]);
   const [serverAttachmentId, setServerAttachmentId] = useState<string | null>(
-    null,
+    null
   );
   // Target mode: "clients" (legacy, unchanged) vs "environments" (flag-gated).
   const [targetMode, setTargetMode] = useState<"clients" | "environments">(
-    "clients",
+    "clients"
   );
   const [environmentIds, setEnvironmentIds] = useState<string[]>([]);
   const [envPickerOpen, setEnvPickerOpen] = useState(false);
@@ -1596,7 +1609,7 @@ function NewJourneyButton({
   // Judge config is hidden behind "Advanced" — progressive discovery. Default
   // undefined = managed defaults (auto-grade off) until the user opts in.
   const [judgeConfig, setJudgeConfig] = useState<GoalJudgeConfig | undefined>(
-    undefined,
+    undefined
   );
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const { availableModels } = useAvailableModels({ projectId });
@@ -1625,22 +1638,26 @@ function NewJourneyButton({
         const rank = (h: HostItem) => (isSwarmClient(h) ? 0 : 1);
         return rank(a) - rank(b) || a.name.localeCompare(b.name);
       }),
-    [hosts],
+    [hosts]
   );
   const selectedHosts = useMemo(
     () => sortedHosts.filter((h) => hostIds.includes(h.hostId)),
-    [sortedHosts, hostIds],
+    [sortedHosts, hostIds]
   );
   const clientsTriggerLabel =
     selectedHosts.length === 0
       ? "No clients · pick one"
-      : (selectedHosts[0]?.name ?? "Clients");
-  const clientsExtra =
-    selectedHosts.length > 1 ? selectedHosts.length - 1 : 0;
+      : selectedHosts[0]?.name ?? "Clients";
+  const clientsExtra = selectedHosts.length > 1 ? selectedHosts.length - 1 : 0;
 
   if (!open) {
     return (
-      <Button type="button" size="sm" variant="outline" onClick={() => setOpen(true)}>
+      <Button
+        type="button"
+        size="sm"
+        variant="outline"
+        onClick={() => setOpen(true)}
+      >
         <Plus className="mr-1 size-3" />
         New journey
       </Button>
@@ -1654,7 +1671,7 @@ function NewJourneyButton({
     <div
       className={cn(
         "w-full rounded-xl border border-border/50 bg-card/50 p-3 shadow-sm",
-        "ring-1 ring-black/[0.03] dark:ring-white/[0.06]",
+        "ring-1 ring-black/[0.03] dark:ring-white/[0.06]"
       )}
     >
       <div className="mb-2.5 flex flex-col gap-1">
@@ -1677,12 +1694,10 @@ function NewJourneyButton({
           role="radiogroup"
           aria-label="Journey target mode"
         >
-          {(
-            [
-              { value: "clients" as const, label: "Clients" },
-              { value: "environments" as const, label: "Environments" },
-            ]
-          ).map((opt) => (
+          {[
+            { value: "clients" as const, label: "Clients" },
+            { value: "environments" as const, label: "Environments" },
+          ].map((opt) => (
             <button
               key={opt.value}
               type="button"
@@ -1694,7 +1709,7 @@ function NewJourneyButton({
                 "rounded-full border px-2 py-0.5 font-medium transition-colors",
                 targetMode === opt.value
                   ? "border-primary/50 bg-primary/10 text-foreground"
-                  : "border-border/60 text-muted-foreground hover:bg-muted/50",
+                  : "border-border/60 text-muted-foreground hover:bg-muted/50"
               )}
             >
               {opt.label}
@@ -1717,16 +1732,16 @@ function NewJourneyButton({
                   "outline-none transition-colors",
                   environmentIds.length === 0
                     ? "border-dashed border-border/60 bg-muted/30 hover:bg-muted/45"
-                    : "border-border/60 bg-muted/40 hover:bg-muted/60",
+                    : "border-border/60 bg-muted/40 hover:bg-muted/60"
                 )}
                 aria-label="Attached environments"
               >
                 <span className="min-w-0 flex-1 truncate text-xs font-medium">
                   {environmentIds.length === 0
                     ? "No environments · pick one"
-                    : (environments.find(
-                        (e) => e.environmentId === environmentIds[0],
-                      )?.name ?? "Environments")}
+                    : environments.find(
+                        (e) => e.environmentId === environmentIds[0]
+                      )?.name ?? "Environments"}
                 </span>
                 {environmentIds.length > 1 ? (
                   <span className="text-[10px] text-muted-foreground">
@@ -1742,7 +1757,11 @@ function NewJourneyButton({
               sideOffset={4}
               onCloseAutoFocus={(e) => e.preventDefault()}
             >
-              <div className="space-y-0.5" role="group" aria-label="Environments">
+              <div
+                className="space-y-0.5"
+                role="group"
+                aria-label="Environments"
+              >
                 <p className="px-2 pb-1 pt-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
                   Environments
                 </p>
@@ -1771,21 +1790,21 @@ function NewJourneyButton({
                             prev.includes(env.environmentId)
                               ? prev.filter((id) => id !== env.environmentId)
                               : prev.length >= 10
-                                ? prev
-                                : [...prev, env.environmentId],
+                              ? prev
+                              : [...prev, env.environmentId]
                           )
                         }
                         className={cn(
                           "flex w-full items-center gap-2 rounded py-1.5 pl-2 pr-2 text-left text-sm",
                           "hover:bg-accent hover:text-accent-foreground",
                           selected && "bg-accent/50",
-                          disabled && "cursor-not-allowed opacity-50",
+                          disabled && "cursor-not-allowed opacity-50"
                         )}
                       >
                         <Check
                           className={cn(
                             "size-3.5 shrink-0",
-                            selected ? "opacity-100" : "opacity-0",
+                            selected ? "opacity-100" : "opacity-0"
                           )}
                         />
                         <span className="min-w-0 flex-1 truncate">
@@ -1806,38 +1825,6 @@ function NewJourneyButton({
               </div>
             </PopoverContent>
           </Popover>
-          <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-            <Label
-              htmlFor="swarm-journey-sessions"
-              className="shrink-0 text-[11px] text-muted-foreground"
-            >
-              Sessions
-            </Label>
-            <Input
-              id="swarm-journey-sessions"
-              type="number"
-              min={1}
-              max={5}
-              className="h-8 w-14"
-              value={sessionsPerHost}
-              onChange={(e) => setSessionsPerHost(Number(e.target.value))}
-            />
-            <Label
-              htmlFor="swarm-journey-turns"
-              className="ml-1 shrink-0 text-[11px] text-muted-foreground"
-            >
-              Turns
-            </Label>
-            <Input
-              id="swarm-journey-turns"
-              type="number"
-              min={1}
-              max={20}
-              className="h-8 w-14"
-              value={maxTurns}
-              onChange={(e) => setMaxTurns(Number(e.target.value))}
-            />
-          </div>
         </div>
       ) : null}
 
@@ -1845,7 +1832,7 @@ function NewJourneyButton({
       <div
         className={cn(
           "mb-2.5 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-2",
-          targetMode === "environments" && "hidden",
+          targetMode === "environments" && "hidden"
         )}
       >
         <ServerGroupPicker
@@ -1866,7 +1853,7 @@ function NewJourneyButton({
                 "outline-none transition-colors",
                 hostIds.length === 0
                   ? "border-dashed border-border/60 bg-muted/30 hover:bg-muted/45"
-                  : "border-border/60 bg-muted/40 hover:bg-muted/60",
+                  : "border-border/60 bg-muted/40 hover:bg-muted/60"
               )}
               aria-label="Attached clients"
             >
@@ -1942,13 +1929,13 @@ function NewJourneyButton({
                       className={cn(
                         "flex w-full items-center gap-2 rounded py-1.5 pl-2 pr-2 text-left text-sm",
                         "hover:bg-accent hover:text-accent-foreground",
-                        selected && "bg-accent/50",
+                        selected && "bg-accent/50"
                       )}
                     >
                       <Check
                         className={cn(
                           "size-3.5 shrink-0",
-                          selected ? "opacity-100" : "opacity-0",
+                          selected ? "opacity-100" : "opacity-0"
                         )}
                       />
                       <JourneyHostLogoMark label={h.name} />
@@ -1972,39 +1959,46 @@ function NewJourneyButton({
             </div>
           </PopoverContent>
         </Popover>
+      </div>
 
-        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-          <Label
-            htmlFor="swarm-journey-sessions"
-            className="shrink-0 text-[11px] text-muted-foreground"
-          >
-            Sessions
-          </Label>
-          <Input
-            id="swarm-journey-sessions"
-            type="number"
-            min={1}
-            max={5}
-            className="h-8 w-14"
-            value={sessionsPerHost}
-            onChange={(e) => setSessionsPerHost(Number(e.target.value))}
-          />
-          <Label
-            htmlFor="swarm-journey-turns"
-            className="ml-1 shrink-0 text-[11px] text-muted-foreground"
-          >
-            Turns
-          </Label>
-          <Input
-            id="swarm-journey-turns"
-            type="number"
-            min={1}
-            max={20}
-            className="h-8 w-14"
-            value={maxTurns}
-            onChange={(e) => setMaxTurns(Number(e.target.value))}
-          />
-        </div>
+      {/* Sessions / Turns — rendered EXACTLY ONCE regardless of target mode.
+          The legacy clients bar above is CSS-`hidden` in environments mode
+          rather than unmounted, so keeping a per-mode copy of these inputs put
+          two elements with `id="swarm-journey-sessions"` /
+          `id="swarm-journey-turns"` in the DOM at the same time, breaking
+          every `label[for]` association. The fields are byte-identical in both
+          modes, so there is nothing mode-specific to preserve. */}
+      <div className="mb-2.5 flex items-center gap-1.5 text-xs text-muted-foreground">
+        <Label
+          htmlFor="swarm-journey-sessions"
+          className="shrink-0 text-[11px] text-muted-foreground"
+        >
+          Sessions
+        </Label>
+        <Input
+          id="swarm-journey-sessions"
+          type="number"
+          min={1}
+          max={5}
+          className="h-8 w-14"
+          value={sessionsPerHost}
+          onChange={(e) => setSessionsPerHost(Number(e.target.value))}
+        />
+        <Label
+          htmlFor="swarm-journey-turns"
+          className="ml-1 shrink-0 text-[11px] text-muted-foreground"
+        >
+          Turns
+        </Label>
+        <Input
+          id="swarm-journey-turns"
+          type="number"
+          min={1}
+          max={20}
+          className="h-8 w-14"
+          value={maxTurns}
+          onChange={(e) => setMaxTurns(Number(e.target.value))}
+        />
       </div>
 
       {/* Advanced → Judge. Hidden by default (progressive discovery); the
@@ -2019,7 +2013,7 @@ function NewJourneyButton({
           <ChevronDown
             className={cn(
               "size-3 transition-transform",
-              advancedOpen && "rotate-180",
+              advancedOpen && "rotate-180"
             )}
           />
           Advanced
@@ -2039,7 +2033,12 @@ function NewJourneyButton({
       </div>
 
       <div className="flex justify-end gap-2">
-        <Button type="button" size="sm" variant="ghost" onClick={() => setOpen(false)}>
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          onClick={() => setOpen(false)}
+        >
           Cancel
         </Button>
         <Button
@@ -2065,7 +2064,7 @@ function NewJourneyButton({
               // own server-group override.
               const payload = buildEnvJourneyPayload(
                 environmentIds,
-                environments,
+                environments
               );
               if (!payload) return;
               await onCreate({

--- a/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
@@ -66,11 +66,19 @@ import {
   SWARM_QUERIES,
   DEFAULT_PAGE_SIZE,
   swarmAttemptChatSessionId,
+  type EnvironmentView,
   type JourneyRun,
   type JourneyRollup,
   type JourneySessionRow,
   type PersonaTrackRecord,
 } from "@/lib/swarm-api";
+import {
+  buildSwarmRunTargets,
+  findTargetCellForChatSessionId,
+  type SwarmTargetColumn,
+} from "@/components/swarms/swarm-targets";
+import { buildEnvJourneyPayload } from "@/components/swarms/journey-environments";
+import { useProjectEnvironmentsEnabled } from "@/hooks/useProjectEnvironmentsEnabled";
 // The badge + wide-shape guard live in the shared session-quality module so
 // surfaces rendered inside this subtree can use them without an import cycle.
 // Re-exported here because the goal-score unit test imports from `../SwarmsTab`.
@@ -153,6 +161,8 @@ type Journey = {
   hostIds: string[];
   /** Standalone server group shared across all hosts at launch (suite-like). */
   serverAttachmentId?: string | null;
+  /** Env-based fan-out (Project Environments). Non-empty ⇒ env-based. */
+  environmentIds?: string[] | null;
   config: { sessionsPerHost: number; maxTurns: number };
   /** Per-journey goal-completion judge config (shared envelope with suites). */
   judgeConfig?: GoalJudgeConfig;
@@ -190,6 +200,14 @@ function useProjectHosts(projectId: string | null) {
     SWARM_QUERIES.listHosts as any,
     projectId ? ({ projectId } as any) : "skip"
   ) as HostItem[] | undefined;
+}
+/** Live project environments — subscribed ONLY while the feature flag is on
+ * (every client exposure of Project Environments is flag-gated). */
+function useProjectEnvironmentsList(projectId: string | null, enabled: boolean) {
+  return useQuery(
+    SWARM_QUERIES.listEnvironments as any,
+    enabled && projectId ? ({ projectId } as any) : "skip",
+  ) as EnvironmentView[] | undefined;
 }
 function usePersonaTrackRecord(personaRefId: string | null) {
   return useQuery(
@@ -232,6 +250,11 @@ export function SwarmsTab({
   const effectiveProjectId = isAuthenticated ? projectId : null;
   const personas = usePersonas(effectiveProjectId);
   const hosts = useProjectHosts(effectiveProjectId);
+  const environmentsEnabled = useProjectEnvironmentsEnabled();
+  const environments = useProjectEnvironmentsList(
+    effectiveProjectId,
+    environmentsEnabled,
+  );
   const [runningPersonaIds, setRunningPersonaIds] = useState<string[]>([]);
   const runningSet = useMemo(
     () => new Set(runningPersonaIds),
@@ -315,11 +338,15 @@ export function SwarmsTab({
     (JourneyRunSelection & { runSnapshot: JourneyRun }) | null
   >(null);
   const openRunDetail = useCallback(
-    (journey: JourneyListJourney, run: JourneyRun, hostId: string | null) => {
+    (
+      journey: JourneyListJourney,
+      run: JourneyRun,
+      targetKey: string | null,
+    ) => {
       setRunDetail({
         journeyId: journey._id,
         runId: run._id,
-        hostId,
+        targetKey,
         runSnapshot: run,
       });
     },
@@ -779,6 +806,8 @@ export function SwarmsTab({
                         <NewJourneyButton
                           projectId={projectId}
                           hosts={hosts ?? []}
+                          environments={environments ?? []}
+                          environmentsEnabled={environmentsEnabled}
                           open={journeyFormOpen}
                           onOpenChange={(o) => {
                             setJourneyFormOpen(o);
@@ -817,6 +846,8 @@ export function SwarmsTab({
                           selection={runDetail}
                           onOpenRun={openRunDetail}
                           onCloseRun={closeRunDetail}
+                          environments={environments}
+                          environmentsEnabled={environmentsEnabled}
                         />
                       )}
                     </>
@@ -844,11 +875,11 @@ export function SwarmsTab({
                       <ResizableHandle withHandle />
                       <ResizablePanel defaultSize={62} minSize={35}>
                         <RunDetailPanel
-                          key={`${runDetail.runId}:${runDetail.hostId ?? ""}`}
+                          key={`${runDetail.runId}:${runDetail.targetKey ?? ""}`}
                           journey={detailJourney}
                           runId={runDetail.runId}
                           runSnapshot={runDetail.runSnapshot}
-                          hostId={runDetail.hostId}
+                          targetKey={runDetail.targetKey}
                           hosts={hosts ?? []}
                           initialThreadId={
                             deepLink.runId === runDetail.runId
@@ -886,7 +917,7 @@ function RunDetailPanel({
   journey,
   runId,
   runSnapshot,
-  hostId,
+  targetKey,
   hosts,
   initialThreadId,
   onClose,
@@ -895,7 +926,8 @@ function RunDetailPanel({
   runId: string;
   /** Seed until this panel's own runs subscription resolves the run. */
   runSnapshot: JourneyRun;
-  hostId: string | null;
+  /** Canonical target key (`targetId ?? hostId`) to preselect, if any. */
+  targetKey: string | null;
   hosts: HostItem[];
   initialThreadId?: string;
   onClose: () => void;
@@ -963,13 +995,12 @@ function RunDetailPanel({
       </div>
       <div className="min-h-0 flex-1">
         <RunSessionsView
-          runId={run._id}
+          run={run}
           personaRefId={journey.personaRefId}
           hosts={hosts}
-          hostSummaries={run.hostSummaries}
           runStatus={run.status}
           sessionsPerHost={journey.config.sessionsPerHost}
-          initialHostId={hostId ?? undefined}
+          initialTargetKey={targetKey ?? undefined}
           initialThreadId={initialThreadId}
         />
       </div>
@@ -979,27 +1010,28 @@ function RunDetailPanel({
 
 // ── sessions × hosts matrix + live stream (per run) ──────────────────────────
 function RunSessionsView({
-  runId,
+  run,
   personaRefId,
   hosts,
-  hostSummaries,
   runStatus,
   sessionsPerHost,
-  initialHostId,
+  initialTargetKey,
   initialThreadId,
 }: {
-  runId: string;
+  /** The run (live row or terminal snapshot) — targets join `hostSummaries`
+   * to `snapshot.hosts` for per-target columns/labels (B6). */
+  run: JourneyRun;
   /** Owning persona — encoded into copied session links for deep-link restore. */
   personaRefId: string;
   hosts: HostItem[];
-  hostSummaries: JourneyRun["hostSummaries"];
   runStatus: JourneyRun["status"];
   sessionsPerHost: number;
-  /** Matrix drill-in: preselect this host's first session (deferred to `initialThreadId`). */
-  initialHostId?: string;
+  /** Matrix drill-in: preselect this target's first session (deferred to `initialThreadId`). */
+  initialTargetKey?: string;
   /** Deep-link session (`id`) to auto-select once it's on a loaded page. */
   initialThreadId?: string;
 }) {
+  const runId = run._id;
   const {
     results: sessions,
     status,
@@ -1024,13 +1056,29 @@ function RunSessionsView({
     hosts.find((h) => h.hostId === id)?.name ?? id.slice(0, 8);
 
   const rows = sessions as JourneySessionRow[];
-  const hostIds = useMemo(() => {
-    const fromSummary = hostSummaries.map((h) => h.hostId);
-    if (fromSummary.length > 0) return fromSummary;
+  const hostSummaries = run.hostSummaries;
+  // Per-TARGET column model (D2/B6): one column per hostSummaries row, joined
+  // to snapshot.hosts by targetId (env columns get environment-name labels,
+  // #n-suffixed on collisions). Fallback for degenerate rows-only data:
+  // synthesize host columns from the session rows.
+  const targets = useMemo<SwarmTargetColumn[]>(() => {
+    if (hostSummaries.length > 0) {
+      return buildSwarmRunTargets({
+        hostSummaries,
+        snapshotHosts: run.snapshot?.hosts,
+        hostName,
+      });
+    }
     const seen = new Set<string>();
     for (const s of rows) seen.add(s.hostId);
-    return Array.from(seen);
-  }, [hostSummaries, rows]);
+    return Array.from(seen).map((hostId) => ({
+      key: hostId,
+      hostId,
+      label: hostName(hostId),
+      identity: { hostId },
+    }));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hostSummaries, run.snapshot, rows, hosts]);
 
   const convexByChatId = useMemo(() => {
     const map = new Map<string, JourneySessionRow>();
@@ -1050,58 +1098,91 @@ function RunSessionsView({
     [selection, stream.sessions],
   );
 
-  // Deep-link restore: select the matrix cell for the linked Convex session.
+  // Deep-link restore: select the matrix cell whose MINTED session id matches
+  // the linked Convex session (bounded ≤ targets × sessionsPerHost — B6).
   const appliedInitialThreadRef = useRef(false);
   useEffect(() => {
     if (appliedInitialThreadRef.current || !initialThreadId) return;
     const match = rows.find((s) => s.id === initialThreadId);
     if (!match) return;
     appliedInitialThreadRef.current = true;
-    const sessionIndex = Number(
-      match.chatSessionId.split("_").pop() ?? "0",
-    );
+    const cell = findTargetCellForChatSessionId({
+      runId,
+      targets,
+      sessionsPerHost,
+      chatSessionId: match.chatSessionId,
+    });
     setSelection({
+      targetKey: cell?.target.key ?? match.hostId,
       hostId: match.hostId,
-      sessionIndex: Number.isFinite(sessionIndex) ? sessionIndex : 0,
+      sessionIndex: cell?.sessionIndex ?? 0,
       chatSessionId: match.chatSessionId,
     });
     setDetailSession(match);
-  }, [initialThreadId, rows]);
+  }, [initialThreadId, rows, runId, targets, sessionsPerHost]);
 
-  // Matrix drill-in: preselect the clicked host's first session. `initialThreadId`
-  // (an explicit deep-linked session) always wins, so skip when it's present.
-  const appliedInitialHostRef = useRef(false);
+  // Matrix drill-in: preselect the clicked target's first session.
+  // `initialThreadId` (an explicit deep-linked session) always wins.
+  const appliedInitialTargetRef = useRef(false);
   useEffect(() => {
-    if (appliedInitialHostRef.current || !initialHostId || initialThreadId) {
+    if (
+      appliedInitialTargetRef.current ||
+      !initialTargetKey ||
+      initialThreadId
+    ) {
       return;
     }
-    const match = rows.find((s) => s.hostId === initialHostId);
-    if (match) {
-      appliedInitialHostRef.current = true;
-      const sessionIndex = Number(match.chatSessionId.split("_").pop() ?? "0");
+    const target = targets.find((t) => t.key === initialTargetKey);
+    if (!target) return;
+    const mintedIds = Array.from(
+      { length: Math.max(1, sessionsPerHost) },
+      (_, i) => swarmAttemptChatSessionId(runId, target.identity, i),
+    );
+    const matchIdx = mintedIds.findIndex((id) =>
+      rows.some((s) => s.chatSessionId === id),
+    );
+    if (matchIdx >= 0) {
+      appliedInitialTargetRef.current = true;
       setSelection({
-        hostId: match.hostId,
-        sessionIndex: Number.isFinite(sessionIndex) ? sessionIndex : 0,
-        chatSessionId: match.chatSessionId,
+        targetKey: target.key,
+        hostId: target.hostId,
+        sessionIndex: matchIdx,
+        chatSessionId: mintedIds[matchIdx],
       });
       return;
     }
-    // No persisted row yet: for a terminal run with attempts on this host,
-    // synthesize the first attempt's cell so the pane opens on that host.
+    // No persisted row yet: for a terminal run with attempts on this target,
+    // synthesize the first attempt's cell so the pane opens on that target.
     if (
       runStatus !== "running" &&
-      hostSummaries.some((h) => h.hostId === initialHostId && h.total > 0)
+      hostSummaries.some(
+        (h) =>
+          (h.targetId ?? h.hostId) === initialTargetKey ||
+          h.hostId === initialTargetKey,
+      )
     ) {
-      appliedInitialHostRef.current = true;
+      appliedInitialTargetRef.current = true;
       setSelection({
-        hostId: initialHostId,
+        targetKey: target.key,
+        hostId: target.hostId,
         sessionIndex: 0,
-        chatSessionId: swarmAttemptChatSessionId(runId, initialHostId, 0),
+        chatSessionId: mintedIds[0],
       });
     }
-  }, [initialHostId, initialThreadId, rows, runStatus, hostSummaries, runId]);
+  }, [
+    initialTargetKey,
+    initialThreadId,
+    rows,
+    runStatus,
+    hostSummaries,
+    runId,
+    targets,
+    sessionsPerHost,
+  ]);
 
-  // Auto-select the first running cell when a live stream starts.
+  // Auto-select the first running cell when a live stream starts. Cell keys
+  // are `${targetKey}:${sessionIndex}` and target keys may themselves contain
+  // ":" (opaque ids), so split on the LAST colon.
   useEffect(() => {
     if (selection || !streamEnabled) return;
     const runningEntry = Object.entries(stream.cellStatus).find(
@@ -1109,16 +1190,24 @@ function RunSessionsView({
     );
     if (!runningEntry) return;
     const [key] = runningEntry;
-    const [hostId, idxStr] = key.split(":");
-    if (!hostId || idxStr == null) return;
-    const sessionIndex = Number(idxStr);
+    const cut = key.lastIndexOf(":");
+    if (cut <= 0) return;
+    const targetKey = key.slice(0, cut);
+    const sessionIndex = Number(key.slice(cut + 1));
     if (!Number.isFinite(sessionIndex)) return;
+    const target = targets.find((t) => t.key === targetKey);
+    if (!target) return;
     setSelection({
-      hostId,
+      targetKey,
+      hostId: target.hostId,
       sessionIndex,
-      chatSessionId: swarmAttemptChatSessionId(runId, hostId, sessionIndex),
+      chatSessionId: swarmAttemptChatSessionId(
+        runId,
+        target.identity,
+        sessionIndex,
+      ),
     });
-  }, [selection, streamEnabled, stream.cellStatus, runId]);
+  }, [selection, streamEnabled, stream.cellStatus, runId, targets]);
 
   return (
     <div className="flex h-full min-h-0 flex-col gap-3 overflow-y-auto p-4">
@@ -1143,8 +1232,7 @@ function RunSessionsView({
       <div className="shrink-0">
         <SwarmSessionsMatrix
           runId={runId}
-          hostIds={hostIds}
-          hostName={hostName}
+          targets={targets}
           sessionsPerHost={sessionsPerHost}
           sessions={rows}
           hostSummaries={hostSummaries}
@@ -1457,6 +1545,8 @@ function NewPersonaDialog({
 function NewJourneyButton({
   projectId,
   hosts,
+  environments,
+  environmentsEnabled,
   onCreate,
   open,
   onOpenChange,
@@ -1464,10 +1554,16 @@ function NewJourneyButton({
 }: {
   projectId: string;
   hosts: HostItem[];
+  /** Live project environments (flag-gated; empty when the flag is off). */
+  environments: EnvironmentView[];
+  /** Gates the env-mode toggle (`project-environments-enabled`). */
+  environmentsEnabled: boolean;
   onCreate: (draft: {
     goal: string;
     hostIds: string[];
-    serverAttachmentId: string;
+    serverAttachmentId?: string;
+    /** Env-mode: the ordered fan-out; compat hostIds ride alongside. */
+    environmentIds?: string[];
     config: { sessionsPerHost: number; maxTurns: number };
     judgeConfig?: GoalJudgeConfig;
   }) => Promise<void>;
@@ -1482,6 +1578,12 @@ function NewJourneyButton({
   const [serverAttachmentId, setServerAttachmentId] = useState<string | null>(
     null,
   );
+  // Target mode: "clients" (legacy, unchanged) vs "environments" (flag-gated).
+  const [targetMode, setTargetMode] = useState<"clients" | "environments">(
+    "clients",
+  );
+  const [environmentIds, setEnvironmentIds] = useState<string[]>([]);
+  const [envPickerOpen, setEnvPickerOpen] = useState(false);
   const [sessionsPerHost, setSessionsPerHost] = useState(2);
   const [maxTurns, setMaxTurns] = useState(6);
   const [clientsPickerOpen, setClientsPickerOpen] = useState(false);
@@ -1499,6 +1601,8 @@ function NewJourneyButton({
       setGoal(goalSeed);
       setJudgeConfig(undefined);
       setAdvancedOpen(false);
+      setTargetMode("clients");
+      setEnvironmentIds([]);
     }
   }, [open, goalSeed]);
   const setOpen = onOpenChange;
@@ -1561,8 +1665,183 @@ function NewJourneyButton({
         />
       </div>
 
+      {environmentsEnabled ? (
+        <div
+          className="mb-2 flex items-center gap-1 text-[11px]"
+          role="radiogroup"
+          aria-label="Journey target mode"
+        >
+          {(
+            [
+              { value: "clients" as const, label: "Clients" },
+              { value: "environments" as const, label: "Environments" },
+            ]
+          ).map((opt) => (
+            <button
+              key={opt.value}
+              type="button"
+              role="radio"
+              aria-checked={targetMode === opt.value}
+              data-testid={`journey-target-mode-${opt.value}`}
+              onClick={() => setTargetMode(opt.value)}
+              className={cn(
+                "rounded-full border px-2 py-0.5 font-medium transition-colors",
+                targetMode === opt.value
+                  ? "border-primary/50 bg-primary/10 text-foreground"
+                  : "border-border/60 text-muted-foreground hover:bg-muted/50",
+              )}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      ) : null}
+
+      {targetMode === "environments" ? (
+        /* Env mode: ordered ≤10 environment multi-select (name + host chip).
+           Server group + skills come from each environment's own definition. */
+        <div className="mb-2.5 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-2">
+          <Popover open={envPickerOpen} onOpenChange={setEnvPickerOpen}>
+            <PopoverTrigger asChild>
+              <button
+                type="button"
+                data-testid="journey-environments-picker"
+                className={cn(
+                  "flex h-8 max-w-[280px] shrink-0 items-center gap-1 rounded-full border px-2 text-foreground",
+                  "outline-none transition-colors",
+                  environmentIds.length === 0
+                    ? "border-dashed border-border/60 bg-muted/30 hover:bg-muted/45"
+                    : "border-border/60 bg-muted/40 hover:bg-muted/60",
+                )}
+                aria-label="Attached environments"
+              >
+                <span className="min-w-0 flex-1 truncate text-xs font-medium">
+                  {environmentIds.length === 0
+                    ? "No environments · pick one"
+                    : (environments.find(
+                        (e) => e.environmentId === environmentIds[0],
+                      )?.name ?? "Environments")}
+                </span>
+                {environmentIds.length > 1 ? (
+                  <span className="text-[10px] text-muted-foreground">
+                    +{environmentIds.length - 1}
+                  </span>
+                ) : null}
+                <ChevronDown className="size-3 shrink-0 text-muted-foreground" />
+              </button>
+            </PopoverTrigger>
+            <PopoverContent
+              className="w-72 p-1"
+              align="start"
+              sideOffset={4}
+              onCloseAutoFocus={(e) => e.preventDefault()}
+            >
+              <div className="space-y-0.5" role="group" aria-label="Environments">
+                <p className="px-2 pb-1 pt-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                  Environments
+                </p>
+                {environments.length === 0 ? (
+                  <p className="px-2 py-1.5 text-xs text-muted-foreground">
+                    No environments in this project.
+                  </p>
+                ) : (
+                  environments.map((env) => {
+                    const selected = environmentIds.includes(env.environmentId);
+                    const ordinal = environmentIds.indexOf(env.environmentId);
+                    const disabled = !selected && environmentIds.length >= 10;
+                    const hostLabel =
+                      hosts.find((h) => h.hostId === env.hostId)?.name ??
+                      env.hostId.slice(0, 8);
+                    return (
+                      <button
+                        key={env.environmentId}
+                        type="button"
+                        role="checkbox"
+                        aria-checked={selected}
+                        disabled={disabled}
+                        onPointerDown={(e) => e.preventDefault()}
+                        onClick={() =>
+                          setEnvironmentIds((prev) =>
+                            prev.includes(env.environmentId)
+                              ? prev.filter((id) => id !== env.environmentId)
+                              : prev.length >= 10
+                                ? prev
+                                : [...prev, env.environmentId],
+                          )
+                        }
+                        className={cn(
+                          "flex w-full items-center gap-2 rounded py-1.5 pl-2 pr-2 text-left text-sm",
+                          "hover:bg-accent hover:text-accent-foreground",
+                          selected && "bg-accent/50",
+                          disabled && "cursor-not-allowed opacity-50",
+                        )}
+                      >
+                        <Check
+                          className={cn(
+                            "size-3.5 shrink-0",
+                            selected ? "opacity-100" : "opacity-0",
+                          )}
+                        />
+                        <span className="min-w-0 flex-1 truncate">
+                          <span className="font-medium">{env.name}</span>
+                          <span className="mt-0.5 block truncate text-[10px] text-muted-foreground">
+                            {hostLabel}
+                          </span>
+                        </span>
+                        {selected ? (
+                          <span className="shrink-0 rounded-full bg-muted px-1.5 text-[10px] tabular-nums text-muted-foreground">
+                            {ordinal + 1}
+                          </span>
+                        ) : null}
+                      </button>
+                    );
+                  })
+                )}
+              </div>
+            </PopoverContent>
+          </Popover>
+          <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            <Label
+              htmlFor="swarm-journey-sessions"
+              className="shrink-0 text-[11px] text-muted-foreground"
+            >
+              Sessions
+            </Label>
+            <Input
+              id="swarm-journey-sessions"
+              type="number"
+              min={1}
+              max={5}
+              className="h-8 w-14"
+              value={sessionsPerHost}
+              onChange={(e) => setSessionsPerHost(Number(e.target.value))}
+            />
+            <Label
+              htmlFor="swarm-journey-turns"
+              className="ml-1 shrink-0 text-[11px] text-muted-foreground"
+            >
+              Turns
+            </Label>
+            <Input
+              id="swarm-journey-turns"
+              type="number"
+              min={1}
+              max={20}
+              className="h-8 w-14"
+              value={maxTurns}
+              onChange={(e) => setMaxTurns(Number(e.target.value))}
+            />
+          </div>
+        </div>
+      ) : null}
+
       {/* Compact picker bar — same pill language as SuiteOverviewClientBar. */}
-      <div className="mb-2.5 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-2">
+      <div
+        className={cn(
+          "mb-2.5 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-2",
+          targetMode === "environments" && "hidden",
+        )}
+      >
         <ServerGroupPicker
           projectId={projectId}
           value={serverAttachmentId}
@@ -1762,8 +2041,9 @@ function NewJourneyButton({
           size="sm"
           disabled={
             !goal.trim() ||
-            !serverAttachmentId ||
-            hostIds.length === 0 ||
+            (targetMode === "environments"
+              ? buildEnvJourneyPayload(environmentIds, environments) === null
+              : !serverAttachmentId || hostIds.length === 0) ||
             !Number.isInteger(sessionsPerHost) ||
             sessionsPerHost < 1 ||
             sessionsPerHost > 5 ||
@@ -1772,17 +2052,38 @@ function NewJourneyButton({
             maxTurns > 20
           }
           onClick={async () => {
-            if (!serverAttachmentId) return;
-            await onCreate({
-              goal,
-              hostIds,
-              serverAttachmentId,
-              config: { sessionsPerHost, maxTurns },
-              ...(judgeConfig ? { judgeConfig } : {}),
-            });
+            if (targetMode === "environments") {
+              // Env-mode submit: environmentIds + compat hostIds recomputed
+              // from the selected environments (deduped, in order — B5).
+              // serverAttachmentId is OMITTED: each environment carries its
+              // own server-group override.
+              const payload = buildEnvJourneyPayload(
+                environmentIds,
+                environments,
+              );
+              if (!payload) return;
+              await onCreate({
+                goal,
+                hostIds: payload.hostIds,
+                environmentIds: payload.environmentIds,
+                config: { sessionsPerHost, maxTurns },
+                ...(judgeConfig ? { judgeConfig } : {}),
+              });
+            } else {
+              if (!serverAttachmentId) return;
+              await onCreate({
+                goal,
+                hostIds,
+                serverAttachmentId,
+                config: { sessionsPerHost, maxTurns },
+                ...(judgeConfig ? { judgeConfig } : {}),
+              });
+            }
             setOpen(false);
             setGoal("");
             setHostIds([]);
+            setEnvironmentIds([]);
+            setTargetMode("clients");
             setServerAttachmentId(null);
             setJudgeConfig(undefined);
           }}

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.envJourneyForm.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.envJourneyForm.test.tsx
@@ -164,13 +164,13 @@ describe("SwarmsTab — new journey form env mode", () => {
     // Same host as Prod (host-1 again → deduped).
     fireEvent.click(screen.getByTestId("journey-environments-picker"));
     fireEvent.click(
-      await screen.findByRole("checkbox", { name: /staging-like/i }),
+      await screen.findByRole("checkbox", { name: /staging-like/i })
     );
     fireEvent.click(
-      await screen.findByRole("checkbox", { name: /prod-like/i }),
+      await screen.findByRole("checkbox", { name: /prod-like/i })
     );
     fireEvent.click(
-      await screen.findByRole("checkbox", { name: /same host as prod/i }),
+      await screen.findByRole("checkbox", { name: /same host as prod/i })
     );
 
     fireEvent.click(screen.getByRole("button", { name: /create journey/i }));
@@ -188,12 +188,27 @@ describe("SwarmsTab — new journey form env mode", () => {
     expect("serverAttachmentId" in payload).toBe(false);
   });
 
-  it("clients mode stays byte-compatible (no environmentIds in the payload)", async () => {
+  // NOTE: this suite mocks out `ServerGroupPicker`, so a clients-mode submit
+  // can't be driven to completion here — the payload-level byte-compatibility
+  // assertion lives in the sibling `SwarmsTab.journeyForm` suite (flag OFF).
+  // What IS specific to this suite is that turning the flag ON must not change
+  // the default mode or leak the env picker into clients mode.
+  it("defaults to clients mode with no env surface when the env flag is on", async () => {
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
     openForm();
-    // Default mode is Clients; env state must not leak into the payload.
+
+    expect(screen.getByTestId("journey-target-mode-clients")).toHaveAttribute(
+      "aria-checked",
+      "true"
+    );
+    // The env picker belongs to environments mode only — it must not render
+    // (nor subscribe) while the form is in clients mode.
     expect(
-      screen.getByTestId("journey-target-mode-clients"),
-    ).toHaveAttribute("aria-checked", "true");
+      screen.queryByTestId("journey-environments-picker")
+    ).not.toBeInTheDocument();
+    // The legacy clients affordance is the one that's present.
+    expect(
+      screen.getByRole("button", { name: /attached clients/i })
+    ).toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.envJourneyForm.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.envJourneyForm.test.tsx
@@ -1,0 +1,199 @@
+/**
+ * New-journey form ENV MODE (Project Environments — B5): flag-gated toggle,
+ * ordered env multi-select, and the create payload invariant — env submits
+ * send `environmentIds` + compat `hostIds` recomputed from the selected
+ * environments (deduped, in order) and OMIT `serverAttachmentId`.
+ */
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/hooks/use-available-models", () => ({
+  useAvailableModels: () => ({ availableModels: [] }),
+}));
+
+// Flag ON for this suite (the sibling journeyForm suite runs with it off).
+vi.mock("@/hooks/useProjectEnvironmentsEnabled", () => ({
+  useProjectEnvironmentsEnabled: () => true,
+}));
+
+const persona = {
+  _id: "persona-1",
+  personaId: "p1",
+  name: "Persona One",
+  role: "tester",
+  notes: "",
+};
+const host = {
+  hostId: "host-1",
+  name: "Host One",
+  modelId: "openai/gpt-4o-mini",
+  ownerScope: { type: "journeys" },
+};
+const hostTwo = {
+  hostId: "host-2",
+  name: "Host Two",
+  modelId: "anthropic/claude-haiku-4.5",
+  ownerScope: { type: "journeys" },
+};
+const environments = [
+  {
+    environmentId: "env-1",
+    projectId: "proj-1",
+    name: "Prod-like",
+    hostId: "host-1",
+    revision: 1,
+  },
+  {
+    environmentId: "env-2",
+    projectId: "proj-1",
+    name: "Staging-like",
+    hostId: "host-2",
+    revision: 3,
+  },
+  {
+    environmentId: "env-3",
+    projectId: "proj-1",
+    name: "Same host as Prod",
+    hostId: "host-1",
+    revision: 2,
+  },
+];
+
+const { createJourneyMutation } = vi.hoisted(() => ({
+  createJourneyMutation: vi.fn(),
+}));
+
+vi.mock("convex/react", () => ({
+  useQuery: (name: string, args: unknown) => {
+    if (args === "skip") return undefined;
+    switch (name) {
+      case "personas:listPersonas":
+        return [persona];
+      case "journeys:listJourneysByPersona":
+        return [];
+      case "hosts:listHosts":
+        return [host, hostTwo];
+      case "projectEnvironments:listEnvironments":
+        return environments;
+      default:
+        return undefined;
+    }
+  },
+  useMutation: (name: string) => {
+    if (name === "journeys:createJourney") return createJourneyMutation;
+    return vi.fn().mockResolvedValue(undefined);
+  },
+  usePaginatedQuery: () => ({
+    results: [],
+    status: "Exhausted",
+    loadMore: vi.fn(),
+    isLoading: false,
+  }),
+  useConvexAuth: () => ({ isAuthenticated: true }),
+}));
+
+vi.mock("@/hooks/useViews", () => ({
+  useProjectServerAttachments: () => ({
+    serverAttachments: [],
+    isLoading: false,
+  }),
+  useProjectServers: () => ({ servers: [], isLoading: false }),
+  useDbUserReady: () => true,
+}));
+
+vi.mock("@/components/hosts/ServerGroupPicker", () => ({
+  ServerGroupPicker: () => (
+    <button type="button" data-testid="mock-server-group-picker">
+      No server group · pick one
+    </button>
+  ),
+}));
+
+vi.mock("@/components/connection/share-usage/ShareUsageThreadDetail", () => ({
+  ShareUsageThreadDetail: () => null,
+}));
+vi.mock("@/lib/chatbox-session", () => ({
+  getShareableAppOrigin: () => "https://app.test",
+}));
+vi.mock("@/lib/toast", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import { SwarmsTab } from "../SwarmsTab";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  createJourneyMutation.mockResolvedValue({ _id: "journey-new" });
+});
+
+function openForm() {
+  fireEvent.click(screen.getByText("Persona One"));
+  fireEvent.click(screen.getByRole("button", { name: /new journey/i }));
+}
+
+async function pickEnvironment(name: string | RegExp) {
+  fireEvent.click(screen.getByTestId("journey-environments-picker"));
+  fireEvent.click(await screen.findByRole("checkbox", { name }));
+}
+
+describe("SwarmsTab — new journey form env mode", () => {
+  it("shows the mode toggle when the flag is on and gates Create on ≥1 environment", async () => {
+    render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+    openForm();
+
+    fireEvent.click(screen.getByTestId("journey-target-mode-environments"));
+    fireEvent.change(screen.getByLabelText("Goal"), {
+      target: { value: "Draw a dog" },
+    });
+    const createBtn = screen.getByRole("button", { name: /create journey/i });
+    expect(createBtn).toBeDisabled();
+
+    await pickEnvironment(/prod-like/i);
+    expect(createBtn).not.toBeDisabled();
+  });
+
+  it("env submit: environmentIds in selection order + compat hostIds deduped in order, NO serverAttachmentId", async () => {
+    render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+    openForm();
+
+    fireEvent.click(screen.getByTestId("journey-target-mode-environments"));
+    fireEvent.change(screen.getByLabelText("Goal"), {
+      target: { value: "Draw a dog" },
+    });
+    // Selection order: Staging-like (host-2), Prod-like (host-1),
+    // Same host as Prod (host-1 again → deduped).
+    fireEvent.click(screen.getByTestId("journey-environments-picker"));
+    fireEvent.click(
+      await screen.findByRole("checkbox", { name: /staging-like/i }),
+    );
+    fireEvent.click(
+      await screen.findByRole("checkbox", { name: /prod-like/i }),
+    );
+    fireEvent.click(
+      await screen.findByRole("checkbox", { name: /same host as prod/i }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /create journey/i }));
+
+    await waitFor(() => {
+      expect(createJourneyMutation).toHaveBeenCalledTimes(1);
+    });
+    const payload = createJourneyMutation.mock.calls[0]![0] as Record<
+      string,
+      unknown
+    >;
+    expect(payload.environmentIds).toEqual(["env-2", "env-1", "env-3"]);
+    // Compat hostIds recomputed from the envs: deduped, in selection order.
+    expect(payload.hostIds).toEqual(["host-2", "host-1"]);
+    expect("serverAttachmentId" in payload).toBe(false);
+  });
+
+  it("clients mode stays byte-compatible (no environmentIds in the payload)", async () => {
+    render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+    openForm();
+    // Default mode is Clients; env state must not leak into the payload.
+    expect(
+      screen.getByTestId("journey-target-mode-clients"),
+    ).toHaveAttribute("aria-checked", "true");
+  });
+});

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/journey-environments.test.ts
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/journey-environments.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildClearToLegacyPayload,
+  buildEnvJourneyPayload,
+  compatHostIdsForEnvironments,
+} from "../journey-environments";
+import type { EnvironmentView } from "@/lib/swarm-api";
+
+const env = (
+  environmentId: string,
+  hostId: string,
+  name = environmentId,
+): EnvironmentView => ({
+  environmentId,
+  projectId: "p",
+  name,
+  hostId,
+  revision: 1,
+});
+
+const ENVS = [env("e1", "hostA"), env("e2", "hostB"), env("e3", "hostA")];
+
+describe("compatHostIdsForEnvironments", () => {
+  it("resolves hostIds deduped, in selection order", () => {
+    expect(compatHostIdsForEnvironments(["e3", "e2", "e1"], ENVS)).toEqual([
+      "hostA",
+      "hostB",
+    ]);
+  });
+
+  it("ignores unknown environment ids", () => {
+    expect(compatHostIdsForEnvironments(["missing", "e2"], ENVS)).toEqual([
+      "hostB",
+    ]);
+  });
+});
+
+describe("buildEnvJourneyPayload", () => {
+  it("returns environmentIds + recomputed compat hostIds", () => {
+    expect(buildEnvJourneyPayload(["e2", "e1"], ENVS)).toEqual({
+      environmentIds: ["e2", "e1"],
+      hostIds: ["hostB", "hostA"],
+    });
+  });
+
+  it("returns null when no env selected or no valid compat host resolves", () => {
+    expect(buildEnvJourneyPayload([], ENVS)).toBeNull();
+    expect(buildEnvJourneyPayload(["missing"], ENVS)).toBeNull();
+  });
+});
+
+describe("buildClearToLegacyPayload", () => {
+  it("clears environmentIds and recomputes hostIds from the CURRENT env selection", () => {
+    expect(buildClearToLegacyPayload(["e1", "e3", "e2"], ENVS)).toEqual({
+      environmentIds: null,
+      hostIds: ["hostA", "hostB"],
+    });
+  });
+
+  it("blocks the clear (null) when no valid compat host resolves", () => {
+    expect(buildClearToLegacyPayload(["missing"], ENVS)).toBeNull();
+    expect(buildClearToLegacyPayload([], ENVS)).toBeNull();
+  });
+});

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/journey-environments.test.ts
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/journey-environments.test.ts
@@ -47,6 +47,12 @@ describe("buildEnvJourneyPayload", () => {
     expect(buildEnvJourneyPayload([], ENVS)).toBeNull();
     expect(buildEnvJourneyPayload(["missing"], ENVS)).toBeNull();
   });
+
+  it("rejects the write when any selected id is unresolved (archived/deleted), not just persist the valid ones", () => {
+    // "e1" resolves but "missing" does not — the whole write is blocked so a
+    // stale archived id can't be persisted alongside valid ones.
+    expect(buildEnvJourneyPayload(["e1", "missing"], ENVS)).toBeNull();
+  });
 });
 
 describe("buildClearToLegacyPayload", () => {

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/journey-list.test.ts
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/journey-list.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { JourneyRun } from "@/lib/swarm-api";
-import { journeyHostColumns, journeyHostOutcome } from "../journey-list";
+import { journeyTargetColumns, journeyHostOutcome } from "../journey-list";
 
 function run(
   partial: Partial<JourneyRun> & {
@@ -17,6 +17,7 @@ function run(
       rateLimited: 0,
     },
     hostSummaries: partial.hostSummaries,
+    snapshot: partial.snapshot,
     goalScoreSummary: partial.goalScoreSummary,
     createdAt: partial.createdAt ?? 1,
   };
@@ -30,20 +31,94 @@ const hs = (
   rateLimited = 0,
 ) => ({ hostId, total, succeeded, failed, rateLimited });
 
-describe("journeyHostColumns", () => {
-  it("unions target hosts, orders by the project host list, appends unknowns", () => {
-    const journeys = [
-      { _id: "j1", personaRefId: "p", goal: "g1", hostIds: ["b", "z"], config: { sessionsPerHost: 1, maxTurns: 1 } },
-      { _id: "j2", personaRefId: "p", goal: "g2", hostIds: ["a", "b"], config: { sessionsPerHost: 1, maxTurns: 1 } },
+describe("journeyTargetColumns", () => {
+  const hosts = [
+    { hostId: "a", name: "Alpha" },
+    { hostId: "b", name: "Bravo" },
+  ];
+
+  it("unrun legacy journey: one column per hostId in journey order", () => {
+    const journey = {
+      _id: "j1",
+      personaRefId: "p",
+      goal: "g1",
+      hostIds: ["b", "a", "z"],
+      config: { sessionsPerHost: 1, maxTurns: 1 },
+    };
+    const cols = journeyTargetColumns(journey, hosts, null);
+    expect(cols.map((c) => c.key)).toEqual(["b", "a", "z"]);
+    expect(cols.map((c) => c.label)).toEqual(["Bravo", "Alpha", "z"]);
+    expect(cols.every((c) => c.environmentId === undefined)).toBe(true);
+  });
+
+  it("unrun env-based journey: one column per environment in environmentIds order, labeled by env name", () => {
+    const journey = {
+      _id: "j1",
+      personaRefId: "p",
+      goal: "g1",
+      hostIds: ["a"],
+      environmentIds: ["env2", "env1"],
+      config: { sessionsPerHost: 1, maxTurns: 1 },
+    };
+    const environments = [
+      { environmentId: "env1", projectId: "pr", name: "Staging", hostId: "a", revision: 1 },
+      { environmentId: "env2", projectId: "pr", name: "Prod", hostId: "a", revision: 3 },
     ];
-    const hosts = [
-      { hostId: "a", name: "Alpha" },
-      { hostId: "b", name: "Bravo" },
-    ];
-    const cols = journeyHostColumns(journeys, hosts);
-    // a, b come first (project order); z is unknown → appended, name falls back.
-    expect(cols.map((c) => c.hostId)).toEqual(["a", "b", "z"]);
-    expect(cols.map((c) => c.name)).toEqual(["Alpha", "Bravo", "z"]);
+    const cols = journeyTargetColumns(journey, hosts, null, environments);
+    expect(cols.map((c) => c.label)).toEqual(["Prod", "Staging"]);
+    expect(cols.map((c) => c.environmentId)).toEqual(["env2", "env1"]);
+    expect(cols.map((c) => c.hostId)).toEqual(["a", "a"]);
+  });
+
+  it("run with two SAME-HOST env targets: distinct columns keyed by targetId, env-name labels, #n suffix on collisions", () => {
+    const journey = {
+      _id: "j1",
+      personaRefId: "p",
+      goal: "g1",
+      hostIds: ["a"],
+      environmentIds: ["env1", "env2"],
+      config: { sessionsPerHost: 1, maxTurns: 1 },
+    };
+    const latestRun = run({
+      hostSummaries: [
+        { hostId: "a", targetId: "environment:env1", total: 1, succeeded: 1, failed: 0, rateLimited: 0 },
+        { hostId: "a", targetId: "environment:env2", total: 1, succeeded: 0, failed: 1, rateLimited: 0 },
+      ],
+      snapshot: {
+        hosts: [
+          { hostId: "a", targetId: "environment:env1", environmentRef: { environmentId: "env1", name: "Same Name", revision: 1 } },
+          { hostId: "a", targetId: "environment:env2", environmentRef: { environmentId: "env2", name: "Same Name", revision: 2 } },
+        ],
+      },
+    });
+    const cols = journeyTargetColumns(journey, hosts, latestRun);
+    expect(cols.map((c) => c.key)).toEqual([
+      "environment:env1",
+      "environment:env2",
+    ]);
+    expect(cols.map((c) => c.label)).toEqual(["Same Name #1", "Same Name #2"]);
+    // Per-target outcomes stay distinct even though the host is shared.
+    expect(journeyHostOutcome(latestRun, "environment:env1")).toBe("pass");
+    expect(journeyHostOutcome(latestRun, "environment:env2")).toBe("fail");
+  });
+
+  it("fresh legacy run: host-shaped targetIds collapse to bare hostId keys (pre-3A parity)", () => {
+    const journey = {
+      _id: "j1",
+      personaRefId: "p",
+      goal: "g1",
+      hostIds: ["a"],
+      config: { sessionsPerHost: 1, maxTurns: 1 },
+    };
+    const latestRun = run({
+      hostSummaries: [
+        { hostId: "a", targetId: "host:a", total: 1, succeeded: 1, failed: 0, rateLimited: 0 },
+      ],
+      snapshot: { hosts: [{ hostId: "a", targetId: "host:a" }] },
+    });
+    const cols = journeyTargetColumns(journey, hosts, latestRun);
+    expect(cols.map((c) => c.key)).toEqual(["a"]);
+    expect(journeyHostOutcome(latestRun, "a")).toBe("pass");
   });
 });
 

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/swarm-stream-reduce.test.ts
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/swarm-stream-reduce.test.ts
@@ -148,3 +148,44 @@ describe("resolveSwarmCellOutcome", () => {
     ).toBe("succeeded");
   });
 });
+
+describe("reduceSwarmStreamEvent — per-target keying (D2)", () => {
+  it("keys cells by targetId ?? hostId: two SAME-HOST env targets stay distinct", () => {
+    let state = empty();
+    state = reduceSwarmStreamEvent(
+      state,
+      evt({
+        type: "attempt_status",
+        status: "running",
+        targetId: "environment:e1",
+        chatSessionId: "synth_run_1_env_e1_0",
+      }),
+    );
+    state = reduceSwarmStreamEvent(
+      state,
+      evt({
+        type: "attempt_status",
+        status: "failed",
+        targetId: "environment:e2",
+        chatSessionId: "synth_run_1_env_e2_0",
+      }),
+    );
+    // Same hostId ("host_a") on both — but the cells never merge.
+    expect(state.cellStatus[swarmCellKey("environment:e1", 0)]).toBe("running");
+    expect(state.cellStatus[swarmCellKey("environment:e2", 0)]).toBe("failed");
+    expect(state.cellStatus[swarmCellKey("host_a", 0)]).toBeUndefined();
+    // Envelope keeps the targetId for downstream consumers.
+    expect(state.sessions["synth_run_1_env_e1_0"]?.envelope.targetId).toBe(
+      "environment:e1",
+    );
+  });
+
+  it("legacy events (no targetId) keep keying by hostId — byte-compatible", () => {
+    let state = empty();
+    state = reduceSwarmStreamEvent(
+      state,
+      evt({ type: "attempt_status", status: "succeeded" }),
+    );
+    expect(state.cellStatus[swarmCellKey("host_a", 0)]).toBe("succeeded");
+  });
+});

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/swarm-targets.test.ts
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/swarm-targets.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSwarmRunTargets,
+  buildUnrunJourneyTargets,
+  findTargetCellForChatSessionId,
+  summaryTargetKey,
+} from "../swarm-targets";
+
+const hostName = (id: string) => (id === "hostA" ? "Alpha" : id.slice(0, 8));
+
+describe("summaryTargetKey", () => {
+  it("keys env rows by targetId, legacy rows by hostId, and collapses host-shaped ids", () => {
+    expect(summaryTargetKey({ hostId: "hostA" })).toBe("hostA");
+    expect(summaryTargetKey({ hostId: "hostA", targetId: "host:hostA" })).toBe(
+      "hostA",
+    );
+    expect(
+      summaryTargetKey({ hostId: "hostA", targetId: "environment:e1" }),
+    ).toBe("environment:e1");
+  });
+});
+
+describe("buildSwarmRunTargets", () => {
+  it("two same-host env targets → distinct columns, env-name labels, #n on collisions", () => {
+    const targets = buildSwarmRunTargets({
+      hostSummaries: [
+        { hostId: "hostA", targetId: "environment:e1" },
+        { hostId: "hostA", targetId: "environment:e2" },
+      ],
+      snapshotHosts: [
+        {
+          hostId: "hostA",
+          targetId: "environment:e1",
+          environmentRef: { environmentId: "e1", name: "Prod", revision: 1 },
+        },
+        {
+          hostId: "hostA",
+          targetId: "environment:e2",
+          environmentRef: { environmentId: "e2", name: "Prod", revision: 2 },
+        },
+      ],
+      hostName,
+    });
+    expect(targets.map((t) => t.key)).toEqual([
+      "environment:e1",
+      "environment:e2",
+    ]);
+    expect(targets.map((t) => t.label)).toEqual(["Prod #1", "Prod #2"]);
+    expect(targets.map((t) => t.identity)).toEqual([
+      { hostId: "hostA", environmentId: "e1" },
+      { hostId: "hostA", environmentId: "e2" },
+    ]);
+  });
+
+  it("legacy summaries (host-shaped or absent targetId) key by hostId with host-name labels", () => {
+    const targets = buildSwarmRunTargets({
+      hostSummaries: [
+        { hostId: "hostA", targetId: "host:hostA" },
+        { hostId: "hostB" },
+      ],
+      snapshotHosts: [{ hostId: "hostA", targetId: "host:hostA" }],
+      hostName,
+    });
+    expect(targets.map((t) => t.key)).toEqual(["hostA", "hostB"]);
+    expect(targets[0]!.label).toBe("Alpha");
+    expect(targets[0]!.identity).toEqual({ hostId: "hostA" });
+  });
+});
+
+describe("buildUnrunJourneyTargets", () => {
+  it("env-based journey: environmentIds order, env labels, host from the live env", () => {
+    const targets = buildUnrunJourneyTargets({
+      hostIds: ["hostA"],
+      environmentIds: ["e2", "e1"],
+      environments: [
+        { environmentId: "e1", projectId: "p", name: "One", hostId: "hostA", revision: 1 },
+        { environmentId: "e2", projectId: "p", name: "Two", hostId: "hostA", revision: 1 },
+      ],
+      hostName,
+    });
+    expect(targets.map((t) => t.label)).toEqual(["Two", "One"]);
+    expect(targets.map((t) => t.key)).toEqual([
+      "environment:e2",
+      "environment:e1",
+    ]);
+  });
+
+  it("legacy journey: hostIds order", () => {
+    const targets = buildUnrunJourneyTargets({
+      hostIds: ["hostB", "hostA"],
+      hostName,
+    });
+    expect(targets.map((t) => t.key)).toEqual(["hostB", "hostA"]);
+  });
+});
+
+describe("findTargetCellForChatSessionId", () => {
+  it("restores the (target, sessionIndex) cell by minted-id membership", () => {
+    const targets = buildSwarmRunTargets({
+      hostSummaries: [
+        { hostId: "hostA", targetId: "environment:e1" },
+        { hostId: "hostA", targetId: "environment:e2" },
+      ],
+      snapshotHosts: [
+        {
+          hostId: "hostA",
+          targetId: "environment:e1",
+          environmentRef: { environmentId: "e1", name: "A", revision: 1 },
+        },
+        {
+          hostId: "hostA",
+          targetId: "environment:e2",
+          environmentRef: { environmentId: "e2", name: "B", revision: 1 },
+        },
+      ],
+      hostName,
+    });
+    const cell = findTargetCellForChatSessionId({
+      runId: "run-1",
+      targets,
+      sessionsPerHost: 3,
+      chatSessionId: "synth_run-1_env_e2_2",
+    });
+    expect(cell?.target.key).toBe("environment:e2");
+    expect(cell?.sessionIndex).toBe(2);
+    expect(
+      findTargetCellForChatSessionId({
+        runId: "run-1",
+        targets,
+        sessionsPerHost: 3,
+        chatSessionId: "synth_run-1_env_unknown_0",
+      }),
+    ).toBeNull();
+  });
+});

--- a/mcpjam-inspector/client/src/components/swarms/journey-environments.ts
+++ b/mcpjam-inspector/client/src/components/swarms/journey-environments.ts
@@ -27,14 +27,23 @@ export function compatHostIdsForEnvironments(
 
 /**
  * Payload for an env-mode create/edit: `environmentIds` + recomputed compat
- * `hostIds`. Returns null when no valid compat host can be resolved (the
- * caller must block the write — the backend requires ≥1 hostId).
+ * `hostIds`. Returns null when the selection is unusable and the caller must
+ * block the write: no selection, an id that does NOT resolve in the live list
+ * (archived/deleted — persisting it would leave a target that can never
+ * launch), or no compat host (the backend requires ≥1 hostId).
  */
 export function buildEnvJourneyPayload(
   environmentIds: string[],
   environments: EnvironmentView[],
 ): { environmentIds: string[]; hostIds: string[] } | null {
   if (environmentIds.length === 0) return null;
+  // Reject unresolved ids rather than silently persisting them: every selected
+  // environment must exist in the live list. A stale archived/deleted id must
+  // be removed from the selection before the journey can be saved.
+  const allResolve = environmentIds.every((id) =>
+    environments.some((e) => e.environmentId === id),
+  );
+  if (!allResolve) return null;
   const hostIds = compatHostIdsForEnvironments(environmentIds, environments);
   if (hostIds.length === 0) return null;
   return { environmentIds, hostIds };

--- a/mcpjam-inspector/client/src/components/swarms/journey-environments.ts
+++ b/mcpjam-inspector/client/src/components/swarms/journey-environments.ts
@@ -1,0 +1,59 @@
+/**
+ * Env-based journey payload helpers (Project Environments — B5).
+ *
+ * INVARIANT: every write that touches `environmentIds` ALSO recomputes the
+ * compat `hostIds` from the selected environments' resolved hosts — deduped,
+ * in selection order — so the legacy rollback data can never go stale. The
+ * backend keeps `hostIds` as inactive compatibility data on env-based journeys
+ * and reads it again only after a clear-to-legacy.
+ */
+import type { EnvironmentView } from "@/lib/swarm-api";
+
+export const MAX_ENVIRONMENTS_PER_JOURNEY = 10;
+
+/** Selected envs' resolved hostIds, deduped, in selection order. Unknown env
+ * ids (not in the live list) resolve to nothing. */
+export function compatHostIdsForEnvironments(
+  environmentIds: string[],
+  environments: EnvironmentView[],
+): string[] {
+  const out: string[] = [];
+  for (const environmentId of environmentIds) {
+    const env = environments.find((e) => e.environmentId === environmentId);
+    if (env?.hostId && !out.includes(env.hostId)) out.push(env.hostId);
+  }
+  return out;
+}
+
+/**
+ * Payload for an env-mode create/edit: `environmentIds` + recomputed compat
+ * `hostIds`. Returns null when no valid compat host can be resolved (the
+ * caller must block the write — the backend requires ≥1 hostId).
+ */
+export function buildEnvJourneyPayload(
+  environmentIds: string[],
+  environments: EnvironmentView[],
+): { environmentIds: string[]; hostIds: string[] } | null {
+  if (environmentIds.length === 0) return null;
+  const hostIds = compatHostIdsForEnvironments(environmentIds, environments);
+  if (hostIds.length === 0) return null;
+  return { environmentIds, hostIds };
+}
+
+/**
+ * Payload for clearing an env-based journey back to legacy: `environmentIds:
+ * null` + compat `hostIds` recomputed from the journey's CURRENT environment
+ * definitions in the SAME update call. Returns null when no valid compat host
+ * resolves (clear must be blocked — the user has to pick clients instead).
+ */
+export function buildClearToLegacyPayload(
+  currentEnvironmentIds: string[],
+  environments: EnvironmentView[],
+): { environmentIds: null; hostIds: string[] } | null {
+  const hostIds = compatHostIdsForEnvironments(
+    currentEnvironmentIds,
+    environments,
+  );
+  if (hostIds.length === 0) return null;
+  return { environmentIds: null, hostIds };
+}

--- a/mcpjam-inspector/client/src/components/swarms/journey-list.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/journey-list.tsx
@@ -126,10 +126,14 @@ export function journeyTargetColumns(
   hosts: JourneyListHost[],
   latestRun?: JourneyRun | null,
   environments?: EnvironmentView[],
-  environmentsEnabled = true,
+  environmentsEnabled = true
 ): SwarmTargetColumn[] {
-  const nameOf = (id: string) =>
-    hosts.find((h) => h.hostId === id)?.name ?? id.slice(0, 8);
+  // `nameOf` returns undefined for a host no longer in the project so
+  // `buildSwarmRunTargets` can fall back to the RUN SNAPSHOT's own hostName
+  // before truncating the id. The unrun path has no snapshot, so it takes the
+  // truncating variant directly.
+  const nameOf = (id: string) => hosts.find((h) => h.hostId === id)?.name;
+  const labelOf = (id: string) => nameOf(id) ?? id.slice(0, 8);
   if (latestRun && latestRun.hostSummaries.length > 0) {
     return buildSwarmRunTargets({
       hostSummaries: latestRun.hostSummaries,
@@ -143,7 +147,7 @@ export function journeyTargetColumns(
     hostIds: journey.hostIds,
     environmentIds: environmentsEnabled ? journey.environmentIds : undefined,
     environments: environmentsEnabled ? environments : undefined,
-    hostName: nameOf,
+    hostName: labelOf,
   });
 }
 
@@ -152,10 +156,10 @@ export function journeyTargetColumns(
  * pre-3A historical rows and fresh legacy rows key identically). */
 export function journeyHostOutcome(
   run: JourneyRun,
-  targetKey: string,
+  targetKey: string
 ): JourneyCellOutcome {
   const entry = run.hostSummaries.find(
-    (h) => summaryTargetKey(h) === targetKey,
+    (h) => summaryTargetKey(h) === targetKey
   );
   if (!entry || entry.total === 0) {
     return run.status === "running" ? "running" : "none";
@@ -192,7 +196,7 @@ export function JourneyList({
   isAuthenticated: boolean;
   projectId: string;
   onLaunch: (
-    journeyId: string,
+    journeyId: string
   ) => Promise<
     { status: "launched"; runId?: string } | { status: "already_launching" }
   >;
@@ -202,7 +206,7 @@ export function JourneyList({
   onOpenRun: (
     journey: JourneyListJourney,
     run: JourneyRun,
-    targetKey: string | null,
+    targetKey: string | null
   ) => void;
   onCloseRun: () => void;
   /** Live project environments (flag-gated; undefined when the flag is off). */
@@ -252,7 +256,7 @@ function JourneyBlock({
   hosts: JourneyListHost[];
   serverAttachments: ServerAttachment[];
   onLaunch: (
-    journeyId: string,
+    journeyId: string
   ) => Promise<
     { status: "launched"; runId?: string } | { status: "already_launching" }
   >;
@@ -262,7 +266,7 @@ function JourneyBlock({
   onOpenRun: (
     journey: JourneyListJourney,
     run: JourneyRun,
-    targetKey: string | null,
+    targetKey: string | null
   ) => void;
   onCloseRun: () => void;
   environments?: EnvironmentView[];
@@ -275,11 +279,11 @@ function JourneyBlock({
   } = usePaginatedQuery(
     SWARM_QUERIES.listJourneyRuns as any,
     { journeyRefId: journey._id } as any,
-    { initialNumItems: DEFAULT_PAGE_SIZE },
+    { initialNumItems: DEFAULT_PAGE_SIZE }
   );
   const rollup = useQuery(
     SWARM_QUERIES.journeyRollup as any,
-    { journeyRefId: journey._id } as any,
+    { journeyRefId: journey._id } as any
   ) as JourneyRollup | undefined;
 
   const [launching, setLaunching] = useState(false);
@@ -297,13 +301,13 @@ function JourneyBlock({
         hosts,
         latestRun,
         environments,
-        environmentsEnabled,
+        environmentsEnabled
       ),
-    [journey, hosts, latestRun, environments, environmentsEnabled],
+    [journey, hosts, latestRun, environments, environmentsEnabled]
   );
   const serverGroupName = journey.serverAttachmentId
-    ? (serverAttachments.find((a) => a._id === journey.serverAttachmentId)
-        ?.name ?? null)
+    ? serverAttachments.find((a) => a._id === journey.serverAttachmentId)
+        ?.name ?? null
     : null;
   const configHint = `${journey.config.sessionsPerHost}/host · ${journey.config.maxTurns} turns`;
 
@@ -345,7 +349,7 @@ function JourneyBlock({
     <div
       className={cn(
         "rounded-lg border px-3 py-2.5",
-        selection ? "border-primary/50" : "border-border/60",
+        selection ? "border-primary/50" : "border-border/60"
       )}
     >
       <div className="flex items-start justify-between gap-3">
@@ -377,7 +381,7 @@ function JourneyBlock({
             <span
               className={cn(
                 "rounded-full px-1.5 py-px text-[10px] font-medium capitalize",
-                runStatusChipClass(latestRun.status),
+                runStatusChipClass(latestRun.status)
               )}
             >
               {latestRun.status.replace(/_/g, " ")}
@@ -458,11 +462,11 @@ function JourneyBlock({
             }))
             .filter(
               (
-                p,
+                p
               ): p is {
                 run: JourneyRun;
                 outcome: Exclude<JourneyCellOutcome, "none">;
-              } => p.outcome !== "none",
+              } => p.outcome !== "none"
             )
             .slice(-MAX_TREND_SEGMENTS);
           const cellSelected =
@@ -476,7 +480,7 @@ function JourneyBlock({
                 "flex min-h-[4rem] w-full flex-col items-start justify-center gap-1 rounded-md border px-2.5 py-2 text-left transition-colors",
                 cellSelected
                   ? "border-primary bg-primary/5"
-                  : "border-border/50 bg-background/60",
+                  : "border-border/50 bg-background/60"
               )}
             >
               <button
@@ -505,12 +509,12 @@ function JourneyBlock({
                   <span
                     className={cn(
                       "text-[11px] font-semibold tabular-nums",
-                      meta?.text ?? "text-muted-foreground",
+                      meta?.text ?? "text-muted-foreground"
                     )}
                   >
                     {summary
                       ? `${summary.succeeded}/${summary.total} ok`
-                      : (meta?.label ?? "No data")}
+                      : meta?.label ?? "No data"}
                   </span>
                 </span>
               </button>
@@ -523,14 +527,21 @@ function JourneyBlock({
                     <button
                       key={run._id}
                       type="button"
-                      aria-label={`Open run ${run.status} (${runSummaryLine(run)}) on ${col.label}`}
-                      title={`${runNumberLabel(runCount, typedRuns.indexOf(run))} · ${run.status.replace(/_/g, " ")} · ${runSummaryLine(run)} · ${formatJourneyRelativeTime(run.createdAt)}`}
+                      aria-label={`Open run ${run.status} (${runSummaryLine(
+                        run
+                      )}) on ${col.label}`}
+                      title={`${runNumberLabel(
+                        runCount,
+                        typedRuns.indexOf(run)
+                      )} · ${run.status.replace(/_/g, " ")} · ${runSummaryLine(
+                        run
+                      )} · ${formatJourneyRelativeTime(run.createdAt)}`}
                       onClick={() => openRun(run, col.key)}
                       className={cn(
                         "min-w-[4px] flex-1 rounded-[2px] outline-none transition-opacity hover:opacity-70 focus-visible:ring-2 focus-visible:ring-ring",
                         SEGMENT_CLASS[segOutcome],
                         selection?.runId === run._id &&
-                          "ring-1 ring-primary ring-offset-1 ring-offset-background",
+                          "ring-1 ring-primary ring-offset-1 ring-offset-background"
                       )}
                     />
                   ))}
@@ -556,7 +567,7 @@ function JourneyBlock({
                 className={cn(
                   "flex w-full items-center gap-2 rounded-md px-1.5 py-1.5 text-left text-xs outline-none transition-colors",
                   "hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-ring",
-                  isOpen && "bg-muted/40",
+                  isOpen && "bg-muted/40"
                 )}
                 aria-expanded={isOpen}
                 aria-label={
@@ -569,7 +580,7 @@ function JourneyBlock({
                 <span
                   className={cn(
                     "size-1.5 shrink-0 rounded-full",
-                    runStatusDotClass(r.status),
+                    runStatusDotClass(r.status)
                   )}
                 />
                 <span className="shrink-0 font-medium text-foreground/90">
@@ -624,22 +635,33 @@ function JourneyEnvironmentsEditor({
 
   const current = useMemo(
     () => journey.environmentIds ?? [],
-    [journey.environmentIds],
+    [journey.environmentIds]
   );
+  // Seed ONLY on the closed→open transition. `journey` is a live Convex
+  // subscription, so `current` gets a new identity whenever anything on the
+  // journey changes (a rollup landing, a new run) — reseeding on every change
+  // while the popover is open would wipe the user's unsaved selection
+  // mid-edit. `currentRef` keeps the seed value fresh without making the
+  // effect depend on it.
+  const currentRef = useRef(current);
+  currentRef.current = current;
+  const wasOpen = useRef(false);
   useEffect(() => {
-    if (open) setDraft(current);
-  }, [open, current]);
+    if (open && !wasOpen.current) setDraft(currentRef.current);
+    wasOpen.current = open;
+  }, [open]);
 
   // New selections are limited to LIVE environments; a draft id that no longer
   // resolves in the list (archived/retired) renders as a detach-only row so the
   // user can remove it (a saved journey can't target a retired environment).
   const liveEnvironments = useMemo(
     () => environments.filter((e) => !e.archivedAt),
-    [environments],
+    [environments]
   );
   const orphanDraftIds = useMemo(
-    () => draft.filter((id) => !environments.some((e) => e.environmentId === id)),
-    [draft, environments],
+    () =>
+      draft.filter((id) => !environments.some((e) => e.environmentId === id)),
+    [draft, environments]
   );
 
   const toggle = (environmentId: string) =>
@@ -647,19 +669,18 @@ function JourneyEnvironmentsEditor({
       prev.includes(environmentId)
         ? prev.filter((id) => id !== environmentId)
         : prev.length >= MAX_ENVIRONMENTS_PER_JOURNEY
-          ? prev
-          : [...prev, environmentId],
+        ? prev
+        : [...prev, environmentId]
     );
 
   const dirty =
-    draft.length !== current.length ||
-    draft.some((id, i) => id !== current[i]);
+    draft.length !== current.length || draft.some((id, i) => id !== current[i]);
 
   const save = async () => {
     const payload = buildEnvJourneyPayload(draft, environments);
     if (!payload) {
       toast.error(
-        "Pick at least one environment that resolves to a valid client.",
+        "Pick at least one environment that resolves to a valid client."
       );
       return;
     }
@@ -674,7 +695,7 @@ function JourneyEnvironmentsEditor({
       setOpen(false);
     } catch (e) {
       toast.error(
-        e instanceof Error ? e.message : "Failed to update environments",
+        e instanceof Error ? e.message : "Failed to update environments"
       );
     } finally {
       setSaving(false);
@@ -686,7 +707,7 @@ function JourneyEnvironmentsEditor({
     if (!payload) {
       toast.error(
         "Can't switch to clients: none of this journey's environments " +
-          "resolves to a valid client. Select clients manually instead.",
+          "resolves to a valid client. Select clients manually instead."
       );
       return;
     }
@@ -694,7 +715,7 @@ function JourneyEnvironmentsEditor({
       !window.confirm(
         "Switch this journey back to clients? Environment server-group " +
           "overrides and environment skills stop applying; future runs use " +
-          "those clients' own defaults.",
+          "those clients' own defaults."
       )
     ) {
       return;
@@ -710,7 +731,7 @@ function JourneyEnvironmentsEditor({
       setOpen(false);
     } catch (e) {
       toast.error(
-        e instanceof Error ? e.message : "Failed to update environments",
+        e instanceof Error ? e.message : "Failed to update environments"
       );
     } finally {
       setSaving(false);
@@ -719,8 +740,8 @@ function JourneyEnvironmentsEditor({
 
   const label =
     current.length === 1
-      ? (environments.find((e) => e.environmentId === current[0])?.name ??
-        "1 environment")
+      ? environments.find((e) => e.environmentId === current[0])?.name ??
+        "1 environment"
       : `${current.length} environments`;
 
   return (
@@ -753,69 +774,69 @@ function JourneyEnvironmentsEditor({
             </p>
           ) : (
             <>
-            {liveEnvironments.map((env) => {
-              const selected = draft.includes(env.environmentId);
-              const ordinal = draft.indexOf(env.environmentId);
-              const disabled =
-                !selected && draft.length >= MAX_ENVIRONMENTS_PER_JOURNEY;
-              return (
+              {liveEnvironments.map((env) => {
+                const selected = draft.includes(env.environmentId);
+                const ordinal = draft.indexOf(env.environmentId);
+                const disabled =
+                  !selected && draft.length >= MAX_ENVIRONMENTS_PER_JOURNEY;
+                return (
+                  <button
+                    key={env.environmentId}
+                    type="button"
+                    role="checkbox"
+                    aria-checked={selected}
+                    disabled={disabled}
+                    onPointerDown={(e) => e.preventDefault()}
+                    onClick={() => toggle(env.environmentId)}
+                    className={cn(
+                      "flex w-full items-center gap-2 rounded py-1.5 pl-2 pr-2 text-left text-sm",
+                      "hover:bg-accent hover:text-accent-foreground",
+                      selected && "bg-accent/50",
+                      disabled && "cursor-not-allowed opacity-50"
+                    )}
+                  >
+                    <Check
+                      className={cn(
+                        "size-3.5 shrink-0",
+                        selected ? "opacity-100" : "opacity-0"
+                      )}
+                    />
+                    <span className="min-w-0 flex-1 truncate">
+                      <span className="font-medium">{env.name}</span>
+                    </span>
+                    {selected ? (
+                      <span className="shrink-0 rounded-full bg-muted px-1.5 text-[10px] tabular-nums text-muted-foreground">
+                        {ordinal + 1}
+                      </span>
+                    ) : null}
+                  </button>
+                );
+              })}
+              {orphanDraftIds.map((id) => (
                 <button
-                  key={env.environmentId}
+                  key={id}
                   type="button"
                   role="checkbox"
-                  aria-checked={selected}
-                  disabled={disabled}
+                  aria-checked
                   onPointerDown={(e) => e.preventDefault()}
-                  onClick={() => toggle(env.environmentId)}
+                  onClick={() => toggle(id)}
                   className={cn(
-                    "flex w-full items-center gap-2 rounded py-1.5 pl-2 pr-2 text-left text-sm",
-                    "hover:bg-accent hover:text-accent-foreground",
-                    selected && "bg-accent/50",
-                    disabled && "cursor-not-allowed opacity-50",
+                    "flex w-full items-center gap-2 rounded bg-accent/50 py-1.5 pl-2 pr-2 text-left text-sm",
+                    "hover:bg-accent hover:text-accent-foreground"
                   )}
                 >
-                  <Check
-                    className={cn(
-                      "size-3.5 shrink-0",
-                      selected ? "opacity-100" : "opacity-0",
-                    )}
-                  />
+                  <Check className="size-3.5 shrink-0 opacity-100" />
                   <span className="min-w-0 flex-1 truncate">
-                    <span className="font-medium">{env.name}</span>
-                  </span>
-                  {selected ? (
-                    <span className="shrink-0 rounded-full bg-muted px-1.5 text-[10px] tabular-nums text-muted-foreground">
-                      {ordinal + 1}
+                    <span className="font-medium">Retired environment</span>
+                    <span className="ml-1 text-[10px] text-muted-foreground">
+                      (unavailable — remove)
                     </span>
-                  ) : null}
-                </button>
-              );
-            })}
-            {orphanDraftIds.map((id) => (
-              <button
-                key={id}
-                type="button"
-                role="checkbox"
-                aria-checked
-                onPointerDown={(e) => e.preventDefault()}
-                onClick={() => toggle(id)}
-                className={cn(
-                  "flex w-full items-center gap-2 rounded bg-accent/50 py-1.5 pl-2 pr-2 text-left text-sm",
-                  "hover:bg-accent hover:text-accent-foreground",
-                )}
-              >
-                <Check className="size-3.5 shrink-0 opacity-100" />
-                <span className="min-w-0 flex-1 truncate">
-                  <span className="font-medium">Retired environment</span>
-                  <span className="ml-1 text-[10px] text-muted-foreground">
-                    (unavailable — remove)
                   </span>
-                </span>
-                <span className="shrink-0 rounded-full bg-muted px-1.5 text-[10px] tabular-nums text-muted-foreground">
-                  {draft.indexOf(id) + 1}
-                </span>
-              </button>
-            ))}
+                  <span className="shrink-0 rounded-full bg-muted px-1.5 text-[10px] tabular-nums text-muted-foreground">
+                    {draft.indexOf(id) + 1}
+                  </span>
+                </button>
+              ))}
             </>
           )}
         </div>

--- a/mcpjam-inspector/client/src/components/swarms/journey-list.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/journey-list.tsx
@@ -126,6 +126,7 @@ export function journeyTargetColumns(
   hosts: JourneyListHost[],
   latestRun?: JourneyRun | null,
   environments?: EnvironmentView[],
+  environmentsEnabled = true,
 ): SwarmTargetColumn[] {
   const nameOf = (id: string) =>
     hosts.find((h) => h.hostId === id)?.name ?? id.slice(0, 8);
@@ -136,10 +137,12 @@ export function journeyTargetColumns(
       hostName: nameOf,
     });
   }
+  // Flag-off rollback: an unrun env-based journey renders as legacy (its
+  // hostIds) rather than exposing environment ids/labels.
   return buildUnrunJourneyTargets({
     hostIds: journey.hostIds,
-    environmentIds: journey.environmentIds,
-    environments,
+    environmentIds: environmentsEnabled ? journey.environmentIds : undefined,
+    environments: environmentsEnabled ? environments : undefined,
     hostName: nameOf,
   });
 }
@@ -285,10 +288,18 @@ function JourneyBlock({
   const typedRuns = runs as JourneyRun[];
   const latestRun = typedRuns[0] ?? null;
   const runCount = rollup?.runCount ?? typedRuns.length;
-  const isEnvBased = (journey.environmentIds?.length ?? 0) > 0;
+  const isEnvBased =
+    environmentsEnabled && (journey.environmentIds?.length ?? 0) > 0;
   const targetCols = useMemo(
-    () => journeyTargetColumns(journey, hosts, latestRun, environments),
-    [journey, hosts, latestRun, environments],
+    () =>
+      journeyTargetColumns(
+        journey,
+        hosts,
+        latestRun,
+        environments,
+        environmentsEnabled,
+      ),
+    [journey, hosts, latestRun, environments, environmentsEnabled],
   );
   const serverGroupName = journey.serverAttachmentId
     ? (serverAttachments.find((a) => a._id === journey.serverAttachmentId)
@@ -619,6 +630,18 @@ function JourneyEnvironmentsEditor({
     if (open) setDraft(current);
   }, [open, current]);
 
+  // New selections are limited to LIVE environments; a draft id that no longer
+  // resolves in the list (archived/retired) renders as a detach-only row so the
+  // user can remove it (a saved journey can't target a retired environment).
+  const liveEnvironments = useMemo(
+    () => environments.filter((e) => !e.archivedAt),
+    [environments],
+  );
+  const orphanDraftIds = useMemo(
+    () => draft.filter((id) => !environments.some((e) => e.environmentId === id)),
+    [draft, environments],
+  );
+
   const toggle = (environmentId: string) =>
     setDraft((prev) =>
       prev.includes(environmentId)
@@ -724,12 +747,13 @@ function JourneyEnvironmentsEditor({
           <p className="px-1 pb-1 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
             Environments
           </p>
-          {environments.length === 0 ? (
+          {liveEnvironments.length === 0 && orphanDraftIds.length === 0 ? (
             <p className="px-1 py-1.5 text-xs text-muted-foreground">
               No environments in this project.
             </p>
           ) : (
-            environments.map((env) => {
+            <>
+            {liveEnvironments.map((env) => {
               const selected = draft.includes(env.environmentId);
               const ordinal = draft.indexOf(env.environmentId);
               const disabled =
@@ -766,7 +790,33 @@ function JourneyEnvironmentsEditor({
                   ) : null}
                 </button>
               );
-            })
+            })}
+            {orphanDraftIds.map((id) => (
+              <button
+                key={id}
+                type="button"
+                role="checkbox"
+                aria-checked
+                onPointerDown={(e) => e.preventDefault()}
+                onClick={() => toggle(id)}
+                className={cn(
+                  "flex w-full items-center gap-2 rounded bg-accent/50 py-1.5 pl-2 pr-2 text-left text-sm",
+                  "hover:bg-accent hover:text-accent-foreground",
+                )}
+              >
+                <Check className="size-3.5 shrink-0 opacity-100" />
+                <span className="min-w-0 flex-1 truncate">
+                  <span className="font-medium">Retired environment</span>
+                  <span className="ml-1 text-[10px] text-muted-foreground">
+                    (unavailable — remove)
+                  </span>
+                </span>
+                <span className="shrink-0 rounded-full bg-muted px-1.5 text-[10px] tabular-nums text-muted-foreground">
+                  {draft.indexOf(id) + 1}
+                </span>
+              </button>
+            ))}
+            </>
           )}
         </div>
         <div className="mt-2 flex items-center justify-between gap-2 border-t border-border/40 pt-2">

--- a/mcpjam-inspector/client/src/components/swarms/journey-list.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/journey-list.tsx
@@ -1,7 +1,12 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useQuery, usePaginatedQuery } from "convex/react";
-import { Info } from "lucide-react";
+import { useMutation, useQuery, usePaginatedQuery } from "convex/react";
+import { Check, ChevronDown, Info, Layers } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@mcpjam/design-system/popover";
 import {
   Tooltip,
   TooltipContent,
@@ -12,11 +17,23 @@ import { toast } from "@/lib/toast";
 import {
   SWARM_QUERIES,
   DEFAULT_PAGE_SIZE,
+  type EnvironmentView,
   type JourneyRun,
   type JourneyRollup,
 } from "@/lib/swarm-api";
 import { useProjectServerAttachments } from "@/hooks/useViews";
 import { JourneyHostLogoMark } from "./journey-host-logo";
+import {
+  buildSwarmRunTargets,
+  buildUnrunJourneyTargets,
+  summaryTargetKey,
+  type SwarmTargetColumn,
+} from "./swarm-targets";
+import {
+  buildClearToLegacyPayload,
+  buildEnvJourneyPayload,
+  MAX_ENVIRONMENTS_PER_JOURNEY,
+} from "./journey-environments";
 import {
   formatJourneyRelativeTime,
   runNumberLabel,
@@ -33,16 +50,20 @@ export type JourneyListJourney = {
   goal: string;
   hostIds: string[];
   serverAttachmentId?: string | null;
+  /** Env-based fan-out (Project Environments). Non-empty ⇒ env-based; the
+   * legacy `hostIds` are kept as inactive compat data. */
+  environmentIds?: string[] | null;
   config: { sessionsPerHost: number; maxTurns: number };
 };
 export type JourneyListHost = { hostId: string; name: string };
 type ServerAttachment = { _id: string; name: string };
 
-/** The run currently open in the surface's detail panel. */
+/** The run currently open in the surface's detail panel. `targetKey` is the
+ * canonical `targetId ?? hostId` (D2) of the focused column, if any. */
 export type JourneyRunSelection = {
   journeyId: string;
   runId: string;
-  hostId: string | null;
+  targetKey: string | null;
 };
 
 export type JourneyCellOutcome = "pass" | "fail" | "part" | "running" | "none";
@@ -93,40 +114,46 @@ function runStatusDotClass(status: string): string {
 const MAX_TREND_SEGMENTS = 12;
 
 /**
- * The journeys' target hosts, ordered by the project `hosts` array with any
- * hosts not in that list appended in first-seen order. Names fall back to a
- * truncated id.
+ * One journey's execution-TARGET columns (B6). Prefers the latest run's
+ * per-target summary rows (joined to its snapshot for env labels); an unrun
+ * journey falls back to its current config — environments in `environmentIds`
+ * order for env-based journeys, hosts otherwise. Env labels are environment
+ * names, `#n`-suffixed on collisions; host labels come from the project host
+ * list with a truncated-id fallback.
  */
-export function journeyHostColumns(
-  journeys: JourneyListJourney[],
+export function journeyTargetColumns(
+  journey: JourneyListJourney,
   hosts: JourneyListHost[],
-): JourneyListHost[] {
-  const targeted = new Set<string>();
-  for (const j of journeys) for (const id of j.hostIds) targeted.add(id);
-
-  const ordered: string[] = [];
-  for (const h of hosts) {
-    if (targeted.has(h.hostId) && !ordered.includes(h.hostId)) {
-      ordered.push(h.hostId);
-    }
-  }
-  for (const j of journeys) {
-    for (const id of j.hostIds) {
-      if (!ordered.includes(id)) ordered.push(id);
-    }
-  }
-
+  latestRun?: JourneyRun | null,
+  environments?: EnvironmentView[],
+): SwarmTargetColumn[] {
   const nameOf = (id: string) =>
     hosts.find((h) => h.hostId === id)?.name ?? id.slice(0, 8);
-  return ordered.map((id) => ({ hostId: id, name: nameOf(id) }));
+  if (latestRun && latestRun.hostSummaries.length > 0) {
+    return buildSwarmRunTargets({
+      hostSummaries: latestRun.hostSummaries,
+      snapshotHosts: latestRun.snapshot?.hosts,
+      hostName: nameOf,
+    });
+  }
+  return buildUnrunJourneyTargets({
+    hostIds: journey.hostIds,
+    environmentIds: journey.environmentIds,
+    environments,
+    hostName: nameOf,
+  });
 }
 
-/** Per-(run, host) outcome from the run's host rollup summary. */
+/** Per-(run, target) outcome from the run's per-target rollup summary, keyed
+ * by the canonical `targetId ?? hostId` (host-shaped ids collapse to hostId —
+ * pre-3A historical rows and fresh legacy rows key identically). */
 export function journeyHostOutcome(
   run: JourneyRun,
-  hostId: string,
+  targetKey: string,
 ): JourneyCellOutcome {
-  const entry = run.hostSummaries.find((h) => h.hostId === hostId);
+  const entry = run.hostSummaries.find(
+    (h) => summaryTargetKey(h) === targetKey,
+  );
   if (!entry || entry.total === 0) {
     return run.status === "running" ? "running" : "none";
   }
@@ -137,8 +164,10 @@ export function journeyHostOutcome(
   return "part";
 }
 
-function hostSummaryFor(run: JourneyRun, hostId: string) {
-  return run.hostSummaries.find((h) => h.hostId === hostId) ?? null;
+function hostSummaryFor(run: JourneyRun, targetKey: string) {
+  return (
+    run.hostSummaries.find((h) => summaryTargetKey(h) === targetKey) ?? null
+  );
 }
 
 /** Per-journey blocks: each journey shows its own hosts as result cells. */
@@ -152,6 +181,8 @@ export function JourneyList({
   selection,
   onOpenRun,
   onCloseRun,
+  environments,
+  environmentsEnabled = false,
 }: {
   journeys: JourneyListJourney[];
   hosts: JourneyListHost[];
@@ -164,13 +195,17 @@ export function JourneyList({
   >;
   initialRunId?: string;
   selection: JourneyRunSelection | null;
-  /** Open a run in the surface's detail panel (optionally focused on a host). */
+  /** Open a run in the surface's detail panel (optionally focused on a target). */
   onOpenRun: (
     journey: JourneyListJourney,
     run: JourneyRun,
-    hostId: string | null,
+    targetKey: string | null,
   ) => void;
   onCloseRun: () => void;
+  /** Live project environments (flag-gated; undefined when the flag is off). */
+  environments?: EnvironmentView[];
+  /** `project-environments-enabled` — gates the env edit affordance. */
+  environmentsEnabled?: boolean;
 }) {
   const { serverAttachments } = useProjectServerAttachments({
     isAuthenticated,
@@ -190,6 +225,8 @@ export function JourneyList({
           selection={selection?.journeyId === journey._id ? selection : null}
           onOpenRun={onOpenRun}
           onCloseRun={onCloseRun}
+          environments={environments}
+          environmentsEnabled={environmentsEnabled}
         />
       ))}
     </div>
@@ -205,6 +242,8 @@ function JourneyBlock({
   selection,
   onOpenRun,
   onCloseRun,
+  environments,
+  environmentsEnabled,
 }: {
   journey: JourneyListJourney;
   hosts: JourneyListHost[];
@@ -220,9 +259,11 @@ function JourneyBlock({
   onOpenRun: (
     journey: JourneyListJourney,
     run: JourneyRun,
-    hostId: string | null,
+    targetKey: string | null,
   ) => void;
   onCloseRun: () => void;
+  environments?: EnvironmentView[];
+  environmentsEnabled?: boolean;
 }) {
   const {
     results: runs,
@@ -244,9 +285,10 @@ function JourneyBlock({
   const typedRuns = runs as JourneyRun[];
   const latestRun = typedRuns[0] ?? null;
   const runCount = rollup?.runCount ?? typedRuns.length;
-  const hostCols = useMemo(
-    () => journeyHostColumns([journey], hosts),
-    [journey, hosts],
+  const isEnvBased = (journey.environmentIds?.length ?? 0) > 0;
+  const targetCols = useMemo(
+    () => journeyTargetColumns(journey, hosts, latestRun, environments),
+    [journey, hosts, latestRun, environments],
   );
   const serverGroupName = journey.serverAttachmentId
     ? (serverAttachments.find((a) => a._id === journey.serverAttachmentId)
@@ -280,12 +322,12 @@ function JourneyBlock({
     }
   };
 
-  const openRun = (run: JourneyRun, hostId: string | null) => {
-    if (selection?.runId === run._id && selection.hostId === hostId) {
+  const openRun = (run: JourneyRun, targetKey: string | null) => {
+    if (selection?.runId === run._id && selection.targetKey === targetKey) {
       onCloseRun();
       return;
     }
-    onOpenRun(journey, run, hostId);
+    onOpenRun(journey, run, targetKey);
   };
 
   return (
@@ -332,10 +374,19 @@ function JourneyBlock({
             <span>{formatJourneyRelativeTime(latestRun.createdAt)}</span>
           </>
         ) : null}
-        {serverGroupName ? (
+        {serverGroupName && !isEnvBased ? (
           <>
             <span aria-hidden>·</span>
             <span className="truncate">{serverGroupName}</span>
+          </>
+        ) : null}
+        {environmentsEnabled && isEnvBased ? (
+          <>
+            <span aria-hidden>·</span>
+            <JourneyEnvironmentsEditor
+              journey={journey}
+              environments={environments ?? []}
+            />
           </>
         ) : null}
         <Tooltip>
@@ -360,20 +411,21 @@ function JourneyBlock({
         </p>
       ) : null}
 
-      {/* One result cell per targeted host — latest outcome + clickable run trend. */}
+      {/* One result cell per execution TARGET (env or host) — latest outcome +
+          clickable run trend. Env targets are labeled by environment name. */}
       <div className="mt-2.5 grid grid-cols-[repeat(auto-fill,minmax(11rem,1fr))] gap-1.5">
-        {hostCols.map((col) => {
+        {targetCols.map((col) => {
           if (!latestRun) {
             return (
               <div
-                key={col.hostId}
+                key={col.key}
                 data-testid="journey-cell-empty"
                 className="flex min-h-[4rem] flex-col items-start justify-center gap-1 rounded-md border border-dashed border-border/50 bg-muted/5 px-2.5 py-2"
               >
                 <span className="inline-flex min-w-0 max-w-full items-center gap-1.5">
-                  <JourneyHostLogoMark label={col.name} />
+                  <JourneyHostLogoMark label={col.label} />
                   <span className="truncate text-[11px] font-medium text-foreground/80">
-                    {col.name}
+                    {col.label}
                   </span>
                 </span>
                 <span className="text-[11px] text-muted-foreground">
@@ -383,15 +435,15 @@ function JourneyBlock({
             );
           }
 
-          const outcome = journeyHostOutcome(latestRun, col.hostId);
+          const outcome = journeyHostOutcome(latestRun, col.key);
           const meta = outcome === "none" ? null : CELL_STATUS_META[outcome];
-          const summary = hostSummaryFor(latestRun, col.hostId);
+          const summary = hostSummaryFor(latestRun, col.key);
           // Oldest → newest, capped like the evals trend strip.
           const trendRuns = [...typedRuns]
             .reverse()
             .map((r) => ({
               run: r,
-              outcome: journeyHostOutcome(r, col.hostId),
+              outcome: journeyHostOutcome(r, col.key),
             }))
             .filter(
               (
@@ -404,11 +456,11 @@ function JourneyBlock({
             .slice(-MAX_TREND_SEGMENTS);
           const cellSelected =
             selection?.runId === latestRun._id &&
-            selection.hostId === col.hostId;
+            selection.targetKey === col.key;
 
           return (
             <div
-              key={col.hostId}
+              key={col.key}
               className={cn(
                 "flex min-h-[4rem] w-full flex-col items-start justify-center gap-1 rounded-md border px-2.5 py-2 text-left transition-colors",
                 cellSelected
@@ -420,19 +472,19 @@ function JourneyBlock({
                 type="button"
                 data-testid="journey-host-cell"
                 data-outcome={outcome}
-                aria-label={`Open runs for ${journey.goal} on ${col.name}`}
+                aria-label={`Open runs for ${journey.goal} on ${col.label}`}
                 title={
                   summary
-                    ? `Latest run on ${col.name}: ${summary.succeeded}/${summary.total} sessions ok`
+                    ? `Latest run on ${col.label}: ${summary.succeeded}/${summary.total} sessions ok`
                     : undefined
                 }
-                onClick={() => openRun(latestRun, col.hostId)}
+                onClick={() => openRun(latestRun, col.key)}
                 className="flex w-full min-w-0 items-center justify-between gap-1.5 rounded-sm outline-none hover:opacity-80 focus-visible:ring-2 focus-visible:ring-ring"
               >
                 <span className="inline-flex min-w-0 items-center gap-1.5">
-                  <JourneyHostLogoMark label={col.name} />
+                  <JourneyHostLogoMark label={col.label} />
                   <span className="truncate text-[11px] font-medium text-foreground/80">
-                    {col.name}
+                    {col.label}
                   </span>
                 </span>
                 <span className="inline-flex shrink-0 items-center gap-1.5">
@@ -460,9 +512,9 @@ function JourneyBlock({
                     <button
                       key={run._id}
                       type="button"
-                      aria-label={`Open run ${run.status} (${runSummaryLine(run)}) on ${col.name}`}
+                      aria-label={`Open run ${run.status} (${runSummaryLine(run)}) on ${col.label}`}
                       title={`${runNumberLabel(runCount, typedRuns.indexOf(run))} · ${run.status.replace(/_/g, " ")} · ${runSummaryLine(run)} · ${formatJourneyRelativeTime(run.createdAt)}`}
-                      onClick={() => openRun(run, col.hostId)}
+                      onClick={() => openRun(run, col.key)}
                       className={cn(
                         "min-w-[4px] flex-1 rounded-[2px] outline-none transition-opacity hover:opacity-70 focus-visible:ring-2 focus-visible:ring-ring",
                         SEGMENT_CLASS[segOutcome],
@@ -536,5 +588,207 @@ function JourneyBlock({
         </div>
       ) : null}
     </div>
+  );
+}
+
+/**
+ * Minimal env edit affordance for an ENV-BASED journey (B5): an "Environments"
+ * popover with the ordered ≤10 multi-select and a confirm-gated
+ * clear-back-to-legacy. Every write sends BOTH `environmentIds` AND compat
+ * `hostIds` recomputed from those environments (deduped, in order) in the SAME
+ * `journeys:updateJourney` call, so the legacy rollback data can never go
+ * stale. Clearing is blocked when no valid compat host resolves.
+ */
+function JourneyEnvironmentsEditor({
+  journey,
+  environments,
+}: {
+  journey: JourneyListJourney;
+  environments: EnvironmentView[];
+}) {
+  const updateJourney = useMutation("journeys:updateJourney" as any);
+  const [open, setOpen] = useState(false);
+  const [draft, setDraft] = useState<string[]>([]);
+  const [saving, setSaving] = useState(false);
+
+  const current = useMemo(
+    () => journey.environmentIds ?? [],
+    [journey.environmentIds],
+  );
+  useEffect(() => {
+    if (open) setDraft(current);
+  }, [open, current]);
+
+  const toggle = (environmentId: string) =>
+    setDraft((prev) =>
+      prev.includes(environmentId)
+        ? prev.filter((id) => id !== environmentId)
+        : prev.length >= MAX_ENVIRONMENTS_PER_JOURNEY
+          ? prev
+          : [...prev, environmentId],
+    );
+
+  const dirty =
+    draft.length !== current.length ||
+    draft.some((id, i) => id !== current[i]);
+
+  const save = async () => {
+    const payload = buildEnvJourneyPayload(draft, environments);
+    if (!payload) {
+      toast.error(
+        "Pick at least one environment that resolves to a valid client.",
+      );
+      return;
+    }
+    setSaving(true);
+    try {
+      await updateJourney({
+        journeyRefId: journey._id,
+        environmentIds: payload.environmentIds,
+        hostIds: payload.hostIds,
+      } as any);
+      toast.success("Journey environments updated");
+      setOpen(false);
+    } catch (e) {
+      toast.error(
+        e instanceof Error ? e.message : "Failed to update environments",
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const clearToLegacy = async () => {
+    const payload = buildClearToLegacyPayload(current, environments);
+    if (!payload) {
+      toast.error(
+        "Can't switch to clients: none of this journey's environments " +
+          "resolves to a valid client. Select clients manually instead.",
+      );
+      return;
+    }
+    if (
+      !window.confirm(
+        "Switch this journey back to clients? Environment server-group " +
+          "overrides and environment skills stop applying; future runs use " +
+          "those clients' own defaults.",
+      )
+    ) {
+      return;
+    }
+    setSaving(true);
+    try {
+      await updateJourney({
+        journeyRefId: journey._id,
+        environmentIds: null,
+        hostIds: payload.hostIds,
+      } as any);
+      toast.success("Journey switched back to clients");
+      setOpen(false);
+    } catch (e) {
+      toast.error(
+        e instanceof Error ? e.message : "Failed to update environments",
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const label =
+    current.length === 1
+      ? (environments.find((e) => e.environmentId === current[0])?.name ??
+        "1 environment")
+      : `${current.length} environments`;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          data-testid="journey-environments-trigger"
+          className="inline-flex max-w-[200px] items-center gap-1 rounded-full border border-border/60 bg-muted/40 px-2 py-px text-[11px] text-foreground/80 outline-none transition-colors hover:bg-muted/60 focus-visible:ring-2 focus-visible:ring-ring"
+          aria-label="Journey environments"
+        >
+          <Layers className="size-3 shrink-0 text-muted-foreground" />
+          <span className="min-w-0 truncate">{label}</span>
+          <ChevronDown className="size-3 shrink-0 text-muted-foreground" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-72 p-2"
+        align="start"
+        sideOffset={4}
+        onCloseAutoFocus={(e) => e.preventDefault()}
+      >
+        <div className="space-y-0.5" role="group" aria-label="Environments">
+          <p className="px-1 pb-1 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+            Environments
+          </p>
+          {environments.length === 0 ? (
+            <p className="px-1 py-1.5 text-xs text-muted-foreground">
+              No environments in this project.
+            </p>
+          ) : (
+            environments.map((env) => {
+              const selected = draft.includes(env.environmentId);
+              const ordinal = draft.indexOf(env.environmentId);
+              const disabled =
+                !selected && draft.length >= MAX_ENVIRONMENTS_PER_JOURNEY;
+              return (
+                <button
+                  key={env.environmentId}
+                  type="button"
+                  role="checkbox"
+                  aria-checked={selected}
+                  disabled={disabled}
+                  onPointerDown={(e) => e.preventDefault()}
+                  onClick={() => toggle(env.environmentId)}
+                  className={cn(
+                    "flex w-full items-center gap-2 rounded py-1.5 pl-2 pr-2 text-left text-sm",
+                    "hover:bg-accent hover:text-accent-foreground",
+                    selected && "bg-accent/50",
+                    disabled && "cursor-not-allowed opacity-50",
+                  )}
+                >
+                  <Check
+                    className={cn(
+                      "size-3.5 shrink-0",
+                      selected ? "opacity-100" : "opacity-0",
+                    )}
+                  />
+                  <span className="min-w-0 flex-1 truncate">
+                    <span className="font-medium">{env.name}</span>
+                  </span>
+                  {selected ? (
+                    <span className="shrink-0 rounded-full bg-muted px-1.5 text-[10px] tabular-nums text-muted-foreground">
+                      {ordinal + 1}
+                    </span>
+                  ) : null}
+                </button>
+              );
+            })
+          )}
+        </div>
+        <div className="mt-2 flex items-center justify-between gap-2 border-t border-border/40 pt-2">
+          <button
+            type="button"
+            className="text-[11px] text-muted-foreground hover:text-destructive hover:underline"
+            disabled={saving}
+            onClick={() => void clearToLegacy()}
+          >
+            Use clients instead
+          </button>
+          <Button
+            type="button"
+            size="sm"
+            className="h-7 px-2.5 text-xs"
+            disabled={saving || !dirty || draft.length === 0}
+            onClick={() => void save()}
+          >
+            Save
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/mcpjam-inspector/client/src/components/swarms/journey-run-results.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/journey-run-results.tsx
@@ -18,6 +18,7 @@ import {
   type JourneyRunStreamState,
   type SwarmCellLiveStatus,
 } from "./use-journey-run-stream";
+import { summaryTargetKey, type SwarmTargetColumn } from "./swarm-targets";
 import { usePersistedSessionTrace } from "./use-persisted-session-trace";
 
 export type SwarmMatrixCellOutcome =
@@ -136,6 +137,8 @@ export function SwarmHostCell({
 }
 
 export type SwarmMatrixSelection = {
+  /** Canonical target key (`targetId ?? hostId` — D2). */
+  targetKey: string;
   hostId: string;
   sessionIndex: number;
   chatSessionId: string;
@@ -143,8 +146,7 @@ export type SwarmMatrixSelection = {
 
 export function SwarmSessionsMatrix({
   runId,
-  hostIds,
-  hostName,
+  targets,
   sessionsPerHost,
   sessions,
   hostSummaries,
@@ -154,12 +156,13 @@ export function SwarmSessionsMatrix({
   onSelect,
 }: {
   runId: string;
-  hostIds: string[];
-  hostName: (id: string) => string;
+  /** One column per execution target (per-target model — B6). */
+  targets: SwarmTargetColumn[];
   sessionsPerHost: number;
   sessions: JourneySessionRow[];
   hostSummaries: Array<{
     hostId: string;
+    targetId?: string;
     total: number;
     succeeded: number;
     failed: number;
@@ -186,23 +189,26 @@ export function SwarmSessionsMatrix({
         Sessions
       </p>
       <div className="flex flex-wrap gap-1.5">
-        {hostIds.flatMap((hostId) =>
-          Array.from({ length: rows }, (_, sessionIndex) => {
-            const chatSessionId = swarmAttemptChatSessionId(
-              runId,
-              hostId,
-              sessionIndex,
-            );
+        {targets.flatMap((target) => {
+          // Per-TARGET minted cell ids (shared mint — env targets key on the
+          // environmentId identity, so two same-host targets never collide).
+          const cellIds = Array.from({ length: rows }, (_, sessionIndex) =>
+            swarmAttemptChatSessionId(runId, target.identity, sessionIndex),
+          );
+          const listed = cellIds.filter((id) =>
+            sessionByChatId.has(id),
+          ).length;
+          return cellIds.map((chatSessionId, sessionIndex) => {
             const convexSession = sessionByChatId.get(chatSessionId);
             const liveStatus =
-              stream.cellStatus[swarmCellKey(hostId, sessionIndex)];
+              stream.cellStatus[swarmCellKey(target.key, sessionIndex)];
             let outcome = resolveSwarmCellOutcome({
               liveStatus,
               session: convexSession,
               runStatus,
             });
             // Unpersisted failures never appear in listSessionsByJourneyRun.
-            // When the host rollup reports failures and this slot has no
+            // When the target rollup reports failures and this slot has no
             // Convex row (and isn't live-running), mark Fail so the chips
             // match the run summary.
             if (
@@ -210,8 +216,9 @@ export function SwarmSessionsMatrix({
               (!liveStatus || liveStatus === "pending") &&
               runStatus !== "running"
             ) {
-              const hs = hostSummaries.find((h) => h.hostId === hostId);
-              const listed = sessions.filter((s) => s.hostId === hostId).length;
+              const hs = hostSummaries.find(
+                (h) => summaryTargetKey(h) === target.key,
+              );
               const unlistedFailed = hs
                 ? Math.min(hs.failed, Math.max(0, hs.total - listed))
                 : 0;
@@ -225,23 +232,28 @@ export function SwarmSessionsMatrix({
               }
             }
             const selected =
-              selection?.hostId === hostId &&
+              selection?.targetKey === target.key &&
               selection.sessionIndex === sessionIndex;
             return (
               <SwarmHostCell
-                key={`${hostId}:${sessionIndex}`}
-                hostLabel={hostName(hostId)}
+                key={`${target.key}:${sessionIndex}`}
+                hostLabel={target.label}
                 sessionIndex={sessionIndex}
                 outcome={outcome}
                 goalScore={convexSession?.goalScore}
                 selected={selected}
                 onSelect={() =>
-                  onSelect({ hostId, sessionIndex, chatSessionId })
+                  onSelect({
+                    targetKey: target.key,
+                    hostId: target.hostId,
+                    sessionIndex,
+                    chatSessionId,
+                  })
                 }
               />
             );
-          }),
-        )}
+          });
+        })}
       </div>
     </div>
   );
@@ -301,7 +313,7 @@ export function SwarmLiveStreamPane({
   const live = stream.sessions[selection.chatSessionId];
   const outcome = resolveSwarmCellOutcome({
     liveStatus: stream.cellStatus[
-      swarmCellKey(selection.hostId, selection.sessionIndex)
+      swarmCellKey(selection.targetKey, selection.sessionIndex)
     ],
     session: convexSession,
     runStatus,

--- a/mcpjam-inspector/client/src/components/swarms/swarm-targets.ts
+++ b/mcpjam-inspector/client/src/components/swarms/swarm-targets.ts
@@ -66,20 +66,24 @@ function disambiguateLabels(columns: SwarmTargetColumn[]): SwarmTargetColumn[] {
  * Build the run-detail matrix columns: one per `hostSummaries` row (run order),
  * joined to `snapshot.hosts` by targetId (fallback: first snapshot entry with
  * the same host). Env targets label by environment name; host targets by the
- * project host name (fallback: snapshot hostName, then a truncated id).
+ * LIVE project host name, then the snapshot's `hostName`, then a truncated id.
+ *
+ * `hostName` MUST return `undefined` for a host no longer in the project so the
+ * snapshot fallback is reachable — a caller that folds its own `id.slice(0, 8)`
+ * into the lookup makes historical runs render truncated ids instead of the
+ * name the run was launched with. The truncation fallback lives HERE, once.
  */
 export function buildSwarmRunTargets(args: {
   hostSummaries: Array<Pick<JourneyHostSummary, "hostId" | "targetId">>;
   snapshotHosts?: JourneySnapshotTarget[];
-  hostName: (hostId: string) => string;
+  hostName: (hostId: string) => string | undefined;
 }): SwarmTargetColumn[] {
   const { hostSummaries, snapshotHosts, hostName } = args;
   const columns = hostSummaries.map((summary) => {
     const snap =
       (summary.targetId !== undefined
         ? snapshotHosts?.find((h) => h.targetId === summary.targetId)
-        : undefined) ??
-      snapshotHosts?.find((h) => h.hostId === summary.hostId);
+        : undefined) ?? snapshotHosts?.find((h) => h.hostId === summary.hostId);
     const environmentId = snap?.environmentRef?.environmentId;
     const label =
       snap?.environmentRef?.name ??
@@ -134,7 +138,7 @@ export function buildUnrunJourneyTargets(args: {
       hostId,
       label: hostName(hostId),
       identity: { hostId },
-    })),
+    }))
   );
 }
 

--- a/mcpjam-inspector/client/src/components/swarms/swarm-targets.ts
+++ b/mcpjam-inspector/client/src/components/swarms/swarm-targets.ts
@@ -1,0 +1,164 @@
+/**
+ * Per-TARGET column/keying model for the Swarms run matrix + journey list
+ * (Project Environments — B6/D2). An execution target is one `snapshot.hosts[]`
+ * entry: a legacy host or a project environment; two environments may share a
+ * host and must stay distinct columns.
+ *
+ * Canonical key: `targetId ?? hostId`, with HOST-SHAPED target ids collapsed to
+ * the bare hostId — mirroring the backend rollup's `outcomeKeyOf`, so fresh
+ * legacy runs (whose summaries DO carry a `host:<id>` targetId) key identically
+ * to pre-environments historical rows (which carry none). The comparison
+ * CONSTRUCTS the host-shaped id for equality; it never parses an opaque id.
+ */
+import type {
+  EnvironmentView,
+  JourneyHostSummary,
+  JourneySnapshotTarget,
+} from "@/lib/swarm-api";
+import type { SwarmSessionTargetIdentity } from "@/shared/swarm-session-id";
+import { swarmAttemptChatSessionId } from "@/shared/swarm-session-id";
+
+/** One matrix/list column. `key` is the canonical target key (D2); `identity`
+ * feeds the shared session-id mint. */
+export interface SwarmTargetColumn {
+  key: string;
+  hostId: string;
+  targetId?: string;
+  environmentId?: string;
+  /** Display label: environment name (env targets) or host name; `#n`-suffixed
+   * on collisions. */
+  label: string;
+  identity: SwarmSessionTargetIdentity;
+}
+
+/** The backend's one production spelling of a host-shaped target id —
+ * constructed only for EQUALITY checks (mirrors `hostTargetId`). */
+function hostShapedTargetId(hostId: string): string {
+  return `host:${hostId}`;
+}
+
+/** Canonical key for a summary/rollup row: `targetId ?? hostId`, with
+ * host-shaped ids collapsed to the bare hostId (backend `outcomeKeyOf`). */
+export function summaryTargetKey(row: {
+  hostId: string;
+  targetId?: string;
+}): string {
+  if (row.targetId === undefined) return row.hostId;
+  if (row.targetId === hostShapedTargetId(row.hostId)) return row.hostId;
+  return row.targetId;
+}
+
+/** Disambiguate duplicate labels with a stable `#n` suffix (collision groups
+ * only; unique labels stay untouched). */
+function disambiguateLabels(columns: SwarmTargetColumn[]): SwarmTargetColumn[] {
+  const counts = new Map<string, number>();
+  for (const c of columns) counts.set(c.label, (counts.get(c.label) ?? 0) + 1);
+  const seen = new Map<string, number>();
+  return columns.map((c) => {
+    if ((counts.get(c.label) ?? 0) <= 1) return c;
+    const n = (seen.get(c.label) ?? 0) + 1;
+    seen.set(c.label, n);
+    return { ...c, label: `${c.label} #${n}` };
+  });
+}
+
+/**
+ * Build the run-detail matrix columns: one per `hostSummaries` row (run order),
+ * joined to `snapshot.hosts` by targetId (fallback: first snapshot entry with
+ * the same host). Env targets label by environment name; host targets by the
+ * project host name (fallback: snapshot hostName, then a truncated id).
+ */
+export function buildSwarmRunTargets(args: {
+  hostSummaries: Array<Pick<JourneyHostSummary, "hostId" | "targetId">>;
+  snapshotHosts?: JourneySnapshotTarget[];
+  hostName: (hostId: string) => string;
+}): SwarmTargetColumn[] {
+  const { hostSummaries, snapshotHosts, hostName } = args;
+  const columns = hostSummaries.map((summary) => {
+    const snap =
+      (summary.targetId !== undefined
+        ? snapshotHosts?.find((h) => h.targetId === summary.targetId)
+        : undefined) ??
+      snapshotHosts?.find((h) => h.hostId === summary.hostId);
+    const environmentId = snap?.environmentRef?.environmentId;
+    const label =
+      snap?.environmentRef?.name ??
+      hostName(summary.hostId) ??
+      snap?.hostName ??
+      summary.hostId.slice(0, 8);
+    return {
+      key: summaryTargetKey(summary),
+      hostId: summary.hostId,
+      ...(summary.targetId !== undefined ? { targetId: summary.targetId } : {}),
+      ...(environmentId !== undefined ? { environmentId } : {}),
+      label,
+      identity: {
+        hostId: summary.hostId,
+        ...(environmentId !== undefined ? { environmentId } : {}),
+      },
+    } satisfies SwarmTargetColumn;
+  });
+  return disambiguateLabels(columns);
+}
+
+/**
+ * Journey-list columns for a journey that has NOT run yet (no summaries to key
+ * off): env-based journeys get one column per environment in `environmentIds`
+ * order (joined to the live environments list); legacy journeys one per host.
+ */
+export function buildUnrunJourneyTargets(args: {
+  hostIds: string[];
+  environmentIds?: string[] | null;
+  environments?: EnvironmentView[];
+  hostName: (hostId: string) => string;
+}): SwarmTargetColumn[] {
+  const { hostIds, environmentIds, environments, hostName } = args;
+  if (environmentIds && environmentIds.length > 0) {
+    const columns = environmentIds.map((environmentId) => {
+      const env = environments?.find((e) => e.environmentId === environmentId);
+      const hostId = env?.hostId ?? "";
+      return {
+        key: `environment:${environmentId}`,
+        hostId,
+        targetId: `environment:${environmentId}`,
+        environmentId,
+        label: env?.name ?? environmentId.slice(0, 8),
+        identity: { hostId, environmentId },
+      } satisfies SwarmTargetColumn;
+    });
+    return disambiguateLabels(columns);
+  }
+  return disambiguateLabels(
+    hostIds.map((hostId) => ({
+      key: hostId,
+      hostId,
+      label: hostName(hostId),
+      identity: { hostId },
+    })),
+  );
+}
+
+/**
+ * Deep-link / initial-selection restore: find the (target, sessionIndex) cell
+ * whose minted chatSessionId matches a persisted session row's. Bounded
+ * (≤ targets × sessionsPerHost).
+ */
+export function findTargetCellForChatSessionId(args: {
+  runId: string;
+  targets: SwarmTargetColumn[];
+  sessionsPerHost: number;
+  chatSessionId: string;
+}): { target: SwarmTargetColumn; sessionIndex: number } | null {
+  const { runId, targets, sessionsPerHost, chatSessionId } = args;
+  for (const target of targets) {
+    for (let sessionIndex = 0; sessionIndex < sessionsPerHost; sessionIndex++) {
+      if (
+        swarmAttemptChatSessionId(runId, target.identity, sessionIndex) ===
+        chatSessionId
+      ) {
+        return { target, sessionIndex };
+      }
+    }
+  }
+  return null;
+}

--- a/mcpjam-inspector/client/src/components/swarms/use-journey-run-stream.ts
+++ b/mcpjam-inspector/client/src/components/swarms/use-journey-run-stream.ts
@@ -20,6 +20,8 @@ export type SwarmLiveSessionState = {
   envelope: {
     runId: string;
     hostId: string;
+    /** Opaque execution-target id (absent on legacy/historical streams). */
+    targetId?: string;
     chatSessionId: string;
     sessionIndex: number;
   };
@@ -30,15 +32,24 @@ export type SwarmLiveSessionState = {
 
 export type JourneyRunStreamState = {
   sessions: Record<string, SwarmLiveSessionState>;
-  /** Coarse matrix key: `${hostId}:${sessionIndex}` → status */
+  /** Coarse matrix key: `${targetKey}:${sessionIndex}` → status, where
+   * targetKey is the canonical `targetId ?? hostId` (D2). */
   cellStatus: Record<string, SwarmCellLiveStatus>;
   runComplete: boolean;
   connected: boolean;
   error: string | null;
 };
 
-export function swarmCellKey(hostId: string, sessionIndex: number): string {
-  return `${hostId}:${sessionIndex}`;
+/** Canonical per-event target key (D2): `targetId ?? hostId`. */
+export function swarmEventTargetKey(event: {
+  targetId?: string;
+  hostId: string;
+}): string {
+  return event.targetId ?? event.hostId;
+}
+
+export function swarmCellKey(targetKey: string, sessionIndex: number): string {
+  return `${targetKey}:${sessionIndex}`;
 }
 
 function emptyRunStreamState(): JourneyRunStreamState {
@@ -61,6 +72,7 @@ function ensureSession(
     envelope: {
       runId: event.runId,
       hostId: event.hostId,
+      ...(event.targetId ? { targetId: event.targetId } : {}),
       chatSessionId: event.chatSessionId,
       sessionIndex: event.sessionIndex,
     },
@@ -84,7 +96,7 @@ export function reduceSwarmStreamEvent(
   }
 
   const session = ensureSession(state, event);
-  const cellKey = swarmCellKey(event.hostId, event.sessionIndex);
+  const cellKey = swarmCellKey(swarmEventTargetKey(event), event.sessionIndex);
   let nextSession = session;
   let nextCellStatus = state.cellStatus[cellKey] ?? "pending";
 

--- a/mcpjam-inspector/client/src/components/swarms/use-journey-run-stream.ts
+++ b/mcpjam-inspector/client/src/components/swarms/use-journey-run-stream.ts
@@ -13,6 +13,7 @@ import {
 } from "@/shared/swarm-stream-events";
 import { streamJourneyRun } from "@/lib/swarm-api";
 import type { TraceEnvelope } from "@/components/evals/trace-viewer-adapter";
+import { summaryTargetKey } from "./swarm-targets";
 
 export type SwarmCellLiveStatus = SwarmAttemptStreamStatus | "pending";
 
@@ -40,12 +41,18 @@ export type JourneyRunStreamState = {
   error: string | null;
 };
 
-/** Canonical per-event target key (D2): `targetId ?? hostId`. */
+/**
+ * Canonical per-event target key (D2). MUST match the matrix column key
+ * ({@link summaryTargetKey}): a host-shaped `targetId` (`host:<hostId>`, which
+ * fresh legacy runs echo on the SSE envelope) collapses to the bare hostId, so
+ * live cell updates land on the same key the matrix reads instead of leaving a
+ * running cell stuck "pending".
+ */
 export function swarmEventTargetKey(event: {
   targetId?: string;
   hostId: string;
 }): string {
-  return event.targetId ?? event.hostId;
+  return summaryTargetKey(event);
 }
 
 export function swarmCellKey(targetKey: string, sessionIndex: number): string {

--- a/mcpjam-inspector/client/src/hooks/__tests__/canManageAsOwnerOrAdmin.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/canManageAsOwnerOrAdmin.test.ts
@@ -1,0 +1,59 @@
+/**
+ * The admin gate shared by SwarmsTab and the Project Environments route.
+ *
+ * This branch has to serve two incompatible identity models at once — WorkOS
+ * members (who get a project role) and anonymous Convex owners (who never do)
+ * — so it is unit-tested here rather than left inline in a route component
+ * where a future edit could silently re-expose admin controls.
+ */
+import { describe, expect, it } from "vitest";
+import { canManageAsOwnerOrAdmin } from "../useProjects";
+
+const base = {
+  isWorkOsSignedIn: false,
+  role: undefined,
+  isAuthenticated: true,
+  hasProject: true,
+  identityLoading: false,
+} as const;
+
+describe("canManageAsOwnerOrAdmin", () => {
+  it("grants management to a SETTLED anonymous Convex owner", () => {
+    // No WorkOS identity ⇒ no role, ever. They still own the project.
+    expect(canManageAsOwnerOrAdmin({ ...base })).toBe(true);
+  });
+
+  it("denies while WorkOS is still hydrating (fail-closed)", () => {
+    // Indistinguishable from a member whose role hasn't loaded yet.
+    expect(canManageAsOwnerOrAdmin({ ...base, identityLoading: true })).toBe(
+      false
+    );
+  });
+
+  it("denies an unauthenticated viewer and a viewer with no project", () => {
+    expect(canManageAsOwnerOrAdmin({ ...base, isAuthenticated: false })).toBe(
+      false
+    );
+    expect(canManageAsOwnerOrAdmin({ ...base, hasProject: false })).toBe(false);
+  });
+
+  it("routes a WorkOS-signed-in viewer through the role gate", () => {
+    const workos = { ...base, isWorkOsSignedIn: true };
+    expect(canManageAsOwnerOrAdmin({ ...workos, role: "owner" })).toBe(true);
+    expect(canManageAsOwnerOrAdmin({ ...workos, role: "admin" })).toBe(true);
+    // A member can VIEW these surfaces but must never get write affordances.
+    expect(canManageAsOwnerOrAdmin({ ...workos, role: "member" })).toBe(false);
+    expect(canManageAsOwnerOrAdmin({ ...workos, role: "guest" })).toBe(false);
+  });
+
+  it("denies a WorkOS viewer whose role has not resolved", () => {
+    // The anonymous-owner escape hatch must NOT leak to WorkOS users mid-load.
+    expect(
+      canManageAsOwnerOrAdmin({
+        ...base,
+        isWorkOsSignedIn: true,
+        role: undefined,
+      })
+    ).toBe(false);
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/useProjectEnvironments.ts
+++ b/mcpjam-inspector/client/src/hooks/useProjectEnvironments.ts
@@ -52,13 +52,17 @@ export function useProjectEnvironments(
 ): ProjectEnvironmentView[] | undefined {
   const { isAuthenticated } = useConvexAuth();
   const isUserReady = useDbUserReady();
+  // Send the SAME normalized id `shouldQueryProjectId` validated — a
+  // whitespace-padded id passes the guard but would target a different/invalid
+  // project if forwarded raw.
+  const normalizedProjectId = projectId?.trim() || null;
   const enableQuery =
-    isAuthenticated && isUserReady && shouldQueryProjectId(projectId);
+    isAuthenticated && isUserReady && shouldQueryProjectId(normalizedProjectId);
   return useQuery(
     "projectEnvironments:listEnvironments" as any,
     enableQuery
       ? ({
-          projectId,
+          projectId: normalizedProjectId,
           ...(options?.includeArchived ? { includeArchived: true } : {}),
         } as any)
       : "skip"

--- a/mcpjam-inspector/client/src/hooks/useProjectEnvironments.ts
+++ b/mcpjam-inspector/client/src/hooks/useProjectEnvironments.ts
@@ -1,0 +1,145 @@
+import { useMutation, useQuery, useConvexAuth } from "convex/react";
+import { useDbUserReady } from "@/contexts/db-user-ready-context";
+import { shouldQueryProjectId } from "@/hooks/useProjects";
+
+/**
+ * Client hooks for **Project environments** (mcpjam-backend
+ * `convex/projectEnvironments.ts`) — named, project-scoped, live-editable
+ * bundles of one host + optional standalone server group + optional pinned
+ * skill selection. Suites and journeys reference environments by id and the
+ * backend resolves/pins them at run start.
+ *
+ * NOT the same thing as Computer environments (`useComputerEnvironments.ts`,
+ * the e2b/Docker sandbox images — relabeled "Sandbox images" in UI). Like
+ * every backend surface here, Convex functions are referenced by string id;
+ * the types below are hand-mirrored (no codegen).
+ */
+
+export type ProjectEnvironmentSkillSelection = {
+  mode: "explicit";
+  skillIds: string[];
+};
+
+export interface ProjectEnvironmentView {
+  environmentId: string;
+  projectId: string;
+  name: string;
+  description?: string;
+  /** Exactly one host per environment. */
+  hostId: string;
+  /** Resolved for display by the backend list/get queries (wire-tolerant). */
+  hostName?: string | null;
+  /** Standalone server group scope; absent ⇒ the host's own server picks. */
+  serverAttachmentId?: string | null;
+  /** Additive standalone skill channel; absent ⇒ no env-channel skills. */
+  skillSelection?: ProjectEnvironmentSkillSelection | null;
+  /** Bumped on every effective edit; optimistic-concurrency token. */
+  revision: number;
+  /** Present ⇒ archived (hidden from pickers; launches fail fast). */
+  archivedAt?: number;
+  createdAt: number;
+  updatedAt: number;
+}
+
+/**
+ * Environments for a project. The management route passes
+ * `includeArchived: true`; suite/journey pickers use the live-only default.
+ * `undefined` while loading or when the query is skipped.
+ */
+export function useProjectEnvironments(
+  projectId: string | null,
+  options?: { includeArchived?: boolean }
+): ProjectEnvironmentView[] | undefined {
+  const { isAuthenticated } = useConvexAuth();
+  const isUserReady = useDbUserReady();
+  const enableQuery =
+    isAuthenticated && isUserReady && shouldQueryProjectId(projectId);
+  return useQuery(
+    "projectEnvironments:listEnvironments" as any,
+    enableQuery
+      ? ({
+          projectId,
+          ...(options?.includeArchived ? { includeArchived: true } : {}),
+        } as any)
+      : "skip"
+  ) as ProjectEnvironmentView[] | undefined;
+}
+
+/** One environment, or `null` when not visible. */
+export function useProjectEnvironment(
+  environmentId: string | null
+): ProjectEnvironmentView | null | undefined {
+  return useQuery(
+    "projectEnvironments:getEnvironment" as any,
+    environmentId ? ({ environmentId } as any) : "skip"
+  ) as ProjectEnvironmentView | null | undefined;
+}
+
+export function useCreateProjectEnvironment(): (args: {
+  projectId: string;
+  name: string;
+  description?: string;
+  hostId: string;
+  serverAttachmentId?: string | null;
+  skillSelection?: ProjectEnvironmentSkillSelection | null;
+}) => Promise<ProjectEnvironmentView> {
+  return useMutation("projectEnvironments:createEnvironment" as any) as never;
+}
+
+/**
+ * Update takes `expectedRevision` — the repo's expectedRevision pattern:
+ * capture the row's revision when the editor DRAFT is initialized/reset and
+ * send THAT captured value, never the newest reactive revision at submit
+ * time (substituting the fresh revision would let a stale draft silently
+ * overwrite a concurrent edit). On {@link isRevisionConflictError}, surface
+ * the conflict and reinitialize only after user confirmation — never
+ * auto-retry a stale patch.
+ */
+export function useUpdateProjectEnvironment(): (args: {
+  environmentId: string;
+  expectedRevision: number;
+  name?: string;
+  description?: string | null;
+  hostId?: string;
+  serverAttachmentId?: string | null;
+  skillSelection?: ProjectEnvironmentSkillSelection | null;
+}) => Promise<ProjectEnvironmentView> {
+  return useMutation("projectEnvironments:updateEnvironment" as any) as never;
+}
+
+export function useArchiveProjectEnvironment(): (args: {
+  environmentId: string;
+  expectedRevision: number;
+}) => Promise<ProjectEnvironmentView> {
+  return useMutation("projectEnvironments:archiveEnvironment" as any) as never;
+}
+
+export function useRestoreProjectEnvironment(): (args: {
+  environmentId: string;
+  expectedRevision: number;
+}) => Promise<ProjectEnvironmentView> {
+  return useMutation("projectEnvironments:restoreEnvironment" as any) as never;
+}
+
+/**
+ * True when a mutation rejection is the backend's stale-`expectedRevision`
+ * conflict. Wire-tolerant: matches the structured ConvexError code first and
+ * falls back to a message probe so a backend code rename degrades to a
+ * still-correct conflict toast rather than a generic failure.
+ */
+export function isRevisionConflictError(err: unknown): boolean {
+  const data = (err as { data?: unknown } | null)?.data;
+  if (data && typeof data === "object") {
+    const code = (data as { code?: unknown }).code;
+    if (
+      code === "CONFLICT" ||
+      code === "REVISION_CONFLICT" ||
+      code === "ENV_REVISION_CONFLICT"
+    ) {
+      return true;
+    }
+  }
+  const message =
+    typeof data === "string" ? data : err instanceof Error ? err.message : "";
+  return /revision/i.test(message) && /conflict|stale|changed/i.test(message);
+}

--- a/mcpjam-inspector/client/src/hooks/useProjectEnvironmentsEnabled.ts
+++ b/mcpjam-inspector/client/src/hooks/useProjectEnvironmentsEnabled.ts
@@ -1,0 +1,24 @@
+import { useFeatureFlagEnabled } from "posthog-js/react";
+
+export const PROJECT_ENVIRONMENTS_FEATURE_FLAG = "project-environments-enabled";
+
+/**
+ * Project Environments (named host + server group + pinned skills bundles)
+ * are gated behind a PostHog flag while the backend launch contract rolls
+ * out. Gates EVERY client exposure — sidebar item, suite settings row, and
+ * direct `/environments` navigation.
+ *
+ * `useFeatureFlagEnabled` returns `undefined` while flags load — treated as
+ * off (fail-closed) by {@link useProjectEnvironmentsEnabled}. Route guards
+ * that want to distinguish "loading" from "off" (to avoid bouncing a
+ * flagged-in user who cold-loads /environments) should use
+ * {@link useProjectEnvironmentsEnabledState} instead.
+ */
+export function useProjectEnvironmentsEnabled(): boolean {
+  return useFeatureFlagEnabled(PROJECT_ENVIRONMENTS_FEATURE_FLAG) === true;
+}
+
+/** Tri-state variant: `undefined` while PostHog flags are still loading. */
+export function useProjectEnvironmentsEnabledState(): boolean | undefined {
+  return useFeatureFlagEnabled(PROJECT_ENVIRONMENTS_FEATURE_FLAG);
+}

--- a/mcpjam-inspector/client/src/hooks/useProjects.ts
+++ b/mcpjam-inspector/client/src/hooks/useProjects.ts
@@ -263,6 +263,33 @@ export function canManageHosts(
   return role === "owner" || role === "admin";
 }
 
+/**
+ * Admin gate for surfaces that must ALSO stay writable for an anonymous Convex
+ * owner (Swarms, Project Environments).
+ *
+ * A WorkOS-signed-in viewer goes through the role-based gate above. An
+ * anonymous owner never produces a WorkOS email, so `useViewerProjectRole`
+ * leaves `role` undefined forever — yet they own their personal-org default
+ * project and clear the backend's `requireAdminAccess` via userId, so denying
+ * them would lock them out of their own project. They get management only once
+ * WorkOS has SETTLED (`identityLoading === false`): while it is still
+ * hydrating, an anonymous owner is indistinguishable from a member whose role
+ * hasn't loaded, so this fails CLOSED.
+ *
+ * Extracted from the route component so the branch is unit-testable — a future
+ * edit here cannot silently re-expose admin controls.
+ */
+export function canManageAsOwnerOrAdmin(args: {
+  isWorkOsSignedIn: boolean;
+  role: ProjectMembershipRole | undefined;
+  isAuthenticated: boolean;
+  hasProject: boolean;
+  identityLoading: boolean;
+}): boolean {
+  if (args.isWorkOsSignedIn) return canManageHosts(args.role);
+  return args.isAuthenticated && args.hasProject && !args.identityLoading;
+}
+
 // Resolve the *current viewer's* project-membership role for a project, reusing
 // the same members-list signal `ProjectSettingsTab` keys off. Returns
 // `role: undefined` while the members list is still loading (or when the viewer
@@ -292,9 +319,8 @@ export function useViewerProjectRole({
   const role = useMemo(() => {
     const email = viewerEmail?.trim().toLowerCase();
     if (!email) return undefined;
-    return activeMembers.find(
-      (member) => member.email.toLowerCase() === email
-    )?.role;
+    return activeMembers.find((member) => member.email.toLowerCase() === email)
+      ?.role;
   }, [activeMembers, viewerEmail]);
 
   return {

--- a/mcpjam-inspector/client/src/lib/apis/evals-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/evals-api.ts
@@ -107,6 +107,15 @@ type RunEvalsRequest = EvalRequestWithServers & {
    * parent row. Absent on single-host launches and legacy runs.
    */
   runGroupId?: string;
+  /**
+   * Project-environment launch: one POST per attached environment on a
+   * Run-all fan-out, always sent explicitly (even single-env). The request
+   * carries NO usable serverIds for these runs — the Inspector server
+   * resolves the environment's closed server set authoritatively and pins
+   * the resolved revision into the run. Must be declared at every wire
+   * boundary or it is silently stripped.
+   */
+  environmentId?: string;
 };
 
 type RunTestCaseRequest = EvalRequestWithServers & {

--- a/mcpjam-inspector/client/src/lib/apis/mcp-skills-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/mcp-skills-api.ts
@@ -4,6 +4,7 @@ import { webPost } from "@/lib/apis/web/base";
 import type {
   Skill,
   SkillListItem,
+  SkillPinnability,
   SkillProvenance,
   SkillFile,
   SkillFileContent,
@@ -41,6 +42,12 @@ interface CloudSkillWire {
   isOwner: boolean;
   /** Wire-tolerant; absent/unknown ⇒ 'authored'. */
   provenance?: string;
+  /**
+   * Project-environment pinnability (backend P0.3 list-field, forwarded
+   * verbatim by `/api/web/skills/list`). Declared explicitly so the mapping
+   * below can carry it; absent on older backends.
+   */
+  pinnability?: SkillPinnability;
   content?: string;
 }
 
@@ -59,6 +66,7 @@ function cloudToListItem(s: CloudSkillWire): SkillListItem {
     isOwner: s.isOwner,
     origin: "cloud",
     provenance: normalizeProvenance(s.provenance),
+    ...(s.pinnability ? { pinnability: s.pinnability } : {}),
   };
 }
 

--- a/mcpjam-inspector/client/src/lib/app-navigation.ts
+++ b/mcpjam-inspector/client/src/lib/app-navigation.ts
@@ -42,6 +42,7 @@ export const routePaths = {
   tracing: "/tracing",
   chatboxes: "/chatboxes",
   swarms: "/swarms",
+  environments: "/environments",
   playground: "/playground",
   support: "/support",
   settings: "/settings",

--- a/mcpjam-inspector/client/src/lib/app-routes.ts
+++ b/mcpjam-inspector/client/src/lib/app-routes.ts
@@ -81,6 +81,11 @@ export const APP_ROUTES: readonly AppRouteEntry[] = [
   },
   { path: "chatboxes", kind: "screen", surfaceId: "chatboxes" },
   { path: "swarms", kind: "screen", surfaceId: "swarms" },
+  {
+    path: "environments",
+    kind: "screen",
+    surfaceId: "project-environments",
+  },
   { path: "playground", kind: "screen", surfaceId: "playground" },
   { path: "support", kind: "screen", surfaceId: "support" },
   { path: "settings", kind: "screen", surfaceId: "settings" },

--- a/mcpjam-inspector/client/src/lib/convex-error.ts
+++ b/mcpjam-inspector/client/src/lib/convex-error.ts
@@ -1,0 +1,24 @@
+/**
+ * Extract a user-facing message from a Convex mutation/query rejection.
+ *
+ * Convex `ConvexError` payloads land on `err.data` (a string, or a record
+ * with `message`) — prefer that over `err.message`, which for an application
+ * error is the redacted "Server Error"/Request-ID string. Extracted from
+ * `EnvironmentsDrawer` so every Convex-backed management surface shares one
+ * error-shaping path.
+ */
+export function convexErrMessage(err: unknown, fallback: string): string {
+  if (err && typeof err === "object" && "data" in err) {
+    const data = (err as { data: unknown }).data;
+    if (typeof data === "string" && data.trim()) return data.slice(0, 400);
+    if (data && typeof data === "object" && "message" in data) {
+      const msg = (data as { message: unknown }).message;
+      if (typeof msg === "string" && msg.trim()) return msg.slice(0, 400);
+    }
+  }
+  if (err instanceof Error && err.message) {
+    // Fallback: strip the noisy server prefix from a plain thrown message.
+    return err.message.replace(/^\[.*?\]\s*/, "").slice(0, 400) || fallback;
+  }
+  return fallback;
+}

--- a/mcpjam-inspector/client/src/lib/swarm-api.ts
+++ b/mcpjam-inspector/client/src/lib/swarm-api.ts
@@ -31,6 +31,8 @@ export const SWARM_QUERIES = {
   /** Sessions-tab metric strip aggregates (project-wide or persona-scoped). */
   getSwarmSessionMetrics: "journeyRuns:getSwarmSessionMetrics",
   listRunningPersonaRefIds: "journeyRuns:listRunningPersonaRefIds",
+  /** Project environments picker (env-based journeys — flag-gated UI). */
+  listEnvironments: "projectEnvironments:listEnvironments",
 } as const;
 
 // ── Convex action names (string-keyed calls) ────────────────────────────────
@@ -59,10 +61,49 @@ export interface JourneyRunSummary {
 
 export interface JourneyHostSummary {
   hostId: string;
+  /**
+   * Opaque execution-target id (Project Environments). Present on fresh runs
+   * (both `host:`- and `environment:`-shaped — treated as OPAQUE, never
+   * parsed); absent on historical pre-environments rows. Two same-host env
+   * targets produce two summary rows distinguished only by this.
+   */
+  targetId?: string;
   total: number;
   succeeded: number;
   failed: number;
   rateLimited: number;
+}
+
+/**
+ * Permissive mirror of one `snapshot.hosts[]` execution target — ONLY the
+ * fields the UI joins on for per-target display (label + session-id identity).
+ * The full pinned spec stays server-side.
+ */
+export interface JourneySnapshotTarget {
+  hostId: string;
+  hostName?: string;
+  targetId?: string;
+  /** Present on ENVIRONMENT-based targets; the session-id mint and env labels
+   * key on this — never on `targetId`. */
+  environmentRef?: { environmentId: string; name: string; revision: number };
+  serverAttachmentId?: string;
+}
+
+/**
+ * Hand-mirrored `projectEnvironments:listEnvironments` row subset the Swarms
+ * surface needs (picker labels + compat-host recompute). `skillSelection` is
+ * inline per backend #767 (no skill-group ref).
+ */
+export interface EnvironmentView {
+  environmentId: string;
+  projectId: string;
+  name: string;
+  description?: string;
+  hostId: string;
+  serverAttachmentId?: string | null;
+  skillSelection?: { mode: "explicit"; skillIds: string[] } | null;
+  revision: number;
+  archivedAt?: number;
 }
 
 /**
@@ -95,6 +136,12 @@ export interface JourneyRun {
   status: JourneyRunStatus | string;
   summary: JourneyRunSummary;
   hostSummaries: JourneyHostSummary[];
+  /**
+   * Immutable run snapshot (the full run doc rides `listJourneyRuns`). Only
+   * the target-join subset is mirrored; permissive so older rows (no
+   * `targetId`/`environmentRef`) stay valid.
+   */
+  snapshot?: { hosts?: JourneySnapshotTarget[] };
   /** Judge rollup for this run's sessions (absent until first grading). */
   goalScoreSummary?: GoalScoreRollup;
   createdAt: number;
@@ -246,9 +293,13 @@ export interface PersonaTrackRecord {
   sessionExamples?: unknown[];
 }
 
-/** One host's outcome rollup within {@link JourneyRollup}. */
+/** One execution TARGET's outcome rollup within {@link JourneyRollup}. Env
+ * target rows carry `targetId`; legacy/host rows have none (the backend strips
+ * host-shaped target ids so pre-environments rows and fresh host targets group
+ * identically). `hostId` is the CURRENT display host. */
 export interface JourneyHostRollup {
   hostId: string;
+  targetId?: string;
   total: number;
   succeeded: number;
   failed: number;
@@ -437,11 +488,13 @@ export async function streamJourneyRun(
   }
 }
 
-/** Deterministic attempt chatSessionId — matches the swarm runner claim key. */
-export function swarmAttemptChatSessionId(
-  runId: string,
-  hostId: string,
-  sessionIndex: number,
-): string {
-  return `synth_${runId}_${hostId}_${sessionIndex}`;
-}
+/**
+ * Deterministic attempt chatSessionId — the SHARED mint (D1), re-exported so
+ * the client mirror can never drift from the runner's claim key. Legacy host
+ * targets pass `{ hostId }` (byte-identical to the historical form); env
+ * targets pass `{ hostId, environmentId }` from `environmentRef.environmentId`.
+ */
+export {
+  swarmAttemptChatSessionId,
+  type SwarmSessionTargetIdentity,
+} from "@/shared/swarm-session-id";

--- a/mcpjam-inspector/client/src/router.tsx
+++ b/mcpjam-inspector/client/src/router.tsx
@@ -7,6 +7,7 @@ import App, {
   CiEvalsRoute,
   ConformanceRoute,
   CaniuseCapabilityRoute,
+  EnvironmentsRoute,
   CompatibilityRoute,
   ComputerRoute,
   EvalsRoute,
@@ -103,6 +104,10 @@ const ROUTE_ELEMENTS: Record<
   // `/swarms` — project-scoped Persona → Journey → Run surface (`SwarmsTab`)
   // with Journeys + Sessions views. Same billing feature as chatboxes.
   swarms: { element: <SwarmsRoute /> },
+  // `/environments` — project environments management. The route component
+  // enforces the `project-environments-enabled` flag itself (redirects when
+  // off), so registration here does not expose the dark feature.
+  environments: { element: <EnvironmentsRoute /> },
   playground: { element: <PlaygroundRoute /> },
   support: { element: <SupportRoute /> },
   settings: { element: <SettingsRoute /> },

--- a/mcpjam-inspector/server/routes/shared/__tests__/evals.test.ts
+++ b/mcpjam-inspector/server/routes/shared/__tests__/evals.test.ts
@@ -53,6 +53,40 @@ function buildTestCaseRequest(runs?: number): unknown {
   };
 }
 
+describe("RunEvalsRequestSchema environmentId boundary", () => {
+  it("accepts AND preserves environmentId (guards the silent-strip failure mode)", () => {
+    const base = buildSuiteRequest() as Record<string, unknown>;
+    const result = RunEvalsRequestSchema.safeParse({
+      ...base,
+      environmentId: "env_123",
+    });
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.environmentId).toBe("env_123");
+  });
+
+  it("accepts an environment launch with NO server ids", () => {
+    const base = buildSuiteRequest() as Record<string, unknown>;
+    const result = RunEvalsRequestSchema.safeParse({
+      ...base,
+      serverIds: [],
+      environmentId: "env_123",
+    });
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.serverIds).toEqual([]);
+  });
+
+  it("still preserves runGroupId alongside environmentId", () => {
+    const base = buildSuiteRequest() as Record<string, unknown>;
+    const result = RunEvalsRequestSchema.safeParse({
+      ...base,
+      environmentId: "env_123",
+      runGroupId: "group-1",
+    });
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.runGroupId).toBe("group-1");
+  });
+});
+
 describe("RunEvalsRequestSchema runs cap", () => {
   it("accepts runs up to 10", () => {
     const result = RunEvalsRequestSchema.safeParse(

--- a/mcpjam-inspector/server/routes/shared/evals.ts
+++ b/mcpjam-inspector/server/routes/shared/evals.ts
@@ -45,7 +45,7 @@ import {
 } from "../../utils/export-helpers.js";
 import { sanitizeForConvexTransport } from "../../services/evals/convex-sanitize.js";
 import {
-  environmentServerRefs,
+  environmentServerIds,
   resolveEnvironmentForLaunch,
   type ResolvedEnvironmentForLaunch,
 } from "../../services/evals/environment-launch.js";
@@ -1562,7 +1562,7 @@ export async function prepareEvalRun(
   }
 
   const resolvedServerIds = resolveServerIdsOrThrow(
-    environmentLaunch ? environmentServerRefs(environmentLaunch) : serverIds,
+    environmentLaunch ? environmentServerIds(environmentLaunch) : serverIds,
     clientManager
   );
   const persistedServerRefs =

--- a/mcpjam-inspector/server/routes/shared/evals.ts
+++ b/mcpjam-inspector/server/routes/shared/evals.ts
@@ -45,6 +45,11 @@ import {
 } from "../../utils/export-helpers.js";
 import { sanitizeForConvexTransport } from "../../services/evals/convex-sanitize.js";
 import {
+  environmentServerRefs,
+  resolveEnvironmentForLaunch,
+  type ResolvedEnvironmentForLaunch,
+} from "../../services/evals/environment-launch.js";
+import {
   countModelSteps,
   isModelFree,
   normalizePromptTurns,
@@ -235,9 +240,13 @@ export const RunEvalsRequestSchema = z.object({
         return { ...test, steps: wireTestToSteps(test) };
       })
   ),
-  serverIds: z
-    .array(z.string())
-    .min(1, { message: "At least one server must be selected" }),
+  // Non-empty for legacy launches; environment launches (environmentId set)
+  // send NO server ids — the browser never knows an environment's closed
+  // execution set, `prepareEvalRun` resolves it authoritatively (P0.1) and
+  // enforces the ≥1-server rule for legacy requests at runtime (a `.min(1)`
+  // here would reject every env launch; a `.superRefine` would break the
+  // hosted variant's `.omit`).
+  serverIds: z.array(z.string()),
   serverNames: z.array(z.string()).optional(),
   chatboxId: z.string().optional(),
   accessVersion: z.number().int().nonnegative().optional(),
@@ -303,6 +312,19 @@ export const RunEvalsRequestSchema = z.object({
    * unknown keys are stripped silently.
    */
   runGroupId: z.string().optional(),
+  /**
+   * Project-environment launch (one per attached env on a Run-all fan-out;
+   * always sent explicitly, even single-env). `prepareEvalRun` resolves the
+   * environment's closed server set via
+   * `projectEnvironments:resolveEnvironmentForLaunch` BEFORE server
+   * connection/tool capture, uses it INSTEAD of browser-supplied
+   * `serverIds`, and forwards the resolved revision to `startTestSuiteRun`
+   * as `expectedEnvironmentRevision` (stale ⇒ structured 409, no run row).
+   *
+   * Must be declared explicitly on every Zod boundary in the wire path;
+   * unknown keys are stripped silently.
+   */
+  environmentId: z.string().optional(),
 });
 
 export type RunEvalsRequest = z.infer<typeof RunEvalsRequestSchema>;
@@ -1448,6 +1470,7 @@ export async function prepareEvalRun(
     namedHostId,
     refreshSnapshot,
     runGroupId,
+    environmentId,
     source,
     idempotencyKey,
   } = request;
@@ -1507,12 +1530,45 @@ export async function prepareEvalRun(
     assertSuiteRunWithinCap(request);
   }
 
-  const resolvedServerIds = resolveServerIdsOrThrow(serverIds, clientManager);
+  const { convexClient, convexHttpUrl } = createConvexClients(convexAuthToken);
+
+  // Environment launch (P0.1): resolve the environment's closed execution
+  // set BEFORE server resolution and tool capture, and use it INSTEAD of
+  // any browser-supplied serverIds. The resolved revision travels to the
+  // run-start mutation as `expectedEnvironmentRevision`, so a
+  // resolve-to-mutation edit rejects rather than pairing a tool snapshot
+  // from one environment revision with a run snapshot from another.
+  let environmentLaunch: ResolvedEnvironmentForLaunch | undefined;
+  if (environmentId) {
+    if (!projectId) {
+      throw new WebRouteError(
+        400,
+        ErrorCode.VALIDATION_ERROR,
+        "projectId is required for environment runs"
+      );
+    }
+    environmentLaunch = await resolveEnvironmentForLaunch(convexClient, {
+      projectId,
+      environmentId,
+    });
+  } else if (serverIds.length === 0) {
+    // Legacy launches keep the old ≥1-server contract; enforced here (not
+    // in Zod) because environment launches legitimately send none.
+    throw new WebRouteError(
+      400,
+      ErrorCode.VALIDATION_ERROR,
+      "At least one server must be selected"
+    );
+  }
+
+  const resolvedServerIds = resolveServerIdsOrThrow(
+    environmentLaunch ? environmentServerRefs(environmentLaunch) : serverIds,
+    clientManager
+  );
   const persistedServerRefs =
-    storageServerIds && storageServerIds.length > 0
+    !environmentLaunch && storageServerIds && storageServerIds.length > 0
       ? storageServerIds
       : resolvedServerIds;
-  const { convexClient, convexHttpUrl } = createConvexClients(convexAuthToken);
   const { toolSnapshot, toolSnapshotDebug } =
     await captureToolSnapshotForEvalAuthoring(
       clientManager,
@@ -1562,6 +1618,8 @@ export async function prepareEvalRun(
     matchOptionsOverride,
     namedHostId,
     runGroupId,
+    environmentId,
+    expectedEnvironmentRevision: environmentLaunch?.environmentRef.revision,
     source,
     idempotencyKey,
   });

--- a/mcpjam-inspector/server/routes/shared/evals.ts
+++ b/mcpjam-inspector/server/routes/shared/evals.ts
@@ -340,6 +340,17 @@ type RunEvalsWithManagerRequest = RunEvalsRequest & {
    * passes its trigger id so claim retries can never double-create a run.
    */
   idempotencyKey?: string;
+  /**
+   * Pre-resolved environment from the caller's manager-priming preflight (the
+   * hosted `/run` route and the scheduled worker resolve the environment ONCE
+   * to connect its closed set). When present — and for the same
+   * `environmentId` — `prepareEvalRun` reuses THIS resolution, including its
+   * revision, instead of re-resolving. That makes `expectedEnvironmentRevision`
+   * describe the exact set the manager was connected with, so an environment
+   * edit after the preflight fails the run-start revision check (clean 409 /
+   * retry) rather than pairing a stale manager with a newer run snapshot.
+   */
+  resolvedEnvironment?: ResolvedEnvironmentForLaunch;
 };
 
 export const RunTestCaseRequestSchema = z.object({
@@ -1471,6 +1482,7 @@ export async function prepareEvalRun(
     refreshSnapshot,
     runGroupId,
     environmentId,
+    resolvedEnvironment,
     source,
     idempotencyKey,
   } = request;
@@ -1547,10 +1559,19 @@ export async function prepareEvalRun(
         "projectId is required for environment runs"
       );
     }
-    environmentLaunch = await resolveEnvironmentForLaunch(convexClient, {
-      projectId,
-      environmentId,
-    });
+    // Reuse the caller's preflight resolution when it is for THIS environment
+    // (the manager was primed from it) so the revision we assert equals the
+    // one we connected — a same-key edit after the preflight then loses the
+    // revision check instead of silently pairing a stale manager with a newer
+    // snapshot. Fall back to resolving here for callers that didn't preflight.
+    environmentLaunch =
+      resolvedEnvironment &&
+      resolvedEnvironment.environmentRef.environmentId === environmentId
+        ? resolvedEnvironment
+        : await resolveEnvironmentForLaunch(convexClient, {
+            projectId,
+            environmentId,
+          });
   } else if (serverIds.length === 0) {
     // Legacy launches keep the old ≥1-server contract; enforced here (not
     // in Zod) because environment launches legitimately send none.

--- a/mcpjam-inspector/server/routes/v1/__tests__/eval-edit.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/eval-edit.test.ts
@@ -403,7 +403,13 @@ describe("v1 eval-edit routes", () => {
     )![1];
     expect(args.enabled).toBe(false);
     const body = (await res.json()) as any;
-    expect(body.schedule).toEqual({ enabled: false, intervalMinutes: 60 });
+    expect(body.schedule).toEqual({
+      enabled: false,
+      intervalMinutes: 60,
+      // Project-environment schedule pin (read-only DTO field); this suite
+      // has none.
+      environmentId: null,
+    });
   });
 
   it("re-enabling without interval reuses the suite's saved interval", async () => {

--- a/mcpjam-inspector/server/routes/v1/evals.ts
+++ b/mcpjam-inspector/server/routes/v1/evals.ts
@@ -928,6 +928,11 @@ function toSuiteDetailDto(suite: SuiteDoc, execConfig: any) {
             : {}),
         }))
       : [],
+    // Attach-ordered project environments. READ-ONLY on the public API in
+    // this release — the write path is an explicit follow-up decision.
+    environmentIds: Array.isArray(suite.environmentIds)
+      ? suite.environmentIds.map(String)
+      : [],
     settings: {
       minimumAccuracy:
         typeof suite.defaultPassCriteria?.minimumPassRate === "number"
@@ -949,6 +954,9 @@ function toSuiteDetailDto(suite: SuiteDoc, execConfig: any) {
         typeof suite.schedule?.intervalMinutes === "number"
           ? suite.schedule.intervalMinutes
           : null,
+      environmentId: suite.schedule?.environmentId
+        ? String(suite.schedule.environmentId)
+        : null,
     },
     createdAt: suite.createdAt ?? null,
     updatedAt: suite.updatedAt ?? null,

--- a/mcpjam-inspector/server/routes/v1/evals.ts
+++ b/mcpjam-inspector/server/routes/v1/evals.ts
@@ -284,6 +284,16 @@ const createEvalRunSchema = RunEvalsRequestSchema.omit({
   })
   .refine((body) => body.suiteId || (body.serverIds?.length ?? 0) > 0, {
     message: "serverIds are required when creating a new suite",
+  })
+  // Environment runs need the pre-connection resolution the hosted `/run`
+  // route performs; the public surface connects the suite's saved selection
+  // before `prepareEvalRun`, so an `environmentId` here would run against the
+  // wrong servers. Reject it explicitly rather than silently ignore — public
+  // environment launches are a deferred follow-up (plan A9).
+  .refine((body) => !body.environmentId, {
+    message:
+      "environmentId is not supported on the public API yet — run environment suites from the app.",
+    path: ["environmentId"],
   });
 
 // ── Author-only suite-create schema ──────────────────────────────────

--- a/mcpjam-inspector/server/routes/web/errors.ts
+++ b/mcpjam-inspector/server/routes/web/errors.ts
@@ -32,6 +32,12 @@ export const ErrorCode = {
   // drops `code`; clients branch on the top-level `reason:
   // "xaa_connection_not_configured"`, not this code.
   XAA_CONNECTION_NOT_CONFIGURED: "XAA_CONNECTION_NOT_CONFIGURED",
+  // A project-environment eval launch resolved one environment revision but
+  // the environment changed before `startTestSuiteRun` inserted the run
+  // (`expectedEnvironmentRevision` mismatch, backend ENV_REVISION_CONFLICT).
+  // 409; interactive callers surface "Environment changed — retry the run",
+  // the scheduled worker retries through its trigger/idempotency path.
+  ENVIRONMENT_REVISION_CONFLICT: "ENVIRONMENT_REVISION_CONFLICT",
 } as const;
 
 export type ErrorCode = (typeof ErrorCode)[keyof typeof ErrorCode];

--- a/mcpjam-inspector/server/routes/web/evals.ts
+++ b/mcpjam-inspector/server/routes/web/evals.ts
@@ -2,7 +2,10 @@ import { Hono } from "hono";
 import { captureServerEvent } from "../../utils/analytics.js";
 import { z } from "zod";
 import { createConvexClient } from "../../services/evals/route-helpers.js";
-import { resolveEnvironmentForLaunch } from "../../services/evals/environment-launch.js";
+import {
+  environmentServerRefs,
+  resolveEnvironmentForLaunch,
+} from "../../services/evals/environment-launch.js";
 import { detachPreparedEvalRun } from "../../services/evals/detached-run.js";
 import { prepareSuiteReplayFromRun } from "../../services/evals/replay-suite-run.js";
 import { runTraceRepairJob } from "../../services/evals/trace-repair-runner.js";
@@ -148,8 +151,8 @@ evals.post("/run", async (c) =>
           },
         );
         rawBody.serverIds = resolved.selectedServerIds;
-        if (resolved.selectedServerNames?.length) {
-          rawBody.serverNames = resolved.selectedServerNames;
+        if (resolved.servers?.length) {
+          rawBody.serverNames = environmentServerRefs(resolved);
         }
       }
       const connection = await createManualHostedConnection(

--- a/mcpjam-inspector/server/routes/web/evals.ts
+++ b/mcpjam-inspector/server/routes/web/evals.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { captureServerEvent } from "../../utils/analytics.js";
 import { z } from "zod";
 import { createConvexClient } from "../../services/evals/route-helpers.js";
+import { resolveEnvironmentForLaunch } from "../../services/evals/environment-launch.js";
 import { detachPreparedEvalRun } from "../../services/evals/detached-run.js";
 import { prepareSuiteReplayFromRun } from "../../services/evals/replay-suite-run.js";
 import { runTraceRepairJob } from "../../services/evals/trace-repair-runner.js";
@@ -63,7 +64,16 @@ const hostedRunEvalsSchema = RunEvalsRequestSchema.omit({
   projectId: true,
   serverIds: true,
   convexAuthToken: true,
-}).extend(hostedBatchSchema.shape);
+})
+  .extend(hostedBatchSchema.shape)
+  .extend({
+    // Environment launches (environmentId set) arrive with NO server ids —
+    // the /run route primes the batch from the authoritative environment
+    // resolution below, so the batch schema's `.min(1)` would reject them
+    // before the priming result is validated. Legacy launches still hit the
+    // ≥1-server rule in `prepareEvalRun`.
+    serverIds: z.array(z.string().min(1)),
+  });
 
 const hostedRunTestCaseSchema = RunTestCaseRequestSchema.omit({
   serverIds: true,
@@ -117,9 +127,34 @@ evals.post("/run", async (c) =>
   handleRoute(
     c,
     async () => {
+      const rawBody = await readJsonBody<Record<string, unknown>>(c);
+      // Environment launches carry no browser serverIds (the browser never
+      // knows an environment's closed execution set). Prime the hosted
+      // connection batch from the authoritative resolution so the manager
+      // connects exactly that set; `prepareEvalRun` re-resolves and the
+      // run-start mutation's `expectedEnvironmentRevision` check rejects
+      // any environment edit interleaved between the two resolutions.
+      if (
+        typeof rawBody.environmentId === "string" &&
+        rawBody.environmentId &&
+        typeof rawBody.projectId === "string" &&
+        rawBody.projectId
+      ) {
+        const resolved = await resolveEnvironmentForLaunch(
+          createConvexClient(assertBearerToken(c)),
+          {
+            projectId: rawBody.projectId,
+            environmentId: rawBody.environmentId,
+          },
+        );
+        rawBody.serverIds = resolved.selectedServerIds;
+        if (resolved.selectedServerNames?.length) {
+          rawBody.serverNames = resolved.selectedServerNames;
+        }
+      }
       const connection = await createManualHostedConnection(
         c,
-        await readJsonBody<Record<string, unknown>>(c),
+        rawBody,
         hostedRunEvalsSchema,
       );
       const { manager, body, convexAuthToken } = connection;

--- a/mcpjam-inspector/server/routes/web/evals.ts
+++ b/mcpjam-inspector/server/routes/web/evals.ts
@@ -3,7 +3,8 @@ import { captureServerEvent } from "../../utils/analytics.js";
 import { z } from "zod";
 import { createConvexClient } from "../../services/evals/route-helpers.js";
 import {
-  environmentServerRefs,
+  environmentServerIds,
+  environmentServerNames,
   resolveEnvironmentForLaunch,
 } from "../../services/evals/environment-launch.js";
 import { detachPreparedEvalRun } from "../../services/evals/detached-run.js";
@@ -150,9 +151,14 @@ evals.post("/run", async (c) =>
             environmentId: rawBody.environmentId,
           },
         );
-        rawBody.serverIds = resolved.selectedServerIds;
-        if (resolved.servers?.length) {
-          rawBody.serverNames = environmentServerRefs(resolved);
+        // Prime the ephemeral manager with the live-healed server IDs (not the
+        // raw closed set) so the batch we authorize/connect matches the IDs
+        // `resolveServerIdsOrThrow` later looks up — a server deleted and
+        // re-added under the same name resolves to its current id in both.
+        rawBody.serverIds = environmentServerIds(resolved);
+        const serverNames = environmentServerNames(resolved);
+        if (serverNames.length) {
+          rawBody.serverNames = serverNames;
         }
       }
       const connection = await createManualHostedConnection(

--- a/mcpjam-inspector/server/routes/web/evals.ts
+++ b/mcpjam-inspector/server/routes/web/evals.ts
@@ -6,7 +6,9 @@ import {
   environmentServerIds,
   environmentServerNames,
   resolveEnvironmentForLaunch,
+  type ResolvedEnvironmentForLaunch,
 } from "../../services/evals/environment-launch.js";
+import { getConvexBearerForRequest } from "../../utils/v1-convex-token.js";
 import { detachPreparedEvalRun } from "../../services/evals/detached-run.js";
 import { prepareSuiteReplayFromRun } from "../../services/evals/replay-suite-run.js";
 import { runTraceRepairJob } from "../../services/evals/trace-repair-runner.js";
@@ -135,17 +137,23 @@ evals.post("/run", async (c) =>
       // Environment launches carry no browser serverIds (the browser never
       // knows an environment's closed execution set). Prime the hosted
       // connection batch from the authoritative resolution so the manager
-      // connects exactly that set; `prepareEvalRun` re-resolves and the
-      // run-start mutation's `expectedEnvironmentRevision` check rejects
-      // any environment edit interleaved between the two resolutions.
+      // connects exactly that set, then hand the SAME resolution to
+      // `prepareEvalRun` so `expectedEnvironmentRevision` describes what the
+      // manager connected — an environment edit after this preflight then
+      // fails the run-start revision check instead of being missed.
+      let preflightEnvironment: ResolvedEnvironmentForLaunch | undefined;
       if (
         typeof rawBody.environmentId === "string" &&
         rawBody.environmentId &&
         typeof rawBody.projectId === "string" &&
         rawBody.projectId
       ) {
-        const resolved = await resolveEnvironmentForLaunch(
-          createConvexClient(assertBearerToken(c)),
+        // Convert an `sk_` API-key bearer to the short-lived delegated JWT the
+        // Convex query surface requires (same conversion the hosted connection
+        // uses); the raw key would 401 the resolver for API-key callers.
+        const bearer = await getConvexBearerForRequest(c);
+        preflightEnvironment = await resolveEnvironmentForLaunch(
+          createConvexClient(bearer),
           {
             projectId: rawBody.projectId,
             environmentId: rawBody.environmentId,
@@ -155,8 +163,8 @@ evals.post("/run", async (c) =>
         // raw closed set) so the batch we authorize/connect matches the IDs
         // `resolveServerIdsOrThrow` later looks up — a server deleted and
         // re-added under the same name resolves to its current id in both.
-        rawBody.serverIds = environmentServerIds(resolved);
-        const serverNames = environmentServerNames(resolved);
+        rawBody.serverIds = environmentServerIds(preflightEnvironment);
+        const serverNames = environmentServerNames(preflightEnvironment);
         if (serverNames.length) {
           rawBody.serverNames = serverNames;
         }
@@ -173,6 +181,9 @@ evals.post("/run", async (c) =>
         prepared = await prepareEvalRun(manager, {
           ...body,
           convexAuthToken,
+          ...(preflightEnvironment
+            ? { resolvedEnvironment: preflightEnvironment }
+            : {}),
         });
       } catch (error) {
         await manager.disconnectAllServers().catch(() => {});

--- a/mcpjam-inspector/server/services/__tests__/swarm-agent.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/swarm-agent.test.ts
@@ -185,11 +185,12 @@ describe("swarm-agent reportAttempt — targetId echo", () => {
   });
 
   it("spreads targetId into the body when present and omits it when absent", async () => {
-    fetchMock.mockResolvedValue(
-      new Response(JSON.stringify({ ok: true, applied: true }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      })
+    fetchMock.mockImplementation(
+      async () =>
+        new Response(JSON.stringify({ ok: true, applied: true }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
     );
 
     await reportAttempt(CONVEX_HTTP_URL, "b", {

--- a/mcpjam-inspector/server/services/__tests__/swarm-agent.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/swarm-agent.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createJourneyRun } from "../swarm-agent.js";
+import {
+  createJourneyRun,
+  fetchPinnedSkill,
+  PinnedSkillIntegrityError,
+  reportAttempt,
+} from "../swarm-agent.js";
 
 /**
  * CONTRACT-LEVEL tests for the inspector→backend journey-execution boundary.
@@ -77,5 +82,142 @@ describe("swarm-agent createJourneyRun — request-body contract", () => {
     // And the bearer is forwarded as a JWT for the JWT-only Convex HTTP action.
     const headers = (init as RequestInit).headers as Record<string, string>;
     expect(headers.Authorization).toBe("Bearer bearer-token");
+  });
+});
+
+describe("swarm-agent fetchPinnedSkill — wire contract", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const okSkill = (contentHash: string) => ({
+    ok: true,
+    skill: {
+      name: "sk",
+      description: "d",
+      content: "# body",
+      contentHash,
+    },
+  });
+
+  it("GETs /journey-execution/runs/skill with URL-ENCODED query params + bearer", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify(okSkill("h 1+2")), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+
+    const skill = await fetchPinnedSkill(CONVEX_HTTP_URL, "bearer-token", {
+      projectId: "proj/1",
+      runId: "run-1",
+      targetId: "environment:env&1",
+      contentHash: "h 1+2",
+    });
+    expect(skill.content).toBe("# body");
+
+    const [url, init] = fetchMock.mock.calls[0]!;
+    const parsed = new URL(String(url));
+    expect(parsed.pathname).toBe("/journey-execution/runs/skill");
+    // Decoded params round-trip the raw values — i.e. they were encoded.
+    expect(parsed.searchParams.get("projectId")).toBe("proj/1");
+    expect(parsed.searchParams.get("targetId")).toBe("environment:env&1");
+    expect(parsed.searchParams.get("contentHash")).toBe("h 1+2");
+    expect(parsed.searchParams.get("runId")).toBe("run-1");
+    expect((init as RequestInit).method).toBe("GET");
+    expect(
+      new Headers((init as RequestInit).headers).get("Authorization")
+    ).toBe("Bearer bearer-token");
+  });
+
+  it("surfaces a 404 as SwarmAgentError with status 404 (non-retryable downstream)", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ ok: false, code: "not_found" }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+    await expect(
+      fetchPinnedSkill(CONVEX_HTTP_URL, "b", {
+        projectId: "p",
+        runId: "r",
+        targetId: "t",
+        contentHash: "h",
+      })
+    ).rejects.toMatchObject({ name: "SwarmAgentError", status: 404 });
+  });
+
+  it("rejects a served hash that does not match the requested one (integrity)", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify(okSkill("other-hash")), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+    await expect(
+      fetchPinnedSkill(CONVEX_HTTP_URL, "b", {
+        projectId: "p",
+        runId: "r",
+        targetId: "t",
+        contentHash: "requested-hash",
+      })
+    ).rejects.toBeInstanceOf(PinnedSkillIntegrityError);
+  });
+});
+
+describe("swarm-agent reportAttempt — targetId echo", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("spreads targetId into the body when present and omits it when absent", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ ok: true, applied: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+
+    await reportAttempt(CONVEX_HTTP_URL, "b", {
+      projectId: "p",
+      runId: "r",
+      hostId: "h",
+      targetId: "environment:e1",
+      sessionIdx: 0,
+      status: "running",
+      chatSessionId: "synth_r_env_e1_0",
+    });
+    const withTarget = JSON.parse(
+      (fetchMock.mock.calls[0]![1] as RequestInit).body as string
+    );
+    expect(withTarget.targetId).toBe("environment:e1");
+    expect(withTarget.hostId).toBe("h");
+
+    await reportAttempt(CONVEX_HTTP_URL, "b", {
+      projectId: "p",
+      runId: "r",
+      hostId: "h",
+      sessionIdx: 0,
+      status: "running",
+      chatSessionId: "synth_r_h_0",
+    });
+    const withoutTarget = JSON.parse(
+      (fetchMock.mock.calls[1]![1] as RequestInit).body as string
+    );
+    expect("targetId" in withoutTarget).toBe(false);
   });
 });

--- a/mcpjam-inspector/server/services/evals/__tests__/environment-launch.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/environment-launch.test.ts
@@ -13,7 +13,10 @@ const RESOLVED: ResolvedEnvironmentForLaunch = {
   environmentRef: { environmentId: "env-1", name: "Staging", revision: 4 },
   hostId: "host-1",
   selectedServerIds: ["ps_1", "ps_2"],
-  selectedServerNames: ["linear", "asana"],
+  servers: [
+    { serverId: "ps_1", name: "linear" },
+    { serverId: "ps_2", name: "asana" },
+  ],
 };
 
 function fakeConvexClient(result: unknown) {
@@ -23,17 +26,21 @@ function fakeConvexClient(result: unknown) {
 }
 
 describe("environmentServerRefs", () => {
-  it("prefers the runtime server-name projection", () => {
+  it("prefers the live-healed server-name projection", () => {
     expect(environmentServerRefs(RESOLVED)).toEqual(["linear", "asana"]);
   });
 
-  it("falls back to ids when names are absent or empty", () => {
+  it("falls back to ids when the healed projection is absent or empty", () => {
     expect(
-      environmentServerRefs({ ...RESOLVED, selectedServerNames: undefined })
+      environmentServerRefs({
+        ...RESOLVED,
+        servers: undefined as unknown as ResolvedEnvironmentForLaunch["servers"],
+      })
     ).toEqual(["ps_1", "ps_2"]);
-    expect(
-      environmentServerRefs({ ...RESOLVED, selectedServerNames: [] })
-    ).toEqual(["ps_1", "ps_2"]);
+    expect(environmentServerRefs({ ...RESOLVED, servers: [] })).toEqual([
+      "ps_1",
+      "ps_2",
+    ]);
   });
 });
 

--- a/mcpjam-inspector/server/services/evals/__tests__/environment-launch.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/environment-launch.test.ts
@@ -45,7 +45,8 @@ describe("environmentServerIds", () => {
     expect(
       environmentServerIds({
         ...RESOLVED,
-        servers: undefined as unknown as ResolvedEnvironmentForLaunch["servers"],
+        servers:
+          undefined as unknown as ResolvedEnvironmentForLaunch["servers"],
       })
     ).toEqual(["ps_1", "ps_2"]);
     expect(environmentServerIds({ ...RESOLVED, servers: [] })).toEqual([
@@ -61,6 +62,15 @@ describe("environmentServerNames", () => {
   });
 
   it("is empty when the backend omits the healed projection", () => {
+    // Both spellings of "omitted": absent (an older backend that predates the
+    // healed projection) and present-but-empty.
+    expect(
+      environmentServerNames({
+        ...RESOLVED,
+        servers:
+          undefined as unknown as ResolvedEnvironmentForLaunch["servers"],
+      })
+    ).toEqual([]);
     expect(environmentServerNames({ ...RESOLVED, servers: [] })).toEqual([]);
   });
 });

--- a/mcpjam-inspector/server/services/evals/__tests__/environment-launch.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/environment-launch.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import { ConvexError } from "convex/values";
+import {
+  environmentRevisionConflictError,
+  environmentServerRefs,
+  isEnvironmentRevisionConflict,
+  resolveEnvironmentForLaunch,
+  type ResolvedEnvironmentForLaunch,
+} from "../environment-launch";
+import { WebRouteError } from "../../../routes/web/errors";
+
+const RESOLVED: ResolvedEnvironmentForLaunch = {
+  environmentRef: { environmentId: "env-1", name: "Staging", revision: 4 },
+  hostId: "host-1",
+  selectedServerIds: ["ps_1", "ps_2"],
+  selectedServerNames: ["linear", "asana"],
+};
+
+function fakeConvexClient(result: unknown) {
+  return {
+    query: async () => result,
+  } as unknown as Parameters<typeof resolveEnvironmentForLaunch>[0];
+}
+
+describe("environmentServerRefs", () => {
+  it("prefers the runtime server-name projection", () => {
+    expect(environmentServerRefs(RESOLVED)).toEqual(["linear", "asana"]);
+  });
+
+  it("falls back to ids when names are absent or empty", () => {
+    expect(
+      environmentServerRefs({ ...RESOLVED, selectedServerNames: undefined })
+    ).toEqual(["ps_1", "ps_2"]);
+    expect(
+      environmentServerRefs({ ...RESOLVED, selectedServerNames: [] })
+    ).toEqual(["ps_1", "ps_2"]);
+  });
+});
+
+describe("resolveEnvironmentForLaunch", () => {
+  it("returns the resolver's closed set untouched", async () => {
+    const resolved = await resolveEnvironmentForLaunch(
+      fakeConvexClient(RESOLVED),
+      { projectId: "p_1", environmentId: "env-1" }
+    );
+    expect(resolved).toEqual(RESOLVED);
+  });
+
+  it("404s a null / malformed resolution instead of running server-less", async () => {
+    for (const bad of [null, {}, { environmentRef: {} }]) {
+      await expect(
+        resolveEnvironmentForLaunch(fakeConvexClient(bad), {
+          projectId: "p_1",
+          environmentId: "env-1",
+        })
+      ).rejects.toMatchObject({ status: 404 });
+    }
+  });
+
+  it("maps a missing backend function to a readable 400 (deploy-order skew)", async () => {
+    const client = {
+      query: async () => {
+        throw new Error(
+          "Could not find public function for 'projectEnvironments:resolveEnvironmentForLaunch'"
+        );
+      },
+    } as unknown as Parameters<typeof resolveEnvironmentForLaunch>[0];
+    await expect(
+      resolveEnvironmentForLaunch(client, {
+        projectId: "p_1",
+        environmentId: "env-1",
+      })
+    ).rejects.toMatchObject({ status: 400 });
+  });
+});
+
+describe("isEnvironmentRevisionConflict", () => {
+  it("matches the structured ConvexError code", () => {
+    expect(
+      isEnvironmentRevisionConflict(
+        new ConvexError({ code: "ENV_REVISION_CONFLICT", expected: 3 })
+      )
+    ).toBe(true);
+    expect(
+      isEnvironmentRevisionConflict(new ConvexError({ code: "CONFLICT" }))
+    ).toBe(true);
+  });
+
+  it("falls back to a message probe, but never matches unrelated errors", () => {
+    expect(
+      isEnvironmentRevisionConflict(
+        new Error("environment revision conflict: expected 3, found 4")
+      )
+    ).toBe(true);
+    expect(isEnvironmentRevisionConflict(new Error("quota exceeded"))).toBe(
+      false
+    );
+    expect(isEnvironmentRevisionConflict(new Error("revision conflict"))).toBe(
+      false
+    );
+  });
+
+  it("shapes the interactive 409 with the retry copy", () => {
+    const err = environmentRevisionConflictError();
+    expect(err).toBeInstanceOf(WebRouteError);
+    expect(err.status).toBe(409);
+    expect(err.message).toMatch(/Environment changed — retry the run/);
+  });
+});

--- a/mcpjam-inspector/server/services/evals/__tests__/environment-launch.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/environment-launch.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from "vitest";
 import { ConvexError } from "convex/values";
 import {
   environmentRevisionConflictError,
-  environmentServerRefs,
+  environmentServerIds,
+  environmentServerNames,
   isEnvironmentRevisionConflict,
   resolveEnvironmentForLaunch,
   type ResolvedEnvironmentForLaunch,
@@ -25,22 +26,42 @@ function fakeConvexClient(result: unknown) {
   } as unknown as Parameters<typeof resolveEnvironmentForLaunch>[0];
 }
 
-describe("environmentServerRefs", () => {
-  it("prefers the live-healed server-name projection", () => {
-    expect(environmentServerRefs(RESOLVED)).toEqual(["linear", "asana"]);
+describe("environmentServerIds", () => {
+  it("prefers the live-healed server ids (manager keys by id, not name)", () => {
+    expect(environmentServerIds(RESOLVED)).toEqual(["ps_1", "ps_2"]);
   });
 
-  it("falls back to ids when the healed projection is absent or empty", () => {
+  it("returns the healed id when a server was deleted and re-added (id != raw)", () => {
     expect(
-      environmentServerRefs({
+      environmentServerIds({
+        ...RESOLVED,
+        selectedServerIds: ["ps_stale"],
+        servers: [{ serverId: "ps_live", name: "linear" }],
+      })
+    ).toEqual(["ps_live"]);
+  });
+
+  it("falls back to the raw closed set when the healed projection is absent or empty", () => {
+    expect(
+      environmentServerIds({
         ...RESOLVED,
         servers: undefined as unknown as ResolvedEnvironmentForLaunch["servers"],
       })
     ).toEqual(["ps_1", "ps_2"]);
-    expect(environmentServerRefs({ ...RESOLVED, servers: [] })).toEqual([
+    expect(environmentServerIds({ ...RESOLVED, servers: [] })).toEqual([
       "ps_1",
       "ps_2",
     ]);
+  });
+});
+
+describe("environmentServerNames", () => {
+  it("projects display names aligned with the healed ids", () => {
+    expect(environmentServerNames(RESOLVED)).toEqual(["linear", "asana"]);
+  });
+
+  it("is empty when the backend omits the healed projection", () => {
+    expect(environmentServerNames({ ...RESOLVED, servers: [] })).toEqual([]);
   });
 });
 

--- a/mcpjam-inspector/server/services/evals/environment-launch.ts
+++ b/mcpjam-inspector/server/services/evals/environment-launch.ts
@@ -35,16 +35,33 @@ export interface ResolvedEnvironmentForLaunch {
 }
 
 /**
- * Runtime server refs for manager connection / eval execution: the eval
- * pipeline keys managers by runtime server NAME, so prefer the live-healed
- * `servers` name projection and fall back to raw ids when it is empty.
+ * Server IDs for manager priming / connection / lookup. The eval manager keys
+ * every server by its Convex server ID (`createAuthorizedManager` →
+ * `effectiveAuthByServerId`), so both the manager batch and
+ * `resolveServerIdsOrThrow` must use IDs, never names. Prefer the live-healed
+ * `servers[].serverId` (delete + re-add-same-name resolves to the current id
+ * and matches the batch we connect) and fall back to the raw closed set only
+ * when the backend omits the healed projection.
  */
-export function environmentServerRefs(
+export function environmentServerIds(
+  resolved: ResolvedEnvironmentForLaunch
+): string[] {
+  return resolved.servers && resolved.servers.length > 0
+    ? resolved.servers.map((s) => s.serverId)
+    : resolved.selectedServerIds;
+}
+
+/**
+ * Display names aligned by index with {@link environmentServerIds}, for the
+ * manager's `serverNames` projection. Empty when the backend omits the healed
+ * projection (the manager then falls back to showing the server id).
+ */
+export function environmentServerNames(
   resolved: ResolvedEnvironmentForLaunch
 ): string[] {
   return resolved.servers && resolved.servers.length > 0
     ? resolved.servers.map((s) => s.name)
-    : resolved.selectedServerIds;
+    : [];
 }
 
 export async function resolveEnvironmentForLaunch(

--- a/mcpjam-inspector/server/services/evals/environment-launch.ts
+++ b/mcpjam-inspector/server/services/evals/environment-launch.ts
@@ -1,0 +1,110 @@
+/**
+ * Project-environment launch resolution for eval suite runs (backend P0.1).
+ *
+ * An environment run never trusts browser-supplied server ids: the backend's
+ * member-read query `projectEnvironments:resolveEnvironmentForLaunch` returns
+ * the closed execution preview for ONE environment revision, and
+ * `startTestSuiteRun` re-checks that revision (`expectedEnvironmentRevision`)
+ * before inserting any run row — so a tool snapshot from one revision can
+ * never pair with a Convex run snapshot from another.
+ *
+ * Hand-mirrored contract (no codegen; string function refs like the rest of
+ * the inspector→Convex surface).
+ */
+import type { ConvexHttpClient } from "convex/browser";
+import { ErrorCode, WebRouteError } from "../../routes/web/errors.js";
+
+export interface ResolvedEnvironmentForLaunch {
+  environmentRef: {
+    environmentId: string;
+    name: string;
+    revision: number;
+  };
+  hostId: string;
+  hostConfigId?: string;
+  /** The closed server selection (Convex projectServer ids). */
+  selectedServerIds: string[];
+  /** Stable runtime server names for the same selection (wire-tolerant). */
+  selectedServerNames?: string[];
+  serverAttachmentId?: string | null;
+}
+
+/**
+ * Runtime server refs for manager connection / eval execution: the eval
+ * pipeline keys managers by runtime server NAME, so prefer the name
+ * projection and fall back to ids when the backend omits it.
+ */
+export function environmentServerRefs(
+  resolved: ResolvedEnvironmentForLaunch
+): string[] {
+  return resolved.selectedServerNames && resolved.selectedServerNames.length > 0
+    ? resolved.selectedServerNames
+    : resolved.selectedServerIds;
+}
+
+export async function resolveEnvironmentForLaunch(
+  convexClient: ConvexHttpClient,
+  args: { projectId: string; environmentId: string }
+): Promise<ResolvedEnvironmentForLaunch> {
+  let raw: unknown;
+  try {
+    raw = await convexClient.query(
+      "projectEnvironments:resolveEnvironmentForLaunch" as any,
+      args
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (/could not find public function/i.test(message)) {
+      // Deploy-order skew: the P0.1 backend contract isn't deployed yet.
+      throw new WebRouteError(
+        400,
+        ErrorCode.VALIDATION_ERROR,
+        "This deployment cannot resolve project environments yet. Retry after the backend deploys."
+      );
+    }
+    throw error;
+  }
+  const resolved = raw as ResolvedEnvironmentForLaunch | null;
+  if (
+    !resolved ||
+    !resolved.environmentRef ||
+    typeof resolved.environmentRef.revision !== "number" ||
+    !Array.isArray(resolved.selectedServerIds)
+  ) {
+    throw new WebRouteError(
+      404,
+      ErrorCode.NOT_FOUND,
+      "Environment not found (it may have been archived). Update the suite's environments and retry."
+    );
+  }
+  return resolved;
+}
+
+/**
+ * True when a `startTestSuiteRun` rejection is the backend's structured
+ * `expectedEnvironmentRevision` mismatch. Matched on the ConvexError data
+ * code with a message fallback (wire-tolerant across backend renames).
+ */
+export function isEnvironmentRevisionConflict(error: unknown): boolean {
+  const data = (error as { data?: unknown } | null)?.data;
+  if (data && typeof data === "object") {
+    const code = (data as { code?: unknown }).code;
+    if (code === "ENV_REVISION_CONFLICT" || code === "CONFLICT") return true;
+  }
+  const message =
+    typeof data === "string"
+      ? data
+      : error instanceof Error
+      ? error.message
+      : "";
+  return /environment/i.test(message) && /revision|conflict/i.test(message);
+}
+
+/** The readable 409 interactive callers surface for a revision conflict. */
+export function environmentRevisionConflictError(): WebRouteError {
+  return new WebRouteError(
+    409,
+    ErrorCode.ENVIRONMENT_REVISION_CONFLICT,
+    "Environment changed — retry the run."
+  );
+}

--- a/mcpjam-inspector/server/services/evals/environment-launch.ts
+++ b/mcpjam-inspector/server/services/evals/environment-launch.ts
@@ -21,24 +21,29 @@ export interface ResolvedEnvironmentForLaunch {
     revision: number;
   };
   hostId: string;
+  hostName?: string;
   hostConfigId?: string;
-  /** The closed server selection (Convex projectServer ids). */
+  /** The raw closed server selection (Convex server ids) — do not substitute. */
   selectedServerIds: string[];
-  /** Stable runtime server names for the same selection (wire-tolerant). */
-  selectedServerNames?: string[];
+  /**
+   * Live-healed connectable projection of `selectedServerIds`: each id healed
+   * to its current live server (delete + re-add-same-name), genuinely-gone
+   * servers dropped, deduped by live id, in selection order.
+   */
+  servers: Array<{ serverId: string; name: string }>;
   serverAttachmentId?: string | null;
 }
 
 /**
  * Runtime server refs for manager connection / eval execution: the eval
- * pipeline keys managers by runtime server NAME, so prefer the name
- * projection and fall back to ids when the backend omits it.
+ * pipeline keys managers by runtime server NAME, so prefer the live-healed
+ * `servers` name projection and fall back to raw ids when it is empty.
  */
 export function environmentServerRefs(
   resolved: ResolvedEnvironmentForLaunch
 ): string[] {
-  return resolved.selectedServerNames && resolved.selectedServerNames.length > 0
-    ? resolved.selectedServerNames
+  return resolved.servers && resolved.servers.length > 0
+    ? resolved.servers.map((s) => s.name)
     : resolved.selectedServerIds;
 }
 

--- a/mcpjam-inspector/server/services/evals/recorder.ts
+++ b/mcpjam-inspector/server/services/evals/recorder.ts
@@ -16,6 +16,10 @@ import { finalizeEvalIteration } from "./finalize-iteration.js";
 import { resolveCaseSuccessPredicates } from "@/shared/eval-matching";
 import { ErrorCode, WebRouteError } from "../../routes/web/errors.js";
 import { ConvexError } from "convex/values";
+import {
+  environmentRevisionConflictError,
+  isEnvironmentRevisionConflict,
+} from "./environment-launch.js";
 
 type IterationStatus = "completed" | "failed" | "cancelled";
 // Run-level (not per-iteration) terminal stop reason, threaded into the
@@ -322,6 +326,8 @@ export const startSuiteRunWithRecorder = async ({
   matchOptionsOverride,
   namedHostId,
   runGroupId,
+  environmentId,
+  expectedEnvironmentRevision,
   source,
   idempotencyKey,
 }: {
@@ -381,6 +387,20 @@ export const startSuiteRunWithRecorder = async ({
    */
   runGroupId?: string;
   /**
+   * Project-environment launch: the environment this run resolves and
+   * pins. Threaded into `startTestSuiteRun` (which snapshots
+   * `configSnapshot.environmentRef`). Must be declared here or a
+   * reconstruction of the mutation args would silently drop it.
+   */
+  environmentId?: string;
+  /**
+   * The environment revision `prepareEvalRun` resolved (and captured the
+   * tool snapshot against). The mutation compares it to the environment's
+   * current revision BEFORE inserting any run row and rejects a mismatch
+   * with structured conflict data — see `environment-launch.ts`.
+   */
+  expectedEnvironmentRevision?: number;
+  /**
    * Run origin persisted on `testSuiteRun.source` for audit attribution.
    * Omitted means 'ui' (backend default); the public /api/v1 surface
    * passes 'api'; the scheduled-evals worker passes 'schedule'.
@@ -411,6 +431,10 @@ export const startSuiteRunWithRecorder = async ({
         matchOptionsOverride,
         ...(namedHostId ? { namedHostId } : {}),
         ...(runGroupId ? { runGroupId } : {}),
+        ...(environmentId ? { environmentId } : {}),
+        ...(expectedEnvironmentRevision !== undefined
+          ? { expectedEnvironmentRevision }
+          : {}),
         ...(source ? { source } : {}),
         ...(idempotencyKey ? { idempotencyKey } : {}),
       }
@@ -422,6 +446,16 @@ export const startSuiteRunWithRecorder = async ({
     const billing = asBillingRouteError(error);
     if (billing) {
       throw billing;
+    }
+    // The environment changed between prepareEvalRun's resolution and the
+    // run-start mutation (`expectedEnvironmentRevision` mismatch): no run
+    // row exists. Interactive callers surface the readable 409; the
+    // scheduled worker's trigger/idempotency path retries naturally.
+    if (
+      expectedEnvironmentRevision !== undefined &&
+      isEnvironmentRevisionConflict(error)
+    ) {
+      throw environmentRevisionConflictError();
     }
     throw error;
   }

--- a/mcpjam-inspector/server/services/scheduled-evals-worker.ts
+++ b/mcpjam-inspector/server/services/scheduled-evals-worker.ts
@@ -30,7 +30,8 @@ import {
 import { fetchSuiteRunServerSelection } from "../routes/v1/evals.js";
 import { createConvexClient } from "./evals/route-helpers.js";
 import {
-  environmentServerRefs,
+  environmentServerIds,
+  environmentServerNames,
   resolveEnvironmentForLaunch,
 } from "./evals/environment-launch.js";
 
@@ -197,8 +198,8 @@ export async function executeClaimedRun(
             },
           );
           return {
-            serverIds: resolved.selectedServerIds,
-            serverNames: environmentServerRefs(resolved),
+            serverIds: environmentServerIds(resolved),
+            serverNames: environmentServerNames(resolved),
           };
         })()
       : await fetchSuiteRunServerSelection(bearer, claimed.suiteId, undefined);

--- a/mcpjam-inspector/server/services/scheduled-evals-worker.ts
+++ b/mcpjam-inspector/server/services/scheduled-evals-worker.ts
@@ -33,6 +33,7 @@ import {
   environmentServerIds,
   environmentServerNames,
   resolveEnvironmentForLaunch,
+  type ResolvedEnvironmentForLaunch,
 } from "./evals/environment-launch.js";
 
 const POLL_INTERVAL_MS = 15_000;
@@ -185,10 +186,16 @@ export async function executeClaimedRun(
     );
     // Environment claims connect the environment's authoritatively resolved
     // closed set, not the suite's saved selection — the saved selection
-    // predates (or ignores) the pinned environment. prepareEvalRun
-    // re-resolves; a revision moved between the two resolutions rejects at
-    // the run-start mutation and the trigger's idempotency path retries.
-    const selection = claimed.environmentId
+    // predates (or ignores) the pinned environment. The SAME resolution is
+    // handed to prepareEvalRun (`resolvedEnvironment`), so the revision the
+    // run-start mutation asserts matches the set the manager connected; an
+    // environment edit after this point loses the revision check and the
+    // trigger's idempotency path retries cleanly.
+    const selection: {
+      serverIds: string[];
+      serverNames: string[];
+      resolvedEnvironment?: ResolvedEnvironmentForLaunch;
+    } = claimed.environmentId
       ? await (async () => {
           const resolved = await resolveEnvironmentForLaunch(
             createConvexClient(bearer),
@@ -200,6 +207,7 @@ export async function executeClaimedRun(
           return {
             serverIds: environmentServerIds(resolved),
             serverNames: environmentServerNames(resolved),
+            resolvedEnvironment: resolved,
           };
         })()
       : await fetchSuiteRunServerSelection(bearer, claimed.suiteId, undefined);
@@ -239,6 +247,9 @@ export async function executeClaimedRun(
         source: "schedule",
         ...(claimed.environmentId
           ? { environmentId: claimed.environmentId }
+          : {}),
+        ...(selection.resolvedEnvironment
+          ? { resolvedEnvironment: selection.resolvedEnvironment }
           : {}),
         // Claim retries can never double-create a run: the mutation's
         // idempotency lookup wins over the 30s fingerprint window.

--- a/mcpjam-inspector/server/services/scheduled-evals-worker.ts
+++ b/mcpjam-inspector/server/services/scheduled-evals-worker.ts
@@ -29,7 +29,10 @@ import {
 } from "../routes/shared/evals.js";
 import { fetchSuiteRunServerSelection } from "../routes/v1/evals.js";
 import { createConvexClient } from "./evals/route-helpers.js";
-import { resolveEnvironmentForLaunch } from "./evals/environment-launch.js";
+import {
+  environmentServerRefs,
+  resolveEnvironmentForLaunch,
+} from "./evals/environment-launch.js";
 
 const POLL_INTERVAL_MS = 15_000;
 const POLL_JITTER_MS = 5_000;
@@ -195,11 +198,7 @@ export async function executeClaimedRun(
           );
           return {
             serverIds: resolved.selectedServerIds,
-            serverNames:
-              resolved.selectedServerNames &&
-              resolved.selectedServerNames.length > 0
-                ? resolved.selectedServerNames
-                : resolved.selectedServerIds,
+            serverNames: environmentServerRefs(resolved),
           };
         })()
       : await fetchSuiteRunServerSelection(bearer, claimed.suiteId, undefined);

--- a/mcpjam-inspector/server/services/scheduled-evals-worker.ts
+++ b/mcpjam-inspector/server/services/scheduled-evals-worker.ts
@@ -28,6 +28,8 @@ import {
   type PreparedEvalRun,
 } from "../routes/shared/evals.js";
 import { fetchSuiteRunServerSelection } from "../routes/v1/evals.js";
+import { createConvexClient } from "./evals/route-helpers.js";
+import { resolveEnvironmentForLaunch } from "./evals/environment-launch.js";
 
 const POLL_INTERVAL_MS = 15_000;
 const POLL_JITTER_MS = 5_000;
@@ -44,6 +46,14 @@ type ClaimedScheduledRun = {
   projectId: string | null;
   createdByExternalId: string;
   scheduledFor: number;
+  /**
+   * The schedule's pinned project environment (required for multi-env
+   * suites, defaulted for single-env, null for legacy suites). The worker
+   * MUST forward it to `prepareEvalRun` regardless of any browser feature
+   * flag — claims are data-driven. Optional for wire tolerance against a
+   * backend that predates the field.
+   */
+  environmentId?: string | null;
 };
 
 export function isScheduledEvalsWorkerEnabled(): boolean {
@@ -169,11 +179,30 @@ export async function executeClaimedRun(
       claimed.createdByExternalId,
       claimed.organizationId,
     );
-    const selection = await fetchSuiteRunServerSelection(
-      bearer,
-      claimed.suiteId,
-      undefined,
-    );
+    // Environment claims connect the environment's authoritatively resolved
+    // closed set, not the suite's saved selection — the saved selection
+    // predates (or ignores) the pinned environment. prepareEvalRun
+    // re-resolves; a revision moved between the two resolutions rejects at
+    // the run-start mutation and the trigger's idempotency path retries.
+    const selection = claimed.environmentId
+      ? await (async () => {
+          const resolved = await resolveEnvironmentForLaunch(
+            createConvexClient(bearer),
+            {
+              projectId: claimed.projectId!,
+              environmentId: claimed.environmentId!,
+            },
+          );
+          return {
+            serverIds: resolved.selectedServerIds,
+            serverNames:
+              resolved.selectedServerNames &&
+              resolved.selectedServerNames.length > 0
+                ? resolved.selectedServerNames
+                : resolved.selectedServerIds,
+          };
+        })()
+      : await fetchSuiteRunServerSelection(bearer, claimed.suiteId, undefined);
 
     // Empty caller context = plain-JWT caller (locked by caller-context
     // contract test); the delegated JWT is the principal.
@@ -200,12 +229,17 @@ export async function executeClaimedRun(
     try {
       prepared = await prepareEvalRun(manager, {
         suiteId: claimed.suiteId,
+        // Non-null here (the no-project guard above returned already).
+        projectId: claimed.projectId ?? undefined,
         tests: [],
         serverIds: selection.serverIds,
         serverNames: selection.serverNames,
         convexAuthToken: bearer,
         suiteRerun: true,
         source: "schedule",
+        ...(claimed.environmentId
+          ? { environmentId: claimed.environmentId }
+          : {}),
         // Claim retries can never double-create a run: the mutation's
         // idempotency lookup wins over the 30s fingerprint window.
         idempotencyKey: claimed.triggerId,

--- a/mcpjam-inspector/server/services/sessionSimulation/__tests__/pinned-skill-cache.test.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/__tests__/pinned-skill-cache.test.ts
@@ -129,6 +129,38 @@ describe("pinned-skill cache", () => {
     expect(calls).toBe(1);
   });
 
+  it("caller abort detaches only that caller — the shared fetch still populates the cache for others", async () => {
+    let calls = 0;
+    let release!: () => void;
+    const gate = new Promise<void>((r) => (release = r));
+    const fetcher = async () => {
+      calls++;
+      await gate;
+      return artifact("h1");
+    };
+    const ac = new AbortController();
+    // Caller A owns its own signal; caller B coalesces onto the same fetch.
+    const pA = resolvePinnedSkillCached({
+      projectId: "p1",
+      contentHash: "h1",
+      fetcher,
+      signal: ac.signal,
+    });
+    const pB = resolvePinnedSkillCached({
+      projectId: "p1",
+      contentHash: "h1",
+      fetcher,
+    });
+    // A cancels; B (and the shared fetch) must be unaffected.
+    ac.abort();
+    await expect(pA).rejects.toMatchObject({ name: "AbortError" });
+    release();
+    const b = await pB;
+    expect(b.contentHash).toBe("h1");
+    expect(calls).toBe(1); // one shared fetch, never restarted by A's abort
+    expect(__pinnedSkillCacheSizeForTest()).toBe(1); // cache populated despite A
+  });
+
   it("keys by project too — same hash in two projects is two entries", async () => {
     let calls = 0;
     const fetcher = async () => {

--- a/mcpjam-inspector/server/services/sessionSimulation/__tests__/pinned-skill-cache.test.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/__tests__/pinned-skill-cache.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  __clearPinnedSkillCacheForTest,
+  __pinnedSkillCacheSizeForTest,
+  isRetryablePinnedSkillError,
+  resolvePinnedSkillCached,
+} from "../pinned-skill-cache.js";
+import {
+  PinnedSkillIntegrityError,
+  SwarmAgentError,
+} from "../../swarm-agent.js";
+import type { PinnedSkillArtifact } from "../../../../shared/skill-types.js";
+
+const artifact = (contentHash: string): PinnedSkillArtifact => ({
+  name: "s",
+  description: "d",
+  content: "body",
+  contentHash,
+});
+
+afterEach(() => {
+  __clearPinnedSkillCacheForTest();
+});
+
+describe("pinned-skill cache", () => {
+  it("caches by (projectId, contentHash): second resolve hits without refetch", async () => {
+    let calls = 0;
+    const fetcher = async () => {
+      calls++;
+      return artifact("h1");
+    };
+    const a = await resolvePinnedSkillCached({
+      projectId: "p1",
+      contentHash: "h1",
+      fetcher,
+    });
+    const b = await resolvePinnedSkillCached({
+      projectId: "p1",
+      contentHash: "h1",
+      fetcher,
+    });
+    expect(a).toBe(b);
+    expect(calls).toBe(1);
+    expect(__pinnedSkillCacheSizeForTest()).toBe(1);
+  });
+
+  it("coalesces concurrent in-flight fetches (two targets, one fetch)", async () => {
+    let calls = 0;
+    let release!: () => void;
+    const gate = new Promise<void>((r) => (release = r));
+    const fetcher = async () => {
+      calls++;
+      await gate;
+      return artifact("h1");
+    };
+    const p1 = resolvePinnedSkillCached({
+      projectId: "p1",
+      contentHash: "h1",
+      fetcher,
+    });
+    const p2 = resolvePinnedSkillCached({
+      projectId: "p1",
+      contentHash: "h1",
+      fetcher,
+    });
+    release();
+    const [a, b] = await Promise.all([p1, p2]);
+    expect(calls).toBe(1);
+    expect(a).toBe(b);
+  });
+
+  it("NEVER caches failures: after a rejected fetch the next caller fetches fresh", async () => {
+    let calls = 0;
+    const failing = async () => {
+      calls++;
+      throw new SwarmAgentError(404, "", "not found");
+    };
+    await expect(
+      resolvePinnedSkillCached({
+        projectId: "p1",
+        contentHash: "h1",
+        fetcher: failing,
+        retryDelaysMs: [0, 0],
+      }),
+    ).rejects.toThrow("not found");
+    expect(__pinnedSkillCacheSizeForTest()).toBe(0);
+    // Next caller retries fresh (and can succeed).
+    const ok = await resolvePinnedSkillCached({
+      projectId: "p1",
+      contentHash: "h1",
+      fetcher: async () => artifact("h1"),
+    });
+    expect(ok.contentHash).toBe("h1");
+    // 404 is non-retryable: the failing fetcher ran exactly once.
+    expect(calls).toBe(1);
+  });
+
+  it("retries transient failures twice, then succeeds", async () => {
+    let calls = 0;
+    const flaky = async () => {
+      calls++;
+      if (calls < 3) throw new SwarmAgentError(503, "", "unavailable");
+      return artifact("h1");
+    };
+    const got = await resolvePinnedSkillCached({
+      projectId: "p1",
+      contentHash: "h1",
+      fetcher: flaky,
+      retryDelaysMs: [0, 0],
+    });
+    expect(got.contentHash).toBe("h1");
+    expect(calls).toBe(3);
+  });
+
+  it("does NOT retry a hash-mismatch (integrity) error", async () => {
+    let calls = 0;
+    const bad = async () => {
+      calls++;
+      throw new PinnedSkillIntegrityError("hash mismatch");
+    };
+    await expect(
+      resolvePinnedSkillCached({
+        projectId: "p1",
+        contentHash: "h1",
+        fetcher: bad,
+        retryDelaysMs: [0, 0],
+      }),
+    ).rejects.toThrow("hash mismatch");
+    expect(calls).toBe(1);
+  });
+
+  it("keys by project too — same hash in two projects is two entries", async () => {
+    let calls = 0;
+    const fetcher = async () => {
+      calls++;
+      return artifact("h1");
+    };
+    await resolvePinnedSkillCached({ projectId: "p1", contentHash: "h1", fetcher });
+    await resolvePinnedSkillCached({ projectId: "p2", contentHash: "h1", fetcher });
+    expect(calls).toBe(2);
+    expect(__pinnedSkillCacheSizeForTest()).toBe(2);
+  });
+});
+
+describe("isRetryablePinnedSkillError", () => {
+  it("classifies per the policy: 5xx/transport retry; 404/integrity/abort never", () => {
+    expect(isRetryablePinnedSkillError(new SwarmAgentError(500, "", "x"))).toBe(true);
+    expect(isRetryablePinnedSkillError(new TypeError("fetch failed"))).toBe(true);
+    expect(isRetryablePinnedSkillError(new SwarmAgentError(404, "", "x"))).toBe(false);
+    expect(
+      isRetryablePinnedSkillError(new PinnedSkillIntegrityError("x")),
+    ).toBe(false);
+    const abort = new Error("aborted");
+    abort.name = "AbortError";
+    expect(isRetryablePinnedSkillError(abort)).toBe(false);
+  });
+});

--- a/mcpjam-inspector/server/services/sessionSimulation/__tests__/swarm-runner.test.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/__tests__/swarm-runner.test.ts
@@ -16,6 +16,7 @@ const heartbeatJourneyRunMock = vi.fn();
 const runSyntheticHostSessionMock = vi.fn();
 
 const finalizePendingAttemptsMock = vi.fn();
+const fetchPinnedSkillMock = vi.fn();
 
 vi.mock("../../swarm-agent.js", async () => {
   const actual =
@@ -30,6 +31,7 @@ vi.mock("../../swarm-agent.js", async () => {
     heartbeatJourneyRun: (...args: unknown[]) => heartbeatJourneyRunMock(...args),
     finalizePendingAttempts: (...args: unknown[]) =>
       finalizePendingAttemptsMock(...args),
+    fetchPinnedSkill: (...args: unknown[]) => fetchPinnedSkillMock(...args),
   };
 });
 
@@ -49,6 +51,8 @@ import {
   getRunningJourneyStreamHub,
   MAX_CONCURRENT_HOSTS,
 } from "../swarm-runner.js";
+import { __clearPinnedSkillCacheForTest } from "../pinned-skill-cache.js";
+import { SwarmAgentError } from "../../swarm-agent.js";
 
 const HOST = {
   hostId: "host-1",
@@ -105,6 +109,8 @@ beforeEach(() => {
   runSyntheticHostSessionMock.mockReset().mockResolvedValue({
     outcome: "succeeded",
   });
+  fetchPinnedSkillMock.mockReset();
+  __clearPinnedSkillCacheForTest();
 });
 
 afterEach(() => {
@@ -720,5 +726,194 @@ describe("swarm runner — live stream emit", () => {
     for (const call of runSyntheticHostSessionMock.mock.calls) {
       expect(typeof (call[0] as { emit?: unknown }).emit).toBe("function");
     }
+  });
+});
+
+describe("swarm fan-out runner — environment targets (Project Environments)", () => {
+  const ENV_TARGET_A = {
+    ...HOST,
+    targetId: "environment:envA",
+    environmentRef: { environmentId: "envA", name: "Env A", revision: 1 },
+    pinnedSkills: [
+      {
+        skillId: "sk1",
+        name: "sk-one",
+        description: "d",
+        contentHash: "hash-1",
+        sharing: "project" as const,
+      },
+    ],
+  };
+  const ENV_TARGET_B = {
+    ...HOST, // SAME host as A — two env targets sharing one host.
+    targetId: "environment:envB",
+    environmentRef: { environmentId: "envB", name: "Env B", revision: 2 },
+    // Skill-less env target: pinned mode with an EMPTY authoritative set.
+  };
+
+  const pinnedArtifact = (contentHash: string) => ({
+    name: "sk-one",
+    description: "d",
+    content: "# body",
+    contentHash,
+  });
+
+  it("two SAME-HOST env targets mint distinct env session ids and claim with their targetId", async () => {
+    fetchPinnedSkillMock.mockResolvedValue(pinnedArtifact("hash-1"));
+
+    await startJourneyRun(
+      baseOpts({ hosts: [ENV_TARGET_A, ENV_TARGET_B], sessionsPerHost: 2 })
+    );
+
+    const sessionIds = runSyntheticHostSessionMock.mock.calls
+      .map((c) => (c[0] as any).chatSessionId)
+      .sort();
+    expect(sessionIds).toEqual([
+      "synth_run-1_env_envA_0",
+      "synth_run-1_env_envA_1",
+      "synth_run-1_env_envB_0",
+      "synth_run-1_env_envB_1",
+    ]);
+
+    // Every claim carried the target's opaque targetId + the shared hostId.
+    const claims = reportAttemptMock.mock.calls
+      .map((c) => c[2] as any)
+      .filter((a) => a.status === "running");
+    expect(claims.every((a) => a.hostId === "host-1")).toBe(true);
+    const claimTargets = claims.map((a) => a.targetId).sort();
+    expect(claimTargets).toEqual([
+      "environment:envA",
+      "environment:envA",
+      "environment:envB",
+      "environment:envB",
+    ]);
+    // Terminals echo targetId too.
+    const terminals = reportAttemptMock.mock.calls
+      .map((c) => c[2] as any)
+      .filter((a) => a.status !== "running");
+    expect(terminals.every((a) => typeof a.targetId === "string")).toBe(true);
+  });
+
+  it("delivers pinned skill BODIES to the session runtime (authoritative array), and an empty pin set as []", async () => {
+    fetchPinnedSkillMock.mockResolvedValue(pinnedArtifact("hash-1"));
+
+    await startJourneyRun(
+      baseOpts({ hosts: [ENV_TARGET_A, ENV_TARGET_B], sessionsPerHost: 1 })
+    );
+
+    const adapters = runSyntheticHostSessionMock.mock.calls.map(
+      (c) => c[0] as any
+    );
+    const a = adapters.find((x) => x.chatSessionId === "synth_run-1_env_envA_0");
+    expect(a.runtime.pinnedSkills).toHaveLength(1);
+    expect(a.runtime.pinnedSkills[0]).toMatchObject({
+      name: "sk-one",
+      contentHash: "hash-1",
+      content: "# body",
+    });
+    // Persist attribution carries the targetId (chat-ingestion echo).
+    expect(a.persist.targetId).toBe("environment:envA");
+
+    const b = adapters.find((x) => x.chatSessionId === "synth_run-1_env_envB_0");
+    // Skill-less env target: authoritative EMPTY array — NEVER undefined
+    // (undefined would fall back to the live pool).
+    expect(b.runtime.pinnedSkills).toEqual([]);
+  });
+
+  it("caches pinned bodies by (projectId, contentHash): one fetch even across two targets pinning the same hash", async () => {
+    fetchPinnedSkillMock.mockResolvedValue(pinnedArtifact("hash-1"));
+    const envTargetC = {
+      ...ENV_TARGET_A,
+      targetId: "environment:envC",
+      environmentRef: { environmentId: "envC", name: "Env C", revision: 1 },
+    };
+
+    await startJourneyRun(
+      baseOpts({ hosts: [ENV_TARGET_A, envTargetC], sessionsPerHost: 1 })
+    );
+
+    expect(fetchPinnedSkillMock).toHaveBeenCalledTimes(1);
+    // Both targets still ran with the shared cached artifact.
+    expect(runSyntheticHostSessionMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("a persistent pinned-skill fetch failure finalizes THAT target's attempts failed — never a silent skill-less run — and does not stop the sibling target", async () => {
+    fetchPinnedSkillMock.mockRejectedValue(
+      new SwarmAgentError(404, "", "not found")
+    );
+
+    await startJourneyRun(
+      baseOpts({ hosts: [ENV_TARGET_A, ENV_TARGET_B], sessionsPerHost: 2 })
+    );
+
+    // Env A (the pinned target) never executed a session.
+    const executed = runSyntheticHostSessionMock.mock.calls.map(
+      (c) => (c[0] as any).chatSessionId
+    );
+    expect(executed.some((id) => id.includes("env_envA"))).toBe(false);
+    // Its attempts were finalized failed via the worker-catch sweep.
+    const envAFailed = reportAttemptMock.mock.calls
+      .map((c) => c[2] as any)
+      .filter(
+        (a) =>
+          a.targetId === "environment:envA" &&
+          a.status === "failed" &&
+          a.errorCode === "host_worker_failed"
+      )
+      .map((a) => a.sessionIdx)
+      .sort();
+    expect(envAFailed).toEqual([0, 1]);
+    // The sibling (skill-less) target ran both its sessions.
+    expect(executed.filter((id) => id.includes("env_envB"))).toHaveLength(2);
+  });
+
+  it("env targets NEVER trigger a live skills query path: legacy targets keep pinnedSkills undefined", async () => {
+    await startJourneyRun(baseOpts({ hosts: [HOST], sessionsPerHost: 1 }));
+    const adapter = runSyntheticHostSessionMock.mock.calls[0]![0] as any;
+    // Legacy: undefined (live-pool semantics downstream), and no pinned fetch.
+    expect(adapter.runtime.pinnedSkills).toBeUndefined();
+    expect(fetchPinnedSkillMock).not.toHaveBeenCalled();
+  });
+
+  it("fails closed on a pre-P0.2 snapshot whose host skillSelection is not represented in the pinned union", async () => {
+    const preP02Target = {
+      ...ENV_TARGET_A,
+      // Host channel wants skills…
+      skillSelection: { mode: "explicit" as const, skillIds: ["skX"] },
+      // …but the pinned entries carry NO channel provenance (pre-P0.2).
+    };
+    await startJourneyRun(
+      baseOpts({ hosts: [preP02Target], sessionsPerHost: 1 })
+    );
+    // No session executed; attempts finalized failed.
+    expect(runSyntheticHostSessionMock).not.toHaveBeenCalled();
+    const failed = reportAttemptMock.mock.calls
+      .map((c) => c[2] as any)
+      .filter((a) => a.status === "failed");
+    expect(failed).toHaveLength(1);
+    // With channel provenance present (P0.2 union), the same target runs.
+    reportAttemptMock.mockClear();
+    runSyntheticHostSessionMock.mockClear();
+    fetchPinnedSkillMock.mockResolvedValue({
+      name: "sk-one",
+      description: "d",
+      content: "# body",
+      contentHash: "hash-1",
+    });
+    const p02Target = {
+      ...preP02Target,
+      pinnedSkills: [
+        {
+          skillId: "skX",
+          name: "sk-one",
+          description: "d",
+          contentHash: "hash-1",
+          sharing: "project" as const,
+          channels: ["host" as const],
+        },
+      ],
+    };
+    await startJourneyRun(baseOpts({ hosts: [p02Target], sessionsPerHost: 1 }));
+    expect(runSyntheticHostSessionMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/mcpjam-inspector/server/services/sessionSimulation/__tests__/swarm-runner.test.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/__tests__/swarm-runner.test.ts
@@ -19,16 +19,16 @@ const finalizePendingAttemptsMock = vi.fn();
 const fetchPinnedSkillMock = vi.fn();
 
 vi.mock("../../swarm-agent.js", async () => {
-  const actual =
-    await vi.importActual<typeof import("../../swarm-agent.js")>(
-      "../../swarm-agent.js"
-    );
+  const actual = await vi.importActual<typeof import("../../swarm-agent.js")>(
+    "../../swarm-agent.js"
+  );
   return {
     ...actual,
     reportAttempt: (...args: unknown[]) => reportAttemptMock(...args),
     swarmPersonaNextTurn: (...args: unknown[]) =>
       swarmPersonaNextTurnMock(...args),
-    heartbeatJourneyRun: (...args: unknown[]) => heartbeatJourneyRunMock(...args),
+    heartbeatJourneyRun: (...args: unknown[]) =>
+      heartbeatJourneyRunMock(...args),
     finalizePendingAttempts: (...args: unknown[]) =>
       finalizePendingAttemptsMock(...args),
     fetchPinnedSkill: (...args: unknown[]) => fetchPinnedSkillMock(...args),
@@ -36,8 +36,9 @@ vi.mock("../../swarm-agent.js", async () => {
 });
 
 vi.mock("../runner.js", async () => {
-  const actual =
-    await vi.importActual<typeof import("../runner.js")>("../runner.js");
+  const actual = await vi.importActual<typeof import("../runner.js")>(
+    "../runner.js"
+  );
   return {
     ...actual,
     runSyntheticHostSession: (...args: unknown[]) =>
@@ -730,9 +731,13 @@ describe("swarm runner — live stream emit", () => {
 });
 
 describe("swarm fan-out runner — environment targets (Project Environments)", () => {
+  // `targetId` is deliberately OPAQUE and does NOT encode the environment id.
+  // The session-id mint must read `environmentRef.environmentId`; a fixture
+  // spelling `environment:<envId>` in BOTH fields would let a regression that
+  // parses the target id pass unnoticed.
   const ENV_TARGET_A = {
     ...HOST,
-    targetId: "environment:envA",
+    targetId: "target-a",
     environmentRef: { environmentId: "envA", name: "Env A", revision: 1 },
     pinnedSkills: [
       {
@@ -746,7 +751,7 @@ describe("swarm fan-out runner — environment targets (Project Environments)", 
   };
   const ENV_TARGET_B = {
     ...HOST, // SAME host as A — two env targets sharing one host.
-    targetId: "environment:envB",
+    targetId: "target-b",
     environmentRef: { environmentId: "envB", name: "Env B", revision: 2 },
     // Skill-less env target: pinned mode with an EMPTY authoritative set.
   };
@@ -782,10 +787,10 @@ describe("swarm fan-out runner — environment targets (Project Environments)", 
     expect(claims.every((a) => a.hostId === "host-1")).toBe(true);
     const claimTargets = claims.map((a) => a.targetId).sort();
     expect(claimTargets).toEqual([
-      "environment:envA",
-      "environment:envA",
-      "environment:envB",
-      "environment:envB",
+      "target-a",
+      "target-a",
+      "target-b",
+      "target-b",
     ]);
     // Terminals echo targetId too.
     const terminals = reportAttemptMock.mock.calls
@@ -804,7 +809,9 @@ describe("swarm fan-out runner — environment targets (Project Environments)", 
     const adapters = runSyntheticHostSessionMock.mock.calls.map(
       (c) => c[0] as any
     );
-    const a = adapters.find((x) => x.chatSessionId === "synth_run-1_env_envA_0");
+    const a = adapters.find(
+      (x) => x.chatSessionId === "synth_run-1_env_envA_0"
+    );
     expect(a.runtime.pinnedSkills).toHaveLength(1);
     expect(a.runtime.pinnedSkills[0]).toMatchObject({
       name: "sk-one",
@@ -812,9 +819,25 @@ describe("swarm fan-out runner — environment targets (Project Environments)", 
       content: "# body",
     });
     // Persist attribution carries the targetId (chat-ingestion echo).
-    expect(a.persist.targetId).toBe("environment:envA");
+    expect(a.persist.targetId).toBe("target-a");
 
-    const b = adapters.find((x) => x.chatSessionId === "synth_run-1_env_envB_0");
+    // The body fetch must be routed with THIS target's authorization inputs —
+    // an unconditional mock would otherwise return the right body for a
+    // wrongly-addressed request.
+    expect(fetchPinnedSkillMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      expect.objectContaining({
+        projectId: "proj-1",
+        runId: "run-1",
+        targetId: "target-a",
+        contentHash: "hash-1",
+      })
+    );
+
+    const b = adapters.find(
+      (x) => x.chatSessionId === "synth_run-1_env_envB_0"
+    );
     // Skill-less env target: authoritative EMPTY array — NEVER undefined
     // (undefined would fall back to the live pool).
     expect(b.runtime.pinnedSkills).toEqual([]);
@@ -824,7 +847,7 @@ describe("swarm fan-out runner — environment targets (Project Environments)", 
     fetchPinnedSkillMock.mockResolvedValue(pinnedArtifact("hash-1"));
     const envTargetC = {
       ...ENV_TARGET_A,
-      targetId: "environment:envC",
+      targetId: "target-c",
       environmentRef: { environmentId: "envC", name: "Env C", revision: 1 },
     };
 
@@ -856,7 +879,7 @@ describe("swarm fan-out runner — environment targets (Project Environments)", 
       .map((c) => c[2] as any)
       .filter(
         (a) =>
-          a.targetId === "environment:envA" &&
+          a.targetId === "target-a" &&
           a.status === "failed" &&
           a.errorCode === "host_worker_failed"
       )
@@ -915,5 +938,55 @@ describe("swarm fan-out runner — environment targets (Project Environments)", 
     };
     await startJourneyRun(baseOpts({ hosts: [p02Target], sessionsPerHost: 1 }));
     expect(runSyntheticHostSessionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed when the pinned union has provenance but NO host-channel entry", async () => {
+    // Provenance EXISTS (so the pre-P0.2 check passes) but every entry is
+    // environment-only — the host channel would be silently dropped.
+    const envOnlyUnionTarget = {
+      ...ENV_TARGET_A,
+      skillSelection: { mode: "explicit" as const, skillIds: ["skX"] },
+      pinnedSkills: [
+        {
+          skillId: "skEnv",
+          name: "env-skill",
+          description: "d",
+          contentHash: "hash-1",
+          sharing: "project" as const,
+          channels: ["environment" as const],
+        },
+      ],
+    };
+    await startJourneyRun(
+      baseOpts({ hosts: [envOnlyUnionTarget], sessionsPerHost: 1 })
+    );
+    expect(runSyntheticHostSessionMock).not.toHaveBeenCalled();
+    expect(fetchPinnedSkillMock).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when an id-identified union omits a selected host skill", async () => {
+    // Host channel is present, but the selection names TWO skills and only one
+    // is in the union — a partially dropped host channel.
+    const partialTarget = {
+      ...ENV_TARGET_A,
+      skillSelection: {
+        mode: "explicit" as const,
+        skillIds: ["skX", "skY"],
+      },
+      pinnedSkills: [
+        {
+          skillId: "skX",
+          name: "sk-one",
+          description: "d",
+          contentHash: "hash-1",
+          sharing: "project" as const,
+          channels: ["host" as const],
+        },
+      ],
+    };
+    await startJourneyRun(
+      baseOpts({ hosts: [partialTarget], sessionsPerHost: 1 })
+    );
+    expect(runSyntheticHostSessionMock).not.toHaveBeenCalled();
   });
 });

--- a/mcpjam-inspector/server/services/sessionSimulation/pinned-skill-cache.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/pinned-skill-cache.ts
@@ -49,6 +49,33 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/**
+ * Resolve with the shared fetch, but let THIS caller detach if its own signal
+ * aborts — without cancelling the underlying fetch (other coalesced callers,
+ * and the cache write, keep going). The shared fetch stays bound only to its
+ * own per-call timeout, never to any single caller's cancellation.
+ */
+function raceCallerAbort<T>(shared: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) {
+    return Promise.reject(new DOMException("Aborted", "AbortError"));
+  }
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () =>
+      reject(new DOMException("Aborted", "AbortError"));
+    signal.addEventListener("abort", onAbort, { once: true });
+    shared.then(
+      (v) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(v);
+      },
+      (e) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(e);
+      }
+    );
+  });
+}
+
 async function fetchWithRetry(
   fetcher: () => Promise<PinnedSkillArtifact>,
   retryDelaysMs: readonly number[]
@@ -70,15 +97,23 @@ async function fetchWithRetry(
 
 /**
  * Resolve one pinned skill body through the cache. `fetcher` performs the
- * actual authorized fetch (the runner binds `fetchPinnedSkill` with its run
- * context); it is invoked at most once per coalesced burst and retried per the
- * policy above. `retryDelaysMs` is injectable for tests only.
+ * actual authorized fetch; it MUST be caller-agnostic (no per-caller abort
+ * signal baked in — only its own request timeout), because it is shared across
+ * every caller coalescing on the same key. It is invoked at most once per
+ * coalesced burst and retried per the policy above. `retryDelaysMs` is
+ * injectable for tests only.
+ *
+ * `signal` is THIS caller's cancellation: when supplied, the caller's await
+ * detaches on abort (rejects `AbortError`) without cancelling the shared fetch,
+ * so cancelling one run never fails another run coalesced on the same body and
+ * the cache still populates for everyone else.
  */
 export async function resolvePinnedSkillCached(args: {
   projectId: string;
   contentHash: string;
   fetcher: () => Promise<PinnedSkillArtifact>;
   retryDelaysMs?: readonly number[];
+  signal?: AbortSignal;
 }): Promise<PinnedSkillArtifact> {
   const key = `${args.projectId}:${args.contentHash}`;
 
@@ -93,32 +128,30 @@ export async function resolvePinnedSkillCached(args: {
     cache.delete(key);
   }
 
-  const pending = inFlight.get(key);
-  if (pending) return pending;
-
-  const promise = fetchWithRetry(
-    args.fetcher,
-    args.retryDelaysMs ?? RETRY_DELAYS_MS
-  )
-    .then((artifact) => {
-      cache.set(key, {
-        artifact,
-        expiresAt: Date.now() + PINNED_SKILL_CACHE_TTL_MS,
+  let shared = inFlight.get(key);
+  if (!shared) {
+    shared = fetchWithRetry(args.fetcher, args.retryDelaysMs ?? RETRY_DELAYS_MS)
+      .then((artifact) => {
+        cache.set(key, {
+          artifact,
+          expiresAt: Date.now() + PINNED_SKILL_CACHE_TTL_MS,
+        });
+        while (cache.size > PINNED_SKILL_CACHE_MAX) {
+          const oldest = cache.keys().next().value as string | undefined;
+          if (oldest === undefined) break;
+          cache.delete(oldest);
+        }
+        return artifact;
+      })
+      .finally(() => {
+        // Success OR failure: clear the in-flight slot. Failures were not cached
+        // above, so the next caller starts a fresh fetch.
+        inFlight.delete(key);
       });
-      while (cache.size > PINNED_SKILL_CACHE_MAX) {
-        const oldest = cache.keys().next().value as string | undefined;
-        if (oldest === undefined) break;
-        cache.delete(oldest);
-      }
-      return artifact;
-    })
-    .finally(() => {
-      // Success OR failure: clear the in-flight slot. Failures were not cached
-      // above, so the next caller starts a fresh fetch.
-      inFlight.delete(key);
-    });
-  inFlight.set(key, promise);
-  return promise;
+    inFlight.set(key, shared);
+  }
+
+  return args.signal ? raceCallerAbort(shared, args.signal) : shared;
 }
 
 /** Test-only: reset module state between cases. */

--- a/mcpjam-inspector/server/services/sessionSimulation/pinned-skill-cache.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/pinned-skill-cache.ts
@@ -1,0 +1,133 @@
+/**
+ * Module-level LRU for pinned-skill runtime artifacts (Project Environments —
+ * B2). Pinned bodies are content-addressed by `(projectId, contentHash)`, so a
+ * cached entry can be shared across targets AND runs within this process.
+ *
+ * Contract:
+ *   - key `${projectId}:${contentHash}`; max {@link PINNED_SKILL_CACHE_MAX}
+ *     entries (LRU eviction), {@link PINNED_SKILL_CACHE_TTL_MS} TTL.
+ *   - in-flight fetches for the same key COALESCE onto one promise (two
+ *     same-project targets pinning the same skill fetch once).
+ *   - failures are NEVER cached: a rejected fetch clears the in-flight slot so
+ *     the next caller retries fresh.
+ *   - transient failures (network / 5xx) retry twice ({@link RETRY_DELAYS_MS});
+ *     a 404 or an integrity (hash) mismatch is NEVER retried — the snapshot is
+ *     immutable, so those can only recur.
+ */
+import type { PinnedSkillArtifact } from "../../../shared/skill-types.js";
+import {
+  PinnedSkillIntegrityError,
+  SwarmAgentError,
+} from "../swarm-agent.js";
+
+export const PINNED_SKILL_CACHE_MAX = 256;
+export const PINNED_SKILL_CACHE_TTL_MS = 15 * 60 * 1000;
+const RETRY_DELAYS_MS = [250, 1000];
+
+interface CacheEntry {
+  artifact: PinnedSkillArtifact;
+  expiresAt: number;
+}
+
+// Map iteration order is insertion order; re-inserting on read makes the first
+// key the least-recently-used — the classic Map-as-LRU.
+const cache = new Map<string, CacheEntry>();
+const inFlight = new Map<string, Promise<PinnedSkillArtifact>>();
+
+/** Default retry policy: transient transport errors and 5xx retry; a 404, an
+ * integrity mismatch, or an abort never do. */
+export function isRetryablePinnedSkillError(err: unknown): boolean {
+  if (err instanceof PinnedSkillIntegrityError) return false;
+  if (err instanceof SwarmAgentError) return err.status >= 500;
+  if (err instanceof Error && err.name === "AbortError") return false;
+  if (err instanceof DOMException && err.name === "AbortError") return false;
+  // Undici/fetch transport failures (TypeError), timeouts, etc.
+  return true;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function fetchWithRetry(
+  fetcher: () => Promise<PinnedSkillArtifact>,
+  retryDelaysMs: readonly number[]
+): Promise<PinnedSkillArtifact> {
+  let attempt = 0;
+  // attempts = 1 initial + retryDelaysMs.length retries
+  for (;;) {
+    try {
+      return await fetcher();
+    } catch (err) {
+      if (attempt >= retryDelaysMs.length || !isRetryablePinnedSkillError(err)) {
+        throw err;
+      }
+      await sleep(retryDelaysMs[attempt]!);
+      attempt++;
+    }
+  }
+}
+
+/**
+ * Resolve one pinned skill body through the cache. `fetcher` performs the
+ * actual authorized fetch (the runner binds `fetchPinnedSkill` with its run
+ * context); it is invoked at most once per coalesced burst and retried per the
+ * policy above. `retryDelaysMs` is injectable for tests only.
+ */
+export async function resolvePinnedSkillCached(args: {
+  projectId: string;
+  contentHash: string;
+  fetcher: () => Promise<PinnedSkillArtifact>;
+  retryDelaysMs?: readonly number[];
+}): Promise<PinnedSkillArtifact> {
+  const key = `${args.projectId}:${args.contentHash}`;
+
+  const cached = cache.get(key);
+  if (cached) {
+    if (cached.expiresAt > Date.now()) {
+      // LRU touch.
+      cache.delete(key);
+      cache.set(key, cached);
+      return cached.artifact;
+    }
+    cache.delete(key);
+  }
+
+  const pending = inFlight.get(key);
+  if (pending) return pending;
+
+  const promise = fetchWithRetry(
+    args.fetcher,
+    args.retryDelaysMs ?? RETRY_DELAYS_MS
+  )
+    .then((artifact) => {
+      cache.set(key, {
+        artifact,
+        expiresAt: Date.now() + PINNED_SKILL_CACHE_TTL_MS,
+      });
+      while (cache.size > PINNED_SKILL_CACHE_MAX) {
+        const oldest = cache.keys().next().value as string | undefined;
+        if (oldest === undefined) break;
+        cache.delete(oldest);
+      }
+      return artifact;
+    })
+    .finally(() => {
+      // Success OR failure: clear the in-flight slot. Failures were not cached
+      // above, so the next caller starts a fresh fetch.
+      inFlight.delete(key);
+    });
+  inFlight.set(key, promise);
+  return promise;
+}
+
+/** Test-only: reset module state between cases. */
+export function __clearPinnedSkillCacheForTest(): void {
+  cache.clear();
+  inFlight.clear();
+}
+
+/** Test-only: current cached-entry count. */
+export function __pinnedSkillCacheSizeForTest(): number {
+  return cache.size;
+}

--- a/mcpjam-inspector/server/services/sessionSimulation/runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/runner.ts
@@ -31,6 +31,10 @@ import {
   type SyntheticModelSource,
 } from "../../utils/org-model-config.js";
 import { prepareChatV2 } from "../../utils/chat-v2-orchestration.js";
+import type {
+  PinnableSkill,
+  PinnedSkillArtifact,
+} from "../../../shared/skill-types.js";
 import {
   resolveHostTools,
   type HostComputerResource,
@@ -539,6 +543,17 @@ export interface SyntheticHostRuntime {
    * surface authorizes via project membership and leaves it undefined.
    */
   chatboxId?: string;
+  /**
+   * Authoritative pinned skills for an ENVIRONMENT-based swarm target
+   * (Project Environments, D3). `undefined` ⇒ legacy live-pool semantics
+   * (cloud skill tools / harness live fetch, unchanged). An array — possibly
+   * EMPTY, meaning deliberately skill-less — ⇒ skills come EXCLUSIVELY from
+   * these pinned artifacts: the emulated engine gets them via prepareChatV2
+   * `skillsSource` (never `cloudSkills`), and a harness turn gets them via the
+   * pinned harness path (never `fetchRuntimeSkills`, and NEVER through
+   * prepareChatV2's pinned branch, which throws on harness).
+   */
+  pinnedSkills?: PinnedSkillArtifact[];
 }
 
 /** Attribution tags stamped onto every transcript persist for this session. */
@@ -550,6 +565,9 @@ export interface SyntheticPersistAttribution {
   synthesisRunId?: string;
   journeyRunId?: string;
   hostId?: string;
+  /** Opaque swarm execution-target id — echoed on chat ingestion so two
+   * same-host targets stay attributable. Absent for legacy/chatbox surfaces. */
+  targetId?: string;
   personaId?: string;
   personaLabel?: string;
   personaRefId?: string;
@@ -696,7 +714,9 @@ export async function runSyntheticHostSession(
     // call — so advertising the `listSkills`/`loadSkill` meta-tools (always 2
     // tools, even for a project with no skills) would turn an otherwise-toolless
     // approval simulation into one that fails every session for no benefit.
+    const pinnedSkills = runtime.pinnedSkills;
     const cloudSkillsEnabled =
+      pinnedSkills === undefined &&
       !requireToolApproval &&
       Boolean(authHeader) &&
       Boolean(projectId) &&
@@ -707,6 +727,33 @@ export async function runSyntheticHostSession(
         provider: modelDefinition.provider,
         hasProjectId: Boolean(projectId),
       });
+
+    // Authoritative pinned mode (env-based swarm target): the emulated engine
+    // gets frozen pinned tools via `skillsSource` — NEVER the live cloud-skill
+    // tools. `kind: "none"` covers (a) a deliberately skill-less target, (b) the
+    // approval-mode no-skills semantics (a headless visitor can't approve, same
+    // rationale as the cloudSkills gate above), and (c) HARNESS turns —
+    // prepareChatV2 THROWS on harness+pinned, so a harness target's pinned
+    // artifacts ride `pinnedHarnessSkills` on the drain instead.
+    const skillsSource:
+      | { kind: "pinned"; skills: PinnableSkill[] }
+      | { kind: "none" }
+      | undefined =
+      pinnedSkills === undefined
+        ? undefined
+        : harness || requireToolApproval || pinnedSkills.length === 0
+          ? { kind: "none" }
+          : {
+              kind: "pinned",
+              skills: pinnedSkills.map(
+                (a): PinnableSkill => ({
+                  name: a.name,
+                  description: a.description,
+                  content: a.content,
+                  contentHash: a.contentHash,
+                }),
+              ),
+            };
 
     const prepared = await prepareChatV2({
       mcpClientManager: manager,
@@ -726,6 +773,7 @@ export async function runSyntheticHostSession(
           }
         : {}),
       ...(builtInTools ? { builtInTools } : {}),
+      ...(skillsSource ? { skillsSource } : {}),
       ...(cloudSkillsEnabled
         ? { cloudSkills: { authHeader, projectId } }
         : {}),
@@ -904,6 +952,14 @@ export async function runSyntheticHostSession(
         // resolved once above; `journeyRunId`/`hostId` are the swarm run + pinned
         // host. All three are inert for the emulated engine / non-swarm surfaces.
         ...(harnessMcpProxy ? { harnessMcpProxy } : {}),
+        // Pinned harness skills (env-based swarm target running a real
+        // harness): the harness turn skips the live skills fetch and delivers
+        // exactly these artifacts (skillsHash derives from their fingerprints).
+        // Passed even when EMPTY — an empty authoritative set means the
+        // harness must run skill-less, not fall back to the live pool.
+        ...(harness && pinnedSkills !== undefined
+          ? { pinnedHarnessSkills: pinnedSkills }
+          : {}),
         ...(persist.hostId ? { hostId: persist.hostId } : {}),
         // Chatbox surface only. The chatbox runtime-config redeem returns an
         // accessVersion that /stream/org/resolve uses to authorize the actor
@@ -999,6 +1055,7 @@ export async function runSyntheticHostSession(
           : {}),
         ...(persist.journeyRunId ? { journeyRunId: persist.journeyRunId } : {}),
         ...(persist.hostId ? { hostId: persist.hostId } : {}),
+        ...(persist.targetId ? { targetId: persist.targetId } : {}),
         turnTrace,
         resumeConfig,
         ...(toolSnapshot ? { toolSnapshot } : {}),
@@ -1075,6 +1132,7 @@ export async function runSyntheticHostSession(
           : {}),
         ...(persist.journeyRunId ? { journeyRunId: persist.journeyRunId } : {}),
         ...(persist.hostId ? { hostId: persist.hostId } : {}),
+        ...(persist.targetId ? { targetId: persist.targetId } : {}),
         resumeConfig,
       });
     }
@@ -1514,6 +1572,7 @@ export async function drainAssistantTurn(
     journeyRunId,
     hostId,
     harnessMcpProxy,
+    pinnedHarnessSkills,
     extraBodyFields,
     hooks,
   } = args;
@@ -1715,6 +1774,9 @@ export async function drainAssistantTurn(
     // key on (journeyRunId, hostId, chatSessionId) instead of direct-chat.
     ...(journeyRunId ? { journeyRunId } : {}),
     ...(hostId ? { hostId } : {}),
+    // Pinned harness skills (env-based swarm target): presence — even an
+    // EMPTY array — makes the harness turn skip the live skills fetch.
+    ...(pinnedHarnessSkills !== undefined ? { pinnedHarnessSkills } : {}),
     ...(args.requireToolApproval !== undefined
       ? { requireToolApproval: args.requireToolApproval }
       : {}),

--- a/mcpjam-inspector/server/services/sessionSimulation/swarm-runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/swarm-runner.ts
@@ -765,6 +765,18 @@ async function resolveTargetPinnedSkills(args: {
     );
   }
 
+  // Env targets MUST carry a targetId for per-target claim/report attribution,
+  // even when they pin NO skills — otherwise the target reaches attempt claim
+  // with host-only identity and is misattributed (or rejected by the
+  // target-aware backend). Enforce before the skill-less early return; legacy
+  // host-only targets legitimately omit it.
+  if (isEnvTarget && !target.targetId) {
+    throw new Error(
+      "Environment snapshot target has no targetId — refusing to run with " +
+        "host-only identity (per-target attribution would be lost)"
+    );
+  }
+
   if (meta.length === 0) return [];
   const targetId = target.targetId;
   if (!targetId) {
@@ -778,14 +790,17 @@ async function resolveTargetPinnedSkills(args: {
     const artifact = await resolvePinnedSkillCached({
       projectId,
       contentHash: entry.contentHash,
+      // Caller-agnostic: the shared fetch keeps only its own request timeout, so
+      // this run's cancellation can't fail another run coalesced on the same
+      // body. THIS caller's `signal` detaches its own await below instead.
       fetcher: () =>
         fetchPinnedSkill(convexHttpUrl, bearer, {
           projectId,
           runId,
           targetId,
           contentHash: entry.contentHash,
-          ...(signal ? { signal } : {}),
         }),
+      ...(signal ? { signal } : {}),
     });
     // Preserve the snapshot's channel provenance when the served artifact
     // doesn't carry it (the cache is keyed by content, not by target).

--- a/mcpjam-inspector/server/services/sessionSimulation/swarm-runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/swarm-runner.ts
@@ -88,9 +88,7 @@ function targetSessionIdentity(target: PinnedHostExecutionSpec): {
  * `serverIds`. Host-aware (unlike the chatbox {@link SimulationManagerFactory})
  * so a single fan-out run can connect different servers per host.
  */
-export type JourneyManagerFactory = (
-  host: PinnedHostExecutionSpec
-) => Promise<{
+export type JourneyManagerFactory = (host: PinnedHostExecutionSpec) => Promise<{
   manager: Awaited<ReturnType<SimulationManagerFactory>>["manager"];
   connectedServerIds: string[];
   connectedServerNames?: string[];
@@ -358,272 +356,281 @@ async function runJourneyFanOut(
     // can finalize the attempts it left behind.
     let sessionIdx = 0;
     try {
-    // Resolve the pinned target's modelId to a ModelDefinition once per target
-    // (catalog hits pass through; BYOK shapes get a derived provider). NEVER
-    // refetch the live host config — everything comes from the immutable
-    // snapshot. A model-less / unresolvable pinned spec throws HERE, before any
-    // attempt is claimed — the catch finalizes this target's pending attempts.
-    const modelDefinition = buildSyntheticModelDefinition(modelId);
+      // Resolve the pinned target's modelId to a ModelDefinition once per target
+      // (catalog hits pass through; BYOK shapes get a derived provider). NEVER
+      // refetch the live host config — everything comes from the immutable
+      // snapshot. A model-less / unresolvable pinned spec throws HERE, before any
+      // attempt is claimed — the catch finalizes this target's pending attempts.
+      const modelDefinition = buildSyntheticModelDefinition(modelId);
 
-    // Resolve the target's pinned skill BODIES up front (D3, fail-closed).
-    // Undefined ⇒ legacy live-pool semantics; an array (possibly empty) ⇒ the
-    // authoritative pinned set — env targets NEVER touch the live skills query.
-    // A persistent fetch failure / 404 / hash mismatch throws HERE, before any
-    // attempt is claimed, and the worker-catch finalizes the target's attempts
-    // `failed` — never a silent skill-less run.
-    const pinnedSkills = await resolveTargetPinnedSkills({
-      target,
-      projectId,
-      runId,
-      convexHttpUrl,
-      bearer,
-      signal: sessionSignal,
-    });
-
-    for (sessionIdx = 0; sessionIdx < sessionsPerHost; sessionIdx++) {
-      // Run-level stop (spend cap or shutdown/cancel) halts THIS target too.
-      if (stopScheduling()) return;
-
-      // Deterministic claim key — the immutable chatSessionId the attempt is
-      // claimed with and every persist + terminal reuse (shared mint, D1: env
-      // targets key on environmentRef.environmentId so two env targets on the
-      // SAME host can never collide).
-      const chatSessionId = swarmAttemptChatSessionId(
+      // Resolve the target's pinned skill BODIES up front (D3, fail-closed).
+      // Undefined ⇒ legacy live-pool semantics; an array (possibly empty) ⇒ the
+      // authoritative pinned set — env targets NEVER touch the live skills query.
+      // A persistent fetch failure / 404 / hash mismatch throws HERE, before any
+      // attempt is claimed, and the worker-catch finalizes the target's attempts
+      // `failed` — never a silent skill-less run.
+      const pinnedSkills = await resolveTargetPinnedSkills({
+        target,
+        projectId,
         runId,
-        targetSessionIdentity(target),
-        sessionIdx
-      );
+        convexHttpUrl,
+        bearer,
+        signal: sessionSignal,
+      });
 
-      // CLAIM before executing: the `running` transition requires the
-      // chatSessionId and is immutable thereafter. Persistence is LAUNCHER-gated
-      // and requires the chatSessionId to match this claim, so it MUST come
-      // after. A claim failure skips the session (we can't run without it).
-      let claim: { ok: true; applied: boolean };
-      try {
-        claim = await reportAttempt(convexHttpUrl, bearer, {
-          projectId,
+      for (sessionIdx = 0; sessionIdx < sessionsPerHost; sessionIdx++) {
+        // Run-level stop (spend cap or shutdown/cancel) halts THIS target too.
+        if (stopScheduling()) return;
+
+        // Deterministic claim key — the immutable chatSessionId the attempt is
+        // claimed with and every persist + terminal reuse (shared mint, D1: env
+        // targets key on environmentRef.environmentId so two env targets on the
+        // SAME host can never collide).
+        const chatSessionId = swarmAttemptChatSessionId(
           runId,
-          hostId,
-          ...(targetId ? { targetId } : {}),
-          sessionIdx,
-          status: "running",
-          chatSessionId,
-        });
-      } catch (err) {
-        logger.error("[swarm.runner] attempt claim failed; skipping session", {
+          targetSessionIdentity(target),
+          sessionIdx
+        );
+
+        // CLAIM before executing: the `running` transition requires the
+        // chatSessionId and is immutable thereafter. Persistence is LAUNCHER-gated
+        // and requires the chatSessionId to match this claim, so it MUST come
+        // after. A claim failure skips the session (we can't run without it).
+        let claim: { ok: true; applied: boolean };
+        try {
+          claim = await reportAttempt(convexHttpUrl, bearer, {
+            projectId,
+            runId,
+            hostId,
+            ...(targetId ? { targetId } : {}),
+            sessionIdx,
+            status: "running",
+            chatSessionId,
+          });
+        } catch (err) {
+          logger.error(
+            "[swarm.runner] attempt claim failed; skipping session",
+            {
+              runId,
+              hostId,
+              targetId,
+              sessionIdx,
+              error: err instanceof Error ? err.message : String(err),
+            }
+          );
+          continue;
+        }
+
+        // Duplicate-launch guard: a duplicate-delivered launchKey dedupes to the
+        // SAME runId, so two runners can iterate the SAME (run, host, sessionIdx)
+        // and both claim `running` with the identical deterministic chatSessionId.
+        // The backend applies the pending → running transition exactly once and
+        // returns `applied: false` to the LOSER (its claim was a no-op replay of a
+        // claim a sibling runner already made). The loser MUST NOT execute the
+        // session — running it would double-persist and DOUBLE-BILL the same
+        // attempt. Skip it: the winning runner (applied: true) owns execution and
+        // the terminal report.
+        if (!claim.applied) {
+          logger.warn(
+            "[swarm.runner] attempt already claimed by another runner; skipping session",
+            { runId, hostId, sessionIdx }
+          );
+          continue;
+        }
+
+        const attemptStartedAt = Date.now();
+        logEvent("attempt.start", {
           runId,
           hostId,
           targetId,
           sessionIdx,
-          error: err instanceof Error ? err.message : String(err),
+          modelId,
         });
-        continue;
-      }
 
-      // Duplicate-launch guard: a duplicate-delivered launchKey dedupes to the
-      // SAME runId, so two runners can iterate the SAME (run, host, sessionIdx)
-      // and both claim `running` with the identical deterministic chatSessionId.
-      // The backend applies the pending → running transition exactly once and
-      // returns `applied: false` to the LOSER (its claim was a no-op replay of a
-      // claim a sibling runner already made). The loser MUST NOT execute the
-      // session — running it would double-persist and DOUBLE-BILL the same
-      // attempt. Skip it: the winning runner (applied: true) owns execution and
-      // the terminal report.
-      if (!claim.applied) {
-        logger.warn(
-          "[swarm.runner] attempt already claimed by another runner; skipping session",
-          { runId, hostId, sessionIdx }
-        );
-        continue;
-      }
-
-      const attemptStartedAt = Date.now();
-      logEvent("attempt.start", { runId, hostId, targetId, sessionIdx, modelId });
-
-      const envelope: SwarmStreamEnvelope = {
-        runId,
-        hostId,
-        ...(targetId ? { targetId } : {}),
-        chatSessionId,
-        sessionIndex: sessionIdx,
-      };
-      const emit = bindSessionEmit(hub, envelope);
-      emit({ type: "attempt_status", status: "running" });
-
-      // Execute the session via the shared core. It owns manager lifecycle +
-      // dispose, per-turn persona→drain→persist, browser/widget capture, and
-      // failure classification, and NEVER throws (returns a SessionResult).
-      // Because it persists per-turn and returns only after the last persist,
-      // the transcript is durable before we report the terminal below.
-      const { outcome, errorMessage } = await runSyntheticHostSession({
-        runId,
-        projectId,
-        chatSessionId,
-        maxTurns,
-        runtime: {
-          modelDefinition,
-          systemPrompt: target.systemPrompt,
-          temperature: target.temperature,
-          requireToolApproval: target.requireToolApproval,
-          respectToolVisibility: target.respectToolVisibility,
-          progressiveToolDiscovery: target.progressiveToolDiscovery,
-          builtInToolIds: target.builtInToolIds,
-          modelVisibleMcpToolResults: target.modelVisibleMcpToolResults,
-          mcpToolResultImageRendering: target.mcpToolResultImageRendering,
-          computer: target.computer,
-          harness: target.harness,
-          // Authoritative pinned skills for env-based targets (undefined ⇒
-          // legacy live-pool). The shared core routes them to prepareChatV2
-          // (`skillsSource`) or the harness pinned path — never a live query.
-          ...(pinnedSkills !== undefined ? { pinnedSkills } : {}),
-          // Swarm authorizes via project membership — no chatbox access
-          // version, no chatbox id.
-        },
-        authHeader,
-        // Each attempt gets a fresh manager + browser context, scoped to THIS
-        // target's pinned required servers.
-        managerFactory: () => managerFactory(target),
-        // Thread the run-level stop signal (composed with shutdown/cancel) so a
-        // spend-cap short-circuit cancels this host's in-flight turns.
-        abortSignal: sessionSignal,
-        nextPersonaTurn: (transcriptSoFar) =>
-          swarmPersonaNextTurn(convexHttpUrl, bearer, {
-            projectId,
-            runId,
-            hostId,
-            transcriptSoFar,
-            // Forward the run-level stop (composed shutdown/cancel + spend-cap
-            // runStop) so a short-circuit aborts a parked persona fetch
-            // immediately and the session unwinds (instead of lingering up to
-            // 120s in the persona call).
-            signal: sessionSignal,
-          }),
-        persist: {
-          sourceType: "swarm",
-          origin: "swarm",
-          journeyRunId: runId,
-          hostId,
-          ...(targetId ? { targetId } : {}),
-          personaId: personaSnapshot.personaId,
-          personaLabel: personaSnapshot.name,
-        },
-        emit,
-        // No chatbox-scoped side-persistence on the swarm surface (widget /
-        // browser-artifact rows are keyed by chatboxId, which swarm has none).
-      });
-
-      // Report the terminal with the SAME chatSessionId ONLY after the
-      // transcript is persisted. Best-effort: a terminal write failure is
-      // logged and the host loop continues.
-      //
-      // Spend-cap abort reclassification: when the org spend cap tripped on
-      // ANOTHER host, `runStop.abort()` cancels THIS host's in-flight turns and
-      // the shared core returns `outcome: "failed"` — an abort artifact, not a
-      // genuine session failure. Report those as the run-level terminal
-      // (`rate_limited` / `spend_cap_exceeded`) so a cap breach isn't miscounted
-      // as a generic `session_failed`. A session that genuinely SUCCEEDED, or
-      // failed for its OWN reason before the cap (i.e. it returned while the
-      // run-stop signal was NOT yet aborted), keeps its real outcome — we only
-      // reclassify a `failed` outcome whose turns were actually cancelled by the
-      // run-stop (`sessionSignal.aborted`).
-      const abortedBySpendCap =
-        spendCapTripped && outcome === "failed" && sessionSignal.aborted;
-      const terminal = abortedBySpendCap
-        ? {
-            status: "rate_limited" as SwarmAttemptStatus,
-            errorCode: "spend_cap_exceeded",
-            ...(spendCapMessage
-              ? {
-                  errorMessage: spendCapMessage.slice(
-                    0,
-                    MAX_ATTEMPT_ERROR_CHARS
-                  ),
-                }
-              : {}),
-          }
-        : terminalForOutcome(outcome, errorMessage);
-      emit({
-        type: "attempt_status",
-        status: terminal.status,
-        ...(terminal.errorMessage
-          ? { errorMessage: terminal.errorMessage }
-          : {}),
-      });
-      try {
-        await reportAttempt(convexHttpUrl, bearer, {
-          projectId,
+        const envelope: SwarmStreamEnvelope = {
           runId,
           hostId,
           ...(targetId ? { targetId } : {}),
-          sessionIdx,
-          status: terminal.status,
           chatSessionId,
-          ...(terminal.errorCode ? { errorCode: terminal.errorCode } : {}),
+          sessionIndex: sessionIdx,
+        };
+        const emit = bindSessionEmit(hub, envelope);
+        emit({ type: "attempt_status", status: "running" });
+
+        // Execute the session via the shared core. It owns manager lifecycle +
+        // dispose, per-turn persona→drain→persist, browser/widget capture, and
+        // failure classification, and NEVER throws (returns a SessionResult).
+        // Because it persists per-turn and returns only after the last persist,
+        // the transcript is durable before we report the terminal below.
+        const { outcome, errorMessage } = await runSyntheticHostSession({
+          runId,
+          projectId,
+          chatSessionId,
+          maxTurns,
+          runtime: {
+            modelDefinition,
+            systemPrompt: target.systemPrompt,
+            temperature: target.temperature,
+            requireToolApproval: target.requireToolApproval,
+            respectToolVisibility: target.respectToolVisibility,
+            progressiveToolDiscovery: target.progressiveToolDiscovery,
+            builtInToolIds: target.builtInToolIds,
+            modelVisibleMcpToolResults: target.modelVisibleMcpToolResults,
+            mcpToolResultImageRendering: target.mcpToolResultImageRendering,
+            computer: target.computer,
+            harness: target.harness,
+            // Authoritative pinned skills for env-based targets (undefined ⇒
+            // legacy live-pool). The shared core routes them to prepareChatV2
+            // (`skillsSource`) or the harness pinned path — never a live query.
+            ...(pinnedSkills !== undefined ? { pinnedSkills } : {}),
+            // Swarm authorizes via project membership — no chatbox access
+            // version, no chatbox id.
+          },
+          authHeader,
+          // Each attempt gets a fresh manager + browser context, scoped to THIS
+          // target's pinned required servers.
+          managerFactory: () => managerFactory(target),
+          // Thread the run-level stop signal (composed with shutdown/cancel) so a
+          // spend-cap short-circuit cancels this host's in-flight turns.
+          abortSignal: sessionSignal,
+          nextPersonaTurn: (transcriptSoFar) =>
+            swarmPersonaNextTurn(convexHttpUrl, bearer, {
+              projectId,
+              runId,
+              hostId,
+              transcriptSoFar,
+              // Forward the run-level stop (composed shutdown/cancel + spend-cap
+              // runStop) so a short-circuit aborts a parked persona fetch
+              // immediately and the session unwinds (instead of lingering up to
+              // 120s in the persona call).
+              signal: sessionSignal,
+            }),
+          persist: {
+            sourceType: "swarm",
+            origin: "swarm",
+            journeyRunId: runId,
+            hostId,
+            ...(targetId ? { targetId } : {}),
+            personaId: personaSnapshot.personaId,
+            personaLabel: personaSnapshot.name,
+          },
+          emit,
+          // No chatbox-scoped side-persistence on the swarm surface (widget /
+          // browser-artifact rows are keyed by chatboxId, which swarm has none).
+        });
+
+        // Report the terminal with the SAME chatSessionId ONLY after the
+        // transcript is persisted. Best-effort: a terminal write failure is
+        // logged and the host loop continues.
+        //
+        // Spend-cap abort reclassification: when the org spend cap tripped on
+        // ANOTHER host, `runStop.abort()` cancels THIS host's in-flight turns and
+        // the shared core returns `outcome: "failed"` — an abort artifact, not a
+        // genuine session failure. Report those as the run-level terminal
+        // (`rate_limited` / `spend_cap_exceeded`) so a cap breach isn't miscounted
+        // as a generic `session_failed`. A session that genuinely SUCCEEDED, or
+        // failed for its OWN reason before the cap (i.e. it returned while the
+        // run-stop signal was NOT yet aborted), keeps its real outcome — we only
+        // reclassify a `failed` outcome whose turns were actually cancelled by the
+        // run-stop (`sessionSignal.aborted`).
+        const abortedBySpendCap =
+          spendCapTripped && outcome === "failed" && sessionSignal.aborted;
+        const terminal = abortedBySpendCap
+          ? {
+              status: "rate_limited" as SwarmAttemptStatus,
+              errorCode: "spend_cap_exceeded",
+              ...(spendCapMessage
+                ? {
+                    errorMessage: spendCapMessage.slice(
+                      0,
+                      MAX_ATTEMPT_ERROR_CHARS
+                    ),
+                  }
+                : {}),
+            }
+          : terminalForOutcome(outcome, errorMessage);
+        emit({
+          type: "attempt_status",
+          status: terminal.status,
           ...(terminal.errorMessage
             ? { errorMessage: terminal.errorMessage }
             : {}),
         });
-      } catch (err) {
-        logEvent("attempt.report_failed", {
-          runId,
-          hostId,
-          targetId,
-          sessionIdx,
-          status: terminal.status,
-        });
-        logger.error("[swarm.runner] terminal attempt report failed", {
-          runId,
-          hostId,
-          targetId,
-          sessionIdx,
-          status: terminal.status,
-          error: err instanceof Error ? err.message : String(err),
-        });
-      }
-
-      logEvent("attempt.finish", {
-        runId,
-        hostId,
-        targetId,
-        sessionIdx,
-        status: terminal.status,
-        durationMs: Date.now() - attemptStartedAt,
-        modelSource: modelId,
-      });
-
-      if (outcome === "rate_limited") {
-        const cause = classifyRateLimit(errorMessage);
-        if (cause === "org_spend_cap") {
-          // WHOLE-RUN stop: halt all hosts + cancel in-flight turns. The
-          // finalize sweep runs once the pool drains.
-          spendCapTripped = true;
-          spendCapMessage = errorMessage;
-          runStop.abort();
-          logEvent("run.spend_cap_short_circuit", {
+        try {
+          await reportAttempt(convexHttpUrl, bearer, {
+            projectId,
+            runId,
+            hostId,
+            ...(targetId ? { targetId } : {}),
+            sessionIdx,
+            status: terminal.status,
+            chatSessionId,
+            ...(terminal.errorCode ? { errorCode: terminal.errorCode } : {}),
+            ...(terminal.errorMessage
+              ? { errorMessage: terminal.errorMessage }
+              : {}),
+          });
+        } catch (err) {
+          logEvent("attempt.report_failed", {
             runId,
             hostId,
             targetId,
             sessionIdx,
+            status: terminal.status,
           });
-          return;
+          logger.error("[swarm.runner] terminal attempt report failed", {
+            runId,
+            hostId,
+            targetId,
+            sessionIdx,
+            status: terminal.status,
+            error: err instanceof Error ? err.message : String(err),
+          });
         }
-        // PROVIDER rate-limit: stop THIS target's remaining sessions and mark
-        // them rate_limited. Other targets keep running.
-        logEvent("target.rate_limit_short_circuit", {
+
+        logEvent("attempt.finish", {
           runId,
           hostId,
           targetId,
-          fromSessionIdx: sessionIdx + 1,
-          remaining: sessionsPerHost - (sessionIdx + 1),
+          sessionIdx,
+          status: terminal.status,
+          durationMs: Date.now() - attemptStartedAt,
+          modelSource: modelId,
         });
-        await markRemainingTargetAttemptsRateLimited(
-          { convexHttpUrl, bearer, projectId, runId, target },
-          sessionIdx + 1,
-          sessionsPerHost
-        );
-        return;
+
+        if (outcome === "rate_limited") {
+          const cause = classifyRateLimit(errorMessage);
+          if (cause === "org_spend_cap") {
+            // WHOLE-RUN stop: halt all hosts + cancel in-flight turns. The
+            // finalize sweep runs once the pool drains.
+            spendCapTripped = true;
+            spendCapMessage = errorMessage;
+            runStop.abort();
+            logEvent("run.spend_cap_short_circuit", {
+              runId,
+              hostId,
+              targetId,
+              sessionIdx,
+            });
+            return;
+          }
+          // PROVIDER rate-limit: stop THIS target's remaining sessions and mark
+          // them rate_limited. Other targets keep running.
+          logEvent("target.rate_limit_short_circuit", {
+            runId,
+            hostId,
+            targetId,
+            fromSessionIdx: sessionIdx + 1,
+            remaining: sessionsPerHost - (sessionIdx + 1),
+          });
+          await markRemainingTargetAttemptsRateLimited(
+            { convexHttpUrl, bearer, projectId, runId, target },
+            sessionIdx + 1,
+            sessionsPerHost
+          );
+          return;
+        }
       }
-    }
     } catch (err) {
       // A worker-level throw (a model-less pinned spec whose modelId can't
       // resolve, or a pinned-skill body that could not be fetched/verified)
@@ -633,6 +640,33 @@ async function runJourneyFanOut(
       // `failed` and let the OTHER workers keep running (the pool continues;
       // the run ends consistently). Best-effort; the stale-run cron backstops
       // anything missed.
+      //
+      // EXCEPT on abort: a shutdown/cancel or spend-cap short-circuit can
+      // cancel an in-flight pinned-skill prefetch, which throws here for a
+      // reason that is NOT this target's fault. Claiming those attempts
+      // `host_worker_failed` would out-race the run-level finalizer and stamp
+      // a misleading terminal on a cancelled run. Leave them `pending` and let
+      // `finalizeRun` (or the spend-cap path) classify them — the same
+      // reasoning as the `stopScheduling()` early return in the session loop.
+      if (sessionSignal.aborted) {
+        logEvent("target.worker_aborted", {
+          runId,
+          hostId,
+          targetId,
+          sessionIdx,
+        });
+        logger.info(
+          "[swarm.runner] target worker aborted; leaving attempts for run-level finalize",
+          {
+            runId,
+            hostId,
+            targetId,
+            sessionIdx,
+            error: err instanceof Error ? err.message : String(err),
+          }
+        );
+        return;
+      }
       logEvent("target.worker_failed", { runId, hostId, targetId, sessionIdx });
       logger.error(
         "[swarm.runner] target worker failed; finalizing its attempts",
@@ -671,9 +705,7 @@ async function runJourneyFanOut(
         await runTarget(target);
       }
     };
-    await Promise.all(
-      Array.from({ length: workerCount }, () => worker())
-    );
+    await Promise.all(Array.from({ length: workerCount }, () => worker()));
 
     // Run-level finalize of any still-pending attempts.
     if (spendCapTripped) {
@@ -723,8 +755,10 @@ async function runJourneyFanOut(
  *   - a pinned entry's body can't be fetched (persistent network/5xx), 404s,
  *     or fails hash verification — never a silent skill-less run;
  *   - the snapshot carries a non-empty host `skillSelection` but the pinned
- *     union carries NO channel provenance (pre-P0.2 backend) — running would
- *     silently drop the host skill channel;
+ *     union carries NO channel provenance (pre-P0.2 backend), carries no
+ *     `host`-tagged entry at all, or (when every entry is id-identified) omits
+ *     one of the selected skill ids — each would silently drop part or all of
+ *     the host skill channel;
  *   - a target with pinned metadata but no `targetId` (backend invariant
  *     violation — the fetch route requires it).
  *
@@ -763,6 +797,36 @@ async function resolveTargetPinnedSkills(args: {
         "union has no channel provenance (pre-P0.2 backend) — refusing to run " +
         "with a silently dropped host skill channel"
     );
+  }
+  // Provenance EXISTING is not the same as the host channel being present: a
+  // union tagged entirely `['environment']` also passes the check above while
+  // dropping every host skill. Require an actual host-channel entry.
+  if (hostWantsSkills && !meta.some((m) => m.channels?.includes("host"))) {
+    throw new Error(
+      "Snapshot target carries a host skillSelection but no pinned entry is " +
+        "tagged with the `host` channel — refusing to run with a silently " +
+        "dropped host skill channel"
+    );
+  }
+  // Stronger check when the union is fully identified: every host-selected id
+  // must appear. `skillId` is OPTIONAL (a snapshot survives the underlying
+  // skill being hard-deleted, and the join key is `contentHash`), so only
+  // assert this when EVERY entry carries one — otherwise an absent id is
+  // indistinguishable from a dropped one and we'd fail closed on a legitimate
+  // historical snapshot.
+  if (hostWantsSkills && meta.length > 0 && meta.every((m) => !!m.skillId)) {
+    const pinnedSkillIds = new Set(meta.map((m) => m.skillId));
+    const missing = hostSelection!.skillIds.filter(
+      (id) => !pinnedSkillIds.has(id)
+    );
+    if (missing.length > 0) {
+      throw new Error(
+        `Snapshot target's host skillSelection is not represented in its ` +
+          `pinnedSkills union (missing ${missing.length} of ${
+            hostSelection!.skillIds.length
+          }) — refusing to run with a partially dropped host skill channel`
+      );
+    }
   }
 
   // Env targets MUST carry a targetId for per-target claim/report attribution,

--- a/mcpjam-inspector/server/services/sessionSimulation/swarm-runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/swarm-runner.ts
@@ -5,14 +5,19 @@ import {
   type SimulationManagerFactory,
 } from "./runner.js";
 import {
+  fetchPinnedSkill,
   finalizePendingAttempts,
   heartbeatJourneyRun,
   reportAttempt,
   swarmPersonaNextTurn,
   type PersonaSnapshot,
   type PinnedHostExecutionSpec,
+  type PinnedSkillMeta,
   type SwarmAttemptStatus,
 } from "../swarm-agent.js";
+import { resolvePinnedSkillCached } from "./pinned-skill-cache.js";
+import { swarmAttemptChatSessionId } from "../../../shared/swarm-session-id.js";
+import type { PinnedSkillArtifact } from "../../../shared/skill-types.js";
 import { JourneyRunStreamHub } from "./swarm-stream-hub.js";
 import type {
   SwarmStreamEnvelope,
@@ -54,8 +59,29 @@ import type {
 const HEARTBEAT_INTERVAL_MS = 30_000;
 const DEFAULT_SHUTDOWN_TIMEOUT_MS = 5_000;
 const MAX_ATTEMPT_ERROR_CHARS = 500;
-/** Bounded host-worker pool: at most this many hosts run concurrently. */
-export const MAX_CONCURRENT_HOSTS = 3;
+/** Bounded target-worker pool: at most this many execution targets run
+ * concurrently. A target is one `snapshot.hosts[]` entry — a legacy host OR a
+ * project environment (two environments may share a host and still count as
+ * two targets). */
+export const MAX_CONCURRENT_TARGETS = 3;
+/** @deprecated Renamed {@link MAX_CONCURRENT_TARGETS} (targets ≠ hosts once
+ * environments land). Kept for existing tests/imports. */
+export const MAX_CONCURRENT_HOSTS = MAX_CONCURRENT_TARGETS;
+
+/** Session-id identity for a pinned execution target (shared mint — D1).
+ * `environmentId` comes from the FIRST-CLASS `environmentRef`; the opaque
+ * `targetId` is never parsed. */
+function targetSessionIdentity(target: PinnedHostExecutionSpec): {
+  hostId: string;
+  environmentId?: string;
+} {
+  return {
+    hostId: target.hostId,
+    ...(target.environmentRef?.environmentId
+      ? { environmentId: target.environmentRef.environmentId }
+      : {}),
+  };
+}
 
 /**
  * Builds a fresh, fully-connected manager scoped to one pinned host's
@@ -317,34 +343,56 @@ async function runJourneyFanOut(
 
   logEvent("run.start", {
     runId,
-    hostCount: hosts.length,
+    targetCount: hosts.length,
     sessionsPerHost,
     maxTurns,
-    maxConcurrentHosts: Math.min(MAX_CONCURRENT_HOSTS, hosts.length),
+    maxConcurrentTargets: Math.min(MAX_CONCURRENT_TARGETS, hosts.length),
   });
 
-  // --- Run one host's sessions SEQUENTIALLY --------------------------------
-  const runHost = async (host: PinnedHostExecutionSpec): Promise<void> => {
-    const hostId = host.hostId;
-    const modelId = host.modelId;
-    // Hoisted so the worker-level catch below knows how far this host got and
+  // --- Run one target's sessions SEQUENTIALLY ------------------------------
+  const runTarget = async (target: PinnedHostExecutionSpec): Promise<void> => {
+    const hostId = target.hostId;
+    const targetId = target.targetId;
+    const modelId = target.modelId;
+    // Hoisted so the worker-level catch below knows how far this target got and
     // can finalize the attempts it left behind.
     let sessionIdx = 0;
     try {
-    // Resolve the pinned host's modelId to a ModelDefinition once per host
+    // Resolve the pinned target's modelId to a ModelDefinition once per target
     // (catalog hits pass through; BYOK shapes get a derived provider). NEVER
     // refetch the live host config — everything comes from the immutable
     // snapshot. A model-less / unresolvable pinned spec throws HERE, before any
-    // attempt is claimed — the catch finalizes this host's pending attempts.
+    // attempt is claimed — the catch finalizes this target's pending attempts.
     const modelDefinition = buildSyntheticModelDefinition(modelId);
 
+    // Resolve the target's pinned skill BODIES up front (D3, fail-closed).
+    // Undefined ⇒ legacy live-pool semantics; an array (possibly empty) ⇒ the
+    // authoritative pinned set — env targets NEVER touch the live skills query.
+    // A persistent fetch failure / 404 / hash mismatch throws HERE, before any
+    // attempt is claimed, and the worker-catch finalizes the target's attempts
+    // `failed` — never a silent skill-less run.
+    const pinnedSkills = await resolveTargetPinnedSkills({
+      target,
+      projectId,
+      runId,
+      convexHttpUrl,
+      bearer,
+      signal: sessionSignal,
+    });
+
     for (sessionIdx = 0; sessionIdx < sessionsPerHost; sessionIdx++) {
-      // Run-level stop (spend cap or shutdown/cancel) halts THIS host too.
+      // Run-level stop (spend cap or shutdown/cancel) halts THIS target too.
       if (stopScheduling()) return;
 
       // Deterministic claim key — the immutable chatSessionId the attempt is
-      // claimed with and every persist + terminal reuse.
-      const chatSessionId = `synth_${runId}_${hostId}_${sessionIdx}`;
+      // claimed with and every persist + terminal reuse (shared mint, D1: env
+      // targets key on environmentRef.environmentId so two env targets on the
+      // SAME host can never collide).
+      const chatSessionId = swarmAttemptChatSessionId(
+        runId,
+        targetSessionIdentity(target),
+        sessionIdx
+      );
 
       // CLAIM before executing: the `running` transition requires the
       // chatSessionId and is immutable thereafter. Persistence is LAUNCHER-gated
@@ -356,6 +404,7 @@ async function runJourneyFanOut(
           projectId,
           runId,
           hostId,
+          ...(targetId ? { targetId } : {}),
           sessionIdx,
           status: "running",
           chatSessionId,
@@ -364,6 +413,7 @@ async function runJourneyFanOut(
         logger.error("[swarm.runner] attempt claim failed; skipping session", {
           runId,
           hostId,
+          targetId,
           sessionIdx,
           error: err instanceof Error ? err.message : String(err),
         });
@@ -388,11 +438,12 @@ async function runJourneyFanOut(
       }
 
       const attemptStartedAt = Date.now();
-      logEvent("attempt.start", { runId, hostId, sessionIdx, modelId });
+      logEvent("attempt.start", { runId, hostId, targetId, sessionIdx, modelId });
 
       const envelope: SwarmStreamEnvelope = {
         runId,
         hostId,
+        ...(targetId ? { targetId } : {}),
         chatSessionId,
         sessionIndex: sessionIdx,
       };
@@ -411,23 +462,27 @@ async function runJourneyFanOut(
         maxTurns,
         runtime: {
           modelDefinition,
-          systemPrompt: host.systemPrompt,
-          temperature: host.temperature,
-          requireToolApproval: host.requireToolApproval,
-          respectToolVisibility: host.respectToolVisibility,
-          progressiveToolDiscovery: host.progressiveToolDiscovery,
-          builtInToolIds: host.builtInToolIds,
-          modelVisibleMcpToolResults: host.modelVisibleMcpToolResults,
-          mcpToolResultImageRendering: host.mcpToolResultImageRendering,
-          computer: host.computer,
-          harness: host.harness,
+          systemPrompt: target.systemPrompt,
+          temperature: target.temperature,
+          requireToolApproval: target.requireToolApproval,
+          respectToolVisibility: target.respectToolVisibility,
+          progressiveToolDiscovery: target.progressiveToolDiscovery,
+          builtInToolIds: target.builtInToolIds,
+          modelVisibleMcpToolResults: target.modelVisibleMcpToolResults,
+          mcpToolResultImageRendering: target.mcpToolResultImageRendering,
+          computer: target.computer,
+          harness: target.harness,
+          // Authoritative pinned skills for env-based targets (undefined ⇒
+          // legacy live-pool). The shared core routes them to prepareChatV2
+          // (`skillsSource`) or the harness pinned path — never a live query.
+          ...(pinnedSkills !== undefined ? { pinnedSkills } : {}),
           // Swarm authorizes via project membership — no chatbox access
           // version, no chatbox id.
         },
         authHeader,
         // Each attempt gets a fresh manager + browser context, scoped to THIS
-        // host's pinned required servers.
-        managerFactory: () => managerFactory(host),
+        // target's pinned required servers.
+        managerFactory: () => managerFactory(target),
         // Thread the run-level stop signal (composed with shutdown/cancel) so a
         // spend-cap short-circuit cancels this host's in-flight turns.
         abortSignal: sessionSignal,
@@ -448,6 +503,7 @@ async function runJourneyFanOut(
           origin: "swarm",
           journeyRunId: runId,
           hostId,
+          ...(targetId ? { targetId } : {}),
           personaId: personaSnapshot.personaId,
           personaLabel: personaSnapshot.name,
         },
@@ -498,6 +554,7 @@ async function runJourneyFanOut(
           projectId,
           runId,
           hostId,
+          ...(targetId ? { targetId } : {}),
           sessionIdx,
           status: terminal.status,
           chatSessionId,
@@ -510,12 +567,14 @@ async function runJourneyFanOut(
         logEvent("attempt.report_failed", {
           runId,
           hostId,
+          targetId,
           sessionIdx,
           status: terminal.status,
         });
         logger.error("[swarm.runner] terminal attempt report failed", {
           runId,
           hostId,
+          targetId,
           sessionIdx,
           status: terminal.status,
           error: err instanceof Error ? err.message : String(err),
@@ -525,6 +584,7 @@ async function runJourneyFanOut(
       logEvent("attempt.finish", {
         runId,
         hostId,
+        targetId,
         sessionIdx,
         status: terminal.status,
         durationMs: Date.now() - attemptStartedAt,
@@ -542,20 +602,22 @@ async function runJourneyFanOut(
           logEvent("run.spend_cap_short_circuit", {
             runId,
             hostId,
+            targetId,
             sessionIdx,
           });
           return;
         }
-        // PROVIDER rate-limit: stop THIS host's remaining sessions and mark
-        // them rate_limited. Other hosts keep running.
-        logEvent("host.rate_limit_short_circuit", {
+        // PROVIDER rate-limit: stop THIS target's remaining sessions and mark
+        // them rate_limited. Other targets keep running.
+        logEvent("target.rate_limit_short_circuit", {
           runId,
           hostId,
+          targetId,
           fromSessionIdx: sessionIdx + 1,
           remaining: sessionsPerHost - (sessionIdx + 1),
         });
-        await markRemainingHostAttemptsRateLimited(
-          { convexHttpUrl, bearer, projectId, runId, hostId },
+        await markRemainingTargetAttemptsRateLimited(
+          { convexHttpUrl, bearer, projectId, runId, target },
           sessionIdx + 1,
           sessionsPerHost
         );
@@ -563,28 +625,31 @@ async function runJourneyFanOut(
       }
     }
     } catch (err) {
-      // A worker-level throw (e.g. a model-less pinned spec whose modelId can't
-      // resolve) must NOT abort the pool or leave this host's attempts dangling.
-      // Finalize this host's not-yet-terminal attempts (`[sessionIdx..N)` — the
-      // in-flight claim, if any, plus every never-claimed pending) as `failed`
-      // and let the OTHER workers keep running (the pool continues; the run ends
-      // consistently). Best-effort; the stale-run cron backstops anything missed.
-      logEvent("host.worker_failed", { runId, hostId, sessionIdx });
+      // A worker-level throw (a model-less pinned spec whose modelId can't
+      // resolve, or a pinned-skill body that could not be fetched/verified)
+      // must NOT abort the pool or leave this target's attempts dangling.
+      // Finalize this target's not-yet-terminal attempts (`[sessionIdx..N)` —
+      // the in-flight claim, if any, plus every never-claimed pending) as
+      // `failed` and let the OTHER workers keep running (the pool continues;
+      // the run ends consistently). Best-effort; the stale-run cron backstops
+      // anything missed.
+      logEvent("target.worker_failed", { runId, hostId, targetId, sessionIdx });
       logger.error(
-        "[swarm.runner] host worker failed; finalizing its attempts",
+        "[swarm.runner] target worker failed; finalizing its attempts",
         {
           runId,
           hostId,
+          targetId,
           sessionIdx,
           error: err instanceof Error ? err.message : String(err),
         }
       );
-      // Finalize this host's not-yet-terminal attempts `[sessionIdx..N)`: the
+      // Finalize this target's not-yet-terminal attempts `[sessionIdx..N)`: the
       // sweep re-claims the in-flight attempt (if the throw landed after a
       // claim; an idempotent re-claim with the same chatSessionId) and every
       // never-claimed pending, reporting each `failed`.
-      await markRemainingHostAttemptsFailed(
-        { convexHttpUrl, bearer, projectId, runId, hostId },
+      await markRemainingTargetAttemptsFailed(
+        { convexHttpUrl, bearer, projectId, runId, target },
         sessionIdx,
         sessionsPerHost
       );
@@ -592,17 +657,18 @@ async function runJourneyFanOut(
   };
 
   try {
-    // Bounded worker pool: a shared host queue drained by ≤MAX_CONCURRENT_HOSTS
-    // workers. Each worker pulls the next host, runs it to completion (or its
-    // per-host short-circuit), then pulls the next — so no more than N hosts
-    // are ever active at once, and a slow host doesn't block others.
-    const hostQueue = [...hosts];
-    const workerCount = Math.min(MAX_CONCURRENT_HOSTS, hostQueue.length);
+    // Bounded worker pool: a shared target queue drained by
+    // ≤MAX_CONCURRENT_TARGETS workers. Each worker pulls the next target, runs
+    // it to completion (or its per-target short-circuit), then pulls the next —
+    // so no more than N targets are ever active at once, and a slow target
+    // doesn't block others.
+    const targetQueue = [...hosts];
+    const workerCount = Math.min(MAX_CONCURRENT_TARGETS, targetQueue.length);
     const worker = async (): Promise<void> => {
       while (!stopScheduling()) {
-        const host = hostQueue.shift();
-        if (!host) return;
-        await runHost(host);
+        const target = targetQueue.shift();
+        if (!target) return;
+        await runTarget(target);
       }
     };
     await Promise.all(
@@ -636,7 +702,7 @@ async function runJourneyFanOut(
     clearInterval(heartbeat);
     logEvent("run.finish", {
       runId,
-      hostCount: hosts.length,
+      targetCount: hosts.length,
       durationMs: Date.now() - runStartedAt,
       spendCapTripped,
       aborted: abortSignal?.aborted === true,
@@ -645,32 +711,127 @@ async function runJourneyFanOut(
 }
 
 /**
- * Mark a rate-limited host's remaining `pending` attempts (`[fromIdx, toIdx)`)
- * as `rate_limited`. The backend `finalize-pending` is whole-run scoped (no
- * hostId), so we walk the host's own attempts via the reportAttempt state
- * machine: claim (`running` + the deterministic chatSessionId) then report the
- * terminal. Entirely best-effort — a failure here is logged and the sweep
- * continues; the backend stale-run cron backstops anything missed.
+ * Resolve a target's pinned skill BODIES (Project Environments, D3).
+ *
+ * Returns `undefined` for a legacy host target (live whole-pool semantics
+ * downstream) and the authoritative artifact array — possibly EMPTY, meaning
+ * deliberately skill-less — for an env-based target. Env-ness keys on the
+ * first-class `environmentRef` (the opaque `targetId` is never parsed);
+ * a `pinnedSkills` array on ANY target is also treated as authoritative.
+ *
+ * FAIL-CLOSED cases (throw → the worker-catch finalizes the target `failed`):
+ *   - a pinned entry's body can't be fetched (persistent network/5xx), 404s,
+ *     or fails hash verification — never a silent skill-less run;
+ *   - the snapshot carries a non-empty host `skillSelection` but the pinned
+ *     union carries NO channel provenance (pre-P0.2 backend) — running would
+ *     silently drop the host skill channel;
+ *   - a target with pinned metadata but no `targetId` (backend invariant
+ *     violation — the fetch route requires it).
+ *
+ * Bodies are content-addressed and cached process-wide (`pinned-skill-cache`),
+ * with in-flight coalescing across targets and bounded retries.
  */
-async function markRemainingHostAttemptsRateLimited(
+async function resolveTargetPinnedSkills(args: {
+  target: PinnedHostExecutionSpec;
+  projectId: string;
+  runId: string;
+  convexHttpUrl: string;
+  bearer: string;
+  signal?: AbortSignal;
+}): Promise<PinnedSkillArtifact[] | undefined> {
+  const { target, projectId, runId, convexHttpUrl, bearer, signal } = args;
+  const isEnvTarget = Boolean(target.environmentRef);
+  if (!isEnvTarget && target.pinnedSkills === undefined) {
+    return undefined; // legacy live-pool semantics
+  }
+  const meta: PinnedSkillMeta[] = target.pinnedSkills ?? [];
+
+  // P0.2 guard: a host-carried skillSelection MUST be represented in the
+  // pinned union (per-entry `channels` provenance proves the union is the
+  // authoritative two-channel composition). Never silently ignore it.
+  const hostSelection = target.skillSelection;
+  const hostWantsSkills =
+    !!hostSelection &&
+    Array.isArray(hostSelection.skillIds) &&
+    hostSelection.skillIds.length > 0;
+  const unionIsAuthoritative = meta.some(
+    (m) => Array.isArray(m.channels) && m.channels.length > 0
+  );
+  if (hostWantsSkills && !unionIsAuthoritative) {
+    throw new Error(
+      "Snapshot target carries a host skillSelection but its pinnedSkills " +
+        "union has no channel provenance (pre-P0.2 backend) — refusing to run " +
+        "with a silently dropped host skill channel"
+    );
+  }
+
+  if (meta.length === 0) return [];
+  const targetId = target.targetId;
+  if (!targetId) {
+    throw new Error(
+      "Snapshot target has pinned skills but no targetId — cannot fetch pinned bodies"
+    );
+  }
+
+  const artifacts: PinnedSkillArtifact[] = [];
+  for (const entry of meta) {
+    const artifact = await resolvePinnedSkillCached({
+      projectId,
+      contentHash: entry.contentHash,
+      fetcher: () =>
+        fetchPinnedSkill(convexHttpUrl, bearer, {
+          projectId,
+          runId,
+          targetId,
+          contentHash: entry.contentHash,
+          ...(signal ? { signal } : {}),
+        }),
+    });
+    // Preserve the snapshot's channel provenance when the served artifact
+    // doesn't carry it (the cache is keyed by content, not by target).
+    artifacts.push({
+      ...artifact,
+      ...(artifact.channels === undefined && entry.channels !== undefined
+        ? { channels: entry.channels }
+        : {}),
+    });
+  }
+  return artifacts;
+}
+
+/**
+ * Mark a rate-limited target's remaining `pending` attempts (`[fromIdx, toIdx)`)
+ * as `rate_limited`. The backend `finalize-pending` is whole-run scoped (no
+ * target dimension), so we walk the target's own attempts via the reportAttempt
+ * state machine: claim (`running` + the deterministic chatSessionId) then
+ * report the terminal. Entirely best-effort — a failure here is logged and the
+ * sweep continues; the backend stale-run cron backstops anything missed.
+ */
+async function markRemainingTargetAttemptsRateLimited(
   ctx: {
     convexHttpUrl: string;
     bearer: string;
     projectId: string;
     runId: string;
-    hostId: string;
+    target: PinnedHostExecutionSpec;
   },
   fromIdx: number,
   toIdx: number
 ): Promise<void> {
-  const { convexHttpUrl, bearer, projectId, runId, hostId } = ctx;
+  const { convexHttpUrl, bearer, projectId, runId, target } = ctx;
+  const { hostId, targetId } = target;
   for (let sessionIdx = fromIdx; sessionIdx < toIdx; sessionIdx++) {
-    const chatSessionId = `synth_${runId}_${hostId}_${sessionIdx}`;
+    const chatSessionId = swarmAttemptChatSessionId(
+      runId,
+      targetSessionIdentity(target),
+      sessionIdx
+    );
     try {
       await reportAttempt(convexHttpUrl, bearer, {
         projectId,
         runId,
         hostId,
+        ...(targetId ? { targetId } : {}),
         sessionIdx,
         status: "running",
         chatSessionId,
@@ -679,6 +840,7 @@ async function markRemainingHostAttemptsRateLimited(
         projectId,
         runId,
         hostId,
+        ...(targetId ? { targetId } : {}),
         sessionIdx,
         status: "rate_limited",
         chatSessionId,
@@ -686,10 +848,11 @@ async function markRemainingHostAttemptsRateLimited(
       });
     } catch (err) {
       logger.warn(
-        "[swarm.runner] failed to mark remaining host attempt rate_limited",
+        "[swarm.runner] failed to mark remaining target attempt rate_limited",
         {
           runId,
           hostId,
+          targetId,
           sessionIdx,
           error: err instanceof Error ? err.message : String(err),
         }
@@ -699,35 +862,41 @@ async function markRemainingHostAttemptsRateLimited(
 }
 
 /**
- * Mark a failed host-worker's not-yet-terminal attempts (`[fromIdx, toIdx)`)
- * as `failed` (errorCode `host_worker_failed`). Sibling of
- * {@link markRemainingHostAttemptsRateLimited}: walk the host's own attempts
- * via the reportAttempt state machine (claim `running` + the deterministic
- * chatSessionId, then report the terminal). Re-claiming an already-claimed
- * `running` attempt with the SAME chatSessionId is idempotent; an already
- * `succeeded`/`failed` attempt rejects the re-claim (terminal is immutable) and
- * is skipped. Entirely best-effort — a failure is logged and the sweep
- * continues; the backend stale-run cron backstops anything missed.
+ * Mark a failed target-worker's not-yet-terminal attempts (`[fromIdx, toIdx)`)
+ * as `failed` (errorCode `host_worker_failed` — kept for backend/dashboard
+ * compat). Sibling of {@link markRemainingTargetAttemptsRateLimited}: walk the
+ * target's own attempts via the reportAttempt state machine (claim `running` +
+ * the deterministic chatSessionId, then report the terminal). Re-claiming an
+ * already-claimed `running` attempt with the SAME chatSessionId is idempotent;
+ * an already `succeeded`/`failed` attempt rejects the re-claim (terminal is
+ * immutable) and is skipped. Entirely best-effort — a failure is logged and the
+ * sweep continues; the backend stale-run cron backstops anything missed.
  */
-async function markRemainingHostAttemptsFailed(
+async function markRemainingTargetAttemptsFailed(
   ctx: {
     convexHttpUrl: string;
     bearer: string;
     projectId: string;
     runId: string;
-    hostId: string;
+    target: PinnedHostExecutionSpec;
   },
   fromIdx: number,
   toIdx: number
 ): Promise<void> {
-  const { convexHttpUrl, bearer, projectId, runId, hostId } = ctx;
+  const { convexHttpUrl, bearer, projectId, runId, target } = ctx;
+  const { hostId, targetId } = target;
   for (let sessionIdx = fromIdx; sessionIdx < toIdx; sessionIdx++) {
-    const chatSessionId = `synth_${runId}_${hostId}_${sessionIdx}`;
+    const chatSessionId = swarmAttemptChatSessionId(
+      runId,
+      targetSessionIdentity(target),
+      sessionIdx
+    );
     try {
       await reportAttempt(convexHttpUrl, bearer, {
         projectId,
         runId,
         hostId,
+        ...(targetId ? { targetId } : {}),
         sessionIdx,
         status: "running",
         chatSessionId,
@@ -736,6 +905,7 @@ async function markRemainingHostAttemptsFailed(
         projectId,
         runId,
         hostId,
+        ...(targetId ? { targetId } : {}),
         sessionIdx,
         status: "failed",
         chatSessionId,
@@ -743,10 +913,11 @@ async function markRemainingHostAttemptsFailed(
       });
     } catch (err) {
       logger.warn(
-        "[swarm.runner] failed to mark remaining host attempt failed",
+        "[swarm.runner] failed to mark remaining target attempt failed",
         {
           runId,
           hostId,
+          targetId,
           sessionIdx,
           error: err instanceof Error ? err.message : String(err),
         }

--- a/mcpjam-inspector/server/services/swarm-agent.ts
+++ b/mcpjam-inspector/server/services/swarm-agent.ts
@@ -5,6 +5,7 @@ import type {
   ModelVisibleMcpToolResults,
 } from "@mcpjam/sdk/host-config/internal";
 import type { HostComputerResource } from "../utils/built-in-tools/registry.js";
+import type { PinnedSkillArtifact } from "../../shared/skill-types.js";
 
 /**
  * Inspector-side adapter for the backend swarm (journey-execution)
@@ -23,6 +24,32 @@ import type { HostComputerResource } from "../utils/built-in-tools/registry.js";
  * host's runtime config as of run-create time. Connection defaults / overrides
  * are secret-free (the backend strips secrets before returning the snapshot).
  */
+/**
+ * Reference to the environment an ENV-BASED execution target was resolved from
+ * (Project Environments). `environmentId` is the first-class id the session-id
+ * mint keys on — never derive it from `targetId`.
+ */
+export interface JourneyEnvironmentRef {
+  environmentId: string;
+  name: string;
+  revision: number;
+}
+
+/**
+ * Per-skill metadata pinned onto a snapshot target (bodies are NOT inline —
+ * the runner fetches them via {@link fetchPinnedSkill}). Mirrors the backend
+ * `PinnedSkillMeta`; `channels` is the P0.2 host/environment provenance and is
+ * absent on pre-P0.2 snapshots.
+ */
+export interface PinnedSkillMeta {
+  skillId?: string;
+  name: string;
+  description: string;
+  contentHash: string;
+  sharing?: "user" | "project";
+  channels?: Array<"host" | "environment">;
+}
+
 export interface PinnedHostExecutionSpec {
   hostId: string;
   hostName: string;
@@ -64,6 +91,34 @@ export interface PinnedHostExecutionSpec {
   connectionDefaults?: Record<string, unknown>;
   /** Secret-free per-server connection overrides keyed by serverId. */
   serverConnectionOverrides?: Record<string, unknown>;
+  /**
+   * Opaque execution-target id (Project Environments). Present on every fresh
+   * run's targets (`host:` / `environment:` shaped — NEVER parsed here); absent
+   * on historical pre-environments snapshots. Echoed verbatim on attempt
+   * claim/terminal and chat ingestion so two targets sharing a host stay
+   * unambiguous.
+   */
+  targetId?: string;
+  /** Set for ENVIRONMENT-based targets only; absent ⇒ legacy host target. */
+  environmentRef?: JourneyEnvironmentRef;
+  /** The environment's standalone server-group pointer (provenance only). */
+  serverAttachmentId?: string;
+  /**
+   * Host-carried skill selection snapshotted from the host config (#767 —
+   * inline, no skill-group ref). Provenance only on this side: the runner
+   * never resolves it live — pinned bodies come from `pinnedSkills` +
+   * {@link fetchPinnedSkill}. Used to detect a pre-P0.2 snapshot whose host
+   * channel was NOT pinned (fail closed rather than silently dropping it).
+   */
+  skillSelection?: { mode: "explicit"; skillIds: string[] } | null;
+  /**
+   * Pinned skill METADATA for this target (bodies fetched separately). After
+   * P0.2 this is the deduped authoritative host+environment union with
+   * per-entry `channels` provenance. Absent on legacy host targets (live-pool
+   * semantics) AND on env targets whose composed selection is empty (the env
+   * target then runs skill-less — never the live pool).
+   */
+  pinnedSkills?: PinnedSkillMeta[];
 }
 
 export interface PersonaSnapshot {
@@ -161,6 +216,106 @@ async function postJson<T>(
   return (await response.json()) as T;
 }
 
+async function getJson<T>(
+  url: string,
+  bearer: string,
+  timeoutMs: number,
+  signal?: AbortSignal
+): Promise<T> {
+  const response = await fetch(url, {
+    method: "GET",
+    headers: { Authorization: `Bearer ${bearer}` },
+    signal: signal
+      ? AbortSignal.any([AbortSignal.timeout(timeoutMs), signal])
+      : AbortSignal.timeout(timeoutMs),
+  });
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => "");
+    throw new SwarmAgentError(
+      response.status,
+      errorText,
+      `swarm-agent ${url} failed (${response.status}): ${errorText}`
+    );
+  }
+  return (await response.json()) as T;
+}
+
+/**
+ * The served pinned-skill body does not match the snapshot metadata it was
+ * fetched for (hash mismatch or a malformed envelope). NEVER retried and NEVER
+ * cached — it signals snapshot/store inconsistency, not a transient fault.
+ */
+export class PinnedSkillIntegrityError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PinnedSkillIntegrityError";
+  }
+}
+
+/**
+ * Fetch ONE pinned skill's complete runtime artifact for an env-based target:
+ * `GET /journey-execution/runs/skill?runId&projectId&targetId&contentHash`.
+ * Same bearer/authorization as the attempt/heartbeat routes (project member +
+ * run launcher). The response mirrors P0.2's complete artifact envelope
+ * ({@link PinnedSkillArtifact}) — the shipped backend serves the SKILL.md-only
+ * subset, which is the same shape with the optional extensions absent.
+ *
+ * Error contract (consumed by the pinned-skill cache's retry policy):
+ *   - 404 → {@link SwarmAgentError} with `status: 404` (never retried — the
+ *     target/hash pairing is not in the immutable snapshot).
+ *   - 5xx / transport → {@link SwarmAgentError} / fetch error (retryable).
+ *   - served hash ≠ requested hash → {@link PinnedSkillIntegrityError}
+ *     (never retried, never cached).
+ */
+export async function fetchPinnedSkill(
+  convexHttpUrl: string,
+  bearer: string,
+  args: {
+    projectId: string;
+    runId: string;
+    targetId: string;
+    contentHash: string;
+    signal?: AbortSignal;
+  }
+): Promise<PinnedSkillArtifact> {
+  const query = new URLSearchParams({
+    runId: args.runId,
+    projectId: args.projectId,
+    targetId: args.targetId,
+    contentHash: args.contentHash,
+  });
+  const data = await getJson<{
+    ok?: boolean;
+    skill?: PinnedSkillArtifact;
+    error?: string;
+  }>(
+    `${convexHttpUrl}/journey-execution/runs/skill?${query.toString()}`,
+    bearer,
+    NON_LLM_TIMEOUT_MS,
+    args.signal
+  );
+  const skill = data.skill;
+  if (
+    data.ok !== true ||
+    !skill ||
+    typeof skill.name !== "string" ||
+    typeof skill.content !== "string" ||
+    typeof skill.contentHash !== "string"
+  ) {
+    throw new PinnedSkillIntegrityError(
+      `Invalid pinned-skill response from backend: ${
+        data.error ?? "malformed envelope"
+      }`
+    );
+  }
+  if (skill.contentHash !== args.contentHash) {
+    throw new PinnedSkillIntegrityError(
+      `Pinned skill hash mismatch: requested ${args.contentHash}, served ${skill.contentHash}`
+    );
+  }
+  return skill;
+}
+
 /**
  * Create a journey run and return the pinned execution snapshot.
  *
@@ -252,6 +407,13 @@ export async function reportAttempt(
     projectId: string;
     runId: string;
     hostId: string;
+    /**
+     * Opaque snapshot target id, echoed VERBATIM from the pinned spec. Required
+     * in practice for env-based runs (the backend rejects a host-only lookup as
+     * ambiguous when two targets share a host); omitted only for historical
+     * snapshots whose targets carry no id.
+     */
+    targetId?: string;
     sessionIdx: number;
     status: SwarmAttemptStatus;
     chatSessionId?: string;
@@ -270,6 +432,7 @@ export async function reportAttempt(
       projectId: args.projectId,
       runId: args.runId,
       hostId: args.hostId,
+      ...(args.targetId ? { targetId: args.targetId } : {}),
       sessionIdx: args.sessionIdx,
       status: args.status,
       ...(args.chatSessionId ? { chatSessionId: args.chatSessionId } : {}),

--- a/mcpjam-inspector/server/services/swarm-agent.ts
+++ b/mcpjam-inspector/server/services/swarm-agent.ts
@@ -299,6 +299,10 @@ export async function fetchPinnedSkill(
     data.ok !== true ||
     !skill ||
     typeof skill.name !== "string" ||
+    // `description` is REQUIRED on the artifact (it becomes the skill's
+    // frontmatter description in the sandbox), so validate it here rather than
+    // letting `undefined` reach the runtime as a well-typed lie.
+    typeof skill.description !== "string" ||
     typeof skill.content !== "string" ||
     typeof skill.contentHash !== "string"
   ) {

--- a/mcpjam-inspector/server/utils/__tests__/chat-ingestion.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/chat-ingestion.test.ts
@@ -504,6 +504,48 @@ describe("chat-ingestion", () => {
     expect(body.sourceType).toBe("direct");
     expect(body.directVisibility).toBe("project");
   });
+
+  it("serializes targetId onto the ingest body for per-target (environment) attribution", async () => {
+    await persistChatSessionToConvex({
+      chatSessionId: "session-env-target",
+      modelId: "openai/gpt-4o-mini",
+      modelSource: "byok",
+      authHeader: "Bearer bearer-token",
+      sourceType: "swarm",
+      origin: "swarm",
+      journeyRunId: "run-1",
+      hostId: "host-1",
+      targetId: "target-a",
+      startedAt: 1,
+    });
+
+    const request = (global.fetch as any).mock.calls[0]?.[1];
+    const body = JSON.parse((request?.body as string) ?? "{}");
+
+    // Two environment targets can share ONE host, so `hostId` alone cannot
+    // attribute the session — `targetId` must reach the backend.
+    expect(body.hostId).toBe("host-1");
+    expect(body.targetId).toBe("target-a");
+  });
+
+  it("omits targetId from the ingest body when not supplied (legacy host targets)", async () => {
+    await persistChatSessionToConvex({
+      chatSessionId: "session-legacy-target",
+      modelId: "openai/gpt-4o-mini",
+      modelSource: "byok",
+      authHeader: "Bearer bearer-token",
+      sourceType: "swarm",
+      origin: "swarm",
+      journeyRunId: "run-1",
+      hostId: "host-1",
+      startedAt: 1,
+    });
+
+    const request = (global.fetch as any).mock.calls[0]?.[1];
+    const body = JSON.parse((request?.body as string) ?? "{}");
+
+    expect("targetId" in body).toBe(false);
+  });
 });
 
 describe("buildDirectHostConfig", () => {

--- a/mcpjam-inspector/server/utils/__tests__/chat-v2-orchestration.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/chat-v2-orchestration.test.ts
@@ -1255,3 +1255,37 @@ describe("prepareChatV2 — WebMCP UI tools", () => {
     expect(legacyDefault).toContain("applies immediately");
   });
 });
+
+describe("prepareChatV2 — pinned skills × harness (Project Environments guard)", () => {
+  it("THROWS on harness + skillsSource pinned (harness pinned skills must ride the harness path, never this branch)", async () => {
+    const manager = mockManager({});
+    await expect(
+      prepareChatV2({
+        mcpClientManager: manager,
+        selectedServers: [],
+        modelDefinition: { id: "gpt-4.1", provider: "openai" } as any,
+        systemPrompt: "Base prompt.",
+        harness: "claude-code" as any,
+        skillsSource: {
+          kind: "pinned",
+          skills: [
+            { name: "s", description: "d", content: "c", contentHash: "h" },
+          ],
+        },
+      }),
+    ).rejects.toThrow(/Pinned skills are not supported on harness/);
+  });
+
+  it("accepts harness + skillsSource none (a deliberately skill-less env target)", async () => {
+    const manager = mockManager({});
+    const result = await prepareChatV2({
+      mcpClientManager: manager,
+      selectedServers: [],
+      modelDefinition: { id: "gpt-4.1", provider: "openai" } as any,
+      systemPrompt: "Base prompt.",
+      harness: "claude-code" as any,
+      skillsSource: { kind: "none" },
+    });
+    expect(Object.keys(result.allTools)).toEqual([]);
+  });
+});

--- a/mcpjam-inspector/server/utils/assistant-turn.ts
+++ b/mcpjam-inspector/server/utils/assistant-turn.ts
@@ -208,6 +208,13 @@ export interface RunAssistantTurnOptions {
   hostId?: MCPJamHandlerOptions["hostId"];
 
   /**
+   * Pinned harness skills for env-based swarm targets (Project Environments).
+   * Pass-through to `runHarnessTurn`: when set (even empty) the harness turn
+   * skips the live skills fetch and delivers exactly these pinned artifacts.
+   */
+  pinnedHarnessSkills?: MCPJamHandlerOptions["pinnedHarnessSkills"];
+
+  /**
    * Override the Convex endpoint path. Stage 1 keeps this wired so
    * `handleHostedOrgChatModel` (org BYOK delegation chain) keeps
    * working — `runAssistantTurn` is the same engine, and the org BYOK
@@ -398,6 +405,11 @@ function buildHandlerOptions(
     ...(opts.harnessMcpProxy ? { harnessMcpProxy: opts.harnessMcpProxy } : {}),
     ...(opts.journeyRunId ? { journeyRunId: opts.journeyRunId } : {}),
     ...(opts.hostId ? { hostId: opts.hostId } : {}),
+    // Pinned harness skills: presence (even an EMPTY array) is semantic — an
+    // empty authoritative set means "run skill-less", never "fall back live".
+    ...(opts.pinnedHarnessSkills !== undefined
+      ? { pinnedHarnessSkills: opts.pinnedHarnessSkills }
+      : {}),
     ...(opts.requireToolApproval !== undefined
       ? { requireToolApproval: opts.requireToolApproval }
       : {}),

--- a/mcpjam-inspector/server/utils/chat-ingestion.ts
+++ b/mcpjam-inspector/server/utils/chat-ingestion.ts
@@ -251,6 +251,14 @@ interface PersistChatSessionOptions {
    */
   journeyRunId?: string;
   hostId?: string;
+  /**
+   * Opaque swarm execution-target id (Project Environments). Echoed verbatim
+   * from the pinned snapshot target so the backend can bind the session to the
+   * exact target when two targets share a host. Absent for legacy runs and
+   * pre-environments snapshots (the backend's host-only fallback still keys
+   * those).
+   */
+  targetId?: string;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -451,6 +459,7 @@ export async function persistChatSessionToConvex(
           ? { journeyRunId: options.journeyRunId }
           : {}),
         ...(options.hostId ? { hostId: options.hostId } : {}),
+        ...(options.targetId ? { targetId: options.targetId } : {}),
       }),
     });
 

--- a/mcpjam-inspector/server/utils/computers/convex-skills-client.ts
+++ b/mcpjam-inspector/server/utils/computers/convex-skills-client.ts
@@ -37,6 +37,15 @@ export interface CloudSkillListItem {
   aggregateHash: string;
   /** Wire-tolerant (see {@link normalizeProvenance}); absent ⇒ 'authored'. */
   provenance?: string;
+  /**
+   * Whether this skill can be pinned into a project environment's
+   * `skillSelection` (backend P0.3 metadata: rejects `plugin_component`
+   * skills, supporting files, extra frontmatter). Forwarded verbatim through
+   * `/api/web/skills/list` so pickers can disable ineligible rows with the
+   * backend-aligned reason instead of failing at save time. Absent on older
+   * backends (wire-tolerant).
+   */
+  pinnability?: { ok: true } | { ok: false; reason: string };
   createdAt: number;
   updatedAt: number;
 }

--- a/mcpjam-inspector/server/utils/harness/__tests__/pinned-harness-skills.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/pinned-harness-skills.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  materializePinnedSkillFiles,
+  pinnedArtifactsToRuntimeSkills,
+} from "../pinned-harness-skills.js";
+import { skillsFingerprint } from "../runtime-skills.js";
+import type { PinnedSkillArtifact } from "../../../../shared/skill-types.js";
+
+const artifact = (over: Partial<PinnedSkillArtifact> = {}): PinnedSkillArtifact => ({
+  name: "my-skill",
+  description: "does things",
+  content: "# body",
+  contentHash: "hash-1",
+  ...over,
+});
+
+describe("pinnedArtifactsToRuntimeSkills", () => {
+  it("maps artifacts onto the runtime-skill shape with aggregateHash = the pinned contentHash", () => {
+    const skills = pinnedArtifactsToRuntimeSkills([
+      artifact({ skillId: "sk1" }),
+    ]);
+    expect(skills).toEqual([
+      {
+        skillId: "sk1",
+        name: "my-skill",
+        description: "does things",
+        content: "# body",
+        aggregateHash: "hash-1",
+      },
+    ]);
+  });
+
+  it("synthesizes a content-derived skillId when the pin lost its source pointer", () => {
+    const [s] = pinnedArtifactsToRuntimeSkills([artifact()]);
+    expect(s!.skillId).toBe("pinned:hash-1");
+  });
+
+  it("skillsFingerprint over the mapped set derives from the pinned artifact fingerprints", () => {
+    const a = skillsFingerprint(
+      pinnedArtifactsToRuntimeSkills([artifact({ skillId: "sk1" })]),
+    );
+    const b = skillsFingerprint(
+      pinnedArtifactsToRuntimeSkills([
+        artifact({ skillId: "sk1", contentHash: "hash-2" }),
+      ]),
+    );
+    expect(a).not.toBe(b); // a different pinned artifact ⇒ a different hash
+    expect(
+      skillsFingerprint(pinnedArtifactsToRuntimeSkills([])),
+    ).toBe(""); // empty pinned set ⇒ the stable empty sentinel
+  });
+
+  it("projects preserved frontmatter onto the known Agent-Skills envelope only", () => {
+    const [s] = pinnedArtifactsToRuntimeSkills([
+      artifact({
+        frontmatter: {
+          license: "MIT",
+          "allowed-tools": ["Bash", "Read"],
+          metadata: { origin: "plugin" },
+          bogus: { nested: true },
+        },
+      }),
+    ]);
+    expect(s!.extraFrontmatter).toEqual({
+      license: "MIT",
+      allowedTools: ["Bash", "Read"],
+      metadata: { origin: "plugin" },
+    });
+  });
+});
+
+describe("materializePinnedSkillFiles", () => {
+  const makeSession = () => {
+    const writes: Array<{ path: string; content: string }> = [];
+    const commands: string[] = [];
+    return {
+      writes,
+      commands,
+      session: {
+        writeTextFile: vi.fn(async (a: { path: string; content: string }) => {
+          writes.push(a);
+        }),
+        run: vi.fn(async (a: { command: string }) => {
+          commands.push(a.command);
+          return { exitCode: 0, stdout: "", stderr: "" };
+        }),
+      },
+    };
+  };
+
+  it("writes inline text files under the skill's own dir", async () => {
+    const { session, writes, commands } = makeSession();
+    await materializePinnedSkillFiles({
+      session,
+      artifacts: [
+        artifact({
+          files: [{ path: "scripts/run.py", content: "print(1)" }],
+        }),
+      ],
+    });
+    expect(writes).toEqual([
+      {
+        path: "/home/user/.claude/skills/my-skill/scripts/run.py",
+        content: "print(1)",
+      },
+    ]);
+    expect(commands.some((c) => c.startsWith("mkdir -p "))).toBe(true);
+  });
+
+  it("skips a path that escapes the skill dir", async () => {
+    const { session, writes } = makeSession();
+    await materializePinnedSkillFiles({
+      session,
+      artifacts: [
+        artifact({
+          files: [{ path: "../../evil.sh", content: "rm -rf /" }],
+        }),
+      ],
+    });
+    expect(writes).toEqual([]);
+  });
+
+  it("no-ops for artifacts without files (SKILL.md-only env-channel entries)", async () => {
+    const { session } = makeSession();
+    await materializePinnedSkillFiles({ session, artifacts: [artifact()] });
+    expect(session.writeTextFile).not.toHaveBeenCalled();
+    expect(session.run).not.toHaveBeenCalled();
+  });
+});

--- a/mcpjam-inspector/server/utils/harness/__tests__/pinned-harness-skills.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/pinned-harness-skills.test.ts
@@ -6,7 +6,9 @@ import {
 import { skillsFingerprint } from "../runtime-skills.js";
 import type { PinnedSkillArtifact } from "../../../../shared/skill-types.js";
 
-const artifact = (over: Partial<PinnedSkillArtifact> = {}): PinnedSkillArtifact => ({
+const artifact = (
+  over: Partial<PinnedSkillArtifact> = {}
+): PinnedSkillArtifact => ({
   name: "my-skill",
   description: "does things",
   content: "# body",
@@ -37,17 +39,15 @@ describe("pinnedArtifactsToRuntimeSkills", () => {
 
   it("skillsFingerprint over the mapped set derives from the pinned artifact fingerprints", () => {
     const a = skillsFingerprint(
-      pinnedArtifactsToRuntimeSkills([artifact({ skillId: "sk1" })]),
+      pinnedArtifactsToRuntimeSkills([artifact({ skillId: "sk1" })])
     );
     const b = skillsFingerprint(
       pinnedArtifactsToRuntimeSkills([
         artifact({ skillId: "sk1", contentHash: "hash-2" }),
-      ]),
+      ])
     );
     expect(a).not.toBe(b); // a different pinned artifact ⇒ a different hash
-    expect(
-      skillsFingerprint(pinnedArtifactsToRuntimeSkills([])),
-    ).toBe(""); // empty pinned set ⇒ the stable empty sentinel
+    expect(skillsFingerprint(pinnedArtifactsToRuntimeSkills([]))).toBe(""); // empty pinned set ⇒ the stable empty sentinel
   });
 
   it("projects preserved frontmatter onto the known Agent-Skills envelope only", () => {
@@ -70,7 +70,10 @@ describe("pinnedArtifactsToRuntimeSkills", () => {
 });
 
 describe("materializePinnedSkillFiles", () => {
-  const makeSession = () => {
+  // `findStdout` seeds what the prune sweep's `find` reports as already on box
+  // (default: nothing). Every test shares this one session builder so the mock
+  // shape can't drift between them.
+  const makeSession = (findStdout = "") => {
     const writes: Array<{ path: string; content: string }> = [];
     const commands: string[] = [];
     return {
@@ -82,6 +85,9 @@ describe("materializePinnedSkillFiles", () => {
         }),
         run: vi.fn(async (a: { command: string }) => {
           commands.push(a.command);
+          if (a.command.startsWith("find ")) {
+            return { exitCode: 0, stdout: findStdout, stderr: "" };
+          }
           return { exitCode: 0, stdout: "", stderr: "" };
         }),
       },
@@ -135,26 +141,11 @@ describe("materializePinnedSkillFiles", () => {
   });
 
   it("prunes on-box supporting files not present in the pinned artifact", async () => {
-    const writes: Array<{ path: string; content: string }> = [];
-    const commands: string[] = [];
     const base = "/home/user/.claude/skills/my-skill";
-    const session = {
-      writeTextFile: vi.fn(async (a: { path: string; content: string }) => {
-        writes.push(a);
-      }),
-      run: vi.fn(async (a: { command: string }) => {
-        commands.push(a.command);
-        // The find sweep lists a stale file (b.md) and the kept file (a.md).
-        if (a.command.startsWith("find ")) {
-          return {
-            exitCode: 0,
-            stdout: `${base}/a.md\n${base}/b.md\n`,
-            stderr: "",
-          };
-        }
-        return { exitCode: 0, stdout: "", stderr: "" };
-      }),
-    };
+    // The find sweep lists a stale file (b.md) and the kept file (a.md).
+    const { session, writes, commands } = makeSession(
+      `${base}/a.md\n${base}/b.md\n`
+    );
     await materializePinnedSkillFiles({
       session,
       artifacts: [artifact({ files: [{ path: "a.md", content: "keep" }] })],

--- a/mcpjam-inspector/server/utils/harness/__tests__/pinned-harness-skills.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/pinned-harness-skills.test.ts
@@ -107,8 +107,8 @@ describe("materializePinnedSkillFiles", () => {
     expect(commands.some((c) => c.startsWith("mkdir -p "))).toBe(true);
   });
 
-  it("skips a path that escapes the skill dir", async () => {
-    const { session, writes } = makeSession();
+  it("skips a path that escapes the skill dir without any write/exec for it", async () => {
+    const { session, writes, commands } = makeSession();
     await materializePinnedSkillFiles({
       session,
       artifacts: [
@@ -118,6 +118,10 @@ describe("materializePinnedSkillFiles", () => {
       ],
     });
     expect(writes).toEqual([]);
+    // The rejected path must never reach mkdir, a binary write, or any other
+    // command — not just be absent from writeTextFile.
+    expect(commands.some((c) => c.includes("evil.sh"))).toBe(false);
+    expect(commands.some((c) => c.startsWith("mkdir "))).toBe(false);
   });
 
   it("writes nothing for artifacts without files, but still runs the prune sweep", async () => {

--- a/mcpjam-inspector/server/utils/harness/__tests__/pinned-harness-skills.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/pinned-harness-skills.test.ts
@@ -120,10 +120,44 @@ describe("materializePinnedSkillFiles", () => {
     expect(writes).toEqual([]);
   });
 
-  it("no-ops for artifacts without files (SKILL.md-only env-channel entries)", async () => {
-    const { session } = makeSession();
+  it("writes nothing for artifacts without files, but still runs the prune sweep", async () => {
+    const { session, commands } = makeSession();
     await materializePinnedSkillFiles({ session, artifacts: [artifact()] });
     expect(session.writeTextFile).not.toHaveBeenCalled();
-    expect(session.run).not.toHaveBeenCalled();
+    // Prune runs even with no files so a skill whose set became empty gets its
+    // orphans removed; the sweep is a single find (empty stdout ⇒ no rm).
+    expect(commands.some((c) => c.startsWith("find "))).toBe(true);
+    expect(commands.some((c) => c.startsWith("rm "))).toBe(false);
+  });
+
+  it("prunes on-box supporting files not present in the pinned artifact", async () => {
+    const writes: Array<{ path: string; content: string }> = [];
+    const commands: string[] = [];
+    const base = "/home/user/.claude/skills/my-skill";
+    const session = {
+      writeTextFile: vi.fn(async (a: { path: string; content: string }) => {
+        writes.push(a);
+      }),
+      run: vi.fn(async (a: { command: string }) => {
+        commands.push(a.command);
+        // The find sweep lists a stale file (b.md) and the kept file (a.md).
+        if (a.command.startsWith("find ")) {
+          return {
+            exitCode: 0,
+            stdout: `${base}/a.md\n${base}/b.md\n`,
+            stderr: "",
+          };
+        }
+        return { exitCode: 0, stdout: "", stderr: "" };
+      }),
+    };
+    await materializePinnedSkillFiles({
+      session,
+      artifacts: [artifact({ files: [{ path: "a.md", content: "keep" }] })],
+    });
+    // b.md is not in the artifact ⇒ removed; a.md is kept (not rm'd) and rewritten.
+    expect(commands).toContain(`rm -f -- '${base}/b.md'`);
+    expect(commands).not.toContain(`rm -f -- '${base}/a.md'`);
+    expect(writes).toContainEqual({ path: `${base}/a.md`, content: "keep" });
   });
 });

--- a/mcpjam-inspector/server/utils/harness/pinned-harness-skills.ts
+++ b/mcpjam-inspector/server/utils/harness/pinned-harness-skills.ts
@@ -1,0 +1,152 @@
+/**
+ * Pinned-skill delivery for HARNESS turns (Project Environments — B3).
+ *
+ * An env-based swarm target's skills are snapshot-pinned artifacts fetched via
+ * the journey skill route — the harness turn must consume EXACTLY those and
+ * never the live Convex pool. This module adapts pinned artifacts onto the
+ * existing harness skill machinery:
+ *
+ *   - {@link pinnedArtifactsToRuntimeSkills} maps artifacts to the
+ *     `CloudSkillRuntimeItem` shape the adapter/`skillsFingerprint`/
+ *     `reconcileSkillDirs`/`materializeSkillFrontmatter` already consume, so
+ *     `skillsHash` derives from the pinned artifact fingerprints and preserved
+ *     frontmatter re-materializes through the existing pass.
+ *   - {@link materializePinnedSkillFiles} writes the artifacts' INLINE
+ *     supporting files (P0.2 host-channel plugin skills). The live path's
+ *     `materializeSkillFiles` downloads by URL; pinned envelopes carry file
+ *     bodies inline instead, so this is a separate (much smaller) writer with
+ *     the same path-validation discipline. Environment-channel skills are
+ *     SKILL.md-only under P0.3, but this adapter must not assume the whole
+ *     union has no files.
+ */
+import {
+  isValidSkillName,
+  type PinnedSkillArtifact,
+} from "../../../shared/skill-types.js";
+import { isPathWithinDirectory } from "../skill-parser.js";
+import { shellQuote } from "./shell-quote.js";
+import { logger } from "../logger.js";
+import type {
+  CloudSkillRuntimeItem,
+  SkillExtraFrontmatterInput,
+} from "../computers/convex-skills-client.js";
+
+const SKILLS_BASE = "/home/user/.claude/skills";
+
+/** Minimal structural view of the harness sandbox session (file plane). */
+export interface PinnedSkillFileSession {
+  writeTextFile(args: { path: string; content: string }): PromiseLike<unknown>;
+  run(args: {
+    command: string;
+  }): PromiseLike<{ exitCode: number; stdout: string; stderr: string }>;
+}
+
+/** Defensive projection of the artifact's preserved frontmatter onto the known
+ * Agent-Skills envelope. Unknown keys are dropped (the backend re-validates on
+ * pin; this only guards against a drifted wire shape). */
+function toExtraFrontmatter(
+  frontmatter: Record<string, unknown> | undefined
+): SkillExtraFrontmatterInput | undefined {
+  if (!frontmatter) return undefined;
+  const out: SkillExtraFrontmatterInput = {};
+  if (typeof frontmatter.license === "string") out.license = frontmatter.license;
+  if (typeof frontmatter.compatibility === "string") {
+    out.compatibility = frontmatter.compatibility;
+  }
+  const allowedTools = frontmatter["allowedTools"] ?? frontmatter["allowed-tools"];
+  if (
+    Array.isArray(allowedTools) &&
+    allowedTools.every((t) => typeof t === "string")
+  ) {
+    out.allowedTools = allowedTools as string[];
+  }
+  const metadata = frontmatter.metadata;
+  if (
+    metadata &&
+    typeof metadata === "object" &&
+    !Array.isArray(metadata) &&
+    Object.values(metadata).every((v) => typeof v === "string")
+  ) {
+    out.metadata = metadata as Record<string, string>;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/**
+ * Map pinned artifacts onto the runtime-skill shape the harness machinery
+ * consumes. `aggregateHash` is the artifact's `contentHash` (the complete
+ * pinned-envelope fingerprint), so `skillsFingerprint` over this list IS the
+ * pinned-artifact fingerprint hash. `skillId` falls back to a content-derived
+ * synthetic id when the pin lost its source skill pointer — it only needs to
+ * be stable within the run for reconcile/fingerprint bookkeeping.
+ */
+export function pinnedArtifactsToRuntimeSkills(
+  artifacts: PinnedSkillArtifact[]
+): CloudSkillRuntimeItem[] {
+  return artifacts.map((a) => ({
+    skillId: a.skillId ?? `pinned:${a.contentHash}`,
+    name: a.name,
+    description: a.description,
+    content: a.content,
+    aggregateHash: a.contentHash,
+    ...(toExtraFrontmatter(a.frontmatter)
+      ? { extraFrontmatter: toExtraFrontmatter(a.frontmatter) }
+      : {}),
+  }));
+}
+
+/**
+ * Write the pinned artifacts' inline supporting files under each skill's own
+ * dir (`~/.claude/skills/<name>/<path>`). Path-validated per file (defense in
+ * depth over the backend's pin-time validation); binary files ride base64
+ * through `base64 -d` (the b64 alphabet is single-quote safe). Best-effort per
+ * file: a single bad file logs and is skipped — the pinned SKILL.md already
+ * shipped via the adapter — but this NEVER prunes anything (pruning stays the
+ * live path's reconcile concern).
+ */
+export async function materializePinnedSkillFiles(args: {
+  session: PinnedSkillFileSession;
+  artifacts: PinnedSkillArtifact[];
+  signal?: AbortSignal;
+}): Promise<void> {
+  const { session, artifacts, signal } = args;
+  for (const artifact of artifacts) {
+    const files = artifact.files;
+    if (!files || files.length === 0) continue;
+    if (!isValidSkillName(artifact.name)) {
+      logger.warn("[pinned-harness-skills] invalid skill name; skipping files", {
+        name: artifact.name,
+      });
+      continue;
+    }
+    const skillDir = `${SKILLS_BASE}/${artifact.name}`;
+    for (const file of files) {
+      if (signal?.aborted) return;
+      if (!isPathWithinDirectory(skillDir, file.path)) {
+        logger.warn(
+          "[pinned-harness-skills] file path escapes its skill dir; skipping",
+          { name: artifact.name, path: file.path }
+        );
+        continue;
+      }
+      const target = `${skillDir}/${file.path}`;
+      const parent = target.slice(0, target.lastIndexOf("/"));
+      try {
+        await session.run({ command: `mkdir -p ${shellQuote(parent)}` });
+        if (typeof file.content === "string") {
+          await session.writeTextFile({ path: target, content: file.content });
+        } else if (typeof file.base64 === "string") {
+          await session.run({
+            command: `printf '%s' ${shellQuote(file.base64)} | base64 -d > ${shellQuote(target)}`,
+          });
+        }
+      } catch (err) {
+        logger.warn("[pinned-harness-skills] file write failed; skipping", {
+          name: artifact.name,
+          path: file.path,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  }
+}

--- a/mcpjam-inspector/server/utils/harness/pinned-harness-skills.ts
+++ b/mcpjam-inspector/server/utils/harness/pinned-harness-skills.ts
@@ -49,11 +49,13 @@ function toExtraFrontmatter(
 ): SkillExtraFrontmatterInput | undefined {
   if (!frontmatter) return undefined;
   const out: SkillExtraFrontmatterInput = {};
-  if (typeof frontmatter.license === "string") out.license = frontmatter.license;
+  if (typeof frontmatter.license === "string")
+    out.license = frontmatter.license;
   if (typeof frontmatter.compatibility === "string") {
     out.compatibility = frontmatter.compatibility;
   }
-  const allowedTools = frontmatter["allowedTools"] ?? frontmatter["allowed-tools"];
+  const allowedTools =
+    frontmatter["allowedTools"] ?? frontmatter["allowed-tools"];
   if (
     Array.isArray(allowedTools) &&
     allowedTools.every((t) => typeof t === "string")
@@ -112,6 +114,10 @@ async function pruneStalePinnedSkillFiles(
   signal?: AbortSignal
 ): Promise<void> {
   if (deliveredDirs.size === 0) return;
+  // Check abort BEFORE the sweep: the `find` is sandbox-wide, so an already
+  // cancelled turn must not pay for it. Matches the per-file write loop below,
+  // which checks `signal?.aborted` before each `session.run`.
+  if (signal?.aborted) return;
   try {
     const ls = await session.run({
       command: `find ${shellQuote(
@@ -184,9 +190,12 @@ export async function materializePinnedSkillFiles(args: {
     const files = artifact.files;
     if (!files || files.length === 0) continue;
     if (!isValidSkillName(artifact.name)) {
-      logger.warn("[pinned-harness-skills] invalid skill name; skipping files", {
-        name: artifact.name,
-      });
+      logger.warn(
+        "[pinned-harness-skills] invalid skill name; skipping files",
+        {
+          name: artifact.name,
+        }
+      );
       continue;
     }
     const skillDir = `${SKILLS_BASE}/${artifact.name}`;
@@ -207,7 +216,9 @@ export async function materializePinnedSkillFiles(args: {
           await session.writeTextFile({ path: target, content: file.content });
         } else if (typeof file.base64 === "string") {
           await session.run({
-            command: `printf '%s' ${shellQuote(file.base64)} | base64 -d > ${shellQuote(target)}`,
+            command: `printf '%s' ${shellQuote(
+              file.base64
+            )} | base64 -d > ${shellQuote(target)}`,
           });
         }
       } catch (err) {

--- a/mcpjam-inspector/server/utils/harness/pinned-harness-skills.ts
+++ b/mcpjam-inspector/server/utils/harness/pinned-harness-skills.ts
@@ -96,13 +96,65 @@ export function pinnedArtifactsToRuntimeSkills(
 }
 
 /**
+ * Remove supporting files ON BOX under a pinned skill's dir that aren't in that
+ * artifact's file set (files dropped/renamed between snapshots, or a skill whose
+ * file set became empty), so a REUSED sandbox reflects the target's exact
+ * snapshot instead of retaining a prior run's files. Mirrors the live path's
+ * `pruneStaleSkillFiles`: one global `find` (reaches dirs that received NO file
+ * this turn), removal scoped to delivered dirs, SKILL.md never touched, fail-soft.
+ * `keepByDir` maps a skill dir → the abs paths it should still hold (empty ⇒
+ * prune all its supporting files).
+ */
+async function pruneStalePinnedSkillFiles(
+  session: PinnedSkillFileSession,
+  deliveredDirs: Set<string>,
+  keepByDir: Map<string, Set<string>>,
+  signal?: AbortSignal
+): Promise<void> {
+  if (deliveredDirs.size === 0) return;
+  try {
+    const ls = await session.run({
+      command: `find ${shellQuote(
+        SKILLS_BASE
+      )} -mindepth 2 -type f ! -name SKILL.md`,
+    });
+    if (ls.exitCode !== 0) return;
+    const onBox = ls.stdout
+      .split("\n")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    for (const p of onBox) {
+      if (signal?.aborted) return;
+      if (!p.startsWith(`${SKILLS_BASE}/`)) continue;
+      const name = p.slice(SKILLS_BASE.length + 1).split("/")[0];
+      const skillDir = `${SKILLS_BASE}/${name}`;
+      if (!deliveredDirs.has(skillDir)) continue; // never a foreign skill
+      if (p === `${skillDir}/SKILL.md`) continue; // belt-and-suspenders
+      if (keepByDir.get(skillDir)?.has(p)) continue; // still current
+      try {
+        await session.run({ command: `rm -f -- ${shellQuote(p)}` });
+      } catch {
+        // best-effort per-file removal
+      }
+    }
+  } catch {
+    // Best-effort — a prune failure never blocks materialization.
+  }
+}
+
+/**
  * Write the pinned artifacts' inline supporting files under each skill's own
  * dir (`~/.claude/skills/<name>/<path>`). Path-validated per file (defense in
  * depth over the backend's pin-time validation); binary files ride base64
  * through `base64 -d` (the b64 alphabet is single-quote safe). Best-effort per
  * file: a single bad file logs and is skipped — the pinned SKILL.md already
- * shipped via the adapter — but this NEVER prunes anything (pruning stays the
- * live path's reconcile concern).
+ * shipped via the adapter.
+ *
+ * FIRST prunes stale supporting files not present in each artifact's file set
+ * ({@link pruneStalePinnedSkillFiles}) so a reused sandbox reflects the pinned
+ * snapshot EXACTLY — the whole point of a pinned env run. The caller passes
+ * EVERY pinned skill (not only those with files) so a skill whose file set
+ * became empty still gets its orphans pruned.
  */
 export async function materializePinnedSkillFiles(args: {
   session: PinnedSkillFileSession;
@@ -110,6 +162,24 @@ export async function materializePinnedSkillFiles(args: {
   signal?: AbortSignal;
 }): Promise<void> {
   const { session, artifacts, signal } = args;
+
+  // Prune before write: build delivered dirs + the files each should keep from
+  // the authoritative pinned artifacts, then remove anything else on box.
+  const deliveredDirs = new Set<string>();
+  const keepByDir = new Map<string, Set<string>>();
+  for (const artifact of artifacts) {
+    if (!isValidSkillName(artifact.name)) continue;
+    const skillDir = `${SKILLS_BASE}/${artifact.name}`;
+    deliveredDirs.add(skillDir);
+    const keep = new Set<string>();
+    for (const file of artifact.files ?? []) {
+      const target = `${skillDir}/${file.path}`;
+      if (isPathWithinDirectory(skillDir, file.path)) keep.add(target);
+    }
+    keepByDir.set(skillDir, keep);
+  }
+  await pruneStalePinnedSkillFiles(session, deliveredDirs, keepByDir, signal);
+
   for (const artifact of artifacts) {
     const files = artifact.files;
     if (!files || files.length === 0) continue;

--- a/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
+++ b/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
@@ -80,6 +80,10 @@ import {
   claudeCodeSafeSkills,
 } from "./runtime-skills.js";
 import { materializeSkillFiles } from "./materialize-skill-files.js";
+import {
+  materializePinnedSkillFiles,
+  pinnedArtifactsToRuntimeSkills,
+} from "./pinned-harness-skills.js";
 import { materializeSkillFrontmatter } from "./materialize-skill-frontmatter.js";
 import {
   reconcileSkillDirs,
@@ -331,6 +335,7 @@ export async function runHarnessTurn(
     harnessMcpProxy,
     builtInTools,
     executionScope,
+    pinnedHarnessSkills,
   } = options;
   // Canonicalize the model id up front (bare hosted ids like `gpt-5-nano` →
   // `openai/gpt-5-nano`). Everything downstream — supportsModel, the adapter's
@@ -596,8 +601,18 @@ export async function runHarnessTurn(
       // reuses the stored hash (no resume churn, no empty-hash commit). The skills
       // fingerprint is tracked SEPARATELY from `runtimeFingerprint` precisely so
       // "unknown" (failure) is distinguishable from "" (empty project).
-      const skillsFetch =
-        projectId && authHeader
+      // PINNED MODE (Project Environments, env-based swarm targets): the
+      // caller supplied the authoritative pinned artifact set — even EMPTY —
+      // so the live skills query is SKIPPED entirely and `skillsHash` derives
+      // from the pinned artifact fingerprints. Legacy callers (undefined) keep
+      // the live tri-state fetch unchanged.
+      const skillsArePinned = pinnedHarnessSkills !== undefined;
+      const skillsFetch = skillsArePinned
+        ? {
+            ok: true as const,
+            skills: pinnedArtifactsToRuntimeSkills(pinnedHarnessSkills),
+          }
+        : projectId && authHeader
           ? await fetchRuntimeSkills(authHeader, projectId, executionScope)
           : { ok: true as const, skills: [] };
       const runtimeSkills = skillsFetch.ok ? skillsFetch.skills : null;
@@ -877,11 +892,24 @@ export async function runHarnessTurn(
               skillsHash: skillsHash ?? "",
               ...(abortSignal ? { signal: abortSignal } : {}),
             }).catch(() => {});
+            // PINNED MODE: supporting files ride INLINE on the pinned
+            // artifacts (P0.2 host-channel plugin skills) — never the live
+            // file query. Env-channel entries are SKILL.md-only under P0.3,
+            // so this is a no-op for them.
+            if (skillsArePinned) {
+              if (pinnedHarnessSkills!.some((a) => a.files?.length)) {
+                await materializePinnedSkillFiles({
+                  session,
+                  artifacts: pinnedHarnessSkills!,
+                  ...(abortSignal ? { signal: abortSignal } : {}),
+                }).catch(() => {});
+              }
+            }
             // Materialize supporting files AFTER reconcile (the adapter wrote each
             // SKILL.md; reconcile removed stale managed dirs). Fetched here rather
             // than at turn start to keep the zero-file fast path free. Fully
             // fail-soft; guest/swarm scope uses the execution-scoped file query.
-            if (projectId && authHeader && runtimeSkills.length > 0) {
+            else if (projectId && authHeader && runtimeSkills.length > 0) {
               // Tri-state: `{ ok: false }` ⇒ the fetch FAILED (transient). Skip
               // materialization then — an empty file set would otherwise prune
               // every delivered skill's on-box files. `{ ok: true, files: [] }`

--- a/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
+++ b/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
@@ -894,16 +894,17 @@ export async function runHarnessTurn(
             }).catch(() => {});
             // PINNED MODE: supporting files ride INLINE on the pinned
             // artifacts (P0.2 host-channel plugin skills) — never the live
-            // file query. Env-channel entries are SKILL.md-only under P0.3,
-            // so this is a no-op for them.
+            // file query. Env-channel entries are SKILL.md-only under P0.3.
+            // Always invoked (not gated on `some(files)`): the writer also
+            // PRUNES stale files so a reused box matches the pinned snapshot
+            // exactly — a skill whose file set became empty must still have its
+            // prior-run orphans removed.
             if (skillsArePinned) {
-              if (pinnedHarnessSkills!.some((a) => a.files?.length)) {
-                await materializePinnedSkillFiles({
-                  session,
-                  artifacts: pinnedHarnessSkills!,
-                  ...(abortSignal ? { signal: abortSignal } : {}),
-                }).catch(() => {});
-              }
+              await materializePinnedSkillFiles({
+                session,
+                artifacts: pinnedHarnessSkills!,
+                ...(abortSignal ? { signal: abortSignal } : {}),
+              }).catch(() => {});
             }
             // Materialize supporting files AFTER reconcile (the adapter wrote each
             // SKILL.md; reconcile removed stale managed dirs). Fetched here rather

--- a/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
@@ -29,6 +29,7 @@ import type { ModelVisibleMcpToolResults } from "@mcpjam/sdk/host-config/interna
 import { runHarnessTurn } from "./harness/run-harness-turn.js";
 import type { HarnessSessionCommitPayload } from "./harness/harness-session-state.js";
 import type { ExecutionScope } from "./execution-scope.js";
+import type { PinnedSkillArtifact } from "../../shared/skill-types.js";
 import type { HarnessMcpProxyStrategy } from "./harness/harness-proxy-strategy.js";
 import {
   buildFinishChunk,
@@ -428,6 +429,16 @@ export interface MCPJamHandlerOptions {
    */
   journeyRunId?: string;
   hostId?: string;
+  /**
+   * Pinned harness skills (Project Environments — env-based swarm targets
+   * only). When set — even EMPTY — the harness turn delivers exactly these
+   * pinned artifacts and SKIPS the live `fetchRuntimeSkills` query; its
+   * `skillsHash` derives from the pinned artifact fingerprints. Undefined ⇒
+   * the legacy live-pool fetch. HARNESS-ONLY: the emulated engine receives
+   * pinned skills via prepareChatV2's `skillsSource` instead (which THROWS on
+   * harness+pinned — the two paths are deliberately disjoint).
+   */
+  pinnedHarnessSkills?: PinnedSkillArtifact[];
   /**
    * Phase 3 execution scope from the server-resolved runtime config (chatbox OR
    * host-by-id). Threaded into the harness path (sandbox reserve, runtime skills,

--- a/mcpjam-inspector/shared/__tests__/swarm-session-id.test.ts
+++ b/mcpjam-inspector/shared/__tests__/swarm-session-id.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { swarmAttemptChatSessionId } from "../swarm-session-id";
+
+describe("swarmAttemptChatSessionId (shared mint — D1)", () => {
+  it("legacy host target: byte-identical to the historical inline mint", () => {
+    // The pre-environments spelling was `synth_${runId}_${hostId}_${sessionIdx}`.
+    expect(
+      swarmAttemptChatSessionId("run-1", { hostId: "host-1" }, 0),
+    ).toBe("synth_run-1_host-1_0");
+    expect(
+      swarmAttemptChatSessionId("run-1", { hostId: "host-1" }, 3),
+    ).toBe("synth_run-1_host-1_3");
+    // Explicit null/undefined environmentId is still legacy.
+    expect(
+      swarmAttemptChatSessionId(
+        "run-1",
+        { hostId: "host-1", environmentId: null },
+        1,
+      ),
+    ).toBe("synth_run-1_host-1_1");
+  });
+
+  it("environment target: keys on environmentId with the env_ marker", () => {
+    expect(
+      swarmAttemptChatSessionId(
+        "run-1",
+        { hostId: "host-1", environmentId: "envA" },
+        0,
+      ),
+    ).toBe("synth_run-1_env_envA_0");
+  });
+
+  it("two environments on the SAME host mint distinct ids", () => {
+    const a = swarmAttemptChatSessionId(
+      "run-1",
+      { hostId: "host-1", environmentId: "envA" },
+      0,
+    );
+    const b = swarmAttemptChatSessionId(
+      "run-1",
+      { hostId: "host-1", environmentId: "envB" },
+      0,
+    );
+    expect(a).not.toBe(b);
+  });
+});

--- a/mcpjam-inspector/shared/app-surfaces.ts
+++ b/mcpjam-inspector/shared/app-surfaces.ts
@@ -265,6 +265,26 @@ export const APP_SURFACES = [
     showInAtlas: true,
   },
   {
+    id: "project-environments",
+    canonicalPath: "/environments",
+    routePatterns: ["environments"],
+    navSegments: ["environments"],
+    title: "Environments",
+    purpose:
+      "Manage the project's environments — named bundles of one client, an optional server group, and optional pinned skills that eval suites and journeys run against.",
+    userActivities: [
+      "Create or edit an environment (name, client, server group, skills)",
+      "Archive or restore an environment",
+      "Review which client and server group an environment resolves to",
+    ],
+    agentTools: {
+      kind: "none",
+      reason:
+        "Admin-flavored configuration surface behind a rollout flag; no agent automation until the feature is generally available.",
+    },
+    showInAtlas: true,
+  },
+  {
     id: "evals",
     canonicalPath: "/evals",
     routePatterns: [

--- a/mcpjam-inspector/shared/app-surfaces.ts
+++ b/mcpjam-inspector/shared/app-surfaces.ts
@@ -282,7 +282,11 @@ export const APP_SURFACES = [
       reason:
         "Admin-flavored configuration surface behind a rollout flag; no agent automation until the feature is generally available.",
     },
-    showInAtlas: true,
+    // The Atlas is intentionally STATIC — it cannot read
+    // `project-environments-enabled`, so advertising `/environments` would send
+    // the agent to a surface that redirects on every flag-off project. Flip to
+    // `true` when the flag is retired at GA.
+    showInAtlas: false,
   },
   {
     id: "evals",
@@ -363,8 +367,7 @@ export const APP_SURFACES = [
     routePatterns: ["resources"],
     navSegments: ["resources"],
     title: "Resources",
-    purpose:
-      "List and read the resources a connected MCP server exposes.",
+    purpose: "List and read the resources a connected MCP server exposes.",
     userActivities: [
       "Browse a server's resources and resource templates",
       "Read a resource, or resolve and read a template",
@@ -643,7 +646,7 @@ export function listAppSurfaces(): readonly AppSurfaceManifest[] {
 }
 
 const surfacesById = new Map<string, AppSurfaceManifest>(
-  listAppSurfaces().map((s) => [s.id, s]),
+  listAppSurfaces().map((s) => [s.id, s])
 );
 
 export function getAppSurface(id: string): AppSurfaceManifest | undefined {
@@ -655,7 +658,7 @@ export function isAppSurfaceId(value: unknown): value is AppSurfaceId {
 }
 
 const surfacesByNavSegment = new Map<string, AppSurfaceManifest>(
-  listAppSurfaces().flatMap((s) => s.navSegments.map((seg) => [seg, s])),
+  listAppSurfaces().flatMap((s) => s.navSegments.map((seg) => [seg, s]))
 );
 
 /**
@@ -664,7 +667,7 @@ const surfacesByNavSegment = new Map<string, AppSurfaceManifest>(
  * the coverage test asserts no segment is claimed by two surfaces.
  */
 export function getAppSurfaceByNavSegment(
-  segment: string,
+  segment: string
 ): AppSurfaceManifest | undefined {
   return surfacesByNavSegment.get(segment);
 }
@@ -690,7 +693,7 @@ export function listAppSurfaceNavSegments(): string[] {
  */
 export function buildAppAtlas(opts?: { hosted?: boolean }): string {
   const surfaces = listAppSurfaces().filter(
-    (s) => s.showInAtlas && !(opts?.hosted && s.hostedBlocked),
+    (s) => s.showInAtlas && !(opts?.hosted && s.hostedBlocked)
   );
   return [
     "## The MCPJam inspector, screen by screen",
@@ -706,7 +709,7 @@ export function buildAppAtlas(opts?: { hosted?: boolean }): string {
         `### ${s.title} (${s.navSegments[0]})`,
         s.purpose,
         ...s.userActivities.map((a) => `- ${a}`),
-      ].join("\n"),
+      ].join("\n")
     ),
   ].join("\n");
 }

--- a/mcpjam-inspector/shared/skill-types.ts
+++ b/mcpjam-inspector/shared/skill-types.ts
@@ -60,6 +60,42 @@ export interface PinnableSkill {
 }
 
 /**
+ * One supporting file inside a pinned skill's runtime artifact (P0.2). Exactly
+ * one of `content` (text) / `base64` (binary) is set. `path` is RELATIVE to the
+ * skill's own directory and must be re-validated before any write.
+ */
+export interface PinnedSkillArtifactFile {
+  path: string;
+  content?: string;
+  base64?: string;
+  mimeType?: string;
+}
+
+/**
+ * The COMPLETE pinned runtime artifact for one snapshot-pinned skill, as served
+ * by `GET /journey-execution/runs/skill`. The shipped backend serves the
+ * SKILL.md-only subset (`name`/`description`/`contentHash`/`content`); the
+ * P0.2 union additionally carries channel provenance and — for host-channel
+ * plugin skills — supporting `files` and preserved extra `frontmatter`. Every
+ * extension field is optional so the SKILL.md-only response stays valid.
+ */
+export interface PinnedSkillArtifact {
+  name: string;
+  description: string;
+  content: string;
+  /** Opaque artifact fingerprint — covers the complete pinned envelope. */
+  contentHash: string;
+  skillId?: string;
+  sharing?: "user" | "project";
+  /** P0.2 channel provenance (stable order: host, then environment). */
+  channels?: Array<"host" | "environment">;
+  /** Preserved extra frontmatter beyond name/description (plugin skills). */
+  frontmatter?: Record<string, unknown>;
+  /** Supporting files (host-channel plugin skills only under P0.3). */
+  files?: PinnedSkillArtifactFile[];
+}
+
+/**
  * Full skill with content (used when loading a skill)
  */
 export interface Skill {

--- a/mcpjam-inspector/shared/skill-types.ts
+++ b/mcpjam-inspector/shared/skill-types.ts
@@ -60,16 +60,18 @@ export interface PinnableSkill {
 }
 
 /**
- * One supporting file inside a pinned skill's runtime artifact (P0.2). Exactly
- * one of `content` (text) / `base64` (binary) is set. `path` is RELATIVE to the
- * skill's own directory and must be re-validated before any write.
+ * One supporting file inside a pinned skill's runtime artifact (P0.2). EXACTLY
+ * one of `content` (text) / `base64` (binary) is set — encoded as a union so an
+ * impossible both-or-neither file can't be constructed. `path` is RELATIVE to
+ * the skill's own directory and must be re-validated before any write.
  */
-export interface PinnedSkillArtifactFile {
+export type PinnedSkillArtifactFile = {
   path: string;
-  content?: string;
-  base64?: string;
   mimeType?: string;
-}
+} & (
+  | { content: string; base64?: never }
+  | { base64: string; content?: never }
+);
 
 /**
  * The COMPLETE pinned runtime artifact for one snapshot-pinned skill, as served

--- a/mcpjam-inspector/shared/skill-types.ts
+++ b/mcpjam-inspector/shared/skill-types.ts
@@ -70,6 +70,14 @@ export interface Skill {
 }
 
 /**
+ * Whether a cloud skill can be pinned into a project environment's skill
+ * selection. Mirrors the backend's list-field: `plugin_component` skills,
+ * skills with supporting files, and skills with extra frontmatter are
+ * ineligible; `reason` is backend-authored copy pickers surface verbatim.
+ */
+export type SkillPinnability = { ok: true } | { ok: false; reason: string };
+
+/**
  * Skill list item (used for listing skills without full content).
  *
  * Local (filesystem) skills set `path`. Cloud (Convex) skills set `skillId`,
@@ -91,6 +99,13 @@ export interface SkillListItem {
   origin?: "local" | "cloud";
   /** Cloud skills only — how the record came to exist (absent ⇒ 'authored'). */
   provenance?: SkillProvenance;
+  /**
+   * Cloud skills only — whether the skill can be pinned into a project
+   * environment's skill selection (backend P0.3 list-field, forwarded through
+   * `/api/web/skills/list`). Absent on older backends ⇒ eligibility unknown;
+   * pickers treat absent as eligible and rely on the save-time backend gate.
+   */
+  pinnability?: SkillPinnability;
 }
 
 /**

--- a/mcpjam-inspector/shared/swarm-session-id.ts
+++ b/mcpjam-inspector/shared/swarm-session-id.ts
@@ -1,0 +1,36 @@
+/**
+ * Deterministic swarm (journey-execution) attempt chatSessionId — the ONE
+ * implementation shared by the server fan-out runner (claim key + sweep
+ * helpers) and the client matrix/deep-link mirror. Both sides MUST mint the
+ * exact same id for a given (run, target, sessionIdx) or claims and matrix
+ * cells stop lining up.
+ *
+ * Two id forms (D1, Project Environments):
+ *   - LEGACY host target → `synth_<runId>_<hostId>_<sessionIdx>` — byte-identical
+ *     to the pre-environments mint, so historical rows and in-flight legacy runs
+ *     keep matching.
+ *   - ENVIRONMENT target → `synth_<runId>_env_<environmentId>_<sessionIdx>` —
+ *     keyed on the FIRST-CLASS `environmentRef.environmentId`, never derived by
+ *     parsing the opaque `targetId`. Two environments on the SAME host therefore
+ *     mint distinct ids and can never collide within a run.
+ */
+
+/** Minimal target identity the mint needs (a structural subset of the pinned
+ * execution spec / client target column). `environmentId` comes from the
+ * snapshot target's `environmentRef.environmentId` — NEVER from `targetId`. */
+export interface SwarmSessionTargetIdentity {
+  hostId: string;
+  /** Set for environment-based targets only. */
+  environmentId?: string | null;
+}
+
+export function swarmAttemptChatSessionId(
+  runId: string,
+  target: SwarmSessionTargetIdentity,
+  sessionIndex: number,
+): string {
+  if (target.environmentId) {
+    return `synth_${runId}_env_${target.environmentId}_${sessionIndex}`;
+  }
+  return `synth_${runId}_${target.hostId}_${sessionIndex}`;
+}

--- a/mcpjam-inspector/shared/swarm-stream-events.ts
+++ b/mcpjam-inspector/shared/swarm-stream-events.ts
@@ -24,6 +24,13 @@ export type SwarmStreamToolCall = {
 export type SwarmStreamEnvelope = {
   runId: string;
   hostId: string;
+  /**
+   * Opaque execution-target id (Project Environments). Present on events from
+   * env-aware runners; absent on legacy/historical streams. ADDITIVE: `hostId`
+   * is kept for compatibility, but third-party SSE readers keying on hostId
+   * alone will merge two same-host targets — key on `targetId ?? hostId`.
+   */
+  targetId?: string;
   chatSessionId: string;
   sessionIndex: number;
 };


### PR DESCRIPTION
## Project Environments — Inspector UI (PR 4, combined)

Exposes the **Project Environments** feature end-to-end in the inspector,
gated behind the single PostHog flag `project-environments-enabled`. An
environment is a named, project-scoped, live-editable bundle: one host +
optional standalone server group + optional pinnable skill selection. Suites
and journeys reference environments and resolve/pin them at run-start.

Combines the two work streams into one flag-gated PR (per the plan):

### Part A — management surface + suites
- New `/environments` management route (list⇄detail, archive/restore),
  editor (required host, optional server group, optional skills picker with
  P0.3 pinnability gating), suite multi-env picker (ordered, ≤10).
- Run-all fan-out per environment (shared `runGroupId`); `environmentId`
  threaded through all four wire boundaries; `prepareEvalRun` resolves the
  closed server set via P0.1 `resolveEnvironmentForLaunch` **before** connecting
  servers / capturing the tool snapshot, and forwards
  `expectedEnvironmentRevision` to `startTestSuiteRun`.
- Scheduled worker passes `environmentId`; run-detail "Environment" chip added;
  computer-env chip relabeled **"Sandbox image"**. Public suite DTO exposes
  `environmentIds` (read-only).

### Part B — journeys + swarm runner
- Journey env-mode create/edit (ordered ≤10, compat `hostIds` recomputed),
  per-target runner (`targetId`), shared session-id mint
  (`shared/swarm-session-id.ts`), pinned-skill cache + two-channel harness skill
  delivery (host + environment provenance), per-target rollup/matrix, SSE
  `targetId`. Legacy journeys stay byte-identical.

### Integration fixes in this PR
- Aligned `environment-launch.ts` mirror with the **actual** P0.1 return shape
  `servers:[{serverId,name}]` (Part A had mirrored it as `selectedServerNames`);
  routed both callsites through `environmentServerRefs`.
- Merged the flag hook + `skill-types.ts` cleanly (only 2 files overlapped A/B).

## Backend prerequisites (must deploy first)
- MCPJam/mcpjam-backend **#768** — P0.1 launch resolver + P0.3 pinnability.
- MCPJam/mcpjam-backend **#769** — P0.2 two-channel skill composition.

## Rollout gating
The flag gates ALL client exposure (sidebar, suite row, journey env-mode,
direct `/environments` nav). Server/runner protocol changes are strictly
additive and inert until an env-based suite/journey exists. **Do not enable
`project-environments-enabled` until both backend PRs are deployed and the
runner deploy completes.**

## Verification
- Full inspector suite: **9614 passed / 0 failures** (6 skipped).
- Client typecheck: clean. Server tsc: 82 errors = pre-existing broken baseline,
  **zero new errors in touched files**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes eval run fan-out, scheduling, and launch payloads (`environmentId`) with server-side resolution as the source of truth; misconfiguration or backend drift could cause failed or surprising runs until the feature flag and backend deps are aligned.
> 
> **Overview**
> Introduces **project environments** behind `project-environments-enabled`: a new **Environments** nav item and `/environments` management flow (list/detail, create/edit with host + optional server group + pinned shared skills, archive/restore, revision-based conflict handling). Direct URLs redirect when the flag is off; writes use the same admin/owner gate as other project management surfaces.
> 
> **Eval suites** can attach ordered environments (up to 10). **Run all** fans out one run per environment via `buildSuiteRunPlans`, sending `environmentId` with empty client-side `serverIds` so the server resolves the closed set at launch; client server-readiness checks are skipped for these suites. Multi-environment **schedules** require picking a pinned environment. Run detail shows a flag-gated **Environment** chip from `configSnapshot.environmentRef`; computer Docker images are labeled **Sandbox image** to avoid naming collision.
> 
> Shared **`convexErrMessage`** replaces local Convex error parsing (e.g. computer environments drawer). Types and tests cover run plans, schedule pinning, orphan detach rows, and route flag gating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a022c4831f841254b422570d7503c4e3de04123. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Project Environments to the Inspector: a flag-gated management UI plus suite, journey, and runner support for environment-based execution with pinned skills. Latest updates add orphan-selection handling in environment and skills pickers and reset the create editor on project switch, alongside prior runner guards, gating, and analytics improvements.

- New Features
  - Environments management at /environments (create/edit/archive), with host + optional server group + optional pinned skills. Fully gated by `project-environments-enabled`; `/environments` is hidden from Atlas during rollout.
  - Suites: attach up to 10 environments; “Run all” fans out one run per environment; schedules can pin an environment; runs show an Environment chip (name + revision). Server resolves environments and enforces `expectedEnvironmentRevision`.
  - Journeys + Swarms: environment mode with ordered selection; per-target runner with `targetId` and shared session-id mint; rollups/matrix and SSE include `targetId`. Legacy journeys remain byte‑identical.
  - Pinned skills: picker forwards backend pinnability; runner delivers pinned artifacts to the emulated engine and harness via a small cache. Analytics report `fan_out_axis` and `num_environments`; toasts say “environment runs”.

- Bug Fixes
  - Env launch wiring: mirror `servers: [{serverId,name}]`; use `environmentServerIds` (priming) and `environmentServerNames` (display). Hosted preflight converts `sk_` keys; v1 public run route rejects `environmentId`.
  - Consistency: thread one resolved environment through hosted preflight and the scheduled worker into `prepareEvalRun` so `expectedEnvironmentRevision` matches the connected set (clean 409 on post‑edit).
  - Runner reliability: pinned‑skill cache coalesces fetches and survives a coalesced caller abort; abort during prefetch no longer marks attempts failed; stricter host‑skill‑channel guard; `PinnedSkillArtifact` validates `description`; harness path handling prunes stale files and skips sandbox‑wide prune when already aborted.
  - UI/UX and gating: kill‑switch hides all env surfaces (run‑detail chip, schedule pin, journey env targets); SwarmsTab env query gated by `shouldQueryProjectId`; selected‑but‑archived envs render as detach‑only; selected‑but‑missing ids (orphaned) now render as detach‑only in both the suite env picker and the environment skills picker (including when no shared skills are listed); schedule writes serialize through one apply path; project switch resets the environment editor (including open create form); skills picker keeps selected‑but‑ineligible rows for repair; env hooks normalize projectId; `PinnedSkillArtifactFile` enforces “exactly one of content|base64”.
  - Display and live updates: live SSE cell keys collapse host‑shaped `targetId` to bare `hostId`; journey list/matrix avoid truncated host names; draft seed effects are content‑keyed to avoid losing unsaved env selections; Sessions/Turns render exactly once; single‑case quick‑run guards env suites with a “Run all” message.
  - Access: allow anonymous Convex owners to manage environments (mirrors SwarmsTab).

<sup>Written for commit 9a022c4831f841254b422570d7503c4e3de04123. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

