### PR TITLE
fix(servers): tidy the Config tab, and stop it crashing the page in local mode

### DIFF
--- a/mcpjam-inspector/client/src/components/ServersTab.tsx
+++ b/mcpjam-inspector/client/src/components/ServersTab.tsx
@@ -1162,7 +1162,14 @@ export function ServersTab({
 
   const activeProject = projects[activeProjectId];
   const sharedProjectId = activeProject?.sharedProjectId;
-  const hostedProjectId = sharedProjectId ?? activeProjectId;
+  // Convex-only. Falling back to `activeProjectId` leaked a LOCAL project id
+  // (a `crypto.randomUUID()` value) into `ServerDetailModal`, which passes it
+  // straight to `projectServerConfig:getConfig` — a `v.id("projects")` arg.
+  // The rejection throws during render and, with no route ErrorBoundary,
+  // took down the whole page when opening a server's Config. Null here is
+  // what every other project-scoped Convex consumer expects for local mode,
+  // and matches `sharedProjectIdForHostScope` on the Add Server modal.
+  const hostedProjectId = sharedProjectId ?? null;
   const { serversRecord: sharedProjectServersRecord } = useRemoteProjectServers(
     {
       projectId: sharedProjectId ?? null,

--- a/mcpjam-inspector/client/src/components/connection/AddServerModal.tsx
+++ b/mcpjam-inspector/client/src/components/connection/AddServerModal.tsx
@@ -389,7 +389,6 @@ export function AddServerModal({
               onChange={(e) => formState.setName(e.target.value)}
               placeholder="my-mcp-server"
               required
-              className="h-10"
             />
           </div>
 

--- a/mcpjam-inspector/client/src/components/connection/EditServerFormContent.tsx
+++ b/mcpjam-inspector/client/src/components/connection/EditServerFormContent.tsx
@@ -125,7 +125,6 @@ export function EditServerFormContent({
           onChange={(e) => formState.setName(e.target.value)}
           placeholder="my-mcp-server"
           required
-          className="h-10"
         />
         {isDuplicateServerName && (
           <p className="text-xs text-destructive">
@@ -310,69 +309,76 @@ export function EditServerFormContent({
         </div>
       )}
 
-      {formState.type === "stdio" && (
-        <EnvVarsSection
-          envVars={formState.envVars}
-          showEnvVars={formState.showEnvVars}
-          onToggle={() => formState.setShowEnvVars(!formState.showEnvVars)}
-          onAdd={formState.addEnvVar}
-          onRemove={formState.removeEnvVar}
-          onUpdate={formState.updateEnvVar}
-          hasStoredEnv={formState.hasStoredEnv}
-          isRevealing={revealingEnv}
-          revealError={envRevealError}
-          onReveal={() => revealSecrets("env")}
-        />
-      )}
+      {/* Optional sections. The rule separates the required identity /
+          transport fields above from the two disclosures, which otherwise sit
+          on the same rhythm and read as more required fields. */}
+      <div className="space-y-4 border-t border-border/60 pt-5">
+        {formState.type === "stdio" && (
+          <EnvVarsSection
+            envVars={formState.envVars}
+            showEnvVars={formState.showEnvVars}
+            onToggle={() => formState.setShowEnvVars(!formState.showEnvVars)}
+            onAdd={formState.addEnvVar}
+            onRemove={formState.removeEnvVar}
+            onUpdate={formState.updateEnvVar}
+            hasStoredEnv={formState.hasStoredEnv}
+            isRevealing={revealingEnv}
+            revealError={envRevealError}
+            onReveal={() => revealSecrets("env")}
+          />
+        )}
 
-      <AdvancedConnectionSettingsSection
-        showConfiguration={formState.showConfiguration}
-        onToggle={() =>
-          formState.setShowConfiguration(!formState.showConfiguration)
-        }
-        requestTimeout={formState.requestTimeout}
-        onRequestTimeoutChange={formState.setRequestTimeout}
-        inheritedRequestTimeout={formState.inheritedRequestTimeout}
-        clientCapabilitiesOverrideEnabled={
-          formState.clientCapabilitiesOverrideEnabled
-        }
-        onClientCapabilitiesOverrideEnabledChange={(enabled) => {
-          formState.setClientCapabilitiesOverrideEnabled(enabled);
-          if (!enabled) {
-            formState.setClientCapabilitiesOverrideError(null);
+        <AdvancedConnectionSettingsSection
+          showConfiguration={formState.showConfiguration}
+          onToggle={() =>
+            formState.setShowConfiguration(!formState.showConfiguration)
           }
-        }}
-        clientCapabilitiesOverrideText={
-          formState.clientCapabilitiesOverrideText
-        }
-        onClientCapabilitiesOverrideTextChange={
-          formState.setClientCapabilitiesOverrideText
-        }
-        clientCapabilitiesOverrideError={
-          formState.clientCapabilitiesOverrideError
-        }
-        /* Render the row regardless of whether a setter is wired. When
-           `onMcpProtocolVersionOverrideChange` is absent (no project/server
-           id, or project config still loading), the select disables but
-           remains visible for discoverability. */
-        showMcpProtocolVersionOverride
-        mcpProtocolVersionOverride={mcpProtocolVersionOverride}
-        onMcpProtocolVersionOverrideChange={onMcpProtocolVersionOverrideChange}
-        transportKind={formState.type}
-        {...(formState.type === "http"
-          ? {
-              customHeaders: formState.customHeaders,
-              onAddHeader: formState.addCustomHeader,
-              onRemoveHeader: formState.removeCustomHeader,
-              onUpdateHeader: formState.updateCustomHeader,
-              hasStoredHeaders: formState.hasStoredHeaders,
-              isRevealingHeaders: revealingHeaders,
-              headersRevealError,
-              onRevealHeaders: () => revealSecrets("headers"),
-              headersWarning: formState.oauthAuthorizationHeaderWarning,
+          requestTimeout={formState.requestTimeout}
+          onRequestTimeoutChange={formState.setRequestTimeout}
+          inheritedRequestTimeout={formState.inheritedRequestTimeout}
+          clientCapabilitiesOverrideEnabled={
+            formState.clientCapabilitiesOverrideEnabled
+          }
+          onClientCapabilitiesOverrideEnabledChange={(enabled) => {
+            formState.setClientCapabilitiesOverrideEnabled(enabled);
+            if (!enabled) {
+              formState.setClientCapabilitiesOverrideError(null);
             }
-          : {})}
-      />
+          }}
+          clientCapabilitiesOverrideText={
+            formState.clientCapabilitiesOverrideText
+          }
+          onClientCapabilitiesOverrideTextChange={
+            formState.setClientCapabilitiesOverrideText
+          }
+          clientCapabilitiesOverrideError={
+            formState.clientCapabilitiesOverrideError
+          }
+          /* Render the row regardless of whether a setter is wired. When
+             `onMcpProtocolVersionOverrideChange` is absent (no project/server
+             id, or project config still loading), the select disables but
+             remains visible for discoverability. */
+          showMcpProtocolVersionOverride
+          mcpProtocolVersionOverride={mcpProtocolVersionOverride}
+          onMcpProtocolVersionOverrideChange={
+            onMcpProtocolVersionOverrideChange
+          }
+          transportKind={formState.type}
+          {...(formState.type === "http"
+            ? {
+                customHeaders: formState.customHeaders,
+                onAddHeader: formState.addCustomHeader,
+                onRemoveHeader: formState.removeCustomHeader,
+                onUpdateHeader: formState.updateCustomHeader,
+                hasStoredHeaders: formState.hasStoredHeaders,
+                isRevealingHeaders: revealingHeaders,
+                headersRevealError,
+                onRevealHeaders: () => revealSecrets("headers"),
+                headersWarning: formState.oauthAuthorizationHeaderWarning,
+              }
+            : {})}
+        />
+      </div>
     </div>
   );
 }

--- a/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
@@ -49,6 +49,7 @@ import {
 import { EffectiveProtocolVersionChip } from "./shared/EffectiveProtocolVersionChip";
 import { fetchServerSecrets } from "@/lib/apis/server-secrets-api";
 import { useActiveMcpProfile } from "@/contexts/active-mcp-profile-context";
+import { shouldQueryProjectId } from "@/hooks/useProjects";
 
 export type ServerDetailTab =
   | "overview"
@@ -129,9 +130,15 @@ export function ServerDetailModal({
   // round-trip rather than a server-update. Read/write here so the
   // form control inside `EditServerFormContent` can stay a pure prop
   // consumer.
+  // Only a real Convex project id may reach this query — `getConfig` validates
+  // `projectId` as `v.id("projects")`, and a LOCAL id (UUID, or a `local_` /
+  // `project_` placeholder) makes it reject during render. Same guard every
+  // other project-scoped Convex consumer uses; callers in local mode should
+  // pass null, but this keeps a stray local id from taking down the page.
+  const canQueryProjectServerConfig = shouldQueryProjectId(projectId);
   const projectServerConfigDto = useQuery(
     "projectServerConfig:getConfig" as never,
-    projectId ? ({ projectId } as never) : "skip"
+    canQueryProjectServerConfig ? ({ projectId } as never) : "skip"
   ) as ProjectServerConfigDto | null | undefined;
   const setProjectServerConfigMutation = useMutation(
     "projectServerConfig:setConfig" as never
@@ -171,7 +178,9 @@ export function ServerDetailModal({
   const resolvedHostDefaultMcpProtocolVersion: McpProtocolVersion | undefined =
     hostDefaultMcpProtocolVersion ?? activeMcpProfile?.mcpProtocolVersion;
   const canEditMcpProtocolVersionOverride = Boolean(
-    projectId && serverId && projectServerConfigDto !== undefined
+    canQueryProjectServerConfig &&
+      serverId &&
+      projectServerConfigDto !== undefined
   );
   const protocolOverrideAutoEnrolledRef = useRef<
     Map<string, ProtocolOverrideAutoEnrollRecord>
@@ -208,7 +217,7 @@ export function ServerDetailModal({
   const handleMcpProtocolVersionOverrideChange = async (
     next: McpProtocolVersion | undefined
   ): Promise<void> => {
-    if (!projectId) {
+    if (!canQueryProjectServerConfig || !projectId) {
       toast.error(
         "Wire mode override requires a project context; cannot save without projectId."
       );

--- a/mcpjam-inspector/client/src/components/connection/__tests__/ServerDetailModal.hosted.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/ServerDetailModal.hosted.test.tsx
@@ -147,7 +147,7 @@ describe("ServerDetailModal hosted reconnect", () => {
           useOAuth: true,
         })}
         defaultTab="overview"
-        projectId="project_123"
+        projectId="jh7abc123def456ghi789jk"
         hostedServerId="server_123"
       />,
     );
@@ -164,7 +164,7 @@ describe("ServerDetailModal hosted reconnect", () => {
 
     await waitFor(() => {
       expect(mockFetchHostedOAuthTokens).toHaveBeenCalledWith({
-        projectId: "project_123",
+        projectId: "jh7abc123def456ghi789jk",
         serverId: "server_123",
       });
     });
@@ -200,7 +200,7 @@ describe("ServerDetailModal hosted reconnect", () => {
           useOAuth: true,
         })}
         defaultTab="overview"
-        projectId="project_123"
+        projectId="jh7abc123def456ghi789jk"
         hostedServerId="server_123"
       />,
     );

--- a/mcpjam-inspector/client/src/components/connection/__tests__/ServerDetailModal.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/ServerDetailModal.test.tsx
@@ -156,7 +156,7 @@ describe("ServerDetailModal", () => {
     mockUseFeatureFlagEnabled.mockReturnValue(false);
     mockUseQuery.mockReturnValue(undefined);
     mockSetProjectServerConfig.mockResolvedValue({
-      projectId: "project_123",
+      projectId: "jh7abc123def456ghi789jk",
       serverIds: [],
       overrides: {},
     });
@@ -165,6 +165,45 @@ describe("ServerDetailModal", () => {
     mockListTools.mockResolvedValue({
       tools: [],
       toolsMetadata: {},
+    });
+  });
+
+  // Regression: local mode used to hand this modal the LOCAL project id (a
+  // `crypto.randomUUID()` value). `projectServerConfig:getConfig` validates
+  // `projectId` as `v.id("projects")`, so the query rejected during render
+  // and — with no route ErrorBoundary — replaced the entire page with the
+  // router error screen the moment you opened a server's Config.
+  it.each([
+    ["a local UUID project id", "d0b25b78-8daa-429e-b7cc-9af4716cbe84"],
+    ["a local_ placeholder project id", "local_pending"],
+    ["no project id", null],
+  ])("skips the project-server-config query for %s", (_label, projectId) => {
+    render(<ServerDetailModal {...defaultProps} projectId={projectId} />);
+
+    const configCalls = mockUseQuery.mock.calls.filter(
+      ([name]) => name === "projectServerConfig:getConfig"
+    );
+    expect(configCalls.length).toBeGreaterThan(0);
+    for (const [, args] of configCalls) {
+      expect(args).toBe("skip");
+    }
+  });
+
+  it("queries the project-server config for a real Convex project id", () => {
+    render(
+      <ServerDetailModal
+        {...defaultProps}
+        projectId="jh7abc123def456ghi789jk"
+        hostedServerId="server_123"
+      />
+    );
+
+    const configCalls = mockUseQuery.mock.calls.filter(
+      ([name]) => name === "projectServerConfig:getConfig"
+    );
+    expect(configCalls.length).toBeGreaterThan(0);
+    expect(configCalls.at(-1)?.[1]).toEqual({
+      projectId: "jh7abc123def456ghi789jk",
     });
   });
 
@@ -303,7 +342,7 @@ describe("ServerDetailModal", () => {
     installPointerCaptureMocks();
     mockUseFeatureFlagEnabled.mockReturnValue(true);
     mockUseQuery.mockReturnValue({
-      projectId: "project_123",
+      projectId: "jh7abc123def456ghi789jk",
       serverIds: [],
       overrides: {},
     });
@@ -311,7 +350,7 @@ describe("ServerDetailModal", () => {
     render(
       <ServerDetailModal
         {...defaultProps}
-        projectId="project_123"
+        projectId="jh7abc123def456ghi789jk"
         hostedServerId="server_123"
         hostDefaultMcpProtocolVersion="2026-07-28"
       />
@@ -331,7 +370,7 @@ describe("ServerDetailModal", () => {
 
     await waitFor(() => {
       expect(mockSetProjectServerConfig).toHaveBeenCalledWith({
-        projectId: "project_123",
+        projectId: "jh7abc123def456ghi789jk",
         input: {
           serverIds: ["server_123"],
           overrides: {
@@ -349,7 +388,7 @@ describe("ServerDetailModal", () => {
     installPointerCaptureMocks();
     mockUseFeatureFlagEnabled.mockReturnValue(true);
     let projectServerConfig = {
-      projectId: "project_123",
+      projectId: "jh7abc123def456ghi789jk",
       serverIds: [] as string[],
       overrides: {},
     };
@@ -358,7 +397,7 @@ describe("ServerDetailModal", () => {
     const renderModal = () => (
       <ServerDetailModal
         {...defaultProps}
-        projectId="project_123"
+        projectId="jh7abc123def456ghi789jk"
         hostedServerId="server_123"
         hostDefaultMcpProtocolVersion="2026-07-28"
       />
@@ -378,7 +417,7 @@ describe("ServerDetailModal", () => {
 
     await waitFor(() => {
       expect(mockSetProjectServerConfig).toHaveBeenCalledWith({
-        projectId: "project_123",
+        projectId: "jh7abc123def456ghi789jk",
         input: {
           serverIds: ["server_123"],
           overrides: {
@@ -397,7 +436,7 @@ describe("ServerDetailModal", () => {
     unmount();
 
     projectServerConfig = {
-      projectId: "project_123",
+      projectId: "jh7abc123def456ghi789jk",
       serverIds: ["server_123"],
       overrides: {
         server_123: {
@@ -422,7 +461,7 @@ describe("ServerDetailModal", () => {
 
     await waitFor(() => {
       expect(mockSetProjectServerConfig).toHaveBeenCalledWith({
-        projectId: "project_123",
+        projectId: "jh7abc123def456ghi789jk",
         input: {
           serverIds: [],
           overrides: {},
@@ -436,7 +475,7 @@ describe("ServerDetailModal", () => {
     installPointerCaptureMocks();
     mockUseFeatureFlagEnabled.mockReturnValue(true);
     mockUseQuery.mockReturnValue({
-      projectId: "project_123",
+      projectId: "jh7abc123def456ghi789jk",
       serverIds: ["server_123"],
       overrides: {
         server_123: {
@@ -448,7 +487,7 @@ describe("ServerDetailModal", () => {
     render(
       <ServerDetailModal
         {...defaultProps}
-        projectId="project_123"
+        projectId="jh7abc123def456ghi789jk"
         hostedServerId="server_123"
         hostDefaultMcpProtocolVersion="2026-07-28"
       />
@@ -467,7 +506,7 @@ describe("ServerDetailModal", () => {
 
     await waitFor(() => {
       expect(mockSetProjectServerConfig).toHaveBeenCalledWith({
-        projectId: "project_123",
+        projectId: "jh7abc123def456ghi789jk",
         input: {
           serverIds: ["server_123"],
           overrides: {},
@@ -773,7 +812,7 @@ describe("ServerDetailModal", () => {
       // Per-server wire pin (project-layer override) is 2026 while the host
       // default is unset — the override must win and bake the 2026 era.
       mockUseQuery.mockReturnValue({
-        projectId: "project_123",
+        projectId: "jh7abc123def456ghi789jk",
         serverIds: ["server_123"],
         overrides: {
           server_123: { mcpProtocolVersionOverride: "2026-07-28" },
@@ -785,7 +824,7 @@ describe("ServerDetailModal", () => {
           {...defaultProps}
           server={createServer({ authMethod: "auto" })}
           onSubmit={onSubmit}
-          projectId="project_123"
+          projectId="jh7abc123def456ghi789jk"
           hostedServerId="server_123"
         />
       );

--- a/mcpjam-inspector/client/src/components/connection/shared/AdvancedConnectionSettingsSection.tsx
+++ b/mcpjam-inspector/client/src/components/connection/shared/AdvancedConnectionSettingsSection.tsx
@@ -1,3 +1,4 @@
+import { useId } from "react";
 import { ChevronDown, ChevronRight, Plus, X } from "lucide-react";
 import { Input } from "@mcpjam/design-system/input";
 import { Switch } from "@mcpjam/design-system/switch";
@@ -136,6 +137,9 @@ export function AdvancedConnectionSettingsSection({
     if (opt.value === "rc" && !isHttp) return false;
     return true;
   });
+  // Per-instance so several of these forms can be mounted at once without
+  // colliding on a shared element id.
+  const bodyId = useId();
   const selectedDropdownValue: DropdownValue =
     mcpProtocolVersionOverride === "2026-07-28"
       ? "rc"
@@ -144,219 +148,259 @@ export function AdvancedConnectionSettingsSection({
       : "inherit";
 
   return (
-    <div className="space-y-0">
+    <div className="space-y-2">
       <button
         type="button"
         onClick={onToggle}
-        className="flex w-full cursor-pointer items-center gap-1.5 py-1 text-left text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+        aria-expanded={showConfiguration}
+        aria-controls={bodyId}
+        className="group flex cursor-pointer items-center gap-1.5 text-left"
       >
         {showConfiguration ? (
-          <ChevronDown className="h-3 w-3" />
+          <ChevronDown className="h-3.5 w-3.5 text-muted-foreground transition-colors group-hover:text-foreground" />
         ) : (
-          <ChevronRight className="h-3 w-3" />
+          <ChevronRight className="h-3.5 w-3.5 text-muted-foreground transition-colors group-hover:text-foreground" />
         )}
-        Connection overrides
+        <span className="text-sm font-medium text-foreground">
+          Connection overrides
+        </span>
       </button>
 
-      {showConfiguration && (
-        <div className="mt-2 space-y-3 border-l-2 border-border/60 pl-3">
-          {/* Timeout */}
-          <div className="space-y-1">
-            <label className="text-xs font-medium text-foreground">
-              Timeout{" "}
-              <span className="font-normal text-muted-foreground">
-                (ms, default {inheritedRequestTimeout})
-              </span>
-            </label>
-            <Input
-              type="number"
-              value={requestTimeout}
-              onChange={(e) => onRequestTimeoutChange(e.target.value)}
-              placeholder={String(inheritedRequestTimeout)}
-              className="h-8 text-xs"
-              min="1000"
-              max="600000"
-              step="1000"
-            />
-          </div>
-
-          {/* Headers */}
-          {showHeaderControls && (
+      {/* Always mounted so `aria-controls` resolves while collapsed. */}
+      <div id={bodyId}>
+        {showConfiguration && (
+          <div className="space-y-4">
+            {/* Timeout */}
             <div className="space-y-1.5">
-              <div className="flex items-center justify-between">
-                <label className="text-xs font-medium text-foreground">
-                  Headers
-                </label>
-                <button
-                  type="button"
-                  onClick={onAddHeader}
-                  disabled={headersHidden}
-                  className="flex items-center gap-1 text-[11px] text-muted-foreground transition-colors hover:text-foreground"
-                >
-                  <Plus className="h-3 w-3" />
-                  Add
-                </button>
-              </div>
-              {headersHidden && (
-                <div className="flex items-center justify-between gap-3 rounded border border-border bg-background px-3 py-2">
-                  <div>
-                    <p className="text-xs font-medium text-foreground">
-                      Hidden — Reveal to view
-                    </p>
-                    {headersRevealError && (
-                      <p role="alert" className="mt-1 text-xs text-destructive">
-                        {headersRevealError}
-                      </p>
-                    )}
-                  </div>
+              <label className="text-xs font-medium text-foreground">
+                Timeout{" "}
+                <span className="font-normal text-muted-foreground">
+                  (ms, default {inheritedRequestTimeout})
+                </span>
+              </label>
+              <Input
+                type="number"
+                value={requestTimeout}
+                onChange={(e) => onRequestTimeoutChange(e.target.value)}
+                placeholder={String(inheritedRequestTimeout)}
+                className="h-8 text-xs"
+                min="1000"
+                max="600000"
+                step="1000"
+              />
+            </div>
+
+            {/* Headers. Same row idiom as the env-var editor: monospace
+                key/value pair, muted separator, ghost remove. */}
+            {showHeaderControls && (
+              <div className="space-y-1.5">
+                <div className="flex items-center justify-between">
+                  <label className="text-xs font-medium text-foreground">
+                    Headers
+                  </label>
                   <button
                     type="button"
-                    disabled={isRevealingHeaders || !onRevealHeaders}
-                    onClick={onRevealHeaders}
-                    className="rounded border border-border px-2.5 py-1 text-xs text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+                    onClick={onAddHeader}
+                    disabled={headersHidden}
+                    className="flex items-center gap-1 rounded px-1.5 py-1 text-xs text-muted-foreground transition-colors hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
                   >
-                    {isRevealingHeaders ? "Revealing..." : "Reveal"}
+                    <Plus className="h-3.5 w-3.5" />
+                    Add
                   </button>
                 </div>
-              )}
-              {customHeaders.length > 0 && (
-                <div className="space-y-1">
-                  {customHeaders.map((header, index) => (
-                    <div
-                      key={header.id ?? `${header.key}-${index}`}
-                      className="flex items-center gap-1.5"
+                {headersHidden && (
+                  <div className="flex items-center justify-between gap-3 rounded-md border border-border bg-muted/30 px-3 py-2.5">
+                    <div>
+                      <p className="text-xs font-medium text-foreground">
+                        Hidden — Reveal to view
+                      </p>
+                      {headersRevealError && (
+                        <p
+                          role="alert"
+                          className="mt-1 text-xs text-destructive"
+                        >
+                          {headersRevealError}
+                        </p>
+                      )}
+                    </div>
+                    <button
+                      type="button"
+                      disabled={isRevealingHeaders || !onRevealHeaders}
+                      onClick={onRevealHeaders}
+                      className="rounded border border-border bg-background px-2.5 py-1 text-xs text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
                     >
-                      <Input
-                        value={header.key}
-                        onChange={(e) =>
-                          onUpdateHeader(index, "key", e.target.value)
-                        }
-                        placeholder="Key"
-                        className="h-7 flex-1 text-xs"
-                      />
-                      <Input
-                        value={header.value}
-                        onChange={(e) =>
-                          onUpdateHeader(index, "value", e.target.value)
-                        }
-                        placeholder="Value"
-                        className="h-7 flex-1 text-xs"
-                      />
-                      <button
-                        type="button"
-                        onClick={() => onRemoveHeader(index)}
-                        className="flex h-7 w-7 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-                      >
-                        <X className="h-3 w-3" />
-                      </button>
-                    </div>
-                  ))}
-                </div>
-              )}
-              {headersWarning && (
-                <p role="alert" className="text-xs text-amber-700">
-                  {headersWarning}
-                </p>
-              )}
-            </div>
-          )}
-
-          {/* Client capabilities override */}
-          {showClientCapabilitiesControls && (
-            <div className="space-y-2">
-              <div className="flex items-center justify-between">
-                <label className="text-xs font-medium text-foreground">
-                  Capabilities override
-                </label>
-                <Switch
-                  checked={clientCapabilitiesOverrideEnabled}
-                  onCheckedChange={onClientCapabilitiesOverrideEnabledChange}
-                  aria-label="Toggle client capabilities override"
-                  className="scale-90"
-                />
-              </div>
-
-              {clientCapabilitiesOverrideEnabled && (
-                <>
-                  {clientCapabilitiesOverrideError && (
-                    <div className="rounded border border-destructive/30 bg-destructive/5 px-2.5 py-1.5 text-xs text-destructive">
-                      {clientCapabilitiesOverrideError}
-                    </div>
-                  )}
-                  <div className="overflow-hidden rounded border border-border bg-background">
-                    <JsonEditor
-                      rawContent={clientCapabilitiesOverrideText}
-                      onRawChange={onClientCapabilitiesOverrideTextChange}
-                      mode="edit"
-                      showModeToggle={false}
-                      showToolbar={false}
-                      className="h-[160px]"
-                      height="160px"
-                      wrapLongLinesInEdit={false}
-                      showLineNumbers
-                      showValidationErrorInStatusBar={false}
-                    />
+                      {isRevealingHeaders ? "Revealing..." : "Reveal"}
+                    </button>
                   </div>
-                </>
-              )}
-            </div>
-          )}
+                )}
+                {!headersHidden && customHeaders.length === 0 && (
+                  <button
+                    type="button"
+                    onClick={onAddHeader}
+                    className="flex w-full items-center justify-center gap-1.5 rounded-md border border-dashed border-border py-2.5 text-xs text-muted-foreground transition-colors hover:border-foreground/30 hover:bg-muted/40 hover:text-foreground"
+                  >
+                    <Plus className="h-3.5 w-3.5" />
+                    Add header
+                  </button>
+                )}
+                {customHeaders.length > 0 && (
+                  <div className="space-y-1.5">
+                    {customHeaders.map((header, index) => (
+                      <div
+                        key={header.id ?? `${header.key}-${index}`}
+                        className="flex items-center gap-1.5"
+                      >
+                        <Input
+                          value={header.key}
+                          onChange={(e) =>
+                            onUpdateHeader(index, "key", e.target.value)
+                          }
+                          placeholder="Header"
+                          spellCheck={false}
+                          autoCapitalize="off"
+                          autoCorrect="off"
+                          aria-label={`Header ${index + 1} name`}
+                          className="h-8 flex-1 font-mono text-xs"
+                        />
+                        <span
+                          aria-hidden="true"
+                          className="shrink-0 select-none text-xs text-muted-foreground/70"
+                        >
+                          :
+                        </span>
+                        <Input
+                          value={header.value}
+                          onChange={(e) =>
+                            onUpdateHeader(index, "value", e.target.value)
+                          }
+                          placeholder="value"
+                          spellCheck={false}
+                          autoCapitalize="off"
+                          autoCorrect="off"
+                          aria-label={`Header ${index + 1} value`}
+                          className="h-8 flex-[1.4] font-mono text-xs"
+                        />
+                        <button
+                          type="button"
+                          onClick={() => onRemoveHeader(index)}
+                          aria-label={
+                            header.key
+                              ? `Remove ${header.key}`
+                              : `Remove header ${index + 1}`
+                          }
+                          className="flex h-8 w-8 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-destructive"
+                        >
+                          <X className="h-3.5 w-3.5" />
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                )}
+                {headersWarning && (
+                  <p role="alert" className="text-xs text-amber-700">
+                    {headersWarning}
+                  </p>
+                )}
+              </div>
+            )}
 
-          {/* Per-server MCP protocol-version pin. Tri-state picker:
-              "Latest" → `"2025-11-25"` (legacy adapter + initialize
-              handshake); "2026 RC" → `"2026-07-28"` (stateless RC
-              preview client). The RC option is hidden on non-HTTP
-              transports because MCPJam's current stateless client
-              requires Streamable HTTP. */}
-          {showProtocolVersionControl && (
-            <div className="space-y-1.5">
-              <label
-                className="text-xs font-medium text-foreground"
-                title="Latest: the current stable MCP wire version (2025-11-25). 2026 RC: MCPJam's current 2026-07-28 stateless preview over Streamable HTTP POST."
-              >
-                Protocol version
-              </label>
-              <Select
-                value={selectedDropdownValue}
-                disabled={!canEditProtocolVersion}
-                onValueChange={(next) => {
-                  if (!onMcpProtocolVersionOverrideChange) return;
-                  onMcpProtocolVersionOverrideChange(
-                    next === "rc"
-                      ? "2026-07-28"
-                      : next === "latest"
-                      ? "2025-11-25"
-                      : undefined
-                  );
-                }}
-              >
-                <SelectTrigger className="h-9 w-full text-xs">
-                  <SelectValue placeholder="Latest" />
-                </SelectTrigger>
-                <SelectContent>
-                  {visibleOptions.map((opt) => (
-                    <SelectItem key={opt.value} value={opt.value}>
-                      {opt.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              {!isHttp && (
-                <p className="text-xs text-muted-foreground">
-                  MCPJam's current 2026 RC preview requires Streamable HTTP —
-                  only Latest is selectable for this transport.
-                </p>
-              )}
-              {!canEditProtocolVersion && (
-                <p className="text-xs text-muted-foreground">
-                  Project configuration must finish loading before setting a
-                  per-server protocol override.
-                </p>
-              )}
-            </div>
-          )}
-        </div>
-      )}
+            {/* Client capabilities override */}
+            {showClientCapabilitiesControls && (
+              <div className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <label className="text-xs font-medium text-foreground">
+                    Capabilities override
+                  </label>
+                  <Switch
+                    checked={clientCapabilitiesOverrideEnabled}
+                    onCheckedChange={onClientCapabilitiesOverrideEnabledChange}
+                    aria-label="Toggle client capabilities override"
+                    className="scale-90"
+                  />
+                </div>
+
+                {clientCapabilitiesOverrideEnabled && (
+                  <>
+                    {clientCapabilitiesOverrideError && (
+                      <div className="rounded border border-destructive/30 bg-destructive/5 px-2.5 py-1.5 text-xs text-destructive">
+                        {clientCapabilitiesOverrideError}
+                      </div>
+                    )}
+                    <div className="overflow-hidden rounded border border-border bg-background">
+                      <JsonEditor
+                        rawContent={clientCapabilitiesOverrideText}
+                        onRawChange={onClientCapabilitiesOverrideTextChange}
+                        mode="edit"
+                        showModeToggle={false}
+                        showToolbar={false}
+                        className="h-[160px]"
+                        height="160px"
+                        wrapLongLinesInEdit={false}
+                        showLineNumbers
+                        showValidationErrorInStatusBar={false}
+                      />
+                    </div>
+                  </>
+                )}
+              </div>
+            )}
+
+            {/* Per-server MCP protocol-version pin. Tri-state picker:
+                "Latest" → `"2025-11-25"` (legacy adapter + initialize
+                handshake); "2026 RC" → `"2026-07-28"` (stateless RC
+                preview client). The RC option is hidden on non-HTTP
+                transports because MCPJam's current stateless client
+                requires Streamable HTTP. */}
+            {showProtocolVersionControl && (
+              <div className="space-y-1.5">
+                <label
+                  className="text-xs font-medium text-foreground"
+                  title="Latest: the current stable MCP wire version (2025-11-25). 2026 RC: MCPJam's current 2026-07-28 stateless preview over Streamable HTTP POST."
+                >
+                  Protocol version
+                </label>
+                <Select
+                  value={selectedDropdownValue}
+                  disabled={!canEditProtocolVersion}
+                  onValueChange={(next) => {
+                    if (!onMcpProtocolVersionOverrideChange) return;
+                    onMcpProtocolVersionOverrideChange(
+                      next === "rc"
+                        ? "2026-07-28"
+                        : next === "latest"
+                        ? "2025-11-25"
+                        : undefined
+                    );
+                  }}
+                >
+                  <SelectTrigger className="h-8 w-full text-xs">
+                    <SelectValue placeholder="Latest" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {visibleOptions.map((opt) => (
+                      <SelectItem key={opt.value} value={opt.value}>
+                        {opt.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                {!isHttp && (
+                  <p className="text-xs text-muted-foreground">
+                    MCPJam's current 2026 RC preview requires Streamable HTTP —
+                    only Latest is selectable for this transport.
+                  </p>
+                )}
+                {!canEditProtocolVersion && (
+                  <p className="text-xs text-muted-foreground">
+                    Project configuration must finish loading before setting a
+                    per-server protocol override.
+                  </p>
+                )}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/mcpjam-inspector/client/src/components/connection/shared/AdvancedConnectionSettingsSection.tsx
+++ b/mcpjam-inspector/client/src/components/connection/shared/AdvancedConnectionSettingsSection.tsx
@@ -138,8 +138,12 @@ export function AdvancedConnectionSettingsSection({
     return true;
   });
   // Per-instance so several of these forms can be mounted at once without
-  // colliding on a shared element id.
+  // colliding on a shared element id. Suffixed for the controls whose visible
+  // label sits in a sibling element and so needs an explicit association.
   const bodyId = useId();
+  const timeoutFieldId = `${bodyId}-timeout`;
+  const protocolLabelId = `${bodyId}-protocol-label`;
+  const protocolTriggerId = `${bodyId}-protocol-trigger`;
   const selectedDropdownValue: DropdownValue =
     mcpProtocolVersionOverride === "2026-07-28"
       ? "rc"
@@ -172,13 +176,17 @@ export function AdvancedConnectionSettingsSection({
           <div className="space-y-4">
             {/* Timeout */}
             <div className="space-y-1.5">
-              <label className="text-xs font-medium text-foreground">
+              <label
+                htmlFor={timeoutFieldId}
+                className="text-xs font-medium text-foreground"
+              >
                 Timeout{" "}
                 <span className="font-normal text-muted-foreground">
                   (ms, default {inheritedRequestTimeout})
                 </span>
               </label>
               <Input
+                id={timeoutFieldId}
                 type="number"
                 value={requestTimeout}
                 onChange={(e) => onRequestTimeoutChange(e.target.value)}
@@ -354,6 +362,7 @@ export function AdvancedConnectionSettingsSection({
             {showProtocolVersionControl && (
               <div className="space-y-1.5">
                 <label
+                  id={protocolLabelId}
                   className="text-xs font-medium text-foreground"
                   title="Latest: the current stable MCP wire version (2025-11-25). 2026 RC: MCPJam's current 2026-07-28 stateless preview over Streamable HTTP POST."
                 >
@@ -373,7 +382,14 @@ export function AdvancedConnectionSettingsSection({
                     );
                   }}
                 >
-                  <SelectTrigger className="h-8 w-full text-xs">
+                  {/* Name from the visible label AND the trigger's own text, so
+                      the selected version is still announced — a bare
+                      `aria-label` would replace the value, not add to it. */}
+                  <SelectTrigger
+                    id={protocolTriggerId}
+                    aria-labelledby={`${protocolLabelId} ${protocolTriggerId}`}
+                    className="h-8 w-full text-xs"
+                  >
                     <SelectValue placeholder="Latest" />
                   </SelectTrigger>
                   <SelectContent>


### PR DESCRIPTION
Follow-up to #3410. That PR tidied the environment-variables editor; this one brings the rest of the **Config tab** (server detail modal, the panel you get after connecting a server) into the same idiom.

## The problem

The panel used three different treatments for what are peer sections:

| Section | Before |
|---|---|
| Server Name / Connection Type | `text-sm font-medium` label + field |
| Environment Variables | `text-sm font-medium` disclosure (from #3410) |
| Connection overrides | small muted `text-xs` disclosure + left rail |

Input heights laddered `h-10` → `h-9` → `h-8` → `h-7` going down the panel, so nothing lined up — most visibly Server Name sitting a step taller than the connection row directly beneath it.

## Changes

- **"Connection overrides" now matches the env-vars disclosure** — same chevron, same `text-sm font-medium` label — so the two disclosures read as peers. The left rail is gone; the type-size hierarchy carries the nesting, exactly as it does in the env-vars body.
- **A11y on that toggle**: it had no `aria-expanded` and no `aria-controls`. Both are wired now. The body div stays mounted while collapsed so `aria-controls` always resolves to a real element, and the id comes from `useId()` so two mounted forms can't collide — same fix as the review catch on #3410.
- **Headers rows now match the env-var rows**: monospace `h-8` inputs, muted separator, ghost remove button. They also had *no accessible names at all* — every field and remove button now carries an `aria-label`. Adds the dashed empty state the env editor already has.
- **Heights settled**: dropped the `h-10` override on Server Name (both here and in Add Server, which shares the look) so it lines up with the connection row; protocol select moved to `h-8` to sit with the timeout input.
- **A rule separates the two disclosures from the required fields above**, so they stop reading as more required fields.

## Before / after

**STDIO — the panel from the report**

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/olartgabo/inspector/screenshots/server-config-tab/mcpjam-inspector/shots/before-config-tab.png" width="420"> | <img src="https://raw.githubusercontent.com/olartgabo/inspector/screenshots/server-config-tab/mcpjam-inspector/shots/after-config-tab.png" width="420"> |

**HTTP — the Headers editor inside Connection overrides**

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/olartgabo/inspector/screenshots/server-config-tab/mcpjam-inspector/shots/before-http-headers.png" width="420"> | <img src="https://raw.githubusercontent.com/olartgabo/inspector/screenshots/server-config-tab/mcpjam-inspector/shots/after-http-headers.png" width="420"> |

**Dark mode, disclosures collapsed** — the two now read as a matched pair:

<img src="https://raw.githubusercontent.com/olartgabo/inspector/screenshots/server-config-tab/mcpjam-inspector/shots/after-dark-collapsed.png" width="420">

## Also in this PR: the Config modal crashed the whole page in local mode

Found while testing the above. Opening a server’s Config while signed out replaced the entire app with the React Router error screen:

```
[CONVEX Q(projectServerConfig:getConfig)] ArgumentValidationError:
Path: .projectId  Value: "d0b25b78-8daa-429e-b7cc-9af4716cbe84"  Validator: v.id("projects")
```

Pre-existing on `main`, unrelated to the styling — reproduces for any signed-out user.

**Root cause.** `ServersTab` derived the modal’s project id with a fallback:

```ts
const hostedProjectId = sharedProjectId ?? activeProjectId;   // <-- leak
```

A project never synced to Convex has no `sharedProjectId`, so this yields `activeProjectId` — a local `crypto.randomUUID()` value. The modal passes it straight into `projectServerConfig:getConfig`, whose arg is `v.id("projects")`.

Two things make it fatal rather than cosmetic: the modal’s guard was bare truthiness (`projectId ? { projectId } : "skip"`), and Convex surfaces the rejection by **throwing during render** — with no `errorElement` on any route in `router.tsx`, React Router’s default boundary unmounts the whole app. The same file already gets it right one line away: `AddServerModal` receives `sharedProjectId ?? null`, which is why *adding* a server never crashed.

**Fix.**

- `hostedProjectId` is now `sharedProjectId ?? null`. It has exactly one consumer (the modal’s `projectId` prop), so nothing else changes shape, and every downstream branch already handles null.
- The query is gated with `shouldQueryProjectId` — the helper `useClients`, `useViews`, `useChatboxes`, `useProjectEnvironments` and ~6 other project-scoped consumers already use. The `setConfig` write path and the `canEditMcpProtocolVersionOverride` gate read the same flag, so read gate, write gate and UI can’t diverge.

**On the test fixtures.** The existing tests passed `projectId="project_123"` as a stand-in for a Convex id — but `project_` is one of the prefixes `shouldQueryProjectId` classifies as *local*, so those fixtures were quietly wrong and would have made the protocol-override tests pass for the wrong reason. Switched to a Convex-shaped id. New coverage pins the bug: local UUID / `local_` placeholder / null all skip the query, a real Convex id still issues it. Each case fails against the old code.

## Notes

- The styling commit is presentation only — no behaviour, props, or persistence changed. The crash fix below is the one behavioural change.
- The diff looks larger than it is: wrapping the overrides body in the always-mounted `aria-controls` target reindented it. `git diff -w` is **+72 / −23**.
- **Still open (not in this PR):** the missing route-level `ErrorBoundary` is why one bad query arg can take down the app. `ErrorBoundary` exists in `client/src/components/ui/error-boundary.tsx` and is used on the OAuth/XAA/Evals/Swarms routes; the main routes in `router.tsx` have none.
- **Deliberately left alone:** the `Authentication` section still uses the bordered-card idiom (visible in the HTTP shots). It's a much larger component (OAuth / XAA / DCR) and restyling its container is its own change — happy to take it as a follow-up.

## Validation

- `tsc --noEmit -p client/tsconfig.typecheck.json` — clean.
- `vitest run` on `client/src/components/connection/__tests__/` + `ServersTab.test.tsx` — 180 passed / 13 files.
- Checked live in both transports, light and dark, expanded and collapsed. Verified `aria-controls` resolves to exactly one element and `aria-expanded` flips on toggle, including while collapsed.
- Reproduced the crash on `main` signed-out, then confirmed on this branch: modal opens, all four tabs (Config / Overview / Tools / Clients) render, zero page errors.
