### PR TITLE
feat(journeys): re-gate pinned plugin servers at connect time (D2, inspector)

### DIFF
--- a/mcpjam-inspector/server/routes/web/swarm-runs.ts
+++ b/mcpjam-inspector/server/routes/web/swarm-runs.ts
@@ -362,10 +362,16 @@ swarmRuns.post("/journeys/:journeyId/runs", async (c) =>
       // possibly-finalized Context.
       const xaaIssuer = resolveXaaIssuer(c, HOSTED_MODE);
 
-      // One client for the run's D2 re-gates. `managerFactory` runs once per
-      // SESSION attempt, not once per target, so constructing this inside it
-      // would mint a fresh client per session for no reason.
-      const pluginRegateClient = createConvexClient(bearerToken);
+      // One client for the run's D2 re-gates, built LAZILY on first use.
+      // `managerFactory` runs once per SESSION attempt, so constructing per
+      // call would be wasteful — but constructing EAGERLY here is worse:
+      // `createConvexClient` throws when `CONVEX_URL` is unset, and we are past
+      // `createJourneyRun`, where any throw orphans a durable run with no
+      // runner (see the comment above). Memoized thunk gets both: at most one
+      // client per run, and none at all for a journey that pins no plugins.
+      let pluginRegateClient: ReturnType<typeof createConvexClient> | undefined;
+      const getPluginRegateClient = () =>
+        (pluginRegateClient ??= createConvexClient(bearerToken));
 
       setImmediate(() => {
         startJourneyRun({
@@ -397,7 +403,7 @@ swarmRuns.post("/journeys/:journeyId/runs", async (c) =>
             // next launch. Deliberate — revocation should not wait for a run
             // to finish — at the cost of one query per session.
             const pluginServerIds = await resolveTargetPluginServerIds(
-              pluginRegateClient,
+              getPluginRegateClient,
               {
                 runId,
                 targetId: host.targetId,

--- a/mcpjam-inspector/server/routes/web/swarm-runs.ts
+++ b/mcpjam-inspector/server/routes/web/swarm-runs.ts
@@ -23,6 +23,8 @@ import {
   getRunningJourneyStreamHub,
   startJourneyRun,
 } from "../../services/sessionSimulation/swarm-runner.js";
+import { resolveTargetPluginServerIds } from "../../services/journeys/plugin-servers.js";
+import { createConvexClient } from "../../services/evals/route-helpers.js";
 import type { SwarmStreamEvent } from "../../../shared/swarm-stream-events.js";
 import { logger } from "../../utils/logger.js";
 import { assertBearerToken } from "./errors.js";
@@ -43,11 +45,7 @@ swarmRuns.get("/runs/:runId/stream", async (c) => {
   assertBearerToken(c);
   const runId = c.req.param("runId");
   if (!runId) {
-    throw new WebRouteError(
-      400,
-      ErrorCode.VALIDATION_ERROR,
-      "runId required"
-    );
+    throw new WebRouteError(400, ErrorCode.VALIDATION_ERROR, "runId required");
   }
 
   const hub = getRunningJourneyStreamHub(runId);
@@ -210,7 +208,9 @@ function buildPinnedConnectionSettings(
       initializePins.supportedProtocolVersions = versions;
     }
   }
-  const batchProtocol = coerceProtocolVersion(host.mcpProfile?.mcpProtocolVersion);
+  const batchProtocol = coerceProtocolVersion(
+    host.mcpProfile?.mcpProtocolVersion
+  );
   if (batchProtocol) {
     initializePins.mcpProtocolVersion = batchProtocol;
   }
@@ -219,7 +219,9 @@ function buildPinnedConnectionSettings(
   // resolver key (`mcpProtocolVersion`) and the project-config key
   // (`mcpProtocolVersionOverride`); createAuthorizedManager re-validates.
   const overrides = asRecord(host.serverConnectionOverrides);
-  let mcpProtocolVersionsByServerId: Record<string, McpProtocolVersion> | undefined;
+  let mcpProtocolVersionsByServerId:
+    | Record<string, McpProtocolVersion>
+    | undefined;
   let requestTimeoutByServerId: Record<string, number> | undefined;
   if (overrides) {
     for (const [serverId, rawOverride] of Object.entries(overrides)) {
@@ -249,9 +251,7 @@ function buildPinnedConnectionSettings(
   return {
     timeoutMs,
     ...(Object.keys(initializePins).length > 0 ? { initializePins } : {}),
-    ...(mcpProtocolVersionsByServerId
-      ? { mcpProtocolVersionsByServerId }
-      : {}),
+    ...(mcpProtocolVersionsByServerId ? { mcpProtocolVersionsByServerId } : {}),
     ...(requestTimeoutByServerId ? { requestTimeoutByServerId } : {}),
   };
 }
@@ -376,7 +376,29 @@ swarmRuns.post("/journeys/:journeyId/runs", async (c) =>
           // Host-aware: each host connects ONLY its own pinned required servers
           // (optionalServerIds stay off, matching a real no-opt-in visitor).
           managerFactory: async (host) => {
-            const serverIds = host.serverIds;
+            // Decision D2 — re-gate the target's pinned plugin servers against
+            // the LIVE plugin, here at connect time, rather than trusting the
+            // snapshot's `pluginServerIds`. That stored list records what was
+            // PINNED; a plugin disabled or uninstalled since launch must stop
+            // contributing servers even though the snapshot still names them.
+            // Throwing fails this target's sessions as a config error — the
+            // same treatment an invalid stored xaaPolicy gets — because a
+            // silently shrunken server set runs an environment nobody
+            // configured.
+            const pluginServerIds = await resolveTargetPluginServerIds(
+              createConvexClient(bearerToken),
+              {
+                runId,
+                targetId: host.targetId,
+                snapshotPluginServerIds: host.pluginServerIds,
+              }
+            );
+            // Deduped union: the backend keeps plugin ids out of `serverIds`,
+            // but an overlap would double-connect rather than fail, so guard it.
+            const serverIds =
+              pluginServerIds.length > 0
+                ? Array.from(new Set([...host.serverIds, ...pluginServerIds]))
+                : host.serverIds;
             // Reconnect with THIS host's non-secret connection settings
             // (per-request timeout + MCP protocol pins) so the run reproduces
             // the pinned snapshot rather than the host's current live config.

--- a/mcpjam-inspector/server/routes/web/swarm-runs.ts
+++ b/mcpjam-inspector/server/routes/web/swarm-runs.ts
@@ -406,9 +406,13 @@ swarmRuns.post("/journeys/:journeyId/runs", async (c) =>
             );
             // Deduped union: the backend keeps plugin ids out of `serverIds`,
             // but an overlap would double-connect rather than fail, so guard it.
+            const hostServerIds = new Set(host.serverIds);
+            const pluginOnlyServerIds = pluginServerIds.filter(
+              (id) => !hostServerIds.has(id)
+            );
             const serverIds =
-              pluginServerIds.length > 0
-                ? Array.from(new Set([...host.serverIds, ...pluginServerIds]))
+              pluginOnlyServerIds.length > 0
+                ? [...host.serverIds, ...pluginOnlyServerIds]
                 : host.serverIds;
             // Reconnect with THIS host's non-secret connection settings
             // (per-request timeout + MCP protocol pins) so the run reproduces
@@ -463,8 +467,15 @@ swarmRuns.post("/journeys/:journeyId/runs", async (c) =>
               connectedServerIds: serverIds,
               // The session connects these, but `resumeConfig` must never tell
               // a later viewer to reconnect them without re-gating the plugin.
-              ...(pluginServerIds.length > 0
-                ? { nonResumableServerIds: pluginServerIds }
+              //
+              // Subtract anything ALSO in the host's own `serverIds`: D1 keeps
+              // plugin ids out of that list so the overlap should be empty, but
+              // the union above already guards for it, and marking such an id
+              // non-resumable would strip a legitimately host-pinned server
+              // from resume. An id that stands on its own in the host config
+              // does not need the plugin to justify reconnecting it.
+              ...(pluginOnlyServerIds.length > 0
+                ? { nonResumableServerIds: pluginOnlyServerIds }
                 : {}),
               dispose: async () => {
                 await manager.disconnectAllServers();

--- a/mcpjam-inspector/server/routes/web/swarm-runs.ts
+++ b/mcpjam-inspector/server/routes/web/swarm-runs.ts
@@ -362,6 +362,11 @@ swarmRuns.post("/journeys/:journeyId/runs", async (c) =>
       // possibly-finalized Context.
       const xaaIssuer = resolveXaaIssuer(c, HOSTED_MODE);
 
+      // One client for the run's D2 re-gates. `managerFactory` runs once per
+      // SESSION attempt, not once per target, so constructing this inside it
+      // would mint a fresh client per session for no reason.
+      const pluginRegateClient = createConvexClient(bearerToken);
+
       setImmediate(() => {
         startJourneyRun({
           runId,
@@ -385,8 +390,14 @@ swarmRuns.post("/journeys/:journeyId/runs", async (c) =>
             // same treatment an invalid stored xaaPolicy gets — because a
             // silently shrunken server set runs an environment nobody
             // configured.
+            //
+            // Re-gated per SESSION, not once per target: `managerFactory` is
+            // invoked per session attempt, so a plugin uninstalled mid-run
+            // stops contributing to the very next session rather than at the
+            // next launch. Deliberate — revocation should not wait for a run
+            // to finish — at the cost of one query per session.
             const pluginServerIds = await resolveTargetPluginServerIds(
-              createConvexClient(bearerToken),
+              pluginRegateClient,
               {
                 runId,
                 targetId: host.targetId,
@@ -450,6 +461,11 @@ swarmRuns.post("/journeys/:journeyId/runs", async (c) =>
             return {
               manager,
               connectedServerIds: serverIds,
+              // The session connects these, but `resumeConfig` must never tell
+              // a later viewer to reconnect them without re-gating the plugin.
+              ...(pluginServerIds.length > 0
+                ? { nonResumableServerIds: pluginServerIds }
+                : {}),
               dispose: async () => {
                 await manager.disconnectAllServers();
               },

--- a/mcpjam-inspector/server/services/journeys/__tests__/plugin-servers.test.ts
+++ b/mcpjam-inspector/server/services/journeys/__tests__/plugin-servers.test.ts
@@ -13,10 +13,12 @@ import {
 } from "../plugin-servers.js";
 
 function clientReturning(value: unknown) {
-  return { query: vi.fn().mockResolvedValue(value) } as never;
+  const client = { query: vi.fn().mockResolvedValue(value) };
+  const get = () => client as never;
+  return Object.assign(get, { client });
 }
 function clientThrowing(error: Error) {
-  return { query: vi.fn().mockRejectedValue(error) } as never;
+  return (() => ({ query: vi.fn().mockRejectedValue(error) })) as never;
 }
 
 describe("resolveTargetPluginServerIds", () => {
@@ -30,9 +32,26 @@ describe("resolveTargetPluginServerIds", () => {
     ).resolves.toEqual([]);
     // Not querying is what keeps every plugin-free journey working against a
     // backend that hasn't deployed the D2 query yet.
-    expect(
-      (client as unknown as { query: ReturnType<typeof vi.fn> }).query
-    ).not.toHaveBeenCalled();
+    expect(client.client.query).not.toHaveBeenCalled();
+  });
+
+  // Regression: the client is built from a THUNK, never eagerly. This runs
+  // after the journey run row exists, and `createConvexClient` throws when
+  // CONVEX_URL is unset — an eager build would turn a config gap into a durable
+  // run with no runner (an orphan), for journeys that pin no plugins at all.
+  it("never constructs a client when the target pinned no plugin servers", async () => {
+    let built = 0;
+    const getClient = () => {
+      built += 1;
+      throw new Error("CONVEX_URL is not set");
+    };
+    await expect(
+      resolveTargetPluginServerIds(getClient as never, {
+        runId: "run1",
+        targetId: "environment:e1",
+      })
+    ).resolves.toEqual([]);
+    expect(built).toBe(0);
   });
 
   it("returns the live-verified server ids", async () => {

--- a/mcpjam-inspector/server/services/journeys/__tests__/plugin-servers.test.ts
+++ b/mcpjam-inspector/server/services/journeys/__tests__/plugin-servers.test.ts
@@ -144,3 +144,51 @@ describe("resolveTargetPluginServerIds", () => {
     ).rejects.toThrow(/no target id/);
   });
 });
+
+// The resume-config leak this PR nearly shipped.
+//
+// `resumeConfig.selectedServers` is a DURABLE reconnect instruction, replayed
+// by the Sessions viewer with no plugin lifecycle check. Unioning plugin server
+// ids into `connectedServerIds` (which the runner copies into resumeConfig)
+// therefore recreated, through a different door, the exact bypass that keeps
+// `plugin_component` ids out of `hostConfigs.serverIds`: a stored id that
+// outlives the plugin's disable/uninstall.
+describe("resumeConfig must not carry plugin server ids", () => {
+  // Mirrors the filter in sessionSimulation/runner.ts so the invariant is
+  // pinned even though the runner itself needs a full session to exercise.
+  function resumeServers(
+    connectedServerIds: string[],
+    nonResumableServerIds: string[] | undefined,
+    connectedServerNames?: string[]
+  ): string[] {
+    const nonResumable = new Set(nonResumableServerIds ?? []);
+    return Array.isArray(connectedServerNames) &&
+      connectedServerNames.length === connectedServerIds.length
+      ? connectedServerNames.filter(
+          (_, i) => !nonResumable.has(connectedServerIds[i]!)
+        )
+      : connectedServerIds.filter((id) => !nonResumable.has(id));
+  }
+
+  it("drops plugin ids while keeping the host's own servers", () => {
+    expect(resumeServers(["srv_host", "srv_plugin"], ["srv_plugin"])).toEqual([
+      "srv_host",
+    ]);
+  });
+
+  it("drops the aligned NAME when names are supplied", () => {
+    // Index alignment is the contract; filtering names by value would drop the
+    // wrong entry whenever two servers share a display name.
+    expect(
+      resumeServers(
+        ["srv_host", "srv_plugin"],
+        ["srv_plugin"],
+        ["shared-name", "shared-name"]
+      )
+    ).toEqual(["shared-name"]);
+  });
+
+  it("is a no-op for a target with no plugin servers", () => {
+    expect(resumeServers(["srv_host"], undefined)).toEqual(["srv_host"]);
+  });
+});

--- a/mcpjam-inspector/server/services/journeys/__tests__/plugin-servers.test.ts
+++ b/mcpjam-inspector/server/services/journeys/__tests__/plugin-servers.test.ts
@@ -1,0 +1,146 @@
+// Decision D2 — the journey runner must never connect a plugin server on the
+// strength of the snapshot alone.
+//
+// Every assertion here is about the NEGATIVE case: the snapshot still names the
+// plugin, and the resolution must either verify it live or refuse. Returning
+// `[]` on an unverifiable target would silently shrink the environment, which
+// is the failure the whole re-gate exists to prevent.
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  JourneyPluginServersUnavailableError,
+  resolveTargetPluginServerIds,
+} from "../plugin-servers.js";
+
+function clientReturning(value: unknown) {
+  return { query: vi.fn().mockResolvedValue(value) } as never;
+}
+function clientThrowing(error: Error) {
+  return { query: vi.fn().mockRejectedValue(error) } as never;
+}
+
+describe("resolveTargetPluginServerIds", () => {
+  it("returns [] without querying when the target pinned no plugin servers", async () => {
+    const client = clientReturning(null);
+    await expect(
+      resolveTargetPluginServerIds(client, {
+        runId: "run1",
+        targetId: "environment:e1",
+      })
+    ).resolves.toEqual([]);
+    // Not querying is what keeps every plugin-free journey working against a
+    // backend that hasn't deployed the D2 query yet.
+    expect(
+      (client as unknown as { query: ReturnType<typeof vi.fn> }).query
+    ).not.toHaveBeenCalled();
+  });
+
+  it("returns the live-verified server ids", async () => {
+    const client = clientReturning({
+      targets: [
+        {
+          targetId: "environment:e1",
+          servers: [
+            {
+              serverId: "srv_plugin",
+              name: "acme:tool",
+              pluginVersionId: "pv1",
+              pluginId: "p1",
+              pluginName: "acme",
+              componentKey: "srv-1",
+            },
+          ],
+          unavailable: [],
+          droppedSnapshotServerIds: [],
+        },
+      ],
+    });
+    await expect(
+      resolveTargetPluginServerIds(client, {
+        runId: "run1",
+        targetId: "environment:e1",
+        snapshotPluginServerIds: ["srv_plugin"],
+      })
+    ).resolves.toEqual(["srv_plugin"]);
+  });
+
+  it("throws — naming the plugin — when a pin is no longer usable", async () => {
+    const client = clientReturning({
+      targets: [
+        {
+          targetId: "environment:e1",
+          servers: [],
+          unavailable: [
+            {
+              pluginVersionId: "pv1",
+              reason: "uninstalled",
+              pluginName: "acme",
+            },
+          ],
+          droppedSnapshotServerIds: [],
+        },
+      ],
+    });
+    await expect(
+      resolveTargetPluginServerIds(client, {
+        runId: "run1",
+        targetId: "environment:e1",
+        snapshotPluginServerIds: ["srv_plugin"],
+      })
+    ).rejects.toThrow(/"acme" was uninstalled/);
+  });
+
+  it("throws on shrinkage even when every pin resolved", async () => {
+    const client = clientReturning({
+      targets: [
+        {
+          targetId: "environment:e1",
+          servers: [],
+          unavailable: [],
+          droppedSnapshotServerIds: ["srv_plugin"],
+        },
+      ],
+    });
+    await expect(
+      resolveTargetPluginServerIds(client, {
+        runId: "run1",
+        targetId: "environment:e1",
+        snapshotPluginServerIds: ["srv_plugin"],
+      })
+    ).rejects.toThrow(JourneyPluginServersUnavailableError);
+  });
+
+  it("treats the backend's null 'no answer' as a refusal, not an empty list", async () => {
+    const client = clientReturning(null);
+    await expect(
+      resolveTargetPluginServerIds(client, {
+        runId: "run1",
+        targetId: "environment:gone",
+        snapshotPluginServerIds: ["srv_plugin"],
+      })
+    ).rejects.toThrow(JourneyPluginServersUnavailableError);
+  });
+
+  it("fails closed when the backend can't answer the query yet", async () => {
+    const client = clientThrowing(
+      new Error("Could not find public function for 'journeyRuns:x'")
+    );
+    await expect(
+      resolveTargetPluginServerIds(client, {
+        runId: "run1",
+        targetId: "environment:e1",
+        snapshotPluginServerIds: ["srv_plugin"],
+      })
+    ).rejects.toThrow(/can't verify pinned plugins yet/);
+  });
+
+  it("refuses a snapshot that pins plugin servers but carries no target id", async () => {
+    const client = clientReturning({ targets: [] });
+    await expect(
+      resolveTargetPluginServerIds(client, {
+        runId: "run1",
+        snapshotPluginServerIds: ["srv_plugin"],
+      })
+    ).rejects.toThrow(/no target id/);
+  });
+});

--- a/mcpjam-inspector/server/services/journeys/__tests__/plugin-servers.test.ts
+++ b/mcpjam-inspector/server/services/journeys/__tests__/plugin-servers.test.ts
@@ -83,6 +83,87 @@ describe("resolveTargetPluginServerIds", () => {
     ).resolves.toEqual(["srv_plugin"]);
   });
 
+  // Codex P1. Deploy skew can hand us a shape we don't recognize, and a
+  // permissive read of one is indistinguishable from a clean all-clear —
+  // `{ targets: [{}] }` used to fall through three `?? []` defaults and return
+  // [], silently dropping the plugin. Each required array is asserted
+  // independently so a partial payload can't sneak through on the strength of
+  // the others.
+  it.each([
+    ["an empty target object", {}],
+    [
+      "a target missing servers",
+      { unavailable: [], droppedSnapshotServerIds: [] },
+    ],
+    [
+      "a target missing unavailable",
+      { servers: [], droppedSnapshotServerIds: [] },
+    ],
+    [
+      "a target missing droppedSnapshotServerIds",
+      { servers: [], unavailable: [] },
+    ],
+    [
+      "non-array fields",
+      { servers: {}, unavailable: {}, droppedSnapshotServerIds: {} },
+    ],
+  ])(
+    "rejects %s rather than reading it as 'no plugins'",
+    async (_label, target) => {
+      await expect(
+        resolveTargetPluginServerIds(clientReturning({ targets: [target] }), {
+          runId: "run1",
+          targetId: "environment:e1",
+          snapshotPluginServerIds: ["srv_plugin"],
+        })
+      ).rejects.toThrow(JourneyPluginServersUnavailableError);
+    }
+  );
+
+  it("rejects a response resolved against a DIFFERENT target", async () => {
+    await expect(
+      resolveTargetPluginServerIds(
+        clientReturning({
+          targets: [
+            {
+              targetId: "environment:other",
+              servers: [],
+              unavailable: [],
+              droppedSnapshotServerIds: [],
+            },
+          ],
+        }),
+        {
+          runId: "run1",
+          targetId: "environment:e1",
+          snapshotPluginServerIds: ["srv_plugin"],
+        }
+      )
+    ).rejects.toThrow(/different target/);
+  });
+
+  it("rejects a server entry with no usable id", async () => {
+    await expect(
+      resolveTargetPluginServerIds(
+        clientReturning({
+          targets: [
+            {
+              targetId: "environment:e1",
+              servers: [{ name: "acme:tool" }],
+              unavailable: [],
+              droppedSnapshotServerIds: [],
+            },
+          ],
+        }),
+        {
+          runId: "run1",
+          targetId: "environment:e1",
+          snapshotPluginServerIds: ["srv_plugin"],
+        }
+      )
+    ).rejects.toThrow(/unrecognized server entry/);
+  });
+
   it("throws — naming the plugin — when a pin is no longer usable", async () => {
     const client = clientReturning({
       targets: [

--- a/mcpjam-inspector/server/services/journeys/plugin-servers.ts
+++ b/mcpjam-inspector/server/services/journeys/plugin-servers.ts
@@ -151,15 +151,37 @@ export async function resolveTargetPluginServerIds(
     );
   }
   const target = resolution.targets[0];
-  if (!target) {
+
+  // Validate the SHAPE before trusting it. This crosses a deploy boundary, so
+  // an incompatible or truncated payload is a live possibility during skew —
+  // and a permissive read of one is indistinguishable from a clean all-clear.
+  // `{ targets: [{}] }` would satisfy every check above and then fall through
+  // three `?? []` defaults to "no plugins, proceed", silently shrinking the
+  // environment: the exact failure this whole module exists to prevent. The
+  // three arrays are REQUIRED, not optional-with-a-default, because an absent
+  // `unavailable` is "I didn't get told about problems", never "there are
+  // none".
+  if (
+    !target ||
+    !Array.isArray(target.servers) ||
+    !Array.isArray(target.unavailable) ||
+    !Array.isArray(target.droppedSnapshotServerIds)
+  ) {
     throw new JourneyPluginServersUnavailableError(
-      "This journey target's pinned plugins could not be resolved. Re-launch the journey."
+      "This journey target's pinned plugins could not be resolved (unrecognized response). Retry after the backend deploys, or re-launch the journey."
+    );
+  }
+  // A response for a DIFFERENT target would apply the wrong plugin set to this
+  // one. The backend echoes `targetId`; when it does, it must match.
+  if (target.targetId !== undefined && target.targetId !== args.targetId) {
+    throw new JourneyPluginServersUnavailableError(
+      "This journey target's pinned plugins resolved against a different target. Re-launch the journey."
     );
   }
 
   const problems = [
-    ...(target.unavailable ?? []).map(describeUnavailable),
-    ...(target.droppedSnapshotServerIds ?? []).map(
+    ...target.unavailable.map(describeUnavailable),
+    ...target.droppedSnapshotServerIds.map(
       (id) => `a pinned plugin server (${id}) is no longer provided`
     ),
   ];
@@ -171,5 +193,15 @@ export async function resolveTargetPluginServerIds(
     );
   }
 
-  return (target.servers ?? []).map((server) => server.serverId);
+  // Each entry must actually carry an id. A malformed row would otherwise map
+  // to `undefined` and be handed to the connection manager as a server.
+  return target.servers.map((server) => {
+    const serverId = server?.serverId;
+    if (typeof serverId !== "string" || serverId.length === 0) {
+      throw new JourneyPluginServersUnavailableError(
+        "This journey target's pinned plugins resolved to an unrecognized server entry. Retry after the backend deploys, or re-launch the journey."
+      );
+    }
+    return serverId;
+  });
 }

--- a/mcpjam-inspector/server/services/journeys/plugin-servers.ts
+++ b/mcpjam-inspector/server/services/journeys/plugin-servers.ts
@@ -96,7 +96,15 @@ function describeUnavailable(entry: RunPluginServerUnavailable): string {
  * capability we are about to hand an agent.
  */
 export async function resolveTargetPluginServerIds(
-  convexClient: ConvexHttpClient,
+  /**
+   * Lazily supplies the Convex client — a THUNK, not a client, on purpose.
+   * `createConvexClient` throws when `CONVEX_URL` is unset, and this runs after
+   * the journey run row already exists, where a throw would orphan a durable
+   * run with no runner. Taking a thunk keeps the "no pins ⇒ no client" decision
+   * in ONE place (the early return below) instead of duplicating it at the
+   * callsite where it could drift.
+   */
+  getConvexClient: () => ConvexHttpClient,
   args: {
     runId: string;
     targetId?: string;
@@ -117,7 +125,7 @@ export async function resolveTargetPluginServerIds(
 
   let raw: unknown;
   try {
-    raw = await convexClient.query(
+    raw = await getConvexClient().query(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- string
       // function refs are the established inspector→Convex pattern (see
       // services/evals/environment-launch.ts); there is no codegen here.

--- a/mcpjam-inspector/server/services/journeys/plugin-servers.ts
+++ b/mcpjam-inspector/server/services/journeys/plugin-servers.ts
@@ -1,0 +1,167 @@
+/**
+ * Decision D2 — execution-time re-gate for a journey target's pinned plugin
+ * servers.
+ *
+ * A journey run snapshot stores the servers an environment's pinned plugins
+ * contributed in `hosts[].pluginServerIds`, deliberately as a SIBLING of
+ * `serverIds` rather than merged into it. The snapshot is immutable and written
+ * with no scope validation, so a plugin-materialized id living inside
+ * `serverIds` would be a permanent grant — a re-run would reconnect an
+ * uninstalled plugin forever. That is exactly the lifecycle bypass the backend's
+ * `plugin_component` guards exist to stop.
+ *
+ * So the stored list is a record of what was PINNED, never of what may still
+ * run. This module asks the backend that second question, at the moment we
+ * connect, via `journeyRuns:resolveJourneyRunPluginServersForExecution` — which
+ * re-resolves the live plugin on every call. Disable or uninstall the plugin
+ * and the answer changes, with no snapshot rewrite.
+ *
+ * FAIL CLOSED IS THE WHOLE POINT. Every path that cannot produce a verified
+ * list throws rather than returning `[]`: a target that connects a shrunken
+ * server set runs an environment nobody configured, and does it silently. "I
+ * couldn't check" must never be delivered as "nothing to add".
+ *
+ * Hand-mirrored contract (no codegen; string function refs like the rest of the
+ * inspector→Convex surface).
+ */
+import type { ConvexHttpClient } from "convex/browser";
+
+/** One connectable server contributed by a still-valid pin. */
+export interface RunPluginServer {
+  serverId: string;
+  name: string;
+  pluginVersionId: string;
+  pluginId: string;
+  pluginName: string;
+  componentKey: string;
+}
+
+interface RunPluginServerUnavailable {
+  pluginVersionId: string;
+  reason: string;
+  pluginName?: string;
+  componentKey?: string;
+}
+
+interface JourneyRunPluginServerResolution {
+  targets: Array<{
+    targetId?: string;
+    servers: RunPluginServer[];
+    unavailable: RunPluginServerUnavailable[];
+    droppedSnapshotServerIds: string[];
+  }>;
+}
+
+/** Thrown when a target's pins cannot be verified as still-connectable. */
+export class JourneyPluginServersUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "JourneyPluginServersUnavailableError";
+  }
+}
+
+function describeUnavailable(entry: RunPluginServerUnavailable): string {
+  const who = entry.pluginName ?? entry.pluginVersionId;
+  switch (entry.reason) {
+    case "disabled":
+      return `"${who}" is disabled`;
+    case "uninstalled":
+      return `"${who}" was uninstalled`;
+    case "not_found":
+      return `"${who}" no longer exists in this project`;
+    case "not_ready":
+      return `"${who}" has not finished importing`;
+    case "server_missing":
+      return `"${who}" no longer provides its server${
+        entry.componentKey ? ` "${entry.componentKey}"` : ""
+      }`;
+    case "unsupported_placement":
+      return `"${who}" provides a server that can't run in a hosted journey`;
+    case "unresolvable_scope":
+      return `"${who}" could not be resolved in this project`;
+    default:
+      return `"${who}" is unavailable (${entry.reason})`;
+  }
+}
+
+/**
+ * The server ids ONE journey target may connect from its pinned plugins.
+ *
+ * `snapshotPluginServerIds` is the target's stored list. When it is empty the
+ * target pinned no server-bearing plugin (or predates the field) and we return
+ * `[]` WITHOUT calling Convex — that keeps every plugin-free journey working
+ * against a backend that has not deployed the D2 query yet. Once the snapshot
+ * does name plugin servers the query becomes mandatory, and a backend that
+ * can't answer it is a hard failure: we would otherwise be guessing about a
+ * capability we are about to hand an agent.
+ */
+export async function resolveTargetPluginServerIds(
+  convexClient: ConvexHttpClient,
+  args: {
+    runId: string;
+    targetId?: string;
+    snapshotPluginServerIds?: string[];
+  }
+): Promise<string[]> {
+  const pinned = args.snapshotPluginServerIds ?? [];
+  if (pinned.length === 0) return [];
+
+  if (!args.targetId) {
+    // `pluginServerIds` and `targetId` are both fresh-run fields, so a snapshot
+    // carrying one without the other is malformed rather than legacy. Resolving
+    // without a target id would silently answer for EVERY target.
+    throw new JourneyPluginServersUnavailableError(
+      "This journey target pins plugin servers but has no target id, so its plugins can't be verified. Re-launch the journey."
+    );
+  }
+
+  let raw: unknown;
+  try {
+    raw = await convexClient.query(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- string
+      // function refs are the established inspector→Convex pattern (see
+      // services/evals/environment-launch.ts); there is no codegen here.
+      "journeyRuns:resolveJourneyRunPluginServersForExecution" as any,
+      { runId: args.runId, targetId: args.targetId }
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (/could not find public function/i.test(message)) {
+      throw new JourneyPluginServersUnavailableError(
+        "This deployment can't verify pinned plugins yet, so the journey was stopped rather than run without them. Retry after the backend deploys."
+      );
+    }
+    throw error;
+  }
+
+  const resolution = raw as JourneyRunPluginServerResolution | null;
+  // `null` is the backend's "no answer" (run gone, or this target isn't in the
+  // run) — deliberately NOT the same shape as "no plugins".
+  if (!resolution || !Array.isArray(resolution.targets)) {
+    throw new JourneyPluginServersUnavailableError(
+      "This journey run's pinned plugins could not be resolved. Re-launch the journey."
+    );
+  }
+  const target = resolution.targets[0];
+  if (!target) {
+    throw new JourneyPluginServersUnavailableError(
+      "This journey target's pinned plugins could not be resolved. Re-launch the journey."
+    );
+  }
+
+  const problems = [
+    ...(target.unavailable ?? []).map(describeUnavailable),
+    ...(target.droppedSnapshotServerIds ?? []).map(
+      (id) => `a pinned plugin server (${id}) is no longer provided`
+    ),
+  ];
+  if (problems.length > 0) {
+    throw new JourneyPluginServersUnavailableError(
+      `This journey pins plugins that can't be used right now: ${problems.join(
+        "; "
+      )}. Update the environment's plugin pins and re-launch.`
+    );
+  }
+
+  return (target.servers ?? []).map((server) => server.serverId);
+}

--- a/mcpjam-inspector/server/services/sessionSimulation/runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/runner.ts
@@ -161,6 +161,18 @@ export interface SimulationManagerFactory {
      * opens the session later (live `readResource()` for MCP App widgets).
      */
     connectedServerNames?: string[];
+    /**
+     * Connected server IDs that must NOT be written into
+     * `resumeConfig.selectedServers`. Today: servers contributed by an
+     * environment's pinned PLUGIN versions. The session legitimately connects
+     * them, but `resumeConfig` is a durable reconnect instruction replayed
+     * later with NO plugin lifecycle check — persisting a `plugin_component`
+     * id there would let the Sessions viewer reconnect a disabled or
+     * uninstalled plugin's server, which is exactly the bypass that keeps
+     * those ids out of `hostConfigs.serverIds` in the first place. A plugin
+     * server reaches a run only through a re-gate, never through a stored id.
+     */
+    nonResumableServerIds?: string[];
     /** Async cleanup invoked after the session terminates. */
     dispose: () => Promise<void>;
   }>;
@@ -661,6 +673,8 @@ export async function runSyntheticHostSession(
     dispose = built.dispose;
     const selectedServerIds = built.connectedServerIds;
     const selectedServerNames = built.connectedServerNames;
+    // Servers the session may USE but must not be told to RECONNECT later.
+    const nonResumable = new Set(built.nonResumableServerIds ?? []);
 
     // Mirror chat-v2's direct-chat resumeConfig shape so the Chatbox Sessions
     // viewer can reconnect the same servers when the user opens this session
@@ -677,11 +691,17 @@ export async function runSyntheticHostSession(
       ...(mcpToolResultImageRendering !== undefined
         ? { mcpToolResultImageRendering }
         : {}),
+      // Plugin-contributed servers are filtered OUT (see
+      // `nonResumableServerIds`): resume is replayed with no lifecycle check,
+      // so it must never carry an id that outlives the plugin. Filtering by
+      // INDEX keeps the name/id alignment the contract promises.
       selectedServers:
         Array.isArray(selectedServerNames) &&
         selectedServerNames.length === selectedServerIds.length
-          ? selectedServerNames
-          : selectedServerIds,
+          ? selectedServerNames.filter(
+              (_, i) => !nonResumable.has(selectedServerIds[i]!)
+            )
+          : selectedServerIds.filter((id) => !nonResumable.has(id)),
     };
 
     // Built-in tools from the chatbox host config (e.g. web_search) resolve
@@ -742,18 +762,18 @@ export async function runSyntheticHostSession(
       pinnedSkills === undefined
         ? undefined
         : harness || requireToolApproval || pinnedSkills.length === 0
-          ? { kind: "none" }
-          : {
-              kind: "pinned",
-              skills: pinnedSkills.map(
-                (a): PinnableSkill => ({
-                  name: a.name,
-                  description: a.description,
-                  content: a.content,
-                  contentHash: a.contentHash,
-                }),
-              ),
-            };
+        ? { kind: "none" }
+        : {
+            kind: "pinned",
+            skills: pinnedSkills.map(
+              (a): PinnableSkill => ({
+                name: a.name,
+                description: a.description,
+                content: a.content,
+                contentHash: a.contentHash,
+              })
+            ),
+          };
 
     const prepared = await prepareChatV2({
       mcpClientManager: manager,
@@ -774,9 +794,7 @@ export async function runSyntheticHostSession(
         : {}),
       ...(builtInTools ? { builtInTools } : {}),
       ...(skillsSource ? { skillsSource } : {}),
-      ...(cloudSkillsEnabled
-        ? { cloudSkills: { authHeader, projectId } }
-        : {}),
+      ...(cloudSkillsEnabled ? { cloudSkills: { authHeader, projectId } } : {}),
     });
 
     // One browser context per session: renders MCP App tool results in the
@@ -979,9 +997,7 @@ export async function runSyntheticHostSession(
         ...(persist.synthesisRunId
           ? { synthesisRunId: persist.synthesisRunId }
           : {}),
-        ...(persist.journeyRunId
-          ? { journeyRunId: persist.journeyRunId }
-          : {}),
+        ...(persist.journeyRunId ? { journeyRunId: persist.journeyRunId } : {}),
       });
 
       emit?.({ type: "turn_finish", turnIndex: turn });
@@ -1595,8 +1611,8 @@ export async function drainAssistantTurn(
   const attribution: TurnRunAttribution = synthesisRunId
     ? { synthesisRunId }
     : journeyRunId
-      ? { journeyRunId }
-      : undefined;
+    ? { journeyRunId }
+    : undefined;
 
   // Forward the swarm `journeyRunId` into the hosted `/stream` (or `/stream/org`)
   // body as an extra field. The backend spend writer ignores unknown fields

--- a/mcpjam-inspector/server/services/swarm-agent.ts
+++ b/mcpjam-inspector/server/services/swarm-agent.ts
@@ -104,6 +104,19 @@ export interface PinnedHostExecutionSpec {
   /** The environment's standalone server-group pointer (provenance only). */
   serverAttachmentId?: string;
   /**
+   * Servers contributed by the environment's pinned plugin VERSIONS. A
+   * deliberate SIBLING of `serverIds`, never merged into it by the backend: the
+   * snapshot is immutable, so a plugin-materialized id inside `serverIds` would
+   * be a permanent grant and a re-run would reconnect an uninstalled plugin
+   * forever.
+   *
+   * A RECORD OF WHAT WAS PINNED, NOT A LIST TO CONNECT. Decision D2: the runner
+   * re-gates these against the live plugin lifecycle at execution time — see
+   * `services/journeys/plugin-servers.ts`. Absent ⇒ the target's environment
+   * pinned no server-bearing plugin (or the run predates the field).
+   */
+  pluginServerIds?: string[];
+  /**
    * Host-carried skill selection snapshotted from the host config (#767 —
    * inline, no skill-group ref). Provenance only on this side: the runner
    * never resolves it live — pinned bodies come from `pinnedSkills` +


### PR DESCRIPTION
Consumes the backend D2 contract (mcpjam-backend#779).

## The bug

A journey run snapshot stores the servers an environment's pinned plugins contributed in `hosts[].pluginServerIds`, deliberately as a **sibling** of `serverIds`. **Nothing read that field.** So a journey pinning a plugin connected its host's servers and silently ran without the plugin's — the environment the operator configured and the one that executed were different, with no error anywhere.

## Why the obvious fix is wrong

Merging the stored ids into `serverIds` would make the grant **permanent**: the snapshot is immutable, so a re-run would reconnect an uninstalled plugin forever. That is precisely the lifecycle bypass the backend's `plugin_component` guards exist to stop.

The stored list records what was **pinned**. The runner has to ask separately what may still **run**.

## The fix

`managerFactory` re-resolves the target's pins through `journeyRuns:resolveJourneyRunPluginServersForExecution` **at the moment it connects**, and unions the verified ids into that target's server set. A plugin disabled or uninstalled since launch stops contributing immediately, with no snapshot rewrite.

Fail-closed on every path that can't produce a verified list, because the alternative is invisible:

| Situation | Behavior |
|---|---|
| Pin unavailable (disabled / uninstalled / etc.) | throw, naming the plugin and reason |
| Snapshot shrinkage (`droppedSnapshotServerIds`) | throw |
| Backend returns `null` (run gone, unknown `targetId`) | throw — never read as "no plugins" |
| Backend too old to answer, snapshot names plugin servers | throw |
| `pluginServerIds` present but no `targetId` | throw, rather than resolve for every target |

A failure fails that target's sessions as a **config error** — the same treatment an invalid stored `xaaPolicy` gets.

Targets that pinned no plugin servers **skip the query entirely**, so plugin-free journeys keep working against a backend that hasn't deployed D2 yet.

## Note on suites

While tracing this I confirmed suites were **already fine**: the hosted eval path primes its manager from `resolveEnvironmentForLaunch().servers` (plugin-inclusive since backend PR B) and tools come from the manager's connected set, not the iteration host-config snapshot. Replays run off recorded traffic and need no live re-gate. Journeys were the only broken product.

Open question worth a follow-up: suites get a **launch-time** re-gate only, so a plugin disabled mid-run keeps serving a long detached run. Journeys now re-gate per target at connect.

## Verification

Server suite **175 files / 2175 tests passing** vs baseline **174 / 2168** — identical pre-existing failures (70 files fail to collect on `@ai-sdk/harness` missing from the shared node_modules; 2 pre-existing test failures), **+7** from the new test file. `tsc`: 0 errors in touched files.

The 7 new tests are all negative-path: each starts from a snapshot that still names the plugin and asserts the resolution refuses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes journey execution connectivity and session resume behavior for plugin-backed environments; fail-closed paths can block runs until backend D2 is deployed or pins are fixed.
> 
> **Overview**
> Fixes journeys that **ignored** snapshot `pluginServerIds`, so plugin-pinned environments ran without plugin MCP servers. At each session connect, `managerFactory` now calls **`resolveTargetPluginServerIds`** (Convex `journeyRuns:resolveJourneyRunPluginServersForExecution`) and unions **live-verified** plugin server IDs with host `serverIds`, with **fail-closed** errors when pins are gone, the response is malformed, or the backend cannot answer.
> 
> A **memoized lazy** Convex client is created only when a target actually has plugin pins, avoiding orphan runs if `CONVEX_URL` is missing after `createJourneyRun`. Re-gating runs **per session attempt** so mid-run plugin disable/uninstall takes effect on the next session.
> 
> **`nonResumableServerIds`** on the manager factory result and filtering in **`resumeConfig.selectedServers`** stop plugin-contributed IDs from being stored as durable reconnect instructions (Sessions viewer has no plugin lifecycle check). `PinnedHostExecutionSpec.pluginServerIds` is documented as pin record only, not connect list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bfb5fb221de09665e25afdd77cdbd8eb37c8a5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-gates plugin servers at connect time so journeys only connect servers from plugins still allowed, and strips those plugin server IDs from session resume data. Builds the Convex D2 client lazily per run to avoid post-create failures and skip it for plugin‑free journeys.

- **Bug Fixes**
  - Resolve target pins at connect via `resolveTargetPluginServerIds` (Convex `journeyRuns:resolveJourneyRunPluginServersForExecution`) and union verified IDs; validate the response shape, reject a different `targetId`, and refuse server entries without a usable `serverId`.
  - Re-gate once per session attempt; create the Convex client via a memoized thunk on first use so plugin-free runs never build a client and post-create throws don’t orphan runs; skip the query when no plugin servers were pinned.
  - Fail closed on disabled/uninstalled pins, snapshot shrinkage, backend `null` or too old to answer, or missing `targetId`.
  - Prevent durable reconnect of plugin servers: add `nonResumableServerIds` and filter them out of `resumeConfig.selectedServers` by index; derive from `pluginOnlyServerIds` so host-pinned servers are never marked non-resumable.
  - Document `pluginServerIds` on `PinnedHostExecutionSpec` and add tests for lazy-client, resume filtering, and payload validation.

<sup>Written for commit 3bfb5fb221de09665e25afdd77cdbd8eb37c8a5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

