### PR TITLE
Feat/oauth 2r stepup surface wiring

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -1251,6 +1251,7 @@ export function ResourcesRoute() {
       <ResourcesTab
         serverConfig={selectedMCPConfig}
         serverName={appState.selectedServer}
+        server={selectedServerEntry ?? undefined}
         serverConnectionStatus={
           selectedServerEntry?.connectionStatus ?? "disconnected"
         }
@@ -1267,6 +1268,7 @@ export function PromptsRoute() {
       <PromptsTab
         serverConfig={selectedMCPConfig}
         serverName={appState.selectedServer}
+        server={selectedServerEntry ?? undefined}
         serverConnectionStatus={
           selectedServerEntry?.connectionStatus ?? "disconnected"
         }

--- a/mcpjam-inspector/client/src/components/PromptsTab.tsx
+++ b/mcpjam-inspector/client/src/components/PromptsTab.tsx
@@ -23,6 +23,12 @@ import { ThreePanelLayout } from "./ui/three-panel-layout";
 import { JsonEditor } from "@/components/ui/json-editor";
 import { extractDisplayFromValue } from "@/components/chat-v2/shared/tool-result-text";
 import type { MCPPrompt, MCPServerConfig } from "@mcpjam/sdk/browser";
+import { insufficientScopeFromError } from "@/lib/apis/insufficient-scope";
+import {
+  applyToolCallStepUp,
+  resetToolCallStepUp,
+} from "@/state/oauth-orchestrator";
+import type { ServerWithName } from "@/state/app-types";
 import {
   getPrompt as getPromptApi,
   listPrompts as listPromptsApi,
@@ -85,6 +91,12 @@ function capPromptContentForTranscript(content: unknown): {
 interface PromptsTabProps {
   serverConfig?: MCPServerConfig;
   serverName?: string;
+  /**
+   * The resolved server entry, needed to drive a SEP-2350 scope step-up on a
+   * `403 insufficient_scope`. Optional: without it a failure just surfaces the
+   * error.
+   */
+  server?: ServerWithName;
   serverConnectionStatus?: ConnectionStatus;
 }
 
@@ -104,6 +116,7 @@ interface FormField {
 export function PromptsTab({
   serverConfig,
   serverName,
+  server,
   serverConnectionStatus,
 }: PromptsTabProps) {
   const [prompts, setPrompts] = useState<MCPPrompt[]>([]);
@@ -116,9 +129,48 @@ export function PromptsTab({
   const [isSidebarVisible, setIsSidebarVisible] = useState(true);
   const promptsFetchVersionRef = useRef(0);
   const promptGetVersionRef = useRef(0);
+  // SEP-2350: dedupes step-up per server (no double redirect / double counter
+  // bump while the first is in flight).
+  const stepUpInFlightRef = useRef<Set<string>>(new Set());
   const isServerConnected =
     serverConnectionStatus === undefined ||
     serverConnectionStatus === "connected";
+
+  // A successful get clears the bounded step-up counter so a future legitimate
+  // scope step-up starts fresh.
+  const resetStepUpOnSuccess = useCallback(() => {
+    if (!server) return;
+    try {
+      resetToolCallStepUp(server);
+    } catch {
+      // best-effort; must not mask a successful get
+    }
+  }, [server]);
+
+  // Drive the bounded, union-scope re-authorization when a get failed with a
+  // `403 insufficient_scope`. `reauthorize` redirects the browser; `throw` /
+  // `manual` leave the surfaced error in place.
+  const driveStepUpFromError = useCallback(
+    (err: unknown) => {
+      if (!server) return;
+      const challenge = insufficientScopeFromError(err);
+      if (!challenge) return;
+      const stepUpKey = server.name;
+      if (stepUpInFlightRef.current.has(stepUpKey)) return;
+      stepUpInFlightRef.current.add(stepUpKey);
+      void applyToolCallStepUp(server, {
+        requiredScope: challenge.requiredScope,
+        resourceMetadataUrl: challenge.resourceMetadataUrl,
+      })
+        .catch(() => {
+          // step-up failure is surfaced via the get error already set
+        })
+        .finally(() => {
+          stepUpInFlightRef.current.delete(stepUpKey);
+        });
+    },
+    [server],
+  );
 
   const selectedPromptData = useMemo(() => {
     return prompts.find((prompt) => prompt.name === selectedPrompt) ?? null;
@@ -273,18 +325,28 @@ export function PromptsTab({
         );
         if (getVersion !== promptGetVersionRef.current) return;
         setPromptContent(data.content);
+        resetStepUpOnSuccess();
       } catch (err) {
         if (getVersion !== promptGetVersionRef.current) return;
         const message =
           err instanceof Error ? err.message : `Error getting prompt: ${err}`;
         setError(message);
+        // SEP-2350: on a `403 insufficient_scope`, drive the union-scope step-up.
+        driveStepUpFromError(err);
       } finally {
         if (getVersion === promptGetVersionRef.current) {
           setLoading(false);
         }
       }
     },
-    [selectedPrompt, serverName, isServerConnected, buildParameters],
+    [
+      selectedPrompt,
+      serverName,
+      isServerConnected,
+      buildParameters,
+      resetStepUpOnSuccess,
+      driveStepUpFromError,
+    ],
   );
 
   const promptNames = prompts.map((prompt) => prompt.name);

--- a/mcpjam-inspector/client/src/components/ResourcesTab.tsx
+++ b/mcpjam-inspector/client/src/components/ResourcesTab.tsx
@@ -27,6 +27,12 @@ import {
   listResources,
   readResource as readResourceApi,
 } from "@/lib/apis/mcp-resources-api";
+import { insufficientScopeFromError } from "@/lib/apis/insufficient-scope";
+import {
+  applyToolCallStepUp,
+  resetToolCallStepUp,
+} from "@/state/oauth-orchestrator";
+import type { ServerWithName } from "@/state/app-types";
 import { listResourceTemplates } from "@/lib/apis/mcp-resource-templates-api";
 import { parseTemplate } from "url-template";
 import { HOSTED_MODE } from "@/lib/config";
@@ -80,6 +86,12 @@ function capResourceContentForTranscript(content: unknown): {
 interface ResourcesTabProps {
   serverConfig?: MCPServerConfig;
   serverName?: string;
+  /**
+   * The resolved server entry, needed to drive a SEP-2350 scope step-up on a
+   * `403 insufficient_scope` (its stored issuer + originally-granted scopes).
+   * Optional: without it a read failure just surfaces the error.
+   */
+  server?: ServerWithName;
   serverConnectionStatus?: ConnectionStatus;
 }
 
@@ -164,6 +176,7 @@ function renderResourceTextContent(
 export function ResourcesTab({
   serverConfig,
   serverName,
+  server,
   serverConnectionStatus,
 }: ResourcesTabProps) {
   const [activeTab, setActiveTab] = useState<"resources" | "templates">(
@@ -200,6 +213,43 @@ export function ResourcesTab({
   const resourceReadVersionRef = useRef(0);
   const templatesFetchVersionRef = useRef(0);
   const templateReadVersionRef = useRef(0);
+  // SEP-2350: guards against a repeated read error kicking off a duplicate
+  // step-up (double redirect / double counter bump) while the first is still in
+  // flight. Keyed by server name so distinct servers never block each other.
+  const stepUpInFlightRef = useRef<Set<string>>(new Set());
+
+  // A successful read clears the bounded step-up counter so a future legitimate
+  // scope step-up starts fresh rather than inheriting a stale count.
+  const resetStepUpOnSuccess = () => {
+    if (!server) return;
+    try {
+      resetToolCallStepUp(server);
+    } catch {
+      // best-effort; a failed reset must not mask a successful read
+    }
+  };
+
+  // Drive the bounded, union-scope re-authorization when a read failed with a
+  // `403 insufficient_scope`. Deduped per server; `reauthorize` redirects the
+  // browser to the authorization server, `throw` / `manual` leave the error.
+  const driveStepUpFromError = (err: unknown) => {
+    if (!server) return;
+    const challenge = insufficientScopeFromError(err);
+    if (!challenge) return;
+    const stepUpKey = server.name;
+    if (stepUpInFlightRef.current.has(stepUpKey)) return;
+    stepUpInFlightRef.current.add(stepUpKey);
+    void applyToolCallStepUp(server, {
+      requiredScope: challenge.requiredScope,
+      resourceMetadataUrl: challenge.resourceMetadataUrl,
+    })
+      .catch(() => {
+        // step-up failure is surfaced via the read error already set
+      })
+      .finally(() => {
+        stepUpInFlightRef.current.delete(stepUpKey);
+      });
+  };
   const isServerConnected =
     serverConnectionStatus === undefined ||
     serverConnectionStatus === "connected";
@@ -391,9 +441,12 @@ export function ResourcesTab({
       const data = await readResourceApi(serverName, uri);
       if (readVersion !== resourceReadVersionRef.current) return;
       setResourceContent(data?.content ?? null);
+      resetStepUpOnSuccess();
     } catch (err) {
       if (readVersion !== resourceReadVersionRef.current) return;
       setError(`Error reading resource: ${err}`);
+      // SEP-2350: on a `403 insufficient_scope`, drive the union-scope step-up.
+      driveStepUpFromError(err);
     } finally {
       if (readVersion === resourceReadVersionRef.current) {
         setLoading(false);

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/session-readiness.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/session-readiness.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import {
+  buildReadinessDetailLines,
   SessionInsightBar,
   SessionReadinessBadge,
   type SessionReadiness,
@@ -31,29 +32,44 @@ describe("SessionReadinessBadge", () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it("shows an analyzing state while pending", () => {
-    render(<SessionReadinessBadge readiness={ready({ status: "pending" })} />);
-    expect(screen.getByText(/analyzing/i)).toBeInTheDocument();
+  it("hides the badge for ready sessions", () => {
+    const { container } = render(
+      <SessionReadinessBadge readiness={ready()} />
+    );
+    expect(container).toBeEmptyDOMElement();
   });
 
-  it("shows the verdict and issue count", () => {
+  it("shows a spinner while pending", () => {
+    render(<SessionReadinessBadge readiness={ready({ status: "pending" })} />);
+    expect(screen.getByLabelText(/analyzing readiness/i)).toBeInTheDocument();
+  });
+
+  it("shows a verdict dot with an accessible label", () => {
     render(
       <SessionReadinessBadge
         readiness={ready({ verdict: "not_ready", issueCount: 2 })}
       />
     );
-    expect(screen.getByText(/Not ready/)).toBeInTheDocument();
-    expect(screen.getByText(/· 2/)).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(/Not ready, 2 issues/i)
+    ).toBeInTheDocument();
   });
 
   it("shows a distinct failed state", () => {
     render(<SessionReadinessBadge readiness={ready({ status: "failed" })} />);
-    expect(screen.getByText(/Readiness failed/i)).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(/Readiness analysis failed/i)
+    ).toBeInTheDocument();
   });
 });
 
 describe("SessionInsightBar", () => {
-  it("renders findings from server-denormalized fields", () => {
+  it("hides the bar for ready sessions", () => {
+    const { container } = render(<SessionInsightBar readiness={ready()} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("surfaces the primary finding and detail trigger", () => {
     render(
       <SessionInsightBar
         readiness={ready({
@@ -74,17 +90,39 @@ describe("SessionInsightBar", () => {
         })}
       />
     );
-    expect(screen.getByText("Not ready")).toBeInTheDocument();
-    expect(screen.getByText(/2\/4 tool calls failed/)).toBeInTheDocument();
-    expect(screen.getByText(/1 undeclared tool/)).toBeInTheDocument();
-    expect(screen.getByText(/not an advertised tool/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/not an advertised tool/i)
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/Readiness details/i)).toBeInTheDocument();
+    expect(buildReadinessDetailLines(ready({
+      verdict: "not_ready",
+      issueCount: 1,
+      toolErrorCount: 2,
+      toolCallCount: 4,
+      hallucinatedTools: ["made_up_tool"],
+      issues: [
+        {
+          code: "hallucinated_tool",
+          severity: "error",
+          message: 'Called "made_up_tool", which is not an advertised tool.',
+          toolName: "made_up_tool",
+        },
+      ],
+    }))).toEqual(
+      expect.arrayContaining([
+        "Not ready",
+        "2/4 tool calls failed",
+        "1 undeclared tool",
+      ]),
+    );
   });
 
-  it("renders host-response latency from the readiness record", () => {
-    render(
-      <SessionInsightBar readiness={ready({ hostLatencyMs: 3500 })} />
-    );
-    expect(screen.getByText(/3\.5s client latency/)).toBeInTheDocument();
+  it("puts host-response latency in the detail tooltip copy", () => {
+    expect(
+      buildReadinessDetailLines(
+        ready({ verdict: "needs_attention", hostLatencyMs: 3500 }),
+      ),
+    ).toContain("3.5s client latency");
   });
 
   it("flags partial readiness when the tool inventory was unavailable", () => {
@@ -92,17 +130,20 @@ describe("SessionInsightBar", () => {
       <SessionInsightBar
         readiness={ready({
           status: "partial",
+          verdict: "needs_attention",
           coverageRatio: undefined,
           advertisedToolsKnown: false,
         })}
       />
     );
-    expect(screen.getByText(/tool inventory unavailable/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/tool inventory was unavailable/i)
+    ).toBeInTheDocument();
   });
 
   it("shows a progress state while pending", () => {
     render(<SessionInsightBar readiness={ready({ status: "pending" })} />);
-    expect(screen.getByText(/in progress/i)).toBeInTheDocument();
+    expect(screen.getByText(/Analyzing readiness/i)).toBeInTheDocument();
   });
 
   it("surfaces the error on a failed analysis", () => {
@@ -114,7 +155,7 @@ describe("SessionInsightBar", () => {
         })}
       />
     );
-    expect(screen.getByText(/Readiness analysis failed/i)).toBeInTheDocument();
+    expect(screen.getByText(/Readiness unavailable/i)).toBeInTheDocument();
     expect(screen.getByText(/trace unreadable/)).toBeInTheDocument();
   });
 
@@ -131,7 +172,6 @@ describe("SessionInsightBar", () => {
         })}
       />
     );
-    expect(screen.getByText(/Why this needs attention/i)).toBeInTheDocument();
     expect(
       screen.getByText(/Only 20% of advertised tools were used/i),
     ).toBeInTheDocument();

--- a/mcpjam-inspector/client/src/components/chatboxes/session-readiness.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/session-readiness.tsx
@@ -6,18 +6,17 @@
  * client-side trace parsing is fallback/test-only). Nothing here re-parses the
  * trace.
  *
- *   - `SessionReadinessBadge` — compact verdict pill for synthetic session rows
+ *   - `SessionReadinessBadge` — compact verdict dot for synthetic session rows
  *   - `SessionInsightBar`      — findings strip atop a synthetic session detail
  */
 
+import type { ReactNode } from "react";
+import { Info, Loader2, XCircle } from "lucide-react";
 import {
-  AlertTriangle,
-  CheckCircle2,
-  Loader2,
-  ShieldAlert,
-  ShieldCheck,
-  XCircle,
-} from "lucide-react";
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@mcpjam/design-system/tooltip";
 
 // ── types (mirror convex/lib/sessionReadiness.ts) ─────────────────────────────
 
@@ -83,25 +82,22 @@ export interface SessionReadinessRollup {
 
 const VERDICT_META: Record<
   ReadinessVerdict,
-  { label: string; pill: string; text: string; Icon: typeof ShieldCheck }
+  { label: string; dot: string; text: string }
 > = {
   ready: {
     label: "Ready",
-    pill: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400",
+    dot: "bg-emerald-500",
     text: "text-emerald-600 dark:text-emerald-400",
-    Icon: ShieldCheck,
   },
   needs_attention: {
     label: "Needs attention",
-    pill: "bg-amber-500/10 text-amber-700 dark:text-amber-400",
+    dot: "bg-amber-500",
     text: "text-amber-600 dark:text-amber-400",
-    Icon: AlertTriangle,
   },
   not_ready: {
     label: "Not ready",
-    pill: "bg-red-500/10 text-red-700 dark:text-red-400",
+    dot: "bg-red-500",
     text: "text-red-600 dark:text-red-400",
-    Icon: ShieldAlert,
   },
 };
 
@@ -118,7 +114,7 @@ function formatLatency(ms: number | null | undefined): string | null {
 const LOW_COVERAGE_THRESHOLD = 0.5;
 
 /** When the server omits `issues[]`, derive human explanations from denormalized fields. */
-function explainReadinessIssues(
+export function explainReadinessIssues(
   readiness: SessionReadiness,
 ): SessionReadinessIssue[] {
   if ((readiness.issues?.length ?? 0) > 0) {
@@ -203,6 +199,79 @@ function explainReadinessIssues(
   return fallbacks;
 }
 
+/** Tooltip copy for list-row dots and the detail-bar info trigger. */
+export function buildReadinessDetailLines(
+  readiness: SessionReadiness,
+): string[] {
+  const verdict = readiness.verdict ?? "ready";
+  const meta = VERDICT_META[verdict];
+  const lines = [meta.label];
+
+  if (readiness.issueCount > 0) {
+    lines.push(
+      `${readiness.issueCount} issue${readiness.issueCount === 1 ? "" : "s"}`,
+    );
+  }
+  if (readiness.status === "partial") {
+    lines.push("Partial analysis — tool inventory was unavailable");
+  }
+  if (typeof readiness.toolCallCount === "number") {
+    lines.push(
+      `${readiness.toolErrorCount ?? 0}/${readiness.toolCallCount} tool calls failed`,
+    );
+  }
+  const coverage = coveragePct(readiness.coverageRatio);
+  if (coverage) {
+    lines.push(`${coverage} tool coverage`);
+  }
+  if ((readiness.hallucinatedTools?.length ?? 0) > 0) {
+    lines.push(
+      `${readiness.hallucinatedTools!.length} undeclared tool${readiness.hallucinatedTools!.length === 1 ? "" : "s"}`,
+    );
+  }
+  const latency = formatLatency(readiness.hostLatencyMs);
+  if (latency) {
+    lines.push(`${latency} client latency`);
+  }
+
+  for (const issue of explainReadinessIssues(readiness)) {
+    if (!lines.includes(issue.message)) {
+      lines.push(issue.message);
+    }
+  }
+
+  if (readiness.status === "failed" && readiness.errorMessage) {
+    lines.push(readiness.errorMessage);
+  }
+
+  return lines;
+}
+
+function ReadinessDetailTooltip({
+  readiness,
+  children,
+}: {
+  readiness: SessionReadiness;
+  children: ReactNode;
+}) {
+  const lines = buildReadinessDetailLines(readiness);
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{children}</TooltipTrigger>
+      <TooltipContent
+        variant="muted"
+        side="bottom"
+        align="start"
+        className="max-w-xs space-y-1 px-3 py-2"
+      >
+        {lines.map((line) => (
+          <p key={line}>{line}</p>
+        ))}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
 // ── badge (session row) ───────────────────────────────────────────────────────
 
 export function SessionReadinessBadge({
@@ -214,57 +283,52 @@ export function SessionReadinessBadge({
 
   if (readiness.status === "pending") {
     return (
-      <span className="inline-flex items-center gap-0.5 text-[10px] text-muted-foreground">
-        <Loader2 className="size-2.5 animate-spin" />
-        Analyzing
-      </span>
+      <ReadinessDetailTooltip readiness={readiness}>
+        <span
+          className="inline-flex shrink-0 items-center text-muted-foreground"
+          aria-label="Analyzing readiness"
+        >
+          <Loader2 className="size-2.5 animate-spin" />
+        </span>
+      </ReadinessDetailTooltip>
     );
   }
   if (readiness.status === "failed") {
     return (
-      <span className="inline-flex items-center gap-0.5 text-[10px] text-muted-foreground">
-        <XCircle className="size-2.5" />
-        Readiness failed
-      </span>
+      <ReadinessDetailTooltip readiness={readiness}>
+        <span
+          className="inline-flex shrink-0 items-center text-muted-foreground"
+          aria-label="Readiness analysis failed"
+        >
+          <XCircle className="size-2.5" />
+        </span>
+      </ReadinessDetailTooltip>
     );
   }
 
   const verdict = readiness.verdict ?? "ready";
+  if (verdict === "ready" && readiness.status !== "partial") {
+    return null;
+  }
+
   const meta = VERDICT_META[verdict];
-  const { Icon } = meta;
+  const label =
+    readiness.issueCount > 0
+      ? `${meta.label}, ${readiness.issueCount} issue${readiness.issueCount === 1 ? "" : "s"}`
+      : meta.label;
+
   return (
-    <span
-      className={`inline-flex items-center gap-0.5 text-[10px] font-medium ${meta.text}`}
-      title={
-        readiness.status === "partial"
-          ? "Partial readiness — tool inventory was unavailable"
-          : undefined
-      }
-    >
-      <Icon className="size-2.5" />
-      {meta.label}
-      {readiness.issueCount > 0 ? ` · ${readiness.issueCount}` : ""}
-      {readiness.status === "partial" ? " · partial" : ""}
-    </span>
+    <ReadinessDetailTooltip readiness={readiness}>
+      <span
+        className={`inline-block size-1.5 shrink-0 rounded-full ${meta.dot}`}
+        aria-label={label}
+        role="img"
+      />
+    </ReadinessDetailTooltip>
   );
 }
 
 // ── insight bar (session detail) ──────────────────────────────────────────────
-
-const ISSUE_ICON: Record<
-  SessionReadinessIssue["severity"],
-  typeof AlertTriangle
-> = {
-  error: XCircle,
-  warning: AlertTriangle,
-  info: CheckCircle2,
-};
-
-const ISSUE_TONE: Record<SessionReadinessIssue["severity"], string> = {
-  error: "text-red-600 dark:text-red-400",
-  warning: "text-amber-600 dark:text-amber-400",
-  info: "text-muted-foreground",
-};
 
 export function SessionInsightBar({
   readiness,
@@ -275,108 +339,73 @@ export function SessionInsightBar({
 
   if (readiness.status === "pending") {
     return (
-      <div className="flex items-center gap-2 border-b bg-muted/30 px-4 py-2 text-xs text-muted-foreground">
-        <Loader2 className="size-3.5 animate-spin" />
-        Readiness analysis in progress…
+      <div className="flex items-center gap-2 border-b px-4 py-2 text-xs text-muted-foreground">
+        <Loader2 className="size-3 animate-spin" />
+        Analyzing readiness…
       </div>
     );
   }
   if (readiness.status === "failed") {
     return (
-      <div className="flex items-center gap-2 border-b bg-muted/30 px-4 py-2 text-xs text-muted-foreground">
-        <XCircle className="size-3.5" />
-        Readiness analysis failed
-        {readiness.errorMessage ? `: ${readiness.errorMessage}` : ""}
+      <div className="flex items-center gap-2 border-b px-4 py-2 text-xs text-muted-foreground">
+        <XCircle className="size-3 shrink-0" />
+        <span className="truncate">
+          Readiness unavailable
+          {readiness.errorMessage ? `: ${readiness.errorMessage}` : ""}
+        </span>
       </div>
     );
   }
 
   const verdict = readiness.verdict ?? "ready";
+  if (verdict === "ready" && readiness.status !== "partial") {
+    return null;
+  }
+
   const meta = VERDICT_META[verdict];
-  const { Icon } = meta;
-  const coverage = coveragePct(readiness.coverageRatio);
   const issues = explainReadinessIssues(readiness);
-  const showFindings =
-    verdict !== "ready" || issues.length > 0 || readiness.status === "partial";
-  const findingsLabel =
-    verdict === "ready"
-      ? "Readiness"
-      : verdict === "not_ready"
-        ? "Why this is not ready"
-        : "Why this needs attention";
+  const primaryIssue =
+    issues[0]?.message ??
+    (readiness.status === "partial"
+      ? "Tool inventory was unavailable — coverage could not be fully verified."
+      : meta.label);
+  const detailLines = buildReadinessDetailLines(readiness);
+  const hasExtraDetail = detailLines.length > 1;
 
   return (
-    <div className="border-b bg-muted/20 px-4 py-2.5">
-      <p className="mb-1.5 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-        {findingsLabel}
+    <div
+      className="flex items-start gap-2.5 border-b px-4 py-2"
+      data-testid="session-insight-bar"
+    >
+      <span
+        className={`mt-1.5 size-1.5 shrink-0 rounded-full ${meta.dot}`}
+        aria-hidden
+      />
+      <p className={`min-w-0 flex-1 text-xs leading-snug ${meta.text}`}>
+        {primaryIssue}
       </p>
-      <div className="flex flex-wrap items-center gap-2 text-xs">
-        <span
-          className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 font-medium ${meta.pill}`}
-        >
-          <Icon className="size-3" />
-          {meta.label}
-        </span>
-        {typeof readiness.toolCallCount === "number" ? (
-          <span className="text-muted-foreground">
-            {readiness.toolErrorCount ?? 0}/{readiness.toolCallCount} tool calls
-            failed
-          </span>
-        ) : null}
-        {coverage ? (
-          <>
-            <span className="text-muted-foreground/40">·</span>
-            <span className="text-muted-foreground">
-              {coverage} tool coverage
-            </span>
-          </>
-        ) : null}
-        {readiness.status === "partial" ? (
-          <>
-            <span className="text-muted-foreground/40">·</span>
-            <span className="text-muted-foreground/80">
-              tool inventory unavailable
-            </span>
-          </>
-        ) : null}
-        {(readiness.hallucinatedTools?.length ?? 0) > 0 ? (
-          <>
-            <span className="text-muted-foreground/40">·</span>
-            <span className="text-red-600 dark:text-red-400">
-              {readiness.hallucinatedTools!.length} undeclared tool
-              {readiness.hallucinatedTools!.length === 1 ? "" : "s"}
-            </span>
-          </>
-        ) : null}
-        {formatLatency(readiness.hostLatencyMs) ? (
-          <>
-            <span className="text-muted-foreground/40">·</span>
-            <span
-              className="text-muted-foreground"
-              title="Client-response latency (server work time across turns; excludes the persona driver's own LLM time)"
+      {hasExtraDetail ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              className="mt-0.5 shrink-0 rounded-sm p-0.5 text-muted-foreground/50 transition-colors hover:text-muted-foreground"
+              aria-label="Readiness details"
             >
-              {formatLatency(readiness.hostLatencyMs)} client latency
-            </span>
-          </>
-        ) : null}
-      </div>
-      {showFindings && issues.length > 0 ? (
-        <ul className="mt-2 space-y-1">
-          {issues.map((issue, i) => {
-            const IssueIcon = ISSUE_ICON[issue.severity];
-            return (
-              <li
-                key={`${issue.code}-${i}`}
-                className={`flex items-start gap-1.5 text-xs ${
-                  ISSUE_TONE[issue.severity]
-                }`}
-              >
-                <IssueIcon className="mt-0.5 size-3 shrink-0" />
-                <span>{issue.message}</span>
-              </li>
-            );
-          })}
-        </ul>
+              <Info className="size-3.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent
+            variant="muted"
+            side="bottom"
+            align="end"
+            className="max-w-xs space-y-1 px-3 py-2"
+          >
+            {detailLines.map((line) => (
+              <p key={line}>{line}</p>
+            ))}
+          </TooltipContent>
+        </Tooltip>
       ) : null}
     </div>
   );

--- a/mcpjam-inspector/client/src/components/connection/share-usage/ShareUsageThreadList.tsx
+++ b/mcpjam-inspector/client/src/components/connection/share-usage/ShareUsageThreadList.tsx
@@ -150,10 +150,14 @@ function ThreadCard({
             {thread.visitorDisplayName ?? "Anonymous"}
           </span>
           {thread.synthetic === true ? (
-            <span
-              className="size-1.5 shrink-0 rounded-full bg-muted-foreground/40"
-              aria-label="Synthetic session"
-            />
+            <>
+              <span
+                className="size-1.5 shrink-0 rounded-full bg-muted-foreground/40"
+                aria-label="Synthetic session"
+                role="img"
+              />
+              <SessionReadinessBadge readiness={thread.readiness} />
+            </>
           ) : null}
         </p>
         <span className="flex shrink-0 items-center gap-1 font-mono text-xs text-muted-foreground">
@@ -190,9 +194,6 @@ function ThreadCard({
           <span className="max-w-[140px] truncate text-[10px] text-muted-foreground">
             {thread.personaLabel}
           </span>
-        ) : null}
-        {thread.synthetic === true ? (
-          <SessionReadinessBadge readiness={thread.readiness} />
         ) : null}
         {/* Judge verdict — only when a goalScore exists; absence = ungraded,
             not "broken". readiness = "ran cleanly"; judge = "hit the goal". */}

--- a/mcpjam-inspector/client/src/components/connection/share-usage/__tests__/ShareUsageThreadDetail.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/share-usage/__tests__/ShareUsageThreadDetail.test.tsx
@@ -230,10 +230,7 @@ describe("ShareUsageThreadDetail", () => {
     render(<ShareUsageThreadDetail threadId="thread-1" />);
 
     expect(
-      await screen.findByText(/Why this needs attention/i)
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(/Only 20% of advertised tools were used/i)
+      await screen.findByText(/Only 20% of advertised tools were used/i)
     ).toBeInTheDocument();
   });
 

--- a/mcpjam-inspector/client/src/components/ui-playground/hooks/__tests__/useToolExecution.app-routing.test.ts
+++ b/mcpjam-inspector/client/src/components/ui-playground/hooks/__tests__/useToolExecution.app-routing.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { renderHook, act } from "@testing-library/react";
+import { createElement } from "react";
 
 import { classifySelectedTool, useToolExecution } from "../useToolExecution";
 import {
@@ -7,6 +8,8 @@ import {
   type AppInstance,
   type AppToolDescriptor,
 } from "@/components/chat-v2/thread/mcp-apps/app-tools-registry";
+import { AppStateProvider } from "@/state/app-state-context";
+import type { AppState, ServerWithName } from "@/state/app-types";
 
 // --- Mocks ------------------------------------------------------------------
 
@@ -30,6 +33,15 @@ vi.mock("@/lib/apis/mcp-tools-api", () => ({
 const mockReadResource = vi.fn();
 vi.mock("@/lib/apis/mcp-resources-api", () => ({
   readResource: (...args: unknown[]) => mockReadResource(...args),
+}));
+
+const mockApplyToolCallStepUp = vi.fn();
+const mockResetToolCallStepUp = vi.fn();
+vi.mock("@/state/oauth-orchestrator", () => ({
+  applyToolCallStepUp: (...args: unknown[]) =>
+    mockApplyToolCallStepUp(...args),
+  resetToolCallStepUp: (...args: unknown[]) =>
+    mockResetToolCallStepUp(...args),
 }));
 
 // --- Helpers ----------------------------------------------------------------
@@ -89,6 +101,9 @@ beforeEach(() => {
   });
   mockExecuteToolApi.mockReset();
   mockReadResource.mockReset();
+  mockApplyToolCallStepUp.mockReset();
+  mockApplyToolCallStepUp.mockResolvedValue({ action: "throw" });
+  mockResetToolCallStepUp.mockReset();
 });
 
 afterEach(() => {
@@ -450,5 +465,80 @@ describe("useToolExecution app-tool routing", () => {
 
     expect(outcome?.ok).toBe(true);
     expect(callTool).toHaveBeenCalled();
+  });
+});
+
+describe("useToolExecution step-up (SEP-2350)", () => {
+  function withServer(server: ServerWithName) {
+    const appState = {
+      servers: { [server.name]: server },
+    } as unknown as AppState;
+    return ({ children }: { children: React.ReactNode }) =>
+      createElement(AppStateProvider, { appState }, children);
+  }
+
+  const server = {
+    name: "srv-1",
+    connectionStatus: "connected",
+  } as unknown as ServerWithName;
+
+  it("drives applyToolCallStepUp on a 403 insufficient_scope response", async () => {
+    mockExecuteToolApi.mockResolvedValueOnce({
+      error: "Insufficient scope",
+      insufficientScope: {
+        requiredScope: "read write admin",
+        resourceMetadataUrl: "https://rs.example/.well-known",
+      },
+    });
+
+    const { result } = renderHook(
+      () => useToolExecution(makeHookOptions({ selectedTool: "get_weather" })),
+      { wrapper: withServer(server) },
+    );
+
+    await act(async () => {
+      await result.current.executeTool({ parameters: {} });
+    });
+
+    expect(mockApplyToolCallStepUp).toHaveBeenCalledTimes(1);
+    expect(mockApplyToolCallStepUp).toHaveBeenCalledWith(server, {
+      requiredScope: "read write admin",
+      resourceMetadataUrl: "https://rs.example/.well-known",
+    });
+    expect(mockResetToolCallStepUp).not.toHaveBeenCalled();
+  });
+
+  it("resets the step-up counter after a successful call", async () => {
+    mockExecuteToolApi.mockResolvedValueOnce({
+      status: "completed",
+      result: { content: [{ type: "text", text: "ok" }] },
+    });
+
+    const { result } = renderHook(
+      () => useToolExecution(makeHookOptions({ selectedTool: "get_weather" })),
+      { wrapper: withServer(server) },
+    );
+
+    await act(async () => {
+      await result.current.executeTool({ parameters: {} });
+    });
+
+    expect(mockResetToolCallStepUp).toHaveBeenCalledWith(server);
+    expect(mockApplyToolCallStepUp).not.toHaveBeenCalled();
+  });
+
+  it("does not drive step-up for an ordinary error (no challenge)", async () => {
+    mockExecuteToolApi.mockResolvedValueOnce({ error: "Boom" });
+
+    const { result } = renderHook(
+      () => useToolExecution(makeHookOptions({ selectedTool: "get_weather" })),
+      { wrapper: withServer(server) },
+    );
+
+    await act(async () => {
+      await result.current.executeTool({ parameters: {} });
+    });
+
+    expect(mockApplyToolCallStepUp).not.toHaveBeenCalled();
   });
 });

--- a/mcpjam-inspector/client/src/components/ui-playground/hooks/useToolExecution.ts
+++ b/mcpjam-inspector/client/src/components/ui-playground/hooks/useToolExecution.ts
@@ -6,7 +6,7 @@
  * execution state for chat injection.
  */
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { FormField } from "@/lib/tool-form";
 import { buildParametersFromFields } from "@/lib/tool-form";
 import {
@@ -14,6 +14,12 @@ import {
   type ToolExecutionResponse,
 } from "@/lib/apis/mcp-tools-api";
 import { readResource } from "@/lib/apis/mcp-resources-api";
+import { parseInsufficientScopeChallenge } from "@/lib/apis/insufficient-scope";
+import {
+  applyToolCallStepUp,
+  resetToolCallStepUp,
+} from "@/state/oauth-orchestrator";
+import { useOptionalSharedAppState } from "@/state/app-state-context";
 import {
   mcpCallToolResultToModelOutput,
   mcpCallToolResultToModelOutputWithLinkedResources,
@@ -218,6 +224,52 @@ export function useToolExecution({
     setPendingExecution(null);
   }, []);
 
+  // SEP-2350 step-up. Resolve the live server entry (non-throwing: the hook is
+  // exercised in tests without an AppStateProvider) so the orchestrator can read
+  // its stored issuer + originally-granted scopes on a `403 insufficient_scope`.
+  const sharedAppState = useOptionalSharedAppState();
+  // Dedupes step-up per server (no double redirect / double counter bump while
+  // the first is in flight).
+  const stepUpInFlightRef = useRef<Set<string>>(new Set());
+
+  const resetStepUpOnSuccess = useCallback(
+    (name: string | undefined) => {
+      const server = name ? sharedAppState?.servers[name] : undefined;
+      if (!server) return;
+      try {
+        resetToolCallStepUp(server);
+      } catch {
+        // best-effort; must not mask a successful execution
+      }
+    },
+    [sharedAppState],
+  );
+
+  const driveStepUpFromResponse = useCallback(
+    (name: string | undefined, response: ToolExecutionResponse) => {
+      const server = name ? sharedAppState?.servers[name] : undefined;
+      if (!server) return;
+      const challenge = parseInsufficientScopeChallenge(
+        (response as { insufficientScope?: unknown }).insufficientScope,
+      );
+      if (!challenge) return;
+      const stepUpKey = server.name;
+      if (stepUpInFlightRef.current.has(stepUpKey)) return;
+      stepUpInFlightRef.current.add(stepUpKey);
+      void applyToolCallStepUp(server, {
+        requiredScope: challenge.requiredScope,
+        resourceMetadataUrl: challenge.resourceMetadataUrl,
+      })
+        .catch(() => {
+          // step-up failure is surfaced via the execution error already set
+        })
+        .finally(() => {
+          stepUpInFlightRef.current.delete(stepUpKey);
+        });
+    },
+    [sharedAppState],
+  );
+
   const storeCompletedToolResult = useCallback(
     (
       effectiveToolName: string,
@@ -320,6 +372,9 @@ export function useToolExecution({
           });
 
           setExecutionError(response.error);
+          // SEP-2350: on a `403 insufficient_scope`, drive the union-scope
+          // step-up re-authorization for this server.
+          driveStepUpFromResponse(effectiveServerName, response);
           return {
             ok: false,
             toolName: effectiveToolName,
@@ -378,6 +433,9 @@ export function useToolExecution({
           success: true,
         });
 
+        // SEP-2350: a successful call clears the bounded step-up counter.
+        resetStepUpOnSuccess(effectiveServerName);
+
         return {
           ok: true,
           toolName: effectiveToolName,
@@ -417,6 +475,8 @@ export function useToolExecution({
       setIsExecuting,
       storeCompletedToolResult,
       modelVisibleMcpToolResults,
+      driveStepUpFromResponse,
+      resetStepUpOnSuccess,
     ]
   );
 

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -120,6 +120,7 @@ import {
   type HostedElicitationRequestEvent,
   type HostedElicitationUrlRequiredEvent,
 } from "@/shared/hosted-elicitation";
+import { applyToolCallStepUp } from "@/state/oauth-orchestrator";
 import { respondToChatElicitation } from "@/lib/apis/elicitation-api";
 import {
   isHarnessSessionDataPart,
@@ -1249,6 +1250,10 @@ export function useChatSession(
   const [urlElicitationRequired, setUrlElicitationRequired] = useState<
     HostedElicitationUrlRequiredEvent[]
   >([]);
+  // SEP-2350: dedupes the chat step-up per server so a re-delivered
+  // `insufficient_scope` part (or a second failing tool call) can't fire a
+  // duplicate redirect / double counter bump while the first is in flight.
+  const chatStepUpInFlightRef = useRef<Set<string>>(new Set());
   const resumedVersionRef = useRef<number | null>(null);
   const restoredToolRenderOverridesRef = useRef<
     Record<string, ToolRenderOverride>
@@ -1402,6 +1407,41 @@ export function useChatSession(
             );
           } else if (event.kind === "url_required") {
             setUrlElicitationRequired((current) => [...current, event]);
+          } else if (event.kind === "insufficient_scope") {
+            // SEP-2350: a tool call in the agent loop failed with a runtime
+            // `403 insufficient_scope`. Drive the bounded, union-scope step-up
+            // re-authorization (`reauthorize` redirects the browser to the
+            // authorization server). Resolve the live server entry from the
+            // same store ToolsTab uses; without it there is no stored issuer /
+            // granted scopes to widen, so skip.
+            const activeProject =
+              appState?.projects?.[
+                hostedProjectId ?? appState?.activeProjectId ?? ""
+              ];
+            const server =
+              (event.serverName
+                ? (appState?.servers?.[event.serverName] ??
+                  activeProject?.servers?.[event.serverName])
+                : undefined) ??
+              appState?.servers?.[event.serverId] ??
+              activeProject?.servers?.[event.serverId];
+            if (server && (event.requiredScope || event.resourceMetadataUrl)) {
+              const stepUpKey = server.name;
+              if (!chatStepUpInFlightRef.current.has(stepUpKey)) {
+                chatStepUpInFlightRef.current.add(stepUpKey);
+                void applyToolCallStepUp(server, {
+                  requiredScope: event.requiredScope,
+                  resourceMetadataUrl: event.resourceMetadataUrl,
+                })
+                  .catch(() => {
+                    // A failed step-up leaves the model-facing tool error in
+                    // place; nothing else to surface here.
+                  })
+                  .finally(() => {
+                    chatStepUpInFlightRef.current.delete(stepUpKey);
+                  });
+              }
+            }
           }
         } else if (isHostedRpcLogDataPart(part)) {
           ingestHostedRpcLogs([part.data]);
@@ -1427,7 +1467,7 @@ export function useChatSession(
 
       setLiveTraceState((current) => applyLiveTraceEvent(current, part.data));
     },
-    [hostedProjectId, hostedHostId],
+    [hostedProjectId, hostedHostId, appState],
   );
 
   const syncResumedVersion = useCallback((version: number | null) => {

--- a/mcpjam-inspector/client/src/lib/apis/__tests__/insufficient-scope.test.ts
+++ b/mcpjam-inspector/client/src/lib/apis/__tests__/insufficient-scope.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { WebApiError } from "@/lib/apis/web/base";
+import {
+  McpRequestError,
+  insufficientScopeFromError,
+  parseInsufficientScopeChallenge,
+} from "@/lib/apis/insufficient-scope";
+
+describe("parseInsufficientScopeChallenge (SEP-2350)", () => {
+  it("narrows a valid challenge payload", () => {
+    expect(
+      parseInsufficientScopeChallenge({
+        requiredScope: "read write",
+        resourceMetadataUrl: "https://rs.example/.well-known",
+        errorDescription: "more scope needed",
+      }),
+    ).toEqual({
+      requiredScope: "read write",
+      resourceMetadataUrl: "https://rs.example/.well-known",
+      errorDescription: "more scope needed",
+    });
+  });
+
+  it("returns undefined when no string field is present", () => {
+    expect(parseInsufficientScopeChallenge({})).toBeUndefined();
+    expect(parseInsufficientScopeChallenge({ requiredScope: 1 })).toBeUndefined();
+    expect(parseInsufficientScopeChallenge(undefined)).toBeUndefined();
+    expect(parseInsufficientScopeChallenge("nope")).toBeUndefined();
+  });
+});
+
+describe("insufficientScopeFromError (SEP-2350)", () => {
+  it("reads the challenge off an McpRequestError (local throw path)", () => {
+    const err = new McpRequestError("read failed", {
+      insufficientScope: { requiredScope: "read:tickets" },
+      status: 403,
+    });
+    expect(insufficientScopeFromError(err)).toEqual({
+      requiredScope: "read:tickets",
+    });
+  });
+
+  it("reads the challenge off a hosted WebApiError.details", () => {
+    const err = new WebApiError(403, "FORBIDDEN", "forbidden", undefined, {
+      insufficientScope: {
+        requiredScope: "read write admin",
+        resourceMetadataUrl: "https://rs.example/.well-known",
+      },
+    });
+    expect(insufficientScopeFromError(err)).toEqual({
+      requiredScope: "read write admin",
+      resourceMetadataUrl: "https://rs.example/.well-known",
+      errorDescription: undefined,
+    });
+  });
+
+  it("returns undefined for an ordinary error", () => {
+    expect(insufficientScopeFromError(new Error("boom"))).toBeUndefined();
+  });
+
+  it("returns undefined for an McpRequestError without a challenge", () => {
+    expect(
+      insufficientScopeFromError(new McpRequestError("plain 500", { status: 500 })),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when the WebApiError details carry no challenge fields", () => {
+    const err = new WebApiError(500, "INTERNAL_ERROR", "boom", undefined, {
+      insufficientScope: {},
+    });
+    expect(insufficientScopeFromError(err)).toBeUndefined();
+  });
+});

--- a/mcpjam-inspector/client/src/lib/apis/insufficient-scope.ts
+++ b/mcpjam-inspector/client/src/lib/apis/insufficient-scope.ts
@@ -1,0 +1,88 @@
+/**
+ * Shared SEP-2350 runtime scope step-up (`403 insufficient_scope`) challenge
+ * plumbing for every client API surface — tools, resources, prompts.
+ *
+ * The server surfaces an upstream `InsufficientScopeError`'s `WWW-Authenticate`
+ * challenge on the error body:
+ *   - local routes: `mcpError.insufficientScope` (via the `jsonError` helper)
+ *   - hosted routes: `details.insufficientScope` (via `mapRuntimeError` → 403)
+ *
+ * Both shapes flow through `parseInsufficientScopeChallenge`, which narrows the
+ * untrusted resource-server payload. Consumers pass `requiredScope` into the
+ * client step-up re-authorization (union of previously-granted + challenged
+ * scopes, bounded per session). Treat every field as untrusted when rendering.
+ */
+
+/** The `WWW-Authenticate` step-up challenge surfaced on a failed MCP request. */
+export type InsufficientScopeChallenge = {
+  requiredScope?: string;
+  resourceMetadataUrl?: string;
+  errorDescription?: string;
+};
+
+/**
+ * Narrow an untrusted `insufficientScope` payload to the challenge shape.
+ * Returns `undefined` unless at least one string field is present, so a
+ * malformed or empty block never masquerades as an actionable step-up.
+ */
+export function parseInsufficientScopeChallenge(
+  raw: unknown,
+): InsufficientScopeChallenge | undefined {
+  if (!raw || typeof raw !== "object") {
+    return undefined;
+  }
+  const r = raw as Record<string, unknown>;
+  const requiredScope =
+    typeof r.requiredScope === "string" ? r.requiredScope : undefined;
+  const resourceMetadataUrl =
+    typeof r.resourceMetadataUrl === "string" ? r.resourceMetadataUrl : undefined;
+  const errorDescription =
+    typeof r.errorDescription === "string" ? r.errorDescription : undefined;
+  if (!requiredScope && !resourceMetadataUrl && !errorDescription) {
+    return undefined;
+  }
+  return { requiredScope, resourceMetadataUrl, errorDescription };
+}
+
+/**
+ * Error thrown by the throw-based client APIs (resource read, prompt get) when
+ * a request fails, carrying an optional SEP-2350 step-up challenge so the
+ * `catch` site can drive the union-scope re-authorization without re-parsing
+ * the transport-specific error body. `executeToolApi` uses a return-value
+ * channel instead (its consumers read `response.insufficientScope`); this class
+ * serves the surfaces whose consumers already `try/catch`.
+ */
+export class McpRequestError extends Error {
+  insufficientScope?: InsufficientScopeChallenge;
+  status?: number;
+
+  constructor(
+    message: string,
+    opts?: {
+      insufficientScope?: InsufficientScopeChallenge;
+      status?: number;
+    },
+  ) {
+    super(message);
+    this.name = "McpRequestError";
+    this.insufficientScope = opts?.insufficientScope;
+    this.status = opts?.status;
+  }
+}
+
+/**
+ * Pull a step-up challenge off a caught error regardless of transport shape:
+ * an `McpRequestError.insufficientScope` (local throw path) or a hosted
+ * `WebApiError`'s `details.insufficientScope`. Returns `undefined` for anything
+ * else, so an ordinary failure never triggers a spurious re-authorization.
+ */
+export function insufficientScopeFromError(
+  error: unknown,
+): InsufficientScopeChallenge | undefined {
+  if (error instanceof McpRequestError && error.insufficientScope) {
+    return error.insufficientScope;
+  }
+  const details = (error as { details?: { insufficientScope?: unknown } })
+    ?.details;
+  return parseInsufficientScopeChallenge(details?.insufficientScope);
+}

--- a/mcpjam-inspector/client/src/lib/apis/mcp-prompts-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/mcp-prompts-api.ts
@@ -7,6 +7,11 @@ import {
 } from "@/lib/apis/web/prompts-api";
 import { resolveHostedServerId } from "@/lib/apis/web/context";
 import { runByMode } from "@/lib/apis/mode-client";
+import { WebApiError } from "@/lib/apis/web/base";
+import {
+  McpRequestError,
+  parseInsufficientScopeChallenge,
+} from "@/lib/apis/insufficient-scope";
 
 export interface PromptContentResponse {
   content: any;
@@ -55,12 +60,29 @@ export async function getPrompt(
   args?: Record<string, string>,
 ): Promise<PromptContentResponse> {
   return runByMode({
-    hosted: async () =>
-      (await getHostedPrompt({
-        serverNameOrId: serverId,
-        promptName: name,
-        arguments: args,
-      })) as PromptContentResponse,
+    hosted: async () => {
+      try {
+        return (await getHostedPrompt({
+          serverNameOrId: serverId,
+          promptName: name,
+          arguments: args,
+        })) as PromptContentResponse;
+      } catch (error) {
+        // SEP-2350: rethrow as an McpRequestError carrying the challenge the
+        // hosted 403 forwarded on `details.insufficientScope`.
+        const insufficientScope =
+          error instanceof WebApiError
+            ? parseInsufficientScopeChallenge(
+                (error.details as any)?.insufficientScope,
+              )
+            : undefined;
+        const message = error instanceof Error ? error.message : String(error);
+        throw new McpRequestError(message, {
+          insufficientScope,
+          status: error instanceof WebApiError ? error.status : undefined,
+        });
+      }
+    },
     local: async () => {
       const res = await authFetch("/api/mcp/prompts/get", {
         method: "POST",
@@ -75,7 +97,14 @@ export async function getPrompt(
 
       if (!res.ok) {
         const message = body?.error || `Get prompt failed (${res.status})`;
-        throw new Error(message);
+        // SEP-2350: the /prompts/get route serializes a 403 challenge onto
+        // `mcpError.insufficientScope` (via jsonError). Surface it for step-up.
+        throw new McpRequestError(message, {
+          insufficientScope: parseInsufficientScopeChallenge(
+            body?.mcpError?.insufficientScope,
+          ),
+          status: res.status,
+        });
       }
 
       return body as PromptContentResponse;

--- a/mcpjam-inspector/client/src/lib/apis/mcp-resources-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/mcp-resources-api.ts
@@ -4,6 +4,11 @@ import {
   readHostedResource,
 } from "@/lib/apis/web/resources-api";
 import { runByMode } from "@/lib/apis/mode-client";
+import { WebApiError } from "@/lib/apis/web/base";
+import {
+  McpRequestError,
+  parseInsufficientScopeChallenge,
+} from "@/lib/apis/insufficient-scope";
 
 export type ListResourcesResult = {
   resources: Array<{
@@ -63,14 +68,51 @@ export async function readResource(
 ) {
   return runByMode({
     forceHosted: opts?.forceHosted,
-    hosted: async () => readHostedResource({ serverNameOrId: serverId, uri }),
+    hosted: async () => {
+      try {
+        return await readHostedResource({ serverNameOrId: serverId, uri });
+      } catch (error) {
+        // SEP-2350: rethrow as an McpRequestError carrying the challenge the
+        // hosted 403 forwarded on `details.insufficientScope`, so the consumer
+        // catch can drive the union-scope step-up.
+        const insufficientScope =
+          error instanceof WebApiError
+            ? parseInsufficientScopeChallenge(
+                (error.details as any)?.insufficientScope,
+              )
+            : undefined;
+        const message = error instanceof Error ? error.message : String(error);
+        throw new McpRequestError(message, {
+          insufficientScope,
+          status: error instanceof WebApiError ? error.status : undefined,
+        });
+      }
+    },
     local: async () => {
       const response = await authFetch(`/api/mcp/resources/read`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ serverId, uri }),
       });
-      return response.json();
+      let body: any = null;
+      try {
+        body = await response.json();
+      } catch {}
+      if (!response.ok) {
+        // SEP-2350: the /resources/read route serializes a 403 challenge onto
+        // `mcpError.insufficientScope` (via jsonError). Surface it so the
+        // consumer can step up. Previously this path returned the error body
+        // as if it were a successful read.
+        const message =
+          body?.error || `Error reading resource (${response.status})`;
+        throw new McpRequestError(message, {
+          insufficientScope: parseInsufficientScopeChallenge(
+            body?.mcpError?.insufficientScope,
+          ),
+          status: response.status,
+        });
+      }
+      return body;
     },
   });
 }

--- a/mcpjam-inspector/client/src/lib/apis/mcp-tools-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/mcp-tools-api.ts
@@ -16,6 +16,10 @@ import { WebApiError } from "@/lib/apis/web/base";
 import { executeHostedTool, listHostedTools } from "@/lib/apis/web/tools-api";
 import { isHostedMode, runByMode } from "@/lib/apis/mode-client";
 import { attachToolMetadata } from "@/lib/apis/tool-metadata";
+import {
+  parseInsufficientScopeChallenge,
+  type InsufficientScopeChallenge,
+} from "@/lib/apis/insufficient-scope";
 
 export type ListToolsResultWithMetadata = ListToolsResult & {
   toolsMetadata?: Record<string, Record<string, any>>;
@@ -74,36 +78,11 @@ export type ToolExecutionResponse =
       insufficientScope?: ToolInsufficientScopeChallenge;
     };
 
-/** The `WWW-Authenticate` step-up challenge surfaced on a failed tool call. */
-export type ToolInsufficientScopeChallenge = {
-  requiredScope?: string;
-  resourceMetadataUrl?: string;
-  errorDescription?: string;
-};
-
-/**
- * Narrow an untrusted `mcpError.insufficientScope` payload to the challenge
- * shape. Returns `undefined` unless at least one string field is present, so a
- * malformed or empty block never masquerades as an actionable step-up.
- */
-export function parseInsufficientScopeChallenge(
-  raw: unknown,
-): ToolInsufficientScopeChallenge | undefined {
-  if (!raw || typeof raw !== "object") {
-    return undefined;
-  }
-  const r = raw as Record<string, unknown>;
-  const requiredScope =
-    typeof r.requiredScope === "string" ? r.requiredScope : undefined;
-  const resourceMetadataUrl =
-    typeof r.resourceMetadataUrl === "string" ? r.resourceMetadataUrl : undefined;
-  const errorDescription =
-    typeof r.errorDescription === "string" ? r.errorDescription : undefined;
-  if (!requiredScope && !resourceMetadataUrl && !errorDescription) {
-    return undefined;
-  }
-  return { requiredScope, resourceMetadataUrl, errorDescription };
-}
+// SEP-2350 challenge plumbing now lives in the surface-agnostic
+// `insufficient-scope` module (shared by tools / resources / prompts). Re-export
+// here under the original names so existing importers stay green.
+export type ToolInsufficientScopeChallenge = InsufficientScopeChallenge;
+export { parseInsufficientScopeChallenge };
 
 export async function listTools({
   serverId,

--- a/mcpjam-inspector/server/routes/mcp/__tests__/tools.serialize-error.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/tools.serialize-error.test.ts
@@ -35,6 +35,25 @@ describe("extractInsufficientScopeChallenge (SEP-2350)", () => {
     });
   });
 
+  it("normalizes a URL-object resourceMetadataUrl to a string (real runtime shape)", () => {
+    // The upstream transport constructs InsufficientScopeError with
+    // `resourceMetadataUrl` as a `URL` (from `new URL(...)` on the
+    // WWW-Authenticate header), NOT a string. The extractor must accept it and
+    // normalize, otherwise the real production value is silently dropped.
+    const err = new InsufficientScopeError({
+      requiredScope: "read write",
+      resourceMetadataUrl: new URL(
+        "https://rs.example/.well-known/oauth-protected-resource",
+      ) as any,
+    });
+    expect(extractInsufficientScopeChallenge(err)).toEqual({
+      requiredScope: "read write",
+      resourceMetadataUrl:
+        "https://rs.example/.well-known/oauth-protected-resource",
+      errorDescription: undefined,
+    });
+  });
+
   it("walks the cause chain to find a wrapped InsufficientScopeError", () => {
     const inner = new InsufficientScopeError({ requiredScope: "read:tickets" });
     const outer = new Error("tool call failed");

--- a/mcpjam-inspector/server/routes/mcp/prompts.ts
+++ b/mcpjam-inspector/server/routes/mcp/prompts.ts
@@ -6,6 +6,7 @@ import {
   listPromptsMulti,
   getPrompt,
 } from "../../utils/route-handlers.js";
+import { jsonError } from "../../utils/mcp-error-serialize.js";
 
 const prompts = new Hono();
 
@@ -98,13 +99,10 @@ prompts.post("/get", async (c) => {
     );
   } catch (error) {
     logger.error("Error getting prompt", error);
-    return c.json(
-      {
-        success: false,
-        error: error instanceof Error ? error.message : "Unknown error",
-      },
-      500,
-    );
+    // SEP-2350: surface a 403 `insufficient_scope` challenge (on
+    // `mcpError.insufficientScope`) so the client can drive the union-scope
+    // step-up re-authorization; ordinary errors keep the 500 fallback.
+    return jsonError(c, error, 500);
   }
 });
 

--- a/mcpjam-inspector/server/routes/mcp/resources.ts
+++ b/mcpjam-inspector/server/routes/mcp/resources.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import "../../types/hono"; // Type extensions
 import { logger } from "../../utils/logger";
 import { listResources, readResource } from "../../utils/route-handlers.js";
+import { jsonError } from "../../utils/mcp-error-serialize.js";
 
 const resources = new Hono();
 
@@ -55,13 +56,10 @@ resources.post("/read", async (c) => {
     return c.json(await readResource(c.mcpClientManager, { serverId, uri }));
   } catch (error) {
     logger.error("Error reading resource", error, { serverId, uri });
-    return c.json(
-      {
-        success: false,
-        error: error instanceof Error ? error.message : "Unknown error",
-      },
-      500,
-    );
+    // SEP-2350: surface a 403 `insufficient_scope` challenge (on
+    // `mcpError.insufficientScope`) so the client can drive the union-scope
+    // step-up re-authorization; ordinary errors keep the 500 fallback.
+    return jsonError(c, error, 500);
   }
 });
 

--- a/mcpjam-inspector/server/routes/mcp/tools.ts
+++ b/mcpjam-inspector/server/routes/mcp/tools.ts
@@ -6,7 +6,23 @@ import type {
 } from "@modelcontextprotocol/client";
 import "../../types/hono"; // Type extensions
 import { listTools as listToolsShared } from "../../utils/route-handlers.js";
-import { describeError } from "@mcpjam/sdk";
+import {
+  extractInsufficientScopeChallenge,
+  serializeMcpError,
+  jsonError,
+  type InsufficientScopeChallenge,
+} from "../../utils/mcp-error-serialize.js";
+
+// Re-exported so existing importers (and
+// `__tests__/tools.serialize-error.test.ts`) keep resolving these from
+// `mcp/tools`; the implementations now live in the shared serializer used by
+// every route surface that can receive a `403 insufficient_scope` (SEP-2350).
+export {
+  extractInsufficientScopeChallenge,
+  serializeMcpError,
+  jsonError,
+  type InsufficientScopeChallenge,
+};
 
 const tools = new Hono();
 
@@ -87,115 +103,6 @@ function resetExecution(context: ExecutionContext, clear: () => void) {
 
 function getExecutionDurationMs(context: ExecutionContext): number {
   return Math.max(0, Date.now() - context.startedAtMs);
-}
-
-/** The `WWW-Authenticate` step-up challenge fields surfaced to the client. */
-export type InsufficientScopeChallenge = {
-  requiredScope?: string;
-  resourceMetadataUrl?: string;
-  errorDescription?: string;
-};
-
-/**
- * Recognize an upstream `InsufficientScopeError` (SEP-2350) anywhere in the
- * error / cause chain and return its `WWW-Authenticate` challenge fields.
- *
- * A runtime `403 insufficient_scope` from a live MCP request surfaces here as
- * this transport-layer error (the SDK constructs the transport with
- * `onInsufficientScope: "throw"`, so it never attempts a doomed server-side
- * interactive re-authorization). Detection is strictly by
- * `constructor.mcpBrand` / `.name` — an actual `InsufficientScopeError`, never
- * a duck-typed `requiredScope` field (an unrelated error carrying that field
- * must not masquerade as a step-up challenge). The class does not extend
- * `OAuthError`, and its fields (`requiredScope`, `resourceMetadataUrl`)
- * originate from the resource server's header, so treat them as untrusted when
- * rendering. Returning the challenge lets the client drive the union-scope
- * step-up re-authorization.
- */
-export function extractInsufficientScopeChallenge(
-  error: unknown,
-): InsufficientScopeChallenge | undefined {
-  const seen = new Set<unknown>();
-  let current: any = error;
-  while (current && typeof current === "object" && !seen.has(current)) {
-    seen.add(current);
-    // Recognize ONLY an actual `InsufficientScopeError` — by its class brand
-    // (`mcpBrand`, survives minification/cross-realm) or `.name`. Do NOT
-    // duck-type on a `requiredScope` string: an unrelated error that happens
-    // to carry a `requiredScope` field must not be serialized to the client as
-    // an OAuth step-up challenge (it would trigger a spurious re-authorization).
-    const isInsufficientScope =
-      current.constructor?.mcpBrand === "mcp.InsufficientScopeError" ||
-      current.name === "InsufficientScopeError";
-    if (isInsufficientScope) {
-      const requiredScope =
-        typeof current.requiredScope === "string"
-          ? current.requiredScope
-          : undefined;
-      const resourceMetadataUrl =
-        typeof current.resourceMetadataUrl === "string"
-          ? current.resourceMetadataUrl
-          : undefined;
-      const errorDescription =
-        typeof current.errorDescription === "string"
-          ? current.errorDescription
-          : undefined;
-      // Only surface when at least one challenge field is present — a bare
-      // name match with no fields carries nothing actionable.
-      if (requiredScope || resourceMetadataUrl || errorDescription) {
-        return { requiredScope, resourceMetadataUrl, errorDescription };
-      }
-    }
-    current = current.cause;
-  }
-  return undefined;
-}
-
-export function serializeMcpError(error: unknown) {
-  const anyErr = error as any;
-  const base = {
-    name: anyErr?.name ?? "Error",
-    message: anyErr?.message ?? String(error),
-    code: anyErr?.code ?? anyErr?.error?.code,
-    data: anyErr?.data ?? anyErr?.error?.data,
-  } as Record<string, unknown>;
-  const cause = anyErr?.cause;
-  if (cause && typeof cause === "object") {
-    base.cause = {
-      name: (cause as any)?.name,
-      message: (cause as any)?.message,
-      code: (cause as any)?.code,
-      data: (cause as any)?.data,
-    };
-  }
-  const insufficientScope = extractInsufficientScopeChallenge(error);
-  if (insufficientScope) {
-    base.insufficientScope = insufficientScope;
-  }
-  if (process.env.NODE_ENV === "development" && anyErr?.stack) {
-    base.stack = anyErr.stack;
-  }
-  return base;
-}
-
-export function jsonError(c: any, error: unknown, fallbackStatus = 500) {
-  const details = serializeMcpError(error);
-  const explicitStatus =
-    typeof (error as any)?.status === "number"
-      ? (error as any).status
-      : undefined;
-  // SEP-2350: an `InsufficientScopeError` from `onInsufficientScope: "throw"`
-  // carries no numeric `status`, so without this the challenge would serialize
-  // with the generic 500 fallback. A scope step-up challenge MUST come back as
-  // HTTP 403 so the client recognizes it and drives the bounded re-auth. Honor
-  // an explicit numeric status if the error already carried one.
-  const status =
-    explicitStatus ?? (details.insufficientScope ? 403 : fallbackStatus);
-  const normalized = describeError(error);
-  return c.json(
-    { error: details.message as string, mcpError: details, normalized },
-    status,
-  );
 }
 
 tools.post("/list", async (c) => {

--- a/mcpjam-inspector/server/routes/web/__tests__/errors.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/errors.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { InsufficientScopeError } from "@modelcontextprotocol/client";
 
 import { ErrorCode, WebRouteError, mapRuntimeError } from "../errors.js";
 
@@ -79,5 +80,39 @@ describe("mapRuntimeError", () => {
     const mapped = mapRuntimeError(new Error("Something else went wrong"));
     expect(mapped.status).toBe(500);
     expect(mapped.code).toBe(ErrorCode.INTERNAL_ERROR);
+  });
+
+  it("maps a SEP-2350 insufficient_scope challenge to 403 FORBIDDEN with details.insufficientScope", () => {
+    // A live hosted MCP request that 403s `insufficient_scope` surfaces as an
+    // `InsufficientScopeError`. It carries no numeric status, so without the
+    // dedicated branch it would fall through to the generic 500 and the
+    // client would never see the challenge fields.
+    const mapped = mapRuntimeError(
+      new InsufficientScopeError({
+        requiredScope: "read write admin",
+        resourceMetadataUrl:
+          "https://rs.example/.well-known/oauth-protected-resource",
+      }),
+    );
+    expect(mapped.status).toBe(403);
+    expect(mapped.code).toBe(ErrorCode.FORBIDDEN);
+    expect(mapped.details?.insufficientScope).toEqual({
+      requiredScope: "read write admin",
+      resourceMetadataUrl:
+        "https://rs.example/.well-known/oauth-protected-resource",
+      errorDescription: undefined,
+    });
+  });
+
+  it("recognizes a wrapped insufficient_scope challenge (cause chain) as 403", () => {
+    const inner = new InsufficientScopeError({ requiredScope: "read:tickets" });
+    const outer = new Error("tool call failed");
+    (outer as any).cause = inner;
+    const mapped = mapRuntimeError(outer);
+    expect(mapped.status).toBe(403);
+    expect(mapped.code).toBe(ErrorCode.FORBIDDEN);
+    expect((mapped.details?.insufficientScope as any)?.requiredScope).toBe(
+      "read:tickets",
+    );
   });
 });

--- a/mcpjam-inspector/server/routes/web/__tests__/hosted-elicitation.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/hosted-elicitation.test.ts
@@ -531,4 +531,42 @@ describe("HostedElicitationBridge", () => {
 
     expect(events()).toHaveLength(0);
   });
+
+  it("emits insufficient_scope for a 403 challenge without creating a rendezvous row", async () => {
+    stubFetch({});
+    const { writer, events } = makeWriter();
+    const bridge = makeBridge();
+    bridge.attachStreamWriter(writer);
+
+    bridge.emitInsufficientScope({
+      serverId: "srv-1",
+      toolCallId: "call-42",
+      requiredScope: "read write admin",
+      resourceMetadataUrl: "https://rs.example/.well-known",
+    });
+
+    expect(events()).toContainEqual(
+      expect.objectContaining({
+        kind: "insufficient_scope",
+        serverId: "srv-1",
+        serverName: "GitHub",
+        toolCallId: "call-42",
+        requiredScope: "read write admin",
+        resourceMetadataUrl: "https://rs.example/.well-known",
+      }),
+    );
+    // Display-only: no JSON-RPC response is owed on the error path.
+    expect(mutation).not.toHaveBeenCalled();
+  });
+
+  it("drops an insufficient_scope with no challenge fields rather than emit an empty notice", async () => {
+    stubFetch({});
+    const { writer, events } = makeWriter();
+    const bridge = makeBridge();
+    bridge.attachStreamWriter(writer);
+
+    bridge.emitInsufficientScope({ serverId: "srv-1", toolCallId: "call-1" });
+
+    expect(events()).toHaveLength(0);
+  });
 });

--- a/mcpjam-inspector/server/routes/web/errors.ts
+++ b/mcpjam-inspector/server/routes/web/errors.ts
@@ -4,6 +4,7 @@ import {
   isUnauthorized401,
   type NormalizedError,
 } from "@mcpjam/sdk";
+import { extractInsufficientScopeChallenge } from "../../utils/mcp-error-serialize.js";
 
 export const ErrorCode = {
   UNAUTHORIZED: "UNAUTHORIZED",
@@ -134,6 +135,25 @@ export function mapRuntimeError(error: unknown): WebRouteError {
   const message = parseErrorMessage(error);
   const lower = message.toLowerCase();
   const normalized = describeError(error);
+
+  // SEP-2350 runtime scope step-up. A live MCP request against the hosted
+  // proxy can surface a 403 `insufficient_scope` as an upstream
+  // `InsufficientScopeError` (the SDK builds the transport
+  // `onInsufficientScope: "throw"`). Recognize it BEFORE the generic 500 and
+  // return 403 FORBIDDEN carrying the `WWW-Authenticate` challenge in
+  // `details.insufficientScope`, so `webError` forwards it and the client can
+  // drive the union-scope re-authorization. This single branch covers the
+  // hosted tools / resources / prompts twins, which all rethrow into `onError`.
+  const insufficientScope = extractInsufficientScopeChallenge(error);
+  if (insufficientScope) {
+    return new WebRouteError(
+      403,
+      ErrorCode.FORBIDDEN,
+      message,
+      { insufficientScope },
+      normalized
+    );
+  }
 
   // A raw 401 from the target MCP server is an authorization failure, not an
   // internal error — return the honest status. No `oauthRequired` here: this

--- a/mcpjam-inspector/server/routes/web/hosted-elicitation.ts
+++ b/mcpjam-inspector/server/routes/web/hosted-elicitation.ts
@@ -228,6 +228,42 @@ export class HostedElicitationBridge {
   }
 
   /**
+   * Surface a runtime `403 insufficient_scope` (SEP-2350) raised by a failed
+   * `tools/call` inside the chat/agent tool loop. Display-only: the call already
+   * failed, so no JSON-RPC response is owed and there is nothing to rendezvous
+   * on. The client drives the union-scope step-up re-authorization.
+   */
+  emitInsufficientScope(info: {
+    serverId: string;
+    toolCallId?: string;
+    requiredScope?: string;
+    resourceMetadataUrl?: string;
+    errorDescription?: string;
+  }): void {
+    // Nothing actionable without at least one challenge field.
+    if (
+      !info.requiredScope &&
+      !info.resourceMetadataUrl &&
+      !info.errorDescription
+    ) {
+      return;
+    }
+    this.emit({
+      kind: "insufficient_scope",
+      serverId: info.serverId,
+      serverName: this.options.serverNamesById[info.serverId],
+      ...(info.toolCallId ? { toolCallId: info.toolCallId } : {}),
+      ...(info.requiredScope ? { requiredScope: info.requiredScope } : {}),
+      ...(info.resourceMetadataUrl
+        ? { resourceMetadataUrl: info.resourceMetadataUrl }
+        : {}),
+      ...(info.errorDescription
+        ? { errorDescription: info.errorDescription }
+        : {}),
+    });
+  }
+
+  /**
    * End-of-turn cleanup. Withdraws any row still pending so a closed stream
    * can't leave an answerable prompt behind for its TTL.
    */

--- a/mcpjam-inspector/server/utils/mcp-error-serialize.ts
+++ b/mcpjam-inspector/server/utils/mcp-error-serialize.ts
@@ -43,10 +43,22 @@ export function extractInsufficientScopeChallenge(
         typeof current.requiredScope === "string"
           ? current.requiredScope
           : undefined;
+      // The upstream `InsufficientScopeError` carries `resourceMetadataUrl` as a
+      // `URL` object at runtime (the transport builds it via `new URL(...)` when
+      // parsing the `WWW-Authenticate` header), even though older callers passed
+      // a string. A bare `typeof === "string"` check would silently DROP the
+      // real production value. Accept a string or a URL(-like) object and
+      // normalize to a string for JSON serialization.
+      const rawResourceMetadataUrl = current.resourceMetadataUrl;
       const resourceMetadataUrl =
-        typeof current.resourceMetadataUrl === "string"
-          ? current.resourceMetadataUrl
-          : undefined;
+        typeof rawResourceMetadataUrl === "string"
+          ? rawResourceMetadataUrl
+          : rawResourceMetadataUrl instanceof URL ||
+              (rawResourceMetadataUrl &&
+                typeof rawResourceMetadataUrl === "object" &&
+                typeof rawResourceMetadataUrl.href === "string")
+            ? String(rawResourceMetadataUrl)
+            : undefined;
       const errorDescription =
         typeof current.errorDescription === "string"
           ? current.errorDescription

--- a/mcpjam-inspector/server/utils/mcp-error-serialize.ts
+++ b/mcpjam-inspector/server/utils/mcp-error-serialize.ts
@@ -1,0 +1,110 @@
+import { describeError } from "@mcpjam/sdk";
+
+/** The `WWW-Authenticate` step-up challenge fields surfaced to the client. */
+export type InsufficientScopeChallenge = {
+  requiredScope?: string;
+  resourceMetadataUrl?: string;
+  errorDescription?: string;
+};
+
+/**
+ * Recognize an upstream `InsufficientScopeError` (SEP-2350) anywhere in the
+ * error / cause chain and return its `WWW-Authenticate` challenge fields.
+ *
+ * A runtime `403 insufficient_scope` from a live MCP request surfaces here as
+ * this transport-layer error (the SDK constructs the transport with
+ * `onInsufficientScope: "throw"`, so it never attempts a doomed server-side
+ * interactive re-authorization). Detection is strictly by
+ * `constructor.mcpBrand` / `.name` — an actual `InsufficientScopeError`, never
+ * a duck-typed `requiredScope` field (an unrelated error carrying that field
+ * must not masquerade as a step-up challenge). The class does not extend
+ * `OAuthError`, and its fields (`requiredScope`, `resourceMetadataUrl`)
+ * originate from the resource server's header, so treat them as untrusted when
+ * rendering. Returning the challenge lets the client drive the union-scope
+ * step-up re-authorization.
+ */
+export function extractInsufficientScopeChallenge(
+  error: unknown,
+): InsufficientScopeChallenge | undefined {
+  const seen = new Set<unknown>();
+  let current: any = error;
+  while (current && typeof current === "object" && !seen.has(current)) {
+    seen.add(current);
+    // Recognize ONLY an actual `InsufficientScopeError` — by its class brand
+    // (`mcpBrand`, survives minification/cross-realm) or `.name`. Do NOT
+    // duck-type on a `requiredScope` string: an unrelated error that happens
+    // to carry a `requiredScope` field must not be serialized to the client as
+    // an OAuth step-up challenge (it would trigger a spurious re-authorization).
+    const isInsufficientScope =
+      current.constructor?.mcpBrand === "mcp.InsufficientScopeError" ||
+      current.name === "InsufficientScopeError";
+    if (isInsufficientScope) {
+      const requiredScope =
+        typeof current.requiredScope === "string"
+          ? current.requiredScope
+          : undefined;
+      const resourceMetadataUrl =
+        typeof current.resourceMetadataUrl === "string"
+          ? current.resourceMetadataUrl
+          : undefined;
+      const errorDescription =
+        typeof current.errorDescription === "string"
+          ? current.errorDescription
+          : undefined;
+      // Only surface when at least one challenge field is present — a bare
+      // name match with no fields carries nothing actionable.
+      if (requiredScope || resourceMetadataUrl || errorDescription) {
+        return { requiredScope, resourceMetadataUrl, errorDescription };
+      }
+    }
+    current = current.cause;
+  }
+  return undefined;
+}
+
+export function serializeMcpError(error: unknown) {
+  const anyErr = error as any;
+  const base = {
+    name: anyErr?.name ?? "Error",
+    message: anyErr?.message ?? String(error),
+    code: anyErr?.code ?? anyErr?.error?.code,
+    data: anyErr?.data ?? anyErr?.error?.data,
+  } as Record<string, unknown>;
+  const cause = anyErr?.cause;
+  if (cause && typeof cause === "object") {
+    base.cause = {
+      name: (cause as any)?.name,
+      message: (cause as any)?.message,
+      code: (cause as any)?.code,
+      data: (cause as any)?.data,
+    };
+  }
+  const insufficientScope = extractInsufficientScopeChallenge(error);
+  if (insufficientScope) {
+    base.insufficientScope = insufficientScope;
+  }
+  if (process.env.NODE_ENV === "development" && anyErr?.stack) {
+    base.stack = anyErr.stack;
+  }
+  return base;
+}
+
+export function jsonError(c: any, error: unknown, fallbackStatus = 500) {
+  const details = serializeMcpError(error);
+  const explicitStatus =
+    typeof (error as any)?.status === "number"
+      ? (error as any).status
+      : undefined;
+  // SEP-2350: an `InsufficientScopeError` from `onInsufficientScope: "throw"`
+  // carries no numeric `status`, so without this the challenge would serialize
+  // with the generic 500 fallback. A scope step-up challenge MUST come back as
+  // HTTP 403 so the client recognizes it and drives the bounded re-auth. Honor
+  // an explicit numeric status if the error already carried one.
+  const status =
+    explicitStatus ?? (details.insufficientScope ? 403 : fallbackStatus);
+  const normalized = describeError(error);
+  return c.json(
+    { error: details.message as string, mcpError: details, normalized },
+    status,
+  );
+}

--- a/mcpjam-inspector/server/utils/web-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/web-chat-turn.ts
@@ -68,6 +68,7 @@ import type { HarnessSessionCommitPayload } from "./harness/harness-session-stat
 import { exportConnectedServerToolSnapshotForEvalAuthoring } from "./export-helpers.js";
 import { ErrorCode, WebRouteError } from "./../routes/web/errors.js";
 import { readUrlElicitations } from "@/shared/http-tool-calls";
+import { extractInsufficientScopeChallenge } from "./mcp-error-serialize.js";
 import {
   classifyUiToolApprovals,
   type UiToolApprovalClassification,
@@ -381,6 +382,22 @@ export async function streamWebChatTurn(
                         serverId: (tool as any)._serverId ?? "unknown",
                         toolCallId: options?.toolCallId,
                         elicitations,
+                      });
+                    }
+                    // SEP-2350: a runtime `403 insufficient_scope` thrown here is
+                    // about to be collapsed by the AI-SDK into a model-facing
+                    // error-text part, so route the challenge out-of-band on the
+                    // display channel. The client drives the union-scope step-up.
+                    const insufficientScope =
+                      extractInsufficientScopeChallenge(error);
+                    if (insufficientScope) {
+                      runtime.elicitationBridge?.emitInsufficientScope({
+                        serverId: (tool as any)._serverId ?? "unknown",
+                        toolCallId: options?.toolCallId,
+                        requiredScope: insufficientScope.requiredScope,
+                        resourceMetadataUrl:
+                          insufficientScope.resourceMetadataUrl,
+                        errorDescription: insufficientScope.errorDescription,
                       });
                     }
                     throw error;

--- a/mcpjam-inspector/shared/__tests__/hosted-elicitation.test.ts
+++ b/mcpjam-inspector/shared/__tests__/hosted-elicitation.test.ts
@@ -195,3 +195,57 @@ describe("isHostedElicitationDataPart", () => {
     ).toBe(false);
   });
 });
+
+describe("isHostedElicitationEvent — insufficient_scope (SEP-2350)", () => {
+  it("accepts a challenge carrying requiredScope", () => {
+    expect(
+      isHostedElicitationEvent({
+        kind: "insufficient_scope",
+        serverId: "srv-1",
+        serverName: "GitHub",
+        toolCallId: "call-1",
+        requiredScope: "read write",
+        resourceMetadataUrl: "https://rs.example/.well-known",
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts a challenge carrying only resourceMetadataUrl", () => {
+    expect(
+      isHostedElicitationEvent({
+        kind: "insufficient_scope",
+        serverId: "srv-1",
+        resourceMetadataUrl: "https://rs.example/.well-known",
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects a challenge with no actionable fields", () => {
+    expect(
+      isHostedElicitationEvent({
+        kind: "insufficient_scope",
+        serverId: "srv-1",
+        toolCallId: "call-1",
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects a challenge with a non-string requiredScope", () => {
+    expect(
+      isHostedElicitationEvent({
+        kind: "insufficient_scope",
+        serverId: "srv-1",
+        requiredScope: 42,
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects a challenge missing serverId", () => {
+    expect(
+      isHostedElicitationEvent({
+        kind: "insufficient_scope",
+        requiredScope: "read",
+      }),
+    ).toBe(false);
+  });
+});

--- a/mcpjam-inspector/shared/hosted-elicitation.ts
+++ b/mcpjam-inspector/shared/hosted-elicitation.ts
@@ -103,10 +103,34 @@ export interface HostedElicitationUrlRequiredEvent {
   }>;
 }
 
+/**
+ * A `tools/call` inside the chat/agent tool loop failed with a runtime
+ * `403 insufficient_scope` (SEP-2350). The AI-SDK collapses the thrown
+ * `InsufficientScopeError` into a model-facing error-text part, so the raw
+ * challenge is routed out-of-band on this display channel instead (mirroring
+ * `url_required`).
+ *
+ * Display-only — no rendezvous row, no JSON-RPC response owed. The client
+ * drives the union-scope step-up re-authorization from `requiredScope`. The
+ * fields originate from the resource server's `WWW-Authenticate` header, so
+ * treat them as untrusted when rendering.
+ */
+export interface HostedElicitationInsufficientScopeEvent {
+  kind: "insufficient_scope";
+  serverId: string;
+  serverName?: string;
+  /** The tool call that failed, so the UI can anchor the notice to it. */
+  toolCallId?: string;
+  requiredScope?: string;
+  resourceMetadataUrl?: string;
+  errorDescription?: string;
+}
+
 export type HostedElicitationEvent =
   | HostedElicitationRequestEvent
   | HostedElicitationResolvedEvent
-  | HostedElicitationUrlRequiredEvent;
+  | HostedElicitationUrlRequiredEvent
+  | HostedElicitationInsufficientScopeEvent;
 
 /** Wire literal for the stream data part carrying a `HostedElicitationEvent`. */
 export const HOSTED_ELICITATION_DATA_PART_TYPE = "data-elicitation" as const;
@@ -198,6 +222,22 @@ export function isHostedElicitationEvent(
           typeof entry.elicitationId === "string" &&
           isOptionalString(entry.message),
       )
+    );
+  }
+
+  if (value.kind === "insufficient_scope") {
+    return (
+      typeof value.serverId === "string" &&
+      isOptionalString(value.serverName) &&
+      isOptionalString(value.toolCallId) &&
+      isOptionalString(value.requiredScope) &&
+      isOptionalString(value.resourceMetadataUrl) &&
+      isOptionalString(value.errorDescription) &&
+      // At least one actionable challenge field — a bare kind match carries
+      // nothing to step up on.
+      (typeof value.requiredScope === "string" ||
+        typeof value.resourceMetadataUrl === "string" ||
+        typeof value.errorDescription === "string")
     );
   }
 

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -109,6 +109,7 @@ export {
   isAuthError,
   isMCPAuthError,
   isUnauthorized401,
+  isInsufficientScopeError,
 } from "./mcp-client-manager/index.js";
 export type { RetryPolicy } from "./retry.js";
 export {

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -56,7 +56,12 @@ import {
   HTTP_CONNECT_TIMEOUT,
 } from "./constants.js";
 import { isMethodUnavailableError, formatError } from "./error-utils.js";
-import { MCPAuthError, isAuthError, isUnauthorized401 } from "./errors.js";
+import {
+  MCPAuthError,
+  isAuthError,
+  isUnauthorized401,
+  isInsufficientScopeError,
+} from "./errors.js";
 import {
   type RetryPolicy,
   isRetryableTransientError,
@@ -1515,6 +1520,18 @@ export class MCPClientManager {
       } catch (error) {
         streamableError = error;
         await this.safeCloseTransport(streamableTransport);
+        // SEP-2350: a connect-time `403 insufficient_scope` surfaces here as a
+        // clean `InsufficientScopeError` (transport built
+        // `onInsufficientScope: "throw"` above). Rethrow it immediately —
+        // falling through to the SSE transport would either discard the
+        // challenge (SSE happens to succeed) or downgrade it to a generic
+        // `MCPAuthError` (SSE fails), stripping `requiredScope` /
+        // `resourceMetadataUrl`. SSE cannot repair scope, so there is nothing
+        // to gain by trying it; preserve the original error so the host can
+        // serialize the challenge and drive the union-scope re-authorization.
+        if (isInsufficientScopeError(error)) {
+          throw error;
+        }
       }
     }
 

--- a/sdk/src/mcp-client-manager/errors.ts
+++ b/sdk/src/mcp-client-manager/errors.ts
@@ -103,6 +103,34 @@ export function isUnauthorized401(error: unknown): boolean {
 }
 
 /**
+ * Strictly detects an upstream `InsufficientScopeError` (SEP-2350 runtime scope
+ * step-up) anywhere in the error / cause chain.
+ *
+ * Matches ONLY the real class — by its brand (`constructor.mcpBrand ===
+ * "mcp.InsufficientScopeError"`, which survives minification / cross-realm) or
+ * `.name` — never a duck-typed `requiredScope` field, so an unrelated error
+ * carrying that field can't masquerade as a step-up challenge. This mirrors the
+ * host-side `extractInsufficientScopeChallenge` recognizer exactly. Used to keep
+ * a connect-time 403 `insufficient_scope` from being swallowed / downgraded by
+ * the Streamable→SSE transport fallback, which would strip the challenge fields.
+ */
+export function isInsufficientScopeError(error: unknown): boolean {
+  const seen = new Set<unknown>();
+  let current: any = error;
+  while (current && typeof current === "object" && !seen.has(current)) {
+    seen.add(current);
+    if (
+      current.constructor?.mcpBrand === "mcp.InsufficientScopeError" ||
+      current.name === "InsufficientScopeError"
+    ) {
+      return true;
+    }
+    current = current.cause;
+  }
+  return false;
+}
+
+/**
  * Checks if an error is an authentication-related error.
  * Detects auth errors by:
  * 1. Error class name (UnauthorizedError from MCP SDK)

--- a/sdk/src/mcp-client-manager/index.ts
+++ b/sdk/src/mcp-client-manager/index.ts
@@ -124,6 +124,7 @@ export {
   MCPAuthError,
   isAuthError,
   isUnauthorized401,
+  isInsufficientScopeError,
   isMCPAuthError,
 } from "./errors.js";
 

--- a/sdk/tests/mcp-client-manager.step-up.test.ts
+++ b/sdk/tests/mcp-client-manager.step-up.test.ts
@@ -1,8 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { InsufficientScopeError } from "@modelcontextprotocol/client";
 
 // Capture the options every StreamableHTTPClientTransport is constructed with,
 // while delegating to the real upstream class so connect still behaves.
 const capturedStreamableOpts: Array<Record<string, unknown>> = [];
+// When set, the spy Streamable transport's `start()` throws this instead of
+// delegating to the real (network) implementation — lets a test simulate a
+// connect-time `403 insufficient_scope` deterministically.
+let streamableStartError: unknown = undefined;
+// Count SSE transport constructions so a test can assert the manager did NOT
+// fall back to SSE.
+let sseConstructedCount = 0;
 
 vi.mock("@modelcontextprotocol/client", async (importOriginal) => {
   const actual =
@@ -12,10 +20,23 @@ vi.mock("@modelcontextprotocol/client", async (importOriginal) => {
       super(url, opts as never);
       capturedStreamableOpts.push({ ...(opts ?? {}) });
     }
+    async start(): Promise<void> {
+      if (streamableStartError !== undefined) {
+        throw streamableStartError;
+      }
+      return super.start();
+    }
+  }
+  class SpySSEClientTransport extends actual.SSEClientTransport {
+    constructor(url: URL, opts?: Record<string, unknown>) {
+      super(url, opts as never);
+      sseConstructedCount += 1;
+    }
   }
   return {
     ...actual,
     StreamableHTTPClientTransport: SpyStreamableHTTPClientTransport,
+    SSEClientTransport: SpySSEClientTransport,
   };
 });
 
@@ -25,6 +46,8 @@ const { MCPClientManager } = await import("../src/mcp-client-manager");
 describe("MCPClientManager step-up transport wiring (SEP-2350)", () => {
   beforeEach(() => {
     capturedStreamableOpts.length = 0;
+    streamableStartError = undefined;
+    sseConstructedCount = 0;
   });
 
   afterEach(() => {
@@ -49,5 +72,38 @@ describe("MCPClientManager step-up transport wiring (SEP-2350)", () => {
     for (const opts of capturedStreamableOpts) {
       expect(opts.onInsufficientScope).toBe("throw");
     }
+  });
+
+  it("rethrows a connect-time InsufficientScopeError without falling back to SSE", async () => {
+    // Simulate the transport throwing a clean `403 insufficient_scope`
+    // challenge during connect (what `onInsufficientScope: "throw"` produces).
+    const challenge = new InsufficientScopeError({
+      requiredScope: "read write admin",
+      resourceMetadataUrl:
+        "https://rs.example/.well-known/oauth-protected-resource",
+    });
+    streamableStartError = challenge;
+
+    const manager = new MCPClientManager();
+    const rejection = await manager
+      .connectToServer("step-up-server", { url: "https://rs.example/mcp" })
+      .then(
+        () => {
+          throw new Error("expected connectToServer to reject");
+        },
+        (error) => error,
+      );
+
+    // The SAME instance is rethrown — brand + challenge fields intact, never
+    // downgraded to MCPAuthError (which would strip requiredScope /
+    // resourceMetadataUrl and mislead the client into a plain token refresh).
+    expect(rejection).toBe(challenge);
+    expect(rejection).toBeInstanceOf(InsufficientScopeError);
+    expect(rejection.name).not.toBe("MCPAuthError");
+    expect((rejection as InsufficientScopeError).requiredScope).toBe(
+      "read write admin",
+    );
+    // SSE cannot repair scope, so the fallback must be skipped entirely.
+    expect(sseConstructedCount).toBe(0);
   });
 });


### PR DESCRIPTION
## What

Final Phase-2 step of the MCP `2026-07-28` OAuth work (`mcp-2026-final-phasing.md` §10): wire the **SEP-2350 runtime scope step-up** challenge (`403 insufficient_scope` → `WWW-Authenticate` → union-scope re-authorization) through **every** surface that can receive it. PR #3390 shipped the core (transport throws a clean `InsufficientScopeError`, local `/tools/execute` serializes it, `oauth-orchestrator` gained `applyToolCallStepUp`/`resetToolCallStepUp`) but wired only the local `ToolsTab`. This finishes the job.

Nothing here branches on protocol version — detection is by error brand + HTTP 403, and `onInsufficientScope:"throw"` is already set unconditionally.

## Phases (one commit each)

- **Phase 0 — shared extraction.** Move `extractInsufficientScopeChallenge`/`serializeMcpError`/`jsonError` into `server/utils/mcp-error-serialize.ts` (re-exported from `mcp/tools.ts`, existing tests untouched). Add `isInsufficientScopeError` to the SDK (strict brand/name match, no duck-typing) beside `isAuthError`/`isUnauthorized401`.
- **Phase 1 — SDK connect-time fix.** The Streamable→SSE connect fallback discarded or downgraded a connect-time `InsufficientScopeError`. Rethrow it before the SSE attempt (SSE can't repair scope), preserving the challenge fields.
- **Phase 2 — hosted route serializer.** `mapRuntimeError` now maps an `InsufficientScopeError` to `403 FORBIDDEN` with the challenge on `details.insufficientScope`, covering the hosted tools/resources/prompts twins in one place. The hosted client path already consumed it.
- **Phase 3 — resources + prompts.** Local `/resources/read` and `/prompts/get` serialize via `jsonError`; a shared client `insufficient-scope` module (`McpRequestError` + `insufficientScopeFromError`) threads the challenge; `ResourcesTab` (Read) and `PromptsTab` (Get) drive the bounded, deduped step-up.
- **Phase 4 — UI Playground.** The App Builder tool-execution hook consumes `response.insufficientScope` and drives step-up, resolving the server from shared app state.
- **Phase 5 — chat / agent tool loop.** The AI-SDK collapses a thrown `InsufficientScopeError` into an error-text part, so the challenge is routed out-of-band on the existing hosted-elicitation display channel (new `insufficient_scope` event + `emitInsufficientScope` bridge method, mirroring `url_required`). `use-chat-session` consumes it and drives step-up. **Per the reviewer's chosen behavior, the chat surface auto-redirects on receipt** (see Notes).

## Bug found & fixed (Phase 0/URL-normalization commit)

`extractInsufficientScopeChallenge` checked `typeof resourceMetadataUrl === "string"`, but the upstream transport builds it as a `URL` object (`new URL(...)` from the `WWW-Authenticate` header), so the PRM discovery hint was **silently dropped** in production. `requiredScope` (a string) was unaffected, which had masked it. Now normalized to `URL | string`.

## Notes / follow-ups

- **Phase 6 (post-callback auto-retry) is deferred** to a follow-up per the approved plan — it crosses a full-page OAuth redirect and needs its own cross-redirect state machine.
- The chat step-up (Phase 5) **auto-redirects mid-stream**; without Phase 6 the in-flight turn is lost and the user re-sends after re-auth. This was an explicit choice; the alternative (a click-to-reauthorize affordance) is noted for the follow-up.
- `ResourceTemplatesTab` is not mounted anywhere in the app (test-only), so its consumer is left unwired; its API path already surfaces the challenge if it is ever mounted.

## Testing

29 files changed. New/extended unit tests across all surfaces — SDK connect-time rethrow, hosted `mapRuntimeError`→403, shared `insufficient-scope` module, Playground hook, and the chat consumer/bridge/guard. Full SDK suite (2491) green; client + SDK typechecks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
