### PR TITLE
types(skills): widen pinned-skill `channels` to include 'plugin'

### DIFF
--- a/mcpjam-inspector/server/services/swarm-agent.ts
+++ b/mcpjam-inspector/server/services/swarm-agent.ts
@@ -47,7 +47,8 @@ export interface PinnedSkillMeta {
   description: string;
   contentHash: string;
   sharing?: "user" | "project";
-  channels?: Array<"host" | "environment">;
+  /** Stable `host` → `environment` → `plugin` order; see PinnedSkillArtifact. */
+  channels?: Array<"host" | "environment" | "plugin">;
 }
 
 export interface PinnedHostExecutionSpec {

--- a/mcpjam-inspector/shared/skill-types.ts
+++ b/mcpjam-inspector/shared/skill-types.ts
@@ -68,10 +68,7 @@ export interface PinnableSkill {
 export type PinnedSkillArtifactFile = {
   path: string;
   mimeType?: string;
-} & (
-  | { content: string; base64?: never }
-  | { base64: string; content?: never }
-);
+} & ({ content: string; base64?: never } | { base64: string; content?: never });
 
 /**
  * The COMPLETE pinned runtime artifact for one snapshot-pinned skill, as served
@@ -89,8 +86,18 @@ export interface PinnedSkillArtifact {
   contentHash: string;
   skillId?: string;
   sharing?: "user" | "project";
-  /** P0.2 channel provenance (stable order: host, then environment). */
-  channels?: Array<"host" | "environment">;
+  /**
+   * Channel provenance, in stable `host` → `environment` → `plugin` order. A
+   * skill reachable through more than one channel is ONE entry carrying every
+   * tag.
+   *
+   * `plugin` entries come from an environment's pinned plugin VERSIONS. The
+   * backend emits them once the environment plugin-pin consumers ship; this
+   * mirror is widened AHEAD of that so a deployed runner never meets a value
+   * its own type says is impossible. Nothing here branches on the value — the
+   * only runtime use is a presence check — so widening is type-level only.
+   */
+  channels?: Array<"host" | "environment" | "plugin">;
   /** Preserved extra frontmatter beyond name/description (plugin skills). */
   frontmatter?: Record<string, unknown>;
   /** Supporting files (host-channel plugin skills only under P0.3). */


### PR DESCRIPTION
## Widen pinned-skill `channels` to include `'plugin'`

Type-level only, ahead of the backend emitting it.

An environment can now pin plugin **versions** (mcpjam-backend #771), and the suite/journey consumers (#772 and its stacked sibling) compose a third `plugin` skill channel into the pinned union. Both inspector mirrors of that envelope declared a **closed** `Array<"host" | "environment">`, so the first `channels: ['plugin']` the backend sends would be a value the runner's own types call impossible.

Widening now, before the emitter ships, keeps the mirrors honest and lets the backend consumers land without a coordinated cross-repo deploy.

### Why this is behaviorally inert

- `resolveEnvironmentForLaunch` parses the resolver response with a structural cast plus three field checks, so unknown fields already pass through untouched.
- **Nothing branches on a channel value.** The only runtime uses are a presence check (`Array.isArray(m.channels) && m.channels.length > 0`) and a pass-through copy; the host-channel guard's `.includes("host")` is unaffected by adding a union member.

### Verification

Client typecheck clean · server `tsc` 82 errors, byte-identical to the pre-existing baseline measured by stashing · 244 tests passing across the skill, harness and swarm surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and TypeScript union widening only; no branching, validation, or API contract changes beyond accepting an extra channel literal.
> 
> **Overview**
> **Type-only** update to pinned-skill provenance: `channels` on `PinnedSkillMeta` (`swarm-agent.ts`) and `PinnedSkillArtifact` (`shared/skill-types.ts`) now allow **`"plugin"`** in addition to `"host"` and `"environment"`, with docs describing stable `host` → `environment` → `plugin` ordering and environment-pinned plugin versions as the source of plugin-channel skills.
> 
> This aligns inspector mirrors with upcoming backend/journey consumers that will emit a third channel before the emitter ships, so runners never receive values their types reject. **No runtime behavior changes**—existing code only checks that `channels` is a non-empty array or copies metadata through; host-specific `.includes("host")` logic is unchanged.
> 
> A trivial formatting-only tweak collapses the `PinnedSkillArtifactFile` content/base64 union onto one line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e97744c5096aac0ee7df804e133dca0dc8a0607f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow 'plugin' as a valid channel for pinned skills so environments can pin plugin versions; types-only change with no runtime impact.

- **Refactors**
  - Expanded `channels` on `PinnedSkillMeta` and `PinnedSkillArtifact` with stable order: `host`, `environment`, `plugin`.
  - Left runtime logic unchanged; code only checks for channel presence.
  - Tidied `PinnedSkillArtifactFile` union formatting (no behavior change).

<sup>Written for commit e97744c5096aac0ee7df804e133dca0dc8a0607f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

