### PR TITLE
feat(plugins): MCP JSON compatibility and plugin client API (INS-1)

### DIFF
--- a/mcpjam-inspector/client/src/hooks/usePluginImportApi.ts
+++ b/mcpjam-inspector/client/src/hooks/usePluginImportApi.ts
@@ -1,0 +1,301 @@
+/**
+ * Typed client for the backend plugin import API (PR INS-1 of
+ * docs/plans/openai-plugin-import-cross-repo.md).
+ *
+ * Follows the repo's Convex convention: string function references through
+ * `convex/react` hooks with hand-mirrored result types (two-repo layout — see
+ * `client/src/lib/plugins/plugin-api-types.ts` for the mirrored contracts).
+ *
+ * Everything here is flag-gated behind `plugins-enabled` (fail-closed):
+ * query hooks resolve to `undefined` (skipped) and the imperative actions
+ * throw `PluginApiError("PLUGINS_DISABLED")` while the flag is off or still
+ * loading. The backend does not read the flag — project-admin authorization
+ * is the security boundary; this gate is a rollout control.
+ *
+ * Import flow (backend state machine: uploaded → inspecting → preview_ready
+ * → committing → completed, any non-terminal → failed):
+ *
+ *   const actions = usePluginImportActions();
+ *   const { importId } = await actions.startImport({ projectId, bundle });
+ *   const row = usePluginImport(importId);       // reactive subscription
+ *   // row.status === "preview_ready" → show row.preview, then:
+ *   await actions.commitImport(importId, { setActive: true });
+ */
+
+import { useCallback, useMemo } from "react";
+import { useAction, useMutation, useQuery } from "convex/react";
+import {
+  toPluginApiError,
+  uploadPluginBundleToUrl,
+} from "@/lib/plugins/plugin-api";
+import {
+  PluginApiError,
+  type PluginCommitResult,
+  type PluginDetail,
+  type PluginImportRow,
+  type PluginInspectResult,
+  type PluginRuntimePreview,
+  type PluginSetupStatus,
+  type PluginSummary,
+  type PluginVersionDetail,
+} from "@/lib/plugins/plugin-api-types";
+import { usePluginsEnabled } from "./usePluginsEnabled";
+
+// ---------------------------------------------------------------------------
+// Query hooks (reactive Convex subscriptions — the "polling" of the plan's
+// import-progress requirement is a live subscription, not an interval).
+// All skip while `plugins-enabled` is off/loading or arguments are absent.
+// ---------------------------------------------------------------------------
+
+/**
+ * Subscribe to an import row's progress (`plugins.getPluginImport`).
+ * `undefined` while skipped or loading; re-renders on every status
+ * transition, including the terminal `completed` / `failed` states with
+ * their `preview` / structured `failure`.
+ */
+export function usePluginImport(
+  importId: string | null | undefined,
+): PluginImportRow | undefined {
+  const enabled = usePluginsEnabled();
+  return useQuery(
+    "plugins:getPluginImport" as any,
+    enabled && importId ? ({ importId } as any) : "skip",
+  ) as PluginImportRow | undefined;
+}
+
+/** Live (non-uninstalled) plugins in a project (`plugins.listProjectPlugins`). */
+export function useProjectPlugins(
+  projectId: string | null | undefined,
+): PluginSummary[] | undefined {
+  const enabled = usePluginsEnabled();
+  return useQuery(
+    "plugins:listProjectPlugins" as any,
+    enabled && projectId ? ({ projectId } as any) : "skip",
+  ) as PluginSummary[] | undefined;
+}
+
+/** A plugin with its versions, newest first (`plugins.getProjectPlugin`). */
+export function useProjectPlugin(
+  pluginId: string | null | undefined,
+): PluginDetail | undefined {
+  const enabled = usePluginsEnabled();
+  return useQuery(
+    "plugins:getProjectPlugin" as any,
+    enabled && pluginId ? ({ pluginId } as any) : "skip",
+  ) as PluginDetail | undefined;
+}
+
+/** A version with its component projections (`plugins.getPluginVersion`). */
+export function usePluginVersion(
+  pluginVersionId: string | null | undefined,
+): PluginVersionDetail | undefined {
+  const enabled = usePluginsEnabled();
+  return useQuery(
+    "plugins:getPluginVersion" as any,
+    enabled && pluginVersionId ? ({ pluginVersionId } as any) : "skip",
+  ) as PluginVersionDetail | undefined;
+}
+
+/** Per-version component readiness (`plugins.getPluginSetupStatus`). */
+export function usePluginSetupStatus(
+  pluginVersionId: string | null | undefined,
+): PluginSetupStatus | undefined {
+  const enabled = usePluginsEnabled();
+  return useQuery(
+    "plugins:getPluginSetupStatus" as any,
+    enabled && pluginVersionId ? ({ pluginVersionId } as any) : "skip",
+  ) as PluginSetupStatus | undefined;
+}
+
+/**
+ * Runtime resolution probe for exact version pins
+ * (`plugins.resolvePluginRuntimePreview`). Never falls back from a missing
+ * version to the plugin's active version; unavailable pins come back with
+ * explicit reasons.
+ */
+export function usePluginRuntimePreview(
+  projectId: string | null | undefined,
+  pluginVersionIds: string[] | null | undefined,
+): PluginRuntimePreview | undefined {
+  const enabled = usePluginsEnabled();
+  return useQuery(
+    "plugins:resolvePluginRuntimePreview" as any,
+    enabled && projectId && pluginVersionIds
+      ? ({ projectId, pluginVersionIds } as any)
+      : "skip",
+  ) as PluginRuntimePreview | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Imperative actions.
+// ---------------------------------------------------------------------------
+
+export interface StartPluginImportArgs {
+  projectId: string;
+  /** The bundle ZIP (from `buildPluginZip` or a user-picked .zip file). */
+  bundle: Blob | Uint8Array;
+  /**
+   * Display label for the source. The backend strips any path component and
+   * caps length, so passing a file/folder name is safe.
+   */
+  sourceLabel?: string;
+}
+
+export interface StartPluginImportResult {
+  importId: string;
+  /** Result of the inspect action (`preview_ready` or `failed`). */
+  inspect: PluginInspectResult;
+}
+
+export interface PluginImportActions {
+  /** Mint a storage upload URL (`plugins.generateBundleUploadUrl`). */
+  generateBundleUploadUrl: (projectId: string) => Promise<string>;
+  /** Stage an uploaded bundle blob as an import (`plugins.createImport`). */
+  createImport: (args: {
+    projectId: string;
+    bundleStorageId: string;
+    sourceLabel?: string;
+  }) => Promise<{ importId: string }>;
+  /** Run the Node inspect action (`pluginsNode.inspectImport`). */
+  inspectImport: (importId: string) => Promise<PluginInspectResult>;
+  /** Commit a preview-ready import (`pluginsNode.commitImport`). */
+  commitImport: (
+    importId: string,
+    options?: { setActive?: boolean },
+  ) => Promise<PluginCommitResult>;
+  /**
+   * Full upload path: mint URL → POST the ZIP to storage → `createImport` →
+   * `inspectImport`. Resolves once inspection lands `preview_ready` (or
+   * `failed` — inspect failures are recorded on the row, not thrown).
+   * Subscribe with `usePluginImport(importId)` for live progress.
+   */
+  startImport: (
+    args: StartPluginImportArgs,
+  ) => Promise<StartPluginImportResult>;
+}
+
+/**
+ * Guarded imperative wrappers around the plugin import mutations/actions.
+ * Every call rejects with `PluginApiError("PLUGINS_DISABLED")` while the
+ * `plugins-enabled` flag is off or unresolved (fail-closed), and maps Convex
+ * rejections to structured `PluginApiError`s (stable codes, RATE_LIMITED
+ * scope/retryAfter).
+ */
+export function usePluginImportActions(): PluginImportActions {
+  const enabled = usePluginsEnabled();
+  const generateUploadUrlMutation = useMutation(
+    "plugins:generateBundleUploadUrl" as any,
+  );
+  const createImportMutation = useMutation("plugins:createImport" as any);
+  const inspectImportAction = useAction("pluginsNode:inspectImport" as any);
+  const commitImportAction = useAction("pluginsNode:commitImport" as any);
+
+  const requireEnabled = useCallback(() => {
+    if (!enabled) {
+      throw new PluginApiError(
+        "PLUGINS_DISABLED",
+        "Plugin import is not enabled for this account.",
+      );
+    }
+  }, [enabled]);
+
+  const generateBundleUploadUrl = useCallback(
+    async (projectId: string): Promise<string> => {
+      requireEnabled();
+      try {
+        return (await generateUploadUrlMutation({
+          projectId,
+        } as any)) as string;
+      } catch (err) {
+        throw toPluginApiError(err, "Could not create an upload URL");
+      }
+    },
+    [requireEnabled, generateUploadUrlMutation],
+  );
+
+  const createImport = useCallback(
+    async (args: {
+      projectId: string;
+      bundleStorageId: string;
+      sourceLabel?: string;
+    }): Promise<{ importId: string }> => {
+      requireEnabled();
+      try {
+        return (await createImportMutation(args as any)) as {
+          importId: string;
+        };
+      } catch (err) {
+        throw toPluginApiError(err, "Could not create the plugin import");
+      }
+    },
+    [requireEnabled, createImportMutation],
+  );
+
+  const inspectImport = useCallback(
+    async (importId: string): Promise<PluginInspectResult> => {
+      requireEnabled();
+      try {
+        return (await inspectImportAction({
+          importId,
+        } as any)) as PluginInspectResult;
+      } catch (err) {
+        throw toPluginApiError(err, "Could not inspect the plugin bundle");
+      }
+    },
+    [requireEnabled, inspectImportAction],
+  );
+
+  const commitImport = useCallback(
+    async (
+      importId: string,
+      options?: { setActive?: boolean },
+    ): Promise<PluginCommitResult> => {
+      requireEnabled();
+      try {
+        return (await commitImportAction({
+          importId,
+          ...(options ? { options } : {}),
+        } as any)) as PluginCommitResult;
+      } catch (err) {
+        throw toPluginApiError(err, "Could not install the plugin");
+      }
+    },
+    [requireEnabled, commitImportAction],
+  );
+
+  const startImport = useCallback(
+    async (args: StartPluginImportArgs): Promise<StartPluginImportResult> => {
+      requireEnabled();
+      const uploadUrl = await generateBundleUploadUrl(args.projectId);
+      const bundleStorageId = await uploadPluginBundleToUrl(
+        uploadUrl,
+        args.bundle,
+      );
+      const { importId } = await createImport({
+        projectId: args.projectId,
+        bundleStorageId,
+        sourceLabel: args.sourceLabel,
+      });
+      const inspect = await inspectImport(importId);
+      return { importId, inspect };
+    },
+    [requireEnabled, generateBundleUploadUrl, createImport, inspectImport],
+  );
+
+  return useMemo(
+    () => ({
+      generateBundleUploadUrl,
+      createImport,
+      inspectImport,
+      commitImport,
+      startImport,
+    }),
+    [
+      generateBundleUploadUrl,
+      createImport,
+      inspectImport,
+      commitImport,
+      startImport,
+    ],
+  );
+}

--- a/mcpjam-inspector/client/src/hooks/usePluginImportApi.ts
+++ b/mcpjam-inspector/client/src/hooks/usePluginImportApi.ts
@@ -23,11 +23,13 @@
  */
 
 import { useCallback, useMemo } from "react";
-import { useAction, useMutation, useQuery } from "convex/react";
+import { useAction, useConvexAuth, useMutation, useQuery } from "convex/react";
 import {
+  assertPluginBundleWithinCap,
   toPluginApiError,
   uploadPluginBundleToUrl,
 } from "@/lib/plugins/plugin-api";
+import { shouldQueryProjectId } from "./useProjects";
 import {
   PluginApiError,
   type PluginCommitResult,
@@ -44,8 +46,19 @@ import { usePluginsEnabled } from "./usePluginsEnabled";
 // ---------------------------------------------------------------------------
 // Query hooks (reactive Convex subscriptions — the "polling" of the plan's
 // import-progress requirement is a live subscription, not an interval).
-// All skip while `plugins-enabled` is off/loading or arguments are absent.
+// All skip while `plugins-enabled` is off/loading, auth has not resolved, or
+// arguments are absent. Project-scoped hooks additionally gate on
+// `shouldQueryProjectId` (the useProjects/useChatboxes convention): a
+// transient LOCAL project id (UUID or `local_`/`project_` placeholder) is
+// truthy but would throw an ArgumentValidationError during hydration.
 // ---------------------------------------------------------------------------
+
+/** Shared gate: `plugins-enabled` (fail-closed) AND Convex auth resolved. */
+function usePluginQueriesReady(): boolean {
+  const enabled = usePluginsEnabled();
+  const { isAuthenticated } = useConvexAuth();
+  return enabled && isAuthenticated;
+}
 
 /**
  * Subscribe to an import row's progress (`plugins.getPluginImport`).
@@ -56,10 +69,10 @@ import { usePluginsEnabled } from "./usePluginsEnabled";
 export function usePluginImport(
   importId: string | null | undefined,
 ): PluginImportRow | undefined {
-  const enabled = usePluginsEnabled();
+  const ready = usePluginQueriesReady();
   return useQuery(
     "plugins:getPluginImport" as any,
-    enabled && importId ? ({ importId } as any) : "skip",
+    ready && importId ? ({ importId } as any) : "skip",
   ) as PluginImportRow | undefined;
 }
 
@@ -67,10 +80,10 @@ export function usePluginImport(
 export function useProjectPlugins(
   projectId: string | null | undefined,
 ): PluginSummary[] | undefined {
-  const enabled = usePluginsEnabled();
+  const ready = usePluginQueriesReady();
   return useQuery(
     "plugins:listProjectPlugins" as any,
-    enabled && projectId ? ({ projectId } as any) : "skip",
+    ready && shouldQueryProjectId(projectId) ? ({ projectId } as any) : "skip",
   ) as PluginSummary[] | undefined;
 }
 
@@ -78,10 +91,10 @@ export function useProjectPlugins(
 export function useProjectPlugin(
   pluginId: string | null | undefined,
 ): PluginDetail | undefined {
-  const enabled = usePluginsEnabled();
+  const ready = usePluginQueriesReady();
   return useQuery(
     "plugins:getProjectPlugin" as any,
-    enabled && pluginId ? ({ pluginId } as any) : "skip",
+    ready && pluginId ? ({ pluginId } as any) : "skip",
   ) as PluginDetail | undefined;
 }
 
@@ -89,10 +102,10 @@ export function useProjectPlugin(
 export function usePluginVersion(
   pluginVersionId: string | null | undefined,
 ): PluginVersionDetail | undefined {
-  const enabled = usePluginsEnabled();
+  const ready = usePluginQueriesReady();
   return useQuery(
     "plugins:getPluginVersion" as any,
-    enabled && pluginVersionId ? ({ pluginVersionId } as any) : "skip",
+    ready && pluginVersionId ? ({ pluginVersionId } as any) : "skip",
   ) as PluginVersionDetail | undefined;
 }
 
@@ -100,10 +113,10 @@ export function usePluginVersion(
 export function usePluginSetupStatus(
   pluginVersionId: string | null | undefined,
 ): PluginSetupStatus | undefined {
-  const enabled = usePluginsEnabled();
+  const ready = usePluginQueriesReady();
   return useQuery(
     "plugins:getPluginSetupStatus" as any,
-    enabled && pluginVersionId ? ({ pluginVersionId } as any) : "skip",
+    ready && pluginVersionId ? ({ pluginVersionId } as any) : "skip",
   ) as PluginSetupStatus | undefined;
 }
 
@@ -117,10 +130,10 @@ export function usePluginRuntimePreview(
   projectId: string | null | undefined,
   pluginVersionIds: string[] | null | undefined,
 ): PluginRuntimePreview | undefined {
-  const enabled = usePluginsEnabled();
+  const ready = usePluginQueriesReady();
   return useQuery(
     "plugins:resolvePluginRuntimePreview" as any,
-    enabled && projectId && pluginVersionIds
+    ready && shouldQueryProjectId(projectId) && pluginVersionIds
       ? ({ projectId, pluginVersionIds } as any)
       : "skip",
   ) as PluginRuntimePreview | undefined;
@@ -266,6 +279,10 @@ export function usePluginImportActions(): PluginImportActions {
   const startImport = useCallback(
     async (args: StartPluginImportArgs): Promise<StartPluginImportResult> => {
       requireEnabled();
+      // Size-check BEFORE minting: generateBundleUploadUrl is rate-limited,
+      // and an oversized bundle must not burn a token on a doomed upload.
+      // uploadPluginBundleToUrl re-checks as defense in depth.
+      assertPluginBundleWithinCap(args.bundle);
       const uploadUrl = await generateBundleUploadUrl(args.projectId);
       const bundleStorageId = await uploadPluginBundleToUrl(
         uploadUrl,

--- a/mcpjam-inspector/client/src/hooks/usePluginsEnabled.ts
+++ b/mcpjam-inspector/client/src/hooks/usePluginsEnabled.ts
@@ -1,0 +1,37 @@
+import { useFeatureFlagEnabled } from "posthog-js/react";
+
+/**
+ * PostHog rollout gate for the OpenAI plugin import surface (Connect
+ * "Add plugin" UI, plugin cards, attachment selectors, and the plugin
+ * import/query API hooks). Flag off ⇒ every plugin surface stays hidden and
+ * the client plugin API refuses to start imports, so rollout is per-user /
+ * percentage-based without a deploy.
+ *
+ * Fail-closed: `useFeatureFlagEnabled` returns `undefined` while flags load
+ * AND when the flag does not exist. Both are treated as "not enabled"
+ * (`=== true`), so plugin surfaces stay hidden until the flag is deliberately
+ * created and flipped on. Unlike `skills-enabled` (hosted-only), this gates
+ * BOTH hosted and local clients until GA — plugin import is a new surface,
+ * not an existing local behavior (see the plan's "PostHog implementation").
+ *
+ * The backend import/commit APIs are NOT flag-gated; project-admin
+ * authorization is the security boundary. The flag is a visibility/rollout
+ * control only.
+ */
+export const PLUGINS_FEATURE_FLAG = "plugins-enabled";
+
+/**
+ * Tri-state flag: `true` enabled, `false` explicitly disabled, `undefined`
+ * while PostHog is still loading (or the flag is absent). Route guards must
+ * distinguish "disabled" from "not resolved yet" so a direct cold load of a
+ * plugin URL does not redirect a flagged-in user before PostHog hydrates
+ * (mirrors `useSkillsEnabledState`). Visibility gates that only hide UI
+ * should use `usePluginsEnabled` instead.
+ */
+export function usePluginsEnabledState(): boolean | undefined {
+  return useFeatureFlagEnabled(PLUGINS_FEATURE_FLAG);
+}
+
+export function usePluginsEnabled(): boolean {
+  return usePluginsEnabledState() === true;
+}

--- a/mcpjam-inspector/client/src/lib/__tests__/json-config-parser.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/json-config-parser.test.ts
@@ -135,11 +135,12 @@ describe("parseJsonConfig", () => {
       );
     });
 
-    it("throws error when mcpServers is missing", () => {
+    it("treats an unknown wrapper key as a direct map and skips its invalid entry", () => {
+      // `{servers: {}}` used to throw ('missing "mcpServers"'); with direct-map
+      // support it is a map with one server named "servers" whose config has
+      // neither command nor url — skipped, yielding zero servers.
       const json = JSON.stringify({ servers: {} });
-      expect(() => parseJsonConfig(json)).toThrow(
-        'missing or invalid "mcpServers"',
-      );
+      expect(parseJsonConfig(json)).toEqual([]);
     });
 
     it("throws error when mcpServers is not an object", () => {
@@ -147,6 +148,21 @@ describe("parseJsonConfig", () => {
       expect(() => parseJsonConfig(json)).toThrow(
         'missing or invalid "mcpServers"',
       );
+    });
+
+    it("throws when both mcp_servers and mcpServers are declared", () => {
+      const json = JSON.stringify({
+        mcpServers: { a: { command: "node" } },
+        mcp_servers: { b: { command: "node" } },
+      });
+      expect(() => parseJsonConfig(json)).toThrow(
+        'both "mcp_servers" and "mcpServers"',
+      );
+    });
+
+    it("throws for a bare single server config", () => {
+      const json = JSON.stringify({ command: "node", args: ["server.js"] });
+      expect(() => parseJsonConfig(json)).toThrow("single server config");
     });
 
     it("skips servers with invalid config objects", () => {
@@ -171,6 +187,46 @@ describe("parseJsonConfig", () => {
 
       const result = parseJsonConfig(json);
       expect(result).toHaveLength(0);
+    });
+  });
+
+  describe("compatible wrapper shapes (SDK plugin-bundle parity)", () => {
+    const servers = {
+      "stdio-server": {
+        command: "node",
+        args: ["server.js"],
+        env: { API_KEY: "secret123" },
+      },
+      "http-server": { url: "https://example.com/mcp" },
+    };
+
+    it("imports mcpServers, mcp_servers, and direct maps identically", () => {
+      const fromCamel = parseJsonConfig(
+        JSON.stringify({ mcpServers: servers }),
+      );
+      const fromSnake = parseJsonConfig(
+        JSON.stringify({ mcp_servers: servers }),
+      );
+      const fromDirect = parseJsonConfig(JSON.stringify(servers));
+
+      expect(fromCamel).toHaveLength(2);
+      expect(fromSnake).toEqual(fromCamel);
+      expect(fromDirect).toEqual(fromCamel);
+    });
+
+    it("keeps env values byte-for-byte across shapes", () => {
+      const fromDirect = parseJsonConfig(JSON.stringify(servers));
+      const stdio = fromDirect.find((s) => s.name === "stdio-server");
+      expect(stdio?.env).toEqual({ API_KEY: "secret123" });
+    });
+
+    it("treats a direct map containing a server NAMED url as a map", () => {
+      // Only STRING command/url values indicate a bare single server; a
+      // server object under the key "url" is a legitimate direct-map entry.
+      const json = JSON.stringify({ url: { command: "node" } });
+      const result = parseJsonConfig(json);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({ name: "url", command: "node" });
     });
   });
 });
@@ -210,6 +266,24 @@ describe("validateJsonConfig", () => {
       const result = validateJsonConfig(json);
       expect(result.success).toBe(true);
     });
+
+    it("returns success for an mcp_servers wrapper (OpenAI shape)", () => {
+      const json = JSON.stringify({
+        mcp_servers: {
+          server: { command: "node" },
+        },
+      });
+
+      expect(validateJsonConfig(json)).toEqual({ success: true });
+    });
+
+    it("returns success for a direct server map", () => {
+      const json = JSON.stringify({
+        server: { command: "node" },
+      });
+
+      expect(validateJsonConfig(json)).toEqual({ success: true });
+    });
   });
 
   describe("invalid configs", () => {
@@ -219,10 +293,31 @@ describe("validateJsonConfig", () => {
       expect(result.error).toContain("Invalid JSON format");
     });
 
-    it("returns error when mcpServers is missing", () => {
+    it("returns error for an empty document (empty direct map)", () => {
+      // `{}` used to fail with 'Missing "mcpServers"'; with direct-map support
+      // it is an empty server map.
       const result = validateJsonConfig(JSON.stringify({}));
       expect(result.success).toBe(false);
-      expect(result.error).toContain('Missing or invalid "mcpServers"');
+      expect(result.error).toContain("No servers found");
+    });
+
+    it("returns error when both wrappers are declared", () => {
+      const result = validateJsonConfig(
+        JSON.stringify({
+          mcpServers: { a: { command: "node" } },
+          mcp_servers: { a: { command: "node" } },
+        }),
+      );
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('both "mcp_servers" and "mcpServers"');
+    });
+
+    it("returns error for a bare single server config", () => {
+      const result = validateJsonConfig(
+        JSON.stringify({ command: "node", args: [] }),
+      );
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("single server config");
     });
 
     it("returns error for empty mcpServers object", () => {

--- a/mcpjam-inspector/client/src/lib/json-config-parser.ts
+++ b/mcpjam-inspector/client/src/lib/json-config-parser.ts
@@ -14,6 +14,84 @@ export interface JsonConfig {
 }
 
 /**
+ * The wrapper shape a pasted/uploaded config used. Mirrors the MCP config
+ * normalization in `@mcpjam/sdk`'s plugin-bundle parser
+ * (sdk/src/plugin-bundle/mcp-config.ts, `normalizePluginMcpConfig`): a direct
+ * server map, an `mcp_servers` wrapper (OpenAI plugin docs), or an
+ * `mcpServers` wrapper (MCPJam/Claude style) all resolve to the same
+ * `Record<serverName, config>` through this one code path.
+ */
+export type JsonConfigShape = "direct" | "mcp_servers" | "mcpServers";
+
+export type ResolvedJsonServerMap =
+  | { ok: true; shape: JsonConfigShape; servers: Record<string, unknown> }
+  | { ok: false; error: string };
+
+/**
+ * Resolve a parsed JSON document to its server map. Single source of truth for
+ * the three compatible source shapes — `parseJsonConfig` and
+ * `validateJsonConfig` both go through here, so they can never disagree about
+ * which shapes are accepted.
+ *
+ * Shape-detection semantics intentionally mirror the SDK plugin-bundle parser
+ * (which the backend runs on imported plugin bundles):
+ * - declaring BOTH `mcp_servers` and `mcpServers` is an error;
+ * - a bare single server object (top-level string `command`/`url`) is
+ *   rejected — only string values indicate that shape, since a direct map may
+ *   legitimately contain a server NAMED "url" or "command" (object value);
+ * - anything else that is a plain object is treated as a direct server map.
+ */
+export function resolveJsonServerMap(config: unknown): ResolvedJsonServerMap {
+  if (config === null || typeof config !== "object" || Array.isArray(config)) {
+    return { ok: false, error: "Configuration must be a JSON object" };
+  }
+  const record = config as Record<string, unknown>;
+
+  const hasSnake = record.mcp_servers !== undefined;
+  const hasCamel = record.mcpServers !== undefined;
+  if (hasSnake && hasCamel) {
+    return {
+      ok: false,
+      error:
+        'Configuration declares both "mcp_servers" and "mcpServers"; use only one',
+    };
+  }
+
+  let shape: JsonConfigShape = "direct";
+  let serverMap: unknown = record;
+  if (hasSnake) {
+    shape = "mcp_servers";
+    serverMap = record.mcp_servers;
+  } else if (hasCamel) {
+    shape = "mcpServers";
+    serverMap = record.mcpServers;
+  } else if (
+    typeof record.command === "string" ||
+    typeof record.url === "string"
+  ) {
+    return {
+      ok: false,
+      error:
+        'Configuration looks like a single server config; wrap it in "mcpServers": { "server-name": { ... } }',
+    };
+  }
+
+  if (
+    serverMap === null ||
+    typeof serverMap !== "object" ||
+    Array.isArray(serverMap)
+  ) {
+    // Preserves the long-standing message for a malformed `mcpServers` value.
+    return {
+      ok: false,
+      error: `missing or invalid "${shape}" property`,
+    };
+  }
+
+  return { ok: true, shape, servers: serverMap as Record<string, unknown> };
+}
+
+/**
  * Formats ServerWithName objects to JSON config format
  * @param serversObj - Record of server names to ServerWithName objects
  * @returns JsonConfig object ready for export
@@ -53,29 +131,37 @@ export function formatJsonConfig(
 }
 
 /**
- * Parses a JSON config file and converts it to ServerFormData array
+ * Parses a JSON config file and converts it to ServerFormData array.
+ * Accepts a direct server map, an `mcp_servers` wrapper, or an `mcpServers`
+ * wrapper — all three resolve through `resolveJsonServerMap` and then share
+ * the same per-server mapping, so identical server configs import identically
+ * regardless of wrapper shape.
  * @param jsonContent - The JSON string content
  * @returns Array of ServerFormData objects
  */
 export function parseJsonConfig(jsonContent: string): ServerFormData[] {
   try {
-    const config: JsonConfig = JSON.parse(jsonContent);
+    const config: unknown = JSON.parse(jsonContent);
 
-    if (!config.mcpServers || typeof config.mcpServers !== "object") {
-      throw new Error(
-        'Invalid JSON config: missing or invalid "mcpServers" property',
-      );
+    const resolved = resolveJsonServerMap(config);
+    if (!resolved.ok) {
+      throw new Error(`Invalid JSON config: ${resolved.error}`);
     }
 
     const servers: ServerFormData[] = [];
 
-    for (const [serverName, serverConfig] of Object.entries(
-      config.mcpServers,
+    for (const [serverName, rawServerConfig] of Object.entries(
+      resolved.servers,
     )) {
-      if (!serverConfig || typeof serverConfig !== "object") {
+      if (
+        !rawServerConfig ||
+        typeof rawServerConfig !== "object" ||
+        Array.isArray(rawServerConfig)
+      ) {
         console.warn(`Skipping invalid server config for "${serverName}"`);
         continue;
       }
+      const serverConfig = rawServerConfig as JsonServerConfig;
 
       // Determine server type based on config
       if (serverConfig.type === "sse" || serverConfig.url) {
@@ -115,7 +201,8 @@ export function parseJsonConfig(jsonContent: string): ServerFormData[] {
 }
 
 /**
- * Validates a JSON config file without parsing it
+ * Validates a JSON config file without parsing it. Accepts the same three
+ * shapes as `parseJsonConfig` (shared `resolveJsonServerMap` code path).
  * @param jsonContent - The JSON string content
  * @returns Validation result with success status and error message
  */
@@ -124,28 +211,28 @@ export function validateJsonConfig(jsonContent: string): {
   error?: string;
 } {
   try {
-    const config = JSON.parse(jsonContent);
+    const config: unknown = JSON.parse(jsonContent);
 
-    if (!config.mcpServers || typeof config.mcpServers !== "object") {
-      return {
-        success: false,
-        error: 'Missing or invalid "mcpServers" property',
-      };
+    const resolved = resolveJsonServerMap(config);
+    if (!resolved.ok) {
+      return { success: false, error: resolved.error };
     }
 
-    const serverNames = Object.keys(config.mcpServers);
+    const serverNames = Object.keys(resolved.servers);
     if (serverNames.length === 0) {
       return {
         success: false,
-        error: 'No servers found in "mcpServers" object',
+        error: "No servers found in the configuration",
       };
     }
 
     // Validate each server config
-    for (const [serverName, serverConfig] of Object.entries(
-      config.mcpServers,
-    )) {
-      if (!serverConfig || typeof serverConfig !== "object") {
+    for (const [serverName, serverConfig] of Object.entries(resolved.servers)) {
+      if (
+        !serverConfig ||
+        typeof serverConfig !== "object" ||
+        Array.isArray(serverConfig)
+      ) {
         return {
           success: false,
           error: `Invalid server config for "${serverName}"`,

--- a/mcpjam-inspector/client/src/lib/json-config-parser.ts
+++ b/mcpjam-inspector/client/src/lib/json-config-parser.ts
@@ -92,6 +92,15 @@ export function resolveJsonServerMap(config: unknown): ResolvedJsonServerMap {
 }
 
 /**
+ * Shared per-entry guard: a server config must be a plain object (not null,
+ * not an array). Used by both `parseJsonConfig` and `validateJsonConfig` so
+ * the two paths cannot silently diverge.
+ */
+function isServerConfigRecord(value: unknown): value is JsonServerConfig {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
  * Formats ServerWithName objects to JSON config format
  * @param serversObj - Record of server names to ServerWithName objects
  * @returns JsonConfig object ready for export
@@ -153,15 +162,11 @@ export function parseJsonConfig(jsonContent: string): ServerFormData[] {
     for (const [serverName, rawServerConfig] of Object.entries(
       resolved.servers,
     )) {
-      if (
-        !rawServerConfig ||
-        typeof rawServerConfig !== "object" ||
-        Array.isArray(rawServerConfig)
-      ) {
+      if (!isServerConfigRecord(rawServerConfig)) {
         console.warn(`Skipping invalid server config for "${serverName}"`);
         continue;
       }
-      const serverConfig = rawServerConfig as JsonServerConfig;
+      const serverConfig = rawServerConfig;
 
       // Determine server type based on config
       if (serverConfig.type === "sse" || serverConfig.url) {
@@ -228,18 +233,14 @@ export function validateJsonConfig(jsonContent: string): {
 
     // Validate each server config
     for (const [serverName, serverConfig] of Object.entries(resolved.servers)) {
-      if (
-        !serverConfig ||
-        typeof serverConfig !== "object" ||
-        Array.isArray(serverConfig)
-      ) {
+      if (!isServerConfigRecord(serverConfig)) {
         return {
           success: false,
           error: `Invalid server config for "${serverName}"`,
         };
       }
 
-      const configObj = serverConfig as JsonServerConfig;
+      const configObj = serverConfig;
       const hasCommand =
         configObj.command && typeof configObj.command === "string";
       const hasUrl = configObj.url && typeof configObj.url === "string";

--- a/mcpjam-inspector/client/src/lib/plugins/__tests__/folder-bundle.test.ts
+++ b/mcpjam-inspector/client/src/lib/plugins/__tests__/folder-bundle.test.ts
@@ -156,4 +156,66 @@ describe("createMemoryPluginFileSource", () => {
       "no such bundle file",
     );
   });
+
+  it("enforces maxBytes (throws instead of returning oversized data)", async () => {
+    const source = createMemoryPluginFileSource([textFile("a.txt", "hello")]);
+    await expect(source.readBytes("a.txt", 4)).rejects.toThrow("read limit");
+  });
+});
+
+describe("zipToPluginFiles zip-bomb hardening", () => {
+  // Highly compressible payload: 64 KiB of zeros deflates to ~100 bytes, so
+  // a "bomb" fixture stays tiny on the compressed side while tripping the
+  // (overridden, small) uncompressed limits during extraction.
+  const compressible = (bytes: number): PluginBundleFile => ({
+    path: "big.bin",
+    bytes: new Uint8Array(bytes), // all zeros
+  });
+
+  it("rejects an entry whose uncompressed size exceeds maxFileBytes before inflating it", async () => {
+    const zip = await buildPluginZip([MANIFEST, compressible(64 * 1024)]);
+    await expect(
+      zipToPluginFiles(zip, { limits: { maxFileBytes: 16 * 1024 } }),
+    ).rejects.toMatchObject({
+      name: "PluginBundleError",
+      code: "FILE_TOO_LARGE",
+    });
+  });
+
+  it("rejects when cumulative uncompressed content exceeds maxTotalBytes", async () => {
+    const zip = await buildPluginZip([
+      MANIFEST,
+      { path: "a.bin", bytes: new Uint8Array(32 * 1024) },
+      { path: "b.bin", bytes: new Uint8Array(32 * 1024) },
+    ]);
+    await expect(
+      zipToPluginFiles(zip, {
+        limits: { maxFileBytes: 40 * 1024, maxTotalBytes: 48 * 1024 },
+      }),
+    ).rejects.toMatchObject({
+      name: "PluginBundleError",
+      code: "BUNDLE_TOO_LARGE",
+    });
+  });
+
+  it("rejects an archive with too many entries before reading any of them", async () => {
+    const many = Array.from({ length: 5 }, (_, i) =>
+      textFile(`file-${i}.txt`, String(i)),
+    );
+    const zip = await buildPluginZip(many);
+    await expect(
+      zipToPluginFiles(zip, { limits: { maxEntries: 4 } }),
+    ).rejects.toMatchObject({
+      name: "PluginBundleError",
+      code: "BUNDLE_TOO_MANY_ENTRIES",
+    });
+  });
+
+  it("extracts a compliant archive under the default limits", async () => {
+    const zip = await buildPluginZip([MANIFEST]);
+    const files = await zipToPluginFiles(zip);
+    expect(files.map((file) => file.path)).toEqual([
+      ".codex-plugin/plugin.json",
+    ]);
+  });
 });

--- a/mcpjam-inspector/client/src/lib/plugins/__tests__/folder-bundle.test.ts
+++ b/mcpjam-inspector/client/src/lib/plugins/__tests__/folder-bundle.test.ts
@@ -218,4 +218,131 @@ describe("zipToPluginFiles zip-bomb hardening", () => {
       ".codex-plugin/plugin.json",
     ]);
   });
+
+  /**
+   * Overwrite the uncompressed-size field of `fileName`'s central-directory
+   * header (PK\x01\x02, size at offset 24, name at offset 46) so the archive
+   * LIES about how big the entry inflates to.
+   */
+  function forgeDeclaredSize(
+    zipBytes: Uint8Array,
+    fileName: string,
+    forgedSize: number,
+  ): Uint8Array {
+    const out = new Uint8Array(zipBytes);
+    const view = new DataView(out.buffer);
+    const nameBytes = encoder.encode(fileName);
+    for (let i = 0; i + 46 <= out.length; i++) {
+      if (
+        out[i] === 0x50 &&
+        out[i + 1] === 0x4b &&
+        out[i + 2] === 0x01 &&
+        out[i + 3] === 0x02
+      ) {
+        const nameLen = view.getUint16(i + 28, true);
+        const name = out.subarray(i + 46, i + 46 + nameLen);
+        if (
+          nameLen === nameBytes.length &&
+          name.every((byte, j) => byte === nameBytes[j])
+        ) {
+          view.setUint32(i + 24, forgedSize, true);
+          return out;
+        }
+      }
+    }
+    throw new Error(`central-directory header for ${fileName} not found`);
+  }
+
+  it("aborts mid-stream when the declared size is forged below the cap", async () => {
+    // 64 KiB of zeros, but the central directory claims 10 bytes — the
+    // declared-size fast-fail passes, so only the bounded stream can stop it.
+    const zip = await buildPluginZip([MANIFEST, compressible(64 * 1024)]);
+    const forged = forgeDeclaredSize(zip, "big.bin", 10);
+    await expect(
+      zipToPluginFiles(forged, { limits: { maxFileBytes: 16 * 1024 } }),
+    ).rejects.toMatchObject({
+      name: "PluginBundleError",
+      code: "FILE_TOO_LARGE",
+      message: expect.stringContaining("during extraction"),
+    });
+  });
+
+  it("counts directory records toward maxEntries (backend parity)", async () => {
+    // The backend rejects on the end-of-central-directory RECORD count before
+    // filtering, so directory records must count here too. jszip's default
+    // createFolders:true emits a "a/" directory record alongside the file.
+    const { default: JSZip } = await import("jszip");
+    const zip = new JSZip();
+    zip.file("a/one.txt", "1");
+    const bytes = await zip.generateAsync({ type: "uint8array" });
+    await expect(
+      zipToPluginFiles(bytes, { limits: { maxEntries: 1 } }),
+    ).rejects.toMatchObject({
+      name: "PluginBundleError",
+      code: "BUNDLE_TOO_MANY_ENTRIES",
+    });
+  });
+
+  it("uploads built by buildPluginZip contain file records only", async () => {
+    const zip = await buildPluginZip([
+      MANIFEST,
+      textFile("skills/demo/SKILL.md", "x"),
+    ]);
+    const { default: JSZip } = await import("jszip");
+    const loaded = await JSZip.loadAsync(zip);
+    expect(
+      Object.values(loaded.files).filter((entry) => entry.dir),
+    ).toHaveLength(0);
+  });
+});
+
+describe("filesFromFolderSelection pre-read limits", () => {
+  function fakeFile(path: string, size: number): File {
+    const file = new File(["x"], path.split("/").pop() ?? "");
+    Object.defineProperty(file, "webkitRelativePath", { value: path });
+    Object.defineProperty(file, "size", { value: size });
+    Object.defineProperty(file, "arrayBuffer", {
+      value: vi.fn(async () => new ArrayBuffer(size)),
+    });
+    return file;
+  }
+
+  it("rejects an oversized file from metadata without reading it", async () => {
+    const big = fakeFile("plugin/big.bin", 2048);
+    await expect(
+      filesFromFolderSelection([big], { limits: { maxFileBytes: 1024 } }),
+    ).rejects.toMatchObject({
+      name: "PluginBundleError",
+      code: "FILE_TOO_LARGE",
+    });
+    expect(big.arrayBuffer).not.toHaveBeenCalled();
+  });
+
+  it("rejects too many files before reading any", async () => {
+    const files = [fakeFile("plugin/a.txt", 1), fakeFile("plugin/b.txt", 1)];
+    await expect(
+      filesFromFolderSelection(files, { limits: { maxEntries: 1 } }),
+    ).rejects.toMatchObject({
+      name: "PluginBundleError",
+      code: "BUNDLE_TOO_MANY_ENTRIES",
+    });
+    for (const file of files) {
+      expect(file.arrayBuffer).not.toHaveBeenCalled();
+    }
+  });
+
+  it("rejects when cumulative declared sizes exceed maxTotalBytes", async () => {
+    const files = [fakeFile("plugin/a.bin", 60), fakeFile("plugin/b.bin", 60)];
+    await expect(
+      filesFromFolderSelection(files, {
+        limits: { maxFileBytes: 80, maxTotalBytes: 100 },
+      }),
+    ).rejects.toMatchObject({
+      name: "PluginBundleError",
+      code: "BUNDLE_TOO_LARGE",
+    });
+    for (const file of files) {
+      expect(file.arrayBuffer).not.toHaveBeenCalled();
+    }
+  });
 });

--- a/mcpjam-inspector/client/src/lib/plugins/__tests__/folder-bundle.test.ts
+++ b/mcpjam-inspector/client/src/lib/plugins/__tests__/folder-bundle.test.ts
@@ -1,11 +1,19 @@
 import { describe, it, expect, beforeAll, vi } from "vitest";
 import { webcrypto } from "node:crypto";
 import {
+  parsePluginBundle,
+  type PluginFileEntry,
+  type PluginFileSource,
+} from "@mcpjam/sdk/plugin-bundle";
+import {
   buildPluginZip,
+  createFolderPluginFileSource,
   createMemoryPluginFileSource,
-  filesFromFolderSelection,
+  createZipPluginFileSource,
+  folderSelectionToPluginZip,
   parsePluginBundleFromFiles,
-  zipToPluginFiles,
+  parsePluginBundleFromFolderSelection,
+  parsePluginBundleFromZip,
   type PluginBundleFile,
 } from "../folder-bundle";
 import { resolveJsonServerMap } from "../../json-config-parser";
@@ -36,6 +44,102 @@ const MCP_SERVERS = {
 
 function bundleFiles(mcpConfigDocument: unknown): PluginBundleFile[] {
   return [MANIFEST, textFile(".mcp.json", JSON.stringify(mcpConfigDocument))];
+}
+
+async function expectIssueCode(
+  promise: Promise<unknown>,
+  code: string,
+): Promise<void> {
+  await expect(promise).rejects.toMatchObject({
+    name: "PluginBundleError",
+    code,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Raw ZIP fixture builder: zero-length STORED entries (CRC32 of empty = 0)
+// with per-entry unix mode / encryption flags, so raw local/central/EOCD
+// records — including ones jszip would sanitize or deduplicate — are fully
+// under the test's control.
+// ---------------------------------------------------------------------------
+
+interface RawZipEntry {
+  name: string;
+  /** Unix mode word (type bits + permissions) for the central record. */
+  mode?: number;
+  /** Set the traditional-encryption general-purpose bit. */
+  encrypted?: boolean;
+}
+
+function buildRawZip(
+  entrySpecs: Array<string | RawZipEntry>,
+  comment = "",
+): Uint8Array {
+  const specs = entrySpecs.map((spec) =>
+    typeof spec === "string" ? { name: spec } : spec,
+  );
+  const locals: Uint8Array[] = [];
+  const centrals: Uint8Array[] = [];
+  let offset = 0;
+  for (const spec of specs) {
+    const nameBytes = encoder.encode(spec.name);
+    const flags = spec.encrypted ? 0x1 : 0;
+    const local = new Uint8Array(30 + nameBytes.length);
+    const lv = new DataView(local.buffer);
+    lv.setUint32(0, 0x04034b50, true); // local file header signature
+    lv.setUint16(4, 20, true); // version needed
+    lv.setUint16(6, flags, true);
+    lv.setUint16(26, nameBytes.length, true);
+    local.set(nameBytes, 30);
+    const central = new Uint8Array(46 + nameBytes.length);
+    const cv = new DataView(central.buffer);
+    cv.setUint32(0, 0x02014b50, true); // central directory signature
+    // version made by: unix (3) when a mode is present so readers surface it.
+    cv.setUint16(4, spec.mode !== undefined ? 0x031e : 20, true);
+    cv.setUint16(6, 20, true); // version needed
+    cv.setUint16(8, flags, true);
+    cv.setUint16(28, nameBytes.length, true);
+    if (spec.mode !== undefined) {
+      cv.setUint32(38, (spec.mode & 0xffff) << 16, true); // external attrs
+    }
+    cv.setUint32(42, offset, true); // local header offset
+    central.set(nameBytes, 46);
+    locals.push(local);
+    centrals.push(central);
+    offset += local.length;
+  }
+  const centralSize = centrals.reduce((sum, c) => sum + c.length, 0);
+  const commentBytes = encoder.encode(comment);
+  const eocd = new Uint8Array(22 + commentBytes.length);
+  const ev = new DataView(eocd.buffer);
+  ev.setUint32(0, 0x06054b50, true); // EOCD signature
+  ev.setUint16(8, specs.length, true); // entries on this disk
+  ev.setUint16(10, specs.length, true); // total entries
+  ev.setUint32(12, centralSize, true);
+  ev.setUint32(16, offset, true); // central directory offset
+  ev.setUint16(20, commentBytes.length, true);
+  eocd.set(commentBytes, 22);
+
+  const chunks = [...locals, ...centrals, eocd];
+  const out = new Uint8Array(chunks.reduce((sum, c) => sum + c.length, 0));
+  let cursor = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, cursor);
+    cursor += chunk.length;
+  }
+  return out;
+}
+
+/**
+ * A `PluginFileSource` over literal entry FACTS (path/size/kind), used to
+ * obtain the SDK parser's own verdict on the same raw facts the client zip
+ * adapter surfaces — the parity oracle.
+ */
+function factSource(entries: PluginFileEntry[]): PluginFileSource {
+  return {
+    list: async () => entries,
+    readBytes: async () => new Uint8Array(0),
+  };
 }
 
 describe("parsePluginBundleFromFiles", () => {
@@ -87,11 +191,9 @@ describe("folder / ZIP bundle hash parity", () => {
 
   it("a folder and a ZIP of identical contents produce the same bundle hash", async () => {
     const folderParsed = await parsePluginBundleFromFiles(files);
-
-    const zipBytes = await buildPluginZip(files);
-    const roundTripped = await zipToPluginFiles(zipBytes);
-    const zipParsed = await parsePluginBundleFromFiles(roundTripped);
-
+    const zipParsed = await parsePluginBundleFromZip(
+      await buildPluginZip(files),
+    );
     expect(zipParsed.bundleHash).toBe(folderParsed.bundleHash);
     expect(zipParsed.manifestHash).toBe(folderParsed.manifestHash);
   });
@@ -108,9 +210,18 @@ describe("folder / ZIP bundle hash parity", () => {
     const second = await buildPluginZip([...files].reverse());
     expect(Buffer.from(second).equals(Buffer.from(first))).toBe(true);
   });
+
+  it("uploads built by buildPluginZip contain file records only", async () => {
+    const zip = await buildPluginZip(files);
+    const { default: JSZip } = await import("jszip");
+    const loaded = await JSZip.loadAsync(zip);
+    expect(
+      Object.values(loaded.files).filter((entry) => entry.dir),
+    ).toHaveLength(0);
+  });
 });
 
-describe("filesFromFolderSelection", () => {
+describe("createFolderPluginFileSource selection mapping", () => {
   function pickedFile(relativePath: string, content: string): File {
     const file = new File([content], relativePath.split("/").pop() ?? "");
     Object.defineProperty(file, "webkitRelativePath", {
@@ -120,27 +231,94 @@ describe("filesFromFolderSelection", () => {
   }
 
   it("strips the shared picked-folder segment and filters OS junk", async () => {
-    const files = await filesFromFolderSelection([
+    const source = createFolderPluginFileSource([
       pickedFile("my-plugin/.codex-plugin/plugin.json", "{}"),
       pickedFile("my-plugin/.mcp.json", "{}"),
       pickedFile("my-plugin/.DS_Store", "junk"),
       pickedFile("my-plugin/__MACOSX/resource", "junk"),
     ]);
-    expect(files.map((file) => file.path).sort()).toEqual([
+    const entries = await source.list();
+    expect(entries.map((entry) => entry.path).sort()).toEqual([
       ".codex-plugin/plugin.json",
       ".mcp.json",
     ]);
   });
 
   it("keeps paths as-is when entries do not share a single root", async () => {
-    const files = await filesFromFolderSelection([
+    const source = createFolderPluginFileSource([
       pickedFile("a/one.txt", "1"),
       pickedFile("b/two.txt", "2"),
     ]);
-    expect(files.map((file) => file.path).sort()).toEqual([
+    const entries = await source.list();
+    expect(entries.map((entry) => entry.path).sort()).toEqual([
       "a/one.txt",
       "b/two.txt",
     ]);
+  });
+
+  it("folderSelectionToPluginZip yields a zip whose parse matches the folder parse", async () => {
+    const selection = [
+      pickedFile(
+        "my-plugin/.codex-plugin/plugin.json",
+        JSON.stringify({ name: "demo-plugin" }),
+      ),
+      pickedFile(
+        "my-plugin/.mcp.json",
+        JSON.stringify({ mcp_servers: MCP_SERVERS }),
+      ),
+    ];
+    const { parsed, zipBytes } = await folderSelectionToPluginZip(selection);
+    const roundTripped = await parsePluginBundleFromZip(zipBytes);
+    expect(roundTripped.bundleHash).toBe(parsed.bundleHash);
+  });
+});
+
+describe("folder selection limits are SDK-enforced before any read", () => {
+  function fakeFile(path: string, size: number): File {
+    const file = new File(["x"], path.split("/").pop() ?? "");
+    Object.defineProperty(file, "webkitRelativePath", { value: path });
+    Object.defineProperty(file, "size", { value: size });
+    Object.defineProperty(file, "arrayBuffer", {
+      value: vi.fn(async () => new ArrayBuffer(size)),
+    });
+    return file;
+  }
+
+  it("rejects an oversized file from metadata without reading it", async () => {
+    const big = fakeFile("plugin/big.bin", 2048);
+    await expectIssueCode(
+      parsePluginBundleFromFolderSelection([big], {
+        limits: { maxFileBytes: 1024 },
+      }),
+      "FILE_TOO_LARGE",
+    );
+    expect(big.arrayBuffer).not.toHaveBeenCalled();
+  });
+
+  it("rejects too many files before reading any", async () => {
+    const files = [fakeFile("plugin/a.txt", 1), fakeFile("plugin/b.txt", 1)];
+    await expectIssueCode(
+      parsePluginBundleFromFolderSelection(files, {
+        limits: { maxEntries: 1 },
+      }),
+      "BUNDLE_TOO_MANY_ENTRIES",
+    );
+    for (const file of files) {
+      expect(file.arrayBuffer).not.toHaveBeenCalled();
+    }
+  });
+
+  it("rejects when cumulative declared sizes exceed maxTotalBytes", async () => {
+    const files = [fakeFile("plugin/a.bin", 60), fakeFile("plugin/b.bin", 60)];
+    await expectIssueCode(
+      parsePluginBundleFromFolderSelection(files, {
+        limits: { maxFileBytes: 80, maxTotalBytes: 100 },
+      }),
+      "BUNDLE_TOO_LARGE",
+    );
+    for (const file of files) {
+      expect(file.arrayBuffer).not.toHaveBeenCalled();
+    }
   });
 });
 
@@ -163,60 +341,79 @@ describe("createMemoryPluginFileSource", () => {
   });
 });
 
-describe("zipToPluginFiles zip-bomb hardening", () => {
-  // Highly compressible payload: 64 KiB of zeros deflates to ~100 bytes, so
-  // a "bomb" fixture stays tiny on the compressed side while tripping the
-  // (overridden, small) uncompressed limits during extraction.
-  const compressible = (bytes: number): PluginBundleFile => ({
-    path: "big.bin",
-    bytes: new Uint8Array(bytes), // all zeros
-  });
-
-  it("rejects an entry whose uncompressed size exceeds maxFileBytes before inflating it", async () => {
-    const zip = await buildPluginZip([MANIFEST, compressible(64 * 1024)]);
-    await expect(
-      zipToPluginFiles(zip, { limits: { maxFileBytes: 16 * 1024 } }),
-    ).rejects.toMatchObject({
+describe("client-only archive screen", () => {
+  it("rejects >maxEntries raw records even when duplicate names would collapse", async () => {
+    // 1001 records sharing one name: jszip's keyed `files` object would
+    // deduplicate this to ONE compliant-looking entry, but the backend's
+    // yauzl EOCD count sees 1001 — the raw count must reject it first.
+    const zip = buildRawZip(Array.from({ length: 1001 }, () => "dup.txt"));
+    await expect(createZipPluginFileSource(zip)).rejects.toMatchObject({
       name: "PluginBundleError",
-      code: "FILE_TOO_LARGE",
+      code: "BUNDLE_TOO_MANY_ENTRIES",
+      message: expect.stringContaining("1001"),
     });
   });
 
-  it("rejects when cumulative uncompressed content exceeds maxTotalBytes", async () => {
-    const zip = await buildPluginZip([
-      MANIFEST,
-      { path: "a.bin", bytes: new Uint8Array(32 * 1024) },
-      { path: "b.bin", bytes: new Uint8Array(32 * 1024) },
-    ]);
-    await expect(
-      zipToPluginFiles(zip, {
-        limits: { maxFileBytes: 40 * 1024, maxTotalBytes: 48 * 1024 },
-      }),
-    ).rejects.toMatchObject({
-      name: "PluginBundleError",
-      code: "BUNDLE_TOO_LARGE",
-    });
-  });
-
-  it("rejects an archive with too many entries before reading any of them", async () => {
-    const many = Array.from({ length: 5 }, (_, i) =>
-      textFile(`file-${i}.txt`, String(i)),
+  it("rejects duplicate names under the record limit as PATH_DUPLICATE", async () => {
+    await expectIssueCode(
+      createZipPluginFileSource(buildRawZip(["dup.txt", "dup.txt"])),
+      "PATH_DUPLICATE",
     );
-    const zip = await buildPluginZip(many);
+  });
+
+  it("counts records correctly through an EOCD trailing comment", async () => {
     await expect(
-      zipToPluginFiles(zip, { limits: { maxEntries: 4 } }),
+      createZipPluginFileSource(
+        buildRawZip(["a.txt", "b.txt", "c.txt"], "hello comment"),
+        { limits: { maxEntries: 2 } },
+      ),
     ).rejects.toMatchObject({
       name: "PluginBundleError",
       code: "BUNDLE_TOO_MANY_ENTRIES",
+      message: expect.stringContaining("3"),
+    });
+
+    // ...and does not false-trigger on a compliant commented archive.
+    const source = await createZipPluginFileSource(
+      buildRawZip(["a.txt"], "hi"),
+    );
+    expect(await source.list()).toEqual([
+      { path: "a.txt", size: 0, kind: "file" },
+    ]);
+  });
+
+  it("rejects the ZIP64 0xFFFF total-entries sentinel", async () => {
+    const eocd = new Uint8Array(22);
+    const view = new DataView(eocd.buffer);
+    view.setUint32(0, 0x06054b50, true);
+    view.setUint16(8, 0xffff, true);
+    view.setUint16(10, 0xffff, true);
+    await expect(createZipPluginFileSource(eocd)).rejects.toMatchObject({
+      name: "PluginBundleError",
+      code: "BUNDLE_TOO_MANY_ENTRIES",
+      message: expect.stringContaining("ZIP64"),
     });
   });
 
-  it("extracts a compliant archive under the default limits", async () => {
-    const zip = await buildPluginZip([MANIFEST]);
-    const files = await zipToPluginFiles(zip);
-    expect(files.map((file) => file.path)).toEqual([
-      ".codex-plugin/plugin.json",
+  it("rejects a configured maxEntries at or above the ZIP64 sentinel", async () => {
+    await expect(
+      createZipPluginFileSource(buildRawZip(["a.txt"]), {
+        limits: { maxEntries: 0xffff },
+      }),
+    ).rejects.toThrow("below 65535");
+  });
+
+  it("aborts mid-stream when the declared size is forged below the cap", async () => {
+    // 64 KiB of zeros, but the central directory claims 10 bytes — phase-1
+    // validation passes (declared sizes look tiny), so only the bounded
+    // stream can stop the actual inflation. The overrun surfaces through
+    // the shared parser as FILE_UNREADABLE, same as the backend read path.
+    const zip = await buildPluginZip([
+      MANIFEST,
+      { path: "big.bin", bytes: new Uint8Array(64 * 1024) },
     ]);
+    const forged = forgeDeclaredSize(zip, "big.bin", 10);
+    await expectIssueCode(parsePluginBundleFromZip(forged), "FILE_UNREADABLE");
   });
 
   /**
@@ -252,199 +449,116 @@ describe("zipToPluginFiles zip-bomb hardening", () => {
     }
     throw new Error(`central-directory header for ${fileName} not found`);
   }
-
-  it("aborts mid-stream when the declared size is forged below the cap", async () => {
-    // 64 KiB of zeros, but the central directory claims 10 bytes — the
-    // declared-size fast-fail passes, so only the bounded stream can stop it.
-    const zip = await buildPluginZip([MANIFEST, compressible(64 * 1024)]);
-    const forged = forgeDeclaredSize(zip, "big.bin", 10);
-    await expect(
-      zipToPluginFiles(forged, { limits: { maxFileBytes: 16 * 1024 } }),
-    ).rejects.toMatchObject({
-      name: "PluginBundleError",
-      code: "FILE_TOO_LARGE",
-      message: expect.stringContaining("during extraction"),
-    });
-  });
-
-  it("counts directory records toward maxEntries (backend parity)", async () => {
-    // The backend rejects on the end-of-central-directory RECORD count before
-    // filtering, so directory records must count here too. jszip's default
-    // createFolders:true emits a "a/" directory record alongside the file.
-    const { default: JSZip } = await import("jszip");
-    const zip = new JSZip();
-    zip.file("a/one.txt", "1");
-    const bytes = await zip.generateAsync({ type: "uint8array" });
-    await expect(
-      zipToPluginFiles(bytes, { limits: { maxEntries: 1 } }),
-    ).rejects.toMatchObject({
-      name: "PluginBundleError",
-      code: "BUNDLE_TOO_MANY_ENTRIES",
-    });
-  });
-
-  it("uploads built by buildPluginZip contain file records only", async () => {
-    const zip = await buildPluginZip([
-      MANIFEST,
-      textFile("skills/demo/SKILL.md", "x"),
-    ]);
-    const { default: JSZip } = await import("jszip");
-    const loaded = await JSZip.loadAsync(zip);
-    expect(
-      Object.values(loaded.files).filter((entry) => entry.dir),
-    ).toHaveLength(0);
-  });
 });
 
-describe("zipToPluginFiles raw EOCD record counting", () => {
-  /**
-   * Hand-build a ZIP of zero-length STORED entries (CRC32 of empty = 0, so
-   * every field is trivially valid) so the raw local/central/EOCD records —
-   * including duplicates jszip would silently deduplicate — are fully under
-   * the test's control.
-   */
-  function buildRawZip(names: string[], comment = ""): Uint8Array {
-    const locals: Uint8Array[] = [];
-    const centrals: Uint8Array[] = [];
-    let offset = 0;
-    for (const name of names) {
-      const nameBytes = encoder.encode(name);
-      const local = new Uint8Array(30 + nameBytes.length);
-      const lv = new DataView(local.buffer);
-      lv.setUint32(0, 0x04034b50, true); // local file header signature
-      lv.setUint16(4, 20, true); // version needed
-      lv.setUint16(26, nameBytes.length, true);
-      local.set(nameBytes, 30);
-      const central = new Uint8Array(46 + nameBytes.length);
-      const cv = new DataView(central.buffer);
-      cv.setUint32(0, 0x02014b50, true); // central directory signature
-      cv.setUint16(4, 20, true); // version made by
-      cv.setUint16(6, 20, true); // version needed
-      cv.setUint16(28, nameBytes.length, true);
-      cv.setUint32(42, offset, true); // local header offset
-      central.set(nameBytes, 46);
-      locals.push(local);
-      centrals.push(central);
-      offset += local.length;
-    }
-    const centralSize = centrals.reduce((sum, c) => sum + c.length, 0);
-    const commentBytes = encoder.encode(comment);
-    const eocd = new Uint8Array(22 + commentBytes.length);
-    const ev = new DataView(eocd.buffer);
-    ev.setUint32(0, 0x06054b50, true); // EOCD signature
-    ev.setUint16(8, names.length, true); // entries on this disk
-    ev.setUint16(10, names.length, true); // total entries
-    ev.setUint32(12, centralSize, true);
-    ev.setUint32(16, offset, true); // central directory offset
-    ev.setUint16(20, commentBytes.length, true);
-    eocd.set(commentBytes, 22);
+// ---------------------------------------------------------------------------
+// Table-driven preflight/authority parity: for each malicious-fixture family,
+// the client verdict on the raw ZIP bytes must equal the SDK parser's verdict
+// on the same raw entry facts (the shared-rulebook guarantee). Families the
+// SDK cannot see (encryption, jszip name collapse, backslash names — archive
+// concerns owned by the backend adapter) assert the documented client-only
+// code instead.
+// ---------------------------------------------------------------------------
 
-    const total = [...locals, ...centrals, eocd];
-    const out = new Uint8Array(total.reduce((sum, c) => sum + c.length, 0));
-    let cursor = 0;
-    for (const chunk of total) {
-      out.set(chunk, cursor);
-      cursor += chunk.length;
-    }
-    return out;
+describe("preflight parity with the SDK parser", () => {
+  const S_IFLNK = 0o120000;
+
+  const families: Array<{
+    family: string;
+    zip: () => Uint8Array | Promise<Uint8Array>;
+    /** Raw entry facts the SDK oracle judges; omitted for client-only cases. */
+    facts?: PluginFileEntry[];
+    expectedCode: string;
+  }> = [
+    {
+      family: "traversal entry name",
+      zip: () => buildRawZip(["ok.txt", "../evil.txt"]),
+      facts: [
+        { path: "ok.txt", size: 0, kind: "file" },
+        { path: "../evil.txt", size: 0, kind: "file" },
+      ],
+      expectedCode: "PATH_TRAVERSAL",
+    },
+    {
+      family: "absolute entry name",
+      zip: () => buildRawZip(["ok.txt", "/abs.txt"]),
+      facts: [
+        { path: "ok.txt", size: 0, kind: "file" },
+        { path: "/abs.txt", size: 0, kind: "file" },
+      ],
+      expectedCode: "PATH_ABSOLUTE",
+    },
+    {
+      family: "symlink record",
+      zip: () =>
+        buildRawZip(["ok.txt", { name: "link.txt", mode: S_IFLNK | 0o777 }]),
+      facts: [
+        { path: "ok.txt", size: 0, kind: "file" },
+        { path: "link.txt", size: 0, kind: "symlink" },
+      ],
+      expectedCode: "PATH_LINK_ENTRY",
+    },
+    {
+      family: "duplicate names",
+      zip: () => buildRawZip(["dup.txt", "dup.txt"]),
+      // jszip collapses the duplicate before the parser can see it, so the
+      // client detects it structurally (EOCD count vs kept entries); the SDK
+      // emits the SAME code for the same duplicate facts.
+      facts: [
+        { path: "dup.txt", size: 0, kind: "file" },
+        { path: "dup.txt", size: 0, kind: "file" },
+      ],
+      expectedCode: "PATH_DUPLICATE",
+    },
+    {
+      family: "too many records",
+      zip: () =>
+        buildRawZip(Array.from({ length: 1001 }, (_, i) => `f${i}.txt`)),
+      facts: Array.from({ length: 1001 }, (_, i) => ({
+        path: `f${i}.txt`,
+        size: 0,
+        kind: "file" as const,
+      })),
+      expectedCode: "BUNDLE_TOO_MANY_ENTRIES",
+    },
+    {
+      family:
+        "encrypted entry (archive-level; backend ARCHIVE_ENCRYPTED_ENTRY)",
+      zip: () =>
+        buildRawZip(["ok.txt", { name: "secret.txt", encrypted: true }]),
+      expectedCode: "FILE_UNREADABLE",
+    },
+    {
+      family: "backslash entry name (archive-level; yauzl rejects raw name)",
+      zip: () => buildRawZip(["ok.txt", "a\\b.txt"]),
+      expectedCode: "PATH_INVALID_CHARACTER",
+    },
+  ];
+
+  for (const { family, zip, facts, expectedCode } of families) {
+    it(`${family} → ${expectedCode}`, async () => {
+      await expectIssueCode(
+        (async () => parsePluginBundleFromZip(await zip()))(),
+        expectedCode,
+      );
+      if (facts) {
+        // The SDK parser's own verdict on the same raw facts — the oracle
+        // the client adapter must agree with.
+        await expectIssueCode(
+          parsePluginBundle(factSource(facts)),
+          expectedCode,
+        );
+      }
+    });
   }
 
-  it("rejects >maxEntries raw records even when duplicate names would collapse", async () => {
-    // 1001 records sharing one name: jszip's keyed `files` object would
-    // deduplicate this to ONE compliant-looking entry, but the backend's
-    // yauzl EOCD count sees 1001 — the raw count must reject it first.
-    const zip = buildRawZip(Array.from({ length: 1001 }, () => "dup.txt"));
-    await expect(zipToPluginFiles(zip)).rejects.toMatchObject({
-      name: "PluginBundleError",
-      code: "BUNDLE_TOO_MANY_ENTRIES",
-      message: expect.stringContaining("1001"),
-    });
-  });
-
-  it("rejects duplicate names under the record limit as PATH_DUPLICATE", async () => {
-    const zip = buildRawZip(["dup.txt", "dup.txt"]);
-    await expect(zipToPluginFiles(zip)).rejects.toMatchObject({
-      name: "PluginBundleError",
-      code: "PATH_DUPLICATE",
-    });
-  });
-
-  it("counts records correctly through an EOCD trailing comment", async () => {
-    const commented = buildRawZip(["a.txt", "b.txt", "c.txt"], "hello comment");
-    await expect(
-      zipToPluginFiles(commented, { limits: { maxEntries: 2 } }),
-    ).rejects.toMatchObject({
-      name: "PluginBundleError",
-      code: "BUNDLE_TOO_MANY_ENTRIES",
-      message: expect.stringContaining("3"),
-    });
-
-    // ...and does not false-trigger on a compliant commented archive.
-    const ok = await zipToPluginFiles(buildRawZip(["a.txt"], "hi"));
-    expect(ok).toEqual([{ path: "a.txt", bytes: new Uint8Array(0) }]);
-  });
-
-  it("rejects the ZIP64 0xFFFF total-entries sentinel", async () => {
-    const eocd = new Uint8Array(22);
-    const view = new DataView(eocd.buffer);
-    view.setUint32(0, 0x06054b50, true);
-    view.setUint16(8, 0xffff, true);
-    view.setUint16(10, 0xffff, true);
-    await expect(zipToPluginFiles(eocd)).rejects.toMatchObject({
-      name: "PluginBundleError",
-      code: "BUNDLE_TOO_MANY_ENTRIES",
-      message: expect.stringContaining("ZIP64"),
-    });
-  });
-});
-
-describe("filesFromFolderSelection pre-read limits", () => {
-  function fakeFile(path: string, size: number): File {
-    const file = new File(["x"], path.split("/").pop() ?? "");
-    Object.defineProperty(file, "webkitRelativePath", { value: path });
-    Object.defineProperty(file, "size", { value: size });
-    Object.defineProperty(file, "arrayBuffer", {
-      value: vi.fn(async () => new ArrayBuffer(size)),
-    });
-    return file;
-  }
-
-  it("rejects an oversized file from metadata without reading it", async () => {
-    const big = fakeFile("plugin/big.bin", 2048);
-    await expect(
-      filesFromFolderSelection([big], { limits: { maxFileBytes: 1024 } }),
-    ).rejects.toMatchObject({
-      name: "PluginBundleError",
-      code: "FILE_TOO_LARGE",
-    });
-    expect(big.arrayBuffer).not.toHaveBeenCalled();
-  });
-
-  it("rejects too many files before reading any", async () => {
-    const files = [fakeFile("plugin/a.txt", 1), fakeFile("plugin/b.txt", 1)];
-    await expect(
-      filesFromFolderSelection(files, { limits: { maxEntries: 1 } }),
-    ).rejects.toMatchObject({
-      name: "PluginBundleError",
-      code: "BUNDLE_TOO_MANY_ENTRIES",
-    });
-    for (const file of files) {
-      expect(file.arrayBuffer).not.toHaveBeenCalled();
-    }
-  });
-
-  it("rejects when cumulative declared sizes exceed maxTotalBytes", async () => {
-    const files = [fakeFile("plugin/a.bin", 60), fakeFile("plugin/b.bin", 60)];
-    await expect(
-      filesFromFolderSelection(files, {
-        limits: { maxFileBytes: 80, maxTotalBytes: 100 },
-      }),
-    ).rejects.toMatchObject({
-      name: "PluginBundleError",
-      code: "BUNDLE_TOO_LARGE",
-    });
-    for (const file of files) {
-      expect(file.arrayBuffer).not.toHaveBeenCalled();
-    }
+  it("clean bundle → accepted by both with the same bundle hash", async () => {
+    const files = bundleFiles({ mcpServers: MCP_SERVERS });
+    const viaSdkSource = await parsePluginBundleFromFiles(files);
+    const viaZipAdapter = await parsePluginBundleFromZip(
+      await buildPluginZip(files),
+    );
+    expect(viaZipAdapter.bundleHash).toBe(viaSdkSource.bundleHash);
+    expect(viaZipAdapter.warnings).toEqual(viaSdkSource.warnings);
   });
 });

--- a/mcpjam-inspector/client/src/lib/plugins/__tests__/folder-bundle.test.ts
+++ b/mcpjam-inspector/client/src/lib/plugins/__tests__/folder-bundle.test.ts
@@ -296,6 +296,108 @@ describe("zipToPluginFiles zip-bomb hardening", () => {
   });
 });
 
+describe("zipToPluginFiles raw EOCD record counting", () => {
+  /**
+   * Hand-build a ZIP of zero-length STORED entries (CRC32 of empty = 0, so
+   * every field is trivially valid) so the raw local/central/EOCD records —
+   * including duplicates jszip would silently deduplicate — are fully under
+   * the test's control.
+   */
+  function buildRawZip(names: string[], comment = ""): Uint8Array {
+    const locals: Uint8Array[] = [];
+    const centrals: Uint8Array[] = [];
+    let offset = 0;
+    for (const name of names) {
+      const nameBytes = encoder.encode(name);
+      const local = new Uint8Array(30 + nameBytes.length);
+      const lv = new DataView(local.buffer);
+      lv.setUint32(0, 0x04034b50, true); // local file header signature
+      lv.setUint16(4, 20, true); // version needed
+      lv.setUint16(26, nameBytes.length, true);
+      local.set(nameBytes, 30);
+      const central = new Uint8Array(46 + nameBytes.length);
+      const cv = new DataView(central.buffer);
+      cv.setUint32(0, 0x02014b50, true); // central directory signature
+      cv.setUint16(4, 20, true); // version made by
+      cv.setUint16(6, 20, true); // version needed
+      cv.setUint16(28, nameBytes.length, true);
+      cv.setUint32(42, offset, true); // local header offset
+      central.set(nameBytes, 46);
+      locals.push(local);
+      centrals.push(central);
+      offset += local.length;
+    }
+    const centralSize = centrals.reduce((sum, c) => sum + c.length, 0);
+    const commentBytes = encoder.encode(comment);
+    const eocd = new Uint8Array(22 + commentBytes.length);
+    const ev = new DataView(eocd.buffer);
+    ev.setUint32(0, 0x06054b50, true); // EOCD signature
+    ev.setUint16(8, names.length, true); // entries on this disk
+    ev.setUint16(10, names.length, true); // total entries
+    ev.setUint32(12, centralSize, true);
+    ev.setUint32(16, offset, true); // central directory offset
+    ev.setUint16(20, commentBytes.length, true);
+    eocd.set(commentBytes, 22);
+
+    const total = [...locals, ...centrals, eocd];
+    const out = new Uint8Array(total.reduce((sum, c) => sum + c.length, 0));
+    let cursor = 0;
+    for (const chunk of total) {
+      out.set(chunk, cursor);
+      cursor += chunk.length;
+    }
+    return out;
+  }
+
+  it("rejects >maxEntries raw records even when duplicate names would collapse", async () => {
+    // 1001 records sharing one name: jszip's keyed `files` object would
+    // deduplicate this to ONE compliant-looking entry, but the backend's
+    // yauzl EOCD count sees 1001 — the raw count must reject it first.
+    const zip = buildRawZip(Array.from({ length: 1001 }, () => "dup.txt"));
+    await expect(zipToPluginFiles(zip)).rejects.toMatchObject({
+      name: "PluginBundleError",
+      code: "BUNDLE_TOO_MANY_ENTRIES",
+      message: expect.stringContaining("1001"),
+    });
+  });
+
+  it("rejects duplicate names under the record limit as PATH_DUPLICATE", async () => {
+    const zip = buildRawZip(["dup.txt", "dup.txt"]);
+    await expect(zipToPluginFiles(zip)).rejects.toMatchObject({
+      name: "PluginBundleError",
+      code: "PATH_DUPLICATE",
+    });
+  });
+
+  it("counts records correctly through an EOCD trailing comment", async () => {
+    const commented = buildRawZip(["a.txt", "b.txt", "c.txt"], "hello comment");
+    await expect(
+      zipToPluginFiles(commented, { limits: { maxEntries: 2 } }),
+    ).rejects.toMatchObject({
+      name: "PluginBundleError",
+      code: "BUNDLE_TOO_MANY_ENTRIES",
+      message: expect.stringContaining("3"),
+    });
+
+    // ...and does not false-trigger on a compliant commented archive.
+    const ok = await zipToPluginFiles(buildRawZip(["a.txt"], "hi"));
+    expect(ok).toEqual([{ path: "a.txt", bytes: new Uint8Array(0) }]);
+  });
+
+  it("rejects the ZIP64 0xFFFF total-entries sentinel", async () => {
+    const eocd = new Uint8Array(22);
+    const view = new DataView(eocd.buffer);
+    view.setUint32(0, 0x06054b50, true);
+    view.setUint16(8, 0xffff, true);
+    view.setUint16(10, 0xffff, true);
+    await expect(zipToPluginFiles(eocd)).rejects.toMatchObject({
+      name: "PluginBundleError",
+      code: "BUNDLE_TOO_MANY_ENTRIES",
+      message: expect.stringContaining("ZIP64"),
+    });
+  });
+});
+
 describe("filesFromFolderSelection pre-read limits", () => {
   function fakeFile(path: string, size: number): File {
     const file = new File(["x"], path.split("/").pop() ?? "");

--- a/mcpjam-inspector/client/src/lib/plugins/__tests__/folder-bundle.test.ts
+++ b/mcpjam-inspector/client/src/lib/plugins/__tests__/folder-bundle.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import { webcrypto } from "node:crypto";
+import {
+  buildPluginZip,
+  createMemoryPluginFileSource,
+  filesFromFolderSelection,
+  parsePluginBundleFromFiles,
+  zipToPluginFiles,
+  type PluginBundleFile,
+} from "../folder-bundle";
+import { resolveJsonServerMap } from "../../json-config-parser";
+
+// The SDK plugin-bundle hashes go through Web Crypto; jsdom does not always
+// provide `crypto.subtle`, Node's webcrypto is byte-identical.
+beforeAll(() => {
+  if (!globalThis.crypto?.subtle) {
+    vi.stubGlobal("crypto", webcrypto);
+  }
+});
+
+const encoder = new TextEncoder();
+
+function textFile(path: string, content: string): PluginBundleFile {
+  return { path, bytes: encoder.encode(content) };
+}
+
+const MANIFEST = textFile(
+  ".codex-plugin/plugin.json",
+  JSON.stringify({ name: "demo-plugin", display_name: "Demo Plugin" }),
+);
+
+const MCP_SERVERS = {
+  demo: { url: "https://example.com/mcp" },
+  local: { command: "node", args: ["server.js"] },
+};
+
+function bundleFiles(mcpConfigDocument: unknown): PluginBundleFile[] {
+  return [MANIFEST, textFile(".mcp.json", JSON.stringify(mcpConfigDocument))];
+}
+
+describe("parsePluginBundleFromFiles", () => {
+  it("parses a minimal bundle and reports a content-defined bundle hash", async () => {
+    const parsed = await parsePluginBundleFromFiles(
+      bundleFiles({ mcpServers: MCP_SERVERS }),
+    );
+    expect(parsed.manifest.name).toBe("demo-plugin");
+    expect(parsed.bundleHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(parsed.mcpServers.map((server) => server.key).sort()).toEqual([
+      "demo",
+      "local",
+    ]);
+  });
+
+  it("accepts direct, mcp_servers, and mcpServers shapes identically (SDK parity)", async () => {
+    const shapes: unknown[] = [
+      MCP_SERVERS,
+      { mcp_servers: MCP_SERVERS },
+      { mcpServers: MCP_SERVERS },
+    ];
+    const parsedKeys: string[][] = [];
+    for (const shape of shapes) {
+      const parsed = await parsePluginBundleFromFiles(bundleFiles(shape));
+      parsedKeys.push(parsed.mcpServers.map((server) => server.key).sort());
+
+      // The inspector's JSON import resolves the same shapes to the same
+      // server names — the two code paths agree on shape detection.
+      const resolved = resolveJsonServerMap(shape);
+      expect(resolved.ok).toBe(true);
+      if (resolved.ok) {
+        expect(Object.keys(resolved.servers).sort()).toEqual(["demo", "local"]);
+      }
+    }
+    expect(parsedKeys[1]).toEqual(parsedKeys[0]);
+    expect(parsedKeys[2]).toEqual(parsedKeys[0]);
+  });
+});
+
+describe("folder / ZIP bundle hash parity", () => {
+  const files = [
+    MANIFEST,
+    textFile(".mcp.json", JSON.stringify({ mcp_servers: MCP_SERVERS })),
+    textFile(
+      "skills/demo/SKILL.md",
+      "---\nname: demo\ndescription: A demo skill for parity tests\n---\nBody\n",
+    ),
+  ];
+
+  it("a folder and a ZIP of identical contents produce the same bundle hash", async () => {
+    const folderParsed = await parsePluginBundleFromFiles(files);
+
+    const zipBytes = await buildPluginZip(files);
+    const roundTripped = await zipToPluginFiles(zipBytes);
+    const zipParsed = await parsePluginBundleFromFiles(roundTripped);
+
+    expect(zipParsed.bundleHash).toBe(folderParsed.bundleHash);
+    expect(zipParsed.manifestHash).toBe(folderParsed.manifestHash);
+  });
+
+  it("bundle hash is independent of file listing order", async () => {
+    const reversed = [...files].reverse();
+    const a = await parsePluginBundleFromFiles(files);
+    const b = await parsePluginBundleFromFiles(reversed);
+    expect(b.bundleHash).toBe(a.bundleHash);
+  });
+
+  it("zipping the same files twice is deterministic", async () => {
+    const first = await buildPluginZip(files);
+    const second = await buildPluginZip([...files].reverse());
+    expect(Buffer.from(second).equals(Buffer.from(first))).toBe(true);
+  });
+});
+
+describe("filesFromFolderSelection", () => {
+  function pickedFile(relativePath: string, content: string): File {
+    const file = new File([content], relativePath.split("/").pop() ?? "");
+    Object.defineProperty(file, "webkitRelativePath", {
+      value: relativePath,
+    });
+    return file;
+  }
+
+  it("strips the shared picked-folder segment and filters OS junk", async () => {
+    const files = await filesFromFolderSelection([
+      pickedFile("my-plugin/.codex-plugin/plugin.json", "{}"),
+      pickedFile("my-plugin/.mcp.json", "{}"),
+      pickedFile("my-plugin/.DS_Store", "junk"),
+      pickedFile("my-plugin/__MACOSX/resource", "junk"),
+    ]);
+    expect(files.map((file) => file.path).sort()).toEqual([
+      ".codex-plugin/plugin.json",
+      ".mcp.json",
+    ]);
+  });
+
+  it("keeps paths as-is when entries do not share a single root", async () => {
+    const files = await filesFromFolderSelection([
+      pickedFile("a/one.txt", "1"),
+      pickedFile("b/two.txt", "2"),
+    ]);
+    expect(files.map((file) => file.path).sort()).toEqual([
+      "a/one.txt",
+      "b/two.txt",
+    ]);
+  });
+});
+
+describe("createMemoryPluginFileSource", () => {
+  it("lists files and serves exact bytes", async () => {
+    const source = createMemoryPluginFileSource([textFile("a.txt", "hello")]);
+    const entries = await source.list();
+    expect(entries).toEqual([{ path: "a.txt", size: 5, kind: "file" }]);
+    expect(
+      new TextDecoder().decode(await source.readBytes("a.txt", 1024)),
+    ).toBe("hello");
+    await expect(source.readBytes("missing.txt", 1024)).rejects.toThrow(
+      "no such bundle file",
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/lib/plugins/__tests__/plugin-api.test.ts
+++ b/mcpjam-inspector/client/src/lib/plugins/__tests__/plugin-api.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  MAX_PLUGIN_BUNDLE_COMPRESSED_BYTES,
+  toPluginApiError,
+  uploadPluginBundleToUrl,
+} from "../plugin-api";
+import { PluginApiError } from "../plugin-api-types";
+
+function okJson(payload: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => payload,
+  } as unknown as Response;
+}
+
+describe("uploadPluginBundleToUrl", () => {
+  it("POSTs the bundle and returns the storage id", async () => {
+    const fetchImpl = vi.fn(async () => okJson({ storageId: "st_123" }));
+    const storageId = await uploadPluginBundleToUrl(
+      "https://upload.example/x",
+      new Uint8Array([1, 2, 3]),
+      fetchImpl as unknown as typeof fetch,
+    );
+    expect(storageId).toBe("st_123");
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://upload.example/x",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("rejects an oversized bundle before uploading (backend cap mirror)", async () => {
+    const fetchImpl = vi.fn();
+    const oversized = {
+      size: MAX_PLUGIN_BUNDLE_COMPRESSED_BYTES + 1,
+    } as unknown as Blob;
+    Object.setPrototypeOf(oversized, Blob.prototype);
+    await expect(
+      uploadPluginBundleToUrl(
+        "https://upload.example/x",
+        oversized,
+        fetchImpl as unknown as typeof fetch,
+      ),
+    ).rejects.toMatchObject({ code: "ARCHIVE_TOO_LARGE_COMPRESSED" });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("maps a non-2xx response to UPLOAD_FAILED", async () => {
+    const fetchImpl = vi.fn(
+      async () => ({ ok: false, status: 500 }) as unknown as Response,
+    );
+    await expect(
+      uploadPluginBundleToUrl(
+        "https://upload.example/x",
+        new Uint8Array([1]),
+        fetchImpl as unknown as typeof fetch,
+      ),
+    ).rejects.toMatchObject({ code: "UPLOAD_FAILED" });
+  });
+
+  it("maps a missing storageId to UPLOAD_FAILED", async () => {
+    const fetchImpl = vi.fn(async () => okJson({}));
+    await expect(
+      uploadPluginBundleToUrl(
+        "https://upload.example/x",
+        new Uint8Array([1]),
+        fetchImpl as unknown as typeof fetch,
+      ),
+    ).rejects.toMatchObject({ code: "UPLOAD_FAILED" });
+  });
+});
+
+describe("toPluginApiError", () => {
+  it("extracts stable code/message/scope/retryAfter from ConvexError data", () => {
+    const err = toPluginApiError({
+      data: {
+        code: "RATE_LIMITED",
+        message: "Too many plugin imports for this project. Try again later.",
+        scope: "project",
+        retryAfter: 1234,
+      },
+    });
+    expect(err).toBeInstanceOf(PluginApiError);
+    expect(err.code).toBe("RATE_LIMITED");
+    expect(err.scope).toBe("project");
+    expect(err.retryAfter).toBe(1234);
+  });
+
+  it("keeps details from structured backend failures", () => {
+    const err = toPluginApiError({
+      data: {
+        code: "CONFLICT",
+        message: "Import is not in a committable state",
+        details: { status: "failed" },
+      },
+    });
+    expect(err.code).toBe("CONFLICT");
+    expect(err.details).toEqual({ status: "failed" });
+  });
+
+  it("passes PluginApiError through unchanged", () => {
+    const original = new PluginApiError("PLUGINS_DISABLED", "off");
+    expect(toPluginApiError(original)).toBe(original);
+  });
+
+  it("falls back to UNKNOWN and strips the request-id prefix for plain errors", () => {
+    const err = toPluginApiError(new Error("[Request ID abc] Server Error"));
+    expect(err.code).toBe("UNKNOWN");
+    expect(err.message).toBe("Server Error");
+  });
+});

--- a/mcpjam-inspector/client/src/lib/plugins/__tests__/plugin-api.test.ts
+++ b/mcpjam-inspector/client/src/lib/plugins/__tests__/plugin-api.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import {
+  assertPluginBundleWithinCap,
   MAX_PLUGIN_BUNDLE_COMPRESSED_BYTES,
   toPluginApiError,
   uploadPluginBundleToUrl,
@@ -20,12 +21,15 @@ describe("uploadPluginBundleToUrl", () => {
     const storageId = await uploadPluginBundleToUrl(
       "https://upload.example/x",
       new Uint8Array([1, 2, 3]),
-      fetchImpl as unknown as typeof fetch,
+      { fetchImpl: fetchImpl as unknown as typeof fetch },
     );
     expect(storageId).toBe("st_123");
     expect(fetchImpl).toHaveBeenCalledWith(
       "https://upload.example/x",
-      expect.objectContaining({ method: "POST" }),
+      expect.objectContaining({
+        method: "POST",
+        signal: expect.any(AbortSignal),
+      }),
     );
   });
 
@@ -36,11 +40,9 @@ describe("uploadPluginBundleToUrl", () => {
     } as unknown as Blob;
     Object.setPrototypeOf(oversized, Blob.prototype);
     await expect(
-      uploadPluginBundleToUrl(
-        "https://upload.example/x",
-        oversized,
-        fetchImpl as unknown as typeof fetch,
-      ),
+      uploadPluginBundleToUrl("https://upload.example/x", oversized, {
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      }),
     ).rejects.toMatchObject({ code: "ARCHIVE_TOO_LARGE_COMPRESSED" });
     expect(fetchImpl).not.toHaveBeenCalled();
   });
@@ -50,23 +52,66 @@ describe("uploadPluginBundleToUrl", () => {
       async () => ({ ok: false, status: 500 }) as unknown as Response,
     );
     await expect(
-      uploadPluginBundleToUrl(
-        "https://upload.example/x",
-        new Uint8Array([1]),
-        fetchImpl as unknown as typeof fetch,
-      ),
+      uploadPluginBundleToUrl("https://upload.example/x", new Uint8Array([1]), {
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      }),
     ).rejects.toMatchObject({ code: "UPLOAD_FAILED" });
   });
 
   it("maps a missing storageId to UPLOAD_FAILED", async () => {
     const fetchImpl = vi.fn(async () => okJson({}));
     await expect(
-      uploadPluginBundleToUrl(
-        "https://upload.example/x",
-        new Uint8Array([1]),
-        fetchImpl as unknown as typeof fetch,
-      ),
+      uploadPluginBundleToUrl("https://upload.example/x", new Uint8Array([1]), {
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      }),
     ).rejects.toMatchObject({ code: "UPLOAD_FAILED" });
+  });
+
+  it("rejects an empty-string storageId as UPLOAD_FAILED", async () => {
+    const fetchImpl = vi.fn(async () => okJson({ storageId: "" }));
+    await expect(
+      uploadPluginBundleToUrl("https://upload.example/x", new Uint8Array([1]), {
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      }),
+    ).rejects.toMatchObject({ code: "UPLOAD_FAILED" });
+  });
+
+  it("aborts a stalled upload after timeoutMs", async () => {
+    const fetchImpl = vi.fn(
+      (_url: string, init: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init.signal?.addEventListener("abort", () =>
+            reject(
+              new DOMException("The operation was aborted.", "AbortError"),
+            ),
+          );
+        }),
+    );
+    await expect(
+      uploadPluginBundleToUrl("https://upload.example/x", new Uint8Array([1]), {
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        timeoutMs: 20,
+      }),
+    ).rejects.toMatchObject({
+      code: "UPLOAD_FAILED",
+      message: expect.stringContaining("timed out"),
+    });
+  });
+});
+
+describe("assertPluginBundleWithinCap", () => {
+  it("accepts a bundle at the cap and rejects one byte over", () => {
+    const atCap = {
+      size: MAX_PLUGIN_BUNDLE_COMPRESSED_BYTES,
+    } as unknown as Blob;
+    Object.setPrototypeOf(atCap, Blob.prototype);
+    expect(() => assertPluginBundleWithinCap(atCap)).not.toThrow();
+
+    const overCap = {
+      size: MAX_PLUGIN_BUNDLE_COMPRESSED_BYTES + 1,
+    } as unknown as Blob;
+    Object.setPrototypeOf(overCap, Blob.prototype);
+    expect(() => assertPluginBundleWithinCap(overCap)).toThrow(PluginApiError);
   });
 });
 

--- a/mcpjam-inspector/client/src/lib/plugins/folder-bundle.ts
+++ b/mcpjam-inspector/client/src/lib/plugins/folder-bundle.ts
@@ -51,10 +51,21 @@ const FOLDER_JUNK = /(^|\/)(\.DS_Store|Thumbs\.db|desktop\.ini|__MACOSX(\/|$))/;
  * name; when every entry shares that single top-level segment it is stripped
  * so the manifest lands at `.codex-plugin/plugin.json` relative to the bundle
  * root, exactly as it would inside a ZIP of the folder's CONTENTS.
+ *
+ * Limits (`DEFAULT_PLUGIN_BUNDLE_LIMITS`, same constants as the ZIP path and
+ * the SDK/backend validators) are enforced from the browser-reported entry
+ * count and `File.size` metadata BEFORE any file content is read, so an
+ * oversized folder selection is rejected without buffering it into memory.
+ * Violations throw the SDK's `PluginBundleError` with the SDK issue codes.
  */
 export async function filesFromFolderSelection(
   selection: File[],
+  options?: { limits?: Partial<PluginBundleLimits> },
 ): Promise<PluginBundleFile[]> {
+  const limits: PluginBundleLimits = {
+    ...DEFAULT_PLUGIN_BUNDLE_LIMITS,
+    ...options?.limits,
+  };
   const named = selection
     .map((file) => ({
       file,
@@ -73,13 +84,45 @@ export async function filesFromFolderSelection(
   const stripRoot =
     roots.size === 1 && named.every((entry) => entry.path.includes("/"));
 
-  const files: PluginBundleFile[] = [];
+  const pending: Array<{ path: string; file: File }> = [];
   for (const entry of named) {
     const path = stripRoot
       ? entry.path.slice(entry.path.indexOf("/") + 1)
       : entry.path;
     if (path.length === 0) continue;
-    files.push({ path, bytes: await readFileBytes(entry.file) });
+    pending.push({ path, file: entry.file });
+  }
+
+  // Metadata-only limit pass BEFORE reading a single byte. `buildPluginZip`
+  // writes file records only (no directory records), so this entry count is
+  // exactly what the backend archive validator will count on the upload.
+  if (pending.length > limits.maxEntries) {
+    throw bundleLimitError(
+      "BUNDLE_TOO_MANY_ENTRIES",
+      `selection has ${pending.length} files; the limit is ${limits.maxEntries}`,
+    );
+  }
+  let declaredTotal = 0;
+  for (const entry of pending) {
+    if (entry.file.size > limits.maxFileBytes) {
+      throw bundleLimitError(
+        "FILE_TOO_LARGE",
+        `file is ${entry.file.size} bytes; the per-file limit is ${limits.maxFileBytes}`,
+        entry.path,
+      );
+    }
+    declaredTotal += entry.file.size;
+    if (declaredTotal > limits.maxTotalBytes) {
+      throw bundleLimitError(
+        "BUNDLE_TOO_LARGE",
+        `selection exceeds ${limits.maxTotalBytes} bytes of total content`,
+      );
+    }
+  }
+
+  const files: PluginBundleFile[] = [];
+  for (const entry of pending) {
+    files.push({ path: entry.path, bytes: await readFileBytes(entry.file) });
   }
   return files;
 }
@@ -174,6 +217,10 @@ export async function buildPluginZip(
     zip.file(file.path, toZipInput(file.bytes), {
       date: ZIP_EPOCH,
       binary: true,
+      // File records only: implicit directory records would count against the
+      // backend's archive record limit, and `filesFromFolderSelection`'s
+      // pre-read entry count assumes the upload contains exactly its files.
+      createFolders: false,
     });
   }
   return zip.generateAsync({
@@ -205,6 +252,82 @@ function declaredUncompressedSize(entry: unknown): number | undefined {
   return typeof size === "number" && size >= 0 ? size : undefined;
 }
 
+/** Minimal surface of jszip's (untyped) per-entry internal stream. */
+interface JsZipInternalStream {
+  on(event: "data", cb: (chunk: Uint8Array) => void): JsZipInternalStream;
+  on(event: "end", cb: () => void): JsZipInternalStream;
+  on(event: "error", cb: (err: Error) => void): JsZipInternalStream;
+  resume(): JsZipInternalStream;
+  pause(): JsZipInternalStream;
+}
+
+/**
+ * Inflate one entry as a bounded stream. The central directory's declared
+ * size is attacker-controlled (a bomb can forge it below the caps), so the
+ * only trustworthy enforcement is counting ACTUAL inflated bytes as they
+ * stream out and aborting mid-entry the moment a cap is crossed — the
+ * remainder is never inflated.
+ */
+function readEntryBounded(
+  entry: unknown,
+  path: string,
+  maxFileBytes: number,
+  remainingTotalBytes: number,
+): Promise<Uint8Array> {
+  return new Promise<Uint8Array>((resolve, reject) => {
+    const stream = (
+      entry as { internalStream(type: "uint8array"): JsZipInternalStream }
+    ).internalStream("uint8array");
+    const chunks: Uint8Array[] = [];
+    let received = 0;
+    let settled = false;
+    const abort = (error: Error) => {
+      if (settled) return;
+      settled = true;
+      stream.pause();
+      reject(error);
+    };
+    stream
+      .on("data", (chunk) => {
+        if (settled) return;
+        received += chunk.length;
+        if (received > maxFileBytes) {
+          abort(
+            bundleLimitError(
+              "FILE_TOO_LARGE",
+              `file exceeded the per-file limit of ${maxFileBytes} bytes during extraction`,
+              path,
+            ),
+          );
+          return;
+        }
+        if (received > remainingTotalBytes) {
+          abort(
+            bundleLimitError(
+              "BUNDLE_TOO_LARGE",
+              `total uncompressed content exceeded the bundle limit during extraction`,
+            ),
+          );
+          return;
+        }
+        chunks.push(chunk);
+      })
+      .on("error", (err) => abort(err))
+      .on("end", () => {
+        if (settled) return;
+        settled = true;
+        const bytes = new Uint8Array(received);
+        let offset = 0;
+        for (const chunk of chunks) {
+          bytes.set(chunk, offset);
+          offset += chunk.length;
+        }
+        resolve(bytes);
+      })
+      .resume();
+  });
+}
+
 /**
  * Read a ZIP back into bundle files (directory entries dropped, contents
  * untouched — deliberately NO junk filtering, mirroring the backend's ZIP
@@ -214,11 +337,13 @@ function declaredUncompressedSize(entry: unknown): number | undefined {
  *
  * Zip-bomb hardening: extraction enforces the SAME limits the SDK parser and
  * backend archive adapter use (`DEFAULT_PLUGIN_BUNDLE_LIMITS`: 1000 entries,
- * 10 MB per file, 100 MB total uncompressed) DURING inflation — entry count
- * before any read, jszip's declared uncompressed size before inflating an
- * entry, and actual per-file/cumulative bytes after each read — so a crafted
- * archive under the 25 MB compressed cap cannot balloon renderer memory
- * before the parser's own checks run. Violations throw the SDK's
+ * 10 MB per file, 100 MB total uncompressed) DURING inflation. The record
+ * count (files AND directories, matching the backend's end-of-central-
+ * directory count) is checked before any read; each entry is then inflated
+ * as a bounded stream (`readEntryBounded`) that counts ACTUAL bytes and
+ * aborts mid-entry when a per-file or cumulative cap is crossed — a forged
+ * central-directory size cannot bypass it. The declared size is still used
+ * as a cheap fast-fail for honest metadata. Violations throw the SDK's
  * `PluginBundleError` with the matching issue codes
  * (`BUNDLE_TOO_MANY_ENTRIES` / `FILE_TOO_LARGE` / `BUNDLE_TOO_LARGE`), so the
  * UI error path is uniform with parser failures.
@@ -234,22 +359,27 @@ export async function zipToPluginFiles(
   const { default: JSZip } = await import("jszip");
   const zip = await JSZip.loadAsync(toZipInput(zipBytes));
 
-  const entries = Object.values(zip.files).filter((entry) => !entry.dir);
-  if (entries.length > limits.maxEntries) {
+  // Count every archive RECORD, directories included — the backend rejects on
+  // the end-of-central-directory record count before filtering, so a client
+  // preflight that ignored directory records would accept archives the
+  // authoritative validator rejects.
+  const allRecords = Object.values(zip.files);
+  if (allRecords.length > limits.maxEntries) {
     throw bundleLimitError(
       "BUNDLE_TOO_MANY_ENTRIES",
-      `archive has ${entries.length} entries; the limit is ${limits.maxEntries}`,
+      `archive has ${allRecords.length} records; the limit is ${limits.maxEntries}`,
     );
   }
+  const entries = allRecords.filter((entry) => !entry.dir);
 
   let totalBytes = 0;
   const files: PluginBundleFile[] = [];
   for (const entry of entries) {
     const path = entry.name.replace(/\\/g, "/");
 
-    // Reject on the DECLARED size first so an oversized or bomb entry is
-    // never inflated at all. The declared size is attacker-controlled, so the
-    // actual byte counts are re-checked after extraction below.
+    // Cheap fast-fail on the DECLARED size (honest metadata never inflates).
+    // The declared size is attacker-controlled, so the authoritative
+    // enforcement is the bounded stream below, which counts actual bytes.
     const declared = declaredUncompressedSize(entry);
     if (declared !== undefined) {
       if (declared > limits.maxFileBytes) {
@@ -267,21 +397,13 @@ export async function zipToPluginFiles(
       }
     }
 
-    const bytes = await entry.async("uint8array");
-    if (bytes.byteLength > limits.maxFileBytes) {
-      throw bundleLimitError(
-        "FILE_TOO_LARGE",
-        `file exceeds the per-file limit of ${limits.maxFileBytes} bytes`,
-        path,
-      );
-    }
+    const bytes = await readEntryBounded(
+      entry,
+      path,
+      limits.maxFileBytes,
+      limits.maxTotalBytes - totalBytes,
+    );
     totalBytes += bytes.byteLength;
-    if (totalBytes > limits.maxTotalBytes) {
-      throw bundleLimitError(
-        "BUNDLE_TOO_LARGE",
-        `total uncompressed content exceeds ${limits.maxTotalBytes} bytes`,
-      );
-    }
     files.push({ path, bytes });
   }
   return files.sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));

--- a/mcpjam-inspector/client/src/lib/plugins/folder-bundle.ts
+++ b/mcpjam-inspector/client/src/lib/plugins/folder-bundle.ts
@@ -22,9 +22,14 @@
 import type {
   ParsedPluginBundle,
   ParsePluginBundleOptions,
+  PluginBundleLimits,
   PluginFileSource,
 } from "@mcpjam/sdk/plugin-bundle";
-import { parsePluginBundle } from "@mcpjam/sdk/plugin-bundle";
+import {
+  DEFAULT_PLUGIN_BUNDLE_LIMITS,
+  parsePluginBundle,
+  PluginBundleError,
+} from "@mcpjam/sdk/plugin-bundle";
 
 export interface PluginBundleFile {
   /** Bundle-root-relative path with `/` separators (no leading `./`). */
@@ -108,10 +113,17 @@ export function createMemoryPluginFileSource(
         size: file.bytes.byteLength,
         kind: "file" as const,
       })),
-    readBytes: async (path: string) => {
+    readBytes: async (path: string, maxBytes: number) => {
       const bytes = byPath.get(path);
       if (bytes === undefined) {
         throw new Error(`no such bundle file: ${path}`);
+      }
+      // The PluginFileSource contract: adapters MUST enforce maxBytes and
+      // throw rather than return oversized (or truncated) data.
+      if (bytes.byteLength > maxBytes) {
+        throw new Error(
+          `bundle file ${path} exceeds the ${maxBytes}-byte read limit`,
+        );
       }
       return bytes;
     },
@@ -171,25 +183,106 @@ export async function buildPluginZip(
   });
 }
 
+function bundleLimitError(
+  code: "BUNDLE_TOO_MANY_ENTRIES" | "BUNDLE_TOO_LARGE" | "FILE_TOO_LARGE",
+  message: string,
+  path?: string,
+): PluginBundleError {
+  return new PluginBundleError([
+    {
+      code,
+      severity: "error",
+      message,
+      ...(path !== undefined ? { path } : {}),
+    },
+  ]);
+}
+
+/** jszip keeps the central-directory uncompressed size on an internal field. */
+function declaredUncompressedSize(entry: unknown): number | undefined {
+  const size = (entry as { _data?: { uncompressedSize?: unknown } })._data
+    ?.uncompressedSize;
+  return typeof size === "number" && size >= 0 ? size : undefined;
+}
+
 /**
  * Read a ZIP back into bundle files (directory entries dropped, contents
  * untouched — deliberately NO junk filtering, mirroring the backend's ZIP
  * adapter so a preflight over these files hashes the same bytes the backend
  * will). Used by tests to prove folder/ZIP hash parity and available to the
  * import UI for ZIP preflight.
+ *
+ * Zip-bomb hardening: extraction enforces the SAME limits the SDK parser and
+ * backend archive adapter use (`DEFAULT_PLUGIN_BUNDLE_LIMITS`: 1000 entries,
+ * 10 MB per file, 100 MB total uncompressed) DURING inflation — entry count
+ * before any read, jszip's declared uncompressed size before inflating an
+ * entry, and actual per-file/cumulative bytes after each read — so a crafted
+ * archive under the 25 MB compressed cap cannot balloon renderer memory
+ * before the parser's own checks run. Violations throw the SDK's
+ * `PluginBundleError` with the matching issue codes
+ * (`BUNDLE_TOO_MANY_ENTRIES` / `FILE_TOO_LARGE` / `BUNDLE_TOO_LARGE`), so the
+ * UI error path is uniform with parser failures.
  */
 export async function zipToPluginFiles(
   zipBytes: Uint8Array,
+  options?: { limits?: Partial<PluginBundleLimits> },
 ): Promise<PluginBundleFile[]> {
+  const limits: PluginBundleLimits = {
+    ...DEFAULT_PLUGIN_BUNDLE_LIMITS,
+    ...options?.limits,
+  };
   const { default: JSZip } = await import("jszip");
   const zip = await JSZip.loadAsync(toZipInput(zipBytes));
+
+  const entries = Object.values(zip.files).filter((entry) => !entry.dir);
+  if (entries.length > limits.maxEntries) {
+    throw bundleLimitError(
+      "BUNDLE_TOO_MANY_ENTRIES",
+      `archive has ${entries.length} entries; the limit is ${limits.maxEntries}`,
+    );
+  }
+
+  let totalBytes = 0;
   const files: PluginBundleFile[] = [];
-  for (const entry of Object.values(zip.files)) {
-    if (entry.dir) continue;
-    files.push({
-      path: entry.name.replace(/\\/g, "/"),
-      bytes: await entry.async("uint8array"),
-    });
+  for (const entry of entries) {
+    const path = entry.name.replace(/\\/g, "/");
+
+    // Reject on the DECLARED size first so an oversized or bomb entry is
+    // never inflated at all. The declared size is attacker-controlled, so the
+    // actual byte counts are re-checked after extraction below.
+    const declared = declaredUncompressedSize(entry);
+    if (declared !== undefined) {
+      if (declared > limits.maxFileBytes) {
+        throw bundleLimitError(
+          "FILE_TOO_LARGE",
+          `file declares ${declared} bytes; the per-file limit is ${limits.maxFileBytes}`,
+          path,
+        );
+      }
+      if (totalBytes + declared > limits.maxTotalBytes) {
+        throw bundleLimitError(
+          "BUNDLE_TOO_LARGE",
+          `total uncompressed content exceeds ${limits.maxTotalBytes} bytes`,
+        );
+      }
+    }
+
+    const bytes = await entry.async("uint8array");
+    if (bytes.byteLength > limits.maxFileBytes) {
+      throw bundleLimitError(
+        "FILE_TOO_LARGE",
+        `file exceeds the per-file limit of ${limits.maxFileBytes} bytes`,
+        path,
+      );
+    }
+    totalBytes += bytes.byteLength;
+    if (totalBytes > limits.maxTotalBytes) {
+      throw bundleLimitError(
+        "BUNDLE_TOO_LARGE",
+        `total uncompressed content exceeds ${limits.maxTotalBytes} bytes`,
+      );
+    }
+    files.push({ path, bytes });
   }
   return files.sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
 }

--- a/mcpjam-inspector/client/src/lib/plugins/folder-bundle.ts
+++ b/mcpjam-inspector/client/src/lib/plugins/folder-bundle.ts
@@ -1,0 +1,195 @@
+/**
+ * Folder-to-ZIP bundling for plugin import (PR INS-1 of
+ * docs/plans/openai-plugin-import-cross-repo.md).
+ *
+ * Local/Electron mode imports a plugin from a directory picked via a
+ * `webkitdirectory` input (same pattern as the skills upload dialog). This
+ * module turns that selection into:
+ *
+ *   - an in-memory `PluginFileSource` for the shared `@mcpjam/sdk`
+ *     plugin-bundle parser — the SAME parser the backend runs on the uploaded
+ *     ZIP, so the client-side preflight `bundleHash` matches the backend's by
+ *     construction (the bundle hash is content-defined: an aggregate over
+ *     sorted `path NUL contentHash NUL` frames, independent of ZIP metadata,
+ *     compression, or entry order); and
+ *   - a ZIP `Uint8Array` to upload through the normal import path.
+ *
+ * Because the hash is content-defined, a folder and a ZIP with identical
+ * contents always produce the same bundle hash, whether computed here or by
+ * the backend inspect action.
+ */
+
+import type {
+  ParsedPluginBundle,
+  ParsePluginBundleOptions,
+  PluginFileSource,
+} from "@mcpjam/sdk/plugin-bundle";
+import { parsePluginBundle } from "@mcpjam/sdk/plugin-bundle";
+
+export interface PluginBundleFile {
+  /** Bundle-root-relative path with `/` separators (no leading `./`). */
+  path: string;
+  bytes: Uint8Array;
+}
+
+/**
+ * OS metadata junk that a directory picker sweeps up but that no plugin
+ * bundle should contain. Filtered from FOLDER selections only — a
+ * user-supplied ZIP is uploaded as-is and the backend inspect of those exact
+ * bytes stays authoritative.
+ */
+const FOLDER_JUNK = /(^|\/)(\.DS_Store|Thumbs\.db|desktop\.ini|__MACOSX(\/|$))/;
+
+/**
+ * Convert a `webkitdirectory` selection into bundle files. Browser folder
+ * selections prefix every `webkitRelativePath` with the picked folder's own
+ * name; when every entry shares that single top-level segment it is stripped
+ * so the manifest lands at `.codex-plugin/plugin.json` relative to the bundle
+ * root, exactly as it would inside a ZIP of the folder's CONTENTS.
+ */
+export async function filesFromFolderSelection(
+  selection: File[],
+): Promise<PluginBundleFile[]> {
+  const named = selection
+    .map((file) => ({
+      file,
+      path: (
+        (file as { webkitRelativePath?: string }).webkitRelativePath ||
+        file.name
+      ).replace(/\\/g, "/"),
+    }))
+    .filter((entry) => !FOLDER_JUNK.test(entry.path));
+
+  // Strip the shared top-level folder segment (present iff the paths came
+  // from a real directory selection rather than loose files).
+  const roots = new Set(
+    named.map((entry) => entry.path.split("/", 1)[0] ?? ""),
+  );
+  const stripRoot =
+    roots.size === 1 && named.every((entry) => entry.path.includes("/"));
+
+  const files: PluginBundleFile[] = [];
+  for (const entry of named) {
+    const path = stripRoot
+      ? entry.path.slice(entry.path.indexOf("/") + 1)
+      : entry.path;
+    if (path.length === 0) continue;
+    files.push({ path, bytes: await readFileBytes(entry.file) });
+  }
+  return files;
+}
+
+/** `Blob.arrayBuffer` with a `FileReader` fallback (older WebKit/jsdom). */
+async function readFileBytes(file: File): Promise<Uint8Array> {
+  if (typeof file.arrayBuffer === "function") {
+    return new Uint8Array(await file.arrayBuffer());
+  }
+  return new Promise<Uint8Array>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(reader.error);
+    reader.onload = () => resolve(new Uint8Array(reader.result as ArrayBuffer));
+    reader.readAsArrayBuffer(file);
+  });
+}
+
+/**
+ * In-memory `PluginFileSource` over already-loaded files. Feed it to the
+ * shared SDK parser for client-side preflight validation and the
+ * content-defined `bundleHash`.
+ */
+export function createMemoryPluginFileSource(
+  files: PluginBundleFile[],
+): PluginFileSource {
+  const byPath = new Map(files.map((file) => [file.path, file.bytes]));
+  return {
+    list: async () =>
+      files.map((file) => ({
+        path: file.path,
+        size: file.bytes.byteLength,
+        kind: "file" as const,
+      })),
+    readBytes: async (path: string) => {
+      const bytes = byPath.get(path);
+      if (bytes === undefined) {
+        throw new Error(`no such bundle file: ${path}`);
+      }
+      return bytes;
+    },
+  };
+}
+
+/**
+ * Parse an in-memory file set with the shared SDK plugin-bundle parser.
+ * Throws the SDK's `PluginBundleError` (with every collected issue) on any
+ * error-severity finding; the result carries `bundleHash` and warnings.
+ */
+export async function parsePluginBundleFromFiles(
+  files: PluginBundleFile[],
+  options?: ParsePluginBundleOptions,
+): Promise<ParsedPluginBundle> {
+  return parsePluginBundle(createMemoryPluginFileSource(files), options);
+}
+
+/** Fixed entry timestamp so repeated zips of the same folder are stable. */
+const ZIP_EPOCH = new Date(Date.UTC(2000, 0, 1, 0, 0, 0));
+
+/**
+ * jszip sniffs input types with `instanceof`, which fails across JS realms
+ * (Node vs jsdom in vitest). `Buffer.isBuffer` is realm-safe, so prefer a
+ * Buffer in Node-flavored environments; browsers (single realm) pass the
+ * Uint8Array straight through.
+ */
+function toZipInput(bytes: Uint8Array): Uint8Array {
+  return typeof Buffer !== "undefined" ? Buffer.from(bytes) : bytes;
+}
+
+/**
+ * Build an uploadable ZIP from bundle files. Entries are sorted by
+ * code-point path order with a fixed timestamp, so zipping the same folder
+ * twice yields the same archive on the same machine. (Byte-identical ZIPs are
+ * NOT required for hash equality — the bundle hash is computed from entry
+ * contents, not archive bytes.)
+ */
+export async function buildPluginZip(
+  files: PluginBundleFile[],
+): Promise<Uint8Array> {
+  const { default: JSZip } = await import("jszip");
+  const zip = new JSZip();
+  const sorted = [...files].sort((a, b) =>
+    a.path < b.path ? -1 : a.path > b.path ? 1 : 0,
+  );
+  for (const file of sorted) {
+    zip.file(file.path, toZipInput(file.bytes), {
+      date: ZIP_EPOCH,
+      binary: true,
+    });
+  }
+  return zip.generateAsync({
+    type: "uint8array",
+    compression: "DEFLATE",
+    compressionOptions: { level: 6 },
+  });
+}
+
+/**
+ * Read a ZIP back into bundle files (directory entries dropped, contents
+ * untouched — deliberately NO junk filtering, mirroring the backend's ZIP
+ * adapter so a preflight over these files hashes the same bytes the backend
+ * will). Used by tests to prove folder/ZIP hash parity and available to the
+ * import UI for ZIP preflight.
+ */
+export async function zipToPluginFiles(
+  zipBytes: Uint8Array,
+): Promise<PluginBundleFile[]> {
+  const { default: JSZip } = await import("jszip");
+  const zip = await JSZip.loadAsync(toZipInput(zipBytes));
+  const files: PluginBundleFile[] = [];
+  for (const entry of Object.values(zip.files)) {
+    if (entry.dir) continue;
+    files.push({
+      path: entry.name.replace(/\\/g, "/"),
+      bytes: await entry.async("uint8array"),
+    });
+  }
+  return files.sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
+}

--- a/mcpjam-inspector/client/src/lib/plugins/folder-bundle.ts
+++ b/mcpjam-inspector/client/src/lib/plugins/folder-bundle.ts
@@ -1,29 +1,36 @@
 /**
- * Folder-to-ZIP bundling for plugin import (PR INS-1 of
+ * Client-side plugin bundle adapters (PR INS-1 of
  * docs/plans/openai-plugin-import-cross-repo.md).
  *
- * Local/Electron mode imports a plugin from a directory picked via a
- * `webkitdirectory` input (same pattern as the skills upload dialog). This
- * module turns that selection into:
+ * ARCHITECTURE — thin adapters over the shared rulebook, not a parallel
+ * validator. This module mirrors the backend's shape (mcpjam-backend
+ * convex/lib/pluginArchive.ts): the adapter layers (jszip for ZIPs, the File
+ * API for folder selections) only surface RAW entry facts — the unsanitized
+ * entry name, link kind from unix mode bits, declared sizes — as
+ * `PluginFileSource` implementations, and the shared `@mcpjam/sdk`
+ * plugin-bundle parser judges them. Every entry-level rule (traversal,
+ * absolute paths, NUL/control characters, duplicate and case-colliding
+ * normalized paths, link entries, path length/depth, per-file/total/entry
+ * count limits, declared-vs-actual sizes, and everything downstream:
+ * manifest, skills, MCP config) runs through the SAME
+ * `parsePluginBundle`/`validateBundleEntries` code the backend inspect
+ * action runs, so a bundle rejected here is rejected there with the same
+ * issue codes, a bundle accepted here passes the shared validation there,
+ * and future SDK checks apply client-side with zero changes here.
  *
- *   - an in-memory `PluginFileSource` for the shared `@mcpjam/sdk`
- *     plugin-bundle parser — the SAME parser the backend runs on the uploaded
- *     ZIP, so the client-side preflight `bundleHash` matches the backend's by
- *     construction (the bundle hash is content-defined: an aggregate over
- *     sorted `path NUL contentHash NUL` frames, independent of ZIP metadata,
- *     compression, or entry order); and
- *   - a ZIP `Uint8Array` to upload through the normal import path.
- *
- * Because the hash is content-defined, a folder and a ZIP with identical
- * contents always produce the same bundle hash, whether computed here or by
- * the backend inspect action.
+ * The ONLY client-side logic outside the shared parser is the
+ * "CLIENT-ONLY ARCHIVE SCREEN" block below (structural jszip gaps +
+ * renderer-memory protection, mirroring the backend's archive adapter) and
+ * the folder-selection UI mapping (junk filter + root strip).
  */
 
 import type {
   ParsedPluginBundle,
   ParsePluginBundleOptions,
   PluginBundleLimits,
+  PluginFileEntry,
   PluginFileSource,
+  PluginValidationIssue,
 } from "@mcpjam/sdk/plugin-bundle";
 import {
   DEFAULT_PLUGIN_BUNDLE_LIMITS,
@@ -37,94 +44,23 @@ export interface PluginBundleFile {
   bytes: Uint8Array;
 }
 
-/**
- * OS metadata junk that a directory picker sweeps up but that no plugin
- * bundle should contain. Filtered from FOLDER selections only — a
- * user-supplied ZIP is uploaded as-is and the backend inspect of those exact
- * bytes stays authoritative.
- */
-const FOLDER_JUNK = /(^|\/)(\.DS_Store|Thumbs\.db|desktop\.ini|__MACOSX(\/|$))/;
+function resolveLimits(options?: ParsePluginBundleOptions): PluginBundleLimits {
+  return { ...DEFAULT_PLUGIN_BUNDLE_LIMITS, ...options?.limits };
+}
 
-/**
- * Convert a `webkitdirectory` selection into bundle files. Browser folder
- * selections prefix every `webkitRelativePath` with the picked folder's own
- * name; when every entry shares that single top-level segment it is stripped
- * so the manifest lands at `.codex-plugin/plugin.json` relative to the bundle
- * root, exactly as it would inside a ZIP of the folder's CONTENTS.
- *
- * Limits (`DEFAULT_PLUGIN_BUNDLE_LIMITS`, same constants as the ZIP path and
- * the SDK/backend validators) are enforced from the browser-reported entry
- * count and `File.size` metadata BEFORE any file content is read, so an
- * oversized folder selection is rejected without buffering it into memory.
- * Violations throw the SDK's `PluginBundleError` with the SDK issue codes.
- */
-export async function filesFromFolderSelection(
-  selection: File[],
-  options?: { limits?: Partial<PluginBundleLimits> },
-): Promise<PluginBundleFile[]> {
-  const limits: PluginBundleLimits = {
-    ...DEFAULT_PLUGIN_BUNDLE_LIMITS,
-    ...options?.limits,
-  };
-  const named = selection
-    .map((file) => ({
-      file,
-      path: (
-        (file as { webkitRelativePath?: string }).webkitRelativePath ||
-        file.name
-      ).replace(/\\/g, "/"),
-    }))
-    .filter((entry) => !FOLDER_JUNK.test(entry.path));
-
-  // Strip the shared top-level folder segment (present iff the paths came
-  // from a real directory selection rather than loose files).
-  const roots = new Set(
-    named.map((entry) => entry.path.split("/", 1)[0] ?? ""),
-  );
-  const stripRoot =
-    roots.size === 1 && named.every((entry) => entry.path.includes("/"));
-
-  const pending: Array<{ path: string; file: File }> = [];
-  for (const entry of named) {
-    const path = stripRoot
-      ? entry.path.slice(entry.path.indexOf("/") + 1)
-      : entry.path;
-    if (path.length === 0) continue;
-    pending.push({ path, file: entry.file });
-  }
-
-  // Metadata-only limit pass BEFORE reading a single byte. `buildPluginZip`
-  // writes file records only (no directory records), so this entry count is
-  // exactly what the backend archive validator will count on the upload.
-  if (pending.length > limits.maxEntries) {
-    throw bundleLimitError(
-      "BUNDLE_TOO_MANY_ENTRIES",
-      `selection has ${pending.length} files; the limit is ${limits.maxEntries}`,
-    );
-  }
-  let declaredTotal = 0;
-  for (const entry of pending) {
-    if (entry.file.size > limits.maxFileBytes) {
-      throw bundleLimitError(
-        "FILE_TOO_LARGE",
-        `file is ${entry.file.size} bytes; the per-file limit is ${limits.maxFileBytes}`,
-        entry.path,
-      );
-    }
-    declaredTotal += entry.file.size;
-    if (declaredTotal > limits.maxTotalBytes) {
-      throw bundleLimitError(
-        "BUNDLE_TOO_LARGE",
-        `selection exceeds ${limits.maxTotalBytes} bytes of total content`,
-      );
-    }
-  }
-
-  const files: PluginBundleFile[] = [];
-  for (const entry of pending) {
-    files.push({ path: entry.path, bytes: await readFileBytes(entry.file) });
-  }
-  return files;
+function issueError(
+  code: PluginValidationIssue["code"],
+  message: string,
+  path?: string,
+): PluginBundleError {
+  return new PluginBundleError([
+    {
+      code,
+      severity: "error",
+      message,
+      ...(path !== undefined ? { path } : {}),
+    },
+  ]);
 }
 
 /** `Blob.arrayBuffer` with a `FileReader` fallback (older WebKit/jsdom). */
@@ -139,6 +75,149 @@ async function readFileBytes(file: File): Promise<Uint8Array> {
     reader.readAsArrayBuffer(file);
   });
 }
+
+/**
+ * jszip sniffs input types with `instanceof`, which fails across JS realms
+ * (Node vs jsdom in vitest). `Buffer.isBuffer` is realm-safe, so prefer a
+ * Buffer in Node-flavored environments; browsers (single realm) pass the
+ * Uint8Array straight through.
+ */
+function toZipInput(bytes: Uint8Array): Uint8Array {
+  return typeof Buffer !== "undefined" ? Buffer.from(bytes) : bytes;
+}
+
+// ---------------------------------------------------------------------------
+// Folder selection (webkitdirectory) — UI mapping + raw-facts source.
+// ---------------------------------------------------------------------------
+
+/**
+ * OS metadata junk that a directory picker sweeps up but that no plugin
+ * bundle should contain. Filtered from FOLDER selections only — a
+ * user-supplied ZIP is uploaded as-is and the backend inspect of those exact
+ * bytes stays authoritative.
+ */
+const FOLDER_JUNK = /(^|\/)(\.DS_Store|Thumbs\.db|desktop\.ini|__MACOSX(\/|$))/;
+
+/**
+ * Map a `webkitdirectory` selection to bundle-relative paths. Browser folder
+ * selections prefix every `webkitRelativePath` with the picked folder's own
+ * name; when every entry shares that single top-level segment it is stripped
+ * so the manifest lands at `.codex-plugin/plugin.json` relative to the
+ * bundle root, exactly as it would inside a ZIP of the folder's CONTENTS.
+ * This is a UI affordance mapping, not validation — the shared parser judges
+ * the resulting paths.
+ */
+function normalizeFolderSelection(
+  selection: File[],
+): Array<{ path: string; file: File }> {
+  const named = selection
+    .map((file) => ({
+      file,
+      path: (
+        (file as { webkitRelativePath?: string }).webkitRelativePath ||
+        file.name
+      ).replace(/\\/g, "/"),
+    }))
+    .filter((entry) => !FOLDER_JUNK.test(entry.path));
+
+  const roots = new Set(
+    named.map((entry) => entry.path.split("/", 1)[0] ?? ""),
+  );
+  const stripRoot =
+    roots.size === 1 && named.every((entry) => entry.path.includes("/"));
+
+  const pending: Array<{ path: string; file: File }> = [];
+  for (const entry of named) {
+    const path = stripRoot
+      ? entry.path.slice(entry.path.indexOf("/") + 1)
+      : entry.path;
+    if (path.length === 0) continue;
+    pending.push({ path, file: entry.file });
+  }
+  return pending;
+}
+
+/**
+ * Lazy `PluginFileSource` over a folder selection. `list()` reports
+ * browser-provided metadata only (`File.size`, no content), so the shared
+ * parser's phase-1 validation — entry count, per-file and total size caps,
+ * path safety — rejects an oversized or malicious selection BEFORE a single
+ * byte is read. `readBytes` enforces `maxBytes` from metadata pre-read and
+ * against actual bytes post-read (the `PluginFileSource` contract: throw,
+ * never truncate).
+ */
+export function createFolderPluginFileSource(
+  selection: File[],
+): PluginFileSource {
+  const pending = normalizeFolderSelection(selection);
+  const byPath = new Map(pending.map((entry) => [entry.path, entry.file]));
+  return {
+    list: async () =>
+      pending.map((entry) => ({
+        path: entry.path,
+        size: entry.file.size,
+        kind: "file" as const,
+      })),
+    readBytes: async (path: string, maxBytes: number) => {
+      const file = byPath.get(path);
+      if (file === undefined) {
+        throw new Error(`no such selected file: ${path}`);
+      }
+      if (file.size > maxBytes) {
+        throw new Error(
+          `selected file ${path} exceeds the ${maxBytes}-byte read limit`,
+        );
+      }
+      const bytes = await readFileBytes(file);
+      if (bytes.byteLength > maxBytes) {
+        throw new Error(
+          `selected file ${path} exceeds the ${maxBytes}-byte read limit`,
+        );
+      }
+      return bytes;
+    },
+  };
+}
+
+/**
+ * Preflight a folder selection with the shared SDK parser (the same parser
+ * the backend inspect action runs). Limit and path violations reject before
+ * any file content is read; success yields the content-defined `bundleHash`
+ * the backend will recompute on the uploaded ZIP.
+ */
+export async function parsePluginBundleFromFolderSelection(
+  selection: File[],
+  options?: ParsePluginBundleOptions,
+): Promise<ParsedPluginBundle> {
+  return parsePluginBundle(createFolderPluginFileSource(selection), options);
+}
+
+/**
+ * Full folder import preflight: validate + hash via the shared parser, then
+ * (only for a valid bundle) read the files and build the uploadable ZIP.
+ * Because the ZIP is built from exactly the validated entries, its backend
+ * inspection sees the same facts the client preflight judged.
+ */
+export async function folderSelectionToPluginZip(
+  selection: File[],
+  options?: ParsePluginBundleOptions,
+): Promise<{ parsed: ParsedPluginBundle; zipBytes: Uint8Array }> {
+  const source = createFolderPluginFileSource(selection);
+  const parsed = await parsePluginBundle(source, options);
+  const limits = resolveLimits(options);
+  const files: PluginBundleFile[] = [];
+  for (const entry of await source.list()) {
+    files.push({
+      path: entry.path,
+      bytes: await source.readBytes(entry.path, limits.maxFileBytes),
+    });
+  }
+  return { parsed, zipBytes: await buildPluginZip(files) };
+}
+
+// ---------------------------------------------------------------------------
+// In-memory source (already-loaded content: tests, pasted files).
+// ---------------------------------------------------------------------------
 
 /**
  * In-memory `PluginFileSource` over already-loaded files. Feed it to the
@@ -185,25 +264,19 @@ export async function parsePluginBundleFromFiles(
   return parsePluginBundle(createMemoryPluginFileSource(files), options);
 }
 
+// ---------------------------------------------------------------------------
+// ZIP building (upload path).
+// ---------------------------------------------------------------------------
+
 /** Fixed entry timestamp so repeated zips of the same folder are stable. */
 const ZIP_EPOCH = new Date(Date.UTC(2000, 0, 1, 0, 0, 0));
 
 /**
- * jszip sniffs input types with `instanceof`, which fails across JS realms
- * (Node vs jsdom in vitest). `Buffer.isBuffer` is realm-safe, so prefer a
- * Buffer in Node-flavored environments; browsers (single realm) pass the
- * Uint8Array straight through.
- */
-function toZipInput(bytes: Uint8Array): Uint8Array {
-  return typeof Buffer !== "undefined" ? Buffer.from(bytes) : bytes;
-}
-
-/**
  * Build an uploadable ZIP from bundle files. Entries are sorted by
  * code-point path order with a fixed timestamp, so zipping the same folder
- * twice yields the same archive on the same machine. (Byte-identical ZIPs are
- * NOT required for hash equality — the bundle hash is computed from entry
- * contents, not archive bytes.)
+ * twice yields the same archive on the same machine. (Byte-identical ZIPs
+ * are NOT required for hash equality — the bundle hash is computed from
+ * entry contents, not archive bytes.)
  */
 export async function buildPluginZip(
   files: PluginBundleFile[],
@@ -217,9 +290,9 @@ export async function buildPluginZip(
     zip.file(file.path, toZipInput(file.bytes), {
       date: ZIP_EPOCH,
       binary: true,
-      // File records only: implicit directory records would count against the
-      // backend's archive record limit, and `filesFromFolderSelection`'s
-      // pre-read entry count assumes the upload contains exactly its files.
+      // File records only: implicit directory records would count against
+      // the backend's archive record limit, and the folder preflight's entry
+      // count assumes the upload contains exactly its files.
       createFolders: false,
     });
   }
@@ -230,24 +303,58 @@ export async function buildPluginZip(
   });
 }
 
-function bundleLimitError(
-  code:
-    | "BUNDLE_TOO_MANY_ENTRIES"
-    | "BUNDLE_TOO_LARGE"
-    | "FILE_TOO_LARGE"
-    | "PATH_DUPLICATE",
-  message: string,
-  path?: string,
-): PluginBundleError {
-  return new PluginBundleError([
-    {
-      code,
-      severity: "error",
-      message,
-      ...(path !== undefined ? { path } : {}),
-    },
-  ]);
-}
+// ---------------------------------------------------------------------------
+// CLIENT-ONLY ARCHIVE SCREEN.
+//
+// Everything in this block exists because of a structural jszip gap or a
+// renderer-memory concern the shared (pure, source-agnostic) SDK parser
+// cannot cover. It deliberately mirrors the backend's Node archive adapter
+// (mcpjam-backend convex/lib/pluginArchive.ts + pluginArchiveLimits.ts),
+// which owns the same archive-level concerns on top of the same SDK parser:
+//
+// 1. RAW EOCD RECORD COUNT — jszip's `files` is a name-keyed object, so
+//    duplicate (and same-sanitizing) names collapse during `loadAsync` and
+//    the parser can never see the true record count. The backend rejects on
+//    the end-of-central-directory count (`zip.entryCount`,
+//    ARCHIVE_TOO_MANY_ENTRIES); the client reads the same field from the
+//    raw bytes. The ZIP64 0xFFFF sentinel is rejected outright rather than
+//    parsing ZIP64 structures — which is also why a configured `maxEntries`
+//    must stay below 0xFFFF (validated at the API boundary): at or above
+//    the sentinel the 16-bit field can no longer represent the real count.
+// 2. COLLAPSED-DUPLICATE DETECTION — when the raw record count exceeds
+//    jszip's deduplicated entry count, duplicate/colliding names were
+//    silently merged last-wins; surfaced as PATH_DUPLICATE, the same code
+//    the SDK parser emits for duplicate normalized paths it CAN see.
+// 3. BACKSLASH ENTRY NAMES — yauzl (the backend's reader) rejects any entry
+//    name containing "\" before the SDK parser ever runs, while the SDK
+//    normalizes "\" to "/". Mirrored here (PATH_INVALID_CHARACTER) so a
+//    backslash-named archive cannot pass client preflight and then fail
+//    backend inspection.
+// 4. ENCRYPTED ENTRIES — jszip cannot read them and throws while parsing
+//    the central directory; mapped to FILE_UNREADABLE (the SDK has no
+//    encryption code — it is an archive-level concern; the backend rejects
+//    with its archive-level ARCHIVE_ENCRYPTED_ENTRY). Either way the
+//    archive is rejected on both sides.
+// 5. BOUNDED STREAMING INFLATION — `readBytes` inflates via jszip's
+//    internalStream with a running byte counter capped at
+//    min(maxBytes, declared size), aborting mid-entry the moment the cap is
+//    crossed (a forged declared size cannot balloon renderer memory).
+//    Mirrors the backend's `readEntryBytes` cap exactly; on both sides an
+//    overrun surfaces through the shared parser as FILE_UNREADABLE.
+//
+// NOT mirrored, with reasons:
+// - Compressed-size cap (25 MB): enforced by `assertPluginBundleWithinCap`
+//   before upload (lib/plugins/plugin-api.ts), same constant as the backend.
+// - Single-entry ratio-bomb heuristic (ARCHIVE_ZIP_BOMB): can never fire
+//   without FILE_TOO_LARGE also firing, because its trigger floor equals
+//   the SDK's per-file cap (10 MB); the SDK check covers it.
+// - Raw names of DIRECTORY records: jszip preserves `unsafeOriginalName`
+//   for file records only, so a crafted traversal-named directory record
+//   (no content) reaches the parser with its sanitized name. Recovering the
+//   raw name would require walking the central directory ourselves, which
+//   preflight deliberately does not do — the backend (yauzl validates every
+//   raw name) stays authoritative and rejects such an archive at import.
+// ---------------------------------------------------------------------------
 
 /**
  * Read the total-record count from the ZIP's end-of-central-directory (EOCD)
@@ -276,14 +383,46 @@ function readEocdTotalEntries(bytes: Uint8Array): number | undefined {
   return undefined;
 }
 
-/** jszip keeps the central-directory uncompressed size on an internal field. */
-function declaredUncompressedSize(entry: unknown): number | undefined {
-  const size = (entry as { _data?: { uncompressedSize?: unknown } })._data
-    ?.uncompressedSize;
-  return typeof size === "number" && size >= 0 ? size : undefined;
+// Unix file-type bits carried in the high 16 bits of externalFileAttributes
+// (mirrors the backend adapter's constants). ZIP has no real hard link; any
+// populated non-regular, non-directory type is surfaced as a link kind so
+// the SDK parser rejects it (PATH_LINK_ENTRY), exactly as the backend
+// rejects the same records (ARCHIVE_LINK_ENTRY).
+const S_IFMT = 0o170000;
+const S_IFLNK = 0o120000;
+const S_IFREG = 0o100000;
+const S_IFDIR = 0o040000;
+
+function entryKind(
+  rawName: string,
+  unixPermissions: number | string | null,
+): NonNullable<PluginFileEntry["kind"]> {
+  if (rawName.endsWith("/")) return "directory";
+  const mode =
+    typeof unixPermissions === "number"
+      ? unixPermissions
+      : typeof unixPermissions === "string"
+        ? Number.parseInt(unixPermissions, 8)
+        : null;
+  if (mode !== null && Number.isFinite(mode)) {
+    const type = mode & S_IFMT;
+    if (type === S_IFLNK) return "symlink";
+    // Some writers leave the type bits unset (0); treat those as files.
+    if (type !== 0 && type !== S_IFREG && type !== S_IFDIR) return "symlink";
+  }
+  return "file";
 }
 
-/** Minimal surface of jszip's (untyped) per-entry internal stream. */
+/** Minimal surface of jszip's (untyped) per-entry facts + internal stream. */
+interface JsZipEntryInternals {
+  name: string;
+  dir: boolean;
+  unsafeOriginalName?: string;
+  unixPermissions: number | string | null;
+  _data?: { uncompressedSize?: unknown };
+  internalStream(type: "uint8array"): JsZipInternalStream;
+}
+
 interface JsZipInternalStream {
   on(event: "data", cb: (chunk: Uint8Array) => void): JsZipInternalStream;
   on(event: "end", cb: () => void): JsZipInternalStream;
@@ -292,23 +431,28 @@ interface JsZipInternalStream {
   pause(): JsZipInternalStream;
 }
 
+/** jszip keeps the central-directory uncompressed size on an internal field. */
+function declaredUncompressedSize(entry: JsZipEntryInternals): number {
+  const size = entry._data?.uncompressedSize;
+  return typeof size === "number" && size >= 0 ? size : 0;
+}
+
 /**
- * Inflate one entry as a bounded stream. The central directory's declared
- * size is attacker-controlled (a bomb can forge it below the caps), so the
- * only trustworthy enforcement is counting ACTUAL inflated bytes as they
- * stream out and aborting mid-entry the moment a cap is crossed — the
- * remainder is never inflated.
+ * Inflate one entry as a bounded stream, capped at
+ * min(maxBytes, declared size) — the same cap as the backend's
+ * `readEntryBytes`. Declared sizes are attacker-controlled, so the counter
+ * runs on ACTUAL inflated bytes and aborts mid-entry; the remainder is never
+ * inflated. Overruns throw and surface through the shared parser as
+ * FILE_UNREADABLE (identical to the backend read path).
  */
 function readEntryBounded(
-  entry: unknown,
-  path: string,
-  maxFileBytes: number,
-  remainingTotalBytes: number,
+  entry: JsZipEntryInternals,
+  rawName: string,
+  maxBytes: number,
 ): Promise<Uint8Array> {
+  const cap = Math.min(maxBytes, declaredUncompressedSize(entry));
   return new Promise<Uint8Array>((resolve, reject) => {
-    const stream = (
-      entry as { internalStream(type: "uint8array"): JsZipInternalStream }
-    ).internalStream("uint8array");
+    const stream = entry.internalStream("uint8array");
     const chunks: Uint8Array[] = [];
     let received = 0;
     let settled = false;
@@ -322,21 +466,10 @@ function readEntryBounded(
       .on("data", (chunk) => {
         if (settled) return;
         received += chunk.length;
-        if (received > maxFileBytes) {
+        if (received > cap) {
           abort(
-            bundleLimitError(
-              "FILE_TOO_LARGE",
-              `file exceeded the per-file limit of ${maxFileBytes} bytes during extraction`,
-              path,
-            ),
-          );
-          return;
-        }
-        if (received > remainingTotalBytes) {
-          abort(
-            bundleLimitError(
-              "BUNDLE_TOO_LARGE",
-              `total uncompressed content exceeded the bundle limit during extraction`,
+            new Error(
+              `entry ${rawName} exceeded its ${cap}-byte read cap during extraction`,
             ),
           );
           return;
@@ -360,54 +493,37 @@ function readEntryBounded(
 }
 
 /**
- * Read a ZIP back into bundle files (directory entries dropped, contents
- * untouched — deliberately NO junk filtering, mirroring the backend's ZIP
- * adapter so a preflight over these files hashes the same bytes the backend
- * will). Used by tests to prove folder/ZIP hash parity and available to the
- * import UI for ZIP preflight.
- *
- * Zip-bomb hardening: extraction enforces the SAME limits the SDK parser and
- * backend archive adapter use (`DEFAULT_PLUGIN_BUNDLE_LIMITS`: 1000 entries,
- * 10 MB per file, 100 MB total uncompressed) DURING inflation. The RAW
- * end-of-central-directory record count (files AND directories, exactly what
- * the backend's yauzl adapter rejects on) is checked before jszip parses the
- * archive; each entry is then inflated as a bounded stream
- * (`readEntryBounded`) that counts ACTUAL bytes and aborts mid-entry when a
- * per-file or cumulative cap is crossed — a forged central-directory size
- * cannot bypass it. The declared size is still used as a cheap fast-fail for
- * honest metadata. Violations throw the SDK's `PluginBundleError` with the
- * matching issue codes (`BUNDLE_TOO_MANY_ENTRIES` / `FILE_TOO_LARGE` /
- * `BUNDLE_TOO_LARGE` / `PATH_DUPLICATE`), so the UI error path is uniform
- * with parser failures.
+ * Lazy `PluginFileSource` over ZIP bytes — the browser twin of the backend's
+ * `createZipPluginSource` (yauzl). Runs the client-only archive screen at
+ * construction, then surfaces RAW entry facts (`unsafeOriginalName`, unix
+ * link kind, declared sizes) for the shared parser to judge; content is
+ * inflated on demand through the bounded stream.
  */
-export async function zipToPluginFiles(
+export async function createZipPluginFileSource(
   zipBytes: Uint8Array,
-  options?: { limits?: Partial<PluginBundleLimits> },
-): Promise<PluginBundleFile[]> {
-  const limits: PluginBundleLimits = {
-    ...DEFAULT_PLUGIN_BUNDLE_LIMITS,
-    ...options?.limits,
-  };
+  options?: ParsePluginBundleOptions,
+): Promise<PluginFileSource> {
+  const limits = resolveLimits(options);
+  if (limits.maxEntries >= 0xffff) {
+    // See the client-only screen notes: the 16-bit EOCD field saturates at
+    // 0xFFFF (ZIP64 sentinel), so a cap at or above it is unenforceable
+    // without parsing ZIP64 structures — which preflight deliberately
+    // rejects instead.
+    throw new Error(
+      `maxEntries must be below 65535 (ZIP64 sentinel); got ${limits.maxEntries}`,
+    );
+  }
 
-  // Enforce maxEntries against the RAW record count from the EOCD record,
-  // BEFORE jszip parses anything. jszip's `files` is a name-keyed object, so
-  // duplicate (or same-normalizing) names collapse during loadAsync — a
-  // crafted archive with thousands of records could otherwise present a
-  // compliant-looking deduplicated count while the authoritative backend
-  // (yauzl EOCD record count) rejects it.
   const recordCount = readEocdTotalEntries(zipBytes);
   if (recordCount !== undefined) {
     if (recordCount === 0xffff) {
-      // ZIP64 sentinel: the real count lives in the ZIP64 EOCD record. Any
-      // archive with >= 65535 records is far over maxEntries (1000), so
-      // reject on the sentinel instead of parsing ZIP64 structures.
-      throw bundleLimitError(
+      throw issueError(
         "BUNDLE_TOO_MANY_ENTRIES",
         `archive declares 65535+ records (ZIP64); the limit is ${limits.maxEntries}`,
       );
     }
     if (recordCount > limits.maxEntries) {
-      throw bundleLimitError(
+      throw issueError(
         "BUNDLE_TOO_MANY_ENTRIES",
         `archive has ${recordCount} records; the limit is ${limits.maxEntries}`,
       );
@@ -415,63 +531,73 @@ export async function zipToPluginFiles(
   }
 
   const { default: JSZip } = await import("jszip");
-  const zip = await JSZip.loadAsync(toZipInput(zipBytes));
-
-  const allRecords = Object.values(zip.files);
-  // Belt-and-braces for the (malformed) case where the EOCD scan found
-  // nothing but jszip still parsed a central directory.
-  if (allRecords.length > limits.maxEntries) {
-    throw bundleLimitError(
-      "BUNDLE_TOO_MANY_ENTRIES",
-      `archive has ${allRecords.length} records; the limit is ${limits.maxEntries}`,
-    );
-  }
-  // If the raw count exceeds what jszip kept, duplicate (or same-normalizing)
-  // names collapsed last-wins during loadAsync. A legitimate bundle has no
-  // reason to contain them, and a deduplicated preview would misrepresent
-  // what stricter parsers (the backend) see. Same code the SDK parser uses
-  // for duplicate normalized paths.
-  if (recordCount !== undefined && recordCount > allRecords.length) {
-    throw bundleLimitError(
-      "PATH_DUPLICATE",
-      `archive contains ${recordCount - allRecords.length} duplicate or colliding entry name(s)`,
-    );
-  }
-  const entries = allRecords.filter((entry) => !entry.dir);
-
-  let totalBytes = 0;
-  const files: PluginBundleFile[] = [];
-  for (const entry of entries) {
-    const path = entry.name.replace(/\\/g, "/");
-
-    // Cheap fast-fail on the DECLARED size (honest metadata never inflates).
-    // The declared size is attacker-controlled, so the authoritative
-    // enforcement is the bounded stream below, which counts actual bytes.
-    const declared = declaredUncompressedSize(entry);
-    if (declared !== undefined) {
-      if (declared > limits.maxFileBytes) {
-        throw bundleLimitError(
-          "FILE_TOO_LARGE",
-          `file declares ${declared} bytes; the per-file limit is ${limits.maxFileBytes}`,
-          path,
-        );
-      }
-      if (totalBytes + declared > limits.maxTotalBytes) {
-        throw bundleLimitError(
-          "BUNDLE_TOO_LARGE",
-          `total uncompressed content exceeds ${limits.maxTotalBytes} bytes`,
-        );
-      }
+  let zip: Awaited<ReturnType<typeof JSZip.loadAsync>>;
+  try {
+    zip = await JSZip.loadAsync(toZipInput(zipBytes));
+  } catch (error) {
+    if (error instanceof Error && /encrypted/i.test(error.message)) {
+      throw issueError(
+        "FILE_UNREADABLE",
+        "archive contains encrypted entries, which are not supported",
+      );
     }
-
-    const bytes = await readEntryBounded(
-      entry,
-      path,
-      limits.maxFileBytes,
-      limits.maxTotalBytes - totalBytes,
-    );
-    totalBytes += bytes.byteLength;
-    files.push({ path, bytes });
+    throw error;
   }
-  return files.sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
+
+  const records = Object.values(zip.files) as unknown as JsZipEntryInternals[];
+  if (recordCount !== undefined && recordCount > records.length) {
+    throw issueError(
+      "PATH_DUPLICATE",
+      `archive contains ${recordCount - records.length} duplicate or colliding entry name(s)`,
+    );
+  }
+
+  const entries: PluginFileEntry[] = [];
+  const byRawName = new Map<string, JsZipEntryInternals>();
+  for (const record of records) {
+    const rawName = record.unsafeOriginalName ?? record.name;
+    if (rawName.includes("\\")) {
+      throw issueError(
+        "PATH_INVALID_CHARACTER",
+        `entry name contains "\\", which the archive reader rejects`,
+        rawName,
+      );
+    }
+    const kind = entryKind(rawName, record.unixPermissions);
+    entries.push({
+      path: rawName,
+      size: kind === "file" ? declaredUncompressedSize(record) : 0,
+      kind,
+    });
+    if (kind !== "directory") {
+      byRawName.set(rawName, record);
+    }
+  }
+
+  return {
+    list: async () => entries,
+    readBytes: async (path: string, maxBytes: number) => {
+      const record = byRawName.get(path);
+      if (record === undefined) {
+        throw new Error(`no such archive entry: ${path}`);
+      }
+      return readEntryBounded(record, path, maxBytes);
+    },
+  };
+}
+
+/**
+ * Preflight ZIP bytes with the shared SDK parser over the raw-facts source
+ * above. The verdict (and `bundleHash`) matches what the backend inspect
+ * action computes on the same bytes: shared parser + equivalent archive
+ * screen.
+ */
+export async function parsePluginBundleFromZip(
+  zipBytes: Uint8Array,
+  options?: ParsePluginBundleOptions,
+): Promise<ParsedPluginBundle> {
+  return parsePluginBundle(
+    await createZipPluginFileSource(zipBytes, options),
+    options,
+  );
 }

--- a/mcpjam-inspector/client/src/lib/plugins/folder-bundle.ts
+++ b/mcpjam-inspector/client/src/lib/plugins/folder-bundle.ts
@@ -231,7 +231,11 @@ export async function buildPluginZip(
 }
 
 function bundleLimitError(
-  code: "BUNDLE_TOO_MANY_ENTRIES" | "BUNDLE_TOO_LARGE" | "FILE_TOO_LARGE",
+  code:
+    | "BUNDLE_TOO_MANY_ENTRIES"
+    | "BUNDLE_TOO_LARGE"
+    | "FILE_TOO_LARGE"
+    | "PATH_DUPLICATE",
   message: string,
   path?: string,
 ): PluginBundleError {
@@ -243,6 +247,33 @@ function bundleLimitError(
       ...(path !== undefined ? { path } : {}),
     },
   ]);
+}
+
+/**
+ * Read the total-record count from the ZIP's end-of-central-directory (EOCD)
+ * record — the same field the backend's yauzl adapter rejects on — directly
+ * from the raw bytes, before jszip parses (and name-deduplicates) anything.
+ *
+ * The EOCD (`PK\x05\x06`) is 22 bytes plus an up-to-65535-byte trailing
+ * comment, so it is scanned backward within the last 65557 bytes; a match
+ * only counts when its comment-length field spans exactly to the end of the
+ * file (rules out the signature appearing inside entry data). Returns
+ * `undefined` when no EOCD is found — jszip's own "corrupted zip" error then
+ * surfaces from `loadAsync`.
+ */
+function readEocdTotalEntries(bytes: Uint8Array): number | undefined {
+  const EOCD_SIZE = 22;
+  if (bytes.length < EOCD_SIZE) return undefined;
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const lowest = Math.max(0, bytes.length - (EOCD_SIZE + 0xffff));
+  for (let i = bytes.length - EOCD_SIZE; i >= lowest; i--) {
+    if (view.getUint32(i, true) !== 0x06054b50) continue;
+    const commentLength = view.getUint16(i + 20, true);
+    if (i + EOCD_SIZE + commentLength !== bytes.length) continue;
+    // Offset 10: total central-directory records across all disks.
+    return view.getUint16(i + 10, true);
+  }
+  return undefined;
 }
 
 /** jszip keeps the central-directory uncompressed size on an internal field. */
@@ -337,16 +368,17 @@ function readEntryBounded(
  *
  * Zip-bomb hardening: extraction enforces the SAME limits the SDK parser and
  * backend archive adapter use (`DEFAULT_PLUGIN_BUNDLE_LIMITS`: 1000 entries,
- * 10 MB per file, 100 MB total uncompressed) DURING inflation. The record
- * count (files AND directories, matching the backend's end-of-central-
- * directory count) is checked before any read; each entry is then inflated
- * as a bounded stream (`readEntryBounded`) that counts ACTUAL bytes and
- * aborts mid-entry when a per-file or cumulative cap is crossed — a forged
- * central-directory size cannot bypass it. The declared size is still used
- * as a cheap fast-fail for honest metadata. Violations throw the SDK's
- * `PluginBundleError` with the matching issue codes
- * (`BUNDLE_TOO_MANY_ENTRIES` / `FILE_TOO_LARGE` / `BUNDLE_TOO_LARGE`), so the
- * UI error path is uniform with parser failures.
+ * 10 MB per file, 100 MB total uncompressed) DURING inflation. The RAW
+ * end-of-central-directory record count (files AND directories, exactly what
+ * the backend's yauzl adapter rejects on) is checked before jszip parses the
+ * archive; each entry is then inflated as a bounded stream
+ * (`readEntryBounded`) that counts ACTUAL bytes and aborts mid-entry when a
+ * per-file or cumulative cap is crossed — a forged central-directory size
+ * cannot bypass it. The declared size is still used as a cheap fast-fail for
+ * honest metadata. Violations throw the SDK's `PluginBundleError` with the
+ * matching issue codes (`BUNDLE_TOO_MANY_ENTRIES` / `FILE_TOO_LARGE` /
+ * `BUNDLE_TOO_LARGE` / `PATH_DUPLICATE`), so the UI error path is uniform
+ * with parser failures.
  */
 export async function zipToPluginFiles(
   zipBytes: Uint8Array,
@@ -356,18 +388,53 @@ export async function zipToPluginFiles(
     ...DEFAULT_PLUGIN_BUNDLE_LIMITS,
     ...options?.limits,
   };
+
+  // Enforce maxEntries against the RAW record count from the EOCD record,
+  // BEFORE jszip parses anything. jszip's `files` is a name-keyed object, so
+  // duplicate (or same-normalizing) names collapse during loadAsync — a
+  // crafted archive with thousands of records could otherwise present a
+  // compliant-looking deduplicated count while the authoritative backend
+  // (yauzl EOCD record count) rejects it.
+  const recordCount = readEocdTotalEntries(zipBytes);
+  if (recordCount !== undefined) {
+    if (recordCount === 0xffff) {
+      // ZIP64 sentinel: the real count lives in the ZIP64 EOCD record. Any
+      // archive with >= 65535 records is far over maxEntries (1000), so
+      // reject on the sentinel instead of parsing ZIP64 structures.
+      throw bundleLimitError(
+        "BUNDLE_TOO_MANY_ENTRIES",
+        `archive declares 65535+ records (ZIP64); the limit is ${limits.maxEntries}`,
+      );
+    }
+    if (recordCount > limits.maxEntries) {
+      throw bundleLimitError(
+        "BUNDLE_TOO_MANY_ENTRIES",
+        `archive has ${recordCount} records; the limit is ${limits.maxEntries}`,
+      );
+    }
+  }
+
   const { default: JSZip } = await import("jszip");
   const zip = await JSZip.loadAsync(toZipInput(zipBytes));
 
-  // Count every archive RECORD, directories included — the backend rejects on
-  // the end-of-central-directory record count before filtering, so a client
-  // preflight that ignored directory records would accept archives the
-  // authoritative validator rejects.
   const allRecords = Object.values(zip.files);
+  // Belt-and-braces for the (malformed) case where the EOCD scan found
+  // nothing but jszip still parsed a central directory.
   if (allRecords.length > limits.maxEntries) {
     throw bundleLimitError(
       "BUNDLE_TOO_MANY_ENTRIES",
       `archive has ${allRecords.length} records; the limit is ${limits.maxEntries}`,
+    );
+  }
+  // If the raw count exceeds what jszip kept, duplicate (or same-normalizing)
+  // names collapsed last-wins during loadAsync. A legitimate bundle has no
+  // reason to contain them, and a deduplicated preview would misrepresent
+  // what stricter parsers (the backend) see. Same code the SDK parser uses
+  // for duplicate normalized paths.
+  if (recordCount !== undefined && recordCount > allRecords.length) {
+    throw bundleLimitError(
+      "PATH_DUPLICATE",
+      `archive contains ${recordCount - allRecords.length} duplicate or colliding entry name(s)`,
     );
   }
   const entries = allRecords.filter((entry) => !entry.dir);

--- a/mcpjam-inspector/client/src/lib/plugins/plugin-api-types.ts
+++ b/mcpjam-inspector/client/src/lib/plugins/plugin-api-types.ts
@@ -1,0 +1,320 @@
+/**
+ * Hand-mirrored DTO types for the backend plugin API (PR INS-1 of
+ * docs/plans/openai-plugin-import-cross-repo.md).
+ *
+ * Source of truth (two-repo layout — Convex lives in `mcpjam-backend`, types
+ * are mirrored by hand):
+ *   - convex/plugins.ts        (queries/mutations, summaries, import row)
+ *   - convex/pluginsNode.ts    (inspectImport / commitImport actions)
+ *   - convex/lib/pluginPreview.ts        (sanitized import preview)
+ *   - convex/lib/pluginRateLimit.ts      (RATE_LIMITED error payload)
+ *   - convex/lib/pluginRuntimeResolution.ts (runtime preview)
+ *
+ * Ids are opaque strings on this side of the wire.
+ */
+
+// ---------------------------------------------------------------------------
+// Import state machine (backend `pluginImports.status`).
+// ---------------------------------------------------------------------------
+
+export const PLUGIN_IMPORT_STATUSES = [
+  "uploaded",
+  "inspecting",
+  "preview_ready",
+  "committing",
+  "completed",
+  "failed",
+] as const;
+
+export type PluginImportStatus = (typeof PLUGIN_IMPORT_STATUSES)[number];
+
+/** Terminal states: the import row will not transition again. */
+export function isPluginImportTerminal(status: PluginImportStatus): boolean {
+  return status === "completed" || status === "failed";
+}
+
+/** States from which `commitImport` may be called (preview reviewed). */
+export function isPluginImportCommittable(status: PluginImportStatus): boolean {
+  return status === "preview_ready";
+}
+
+// ---------------------------------------------------------------------------
+// Sanitized import preview (convex/lib/pluginPreview.ts). Metadata only —
+// the backend guarantees no paths, no file content, no secrets.
+// ---------------------------------------------------------------------------
+
+export interface PluginImportPreviewSkill {
+  modelRef: string;
+  name: string;
+  description: string;
+  supportingFileCount: number;
+  mcpToolDependencyCount: number;
+  hasOpenaiMetadata: boolean;
+  allowImplicitInvocation?: boolean;
+}
+
+export interface PluginImportPreviewServer {
+  key: string;
+  transport: "stdio" | "http";
+  /** Requested env var NAMES only (stdio). Never values. */
+  envRequirements?: Array<{ name: string; required: boolean }>;
+  /** Requested header NAMES only (http). Never values. */
+  headerRequirements?: Array<{ name: string; secret: boolean }>;
+  oauth?: { timing?: "on_install" | "on_use"; scopes?: string[] };
+  /** Presence only — never the (possibly path-bearing) working-dir string. */
+  hasWorkingDirectory?: boolean;
+}
+
+export interface PluginImportPreviewApp {
+  appId: string;
+  binding: string;
+  status: string;
+  serverKey?: string;
+}
+
+export interface PluginImportPreviewAsset {
+  kind: string;
+  contentType: string;
+  size: number;
+}
+
+export interface PluginImportPreviewUnsupported {
+  kind: string;
+  key: string;
+  reason: string;
+  pathCount: number;
+}
+
+export interface PluginImportPreviewWarning {
+  code: string;
+  severity: string;
+  componentKey?: string;
+  message: string;
+}
+
+export interface PluginSetupRequirement {
+  serverKey: string;
+  kind: "env" | "header" | "oauth";
+  name: string;
+  required: boolean;
+  secret?: boolean;
+}
+
+export interface PluginImportPreview {
+  identity: {
+    name: string;
+    displayName?: string;
+    version?: string;
+    description?: string;
+  };
+  bundleHash: string;
+  manifestHash: string;
+  counts: {
+    skills: number;
+    servers: number;
+    apps: number;
+    assets: number;
+    unsupported: number;
+    warnings: number;
+  };
+  skills: PluginImportPreviewSkill[];
+  servers: PluginImportPreviewServer[];
+  apps: PluginImportPreviewApp[];
+  assets: PluginImportPreviewAsset[];
+  setupRequirements: PluginSetupRequirement[];
+  unsupported: PluginImportPreviewUnsupported[];
+  warnings: PluginImportPreviewWarning[];
+}
+
+/** Stable sanitized `{code, message}` persisted on a failed import. */
+export interface PluginImportFailure {
+  code: string;
+  message: string;
+}
+
+// ---------------------------------------------------------------------------
+// Rows returned by the public queries.
+// ---------------------------------------------------------------------------
+
+/** `plugins.getPluginImport` — the progress-polling row. */
+export interface PluginImportRow {
+  importId: string;
+  projectId: string;
+  status: PluginImportStatus;
+  sourceLabel?: string;
+  preview?: PluginImportPreview;
+  failure?: PluginImportFailure;
+  /** Set once the import completes (commit materialized a version). */
+  pluginId?: string;
+  pluginVersionId?: string;
+  createdAt: number;
+  updatedAt: number;
+  expiresAt: number;
+}
+
+/** `plugins.listProjectPlugins` element / `getProjectPlugin` base. */
+export interface PluginSummary {
+  pluginId: string;
+  projectId: string;
+  name: string;
+  displayName: string;
+  description?: string;
+  enabled: boolean;
+  activeVersionId?: string;
+  deletedAt?: number;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface PluginVersionSummary {
+  pluginVersionId: string;
+  pluginId: string;
+  declaredVersion?: string;
+  bundleHash: string;
+  status: "staging" | "ready";
+  componentCounts: {
+    skills: number;
+    servers: number;
+    apps: number;
+    assets: number;
+    unsupported: number;
+  };
+  createdAt: number;
+  readyAt?: number;
+}
+
+/** `plugins.getProjectPlugin` — summary plus versions (newest first). */
+export interface PluginDetail extends PluginSummary {
+  versions: PluginVersionSummary[];
+}
+
+export interface PluginVersionServerComponent {
+  componentId: string;
+  componentKey: string;
+  declaredName: string;
+  placement: "remote" | "local" | "computer";
+  authenticationPolicy: "on_install" | "on_use";
+  materializedServerId?: string;
+}
+
+export interface PluginVersionSkillComponent {
+  componentId: string;
+  componentKey: string;
+  declaredName: string;
+  modelRef: string;
+  materializedSkillId?: string;
+}
+
+/** `plugins.getPluginVersion` — version summary plus component projections. */
+export interface PluginVersionDetail extends PluginVersionSummary {
+  manifestHash: string;
+  servers: PluginVersionServerComponent[];
+  skills: PluginVersionSkillComponent[];
+}
+
+export type PluginComponentReadiness =
+  | "needs_auth"
+  | "local_runtime_required"
+  | "computer_required"
+  | "ready";
+
+/** `plugins.getPluginSetupStatus`. */
+export interface PluginSetupStatus {
+  pluginVersionId: string;
+  status: "staging" | "ready";
+  components: Array<{
+    componentKey: string;
+    placement: "remote" | "local" | "computer";
+    authenticationPolicy: "on_install" | "on_use";
+    readiness: PluginComponentReadiness;
+  }>;
+}
+
+export type PluginUnavailableReason =
+  | "not_found"
+  | "not_ready"
+  | "uninstalled"
+  | "disabled"
+  | (string & {});
+
+/** `plugins.resolvePluginRuntimePreview`. */
+export interface PluginRuntimePreview {
+  pluginVersions: Array<{
+    pluginId: string;
+    pluginVersionId: string;
+    name: string;
+    bundleHash: string;
+  }>;
+  effectiveServerIds: string[];
+  pluginSkills: Array<{ modelRef: string; materializedSkillId: string }>;
+  unavailableComponents: Array<{
+    pluginVersionId: string;
+    reason: PluginUnavailableReason;
+  }>;
+}
+
+// ---------------------------------------------------------------------------
+// Action results.
+// ---------------------------------------------------------------------------
+
+/** `pluginsNode.inspectImport`. */
+export interface PluginInspectResult {
+  importId: string;
+  status: "preview_ready" | "failed";
+  failureCode?: string;
+}
+
+/** `pluginsNode.commitImport`. */
+export interface PluginCommitResult {
+  importId: string;
+  status: "completed" | "failed";
+  pluginVersionId?: string;
+  /** True when the same bundle bytes already produced a ready version. */
+  reused?: boolean;
+  failureCode?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Structured errors. ConvexError payloads land on `err.data`; the backend
+// throws stable machine-readable codes (convex/plugins.ts `fail`,
+// pluginRateLimit.ts, createImport's oversized-bundle check).
+// ---------------------------------------------------------------------------
+
+/** Known stable error codes the plugin API can throw. Non-exhaustive. */
+export type PluginApiErrorCode =
+  | "FORBIDDEN"
+  | "NOT_FOUND"
+  | "CONFLICT"
+  | "RATE_LIMITED"
+  | "ARCHIVE_TOO_LARGE_COMPRESSED"
+  /** Client-side only: the `plugins-enabled` flag is off (fail-closed). */
+  | "PLUGINS_DISABLED"
+  /** Client-side only: the direct-to-storage upload POST failed. */
+  | "UPLOAD_FAILED"
+  | (string & {});
+
+export class PluginApiError extends Error {
+  readonly code: PluginApiErrorCode;
+  /** RATE_LIMITED: which bucket ("project" | "organization"). */
+  readonly scope?: string;
+  /** RATE_LIMITED: milliseconds until a token is available. */
+  readonly retryAfter?: number;
+  readonly details?: Record<string, string>;
+
+  constructor(
+    code: PluginApiErrorCode,
+    message: string,
+    extras?: {
+      scope?: string;
+      retryAfter?: number;
+      details?: Record<string, string>;
+    },
+  ) {
+    super(message);
+    this.name = "PluginApiError";
+    this.code = code;
+    this.scope = extras?.scope;
+    this.retryAfter = extras?.retryAfter;
+    this.details = extras?.details;
+  }
+}

--- a/mcpjam-inspector/client/src/lib/plugins/plugin-api.ts
+++ b/mcpjam-inspector/client/src/lib/plugins/plugin-api.ts
@@ -15,6 +15,38 @@ import { PluginApiError, type PluginApiErrorCode } from "./plugin-api-types";
 export const MAX_PLUGIN_BUNDLE_COMPRESSED_BYTES = 25 * 1024 * 1024; // 25 MB
 
 /**
+ * Default upload timeout. Generous enough for a full 25 MB bundle on a slow
+ * uplink (25 MB at ~1 Mbps ≈ 3.5 min); overridable per call.
+ */
+export const DEFAULT_PLUGIN_UPLOAD_TIMEOUT_MS = 5 * 60 * 1000; // 5 min
+
+/** Compressed byte size of a bundle in either accepted representation. */
+export function pluginBundleByteSize(bundle: Blob | Uint8Array): number {
+  return bundle instanceof Blob ? bundle.size : bundle.byteLength;
+}
+
+/**
+ * Throw `ARCHIVE_TOO_LARGE_COMPRESSED` when a bundle exceeds the backend's
+ * compressed cap. Call this BEFORE minting an upload URL — the mint is
+ * rate-limited, so an oversized bundle must not burn a token on an upload
+ * that can never be imported.
+ */
+export function assertPluginBundleWithinCap(bundle: Blob | Uint8Array): void {
+  if (pluginBundleByteSize(bundle) > MAX_PLUGIN_BUNDLE_COMPRESSED_BYTES) {
+    throw new PluginApiError(
+      "ARCHIVE_TOO_LARGE_COMPRESSED",
+      "The plugin bundle exceeds the maximum compressed size (25 MB).",
+    );
+  }
+}
+
+export interface UploadPluginBundleOptions {
+  fetchImpl?: typeof fetch;
+  /** Abort the upload after this many ms (default 5 minutes). */
+  timeoutMs?: number;
+}
+
+/**
  * Upload a plugin bundle ZIP to a Convex storage upload URL (minted by
  * `plugins.generateBundleUploadUrl`) and return the storage id to pass to
  * `plugins.createImport`.
@@ -22,35 +54,43 @@ export const MAX_PLUGIN_BUNDLE_COMPRESSED_BYTES = 25 * 1024 * 1024; // 25 MB
 export async function uploadPluginBundleToUrl(
   uploadUrl: string,
   bundle: Blob | Uint8Array,
-  fetchImpl: typeof fetch = fetch,
+  options?: UploadPluginBundleOptions,
 ): Promise<string> {
+  const fetchImpl = options?.fetchImpl ?? fetch;
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_PLUGIN_UPLOAD_TIMEOUT_MS;
   const body =
     bundle instanceof Blob
       ? bundle
       : new Blob([bundle as unknown as BlobPart], {
           type: "application/zip",
         });
-  if (body.size > MAX_PLUGIN_BUNDLE_COMPRESSED_BYTES) {
-    throw new PluginApiError(
-      "ARCHIVE_TOO_LARGE_COMPRESSED",
-      "The plugin bundle exceeds the maximum compressed size (25 MB).",
-    );
-  }
+  assertPluginBundleWithinCap(body);
 
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
   let response: Response;
   try {
     response = await fetchImpl(uploadUrl, {
       method: "POST",
       headers: { "Content-Type": "application/zip" },
       body,
+      signal: controller.signal,
     });
   } catch (error) {
+    if (controller.signal.aborted) {
+      throw new PluginApiError(
+        "UPLOAD_FAILED",
+        `Bundle upload timed out after ${timeoutMs}ms`,
+      );
+    }
     throw new PluginApiError(
       "UPLOAD_FAILED",
       `Bundle upload failed: ${
         error instanceof Error ? error.message : String(error)
       }`,
     );
+  } finally {
+    clearTimeout(timeout);
   }
   if (!response.ok) {
     throw new PluginApiError(
@@ -62,13 +102,14 @@ export async function uploadPluginBundleToUrl(
   const payload = (await response.json().catch(() => null)) as {
     storageId?: unknown;
   } | null;
-  if (!payload || typeof payload.storageId !== "string") {
+  const storageId = payload?.storageId;
+  if (typeof storageId !== "string" || storageId.length === 0) {
     throw new PluginApiError(
       "UPLOAD_FAILED",
       "Bundle upload did not return a storage id",
     );
   }
-  return payload.storageId;
+  return storageId;
 }
 
 /**

--- a/mcpjam-inspector/client/src/lib/plugins/plugin-api.ts
+++ b/mcpjam-inspector/client/src/lib/plugins/plugin-api.ts
@@ -1,0 +1,123 @@
+/**
+ * Pure (non-hook) helpers for the plugin import API: the direct-to-storage
+ * bundle upload and structured error mapping. Hook wrappers live in
+ * `client/src/hooks/usePluginImportApi.ts`.
+ */
+
+import { PluginApiError, type PluginApiErrorCode } from "./plugin-api-types";
+
+/**
+ * Mirror of the backend's compressed-bundle cap
+ * (mcpjam-backend convex/lib/pluginArchiveLimits.ts, DEFAULT_ARCHIVE_LIMITS).
+ * Used to reject an oversized ZIP before burning an upload-URL rate-limit
+ * token; the backend re-enforces it at `createImport` and inspect time.
+ */
+export const MAX_PLUGIN_BUNDLE_COMPRESSED_BYTES = 25 * 1024 * 1024; // 25 MB
+
+/**
+ * Upload a plugin bundle ZIP to a Convex storage upload URL (minted by
+ * `plugins.generateBundleUploadUrl`) and return the storage id to pass to
+ * `plugins.createImport`.
+ */
+export async function uploadPluginBundleToUrl(
+  uploadUrl: string,
+  bundle: Blob | Uint8Array,
+  fetchImpl: typeof fetch = fetch,
+): Promise<string> {
+  const body =
+    bundle instanceof Blob
+      ? bundle
+      : new Blob([bundle as unknown as BlobPart], {
+          type: "application/zip",
+        });
+  if (body.size > MAX_PLUGIN_BUNDLE_COMPRESSED_BYTES) {
+    throw new PluginApiError(
+      "ARCHIVE_TOO_LARGE_COMPRESSED",
+      "The plugin bundle exceeds the maximum compressed size (25 MB).",
+    );
+  }
+
+  let response: Response;
+  try {
+    response = await fetchImpl(uploadUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/zip" },
+      body,
+    });
+  } catch (error) {
+    throw new PluginApiError(
+      "UPLOAD_FAILED",
+      `Bundle upload failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+  if (!response.ok) {
+    throw new PluginApiError(
+      "UPLOAD_FAILED",
+      `Bundle upload failed with status ${response.status}`,
+    );
+  }
+
+  const payload = (await response.json().catch(() => null)) as {
+    storageId?: unknown;
+  } | null;
+  if (!payload || typeof payload.storageId !== "string") {
+    throw new PluginApiError(
+      "UPLOAD_FAILED",
+      "Bundle upload did not return a storage id",
+    );
+  }
+  return payload.storageId;
+}
+
+/**
+ * Map an unknown rejection from a plugin Convex call to a structured
+ * `PluginApiError`. Convex `ConvexError` payloads land on `err.data` — the
+ * backend throws `{code, message}` records with stable codes (`FORBIDDEN`,
+ * `NOT_FOUND`, `CONFLICT`, `RATE_LIMITED`, `ARCHIVE_TOO_LARGE_COMPRESSED`),
+ * optional `details`, and for RATE_LIMITED a `scope` + `retryAfter`.
+ * `err.message` for an application error is the redacted "Server Error"
+ * string, so it is only a fallback.
+ */
+export function toPluginApiError(
+  err: unknown,
+  fallbackMessage = "Plugin request failed",
+): PluginApiError {
+  if (err instanceof PluginApiError) return err;
+
+  if (err && typeof err === "object" && "data" in err) {
+    const data = (err as { data: unknown }).data;
+    if (typeof data === "string" && data.trim()) {
+      return new PluginApiError("UNKNOWN", data.slice(0, 400));
+    }
+    if (data && typeof data === "object") {
+      const record = data as Record<string, unknown>;
+      const code =
+        typeof record.code === "string" && record.code
+          ? (record.code as PluginApiErrorCode)
+          : "UNKNOWN";
+      const message =
+        typeof record.message === "string" && record.message.trim()
+          ? record.message.slice(0, 400)
+          : fallbackMessage;
+      return new PluginApiError(code, message, {
+        scope: typeof record.scope === "string" ? record.scope : undefined,
+        retryAfter:
+          typeof record.retryAfter === "number" ? record.retryAfter : undefined,
+        details:
+          record.details && typeof record.details === "object"
+            ? (record.details as Record<string, string>)
+            : undefined,
+      });
+    }
+  }
+
+  if (err instanceof Error && err.message) {
+    return new PluginApiError(
+      "UNKNOWN",
+      err.message.replace(/^\[.*?\]\s*/, "").slice(0, 400) || fallbackMessage,
+    );
+  }
+  return new PluginApiError("UNKNOWN", fallbackMessage);
+}

--- a/mcpjam-inspector/client/vite.config.ts
+++ b/mcpjam-inspector/client/vite.config.ts
@@ -41,6 +41,13 @@ const sdkWidgetRuntimeEntry = path.resolve(
   rootDir,
   "../sdk/src/widget-runtime/index.ts",
 );
+// Shared OpenAI plugin-bundle parser (browser-safe by design). Resolved from
+// source so dev/build never depend on a prior SDK build (mirrors the SDK
+// subpath aliases above).
+const sdkPluginBundleEntry = path.resolve(
+  rootDir,
+  "../sdk/src/plugin-bundle/index.ts",
+);
 // @mcpjam/chat-ui publishes from dist, but a clean checkout has no
 // chat-ui/dist until it is built. Resolve the package from source so the
 // inspector's dev/build/typecheck/test never depend on a chat-ui build.
@@ -108,6 +115,7 @@ export default defineConfig(({ mode }) => {
         "@mcpjam/widget-react": widgetReactEntry,
         "@mcpjam/sdk/browser": sdkBrowserEntry,
         "@mcpjam/sdk/widget-runtime": sdkWidgetRuntimeEntry,
+        "@mcpjam/sdk/plugin-bundle": sdkPluginBundleEntry,
         "@mcpjam/sdk/host-compat": sdkHostCompatEntry,
         "@mcpjam/sdk/host-config/templates": sdkHostConfigTemplatesEntry,
         "@mcpjam/sdk/host-config/internal": sdkHostConfigInternalEntry,

--- a/mcpjam-inspector/client/vitest.config.ts
+++ b/mcpjam-inspector/client/vitest.config.ts
@@ -36,6 +36,12 @@ const sdkWidgetRuntimeEntry = path.resolve(
   rootDir,
   "../sdk/src/widget-runtime/index.ts",
 );
+// Shared OpenAI plugin-bundle parser, aliased to source for the same reason:
+// its package export points at dist, which a clean checkout has not built.
+const sdkPluginBundleEntry = path.resolve(
+  rootDir,
+  "../sdk/src/plugin-bundle/index.ts",
+);
 // Resolve @mcpjam/chat-ui from source (its published exports point at dist,
 // which a clean checkout hasn't built). Mirrors the SDK source aliases above.
 const chatUiEntry = path.resolve(rootDir, "../chat-ui/src/index.ts");
@@ -139,6 +145,10 @@ export default defineConfig({
       {
         find: "@mcpjam/sdk/widget-runtime",
         replacement: sdkWidgetRuntimeEntry,
+      },
+      {
+        find: "@mcpjam/sdk/plugin-bundle",
+        replacement: sdkPluginBundleEntry,
       },
       {
         find: "@mcpjam/sdk/host-compat",

--- a/mcpjam-inspector/package.json
+++ b/mcpjam-inspector/package.json
@@ -169,6 +169,7 @@
     "gray-matter": "^4.0.3",
     "hono": "^4.11.7",
     "jose": "^5.10.0",
+    "jszip": "^3.10.1",
     "lucide-react": "^0.525.0",
     "marked": "^16.4.1",
     "next-themes": "^0.4.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -411,6 +411,7 @@
         "gray-matter": "^4.0.3",
         "hono": "^4.11.7",
         "jose": "^5.10.0",
+        "jszip": "^3.10.1",
         "lucide-react": "^0.525.0",
         "marked": "^16.4.1",
         "next-themes": "^0.4.6",
@@ -18079,7 +18080,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cors": {
@@ -23306,7 +23306,6 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
       "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -25628,7 +25627,6 @@
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
       "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
-      "dev": true,
       "license": "(MIT OR GPL-3.0-or-later)",
       "dependencies": {
         "lie": "~3.3.0",
@@ -25641,14 +25639,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/jszip/node_modules/readable-stream": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -25664,14 +25660,12 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/jszip/node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -25845,7 +25839,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
       "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "immediate": "~3.0.5"
@@ -29662,7 +29655,6 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "dev": true,
       "license": "(MIT AND Zlib)"
     },
     "node_modules/parent-module": {
@@ -30547,7 +30539,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/progress": {
@@ -32440,7 +32431,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/setprototypeof": {
@@ -35323,7 +35313,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/uuid": {


### PR DESCRIPTION
Implements **PR INS-1 — MCP JSON compatibility and plugin client API** from `docs/plans/openai-plugin-import-cross-repo.md` (mcpjam-backend). Import plumbing only: no UI (INS-2), no attachment/HostConfig changes (hosts stay plugin-blind; pins live on projectEnvironments).

## What's in here

### 1. MCP JSON compatibility (one code path)
`client/src/lib/json-config-parser.ts` now resolves the pasted/uploaded document through a single `resolveJsonServerMap` used by both `parseJsonConfig` and `validateJsonConfig`. It accepts:
- a **direct server map** (OpenAI plugin `.mcp.json` style),
- an **`mcp_servers`** wrapper (current OpenAI plugin docs),
- the existing **`mcpServers`** wrapper,

with shape-detection semantics mirroring the SDK plugin-bundle parser (`sdk/src/plugin-bundle/mcp-config.ts`): declaring both wrappers is an error; a bare single server (top-level *string* `command`/`url`) is rejected; a direct map may legitimately contain a server named `url`/`command`. Per-server mapping is unchanged — existing `mcpServers` configs (env values included) import byte-for-byte as before.

Two edge behaviors necessarily changed (previously errors, now legal direct maps): `{"servers": {}}` no longer throws "missing mcpServers" (it parses to zero valid servers), and `{}` validates as "No servers found" instead of "Missing mcpServers". Tests updated accordingly.

### 2. Typed plugin API client (`plugins-enabled` gated, fail-closed)
- `client/src/lib/plugins/plugin-api-types.ts` — hand-mirrored DTOs for the merged backend surface (`convex/plugins.ts`, `pluginsNode.ts`, `lib/pluginPreview.ts`, `lib/pluginRuntimeResolution.ts`): import states, sanitized preview, structured failures, summaries, setup status, runtime preview, commit/inspect results.
- `client/src/lib/plugins/plugin-api.ts` — direct-to-storage bundle upload (mirrors the 25 MB compressed cap client-side) and `toPluginApiError` (stable codes `FORBIDDEN` / `NOT_FOUND` / `CONFLICT` / `RATE_LIMITED` with `scope`+`retryAfter` / `ARCHIVE_TOO_LARGE_COMPRESSED`).
- `client/src/hooks/usePluginImportApi.ts` — string-ref `convex/react` hooks (repo convention): `usePluginImport` (reactive progress subscription), `useProjectPlugins` / `useProjectPlugin` / `usePluginVersion` / `usePluginSetupStatus` / `usePluginRuntimePreview`, and `usePluginImportActions` with `startImport` orchestrating mint URL → upload → `createImport` → `inspectImport`, plus `commitImport`.
- `client/src/hooks/usePluginsEnabled.ts` — PostHog `plugins-enabled` gate copying the `useSkillsEnabled` pattern (fail-closed; tri-state variant for route guards). Query hooks skip and imperative actions throw `PLUGINS_DISABLED` while the flag is off or unresolved. The JSON-shape compatibility itself is not flag-gated: it is MCP config compatibility for the existing import modal, not a plugin surface.

### 3. Folder-to-ZIP + bundle hashing
`client/src/lib/plugins/folder-bundle.ts` — `webkitdirectory` selection → bundle files (shared-root stripping, OS-junk filtering), in-memory `PluginFileSource` over the shared `@mcpjam/sdk/plugin-bundle` parser (the same parser the backend inspect action runs), deterministic ZIP building (jszip, sorted entries, fixed timestamp), and ZIP read-back. The bundle hash is content-defined (sorted `path NUL contentHash NUL` aggregate), so a folder and a ZIP with identical contents hash identically here and on the backend — proven by test.

### Supporting changes
- `jszip ^3.10.1` promoted to a prod dependency of `@mcpjam/inspector` (already in the lockfile as a dev transitive; lock diff is minimal and hand-scoped to the jszip closure). Loaded via dynamic import so it stays out of the main chunk.
- `client/vite.config.ts` / `client/vitest.config.ts`: alias `@mcpjam/sdk/plugin-bundle` to SDK source, mirroring the existing SDK subpath aliases (clean checkouts build/test without a prior SDK build). No `sdk/` sources modified.

## Acceptance (plan)
- Existing `mcpServers` imports still work — full pre-existing parser suite passes unchanged (only the two shape-edge tests noted above were updated).
- OpenAI direct and `mcp_servers` shapes import identically — parity tests across all three shapes, cross-checked against the SDK parser output.
- Folder and ZIP sources produce the same bundle hash — round-trip test (files → parse) vs (files → zip → unzip → parse) asserts equal `bundleHash`/`manifestHash`.

## Verification
- `npm run typecheck:client` — exit 0 (incl. tier-b import guard)
- `npx vitest run --project client` — 627 files / 6175 tests passed, exit 0
- `npx vitest run --project server --project shared --project src` — 269 files / 3555 tests passed, exit 0
- `npm run build:client` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches upload/import and ZIP parsing (abuse surface) plus intentional MCP JSON shape behavior changes; mitigated by shared SDK validation, caps, and backend auth as the real boundary.
> 
> **Overview**
> **INS-1** adds the client plumbing for OpenAI plugin import: no UI yet, but hooks and parsers future Connect flows can call.
> 
> **MCP JSON import** now accepts direct server maps, `mcp_servers`, and `mcpServers` through one `resolveJsonServerMap` path shared by parse and validate (SDK-aligned). Dual wrappers and bare single-server docs error; `{}` and unknown wrappers like `{servers:{}}` behave as empty direct maps instead of requiring `mcpServers`.
> 
> **Plugin API client** adds hand-mirrored DTOs, upload helpers (25 MB cap, timeouts, `PluginApiError` mapping), and Convex hooks for import progress, listing, setup/runtime preview, plus `startImport` / `commitImport`. Everything is gated on PostHog `plugins-enabled` (fail-closed) and auth; project hooks use `shouldQueryProjectId` like other project queries.
> 
> **Bundle preflight** in `folder-bundle.ts` wraps `@mcpjam/sdk/plugin-bundle` for folder, memory, and ZIP sources: deterministic ZIP build, folder root-strip/junk filter, and a client archive screen (EOCD counts, duplicate-name detection, bounded inflation) mirroring backend limits. **`jszip`** is a prod dependency; Vite/Vitest alias `@mcpjam/sdk/plugin-bundle` to SDK source.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efb5fc83b0e7d35c24fa6dd2299975f038ae98c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds MCP JSON compatibility and a typed, feature‑gated plugin import client for INS‑1. Client preflight now uses the shared `@mcpjam/sdk/plugin-bundle` parser with a small archive screen, aligning client and backend validation and hashing.

- **New Features**
  - JSON config: accept direct maps, `mcp_servers`, and `mcpServers` via one resolver (SDK parity). Duplicate wrappers error; bare single‑server rejected; empty doc → “No servers found.”
  - Plugin API client: typed DTOs and `convex/react` hooks for progress, listing/details, runtime preview, and start/commit actions. Structured errors with stable codes and rate‑limit metadata. 25 MB compressed cap mirrored client‑side. Feature gate: PostHog `plugins-enabled` + Convex auth (fail‑closed).
  - Folder/ZIP bundling: deterministic ZIPs with `jszip`; folder and ZIP with identical contents hash the same as the backend. Folder selections strip shared root and filter OS junk.
  - Tooling: Vite/Vitest alias `@mcpjam/sdk/plugin-bundle` to source.

- **Refactors**
  - Client preflight delegates to the shared `@mcpjam/sdk/plugin-bundle` parser; adapters surface raw entry facts only.
  - Client‑only archive screen: enforces raw EOCD record cap, rejects ZIP64 sentinel, detects collapsed duplicate names, rejects backslash entry names, and maps encrypted entries to `FILE_UNREADABLE`.
  - Bounded streaming inflation caps bytes at min(maxBytes, declared) and aborts on overruns (forged sizes can’t balloon memory).
  - Folder selections validate via the shared parser before any reads; ZIP builder writes file records only for stable record counts.

<sup>Written for commit efb5fc83b0e7d35c24fa6dd2299975f038ae98c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

