### PR TITLE
feat(environments): resolve interactive turns from one environment spec (Phase 1, inspector)

### DIFF
--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -299,6 +299,21 @@ chatV2.post("/", async (c) => {
       surface: bodySurface,
       hostId: bodyHostId,
     } = body;
+    // Local execution cannot run a Project Environment, and must say so rather
+    // than quietly ignoring the target and running an ad-hoc turn. Resolving an
+    // environment needs a member-authorized Convex read plus the hosted
+    // authorization plane that primes the manager from the resolved server set;
+    // this route has neither. Fail clearly, at ingress, before anything else
+    // reads the body.
+    if ((body as { executionTarget?: unknown }).executionTarget !== undefined) {
+      return c.json(
+        {
+          error:
+            "Project Environments can't run on local /api/mcp execution — use the hosted chat route.",
+        },
+        400
+      );
+    }
     const isChatboxSession = Boolean(bodyChatboxId);
     const chatSessionSourceType: "chatbox" | "direct" = isChatboxSession
       ? "chatbox"

--- a/mcpjam-inspector/server/routes/web/__tests__/chat-v2.environment.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chat-v2.environment.test.ts
@@ -1,0 +1,440 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+
+// Covers the environment-target half of web/chat-v2 (Project Environments
+// Phase 1): ingress normalization of the execution target, and the rule that
+// once an environment resolves, EVERY downstream consumer uses the resolved
+// values — never the raw body `selectedServerIds`.
+
+const {
+  prepareChatV2Mock,
+  handleMCPJamFreeChatModelMock,
+  fetchHostRuntimeConfigMock,
+  fetchChatboxRuntimeConfigMock,
+  persistChatSessionToConvexMock,
+  disconnectAllServersMock,
+  convexQueryMock,
+} = vi.hoisted(() => ({
+  prepareChatV2Mock: vi.fn(),
+  handleMCPJamFreeChatModelMock: vi.fn(),
+  fetchHostRuntimeConfigMock: vi.fn(),
+  fetchChatboxRuntimeConfigMock: vi.fn(),
+  persistChatSessionToConvexMock: vi.fn(),
+  disconnectAllServersMock: vi.fn(),
+  convexQueryMock: vi.fn(),
+}));
+
+vi.mock("ai", async () => {
+  const actual = await vi.importActual<typeof import("ai")>("ai");
+  return { ...actual, convertToModelMessages: vi.fn((messages) => messages) };
+});
+
+vi.mock("convex/browser", () => ({
+  ConvexHttpClient: vi.fn().mockImplementation(() => ({
+    setAuth: vi.fn(),
+    query: convexQueryMock,
+  })),
+}));
+
+vi.mock("@mcpjam/sdk", async () => {
+  const actual = await vi.importActual<typeof import("@mcpjam/sdk")>(
+    "@mcpjam/sdk"
+  );
+  return {
+    ...actual,
+    isMCPAuthError: vi.fn().mockReturnValue(false),
+    MCPClientManager: vi.fn().mockImplementation(() => ({
+      disconnectAllServers: disconnectAllServersMock,
+      listTools: vi.fn().mockResolvedValue({ tools: [] }),
+      readResource: vi.fn().mockResolvedValue({ contents: [] }),
+    })),
+  };
+});
+
+vi.mock("../../../utils/chat-v2-orchestration.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../utils/chat-v2-orchestration.js")
+  >("../../../utils/chat-v2-orchestration.js");
+  return { ...actual, prepareChatV2: prepareChatV2Mock };
+});
+
+vi.mock("../../../utils/mcpjam-stream-handler.js", () => ({
+  handleMCPJamFreeChatModel: handleMCPJamFreeChatModelMock,
+  warnIfChatAbortSignalMissing: () => {},
+}));
+
+vi.mock("../../../utils/chat-ingestion.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../utils/chat-ingestion.js")
+  >("../../../utils/chat-ingestion.js");
+  return {
+    ...actual,
+    persistChatSessionToConvex: persistChatSessionToConvexMock,
+    pickEnrichmentHeaders: vi.fn(() => ({})),
+  };
+});
+
+vi.mock("../../../utils/host-runtime-config.js", () => ({
+  fetchHostRuntimeConfig: fetchHostRuntimeConfigMock,
+}));
+
+vi.mock("../../../utils/chatbox-runtime-config.js", () => ({
+  fetchChatboxRuntimeConfig: fetchChatboxRuntimeConfigMock,
+}));
+
+// The harness preflight checks server-level runtime prerequisites (broker
+// delivery kill switch, computers data plane) that a unit test process has
+// none of. Those gates are covered by harness-availability's own tests; here we
+// only care about which skill set reaches which engine.
+vi.mock("../../../utils/harness/harness-availability.js", () => ({
+  checkHarnessRuntimeAvailable: () => ({ ok: true }),
+}));
+
+vi.mock("../apps.js", () => ({ default: new Hono() }));
+
+import { createWebTestApp, postJson } from "./helpers/test-app.js";
+
+/** Two environment servers; the body will claim a DIFFERENT, single server. */
+const ENV_SPEC = {
+  specVersion: 1,
+  environmentRef: { environmentId: "env_1", name: "Staging", revision: 7 },
+  host: {
+    hostId: "host_env",
+    hostName: "Alpha",
+    hostConfigId: "hc_1",
+    runtimeConfig: {
+      hostId: "host_env",
+      hostConfigId: "hc_1",
+      modelId: "openai/gpt-5-mini",
+      systemPrompt: "environment prompt",
+      requireToolApproval: false,
+      hostStyle: "claude",
+    },
+  },
+  servers: {
+    selectedServerIds: ["env-server-1"],
+    pluginServerIds: ["env-server-2"],
+    baseEffectiveServerIds: ["env-server-1", "env-server-2"],
+    effectiveServerIds: ["env-server-1", "env-server-2"],
+    connectable: [
+      { serverId: "env-server-1", name: "linear", source: "host_or_group" },
+      { serverId: "env-server-2", name: "asana", source: "plugin" },
+    ],
+  },
+  skills: [
+    {
+      skillId: "sk_env",
+      name: "release-notes",
+      description: "Write release notes",
+      content: "env skill body",
+      aggregateHash: "agg_env",
+      channels: ["environment"],
+      files: [],
+    },
+  ],
+  pluginVersions: [
+    {
+      pluginId: "pl_1",
+      pluginVersionId: "pv_1",
+      name: "linear",
+      bundleHash: "abc",
+    },
+  ],
+};
+
+const BASE_BODY = {
+  projectId: "project-1",
+  // Deliberately WRONG/stale: an environment turn must ignore this entirely.
+  selectedServerIds: ["body-server-9"],
+  selectedServerNames: ["body-server"],
+  chatSessionId: "chat-session-1",
+  messages: [{ role: "user", content: "hi" }],
+  model: { id: "openai/gpt-5-mini", provider: "openai", name: "GPT-5 Mini" },
+};
+
+describe("web chat-v2 — environment execution target", () => {
+  const originalFetch = global.fetch;
+  const originalConvexHttpUrl = process.env.CONVEX_HTTP_URL;
+  const originalConvexUrl = process.env.CONVEX_URL;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CONVEX_HTTP_URL = "https://example.convex.site";
+    process.env.CONVEX_URL = "https://example.convex.cloud";
+
+    convexQueryMock.mockResolvedValue(ENV_SPEC);
+    prepareChatV2Mock.mockResolvedValue({
+      allTools: {},
+      enhancedSystemPrompt: "system",
+      resolvedTemperature: 0.7,
+    });
+    fetchHostRuntimeConfigMock.mockResolvedValue({ ok: true, config: {} });
+    fetchChatboxRuntimeConfigMock.mockResolvedValue({ ok: true, config: {} });
+    handleMCPJamFreeChatModelMock.mockImplementation(async (options: any) => {
+      await options.onConversationComplete?.(
+        [{ role: "user", content: "hi" }],
+        {
+          turnId: "t",
+          promptIndex: 0,
+          startedAt: 1,
+          endedAt: 2,
+          spans: [],
+          modelId: "test-model",
+        }
+      );
+      options.onStreamComplete?.();
+      return new Response("ok", { status: 200 });
+    });
+
+    global.fetch = vi.fn(async (input, init) => {
+      if (String(input).endsWith("/web/authorize-batch")) {
+        const payload = JSON.parse(String(init?.body ?? "{}"));
+        const serverIds: string[] = Array.isArray(payload?.serverIds)
+          ? payload.serverIds
+          : [];
+        return new Response(
+          JSON.stringify({
+            results: Object.fromEntries(
+              serverIds.map((serverId) => [
+                serverId,
+                {
+                  ok: true,
+                  role: "member",
+                  accessLevel: "shared_chat",
+                  permissions: { chatOnly: false },
+                  internalLogContext: {
+                    authType: "signedIn",
+                    userId: "u-alice",
+                    projectId: payload.projectId ?? null,
+                  },
+                  serverConfig: {
+                    transportType: "http",
+                    url: `https://${serverId}.example.com/mcp`,
+                    headers: {},
+                    useOAuth: false,
+                  },
+                },
+              ])
+            ),
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        );
+      }
+      throw new Error(`Unexpected fetch: ${String(input)}`);
+    }) as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    if (originalConvexHttpUrl === undefined) delete process.env.CONVEX_HTTP_URL;
+    else process.env.CONVEX_HTTP_URL = originalConvexHttpUrl;
+    if (originalConvexUrl === undefined) delete process.env.CONVEX_URL;
+    else process.env.CONVEX_URL = originalConvexUrl;
+  });
+
+  it("400s chatboxId + executionTarget instead of silently picking one", async () => {
+    const { app, token } = createWebTestApp();
+    const response = await postJson(
+      app,
+      "/api/web/chat-v2",
+      {
+        ...BASE_BODY,
+        chatboxId: "cbx_1",
+        accessVersion: 1,
+        executionTarget: { kind: "environment", environmentId: "env_1" },
+      },
+      token
+    );
+    expect(response.status).toBe(400);
+    expect(JSON.stringify(await response.json())).toMatch(
+      /cannot be combined/i
+    );
+    // Neither resolution path may have run.
+    expect(convexQueryMock).not.toHaveBeenCalled();
+    expect(fetchChatboxRuntimeConfigMock).not.toHaveBeenCalled();
+  });
+
+  it("400s legacy hostId + executionTarget", async () => {
+    const { app, token } = createWebTestApp();
+    const response = await postJson(
+      app,
+      "/api/web/chat-v2",
+      {
+        ...BASE_BODY,
+        hostId: "host_legacy",
+        executionTarget: { kind: "environment", environmentId: "env_1" },
+      },
+      token
+    );
+    expect(response.status).toBe(400);
+    expect(fetchHostRuntimeConfigMock).not.toHaveBeenCalled();
+  });
+
+  it("still honors a legacy hostId body (unchanged host-target path)", async () => {
+    const { app, token } = createWebTestApp();
+    const response = await postJson(
+      app,
+      "/api/web/chat-v2",
+      { ...BASE_BODY, hostId: "host_legacy" },
+      token
+    );
+    expect(response.status).toBe(200);
+    expect(fetchHostRuntimeConfigMock).toHaveBeenCalledWith(
+      expect.objectContaining({ hostId: "host_legacy" })
+    );
+    expect(convexQueryMock).not.toHaveBeenCalled();
+  });
+
+  it("uses the RESOLVED server set everywhere, never the body's", async () => {
+    const { app, token } = createWebTestApp();
+    const response = await postJson(
+      app,
+      "/api/web/chat-v2",
+      {
+        ...BASE_BODY,
+        executionTarget: { kind: "environment", environmentId: "env_1" },
+      },
+      token
+    );
+    expect(response.status).toBe(200);
+
+    // Manager authorization batch.
+    const authorizeCall = (global.fetch as any).mock.calls.find(
+      ([url]: [string]) => String(url).endsWith("/web/authorize-batch")
+    );
+    expect(JSON.parse(authorizeCall[1].body).serverIds).toEqual([
+      "env-server-1",
+      "env-server-2",
+    ]);
+
+    // prepareChatV2.
+    expect(prepareChatV2Mock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        selectedServers: ["env-server-1", "env-server-2"],
+      })
+    );
+
+    // Direct-chat persistence + resume config.
+    const persistArgs = persistChatSessionToConvexMock.mock.calls[0][0];
+    expect(persistArgs.hostConfig.selectedServerIds).toEqual([
+      "env-server-1",
+      "env-server-2",
+    ]);
+    expect(persistArgs.resumeConfig.selectedServers).toEqual([
+      "linear",
+      "asana",
+    ]);
+    expect(JSON.stringify(persistArgs)).not.toContain("body-server-9");
+  });
+
+  it("forwards the per-turn server override, keeping [] distinct from absent", async () => {
+    const { app, token } = createWebTestApp();
+    await postJson(
+      app,
+      "/api/web/chat-v2",
+      {
+        ...BASE_BODY,
+        executionTarget: { kind: "environment", environmentId: "env_1" },
+        environmentOverrides: { serverIds: [] },
+      },
+      token
+    );
+    expect(convexQueryMock).toHaveBeenCalledWith(
+      "projectEnvironments:resolveEnvironmentForRuntime",
+      {
+        projectId: "project-1",
+        environmentId: "env_1",
+        serverOverrideIds: [],
+      }
+    );
+  });
+
+  it("delivers ONLY the resolved skills to the emulated engine (no cloudSkills)", async () => {
+    const { app, token } = createWebTestApp();
+    await postJson(
+      app,
+      "/api/web/chat-v2",
+      {
+        ...BASE_BODY,
+        executionTarget: { kind: "environment", environmentId: "env_1" },
+      },
+      token
+    );
+    const args = prepareChatV2Mock.mock.calls.at(-1)![0];
+    // Project-wide cloud skills would double-deliver alongside the resolved set.
+    expect(args.cloudSkills).toBeUndefined();
+    expect(args.skillsSource).toEqual({
+      kind: "resolved",
+      skills: [
+        {
+          name: "release-notes",
+          description: "Write release notes",
+          content: "env skill body",
+          contentHash: "agg_env",
+          provenance: "authored",
+        },
+      ],
+    });
+  });
+
+  it("hands the resolved skills to the HARNESS engine instead when the host runs one", async () => {
+    convexQueryMock.mockResolvedValue({
+      ...ENV_SPEC,
+      host: {
+        ...ENV_SPEC.host,
+        runtimeConfig: {
+          ...ENV_SPEC.host.runtimeConfig,
+          harness: "claude-code",
+        },
+      },
+    });
+    const { app, token } = createWebTestApp();
+    await postJson(
+      app,
+      "/api/web/chat-v2",
+      {
+        ...BASE_BODY,
+        executionTarget: { kind: "environment", environmentId: "env_1" },
+      },
+      token
+    );
+    // Emulated skill tools must NOT be advertised on a harness turn.
+    const prepareArgs = prepareChatV2Mock.mock.calls.at(-1)![0];
+    expect(prepareArgs.skillsSource).toBeUndefined();
+    expect(prepareArgs.cloudSkills).toBeUndefined();
+
+    const handlerArgs = handleMCPJamFreeChatModelMock.mock.calls.at(-1)![0];
+    expect(handlerArgs.harness).toBe("claude-code");
+    expect(handlerArgs.runtimeSkillsOverride).toEqual([
+      {
+        skillId: "sk_env",
+        name: "release-notes",
+        description: "Write release notes",
+        content: "env skill body",
+        aggregateHash: "agg_env",
+      },
+    ]);
+  });
+
+  it("propagates a resolver ENV_* failure as a 409 rather than running the turn", async () => {
+    const { ConvexError } = await import("convex/values");
+    convexQueryMock.mockRejectedValue(
+      new ConvexError({
+        code: "ENV_HOST_MISSING",
+        message: "This environment's host no longer exists.",
+      })
+    );
+    const { app, token } = createWebTestApp();
+    const response = await postJson(
+      app,
+      "/api/web/chat-v2",
+      {
+        ...BASE_BODY,
+        executionTarget: { kind: "environment", environmentId: "env_1" },
+      },
+      token
+    );
+    expect(response.status).toBe(409);
+    expect(handleMCPJamFreeChatModelMock).not.toHaveBeenCalled();
+  });
+});

--- a/mcpjam-inspector/server/routes/web/__tests__/environments-preview.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/environments-preview.test.ts
@@ -1,0 +1,188 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Covers the browser-facing environment preview route
+// (server/routes/web/environments.ts). Convex is mocked at the
+// `convex/browser` boundary, so these tests prove what the route FORWARDS and,
+// more importantly, what it REFUSES to return.
+
+const { convexQueryMock } = vi.hoisted(() => ({
+  convexQueryMock: vi.fn(),
+}));
+
+vi.mock("convex/browser", () => ({
+  ConvexHttpClient: vi.fn().mockImplementation(() => ({
+    setAuth: vi.fn(),
+    query: convexQueryMock,
+  })),
+}));
+
+import { createWebTestApp } from "./helpers/test-app.js";
+
+const SPEC = {
+  specVersion: 1,
+  environmentRef: { environmentId: "env_1", name: "Staging", revision: 7 },
+  host: {
+    hostId: "host_1",
+    hostName: "Alpha",
+    hostConfigId: "hc_1",
+    runtimeConfig: {
+      modelId: "openai/gpt-5-mini",
+      systemPrompt: "internal system prompt",
+      hostStyle: "claude",
+      requireToolApproval: true,
+      builtInToolIds: ["web_search"],
+      computer: { kind: "personal", workdir: "/home/user/secret-workdir" },
+      mcpProfile: {
+        extensions: { "com.mcpjam/enterprise-managed-auth": { policy: "on" } },
+      },
+    },
+  },
+  servers: {
+    selectedServerIds: ["ps_1"],
+    pluginServerIds: [],
+    baseEffectiveServerIds: ["ps_1"],
+    effectiveServerIds: ["ps_1"],
+    connectable: [
+      { serverId: "ps_1", name: "linear", source: "host_or_group" },
+    ],
+  },
+  skills: [
+    {
+      skillId: "sk_1",
+      name: "pdf-processing",
+      description: "Fill PDFs",
+      content: "TOP SECRET SKILL BODY",
+      aggregateHash: "agg1",
+      channels: ["host"],
+      files: [
+        {
+          path: "scripts/fill.py",
+          size: 10,
+          url: "https://signed.example/blob?sig=leaked",
+        },
+      ],
+    },
+  ],
+  pluginVersions: [
+    {
+      pluginId: "pl_1",
+      pluginVersionId: "pv_1",
+      name: "linear",
+      bundleHash: "abc123",
+    },
+  ],
+};
+
+function get(path: string, token: string | null = "test-token-123") {
+  const { app } = createWebTestApp();
+  const headers: Record<string, string> = {};
+  if (token) headers.Authorization = `Bearer ${token}`;
+  return app.request(path, { method: "GET", headers });
+}
+
+describe("GET /api/web/environments/:id/preview", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CONVEX_URL = "https://example.convex.cloud";
+    convexQueryMock.mockResolvedValue(SPEC);
+  });
+
+  it("requires a projectId", async () => {
+    const response = await get("/api/web/environments/env_1/preview");
+    expect(response.status).toBe(400);
+  });
+
+  it("requires a bearer token (never anonymous)", async () => {
+    const response = await get(
+      "/api/web/environments/env_1/preview?projectId=p_1",
+      null
+    );
+    expect(response.status).toBe(401);
+  });
+
+  it("forwards the path/query ids to the runtime resolver, with no override", async () => {
+    const response = await get(
+      "/api/web/environments/env_1/preview?projectId=p_1"
+    );
+    expect(response.status).toBe(200);
+    expect(convexQueryMock).toHaveBeenCalledWith(
+      "projectEnvironments:resolveEnvironmentForRuntime",
+      { projectId: "p_1", environmentId: "env_1" }
+    );
+    // A preview describes the SAVED environment; a caller must not be able to
+    // reshape it into a configuration nobody stored.
+    expect(convexQueryMock.mock.calls[0][1]).not.toHaveProperty(
+      "serverOverrideIds"
+    );
+  });
+
+  it("NEVER returns skill content, file URLs, or raw host secrets", async () => {
+    const response = await get(
+      "/api/web/environments/env_1/preview?projectId=p_1"
+    );
+    const text = await response.text();
+    expect(text).not.toContain("TOP SECRET SKILL BODY");
+    expect(text).not.toContain("signed.example");
+    expect(text).not.toContain("scripts/fill.py");
+    expect(text).not.toContain("secret-workdir");
+    expect(text).not.toContain("enterprise-managed-auth");
+    expect(text).not.toContain("internal system prompt");
+
+    const body = JSON.parse(text);
+    expect(body.environment).toEqual({
+      environmentId: "env_1",
+      name: "Staging",
+      revision: 7,
+    });
+    expect(body.skills).toEqual([
+      {
+        skillId: "sk_1",
+        name: "pdf-processing",
+        description: "Fill PDFs",
+        channels: ["host"],
+        hasFiles: true,
+      },
+    ]);
+    expect(body.servers).toEqual([
+      { serverId: "ps_1", name: "linear", source: "host_or_group" },
+    ]);
+    expect(body.plugins).toEqual([
+      { pluginId: "pl_1", pluginVersionId: "pv_1", name: "linear" },
+    ]);
+    expect(body.capabilities).toMatchObject({
+      hasComputer: true,
+      serverCount: 1,
+      skillCount: 1,
+      pluginCount: 1,
+      skillDelivery: "emulated",
+    });
+  });
+
+  it("surfaces a structured ENV_* failure as a 409 with its code", async () => {
+    const { ConvexError } = await import("convex/values");
+    convexQueryMock.mockRejectedValue(
+      new ConvexError({
+        code: "ENV_PLUGIN_UNAVAILABLE",
+        message: "Plugin can no longer provide its server",
+      })
+    );
+    const response = await get(
+      "/api/web/environments/env_1/preview?projectId=p_1"
+    );
+    expect(response.status).toBe(409);
+    const body = await response.json();
+    expect(JSON.stringify(body)).toContain("ENV_PLUGIN_UNAVAILABLE");
+  });
+
+  it("fails closed on a spec missing a host invariant", async () => {
+    convexQueryMock.mockResolvedValue({
+      environmentRef: { environmentId: "env_1", name: "Staging", revision: 7 },
+      host: { hostId: "host_1" },
+      servers: { effectiveServerIds: [] },
+    });
+    const response = await get(
+      "/api/web/environments/env_1/preview?projectId=p_1"
+    );
+    expect(response.status).toBe(502);
+  });
+});

--- a/mcpjam-inspector/server/routes/web/__tests__/hosted-elicitation.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/hosted-elicitation.test.ts
@@ -116,7 +116,7 @@ describe("resolveElicitationGate", () => {
 
   it("enables a direct turn from the body when the client speaks v1", () => {
     const gate = resolveElicitationGate({
-      isChatboxSession: false,
+      hostAuthoritative: false,
       hostClientCapabilities: undefined,
       bodyClientCapabilities: ON,
       clientVersion: 1,
@@ -129,7 +129,25 @@ describe("resolveElicitationGate", () => {
     // THE security property: a share-link visitor controls the body. If the
     // published host has elicitation off, no body can switch it on.
     const gate = resolveElicitationGate({
-      isChatboxSession: true,
+      hostAuthoritative: true,
+      hostClientCapabilities: OFF,
+      bodyClientCapabilities: ON,
+      clientVersion: 1,
+    });
+    expect(gate.enabled).toBe(false);
+    expect(gate.effectiveClientCapabilities).toBe(OFF);
+  });
+
+  it("ignores the body for an ENVIRONMENT turn too", () => {
+    // An environment turn is host-authoritative for the same structural
+    // reason: the server decides what the environment resolves to, so the
+    // capability declaration must come from that resolution rather than the
+    // caller. Deliberately NOT symmetric with model / prompt / temperature /
+    // approval, which stay body-overridable on an environment turn as
+    // ephemeral Playground tweaks — a capability changes what goes on the
+    // initialize wire, which is not a per-turn preference.
+    const gate = resolveElicitationGate({
+      hostAuthoritative: true,
       hostClientCapabilities: OFF,
       bodyClientCapabilities: ON,
       clientVersion: 1,
@@ -140,7 +158,7 @@ describe("resolveElicitationGate", () => {
 
   it("honors a chatbox host that DOES declare elicitation", () => {
     const gate = resolveElicitationGate({
-      isChatboxSession: true,
+      hostAuthoritative: true,
       hostClientCapabilities: ON,
       bodyClientCapabilities: undefined,
       clientVersion: 1,
@@ -153,7 +171,7 @@ describe("resolveElicitationGate", () => {
     // Backend predating the runtime-config field → absent → off, never "trust
     // the body instead".
     const gate = resolveElicitationGate({
-      isChatboxSession: true,
+      hostAuthoritative: true,
       hostClientCapabilities: undefined,
       bodyClientCapabilities: ON,
       clientVersion: 1,
@@ -168,7 +186,7 @@ describe("resolveElicitationGate", () => {
       // Catalog hosts already declare elicitation; without the handshake an old
       // bundle would hang for a TTL on any server that elicits.
       const gate = resolveElicitationGate({
-        isChatboxSession: false,
+        hostAuthoritative: false,
         hostClientCapabilities: undefined,
         bodyClientCapabilities: ON,
         clientVersion: clientVersion as number | undefined,
@@ -183,7 +201,7 @@ describe("resolveElicitationGate", () => {
   it("stays off when the host does not declare it, even at v1", () => {
     expect(
       resolveElicitationGate({
-        isChatboxSession: false,
+        hostAuthoritative: false,
         hostClientCapabilities: undefined,
         bodyClientCapabilities: OFF,
         clientVersion: 1,

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -145,6 +145,19 @@ chatV2.post("/", async (c) => {
     // True when this turn flows through a chatbox surface. sourceType +
     // accessScope decisions hinge on this.
     const isChatboxSession = executionTarget.kind === "chatbox";
+    // True when the execution context was RESOLVED SERVER-SIDE, so its host
+    // config — not the request body — is authoritative for capability
+    // declarations. Chatbox (a share-link visitor controls the body) and
+    // Project Environment (the server decides what the environment resolves
+    // to) both qualify.
+    //
+    // Deliberately narrower than "the environment wins everything": model,
+    // prompt, temperature and approval stay body-overridable on an environment
+    // turn, because those are ephemeral Playground tweaks. A capability
+    // declaration is not a preference — it changes what the SDK advertises on
+    // the initialize wire — so it follows the resolved host either way.
+    const isHostAuthoritative =
+      isChatboxSession || executionTarget.kind === "environment";
 
     if (!Array.isArray(messages) || messages.length === 0) {
       throw new WebRouteError(
@@ -534,7 +547,7 @@ chatV2.post("/", async (c) => {
       effectiveClientCapabilities,
       enabled: elicitationEnabled,
     } = resolveElicitationGate({
-      isChatboxSession,
+      hostAuthoritative: isHostAuthoritative,
       hostClientCapabilities: hostRuntimeConfig?.clientCapabilities,
       bodyClientCapabilities: hostedBody.clientCapabilities,
       clientVersion: hostedBody.hostedElicitationVersion,

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -49,6 +49,17 @@ import {
 import { resolveXaaIssuer } from "../../services/xaa-mint.js";
 import { type ExecutionScope } from "../../utils/execution-scope.js";
 import { checkHarnessRuntimeAvailable } from "../../utils/harness/harness-availability.js";
+import { harnessSupportsSkills } from "../../utils/harness/registry.js";
+import { normalizeExecutionTarget } from "@/shared/execution-target";
+import { createConvexClient } from "../../services/evals/route-helpers.js";
+import {
+  resolveEnvironmentForRuntime,
+  runtimeServerIds,
+  runtimeServerNames,
+  runtimeServersAreOverridden,
+  runtimeSkills as environmentRuntimeSkills,
+  type ResolvedEnvironmentRuntime,
+} from "../../services/environments/runtime.js";
 import { resolveExecutionContext } from "../../utils/host-execution-context.js";
 import { resolveHostTools } from "../../utils/built-in-tools/registry.js";
 import { buildMcpjamPlatformClient } from "./mcpjam-platform-client.js";
@@ -90,6 +101,11 @@ chatV2.post("/", async (c) => {
       // opaque pointer the client may forward; `harness` itself is never trusted
       // from the body.
       hostId?: string;
+      // Phase 1.1 execution target. Normalized (together with the legacy
+      // `hostId` and the access-bearing `chatboxId`) into one closed internal
+      // union below; ambiguous combinations are rejected, never shadowed.
+      executionTarget?: unknown;
+      environmentOverrides?: unknown;
     };
 
     const {
@@ -106,9 +122,29 @@ chatV2.post("/", async (c) => {
       surface,
       hostId,
     } = body;
+    // ONE closed execution target, resolved at ingress. `chatboxId` + an
+    // explicit `executionTarget` (and `hostId` + `executionTarget`) are
+    // REJECTED rather than resolved by branch precedence — see
+    // `shared/execution-target.ts` for why silent shadowing is the failure mode
+    // this normalizer exists to prevent.
+    const normalizedTarget = normalizeExecutionTarget({
+      chatboxId,
+      executionTarget: body.executionTarget,
+      environmentOverrides: body.environmentOverrides,
+      hostId,
+      projectId: hostedBody.projectId,
+    });
+    if (!normalizedTarget.ok) {
+      throw new WebRouteError(
+        400,
+        ErrorCode.VALIDATION_ERROR,
+        normalizedTarget.error,
+      );
+    }
+    const executionTarget = normalizedTarget.target;
     // True when this turn flows through a chatbox surface. sourceType +
     // accessScope decisions hinge on this.
-    const isChatboxSession = Boolean(chatboxId);
+    const isChatboxSession = executionTarget.kind === "chatbox";
 
     if (!Array.isArray(messages) || messages.length === 0) {
       throw new WebRouteError(
@@ -140,7 +176,29 @@ chatV2.post("/", async (c) => {
     // `result.drift`. Pure refactor — `host-execution-context.test.ts`
     // locks the shape.
     let hostRuntimeConfig: Record<string, unknown> | null = null;
-    if (isChatboxSession && chatboxId) {
+    // Set for an environment target only. Once resolved it is the SINGLE
+    // source for this turn's host config, server set, and skills — nothing
+    // downstream may fall back to the body's `selectedServerIds`.
+    let environmentSpec: ResolvedEnvironmentRuntime | null = null;
+    if (executionTarget.kind === "environment") {
+      // One atomic member-read: host runtime config + closed server set +
+      // composed skill union + pinned plugin versions, at one revision. The
+      // browser never supplies any of it.
+      environmentSpec = await resolveEnvironmentForRuntime(
+        // `sk_…` API-key bearers can't query Convex directly; this resolves the
+        // delegated JWT (and passes JWTs through untouched), same as the eval
+        // launch path.
+        createConvexClient(await getConvexBearerForRequest(c)),
+        {
+          projectId: hostedBody.projectId,
+          environmentId: executionTarget.environmentId,
+          ...(executionTarget.overrides
+            ? { overrides: executionTarget.overrides }
+            : {}),
+        },
+      );
+      hostRuntimeConfig = environmentSpec.host.runtimeConfig;
+    } else if (isChatboxSession && chatboxId) {
       const runtime = await fetchChatboxRuntimeConfig({
         chatboxId,
         bearer: bearerToken,
@@ -173,7 +231,8 @@ chatV2.post("/", async (c) => {
           `Couldn't load this chatbox's settings, so the turn was stopped to avoid running with the wrong configuration. ${runtime.error}`
         );
       }
-    } else if (!isChatboxSession && hostId) {
+    } else if (executionTarget.kind === "host") {
+      const targetHostId = executionTarget.hostId;
       // Host-bound direct session (Playground). The host config — including the
       // server-authoritative `harness`/`computer` — is the source of truth for
       // execution shaping. Unlike the chatbox path, FAIL CLOSED here: if we
@@ -181,7 +240,7 @@ chatV2.post("/", async (c) => {
       // emulated engine, because the host may be a harness host and running
       // emulated would misrepresent it as the real Claude Code runtime.
       const runtime = await fetchHostRuntimeConfig({
-        hostId,
+        hostId: targetHostId,
         bearer: bearerToken,
         signal: c.req.raw.signal as AbortSignal | undefined,
       });
@@ -194,7 +253,7 @@ chatV2.post("/", async (c) => {
         logger.warn(
           "[chat-v2] host runtime-config fetch failed; failing closed",
           {
-            hostId,
+            hostId: targetHostId,
             status: runtime.status,
             error: runtime.error,
           },
@@ -206,6 +265,37 @@ chatV2.post("/", async (c) => {
         );
       }
     }
+
+    // ── The turn's effective server set ─────────────────────────────────────
+    // For an environment target this REPLACES the body's `selectedServerIds`
+    // everywhere below — manager authorization/connection, name mapping and
+    // elicitation, prepareChatV2, persistence/resume config, telemetry and the
+    // tool snapshot. Resolving an environment and then still handing the raw
+    // body list to the manager would connect a set the environment never
+    // authorized, which is precisely the hole the atomic resolution closes.
+    const effectiveServerIds = environmentSpec
+      ? runtimeServerIds(environmentSpec)
+      : selectedServerIds;
+    // Names stay index-aligned with the ids. An empty array (older backend
+    // without the name-carrying projection) makes `buildServerNamesById` return
+    // undefined, and the manager falls back to showing the id — the same
+    // degradation the legacy path already has when a client omits names.
+    const environmentServerNameList = environmentSpec
+      ? runtimeServerNames(environmentSpec)
+      : undefined;
+    const effectiveServerNames = environmentSpec
+      ? environmentServerNameList && environmentServerNameList.length > 0
+        ? environmentServerNameList
+        : undefined
+      : selectedServerNames;
+    // The environment's composed skill union, in the shape both engines
+    // consume. Presence — not length — is what makes it authoritative, so an
+    // environment that resolves zero skills delivers zero, and never falls back
+    // to the project-wide pool.
+    const environmentSkills = environmentSpec
+      ? environmentRuntimeSkills(environmentSpec)
+      : undefined;
+
     // Enterprise-managed authorization policy. Server-authoritative wherever
     // a backend host config exists (chatbox / host-bound turns above — the
     // same fail-closed fetch that owns harness/computer): a tampered body
@@ -338,9 +428,13 @@ chatV2.post("/", async (c) => {
         requireToolApproval,
         // Use the SERVER-resolved host server list, not the request body — a
         // stale/tampered request mustn't send an empty array to bypass the
-        // "no MCP servers" fail-closed gate.
-        hasSelectedMcpServers:
-          (resolvedExecution.selectedServerIds ?? selectedServerIds).length > 0,
+        // "no MCP servers" fail-closed gate. An environment target's resolved
+        // set outranks even the host config's own list: it IS the set we are
+        // about to connect.
+        hasSelectedMcpServers: environmentSpec
+          ? effectiveServerIds.length > 0
+          : (resolvedExecution.selectedServerIds ?? selectedServerIds).length >
+            0,
         modelEligible: isHostedCatalogModel(
           String(modelDefinition.id),
           modelDefinition.provider,
@@ -417,7 +511,12 @@ chatV2.post("/", async (c) => {
     // on such a host is rejected by the availability preflight above, so gate
     // on the actual engine (harness id + canonicalized model), not host config
     // alone.
-    const cloudSkillsEnabled = shouldEnableCloudSkillTools({
+    // An environment target NEVER also enables the project-wide cloud skill
+    // tools: its resolved union is authoritative and is delivered through
+    // `runtimeSkillsOverride`. Wiring both would double-deliver — an
+    // environment-scoped `loadSkill` alongside a project-wide one, with the
+    // model free to pull skills the environment deliberately excluded.
+    const cloudSkillsEnabled = !environmentSpec && shouldEnableCloudSkillTools({
       isGuest: Boolean(c.get("guestId")),
       harness: resolvedExecution.harness,
       modelId: String(modelDefinition.id),
@@ -450,7 +549,8 @@ chatV2.post("/", async (c) => {
           projectId: hostedBody.projectId,
           chatSessionId: hostedBody.chatSessionId,
           serverNamesById:
-            buildServerNamesById(selectedServerIds, selectedServerNames) ?? {},
+            buildServerNamesById(effectiveServerIds, effectiveServerNames) ??
+            {},
           abortSignal: c.req.raw.signal as AbortSignal | undefined,
         })
       : undefined;
@@ -467,7 +567,7 @@ chatV2.post("/", async (c) => {
       callerContextFromHono(c),
       bearerToken,
       hostedBody.projectId,
-      selectedServerIds,
+      effectiveServerIds,
       WEB_STREAM_TIMEOUT_MS,
       hostedBody.oauthTokens,
       // Chatbox: advertise the HOST's capabilities, not the body's, so the
@@ -478,7 +578,7 @@ chatV2.post("/", async (c) => {
         chatboxId,
         accessVersion,
         rpcLogger: rpcCollector.rpcLogger,
-        serverNames: selectedServerNames,
+        serverNames: effectiveServerNames,
         initializePins,
         mcpProtocolVersionsByServerId,
         xaaPolicy,
@@ -548,15 +648,48 @@ chatV2.post("/", async (c) => {
       // covered) and captureServerEvent drops it rather than mis-attribute;
       // the client `send_message` still fires, so the block-rate ratio stays
       // directionally correct.
+      // Environment-target telemetry rides the same event. Recorded here rather
+      // than at resolve time so it describes a turn that actually STARTED, and
+      // so `skill_delivery` can name the engine that will carry the skills:
+      // `harness_unsupported` is the honest answer for a skills-incapable
+      // adapter (Codex today) — the skills resolved, and nothing delivered them.
+      const skillDelivery = environmentSpec
+        ? resolvedExecution.harness
+          ? harnessSupportsSkills(resolvedExecution.harness)
+            ? "harness"
+            : "harness_unsupported"
+          : "emulated"
+        : undefined;
       captureServerEvent(c, "send_message_server", {
         origin,
         source_type: sourceType,
+        ...(environmentSpec
+          ? {
+              environment_id: environmentSpec.environmentRef.environmentId,
+              environment_name: environmentSpec.environmentRef.name,
+              environment_revision: environmentSpec.environmentRef.revision,
+              environment_host_id: environmentSpec.host.hostId,
+              environment_host_config_id:
+                environmentSpec.host.hostConfigId ?? null,
+              environment_overridden:
+                runtimeServersAreOverridden(environmentSpec),
+              environment_base_server_count:
+                environmentSpec.servers.baseEffectiveServerIds?.length ??
+                environmentSpec.servers.effectiveServerIds.length,
+              environment_effective_server_count: effectiveServerIds.length,
+              environment_skill_count: environmentSkills?.length ?? 0,
+              environment_skill_delivery: skillDelivery,
+              environment_plugin_version_ids: (
+                environmentSpec.pluginVersions ?? []
+              ).map((plugin) => plugin.pluginVersionId),
+            }
+          : {}),
       });
 
       return await streamWebChatTurn({
         manager,
         prepare: {
-          selectedServerIds,
+          selectedServerIds: effectiveServerIds,
           modelDefinition,
           systemPrompt,
           temperature,
@@ -591,6 +724,12 @@ chatV2.post("/", async (c) => {
                 },
               }
             : {}),
+          // Emulated-engine delivery of the environment's resolved skills.
+          // Mutually exclusive with `cloudSkills` above (gated on the same
+          // `environmentSpec`), and ignored by the helper on a harness turn.
+          ...(environmentSkills !== undefined
+            ? { runtimeSkillsOverride: environmentSkills }
+            : {}),
         },
         persist: {
           chatSessionId: body.chatSessionId,
@@ -607,6 +746,11 @@ chatV2.post("/", async (c) => {
           originalMessages: messages,
           ...(resolvedExecution.harness
             ? { harness: resolvedExecution.harness }
+            : {}),
+          // Harness-engine delivery of the environment's resolved skills.
+          // Presence (even empty) is what makes it authoritative downstream.
+          ...(environmentSkills !== undefined
+            ? { runtimeSkillsOverride: environmentSkills }
             : {}),
           ...(isDirectChat ? { directVisibility: body.directVisibility } : {}),
           // Closure receives `resolvedTemperature` from inside the helper,
@@ -629,11 +773,11 @@ chatV2.post("/", async (c) => {
                     resolvedExecution.modelVisibleMcpToolResults,
                   mcpToolResultImageRendering:
                     resolvedExecution.mcpToolResultImageRendering,
-                  selectedServerIds,
+                  selectedServerIds: effectiveServerIds,
                 })
             : null,
-          selectedServerNames,
-          selectedServerIds,
+          selectedServerNames: effectiveServerNames,
+          selectedServerIds: effectiveServerIds,
           systemPrompt,
           temperature,
           requireToolApproval,

--- a/mcpjam-inspector/server/routes/web/environments.ts
+++ b/mcpjam-inspector/server/routes/web/environments.ts
@@ -1,0 +1,64 @@
+/**
+ * Browser-facing Project Environment routes (Phase 1.3).
+ *
+ * ONE route today: a read-only PREVIEW of what an environment currently
+ * resolves to, so a surface can show "this is what would run" before anyone
+ * spends a turn on it.
+ *
+ * Two boundaries this file exists to hold:
+ *
+ *  1. The browser must never call `/api/v1` (the session-token allowlist only
+ *     admits `/api/v1/harness/`), so the preview lives on `/api/web/*` beside
+ *     every other browser-reachable launch surface.
+ *  2. The preview is a NARROW projection, not the runtime spec. Skill bodies,
+ *     signed supporting-file URLs, server secrets and raw computer/mcpProfile
+ *     configuration never cross this line — see `toEnvironmentPreview`, which
+ *     projects field by field precisely so that a field added to the runtime
+ *     spec cannot arrive here by accident.
+ *
+ * Authorization is the backend's: `resolveEnvironmentForRuntime` is a
+ * member-read. Client EXPOSURE is gated by the `project-environments-enabled`
+ * PostHog flag (`useProjectEnvironmentsEnabled`, fail-closed); the server
+ * accepts the contract unconditionally because the query is member-gated and a
+ * server-side flag would only add a second, drifting gate.
+ */
+import { Hono } from "hono";
+import { createConvexClient } from "../../services/evals/route-helpers.js";
+import {
+  resolveEnvironmentForRuntime,
+  toEnvironmentPreview,
+} from "../../services/environments/runtime.js";
+import { harnessSupportsSkills } from "../../utils/harness/registry.js";
+import { getConvexBearerForRequest } from "../../utils/v1-convex-token.js";
+import { handleRoute } from "./auth.js";
+import { ErrorCode, WebRouteError } from "./errors.js";
+
+const environments = new Hono();
+
+// GET /api/web/environments/:environmentId/preview?projectId=...
+//
+// Read-only. Never applies a per-turn server override: a preview describes the
+// environment itself, and letting a caller shape it would show a configuration
+// nobody saved.
+environments.get("/:environmentId/preview", async (c) =>
+  handleRoute(c, async () => {
+    const environmentId = c.req.param("environmentId");
+    const projectId = c.req.query("projectId");
+    if (!projectId) {
+      throw new WebRouteError(
+        400,
+        ErrorCode.VALIDATION_ERROR,
+        "projectId is required"
+      );
+    }
+    const spec = await resolveEnvironmentForRuntime(
+      // `sk_…` API-key bearers can't query Convex directly; this resolves the
+      // delegated JWT and passes real JWTs through untouched.
+      createConvexClient(await getConvexBearerForRequest(c)),
+      { projectId, environmentId }
+    );
+    return toEnvironmentPreview(spec, { harnessSupportsSkills });
+  })
+);
+
+export default environments;

--- a/mcpjam-inspector/server/routes/web/hosted-elicitation.ts
+++ b/mcpjam-inspector/server/routes/web/hosted-elicitation.ts
@@ -606,13 +606,21 @@ export function hostDeclaresElicitation(
  *
  * Two independent gates, both required:
  *
- * 1. **Capability, from the right authority.** For a chatbox turn the published
- *    host wins — a share-link visitor controls the request body, so reading
+ * 1. **Capability, from the right authority.** When the execution context is
+ *    server-resolved — a chatbox, or a Project Environment — the resolved host
+ *    wins. A share-link visitor controls the request body, so reading
  *    capabilities from it would let anyone switch elicitation on for a host
- *    whose owner has it off. (Same host-wins reasoning chat-v2 already applies
- *    to model/approval.) A backend predating `clientCapabilities` on
- *    runtime-config omits it → treated as absent → fail closed. For a direct
- *    turn the body IS the owner's own host config, sent by their own client.
+ *    whose owner has it off; and an environment's whole point is that the
+ *    server decides what it resolves to. A backend predating
+ *    `clientCapabilities` on runtime-config omits it → treated as absent →
+ *    fail closed. For a plain host-preview or ad-hoc turn the body IS the
+ *    owner's own host config, sent by their own client.
+ *
+ *    NOTE this is a CAPABILITY declaration, not a user preference. It is
+ *    deliberately host-authoritative for environments even though model /
+ *    prompt / temperature / approval stay body-overridable there (ephemeral
+ *    Playground tweaks) — advertising `elicitation` changes what the SDK puts
+ *    on the initialize wire, which is not a per-turn preference to tweak.
  *
  * 2. **Client handshake.** Catalog hosts (claude-code, cursor, vscode, …)
  *    ALREADY declare `elicitation`, so honoring it for every client would make
@@ -621,7 +629,11 @@ export function hostDeclaresElicitation(
  *    the callback; everyone else keeps today's fail-fast behavior.
  */
 export function resolveElicitationGate(args: {
-  isChatboxSession: boolean;
+  /**
+   * True when the execution context was resolved server-side (chatbox or
+   * Project Environment) and its host config is therefore authoritative.
+   */
+  hostAuthoritative: boolean;
   /** `clientCapabilities` from the chatbox/host runtime-config (authoritative). */
   hostClientCapabilities: unknown;
   /** `clientCapabilities` from the request body (owner-supplied on direct turns). */
@@ -633,7 +645,9 @@ export function resolveElicitationGate(args: {
   enabled: boolean;
 } {
   const effectiveClientCapabilities = (
-    args.isChatboxSession ? args.hostClientCapabilities : args.bodyClientCapabilities
+    args.hostAuthoritative
+      ? args.hostClientCapabilities
+      : args.bodyClientCapabilities
   ) as Record<string, unknown> | undefined;
 
   return {

--- a/mcpjam-inspector/server/routes/web/index.ts
+++ b/mcpjam-inspector/server/routes/web/index.ts
@@ -15,6 +15,7 @@ import swarmRuns from "./swarm-runs.js";
 import { harnessMcp } from "./harness-mcp.js";
 import apps from "./apps.js";
 import evals from "./evals.js";
+import environments from "./environments.js";
 import oauthWeb from "./oauth.js";
 import serverSecretsWeb from "./server-secrets.js";
 import exporter from "./export.js";
@@ -41,6 +42,10 @@ web.use("/chatboxes/*", bearerAuthMiddleware, guestRateLimitMiddleware);
 // API it fronts is LAUNCHER-gated + project-member-gated server-side.
 web.use("/swarm/*", bearerAuthMiddleware, guestRateLimitMiddleware);
 web.use("/evals/*", bearerAuthMiddleware, guestRateLimitMiddleware);
+// Project Environment reads — member-gated server-side by the Convex query the
+// route fronts; client exposure is gated by the `project-environments-enabled`
+// flag. Read-only and narrowly projected (never the full runtime spec).
+web.use("/environments/*", bearerAuthMiddleware, guestRateLimitMiddleware);
 web.use("/chat-v2", bearerAuthMiddleware, guestRateLimitMiddleware);
 web.use("/mcpjam-agent", bearerAuthMiddleware, guestRateLimitMiddleware);
 web.use(
@@ -73,6 +78,7 @@ web.route("/chatboxes", chatboxes);
 web.route("/chatboxes", chatboxSessions);
 web.route("/swarm", swarmRuns);
 web.route("/evals", evals);
+web.route("/environments", environments);
 web.route("/export", exporter);
 // Voice transcription handles user-bearer forwarding and guest fallback inside
 // the proxy route so local/npx users can spend MCPJam credits without BYOK.

--- a/mcpjam-inspector/server/services/environments/__tests__/runtime.test.ts
+++ b/mcpjam-inspector/server/services/environments/__tests__/runtime.test.ts
@@ -1,0 +1,374 @@
+import { describe, expect, it, vi } from "vitest";
+import { ConvexError } from "convex/values";
+import {
+  resolveEnvironmentForRuntime,
+  runtimeServerIds,
+  runtimeServerNames,
+  runtimeServersAreOverridden,
+  runtimeSkills,
+  toEnvironmentPreview,
+  translateEnvironmentRuntimeError,
+  type ResolvedEnvironmentRuntime,
+} from "../runtime";
+
+const SPEC: ResolvedEnvironmentRuntime = {
+  specVersion: 1,
+  environmentRef: { environmentId: "env_1", name: "Staging", revision: 7 },
+  host: {
+    hostId: "host_1",
+    hostName: "Alpha",
+    hostConfigId: "hc_1",
+    runtimeConfig: {
+      hostId: "host_1",
+      hostConfigId: "hc_1",
+      modelId: "openai/gpt-5-mini",
+      systemPrompt: "be nice",
+      temperature: 0.4,
+      requireToolApproval: true,
+      respectToolVisibility: false,
+      progressiveToolDiscovery: true,
+      hostStyle: "claude",
+      builtInToolIds: ["web_search"],
+      harness: "claude-code",
+      computer: { kind: "personal", workdir: "/home/user/work" },
+      mcpProfile: { extensions: { "com.mcpjam/enterprise-managed-auth": {} } },
+    },
+  },
+  servers: {
+    selectedServerIds: ["ps_1"],
+    pluginServerIds: ["ps_plugin"],
+    baseEffectiveServerIds: ["ps_1", "ps_plugin"],
+    effectiveServerIds: ["ps_1", "ps_plugin"],
+    connectable: [
+      { serverId: "ps_1", name: "linear", source: "host_or_group" },
+      { serverId: "ps_plugin", name: "asana", source: "plugin" },
+    ],
+  },
+  skills: [
+    {
+      skillId: "sk_1",
+      name: "pdf-processing",
+      description: "Fill PDFs",
+      content: "SECRET INSTRUCTIONS",
+      aggregateHash: "agg1",
+      channels: ["host", "environment"],
+      files: [
+        { path: "scripts/fill.py", size: 12, url: "https://signed.example/1" },
+      ],
+    },
+    {
+      skillId: "sk_2",
+      name: "release-notes",
+      description: "Write notes",
+      content: "MORE SECRET INSTRUCTIONS",
+      aggregateHash: "agg2",
+      channels: ["plugin"],
+      files: [],
+    },
+  ],
+  pluginVersions: [
+    {
+      pluginId: "pl_1",
+      pluginVersionId: "pv_1",
+      name: "linear",
+      bundleHash: "abc123",
+    },
+  ],
+};
+
+function fakeConvexClient(result: unknown, capture?: (args: unknown) => void) {
+  return {
+    query: async (_ref: unknown, args: unknown) => {
+      capture?.(args);
+      return result;
+    },
+  } as unknown as Parameters<typeof resolveEnvironmentForRuntime>[0];
+}
+
+describe("resolveEnvironmentForRuntime", () => {
+  it("returns the resolver's spec untouched", async () => {
+    const spec = await resolveEnvironmentForRuntime(fakeConvexClient(SPEC), {
+      projectId: "p_1",
+      environmentId: "env_1",
+    });
+    expect(spec).toEqual(SPEC);
+  });
+
+  it("keeps an ABSENT override distinct from an EMPTY one on the wire", async () => {
+    const calls: unknown[] = [];
+    const client = fakeConvexClient(SPEC, (args) => calls.push(args));
+
+    await resolveEnvironmentForRuntime(client, {
+      projectId: "p_1",
+      environmentId: "env_1",
+    });
+    expect(calls[0]).not.toHaveProperty("serverOverrideIds");
+
+    await resolveEnvironmentForRuntime(client, {
+      projectId: "p_1",
+      environmentId: "env_1",
+      overrides: { serverIds: [] },
+    });
+    expect(calls[1]).toMatchObject({ serverOverrideIds: [] });
+  });
+
+  it("TOLERATES a backend that omits additive fields", async () => {
+    // Older/newer deploy: no skills, no plugin versions, no connectable
+    // projection, no specVersion. None of those is an invariant.
+    const lean = {
+      environmentRef: { environmentId: "env_1", name: "Staging", revision: 2 },
+      host: { hostId: "host_1", runtimeConfig: { modelId: "m" } },
+      servers: { effectiveServerIds: ["ps_1"] },
+    };
+    const spec = await resolveEnvironmentForRuntime(fakeConvexClient(lean), {
+      projectId: "p_1",
+      environmentId: "env_1",
+    });
+    expect(runtimeServerIds(spec)).toEqual(["ps_1"]);
+    expect(runtimeServerNames(spec)).toEqual([]);
+    expect(runtimeSkills(spec)).toEqual([]);
+  });
+
+  it("FAILS CLOSED when an identity or host invariant is missing", async () => {
+    const cases: Array<[string, unknown]> = [
+      ["null", null],
+      ["no environmentRef", { host: {}, servers: {} }],
+      [
+        "no revision",
+        {
+          environmentRef: { environmentId: "env_1", name: "n" },
+          host: { hostId: "h", runtimeConfig: {} },
+          servers: { effectiveServerIds: [] },
+        },
+      ],
+      [
+        "no host runtimeConfig",
+        {
+          environmentRef: { environmentId: "env_1", name: "n", revision: 1 },
+          host: { hostId: "h" },
+          servers: { effectiveServerIds: [] },
+        },
+      ],
+      [
+        "no effective server set",
+        {
+          environmentRef: { environmentId: "env_1", name: "n", revision: 1 },
+          host: { hostId: "h", runtimeConfig: {} },
+          servers: {},
+        },
+      ],
+    ];
+    for (const [, bad] of cases) {
+      await expect(
+        resolveEnvironmentForRuntime(fakeConvexClient(bad), {
+          projectId: "p_1",
+          environmentId: "env_1",
+        })
+      ).rejects.toMatchObject({ status: 502 });
+    }
+  });
+
+  it("maps a missing backend function to a readable 400 (deploy-order skew)", async () => {
+    const client = {
+      query: async () => {
+        throw new Error(
+          "Could not find public function for 'projectEnvironments:resolveEnvironmentForRuntime'"
+        );
+      },
+    } as unknown as Parameters<typeof resolveEnvironmentForRuntime>[0];
+    await expect(
+      resolveEnvironmentForRuntime(client, {
+        projectId: "p_1",
+        environmentId: "env_1",
+      })
+    ).rejects.toMatchObject({ status: 400 });
+  });
+});
+
+describe("translateEnvironmentRuntimeError", () => {
+  it("passes the ENV_* family through as a 409 carrying the machine code", () => {
+    const err = translateEnvironmentRuntimeError(
+      new ConvexError({
+        code: "ENV_PLUGIN_UNAVAILABLE",
+        message: "Plugin can no longer provide its server",
+      })
+    );
+    expect(err.status).toBe(409);
+    expect(err.details).toMatchObject({ code: "ENV_PLUGIN_UNAVAILABLE" });
+    expect(err.message).toMatch(/no longer provide/);
+  });
+
+  it("404s the not-there codes so a non-member learns nothing", () => {
+    for (const code of ["ENV_NOT_FOUND", "ENV_CROSS_PROJECT", "FORBIDDEN"]) {
+      expect(
+        translateEnvironmentRuntimeError(new ConvexError({ code })).status
+      ).toBe(404);
+    }
+  });
+
+  it("maps VALIDATION to a 400", () => {
+    expect(
+      translateEnvironmentRuntimeError(
+        new ConvexError({ code: "VALIDATION", message: "bad server id" })
+      ).status
+    ).toBe(400);
+  });
+});
+
+describe("runtime projections", () => {
+  it("prefers the live-healed connectable ids/names", () => {
+    expect(runtimeServerIds(SPEC)).toEqual(["ps_1", "ps_plugin"]);
+    expect(runtimeServerNames(SPEC)).toEqual(["linear", "asana"]);
+  });
+
+  it("detects a per-turn override against the base set", () => {
+    expect(runtimeServersAreOverridden(SPEC)).toBe(false);
+    expect(
+      runtimeServersAreOverridden({
+        ...SPEC,
+        servers: { ...SPEC.servers, effectiveServerIds: ["ps_1"] },
+      })
+    ).toBe(true);
+    // An empty override is still an override.
+    expect(
+      runtimeServersAreOverridden({
+        ...SPEC,
+        servers: { ...SPEC.servers, effectiveServerIds: [] },
+      })
+    ).toBe(true);
+  });
+
+  it("projects skills into the runtime skill shape the engines consume", () => {
+    expect(runtimeSkills(SPEC)).toEqual([
+      {
+        skillId: "sk_1",
+        name: "pdf-processing",
+        description: "Fill PDFs",
+        content: "SECRET INSTRUCTIONS",
+        aggregateHash: "agg1",
+      },
+      {
+        skillId: "sk_2",
+        name: "release-notes",
+        description: "Write notes",
+        content: "MORE SECRET INSTRUCTIONS",
+        aggregateHash: "agg2",
+      },
+    ]);
+  });
+});
+
+describe("toEnvironmentPreview", () => {
+  const preview = toEnvironmentPreview(SPEC, {
+    harnessSupportsSkills: () => true,
+  });
+
+  it("STRIPS skill content and every supporting-file reference", () => {
+    const serialized = JSON.stringify(preview);
+    expect(serialized).not.toContain("SECRET INSTRUCTIONS");
+    expect(serialized).not.toContain("signed.example");
+    expect(serialized).not.toContain("scripts/fill.py");
+    expect(preview.skills[0]).toEqual({
+      skillId: "sk_1",
+      name: "pdf-processing",
+      description: "Fill PDFs",
+      channels: ["host", "environment"],
+      hasFiles: true,
+    });
+    expect(preview.skills[1].hasFiles).toBe(false);
+  });
+
+  it("STRIPS raw computer config, mcpProfile, and every unlisted runtimeConfig field", () => {
+    const serialized = JSON.stringify(preview);
+    expect(serialized).not.toContain("/home/user/work");
+    expect(serialized).not.toContain("enterprise-managed-auth");
+    expect(serialized).not.toContain("be nice"); // systemPrompt
+    expect(preview.capabilities.hasComputer).toBe(true);
+  });
+
+  it("cannot leak a NEW runtime-spec field (projection is explicit, never a spread)", () => {
+    // The regression this locks: someone adds a field to the runtime spec and
+    // the preview quietly starts serving it.
+    const leaky = toEnvironmentPreview(
+      {
+        ...SPEC,
+        host: {
+          ...SPEC.host,
+          runtimeConfig: {
+            ...SPEC.host.runtimeConfig,
+            brokerSecret: "sk_live_do_not_ship",
+          },
+        },
+        skills: [
+          {
+            ...SPEC.skills![0],
+            // A hypothetical future artifact field.
+            signedBundleUrl: "https://signed.example/bundle",
+          } as never,
+        ],
+      },
+      { harnessSupportsSkills: () => true }
+    );
+    const serialized = JSON.stringify(leaky);
+    expect(serialized).not.toContain("sk_live_do_not_ship");
+    expect(serialized).not.toContain("signed.example/bundle");
+  });
+
+  it("summarizes identity, servers, plugins and capabilities", () => {
+    expect(preview.environment).toEqual({
+      environmentId: "env_1",
+      name: "Staging",
+      revision: 7,
+    });
+    expect(preview.host).toEqual({
+      hostId: "host_1",
+      hostName: "Alpha",
+      hostConfigId: "hc_1",
+      modelId: "openai/gpt-5-mini",
+      hostStyle: "claude",
+      harness: "claude-code",
+    });
+    expect(preview.servers).toEqual([
+      { serverId: "ps_1", name: "linear", source: "host_or_group" },
+      { serverId: "ps_plugin", name: "asana", source: "plugin" },
+    ]);
+    expect(preview.plugins).toEqual([
+      { pluginId: "pl_1", pluginVersionId: "pv_1", name: "linear" },
+    ]);
+    expect(preview.capabilities).toMatchObject({
+      requireToolApproval: true,
+      respectToolVisibility: false,
+      progressiveToolDiscovery: true,
+      builtInToolIds: ["web_search"],
+      serverCount: 2,
+      skillCount: 2,
+      pluginCount: 1,
+      skillDelivery: "harness",
+      serversOverridden: false,
+    });
+  });
+
+  it("reports `unsupported` skill delivery for a skills-incapable harness", () => {
+    // Codex delivers no skills today. Saying "harness" here would claim a
+    // delivery that never happens.
+    const codex = toEnvironmentPreview(SPEC, {
+      harnessSupportsSkills: () => false,
+    });
+    expect(codex.capabilities.skillDelivery).toBe("unsupported");
+  });
+
+  it("reports `emulated` when the environment's host runs no harness", () => {
+    const emulated = toEnvironmentPreview(
+      {
+        ...SPEC,
+        host: {
+          ...SPEC.host,
+          runtimeConfig: { modelId: "openai/gpt-5-mini" },
+        },
+      },
+      { harnessSupportsSkills: vi.fn(() => true) }
+    );
+    expect(emulated.capabilities.skillDelivery).toBe("emulated");
+    expect(emulated.capabilities.hasComputer).toBe(false);
+  });
+});

--- a/mcpjam-inspector/server/services/environments/runtime.ts
+++ b/mcpjam-inspector/server/services/environments/runtime.ts
@@ -1,0 +1,472 @@
+/**
+ * Project-environment INTERACTIVE runtime resolution (Phase 1.3).
+ *
+ * The launch sibling is `./resolve.ts` (reproducibility: pin a revision, echo it
+ * back, drift-check at run start). This module is the live, per-turn contract:
+ * ONE atomic read of `projectEnvironments:resolveEnvironmentForRuntime` that
+ * yields everything a turn needs — the host's runtime config through the SAME
+ * projection a host-target turn uses, the closed (optionally overridden) server
+ * set, the composed three-channel skill union with supporting-file references
+ * resolved in the same read, and the pinned plugin versions.
+ *
+ * Two consumers, deliberately asymmetric:
+ *   1. `routes/web/chat-v2.ts` — the full spec, used to actually execute.
+ *   2. `routes/web/environments.ts` — a NARROW preview projection for the
+ *      browser ({@link toEnvironmentPreview}), which must never carry skill
+ *      bodies, signed file URLs, or raw computer/mcpProfile config.
+ *
+ * Contract discipline, mirroring `resolve.ts`:
+ *   - Hand-mirrored, string function ref, `ConvexHttpClient` — no codegen.
+ *   - DEPLOY-SKEW TOLERANT for additive fields: anything a newer backend adds
+ *     (or an older one omits) is optional here.
+ *   - FAIL CLOSED on identity/host invariants. A spec with no `environmentRef`,
+ *     no numeric `revision`, or no `host.runtimeConfig` is not a degraded spec —
+ *     it is an unknown one, and running a turn on it would misrepresent which
+ *     configuration the user launched. Those raise, never default.
+ */
+import type { ConvexHttpClient } from "convex/browser";
+import { ErrorCode, WebRouteError } from "../../routes/web/errors.js";
+import type { EnvironmentOverrides } from "../../../shared/execution-target.js";
+import type { RuntimeSkill } from "../../utils/harness/runtime-skills.js";
+
+/** Where a connectable server in the resolved set came from. */
+export type RuntimeServerSource = "host_or_group" | "plugin" | "override";
+
+/** The channel(s) a resolved skill arrived through. */
+export type RuntimeSkillChannel = "host" | "environment" | "plugin";
+
+export interface ResolvedEnvironmentSkill {
+  skillId: string;
+  name: string;
+  description: string;
+  content: string;
+  /** Folds supporting files; equals the content hash when there are none. */
+  aggregateHash: string;
+  extraFrontmatter?: unknown;
+  /** Optional for deploy skew — an older backend may omit channel provenance. */
+  channels?: RuntimeSkillChannel[];
+  /** Optional for deploy skew; absent is read as "no supporting files". */
+  files?: Array<{ path: string; size: number; url: string | null }>;
+}
+
+/**
+ * The inspector-side mirror of the backend's `ResolvedEnvironmentRuntimeSpec`.
+ *
+ * `host.runtimeConfig` is typed as an open record on purpose: it is the same
+ * payload `fetchHostRuntimeConfig` returns, and every consumer already reads it
+ * through `resolveExecutionContext` (which takes `Record<string, unknown>`).
+ * Re-declaring its fields here would create a second, drifting mirror of a
+ * contract that already has one.
+ */
+export interface ResolvedEnvironmentRuntime {
+  /** Additive-compatibility DIAGNOSTIC only — never a substitute for the
+   *  invariant checks in {@link resolveEnvironmentForRuntime}. */
+  specVersion?: number;
+  environmentRef: {
+    environmentId: string;
+    name: string;
+    revision: number;
+  };
+  host: {
+    hostId: string;
+    hostName?: string;
+    hostConfigId?: string;
+    runtimeConfig: Record<string, unknown>;
+  };
+  servers: {
+    selectedServerIds?: string[];
+    pluginServerIds?: string[];
+    baseEffectiveServerIds?: string[];
+    effectiveServerIds: string[];
+    connectable?: Array<{
+      serverId: string;
+      name: string;
+      source?: RuntimeServerSource;
+    }>;
+  };
+  skills?: ResolvedEnvironmentSkill[];
+  pluginVersions?: Array<{
+    pluginId: string;
+    pluginVersionId: string;
+    name: string;
+    bundleHash?: string;
+  }>;
+}
+
+const RUNTIME_FUNCTION_REF =
+  "projectEnvironments:resolveEnvironmentForRuntime" as const;
+
+/** The structured payload a Convex `ConvexError` carries on `.data`. */
+type ConvexErrorData = {
+  code?: string;
+  message?: string;
+  details?: Record<string, string>;
+};
+
+function convexErrorData(error: unknown): ConvexErrorData | null {
+  const data = (error as { data?: unknown } | null)?.data;
+  if (!data || typeof data !== "object" || Array.isArray(data)) return null;
+  return data as ConvexErrorData;
+}
+
+/** `ENV_*` codes that mean "this environment isn't there for you", not
+ *  "it exists but can't currently run". */
+const RUNTIME_NOT_FOUND_CODES = new Set(["ENV_NOT_FOUND", "ENV_CROSS_PROJECT"]);
+
+/**
+ * Map a resolver rejection onto a route error, preserving the backend's
+ * machine-readable `code` in `details` so a caller can branch without parsing
+ * prose. The `ENV_*` family is a STATE conflict (409): the caller's request was
+ * well-formed, the environment simply cannot produce a runnable configuration
+ * right now (a pinned plugin was disabled, the host was deleted, a pinned skill
+ * became unpinnable).
+ */
+export function translateEnvironmentRuntimeError(
+  error: unknown
+): WebRouteError {
+  if (error instanceof WebRouteError) return error;
+  const data = convexErrorData(error);
+  const code = typeof data?.code === "string" ? data.code : undefined;
+  const structuredMessage =
+    typeof data?.message === "string" ? data.message : undefined;
+
+  if (code && code.startsWith("ENV_")) {
+    if (RUNTIME_NOT_FOUND_CODES.has(code)) {
+      return new WebRouteError(
+        404,
+        ErrorCode.NOT_FOUND,
+        "Environment not found"
+      );
+    }
+    return new WebRouteError(
+      409,
+      ErrorCode.CONFLICT,
+      structuredMessage ?? "This environment cannot run right now.",
+      { code, ...(data?.details ?? {}) }
+    );
+  }
+  if (code === "VALIDATION") {
+    return new WebRouteError(
+      400,
+      ErrorCode.VALIDATION_ERROR,
+      structuredMessage ?? "Invalid environment request"
+    );
+  }
+  if (code === "FORBIDDEN" || code === "NOT_FOUND") {
+    // Never confirm that a project/environment id exists to a non-member.
+    return new WebRouteError(
+      404,
+      ErrorCode.NOT_FOUND,
+      "Environment or project not found, or you do not have access to it."
+    );
+  }
+
+  const message = error instanceof Error ? error.message : String(error);
+  if (/could not find public function/i.test(message)) {
+    // Deploy-order skew: the Phase 1 backend contract isn't deployed yet.
+    // Same guard (and wording shape) as `resolveEnvironmentForLaunch`.
+    return new WebRouteError(
+      400,
+      ErrorCode.VALIDATION_ERROR,
+      "This deployment cannot run project environments yet. Retry after the backend deploys."
+    );
+  }
+  if (/not found|unauthorized|not a member/i.test(message)) {
+    return new WebRouteError(
+      404,
+      ErrorCode.NOT_FOUND,
+      "Environment or project not found, or you do not have access to it."
+    );
+  }
+  return new WebRouteError(
+    502,
+    ErrorCode.INTERNAL_ERROR,
+    "Environment could not be resolved"
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * Fail-closed structural validation.
+ *
+ * Everything checked here is an INVARIANT, not a field: identity (which
+ * environment, at which revision), the host it binds, and the host's execution
+ * shape. Missing any of them means we do not know what we would be running, and
+ * a turn must not proceed on a guess. Additive fields (skills, plugin versions,
+ * connectable names, server provenance) are deliberately NOT checked — those are
+ * the deploy-skew surface.
+ */
+function assertRuntimeInvariants(raw: unknown): ResolvedEnvironmentRuntime {
+  const fail = (detail: string): never => {
+    throw new WebRouteError(
+      502,
+      ErrorCode.INTERNAL_ERROR,
+      `This environment resolved to an unusable runtime specification (${detail}). The turn was stopped rather than run with an unknown configuration.`
+    );
+  };
+  if (!isRecord(raw)) return fail("empty response");
+  const ref = (raw as { environmentRef?: unknown }).environmentRef;
+  if (!isRecord(ref) || typeof ref.environmentId !== "string") {
+    return fail("missing environmentRef");
+  }
+  if (typeof ref.revision !== "number") return fail("missing revision");
+  const host = (raw as { host?: unknown }).host;
+  if (!isRecord(host) || typeof host.hostId !== "string") {
+    return fail("missing host identity");
+  }
+  if (!isRecord(host.runtimeConfig)) return fail("missing host runtime config");
+  const servers = (raw as { servers?: unknown }).servers;
+  if (!isRecord(servers) || !Array.isArray(servers.effectiveServerIds)) {
+    return fail("missing effective server set");
+  }
+  return raw as unknown as ResolvedEnvironmentRuntime;
+}
+
+/**
+ * Resolve one environment for a live turn.
+ *
+ * `overrides.serverIds` is forwarded as `serverOverrideIds` ONLY when present:
+ * absent and `[]` are semantically different at the backend (use the
+ * environment vs run with no servers) and must stay different on the way in.
+ */
+export async function resolveEnvironmentForRuntime(
+  convexClient: ConvexHttpClient,
+  args: {
+    projectId: string;
+    environmentId: string;
+    overrides?: EnvironmentOverrides;
+  }
+): Promise<ResolvedEnvironmentRuntime> {
+  const serverOverrideIds = args.overrides?.serverIds;
+  let raw: unknown;
+  try {
+    raw = await convexClient.query(
+      RUNTIME_FUNCTION_REF as any,
+      {
+        projectId: args.projectId,
+        environmentId: args.environmentId,
+        ...(serverOverrideIds !== undefined ? { serverOverrideIds } : {}),
+      } as any
+    );
+  } catch (error) {
+    throw translateEnvironmentRuntimeError(error);
+  }
+  return assertRuntimeInvariants(raw);
+}
+
+// ── Projections used by the executing caller ────────────────────────────────
+
+/** The server ids to connect this turn (already live-healed by the backend). */
+export function runtimeServerIds(spec: ResolvedEnvironmentRuntime): string[] {
+  return Array.isArray(spec.servers.connectable)
+    ? spec.servers.connectable.map((entry) => entry.serverId)
+    : spec.servers.effectiveServerIds;
+}
+
+/**
+ * Display names aligned by index with {@link runtimeServerIds}. Empty when the
+ * backend omits the name-carrying projection (the manager then falls back to
+ * showing the server id) — never a partially-aligned array.
+ */
+export function runtimeServerNames(spec: ResolvedEnvironmentRuntime): string[] {
+  return Array.isArray(spec.servers.connectable)
+    ? spec.servers.connectable.map((entry) => entry.name)
+    : [];
+}
+
+/** True when the resolved set is NOT what the environment resolves to on its
+ *  own — i.e. a per-turn override was applied. */
+export function runtimeServersAreOverridden(
+  spec: ResolvedEnvironmentRuntime
+): boolean {
+  const base = spec.servers.baseEffectiveServerIds;
+  if (!Array.isArray(base)) return false;
+  const effective = spec.servers.effectiveServerIds;
+  if (base.length !== effective.length) return true;
+  return base.some((id, index) => id !== effective[index]);
+}
+
+/**
+ * The environment's skills in the shape the harness/emulated skill machinery
+ * already consumes (`CloudSkillRuntimeItem`). Deliberately a projection, not a
+ * cast: only the fields the runtime needs cross over, so a future spec field
+ * cannot leak into skill delivery by accident.
+ */
+export function runtimeSkills(
+  spec: ResolvedEnvironmentRuntime
+): RuntimeSkill[] {
+  return (spec.skills ?? []).map((skill) => ({
+    skillId: skill.skillId,
+    name: skill.name,
+    description: skill.description,
+    content: skill.content,
+    aggregateHash: skill.aggregateHash,
+    ...(skill.extraFrontmatter
+      ? { extraFrontmatter: skill.extraFrontmatter as never }
+      : {}),
+  }));
+}
+
+// ── Browser preview projection ──────────────────────────────────────────────
+
+/** How this environment's skills would reach the model on a turn. */
+export type EnvironmentSkillDelivery =
+  | "emulated"
+  | "harness"
+  /** The resolved harness has no skill channel (Codex today) — the skills exist
+   *  but WOULD NOT be delivered. Surfaced rather than shown as delivered. */
+  | "unsupported";
+
+export interface EnvironmentPreview {
+  specVersion: number | null;
+  environment: { environmentId: string; name: string; revision: number };
+  host: {
+    hostId: string;
+    hostName: string | null;
+    hostConfigId: string | null;
+    modelId: string | null;
+    hostStyle: string | null;
+    harness: string | null;
+  };
+  servers: Array<{
+    serverId: string;
+    name: string;
+    source: RuntimeServerSource | null;
+  }>;
+  skills: Array<{
+    skillId: string;
+    name: string;
+    description: string;
+    channels: RuntimeSkillChannel[];
+    /** Whether the skill ships supporting files. The files themselves — paths,
+     *  sizes, and above all the signed URLs — are NOT part of the preview. */
+    hasFiles: boolean;
+  }>;
+  plugins: Array<{ pluginId: string; pluginVersionId: string; name: string }>;
+  capabilities: {
+    requireToolApproval: boolean | null;
+    respectToolVisibility: boolean | null;
+    progressiveToolDiscovery: boolean | null;
+    builtInToolIds: string[];
+    /** Presence only. The computer's workdir/kind is execution configuration
+     *  and never crosses to the browser through this route. */
+    hasComputer: boolean;
+    serverCount: number;
+    skillCount: number;
+    skillDelivery: EnvironmentSkillDelivery;
+    pluginCount: number;
+    serversOverridden: boolean;
+  };
+}
+
+function readString(
+  record: Record<string, unknown>,
+  key: string
+): string | null {
+  const value = record[key];
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function readBoolean(
+  record: Record<string, unknown>,
+  key: string
+): boolean | null {
+  const value = record[key];
+  return typeof value === "boolean" ? value : null;
+}
+
+/**
+ * Narrow, read-only projection for the browser.
+ *
+ * EVERY field is written out explicitly. There is no spread anywhere in this
+ * function, and that is the point: adding a field to the runtime spec — a
+ * credential, a signed URL, a raw computer config — must be a no-op here. If a
+ * new field belongs in the preview, someone has to type it out and think about
+ * it.
+ *
+ * Specifically excluded, permanently: skill `content`, skill `files` (paths,
+ * sizes, and the signed `url`s most of all), the host's `computer` block,
+ * `mcpProfile` (carries the enterprise auth policy), `harness` broker/proxy
+ * settings, and anything under `runtimeConfig` not listed below.
+ */
+export function toEnvironmentPreview(
+  spec: ResolvedEnvironmentRuntime,
+  options: { harnessSupportsSkills: (harnessId: string) => boolean }
+): EnvironmentPreview {
+  const runtimeConfig = spec.host.runtimeConfig;
+  const harness = readString(runtimeConfig, "harness");
+  const builtInToolIds = Array.isArray(runtimeConfig.builtInToolIds)
+    ? runtimeConfig.builtInToolIds.filter(
+        (id): id is string => typeof id === "string"
+      )
+    : [];
+  const skills = spec.skills ?? [];
+  const skillDelivery: EnvironmentSkillDelivery = !harness
+    ? "emulated"
+    : options.harnessSupportsSkills(harness)
+    ? "harness"
+    : "unsupported";
+
+  const connectable = Array.isArray(spec.servers.connectable)
+    ? spec.servers.connectable
+    : spec.servers.effectiveServerIds.map((serverId) => ({
+        serverId,
+        name: serverId,
+        source: undefined,
+      }));
+
+  return {
+    specVersion: typeof spec.specVersion === "number" ? spec.specVersion : null,
+    environment: {
+      environmentId: spec.environmentRef.environmentId,
+      name: spec.environmentRef.name,
+      revision: spec.environmentRef.revision,
+    },
+    host: {
+      hostId: spec.host.hostId,
+      hostName: spec.host.hostName ?? null,
+      hostConfigId: spec.host.hostConfigId ?? null,
+      modelId: readString(runtimeConfig, "modelId"),
+      hostStyle: readString(runtimeConfig, "hostStyle"),
+      harness,
+    },
+    servers: connectable.map((entry) => ({
+      serverId: entry.serverId,
+      name: entry.name,
+      source: entry.source ?? null,
+    })),
+    skills: skills.map((skill) => ({
+      skillId: skill.skillId,
+      name: skill.name,
+      description: skill.description,
+      channels: Array.isArray(skill.channels) ? skill.channels : [],
+      hasFiles: Array.isArray(skill.files) && skill.files.length > 0,
+    })),
+    plugins: (spec.pluginVersions ?? []).map((plugin) => ({
+      pluginId: plugin.pluginId,
+      pluginVersionId: plugin.pluginVersionId,
+      name: plugin.name,
+    })),
+    capabilities: {
+      requireToolApproval: readBoolean(runtimeConfig, "requireToolApproval"),
+      respectToolVisibility: readBoolean(
+        runtimeConfig,
+        "respectToolVisibility"
+      ),
+      progressiveToolDiscovery: readBoolean(
+        runtimeConfig,
+        "progressiveToolDiscovery"
+      ),
+      builtInToolIds,
+      hasComputer: isRecord(runtimeConfig.computer),
+      serverCount: connectable.length,
+      skillCount: skills.length,
+      skillDelivery,
+      pluginCount: (spec.pluginVersions ?? []).length,
+      serversOverridden: runtimeServersAreOverridden(spec),
+    },
+  };
+}

--- a/mcpjam-inspector/server/utils/assistant-turn.ts
+++ b/mcpjam-inspector/server/utils/assistant-turn.ts
@@ -215,6 +215,14 @@ export interface RunAssistantTurnOptions {
   pinnedHarnessSkills?: MCPJamHandlerOptions["pinnedHarnessSkills"];
 
   /**
+   * Resolved Project-Environment skills for this turn (Phase 1.4).
+   * Pass-through to `runHarnessTurn`: when set (even empty) the harness turn
+   * delivers exactly these and skips the live project-wide fetch. Ranks below
+   * `pinnedHarnessSkills` — see `harness/skill-delivery.ts`.
+   */
+  runtimeSkillsOverride?: MCPJamHandlerOptions["runtimeSkillsOverride"];
+
+  /**
    * Override the Convex endpoint path. Stage 1 keeps this wired so
    * `handleHostedOrgChatModel` (org BYOK delegation chain) keeps
    * working — `runAssistantTurn` is the same engine, and the org BYOK
@@ -409,6 +417,12 @@ function buildHandlerOptions(
     // empty authoritative set means "run skill-less", never "fall back live".
     ...(opts.pinnedHarnessSkills !== undefined
       ? { pinnedHarnessSkills: opts.pinnedHarnessSkills }
+      : {}),
+    // Environment skill override: same presence-is-semantic rule as pinned —
+    // an empty resolved set means "this environment delivers no skills", never
+    // "fall back to the project pool".
+    ...(opts.runtimeSkillsOverride !== undefined
+      ? { runtimeSkillsOverride: opts.runtimeSkillsOverride }
       : {}),
     ...(opts.requireToolApproval !== undefined
       ? { requireToolApproval: opts.requireToolApproval }

--- a/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
+++ b/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
@@ -34,6 +34,7 @@ import { getSkillToolsAndPrompt } from "./skill-tools.js";
 import {
   getCloudSkillToolsAndPrompt,
   getPinnedSkillToolsAndPrompt,
+  getResolvedSkillToolsAndPrompt,
 } from "./computers/cloud-skill-tools.js";
 import type { PinnableSkill } from "../../shared/skill-types.js";
 import { logger } from "./logger.js";
@@ -684,14 +685,26 @@ export interface PrepareChatV2Options {
    */
   cloudSkills?: { authHeader: string; projectId: string };
   /**
-   * Explicit skill source, ABOVE the cloud/HOSTED/local chain. Set ONLY by eval
-   * runners: `pinned` mints frozen in-memory tools over snapshotted content
-   * (zero network in execute), `none` suppresses skills entirely. Chat callers
-   * never set it → the existing precedence is byte-identical. `pinned` tools
-   * bypass approval (pure reads of frozen content under an auto-deny eval run).
+   * Explicit skill source, ABOVE the cloud/HOSTED/local chain. Chat callers on
+   * the legacy paths never set it → the existing precedence is byte-identical.
+   *
+   *  - `pinned`   — EVAL RUNNERS ONLY. Frozen in-memory tools over snapshotted
+   *    content (zero network in execute). Tools bypass approval: pure reads of
+   *    frozen content under an auto-deny eval run.
+   *  - `resolved` — a Project-Environment turn (Phase 1.4). Same in-memory
+   *    delivery, DIFFERENT policy: this is an ordinary interactive turn, so the
+   *    skill tools follow the host's normal `requireToolApproval` rule. The eval
+   *    approval exemption is deliberately NOT inherited — a user watching their
+   *    own turn should still get the approval prompt they configured.
+   *  - `none`     — suppress skills entirely.
+   *
+   * `resolved` and `pinned` are separate kinds rather than one "in-memory" kind
+   * with a flag precisely because that approval divergence is the whole
+   * distinction, and a shared kind would make it a caller's job to remember.
    */
   skillsSource?:
     | { kind: "pinned"; skills: PinnableSkill[] }
+    | { kind: "resolved"; skills: PinnableSkill[] }
     | { kind: "none" };
 }
 
@@ -922,9 +935,11 @@ export async function prepareChatV2(
     filterAppOnlyTools(mcpTools, mcpClientManager);
   }
   // Skills source, in precedence order:
-  //   0. skillsSource set (EVAL RUNNERS ONLY) ⇒ pinned frozen tools or none.
-  //      Above everything; chat callers never set it, so the chain below is
-  //      byte-identical for them. Pinned tools bypass approval (decision 12).
+  //   0. skillsSource set ⇒ in-memory tools (`pinned` for eval runs,
+  //      `resolved` for a Project-Environment turn) or none. Above everything;
+  //      legacy chat callers never set it, so the chain below is byte-identical
+  //      for them. Only PINNED tools bypass approval (decision 12) — `resolved`
+  //      is an interactive turn and keeps the host's approval rule.
   //   1. cloudSkills set ⇒ the caller's Computer (E2B sandbox) — hosted path
   //      with a provisioned computer. Lazy discovery (no upfront wake).
   //   2. HOSTED_MODE without a computer ⇒ no skills (local FS unavailable).
@@ -942,7 +957,9 @@ export async function prepareChatV2(
     skillsSource
       ? skillsSource.kind === "pinned"
         ? getPinnedSkillToolsAndPrompt(skillsSource.skills)
-        : { tools: {}, systemPromptSection: "" }
+        : skillsSource.kind === "resolved"
+          ? getResolvedSkillToolsAndPrompt(skillsSource.skills)
+          : { tools: {}, systemPromptSection: "" }
       : cloudSkills
         ? getCloudSkillToolsAndPrompt({
             authHeader: cloudSkills.authHeader,

--- a/mcpjam-inspector/server/utils/computers/cloud-skill-tools.ts
+++ b/mcpjam-inspector/server/utils/computers/cloud-skill-tools.ts
@@ -268,3 +268,24 @@ export function getPinnedSkillToolsAndPrompt(skills: PinnableSkill[]): {
     systemPromptSection: SKILLS_PROMPT_BASE,
   };
 }
+
+/**
+ * RESOLVED skill tools for a Project-Environment turn (Phase 1.4). Structurally
+ * identical to the pinned set — an in-memory closure over exactly the artifacts
+ * the environment resolved, with no live project-pool read — because the
+ * environment's set is authoritative for the turn and a live `listSkills` would
+ * advertise skills the environment deliberately excluded.
+ *
+ * The behavioral difference lives at the CALL SITE, not here: `prepareChatV2`
+ * wraps these with `needsApproval` under the host's ordinary
+ * `requireToolApproval`, whereas pinned tools bypass approval. Same reason the
+ * file tools stay omitted: an environment turn delivers SKILL.md bodies through
+ * `loadSkill`; supporting files reach a harness box through materialization, not
+ * through emulated tool calls.
+ */
+export function getResolvedSkillToolsAndPrompt(skills: PinnableSkill[]): {
+  tools: ReturnType<typeof createPinnedSkillTools>;
+  systemPromptSection: string;
+} {
+  return getPinnedSkillToolsAndPrompt(skills);
+}

--- a/mcpjam-inspector/server/utils/harness/__tests__/materialize-skill-files.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/materialize-skill-files.test.ts
@@ -115,6 +115,44 @@ describe("materializeSkillFiles", () => {
     expect(session.writeBinaryFile).not.toHaveBeenCalled();
   });
 
+  it("filters a PROJECT-WIDE file set down to the delivered skills (environment turns)", async () => {
+    // A Project-Environment harness turn delivers only the environment's
+    // resolved skills, but the supporting-file query stays project-wide. This
+    // filtering is what makes that safe, so it is locked here rather than left
+    // implied: a file belonging to an undelivered project skill must not be
+    // written (its dir does not exist), and the prune sweep must not touch that
+    // skill's dir either.
+    const undeliveredDir = `${SKILLS_BASE}/other-project-skill`;
+    const { session, writes, removed } = fakeSession([
+      `${SKILLS_BASE}/env-skill/scripts/run.py`,
+      `${undeliveredDir}/scripts/legacy.py`,
+    ]);
+    const res = await materializeSkillFiles({
+      session,
+      files: [
+        // Delivered by the environment.
+        file({ skillId: "sk_env", path: "scripts/run.py" }),
+        // Project-wide extras the environment did NOT deliver.
+        file({ skillId: "sk_other", path: "scripts/legacy.py" }),
+        file({ skillId: "sk_other_2", path: "assets/logo.png" }),
+      ],
+      // Built from the DELIVERED skills alone.
+      skillNamesById: new Map([["sk_env", "env-skill"]]),
+    });
+
+    expect(res.written).toBe(1);
+    expect(res.skipped).toBe(2);
+    expect(writes.map((w) => w.path)).toEqual([
+      `${SKILLS_BASE}/env-skill/scripts/run.py`,
+    ]);
+    expect(writes.some((w) => w.path.includes("other-project-skill"))).toBe(
+      false
+    );
+    // The undelivered skill's dir is not a prune candidate — its on-box files
+    // survive untouched.
+    expect(removed).toEqual([]);
+  });
+
   it("skips a path that escapes the skill dir (defense-in-depth)", async () => {
     const { session } = fakeSession();
     const res = await materializeSkillFiles({

--- a/mcpjam-inspector/server/utils/harness/__tests__/skill-delivery.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/skill-delivery.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { selectHarnessSkillSource } from "../skill-delivery.js";
+import type { RuntimeSkill } from "../runtime-skills.js";
+import type { PinnedSkillArtifact } from "../../../../shared/skill-types.js";
+
+const PINNED: PinnedSkillArtifact[] = [
+  {
+    skillId: "sk_pinned",
+    name: "pinned-skill",
+    description: "frozen",
+    content: "frozen body",
+    contentHash: "hash_pinned",
+  },
+];
+
+const RESOLVED: RuntimeSkill[] = [
+  {
+    skillId: "sk_env",
+    name: "env-skill",
+    description: "resolved",
+    content: "resolved body",
+    aggregateHash: "hash_env",
+  },
+];
+
+describe("selectHarnessSkillSource", () => {
+  it("prefers frozen run artifacts over an environment override", () => {
+    // Reproducibility outranks live resolution: a pinned run must re-execute
+    // identically, so nothing live may be consulted — not even an environment.
+    const source = selectHarnessSkillSource({
+      pinnedHarnessSkills: PINNED,
+      runtimeSkillsOverride: RESOLVED,
+    });
+    expect(source.mode).toBe("pinned");
+    expect(source.mode !== "live" && source.skills).toEqual([
+      {
+        skillId: "sk_pinned",
+        name: "pinned-skill",
+        description: "frozen",
+        content: "frozen body",
+        aggregateHash: "hash_pinned",
+      },
+    ]);
+  });
+
+  it("uses the environment override when there is no pinned set", () => {
+    const source = selectHarnessSkillSource({
+      runtimeSkillsOverride: RESOLVED,
+    });
+    expect(source.mode).toBe("environment");
+    expect(source.mode !== "live" && source.skills).toEqual(RESOLVED);
+  });
+
+  it("treats an EMPTY environment override as authoritative, not as absent", () => {
+    // The regression this locks: falling through to `live` here would deliver
+    // the whole project skill pool to a turn whose environment pinned none.
+    const source = selectHarnessSkillSource({ runtimeSkillsOverride: [] });
+    expect(source.mode).toBe("environment");
+    expect(source.mode !== "live" && source.skills).toEqual([]);
+  });
+
+  it("treats an EMPTY pinned set as authoritative too", () => {
+    const source = selectHarnessSkillSource({ pinnedHarnessSkills: [] });
+    expect(source.mode).toBe("pinned");
+    expect(source.mode !== "live" && source.skills).toEqual([]);
+  });
+
+  it("falls back to the live project-wide fetch only when neither is present", () => {
+    expect(selectHarnessSkillSource({})).toEqual({ mode: "live" });
+  });
+});

--- a/mcpjam-inspector/server/utils/harness/registry.ts
+++ b/mcpjam-inspector/server/utils/harness/registry.ts
@@ -608,3 +608,15 @@ export function getHarnessAdapter(id: string): HarnessRuntimeAdapter {
 export function registeredHarnessIds(): HarnessId[] {
   return Object.keys(HARNESS_ADAPTERS) as HarnessId[];
 }
+
+/**
+ * Whether a harness id can deliver skills at all, WITHOUT throwing on an
+ * unknown id. Surfaces that DESCRIBE a turn (environment preview, telemetry)
+ * need this before the turn runs, and describing a turn must never be the thing
+ * that fails the request — an unrecognized harness reports `false` ("we cannot
+ * say skills would be delivered"), the same honest answer a skills-incapable
+ * adapter gives today (Codex: `supportsSkills: false`).
+ */
+export function harnessSupportsSkills(id: string): boolean {
+  return isHarnessId(id) ? HARNESS_ADAPTERS[id].supportsSkills : false;
+}

--- a/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
+++ b/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
@@ -84,10 +84,8 @@ import {
   claudeCodeSafeSkills,
 } from "./runtime-skills.js";
 import { materializeSkillFiles } from "./materialize-skill-files.js";
-import {
-  materializePinnedSkillFiles,
-  pinnedArtifactsToRuntimeSkills,
-} from "./pinned-harness-skills.js";
+import { materializePinnedSkillFiles } from "./pinned-harness-skills.js";
+import { selectHarnessSkillSource } from "./skill-delivery.js";
 import { materializeSkillFrontmatter } from "./materialize-skill-frontmatter.js";
 import {
   reconcileSkillDirs,
@@ -341,6 +339,7 @@ export async function runHarnessTurn(
     computerWorkdir,
     executionScope,
     pinnedHarnessSkills,
+    runtimeSkillsOverride,
   } = options;
   // Canonicalize the model id up front (bare hosted ids like `gpt-5-nano` →
   // `openai/gpt-5-nano`). Everything downstream — supportsModel, the adapter's
@@ -606,20 +605,23 @@ export async function runHarnessTurn(
       // reuses the stored hash (no resume churn, no empty-hash commit). The skills
       // fingerprint is tracked SEPARATELY from `runtimeFingerprint` precisely so
       // "unknown" (failure) is distinguishable from "" (empty project).
-      // PINNED MODE (Project Environments, env-based swarm targets): the
-      // caller supplied the authoritative pinned artifact set — even EMPTY —
-      // so the live skills query is SKIPPED entirely and `skillsHash` derives
-      // from the pinned artifact fingerprints. Legacy callers (undefined) keep
-      // the live tri-state fetch unchanged.
-      const skillsArePinned = pinnedHarnessSkills !== undefined;
-      const skillsFetch = skillsArePinned
-        ? {
-            ok: true as const,
-            skills: pinnedArtifactsToRuntimeSkills(pinnedHarnessSkills),
-          }
-        : projectId && authHeader
-          ? await fetchRuntimeSkills(authHeader, projectId, executionScope)
-          : { ok: true as const, skills: [] };
+      // OVERRIDING MODES (see `selectHarnessSkillSource` for the precedence):
+      // `pinned` (eval/swarm frozen artifacts) and `environment` (a Project
+      // Environment's resolved artifacts) each supply the authoritative set —
+      // even EMPTY — so the live skills query is SKIPPED entirely and
+      // `skillsHash` derives from the supplied artifacts. Legacy callers
+      // (neither present) keep the live tri-state fetch unchanged.
+      const skillSource = selectHarnessSkillSource({
+        pinnedHarnessSkills,
+        runtimeSkillsOverride,
+      });
+      const skillsArePinned = skillSource.mode === "pinned";
+      const skillsFetch =
+        skillSource.mode !== "live"
+          ? { ok: true as const, skills: skillSource.skills }
+          : projectId && authHeader
+            ? await fetchRuntimeSkills(authHeader, projectId, executionScope)
+            : { ok: true as const, skills: [] };
       const runtimeSkills = skillsFetch.ok ? skillsFetch.skills : null;
       const skillsHash =
         runtimeSkills !== null ? skillsFingerprint(runtimeSkills) : undefined;
@@ -930,6 +932,14 @@ export async function runHarnessTurn(
             // SKILL.md; reconcile removed stale managed dirs). Fetched here rather
             // than at turn start to keep the zero-file fast path free. Fully
             // fail-soft; guest/swarm scope uses the execution-scoped file query.
+            //
+            // ENVIRONMENT MODE lands here too, on purpose. The file query stays
+            // PROJECT-WIDE while the delivered skill set is the environment's:
+            // `materializeSkillFiles` filters every file through
+            // `skillNamesById`, which is built from `runtimeSkills` alone, so a
+            // file belonging to a project skill the environment did NOT deliver
+            // is skipped and its dir is never created. An empty environment set
+            // short-circuits on the `length > 0` guard above and fetches nothing.
             else if (projectId && authHeader && runtimeSkills.length > 0) {
               // Tri-state: `{ ok: false }` ⇒ the fetch FAILED (transient). Skip
               // materialization then — an empty file set would otherwise prune

--- a/mcpjam-inspector/server/utils/harness/skill-delivery.ts
+++ b/mcpjam-inspector/server/utils/harness/skill-delivery.ts
@@ -1,0 +1,47 @@
+/**
+ * Which skill set a harness turn delivers — the single tri-state decision.
+ *
+ * Three callers can each be authoritative about a turn's skills, and they are
+ * NOT interchangeable, so the precedence is written down once here instead of
+ * being re-derived inside `runHarnessTurn`:
+ *
+ *   1. `pinned` — eval / swarm runs supply frozen `PinnedSkillArtifact`s from a
+ *      run snapshot. Reproducibility outranks everything: a pinned run must be
+ *      byte-identical on re-execution, so nothing live may be consulted.
+ *   2. `environment` — a Project Environment turn supplies the artifacts its
+ *      revision resolved to, in ONE atomic read. Live in the sense that the next
+ *      turn re-resolves, but authoritative for THIS turn.
+ *   3. `live` — the legacy project-wide fetch. Only when neither of the above
+ *      spoke.
+ *
+ * PRESENCE, not length, selects a source in both overriding cases. An EMPTY
+ * environment override is a real answer ("this environment delivers no skills")
+ * and must skip the project-wide fetch: falling through would silently deliver
+ * the whole project pool to a turn whose environment deliberately pinned none.
+ */
+import type { PinnedSkillArtifact } from "../../../shared/skill-types.js";
+import { pinnedArtifactsToRuntimeSkills } from "./pinned-harness-skills.js";
+import type { RuntimeSkill } from "./runtime-skills.js";
+
+export type HarnessSkillSource =
+  | { mode: "pinned"; skills: RuntimeSkill[] }
+  | { mode: "environment"; skills: RuntimeSkill[] }
+  | { mode: "live" };
+
+export function selectHarnessSkillSource(args: {
+  /** Frozen run artifacts (eval / swarm). */
+  pinnedHarnessSkills?: PinnedSkillArtifact[];
+  /** Resolved Project Environment artifacts for this turn. */
+  runtimeSkillsOverride?: RuntimeSkill[];
+}): HarnessSkillSource {
+  if (args.pinnedHarnessSkills !== undefined) {
+    return {
+      mode: "pinned",
+      skills: pinnedArtifactsToRuntimeSkills(args.pinnedHarnessSkills),
+    };
+  }
+  if (args.runtimeSkillsOverride !== undefined) {
+    return { mode: "environment", skills: args.runtimeSkillsOverride };
+  }
+  return { mode: "live" };
+}

--- a/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
@@ -30,6 +30,7 @@ import { runHarnessTurn } from "./harness/run-harness-turn.js";
 import type { HarnessSessionCommitPayload } from "./harness/harness-session-state.js";
 import type { ExecutionScope } from "./execution-scope.js";
 import type { PinnedSkillArtifact } from "../../shared/skill-types.js";
+import type { RuntimeSkill } from "./harness/runtime-skills.js";
 import type { HarnessMcpProxyStrategy } from "./harness/harness-proxy-strategy.js";
 import {
   buildFinishChunk,
@@ -448,6 +449,16 @@ export interface MCPJamHandlerOptions {
    * harness+pinned — the two paths are deliberately disjoint).
    */
   pinnedHarnessSkills?: PinnedSkillArtifact[];
+  /**
+   * Resolved Project-Environment skills for THIS turn (Phase 1.4). When set —
+   * even EMPTY — the harness turn delivers exactly these and SKIPS the live
+   * project-wide `fetchRuntimeSkills` query. Ranks BELOW `pinnedHarnessSkills`
+   * (a pinned run's reproducibility outranks a live environment resolution) and
+   * ABOVE the legacy live fetch; see `harness/skill-delivery.ts` for the single
+   * place that precedence is written down. An empty override is semantic: the
+   * environment delivers no skills, which is not the same as "ask the project".
+   */
+  runtimeSkillsOverride?: RuntimeSkill[];
   /**
    * Phase 3 execution scope from the server-resolved runtime config (chatbox OR
    * host-by-id). Threaded into the harness path (sandbox reserve, runtime skills,

--- a/mcpjam-inspector/server/utils/web-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/web-chat-turn.ts
@@ -65,6 +65,10 @@ import {
   type PersistedTurnTrace,
 } from "./chat-ingestion.js";
 import type { HarnessSessionCommitPayload } from "./harness/harness-session-state.js";
+import {
+  toPinnableSkill,
+  type RuntimeSkill,
+} from "./harness/runtime-skills.js";
 import { exportConnectedServerToolSnapshotForEvalAuthoring } from "./export-helpers.js";
 import { ErrorCode, WebRouteError } from "./../routes/web/errors.js";
 import { readUrlElicitations } from "@/shared/http-tool-calls";
@@ -160,6 +164,16 @@ export interface WebChatTurnPersistContext {
    * behavior.
    */
   captureToolSnapshot?: boolean;
+  /**
+   * Resolved Project-Environment skills for this turn (Phase 1.4), HARNESS
+   * side. Forwarded verbatim to `handleMCPJamFreeChatModel` → `runHarnessTurn`,
+   * where presence (even empty) skips the live project-wide skills fetch.
+   *
+   * It lives on the persist context rather than the prepare inputs because the
+   * harness path is reached through the persist/stream half of this helper —
+   * the same place `harness` and `executionScope` already travel.
+   */
+  runtimeSkillsOverride?: RuntimeSkill[];
 }
 
 /**
@@ -196,6 +210,19 @@ export interface WebChatTurnPrepareInputs {
    * actually has a computer. See `chat-v2-orchestration.ts`.
    */
   cloudSkills?: { authHeader: string; projectId: string };
+  /**
+   * Resolved Project-Environment skills for this turn (Phase 1.4), EMULATED
+   * side. When set (even empty) they are the only skills the emulated engine
+   * advertises: `prepareChatV2` receives them as `skillsSource: "resolved"`,
+   * which sits above the cloud/HOSTED/local chain. Callers must NOT also set
+   * `cloudSkills` — that would double-deliver (an environment-scoped
+   * `loadSkill` plus a project-wide one).
+   *
+   * Ignored when `harness` is set: a harness turn delivers skills natively
+   * through the adapter (see `WebChatTurnPersistContext.runtimeSkillsOverride`),
+   * and advertising emulated skill tools there is a prompt/tool mismatch.
+   */
+  runtimeSkillsOverride?: RuntimeSkill[];
 }
 
 /** Runtime knobs (auth, abort, rpc collector, Hono context for cleanup). */
@@ -334,6 +361,18 @@ export async function streamWebChatTurn(
       uiTools: prepare.uiTools,
       builtInTools: prepare.builtInTools,
       ...(prepare.cloudSkills ? { cloudSkills: prepare.cloudSkills } : {}),
+      // Environment-resolved skills outrank the cloud/HOSTED/local chain for the
+      // EMULATED engine only. On a harness turn the adapter delivers them
+      // natively, so advertising `listSkills`/`loadSkill` on top would describe
+      // a second, different delivery of the same set to the same model.
+      ...(prepare.runtimeSkillsOverride !== undefined && !prepare.harness
+        ? {
+            skillsSource: {
+              kind: "resolved" as const,
+              skills: prepare.runtimeSkillsOverride.map(toPinnableSkill),
+            },
+          }
+        : {}),
     });
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
@@ -751,6 +790,11 @@ export async function streamWebChatTurn(
     ),
     modelVisibleMcpToolResults: prepare.modelVisibleMcpToolResults,
     ...(persist.harness ? { harness: persist.harness } : {}),
+    // Presence is semantic (even an empty array): the harness turn then skips
+    // the live project-wide skills fetch entirely.
+    ...(persist.runtimeSkillsOverride !== undefined
+      ? { runtimeSkillsOverride: persist.runtimeSkillsOverride }
+      : {}),
     ...(harnessMcpProxy ? { harnessMcpProxy } : {}),
     // Forwarded SEPARATELY (also merged into `tools` for the emulated engine)
     // so the harness path can hand MCPJam's server-executed built-ins

--- a/mcpjam-inspector/shared/__tests__/execution-target.test.ts
+++ b/mcpjam-inspector/shared/__tests__/execution-target.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+import { normalizeExecutionTarget } from "../execution-target";
+
+describe("normalizeExecutionTarget", () => {
+  it("REJECTS chatboxId + executionTarget instead of shadowing one", () => {
+    // The whole point of the normalizer: a body with two pointers must not
+    // execute against one of them silently.
+    const result = normalizeExecutionTarget({
+      chatboxId: "cbx_1",
+      executionTarget: { kind: "environment", environmentId: "env_1" },
+      projectId: "p_1",
+    });
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.error).toMatch(/cannot be combined/i);
+  });
+
+  it("REJECTS legacy hostId + executionTarget", () => {
+    const result = normalizeExecutionTarget({
+      hostId: "host_1",
+      executionTarget: { kind: "host", hostId: "host_1" },
+      projectId: "p_1",
+    });
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.error).toMatch(/cannot be combined/i);
+  });
+
+  it("uses an explicit executionTarget", () => {
+    expect(
+      normalizeExecutionTarget({
+        executionTarget: { kind: "environment", environmentId: "env_1" },
+        projectId: "p_1",
+      })
+    ).toEqual({
+      ok: true,
+      target: { kind: "environment", environmentId: "env_1" },
+    });
+    expect(
+      normalizeExecutionTarget({
+        executionTarget: { kind: "host", hostId: "host_1" },
+        projectId: "p_1",
+      })
+    ).toEqual({ ok: true, target: { kind: "host", hostId: "host_1" } });
+  });
+
+  it("normalizes a legacy hostId to a host target", () => {
+    expect(
+      normalizeExecutionTarget({ hostId: "host_1", projectId: "p_1" })
+    ).toEqual({ ok: true, target: { kind: "host", hostId: "host_1" } });
+  });
+
+  it("keeps chatbox precedence over a stray legacy hostId (unchanged legacy behavior)", () => {
+    expect(
+      normalizeExecutionTarget({
+        chatboxId: "cbx_1",
+        hostId: "host_1",
+        projectId: "p_1",
+      })
+    ).toEqual({ ok: true, target: { kind: "chatbox", chatboxId: "cbx_1" } });
+  });
+
+  it("falls through to the ad-hoc direct chat when nothing points anywhere", () => {
+    expect(normalizeExecutionTarget({ projectId: "p_1" })).toEqual({
+      ok: true,
+      target: { kind: "adhoc", projectId: "p_1" },
+    });
+  });
+
+  it("treats an empty-string pointer as absent, not as a target", () => {
+    expect(
+      normalizeExecutionTarget({
+        hostId: "",
+        chatboxId: "  ",
+        projectId: "p_1",
+      })
+    ).toEqual({ ok: true, target: { kind: "adhoc", projectId: "p_1" } });
+  });
+
+  it("rejects a malformed executionTarget rather than ignoring it", () => {
+    for (const bad of [
+      { kind: "environment" },
+      { kind: "host" },
+      { kind: "workspace", workspaceId: "w_1" },
+      "environment",
+      [],
+    ]) {
+      const result = normalizeExecutionTarget({
+        executionTarget: bad,
+        projectId: "p_1",
+      });
+      expect(result.ok).toBe(false);
+    }
+  });
+
+  it("carries environment overrides, keeping ABSENT distinct from []", () => {
+    // Absent ⇒ use the environment's own set.
+    const absent = normalizeExecutionTarget({
+      executionTarget: { kind: "environment", environmentId: "env_1" },
+      projectId: "p_1",
+    });
+    expect(absent.ok && absent.target).toEqual({
+      kind: "environment",
+      environmentId: "env_1",
+    });
+
+    // `[]` ⇒ a real override meaning "no MCP servers this turn".
+    const empty = normalizeExecutionTarget({
+      executionTarget: { kind: "environment", environmentId: "env_1" },
+      environmentOverrides: { serverIds: [] },
+      projectId: "p_1",
+    });
+    expect(empty.ok && empty.target).toEqual({
+      kind: "environment",
+      environmentId: "env_1",
+      overrides: { serverIds: [] },
+    });
+
+    const some = normalizeExecutionTarget({
+      executionTarget: { kind: "environment", environmentId: "env_1" },
+      environmentOverrides: { serverIds: ["ps_1"] },
+      projectId: "p_1",
+    });
+    expect(some.ok && some.target).toEqual({
+      kind: "environment",
+      environmentId: "env_1",
+      overrides: { serverIds: ["ps_1"] },
+    });
+  });
+
+  it("rejects environment overrides sent without an environment target", () => {
+    for (const ingress of [
+      { environmentOverrides: { serverIds: ["ps_1"] }, projectId: "p_1" },
+      {
+        executionTarget: { kind: "host", hostId: "host_1" },
+        environmentOverrides: { serverIds: ["ps_1"] },
+        projectId: "p_1",
+      },
+    ]) {
+      const result = normalizeExecutionTarget(ingress);
+      expect(result.ok).toBe(false);
+      expect(result.ok === false && result.error).toMatch(
+        /requires an environment/i
+      );
+    }
+  });
+
+  it("rejects a malformed override envelope", () => {
+    const result = normalizeExecutionTarget({
+      executionTarget: { kind: "environment", environmentId: "env_1" },
+      environmentOverrides: { serverIds: ["ok", 3] },
+      projectId: "p_1",
+    });
+    expect(result.ok).toBe(false);
+  });
+});

--- a/mcpjam-inspector/shared/chat-v2.ts
+++ b/mcpjam-inspector/shared/chat-v2.ts
@@ -4,9 +4,30 @@ import type {
   McpToolResultImageRenderingPolicy,
   ModelVisibleMcpToolResults,
 } from "@mcpjam/sdk/host-config";
+import type {
+  EnvironmentOverrides,
+  HostedExecutionTarget,
+} from "./execution-target";
 
 export interface ChatV2Request {
   messages: UIMessage[];
+  /**
+   * WHAT this turn executes against (Project Environments — Phase 1.1). One
+   * pointer, ids only; the server re-resolves the authoritative configuration.
+   *
+   * Mutually exclusive with the legacy top-level `hostId` and with the
+   * access-bearing `chatboxId` — the hosted ingress REJECTS those combinations
+   * rather than picking a winner (`shared/execution-target.ts`). Absent ⇒ the
+   * legacy behavior is unchanged.
+   */
+  executionTarget?: HostedExecutionTarget;
+  /**
+   * Per-turn narrowing of an environment target's server set. Only valid
+   * alongside an `environment` execution target. Absent means "use the
+   * environment"; `[]` means "no MCP servers this turn" — the two are
+   * deliberately different.
+   */
+  environmentOverrides?: EnvironmentOverrides;
   chatSessionId?: string;
   directVisibility?: "private" | "project";
   surface?: "preview" | "share_link";

--- a/mcpjam-inspector/shared/execution-target.ts
+++ b/mcpjam-inspector/shared/execution-target.ts
@@ -1,0 +1,216 @@
+/**
+ * Shared execution-target contract (Project Environments — Phase 1.1).
+ *
+ * ONE serializable pointer that says WHAT a hosted chat turn executes against.
+ * The wire form is deliberately tiny — an id plus a discriminant — because the
+ * authoritative configuration is always re-resolved server-side (a host by
+ * `hostId`, an environment by `projectEnvironments:resolveEnvironmentForRuntime`).
+ * Nothing about the resolved shape may be carried in the request body.
+ *
+ * ## Why a union instead of another optional pointer
+ *
+ * chat-v2 already carried `chatboxId` and a legacy `hostId`, resolved by branch
+ * precedence. Adding `environmentId` as a third optional field would mean a body
+ * with two pointers silently executing against one of them — the caller believes
+ * they launched an environment, the server ran a bare host. So ingress
+ * NORMALIZES every legacy field into one closed internal union
+ * ({@link InternalExecutionTarget}) and REJECTS ambiguous combinations instead
+ * of shadowing them.
+ *
+ * `chatboxId` is deliberately NOT folded into the public
+ * {@link HostedExecutionTarget}: it is an access-bearing transport field (the
+ * redeemed share-link identity, paired with `accessVersion`), not a statement
+ * about which configuration to execute. It stays where it is and simply
+ * conflicts with an explicit `executionTarget`.
+ */
+
+/** What the client asks to execute against. Serializable; ids only. */
+export type HostedExecutionTarget =
+  | { kind: "host"; hostId: string }
+  | { kind: "environment"; environmentId: string };
+
+/**
+ * Per-turn, never-persisted narrowing of what an environment resolves to.
+ *
+ * ABSENT and `[]` are different and must stay different: absent means "use the
+ * environment's own server set", `[]` means "run this turn with no MCP servers".
+ * The backend resolver enforces the same distinction, and it never widens
+ * authorization (see `validateRuntimeServerOverride`).
+ */
+export type EnvironmentOverrides = { serverIds?: string[] };
+
+/**
+ * The closed union every hosted chat ingress normalizes to. Unlike the public
+ * wire type this also covers the two shapes that were never explicit targets:
+ * a chatbox-bound turn and a plain ad-hoc project chat.
+ */
+export type InternalExecutionTarget =
+  | { kind: "host"; hostId: string }
+  | {
+      kind: "environment";
+      environmentId: string;
+      overrides?: EnvironmentOverrides;
+    }
+  | { kind: "chatbox"; chatboxId: string }
+  | { kind: "adhoc"; projectId: string };
+
+export type NormalizeExecutionTargetResult =
+  | { ok: true; target: InternalExecutionTarget }
+  | { ok: false; error: string };
+
+/** Raw, untrusted ingress fields. Every one is optional on the wire. */
+export interface ExecutionTargetIngress {
+  chatboxId?: unknown;
+  executionTarget?: unknown;
+  environmentOverrides?: unknown;
+  /** Legacy pointer kept for compatibility; normalized to `{ kind: "host" }`. */
+  hostId?: unknown;
+  projectId?: unknown;
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value
+    : undefined;
+}
+
+/** Parse the public wire target. Returns an error string for a malformed one. */
+function parseHostedExecutionTarget(
+  value: unknown
+): { ok: true; target: HostedExecutionTarget } | { ok: false; error: string } {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return { ok: false, error: "executionTarget must be an object" };
+  }
+  const kind = (value as { kind?: unknown }).kind;
+  if (kind === "host") {
+    const hostId = nonEmptyString((value as { hostId?: unknown }).hostId);
+    if (!hostId) {
+      return { ok: false, error: "executionTarget.hostId is required" };
+    }
+    return { ok: true, target: { kind: "host", hostId } };
+  }
+  if (kind === "environment") {
+    const environmentId = nonEmptyString(
+      (value as { environmentId?: unknown }).environmentId
+    );
+    if (!environmentId) {
+      return { ok: false, error: "executionTarget.environmentId is required" };
+    }
+    return { ok: true, target: { kind: "environment", environmentId } };
+  }
+  return {
+    ok: false,
+    error: "executionTarget.kind must be 'host' or 'environment'",
+  };
+}
+
+/**
+ * Parse the per-turn override envelope. An absent envelope and an envelope with
+ * an absent `serverIds` both mean "no override"; `{ serverIds: [] }` is a real,
+ * meaningful override.
+ */
+function parseEnvironmentOverrides(
+  value: unknown
+):
+  | { ok: true; overrides?: EnvironmentOverrides }
+  | { ok: false; error: string } {
+  if (value === undefined || value === null) return { ok: true };
+  if (typeof value !== "object" || Array.isArray(value)) {
+    return { ok: false, error: "environmentOverrides must be an object" };
+  }
+  const serverIds = (value as { serverIds?: unknown }).serverIds;
+  if (serverIds === undefined) return { ok: true };
+  if (
+    !Array.isArray(serverIds) ||
+    serverIds.some((id) => nonEmptyString(id) === undefined)
+  ) {
+    return {
+      ok: false,
+      error: "environmentOverrides.serverIds must be an array of server ids",
+    };
+  }
+  return { ok: true, overrides: { serverIds: serverIds as string[] } };
+}
+
+/**
+ * Normalize the ingress fields to exactly one internal target.
+ *
+ * Precedence, in order — the FIRST two rules are rejections, never fallbacks:
+ *
+ *   1. `chatboxId` + `executionTarget`  → invalid combination (400).
+ *      A chatbox pins its own host server-side; an explicit target alongside it
+ *      would either be ignored (silently wrong) or override a published
+ *      chatbox's configuration from a share-link body (a security regression).
+ *   2. legacy `hostId` + `executionTarget` → invalid combination (400).
+ *      Two statements about what to run. Old clients send only `hostId`, new
+ *      clients send only `executionTarget`; a body with both is a bug, and
+ *      picking a winner is exactly the silent shadowing this normalizer exists
+ *      to prevent.
+ *   3. `executionTarget`  → use it.
+ *   4. `chatboxId`        → chatbox turn (unchanged legacy behavior; a chatbox
+ *      has always won over a stray `hostId`).
+ *   5. legacy `hostId`    → `{ kind: "host" }`.
+ *   6. neither            → ad-hoc direct chat.
+ *
+ * `environmentOverrides` is only meaningful for an environment target; supplying
+ * it with any other target is rejected rather than dropped.
+ */
+export function normalizeExecutionTarget(
+  ingress: ExecutionTargetIngress
+): NormalizeExecutionTargetResult {
+  const chatboxId = nonEmptyString(ingress.chatboxId);
+  const hostId = nonEmptyString(ingress.hostId);
+  const projectId = nonEmptyString(ingress.projectId) ?? "";
+  const hasExecutionTarget =
+    ingress.executionTarget !== undefined && ingress.executionTarget !== null;
+
+  if (hasExecutionTarget && chatboxId) {
+    return {
+      ok: false,
+      error:
+        "chatboxId and executionTarget cannot be combined — a chatbox already pins its own execution configuration.",
+    };
+  }
+  if (hasExecutionTarget && hostId) {
+    return {
+      ok: false,
+      error:
+        "hostId and executionTarget cannot be combined — send only executionTarget.",
+    };
+  }
+
+  const overrides = parseEnvironmentOverrides(ingress.environmentOverrides);
+  if (!overrides.ok) return { ok: false, error: overrides.error };
+
+  if (hasExecutionTarget) {
+    const parsed = parseHostedExecutionTarget(ingress.executionTarget);
+    if (!parsed.ok) return { ok: false, error: parsed.error };
+    if (parsed.target.kind === "environment") {
+      return {
+        ok: true,
+        target: {
+          kind: "environment",
+          environmentId: parsed.target.environmentId,
+          ...(overrides.overrides ? { overrides: overrides.overrides } : {}),
+        },
+      };
+    }
+    if (overrides.overrides) {
+      return {
+        ok: false,
+        error: "environmentOverrides requires an environment executionTarget.",
+      };
+    }
+    return { ok: true, target: parsed.target };
+  }
+
+  if (overrides.overrides) {
+    return {
+      ok: false,
+      error: "environmentOverrides requires an environment executionTarget.",
+    };
+  }
+  if (chatboxId) return { ok: true, target: { kind: "chatbox", chatboxId } };
+  if (hostId) return { ok: true, target: { kind: "host", hostId } };
+  return { ok: true, target: { kind: "adhoc", projectId } };
+}


### PR DESCRIPTION
The inspector half of Phase 1. Consumes the backend's `projectEnvironments:resolveEnvironmentForRuntime` (mcpjam-backend #786 + #789) so a chat turn bound to a Project Environment gets its host config, closed server set, and skills from **one** read instead of reassembling them from separate queries.

**Server-side only.** No Playground UI, no Connect entry point, no `usePreviewedEnvironmentId` — those are Phase 2. Nothing in the browser sends an environment target yet, so this ships inert.

> Requires mcpjam-backend #789 deployed. The resolver has a deploy-skew guard, so an older backend fails with a readable error rather than a 500.

## 1.1 — Execution target

`shared/execution-target.ts` adds a `HostedExecutionTarget` union and a pure `normalizeExecutionTarget()` that collapses every inbound shape to a closed internal union (`host | environment | chatbox | adhoc`) at ingress. Legacy `hostId` keeps working.

Ambiguous combinations — `chatboxId` + `executionTarget`, or legacy `hostId` + `executionTarget` — are **rejected with a 400** rather than resolved by precedence. A caller that sends two targets has a bug; silently picking one would run it against a different execution context than it asked for. (The second rejection wasn't in the original scope; it follows from the same rule and is tested.)

## 1.3 — Runtime service + browser preview

`server/services/environments/runtime.ts` mirrors the backend spec, tolerating fields an older or newer deploy omits, but failing **closed** when identity or host invariants are missing. A turn that silently degrades is worse than one that errors.

`GET /api/web/environments/:environmentId/preview` serves the browser. The projection is written field-by-field with **no spread**, and deliberately so:

| Runtime spec has | Preview exposes |
| --- | --- |
| `skills[].content`, `skills[].files[].url` | `hasFiles: boolean` only |
| `runtimeConfig.computer` | `hasComputer: boolean` |
| `runtimeConfig.mcpProfile`, `systemPrompt` | *(absent)* |

That matters because the runtime spec carries skill bodies and **signed `_storage` URLs**. Adding a field to the spec later cannot leak it to the browser by default.

## 1.4 — Skills through both engines

**Emulated:** a `resolved` skill source, distinct from the eval-only `pinned` one. It deliberately does *not* inherit the eval rule where pinned skill reads bypass tool approval — an interactive turn approves like any other.

**Harness:** `runtimeSkillsOverride` threaded through the turn inputs, with the precedence written down in exactly one place (`selectHarnessSkillSource`):

```
frozen run artifacts (eval/swarm pinned)  ->  win
environment runtimeSkillsOverride         ->  resolved environment artifacts
neither                                   ->  today's live project-wide fetch
```

An **empty** override is semantic — deliver nothing, don't fall through to the project-wide fetch. Supporting-file fetch stays project-wide because `materializeSkillFiles` already filters by the delivered `skillNamesById`; a regression test now locks that behavior rather than leaving it as an assumption.

`cloudSkills` is disabled for environment turns, so skills reach a turn through exactly one channel — no additive double delivery.

Skills-incapable harness adapters (Codex delivers none today) surface `unsupported` in preview and telemetry instead of pretending skills were delivered.

## Consistent use downstream

Once an environment resolves, its values drive harness preflight, `createAuthorizedManager`, the elicitation name map, `prepareChatV2`, direct-chat persistence/resume, telemetry and the tool snapshot. The failure mode this avoids is resolving the environment and then continuing to pass raw body `selectedServerIds` to the manager.

Local `/api/mcp` execution rejects environment targets outright — it cannot resolve or authorize an environment.

## Verification

- `npx vitest run` — **9,947 passed**, 6 skipped, **0 failures**
- `npx tsc --noEmit -p server/tsconfig.json` — **83 errors vs. an 83 baseline**, diffed by file + code: **zero new**
- `npm run typecheck:client` — clean
- New tests cover ingress normalization (including both invalid combinations), deploy-skew tolerance vs. fail-closed invariants, the preview stripping content/files/secrets, the emulated engine receiving only resolved skills, the harness tri-state including the semantic empty override, and the `materializeSkillFiles` filtering regression.

Canonical Prettier here is 2.8.8, not 3.x. Several modified files were already 2.8.8-dirty at HEAD; I matched local style on inserted lines rather than reformatting them, so there's no collateral churn.

## Worth a reviewer's eye

Environment turns keep `precedence: "override-wins"`, matching the existing host-target Playground path — the actor is the environment's own project member, and `harness`/`computer` are structurally excluded from `ExecutionOverrides`. That's the split-authority model; flag it if environment turns should be host-wins instead.

Also note `runAssistantTurn` turned out **not** to be on the hosted chat path (`web-chat-turn.ts` calls `handleMCPJamFreeChatModel` directly; `runAssistantTurn` is the eval/synthetic facade). The override is threaded through both so they stay at parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hosted chat authorization, elicitation authority, and skill delivery precedence; mistakes could connect wrong MCP servers or leak secrets via preview, though fail-closed guards and explicit preview projection mitigate this.
> 
> **Overview**
> **Server-only Phase 1** for Project Environments: hosted chat can bind to an `executionTarget` and run from a single Convex `resolveEnvironmentForRuntime` read. No Playground UI yet; local `/api/mcp/chat-v2` **rejects** any `executionTarget` with a clear 400.
> 
> **Ingress** adds `shared/execution-target.ts` — `normalizeExecutionTarget()` collapses legacy `hostId`, `chatboxId`, and the new `executionTarget` / `environmentOverrides` into one internal union. **Ambiguous pairs** (`chatboxId` + `executionTarget`, `hostId` + `executionTarget`) return **400** instead of silent precedence.
> 
> **Hosted `web/chat-v2`** resolves an environment atomically, then uses that spec for **everything**: host runtime config, **effective server ids/names** (body `selectedServerIds` ignored), manager authorize/connect, elicitation (host-authoritative like chatbox), harness preflight, persistence/resume, and telemetry. **`cloudSkills`** is off for environment turns so skills use one channel.
> 
> **Skills**: emulated turns get `skillsSource: resolved` (normal tool approval, unlike eval `pinned`); harness turns get `runtimeSkillsOverride` via **`selectHarnessSkillSource`** (pinned run artifacts → environment override → live fetch; **empty override = deliver none**). Supporting files stay project-wide but **`materializeSkillFiles`** filters to delivered skills.
> 
> **Preview**: `GET /api/web/environments/:id/preview` returns an explicit, no-spread projection (`hasFiles`, `hasComputer` only — no skill bodies, signed URLs, `systemPrompt`, or `mcpProfile`). Runtime helper fails closed on bad specs and maps `ENV_*` to **409**.
> 
> Extensive vitest coverage for normalization, preview redaction, resolved-server wiring, and harness/emulated skill paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4397e4d2d2b1224404e57a564413135ab782c5dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds server-side support to run interactive turns against a Project Environment with one backend read, and applies the resolved host config, server set, and skills consistently across hosted chat. Also fixes elicitation to follow the resolved host for chatbox and environment turns, adds strict execution-target normalization, and a safe browser preview.

- **New Features**
  - Added `HostedExecutionTarget` and `normalizeExecutionTarget()`; reject `chatboxId` + `executionTarget` and legacy `hostId` + `executionTarget` with 400; legacy `hostId` still works.
  - Consumes `projectEnvironments:resolveEnvironmentForRuntime`; fails closed on missing identity/host and drives harness preflight, manager auth, persistence/resume, telemetry, and tool snapshot. Local `/api/mcp` rejects environment targets. Introduced resolved-skill delivery: precedence is pinned > environment override > live; an empty override delivers none. `cloudSkills` disabled for environment turns; skills-incapable harnesses are reported; supporting files remain project-wide but are filtered to delivered skills.
  - Hosted elicitation now reads `clientCapabilities` from the resolved host when the server is authoritative (chatbox and environment). The request body is used only for direct turns.
  - Added `GET /api/web/environments/:environmentId/preview` that returns a narrow projection (`hasFiles`, `hasComputer`) without skill bodies, signed URLs, `systemPrompt`, or `mcpProfile`.

- **Migration**
  - Requires backend resolver (`#789`) deployed; guarded against deploy skew with readable errors.
  - Server-only (no UI/Connect). Inert until clients send `executionTarget` (Phase 2).

<sup>Written for commit 4397e4d2d2b1224404e57a564413135ab782c5dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

