### PR TITLE
fix(oauth): use the challenge resourceMetadataUrl when re-authorizing (SEP-2350)

### DIFF
--- a/mcpjam-inspector/client/src/components/ui-playground/hooks/__tests__/useToolExecution.app-routing.test.ts
+++ b/mcpjam-inspector/client/src/components/ui-playground/hooks/__tests__/useToolExecution.app-routing.test.ts
@@ -542,14 +542,39 @@ describe("useToolExecution step-up (SEP-2350)", () => {
     expect(mockApplyToolCallStepUp).not.toHaveBeenCalled();
   });
 
-  it("does not drive step-up for a non-actionable challenge (metadata/errorDescription only, no requiredScope)", async () => {
+  it("drives step-up for a resourceMetadataUrl-only challenge (discovery now consumes the PRM pointer — SEP-2350 follow-up to #3427)", async () => {
     // Same `isActionableStepUpChallenge` gate resources/prompts/chat use: a
-    // challenge with no `requiredScope` cannot widen scope in the orchestrator
-    // today, so redirecting would only burn the bounded step-up budget.
+    // `resourceMetadataUrl` is now actionable on its own — the OAuth flow
+    // discovers the server's authoritative scopes/AS from it.
     mockExecuteToolApi.mockResolvedValueOnce({
       error: "Insufficient scope",
       insufficientScope: {
         resourceMetadataUrl: "https://rs.example/.well-known",
+      },
+    });
+
+    const { result } = renderHook(
+      () => useToolExecution(makeHookOptions({ selectedTool: "get_weather" })),
+      { wrapper: withServer(server) },
+    );
+
+    await act(async () => {
+      await result.current.executeTool({ parameters: {} });
+    });
+
+    expect(mockApplyToolCallStepUp).toHaveBeenCalledTimes(1);
+    expect(mockApplyToolCallStepUp).toHaveBeenCalledWith(server, {
+      requiredScope: undefined,
+      resourceMetadataUrl: "https://rs.example/.well-known",
+    });
+  });
+
+  it("does not drive step-up for an errorDescription-only challenge (nothing to re-authorize with)", async () => {
+    // Neither a `requiredScope` nor a `resourceMetadataUrl` — redirecting would
+    // only burn the bounded step-up budget.
+    mockExecuteToolApi.mockResolvedValueOnce({
+      error: "Insufficient scope",
+      insufficientScope: {
         errorDescription: "more scope needed",
       },
     });

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -1519,8 +1519,8 @@ export function useChatSession(
               appState?.servers?.[event.serverId] ??
               activeProject?.servers?.[event.serverId];
             // The shared lifecycle applies the same actionable-challenge gate
-            // (a `resourceMetadataUrl`-only event is inert in the orchestrator
-            // today and would burn the bounded budget without widening scope)
+            // (a `requiredScope` OR a `resourceMetadataUrl` is now actionable —
+            // discovery consumes the PRM pointer, SEP-2350 follow-up to #3427)
             // and the same cross-surface in-flight dedup.
             driveScopeStepUp(server, {
               requiredScope: event.requiredScope,

--- a/mcpjam-inspector/client/src/lib/apis/__tests__/insufficient-scope.test.ts
+++ b/mcpjam-inspector/client/src/lib/apis/__tests__/insufficient-scope.test.ts
@@ -90,12 +90,18 @@ describe("isActionableStepUpChallenge (SEP-2350)", () => {
     ).toBe(true);
   });
 
-  it("is NOT actionable for a resourceMetadataUrl-only challenge (inert in the orchestrator today — would burn the budget without widening scope)", () => {
+  it("is actionable for a resourceMetadataUrl-only challenge (discovery now consumes the PRM pointer — SEP-2350 follow-up to #3427)", () => {
     expect(
       isActionableStepUpChallenge({
         resourceMetadataUrl: "https://rs.example/.well-known",
       }),
-    ).toBe(false);
+    ).toBe(true);
+  });
+
+  it("is NOT actionable for a whitespace-only resourceMetadataUrl", () => {
+    expect(isActionableStepUpChallenge({ resourceMetadataUrl: "   " })).toBe(
+      false,
+    );
   });
 
   it("is actionable when a requiredScope accompanies a resourceMetadataUrl", () => {

--- a/mcpjam-inspector/client/src/lib/apis/insufficient-scope.ts
+++ b/mcpjam-inspector/client/src/lib/apis/insufficient-scope.ts
@@ -46,19 +46,14 @@ export function parseInsufficientScopeChallenge(
 
 /**
  * Whether a parsed challenge can actually DRIVE a step-up re-authorization.
- * Requires a non-empty `requiredScope` — the scope to fold into the re-auth
- * union. A `resourceMetadataUrl` is deliberately NOT sufficient on its own:
- * the step-up orchestrator currently reads only `requiredScope` and never
- * fetches the protected-resource-metadata endpoint, so a metadata-only
- * challenge would redirect and burn the bounded one-attempt step-up budget
- * without adding any scope. An `errorDescription`-only challenge is likewise
- * display-only. Every surface gates the ACTION on this predicate while still
- * surfacing the underlying error text for the user/model.
- *
- * TODO(SEP-2350): broaden to also accept a `resourceMetadataUrl`-only challenge
- * once discovery consumes it (fetches the PRM endpoint to resolve the scopes) —
- * a deferred core follow-up. Until then, requiring `requiredScope` keeps the
- * bounded budget from being spent on a redirect that cannot widen scope.
+ * Actionable when it names a non-empty `requiredScope` (the scope to fold into
+ * the re-auth union) OR a non-empty `resourceMetadataUrl` — a protected-
+ * resource-metadata pointer the OAuth flow now consumes to discover the
+ * server's authoritative scopes/AS at a non-default location (SEP-2350
+ * follow-up to #3427). An `errorDescription`-only challenge stays display-only:
+ * there is nothing to re-authorize with, so redirecting for it would burn the
+ * bounded one-attempt budget. Every surface gates the ACTION on this predicate
+ * while still surfacing the underlying error text for the user/model.
  */
 export function isActionableStepUpChallenge(
   challenge: InsufficientScopeChallenge | undefined,
@@ -66,9 +61,12 @@ export function isActionableStepUpChallenge(
   // Trim before the non-empty check: a whitespace-only `requiredScope` (e.g.
   // `"   "`) is truthy but parses to zero scopes downstream (the orchestrator
   // splits on `[,\s]+` and drops empties), so treating it as actionable would
-  // burn the bounded step-up budget on a redirect that widens nothing. Such a
-  // value is display-only, like a `resourceMetadataUrl`/`errorDescription`.
-  return Boolean(challenge?.requiredScope?.trim());
+  // burn the bounded step-up budget on a redirect that widens nothing. The
+  // same trim guards a whitespace-only `resourceMetadataUrl`. Such values are
+  // display-only, like an `errorDescription`.
+  return Boolean(
+    challenge?.requiredScope?.trim() || challenge?.resourceMetadataUrl?.trim(),
+  );
 }
 
 /**

--- a/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
@@ -1589,6 +1589,14 @@ export interface MCPOAuthOptions {
   serverUrl: string;
   scopes?: string[];
   customHeaders?: Record<string, string>;
+  /**
+   * SEP-2350 step-up: an explicit protected-resource-metadata URL (validated
+   * same-origin by the caller) to discover from, sourced from a `403
+   * insufficient_scope` challenge's `resource_metadata` hint. Threaded into the
+   * OAuth state machine so PRM discovery honors a non-default metadata location
+   * on re-authorization. `undefined` keeps today's derive-from-server-URL flow.
+   */
+  resourceMetadataUrl?: string;
   resourceUrl?: string;
   clientId?: string;
   clientSecret?: string;
@@ -2862,6 +2870,10 @@ export async function initiateOAuth(
       clientIdMetadataUrl: DEFAULT_MCPJAM_CLIENT_ID_METADATA_URL,
       customScopes: requestedScope,
       customHeaders: options.customHeaders,
+      // SEP-2350 step-up: honor a caller-supplied (same-origin validated)
+      // protected-resource-metadata URL from the challenge instead of deriving
+      // it from the server URL. `undefined` keeps today's discovery behavior.
+      resourceMetadataUrl: options.resourceMetadataUrl,
       authMode: "interactive",
       onTraceUpdate: ({ trace: snapshot }) => {
         emitTraceSnapshot(snapshot);

--- a/mcpjam-inspector/client/src/state/__tests__/oauth-orchestrator.step-up.test.ts
+++ b/mcpjam-inspector/client/src/state/__tests__/oauth-orchestrator.step-up.test.ts
@@ -365,4 +365,64 @@ describe("resolveInsufficientScopeStepUp (SEP-2350)", () => {
         .action,
     ).toBe("reauthorize");
   });
+
+  it("applyToolCallStepUp forwards a SAME-ORIGIN resourceMetadataUrl into the fresh OAuth flow", async () => {
+    readStoredOAuthConfigMock.mockReturnValue({ scopes: ["read"] });
+    initiateOAuthMock.mockResolvedValue({ success: true });
+
+    // Same origin as the server URL (https://mcp.asana.com/sse) — RFC 9728.
+    const resourceMetadataUrl =
+      "https://mcp.asana.com/.well-known/oauth-protected-resource/tenant-a/sse";
+
+    const outcome = await applyToolCallStepUp(createServer(), {
+      requiredScope: "admin",
+      resourceMetadataUrl,
+    });
+
+    expect(outcome.action).toBe("reauthorize");
+    // The challenge's metadata URL is threaded down to PRM discovery.
+    expect(initiateOAuthMock).toHaveBeenCalledWith(
+      expect.objectContaining({ resourceMetadataUrl }),
+    );
+  });
+
+  it("applyToolCallStepUp DROPS a cross-origin resourceMetadataUrl (falls back to derived discovery)", async () => {
+    readStoredOAuthConfigMock.mockReturnValue({ scopes: ["read"] });
+    initiateOAuthMock.mockResolvedValue({ success: true });
+
+    // Attacker-supplied hint on a DIFFERENT origin than the server URL.
+    const outcome = await applyToolCallStepUp(createServer(), {
+      requiredScope: "admin",
+      resourceMetadataUrl:
+        "https://evil.example/.well-known/oauth-protected-resource",
+    });
+
+    expect(outcome.action).toBe("reauthorize");
+    // The cross-origin hint is not threaded — discovery derives the URL itself.
+    expect(initiateOAuthMock).toHaveBeenCalledWith(
+      expect.objectContaining({ resourceMetadataUrl: undefined }),
+    );
+  });
+
+  it("applyToolCallStepUp threads a resourceMetadataUrl-only challenge (no requiredScope) once the gate broadens", async () => {
+    // The server previously requested read+write; a metadata-only challenge
+    // still re-authorizes with those scopes and carries the metadata URL down.
+    persistRequestedScopes("asana", ISSUER, ["read", "write"]);
+    initiateOAuthMock.mockResolvedValue({ success: true });
+
+    const resourceMetadataUrl =
+      "https://mcp.asana.com/.well-known/oauth-protected-resource/tenant-b/sse";
+
+    const outcome = await applyToolCallStepUp(createServer(), {
+      resourceMetadataUrl,
+    });
+
+    expect(outcome.action).toBe("reauthorize");
+    expect(initiateOAuthMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scopes: ["read", "write"],
+        resourceMetadataUrl,
+      }),
+    );
+  });
 });

--- a/mcpjam-inspector/client/src/state/__tests__/oauth-orchestrator.step-up.test.ts
+++ b/mcpjam-inspector/client/src/state/__tests__/oauth-orchestrator.step-up.test.ts
@@ -386,19 +386,40 @@ describe("resolveInsufficientScopeStepUp (SEP-2350)", () => {
     );
   });
 
-  it("applyToolCallStepUp DROPS a cross-origin resourceMetadataUrl (falls back to derived discovery)", async () => {
+  it("applyToolCallStepUp THREADS a valid cross-origin https resourceMetadataUrl (RFC 9728 allows a separate metadata origin)", async () => {
     readStoredOAuthConfigMock.mockReturnValue({ scopes: ["read"] });
     initiateOAuthMock.mockResolvedValue({ success: true });
 
-    // Attacker-supplied hint on a DIFFERENT origin than the server URL.
+    // A legitimate deployment can advertise PRM on a dedicated metadata origin,
+    // DIFFERENT from the server URL. It must be threaded — the SDK's outbound
+    // guard + cross-origin header stripping enforce fetch safety downstream.
+    const resourceMetadataUrl =
+      "https://metadata.asana.com/.well-known/oauth-protected-resource/sse";
+
     const outcome = await applyToolCallStepUp(createServer(), {
       requiredScope: "admin",
-      resourceMetadataUrl:
-        "https://evil.example/.well-known/oauth-protected-resource",
+      resourceMetadataUrl,
     });
 
     expect(outcome.action).toBe("reauthorize");
-    // The cross-origin hint is not threaded — discovery derives the URL itself.
+    expect(initiateOAuthMock).toHaveBeenCalledWith(
+      expect.objectContaining({ resourceMetadataUrl }),
+    );
+  });
+
+  it("applyToolCallStepUp DROPS a non-https resourceMetadataUrl (falls back to derived discovery)", async () => {
+    readStoredOAuthConfigMock.mockReturnValue({ scopes: ["read"] });
+    initiateOAuthMock.mockResolvedValue({ success: true });
+
+    // RFC 9728 mandates https; a non-https (or malformed/relative) hint is not
+    // threaded — discovery derives the URL itself.
+    const outcome = await applyToolCallStepUp(createServer(), {
+      requiredScope: "admin",
+      resourceMetadataUrl:
+        "http://evil.example/.well-known/oauth-protected-resource",
+    });
+
+    expect(outcome.action).toBe("reauthorize");
     expect(initiateOAuthMock).toHaveBeenCalledWith(
       expect.objectContaining({ resourceMetadataUrl: undefined }),
     );

--- a/mcpjam-inspector/client/src/state/oauth-orchestrator.ts
+++ b/mcpjam-inspector/client/src/state/oauth-orchestrator.ts
@@ -543,28 +543,30 @@ function readServerUrlForStepUp(server: ServerWithName): string | undefined {
 
 /**
  * Validate an UNTRUSTED `resource_metadata` hint (from a `403 insufficient_scope`
- * `WWW-Authenticate` header) before threading it into the OAuth flow. Per RFC
- * 9728 the protected-resource-metadata URL lives at the resource server's own
- * well-known path, so it MUST be same-origin with the server URL. Returns the
- * trimmed hint only when both parse and share an origin; otherwise `undefined`,
- * so a malformed or cross-origin hint falls back to derived discovery rather
- * than steering the client to fetch an attacker-chosen endpoint. (The SDK's
- * discovery additionally enforces the outbound-host allowlist and strips
- * MCP-server auth headers on any cross-origin hop — this is defense in depth
- * for the value we choose to thread.)
+ * `WWW-Authenticate` header) before threading it into the OAuth flow. RFC 9728
+ * permits the protected-resource-metadata document to live on a DIFFERENT origin
+ * than the resource server (e.g. a dedicated metadata host), so this does NOT
+ * require same-origin — dropping a valid cross-origin pointer would force the
+ * flow back to the wrong derived well-known URL, the exact regression this path
+ * fixes. It only requires an absolute `https:` URL (RFC 9728 mandates https).
+ * Returns the trimmed hint when it parses as absolute https; otherwise
+ * `undefined`, so a malformed/relative/non-https hint falls back to derived
+ * discovery. Fetch safety of a cross-origin hint is enforced downstream by the
+ * SDK: the factory's outbound-host allowlist (`assertOutboundOAuthUrlAllowed`
+ * blocks private/reserved hosts → SSRF) and cross-origin MCP-Authorization
+ * header stripping (`mergeHeadersForResourceMetadataRequest`).
  */
-function sameOriginResourceMetadataUrl(
-  serverUrl: string | undefined,
+function validResourceMetadataUrlHint(
   resourceMetadataUrl: string | undefined,
 ): string | undefined {
   const hint = resourceMetadataUrl?.trim();
-  if (!hint || !serverUrl) return undefined;
+  if (!hint) return undefined;
   try {
-    if (new URL(hint).origin === new URL(serverUrl).origin) {
+    if (new URL(hint).protocol === "https:") {
       return hint;
     }
   } catch {
-    // Unparseable server URL or hint — treat as no usable override.
+    // Unparseable / relative hint — treat as no usable override.
   }
   return undefined;
 }
@@ -620,11 +622,11 @@ export async function applyToolCallStepUp(
   const serverUrl = readServerUrlForStepUp(server);
   const issuer = resolveStoredIssuer(server.name, serverUrl);
   const challengedScopes = parseOAuthScopes(challenge.requiredScope);
-  // The challenge's `resource_metadata` hint is untrusted: only use it when it
-  // is same-origin with the server URL (RFC 9728), else fall back to derived
-  // discovery. See {@link sameOriginResourceMetadataUrl}.
-  const resourceMetadataUrl = sameOriginResourceMetadataUrl(
-    serverUrl,
+  // The challenge's `resource_metadata` hint is untrusted: thread it only when
+  // it parses as an absolute https URL (RFC 9728). A valid cross-origin pointer
+  // is honored — the SDK's outbound-host guard + cross-origin header stripping
+  // enforce fetch safety. See {@link validResourceMetadataUrlHint}.
+  const resourceMetadataUrl = validResourceMetadataUrlHint(
     challenge.resourceMetadataUrl,
   );
 

--- a/mcpjam-inspector/client/src/state/oauth-orchestrator.ts
+++ b/mcpjam-inspector/client/src/state/oauth-orchestrator.ts
@@ -147,6 +147,14 @@ function buildReconnectOAuthOptions(
    * loop. Only used when a caller drives a scope step-up.
    */
   stepUpScopes?: string[],
+  /**
+   * SEP-2350 step-up: the `resource_metadata` URL a `403 insufficient_scope`
+   * challenge advertised, ALREADY validated same-origin by the caller. When
+   * present the fresh OAuth flow discovers protected-resource metadata from
+   * this URL instead of re-deriving it from the server URL — so a server that
+   * points its metadata elsewhere (Asana) is honored on re-authorization.
+   */
+  resourceMetadataUrl?: string,
 ): MCPOAuthOptions {
   const oauthConfig = readStoredOAuthConfig(server.name);
   const storedClientInfo = readStoredClientInfo(server.name);
@@ -173,6 +181,9 @@ function buildReconnectOAuthOptions(
     serverName: server.name,
     serverUrl,
     scopes: effectiveScopes,
+    // Preserve `undefined` as the default so a non-step-up reconnect never
+    // pins an override and discovery keeps deriving the URL as it does today.
+    resourceMetadataUrl: nonEmptyString(resourceMetadataUrl),
     resourceUrl: nonEmptyString(profile?.resourceUrl) ?? oauthConfig.resourceUrl,
     customHeaders:
       profileHeadersToRecord(profile?.customHeaders) ??
@@ -220,6 +231,13 @@ export async function ensureAuthorizedForReconnect(
      * ({@link resolveInsufficientScopeStepUp}).
      */
     stepUpScopes?: string[];
+    /**
+     * SEP-2350 step-up: the `resource_metadata` URL the challenge advertised,
+     * ALREADY validated same-origin by the caller ({@link applyToolCallStepUp}).
+     * Threaded into the fresh OAuth flow so PRM discovery uses it instead of
+     * re-deriving from the server URL. `undefined` keeps today's behavior.
+     */
+    resourceMetadataUrl?: string;
   },
 ): Promise<OAuthResult> {
   // If server is explicitly configured without OAuth, skip OAuth flow entirely
@@ -268,7 +286,12 @@ export async function ensureAuthorizedForReconnect(
   // Fallback to a fresh OAuth flow if URL is present
   // This may redirect away; the hook should reflect oauth-flow state
   if (url) {
-    const opts = buildReconnectOAuthOptions(server, url, options?.stepUpScopes);
+    const opts = buildReconnectOAuthOptions(
+      server,
+      url,
+      options?.stepUpScopes,
+      options?.resourceMetadataUrl,
+    );
     clearOAuthData(server.name);
     options?.beforeRedirect?.(opts);
     opts.onTraceUpdate = options?.onTraceUpdate;
@@ -518,6 +541,34 @@ function readServerUrlForStepUp(server: ServerWithName): string | undefined {
   }
 }
 
+/**
+ * Validate an UNTRUSTED `resource_metadata` hint (from a `403 insufficient_scope`
+ * `WWW-Authenticate` header) before threading it into the OAuth flow. Per RFC
+ * 9728 the protected-resource-metadata URL lives at the resource server's own
+ * well-known path, so it MUST be same-origin with the server URL. Returns the
+ * trimmed hint only when both parse and share an origin; otherwise `undefined`,
+ * so a malformed or cross-origin hint falls back to derived discovery rather
+ * than steering the client to fetch an attacker-chosen endpoint. (The SDK's
+ * discovery additionally enforces the outbound-host allowlist and strips
+ * MCP-server auth headers on any cross-origin hop — this is defense in depth
+ * for the value we choose to thread.)
+ */
+function sameOriginResourceMetadataUrl(
+  serverUrl: string | undefined,
+  resourceMetadataUrl: string | undefined,
+): string | undefined {
+  const hint = resourceMetadataUrl?.trim();
+  if (!hint || !serverUrl) return undefined;
+  try {
+    if (new URL(hint).origin === new URL(serverUrl).origin) {
+      return hint;
+    }
+  } catch {
+    // Unparseable server URL or hint — treat as no usable override.
+  }
+  return undefined;
+}
+
 function readOriginalOAuthScopes(
   server: ServerWithName,
 ): string[] | undefined {
@@ -566,8 +617,16 @@ export async function applyToolCallStepUp(
     beforeRedirect?: (oauthOptions: MCPOAuthOptions) => void;
   },
 ): Promise<ToolCallStepUpOutcome> {
-  const issuer = resolveStoredIssuer(server.name, readServerUrlForStepUp(server));
+  const serverUrl = readServerUrlForStepUp(server);
+  const issuer = resolveStoredIssuer(server.name, serverUrl);
   const challengedScopes = parseOAuthScopes(challenge.requiredScope);
+  // The challenge's `resource_metadata` hint is untrusted: only use it when it
+  // is same-origin with the server URL (RFC 9728), else fall back to derived
+  // discovery. See {@link sameOriginResourceMetadataUrl}.
+  const resourceMetadataUrl = sameOriginResourceMetadataUrl(
+    serverUrl,
+    challenge.resourceMetadataUrl,
+  );
 
   const decision = resolveInsufficientScopeStepUp({
     serverName: server.name,
@@ -593,6 +652,7 @@ export async function applyToolCallStepUp(
     // ready-unauthenticated instead of redirecting for the widened scopes.
     interactiveOAuthConfirmed: true,
     stepUpScopes: decision.scopes,
+    resourceMetadataUrl,
     onTraceUpdate: options?.onTraceUpdate,
     beforeRedirect: options?.beforeRedirect,
   });

--- a/mcpjam-inspector/server/utils/web-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/web-chat-turn.ts
@@ -419,14 +419,19 @@ export async function streamWebChatTurn(
               const insufficientScope =
                 extractInsufficientScopeChallenge(error);
               // Only emit a step-up notice the client can ACT on: a
-              // `requiredScope` (the scope to fold into the re-auth union). A
-              // `resourceMetadataUrl`-only or errorDescription-only challenge
-              // carries nothing the orchestrator can widen today — redirecting
-              // for it would burn the bounded one-attempt budget — so it stays
-              // plain error text the model already sees, consistent with the
-              // shared `isActionableStepUpChallenge` gate. (Broaden to accept a
-              // metadata-only challenge once discovery consumes it — SEP-2350.)
-              if (insufficientScope && insufficientScope.requiredScope) {
+              // `requiredScope` (the scope to fold into the re-auth union) OR a
+              // `resourceMetadataUrl` (a PRM pointer the client's OAuth flow now
+              // discovers from — SEP-2350 follow-up to #3427). An
+              // `errorDescription`-only challenge carries nothing to
+              // re-authorize with — redirecting for it would burn the bounded
+              // one-attempt budget — so it stays plain error text the model
+              // already sees, consistent with the shared
+              // `isActionableStepUpChallenge` gate.
+              if (
+                insufficientScope &&
+                (insufficientScope.requiredScope ||
+                  insufficientScope.resourceMetadataUrl)
+              ) {
                 const challenge = {
                   serverId,
                   toolCallId: options?.toolCallId,

--- a/sdk/src/oauth/state-machines/debug-oauth-2025-06-18.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-06-18.ts
@@ -425,6 +425,7 @@ export const createDebugOAuthStateMachine = (
     dynamicRegistration,
     customScopes,
     customHeaders,
+    resourceMetadataUrl: overrideResourceMetadataUrl,
     authMode,
     hasClientSecret = false,
     strictConformance = false,
@@ -700,8 +701,13 @@ export const createDebugOAuthStateMachine = (
             const challengeParams = parseBearerAuthenticateParameters(
               state.wwwAuthenticateHeader,
             );
+            // SEP-2350: a caller-supplied PRM URL (the step-up challenge's
+            // `resource_metadata` hint) wins over the value re-derived from the
+            // fresh `WWW-Authenticate` header, so a server that points its
+            // metadata elsewhere is honored on re-authorization. Absent an
+            // override this is exactly today's behavior.
             let extractedResourceMetadataUrl =
-              challengeParams.resource_metadata;
+              overrideResourceMetadataUrl || challengeParams.resource_metadata;
 
             // Fallback to building the URL if not found in header
             if (!extractedResourceMetadataUrl && state.serverUrl) {
@@ -853,8 +859,14 @@ export const createDebugOAuthStateMachine = (
             };
 
             try {
+              // Pass an explicit metadata URL to discovery ONLY when it was
+              // header/override-sourced (not derived from the server URL): a
+              // fresh `WWW-Authenticate` header, or a SEP-2350 caller override.
+              // A derived URL is left undefined so discovery keeps its
+              // well-known + fallback behavior.
               const metadataOptions =
-                state.wwwAuthenticateHeader && state.resourceMetadataUrl
+                (state.wwwAuthenticateHeader || overrideResourceMetadataUrl) &&
+                state.resourceMetadataUrl
                   ? { resourceMetadataUrl: state.resourceMetadataUrl }
                   : undefined;
 

--- a/sdk/src/oauth/state-machines/debug-oauth-2025-11-25.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-11-25.ts
@@ -534,6 +534,7 @@ export const createDebugOAuthStateMachine = (
     clientIdMetadataUrl,
     customScopes,
     customHeaders,
+    resourceMetadataUrl: overrideResourceMetadataUrl,
     authMode,
     hasClientSecret = false,
     strictConformance = false,
@@ -817,8 +818,13 @@ export const createDebugOAuthStateMachine = (
             const challengeParams = parseBearerAuthenticateParameters(
               state.wwwAuthenticateHeader,
             );
+            // SEP-2350: a caller-supplied PRM URL (the step-up challenge's
+            // `resource_metadata` hint) wins over the value re-derived from the
+            // fresh `WWW-Authenticate` header, so a server that points its
+            // metadata elsewhere is honored on re-authorization. Absent an
+            // override this is exactly today's behavior.
             let extractedResourceMetadataUrl =
-              challengeParams.resource_metadata;
+              overrideResourceMetadataUrl || challengeParams.resource_metadata;
 
             // Fallback to building the URL if not found in header
             if (!extractedResourceMetadataUrl && state.serverUrl) {
@@ -946,8 +952,14 @@ export const createDebugOAuthStateMachine = (
             };
 
             try {
+              // Pass an explicit metadata URL to discovery ONLY when it was
+              // header/override-sourced (not derived from the server URL): a
+              // fresh `WWW-Authenticate` header, or a SEP-2350 caller override.
+              // A derived URL is left undefined so discovery keeps its
+              // well-known + fallback behavior.
               const metadataOptions =
-                state.wwwAuthenticateHeader && state.resourceMetadataUrl
+                (state.wwwAuthenticateHeader || overrideResourceMetadataUrl) &&
+                state.resourceMetadataUrl
                   ? { resourceMetadataUrl: state.resourceMetadataUrl }
                   : undefined;
 

--- a/sdk/src/oauth/state-machines/debug-oauth-2026-07-28.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2026-07-28.ts
@@ -628,6 +628,7 @@ export const createDebugOAuthStateMachine = (
     clientIdMetadataUrl,
     customScopes,
     customHeaders,
+    resourceMetadataUrl: overrideResourceMetadataUrl,
     authMode,
     hasClientSecret = false,
     strictConformance = false,
@@ -919,8 +920,13 @@ export const createDebugOAuthStateMachine = (
             const challengeParams = parseBearerAuthenticateParameters(
               state.wwwAuthenticateHeader,
             );
+            // SEP-2350: a caller-supplied PRM URL (the step-up challenge's
+            // `resource_metadata` hint) wins over the value re-derived from the
+            // fresh `WWW-Authenticate` header, so a server that points its
+            // metadata elsewhere is honored on re-authorization. Absent an
+            // override this is exactly today's behavior.
             let extractedResourceMetadataUrl =
-              challengeParams.resource_metadata;
+              overrideResourceMetadataUrl || challengeParams.resource_metadata;
 
             // Fallback to building the URL if not found in header
             if (!extractedResourceMetadataUrl && state.serverUrl) {
@@ -1048,8 +1054,14 @@ export const createDebugOAuthStateMachine = (
             };
 
             try {
+              // Pass an explicit metadata URL to discovery ONLY when it was
+              // header/override-sourced (not derived from the server URL): a
+              // fresh `WWW-Authenticate` header, or a SEP-2350 caller override.
+              // A derived URL is left undefined so discovery keeps its
+              // well-known + fallback behavior.
               const metadataOptions =
-                state.wwwAuthenticateHeader && state.resourceMetadataUrl
+                (state.wwwAuthenticateHeader || overrideResourceMetadataUrl) &&
+                state.resourceMetadataUrl
                   ? { resourceMetadataUrl: state.resourceMetadataUrl }
                   : undefined;
 

--- a/sdk/src/oauth/state-machines/types.ts
+++ b/sdk/src/oauth/state-machines/types.ts
@@ -305,6 +305,22 @@ export interface BaseOAuthStateMachineConfig {
   clientIdMetadataUrl?: string;
   customScopes?: string;
   customHeaders?: Record<string, string>;
+  /**
+   * SEP-2350 step-up: an explicit protected-resource-metadata (PRM) URL to
+   * discover from, sourced from a `WWW-Authenticate` `resource_metadata` hint
+   * (e.g. the `403 insufficient_scope` challenge a runtime tool call surfaced).
+   * When set, PRM discovery uses it verbatim instead of deriving the URL from
+   * the server URL's well-known path — so a server that points its metadata
+   * elsewhere (Asana) is honored on re-authorization. `undefined` (the default)
+   * is today's behavior: derive from the fresh `WWW-Authenticate` header or the
+   * server URL. The 2025-03-26 machine has no PRM step and ignores this field.
+   *
+   * The caller is responsible for validating this untrusted hint (the client
+   * step-up path only threads a value on the SAME ORIGIN as the server URL);
+   * the shared executor additionally enforces the outbound-host allowlist and
+   * the discovery request strips MCP-server auth headers when it hops origin.
+   */
+  resourceMetadataUrl?: string;
   authMode?: OAuthAuthMode;
   strictConformance?: boolean;
   // What to do at PRM discovery when the advertised resource indicator is not

--- a/sdk/tests/oauth/discovery-challenge-conformance.test.ts
+++ b/sdk/tests/oauth/discovery-challenge-conformance.test.ts
@@ -126,4 +126,97 @@ describe("OAuth escalation conformance to the original WWW-Authenticate challeng
     const authUrl = new URL(state.authorizationUrl!);
     expect(authUrl.searchParams.get("scope")).toBe("files:read files:write");
   });
+
+  // SEP-2350 follow-up (deferred "Finding F" from #3427): when a runtime
+  // `403 insufficient_scope` challenge carried a `resource_metadata` hint, the
+  // step-up re-authorization threads it into the machine as
+  // `resourceMetadataUrl`. It MUST win over the value re-derived from the fresh
+  // re-probe's WWW-Authenticate header, so a server whose escalation metadata
+  // lives at a non-default URL (Asana) is honored instead of ignored.
+  it("prefers the SEP-2350 resourceMetadataUrl override over the fresh 401's resource_metadata hint (2025-11-25)", async () => {
+    const OVERRIDE_RESOURCE_METADATA_URL =
+      "https://mcp.example.com/.well-known/oauth-protected-resource/tenant-b/mcp";
+    const FRESH_401_RESOURCE_METADATA_URL =
+      "https://mcp.example.com/.well-known/oauth-protected-resource";
+
+    let state = {
+      ...EMPTY_OAUTH_FLOW_STATE,
+      currentStep: "request_without_token" as const,
+      serverUrl: SERVER_URL,
+      httpHistory: [
+        {
+          step: "request_without_token" as const,
+          timestamp: Date.now(),
+          request: {
+            method: "POST",
+            url: SERVER_URL,
+            headers: {},
+            body: { method: "initialize" },
+          },
+        },
+      ],
+      infoLogs: [],
+    };
+
+    const requestExecutor = jest.fn().mockImplementation((request: any) => {
+      // First hop: the unauthenticated re-probe returns a 401 whose
+      // WWW-Authenticate points at the DEFAULT (non-tenant) metadata URL.
+      if (request.url === SERVER_URL) {
+        return Promise.resolve({
+          ok: false,
+          status: 401,
+          statusText: "Unauthorized",
+          headers: {
+            "www-authenticate": `Bearer resource_metadata="${FRESH_401_RESOURCE_METADATA_URL}", scope="files:read"`,
+          },
+          body: null,
+        });
+      }
+      // Second hop: the PRM GET. Whatever URL it targets is echoed back so the
+      // assertion can prove which one the machine chose.
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/json" },
+        body: {
+          resource: SERVER_URL,
+          authorization_servers: ["https://auth.example.com"],
+          scopes_supported: ["files:read", "files:write"],
+        },
+      });
+    });
+
+    const machine = createOAuthStateMachine({
+      protocolVersion: "2025-11-25",
+      registrationStrategy: "dcr",
+      state,
+      getState: () => state,
+      updateState: (updates) => {
+        state = { ...state, ...updates };
+      },
+      serverUrl: SERVER_URL,
+      serverName: "Test Server",
+      redirectUrl: REDIRECT_URI,
+      requestExecutor,
+      // The step-up override (same origin as the server URL, per the client
+      // guard). It must beat the fresh header's default URL below.
+      resourceMetadataUrl: OVERRIDE_RESOURCE_METADATA_URL,
+      dynamicRegistration: {
+        client_name: "Test Client",
+      },
+    });
+
+    // request_without_token -> received_401_unauthorized
+    await machine.proceedToNextStep();
+    expect(state.currentStep).toBe("received_401_unauthorized");
+
+    // received_401_unauthorized -> request_resource_metadata (prepares the GET)
+    await machine.proceedToNextStep();
+
+    // The override was used, NOT the fresh 401's resource_metadata hint.
+    expect(state.resourceMetadataUrl).toBe(OVERRIDE_RESOURCE_METADATA_URL);
+    expect(state.resourceMetadataUrl).not.toBe(FRESH_401_RESOURCE_METADATA_URL);
+    expect(state.lastRequest?.url).toBe(OVERRIDE_RESOURCE_METADATA_URL);
+  });
 });


### PR DESCRIPTION
## What this does

Follow-up to #3427 (SEP-2350 OAuth scope step-up), landing the deliberately deferred "Finding F": the runtime scope step-up now **uses** the `resourceMetadataUrl` hint from a `403 insufficient_scope` `WWW-Authenticate` challenge when re-authorizing, instead of ignoring it and re-deriving protected-resource-metadata (PRM) from the server URL.

A server that advertises a **non-default** `resource_metadata` location (e.g. Asana's per-tenant PRM) is now honored on re-authorization instead of being discovered from the wrong (derived) well-known path.

## The exact hop that dropped the field

`ToolCallStepUpChallenge` already carried `resourceMetadataUrl`, and `driveScopeStepUp` already forwarded it into `applyToolCallStepUp`. But `applyToolCallStepUp` read only `challenge.requiredScope` and dropped `resourceMetadataUrl`, so `ensureAuthorizedForReconnect` → `buildReconnectOAuthOptions` → `initiateOAuth` → the SDK OAuth state machine never received it and derived the PRM URL from the server URL.

Threaded through, `undefined` preserved as the default at every hop (no behavior change when no hint is present):

```
challenge.resourceMetadataUrl
  → applyToolCallStepUp (same-origin validated)
  → ensureAuthorizedForReconnect (new option)
  → buildReconnectOAuthOptions (new param)
  → MCPOAuthOptions.resourceMetadataUrl (new field)
  → initiateOAuth → runOAuthStateMachine config.resourceMetadataUrl (new, version-agnostic)
  → the state machine's discoverOAuthProtectedResourceMetadata(serverUrl, { resourceMetadataUrl }) override
```

The SDK change reuses the existing discovery override (`discoverOAuthProtectedResourceMetadata`'s `resourceMetadataUrl` opt) — no discovery reimplemented. The optional config field was added to the shared `BaseOAuthStateMachineConfig` and consumed in the three PRM-capable forks (2025-06-18, 2025-11-25, 2026-07-28); 2025-03-26 has no PRM step and ignores it. When an override is present it wins over the value re-derived from the fresh re-probe's `WWW-Authenticate` header; when absent, every fork behaves exactly as before.

## Security / validation stance

`resourceMetadataUrl` is untrusted (attacker-controlled `WWW-Authenticate`). The SDK's `discoverOAuthProtectedResourceMetadata` does **not** validate the override origin, so the client adds a **same-origin guard** at the boundary (`applyToolCallStepUp`): the hint is threaded only when it parses and shares an origin with the server URL (RFC 9728 puts PRM at the resource server's own well-known path); a malformed or cross-origin hint is dropped and discovery falls back to the derived URL. This is defense in depth on top of the SDK executor's existing outbound-host allowlist (`assertOutboundOAuthUrlAllowed`, which already blocks private/reserved hosts) and the discovery request's cross-origin auth-header stripping.

## Actionable-gate broadening

#3427 narrowed `isActionableStepUpChallenge` to require `requiredScope` *because* `resourceMetadataUrl` was inert (with a TODO). Now that discovery consumes it, the gate is broadened back to also accept a `resourceMetadataUrl`-only challenge (still trimmed; an `errorDescription`-only challenge stays display-only). The TODO is removed and the inline mirrors updated consistently — the server emit guard (`web-chat-turn.ts`) and the chat consumer comment (`use-chat-session.ts`) — plus the affected tests.

## Tests

- SDK: new `discovery-challenge-conformance` case proving the override wins over the fresh 401's `resource_metadata` hint.
- Client: `applyToolCallStepUp` forwards a same-origin hint into the OAuth flow, **drops** a cross-origin hint (falls back to derived discovery), and handles a metadata-only challenge; `isActionableStepUpChallenge` metadata-only-now-actionable; `useToolExecution` metadata-only now drives step-up.

All SDK OAuth tests (378) and the affected client suites pass; SDK + client typechecks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth re-authorization and untrusted `WWW-Authenticate` hints, but hints are trimmed/https-validated and behavior is unchanged when no override is present; coverage added on orchestrator and SDK discovery paths.
> 
> **Overview**
> **SEP-2350 follow-up (#3427):** runtime `403 insufficient_scope` re-authorization now **uses** the challenge’s `resourceMetadataUrl` instead of always deriving protected-resource metadata (PRM) from the MCP server URL.
> 
> The client threads a validated `https:` `resource_metadata` hint from `applyToolCallStepUp` through reconnect OAuth options into `MCPOAuthOptions` / `initiateOAuth`. SDK OAuth state machines (2025-06-18, 2025-11-25, 2026-07-28) take an optional `resourceMetadataUrl` override that **wins** over the fresh `WWW-Authenticate` hint when discovery runs.
> 
> **Actionable step-up gate:** `isActionableStepUpChallenge` now treats a non-empty `resourceMetadataUrl` (trimmed) as actionable on its own, not only `requiredScope`; `errorDescription`-only stays display-only. Chat (`web-chat-turn`), tools (`useToolExecution`), and related comments/tests align with that.
> 
> **Safety:** malformed, relative, or non-`https` hints are dropped (derived discovery fallback); cross-origin `https` PRM URLs are allowed per RFC 9728, with fetch constraints deferred to the SDK.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf0b78caf7fbe0614f957dfda9e216337a8118c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honors `resourceMetadataUrl` from `403 insufficient_scope` challenges during OAuth scope step‑up, including cross‑origin `https` hints, so re‑authorization discovers PRM at non‑default locations. Also makes metadata‑only challenges actionable per SEP‑2350.

- **Bug Fixes**
  - Threaded `resourceMetadataUrl` from the tool-call challenge through `applyToolCallStepUp` → reconnect options → `MCPOAuthOptions` → SDK OAuth state machines (2025‑06‑18, 2025‑11‑25, 2026‑07‑28); 2025‑03‑26 unchanged.
  - State machines prefer the override over a fresh 401 and pass it to `discoverOAuthProtectedResourceMetadata` only when header/override‑sourced; otherwise derive from the server URL.
  - Broadened `isActionableStepUpChallenge` and server emit gate to accept `resourceMetadataUrl`‑only; chat and tool execution now drive step‑up on metadata‑only; whitespace‑only values are not actionable.
  - Tests cover override precedence, cross‑origin `https` acceptance and non‑`https` rejection, and metadata‑only flows; updated client and SDK suites.

- **Security**
  - Validate the hint as an absolute `https:` URL; malformed/relative/non‑`https` are ignored; cross‑origin is allowed.
  - Keeps existing protections: outbound-host allowlist and cross-origin auth-header stripping.
  - Preserves `undefined` defaults so non step-up reconnects behave as before.

<sup>Written for commit bf0b78caf7fbe0614f957dfda9e216337a8118c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

