### PR TITLE
fix(oauth): harden metadata proxy SSRF validation

### DIFF
--- a/.changeset/harden-oauth-proxy-transport.md
+++ b/.changeset/harden-oauth-proxy-transport.md
@@ -1,0 +1,7 @@
+---
+"@mcpjam/sdk": minor
+---
+
+Harden generic OAuth proxy requests by validating and pinning DNS results, checking every followed redirect before connecting, and bounding response bodies. Explicit local loopback flows may redirect to validated public hosts, while redirects to other private or reserved destinations remain blocked.
+
+`OAuthProxyResponse` gains a required `finalUrl` field reporting the effective URL after redirects. Reading a proxy response is unaffected; code that constructs an `OAuthProxyResponse` (typically test doubles) must add `finalUrl`.

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
@@ -621,19 +621,29 @@ describe("mcp-oauth", () => {
       expect(directFetch).not.toHaveBeenCalled();
     });
 
-    it("propagates successful proxy responses correctly", async () => {
+    it("validates the upstream URL instead of mistaking the local metadata proxy for an SSRF redirect", async () => {
+      const upstreamMetadataUrl =
+        "https://example.com/.well-known/oauth-protected-resource/mcp";
       const metadataResponse = new Response(
         JSON.stringify({
           authorization_servers: ["https://auth.example.com"],
         }),
-        { status: 200 }
+        {
+          status: 200,
+          headers: {
+            "X-MCPJam-OAuth-Upstream-URL": upstreamMetadataUrl,
+          },
+        }
       );
+      Object.defineProperty(metadataResponse, "url", {
+        value:
+          "http://localhost:5173/api/mcp/oauth/metadata?url=" +
+          encodeURIComponent(upstreamMetadataUrl),
+      });
       authFetch.mockResolvedValue(metadataResponse);
       mockDiscoverOAuthServerInfo.mockImplementation(
         async (_serverUrl, options) => {
-          const response = await options?.fetchFn?.(
-            "https://example.com/.well-known/oauth-protected-resource/mcp"
-          );
+          const response = await options?.fetchFn?.(upstreamMetadataUrl);
           if (!response) {
             throw new Error("Missing OAuth fetch function");
           }
@@ -655,6 +665,104 @@ describe("mcp-oauth", () => {
         ),
         expect.objectContaining({ method: "GET" })
       );
+    });
+
+    it("rejects a proxied metadata response whose real upstream URL redirected to loopback", async () => {
+      const metadataResponse = new Response(
+        JSON.stringify({
+          authorization_servers: ["https://auth.example.com"],
+        }),
+        {
+          status: 200,
+          headers: {
+            "X-MCPJam-OAuth-Upstream-URL":
+              "http://127.0.0.1:8787/private-metadata",
+          },
+        }
+      );
+      Object.defineProperty(metadataResponse, "url", {
+        value:
+          "http://localhost:5173/api/mcp/oauth/metadata?url=" +
+          encodeURIComponent(
+            "https://example.com/.well-known/oauth-protected-resource/mcp"
+          ),
+      });
+      authFetch.mockResolvedValue(metadataResponse);
+      mockDiscoverOAuthServerInfo.mockImplementation(
+        async (_serverUrl, options) => {
+          const response = await options?.fetchFn?.(
+            "https://example.com/.well-known/oauth-protected-resource/mcp"
+          );
+          if (!response) {
+            throw new Error("Missing OAuth fetch function");
+          }
+          expect(response.ok).toBe(true);
+          return createDiscoveryState();
+        }
+      );
+
+      const { initiateOAuth } = await import("../mcp-oauth");
+      const result = await initiateOAuth({
+        serverName: "test-server",
+        serverUrl: "https://example.com/mcp",
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain(
+        'Refusing OAuth response from private/reserved host "127.0.0.1"'
+      );
+    });
+
+    it("allows a proxy-reported loopback URL for an explicitly local MCP server", async () => {
+      const localMetadataUrl =
+        "http://127.0.0.1:8787/.well-known/oauth-protected-resource/mcp";
+      const localDiscoveryState = {
+        authorizationServerUrl: "http://127.0.0.1:8788",
+        resourceMetadataUrl: localMetadataUrl,
+        resourceMetadata: {
+          resource: "http://127.0.0.1:8787/mcp",
+          authorization_servers: ["http://127.0.0.1:8788"],
+        },
+        authorizationServerMetadata: {
+          issuer: "http://127.0.0.1:8788",
+          authorization_endpoint: "http://127.0.0.1:8788/authorize",
+          token_endpoint: "http://127.0.0.1:8788/token",
+          registration_endpoint: "http://127.0.0.1:8788/register",
+        },
+      };
+      const metadataResponse = new Response(
+        JSON.stringify(localDiscoveryState.resourceMetadata),
+        {
+          status: 200,
+          headers: {
+            "X-MCPJam-OAuth-Upstream-URL": localMetadataUrl,
+          },
+        }
+      );
+      Object.defineProperty(metadataResponse, "url", {
+        value:
+          "http://localhost:5173/api/mcp/oauth/metadata?url=" +
+          encodeURIComponent(localMetadataUrl),
+      });
+      authFetch.mockResolvedValue(metadataResponse);
+      mockDiscoverOAuthServerInfo.mockImplementation(
+        async (_serverUrl, options) => {
+          const response = await options?.fetchFn?.(localMetadataUrl);
+          if (!response) {
+            throw new Error("Missing OAuth fetch function");
+          }
+          expect(response.ok).toBe(true);
+          return localDiscoveryState;
+        }
+      );
+
+      const { initiateOAuth } = await import("../mcp-oauth");
+      const result = await initiateOAuth({
+        serverName: "test-server",
+        serverUrl: "http://127.0.0.1:8787/mcp",
+      });
+
+      expect(result.success).toBe(true);
     });
 
     it("forwards custom headers during automatic discovery planning", async () => {

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
@@ -227,7 +227,7 @@ const issuedCallbackState = (): string | null => {
   if (!serverName) return null;
   try {
     const raw = localStorage.getItem(`mcp-oauth-flow-state-${serverName}`);
-    const fromSession = raw ? (JSON.parse(raw).state?.state ?? null) : null;
+    const fromSession = raw ? JSON.parse(raw).state?.state ?? null : null;
     if (fromSession) return fromSession;
   } catch {
     // fall through to the durable key
@@ -710,6 +710,52 @@ describe("mcp-oauth", () => {
       expect(result.success).toBe(false);
       expect(result.error).toContain(
         'Refusing OAuth response from private/reserved host "127.0.0.1"'
+      );
+    });
+
+    it("rejects a proxied OAuth endpoint response whose real upstream URL redirected to loopback", async () => {
+      authFetch.mockImplementation(
+        async () =>
+          new Response(
+            JSON.stringify({
+              status: 200,
+              statusText: "OK",
+              headers: { "content-type": "application/json" },
+              body: { access_token: "should-not-be-consumed" },
+              finalUrl: "http://127.0.0.1:8787/private-token",
+            }),
+            {
+              status: 200,
+              headers: {
+                "Content-Type": "application/json",
+                "X-MCPJam-OAuth-Upstream-URL":
+                  "http://127.0.0.1:8787/private-token",
+              },
+            }
+          )
+      );
+      mockDiscoverOAuthServerInfo.mockImplementation(
+        async (_serverUrl, options) => {
+          await options?.fetchFn?.("https://auth.example.com/token", {
+            method: "POST",
+          });
+          return createDiscoveryState();
+        }
+      );
+
+      const { initiateOAuth } = await import("../mcp-oauth");
+      const result = await initiateOAuth({
+        serverName: "test-server",
+        serverUrl: "https://example.com/mcp",
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain(
+        'Refusing OAuth response from private/reserved host "127.0.0.1"'
+      );
+      expect(authFetch).toHaveBeenCalledWith(
+        expect.stringMatching(/\/api\/mcp\/oauth\/proxy$/),
+        expect.objectContaining({ method: "POST" })
       );
     });
 
@@ -1509,9 +1555,9 @@ describe("mcp-oauth", () => {
         "static-client-id",
         "static-client-secret"
       );
-      expect(
-        providerWithSecret.clientMetadata.token_endpoint_auth_method
-      ).toBe("client_secret_basic");
+      expect(providerWithSecret.clientMetadata.token_endpoint_auth_method).toBe(
+        "client_secret_basic"
+      );
     });
 
     it("round-trips discovery state for the matching server URL", async () => {
@@ -2407,8 +2453,10 @@ describe("mcp-oauth", () => {
       } as any);
 
       // Reading with the ORIGINAL serverUrl still resolves AS A → token present.
-      expect(getStoredTokens("reused-gst", "https://old.example.com/sse")
-        ?.access_token).toBe("token-for-as-a");
+      expect(
+        getStoredTokens("reused-gst", "https://old.example.com/sse")
+          ?.access_token
+      ).toBe("token-for-as-a");
 
       // Reused with a DIFFERENT URL: the stale discovery must NOT resolve an
       // issuer, so AS A's token bucket is NOT surfaced through getStoredTokens.
@@ -2546,7 +2594,10 @@ describe("mcp-oauth", () => {
     const seedAsanaCallback = (discoveryState: any) => {
       localStorage.setItem("mcp-oauth-pending", "asana");
       // Durable issued state (F6 recovery reads this on the no-session path).
-      localStorage.setItem("mcp-oauth-issued-state-asana", "asana-issued-state");
+      localStorage.setItem(
+        "mcp-oauth-issued-state-asana",
+        "asana-issued-state"
+      );
       localStorage.setItem(
         "mcp-serverUrl-asana",
         "https://mcp.asana.com/v2/mcp"
@@ -3203,10 +3254,10 @@ describe("createServerConfig wire-era pin", () => {
     const config = createServerConfig(
       "https://mcp.example.com",
       { access_token: "tok" },
-      "2026-07-28",
+      "2026-07-28"
     );
     expect((config as { mcpProtocolVersion?: string }).mcpProtocolVersion).toBe(
-      "2026-07-28",
+      "2026-07-28"
     );
   });
 
@@ -3215,10 +3266,10 @@ describe("createServerConfig wire-era pin", () => {
     const config = createServerConfig(
       "https://mcp.example.com",
       { access_token: "tok" },
-      "2025-11-25",
+      "2025-11-25"
     );
     expect(
-      (config as { mcpProtocolVersion?: string }).mcpProtocolVersion,
+      (config as { mcpProtocolVersion?: string }).mcpProtocolVersion
     ).toBeUndefined();
   });
 });
@@ -3280,7 +3331,7 @@ describe("evaluateCallbackSecurity (2R-iss callback gate)", () => {
         ...base,
         callbackIss: null,
         issParameterSupported: undefined,
-      }),
+      })
     ).toEqual({ ok: true });
   });
 
@@ -3293,7 +3344,7 @@ describe("evaluateCallbackSecurity (2R-iss callback gate)", () => {
         expectedState: undefined,
         recordedIssuer: "https://as.example.com",
         issParameterSupported: undefined,
-      }),
+      })
     ).toEqual({ ok: true });
   });
 });

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
@@ -227,7 +227,7 @@ const issuedCallbackState = (): string | null => {
   if (!serverName) return null;
   try {
     const raw = localStorage.getItem(`mcp-oauth-flow-state-${serverName}`);
-    const fromSession = raw ? JSON.parse(raw).state?.state ?? null : null;
+    const fromSession = raw ? (JSON.parse(raw).state?.state ?? null) : null;
     if (fromSession) return fromSession;
   } catch {
     // fall through to the durable key
@@ -757,6 +757,51 @@ describe("mcp-oauth", () => {
         expect.stringMatching(/\/api\/mcp\/oauth\/proxy$/),
         expect.objectContaining({ method: "POST" })
       );
+    });
+
+    it("does not trust a provenance header copied from the upstream OAuth response", async () => {
+      authFetch.mockImplementation(
+        async () =>
+          new Response(
+            JSON.stringify({
+              status: 200,
+              statusText: "OK",
+              headers: {
+                "content-type": "application/json",
+                "x-mcpjam-oauth-upstream-url":
+                  "http://127.0.0.1:8787/spoofed-by-upstream",
+              },
+              body: { access_token: "token" },
+            }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            }
+          )
+      );
+      mockDiscoverOAuthServerInfo.mockImplementation(
+        async (_serverUrl, options) => {
+          const response = await options?.fetchFn?.(
+            "https://auth.example.com/token",
+            { method: "POST" }
+          );
+          if (!response) {
+            throw new Error("Missing OAuth fetch function");
+          }
+          expect(
+            response.headers.get("x-mcpjam-oauth-upstream-url")
+          ).toBe("http://127.0.0.1:8787/spoofed-by-upstream");
+          return createDiscoveryState();
+        }
+      );
+
+      const { initiateOAuth } = await import("../mcp-oauth");
+      const result = await initiateOAuth({
+        serverName: "test-server",
+        serverUrl: "https://example.com/mcp",
+      });
+
+      expect(result.success).toBe(true);
     });
 
     it("allows a proxy-reported loopback URL for an explicitly local MCP server", async () => {
@@ -1555,9 +1600,9 @@ describe("mcp-oauth", () => {
         "static-client-id",
         "static-client-secret"
       );
-      expect(providerWithSecret.clientMetadata.token_endpoint_auth_method).toBe(
-        "client_secret_basic"
-      );
+      expect(
+        providerWithSecret.clientMetadata.token_endpoint_auth_method
+      ).toBe("client_secret_basic");
     });
 
     it("round-trips discovery state for the matching server URL", async () => {
@@ -2453,10 +2498,8 @@ describe("mcp-oauth", () => {
       } as any);
 
       // Reading with the ORIGINAL serverUrl still resolves AS A → token present.
-      expect(
-        getStoredTokens("reused-gst", "https://old.example.com/sse")
-          ?.access_token
-      ).toBe("token-for-as-a");
+      expect(getStoredTokens("reused-gst", "https://old.example.com/sse")
+        ?.access_token).toBe("token-for-as-a");
 
       // Reused with a DIFFERENT URL: the stale discovery must NOT resolve an
       // issuer, so AS A's token bucket is NOT surfaced through getStoredTokens.
@@ -2594,10 +2637,7 @@ describe("mcp-oauth", () => {
     const seedAsanaCallback = (discoveryState: any) => {
       localStorage.setItem("mcp-oauth-pending", "asana");
       // Durable issued state (F6 recovery reads this on the no-session path).
-      localStorage.setItem(
-        "mcp-oauth-issued-state-asana",
-        "asana-issued-state"
-      );
+      localStorage.setItem("mcp-oauth-issued-state-asana", "asana-issued-state");
       localStorage.setItem(
         "mcp-serverUrl-asana",
         "https://mcp.asana.com/v2/mcp"
@@ -3254,10 +3294,10 @@ describe("createServerConfig wire-era pin", () => {
     const config = createServerConfig(
       "https://mcp.example.com",
       { access_token: "tok" },
-      "2026-07-28"
+      "2026-07-28",
     );
     expect((config as { mcpProtocolVersion?: string }).mcpProtocolVersion).toBe(
-      "2026-07-28"
+      "2026-07-28",
     );
   });
 
@@ -3266,10 +3306,10 @@ describe("createServerConfig wire-era pin", () => {
     const config = createServerConfig(
       "https://mcp.example.com",
       { access_token: "tok" },
-      "2025-11-25"
+      "2025-11-25",
     );
     expect(
-      (config as { mcpProtocolVersion?: string }).mcpProtocolVersion
+      (config as { mcpProtocolVersion?: string }).mcpProtocolVersion,
     ).toBeUndefined();
   });
 });
@@ -3331,7 +3371,7 @@ describe("evaluateCallbackSecurity (2R-iss callback gate)", () => {
         ...base,
         callbackIss: null,
         issParameterSupported: undefined,
-      })
+      }),
     ).toEqual({ ok: true });
   });
 
@@ -3344,7 +3384,7 @@ describe("evaluateCallbackSecurity (2R-iss callback gate)", () => {
         expectedState: undefined,
         recordedIssuer: "https://as.example.com",
         issParameterSupported: undefined,
-      })
+      }),
     ).toEqual({ ok: true });
   });
 });

--- a/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
@@ -95,10 +95,15 @@ const oauthProxyResponses = new WeakMap<
   { upstreamFinalUrl?: string }
 >();
 
-function markOAuthProxyResponse(response: Response): Response {
+function markOAuthProxyResponse(
+  response: Response,
+  upstreamFinalUrl?: string
+): Response {
   oauthProxyResponses.set(response, {
     upstreamFinalUrl:
-      response.headers.get(OAUTH_UPSTREAM_URL_HEADER) ?? undefined,
+      upstreamFinalUrl ??
+      response.headers.get(OAUTH_UPSTREAM_URL_HEADER) ??
+      undefined,
   });
   return response;
 }
@@ -706,7 +711,8 @@ function shouldRetryMcpRequestViaProxy(
 }
 
 async function executeRequestViaProxy(
-  request: HttpHistoryEntry["request"]
+  request: HttpHistoryEntry["request"],
+  serverUrl?: string
 ): Promise<{
   status: number;
   statusText: string;
@@ -737,6 +743,13 @@ async function executeRequestViaProxy(
         : `MCP request proxy failed (${response.status})`;
     throw new Error(message);
   }
+
+  assertFinalResponseUrlAllowed(
+    response.headers.get(OAUTH_UPSTREAM_URL_HEADER) ?? undefined,
+    {
+      allowLoopback: isLoopbackOAuthUrl(serverUrl),
+    }
+  );
 
   const proxied = (await response.json()) as {
     status: number;
@@ -848,7 +861,7 @@ function createOAuthRequestExecutor(fetchFn: typeof fetch, serverUrl?: string) {
         throw error;
       }
 
-      response = await executeRequestViaProxy(request);
+      response = await executeRequestViaProxy(request, serverUrl);
     }
 
     return {
@@ -1157,7 +1170,7 @@ export function readStoredOAuthConfig(
 
     return config;
   } catch (e) {
-    console.warn('[mcp-oauth] Failed to parse stored OAuth config', e);
+    console.warn("[mcp-oauth] Failed to parse stored OAuth config", e);
     return {
       registryServerId: undefined,
       useRegistryOAuthProxy: false,
@@ -1510,6 +1523,8 @@ function createOAuthFetchInterceptor(
         return markOAuthProxyResponse(response);
       }
 
+      const upstreamFinalUrl =
+        response.headers.get(OAUTH_UPSTREAM_URL_HEADER) ?? undefined;
       const data = await response.json();
       entry.response = createTraceResponseFromResult({
         status: data.status,
@@ -1523,7 +1538,8 @@ function createOAuthFetchInterceptor(
           status: data.status,
           statusText: data.statusText,
           headers: new Headers(data.headers),
-        })
+        }),
+        upstreamFinalUrl
       );
     } catch (error) {
       entry.error = {
@@ -1598,7 +1614,7 @@ export function buildMCPOAuthState(): string {
 }
 
 export function isElectronMcpCallbackState(
-  state: string | null | undefined,
+  state: string | null | undefined
 ): boolean {
   return Boolean(state && state.startsWith(ELECTRON_MCP_CALLBACK_STATE_PREFIX));
 }
@@ -2070,7 +2086,9 @@ export class MCPOAuthProvider implements OAuthClientProvider {
       );
       localStorage.setItem(
         `mcp-client-${this.serverName}`,
-        JSON.stringify(issuer ? writeIssuerKeyed(raw, issuer, stripped) : stripped)
+        JSON.stringify(
+          issuer ? writeIssuerKeyed(raw, issuer, stripped) : stripped
+        )
       );
       return stripped;
     }
@@ -2265,7 +2283,8 @@ export class MCPOAuthProvider implements OAuthClientProvider {
     // persist a refresh fallback for servers it can't reach (e.g. localhost);
     // without it, the backend re-discovers against an unreachable resource on
     // refresh and the credential becomes unusable.
-    const authorizationServerUrl = this.discoveryState()?.authorizationServerUrl;
+    const authorizationServerUrl =
+      this.discoveryState()?.authorizationServerUrl;
     const importPayload: ImportHostedOAuthTokensRequest = {
       projectId: this.convexBinding.projectId,
       serverId: this.convexBinding.serverId,
@@ -2339,12 +2358,12 @@ export class MCPOAuthProvider implements OAuthClientProvider {
         } catch (error) {
           console.warn(
             "Failed to open system browser for MCP OAuth; continuing inside MCPJam Desktop:",
-            error,
+            error
           );
         }
       } else {
         console.warn(
-          "System browser opener is unavailable for MCP OAuth; continuing inside MCPJam Desktop.",
+          "System browser opener is unavailable for MCP OAuth; continuing inside MCPJam Desktop."
         );
       }
 
@@ -2799,9 +2818,7 @@ export async function initiateOAuth(
       delete merged.client_secret;
       localStorage.setItem(
         `mcp-client-${options.serverName}`,
-        JSON.stringify(
-          issuer ? writeIssuerKeyed(raw, issuer, merged) : merged
-        )
+        JSON.stringify(issuer ? writeIssuerKeyed(raw, issuer, merged) : merged)
       );
     }
 
@@ -3607,12 +3624,13 @@ export async function handleOAuthCallback(
     }
     // Validate CSRF `state` (recovered) and RFC 9207 `iss` before redeeming. A
     // missing or mismatched callbackState now fails the state check.
-    const fallbackIssuerMetadata = discoveryState.authorizationServerMetadata as
-      | {
-          issuer?: string;
-          authorization_response_iss_parameter_supported?: boolean;
-        }
-      | undefined;
+    const fallbackIssuerMetadata =
+      discoveryState.authorizationServerMetadata as
+        | {
+            issuer?: string;
+            authorization_response_iss_parameter_supported?: boolean;
+          }
+        | undefined;
     const fallbackSecurity = evaluateCallbackSecurity({
       callbackState: options.callbackState,
       callbackIss: options.callbackIss,
@@ -3818,7 +3836,10 @@ export function getStoredTokens(serverName: string, serverUrl?: string): any {
 /**
  * Checks if OAuth is configured for a server by looking at multiple sources
  */
-export function hasOAuthConfig(serverName: string, serverUrl?: string): boolean {
+export function hasOAuthConfig(
+  serverName: string,
+  serverUrl?: string
+): boolean {
   if (HOSTED_MODE) {
     return false;
   }

--- a/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
@@ -95,16 +95,23 @@ const oauthProxyResponses = new WeakMap<
   { upstreamFinalUrl?: string }
 >();
 
-function markOAuthProxyResponse(
-  response: Response,
-  upstreamFinalUrl?: string
+function markRawOAuthProxyResponse(
+  response: Response
 ): Response {
   oauthProxyResponses.set(response, {
     upstreamFinalUrl:
-      upstreamFinalUrl ??
-      response.headers.get(OAUTH_UPSTREAM_URL_HEADER) ??
-      undefined,
+      response.headers.get(OAUTH_UPSTREAM_URL_HEADER) ?? undefined,
   });
+  return response;
+}
+
+function markReconstructedOAuthProxyResponse(
+  response: Response,
+  upstreamFinalUrl: string | undefined
+): Response {
+  // The reconstructed response contains headers supplied by the upstream OAuth
+  // server. Only trust provenance captured from MCPJam's raw proxy response.
+  oauthProxyResponses.set(response, { upstreamFinalUrl });
   return response;
 }
 
@@ -1170,7 +1177,7 @@ export function readStoredOAuthConfig(
 
     return config;
   } catch (e) {
-    console.warn("[mcp-oauth] Failed to parse stored OAuth config", e);
+    console.warn('[mcp-oauth] Failed to parse stored OAuth config', e);
     return {
       registryServerId: undefined,
       useRegistryOAuthProxy: false,
@@ -1483,7 +1490,7 @@ function createOAuthFetchInterceptor(
         });
         entry.response = await createTraceResponseFromFetch(response);
         entry.duration = Date.now() - entry.timestamp;
-        return markOAuthProxyResponse(response);
+        return markRawOAuthProxyResponse(response);
       }
     }
 
@@ -1499,7 +1506,7 @@ function createOAuthFetchInterceptor(
         const response = await authFetch(proxyUrl, { ...init, method: "GET" });
         entry.response = await createTraceResponseFromFetch(response);
         entry.duration = Date.now() - entry.timestamp;
-        return markOAuthProxyResponse(response);
+        return markRawOAuthProxyResponse(response);
       }
 
       // For OAuth endpoints, serialize and proxy the full request
@@ -1520,7 +1527,7 @@ function createOAuthFetchInterceptor(
       if (!response.ok) {
         entry.response = await createTraceResponseFromFetch(response);
         entry.duration = Date.now() - entry.timestamp;
-        return markOAuthProxyResponse(response);
+        return markRawOAuthProxyResponse(response);
       }
 
       const upstreamFinalUrl =
@@ -1533,7 +1540,7 @@ function createOAuthFetchInterceptor(
         body: data.body,
       });
       entry.duration = Date.now() - entry.timestamp;
-      return markOAuthProxyResponse(
+      return markReconstructedOAuthProxyResponse(
         new Response(JSON.stringify(data.body), {
           status: data.status,
           statusText: data.statusText,
@@ -1614,7 +1621,7 @@ export function buildMCPOAuthState(): string {
 }
 
 export function isElectronMcpCallbackState(
-  state: string | null | undefined
+  state: string | null | undefined,
 ): boolean {
   return Boolean(state && state.startsWith(ELECTRON_MCP_CALLBACK_STATE_PREFIX));
 }
@@ -2086,9 +2093,7 @@ export class MCPOAuthProvider implements OAuthClientProvider {
       );
       localStorage.setItem(
         `mcp-client-${this.serverName}`,
-        JSON.stringify(
-          issuer ? writeIssuerKeyed(raw, issuer, stripped) : stripped
-        )
+        JSON.stringify(issuer ? writeIssuerKeyed(raw, issuer, stripped) : stripped)
       );
       return stripped;
     }
@@ -2283,8 +2288,7 @@ export class MCPOAuthProvider implements OAuthClientProvider {
     // persist a refresh fallback for servers it can't reach (e.g. localhost);
     // without it, the backend re-discovers against an unreachable resource on
     // refresh and the credential becomes unusable.
-    const authorizationServerUrl =
-      this.discoveryState()?.authorizationServerUrl;
+    const authorizationServerUrl = this.discoveryState()?.authorizationServerUrl;
     const importPayload: ImportHostedOAuthTokensRequest = {
       projectId: this.convexBinding.projectId,
       serverId: this.convexBinding.serverId,
@@ -2358,12 +2362,12 @@ export class MCPOAuthProvider implements OAuthClientProvider {
         } catch (error) {
           console.warn(
             "Failed to open system browser for MCP OAuth; continuing inside MCPJam Desktop:",
-            error
+            error,
           );
         }
       } else {
         console.warn(
-          "System browser opener is unavailable for MCP OAuth; continuing inside MCPJam Desktop."
+          "System browser opener is unavailable for MCP OAuth; continuing inside MCPJam Desktop.",
         );
       }
 
@@ -2818,7 +2822,9 @@ export async function initiateOAuth(
       delete merged.client_secret;
       localStorage.setItem(
         `mcp-client-${options.serverName}`,
-        JSON.stringify(issuer ? writeIssuerKeyed(raw, issuer, merged) : merged)
+        JSON.stringify(
+          issuer ? writeIssuerKeyed(raw, issuer, merged) : merged
+        )
       );
     }
 
@@ -3624,13 +3630,12 @@ export async function handleOAuthCallback(
     }
     // Validate CSRF `state` (recovered) and RFC 9207 `iss` before redeeming. A
     // missing or mismatched callbackState now fails the state check.
-    const fallbackIssuerMetadata =
-      discoveryState.authorizationServerMetadata as
-        | {
-            issuer?: string;
-            authorization_response_iss_parameter_supported?: boolean;
-          }
-        | undefined;
+    const fallbackIssuerMetadata = discoveryState.authorizationServerMetadata as
+      | {
+          issuer?: string;
+          authorization_response_iss_parameter_supported?: boolean;
+        }
+      | undefined;
     const fallbackSecurity = evaluateCallbackSecurity({
       callbackState: options.callbackState,
       callbackIss: options.callbackIss,
@@ -3836,10 +3841,7 @@ export function getStoredTokens(serverName: string, serverUrl?: string): any {
 /**
  * Checks if OAuth is configured for a server by looking at multiple sources
  */
-export function hasOAuthConfig(
-  serverName: string,
-  serverUrl?: string
-): boolean {
+export function hasOAuthConfig(serverName: string, serverUrl?: string): boolean {
   if (HOSTED_MODE) {
     return false;
   }

--- a/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
@@ -81,6 +81,28 @@ import {
 // Store original fetch for restoration
 const originalFetch = window.fetch;
 
+const OAUTH_UPSTREAM_URL_HEADER = "x-mcpjam-oauth-upstream-url";
+
+/**
+ * Browser `Response.url` identifies MCPJam's same-origin proxy, not the
+ * upstream OAuth destination fetched by that proxy. Preserve that provenance
+ * out-of-band so the final-URL SSRF guard validates the upstream URL when the
+ * proxy reports one and never mistakes a local Inspector origin for a remote
+ * redirect.
+ */
+const oauthProxyResponses = new WeakMap<
+  Response,
+  { upstreamFinalUrl?: string }
+>();
+
+function markOAuthProxyResponse(response: Response): Response {
+  oauthProxyResponses.set(response, {
+    upstreamFinalUrl:
+      response.headers.get(OAUTH_UPSTREAM_URL_HEADER) ?? undefined,
+  });
+  return response;
+}
+
 interface StoredOAuthDiscoveryState {
   serverUrl: string;
   discoveryState: OAuthDiscoveryState;
@@ -764,8 +786,14 @@ function createTraceResponseFromResult(
  * proxy's job). Re-validate the FINAL URL against the factory guard's policy;
  * an empty/opaque URL can't be inspected and is left to the normal flow.
  */
-function assertFinalResponseUrlAllowed(finalUrl: string | undefined): void {
+function assertFinalResponseUrlAllowed(
+  finalUrl: string | undefined,
+  options: { allowLoopback?: boolean } = {}
+): void {
   if (!finalUrl) return;
+  if (options.allowLoopback && isLoopbackOAuthUrl(finalUrl)) {
+    return;
+  }
   let host: string;
   try {
     host = new URL(finalUrl).hostname;
@@ -797,11 +825,17 @@ function createOAuthRequestExecutor(fetchFn: typeof fetch, serverUrl?: string) {
         headers: request.headers,
         body: serializeOAuthRequestBody(request.body, request.headers),
       });
-      // SSRF defense-in-depth: the factory guard validated the INITIAL url. The
-      // fetch may have already followed a redirect to a private host; reject
-      // CONSUMING that response (a private final URL throws → proxy retry / fail
-      // closed). Does not stop the request itself; DNS-rebind is the proxy's job.
-      assertFinalResponseUrlAllowed(directResponse.url);
+      // SSRF defense-in-depth: the factory guard validated the INITIAL URL. For
+      // direct responses, Response.url is the effective destination. For
+      // same-origin proxy responses, Response.url is MCPJam itself, so validate
+      // the upstream final URL reported by the trusted proxy instead.
+      const proxyResponse = oauthProxyResponses.get(directResponse);
+      const finalUrl = proxyResponse
+        ? proxyResponse.upstreamFinalUrl
+        : directResponse.url;
+      assertFinalResponseUrlAllowed(finalUrl, {
+        allowLoopback: isLoopbackOAuthUrl(serverUrl),
+      });
       response = {
         status: directResponse.status,
         statusText: directResponse.statusText,
@@ -1436,7 +1470,7 @@ function createOAuthFetchInterceptor(
         });
         entry.response = await createTraceResponseFromFetch(response);
         entry.duration = Date.now() - entry.timestamp;
-        return response;
+        return markOAuthProxyResponse(response);
       }
     }
 
@@ -1452,7 +1486,7 @@ function createOAuthFetchInterceptor(
         const response = await authFetch(proxyUrl, { ...init, method: "GET" });
         entry.response = await createTraceResponseFromFetch(response);
         entry.duration = Date.now() - entry.timestamp;
-        return response;
+        return markOAuthProxyResponse(response);
       }
 
       // For OAuth endpoints, serialize and proxy the full request
@@ -1473,7 +1507,7 @@ function createOAuthFetchInterceptor(
       if (!response.ok) {
         entry.response = await createTraceResponseFromFetch(response);
         entry.duration = Date.now() - entry.timestamp;
-        return response;
+        return markOAuthProxyResponse(response);
       }
 
       const data = await response.json();
@@ -1484,11 +1518,13 @@ function createOAuthFetchInterceptor(
         body: data.body,
       });
       entry.duration = Date.now() - entry.timestamp;
-      return new Response(JSON.stringify(data.body), {
-        status: data.status,
-        statusText: data.statusText,
-        headers: new Headers(data.headers),
-      });
+      return markOAuthProxyResponse(
+        new Response(JSON.stringify(data.body), {
+          status: data.status,
+          statusText: data.statusText,
+          headers: new Headers(data.headers),
+        })
+      );
     } catch (error) {
       entry.error = {
         message: error instanceof Error ? error.message : String(error),

--- a/mcpjam-inspector/server/routes/mcp/__tests__/xaa-server-target.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/xaa-server-target.test.ts
@@ -6,6 +6,40 @@ import path from "path";
 import { initXAAIdpKeyPair, resetXAAIdpKeyPairForTests } from "@mcpjam/sdk";
 import { createXaaRouter } from "../xaa.js";
 
+// This suite models the whole network with a `fetch` stub. The OAuth proxy now
+// connects through raw node:http(s) so it can pin a validated DNS address, so
+// route its two outbound calls back through `fetch`, and stub DNS for the
+// `validateUrl` gate that stays real (it fails closed on an unresolvable host,
+// and these synthetic `*.example.com` names NXDOMAIN).
+vi.mock("../../../utils/oauth-proxy.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../utils/oauth-proxy.js")>();
+  const { executeOAuthProxyViaFetch, fetchOAuthMetadataViaFetch } = await import(
+    "../../../test/support/oauth-proxy-fetch-mock.js"
+  );
+  return {
+    ...actual,
+    executeOAuthProxy: vi.fn(executeOAuthProxyViaFetch),
+    fetchOAuthMetadata: vi.fn(fetchOAuthMetadataViaFetch),
+  };
+});
+
+const dnsLookupMock = vi.hoisted(() => vi.fn());
+vi.mock("node:dns", () => ({
+  lookup: dnsLookupMock,
+}));
+
+// Re-installed per test: the shared server setup clears all mocks in afterEach.
+beforeEach(() => {
+  dnsLookupMock.mockImplementation(
+    (
+      _hostname: string,
+      _options: unknown,
+      callback: (error: Error | null, addresses: unknown) => void
+    ) => callback(null, [{ address: "93.184.216.34", family: 4 }])
+  );
+});
+
 const DISCOVERED_TOKEN_ENDPOINT = "https://discovered-as.example.com/oauth/token";
 
 interface ServerSecretResolverResult {

--- a/mcpjam-inspector/server/routes/mcp/__tests__/xaa.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/xaa.test.ts
@@ -27,6 +27,40 @@ import { WebRouteError } from "../../web/errors.js";
 import { NEGATIVE_TEST_MODES } from "../../../../shared/xaa.js";
 import xaa, { createXaaRouter } from "../xaa.js";
 
+// This suite models the whole network with a `fetch` stub. The OAuth proxy now
+// connects through raw node:http(s) so it can pin a validated DNS address, so
+// route its two outbound calls back through `fetch`, and stub DNS for the
+// `validateUrl` gate that stays real (it fails closed on an unresolvable host,
+// and these synthetic `*.example.com` names NXDOMAIN).
+vi.mock("../../../utils/oauth-proxy.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../utils/oauth-proxy.js")>();
+  const { executeOAuthProxyViaFetch, fetchOAuthMetadataViaFetch } = await import(
+    "../../../test/support/oauth-proxy-fetch-mock.js"
+  );
+  return {
+    ...actual,
+    executeOAuthProxy: vi.fn(executeOAuthProxyViaFetch),
+    fetchOAuthMetadata: vi.fn(fetchOAuthMetadataViaFetch),
+  };
+});
+
+const dnsLookupMock = vi.hoisted(() => vi.fn());
+vi.mock("node:dns", () => ({
+  lookup: dnsLookupMock,
+}));
+
+// Re-installed per test: the shared server setup clears all mocks in afterEach.
+beforeEach(() => {
+  dnsLookupMock.mockImplementation(
+    (
+      _hostname: string,
+      _options: unknown,
+      callback: (error: Error | null, addresses: unknown) => void
+    ) => callback(null, [{ address: "93.184.216.34", family: 4 }])
+  );
+});
+
 // The 11 scorecard modes — everything the hosted split must mint and redeem.
 const SCORECARD_MODES = NEGATIVE_TEST_MODES.filter((mode) => mode !== "valid");
 

--- a/mcpjam-inspector/server/routes/mcp/oauth.ts
+++ b/mcpjam-inspector/server/routes/mcp/oauth.ts
@@ -140,6 +140,7 @@ oauth.get("/metadata", async (c) => {
       );
     }
 
+    c.header("X-MCPJam-OAuth-Upstream-URL", result.finalUrl);
     return c.json(result.metadata);
   } catch (error) {
     const targetUrlHost = safeHostname(metadataUrl);

--- a/mcpjam-inspector/server/routes/mcp/oauth.ts
+++ b/mcpjam-inspector/server/routes/mcp/oauth.ts
@@ -11,6 +11,7 @@ import {
 } from "../../utils/oauth-proxy.js";
 
 const oauth = new Hono();
+const OAUTH_UPSTREAM_URL_HEADER = "X-MCPJam-OAuth-Upstream-URL";
 
 function safeHostname(url: string | undefined): string {
   if (!url) return "unknown";
@@ -56,7 +57,7 @@ oauth.post("/debug/proxy", async (c) => {
       });
       return c.json(
         { error: error.message },
-        error.status as ContentfulStatusCode,
+        error.status as ContentfulStatusCode
       );
     }
     getRequestLogger(c, "routes.mcp.oauth").event("mcp.oauth.proxy.failed", {
@@ -70,7 +71,7 @@ oauth.post("/debug/proxy", async (c) => {
         error:
           error instanceof Error ? error.message : "Unknown error occurred",
       },
-      500,
+      500
     );
   }
 });
@@ -88,6 +89,7 @@ oauth.post("/proxy", async (c) => {
     const { url, method, body, headers } = await c.req.json();
     proxyUrl = url;
     const result = await executeOAuthProxy({ url, method, body, headers });
+    c.header(OAUTH_UPSTREAM_URL_HEADER, result.finalUrl);
     return c.json(result);
   } catch (error) {
     const targetUrlHost = safeHostname(proxyUrl);
@@ -100,7 +102,7 @@ oauth.post("/proxy", async (c) => {
       });
       return c.json(
         { error: error.message },
-        error.status as ContentfulStatusCode,
+        error.status as ContentfulStatusCode
       );
     }
     getRequestLogger(c, "routes.mcp.oauth").event("mcp.oauth.proxy.failed", {
@@ -114,7 +116,7 @@ oauth.post("/proxy", async (c) => {
         error:
           error instanceof Error ? error.message : "Unknown error occurred",
       },
-      500,
+      500
     );
   }
 });
@@ -136,11 +138,11 @@ oauth.get("/metadata", async (c) => {
         {
           error: `Failed to fetch OAuth metadata: ${result.status} ${result.statusText}`,
         },
-        result.status as ContentfulStatusCode,
+        result.status as ContentfulStatusCode
       );
     }
 
-    c.header("X-MCPJam-OAuth-Upstream-URL", result.finalUrl);
+    c.header(OAUTH_UPSTREAM_URL_HEADER, result.finalUrl);
     return c.json(result.metadata);
   } catch (error) {
     const targetUrlHost = safeHostname(metadataUrl);
@@ -153,7 +155,7 @@ oauth.get("/metadata", async (c) => {
       });
       return c.json(
         { error: error.message },
-        error.status as ContentfulStatusCode,
+        error.status as ContentfulStatusCode
       );
     }
     getRequestLogger(c, "routes.mcp.oauth").event("mcp.oauth.proxy.failed", {
@@ -167,7 +169,7 @@ oauth.get("/metadata", async (c) => {
         error:
           error instanceof Error ? error.message : "Unknown error occurred",
       },
-      500,
+      500
     );
   }
 });

--- a/mcpjam-inspector/server/routes/mcp/oauth.ts
+++ b/mcpjam-inspector/server/routes/mcp/oauth.ts
@@ -57,7 +57,7 @@ oauth.post("/debug/proxy", async (c) => {
       });
       return c.json(
         { error: error.message },
-        error.status as ContentfulStatusCode
+        error.status as ContentfulStatusCode,
       );
     }
     getRequestLogger(c, "routes.mcp.oauth").event("mcp.oauth.proxy.failed", {
@@ -71,7 +71,7 @@ oauth.post("/debug/proxy", async (c) => {
         error:
           error instanceof Error ? error.message : "Unknown error occurred",
       },
-      500
+      500,
     );
   }
 });
@@ -102,7 +102,7 @@ oauth.post("/proxy", async (c) => {
       });
       return c.json(
         { error: error.message },
-        error.status as ContentfulStatusCode
+        error.status as ContentfulStatusCode,
       );
     }
     getRequestLogger(c, "routes.mcp.oauth").event("mcp.oauth.proxy.failed", {
@@ -116,7 +116,7 @@ oauth.post("/proxy", async (c) => {
         error:
           error instanceof Error ? error.message : "Unknown error occurred",
       },
-      500
+      500,
     );
   }
 });
@@ -138,7 +138,7 @@ oauth.get("/metadata", async (c) => {
         {
           error: `Failed to fetch OAuth metadata: ${result.status} ${result.statusText}`,
         },
-        result.status as ContentfulStatusCode
+        result.status as ContentfulStatusCode,
       );
     }
 
@@ -155,7 +155,7 @@ oauth.get("/metadata", async (c) => {
       });
       return c.json(
         { error: error.message },
-        error.status as ContentfulStatusCode
+        error.status as ContentfulStatusCode,
       );
     }
     getRequestLogger(c, "routes.mcp.oauth").event("mcp.oauth.proxy.failed", {
@@ -169,7 +169,7 @@ oauth.get("/metadata", async (c) => {
         error:
           error instanceof Error ? error.message : "Unknown error occurred",
       },
-      500
+      500,
     );
   }
 });

--- a/mcpjam-inspector/server/routes/web/__tests__/oauth.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/oauth.test.ts
@@ -60,7 +60,7 @@ describe("web routes — oauth requires bearer token", () => {
   it("GET /metadata returns 401 without bearer token", async () => {
     const response = await getJson(
       app,
-      "/api/web/oauth/metadata?url=https://example.com/.well-known/oauth"
+      "/api/web/oauth/metadata?url=https://example.com/.well-known/oauth",
     );
     const { status, data } = await expectJson(response);
 
@@ -84,7 +84,7 @@ describe("web routes — oauth requires bearer token", () => {
       app,
       "/api/web/oauth/proxy",
       { url: "https://example.com/token" },
-      token
+      token,
     );
     const { status, data } = await expectJson(response);
 
@@ -110,7 +110,7 @@ describe("web routes — oauth requires bearer token", () => {
     const response = await getJson(
       app,
       "/api/web/oauth/metadata?url=https://example.com/.well-known/oauth",
-      token
+      token,
     );
     const { status, data } = await expectJson(response);
 
@@ -132,14 +132,14 @@ describe("web routes — oauth error contract", () => {
 
   it("returns compatibility payload for OAuthProxyError on /proxy", async () => {
     executeOAuthProxyMock.mockRejectedValueOnce(
-      new OAuthProxyError(400, "Invalid URL format")
+      new OAuthProxyError(400, "Invalid URL format"),
     );
 
     const response = await postJson(
       app,
       "/api/web/oauth/proxy",
       { url: "bad-url" },
-      token
+      token,
     );
     const { status, data } = await expectJson<OAuthErrorResponse>(response);
 
@@ -172,7 +172,7 @@ describe("web routes — oauth error contract", () => {
     const response = await getJson(
       app,
       "/api/web/oauth/metadata?url=https://oauth.example/.well-known/oauth",
-      token
+      token,
     );
     const { status, data } = await expectJson<OAuthErrorResponse>(response);
 
@@ -186,14 +186,14 @@ describe("web routes — oauth error contract", () => {
 
   it("returns compatibility payload for generic runtime errors", async () => {
     executeOAuthProxyMock.mockRejectedValueOnce(
-      new Error("connect ECONNREFUSED")
+      new Error("connect ECONNREFUSED"),
     );
 
     const response = await postJson(
       app,
       "/api/web/oauth/proxy",
       { url: "https://oauth.example/token", method: "POST", body: {} },
-      token
+      token,
     );
     const { status, data } = await expectJson<OAuthErrorResponse>(response);
 
@@ -220,13 +220,10 @@ describe("web routes — oauth session forwarding", () => {
 
   it("POST /session forwards the bearer-authenticated session bootstrap to Convex", async () => {
     const fetchMock = vi.fn().mockResolvedValueOnce(
-      new Response(
-        JSON.stringify({ success: true, sessionId: "session-123" }),
-        {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        }
-      )
+      new Response(JSON.stringify({ success: true, sessionId: "session-123" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
     );
     vi.stubGlobal("fetch", fetchMock);
 
@@ -240,12 +237,7 @@ describe("web routes — oauth session forwarding", () => {
       },
     };
 
-    const response = await postJson(
-      app,
-      "/api/web/oauth/session",
-      payload,
-      token
-    );
+    const response = await postJson(app, "/api/web/oauth/session", payload, token);
     const { status, data } = await expectJson(response);
 
     expect(status).toBe(200);
@@ -259,7 +251,7 @@ describe("web routes — oauth session forwarding", () => {
           Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify(payload),
-      }
+      },
     );
   });
 
@@ -278,8 +270,8 @@ describe("web routes — oauth session forwarding", () => {
         {
           status: 200,
           headers: { "Content-Type": "application/json" },
-        }
-      )
+        },
+      ),
     );
     vi.stubGlobal("fetch", fetchMock);
 
@@ -288,12 +280,7 @@ describe("web routes — oauth session forwarding", () => {
       serverId: "srv_1",
     };
 
-    const response = await postJson(
-      app,
-      "/api/web/oauth/tokens",
-      payload,
-      token
-    );
+    const response = await postJson(app, "/api/web/oauth/tokens", payload, token);
     const { status, data } = await expectJson(response);
 
     expect(status).toBe(200);
@@ -315,7 +302,7 @@ describe("web routes — oauth session forwarding", () => {
           Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify(payload),
-      }
+      },
     );
   });
 });

--- a/mcpjam-inspector/server/routes/web/__tests__/oauth.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/oauth.test.ts
@@ -99,6 +99,7 @@ describe("web routes — oauth requires bearer token", () => {
   it("GET /metadata succeeds with bearer token", async () => {
     fetchOAuthMetadataMock.mockResolvedValueOnce({
       metadata: { issuer: "https://example.com" },
+      finalUrl: "https://example.com/.well-known/oauth",
     });
 
     const response = await getJson(
@@ -110,6 +111,9 @@ describe("web routes — oauth requires bearer token", () => {
 
     expect(status).toBe(200);
     expect(data).toEqual({ issuer: "https://example.com" });
+    expect(response.headers.get("x-mcpjam-oauth-upstream-url")).toBe(
+      "https://example.com/.well-known/oauth",
+    );
   });
 });
 

--- a/mcpjam-inspector/server/routes/web/__tests__/oauth.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/oauth.test.ts
@@ -60,7 +60,7 @@ describe("web routes — oauth requires bearer token", () => {
   it("GET /metadata returns 401 without bearer token", async () => {
     const response = await getJson(
       app,
-      "/api/web/oauth/metadata?url=https://example.com/.well-known/oauth",
+      "/api/web/oauth/metadata?url=https://example.com/.well-known/oauth"
     );
     const { status, data } = await expectJson(response);
 
@@ -77,13 +77,14 @@ describe("web routes — oauth requires bearer token", () => {
       statusText: "OK",
       headers: {},
       body: { ok: true },
+      finalUrl: "https://example.com/token",
     });
 
     const response = await postJson(
       app,
       "/api/web/oauth/proxy",
       { url: "https://example.com/token" },
-      token,
+      token
     );
     const { status, data } = await expectJson(response);
 
@@ -93,7 +94,11 @@ describe("web routes — oauth requires bearer token", () => {
       statusText: "OK",
       headers: {},
       body: { ok: true },
+      finalUrl: "https://example.com/token",
     });
+    expect(response.headers.get("x-mcpjam-oauth-upstream-url")).toBe(
+      "https://example.com/token"
+    );
   });
 
   it("GET /metadata succeeds with bearer token", async () => {
@@ -105,14 +110,14 @@ describe("web routes — oauth requires bearer token", () => {
     const response = await getJson(
       app,
       "/api/web/oauth/metadata?url=https://example.com/.well-known/oauth",
-      token,
+      token
     );
     const { status, data } = await expectJson(response);
 
     expect(status).toBe(200);
     expect(data).toEqual({ issuer: "https://example.com" });
     expect(response.headers.get("x-mcpjam-oauth-upstream-url")).toBe(
-      "https://example.com/.well-known/oauth",
+      "https://example.com/.well-known/oauth"
     );
   });
 });
@@ -127,14 +132,14 @@ describe("web routes — oauth error contract", () => {
 
   it("returns compatibility payload for OAuthProxyError on /proxy", async () => {
     executeOAuthProxyMock.mockRejectedValueOnce(
-      new OAuthProxyError(400, "Invalid URL format"),
+      new OAuthProxyError(400, "Invalid URL format")
     );
 
     const response = await postJson(
       app,
       "/api/web/oauth/proxy",
       { url: "bad-url" },
-      token,
+      token
     );
     const { status, data } = await expectJson<OAuthErrorResponse>(response);
 
@@ -167,7 +172,7 @@ describe("web routes — oauth error contract", () => {
     const response = await getJson(
       app,
       "/api/web/oauth/metadata?url=https://oauth.example/.well-known/oauth",
-      token,
+      token
     );
     const { status, data } = await expectJson<OAuthErrorResponse>(response);
 
@@ -181,14 +186,14 @@ describe("web routes — oauth error contract", () => {
 
   it("returns compatibility payload for generic runtime errors", async () => {
     executeOAuthProxyMock.mockRejectedValueOnce(
-      new Error("connect ECONNREFUSED"),
+      new Error("connect ECONNREFUSED")
     );
 
     const response = await postJson(
       app,
       "/api/web/oauth/proxy",
       { url: "https://oauth.example/token", method: "POST", body: {} },
-      token,
+      token
     );
     const { status, data } = await expectJson<OAuthErrorResponse>(response);
 
@@ -215,10 +220,13 @@ describe("web routes — oauth session forwarding", () => {
 
   it("POST /session forwards the bearer-authenticated session bootstrap to Convex", async () => {
     const fetchMock = vi.fn().mockResolvedValueOnce(
-      new Response(JSON.stringify({ success: true, sessionId: "session-123" }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      }),
+      new Response(
+        JSON.stringify({ success: true, sessionId: "session-123" }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }
+      )
     );
     vi.stubGlobal("fetch", fetchMock);
 
@@ -232,7 +240,12 @@ describe("web routes — oauth session forwarding", () => {
       },
     };
 
-    const response = await postJson(app, "/api/web/oauth/session", payload, token);
+    const response = await postJson(
+      app,
+      "/api/web/oauth/session",
+      payload,
+      token
+    );
     const { status, data } = await expectJson(response);
 
     expect(status).toBe(200);
@@ -246,7 +259,7 @@ describe("web routes — oauth session forwarding", () => {
           Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify(payload),
-      },
+      }
     );
   });
 
@@ -265,8 +278,8 @@ describe("web routes — oauth session forwarding", () => {
         {
           status: 200,
           headers: { "Content-Type": "application/json" },
-        },
-      ),
+        }
+      )
     );
     vi.stubGlobal("fetch", fetchMock);
 
@@ -275,7 +288,12 @@ describe("web routes — oauth session forwarding", () => {
       serverId: "srv_1",
     };
 
-    const response = await postJson(app, "/api/web/oauth/tokens", payload, token);
+    const response = await postJson(
+      app,
+      "/api/web/oauth/tokens",
+      payload,
+      token
+    );
     const { status, data } = await expectJson(response);
 
     expect(status).toBe(200);
@@ -297,7 +315,7 @@ describe("web routes — oauth session forwarding", () => {
           Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify(payload),
-      },
+      }
     );
   });
 });

--- a/mcpjam-inspector/server/routes/web/oauth.ts
+++ b/mcpjam-inspector/server/routes/web/oauth.ts
@@ -14,6 +14,7 @@ import { getRequestLogger } from "../../utils/request-logger.js";
 import { classifyError } from "../../utils/error-classify.js";
 
 const oauthWeb = new Hono();
+const OAUTH_UPSTREAM_URL_HEADER = "X-MCPJam-OAuth-Upstream-URL";
 
 function safeHostname(url: string | undefined): string {
   if (!url) return "unknown";
@@ -51,7 +52,7 @@ function webErrorCompat(c: Context, routeError: WebRouteError) {
       message: routeError.message,
       error: routeError.message,
     },
-    routeError.status as ContentfulStatusCode,
+    routeError.status as ContentfulStatusCode
   );
 }
 
@@ -63,7 +64,7 @@ function toRouteError(error: unknown): WebRouteError {
     return new WebRouteError(
       error.status,
       statusToErrorCode(error.status),
-      error.message,
+      error.message
     );
   }
   return mapRuntimeError(error);
@@ -75,7 +76,7 @@ function getConvexHttpUrl(): string {
     throw new WebRouteError(
       500,
       ErrorCode.INTERNAL_ERROR,
-      "Server missing CONVEX_HTTP_URL configuration",
+      "Server missing CONVEX_HTTP_URL configuration"
     );
   }
 
@@ -99,7 +100,8 @@ async function proxyConvexOAuthPost(c: Context, path: string) {
   return new Response(bodyText, {
     status: response.status,
     headers: {
-      "Content-Type": response.headers.get("content-type") ?? "application/json",
+      "Content-Type":
+        response.headers.get("content-type") ?? "application/json",
     },
   });
 }
@@ -123,6 +125,7 @@ oauthWeb.post("/proxy", async (c) => {
       headers,
       httpsOnly: true,
     });
+    c.header(OAUTH_UPSTREAM_URL_HEADER, result.finalUrl);
     return c.json(result);
   } catch (error) {
     getRequestLogger(c, "routes.web.oauth").event("mcp.oauth.proxy.failed", {
@@ -148,7 +151,7 @@ oauthWeb.get("/metadata", async (c) => {
       throw new WebRouteError(
         400,
         ErrorCode.VALIDATION_ERROR,
-        "Missing url parameter",
+        "Missing url parameter"
       );
     }
 
@@ -157,11 +160,11 @@ oauthWeb.get("/metadata", async (c) => {
       throw new WebRouteError(
         result.status,
         statusToErrorCode(result.status),
-        `Failed to fetch OAuth metadata: ${result.status} ${result.statusText}`,
+        `Failed to fetch OAuth metadata: ${result.status} ${result.statusText}`
       );
     }
 
-    c.header("X-MCPJam-OAuth-Upstream-URL", result.finalUrl);
+    c.header(OAUTH_UPSTREAM_URL_HEADER, result.finalUrl);
     return c.json(result.metadata);
   } catch (error) {
     getRequestLogger(c, "routes.web.oauth").event("mcp.oauth.proxy.failed", {

--- a/mcpjam-inspector/server/routes/web/oauth.ts
+++ b/mcpjam-inspector/server/routes/web/oauth.ts
@@ -52,7 +52,7 @@ function webErrorCompat(c: Context, routeError: WebRouteError) {
       message: routeError.message,
       error: routeError.message,
     },
-    routeError.status as ContentfulStatusCode
+    routeError.status as ContentfulStatusCode,
   );
 }
 
@@ -64,7 +64,7 @@ function toRouteError(error: unknown): WebRouteError {
     return new WebRouteError(
       error.status,
       statusToErrorCode(error.status),
-      error.message
+      error.message,
     );
   }
   return mapRuntimeError(error);
@@ -76,7 +76,7 @@ function getConvexHttpUrl(): string {
     throw new WebRouteError(
       500,
       ErrorCode.INTERNAL_ERROR,
-      "Server missing CONVEX_HTTP_URL configuration"
+      "Server missing CONVEX_HTTP_URL configuration",
     );
   }
 
@@ -100,8 +100,7 @@ async function proxyConvexOAuthPost(c: Context, path: string) {
   return new Response(bodyText, {
     status: response.status,
     headers: {
-      "Content-Type":
-        response.headers.get("content-type") ?? "application/json",
+      "Content-Type": response.headers.get("content-type") ?? "application/json",
     },
   });
 }
@@ -151,7 +150,7 @@ oauthWeb.get("/metadata", async (c) => {
       throw new WebRouteError(
         400,
         ErrorCode.VALIDATION_ERROR,
-        "Missing url parameter"
+        "Missing url parameter",
       );
     }
 
@@ -160,7 +159,7 @@ oauthWeb.get("/metadata", async (c) => {
       throw new WebRouteError(
         result.status,
         statusToErrorCode(result.status),
-        `Failed to fetch OAuth metadata: ${result.status} ${result.statusText}`
+        `Failed to fetch OAuth metadata: ${result.status} ${result.statusText}`,
       );
     }
 

--- a/mcpjam-inspector/server/routes/web/oauth.ts
+++ b/mcpjam-inspector/server/routes/web/oauth.ts
@@ -161,6 +161,7 @@ oauthWeb.get("/metadata", async (c) => {
       );
     }
 
+    c.header("X-MCPJam-OAuth-Upstream-URL", result.finalUrl);
     return c.json(result.metadata);
   } catch (error) {
     getRequestLogger(c, "routes.web.oauth").event("mcp.oauth.proxy.failed", {

--- a/mcpjam-inspector/server/test/support/oauth-proxy-fetch-mock.ts
+++ b/mcpjam-inspector/server/test/support/oauth-proxy-fetch-mock.ts
@@ -1,0 +1,130 @@
+// Imported from the SDK rather than `../../utils/oauth-proxy.js`: suites mock
+// that module and load this helper from inside the mock factory, so importing
+// it here would be a cycle. The server util is a bare re-export either way.
+import { validateUrl } from "@mcpjam/sdk";
+import type {
+  OAuthProxyRequest,
+  OAuthProxyResponse,
+} from "../../utils/oauth-proxy.js";
+
+/**
+ * In-memory transport seam for server route/service suites.
+ *
+ * `executeOAuthProxy` and `fetchOAuthMetadata` connect through raw
+ * `node:http(s).request` so they can pin a validated DNS address to the socket.
+ * That is deliberately un-stubbable via `global.fetch`, so suites which model
+ * the network with a `fetch` mock route these two calls back through it here.
+ * Production pinning/redirect behavior is covered by
+ * `server/utils/__tests__/oauth-proxy.test.ts` and the SDK's `oauth-proxy`
+ * suite; these adapters exist so route and service tests can stay focused on
+ * their own logic.
+ */
+
+function encodeBody(
+  req: OAuthProxyRequest,
+  method: string,
+): string | undefined {
+  if (method !== "POST" || req.body === undefined || req.body === null) {
+    return undefined;
+  }
+
+  const headers = req.headers ?? {};
+  const contentType = headers["Content-Type"] ?? headers["content-type"] ?? "";
+  if (
+    contentType.includes("application/x-www-form-urlencoded") &&
+    typeof req.body === "object"
+  ) {
+    return new URLSearchParams(
+      Object.entries(req.body as Record<string, unknown>).map(
+        ([key, value]) => [key, String(value)],
+      ),
+    ).toString();
+  }
+  return typeof req.body === "string" ? req.body : JSON.stringify(req.body);
+}
+
+export async function executeOAuthProxyViaFetch(
+  req: OAuthProxyRequest,
+): Promise<OAuthProxyResponse> {
+  // Keep the real SSRF gate: callers assert that a private/reserved target is
+  // refused before any outbound request is attempted.
+  await validateUrl(req.url, req.httpsOnly);
+  const method = (req.method ?? "GET").toUpperCase();
+  const response = await global.fetch(req.url, {
+    method,
+    headers: req.headers,
+    body: encodeBody(req, method),
+    redirect: req.httpsOnly ? "manual" : (req.redirect ?? "follow"),
+    signal:
+      req.timeoutMs === undefined
+        ? undefined
+        : AbortSignal.timeout(req.timeoutMs),
+  });
+
+  const headers: Record<string, string> = {};
+  response.headers.forEach((value, key) => {
+    headers[key] = value;
+  });
+
+  const text = await response.text();
+  let body: unknown = null;
+  if (text) {
+    try {
+      body = JSON.parse(text);
+    } catch {
+      body = text;
+    }
+  }
+
+  return {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+    body,
+    finalUrl: response.url || req.url,
+  };
+}
+
+/** Mirrors the real `fetchOAuthMetadata` result contract, including its
+ * non-JSON and invalid-body 502s, so callers see the same shapes. */
+export async function fetchOAuthMetadataViaFetch(
+  url: string,
+  httpsOnly = false,
+  timeoutMs?: number,
+): Promise<
+  | { metadata: Record<string, unknown>; finalUrl: string; status?: undefined }
+  | { status: number; statusText: string }
+> {
+  // Keep the real SSRF gate: callers assert that a private/reserved target is
+  // refused before any outbound request is attempted.
+  await validateUrl(url, httpsOnly);
+  const response = await global.fetch(url, {
+    method: "GET",
+    headers: { Accept: "application/json" },
+    signal:
+      timeoutMs === undefined ? undefined : AbortSignal.timeout(timeoutMs),
+  });
+
+  if (!response.ok) {
+    return { status: response.status, statusText: response.statusText };
+  }
+
+  const contentType = response.headers.get("content-type");
+  if (!contentType?.includes("application/json")) {
+    return {
+      status: 502,
+      statusText: `Upstream returned non-JSON content-type: ${
+        contentType ?? "(none)"
+      }`,
+    };
+  }
+
+  let metadata: Record<string, unknown>;
+  try {
+    metadata = (await response.json()) as Record<string, unknown>;
+  } catch {
+    return { status: 502, statusText: "Upstream returned invalid JSON body" };
+  }
+
+  return { metadata, finalUrl: response.url || url };
+}

--- a/mcpjam-inspector/server/utils/__tests__/oauth-proxy.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/oauth-proxy.test.ts
@@ -1,23 +1,64 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "node:events";
+import { Readable } from "node:stream";
 import { executeOAuthProxy, OAuthProxyError } from "../oauth-proxy.js";
 
-// Mock dns.resolve4/resolve6 to return empty by default (public hostname)
-vi.mock("node:dns/promises", () => ({
-  default: {
-    resolve4: vi.fn().mockResolvedValue([]),
-    resolve6: vi.fn().mockResolvedValue([]),
-  },
+const httpRequestMock = vi.hoisted(() => vi.fn());
+const httpsRequestMock = vi.hoisted(() => vi.fn());
+const dnsLookupMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:dns", () => ({
+  lookup: dnsLookupMock,
+}));
+vi.mock("node:http", () => ({
+  default: { request: httpRequestMock },
+  request: httpRequestMock,
+}));
+vi.mock("node:https", () => ({
+  default: { request: httpsRequestMock },
+  request: httpsRequestMock,
 }));
 
-// Mock fetch globally so valid URLs don't make real requests
-const fetchMock = vi.fn().mockResolvedValue({
-  status: 200,
-  statusText: "OK",
-  headers: new Headers(),
-  json: async () => ({ ok: true }),
-  text: async () => "",
+function installSuccessfulRequestMock(requestMock: ReturnType<typeof vi.fn>) {
+  requestMock.mockImplementation(
+    (
+      _url: URL,
+      _options: unknown,
+      onResponse: (response: Readable) => void,
+    ) => {
+      const request = new EventEmitter() as EventEmitter & {
+        end: () => void;
+        write: () => void;
+      };
+      request.write = vi.fn();
+      request.end = () => {
+        queueMicrotask(() => {
+          const response = Readable.from([JSON.stringify({ ok: true })]);
+          Object.assign(response, {
+            statusCode: 200,
+            statusMessage: "OK",
+            headers: { "content-type": "application/json" },
+          });
+          onResponse(response);
+        });
+      };
+      return request;
+    },
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  dnsLookupMock.mockImplementation(
+    (
+      _hostname: string,
+      _options: unknown,
+      callback: (error: Error | null, addresses: unknown) => void,
+    ) => callback(null, [{ address: "93.184.216.34", family: 4 }]),
+  );
+  installSuccessfulRequestMock(httpRequestMock);
+  installSuccessfulRequestMock(httpsRequestMock);
 });
-vi.stubGlobal("fetch", fetchMock);
 
 describe("validateUrl — private IP blocking (httpsOnly)", () => {
   const privateHosts = [
@@ -51,14 +92,6 @@ describe("validateUrl — private IP blocking (httpsOnly)", () => {
   }
 
   it("allows https://example.com/foo when httpsOnly", async () => {
-    fetchMock.mockResolvedValueOnce({
-      status: 200,
-      statusText: "OK",
-      headers: new Headers(),
-      json: async () => ({ ok: true }),
-      text: async () => "",
-    });
-
     const result = await executeOAuthProxy({
       url: "https://example.com/foo",
       httpsOnly: true,
@@ -66,15 +99,7 @@ describe("validateUrl — private IP blocking (httpsOnly)", () => {
     expect(result.status).toBe(200);
   });
 
-  it("allows http://127.0.0.1 when httpsOnly is false (no IP blocking)", async () => {
-    fetchMock.mockResolvedValueOnce({
-      status: 200,
-      statusText: "OK",
-      headers: new Headers(),
-      json: async () => ({ ok: true }),
-      text: async () => "",
-    });
-
+  it("allows an explicit loopback URL when httpsOnly is false", async () => {
     const result = await executeOAuthProxy({
       url: "http://127.0.0.1",
       httpsOnly: false,
@@ -85,14 +110,6 @@ describe("validateUrl — private IP blocking (httpsOnly)", () => {
 
 describe("IPv6 checks must not false-positive on hostnames", () => {
   it("allows https://fdroid.org (hostname starts with 'fd')", async () => {
-    fetchMock.mockResolvedValueOnce({
-      status: 200,
-      statusText: "OK",
-      headers: new Headers(),
-      json: async () => ({ ok: true }),
-      text: async () => "",
-    });
-
     const result = await executeOAuthProxy({
       url: "https://fdroid.org/foo",
       httpsOnly: true,
@@ -101,14 +118,6 @@ describe("IPv6 checks must not false-positive on hostnames", () => {
   });
 
   it("allows https://fc-example.com (hostname starts with 'fc')", async () => {
-    fetchMock.mockResolvedValueOnce({
-      status: 200,
-      statusText: "OK",
-      headers: new Headers(),
-      json: async () => ({ ok: true }),
-      text: async () => "",
-    });
-
     const result = await executeOAuthProxy({
       url: "https://fc-example.com/foo",
       httpsOnly: true,
@@ -117,14 +126,6 @@ describe("IPv6 checks must not false-positive on hostnames", () => {
   });
 
   it("allows https://fe90.example.com (hostname matches fe80::/10 regex)", async () => {
-    fetchMock.mockResolvedValueOnce({
-      status: 200,
-      statusText: "OK",
-      headers: new Headers(),
-      json: async () => ({ ok: true }),
-      text: async () => "",
-    });
-
     const result = await executeOAuthProxy({
       url: "https://fe90.example.com/foo",
       httpsOnly: true,
@@ -145,37 +146,30 @@ describe("IPv6 checks must not false-positive on hostnames", () => {
   });
 });
 
-describe("DNS validation — fetch preserves original hostname for TLS", () => {
-  it("uses the original hostname in the fetch URL (not the resolved IP)", async () => {
-    const dns = await import("node:dns/promises");
-    vi.mocked(dns.default.resolve4).mockResolvedValueOnce(["93.184.216.34"]);
-    vi.mocked(dns.default.resolve6).mockResolvedValueOnce([]);
-
-    fetchMock.mockResolvedValueOnce({
-      status: 200,
-      statusText: "OK",
-      headers: new Headers(),
-      json: async () => ({ ok: true }),
-      text: async () => "",
-    });
-
+describe("DNS validation — pinned request preserves original hostname for TLS", () => {
+  it("uses the original hostname while pinning the validated address", async () => {
     await executeOAuthProxy({
       url: "https://example.com/path",
       httpsOnly: true,
     });
 
-    // fetch must use the original hostname so TLS cert validation works
-    const calledUrl = fetchMock.mock.calls[fetchMock.mock.calls.length - 1][0];
-    expect(calledUrl).toContain("example.com");
-    expect(calledUrl).not.toContain("93.184.216.34");
+    expect(httpsRequestMock.mock.calls[0][0]).toEqual(
+      new URL("https://example.com/path"),
+    );
+    expect(httpsRequestMock.mock.calls[0][1].servername).toBe("example.com");
+    expect(httpsRequestMock.mock.calls[0][1].lookup).toBeTypeOf("function");
   });
 });
 
 describe("DNS rebinding protection (httpsOnly)", () => {
   it("blocks a hostname that resolves to a private IPv4", async () => {
-    const dns = await import("node:dns/promises");
-    vi.mocked(dns.default.resolve4).mockResolvedValueOnce(["127.0.0.1"]);
-    vi.mocked(dns.default.resolve6).mockResolvedValueOnce([]);
+    dnsLookupMock.mockImplementationOnce(
+      (
+        _hostname: string,
+        _options: unknown,
+        callback: (error: Error | null, addresses: unknown) => void,
+      ) => callback(null, [{ address: "127.0.0.1", family: 4 }]),
+    );
 
     await expect(
       executeOAuthProxy({
@@ -186,9 +180,13 @@ describe("DNS rebinding protection (httpsOnly)", () => {
   });
 
   it("blocks a hostname that resolves to a private IPv6", async () => {
-    const dns = await import("node:dns/promises");
-    vi.mocked(dns.default.resolve4).mockResolvedValueOnce([]);
-    vi.mocked(dns.default.resolve6).mockResolvedValueOnce(["::1"]);
+    dnsLookupMock.mockImplementationOnce(
+      (
+        _hostname: string,
+        _options: unknown,
+        callback: (error: Error | null, addresses: unknown) => void,
+      ) => callback(null, [{ address: "::1", family: 6 }]),
+    );
 
     await expect(
       executeOAuthProxy({

--- a/sdk/src/oauth-proxy.ts
+++ b/sdk/src/oauth-proxy.ts
@@ -32,6 +32,7 @@ export interface OAuthProxyResponse {
   statusText: string;
   headers: Record<string, string>;
   body: unknown;
+  finalUrl: string;
 }
 
 // SSRF IP classifier + host check moved to the browser-safe `oauth/ssrf-guard`
@@ -67,7 +68,7 @@ async function resolveAndValidateDns(hostname: string): Promise<string | null> {
     if (isPrivateHost(ip)) {
       throw new OAuthProxyError(
         400,
-        "Hostname resolves to a private/reserved IP address",
+        "Hostname resolves to a private/reserved IP address"
       );
     }
   }
@@ -79,10 +80,7 @@ interface ValidatedUrl {
   url: URL;
 }
 
-function parseAndValidateUrl(
-  url: string,
-  httpsOnly = false,
-): URL {
+function parseAndValidateUrl(url: string, httpsOnly = false): URL {
   if (!url) {
     throw new OAuthProxyError(400, "Missing url parameter");
   }
@@ -94,16 +92,13 @@ function parseAndValidateUrl(
     throw new OAuthProxyError(400, "Invalid URL format");
   }
 
-  if (
-    targetUrl.protocol !== "https:" &&
-    targetUrl.protocol !== "http:"
-  ) {
+  if (targetUrl.protocol !== "https:" && targetUrl.protocol !== "http:") {
     throw new OAuthProxyError(400, "Invalid protocol");
   }
   if (httpsOnly && targetUrl.protocol !== "https:") {
     throw new OAuthProxyError(
       400,
-      "Only HTTPS targets are allowed in hosted mode",
+      "Only HTTPS targets are allowed in hosted mode"
     );
   }
 
@@ -112,17 +107,18 @@ function parseAndValidateUrl(
 
 export async function validateUrl(
   url: string,
-  httpsOnly = false,
+  httpsOnly = false
 ): Promise<ValidatedUrl> {
   const targetUrl = parseAndValidateUrl(url, httpsOnly);
 
   // Local mode permits HTTP and explicit loopback OAuth servers; it must not
   // disable SSRF validation for every other host.
-  const explicitLoopback = !httpsOnly && isLoopbackOAuthUrl(targetUrl.toString());
+  const explicitLoopback =
+    !httpsOnly && isLoopbackOAuthUrl(targetUrl.toString());
   if (isPrivateHost(targetUrl.hostname) && !explicitLoopback) {
     throw new OAuthProxyError(
       400,
-      "Private/reserved IP addresses are not allowed",
+      "Private/reserved IP addresses are not allowed"
     );
   }
   if (!explicitLoopback) {
@@ -137,7 +133,7 @@ function buildFetchUrl(targetUrl: URL): string {
 }
 
 function requestTimeoutSignal(
-  timeoutMs: number | undefined,
+  timeoutMs: number | undefined
 ): AbortSignal | undefined {
   if (timeoutMs === undefined) return undefined;
   if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
@@ -159,7 +155,7 @@ async function parseResponseBody(response: Response): Promise<unknown> {
 }
 
 function buildRequestHeaders(
-  customHeaders: Record<string, string> | undefined,
+  customHeaders: Record<string, string> | undefined
 ): Record<string, string> {
   return {
     "User-Agent": "MCP-Inspector/1.0",
@@ -170,19 +166,21 @@ function buildRequestHeaders(
 function encodeRequestBody(
   method: string,
   body: unknown,
-  contentType: string | undefined,
+  contentType: string | undefined
 ): BodyInit | undefined {
   if (method !== "POST" || body === undefined || body === null) {
     return undefined;
   }
 
   const isFormUrlEncoded = contentType?.includes(
-    "application/x-www-form-urlencoded",
+    "application/x-www-form-urlencoded"
   );
 
   if (isFormUrlEncoded && typeof body === "object") {
     const params = new URLSearchParams();
-    for (const [key, value] of Object.entries(body as Record<string, unknown>)) {
+    for (const [key, value] of Object.entries(
+      body as Record<string, unknown>
+    )) {
       params.append(key, String(value));
     }
     return params.toString();
@@ -209,23 +207,24 @@ export async function fetchPinnedPublicDocument(
     headers?: Record<string, string>;
     timeoutMs?: number;
     maxBytes?: number;
-  } = {},
+  } = {}
 ): Promise<OAuthProxyResponse> {
   const url = new URL(urlString);
   if (url.protocol !== "https:") {
     throw new OAuthProxyError(
       400,
-      "The client metadata document must be served over HTTPS",
+      "The client metadata document must be served over HTTPS"
     );
   }
   // Reject a literal private/reserved host before opening any connection.
   if (isPrivateHost(url.hostname)) {
     throw new OAuthProxyError(
       400,
-      `The client metadata host is a private or reserved address (${url.hostname})`,
+      `The client metadata host is a private or reserved address (${url.hostname})`
     );
   }
-  const maxBytes = opts.maxBytes && opts.maxBytes > 0 ? opts.maxBytes : 5 * 1024;
+  const maxBytes =
+    opts.maxBytes && opts.maxBytes > 0 ? opts.maxBytes : 5 * 1024;
   const timeoutMs =
     opts.timeoutMs && opts.timeoutMs > 0 ? opts.timeoutMs : 5000;
 
@@ -245,7 +244,7 @@ export async function fetchPinnedPublicDocument(
         return callback(
           new OAuthProxyError(400, `Could not resolve ${hostname}`),
           "",
-          0,
+          0
         );
       }
       for (const a of list) {
@@ -253,10 +252,10 @@ export async function fetchPinnedPublicDocument(
           return callback(
             new OAuthProxyError(
               400,
-              `${hostname} resolves to a private or reserved address (${a.address})`,
+              `${hostname} resolves to a private or reserved address (${a.address})`
             ),
             "",
-            0,
+            0
           );
         }
       }
@@ -264,7 +263,7 @@ export async function fetchPinnedPublicDocument(
         return (
           callback as unknown as (
             err: NodeJS.ErrnoException | null,
-            addresses: { address: string; family: number }[],
+            addresses: { address: string; family: number }[]
           ) => void
         )(null, list);
       }
@@ -306,8 +305,8 @@ export async function fetchPinnedPublicDocument(
             reject(
               new OAuthProxyError(
                 400,
-                `The client metadata document exceeds the ${maxBytes}-byte cap`,
-              ),
+                `The client metadata document exceeds the ${maxBytes}-byte cap`
+              )
             );
             return;
           }
@@ -321,19 +320,25 @@ export async function fetchPinnedPublicDocument(
           } catch {
             // leave as text; the caller's media-type check reports the mismatch
           }
-          resolve({ status, statusText, headers, body });
+          resolve({
+            status,
+            statusText,
+            headers,
+            body,
+            finalUrl: url.toString(),
+          });
         });
         res.on("error", reject);
-      },
+      }
     );
     request.on("error", (err) => {
       reject(
         deadline.aborted
           ? new OAuthProxyError(
               400,
-              `The client metadata document request exceeded the ${timeoutMs}ms deadline`,
+              `The client metadata document request exceeded the ${timeoutMs}ms deadline`
             )
-          : err,
+          : err
       );
     });
     request.end();
@@ -341,7 +346,7 @@ export async function fetchPinnedPublicDocument(
 }
 
 export async function executeOAuthProxy(
-  req: OAuthProxyRequest,
+  req: OAuthProxyRequest
 ): Promise<OAuthProxyResponse> {
   const { url: targetUrl } = await validateUrl(req.url, req.httpsOnly);
   const method = req.method ?? "GET";
@@ -373,11 +378,12 @@ export async function executeOAuthProxy(
     statusText: response.statusText,
     headers,
     body: await parseResponseBody(response),
+    finalUrl: response.url || targetUrl.toString(),
   };
 }
 
 export async function executeDebugOAuthProxy(
-  req: OAuthProxyRequest,
+  req: OAuthProxyRequest
 ): Promise<OAuthProxyResponse> {
   const { url: targetUrl } = await validateUrl(req.url, req.httpsOnly);
   const method = req.method ?? "GET";
@@ -423,7 +429,7 @@ export async function executeDebugOAuthProxy(
             const { done, value } = await Promise.race([
               reader.read(),
               new Promise<{ done: boolean; value: undefined }>((_, reject) =>
-                setTimeout(() => reject(new Error("Read timeout")), 1000),
+                setTimeout(() => reject(new Error("Read timeout")), 1000)
               ),
             ]);
 
@@ -490,6 +496,7 @@ export async function executeDebugOAuthProxy(
     statusText: response.statusText,
     headers,
     body: responseBody,
+    finalUrl: response.url || targetUrl.toString(),
   };
 }
 
@@ -516,6 +523,7 @@ function isLoopbackAddress(address: string): boolean {
 async function resolvePinnedAddresses(
   targetUrl: URL,
   allowLoopbackFlow: boolean,
+  signal: AbortSignal | undefined
 ): Promise<PinnedAddress[] | null> {
   const targetIsLoopback = isLoopbackOAuthUrl(targetUrl.toString());
 
@@ -523,7 +531,7 @@ async function resolvePinnedAddresses(
     if (!(allowLoopbackFlow && targetIsLoopback)) {
       throw new OAuthProxyError(
         400,
-        `OAuth metadata target is a private/reserved host (${targetUrl.hostname})`,
+        `OAuth metadata target is a private/reserved host (${targetUrl.hostname})`
       );
     }
   }
@@ -538,28 +546,41 @@ async function resolvePinnedAddresses(
   }
 
   const addresses = await new Promise<PinnedAddress[]>((resolve, reject) => {
+    const cleanup = () => signal?.removeEventListener("abort", onAbort);
+    const onAbort = () => {
+      cleanup();
+      reject(signal?.reason ?? new Error("OAuth metadata request aborted"));
+    };
+
+    if (signal?.aborted) {
+      onAbort();
+      return;
+    }
+    signal?.addEventListener("abort", onAbort, { once: true });
+
     dnsLookupCb(
       targetUrl.hostname,
       { all: true, verbatim: true },
       (error, resolved) => {
+        cleanup();
         if (error) {
           reject(
             new OAuthProxyError(
               400,
-              `Could not resolve OAuth metadata host ${targetUrl.hostname}`,
-            ),
+              `Could not resolve OAuth metadata host ${targetUrl.hostname}`
+            )
           );
           return;
         }
         resolve(Array.isArray(resolved) ? resolved : [resolved]);
-      },
+      }
     );
   });
 
   if (addresses.length === 0) {
     throw new OAuthProxyError(
       400,
-      `Could not resolve OAuth metadata host ${targetUrl.hostname}`,
+      `Could not resolve OAuth metadata host ${targetUrl.hostname}`
     );
   }
 
@@ -568,13 +589,13 @@ async function resolvePinnedAddresses(
       if (!isLoopbackAddress(address)) {
         throw new OAuthProxyError(
           400,
-          `Loopback OAuth metadata host resolved outside loopback (${address})`,
+          `Loopback OAuth metadata host resolved outside loopback (${address})`
         );
       }
     } else if (isDisallowedIpAddress(address)) {
       throw new OAuthProxyError(
         400,
-        `OAuth metadata host resolves to a private/reserved IP address (${address})`,
+        `OAuth metadata host resolves to a private/reserved IP address (${address})`
       );
     }
   }
@@ -588,7 +609,7 @@ function createPinnedLookup(addresses: PinnedAddress[]): LookupFunction {
       return (
         callback as unknown as (
           err: NodeJS.ErrnoException | null,
-          resolved: PinnedAddress[],
+          resolved: PinnedAddress[]
         ) => void
       )(null, addresses);
     }
@@ -599,11 +620,12 @@ function createPinnedLookup(addresses: PinnedAddress[]): LookupFunction {
 async function requestPinnedOAuthMetadata(
   targetUrl: URL,
   allowLoopbackFlow: boolean,
-  signal: AbortSignal | undefined,
+  signal: AbortSignal | undefined
 ): Promise<RawOAuthMetadataResponse> {
   const pinnedAddresses = await resolvePinnedAddresses(
     targetUrl,
     allowLoopbackFlow,
+    signal
   );
   const transport = targetUrl.protocol === "https:" ? https : http;
 
@@ -614,6 +636,7 @@ async function requestPinnedOAuthMetadata(
         method: "GET",
         headers: {
           Accept: "application/json",
+          "Accept-Encoding": "identity",
           "User-Agent": "MCP-Inspector/1.0",
         },
         ...(pinnedAddresses
@@ -635,7 +658,7 @@ async function requestPinnedOAuthMetadata(
         const status = response.statusCode ?? 0;
         const statusText = response.statusMessage ?? "";
         if (status >= 300 && status < 400) {
-          response.resume();
+          response.destroy();
           resolve({ status, statusText, headers, body: "" });
           return;
         }
@@ -650,8 +673,8 @@ async function requestPinnedOAuthMetadata(
             reject(
               new OAuthProxyError(
                 400,
-                `OAuth metadata exceeds the ${MAX_OAUTH_METADATA_BYTES}-byte cap`,
-              ),
+                `OAuth metadata exceeds the ${MAX_OAUTH_METADATA_BYTES}-byte cap`
+              )
             );
             return;
           }
@@ -666,7 +689,7 @@ async function requestPinnedOAuthMetadata(
           });
         });
         response.on("error", reject);
-      },
+      }
     );
     request.on("error", reject);
     request.end();
@@ -676,7 +699,7 @@ async function requestPinnedOAuthMetadata(
 export async function fetchOAuthMetadata(
   url: string,
   httpsOnly = false,
-  timeoutMs?: number,
+  timeoutMs?: number
 ): Promise<
   | {
       metadata: Record<string, unknown>;
@@ -693,19 +716,16 @@ export async function fetchOAuthMetadata(
   let response: RawOAuthMetadataResponse | undefined;
 
   for (let redirectCount = 0; ; redirectCount += 1) {
-    if (
-      currentUrl.protocol !== "https:" &&
-      currentUrl.protocol !== "http:"
-    ) {
+    if (currentUrl.protocol !== "https:" && currentUrl.protocol !== "http:") {
       throw new OAuthProxyError(
         400,
-        "OAuth metadata redirect uses an invalid protocol",
+        "OAuth metadata redirect uses an invalid protocol"
       );
     }
     if (httpsOnly && currentUrl.protocol !== "https:") {
       throw new OAuthProxyError(
         400,
-        "OAuth metadata redirect must use HTTPS in hosted mode",
+        "OAuth metadata redirect must use HTTPS in hosted mode"
       );
     }
 
@@ -713,13 +733,13 @@ export async function fetchOAuthMetadata(
       response = await requestPinnedOAuthMetadata(
         currentUrl,
         allowLoopbackFlow,
-        signal,
+        signal
       );
     } catch (error) {
       if (signal?.aborted) {
         throw new OAuthProxyError(
           400,
-          `OAuth metadata request timeout after ${timeoutMs}ms`,
+          `OAuth metadata request timeout after ${timeoutMs}ms`
         );
       }
       throw error;
@@ -742,7 +762,7 @@ export async function fetchOAuthMetadata(
     } catch {
       throw new OAuthProxyError(
         502,
-        "OAuth metadata returned an invalid redirect URL",
+        "OAuth metadata returned an invalid redirect URL"
       );
     }
     // The next iteration validates and pins the redirect destination before
@@ -760,7 +780,9 @@ export async function fetchOAuthMetadata(
   if (!contentType?.includes("application/json")) {
     return {
       status: 502,
-      statusText: `Upstream returned non-JSON content-type: ${contentType ?? "(none)"}`,
+      statusText: `Upstream returned non-JSON content-type: ${
+        contentType ?? "(none)"
+      }`,
     };
   }
 

--- a/sdk/src/oauth-proxy.ts
+++ b/sdk/src/oauth-proxy.ts
@@ -1,5 +1,6 @@
 import dns from "node:dns/promises";
 import { lookup as dnsLookupCb } from "node:dns";
+import http from "node:http";
 import https from "node:https";
 import type { LookupFunction } from "node:net";
 
@@ -38,6 +39,7 @@ export interface OAuthProxyResponse {
 // stays here. Re-exported to preserve the public `isDisallowedIpAddress` symbol.
 import {
   isDisallowedIpAddress,
+  isLoopbackOAuthUrl,
   isPrivateHost,
 } from "./oauth/ssrf-guard.js";
 export { isDisallowedIpAddress };
@@ -77,10 +79,10 @@ interface ValidatedUrl {
   url: URL;
 }
 
-export async function validateUrl(
+function parseAndValidateUrl(
   url: string,
   httpsOnly = false,
-): Promise<ValidatedUrl> {
+): URL {
   if (!url) {
     throw new OAuthProxyError(400, "Missing url parameter");
   }
@@ -92,25 +94,39 @@ export async function validateUrl(
     throw new OAuthProxyError(400, "Invalid URL format");
   }
 
-  if (httpsOnly) {
-    if (targetUrl.protocol !== "https:") {
-      throw new OAuthProxyError(
-        400,
-        "Only HTTPS targets are allowed in hosted mode",
-      );
-    }
-    if (isPrivateHost(targetUrl.hostname)) {
-      throw new OAuthProxyError(
-        400,
-        "Private/reserved IP addresses are not allowed",
-      );
-    }
-    await resolveAndValidateDns(targetUrl.hostname);
-  } else if (
+  if (
     targetUrl.protocol !== "https:" &&
     targetUrl.protocol !== "http:"
   ) {
     throw new OAuthProxyError(400, "Invalid protocol");
+  }
+  if (httpsOnly && targetUrl.protocol !== "https:") {
+    throw new OAuthProxyError(
+      400,
+      "Only HTTPS targets are allowed in hosted mode",
+    );
+  }
+
+  return targetUrl;
+}
+
+export async function validateUrl(
+  url: string,
+  httpsOnly = false,
+): Promise<ValidatedUrl> {
+  const targetUrl = parseAndValidateUrl(url, httpsOnly);
+
+  // Local mode permits HTTP and explicit loopback OAuth servers; it must not
+  // disable SSRF validation for every other host.
+  const explicitLoopback = !httpsOnly && isLoopbackOAuthUrl(targetUrl.toString());
+  if (isPrivateHost(targetUrl.hostname) && !explicitLoopback) {
+    throw new OAuthProxyError(
+      400,
+      "Private/reserved IP addresses are not allowed",
+    );
+  }
+  if (!explicitLoopback) {
+    await resolveAndValidateDns(targetUrl.hostname);
   }
 
   return { url: targetUrl };
@@ -477,34 +493,270 @@ export async function executeDebugOAuthProxy(
   };
 }
 
+const MAX_OAUTH_METADATA_REDIRECTS = 5;
+const MAX_OAUTH_METADATA_BYTES = 1024 * 1024;
+
+interface PinnedAddress {
+  address: string;
+  family: number;
+}
+
+interface RawOAuthMetadataResponse {
+  status: number;
+  statusText: string;
+  headers: Record<string, string>;
+  body: string;
+}
+
+function isLoopbackAddress(address: string): boolean {
+  const host = address.includes(":") ? `[${address}]` : address;
+  return isLoopbackOAuthUrl(`http://${host}`);
+}
+
+async function resolvePinnedAddresses(
+  targetUrl: URL,
+  allowLoopbackFlow: boolean,
+): Promise<PinnedAddress[] | null> {
+  const targetIsLoopback = isLoopbackOAuthUrl(targetUrl.toString());
+
+  if (isPrivateHost(targetUrl.hostname)) {
+    if (!(allowLoopbackFlow && targetIsLoopback)) {
+      throw new OAuthProxyError(
+        400,
+        `OAuth metadata target is a private/reserved host (${targetUrl.hostname})`,
+      );
+    }
+  }
+
+  // Numeric IPs are already the exact socket destination, so there is no DNS
+  // lookup to pin. The literal-host check above has classified them.
+  if (
+    /^\d+\.\d+\.\d+\.\d+$/.test(targetUrl.hostname) ||
+    targetUrl.hostname.includes(":")
+  ) {
+    return null;
+  }
+
+  const addresses = await new Promise<PinnedAddress[]>((resolve, reject) => {
+    dnsLookupCb(
+      targetUrl.hostname,
+      { all: true, verbatim: true },
+      (error, resolved) => {
+        if (error) {
+          reject(
+            new OAuthProxyError(
+              400,
+              `Could not resolve OAuth metadata host ${targetUrl.hostname}`,
+            ),
+          );
+          return;
+        }
+        resolve(Array.isArray(resolved) ? resolved : [resolved]);
+      },
+    );
+  });
+
+  if (addresses.length === 0) {
+    throw new OAuthProxyError(
+      400,
+      `Could not resolve OAuth metadata host ${targetUrl.hostname}`,
+    );
+  }
+
+  for (const { address } of addresses) {
+    if (targetIsLoopback) {
+      if (!isLoopbackAddress(address)) {
+        throw new OAuthProxyError(
+          400,
+          `Loopback OAuth metadata host resolved outside loopback (${address})`,
+        );
+      }
+    } else if (isDisallowedIpAddress(address)) {
+      throw new OAuthProxyError(
+        400,
+        `OAuth metadata host resolves to a private/reserved IP address (${address})`,
+      );
+    }
+  }
+
+  return addresses;
+}
+
+function createPinnedLookup(addresses: PinnedAddress[]): LookupFunction {
+  return (_hostname, options, callback) => {
+    if (typeof options === "object" && options?.all) {
+      return (
+        callback as unknown as (
+          err: NodeJS.ErrnoException | null,
+          resolved: PinnedAddress[],
+        ) => void
+      )(null, addresses);
+    }
+    callback(null, addresses[0].address, addresses[0].family);
+  };
+}
+
+async function requestPinnedOAuthMetadata(
+  targetUrl: URL,
+  allowLoopbackFlow: boolean,
+  signal: AbortSignal | undefined,
+): Promise<RawOAuthMetadataResponse> {
+  const pinnedAddresses = await resolvePinnedAddresses(
+    targetUrl,
+    allowLoopbackFlow,
+  );
+  const transport = targetUrl.protocol === "https:" ? https : http;
+
+  return await new Promise<RawOAuthMetadataResponse>((resolve, reject) => {
+    const request = transport.request(
+      targetUrl,
+      {
+        method: "GET",
+        headers: {
+          Accept: "application/json",
+          "User-Agent": "MCP-Inspector/1.0",
+        },
+        ...(pinnedAddresses
+          ? { lookup: createPinnedLookup(pinnedAddresses) }
+          : {}),
+        ...(targetUrl.protocol === "https:"
+          ? { servername: targetUrl.hostname }
+          : {}),
+        signal,
+      },
+      (response) => {
+        const headers: Record<string, string> = {};
+        for (const [key, value] of Object.entries(response.headers)) {
+          headers[key.toLowerCase()] = Array.isArray(value)
+            ? value.join(", ")
+            : String(value ?? "");
+        }
+
+        const status = response.statusCode ?? 0;
+        const statusText = response.statusMessage ?? "";
+        if (status >= 300 && status < 400) {
+          response.resume();
+          resolve({ status, statusText, headers, body: "" });
+          return;
+        }
+
+        const chunks: Buffer[] = [];
+        let total = 0;
+        response.on("data", (chunk: Buffer | string) => {
+          const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+          total += buffer.length;
+          if (total > MAX_OAUTH_METADATA_BYTES) {
+            request.destroy();
+            reject(
+              new OAuthProxyError(
+                400,
+                `OAuth metadata exceeds the ${MAX_OAUTH_METADATA_BYTES}-byte cap`,
+              ),
+            );
+            return;
+          }
+          chunks.push(buffer);
+        });
+        response.on("end", () => {
+          resolve({
+            status,
+            statusText,
+            headers,
+            body: Buffer.concat(chunks).toString("utf8"),
+          });
+        });
+        response.on("error", reject);
+      },
+    );
+    request.on("error", reject);
+    request.end();
+  });
+}
+
 export async function fetchOAuthMetadata(
   url: string,
   httpsOnly = false,
   timeoutMs?: number,
 ): Promise<
-  | { metadata: Record<string, unknown>; status?: undefined }
+  | {
+      metadata: Record<string, unknown>;
+      finalUrl: string;
+      status?: undefined;
+    }
   | { status: number; statusText: string }
 > {
-  const { url: metadataUrl } = await validateUrl(url, httpsOnly);
+  const metadataUrl = parseAndValidateUrl(url, httpsOnly);
+  const allowLoopbackFlow =
+    !httpsOnly && isLoopbackOAuthUrl(metadataUrl.toString());
+  const signal = requestTimeoutSignal(timeoutMs);
+  let currentUrl = metadataUrl;
+  let response: RawOAuthMetadataResponse | undefined;
 
-  const response = await fetch(buildFetchUrl(metadataUrl), {
-    method: "GET",
-    headers: {
-      Accept: "application/json",
-      "User-Agent": "MCP-Inspector/1.0",
-    },
-    redirect: httpsOnly ? "manual" : "follow",
-    signal: requestTimeoutSignal(timeoutMs),
-  });
+  for (let redirectCount = 0; ; redirectCount += 1) {
+    if (
+      currentUrl.protocol !== "https:" &&
+      currentUrl.protocol !== "http:"
+    ) {
+      throw new OAuthProxyError(
+        400,
+        "OAuth metadata redirect uses an invalid protocol",
+      );
+    }
+    if (httpsOnly && currentUrl.protocol !== "https:") {
+      throw new OAuthProxyError(
+        400,
+        "OAuth metadata redirect must use HTTPS in hosted mode",
+      );
+    }
 
-  if (!response.ok) {
+    try {
+      response = await requestPinnedOAuthMetadata(
+        currentUrl,
+        allowLoopbackFlow,
+        signal,
+      );
+    } catch (error) {
+      if (signal?.aborted) {
+        throw new OAuthProxyError(
+          400,
+          `OAuth metadata request timeout after ${timeoutMs}ms`,
+        );
+      }
+      throw error;
+    }
+
+    if (response.status < 300 || response.status >= 400) {
+      break;
+    }
+
+    const location = response.headers.location;
+    if (!location) {
+      break;
+    }
+    if (redirectCount >= MAX_OAUTH_METADATA_REDIRECTS) {
+      throw new OAuthProxyError(400, "Too many OAuth metadata redirects");
+    }
+
+    try {
+      currentUrl = new URL(location, currentUrl);
+    } catch {
+      throw new OAuthProxyError(
+        502,
+        "OAuth metadata returned an invalid redirect URL",
+      );
+    }
+    // The next iteration validates and pins the redirect destination before
+    // opening its socket.
+  }
+
+  if (response.status < 200 || response.status >= 300) {
     return {
       status: response.status,
       statusText: response.statusText,
     };
   }
 
-  const contentType = response.headers.get("content-type");
+  const contentType = response.headers["content-type"];
   if (!contentType?.includes("application/json")) {
     return {
       status: 502,
@@ -514,7 +766,7 @@ export async function fetchOAuthMetadata(
 
   let metadata: Record<string, unknown>;
   try {
-    metadata = (await response.json()) as Record<string, unknown>;
+    metadata = JSON.parse(response.body) as Record<string, unknown>;
   } catch {
     return {
       status: 502,
@@ -522,5 +774,10 @@ export async function fetchOAuthMetadata(
     };
   }
 
-  return { metadata };
+  return {
+    metadata,
+    // Every redirect hop above was validated and connected through its pinned
+    // address set before this effective URL could be reached.
+    finalUrl: currentUrl.toString(),
+  };
 }

--- a/sdk/src/oauth-proxy.ts
+++ b/sdk/src/oauth-proxy.ts
@@ -1,8 +1,8 @@
-import dns from "node:dns/promises";
 import { lookup as dnsLookupCb } from "node:dns";
 import http from "node:http";
 import https from "node:https";
 import type { LookupFunction } from "node:net";
+import type { IncomingMessage } from "node:http";
 
 export class OAuthProxyError extends Error {
   status: number;
@@ -23,7 +23,7 @@ export interface OAuthProxyRequest {
    * weakened); otherwise an explicit value is honored and omission preserves
    * the historical "follow". */
   redirect?: "follow" | "manual";
-  /** Bound the fetch and response-body read. */
+  /** Bound DNS, connection setup, redirects, and the response-body read. */
   timeoutMs?: number;
 }
 
@@ -45,37 +45,6 @@ import {
 } from "./oauth/ssrf-guard.js";
 export { isDisallowedIpAddress };
 
-async function resolveAndValidateDns(hostname: string): Promise<string | null> {
-  if (/^\d+\.\d+\.\d+\.\d+$/.test(hostname) || hostname.includes(":")) {
-    return null;
-  }
-
-  const resolved: string[] = [];
-  try {
-    const ipv4 = await dns.resolve4(hostname);
-    resolved.push(...ipv4);
-  } catch {
-    // no A records is fine
-  }
-  try {
-    const ipv6 = await dns.resolve6(hostname);
-    resolved.push(...ipv6);
-  } catch {
-    // no AAAA records is fine
-  }
-
-  for (const ip of resolved) {
-    if (isPrivateHost(ip)) {
-      throw new OAuthProxyError(
-        400,
-        "Hostname resolves to a private/reserved IP address"
-      );
-    }
-  }
-
-  return resolved[0] ?? null;
-}
-
 interface ValidatedUrl {
   url: URL;
 }
@@ -95,10 +64,16 @@ function parseAndValidateUrl(url: string, httpsOnly = false): URL {
   if (targetUrl.protocol !== "https:" && targetUrl.protocol !== "http:") {
     throw new OAuthProxyError(400, "Invalid protocol");
   }
+  if (targetUrl.username || targetUrl.password) {
+    throw new OAuthProxyError(
+      400,
+      "OAuth target URL must not contain credentials",
+    );
+  }
   if (httpsOnly && targetUrl.protocol !== "https:") {
     throw new OAuthProxyError(
       400,
-      "Only HTTPS targets are allowed in hosted mode"
+      "Only HTTPS targets are allowed in hosted mode",
     );
   }
 
@@ -107,33 +82,23 @@ function parseAndValidateUrl(url: string, httpsOnly = false): URL {
 
 export async function validateUrl(
   url: string,
-  httpsOnly = false
+  httpsOnly = false,
 ): Promise<ValidatedUrl> {
   const targetUrl = parseAndValidateUrl(url, httpsOnly);
-
-  // Local mode permits HTTP and explicit loopback OAuth servers; it must not
-  // disable SSRF validation for every other host.
-  const explicitLoopback =
+  const allowLoopbackFlow =
     !httpsOnly && isLoopbackOAuthUrl(targetUrl.toString());
-  if (isPrivateHost(targetUrl.hostname) && !explicitLoopback) {
-    throw new OAuthProxyError(
-      400,
-      "Private/reserved IP addresses are not allowed"
-    );
-  }
-  if (!explicitLoopback) {
-    await resolveAndValidateDns(targetUrl.hostname);
-  }
+  await resolvePinnedAddresses(
+    targetUrl,
+    allowLoopbackFlow,
+    undefined,
+    "OAuth target",
+  );
 
   return { url: targetUrl };
 }
 
-function buildFetchUrl(targetUrl: URL): string {
-  return targetUrl.toString();
-}
-
 function requestTimeoutSignal(
-  timeoutMs: number | undefined
+  timeoutMs: number | undefined,
 ): AbortSignal | undefined {
   if (timeoutMs === undefined) return undefined;
   if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
@@ -142,45 +107,55 @@ function requestTimeoutSignal(
   return AbortSignal.timeout(timeoutMs);
 }
 
-async function parseResponseBody(response: Response): Promise<unknown> {
-  try {
-    return await response.json();
-  } catch {
-    try {
-      return await response.text();
-    } catch {
-      return null;
-    }
-  }
-}
-
 function buildRequestHeaders(
-  customHeaders: Record<string, string> | undefined
+  customHeaders: Record<string, string> | undefined,
 ): Record<string, string> {
-  return {
-    "User-Agent": "MCP-Inspector/1.0",
-    ...customHeaders,
-  };
+  const headers: Record<string, string> = {};
+  for (const [name, value] of Object.entries(customHeaders ?? {})) {
+    headers[name.toLowerCase()] = value;
+  }
+
+  // These are connection-specific or must be derived from the actual pinned
+  // request. Do not let a proxy caller override them.
+  for (const name of [
+    "connection",
+    "content-length",
+    "host",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "proxy-connection",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    "upgrade",
+  ]) {
+    delete headers[name];
+  }
+
+  headers["user-agent"] ??= "MCP-Inspector/1.0";
+  // Raw http(s).request does not decompress automatically. Requesting identity
+  // keeps response parsing deterministic and preserves fetch-like semantics.
+  headers["accept-encoding"] = "identity";
+  return headers;
 }
 
 function encodeRequestBody(
   method: string,
   body: unknown,
-  contentType: string | undefined
-): BodyInit | undefined {
+  contentType: string | undefined,
+): string | undefined {
   if (method !== "POST" || body === undefined || body === null) {
     return undefined;
   }
 
   const isFormUrlEncoded = contentType?.includes(
-    "application/x-www-form-urlencoded"
+    "application/x-www-form-urlencoded",
   );
 
   if (isFormUrlEncoded && typeof body === "object") {
     const params = new URLSearchParams();
-    for (const [key, value] of Object.entries(
-      body as Record<string, unknown>
-    )) {
+    for (const [key, value] of Object.entries(body as Record<string, unknown>)) {
       params.append(key, String(value));
     }
     return params.toString();
@@ -207,24 +182,23 @@ export async function fetchPinnedPublicDocument(
     headers?: Record<string, string>;
     timeoutMs?: number;
     maxBytes?: number;
-  } = {}
+  } = {},
 ): Promise<OAuthProxyResponse> {
   const url = new URL(urlString);
   if (url.protocol !== "https:") {
     throw new OAuthProxyError(
       400,
-      "The client metadata document must be served over HTTPS"
+      "The client metadata document must be served over HTTPS",
     );
   }
   // Reject a literal private/reserved host before opening any connection.
   if (isPrivateHost(url.hostname)) {
     throw new OAuthProxyError(
       400,
-      `The client metadata host is a private or reserved address (${url.hostname})`
+      `The client metadata host is a private or reserved address (${url.hostname})`,
     );
   }
-  const maxBytes =
-    opts.maxBytes && opts.maxBytes > 0 ? opts.maxBytes : 5 * 1024;
+  const maxBytes = opts.maxBytes && opts.maxBytes > 0 ? opts.maxBytes : 5 * 1024;
   const timeoutMs =
     opts.timeoutMs && opts.timeoutMs > 0 ? opts.timeoutMs : 5000;
 
@@ -244,7 +218,7 @@ export async function fetchPinnedPublicDocument(
         return callback(
           new OAuthProxyError(400, `Could not resolve ${hostname}`),
           "",
-          0
+          0,
         );
       }
       for (const a of list) {
@@ -252,10 +226,10 @@ export async function fetchPinnedPublicDocument(
           return callback(
             new OAuthProxyError(
               400,
-              `${hostname} resolves to a private or reserved address (${a.address})`
+              `${hostname} resolves to a private or reserved address (${a.address})`,
             ),
             "",
-            0
+            0,
           );
         }
       }
@@ -263,7 +237,7 @@ export async function fetchPinnedPublicDocument(
         return (
           callback as unknown as (
             err: NodeJS.ErrnoException | null,
-            addresses: { address: string; family: number }[]
+            addresses: { address: string; family: number }[],
           ) => void
         )(null, list);
       }
@@ -305,8 +279,8 @@ export async function fetchPinnedPublicDocument(
             reject(
               new OAuthProxyError(
                 400,
-                `The client metadata document exceeds the ${maxBytes}-byte cap`
-              )
+                `The client metadata document exceeds the ${maxBytes}-byte cap`,
+              ),
             );
             return;
           }
@@ -329,174 +303,491 @@ export async function fetchPinnedPublicDocument(
           });
         });
         res.on("error", reject);
-      }
+      },
     );
     request.on("error", (err) => {
       reject(
         deadline.aborted
           ? new OAuthProxyError(
               400,
-              `The client metadata document request exceeded the ${timeoutMs}ms deadline`
+              `The client metadata document request exceeded the ${timeoutMs}ms deadline`,
             )
-          : err
+          : err,
       );
     });
     request.end();
   });
 }
 
+const MAX_OAUTH_PROXY_REDIRECTS = 5;
+const MAX_OAUTH_PROXY_BYTES = 1024 * 1024;
+const DEBUG_SSE_MAX_READ_MS = 5000;
+const DEBUG_SSE_IDLE_TIMEOUT_MS = 1000;
+
+interface PreparedOAuthRequest {
+  method: string;
+  headers: Record<string, string>;
+  body?: Buffer;
+}
+
+interface RawPinnedOAuthResponse {
+  status: number;
+  statusText: string;
+  headers: Record<string, string>;
+  finalUrl: string;
+  stream?: IncomingMessage;
+}
+
+function normalizeResponseHeaders(
+  response: IncomingMessage
+): Record<string, string> {
+  const headers: Record<string, string> = {};
+  for (const [key, value] of Object.entries(response.headers)) {
+    headers[key.toLowerCase()] = Array.isArray(value)
+      ? value.join(", ")
+      : String(value ?? "");
+  }
+  return headers;
+}
+
+function prepareOAuthRequest(req: OAuthProxyRequest): PreparedOAuthRequest {
+  const method = (req.method ?? "GET").toUpperCase();
+  const headers = buildRequestHeaders(req.headers);
+  const contentType = headers["content-type"];
+  if (
+    method === "POST" &&
+    req.body !== undefined &&
+    req.body !== null &&
+    !contentType
+  ) {
+    headers["content-type"] = "application/json";
+  }
+
+  const encodedBody = encodeRequestBody(
+    method,
+    req.body,
+    headers["content-type"]
+  );
+  const body =
+    encodedBody === undefined ? undefined : Buffer.from(encodedBody, "utf8");
+  if (body) {
+    headers["content-length"] = String(body.byteLength);
+  }
+  return { method, headers, body };
+}
+
+function isFetchRedirectStatus(status: number): boolean {
+  return (
+    status === 301 ||
+    status === 302 ||
+    status === 303 ||
+    status === 307 ||
+    status === 308
+  );
+}
+
+function removeHeaders(
+  headers: Record<string, string>,
+  names: readonly string[]
+): void {
+  for (const name of names) {
+    delete headers[name];
+  }
+}
+
+function updateRequestForRedirect(
+  request: PreparedOAuthRequest,
+  status: number,
+  currentUrl: URL,
+  nextUrl: URL
+): PreparedOAuthRequest {
+  const next: PreparedOAuthRequest = {
+    method: request.method,
+    headers: { ...request.headers },
+    body: request.body,
+  };
+
+  // Fetch rewrites POST to GET for 301/302, and every non-GET/HEAD method to
+  // GET for 303. 307/308 preserve both method and body.
+  if (
+    ((status === 301 || status === 302) && next.method === "POST") ||
+    (status === 303 && next.method !== "GET" && next.method !== "HEAD")
+  ) {
+    next.method = "GET";
+    next.body = undefined;
+    removeHeaders(next.headers, [
+      "content-encoding",
+      "content-language",
+      "content-length",
+      "content-location",
+      "content-type",
+    ]);
+  }
+
+  // Match Fetch's credential-boundary behavior. A redirect to another origin
+  // must not receive bearer/basic credentials or cookies supplied to the
+  // original authorization server.
+  if (currentUrl.origin !== nextUrl.origin) {
+    removeHeaders(next.headers, [
+      "authorization",
+      "cookie",
+      "cookie2",
+      "proxy-authorization",
+    ]);
+  }
+
+  return next;
+}
+
+async function requestPinnedOAuthHop(
+  targetUrl: URL,
+  requestInit: PreparedOAuthRequest,
+  allowLoopbackFlow: boolean,
+  signal: AbortSignal | undefined
+): Promise<RawPinnedOAuthResponse> {
+  const pinnedAddresses = await resolvePinnedAddresses(
+    targetUrl,
+    allowLoopbackFlow,
+    signal,
+    "OAuth proxy target"
+  );
+  const transport = targetUrl.protocol === "https:" ? https : http;
+
+  return await new Promise<RawPinnedOAuthResponse>((resolve, reject) => {
+    const request = transport.request(
+      targetUrl,
+      {
+        method: requestInit.method,
+        headers: requestInit.headers,
+        ...(pinnedAddresses
+          ? { lookup: createPinnedLookup(pinnedAddresses) }
+          : {}),
+        ...(targetUrl.protocol === "https:" &&
+        !/^\d+\.\d+\.\d+\.\d+$/.test(targetUrl.hostname) &&
+        !targetUrl.hostname.includes(":")
+          ? { servername: targetUrl.hostname }
+          : {}),
+        signal,
+      },
+      (response) => {
+        resolve({
+          status: response.statusCode ?? 0,
+          statusText: response.statusMessage ?? "",
+          headers: normalizeResponseHeaders(response),
+          finalUrl: targetUrl.toString(),
+          stream: response,
+        });
+      }
+    );
+    request.on("error", reject);
+    if (requestInit.body) {
+      request.write(requestInit.body);
+    }
+    request.end();
+  });
+}
+
+async function executePinnedOAuthRequest(req: OAuthProxyRequest): Promise<{
+  response: RawPinnedOAuthResponse;
+  signal: AbortSignal | undefined;
+}> {
+  const initialUrl = parseAndValidateUrl(req.url, req.httpsOnly);
+  const allowLoopbackFlow =
+    !req.httpsOnly && isLoopbackOAuthUrl(initialUrl.toString());
+  const redirectMode = req.httpsOnly ? "manual" : req.redirect ?? "follow";
+  const signal = requestTimeoutSignal(req.timeoutMs);
+  let currentUrl = initialUrl;
+  let requestInit = prepareOAuthRequest(req);
+
+  try {
+    for (let redirectCount = 0; ; redirectCount += 1) {
+      const response = await requestPinnedOAuthHop(
+        currentUrl,
+        requestInit,
+        allowLoopbackFlow,
+        signal
+      );
+
+      if (!isFetchRedirectStatus(response.status)) {
+        return { response, signal };
+      }
+
+      // Redirect bodies are never useful to the proxy and can otherwise be an
+      // unbounded resource sink. Preserve the status and headers for manual
+      // mode, but close the stream immediately.
+      response.stream?.destroy();
+      response.stream = undefined;
+
+      const location = response.headers.location;
+      if (redirectMode === "manual" || !location) {
+        return { response, signal };
+      }
+      if (redirectCount >= MAX_OAUTH_PROXY_REDIRECTS) {
+        throw new OAuthProxyError(400, "Too many OAuth proxy redirects");
+      }
+
+      let nextUrl: URL;
+      try {
+        nextUrl = new URL(location, currentUrl);
+      } catch {
+        throw new OAuthProxyError(
+          502,
+          "OAuth proxy returned an invalid redirect URL"
+        );
+      }
+      // Validate scheme and hosted HTTPS policy now. DNS/private-network
+      // validation happens in requestPinnedOAuthHop before the next socket.
+      nextUrl = parseAndValidateUrl(nextUrl.toString(), req.httpsOnly);
+      requestInit = updateRequestForRedirect(
+        requestInit,
+        response.status,
+        currentUrl,
+        nextUrl
+      );
+      currentUrl = nextUrl;
+    }
+  } catch (error) {
+    if (signal?.aborted) {
+      throw new OAuthProxyError(
+        400,
+        `OAuth proxy request timeout after ${req.timeoutMs}ms`
+      );
+    }
+    throw error;
+  }
+}
+
+async function readBoundedResponseBody(
+  response: IncomingMessage | undefined
+): Promise<string> {
+  if (!response) return "";
+
+  return await new Promise<string>((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let total = 0;
+    let settled = false;
+
+    const cleanup = () => {
+      response.removeListener("data", onData);
+      response.removeListener("end", onEnd);
+      response.removeListener("error", onError);
+      response.removeListener("aborted", onAborted);
+    };
+    const fail = (error: unknown) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      response.destroy();
+      reject(error);
+    };
+    const onData = (chunk: Buffer | string) => {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      total += buffer.byteLength;
+      if (total > MAX_OAUTH_PROXY_BYTES) {
+        fail(
+          new OAuthProxyError(
+            400,
+            `OAuth proxy response exceeds the ${MAX_OAUTH_PROXY_BYTES}-byte cap`
+          )
+        );
+        return;
+      }
+      chunks.push(buffer);
+    };
+    const onEnd = () => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(Buffer.concat(chunks).toString("utf8"));
+    };
+    const onError = (error: Error) => fail(error);
+    const onAborted = () => fail(new Error("OAuth proxy response was aborted"));
+
+    response.on("data", onData);
+    response.on("end", onEnd);
+    response.on("error", onError);
+    response.on("aborted", onAborted);
+  });
+}
+
+function parseBufferedResponseBody(body: string): unknown {
+  if (!body) return null;
+  try {
+    return JSON.parse(body);
+  } catch {
+    return body;
+  }
+}
+
+async function readDebugSseBody(
+  response: IncomingMessage
+): Promise<Record<string, unknown>> {
+  return await new Promise<Record<string, unknown>>((resolve, reject) => {
+    const decoder = new TextDecoder();
+    let buffer = "";
+    let total = 0;
+    let settled = false;
+    let currentEvent: { event?: string; data?: unknown; id?: string } = {};
+    const events: Array<{ event?: string; data?: unknown; id?: string }> = [];
+    let idleTimer: ReturnType<typeof setTimeout>;
+
+    const cleanup = () => {
+      clearTimeout(idleTimer);
+      clearTimeout(maxTimer);
+      response.removeListener("data", onData);
+      response.removeListener("end", onEnd);
+      response.removeListener("error", onError);
+      response.removeListener("aborted", onAborted);
+    };
+    const result = () => ({
+      transport: "sse",
+      events,
+      isOldTransport: events[0]?.event === "endpoint",
+      endpoint: events[0]?.event === "endpoint" ? events[0].data : null,
+      mcpResponse:
+        events.find((event) => event.event === "message" || !event.event)
+          ?.data || null,
+      rawBuffer: buffer,
+    });
+    const finish = (error?: unknown) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      response.destroy();
+      if (error) reject(error);
+      else resolve(result());
+    };
+    const resetIdleTimer = () => {
+      clearTimeout(idleTimer);
+      idleTimer = setTimeout(
+        () => finish(new Error("Read timeout")),
+        DEBUG_SSE_IDLE_TIMEOUT_MS
+      );
+    };
+    const processLines = () => {
+      const lines = buffer.split(/\r?\n/);
+      buffer = lines.pop() ?? "";
+      for (const line of lines) {
+        if (line.startsWith("event:")) {
+          currentEvent.event = line.substring(6).trim();
+        } else if (line.startsWith("data:")) {
+          const data = line.substring(5).trim();
+          try {
+            currentEvent.data = JSON.parse(data);
+          } catch {
+            currentEvent.data = data;
+          }
+        } else if (line.startsWith("id:")) {
+          currentEvent.id = line.substring(3).trim();
+        } else if (line === "" && Object.keys(currentEvent).length > 0) {
+          events.push(currentEvent);
+          currentEvent = {};
+          finish();
+          return;
+        }
+      }
+    };
+    const onData = (chunk: Buffer | string) => {
+      const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      total += bytes.byteLength;
+      if (total > MAX_OAUTH_PROXY_BYTES) {
+        finish(
+          new OAuthProxyError(
+            400,
+            `OAuth proxy response exceeds the ${MAX_OAUTH_PROXY_BYTES}-byte cap`
+          )
+        );
+        return;
+      }
+      buffer += decoder.decode(bytes, { stream: true });
+      resetIdleTimer();
+      processLines();
+    };
+    const onEnd = () => {
+      buffer += decoder.decode();
+      processLines();
+      if (!settled) finish();
+    };
+    const onError = (error: Error) => finish(error);
+    const onAborted = () =>
+      finish(new Error("OAuth proxy response was aborted"));
+    const maxTimer = setTimeout(() => finish(), DEBUG_SSE_MAX_READ_MS);
+
+    response.on("data", onData);
+    response.on("end", onEnd);
+    response.on("error", onError);
+    response.on("aborted", onAborted);
+    resetIdleTimer();
+  });
+}
+
 export async function executeOAuthProxy(
   req: OAuthProxyRequest
 ): Promise<OAuthProxyResponse> {
-  const { url: targetUrl } = await validateUrl(req.url, req.httpsOnly);
-  const method = req.method ?? "GET";
-  const customHeaders = req.headers;
-
-  const requestHeaders = buildRequestHeaders(customHeaders);
-  const contentType =
-    customHeaders?.["Content-Type"] || customHeaders?.["content-type"];
-
-  if (method === "POST" && req.body && !contentType) {
-    requestHeaders["Content-Type"] = "application/json";
+  const { response, signal } = await executePinnedOAuthRequest(req);
+  try {
+    const body = await readBoundedResponseBody(response.stream);
+    return {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+      body: parseBufferedResponseBody(body),
+      finalUrl: response.finalUrl,
+    };
+  } catch (error) {
+    if (signal?.aborted) {
+      throw new OAuthProxyError(
+        400,
+        `OAuth proxy request timeout after ${req.timeoutMs}ms`
+      );
+    }
+    throw error;
   }
-
-  const response = await fetch(buildFetchUrl(targetUrl), {
-    method,
-    headers: requestHeaders,
-    redirect: req.httpsOnly ? "manual" : req.redirect ?? "follow",
-    body: encodeRequestBody(method, req.body, contentType),
-    signal: requestTimeoutSignal(req.timeoutMs),
-  });
-
-  const headers: Record<string, string> = {};
-  response.headers.forEach((value, key) => {
-    headers[key] = value;
-  });
-
-  return {
-    status: response.status,
-    statusText: response.statusText,
-    headers,
-    body: await parseResponseBody(response),
-    finalUrl: response.url || targetUrl.toString(),
-  };
 }
 
 export async function executeDebugOAuthProxy(
   req: OAuthProxyRequest
 ): Promise<OAuthProxyResponse> {
-  const { url: targetUrl } = await validateUrl(req.url, req.httpsOnly);
-  const method = req.method ?? "GET";
-  const customHeaders = req.headers;
-
-  const requestHeaders = buildRequestHeaders(customHeaders);
-  const contentType =
-    customHeaders?.["Content-Type"] || customHeaders?.["content-type"];
-
-  if (method === "POST" && req.body && !contentType) {
-    requestHeaders["Content-Type"] = "application/json";
-  }
-
-  const response = await fetch(buildFetchUrl(targetUrl), {
-    method,
-    headers: requestHeaders,
-    redirect: req.httpsOnly ? "manual" : req.redirect ?? "follow",
-    body: encodeRequestBody(method, req.body, contentType),
-    signal: requestTimeoutSignal(req.timeoutMs),
-  });
-
-  const headers: Record<string, string> = {};
-  response.headers.forEach((value, key) => {
-    headers[key] = value;
-  });
-
+  const { response, signal } = await executePinnedOAuthRequest(req);
   let responseBody: unknown = null;
-  const contentTypeHeader = headers["content-type"] || "";
 
-  if (contentTypeHeader.includes("text/event-stream")) {
-    try {
-      const reader = response.body?.getReader();
-      const decoder = new TextDecoder();
-      let buffer = "";
-      const events: Array<{ event?: string; data?: unknown; id?: string }> = [];
-      let currentEvent: Record<string, unknown> = {};
-      const maxReadTime = 5000;
-      const startTime = Date.now();
-
-      if (reader) {
-        try {
-          while (Date.now() - startTime < maxReadTime) {
-            const { done, value } = await Promise.race([
-              reader.read(),
-              new Promise<{ done: boolean; value: undefined }>((_, reject) =>
-                setTimeout(() => reject(new Error("Read timeout")), 1000)
-              ),
-            ]);
-
-            if (done) break;
-
-            buffer += decoder.decode(value, { stream: true });
-            const lines = buffer.split(/\r?\n/);
-            buffer = lines.pop() || "";
-
-            for (const line of lines) {
-              if (line.startsWith("event:")) {
-                currentEvent.event = line.substring(6).trim();
-              } else if (line.startsWith("data:")) {
-                const data = line.substring(5).trim();
-                try {
-                  currentEvent.data = JSON.parse(data);
-                } catch {
-                  currentEvent.data = data;
-                }
-              } else if (line.startsWith("id:")) {
-                currentEvent.id = line.substring(3).trim();
-              } else if (line === "") {
-                if (Object.keys(currentEvent).length > 0) {
-                  events.push({ ...currentEvent });
-                  currentEvent = {};
-                  if (events.length >= 1) break;
-                }
-              }
-            }
-
-            if (events.length >= 1) break;
-          }
-        } finally {
-          try {
-            await reader.cancel();
-          } catch {
-            // ignore cancel errors
-          }
+  try {
+    if (
+      response.stream &&
+      response.headers["content-type"]?.includes("text/event-stream")
+    ) {
+      try {
+        responseBody = await readDebugSseBody(response.stream);
+      } catch (error) {
+        if (signal?.aborted) {
+          throw error;
         }
+        responseBody = {
+          error: "Failed to parse SSE stream",
+          details: error instanceof Error ? error.message : String(error),
+        };
       }
-
-      responseBody = {
-        transport: "sse",
-        events,
-        isOldTransport: events[0]?.event === "endpoint",
-        endpoint: events[0]?.event === "endpoint" ? events[0].data : null,
-        mcpResponse:
-          events.find((event) => event.event === "message" || !event.event)
-            ?.data || null,
-        rawBuffer: buffer,
-      };
-    } catch (error) {
-      responseBody = {
-        error: "Failed to parse SSE stream",
-        details: error instanceof Error ? error.message : String(error),
-      };
+    } else {
+      responseBody = parseBufferedResponseBody(
+        await readBoundedResponseBody(response.stream)
+      );
     }
-  } else {
-    responseBody = await parseResponseBody(response);
+  } catch (error) {
+    if (signal?.aborted) {
+      throw new OAuthProxyError(
+        400,
+        `OAuth proxy request timeout after ${req.timeoutMs}ms`
+      );
+    }
+    throw error;
   }
 
   return {
     status: response.status,
     statusText: response.statusText,
-    headers,
+    headers: response.headers,
     body: responseBody,
-    finalUrl: response.url || targetUrl.toString(),
+    finalUrl: response.finalUrl,
   };
 }
 
@@ -523,7 +814,8 @@ function isLoopbackAddress(address: string): boolean {
 async function resolvePinnedAddresses(
   targetUrl: URL,
   allowLoopbackFlow: boolean,
-  signal: AbortSignal | undefined
+  signal: AbortSignal | undefined,
+  targetLabel = "OAuth metadata target"
 ): Promise<PinnedAddress[] | null> {
   const targetIsLoopback = isLoopbackOAuthUrl(targetUrl.toString());
 
@@ -531,7 +823,7 @@ async function resolvePinnedAddresses(
     if (!(allowLoopbackFlow && targetIsLoopback)) {
       throw new OAuthProxyError(
         400,
-        `OAuth metadata target is a private/reserved host (${targetUrl.hostname})`
+        `${targetLabel} is a private/reserved host (${targetUrl.hostname})`
       );
     }
   }
@@ -549,7 +841,7 @@ async function resolvePinnedAddresses(
     const cleanup = () => signal?.removeEventListener("abort", onAbort);
     const onAbort = () => {
       cleanup();
-      reject(signal?.reason ?? new Error("OAuth metadata request aborted"));
+      reject(signal?.reason ?? new Error(`${targetLabel} request aborted`));
     };
 
     if (signal?.aborted) {
@@ -567,7 +859,9 @@ async function resolvePinnedAddresses(
           reject(
             new OAuthProxyError(
               400,
-              `Could not resolve OAuth metadata host ${targetUrl.hostname}`
+              `Could not resolve ${targetLabel.toLowerCase()} ${
+                targetUrl.hostname
+              }`
             )
           );
           return;
@@ -580,7 +874,7 @@ async function resolvePinnedAddresses(
   if (addresses.length === 0) {
     throw new OAuthProxyError(
       400,
-      `Could not resolve OAuth metadata host ${targetUrl.hostname}`
+      `Could not resolve ${targetLabel.toLowerCase()} ${targetUrl.hostname}`
     );
   }
 
@@ -589,13 +883,13 @@ async function resolvePinnedAddresses(
       if (!isLoopbackAddress(address)) {
         throw new OAuthProxyError(
           400,
-          `Loopback OAuth metadata host resolved outside loopback (${address})`
+          `Loopback ${targetLabel.toLowerCase()} resolved outside loopback (${address})`
         );
       }
     } else if (isDisallowedIpAddress(address)) {
       throw new OAuthProxyError(
         400,
-        `OAuth metadata host resolves to a private/reserved IP address (${address})`
+        `${targetLabel} resolves to a private/reserved IP address (${address})`
       );
     }
   }
@@ -642,7 +936,9 @@ async function requestPinnedOAuthMetadata(
         ...(pinnedAddresses
           ? { lookup: createPinnedLookup(pinnedAddresses) }
           : {}),
-        ...(targetUrl.protocol === "https:"
+        ...(targetUrl.protocol === "https:" &&
+        !/^\d+\.\d+\.\d+\.\d+$/.test(targetUrl.hostname) &&
+        !targetUrl.hostname.includes(":")
           ? { servername: targetUrl.hostname }
           : {}),
         signal,
@@ -757,16 +1053,19 @@ export async function fetchOAuthMetadata(
       throw new OAuthProxyError(400, "Too many OAuth metadata redirects");
     }
 
+    let nextUrl: URL;
     try {
-      currentUrl = new URL(location, currentUrl);
+      nextUrl = new URL(location, currentUrl);
     } catch {
       throw new OAuthProxyError(
         502,
         "OAuth metadata returned an invalid redirect URL"
       );
     }
-    // The next iteration validates and pins the redirect destination before
-    // opening its socket.
+    // Validate scheme, hosted HTTPS policy, and embedded credentials now —
+    // same policy as the generic proxy loop. DNS/private-network validation
+    // happens in requestPinnedOAuthMetadata before the next socket.
+    currentUrl = parseAndValidateUrl(nextUrl.toString(), httpsOnly);
   }
 
   if (response.status < 200 || response.status >= 300) {

--- a/sdk/tests/oauth-proxy.test.ts
+++ b/sdk/tests/oauth-proxy.test.ts
@@ -1,4 +1,6 @@
 import dns from "node:dns/promises";
+import { EventEmitter } from "node:events";
+import { Readable } from "node:stream";
 import {
   executeDebugOAuthProxy,
   executeOAuthProxy,
@@ -8,6 +10,10 @@ import {
   OAuthProxyError,
 } from "../src/oauth-proxy.js";
 
+const httpRequestMock = vi.hoisted(() => vi.fn());
+const httpsRequestMock = vi.hoisted(() => vi.fn());
+const dnsLookupMock = vi.hoisted(() => vi.fn());
+
 vi.mock("node:dns/promises", () => ({
   __esModule: true,
   default: {
@@ -15,10 +21,83 @@ vi.mock("node:dns/promises", () => ({
     resolve6: vi.fn().mockResolvedValue([]),
   },
 }));
+vi.mock("node:dns", () => ({
+  __esModule: true,
+  lookup: dnsLookupMock,
+}));
+vi.mock("node:http", () => ({
+  __esModule: true,
+  default: { request: httpRequestMock },
+  request: httpRequestMock,
+}));
+vi.mock("node:https", () => ({
+  __esModule: true,
+  default: { request: httpsRequestMock },
+  request: httpsRequestMock,
+}));
+
+interface MockMetadataResponse {
+  status?: number;
+  statusText?: string;
+  headers?: Record<string, string>;
+  body?: string;
+}
+
+function queueMetadataResponses(
+  requestMock: ReturnType<typeof vi.fn>,
+  responses: MockMetadataResponse[],
+): void {
+  requestMock.mockImplementation(
+    (
+      _url: URL,
+      options: { signal?: AbortSignal },
+      onResponse: (response: Readable) => void,
+    ) => {
+      const request = new EventEmitter() as EventEmitter & {
+        end: () => void;
+        destroy: () => void;
+      };
+      request.end = () => {
+        const next = responses.shift();
+        if (!next) {
+          options.signal?.addEventListener(
+            "abort",
+            () => request.emit("error", options.signal?.reason),
+            { once: true },
+          );
+          return;
+        }
+        queueMicrotask(() => {
+          const response = Readable.from(next.body ? [next.body] : []);
+          Object.assign(response, {
+            statusCode: next.status ?? 200,
+            statusMessage: next.statusText ?? "OK",
+            headers: next.headers ?? {
+              "content-type": "application/json",
+            },
+          });
+          onResponse(response);
+        });
+      };
+      request.destroy = () => {};
+      return request;
+    },
+  );
+}
 
 describe("oauth-proxy helpers", () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     global.fetch = vi.fn() as unknown as typeof fetch;
+    vi.mocked(dns.resolve4).mockResolvedValue(["93.184.216.34"]);
+    vi.mocked(dns.resolve6).mockResolvedValue([]);
+    dnsLookupMock.mockImplementation(
+      (
+        _hostname: string,
+        _options: unknown,
+        callback: (error: Error | null, addresses: unknown) => void,
+      ) => callback(null, [{ address: "93.184.216.34", family: 4 }]),
+    );
   });
 
   it("blocks private hosts when httpsOnly is enabled", async () => {
@@ -60,18 +139,140 @@ describe("oauth-proxy helpers", () => {
   });
 
   it("returns metadata for valid JSON responses", async () => {
-    (global.fetch as jest.Mock).mockResolvedValueOnce(
-      new Response(JSON.stringify({ issuer: "https://auth.example.com" }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      })
-    );
+    queueMetadataResponses(httpsRequestMock, [
+      {
+        body: JSON.stringify({ issuer: "https://auth.example.com" }),
+      },
+    ]);
 
     await expect(
       fetchOAuthMetadata("https://auth.example.com/.well-known/oauth")
     ).resolves.toEqual({
       metadata: { issuer: "https://auth.example.com" },
+      finalUrl: "https://auth.example.com/.well-known/oauth",
     });
+  });
+
+  it("rejects a public metadata request redirected to loopback", async () => {
+    queueMetadataResponses(httpsRequestMock, [
+      {
+        status: 302,
+        statusText: "Found",
+        headers: {
+          location: "http://127.0.0.1:8787/.well-known/oauth",
+        },
+      },
+    ]);
+
+    await expect(
+      fetchOAuthMetadata("https://auth.example.com/.well-known/oauth")
+    ).rejects.toMatchObject({
+      status: 400,
+      message: expect.stringContaining("private/reserved host"),
+    });
+    expect(httpsRequestMock).toHaveBeenCalledTimes(1);
+    expect(httpRequestMock).not.toHaveBeenCalled();
+  });
+
+  it("allows loopback metadata to remain on loopback for an explicit local flow", async () => {
+    dnsLookupMock.mockImplementation(
+      (
+        _hostname: string,
+        _options: unknown,
+        callback: (error: Error | null, addresses: unknown) => void,
+      ) => callback(null, [{ address: "127.0.0.1", family: 4 }]),
+    );
+    queueMetadataResponses(httpRequestMock, [
+      {
+        status: 302,
+        statusText: "Found",
+        headers: {
+          location: "http://127.0.0.1:8787/.well-known/oauth",
+        },
+      },
+      {
+        body: JSON.stringify({ issuer: "http://127.0.0.1:8787" }),
+      },
+    ]);
+
+    await expect(
+      fetchOAuthMetadata("http://localhost:8787/.well-known/oauth")
+    ).resolves.toEqual({
+      metadata: { issuer: "http://127.0.0.1:8787" },
+      finalUrl: "http://127.0.0.1:8787/.well-known/oauth",
+    });
+  });
+
+  it("rejects loopback metadata in hosted HTTPS-only mode", async () => {
+    await expect(
+      fetchOAuthMetadata("https://localhost/.well-known/oauth", true)
+    ).rejects.toMatchObject({
+      status: 400,
+      message: expect.stringContaining("private/reserved host"),
+    });
+    expect(httpsRequestMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a public-looking metadata hostname that resolves privately in local mode", async () => {
+    dnsLookupMock.mockImplementation(
+      (
+        _hostname: string,
+        _options: unknown,
+        callback: (error: Error | null, addresses: unknown) => void,
+      ) => callback(null, [{ address: "10.0.0.5", family: 4 }]),
+    );
+
+    await expect(
+      fetchOAuthMetadata("http://attacker.example/.well-known/oauth")
+    ).rejects.toMatchObject({
+      status: 400,
+      message: expect.stringContaining(
+        "resolves to a private/reserved IP address"
+      ),
+    });
+    expect(httpRequestMock).not.toHaveBeenCalled();
+  });
+
+  it("validates and pins each public redirect hop before connecting", async () => {
+    dnsLookupMock
+      .mockImplementationOnce(
+        (
+          _hostname: string,
+          _options: unknown,
+          callback: (error: Error | null, addresses: unknown) => void,
+        ) => callback(null, [{ address: "93.184.216.34", family: 4 }]),
+      )
+      .mockImplementationOnce(
+        (
+          _hostname: string,
+          _options: unknown,
+          callback: (error: Error | null, addresses: unknown) => void,
+        ) => callback(null, [{ address: "1.1.1.1", family: 4 }]),
+      );
+    queueMetadataResponses(httpsRequestMock, [
+      {
+        status: 302,
+        statusText: "Found",
+        headers: { location: "https://cdn.example/oauth-metadata" },
+      },
+      {
+        body: JSON.stringify({ issuer: "https://auth.example.com" }),
+      },
+    ]);
+
+    await expect(
+      fetchOAuthMetadata("https://auth.example.com/.well-known/oauth")
+    ).resolves.toEqual({
+      metadata: { issuer: "https://auth.example.com" },
+      finalUrl: "https://cdn.example/oauth-metadata",
+    });
+
+    expect(httpsRequestMock).toHaveBeenCalledTimes(2);
+    const firstLookup = httpsRequestMock.mock.calls[0][1].lookup;
+    const secondLookup = httpsRequestMock.mock.calls[1][1].lookup;
+    expect(firstLookup).toBeTypeOf("function");
+    expect(secondLookup).toBeTypeOf("function");
+    expect(firstLookup).not.toBe(secondLookup);
   });
 
   it("bounds regular, debug, and metadata requests with timeoutMs", async () => {
@@ -89,6 +290,7 @@ describe("oauth-proxy helpers", () => {
     await expect(
       executeDebugOAuthProxy({ url: "https://example.com", timeoutMs: 10 })
     ).rejects.toThrow(/timeout/i);
+    queueMetadataResponses(httpsRequestMock, []);
     await expect(
       fetchOAuthMetadata("https://example.com/.well-known/oauth", false, 10)
     ).rejects.toThrow(/timeout/i);

--- a/sdk/tests/oauth-proxy.test.ts
+++ b/sdk/tests/oauth-proxy.test.ts
@@ -1,4 +1,3 @@
-import dns from "node:dns/promises";
 import { EventEmitter } from "node:events";
 import { Readable } from "node:stream";
 import {
@@ -14,13 +13,6 @@ const httpRequestMock = vi.hoisted(() => vi.fn());
 const httpsRequestMock = vi.hoisted(() => vi.fn());
 const dnsLookupMock = vi.hoisted(() => vi.fn());
 
-vi.mock("node:dns/promises", () => ({
-  __esModule: true,
-  default: {
-    resolve4: vi.fn().mockResolvedValue([]),
-    resolve6: vi.fn().mockResolvedValue([]),
-  },
-}));
 vi.mock("node:dns", () => ({
   __esModule: true,
   lookup: dnsLookupMock,
@@ -44,6 +36,8 @@ interface MockMetadataResponse {
   response?: Readable;
 }
 
+const requestWriteMocks: Array<ReturnType<typeof vi.fn>> = [];
+
 function queueMetadataResponses(
   requestMock: ReturnType<typeof vi.fn>,
   responses: MockMetadataResponse[]
@@ -57,20 +51,35 @@ function queueMetadataResponses(
       const request = new EventEmitter() as EventEmitter & {
         end: () => void;
         destroy: () => void;
+        write: ReturnType<typeof vi.fn>;
       };
+      request.write = vi.fn();
+      requestWriteMocks.push(request.write);
+      let activeResponse: Readable | undefined;
+      const onAbort = () => {
+        const reason =
+          options.signal?.reason instanceof Error
+            ? options.signal.reason
+            : new Error("Request aborted");
+        if (activeResponse) {
+          activeResponse.destroy(reason);
+        } else {
+          request.emit("error", reason);
+        }
+      };
+      options.signal?.addEventListener("abort", onAbort, { once: true });
       request.end = () => {
         const next = responses.shift();
         if (!next) {
-          options.signal?.addEventListener(
-            "abort",
-            () => request.emit("error", options.signal?.reason),
-            { once: true }
-          );
           return;
         }
         queueMicrotask(() => {
           const response =
             next.response ?? Readable.from(next.body ? [next.body] : []);
+          activeResponse = response;
+          response.once("close", () =>
+            options.signal?.removeEventListener("abort", onAbort)
+          );
           Object.assign(response, {
             statusCode: next.status ?? 200,
             statusMessage: next.statusText ?? "OK",
@@ -90,9 +99,7 @@ function queueMetadataResponses(
 describe("oauth-proxy helpers", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    global.fetch = vi.fn() as unknown as typeof fetch;
-    vi.mocked(dns.resolve4).mockResolvedValue(["93.184.216.34"]);
-    vi.mocked(dns.resolve6).mockResolvedValue([]);
+    requestWriteMocks.length = 0;
     dnsLookupMock.mockImplementation(
       (
         _hostname: string,
@@ -118,43 +125,477 @@ describe("oauth-proxy helpers", () => {
     ).rejects.toMatchObject({ status: 400 });
   });
 
-  it("preserves the original hostname when fetching a validated URL", async () => {
-    vi.mocked(dns.resolve4).mockResolvedValueOnce(["93.184.216.34"]);
-    vi.mocked(dns.resolve6).mockResolvedValueOnce([]);
-
-    (global.fetch as jest.Mock).mockResolvedValueOnce(
-      new Response(JSON.stringify({ ok: true }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
+  it("rejects OAuth target URLs containing embedded credentials", async () => {
+    await expect(
+      executeOAuthProxy({
+        url: "https://client:secret@auth.example.com/oauth/token",
       })
-    );
+    ).rejects.toMatchObject({
+      status: 400,
+      message: expect.stringContaining("must not contain credentials"),
+    });
+    expect(httpsRequestMock).not.toHaveBeenCalled();
+  });
+
+  it("preserves the original hostname when fetching a validated URL", async () => {
+    queueMetadataResponses(httpsRequestMock, [
+      { body: JSON.stringify({ ok: true }) },
+    ]);
 
     await executeOAuthProxy({
       url: "https://example.com/path",
       httpsOnly: true,
     });
 
-    expect(global.fetch).toHaveBeenCalledWith(
-      expect.stringContaining("https://example.com/path"),
-      expect.any(Object)
+    expect(httpsRequestMock.mock.calls[0][0]).toEqual(
+      new URL("https://example.com/path")
     );
+    expect(httpsRequestMock.mock.calls[0][1]).toMatchObject({
+      servername: "example.com",
+      headers: {
+        "accept-encoding": "identity",
+      },
+    });
+    await expect(
+      new Promise((resolve, reject) =>
+        httpsRequestMock.mock.calls[0][1].lookup(
+          "example.com",
+          { all: true },
+          (
+            error: Error | null,
+            addresses: Array<{ address: string; family: number }>
+          ) => (error ? reject(error) : resolve(addresses))
+        )
+      )
+    ).resolves.toEqual([{ address: "93.184.216.34", family: 4 }]);
   });
 
   it("reports the upstream final URL for generic OAuth proxy responses", async () => {
-    const upstreamResponse = new Response(JSON.stringify({ ok: true }), {
-      status: 200,
-      headers: { "Content-Type": "application/json" },
-    });
-    Object.defineProperty(upstreamResponse, "url", {
-      value: "https://cdn.example.com/oauth/token",
-    });
-    (global.fetch as jest.Mock).mockResolvedValueOnce(upstreamResponse);
+    queueMetadataResponses(httpsRequestMock, [
+      {
+        status: 302,
+        statusText: "Found",
+        headers: { location: "https://cdn.example.com/oauth/token" },
+      },
+      { body: JSON.stringify({ ok: true }) },
+    ]);
 
     await expect(
       executeOAuthProxy({ url: "https://auth.example.com/oauth/token" })
     ).resolves.toMatchObject({
       finalUrl: "https://cdn.example.com/oauth/token",
     });
+  });
+
+  it("rejects private or mixed DNS results before the generic proxy connects", async () => {
+    dnsLookupMock.mockImplementation(
+      (
+        _hostname: string,
+        _options: unknown,
+        callback: (error: Error | null, addresses: unknown) => void
+      ) =>
+        callback(null, [
+          { address: "93.184.216.34", family: 4 },
+          { address: "169.254.169.254", family: 4 },
+        ])
+    );
+
+    await expect(
+      executeOAuthProxy({ url: "https://attacker.example/oauth/token" })
+    ).rejects.toMatchObject({
+      status: 400,
+      message: expect.stringContaining("private/reserved IP address"),
+    });
+    expect(httpsRequestMock).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when generic proxy DNS errors or returns no addresses", async () => {
+    dnsLookupMock.mockImplementationOnce(
+      (
+        _hostname: string,
+        _options: unknown,
+        callback: (error: Error | null, addresses: unknown) => void
+      ) => callback(new Error("ENOTFOUND"), [])
+    );
+    await expect(
+      executeOAuthProxy({ url: "https://missing.example/oauth/token" })
+    ).rejects.toMatchObject({
+      status: 400,
+      message: expect.stringContaining("Could not resolve"),
+    });
+
+    dnsLookupMock.mockImplementationOnce(
+      (
+        _hostname: string,
+        _options: unknown,
+        callback: (error: Error | null, addresses: unknown) => void
+      ) => callback(null, [])
+    );
+    await expect(
+      executeOAuthProxy({ url: "https://empty.example/oauth/token" })
+    ).rejects.toMatchObject({
+      status: 400,
+      message: expect.stringContaining("Could not resolve"),
+    });
+    expect(httpsRequestMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["loopback", "http://127.0.0.1:8787/oauth/token"],
+    ["LAN", "http://192.168.1.10/oauth/token"],
+    ["link-local metadata service", "http://169.254.169.254/latest/meta-data"],
+  ])(
+    "rejects a generic public request redirected to %s before connecting",
+    async (_destinationType, location) => {
+      queueMetadataResponses(httpsRequestMock, [
+        {
+          status: 302,
+          statusText: "Found",
+          headers: { location },
+        },
+      ]);
+
+      await expect(
+        executeOAuthProxy({ url: "https://auth.example.com/oauth/token" })
+      ).rejects.toMatchObject({
+        status: 400,
+        message: expect.stringContaining("private/reserved host"),
+      });
+      expect(httpsRequestMock).toHaveBeenCalledTimes(1);
+      expect(httpRequestMock).not.toHaveBeenCalled();
+    }
+  );
+
+  it("pins every generic public redirect hop", async () => {
+    dnsLookupMock
+      .mockImplementationOnce(
+        (
+          _hostname: string,
+          _options: unknown,
+          callback: (error: Error | null, addresses: unknown) => void
+        ) => callback(null, [{ address: "93.184.216.34", family: 4 }])
+      )
+      .mockImplementationOnce(
+        (
+          _hostname: string,
+          _options: unknown,
+          callback: (error: Error | null, addresses: unknown) => void
+        ) => callback(null, [{ address: "1.1.1.1", family: 4 }])
+      );
+    queueMetadataResponses(httpsRequestMock, [
+      {
+        status: 302,
+        statusText: "Found",
+        headers: { location: "https://cdn.example/oauth/token" },
+      },
+      { body: JSON.stringify({ access_token: "token" }) },
+    ]);
+
+    await expect(
+      executeOAuthProxy({ url: "https://auth.example.com/oauth/token" })
+    ).resolves.toMatchObject({
+      status: 200,
+      finalUrl: "https://cdn.example/oauth/token",
+    });
+    expect(httpsRequestMock).toHaveBeenCalledTimes(2);
+
+    const resolvePinnedLookup = (
+      lookup: (
+        hostname: string,
+        options: { all: true },
+        callback: (
+          error: Error | null,
+          addresses: Array<{ address: string; family: number }>
+        ) => void
+      ) => void,
+      hostname: string
+    ) =>
+      new Promise((resolve, reject) =>
+        lookup(hostname, { all: true }, (error, addresses) =>
+          error ? reject(error) : resolve(addresses)
+        )
+      );
+    await expect(
+      resolvePinnedLookup(
+        httpsRequestMock.mock.calls[0][1].lookup,
+        "auth.example.com"
+      )
+    ).resolves.toEqual([{ address: "93.184.216.34", family: 4 }]);
+    await expect(
+      resolvePinnedLookup(
+        httpsRequestMock.mock.calls[1][1].lookup,
+        "cdn.example"
+      )
+    ).resolves.toEqual([{ address: "1.1.1.1", family: 4 }]);
+  });
+
+  it("allows an explicit loopback proxy flow to redirect to a validated public host", async () => {
+    dnsLookupMock.mockImplementation(
+      (
+        hostname: string,
+        _options: unknown,
+        callback: (error: Error | null, addresses: unknown) => void
+      ) =>
+        callback(null, [
+          {
+            address:
+              hostname === "localhost" ? "127.0.0.1" : "93.184.216.34",
+            family: 4,
+          },
+        ])
+    );
+    queueMetadataResponses(httpRequestMock, [
+      {
+        status: 302,
+        statusText: "Found",
+        headers: { location: "https://public.example/oauth/token" },
+      },
+    ]);
+    queueMetadataResponses(httpsRequestMock, [
+      { body: JSON.stringify({ access_token: "token" }) },
+    ]);
+
+    await expect(
+      executeOAuthProxy({ url: "http://localhost:8787/oauth/token" })
+    ).resolves.toMatchObject({
+      status: 200,
+      finalUrl: "https://public.example/oauth/token",
+    });
+    expect(httpRequestMock).toHaveBeenCalledTimes(1);
+    expect(httpsRequestMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not let an explicit loopback proxy flow redirect to a LAN host", async () => {
+    dnsLookupMock.mockImplementation(
+      (
+        _hostname: string,
+        _options: unknown,
+        callback: (error: Error | null, addresses: unknown) => void
+      ) => callback(null, [{ address: "127.0.0.1", family: 4 }])
+    );
+    queueMetadataResponses(httpRequestMock, [
+      {
+        status: 302,
+        statusText: "Found",
+        headers: { location: "http://192.168.1.10/oauth/token" },
+      },
+    ]);
+
+    await expect(
+      executeOAuthProxy({ url: "http://localhost:8787/oauth/token" })
+    ).rejects.toMatchObject({
+      status: 400,
+      message: expect.stringContaining("private/reserved host"),
+    });
+    expect(httpRequestMock).toHaveBeenCalledTimes(1);
+    expect(httpsRequestMock).not.toHaveBeenCalled();
+  });
+
+  it("rewrites POST to GET and strips credentials on cross-origin 302", async () => {
+    queueMetadataResponses(httpsRequestMock, [
+      {
+        status: 302,
+        statusText: "Found",
+        headers: { location: "https://cdn.example/oauth/token" },
+      },
+      { body: JSON.stringify({ ok: true }) },
+    ]);
+
+    await executeOAuthProxy({
+      url: "https://auth.example.com/oauth/token",
+      method: "POST",
+      headers: {
+        Authorization: "Basic secret",
+        Cookie: "session=secret",
+        "Proxy-Authorization": "Basic proxy-secret",
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: { grant_type: "authorization_code" },
+    });
+
+    expect(httpsRequestMock.mock.calls[0][1]).toMatchObject({
+      method: "POST",
+      headers: expect.objectContaining({
+        authorization: "Basic secret",
+        cookie: "session=secret",
+        "content-type": "application/x-www-form-urlencoded",
+      }),
+    });
+    expect(httpsRequestMock.mock.calls[0][1].headers).not.toHaveProperty(
+      "proxy-authorization"
+    );
+    expect(requestWriteMocks[0]).toHaveBeenCalledWith(
+      Buffer.from("grant_type=authorization_code")
+    );
+    expect(httpsRequestMock.mock.calls[1][1].method).toBe("GET");
+    expect(httpsRequestMock.mock.calls[1][1].headers).not.toHaveProperty(
+      "authorization"
+    );
+    expect(httpsRequestMock.mock.calls[1][1].headers).not.toHaveProperty(
+      "cookie"
+    );
+    expect(httpsRequestMock.mock.calls[1][1].headers).not.toHaveProperty(
+      "content-type"
+    );
+    expect(requestWriteMocks[1]).not.toHaveBeenCalled();
+  });
+
+  it("preserves POST body and strips credentials on cross-origin 307", async () => {
+    queueMetadataResponses(httpsRequestMock, [
+      {
+        status: 307,
+        statusText: "Temporary Redirect",
+        headers: { location: "https://cdn.example/oauth/token" },
+      },
+      { body: JSON.stringify({ ok: true }) },
+    ]);
+
+    await executeOAuthProxy({
+      url: "https://auth.example.com/oauth/token",
+      method: "POST",
+      headers: {
+        Authorization: "Basic secret",
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: { grant_type: "refresh_token" },
+    });
+
+    expect(httpsRequestMock.mock.calls[1][1]).toMatchObject({
+      method: "POST",
+      headers: expect.objectContaining({
+        "content-type": "application/x-www-form-urlencoded",
+      }),
+    });
+    expect(httpsRequestMock.mock.calls[1][1].headers).not.toHaveProperty(
+      "authorization"
+    );
+    expect(requestWriteMocks[1]).toHaveBeenCalledWith(
+      Buffer.from("grant_type=refresh_token")
+    );
+  });
+
+  it.each([
+    { status: 301, expectedMethod: "GET", preservesBody: false },
+    { status: 303, expectedMethod: "GET", preservesBody: false },
+    { status: 308, expectedMethod: "POST", preservesBody: true },
+  ])(
+    "applies Fetch-compatible method semantics for $status redirects",
+    async ({ status, expectedMethod, preservesBody }) => {
+      queueMetadataResponses(httpsRequestMock, [
+        {
+          status,
+          statusText: "Redirect",
+          headers: { location: "/oauth/final" },
+        },
+        { body: JSON.stringify({ ok: true }) },
+      ]);
+
+      await executeOAuthProxy({
+        url: "https://auth.example.com/oauth/token",
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: { grant_type: "authorization_code" },
+      });
+
+      expect(httpsRequestMock.mock.calls[1][1].method).toBe(expectedMethod);
+      if (preservesBody) {
+        expect(requestWriteMocks[1]).toHaveBeenCalledWith(
+          Buffer.from("grant_type=authorization_code")
+        );
+      } else {
+        expect(requestWriteMocks[1]).not.toHaveBeenCalled();
+        expect(httpsRequestMock.mock.calls[1][1].headers).not.toHaveProperty(
+          "content-type"
+        );
+      }
+    }
+  );
+
+  it("rejects a sixth generic OAuth redirect", async () => {
+    queueMetadataResponses(
+      httpsRequestMock,
+      Array.from({ length: 6 }, (_, index) => ({
+        status: 302,
+        statusText: "Found",
+        headers: { location: `/redirect-${index + 1}` },
+      }))
+    );
+
+    await expect(
+      executeOAuthProxy({ url: "https://auth.example.com/oauth/token" })
+    ).rejects.toMatchObject({
+      status: 400,
+      message: expect.stringContaining("Too many"),
+    });
+    expect(httpsRequestMock).toHaveBeenCalledTimes(6);
+  });
+
+  it("caps generic proxy response bodies", async () => {
+    queueMetadataResponses(httpsRequestMock, [
+      { response: Readable.from([Buffer.alloc(1024 * 1024 + 1)]) },
+    ]);
+
+    await expect(
+      executeOAuthProxy({ url: "https://auth.example.com/oauth/token" })
+    ).rejects.toMatchObject({
+      status: 400,
+      message: expect.stringContaining("byte cap"),
+    });
+  });
+
+  it.each([executeOAuthProxy, executeDebugOAuthProxy])(
+    "%o applies timeoutMs while reading a slow response body",
+    async (proxyFn) => {
+      const hangingResponse = new Readable({
+        read() {
+          // Keep the response open until the request signal aborts it.
+        },
+      });
+      queueMetadataResponses(httpsRequestMock, [{ response: hangingResponse }]);
+
+      await expect(
+        proxyFn({
+          url: "https://auth.example.com/oauth/token",
+          timeoutMs: 10,
+        })
+      ).rejects.toThrow(/timeout/i);
+      expect(hangingResponse.destroyed).toBe(true);
+    }
+  );
+
+  it("parses one bounded debug SSE event", async () => {
+    queueMetadataResponses(httpsRequestMock, [
+      {
+        headers: { "content-type": "text/event-stream" },
+        body: 'event: message\ndata: {"ok":true}\n\n',
+      },
+    ]);
+
+    await expect(
+      executeDebugOAuthProxy({ url: "https://auth.example.com/debug" })
+    ).resolves.toMatchObject({
+      body: {
+        transport: "sse",
+        events: [{ event: "message", data: { ok: true } }],
+        mcpResponse: { ok: true },
+      },
+    });
+  });
+
+  it("includes generic proxy DNS resolution in timeoutMs", async () => {
+    dnsLookupMock.mockImplementation(() => {
+      // Simulate a resolver that never calls back.
+    });
+
+    await expect(
+      executeOAuthProxy({
+        url: "https://auth.example.com/oauth/token",
+        timeoutMs: 10,
+      })
+    ).rejects.toThrow(/timeout/i);
+    expect(httpsRequestMock).not.toHaveBeenCalled();
   });
 
   it("returns metadata for valid JSON responses", async () => {
@@ -196,6 +637,26 @@ describe("oauth-proxy helpers", () => {
     expect(httpRequestMock).not.toHaveBeenCalled();
   });
 
+  it("rejects a metadata redirect whose target embeds credentials", async () => {
+    queueMetadataResponses(httpsRequestMock, [
+      {
+        status: 302,
+        statusText: "Found",
+        headers: {
+          location: "https://user:pass@cdn.example/.well-known/oauth",
+        },
+      },
+    ]);
+
+    await expect(
+      fetchOAuthMetadata("https://auth.example.com/.well-known/oauth")
+    ).rejects.toMatchObject({
+      status: 400,
+      message: expect.stringContaining("must not contain credentials"),
+    });
+    expect(httpsRequestMock).toHaveBeenCalledTimes(1);
+  });
+
   it("allows loopback metadata to remain on loopback for an explicit local flow", async () => {
     dnsLookupMock.mockImplementation(
       (
@@ -223,6 +684,74 @@ describe("oauth-proxy helpers", () => {
       metadata: { issuer: "http://127.0.0.1:8787" },
       finalUrl: "http://127.0.0.1:8787/.well-known/oauth",
     });
+  });
+
+  it("allows loopback metadata to redirect to a validated public host", async () => {
+    dnsLookupMock.mockImplementation(
+      (
+        hostname: string,
+        _options: unknown,
+        callback: (error: Error | null, addresses: unknown) => void
+      ) =>
+        callback(null, [
+          {
+            address:
+              hostname === "localhost" ? "127.0.0.1" : "93.184.216.34",
+            family: 4,
+          },
+        ])
+    );
+    queueMetadataResponses(httpRequestMock, [
+      {
+        status: 302,
+        statusText: "Found",
+        headers: {
+          location: "https://auth.example.com/.well-known/oauth",
+        },
+      },
+    ]);
+    queueMetadataResponses(httpsRequestMock, [
+      {
+        body: JSON.stringify({ issuer: "https://auth.example.com" }),
+      },
+    ]);
+
+    await expect(
+      fetchOAuthMetadata("http://localhost:8787/.well-known/oauth")
+    ).resolves.toEqual({
+      metadata: { issuer: "https://auth.example.com" },
+      finalUrl: "https://auth.example.com/.well-known/oauth",
+    });
+    expect(httpRequestMock).toHaveBeenCalledTimes(1);
+    expect(httpsRequestMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not let loopback metadata redirect to a LAN host", async () => {
+    dnsLookupMock.mockImplementation(
+      (
+        _hostname: string,
+        _options: unknown,
+        callback: (error: Error | null, addresses: unknown) => void
+      ) => callback(null, [{ address: "127.0.0.1", family: 4 }])
+    );
+    queueMetadataResponses(httpRequestMock, [
+      {
+        status: 302,
+        statusText: "Found",
+        headers: {
+          location: "http://192.168.1.10/.well-known/oauth",
+        },
+      },
+    ]);
+
+    await expect(
+      fetchOAuthMetadata("http://localhost:8787/.well-known/oauth")
+    ).rejects.toMatchObject({
+      status: 400,
+      message: expect.stringContaining("private/reserved host"),
+    });
+    expect(httpRequestMock).toHaveBeenCalledTimes(1);
+    expect(httpsRequestMock).not.toHaveBeenCalled();
   });
 
   it("rejects loopback metadata in hosted HTTPS-only mode", async () => {
@@ -341,17 +870,11 @@ describe("oauth-proxy helpers", () => {
   });
 
   it("bounds regular, debug, and metadata requests with timeoutMs", async () => {
-    global.fetch = vi.fn(async (_input, init?: RequestInit) => {
-      return await new Promise<Response>((_resolve, reject) => {
-        init?.signal?.addEventListener("abort", () => {
-          reject(init.signal?.reason);
-        });
-      });
-    }) as unknown as typeof fetch;
-
+    queueMetadataResponses(httpsRequestMock, []);
     await expect(
       executeOAuthProxy({ url: "https://example.com", timeoutMs: 10 })
     ).rejects.toThrow(/timeout/i);
+    queueMetadataResponses(httpsRequestMock, []);
     await expect(
       executeDebugOAuthProxy({ url: "https://example.com", timeoutMs: 10 })
     ).rejects.toThrow(/timeout/i);
@@ -362,43 +885,82 @@ describe("oauth-proxy helpers", () => {
   });
 
   describe("redirect option plumbing", () => {
-    const jsonResponse = () =>
-      new Response(JSON.stringify({ ok: true }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      });
-
-    const lastFetchRedirect = () =>
-      (global.fetch as jest.Mock).mock.calls.at(-1)?.[1]?.redirect;
-
     it.each([executeOAuthProxy, executeDebugOAuthProxy])(
       "%o honors an explicit manual redirect without httpsOnly",
       async (proxyFn) => {
-        (global.fetch as jest.Mock).mockResolvedValueOnce(jsonResponse());
-        await proxyFn({
-          url: "http://localhost:3000/client.json",
-          redirect: "manual",
+        dnsLookupMock.mockImplementation(
+          (
+            _hostname: string,
+            _options: unknown,
+            callback: (error: Error | null, addresses: unknown) => void
+          ) => callback(null, [{ address: "127.0.0.1", family: 4 }])
+        );
+        queueMetadataResponses(httpRequestMock, [
+          {
+            status: 302,
+            statusText: "Found",
+            headers: { location: "http://localhost:3000/elsewhere" },
+          },
+        ]);
+        await expect(
+          proxyFn({
+            url: "http://localhost:3000/client.json",
+            redirect: "manual",
+          })
+        ).resolves.toMatchObject({
+          status: 302,
+          finalUrl: "http://localhost:3000/client.json",
         });
-        expect(lastFetchRedirect()).toBe("manual");
+        expect(httpRequestMock).toHaveBeenCalledTimes(1);
       }
     );
 
     it("preserves the historical follow default when redirect is omitted", async () => {
-      (global.fetch as jest.Mock).mockResolvedValueOnce(jsonResponse());
-      await executeDebugOAuthProxy({ url: "http://localhost:3000/metadata" });
-      expect(lastFetchRedirect()).toBe("follow");
+      dnsLookupMock.mockImplementation(
+        (
+          _hostname: string,
+          _options: unknown,
+          callback: (error: Error | null, addresses: unknown) => void
+        ) => callback(null, [{ address: "127.0.0.1", family: 4 }])
+      );
+      queueMetadataResponses(httpRequestMock, [
+        {
+          status: 302,
+          statusText: "Found",
+          headers: { location: "/final" },
+        },
+        { body: JSON.stringify({ ok: true }) },
+      ]);
+      await expect(
+        executeDebugOAuthProxy({
+          url: "http://localhost:3000/client.json",
+        })
+      ).resolves.toMatchObject({
+        status: 200,
+        finalUrl: "http://localhost:3000/final",
+      });
+      expect(httpRequestMock).toHaveBeenCalledTimes(2);
     });
 
     it("cannot weaken httpsOnly to follow with an explicit redirect", async () => {
-      vi.mocked(dns.resolve4).mockResolvedValueOnce(["93.184.216.34"]);
-      vi.mocked(dns.resolve6).mockResolvedValueOnce([]);
-      (global.fetch as jest.Mock).mockResolvedValueOnce(jsonResponse());
-      await executeDebugOAuthProxy({
-        url: "https://example.com/metadata",
-        httpsOnly: true,
-        redirect: "follow",
+      queueMetadataResponses(httpsRequestMock, [
+        {
+          status: 302,
+          statusText: "Found",
+          headers: { location: "https://cdn.example.com/metadata" },
+        },
+      ]);
+      await expect(
+        executeDebugOAuthProxy({
+          url: "https://example.com/metadata",
+          httpsOnly: true,
+          redirect: "follow",
+        })
+      ).resolves.toMatchObject({
+        status: 302,
+        finalUrl: "https://example.com/metadata",
       });
-      expect(lastFetchRedirect()).toBe("manual");
+      expect(httpsRequestMock).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/sdk/tests/oauth-proxy.test.ts
+++ b/sdk/tests/oauth-proxy.test.ts
@@ -41,17 +41,18 @@ interface MockMetadataResponse {
   statusText?: string;
   headers?: Record<string, string>;
   body?: string;
+  response?: Readable;
 }
 
 function queueMetadataResponses(
   requestMock: ReturnType<typeof vi.fn>,
-  responses: MockMetadataResponse[],
+  responses: MockMetadataResponse[]
 ): void {
   requestMock.mockImplementation(
     (
       _url: URL,
       options: { signal?: AbortSignal },
-      onResponse: (response: Readable) => void,
+      onResponse: (response: Readable) => void
     ) => {
       const request = new EventEmitter() as EventEmitter & {
         end: () => void;
@@ -63,12 +64,13 @@ function queueMetadataResponses(
           options.signal?.addEventListener(
             "abort",
             () => request.emit("error", options.signal?.reason),
-            { once: true },
+            { once: true }
           );
           return;
         }
         queueMicrotask(() => {
-          const response = Readable.from(next.body ? [next.body] : []);
+          const response =
+            next.response ?? Readable.from(next.body ? [next.body] : []);
           Object.assign(response, {
             statusCode: next.status ?? 200,
             statusMessage: next.statusText ?? "OK",
@@ -81,7 +83,7 @@ function queueMetadataResponses(
       };
       request.destroy = () => {};
       return request;
-    },
+    }
   );
 }
 
@@ -95,8 +97,8 @@ describe("oauth-proxy helpers", () => {
       (
         _hostname: string,
         _options: unknown,
-        callback: (error: Error | null, addresses: unknown) => void,
-      ) => callback(null, [{ address: "93.184.216.34", family: 4 }]),
+        callback: (error: Error | null, addresses: unknown) => void
+      ) => callback(null, [{ address: "93.184.216.34", family: 4 }])
     );
   });
 
@@ -138,6 +140,23 @@ describe("oauth-proxy helpers", () => {
     );
   });
 
+  it("reports the upstream final URL for generic OAuth proxy responses", async () => {
+    const upstreamResponse = new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+    Object.defineProperty(upstreamResponse, "url", {
+      value: "https://cdn.example.com/oauth/token",
+    });
+    (global.fetch as jest.Mock).mockResolvedValueOnce(upstreamResponse);
+
+    await expect(
+      executeOAuthProxy({ url: "https://auth.example.com/oauth/token" })
+    ).resolves.toMatchObject({
+      finalUrl: "https://cdn.example.com/oauth/token",
+    });
+  });
+
   it("returns metadata for valid JSON responses", async () => {
     queueMetadataResponses(httpsRequestMock, [
       {
@@ -150,6 +169,9 @@ describe("oauth-proxy helpers", () => {
     ).resolves.toEqual({
       metadata: { issuer: "https://auth.example.com" },
       finalUrl: "https://auth.example.com/.well-known/oauth",
+    });
+    expect(httpsRequestMock.mock.calls[0][1].headers).toMatchObject({
+      "Accept-Encoding": "identity",
     });
   });
 
@@ -179,8 +201,8 @@ describe("oauth-proxy helpers", () => {
       (
         _hostname: string,
         _options: unknown,
-        callback: (error: Error | null, addresses: unknown) => void,
-      ) => callback(null, [{ address: "127.0.0.1", family: 4 }]),
+        callback: (error: Error | null, addresses: unknown) => void
+      ) => callback(null, [{ address: "127.0.0.1", family: 4 }])
     );
     queueMetadataResponses(httpRequestMock, [
       {
@@ -218,8 +240,8 @@ describe("oauth-proxy helpers", () => {
       (
         _hostname: string,
         _options: unknown,
-        callback: (error: Error | null, addresses: unknown) => void,
-      ) => callback(null, [{ address: "10.0.0.5", family: 4 }]),
+        callback: (error: Error | null, addresses: unknown) => void
+      ) => callback(null, [{ address: "10.0.0.5", family: 4 }])
     );
 
     await expect(
@@ -234,26 +256,33 @@ describe("oauth-proxy helpers", () => {
   });
 
   it("validates and pins each public redirect hop before connecting", async () => {
+    const redirectResponse = new Readable({
+      read() {
+        // Deliberately never end: redirect bodies must be destroyed after the
+        // headers rather than drained without a bound.
+      },
+    });
     dnsLookupMock
       .mockImplementationOnce(
         (
           _hostname: string,
           _options: unknown,
-          callback: (error: Error | null, addresses: unknown) => void,
-        ) => callback(null, [{ address: "93.184.216.34", family: 4 }]),
+          callback: (error: Error | null, addresses: unknown) => void
+        ) => callback(null, [{ address: "93.184.216.34", family: 4 }])
       )
       .mockImplementationOnce(
         (
           _hostname: string,
           _options: unknown,
-          callback: (error: Error | null, addresses: unknown) => void,
-        ) => callback(null, [{ address: "1.1.1.1", family: 4 }]),
+          callback: (error: Error | null, addresses: unknown) => void
+        ) => callback(null, [{ address: "1.1.1.1", family: 4 }])
       );
     queueMetadataResponses(httpsRequestMock, [
       {
         status: 302,
         statusText: "Found",
         headers: { location: "https://cdn.example/oauth-metadata" },
+        response: redirectResponse,
       },
       {
         body: JSON.stringify({ issuer: "https://auth.example.com" }),
@@ -273,6 +302,42 @@ describe("oauth-proxy helpers", () => {
     expect(firstLookup).toBeTypeOf("function");
     expect(secondLookup).toBeTypeOf("function");
     expect(firstLookup).not.toBe(secondLookup);
+    await expect(
+      new Promise((resolve, reject) =>
+        firstLookup(
+          "auth.example.com",
+          { all: true },
+          (
+            error: Error | null,
+            addresses: Array<{ address: string; family: number }>
+          ) => (error ? reject(error) : resolve(addresses))
+        )
+      )
+    ).resolves.toEqual([{ address: "93.184.216.34", family: 4 }]);
+    await expect(
+      new Promise((resolve, reject) =>
+        secondLookup(
+          "cdn.example",
+          { all: true },
+          (
+            error: Error | null,
+            addresses: Array<{ address: string; family: number }>
+          ) => (error ? reject(error) : resolve(addresses))
+        )
+      )
+    ).resolves.toEqual([{ address: "1.1.1.1", family: 4 }]);
+    expect(redirectResponse.destroyed).toBe(true);
+  });
+
+  it("includes DNS resolution in the metadata timeout", async () => {
+    dnsLookupMock.mockImplementation(() => {
+      // Simulate a resolver that never calls back.
+    });
+
+    await expect(
+      fetchOAuthMetadata("https://example.com/.well-known/oauth", false, 10)
+    ).rejects.toThrow(/timeout/i);
+    expect(httpsRequestMock).not.toHaveBeenCalled();
   });
 
   it("bounds regular, debug, and metadata requests with timeoutMs", async () => {

--- a/sdk/tests/support/oauth-proxy-fetch-mock.ts
+++ b/sdk/tests/support/oauth-proxy-fetch-mock.ts
@@ -1,0 +1,105 @@
+import type {
+  OAuthProxyRequest,
+  OAuthProxyResponse,
+} from "../../src/oauth-proxy.js";
+
+function encodeBody(
+  req: OAuthProxyRequest,
+  method: string
+): string | undefined {
+  if (method !== "POST" || req.body === undefined || req.body === null) {
+    return undefined;
+  }
+
+  const headers = req.headers ?? {};
+  const contentType = headers["Content-Type"] ?? headers["content-type"] ?? "";
+  if (
+    contentType.includes("application/x-www-form-urlencoded") &&
+    typeof req.body === "object"
+  ) {
+    return new URLSearchParams(
+      Object.entries(req.body as Record<string, unknown>).map(
+        ([key, value]) => [key, String(value)]
+      )
+    ).toString();
+  }
+  return typeof req.body === "string" ? req.body : JSON.stringify(req.body);
+}
+
+function parseSseBody(text: string): Record<string, unknown> {
+  const events: Array<{ event?: string; data?: unknown; id?: string }> = [];
+  let current: { event?: string; data?: unknown; id?: string } = {};
+
+  for (const line of text.split(/\r?\n/)) {
+    if (line.startsWith("event:")) {
+      current.event = line.substring(6).trim();
+    } else if (line.startsWith("data:")) {
+      const data = line.substring(5).trim();
+      try {
+        current.data = JSON.parse(data);
+      } catch {
+        current.data = data;
+      }
+    } else if (line.startsWith("id:")) {
+      current.id = line.substring(3).trim();
+    } else if (line === "" && Object.keys(current).length > 0) {
+      events.push(current);
+      current = {};
+    }
+  }
+
+  return {
+    transport: "sse",
+    events,
+    isOldTransport: events[0]?.event === "endpoint",
+    endpoint: events[0]?.event === "endpoint" ? events[0].data : null,
+    mcpResponse:
+      events.find((event) => event.event === "message" || !event.event)?.data ??
+      null,
+    rawBuffer: "",
+  };
+}
+
+/**
+ * In-memory transport seam for XAA flow tests. Production pinning behavior is
+ * covered by oauth-proxy.test.ts; these suites focus on state-machine behavior.
+ */
+export async function executeOAuthProxyViaFetch(
+  req: OAuthProxyRequest
+): Promise<OAuthProxyResponse> {
+  const method = (req.method ?? "GET").toUpperCase();
+  const response = await global.fetch(req.url, {
+    method,
+    headers: req.headers,
+    body: encodeBody(req, method),
+    redirect: req.httpsOnly ? "manual" : req.redirect ?? "follow",
+    signal:
+      req.timeoutMs === undefined
+        ? undefined
+        : AbortSignal.timeout(req.timeoutMs),
+  });
+  const headers: Record<string, string> = {};
+  response.headers.forEach((value, key) => {
+    headers[key] = value;
+  });
+
+  const text = await response.text();
+  let body: unknown = null;
+  if (headers["content-type"]?.includes("text/event-stream")) {
+    body = parseSseBody(text);
+  } else if (text) {
+    try {
+      body = JSON.parse(text);
+    } catch {
+      body = text;
+    }
+  }
+
+  return {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+    body,
+    finalUrl: response.url || req.url,
+  };
+}

--- a/sdk/tests/xaa/in-process-executor.test.ts
+++ b/sdk/tests/xaa/in-process-executor.test.ts
@@ -21,6 +21,22 @@ import {
   XAA_DEBUG_IDP_CLIENT_ID,
 } from "../../src/oauth/client-identity.js";
 
+vi.mock("../../src/oauth-proxy.js", async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import("../../src/oauth-proxy.js")
+  >();
+  const { executeOAuthProxyViaFetch } = await import(
+    "../support/oauth-proxy-fetch-mock.js"
+  );
+  return {
+    ...actual,
+    // These executor tests model upstream token endpoints with global.fetch.
+    // Socket pinning and redirect validation have dedicated proxy tests.
+    executeOAuthProxy: vi.fn(executeOAuthProxyViaFetch),
+    executeDebugOAuthProxy: vi.fn(executeOAuthProxyViaFetch),
+  };
+});
+
 const ISSUER_BASE = "https://issuer.example.com/api/mcp";
 const AS_ISSUER = "https://auth.example.com";
 const TOKEN_ENDPOINT = "https://auth.example.com/oauth/token";

--- a/sdk/tests/xaa/run-xaa-flow-registration.test.ts
+++ b/sdk/tests/xaa/run-xaa-flow-registration.test.ts
@@ -3,7 +3,6 @@ import { mkdtempSync, rmSync } from "fs";
 import os from "os";
 import path from "path";
 import { runXaaFlow } from "../../src/xaa/run-xaa-flow.js";
-import * as oauthProxy from "../../src/oauth-proxy.js";
 import {
   getXAAIdpJwks,
   resetXAAIdpKeyPairForTests,
@@ -18,6 +17,9 @@ vi.mock("../../src/oauth-proxy.js", async (importOriginal) => {
   const actual = await importOriginal<
     typeof import("../../src/oauth-proxy.js")
   >();
+  const { executeOAuthProxyViaFetch } = await import(
+    "../support/oauth-proxy-fetch-mock.js"
+  );
   return {
     ...actual,
     // The flow fixture uses global.fetch for its synthetic OAuth endpoints.
@@ -41,6 +43,38 @@ vi.mock("../../src/oauth-proxy.js", async (importOriginal) => {
           metadata: (await response.json()) as Record<string, unknown>,
           finalUrl: response.url || url,
         };
+      }
+    ),
+    executeOAuthProxy: vi.fn(executeOAuthProxyViaFetch),
+    executeDebugOAuthProxy: vi.fn(executeOAuthProxyViaFetch),
+    validateUrl: vi.fn(async (url: string, httpsOnly = false) => {
+      const parsed = new URL(url);
+      if (parsed.hostname === "127.0.0.1") {
+        return await actual.validateUrl(url, httpsOnly);
+      }
+      return { url: parsed };
+    }),
+    fetchPinnedPublicDocument: vi.fn(
+      async (
+        url: string,
+        opts: {
+          headers?: Record<string, string>;
+          timeoutMs?: number;
+          maxBytes?: number;
+        } = {}
+      ) => {
+        // Keep the real pre-connect rejection for private literals. Public
+        // synthetic endpoints stay on this suite's in-memory fetch seam.
+        if (new URL(url).hostname === "127.0.0.1") {
+          return await actual.fetchPinnedPublicDocument(url, opts);
+        }
+        return await executeOAuthProxyViaFetch({
+          url,
+          headers: opts.headers,
+          timeoutMs: opts.timeoutMs,
+          httpsOnly: true,
+          redirect: "manual",
+        });
       }
     ),
   };
@@ -151,14 +185,11 @@ function registrationStub(config: StubConfig) {
       // ID-JAG redemption.
       if (url === TOKEN_ENDPOINT && method === "POST") {
         counts.token += 1;
-        const t = config.tokenResponses?.[tokenIdx++] ??
+        const t =
+          config.tokenResponses?.[tokenIdx++] ??
           config.token ?? {
             status: 200,
-            body: {
-              access_token: "at-xyz",
-              token_type: "Bearer",
-              expires_in: 300,
-            },
+            body: { access_token: "at-xyz", token_type: "Bearer", expires_in: 300 },
           };
         return json(t.body, t.status);
       }
@@ -179,6 +210,7 @@ describe("runXaaFlow — registration strategies", () => {
   let tempDir: string;
 
   beforeEach(() => {
+    vi.clearAllMocks();
     tempDir = mkdtempSync(path.join(os.tmpdir(), "xaa-reg-"));
     process.env.XAA_IDP_KEY_DIR = tempDir;
     resetXAAIdpKeyPairForTests();
@@ -193,9 +225,7 @@ describe("runXaaFlow — registration strategies", () => {
   });
 
   it("DCR completes without a --client-id, deriving the identity from registration", async () => {
-    const { fetchImpl, counts } = registrationStub({
-      asMetadata: dcrAsMetadata,
-    });
+    const { fetchImpl, counts } = registrationStub({ asMetadata: dcrAsMetadata });
     global.fetch = fetchImpl as unknown as typeof fetch;
 
     const result = await runXaaFlow({
@@ -207,6 +237,7 @@ describe("runXaaFlow — registration strategies", () => {
       // no clientId
     });
 
+    expect(result.error).toBeUndefined();
     expect(result.completed).toBe(true);
     expect(result.redemption?.tokenIssued).toBe(true);
     expect(counts.registration).toBe(1);
@@ -319,31 +350,16 @@ describe("runXaaFlow — registration strategies", () => {
     expect(serialized).toContain("[REDACTED]"); // the scrub fired
   });
 
-  it("public CIMD fetches the custom metadata URL and uses it as the ID-JAG client_id", async () => {
+  it("public CIMD uses the custom metadata URL as the ID-JAG client_id", async () => {
     const { fetchImpl } = registrationStub({
       asMetadata: cimdAsMetadata,
+      cimdDoc: publicCimdDoc,
       token: {
         status: 200,
-        body: {
-          access_token: "at-cimd",
-          token_type: "Bearer",
-          expires_in: 300,
-        },
+        body: { access_token: "at-cimd", token_type: "Bearer", expires_in: 300 },
       },
     });
     global.fetch = fetchImpl as unknown as typeof fetch;
-    // The CIMD document fetch goes through the SSRF-hardened, connection-pinned
-    // path (real https.request) — not global.fetch — so mock it here. Its own
-    // guards are covered in oauth-proxy.test.ts.
-    const pinnedSpy = vi
-      .spyOn(oauthProxy, "fetchPinnedPublicDocument")
-      .mockResolvedValue({
-        status: 200,
-        statusText: "OK",
-        headers: { "content-type": "application/json" },
-        body: publicCimdDoc,
-        finalUrl: CIMD_URL,
-      });
 
     const result = await runXaaFlow({
       serverUrl: SERVER_URL,
@@ -354,8 +370,7 @@ describe("runXaaFlow — registration strategies", () => {
       clientIdMetadataUrl: CIMD_URL,
     });
 
-    expect(pinnedSpy).toHaveBeenCalledWith(CIMD_URL, expect.anything());
-    pinnedSpy.mockRestore();
+    expect(result.error).toBeUndefined();
     expect(result.completed).toBe(true);
     expect(result.redemption?.tokenIssued).toBe(true);
     expect(result.registration?.strategy).toBe("cimd");

--- a/sdk/tests/xaa/run-xaa-flow-registration.test.ts
+++ b/sdk/tests/xaa/run-xaa-flow-registration.test.ts
@@ -14,6 +14,38 @@ import {
   TOKEN_EXCHANGE_GRANT,
 } from "../../src/oauth/client-identity.js";
 
+vi.mock("../../src/oauth-proxy.js", async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import("../../src/oauth-proxy.js")
+  >();
+  return {
+    ...actual,
+    // The flow fixture uses global.fetch for its synthetic OAuth endpoints.
+    // DNS pinning itself is tested in oauth-proxy.test.ts.
+    fetchOAuthMetadata: vi.fn(
+      async (url: string, _httpsOnly = false, timeoutMs?: number) => {
+        const response = await global.fetch(url, {
+          headers: { Accept: "application/json" },
+          signal:
+            timeoutMs === undefined
+              ? undefined
+              : AbortSignal.timeout(timeoutMs),
+        });
+        if (!response.ok) {
+          return {
+            status: response.status,
+            statusText: response.statusText,
+          };
+        }
+        return {
+          metadata: (await response.json()) as Record<string, unknown>,
+          finalUrl: response.url || url,
+        };
+      }
+    ),
+  };
+});
+
 // DCR + CIMD registration strategies driven through the real state machine with
 // a mocked global.fetch (mirrors run-xaa-flow.test.ts). DCR is fully exercised;
 // CIMD here is the public-client variant the engine supports today.
@@ -119,11 +151,14 @@ function registrationStub(config: StubConfig) {
       // ID-JAG redemption.
       if (url === TOKEN_ENDPOINT && method === "POST") {
         counts.token += 1;
-        const t =
-          config.tokenResponses?.[tokenIdx++] ??
+        const t = config.tokenResponses?.[tokenIdx++] ??
           config.token ?? {
             status: 200,
-            body: { access_token: "at-xyz", token_type: "Bearer", expires_in: 300 },
+            body: {
+              access_token: "at-xyz",
+              token_type: "Bearer",
+              expires_in: 300,
+            },
           };
         return json(t.body, t.status);
       }
@@ -158,7 +193,9 @@ describe("runXaaFlow — registration strategies", () => {
   });
 
   it("DCR completes without a --client-id, deriving the identity from registration", async () => {
-    const { fetchImpl, counts } = registrationStub({ asMetadata: dcrAsMetadata });
+    const { fetchImpl, counts } = registrationStub({
+      asMetadata: dcrAsMetadata,
+    });
     global.fetch = fetchImpl as unknown as typeof fetch;
 
     const result = await runXaaFlow({
@@ -287,7 +324,11 @@ describe("runXaaFlow — registration strategies", () => {
       asMetadata: cimdAsMetadata,
       token: {
         status: 200,
-        body: { access_token: "at-cimd", token_type: "Bearer", expires_in: 300 },
+        body: {
+          access_token: "at-cimd",
+          token_type: "Bearer",
+          expires_in: 300,
+        },
       },
     });
     global.fetch = fetchImpl as unknown as typeof fetch;
@@ -301,6 +342,7 @@ describe("runXaaFlow — registration strategies", () => {
         statusText: "OK",
         headers: { "content-type": "application/json" },
         body: publicCimdDoc,
+        finalUrl: CIMD_URL,
       });
 
     const result = await runXaaFlow({

--- a/sdk/tests/xaa/run-xaa-flow.test.ts
+++ b/sdk/tests/xaa/run-xaa-flow.test.ts
@@ -12,6 +12,39 @@ import {
   ID_JAG_GRANT_PROFILE,
 } from "../../src/oauth/client-identity.js";
 
+vi.mock("../../src/oauth-proxy.js", async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import("../../src/oauth-proxy.js")
+  >();
+  return {
+    ...actual,
+    // These flow tests model every remote endpoint with global.fetch. Metadata
+    // transport pinning has dedicated oauth-proxy coverage, so preserve this
+    // suite's in-memory transport seam instead of opening real DNS/sockets.
+    fetchOAuthMetadata: vi.fn(
+      async (url: string, _httpsOnly = false, timeoutMs?: number) => {
+        const response = await global.fetch(url, {
+          headers: { Accept: "application/json" },
+          signal:
+            timeoutMs === undefined
+              ? undefined
+              : AbortSignal.timeout(timeoutMs),
+        });
+        if (!response.ok) {
+          return {
+            status: response.status,
+            statusText: response.statusText,
+          };
+        }
+        return {
+          metadata: (await response.json()) as Record<string, unknown>,
+          finalUrl: response.url || url,
+        };
+      }
+    ),
+  };
+});
+
 const SERVER_URL = "https://mcp.example.com/mcp";
 const AS_ISSUER = "https://auth.example.com";
 const TOKEN_ENDPOINT = "https://auth.example.com/oauth/token";

--- a/sdk/tests/xaa/run-xaa-flow.test.ts
+++ b/sdk/tests/xaa/run-xaa-flow.test.ts
@@ -16,6 +16,9 @@ vi.mock("../../src/oauth-proxy.js", async (importOriginal) => {
   const actual = await importOriginal<
     typeof import("../../src/oauth-proxy.js")
   >();
+  const { executeOAuthProxyViaFetch } = await import(
+    "../support/oauth-proxy-fetch-mock.js"
+  );
   return {
     ...actual,
     // These flow tests model every remote endpoint with global.fetch. Metadata
@@ -42,6 +45,8 @@ vi.mock("../../src/oauth-proxy.js", async (importOriginal) => {
         };
       }
     ),
+    executeOAuthProxy: vi.fn(executeOAuthProxyViaFetch),
+    executeDebugOAuthProxy: vi.fn(executeOAuthProxyViaFetch),
   };
 });
 


### PR DESCRIPTION
## What changed

- Propagate the OAuth metadata request's final upstream URL through the MCPJam proxy so browser-side validation checks the real destination instead of the local proxy URL.
- Follow metadata redirects manually and validate every hop before connecting.
- Resolve and pin validated DNS addresses to close DNS-rebinding and private-network SSRF gaps.
- Preserve explicitly local loopback OAuth flows while rejecting loopback/private targets in hosted HTTPS-only mode.
- Add client, server, and SDK regression coverage for proxy URLs, redirect-to-loopback, private DNS resolution, per-hop pinning, and hosted-mode loopback rejection.

## Why

The staging OAuth flow treated MCPJam's own local metadata proxy URL as the final OAuth metadata destination, causing a false SSRF rejection. At the same time, validating only after an automatic redirect and skipping private DNS checks in local mode left real SSRF gaps.

## Impact

Remote HTTPS OAuth discovery works through the Inspector proxy without false positives, while redirect and DNS validation occurs before any connection to a metadata target. Localhost OAuth remains available only for explicit local development flows.

## Validation

- `npm run test -w @mcpjam/sdk -- --run tests/oauth-proxy.test.ts` (55 tests)
- `npm run test -w @mcpjam/inspector -- --run client/src/lib/oauth/__tests__/mcp-oauth.test.ts server/routes/web/__tests__/oauth.test.ts` (87 tests)
- `npm run typecheck -w @mcpjam/sdk`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened OAuth metadata SSRF validation by validating the real upstream URL, pinning DNS on each hop, and propagating the final URL through the proxy. Hosted HTTPS-only still blocks private hosts; explicit localhost flows remain allowed in local mode.

- **Bug Fixes**
  - Servers set `X-MCPJam-OAuth-Upstream-URL` on both `/proxy` and `/metadata` in `mcp` and `web` routes; the client reads it and validates the upstream final URL (not the Inspector proxy). Proxy responses are tagged via a WeakMap so SSRF checks use the real destination.
  - `@mcpjam/sdk` proxy now uses pinned `dns.lookup` with `http/https` requests, validates each redirect before connecting, enforces timeouts and body limits, and returns `finalUrl` in `OAuthProxyResponse`. Hosted mode enforces HTTPS and rejects private/loopback; loopback is allowed only for explicit local flows.
  - Expanded tests in `@mcpjam/sdk` and `@mcpjam/inspector`, including header propagation checks and fetch-based adapters for server and executor suites.

<sup>Written for commit bafa978823a4f1b7aa9982520ec35e3dd3d2aebd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

