### PR TITLE
fix(plugins): EOCD preflight screen no longer fails open on trailing bytes

### DIFF
--- a/mcpjam-inspector/client/src/lib/plugins/__tests__/folder-bundle.test.ts
+++ b/mcpjam-inspector/client/src/lib/plugins/__tests__/folder-bundle.test.ts
@@ -395,6 +395,42 @@ describe("client-only archive screen", () => {
     });
   });
 
+  it("still screens archives with trailing bytes after the EOCD (jszip tolerates them)", async () => {
+    const withTrailingJunk = (zip: Uint8Array, junk: number[]): Uint8Array => {
+      const out = new Uint8Array(zip.length + junk.length);
+      out.set(zip, 0);
+      out.set(junk, zip.length);
+      return out;
+    };
+
+    // An over-count bomb must still be rejected by the raw record count...
+    const bomb = withTrailingJunk(
+      buildRawZip(Array.from({ length: 1001 }, () => "dup.txt")),
+      [0x00],
+    );
+    await expect(createZipPluginFileSource(bomb)).rejects.toMatchObject({
+      name: "PluginBundleError",
+      code: "BUNDLE_TOO_MANY_ENTRIES",
+      message: expect.stringContaining("1001"),
+    });
+
+    // ...a duplicate pair must still be detected...
+    await expectIssueCode(
+      createZipPluginFileSource(
+        withTrailingJunk(buildRawZip(["dup.txt", "dup.txt"]), [0x01, 0x02]),
+      ),
+      "PATH_DUPLICATE",
+    );
+
+    // ...and a clean junk-suffixed archive still parses with the same hash.
+    const files = bundleFiles({ mcpServers: MCP_SERVERS });
+    const clean = await parsePluginBundleFromFiles(files);
+    const suffixed = await parsePluginBundleFromZip(
+      withTrailingJunk(await buildPluginZip(files), [0xde, 0xad]),
+    );
+    expect(suffixed.bundleHash).toBe(clean.bundleHash);
+  });
+
   it("rejects a configured maxEntries at or above the ZIP64 sentinel", async () => {
     await expect(
       createZipPluginFileSource(buildRawZip(["a.txt"]), {

--- a/mcpjam-inspector/client/src/lib/plugins/folder-bundle.ts
+++ b/mcpjam-inspector/client/src/lib/plugins/folder-bundle.ts
@@ -321,6 +321,12 @@ export async function buildPluginZip(
 //    parsing ZIP64 structures — which is also why a configured `maxEntries`
 //    must stay below 0xFFFF (validated at the API boundary): at or above
 //    the sentinel the 16-bit field can no longer represent the real count.
+//    The scan tolerates trailing bytes after the EOCD, because jszip does
+//    (a stricter scan would fail OPEN: junk-suffixed archives would skip
+//    this screen while still loading). Residual: under that tolerance a
+//    forged signature inside entry data could shadow-count, but the
+//    backward scan prefers the real (outermost) EOCD and the backend's
+//    yauzl count stays authoritative.
 // 2. COLLAPSED-DUPLICATE DETECTION — when the raw record count exceeds
 //    jszip's deduplicated entry count, duplicate/colliding names were
 //    silently merged last-wins; surfaced as PATH_DUPLICATE, the same code
@@ -362,11 +368,18 @@ export async function buildPluginZip(
  * from the raw bytes, before jszip parses (and name-deduplicates) anything.
  *
  * The EOCD (`PK\x05\x06`) is 22 bytes plus an up-to-65535-byte trailing
- * comment, so it is scanned backward within the last 65557 bytes; a match
- * only counts when its comment-length field spans exactly to the end of the
- * file (rules out the signature appearing inside entry data). Returns
- * `undefined` when no EOCD is found — jszip's own "corrupted zip" error then
- * surfaces from `loadAsync`.
+ * comment, scanned backward within the last 65557 bytes. TOLERANCE MUST
+ * MATCH THE PARSER BEING GUARDED: jszip's loader accepts trailing bytes
+ * after the EOCD (it only warns), so requiring the comment to span exactly
+ * to EOF would fail OPEN — a valid archive plus one appended junk byte
+ * would skip this screen entirely while `loadAsync` still succeeds. A
+ * candidate therefore only needs its comment length to FIT in the remaining
+ * bytes; the backward scan picks the LAST (outermost) such signature. A
+ * forged signature inside entry data could in principle shadow-count under
+ * this tolerance, but it sits before the real EOCD so the backward scan
+ * prefers the real one, and the backend's yauzl count stays authoritative
+ * regardless. Returns `undefined` only when no plausible EOCD exists (jszip
+ * then fails `loadAsync` on its own).
  */
 function readEocdTotalEntries(bytes: Uint8Array): number | undefined {
   const EOCD_SIZE = 22;
@@ -376,7 +389,7 @@ function readEocdTotalEntries(bytes: Uint8Array): number | undefined {
   for (let i = bytes.length - EOCD_SIZE; i >= lowest; i--) {
     if (view.getUint32(i, true) !== 0x06054b50) continue;
     const commentLength = view.getUint16(i + 20, true);
-    if (i + EOCD_SIZE + commentLength !== bytes.length) continue;
+    if (commentLength > bytes.length - (i + EOCD_SIZE)) continue;
     // Offset 10: total central-directory records across all disks.
     return view.getUint16(i + 10, true);
   }
@@ -431,10 +444,17 @@ interface JsZipInternalStream {
   pause(): JsZipInternalStream;
 }
 
-/** jszip keeps the central-directory uncompressed size on an internal field. */
-function declaredUncompressedSize(entry: JsZipEntryInternals): number {
+/**
+ * jszip keeps the central-directory uncompressed size on an internal field.
+ * Returns `undefined` when the internal is unavailable — callers must fall
+ * back to their own hard cap, NOT zero: a zero cap would abort every
+ * legitimate read if a future jszip stops populating `_data`.
+ */
+function declaredUncompressedSize(
+  entry: JsZipEntryInternals,
+): number | undefined {
   const size = entry._data?.uncompressedSize;
-  return typeof size === "number" && size >= 0 ? size : 0;
+  return typeof size === "number" && size >= 0 ? size : undefined;
 }
 
 /**
@@ -450,7 +470,9 @@ function readEntryBounded(
   rawName: string,
   maxBytes: number,
 ): Promise<Uint8Array> {
-  const cap = Math.min(maxBytes, declaredUncompressedSize(entry));
+  // When the declared size is unavailable, fall back to the hard cap —
+  // never 0, which would abort every legitimate read.
+  const cap = Math.min(maxBytes, declaredUncompressedSize(entry) ?? maxBytes);
   return new Promise<Uint8Array>((resolve, reject) => {
     const stream = entry.internalStream("uint8array");
     const chunks: Uint8Array[] = [];
@@ -566,7 +588,7 @@ export async function createZipPluginFileSource(
     const kind = entryKind(rawName, record.unixPermissions);
     entries.push({
       path: rawName,
-      size: kind === "file" ? declaredUncompressedSize(record) : 0,
+      size: kind === "file" ? (declaredUncompressedSize(record) ?? 0) : 0,
       kind,
     });
     if (kind !== "directory") {


### PR DESCRIPTION
Follow-up to #3421 (merged mid-review): an independent review found one verified P2 in the client ZIP preflight, plus a cheap hardening. #3421's branch was already merged and deleted, so this lands the fix as its own PR.

## P2 — EOCD screen failed OPEN on trailing bytes
`readEocdTotalEntries` only accepted an end-of-central-directory candidate whose comment field spanned exactly to EOF. jszip's loader **tolerates** trailing bytes after the EOCD (it only warns), so a valid archive plus one appended junk byte made the scanner return `undefined` — silently skipping both the raw record-count screen and the collapsed-duplicate screen while `loadAsync` still succeeded. A 1001-same-name record bomb with one trailing byte was accepted as a single deduplicated entry.

Fix: the scanner now mirrors the tolerance of the parser it guards — it accepts the LAST (outermost, backward-scan) `PK\x05\x06` signature whose comment length FITS in the remaining bytes. The residual is documented honestly in the client-only ledger: under trailing-junk tolerance a forged inner signature could in principle shadow-count, but the backward scan prefers the real (outermost) EOCD and the backend's yauzl count stays authoritative. The previous inline comment falsely claiming jszip errors on trailing bytes is corrected.

Regression tests: junk-suffixed over-count bomb still rejected `BUNDLE_TOO_MANY_ENTRIES`; junk-suffixed duplicate pair still rejected `PATH_DUPLICATE`; a clean junk-suffixed archive still parses with an unchanged bundle hash.

## P3 — declared-size fallback
`declaredUncompressedSize` returned 0 when jszip's internal `_data.uncompressedSize` was absent, which would make the bounded-read cap 0 and abort every legitimate read if a future jszip stops populating that internal. It now returns `undefined` and the read cap falls back to `maxBytes` (the hard cap), with a comment explaining why.

## Verification (exit codes)
- `npm run typecheck:client` — exit 0
- `npx vitest run --project client` — 629 files / 6215 tests passed, exit 0
- `npx vitest run --project server --project shared --project src` — 274 files / 3627 tests passed, exit 0
- `npm run build:client` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes security-sensitive client ZIP preflight logic that gates malicious archives before upload; scope is narrow and well-tested, with backend yauzl counts still authoritative.
> 
> **Overview**
> **Closes a client ZIP preflight gap** where `readEocdTotalEntries` required the EOCD comment to end exactly at EOF. jszip still loads archives with trailing junk, so those bytes skipped the raw record-count and duplicate-name screens while `loadAsync` succeeded (e.g. a 1001-entry bomb with one appended byte).
> 
> The EOCD scan now **matches jszip’s tolerance**: accept the last backward `PK\x05\x06` whose comment length fits in the remaining bytes, with updated docs on residual risk and backend authority.
> 
> **Hardening:** `declaredUncompressedSize` returns `undefined` when jszip’s internal size is missing; bounded reads use `maxBytes` instead of a **0** cap that would break all inflation.
> 
> New regression tests cover junk-suffixed over-count bombs, duplicate pairs, and unchanged bundle hash on clean suffixed archives.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee431617022d12cffcc74ba54d4467af6ca71af2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the ZIP EOCD preflight to tolerate trailing bytes like `jszip`, so junk-suffixed archives still run client screens. Adds a safe read-cap fallback when `jszip` doesn’t expose an uncompressed size.

- **Bug Fixes**
  - EOCD scan now picks the last plausible `PK\x05\x06` whose comment length fits, preventing junk-suffixed zips from skipping the raw-count and duplicate-name screens (backend `yauzl` count remains authoritative).
  - Added tests: over-count bomb with trailing junk is rejected, duplicate pair is flagged, and clean junk-suffixed archives keep the same bundle hash.
  - `declaredUncompressedSize` returns `undefined` when absent; bounded reads cap to `maxBytes` (not 0), and file size metadata falls back to 0 only when needed.

<sup>Written for commit ee431617022d12cffcc74ba54d4467af6ca71af2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

