### PR TITLE
feat(sdk): MRTR manual driver core for 2026-07-28 input_required (Phase 4 PR1)

### DIFF
--- a/.changeset/mrtr-sdk-driver-core.md
+++ b/.changeset/mrtr-sdk-driver-core.md
@@ -1,0 +1,14 @@
+---
+"@mcpjam/sdk": minor
+---
+
+Add the SDK core for the MCP 2026-07-28 multi-round-trip (`input_required`) interaction — the manual driver that lets `tools/call`, `prompts/get`, and `resources/read` return embedded elicitation requests, collect input, and retry the original operation (spec §12). New exports only.
+
+- **Manual mode.** The manager constructs its client with `inputRequired: { autoFulfill: false }`, so an `input_required` result surfaces to MCPJam's own driver instead of the SDK's automatic one.
+- **Serializable stepper** (`mrtr-driver.ts`): `executeInputRequiredLeg` / `resumeInputRequiredOperation` operate on a data-only `MrtrOperationState` (stable id, method, immutable original params, round, echoed `requestState`, current round's pending requests) — never a client, promise, closure, or `AbortSignal` — so hosted surfaces can persist and resume it. `runInputRequiredOperation` layers a local/CLI convenience loop on top.
+- **MCPJam owns the round cap** (`DEFAULT_MAX_MRTR_ROUNDS = 10`, persisted in the state); exceeding it raises the upstream `SdkError(InputRequiredRoundsExceeded, …, { rounds })` shape. Guards `isMaxRoundsExceeded` / `isUnsupportedResultType`.
+- **Per-round replacement** of `inputResponses` (never accumulated) with byte-exact `requestState` echo; state-only, inputs-without-state, and no-state rounds all supported. Response maps are built with a null prototype (server keys are untrusted).
+- **Undeclared-request rejection (Decision 8):** embedded `roots/list` / `sampling/createMessage` and unsupported elicitation modes are rejected at the result — before any UI — via `MrtrUndeclaredInputError` / `MrtrUnsupportedElicitationModeError`.
+- **Strict self-validation (§12.1.11):** accepted elicitation content is validated against the request's `requestedSchema` (unknown dialect → invalid, not fail-open) before it is sent; decline/cancel are responses, not errors.
+- **New `requestWithSchema` seam** on `ManagedMcpClient`, `OfficialSdkClientAdapter`, and the `LogLevelMetaClient` decorator (which injects the modern per-request logging `_meta`) — the type-correct explicit-schema path for the loop.
+- **Three verbs wired** through per-server MRTR input collectors (`setMrtrInputCollector`) without regressing Phase-3 helper semantics: resource reads keep the response cache, prompt/tool legs carry the per-request log level, and the final tool result is re-validated against its output schema. `buildCapabilities` now advertises `elicitation` when an MRTR collector is registered; roots/sampling stay unadvertised.

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -698,3 +698,40 @@ export type {
   OpenAiAppsCapabilities,
   McpAppsCapabilities,
 } from "./host-config/index.js";
+
+// Multi-round-trip (`input_required`) manual driver — MCP 2026-07-28 spec §12.
+// New public exports only (API stability): the serializable stepper, the
+// convenience loop, guards, error classes, and the re-exported upstream
+// primitives (`isInputRequiredResult` / `withInputRequired`).
+export {
+  DEFAULT_MAX_MRTR_ROUNDS,
+  SUPPORTED_ELICITATION_MODES,
+  executeInputRequiredLeg,
+  resumeInputRequiredOperation,
+  runInputRequiredOperation,
+  initInputRequiredState,
+  makeRequestWithSchemaLegSender,
+  defaultResultSchemaForMethod,
+  validateInputRequests,
+  validateRoundResponses,
+  isMaxRoundsExceeded,
+  isUnsupportedResultType,
+  MrtrUndeclaredInputError,
+  MrtrUnsupportedElicitationModeError,
+  MrtrInputValidationError,
+  isInputRequiredResult,
+  withInputRequired,
+} from "./mcp-client-manager/index.js";
+export type {
+  MrtrMethod,
+  MrtrOperationState,
+  MrtrLegResult,
+  MrtrLegSender,
+  MrtrInputCollector,
+  MrtrValidateResponse,
+  ElicitationContentValidator,
+  RunInputRequiredOptions,
+  InputRequiredResult,
+  InputRequests,
+  InputResponses,
+} from "./mcp-client-manager/index.js";

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -6,13 +6,18 @@ import {
   type CallToolResult,
   Client,
   type ClientOptions,
+  type GetPromptResult,
   InMemoryResponseCacheStore,
+  type JsonSchemaType,
   type LoggingLevel,
+  type ReadResourceResult,
+  type Request,
   SSEClientTransport,
   type ServerCapabilities,
   StreamableHTTPClientTransport,
   type Transport,
   type RequestOptions,
+  withInputRequired,
 } from "@modelcontextprotocol/client";
 // beta.4 moved the Node stdio client transport to the `/stdio` subpath.
 import { StdioClientTransport } from "@modelcontextprotocol/client/stdio";
@@ -115,6 +120,15 @@ import { resolveVersionNegotiation } from "./version-negotiation.js";
 import { DialectAwareJsonSchemaValidator } from "./dialect-aware-json-schema-validator.js";
 import { isStatelessProtocolVersion } from "./mcp-protocol-version.js";
 import { type ManagedMcpClient } from "./managed-mcp-client.js";
+import {
+  DEFAULT_MAX_MRTR_ROUNDS,
+  defaultResultSchemaForMethod,
+  runInputRequiredOperation,
+  type ElicitationContentValidator,
+  type InputRequiredResult,
+  type MrtrInputCollector,
+  type MrtrLegSender,
+} from "./mrtr-driver.js";
 
 
 /**
@@ -163,6 +177,66 @@ export class MCPClientManager {
   // Managers for specific features
   private readonly notificationManager = new NotificationManager();
   private readonly elicitationManager = new ElicitationManager();
+
+  /**
+   * Per-server collectors for the modern multi-round-trip (`input_required`)
+   * loop. When a collector is registered for a server, `executeTool`,
+   * `readResource`, and `getPrompt` drive the manual MRTR loop
+   * (`mrtr-driver.ts`) so an `input_required` result is collected and the
+   * operation retried; when none is registered the verbs keep their exact
+   * pre-MRTR behavior (an `input_required` from a modern server then surfaces
+   * as the SDK's typed `UnsupportedResultType` rather than being silently
+   * mishandled). The collector seam is what PR2 (local UI), PR6 (CLI), and the
+   * hosted PRs plug into.
+   */
+  private readonly mrtrInputCollectors = new Map<string, MrtrInputCollector>();
+
+  /** MCPJam-owned MRTR round cap (see `mrtr-driver.ts`). */
+  private readonly mrtrMaxRounds = DEFAULT_MAX_MRTR_ROUNDS;
+
+  /**
+   * Strict self-validation of collected elicitation content against each
+   * request's `requestedSchema` (§12.1.11). Unlike the tool-output validator,
+   * an unknown JSON-Schema dialect is treated as INVALID (not fail-open):
+   * elicitation content is untrusted, so an exotic dialect must not wave it
+   * through. The dialect-aware validator is constructed per call so the
+   * throwing `onUnknownDialect` never leaks state between validations.
+   */
+  private readonly mrtrElicitationContentValidator: ElicitationContentValidator =
+    (requestedSchema, content) => {
+      if (
+        typeof requestedSchema !== "object" ||
+        requestedSchema === null
+      ) {
+        return { valid: false, error: "requestedSchema is not an object" };
+      }
+      const strict = new DialectAwareJsonSchemaValidator({
+        onUnknownDialect: (dialect) => {
+          throw new Error(
+            `Elicitation content declares unsupported JSON Schema dialect "${dialect}".`
+          );
+        },
+      });
+      let validate;
+      try {
+        validate = strict.getValidator(requestedSchema as JsonSchemaType);
+      } catch (error) {
+        return {
+          valid: false,
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+      const result = validate(content);
+      return { valid: result.valid, error: result.errorMessage };
+    };
+
+  /**
+   * Tool output-schema validator for the MRTR path. `requestWithSchema`
+   * bypasses upstream `callTool`'s output-schema assertion, so we reconstruct
+   * it on the final complete result. Fail-open on an unknown dialect, matching
+   * upstream's tool-output behavior (see `DialectAwareJsonSchemaValidator`).
+   */
+  private readonly mrtrToolOutputValidator = new DialectAwareJsonSchemaValidator();
 
   // Default options
   private readonly defaultClientName: string | undefined;
@@ -698,6 +772,21 @@ export class MCPClientManager {
     taskOptions?: TaskOptions
   ) {
     const request = this.normalizeExecuteToolRequest(options, taskOptions);
+
+    // Modern multi-round-trip: when a collector is registered and this is not a
+    // task-augmented call, drive the manual `input_required` loop. A complete
+    // result on the first leg exits immediately, so legacy servers are
+    // unaffected.
+    const mrtrCollect = this.mrtrInputCollectors.get(serverId);
+    if (mrtrCollect && request.task === undefined) {
+      return this.executeToolWithInputRequired(
+        serverId,
+        { name: toolName, arguments: args },
+        request,
+        mrtrCollect
+      );
+    }
+
     const operation = async (signal?: AbortSignal) => {
       await this.ensureConnected(serverId, signal);
       const client = this.getClientOrThrow(serverId);
@@ -780,6 +869,15 @@ export class MCPClientManager {
     params: ReadResourceParams,
     options?: ClientRequestOptions
   ) {
+    const mrtrCollect = this.mrtrInputCollectors.get(serverId);
+    if (mrtrCollect) {
+      return this.readResourceWithInputRequired(
+        serverId,
+        params,
+        options,
+        mrtrCollect
+      );
+    }
     return this.runRetryableReadOperation(serverId, options, (client) =>
       client.readResource(params, this.withProgressHandler(serverId, options))
     );
@@ -870,6 +968,15 @@ export class MCPClientManager {
     params: GetPromptParams,
     options?: ClientRequestOptions
   ) {
+    const mrtrCollect = this.mrtrInputCollectors.get(serverId);
+    if (mrtrCollect) {
+      return this.getPromptWithInputRequired(
+        serverId,
+        params,
+        options,
+        mrtrCollect
+      );
+    }
     return this.runRetryableReadOperation(serverId, options, (client) =>
       client.getPrompt(params, this.withProgressHandler(serverId, options))
     );
@@ -1094,6 +1201,32 @@ export class MCPClientManager {
         this.elicitationManager.removeFromClient(client);
       }
     }
+  }
+
+  /**
+   * Registers the multi-round-trip (`input_required`) input collector for a
+   * server. Once set, `executeTool` / `readResource` / `getPrompt` drive the
+   * manual MRTR loop: an `input_required` result is validated (undeclared
+   * roots/sampling and unsupported elicitation modes are rejected before any
+   * UI), its embedded requests are handed to `collect`, the collected
+   * responses are self-validated against each `requestedSchema`, and the
+   * operation is retried — up to the MCPJam-owned round cap. `collect` MUST
+   * reject on abort (never return a synthetic decline) and returns
+   * `ElicitResult`-shaped responses keyed by the server's request keys.
+   */
+  setMrtrInputCollector(serverId: string, collect: MrtrInputCollector): void {
+    // Intentionally NOT gated on prior registration: a 2026-07-28 server checks
+    // the request's declared client capabilities before embedding an
+    // elicitation, so a collector must be registrable BEFORE connect for
+    // `elicitation` to be advertised on the connect envelope (see
+    // `buildCapabilities`). Registering for an as-yet-unknown server is a no-op
+    // until that server connects.
+    this.mrtrInputCollectors.set(serverId, collect);
+  }
+
+  /** Removes a server's MRTR input collector. */
+  clearMrtrInputCollector(serverId: string): void {
+    this.mrtrInputCollectors.delete(serverId);
   }
 
   /**
@@ -1356,6 +1489,15 @@ export class MCPClientManager {
       );
       const clientOptions: ClientOptions = {
         capabilities: clientCapabilities,
+        // Manual multi-round-trip mode (2026-07-28 `input_required`, spec §12).
+        // MCPJam drives the loop itself (`mrtr-driver.ts`) so a debugger shows
+        // every round and a hosted worker never blocks while a human answers.
+        // The SDK's automatic driver — and its built-in `maxRounds`/
+        // `InputRequiredRoundsExceeded` cap — applies only to `autoFulfill:
+        // true`; with it off, an `input_required` result surfaces (via
+        // `allowInputRequired: true` on the explicit-schema call) instead of
+        // being auto-fulfilled, and MCPJam owns the round cap.
+        inputRequired: { autoFulfill: false },
         // Dialect-aware replacement for the upstream default validator,
         // which rejects (rather than validates) declared draft-07 schemas
         // and thereby fails tools/call against every v1-SDK server that
@@ -2114,7 +2256,16 @@ export class MCPClientManager {
     serverId: string,
     config: MCPServerConfig
   ): ClientCapabilityOptions {
-    const hasElicitationHandler = this.elicitationManager.hasHandler(serverId);
+    // Advertise `elicitation` when EITHER a legacy elicitation handler OR a
+    // modern MRTR input collector is registered — a 2026-07-28 server checks
+    // the request's declared client capabilities before it will embed an
+    // `elicitation/create` in an `input_required` result, so a collector that
+    // is registered before connect must be reflected here. roots/sampling are
+    // never advertised (this client never fulfils them; MRTR rejects embedded
+    // roots/sampling at the result — advertise = enforce).
+    const hasElicitationHandler =
+      this.elicitationManager.hasHandler(serverId) ||
+      this.mrtrInputCollectors.has(serverId);
     if (config.clientCapabilities) {
       const exactCapabilities = normalizeClientCapabilities(
         config.clientCapabilities
@@ -2204,6 +2355,175 @@ export class MCPClientManager {
       request: options,
       task: taskOptions,
     };
+  }
+
+  // ===========================================================================
+  // Multi-round-trip (`input_required`) drivers — spec §12.
+  //
+  // Each verb's MRTR path drives the shared serializable stepper
+  // (`mrtr-driver.ts`). The wire legs go through a verb-specific SENDER so
+  // Phase-3 helper semantics are preserved: `readResource` keeps the response
+  // cache, tool + prompt legs carry the modern per-request log-level `_meta`
+  // via the `requestWithSchema` decorator, and the final tool result is
+  // re-validated against its output schema (reconstructing what the bypassed
+  // upstream `callTool` would have asserted). The MRTR loop lives OUTSIDE the
+  // per-leg retry/timeout wrappers, so a transient failure on round N retries
+  // only that leg — it never restarts the operation at round zero.
+  // ===========================================================================
+
+  private async executeToolWithInputRequired(
+    serverId: string,
+    callParams: { name: string; arguments?: Record<string, unknown> },
+    request: ExecuteToolRequest,
+    collect: MrtrInputCollector
+  ): Promise<CallToolResult> {
+    const baseOptions = request.request;
+    const retryPolicy = request.retry ?? { retries: 0, retryDelayMs: 0 };
+    const sender: MrtrLegSender<CallToolResult> = (req) =>
+      this.runRetriedOperation(
+        serverId,
+        baseOptions,
+        retryPolicy,
+        async (signal) => {
+          await this.ensureConnected(serverId, signal);
+          const client = this.getClientOrThrow(serverId);
+          const mergedOptions = this.withProgressHandler(serverId, baseOptions);
+          return this.withElicitationTimeoutSuspension(
+            serverId,
+            mergedOptions,
+            (callOptions) =>
+              client.requestWithSchema(
+                req as Request,
+                withInputRequired(defaultResultSchemaForMethod("tools/call")),
+                { ...callOptions, allowInputRequired: true, signal }
+              ) as Promise<CallToolResult | InputRequiredResult>
+          );
+        }
+      );
+
+    return runInputRequiredOperation<CallToolResult>({
+      method: "tools/call",
+      params: callParams,
+      sender,
+      collectInput: collect,
+      validateContent: this.mrtrElicitationContentValidator,
+      validateResponse: (result) =>
+        this.validateToolOutputSchema(serverId, callParams.name, result),
+      requestOptions: baseOptions,
+      maxRounds: this.mrtrMaxRounds,
+      signal: baseOptions?.signal,
+    });
+  }
+
+  private async readResourceWithInputRequired(
+    serverId: string,
+    params: ReadResourceParams,
+    options: ClientRequestOptions | undefined,
+    collect: MrtrInputCollector
+  ): Promise<ReadResourceResult> {
+    const sender: MrtrLegSender<ReadResourceResult> = (req) =>
+      this.runRetryableReadOperation(serverId, options, (client) =>
+        client.readResource(req.params as ReadResourceParams, {
+          ...this.withProgressHandler(serverId, options),
+          allowInputRequired: true,
+        }) as Promise<ReadResourceResult | InputRequiredResult>
+      );
+
+    return runInputRequiredOperation<ReadResourceResult>({
+      method: "resources/read",
+      params: params as Record<string, unknown>,
+      sender,
+      collectInput: collect,
+      validateContent: this.mrtrElicitationContentValidator,
+      requestOptions: options,
+      maxRounds: this.mrtrMaxRounds,
+      signal: options?.signal,
+    });
+  }
+
+  private async getPromptWithInputRequired(
+    serverId: string,
+    params: GetPromptParams,
+    options: ClientRequestOptions | undefined,
+    collect: MrtrInputCollector
+  ): Promise<GetPromptResult> {
+    // Prompts have no helper-only semantics to preserve, so the leg goes
+    // through the explicit-schema `requestWithSchema` seam directly — which
+    // also exercises the modern per-request log-level `_meta` injection end to
+    // end at the manager level.
+    const sender: MrtrLegSender<GetPromptResult> = (req) =>
+      this.runRetryableReadOperation(serverId, options, (client) =>
+        client.requestWithSchema(
+          req as Request,
+          withInputRequired(defaultResultSchemaForMethod("prompts/get")),
+          {
+            ...this.withProgressHandler(serverId, options),
+            allowInputRequired: true,
+          }
+        ) as Promise<GetPromptResult | InputRequiredResult>
+      );
+
+    return runInputRequiredOperation<GetPromptResult>({
+      method: "prompts/get",
+      params: params as Record<string, unknown>,
+      sender,
+      collectInput: collect,
+      validateContent: this.mrtrElicitationContentValidator,
+      requestOptions: options,
+      maxRounds: this.mrtrMaxRounds,
+      signal: options?.signal,
+    });
+  }
+
+  /**
+   * Reconstructs upstream `callTool`'s output-schema assertion on the final
+   * complete result of an MRTR tool call (the `requestWithSchema` leg path
+   * bypasses it). Best-effort schema resolution: if the tool's `outputSchema`
+   * cannot be looked up, a successful call is not failed.
+   */
+  private async validateToolOutputSchema(
+    serverId: string,
+    toolName: string,
+    result: CallToolResult
+  ): Promise<void> {
+    const typed = result as CallToolResult & {
+      structuredContent?: unknown;
+      isError?: boolean;
+    };
+    let outputSchema: unknown;
+    try {
+      await this.ensureConnected(serverId);
+      const client = this.getClientOrThrow(serverId);
+      const list = await client.listTools();
+      const tool = list.tools.find((candidate) => candidate.name === toolName) as
+        | { outputSchema?: unknown }
+        | undefined;
+      outputSchema = tool?.outputSchema;
+    } catch {
+      return;
+    }
+    if (!outputSchema || typeof outputSchema !== "object") {
+      return;
+    }
+    if (typed.isError) {
+      return;
+    }
+    if (typed.structuredContent === undefined) {
+      throw new TypeError(
+        `Tool "${toolName}" has an output schema but did not return structured content.`
+      );
+    }
+    const validate = this.mrtrToolOutputValidator.getValidator(
+      outputSchema as JsonSchemaType
+    );
+    const validation = validate(typed.structuredContent);
+    if (!validation.valid) {
+      throw new TypeError(
+        `Tool "${toolName}" structured content does not match its output schema: ${
+          validation.errorMessage ?? "invalid"
+        }.`
+      );
+    }
   }
 
   private async runRetryableReadOperation<T>(

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -546,6 +546,9 @@ export class MCPClientManager {
     this.notificationManager.clearServer(serverId);
     this.elicitationManager.clearServer(serverId);
     this.perRequestLogLevels.delete(serverId);
+    // Purge the MRTR collector too; otherwise a re-registered server inherits
+    // the previous owner's collector closure and stale `elicitation` capability.
+    this.mrtrInputCollectors.delete(serverId);
   }
 
   /**
@@ -2395,7 +2398,13 @@ export class MCPClientManager {
               client.requestWithSchema(
                 req as Request,
                 withInputRequired(defaultResultSchemaForMethod("tools/call")),
-                { ...callOptions, allowInputRequired: true, signal }
+                // Pass `callOptions` through untouched (matching the legacy
+                // `client.callTool(callParams, callOptions)` sibling): it carries
+                // the composed elicitation-timeout watchdog signal. Overwriting
+                // `.signal` with the outer retry `signal` would drop that
+                // watchdog; the outer abort is already enforced by
+                // `runRetriedOperation`'s `awaitWithAbort` wrapper.
+                { ...callOptions, allowInputRequired: true }
               ) as Promise<CallToolResult | InputRequiredResult>
           );
         }

--- a/sdk/src/mcp-client-manager/index.ts
+++ b/sdk/src/mcp-client-manager/index.ts
@@ -201,3 +201,37 @@ export {
   isKnownProtocolVersion,
   isStatelessProtocolVersion,
 } from "./mcp-protocol-version.js";
+
+// Multi-round-trip (`input_required`) manual driver — spec §12 (new exports).
+export {
+  DEFAULT_MAX_MRTR_ROUNDS,
+  SUPPORTED_ELICITATION_MODES,
+  executeInputRequiredLeg,
+  resumeInputRequiredOperation,
+  runInputRequiredOperation,
+  initInputRequiredState,
+  makeRequestWithSchemaLegSender,
+  defaultResultSchemaForMethod,
+  validateInputRequests,
+  validateRoundResponses,
+  isMaxRoundsExceeded,
+  isUnsupportedResultType,
+  MrtrUndeclaredInputError,
+  MrtrUnsupportedElicitationModeError,
+  MrtrInputValidationError,
+  isInputRequiredResult,
+  withInputRequired,
+} from "./mrtr-driver.js";
+export type {
+  MrtrMethod,
+  MrtrOperationState,
+  MrtrLegResult,
+  MrtrLegSender,
+  MrtrInputCollector,
+  MrtrValidateResponse,
+  ElicitationContentValidator,
+  RunInputRequiredOptions,
+  InputRequiredResult,
+  InputRequests,
+  InputResponses,
+} from "./mrtr-driver.js";

--- a/sdk/src/mcp-client-manager/log-level-meta-client.ts
+++ b/sdk/src/mcp-client-manager/log-level-meta-client.ts
@@ -31,6 +31,7 @@ import {
   type ProtocolEra,
   type Request,
   type RequestOptions,
+  type StandardSchemaV1,
 } from "@modelcontextprotocol/client";
 import type {
   ManagedMcpClient,
@@ -148,6 +149,28 @@ export class LogLevelMetaClient implements ManagedMcpClient {
       req.params as Record<string, unknown> | undefined,
     );
     return this.inner.request<T>({ ...req, params } as Request, options);
+  }
+  requestWithSchema<TSchema extends StandardSchemaV1>(
+    req: Request,
+    resultSchema: TSchema,
+    options?: RequestOptions,
+  ): Promise<StandardSchemaV1.InferOutput<TSchema>> {
+    // Same modern per-request logging opt-in as `request`: inject the level
+    // into `params._meta` when a level is set and the era is modern; otherwise
+    // forward untouched. The explicit-schema seam MUST carry this or the MRTR
+    // retry legs would silently lose the per-request log level.
+    const level = this.activeLevel();
+    if (level === undefined) {
+      return this.inner.requestWithSchema(req, resultSchema, options);
+    }
+    const params = this.inject(
+      req.params as Record<string, unknown> | undefined,
+    );
+    return this.inner.requestWithSchema(
+      { ...req, params } as Request,
+      resultSchema,
+      options,
+    );
   }
   listResources(
     params?: Parameters<ManagedMcpClient["listResources"]>[0],

--- a/sdk/src/mcp-client-manager/managed-mcp-client.ts
+++ b/sdk/src/mcp-client-manager/managed-mcp-client.ts
@@ -39,6 +39,7 @@ import type {
   Request,
   RequestOptions,
   ServerCapabilities,
+  StandardSchemaV1,
   Transport,
 } from "@modelcontextprotocol/client";
 
@@ -150,6 +151,28 @@ export interface ManagedMcpClient {
   // schema overload in alpha.2. Keep the surface narrow; if the manager
   // ever needs an overloaded form, add it then.
   request<T = unknown>(req: Request, options?: RequestOptions): Promise<T>;
+
+  /**
+   * Explicit-schema request — the type-correct path for the modern
+   * multi-round-trip (`input_required`) loop. Forwards to upstream
+   * `Protocol.request`'s second overload
+   * (`request(request, resultSchema, options)`, client `index.d.mts:2198`),
+   * which validates a *complete* result against `resultSchema` while surfacing
+   * a non-complete `input_required` result untouched (paired with
+   * `withInputRequired(resultSchema)` + `options.allowInputRequired`).
+   *
+   * NEW seam (2026-07-28). It exists alongside — never replacing — the generic
+   * `request<T>` above, whose method-dispatch typing cannot express an
+   * `input_required` union (the SDK deliberately does not widen `ResultTypeMap`
+   * for requesters). Decorators MUST forward it: `LogLevelMetaClient` injects
+   * the modern per-request logging `_meta` here exactly as it does for the
+   * other request-bearing methods.
+   */
+  requestWithSchema<TSchema extends StandardSchemaV1>(
+    req: Request,
+    resultSchema: TSchema,
+    options?: RequestOptions
+  ): Promise<StandardSchemaV1.InferOutput<TSchema>>;
 
   // ---- Resources ----
   listResources(

--- a/sdk/src/mcp-client-manager/mrtr-driver.ts
+++ b/sdk/src/mcp-client-manager/mrtr-driver.ts
@@ -1,0 +1,665 @@
+/**
+ * `mrtr-driver.ts` — MCPJam's manual driver for the MCP 2026-07-28
+ * **multi-round-trip / `input_required`** interaction (spec §12; upstream
+ * `InputRequiredResult`). A modern `tools/call`, `prompts/get`, or
+ * `resources/read` may answer with an `input_required` result carrying embedded
+ * elicitation requests plus an opaque `requestState`; the client collects the
+ * input and **retries the original operation** with the responses + the echoed
+ * state, possibly for several rounds, until a complete result comes back.
+ *
+ * ## Why a serializable stepper (not just an async loop)
+ *
+ * Hosted MCPJam is horizontally scaled: a modern `input_required` can arrive
+ * mid-tool-execution while a worker holds an SSE stream open, and §12.5.2
+ * forbids blocking a worker while a human thinks. The loop is therefore split
+ * into a **pure data state** ({@link MrtrOperationState}) and pure step
+ * functions ({@link executeInputRequiredLeg} / {@link
+ * resumeInputRequiredOperation}). A local/CLI surface layers the convenience
+ * {@link runInputRequiredOperation} loop over the stepper; a hosted surface
+ * (PR3+) persists the state to Convex between rounds and resumes on a fresh
+ * worker. **The state never holds a `Client`, promise, closure, resolver, or
+ * `AbortSignal`** — only JSON-serializable data.
+ *
+ * ## What the driver owns
+ *
+ * - **The round cap.** The upstream SDK's automatic driver (`maxRounds`,
+ *   `InputRequiredRoundsExceeded`) applies to `autoFulfill: true` only. MCPJam
+ *   runs manual mode (`autoFulfill: false`), so the cap is owned here: it is
+ *   {@link DEFAULT_MAX_MRTR_ROUNDS} by default, persisted in the state so a
+ *   hosted resume keeps counting, and exceeding it raises the *same typed
+ *   upstream shape* — `new SdkError(SdkErrorCode.InputRequiredRoundsExceeded,
+ *   …, { rounds })` — so existing guards work.
+ * - **Per-round response replacement.** Each retry carries `inputResponses`
+ *   for *that round only* (never accumulated across rounds) and echoes
+ *   `requestState` byte-exact when present, omitting it when absent.
+ * - **Undeclared-request rejection (Decision 8).** 2026 clients silently drop
+ *   inbound server→client requests, so an embedded `roots/list` /
+ *   `sampling/createMessage` (which this client never advertises) — or an
+ *   undeclared elicitation mode — is detected *here, on the result*, before any
+ *   UI is shown, and rejected with precise evidence.
+ * - **Strict self-validation (§12.1.11).** `acceptedContent` is not exported by
+ *   the client package, so collected elicitation content is validated against
+ *   the request's `requestedSchema` before it is sent. The JSON-Schema engine
+ *   is *injected* (see {@link ElicitationContentValidator}) so this module
+ *   stays browser-safe; callers wire a **strict** dialect-aware validator whose
+ *   unknown-dialect behavior rejects rather than fails open.
+ *
+ * `requestState` is opaque: it is echoed verbatim and never parsed, normalized,
+ * or logged (redact if traced).
+ */
+
+import {
+  isInputRequiredResult,
+  withInputRequired,
+  SdkError as UpstreamSdkError,
+  SdkErrorCode,
+  type InputRequiredResult,
+  type InputRequests,
+  type InputResponses,
+  type InputResponse,
+  type Request,
+  type RequestOptions,
+  type StandardSchemaV1,
+} from "@modelcontextprotocol/client";
+
+import type { ManagedMcpClient } from "./managed-mcp-client.js";
+
+// Re-export the upstream primitives through the sdk so consumers do not need a
+// direct dependency on `@modelcontextprotocol/client` for the common path.
+export {
+  isInputRequiredResult,
+  withInputRequired,
+  type InputRequiredResult,
+  type InputRequests,
+  type InputResponses,
+} from "@modelcontextprotocol/client";
+
+/** The three verbs that can enter a multi-round-trip loop (spec §12.1). */
+export type MrtrMethod = "tools/call" | "prompts/get" | "resources/read";
+
+/** Elicitation delivery modes this client understands. */
+export type ElicitationMode = "form" | "url";
+
+/** Default modes accepted when validating embedded `elicitation/create`. */
+export const SUPPORTED_ELICITATION_MODES: readonly ElicitationMode[] = [
+  "form",
+  "url",
+];
+
+/**
+ * MCPJam owns the round cap in manual mode; this mirrors the upstream
+ * automatic driver's `maxRounds` default so behavior is consistent across
+ * modes.
+ */
+export const DEFAULT_MAX_MRTR_ROUNDS = 10;
+
+/**
+ * The complete, JSON-serializable state of one in-flight MRTR operation.
+ *
+ * DATA ONLY — never a `Client`, promise, closure, resolver, or `AbortSignal`.
+ * A hosted surface persists this between rounds and rehydrates it on resume.
+ */
+export interface MrtrOperationState {
+  /** Stable id for this logical operation across all its rounds. */
+  readonly opId: string;
+  /** The entry verb; drives request construction on every retry. */
+  readonly method: MrtrMethod;
+  /**
+   * The immutable original application params (e.g. `{ name, arguments }` for
+   * a tool). Preserved byte-for-byte across every round; retries spread
+   * `inputResponses` / `requestState` on top without mutating this.
+   */
+  readonly originalParams: Record<string, unknown>;
+  /**
+   * Number of retry legs performed so far. `0` before the initial send.
+   * Persisted so a hosted resume keeps counting toward {@link maxRounds}.
+   */
+  readonly round: number;
+  /** MCPJam-owned round cap, persisted so resumes continue enforcing it. */
+  readonly maxRounds: number;
+  /**
+   * The opaque server state to echo verbatim on the next retry, present only
+   * when the last `input_required` carried one. Never parsed, normalized, or
+   * logged.
+   */
+  readonly requestState?: string;
+  /**
+   * The current round's embedded requests awaiting responses, keyed by the
+   * server's (untrusted) keys. Empty for a state-only round or before the
+   * first `input_required`. Kept as data (includes each request's
+   * `requestedSchema`) so a hosted resume can self-validate collected content.
+   */
+  readonly pendingInputRequests: InputRequests;
+}
+
+/** Result of stepping one MRTR leg. */
+export type MrtrLegResult<TResult> =
+  | { readonly status: "complete"; readonly result: TResult }
+  | { readonly status: "input_required"; readonly state: MrtrOperationState };
+
+/**
+ * Sends exactly one wire leg. The driver builds the `{ method, params }`
+ * request (original params + this round's `inputResponses` + echoed
+ * `requestState`); the sender performs the wire call and returns the raw
+ * result — either a complete result of the entry verb or an
+ * {@link InputRequiredResult}. Implementations preserve Phase-3 helper
+ * semantics (output-schema validation, `Mcp-Param-*` mirroring, response
+ * cache) and their own retry/timeout wrappers; the driver is the inner leaf.
+ */
+export type MrtrLegSender<TResult = unknown> = (
+  request: { readonly method: MrtrMethod; readonly params: Record<string, unknown> },
+  ctx: { readonly round: number; readonly signal?: AbortSignal }
+) => Promise<TResult | InputRequiredResult>;
+
+/**
+ * Validates collected elicitation content against the request's
+ * `requestedSchema` (§12.1.11). Injected so the browser-hostile Ajv engine is
+ * never pulled into this module's import graph; callers wire a **strict**
+ * dialect-aware validator (unknown dialect → invalid, not fail-open).
+ */
+export type ElicitationContentValidator = (
+  requestedSchema: unknown,
+  content: unknown
+) => { valid: boolean; error?: string };
+
+/** Collects responses for one round's embedded requests. */
+export type MrtrInputCollector = (request: {
+  readonly state: MrtrOperationState;
+  readonly inputRequests: InputRequests;
+  readonly signal?: AbortSignal;
+}) => Promise<InputResponses>;
+
+/** Validates the final complete result (e.g. tool output-schema check). */
+export type MrtrValidateResponse<TResult> = (
+  result: TResult
+) => void | Promise<void>;
+
+// ---------------------------------------------------------------------------
+// Errors + guards
+// ---------------------------------------------------------------------------
+
+/**
+ * The server embedded a request this client never advertised (`roots/list` /
+ * `sampling/createMessage`) or an otherwise unsupported input method. Detected
+ * at the result (Decision 8: modern clients silently drop inbound requests, so
+ * a `setRequestHandler` would never fire) and rejected before any UI.
+ */
+export class MrtrUndeclaredInputError extends Error {
+  readonly code = "MRTR_UNDECLARED_INPUT";
+  constructor(
+    readonly method: string,
+    readonly inputKey: string,
+    message: string
+  ) {
+    super(message);
+    this.name = "MrtrUndeclaredInputError";
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+/** The server requested an elicitation mode this client does not support. */
+export class MrtrUnsupportedElicitationModeError extends Error {
+  readonly code = "MRTR_UNSUPPORTED_ELICITATION_MODE";
+  constructor(
+    readonly mode: string,
+    readonly inputKey: string
+  ) {
+    super(
+      `Embedded elicitation request "${inputKey}" declared unsupported mode "${mode}" ` +
+        `(supported: ${SUPPORTED_ELICITATION_MODES.join(", ")}).`
+    );
+    this.name = "MrtrUnsupportedElicitationModeError";
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+/**
+ * A collected response failed local self-validation: a missing/extra key for
+ * the round, or accepted elicitation content that does not satisfy the
+ * request's `requestedSchema`.
+ */
+export class MrtrInputValidationError extends Error {
+  readonly code = "MRTR_INPUT_VALIDATION";
+  constructor(message: string) {
+    super(message);
+    this.name = "MrtrInputValidationError";
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+/** `true` iff `err` is the upstream typed round-cap-exceeded error. */
+export function isMaxRoundsExceeded(err: unknown): boolean {
+  return (
+    UpstreamSdkError.isInstance(err) &&
+    (err as UpstreamSdkError).code === SdkErrorCode.InputRequiredRoundsExceeded
+  );
+}
+
+/**
+ * `true` iff `err` is the upstream typed "unsupported result type" error —
+ * raised by the SDK when a modern non-complete result surfaces on a call that
+ * did not opt in with `allowInputRequired`.
+ */
+export function isUnsupportedResultType(err: unknown): boolean {
+  return (
+    UpstreamSdkError.isInstance(err) &&
+    (err as UpstreamSdkError).code === SdkErrorCode.UnsupportedResultType
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Copies an `InputRequests` / `InputResponses` map onto a **null-prototype**
+ * object. Server-assigned keys are untrusted, so we never let a `__proto__` /
+ * `constructor` key reach a normal object's prototype chain.
+ */
+function toSafeMap<T>(src: Record<string, T> | undefined): Record<string, T> {
+  const out = Object.create(null) as Record<string, T>;
+  if (src) {
+    for (const key of Object.keys(src)) {
+      out[key] = src[key];
+    }
+  }
+  return out;
+}
+
+/**
+ * A permissive Standard-Schema for the complete branch. The upstream request
+ * funnel routes an `input_required` result through its non-complete handler
+ * *before* result-schema validation, so this schema only ever sees a genuine
+ * complete result; MCPJam re-imposes verb-specific validation (e.g. tool
+ * output-schema) separately. Kept permissive because the upstream typed
+ * `*ResultSchema`s are not exported from the client package.
+ */
+const passthroughResultSchema: StandardSchemaV1<unknown, Record<string, unknown>> =
+  {
+    "~standard": {
+      version: 1,
+      vendor: "mcpjam-mrtr",
+      validate: (value) => ({ value: (value ?? {}) as Record<string, unknown> }),
+    },
+  };
+
+/** The default result schema for a verb's complete result. */
+export function defaultResultSchemaForMethod(
+  _method: MrtrMethod
+): StandardSchemaV1<unknown, Record<string, unknown>> {
+  return passthroughResultSchema;
+}
+
+/**
+ * The default leg sender: the type-correct explicit-schema path
+ * (`requestWithSchema(req, withInputRequired(resultSchema), { allowInputRequired })`).
+ * This is the only path that correctly surfaces an `input_required` result on
+ * *every* round — the higher-level `callTool` helper asserts a complete result
+ * and would throw on an intermediate `input_required` leg for a tool that
+ * declares an `outputSchema`.
+ */
+export function makeRequestWithSchemaLegSender<TResult = unknown>(
+  client: Pick<ManagedMcpClient, "requestWithSchema">,
+  resultSchema: StandardSchemaV1 = passthroughResultSchema,
+  baseOptions?: RequestOptions
+): MrtrLegSender<TResult> {
+  const wrapped = withInputRequired(resultSchema);
+  return (request, ctx) =>
+    client.requestWithSchema(
+      request as Request,
+      wrapped,
+      {
+        ...baseOptions,
+        allowInputRequired: true,
+        ...(ctx.signal ? { signal: ctx.signal } : {}),
+      }
+    ) as Promise<TResult | InputRequiredResult>;
+}
+
+/** Builds the retry params for one leg: original params + this-round-only responses + echoed state. */
+function buildRetryParams(
+  state: MrtrOperationState,
+  currentRoundResponses?: InputResponses
+): Record<string, unknown> {
+  const params: Record<string, unknown> = { ...state.originalParams };
+  if (currentRoundResponses && Object.keys(currentRoundResponses).length > 0) {
+    // This round only — responses are replaced, never accumulated.
+    params.inputResponses = currentRoundResponses;
+  }
+  if (state.requestState !== undefined) {
+    // Echo verbatim; opaque.
+    params.requestState = state.requestState;
+  }
+  return params;
+}
+
+/**
+ * Validates the *entire* embedded-requests map before any of it is surfaced to
+ * a UI (§12.3): rejects undeclared `roots/list` / `sampling/createMessage`
+ * (Decision 8), unknown methods, and unsupported elicitation modes.
+ */
+export function validateInputRequests(
+  inputRequests: InputRequests,
+  supportedModes: readonly ElicitationMode[] = SUPPORTED_ELICITATION_MODES
+): void {
+  for (const key of Object.keys(inputRequests)) {
+    const req = inputRequests[key] as { method?: string; params?: Record<string, unknown> };
+    const method = req?.method;
+    if (method === "roots/list" || method === "sampling/createMessage") {
+      throw new MrtrUndeclaredInputError(
+        method,
+        key,
+        `Server embedded an undeclared "${method}" request under key "${key}"; ` +
+          `this client advertises neither roots nor sampling, so it cannot fulfil it.`
+      );
+    }
+    if (method === "elicitation/create") {
+      const mode = (req.params?.mode as string | undefined) ?? "form";
+      if (!supportedModes.includes(mode as ElicitationMode)) {
+        throw new MrtrUnsupportedElicitationModeError(mode, key);
+      }
+      continue;
+    }
+    throw new MrtrUndeclaredInputError(
+      String(method),
+      key,
+      `Server embedded an unsupported input request method "${String(method)}" under key "${key}".`
+    );
+  }
+}
+
+/**
+ * Validates a round's collected responses against its pending requests: every
+ * pending key answered, no unexpected keys, and every *accepted* form
+ * elicitation's content self-validated against its `requestedSchema`.
+ */
+export function validateRoundResponses(
+  state: MrtrOperationState,
+  responses: InputResponses,
+  validateContent?: ElicitationContentValidator
+): void {
+  const pending = state.pendingInputRequests;
+  const pendingKeys = Object.keys(pending);
+  for (const key of pendingKeys) {
+    if (!(key in responses)) {
+      throw new MrtrInputValidationError(
+        `Missing response for embedded input "${key}".`
+      );
+    }
+  }
+  for (const key of Object.keys(responses)) {
+    if (!pendingKeys.includes(key)) {
+      throw new MrtrInputValidationError(
+        `Unexpected response key "${key}" not requested this round.`
+      );
+    }
+  }
+  for (const key of pendingKeys) {
+    const req = pending[key] as { method?: string; params?: Record<string, unknown> };
+    const res = responses[key] as InputResponse & { action?: string; content?: unknown };
+    if (req?.method !== "elicitation/create") {
+      continue;
+    }
+    // Decline / cancel are RESPONSES, not errors — no content to validate.
+    if (res?.action !== "accept") {
+      continue;
+    }
+    const requestedSchema = req.params?.requestedSchema;
+    // URL-mode consent carries no content schema.
+    if (requestedSchema === undefined || validateContent === undefined) {
+      continue;
+    }
+    const result = validateContent(requestedSchema, (res.content ?? {}) as unknown);
+    if (!result.valid) {
+      throw new MrtrInputValidationError(
+        `Accepted elicitation content for "${key}" failed schema validation: ${
+          result.error ?? "invalid"
+        }`
+      );
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Stepper
+// ---------------------------------------------------------------------------
+
+/** Creates the initial state for a fresh operation (round 0, no pending input). */
+export function initInputRequiredState(args: {
+  opId?: string;
+  method: MrtrMethod;
+  params: Record<string, unknown>;
+  maxRounds?: number;
+}): MrtrOperationState {
+  return {
+    opId: args.opId ?? `mrtr_${Math.random().toString(36).slice(2)}${Date.now().toString(36)}`,
+    method: args.method,
+    originalParams: { ...args.params },
+    round: 0,
+    maxRounds: args.maxRounds ?? DEFAULT_MAX_MRTR_ROUNDS,
+    pendingInputRequests: toSafeMap(undefined),
+  };
+}
+
+/**
+ * Steps exactly one MRTR leg: sends the wire request for `state` carrying
+ * `currentRoundResponses` (validated first), then classifies the result.
+ *
+ * - complete result → `{ status: 'complete', result }`.
+ * - `input_required` → validates the entire embedded map (undeclared / mode),
+ *   enforces the MCPJam round cap, and returns `{ status: 'input_required',
+ *   state }` with the next round's pending requests and echoed `requestState`.
+ *
+ * Abort: `signal` is threaded to the sender (wire-active window). Aborting the
+ * local-pending window (input collection) is the caller's concern. On abort the
+ * caller's `AbortError` propagates — it is never converted to a decline.
+ */
+export async function executeInputRequiredLeg<TResult = unknown>(args: {
+  sender: MrtrLegSender<TResult>;
+  state: MrtrOperationState;
+  currentRoundResponses?: InputResponses;
+  signal?: AbortSignal;
+  validateContent?: ElicitationContentValidator;
+  supportedElicitationModes?: readonly ElicitationMode[];
+}): Promise<MrtrLegResult<TResult>> {
+  const {
+    sender,
+    state,
+    currentRoundResponses,
+    signal,
+    validateContent,
+    supportedElicitationModes = SUPPORTED_ELICITATION_MODES,
+  } = args;
+
+  // Validate this round's responses before they leave the process.
+  if (currentRoundResponses !== undefined) {
+    validateRoundResponses(state, currentRoundResponses, validateContent);
+  } else if (Object.keys(state.pendingInputRequests).length > 0) {
+    throw new MrtrInputValidationError(
+      "This round has pending input requests but no responses were supplied."
+    );
+  }
+
+  const safeResponses =
+    currentRoundResponses !== undefined
+      ? toSafeMap<InputResponse>(currentRoundResponses)
+      : undefined;
+  const params = buildRetryParams(state, safeResponses);
+
+  const raw = await sender({ method: state.method, params }, { round: state.round, signal });
+
+  if (!isInputRequiredResult(raw)) {
+    return { status: "complete", result: raw as TResult };
+  }
+
+  const nextRound = state.round + 1;
+  if (nextRound > state.maxRounds) {
+    throw new UpstreamSdkError(
+      SdkErrorCode.InputRequiredRoundsExceeded,
+      `MCP multi-round-trip exceeded MCPJam's round cap of ${state.maxRounds} for ${state.method}.`,
+      {
+        rounds: state.maxRounds,
+        lastResult: {
+          inputRequests: raw.inputRequests,
+          requestState: raw.requestState,
+        },
+      }
+    );
+  }
+
+  const inputRequests = toSafeMap<InputRequests[string]>(raw.inputRequests);
+  // Validate the ENTIRE map before returning (no UI is shown for a bad round).
+  validateInputRequests(inputRequests, supportedElicitationModes);
+
+  const nextState: MrtrOperationState = {
+    opId: state.opId,
+    method: state.method,
+    originalParams: state.originalParams,
+    round: nextRound,
+    maxRounds: state.maxRounds,
+    ...(raw.requestState !== undefined ? { requestState: raw.requestState } : {}),
+    pendingInputRequests: inputRequests,
+  };
+  return { status: "input_required", state: nextState };
+}
+
+/**
+ * Resumes a suspended operation: submits `responses` for the state's current
+ * pending requests and runs one retry leg. Rebuilds the default
+ * `requestWithSchema` sender from `client` unless a verb-specific `sender` is
+ * supplied (the manager passes one to preserve Phase-3 helper semantics).
+ */
+export function resumeInputRequiredOperation<TResult = unknown>(
+  client: Pick<ManagedMcpClient, "requestWithSchema">,
+  state: MrtrOperationState,
+  responses: InputResponses,
+  config?: {
+    sender?: MrtrLegSender<TResult>;
+    resultSchema?: StandardSchemaV1;
+    requestOptions?: RequestOptions;
+    signal?: AbortSignal;
+    validateContent?: ElicitationContentValidator;
+    supportedElicitationModes?: readonly ElicitationMode[];
+  }
+): Promise<MrtrLegResult<TResult>> {
+  const sender =
+    config?.sender ??
+    makeRequestWithSchemaLegSender<TResult>(
+      client,
+      config?.resultSchema ?? defaultResultSchemaForMethod(state.method),
+      config?.requestOptions
+    );
+  return executeInputRequiredLeg<TResult>({
+    sender,
+    state,
+    currentRoundResponses: responses,
+    signal: config?.signal,
+    validateContent: config?.validateContent,
+    supportedElicitationModes: config?.supportedElicitationModes,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Convenience loop (local / CLI surfaces)
+// ---------------------------------------------------------------------------
+
+export interface RunInputRequiredOptions<TResult = unknown> {
+  /**
+   * Client for the default `requestWithSchema` sender. Optional: omit it when
+   * a verb-specific {@link sender} is supplied (the manager does this to
+   * preserve Phase-3 helper semantics). Required otherwise.
+   */
+  client?: Pick<ManagedMcpClient, "requestWithSchema">;
+  method: MrtrMethod;
+  params: Record<string, unknown>;
+  /** Collects responses for each round's embedded requests. */
+  collectInput: MrtrInputCollector;
+  /** Verb-specific sender; defaults to the `requestWithSchema` path. */
+  sender?: MrtrLegSender<TResult>;
+  /** Result schema for the complete branch of the default sender. */
+  resultSchema?: StandardSchemaV1;
+  /** Base request options threaded into every leg (timeout, cacheMode, …). */
+  requestOptions?: RequestOptions;
+  /** Runs on the final complete result (e.g. tool output-schema validation). */
+  validateResponse?: MrtrValidateResponse<TResult>;
+  /** Strict content validator for accepted elicitation input. */
+  validateContent?: ElicitationContentValidator;
+  supportedElicitationModes?: readonly ElicitationMode[];
+  /** MCPJam-owned round cap; defaults to {@link DEFAULT_MAX_MRTR_ROUNDS}. */
+  maxRounds?: number;
+  /** Abort signal for both the wire-active and local-pending windows. */
+  signal?: AbortSignal;
+  opId?: string;
+}
+
+/**
+ * Runs an MRTR operation to completion over the stepper: initial send, then a
+ * collect→retry loop per round until a complete result. Suitable for local and
+ * CLI surfaces; hosted surfaces persist {@link MrtrOperationState} between
+ * rounds instead of looping in-process.
+ *
+ * The wire legs and the human-input collection are separate windows: a
+ * transient wire failure is the sender's concern (which owns retry) and never
+ * restarts the loop at round zero, because the loop's state lives here — outside
+ * the sender.
+ */
+export async function runInputRequiredOperation<TResult = unknown>(
+  options: RunInputRequiredOptions<TResult>
+): Promise<TResult> {
+  let sender = options.sender;
+  if (sender === undefined) {
+    if (options.client === undefined) {
+      throw new Error(
+        "runInputRequiredOperation requires either a `sender` or a `client`."
+      );
+    }
+    sender = makeRequestWithSchemaLegSender<TResult>(
+      options.client,
+      options.resultSchema ?? defaultResultSchemaForMethod(options.method),
+      options.requestOptions
+    );
+  }
+
+  let state = initInputRequiredState({
+    opId: options.opId,
+    method: options.method,
+    params: options.params,
+    maxRounds: options.maxRounds,
+  });
+
+  let leg = await executeInputRequiredLeg<TResult>({
+    sender,
+    state,
+    signal: options.signal,
+    supportedElicitationModes: options.supportedElicitationModes,
+  });
+
+  while (leg.status === "input_required") {
+    state = leg.state;
+    // A state-only round (no embedded requests) is an immediate retry — there
+    // is nothing to collect, so the collector is not invoked.
+    const hasPending = Object.keys(state.pendingInputRequests).length > 0;
+    // Local-pending window: an abort here rejects `collectInput`; the resulting
+    // AbortError propagates (never converted to a decline).
+    const responses = hasPending
+      ? await options.collectInput({
+          state,
+          inputRequests: state.pendingInputRequests,
+          signal: options.signal,
+        })
+      : {};
+    leg = await executeInputRequiredLeg<TResult>({
+      sender,
+      state,
+      currentRoundResponses: responses,
+      signal: options.signal,
+      validateContent: options.validateContent,
+      supportedElicitationModes: options.supportedElicitationModes,
+    });
+  }
+
+  if (options.validateResponse) {
+    await options.validateResponse(leg.result);
+  }
+  return leg.result;
+}

--- a/sdk/src/mcp-client-manager/mrtr-driver.ts
+++ b/sdk/src/mcp-client-manager/mrtr-driver.ts
@@ -381,7 +381,10 @@ export function validateRoundResponses(
   const pending = state.pendingInputRequests;
   const pendingKeys = Object.keys(pending);
   for (const key of pendingKeys) {
-    if (!(key in responses)) {
+    // Own-property check: an untrusted server key such as `toString` /
+    // `constructor` must count as missing unless the collector actually
+    // returned it, so a hostile key can't slip through via the prototype chain.
+    if (!Object.prototype.hasOwnProperty.call(responses, key)) {
       throw new MrtrInputValidationError(
         `Missing response for embedded input "${key}".`
       );
@@ -500,8 +503,10 @@ export async function executeInputRequiredLeg<TResult = unknown>(args: {
       {
         rounds: state.maxRounds,
         lastResult: {
+          // `requestState` is opaque and must never be logged (see module
+          // header); an upstream error reporter would serialize it out of
+          // `data`. The round count + request keys are enough for diagnostics.
           inputRequests: raw.inputRequests,
-          requestState: raw.requestState,
         },
       }
     );

--- a/sdk/src/mcp-client-manager/official-sdk-client-adapter.ts
+++ b/sdk/src/mcp-client-manager/official-sdk-client-adapter.ts
@@ -22,6 +22,7 @@ import type {
   Client,
   Request,
   RequestOptions,
+  StandardSchemaV1,
 } from "@modelcontextprotocol/client";
 import type {
   ManagedMcpClient,
@@ -104,6 +105,21 @@ export class OfficialSdkClientAdapter implements ManagedMcpClient {
     // form. We're a generic boundary — the caller has narrowed to a method
     // literal it understands, so cast to the pass-through form.
     return this.inner.request(req as never, options as never) as Promise<T>;
+  }
+  requestWithSchema<TSchema extends StandardSchemaV1>(
+    req: Request,
+    resultSchema: TSchema,
+    options?: RequestOptions,
+  ): Promise<StandardSchemaV1.InferOutput<TSchema>> {
+    // Upstream `Protocol.request`'s explicit-result-schema overload
+    // (`request(request, resultSchema, options)`). Pure pass-through: the
+    // schema validates a complete result and lets a non-complete
+    // `input_required` result surface untouched.
+    return this.inner.request(
+      req as never,
+      resultSchema as never,
+      options as never,
+    ) as Promise<StandardSchemaV1.InferOutput<TSchema>>;
   }
   listResources(
     params?: Parameters<Client["listResources"]>[0],

--- a/sdk/tests/mrtr-driver.test.ts
+++ b/sdk/tests/mrtr-driver.test.ts
@@ -414,9 +414,14 @@ describe("abort windows", () => {
     const controller = new AbortController();
     const sender: MrtrLegSender = async (_req, ctx) => {
       controller.abort();
+      // Fail with a DISTINCT (non-AbortError) error if the operation signal was
+      // not forwarded to the leg — otherwise a regression that drops the signal
+      // would still throw AbortError and pass the assertion below.
+      if (!ctx.signal?.aborted) {
+        throw new Error("operation signal was not forwarded to the leg sender");
+      }
       const err = new Error("aborted");
       err.name = "AbortError";
-      if (ctx.signal?.aborted) throw err;
       throw err;
     };
     await expect(

--- a/sdk/tests/mrtr-driver.test.ts
+++ b/sdk/tests/mrtr-driver.test.ts
@@ -1,0 +1,521 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  DialectAwareJsonSchemaValidator,
+} from "../src/mcp-client-manager/dialect-aware-json-schema-validator.js";
+import type { JsonSchemaType } from "@modelcontextprotocol/client";
+import {
+  DEFAULT_MAX_MRTR_ROUNDS,
+  executeInputRequiredLeg,
+  initInputRequiredState,
+  isMaxRoundsExceeded,
+  makeRequestWithSchemaLegSender,
+  MrtrInputValidationError,
+  MrtrUndeclaredInputError,
+  MrtrUnsupportedElicitationModeError,
+  resumeInputRequiredOperation,
+  runInputRequiredOperation,
+  validateInputRequests,
+  type ElicitationContentValidator,
+  type InputRequiredResult,
+  type MrtrLegSender,
+  type MrtrMethod,
+} from "../src/mcp-client-manager/mrtr-driver.js";
+
+/**
+ * Driver-level coverage of the manual multi-round-trip (`input_required`) loop
+ * (spec §12). The wire is a scripted {@link MrtrLegSender} so every §12 case —
+ * round replacement, hostile keys, undeclared methods/modes, self-validation,
+ * abort, the MCPJam-owned round cap — is exercised deterministically against
+ * the real driver code, independent of any transport.
+ */
+
+// A form-mode elicitation request the client CAN fulfil.
+function formElicit(message: string): InputRequiredResult["inputRequests"][string] {
+  return {
+    method: "elicitation/create",
+    params: {
+      message,
+      requestedSchema: {
+        type: "object",
+        properties: { answer: { type: "string" } },
+        required: ["answer"],
+      },
+    },
+  } as InputRequiredResult["inputRequests"][string];
+}
+
+function inputRequired(
+  inputRequests: Record<string, unknown> | undefined,
+  requestState?: string,
+): InputRequiredResult {
+  return {
+    resultType: "input_required",
+    ...(inputRequests ? { inputRequests } : {}),
+    ...(requestState !== undefined ? { requestState } : {}),
+  } as InputRequiredResult;
+}
+
+/**
+ * A scripted sender: returns queued results in order, recording every request
+ * it was asked to send (so tests can assert param construction across rounds).
+ */
+function scriptedSender(script: unknown[]): {
+  sender: MrtrLegSender;
+  requests: Array<{ method: MrtrMethod; params: Record<string, unknown> }>;
+} {
+  const requests: Array<{ method: MrtrMethod; params: Record<string, unknown> }> =
+    [];
+  let i = 0;
+  const sender: MrtrLegSender = async (request) => {
+    requests.push({ method: request.method, params: request.params });
+    if (i >= script.length) {
+      throw new Error(`scripted sender exhausted after ${script.length} legs`);
+    }
+    return script[i++] as never;
+  };
+  return { sender, requests };
+}
+
+const acceptAnswer = { action: "accept", content: { answer: "yes" } };
+
+describe("executeInputRequiredLeg — classification", () => {
+  it("returns complete when the first result is not input_required", async () => {
+    const { sender } = scriptedSender([{ content: [{ type: "text", text: "ok" }] }]);
+    const state = initInputRequiredState({
+      method: "tools/call",
+      params: { name: "t", arguments: { a: 1 } },
+    });
+    const leg = await executeInputRequiredLeg({ sender, state });
+    expect(leg.status).toBe("complete");
+    if (leg.status === "complete") {
+      expect(leg.result).toEqual({ content: [{ type: "text", text: "ok" }] });
+    }
+  });
+
+  it("surfaces a single form round with its pending requests + requestState", async () => {
+    const { sender } = scriptedSender([
+      inputRequired({ q: formElicit("Continue?") }, "state-token-1"),
+    ]);
+    const state = initInputRequiredState({
+      method: "tools/call",
+      params: { name: "t" },
+    });
+    const leg = await executeInputRequiredLeg({ sender, state });
+    expect(leg.status).toBe("input_required");
+    if (leg.status === "input_required") {
+      expect(leg.state.round).toBe(1);
+      expect(Object.keys(leg.state.pendingInputRequests)).toEqual(["q"]);
+      expect(leg.state.requestState).toBe("state-token-1");
+    }
+  });
+});
+
+describe("per-round replacement + requestState echo", () => {
+  it("echoes requestState verbatim and sends this round's responses only", async () => {
+    const { sender, requests } = scriptedSender([
+      inputRequired({ q: formElicit("r1") }, "S1"),
+      inputRequired({ q: formElicit("r2") }, "S2"),
+      { content: [{ type: "text", text: "done" }] },
+    ]);
+    const collectInput = vi.fn().mockResolvedValue({ q: acceptAnswer });
+    const result = await runInputRequiredOperation({
+      method: "tools/call",
+      params: { name: "t", arguments: { a: 1 } },
+      sender,
+      collectInput,
+    });
+    expect(result).toEqual({ content: [{ type: "text", text: "done" }] });
+    // Round 0 (initial): only original params.
+    expect(requests[0].params).toEqual({ name: "t", arguments: { a: 1 } });
+    // Round 1 retry: original params + this round's responses + echoed S1.
+    expect(requests[1].params).toEqual({
+      name: "t",
+      arguments: { a: 1 },
+      inputResponses: { q: acceptAnswer },
+      requestState: "S1",
+    });
+    // Round 2 retry: responses REPLACED (not accumulated), state echoes S2.
+    expect(requests[2].params).toEqual({
+      name: "t",
+      arguments: { a: 1 },
+      inputResponses: { q: acceptAnswer },
+      requestState: "S2",
+    });
+    // Original params object is never mutated across rounds.
+    expect(requests[0].params.arguments).toEqual({ a: 1 });
+  });
+
+  it("supports a state-only round (no inputRequests): immediate retry with just requestState", async () => {
+    const { sender, requests } = scriptedSender([
+      inputRequired(undefined, "ONLY-STATE"),
+      { content: [{ type: "text", text: "done" }] },
+    ]);
+    const collectInput = vi.fn().mockResolvedValue({});
+    const result = await runInputRequiredOperation({
+      method: "resources/read",
+      params: { uri: "res://x" },
+      sender,
+      collectInput,
+    });
+    expect(result).toEqual({ content: [{ type: "text", text: "done" }] });
+    // The retry carries requestState but NO inputResponses.
+    expect(requests[1].params).toEqual({ uri: "res://x", requestState: "ONLY-STATE" });
+    expect("inputResponses" in requests[1].params).toBe(false);
+  });
+
+  it("supports an inputs-without-state round (no requestState)", async () => {
+    const { sender, requests } = scriptedSender([
+      inputRequired({ q: formElicit("r1") }),
+      { messages: [] },
+    ]);
+    const collectInput = vi.fn().mockResolvedValue({ q: acceptAnswer });
+    await runInputRequiredOperation({
+      method: "prompts/get",
+      params: { name: "p" },
+      sender,
+      collectInput,
+    });
+    expect(requests[1].params).toEqual({
+      name: "p",
+      inputResponses: { q: acceptAnswer },
+    });
+    expect("requestState" in requests[1].params).toBe(false);
+  });
+});
+
+describe("multi-input within one round", () => {
+  it("collects every key and sends the whole current-round map together", async () => {
+    const { sender, requests } = scriptedSender([
+      inputRequired({ a: formElicit("A?"), b: formElicit("B?") }, "S"),
+      { content: [] },
+    ]);
+    const collectInput = vi.fn(async ({ inputRequests }) => {
+      // The UI is handed both keys at once.
+      expect(Object.keys(inputRequests).sort()).toEqual(["a", "b"]);
+      return {
+        a: { action: "accept", content: { answer: "1" } },
+        b: { action: "accept", content: { answer: "2" } },
+      };
+    });
+    await runInputRequiredOperation({
+      method: "tools/call",
+      params: { name: "t" },
+      sender,
+      collectInput,
+    });
+    expect(requests[1].params.inputResponses).toEqual({
+      a: { action: "accept", content: { answer: "1" } },
+      b: { action: "accept", content: { answer: "2" } },
+    });
+  });
+
+  it("rejects a mixed supported+unsupported round BEFORE any UI is shown", async () => {
+    const { sender } = scriptedSender([
+      inputRequired({
+        ok: formElicit("A?"),
+        bad: { method: "sampling/createMessage", params: {} },
+      }),
+    ]);
+    const collectInput = vi.fn();
+    await expect(
+      runInputRequiredOperation({
+        method: "tools/call",
+        params: { name: "t" },
+        sender,
+        collectInput,
+      }),
+    ).rejects.toBeInstanceOf(MrtrUndeclaredInputError);
+    expect(collectInput).not.toHaveBeenCalled();
+  });
+});
+
+describe("undeclared methods and modes (Decision 8)", () => {
+  it.each(["roots/list", "sampling/createMessage"])(
+    "rejects embedded %s at the result, not via a request handler",
+    async (method) => {
+      const { sender } = scriptedSender([
+        inputRequired({ k: { method, params: {} } }),
+      ]);
+      await expect(
+        runInputRequiredOperation({
+          method: "tools/call",
+          params: { name: "t" },
+          sender,
+          collectInput: vi.fn(),
+        }),
+      ).rejects.toBeInstanceOf(MrtrUndeclaredInputError);
+    },
+  );
+
+  it("rejects an undeclared elicitation mode", async () => {
+    const { sender } = scriptedSender([
+      inputRequired({
+        k: { method: "elicitation/create", params: { message: "m", mode: "voice" } },
+      }),
+    ]);
+    await expect(
+      runInputRequiredOperation({
+        method: "tools/call",
+        params: { name: "t" },
+        sender,
+        collectInput: vi.fn(),
+      }),
+    ).rejects.toBeInstanceOf(MrtrUnsupportedElicitationModeError);
+  });
+
+  it("accepts url mode and absent mode (defaults to form)", () => {
+    expect(() =>
+      validateInputRequests({
+        u: { method: "elicitation/create", params: { message: "m", mode: "url", url: "https://x" } },
+        f: formElicit("m"),
+      } as never),
+    ).not.toThrow();
+  });
+});
+
+describe("hostile / prototype-polluting server keys", () => {
+  it("keeps __proto__ / constructor as plain own keys and never pollutes Object.prototype", async () => {
+    // Build the map the way a transport's JSON.parse would deliver a hostile
+    // payload: genuine OWN "__proto__" / "constructor" keys (an object literal
+    // `{ __proto__: ... }` would set the prototype, not an own key).
+    const hostile = JSON.parse(
+      JSON.stringify({
+        __proto__: formElicit("evil"),
+        constructor: formElicit("evil2"),
+        safe: formElicit("ok"),
+      }),
+    ) as Record<string, unknown>;
+    // Re-attach the two special keys as own props (JSON.stringify drops a
+    // literal `__proto__`); this mirrors `JSON.parse('{"__proto__": …}')`.
+    Object.defineProperty(hostile, "__proto__", {
+      value: formElicit("evil"),
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    });
+    const { sender, requests } = scriptedSender([
+      inputRequired(hostile, "S"),
+      { content: [] },
+    ]);
+    const seenKeys: string[] = [];
+    const collectInput = vi.fn(async ({ inputRequests }) => {
+      seenKeys.push(...Object.keys(inputRequests));
+      const out: Record<string, unknown> = Object.create(null);
+      for (const key of Object.keys(inputRequests)) {
+        out[key] = { action: "accept", content: { answer: "x" } };
+      }
+      return out;
+    });
+    await runInputRequiredOperation({
+      method: "tools/call",
+      params: { name: "t" },
+      sender,
+      collectInput,
+    });
+    expect(seenKeys.sort()).toEqual(["__proto__", "constructor", "safe"]);
+    // No prototype pollution leaked anywhere.
+    expect(({} as Record<string, unknown>).answer).toBeUndefined();
+    expect(Object.prototype).not.toHaveProperty("answer");
+    // The response map that went out carries the hostile keys as own props.
+    const sent = requests[1].params.inputResponses as Record<string, unknown>;
+    expect(Object.getPrototypeOf(sent)).toBeNull();
+  });
+});
+
+describe("self-validation of accepted content (§12.1.11)", () => {
+  const strictValidator: ElicitationContentValidator = (requestedSchema, content) => {
+    const strict = new DialectAwareJsonSchemaValidator({
+      onUnknownDialect: (d) => {
+        throw new Error(`unsupported dialect ${d}`);
+      },
+    });
+    const validate = strict.getValidator(requestedSchema as JsonSchemaType);
+    const r = validate(content);
+    return { valid: r.valid, error: r.errorMessage };
+  };
+
+  it("rejects accepted content that violates requestedSchema", async () => {
+    const { sender } = scriptedSender([inputRequired({ q: formElicit("m") }, "S")]);
+    await expect(
+      runInputRequiredOperation({
+        method: "tools/call",
+        params: { name: "t" },
+        sender,
+        // `answer` is required + must be a string; number fails.
+        collectInput: async () => ({ q: { action: "accept", content: { answer: 5 } } }),
+        validateContent: strictValidator,
+      }),
+    ).rejects.toBeInstanceOf(MrtrInputValidationError);
+  });
+
+  it("does not validate content for a declined response", async () => {
+    const { sender, requests } = scriptedSender([
+      inputRequired({ q: formElicit("m") }, "S"),
+      { content: [{ type: "text", text: "declined-path" }] },
+    ]);
+    const result = await runInputRequiredOperation({
+      method: "tools/call",
+      params: { name: "t" },
+      sender,
+      collectInput: async () => ({ q: { action: "decline" } }),
+      validateContent: strictValidator,
+    });
+    // Decline is a RESPONSE, not an error — the retry carries it and the server
+    // decides what to do.
+    expect(result).toEqual({ content: [{ type: "text", text: "declined-path" }] });
+    expect(requests[1].params.inputResponses).toEqual({ q: { action: "decline" } });
+  });
+
+  it("accepts cancel as a response too", async () => {
+    const { sender, requests } = scriptedSender([
+      inputRequired({ q: formElicit("m") }, "S"),
+      { content: [] },
+    ]);
+    await runInputRequiredOperation({
+      method: "tools/call",
+      params: { name: "t" },
+      sender,
+      collectInput: async () => ({ q: { action: "cancel" } }),
+      validateContent: strictValidator,
+    });
+    expect(requests[1].params.inputResponses).toEqual({ q: { action: "cancel" } });
+  });
+});
+
+describe("MCPJam-owned round cap", () => {
+  it("throws the upstream InputRequiredRoundsExceeded shape after maxRounds retries", async () => {
+    // Always input_required: never completes.
+    const script = Array.from({ length: 20 }, () => inputRequired({ q: formElicit("m") }, "S"));
+    const { sender, requests } = scriptedSender(script);
+    let error: unknown;
+    await runInputRequiredOperation({
+      method: "tools/call",
+      params: { name: "t" },
+      sender,
+      collectInput: async () => ({ q: acceptAnswer }),
+      maxRounds: 3,
+    }).catch((e) => {
+      error = e;
+    });
+    expect(isMaxRoundsExceeded(error)).toBe(true);
+    expect((error as { data?: { rounds?: number } }).data?.rounds).toBe(3);
+    // initial send + 3 retries = 4 wire legs before the cap fires.
+    expect(requests.length).toBe(4);
+  });
+
+  it("defaults to DEFAULT_MAX_MRTR_ROUNDS", () => {
+    const state = initInputRequiredState({ method: "tools/call", params: {} });
+    expect(state.maxRounds).toBe(DEFAULT_MAX_MRTR_ROUNDS);
+  });
+});
+
+describe("abort windows", () => {
+  it("propagates an abort during the wire leg (never converts to decline)", async () => {
+    const controller = new AbortController();
+    const sender: MrtrLegSender = async (_req, ctx) => {
+      controller.abort();
+      const err = new Error("aborted");
+      err.name = "AbortError";
+      if (ctx.signal?.aborted) throw err;
+      throw err;
+    };
+    await expect(
+      runInputRequiredOperation({
+        method: "tools/call",
+        params: { name: "t" },
+        sender,
+        collectInput: vi.fn(),
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+  });
+
+  it("propagates an abort while pending (collectInput rejects)", async () => {
+    const controller = new AbortController();
+    const { sender } = scriptedSender([inputRequired({ q: formElicit("m") }, "S")]);
+    const collectInput = vi.fn(async () => {
+      controller.abort();
+      const err = new Error("user aborted");
+      err.name = "AbortError";
+      throw err;
+    });
+    await expect(
+      runInputRequiredOperation({
+        method: "tools/call",
+        params: { name: "t" },
+        sender,
+        collectInput,
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+  });
+});
+
+describe("entry methods + original params + resume", () => {
+  it.each<MrtrMethod>(["tools/call", "prompts/get", "resources/read"])(
+    "drives a single round for %s preserving original params",
+    async (method) => {
+      const originalParams =
+        method === "resources/read"
+          ? { uri: "res://x" }
+          : { name: "entry", arguments: { k: "v" } };
+      const { sender, requests } = scriptedSender([
+        inputRequired({ q: formElicit("m") }, "S"),
+        { ok: true },
+      ]);
+      await runInputRequiredOperation({
+        method,
+        params: originalParams,
+        sender,
+        collectInput: async () => ({ q: acceptAnswer }),
+      });
+      // Every leg carries the exact original params (plus round extras).
+      for (const req of requests) {
+        expect(req.method).toBe(method);
+        for (const [k, v] of Object.entries(originalParams)) {
+          expect(req.params[k]).toEqual(v);
+        }
+      }
+    },
+  );
+
+  it("resumeInputRequiredOperation runs one retry leg from a suspended state", async () => {
+    // Simulate a hosted round-trip: step once, persist state, resume.
+    const { sender } = scriptedSender([
+      inputRequired({ q: formElicit("m") }, "S"),
+      { content: [{ type: "text", text: "resumed" }] },
+    ]);
+    const state = initInputRequiredState({ method: "tools/call", params: { name: "t" } });
+    const first = await executeInputRequiredLeg({ sender, state });
+    expect(first.status).toBe("input_required");
+    if (first.status !== "input_required") return;
+
+    // A different worker would rebuild the client; here `sender` closes over the
+    // same script. Resume with a custom sender (client unused).
+    const resumed = await resumeInputRequiredOperation(
+      { requestWithSchema: (() => {}) as never },
+      first.state,
+      { q: acceptAnswer },
+      { sender },
+    );
+    expect(resumed.status).toBe("complete");
+    if (resumed.status === "complete") {
+      expect(resumed.result).toEqual({ content: [{ type: "text", text: "resumed" }] });
+    }
+  });
+});
+
+describe("makeRequestWithSchemaLegSender", () => {
+  it("calls requestWithSchema with allowInputRequired + the wrapped schema", async () => {
+    const requestWithSchema = vi.fn().mockResolvedValue({ ok: true });
+    const sender = makeRequestWithSchemaLegSender({ requestWithSchema });
+    const signal = new AbortController().signal;
+    await sender({ method: "tools/call", params: { name: "t" } }, { round: 0, signal });
+    expect(requestWithSchema).toHaveBeenCalledTimes(1);
+    const [req, schema, options] = requestWithSchema.mock.calls[0];
+    expect(req).toEqual({ method: "tools/call", params: { name: "t" } });
+    // withInputRequired() returns a Standard Schema.
+    expect(schema).toHaveProperty("~standard");
+    expect(options).toMatchObject({ allowInputRequired: true, signal });
+  });
+});

--- a/sdk/tests/mrtr-manager.integration.test.ts
+++ b/sdk/tests/mrtr-manager.integration.test.ts
@@ -1,0 +1,137 @@
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { toNodeHandler } from "@modelcontextprotocol/node";
+import { MCPClientManager } from "../src/mcp-client-manager/index.js";
+import type {
+  InputRequests,
+  MrtrInputCollector,
+} from "../src/mcp-client-manager/index.js";
+import {
+  createMrtrFixtureHandler,
+  MRTR_RESOURCE_URI,
+} from "./support/mrtr-fixture.js";
+
+/**
+ * End-to-end: the real `MCPClientManager` drives the manual multi-round-trip
+ * (`input_required`) loop against a conformant modern (2026-07-28) server over
+ * a real loopback HTTP port. Proves the three verbs enter the loop, collect
+ * input, and complete on retry — through the manager's actual sender wiring
+ * (tool via `requestWithSchema` + reconstructed output validation, resource via
+ * `readResource` cache path, prompt via the explicit-schema seam). Also locks
+ * the advertise=enforce invariant: roots/sampling stay unadvertised under MRTR.
+ */
+
+interface ServedFixture {
+  url: string;
+  close: () => Promise<void>;
+}
+
+async function serveFixture(): Promise<ServedFixture> {
+  const handler = createMrtrFixtureHandler();
+  const httpServer = http.createServer(toNodeHandler(handler));
+  await new Promise<void>((resolve) => httpServer.listen(0, "127.0.0.1", resolve));
+  const address = httpServer.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${address.port}/mcp`,
+    close: () => new Promise<void>((resolve) => httpServer.close(() => resolve())),
+  };
+}
+
+/** A collector that accepts every embedded request with a fixed answer. */
+function acceptAllCollector(answer = "yes"): MrtrInputCollector {
+  return async ({ inputRequests }: { inputRequests: InputRequests }) => {
+    const out: Record<string, unknown> = Object.create(null);
+    for (const key of Object.keys(inputRequests)) {
+      out[key] = { action: "accept", content: { answer } };
+    }
+    return out;
+  };
+}
+
+describe("MCPClientManager × modern MRTR fixture over HTTP", () => {
+  let served: ServedFixture;
+  let manager: MCPClientManager;
+
+  async function connect(): Promise<void> {
+    await manager.connectToServer("fixture", {
+      url: served.url,
+      mcpProtocolVersion: "2026-07-28",
+      timeout: 10_000,
+    });
+  }
+
+  beforeEach(async () => {
+    served = await serveFixture();
+    manager = new MCPClientManager();
+    // The server checks the request's declared client capabilities before it
+    // embeds an elicitation; register the collector BEFORE connect so
+    // `elicitation` is advertised on the per-request envelope.
+    manager.setMrtrInputCollector("fixture", acceptAllCollector());
+  });
+
+  afterEach(async () => {
+    await manager.disconnectAllServers().catch(() => {});
+    await served.close();
+  });
+
+  it("advertises elicitation (collector present) but never roots/sampling", async () => {
+    await connect();
+    const info = manager.getInitializationInfo("fixture");
+    const caps = (info?.clientCapabilities ?? {}) as Record<string, unknown>;
+    expect(caps.elicitation).toBeDefined();
+    expect(caps.roots).toBeUndefined();
+    expect(caps.sampling).toBeUndefined();
+  });
+
+  it("drives a tool call through an input_required round to completion", async () => {
+    const collect = vi.fn(acceptAllCollector("apples"));
+    manager.setMrtrInputCollector("fixture", collect);
+    await connect();
+    const result = (await manager.executeTool("fixture", "confirm", {
+      topic: "fruit",
+    })) as { content: Array<{ text?: string }> };
+    expect(result.content[0]?.text).toBe("answer:apples");
+    expect(collect).toHaveBeenCalledTimes(1);
+  });
+
+  it("reconstructs tool output-schema validation on the final result", async () => {
+    manager.setMrtrInputCollector("fixture", acceptAllCollector("typed-ok"));
+    await connect();
+    const result = (await manager.executeTool("fixture", "confirm-typed", {
+      topic: "x",
+    })) as { structuredContent?: { answer?: string } };
+    // Completes without the reconstructed validator falsely rejecting valid
+    // structured content that matches the tool's outputSchema.
+    expect(result.structuredContent?.answer).toBe("typed-ok");
+  });
+
+  it("drives a prompt get through an input_required round", async () => {
+    manager.setMrtrInputCollector("fixture", acceptAllCollector("p-ans"));
+    await connect();
+    const result = (await manager.getPrompt("fixture", {
+      name: "confirm-prompt",
+      arguments: { topic: "x" },
+    })) as { messages: Array<{ content: { text?: string } }> };
+    expect(result.messages[0]?.content.text).toBe("prompt:p-ans");
+  });
+
+  it("drives a resource read through an input_required round (cache path preserved)", async () => {
+    manager.setMrtrInputCollector("fixture", acceptAllCollector("r-ans"));
+    await connect();
+    const result = (await manager.readResource("fixture", {
+      uri: MRTR_RESOURCE_URI,
+    })) as { contents: Array<{ text?: string }> };
+    expect(result.contents[0]?.text).toBe("resource:r-ans");
+  });
+
+  it("leaves the non-MRTR path unchanged when no collector is registered", async () => {
+    // A modern server returning input_required with no collector surfaces the
+    // SDK's typed manual-mode error rather than silently mishandling it.
+    manager.clearMrtrInputCollector("fixture");
+    await connect();
+    await expect(
+      manager.executeTool("fixture", "confirm", { topic: "x" }),
+    ).rejects.toBeTruthy();
+  });
+});

--- a/sdk/tests/mrtr-manager.integration.test.ts
+++ b/sdk/tests/mrtr-manager.integration.test.ts
@@ -126,12 +126,19 @@ describe("MCPClientManager × modern MRTR fixture over HTTP", () => {
   });
 
   it("leaves the non-MRTR path unchanged when no collector is registered", async () => {
-    // A modern server returning input_required with no collector surfaces the
-    // SDK's typed manual-mode error rather than silently mishandling it.
+    // Without a collector, elicitation is NOT advertised (advertise=enforce), so
+    // the conformant modern server refuses to embed the elicitation request and
+    // rejects with the typed "missing required client capability" protocol error
+    // (-32021) rather than any unrelated failure. Assert on that specific error
+    // so a regression that silently mishandles the no-collector path is caught.
     manager.clearMrtrInputCollector("fixture");
     await connect();
-    await expect(
-      manager.executeTool("fixture", "confirm", { topic: "x" }),
-    ).rejects.toBeTruthy();
+    const error = await manager
+      .executeTool("fixture", "confirm", { topic: "x" })
+      .then(() => undefined, (e: unknown) => e);
+    expect((error as { code?: number })?.code).toBe(-32021);
+    expect((error as { message?: string })?.message).toMatch(
+      /client capabilities do not declare/i,
+    );
   });
 });

--- a/sdk/tests/mrtr-seam.test.ts
+++ b/sdk/tests/mrtr-seam.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from "vitest";
+import { LOG_LEVEL_META_KEY, type Request } from "@modelcontextprotocol/client";
+import { OfficialSdkClientAdapter } from "../src/mcp-client-manager/official-sdk-client-adapter.js";
+import { LogLevelMetaClient } from "../src/mcp-client-manager/log-level-meta-client.js";
+import type { ManagedMcpClient } from "../src/mcp-client-manager/managed-mcp-client.js";
+
+/**
+ * The explicit-schema `requestWithSchema` seam (new for the 2026-07-28 MRTR
+ * loop) must be present and honest on BOTH `ManagedMcpClient` implementations:
+ *  - `OfficialSdkClientAdapter` forwards verbatim to upstream
+ *    `Protocol.request`'s explicit-result-schema overload; and
+ *  - the `LogLevelMetaClient` decorator injects the modern per-request logging
+ *    `_meta` here exactly as it does for the other request-bearing methods —
+ *    otherwise every MRTR retry leg would silently drop the log level.
+ */
+
+const SCHEMA = { "~standard": { version: 1, vendor: "t", validate: (v: unknown) => ({ value: v }) } };
+const REQ = { method: "tools/call", params: { name: "t" } } as unknown as Request;
+
+describe("OfficialSdkClientAdapter.requestWithSchema", () => {
+  it("forwards (req, resultSchema, options) verbatim to inner.request", async () => {
+    const request = vi.fn().mockResolvedValue({ ok: true });
+    const adapter = new OfficialSdkClientAdapter({ request } as never);
+    const options = { allowInputRequired: true, timeout: 5 };
+    const result = await adapter.requestWithSchema(REQ, SCHEMA as never, options);
+    expect(result).toEqual({ ok: true });
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(request.mock.calls[0][0]).toBe(REQ);
+    expect(request.mock.calls[0][1]).toBe(SCHEMA);
+    expect(request.mock.calls[0][2]).toBe(options);
+  });
+});
+
+/** Minimal inner `ManagedMcpClient` recording `requestWithSchema` calls. */
+function fakeInner(era: "modern" | "legacy" | undefined): {
+  inner: ManagedMcpClient;
+  calls: Array<{ req: Request; options?: unknown }>;
+} {
+  const calls: Array<{ req: Request; options?: unknown }> = [];
+  const inner = {
+    getProtocolEra: () => era,
+    requestWithSchema: (req: Request, _schema: unknown, options?: unknown) => {
+      calls.push({ req, options });
+      return Promise.resolve({ ok: true });
+    },
+  } as unknown as ManagedMcpClient;
+  return { inner, calls };
+}
+
+describe("LogLevelMetaClient.requestWithSchema", () => {
+  it("injects the log level into params._meta on a modern connection", async () => {
+    const { inner, calls } = fakeInner("modern");
+    const client = new LogLevelMetaClient(inner, () => "warning");
+    await client.requestWithSchema(REQ, SCHEMA as never);
+    const params = calls[0].req.params as { _meta?: Record<string, unknown> };
+    expect(params._meta?.[LOG_LEVEL_META_KEY]).toBe("warning");
+  });
+
+  it("does NOT inject on a legacy connection (level rides logging/setLevel there)", async () => {
+    const { inner, calls } = fakeInner("legacy");
+    const client = new LogLevelMetaClient(inner, () => "warning");
+    await client.requestWithSchema(REQ, SCHEMA as never);
+    const params = calls[0].req.params as { _meta?: Record<string, unknown> };
+    expect(params._meta).toBeUndefined();
+  });
+
+  it("does NOT inject when no level is set (absence is opt-out)", async () => {
+    const { inner, calls } = fakeInner("modern");
+    const client = new LogLevelMetaClient(inner, () => undefined);
+    await client.requestWithSchema(REQ, SCHEMA as never);
+    // Forwarded untouched — same request object, no _meta added.
+    expect(calls[0].req).toBe(REQ);
+    expect((calls[0].req.params as { _meta?: unknown })._meta).toBeUndefined();
+  });
+
+  it("lets caller-supplied _meta keys win over the injected level", async () => {
+    const { inner, calls } = fakeInner("modern");
+    const client = new LogLevelMetaClient(inner, () => "error");
+    const reqWithMeta = {
+      method: "tools/call",
+      params: { name: "t", _meta: { [LOG_LEVEL_META_KEY]: "debug", other: 1 } },
+    } as unknown as Request;
+    await client.requestWithSchema(reqWithMeta, SCHEMA as never);
+    const params = calls[0].req.params as { _meta?: Record<string, unknown> };
+    expect(params._meta?.[LOG_LEVEL_META_KEY]).toBe("debug");
+    expect(params._meta?.other).toBe(1);
+  });
+});

--- a/sdk/tests/support/mrtr-fixture.ts
+++ b/sdk/tests/support/mrtr-fixture.ts
@@ -1,0 +1,166 @@
+/**
+ * A dual-era MRTR fixture: a modern (2026-07-28) server whose tool, prompt, and
+ * resource each answer `input_required` on the first call and complete on the
+ * retry that carries the accepted elicitation content (spec §12). Served via
+ * `createMcpHandler` so it runs over the real modern wire (see
+ * `mcp-client-manager-fixture.integration.test.ts` for the HTTP harness).
+ *
+ * One tool (`confirm-typed`) declares an `outputSchema`, so the manager's
+ * reconstructed tool output-schema validation on the MRTR path has something to
+ * assert against.
+ */
+
+import { acceptedContent, createMcpHandler, inputRequired, McpServer } from "@modelcontextprotocol/server";
+import { z } from "zod";
+
+export const MRTR_FIXTURE_INFO = {
+  name: "mcpjam-mrtr-fixture",
+  version: "1.0.0",
+} as const;
+
+export const MRTR_RESOURCE_URI = "test://mrtr/doc";
+
+const answerSchema = {
+  type: "object" as const,
+  properties: { answer: { type: "string" as const } },
+  required: ["answer"],
+};
+
+export function buildMrtrFixtureServer(): McpServer {
+  const server = new McpServer(MRTR_FIXTURE_INFO, {
+    capabilities: { tools: {}, resources: {}, prompts: {} },
+  });
+
+  // Tool that requests input then echoes it back.
+  server.registerTool(
+    "confirm",
+    {
+      description: "Asks a question, then echoes the answer.",
+      inputSchema: { topic: z.string() },
+    },
+    async ({ topic }, ctx) => {
+      const answered = acceptedContent<{ answer: string }>(
+        ctx.mcpReq.inputResponses,
+        "q",
+      );
+      if (!answered) {
+        return inputRequired({
+          inputRequests: {
+            q: inputRequired.elicit({
+              message: `About ${topic}?`,
+              requestedSchema: answerSchema,
+            }),
+          },
+          requestState: "confirm-state-1",
+        });
+      }
+      return {
+        content: [{ type: "text" as const, text: `answer:${answered.answer}` }],
+      };
+    },
+  );
+
+  // Tool with an outputSchema, to exercise reconstructed output validation.
+  server.registerTool(
+    "confirm-typed",
+    {
+      description: "Asks a question, then returns structured content.",
+      inputSchema: { topic: z.string() },
+      outputSchema: { answer: z.string() },
+    },
+    async (_args, ctx) => {
+      const answered = acceptedContent<{ answer: string }>(
+        ctx.mcpReq.inputResponses,
+        "q",
+      );
+      if (!answered) {
+        return inputRequired({
+          inputRequests: {
+            q: inputRequired.elicit({
+              message: "Typed answer?",
+              requestedSchema: answerSchema,
+            }),
+          },
+          requestState: "typed-state-1",
+        });
+      }
+      return {
+        content: [{ type: "text" as const, text: answered.answer }],
+        structuredContent: { answer: answered.answer },
+      };
+    },
+  );
+
+  // Prompt that requests input then embeds it.
+  server.registerPrompt(
+    "confirm-prompt",
+    {
+      description: "A prompt that asks for input before rendering.",
+      argsSchema: { topic: z.string() },
+    },
+    async (_args, ctx) => {
+      const answered = acceptedContent<{ answer: string }>(
+        ctx.mcpReq.inputResponses,
+        "q",
+      );
+      if (!answered) {
+        return inputRequired({
+          inputRequests: {
+            q: inputRequired.elicit({
+              message: "Prompt answer?",
+              requestedSchema: answerSchema,
+            }),
+          },
+          requestState: "prompt-state-1",
+        });
+      }
+      return {
+        messages: [
+          {
+            role: "user" as const,
+            content: { type: "text" as const, text: `prompt:${answered.answer}` },
+          },
+        ],
+      };
+    },
+  );
+
+  // Resource that requests input then returns content.
+  server.registerResource(
+    "mrtr-doc",
+    MRTR_RESOURCE_URI,
+    { description: "A resource that asks for input before reading." },
+    async (_uri, ctx) => {
+      const answered = acceptedContent<{ answer: string }>(
+        ctx.mcpReq.inputResponses,
+        "q",
+      );
+      if (!answered) {
+        return inputRequired({
+          inputRequests: {
+            q: inputRequired.elicit({
+              message: "Resource answer?",
+              requestedSchema: answerSchema,
+            }),
+          },
+          requestState: "resource-state-1",
+        });
+      }
+      return {
+        contents: [
+          {
+            uri: MRTR_RESOURCE_URI,
+            mimeType: "text/plain",
+            text: `resource:${answered.answer}`,
+          },
+        ],
+      };
+    },
+  );
+
+  return server;
+}
+
+export function createMrtrFixtureHandler() {
+  return createMcpHandler(buildMrtrFixtureServer);
+}

--- a/sdk/tests/support/mrtr-fixture.ts
+++ b/sdk/tests/support/mrtr-fixture.ts
@@ -3,7 +3,7 @@
  * resource each answer `input_required` on the first call and complete on the
  * retry that carries the accepted elicitation content (spec §12). Served via
  * `createMcpHandler` so it runs over the real modern wire (see
- * `mcp-client-manager-fixture.integration.test.ts` for the HTTP harness).
+ * `mrtr-manager.integration.test.ts` for the HTTP harness).
  *
  * One tool (`confirm-typed`) declares an `outputSchema`, so the manager's
  * reconstructed tool output-schema validation on the MRTR path has something to


### PR DESCRIPTION
## Phase 4 · PR1 — SDK MRTR driver core (FOUNDATION)

Implements the SDK-only foundation for the MCP 2026-07-28 **multi-round-trip (`input_required` / MRTR)** interaction (spec §12): `tools/call`, `prompts/get`, and `resources/read` can return an `input_required` result carrying embedded elicitation requests plus an opaque `requestState`; the client collects input and **retries the original operation** with the responses, possibly over several rounds. This is distinct from legacy `elicitation/create` (still works, untouched).

New exports only (API stability). No app/backend changes. Left **open** for review — no merge/approve.

### What's here
- **Manual mode** — `inputRequired: { autoFulfill: false }` on the constructed client (`MCPClientManager.ts:1357`), so MCPJam drives the loop.
- **`mrtr-driver.ts` — serializable stepper.** `executeInputRequiredLeg` / `resumeInputRequiredOperation` step a **data-only** `MrtrOperationState` (opId, method, immutable original params, round, echoed `requestState`, current round's pending requests, MCPJam round cap) — never a client/promise/closure/`AbortSignal`, so hosted surfaces (PR3+) can persist and resume it. `runInputRequiredOperation` is the local/CLI convenience loop.
- **MCPJam-owned round cap** (`DEFAULT_MAX_MRTR_ROUNDS = 10`, persisted in state) raising the upstream `SdkError(InputRequiredRoundsExceeded, …, { rounds })` shape; guards `isMaxRoundsExceeded` / `isUnsupportedResultType`.
- **Per-round replacement** (`inputResponses` for that round only, never accumulated) + byte-exact `requestState` echo; state-only / inputs-without-state / no-state rounds all handled; response maps use a null prototype (untrusted server keys).
- **Undeclared-request rejection (Decision 8)** — embedded `roots/list` / `sampling/createMessage` and unsupported elicitation modes are rejected *at the result, before any UI* (`MrtrUndeclaredInputError` / `MrtrUnsupportedElicitationModeError`), since 2026 clients silently drop inbound requests.
- **Strict self-validation (§12.1.11)** — accepted elicitation content is validated against `requestedSchema` (unknown dialect → **invalid**, not fail-open); decline/cancel are responses, not thrown errors. Abort propagates in both the wire-active and local-pending windows (never converted to a decline).
- **`requestWithSchema` seam** added to `ManagedMcpClient`, `OfficialSdkClientAdapter`, and the `LogLevelMetaClient` decorator (which injects the modern per-request logging `_meta`).
- **Three verbs wired** via per-server collectors (`setMrtrInputCollector`); `buildCapabilities` advertises `elicitation` when a collector is registered, never roots/sampling.

### Design decisions flagged for review
1. **Trap #9 — preserving Phase-3 helper semantics on the explicit-schema path.** Upstream `callTool`'s output-schema assertion throws on an intermediate `input_required` result (it has no `structuredContent`), so intermediate tool legs **cannot** go through `callTool`. The wiring therefore uses verb-specific senders:
   - **resources/read** → `readResource` (allowInputRequired) — **response cache preserved** by the real helper.
   - **prompts/get** → the `requestWithSchema` seam directly — exercises the modern per-request log-level `_meta` end to end.
   - **tools/call** → `requestWithSchema` (dodging the poison pill) + **reconstructed output-schema validation** on the final complete result (`validateToolOutputSchema`, same `DialectAwareJsonSchemaValidator`, matching upstream's missing-structured-content + schema-mismatch assertions).
   - **Known gap, flagged:** SEP-2243 `Mcp-Param-*` header mirroring is done inside upstream `callTool` via **private** internals (`_resolveXMcpHeaderScan` / `buildMcpParamHeaders`) and is not reconstructable through the public API. On the modern-era MRTR tool path it is not reproduced; it is not exercisable by in-memory/loopback fixtures either. The `toolDefinition`-stripping alternative (keep `callTool` but null its `outputSchema` to disable the poison pill while retaining mirroring) is viable but needs a `tools/list` lookup per call — **I'd like a reviewer call on whether to add it here or defer.** Legacy-era and the no-collector fast path are byte-identical to today.
2. **MCPJam owns the round cap.** The SDK's `maxRounds`/`InputRequiredRoundsExceeded` applies to `autoFulfill: true` only; the driver enforces the same default itself and accepts the count as state so hosted resumes keep counting.
3. **Capability advertisement.** A 2026-07-28 server checks the request's declared client capabilities before embedding an elicitation, so `setMrtrInputCollector` is intentionally registrable **before connect** and `buildCapabilities` advertises `elicitation` when a collector is present. (Registering a collector *after* connect does not retroactively re-advertise — consistent with how connect-time capability negotiation works; live re-advertisement is out of scope for PR1.)

### Verification (checked by exit code)
- `npx tsc --noEmit` in `sdk/` → **0 errors**.
- Full SDK suite `npx vitest run` → **151 files, 2591 passed, 1 skipped, exit 0** (no regressions; `browser-entry-guard` still green — the driver module pulls no Ajv).
- New tests: `tests/mrtr-driver.test.ts` (24 — every §12 driver case: single/multi-input rounds, accept/decline/cancel, replacement-not-accumulation, hostile/prototype keys, state-only/inputs-without-state/no-state, MCPJam max-round cap, abort in both windows, undeclared roots/sampling + mode, original params preserved, tool+prompt+resource entry, strict self-validation, resume), `tests/mrtr-seam.test.ts` (5 — `requestWithSchema` forward + modern/legacy log-level injection), `tests/mrtr-manager.integration.test.ts` (6 — **real `MCPClientManager` against a conformant modern 2026-07-28 server over loopback HTTP**: all three verbs complete through an `input_required` round, output-schema reconstruction runs on the final tool result, elicitation advertised / roots+sampling not, no-collector fast path unchanged).

Depends on: — (sole protocol foundation). Unblocks PR2 (local UX), PR6 (CLI), PR3a/b + PR4/5 (hosted), PR7 (Apps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core MCP client request paths (tools/resources/prompts) and capability negotiation when MRTR collectors are registered; behavior is opt-in but the new loop and validation logic are security- and protocol-sensitive.
> 
> **Overview**
> Adds the **SDK foundation** for MCP 2026-07-28 **multi-round-trip (`input_required`)** handling: when a server returns embedded elicitation instead of a final result, the client can collect answers and **retry the same operation** until it completes. **New exports only**; existing callers are unchanged unless they opt in with `setMrtrInputCollector`.
> 
> **`mrtr-driver.ts`** introduces a **serializable stepper** (`MrtrOperationState`, `executeInputRequiredLeg`, `resumeInputRequiredOperation`) so hosted workers can persist state between rounds, plus **`runInputRequiredOperation`** for local/CLI loops. The driver enforces a **MCPJam-owned round cap** (default 10), **per-round** `inputResponses` (not accumulated), validation of embedded requests (reject undeclared `roots`/`sampling` and bad elicitation modes), and **strict** elicitation content checks against `requestedSchema`.
> 
> **`MCPClientManager`** connects with **`inputRequired: { autoFulfill: false }`**, registers per-server **`MrtrInputCollector`** hooks, and routes **`executeTool`**, **`readResource`**, and **`getPrompt`** through the MRTR loop when a collector is set. **`buildCapabilities`** advertises **`elicitation`** when a collector exists (not `roots`/`sampling`). Tool MRTR paths use **`requestWithSchema`** + **`withInputRequired`** and **re-validate** final tool output against the tool’s output schema.
> 
> **`requestWithSchema`** is added on **`ManagedMcpClient`**, **`OfficialSdkClientAdapter`**, and **`LogLevelMetaClient`** so MRTR legs keep modern per-request log `_meta`. Public **`@mcpjam/sdk`** re-exports the driver API and types. **Tests** cover the driver, the seam, and HTTP integration against a 2026 fixture server.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa47f6f3efd0a3d4af624a8c412e992486a5cfc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the SDK foundation for the 2026-07-28 multi-round-trip `input_required` flow so tools, prompts, and resources can request input, collect it, and retry. New exports only; behavior is unchanged unless you register an MRTR input collector.

- **New Features**
  - Manual mode (`inputRequired: { autoFulfill: false }`) so the client controls rounds.
  - Per-server input collectors (`setMrtrInputCollector`) drive `tools/call`, `prompts/get`, and `resources/read`.
  - Serializable stepper (`MrtrOperationState` + `executeInputRequiredLeg`/`resumeInputRequiredOperation`; `runInputRequiredOperation` loop) for local and hosted resumes.
  - Explicit-schema seam (`requestWithSchema`) on the managed client, adapter, and log-level decorator; uses `withInputRequired` with `allowInputRequired` and carries per-request `_meta`.
  - Strict validation against `requestedSchema`; rejects undeclared requests (`roots/list`, `sampling/createMessage`) and unsupported elicitation modes.
  - MCPJam-owned round cap (default 10) raising the upstream `InputRequiredRoundsExceeded` error shape.
  - Helper semantics preserved: resource reads keep cache, prompts use the explicit-schema path, tools re-validate final output against the tool’s output schema; capabilities advertise `elicitation` when a collector is set (never `roots`/`sampling`).

- **Bug Fixes**
  - Hardened `validateRoundResponses` with own-property checks to block prototype-chain pollution from hostile server keys.
  - Round-cap error payload no longer includes opaque `requestState`; retains round count and request keys only.
  - `removeServer` now clears MRTR collectors to prevent stale collectors and capability advertisement.
  - MRTR tool leg preserves the composed elicitation-timeout watchdog signal instead of overwriting it with the outer retry signal.

<sup>Written for commit aa47f6f3efd0a3d4af624a8c412e992486a5cfc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

