### PR TITLE
fix(servers): stop the Config modal crashing the page in local mode

### DIFF
--- a/mcpjam-inspector/client/src/components/ServersTab.tsx
+++ b/mcpjam-inspector/client/src/components/ServersTab.tsx
@@ -1162,7 +1162,14 @@ export function ServersTab({
 
   const activeProject = projects[activeProjectId];
   const sharedProjectId = activeProject?.sharedProjectId;
-  const hostedProjectId = sharedProjectId ?? activeProjectId;
+  // Convex-only. Falling back to `activeProjectId` leaked a LOCAL project id
+  // (a `crypto.randomUUID()` value) into `ServerDetailModal`, which passes it
+  // straight to `projectServerConfig:getConfig` — a `v.id("projects")` arg.
+  // The rejection throws during render and, with no route ErrorBoundary,
+  // took down the whole page when opening a server's Config. Null here is
+  // what every other project-scoped Convex consumer expects for local mode,
+  // and matches `sharedProjectIdForHostScope` on the Add Server modal.
+  const hostedProjectId = sharedProjectId ?? null;
   const { serversRecord: sharedProjectServersRecord } = useRemoteProjectServers(
     {
       projectId: sharedProjectId ?? null,

--- a/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
@@ -49,6 +49,7 @@ import {
 import { EffectiveProtocolVersionChip } from "./shared/EffectiveProtocolVersionChip";
 import { fetchServerSecrets } from "@/lib/apis/server-secrets-api";
 import { useActiveMcpProfile } from "@/contexts/active-mcp-profile-context";
+import { shouldQueryProjectId } from "@/hooks/useProjects";
 
 export type ServerDetailTab =
   | "overview"
@@ -129,9 +130,15 @@ export function ServerDetailModal({
   // round-trip rather than a server-update. Read/write here so the
   // form control inside `EditServerFormContent` can stay a pure prop
   // consumer.
+  // Only a real Convex project id may reach this query — `getConfig` validates
+  // `projectId` as `v.id("projects")`, and a LOCAL id (UUID, or a `local_` /
+  // `project_` placeholder) makes it reject during render. Same guard every
+  // other project-scoped Convex consumer uses; callers in local mode should
+  // pass null, but this keeps a stray local id from taking down the page.
+  const canQueryProjectServerConfig = shouldQueryProjectId(projectId);
   const projectServerConfigDto = useQuery(
     "projectServerConfig:getConfig" as never,
-    projectId ? ({ projectId } as never) : "skip"
+    canQueryProjectServerConfig ? ({ projectId } as never) : "skip"
   ) as ProjectServerConfigDto | null | undefined;
   const setProjectServerConfigMutation = useMutation(
     "projectServerConfig:setConfig" as never
@@ -171,7 +178,9 @@ export function ServerDetailModal({
   const resolvedHostDefaultMcpProtocolVersion: McpProtocolVersion | undefined =
     hostDefaultMcpProtocolVersion ?? activeMcpProfile?.mcpProtocolVersion;
   const canEditMcpProtocolVersionOverride = Boolean(
-    projectId && serverId && projectServerConfigDto !== undefined
+    canQueryProjectServerConfig &&
+      serverId &&
+      projectServerConfigDto !== undefined
   );
   const protocolOverrideAutoEnrolledRef = useRef<
     Map<string, ProtocolOverrideAutoEnrollRecord>
@@ -208,7 +217,7 @@ export function ServerDetailModal({
   const handleMcpProtocolVersionOverrideChange = async (
     next: McpProtocolVersion | undefined
   ): Promise<void> => {
-    if (!projectId) {
+    if (!canQueryProjectServerConfig || !projectId) {
       toast.error(
         "Wire mode override requires a project context; cannot save without projectId."
       );

--- a/mcpjam-inspector/client/src/components/connection/__tests__/ServerDetailModal.hosted.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/ServerDetailModal.hosted.test.tsx
@@ -147,7 +147,7 @@ describe("ServerDetailModal hosted reconnect", () => {
           useOAuth: true,
         })}
         defaultTab="overview"
-        projectId="project_123"
+        projectId="jh7abc123def456ghi789jk"
         hostedServerId="server_123"
       />,
     );
@@ -164,7 +164,7 @@ describe("ServerDetailModal hosted reconnect", () => {
 
     await waitFor(() => {
       expect(mockFetchHostedOAuthTokens).toHaveBeenCalledWith({
-        projectId: "project_123",
+        projectId: "jh7abc123def456ghi789jk",
         serverId: "server_123",
       });
     });
@@ -200,7 +200,7 @@ describe("ServerDetailModal hosted reconnect", () => {
           useOAuth: true,
         })}
         defaultTab="overview"
-        projectId="project_123"
+        projectId="jh7abc123def456ghi789jk"
         hostedServerId="server_123"
       />,
     );

--- a/mcpjam-inspector/client/src/components/connection/__tests__/ServerDetailModal.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/ServerDetailModal.test.tsx
@@ -156,7 +156,7 @@ describe("ServerDetailModal", () => {
     mockUseFeatureFlagEnabled.mockReturnValue(false);
     mockUseQuery.mockReturnValue(undefined);
     mockSetProjectServerConfig.mockResolvedValue({
-      projectId: "project_123",
+      projectId: "jh7abc123def456ghi789jk",
       serverIds: [],
       overrides: {},
     });
@@ -165,6 +165,45 @@ describe("ServerDetailModal", () => {
     mockListTools.mockResolvedValue({
       tools: [],
       toolsMetadata: {},
+    });
+  });
+
+  // Regression: local mode used to hand this modal the LOCAL project id (a
+  // `crypto.randomUUID()` value). `projectServerConfig:getConfig` validates
+  // `projectId` as `v.id("projects")`, so the query rejected during render
+  // and — with no route ErrorBoundary — replaced the entire page with the
+  // router error screen the moment you opened a server's Config.
+  it.each([
+    ["a local UUID project id", "d0b25b78-8daa-429e-b7cc-9af4716cbe84"],
+    ["a local_ placeholder project id", "local_pending"],
+    ["no project id", null],
+  ])("skips the project-server-config query for %s", (_label, projectId) => {
+    render(<ServerDetailModal {...defaultProps} projectId={projectId} />);
+
+    const configCalls = mockUseQuery.mock.calls.filter(
+      ([name]) => name === "projectServerConfig:getConfig"
+    );
+    expect(configCalls.length).toBeGreaterThan(0);
+    for (const [, args] of configCalls) {
+      expect(args).toBe("skip");
+    }
+  });
+
+  it("queries the project-server config for a real Convex project id", () => {
+    render(
+      <ServerDetailModal
+        {...defaultProps}
+        projectId="jh7abc123def456ghi789jk"
+        hostedServerId="server_123"
+      />
+    );
+
+    const configCalls = mockUseQuery.mock.calls.filter(
+      ([name]) => name === "projectServerConfig:getConfig"
+    );
+    expect(configCalls.length).toBeGreaterThan(0);
+    expect(configCalls.at(-1)?.[1]).toEqual({
+      projectId: "jh7abc123def456ghi789jk",
     });
   });
 
@@ -303,7 +342,7 @@ describe("ServerDetailModal", () => {
     installPointerCaptureMocks();
     mockUseFeatureFlagEnabled.mockReturnValue(true);
     mockUseQuery.mockReturnValue({
-      projectId: "project_123",
+      projectId: "jh7abc123def456ghi789jk",
       serverIds: [],
       overrides: {},
     });
@@ -311,7 +350,7 @@ describe("ServerDetailModal", () => {
     render(
       <ServerDetailModal
         {...defaultProps}
-        projectId="project_123"
+        projectId="jh7abc123def456ghi789jk"
         hostedServerId="server_123"
         hostDefaultMcpProtocolVersion="2026-07-28"
       />
@@ -331,7 +370,7 @@ describe("ServerDetailModal", () => {
 
     await waitFor(() => {
       expect(mockSetProjectServerConfig).toHaveBeenCalledWith({
-        projectId: "project_123",
+        projectId: "jh7abc123def456ghi789jk",
         input: {
           serverIds: ["server_123"],
           overrides: {
@@ -349,7 +388,7 @@ describe("ServerDetailModal", () => {
     installPointerCaptureMocks();
     mockUseFeatureFlagEnabled.mockReturnValue(true);
     let projectServerConfig = {
-      projectId: "project_123",
+      projectId: "jh7abc123def456ghi789jk",
       serverIds: [] as string[],
       overrides: {},
     };
@@ -358,7 +397,7 @@ describe("ServerDetailModal", () => {
     const renderModal = () => (
       <ServerDetailModal
         {...defaultProps}
-        projectId="project_123"
+        projectId="jh7abc123def456ghi789jk"
         hostedServerId="server_123"
         hostDefaultMcpProtocolVersion="2026-07-28"
       />
@@ -378,7 +417,7 @@ describe("ServerDetailModal", () => {
 
     await waitFor(() => {
       expect(mockSetProjectServerConfig).toHaveBeenCalledWith({
-        projectId: "project_123",
+        projectId: "jh7abc123def456ghi789jk",
         input: {
           serverIds: ["server_123"],
           overrides: {
@@ -397,7 +436,7 @@ describe("ServerDetailModal", () => {
     unmount();
 
     projectServerConfig = {
-      projectId: "project_123",
+      projectId: "jh7abc123def456ghi789jk",
       serverIds: ["server_123"],
       overrides: {
         server_123: {
@@ -422,7 +461,7 @@ describe("ServerDetailModal", () => {
 
     await waitFor(() => {
       expect(mockSetProjectServerConfig).toHaveBeenCalledWith({
-        projectId: "project_123",
+        projectId: "jh7abc123def456ghi789jk",
         input: {
           serverIds: [],
           overrides: {},
@@ -436,7 +475,7 @@ describe("ServerDetailModal", () => {
     installPointerCaptureMocks();
     mockUseFeatureFlagEnabled.mockReturnValue(true);
     mockUseQuery.mockReturnValue({
-      projectId: "project_123",
+      projectId: "jh7abc123def456ghi789jk",
       serverIds: ["server_123"],
       overrides: {
         server_123: {
@@ -448,7 +487,7 @@ describe("ServerDetailModal", () => {
     render(
       <ServerDetailModal
         {...defaultProps}
-        projectId="project_123"
+        projectId="jh7abc123def456ghi789jk"
         hostedServerId="server_123"
         hostDefaultMcpProtocolVersion="2026-07-28"
       />
@@ -467,7 +506,7 @@ describe("ServerDetailModal", () => {
 
     await waitFor(() => {
       expect(mockSetProjectServerConfig).toHaveBeenCalledWith({
-        projectId: "project_123",
+        projectId: "jh7abc123def456ghi789jk",
         input: {
           serverIds: ["server_123"],
           overrides: {},
@@ -773,7 +812,7 @@ describe("ServerDetailModal", () => {
       // Per-server wire pin (project-layer override) is 2026 while the host
       // default is unset — the override must win and bake the 2026 era.
       mockUseQuery.mockReturnValue({
-        projectId: "project_123",
+        projectId: "jh7abc123def456ghi789jk",
         serverIds: ["server_123"],
         overrides: {
           server_123: { mcpProtocolVersionOverride: "2026-07-28" },
@@ -785,7 +824,7 @@ describe("ServerDetailModal", () => {
           {...defaultProps}
           server={createServer({ authMethod: "auto" })}
           onSubmit={onSubmit}
-          projectId="project_123"
+          projectId="jh7abc123def456ghi789jk"
           hostedServerId="server_123"
         />
       );


### PR DESCRIPTION
Opening a server's **Config** while signed out (local mode) replaces the entire app with the React Router error screen:

```
[CONVEX Q(projectServerConfig:getConfig)] ArgumentValidationError:
Value does not match validator. Path: .projectId
Value: "d0b25b78-8daa-429e-b7cc-9af4716cbe84"  Validator: v.id("projects")
```

Reproduces on `main` with no account: add any server → click it → whole page gone.

## Root cause

`ServersTab.tsx` derived the modal's project id with a fallback:

```ts
const hostedProjectId = sharedProjectId ?? activeProjectId;   // <-- leak
```

A project that was never synced to Convex has no `sharedProjectId`, so this yields `activeProjectId` — a local `crypto.randomUUID()` value (see `createLocalProjectId()`). `ServerDetailModal` passes that straight into `projectServerConfig:getConfig`, whose arg is `v.id("projects")`.

Two things make it fatal rather than cosmetic:

1. The modal's guard was bare truthiness — `projectId ? { projectId } : "skip"` — so a truthy-but-invalid id fires the query.
2. Convex surfaces the rejection by **throwing during render**, and there is no `errorElement` on any route (`router.tsx`) and no `ErrorBoundary` around `ServersRoute`. So React Router's default boundary catches it and unmounts the whole app instead of one panel.

Note the same file already gets this right one line away: `AddServerModal` receives `sharedProjectIdForHostScope` (`sharedProjectId ?? null`), which is why *adding* a server never crashed.

## Fix

- **`ServersTab.tsx`** — `hostedProjectId` is now `sharedProjectId ?? null`. It has exactly one consumer (the modal's `projectId` prop), so nothing else changes shape. In local mode the modal now gets `null`, which every downstream branch already handles: the query skips, History stays hidden, and the secrets-reveal path shows its existing "can only be revealed after saving" message.
- **`ServerDetailModal.tsx`** — the query is gated with `shouldQueryProjectId`, the helper `useClients`, `useViews`, `useChatboxes`, `useProjectEnvironments` and ~6 other project-scoped consumers already use. Defense in depth: a future caller passing a local id gets a skipped query instead of a downed page. The `setConfig` write path and the `canEditMcpProtocolVersionOverride` gate read the same flag, so the read gate, the write gate, and the UI can't disagree.

## On the test fixtures

The existing tests passed `projectId="project_123"` as a stand-in for a Convex id — but `project_` is one of the prefixes `shouldQueryProjectId` classifies as **local**, so those fixtures were quietly wrong. Left as-is they'd have made the protocol-override tests pass for the wrong reason (query skipped, control disabled). Switched to a Convex-shaped id so they mean what they say.

New coverage pins the actual bug:

- local UUID id → query skipped
- `local_` placeholder id → query skipped
- `null` id → query skipped
- real Convex id → query still issued with `{ projectId }`

Each fails against the old code.

## Validation

- `tsc --noEmit -p client/tsconfig.typecheck.json` — clean.
- `vitest run` on `ServerDetailModal.test.tsx` + `ServerDetailModal.hosted.test.tsx` — 28 passed; `ServersTab.test.tsx` — 37 passed.
- Reproduced the crash on `main` signed-out, then confirmed on this branch: modal opens, all four tabs (Config / Overview / Tools / Clients) render, zero page errors.

## Follow-up worth considering (not in this PR)

The missing route-level `ErrorBoundary` is the reason a single bad query arg can nuke the app. `ErrorBoundary` already exists in `client/src/components/ui/error-boundary.tsx` and is used on the OAuth/XAA routes, Evals and Swarms — the main routes in `router.tsx` have none. Wrapping them would contain the next one of these to a panel. Happy to do it separately.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an app crash when opening a server’s Config in local mode by preventing local project IDs from reaching Convex and skipping the query when no hosted project exists. The modal now opens reliably while signed out.

- **Bug Fixes**
  - `ServersTab.tsx`: set `hostedProjectId` to `sharedProjectId ?? null` to avoid leaking a local UUID into `projectServerConfig:getConfig`.
  - `ServerDetailModal.tsx`: gate reads/writes with `shouldQueryProjectId`; skip the query for local/placeholder/null IDs and enable it only for real Convex IDs. The UI and write path use the same flag.
  - Tests: switch fixtures to a Convex-shaped ID and add coverage for skipped queries with local UUIDs, `local_` placeholders, and `null`.

<sup>Written for commit 91c3b80f96d134c933474368ff603eb453082ec0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

