### PR TITLE
refactor(inspector): make the form-data → persistence secret contract explicit

### DIFF
--- a/mcpjam-inspector/client/src/hooks/__tests__/secret-sync-options.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/secret-sync-options.test.ts
@@ -1,0 +1,93 @@
+/**
+ * The form-data → persistence secret contract, in one place.
+ *
+ * `syncServerToConvex` writes `env` / `headers` exclusively from
+ * `buildSecretSyncOptions`, and reads key PRESENCE as intent. Plain
+ * `formData.env` / `formData.headers` configure the in-memory connection only,
+ * so a producer holding real secrets (a JSON import, a bundle install) must
+ * present them as a `secretPatch`. Getting that wrong is invisible at connect
+ * time and only surfaces as a 401 after a reload — which is why the rule is
+ * pinned here rather than left to an integration test.
+ */
+import { describe, expect, it } from "vitest";
+
+import { buildSecretSyncOptions } from "../use-server-state";
+import type { ServerFormData } from "@/shared/types.js";
+
+const base: ServerFormData = {
+  name: "srv",
+  type: "http",
+  url: "https://example.com/mcp",
+};
+
+describe("buildSecretSyncOptions", () => {
+  it("forwards an explicit header patch", () => {
+    expect(
+      buildSecretSyncOptions({
+        ...base,
+        secretPatch: { headers: { Authorization: "Bearer secret" } },
+      }).headers,
+    ).toEqual({ Authorization: "Bearer secret" });
+  });
+
+  it("forwards an explicit env patch", () => {
+    expect(
+      buildSecretSyncOptions({
+        ...base,
+        type: "stdio",
+        command: "node",
+        secretPatch: { env: { API_TOKEN: "token" } },
+      }).env,
+    ).toEqual({ API_TOKEN: "token" });
+  });
+
+  it("forwards an explicit CLEAR, which is not the same as absence", () => {
+    const cleared = buildSecretSyncOptions({
+      ...base,
+      secretPatch: { headers: {}, env: {} },
+    });
+    expect(cleared).toHaveProperty("headers", {});
+    expect(cleared).toHaveProperty("env", {});
+  });
+
+  it("omits the keys entirely with no patch, leaving stored secrets alone", () => {
+    // The plain fields are deliberately NOT a fallback: an edit form that never
+    // opened the secrets section carries values it must not write back.
+    const options = buildSecretSyncOptions({
+      ...base,
+      headers: { Authorization: "Bearer from-form" },
+      env: { API_TOKEN: "from-form" },
+    });
+    expect(options).not.toHaveProperty("headers");
+    expect(options).not.toHaveProperty("env");
+  });
+
+  it("carries what an import stamped, on both channels", () => {
+    // The persistence end of the chain the JSON import depends on: whatever the
+    // importer marks here is what actually gets written.
+    const imported = buildSecretSyncOptions({
+      ...base,
+      headers: { Authorization: "Bearer imported" },
+      env: { API_TOKEN: "imported" },
+      secretPatch: {
+        headers: { Authorization: "Bearer imported" },
+        env: { API_TOKEN: "imported" },
+      },
+    });
+    expect(imported.headers).toEqual({ Authorization: "Bearer imported" });
+    expect(imported.env).toEqual({ API_TOKEN: "imported" });
+  });
+
+  it("keeps the OAuth client-secret operations independent of the patch", () => {
+    expect(
+      buildSecretSyncOptions({ ...base, clientSecret: "shh" }).clientSecret,
+    ).toBe("shh");
+    expect(
+      buildSecretSyncOptions({ ...base, clearClientSecret: true })
+        .clearClientSecret,
+    ).toBe(true);
+    expect(
+      buildSecretSyncOptions({ ...base, clearXaaConfig: true }).clearXaaConfig,
+    ).toBe(true);
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -834,6 +834,39 @@ export interface EnsureServersReadyResult {
   reauthServerNames: string[];
 }
 
+/**
+ * The ONLY channel by which secrets travel from form data to persistence.
+ *
+ * `syncServerToConvex` writes `env` / `headers` exclusively from what this
+ * returns, and reads key PRESENCE as intent (absent = leave alone, `{}` =
+ * clear, value = replace). Plain `formData.env` / `formData.headers` never
+ * reach it — they configure the in-memory connection only — which is the trap
+ * every import-shaped producer has to know about; see `ServerFormData.secretPatch`.
+ *
+ * Extracted and exported so that contract is unit-testable in one place rather
+ * than re-derived inline by each caller.
+ */
+export function buildSecretSyncOptions(formData: ServerFormData): {
+  clientSecret?: string;
+  clearClientSecret?: boolean;
+  clearXaaConfig?: boolean;
+  env?: Record<string, string>;
+  headers?: Record<string, string>;
+} {
+  return {
+    ...(formData.clientSecret ? { clientSecret: formData.clientSecret } : {}),
+    ...(formData.clearClientSecret ? { clearClientSecret: true } : {}),
+    // One-shot XAA-config reset (modal moved the server off XAA).
+    ...(formData.clearXaaConfig ? { clearXaaConfig: true } : {}),
+    ...(formData.secretPatch?.env !== undefined
+      ? { env: formData.secretPatch.env }
+      : {}),
+    ...(formData.secretPatch?.headers !== undefined
+      ? { headers: formData.secretPatch.headers }
+      : {}),
+  };
+}
+
 export function useServerState({
   appState,
   dispatch,
@@ -2917,20 +2950,7 @@ export function useServerState({
                 existingServerForSave?.hasClientSecret
             )
           : false;
-      const clientSecretSyncOptions = {
-        ...(formData.clientSecret
-          ? { clientSecret: formData.clientSecret }
-          : {}),
-        ...(formData.clearClientSecret ? { clearClientSecret: true } : {}),
-        // One-shot XAA-config reset (modal moved the server off XAA).
-        ...(formData.clearXaaConfig ? { clearXaaConfig: true } : {}),
-        ...(formData.secretPatch?.env !== undefined
-          ? { env: formData.secretPatch.env }
-          : {}),
-        ...(formData.secretPatch?.headers !== undefined
-          ? { headers: formData.secretPatch.headers }
-          : {}),
-      };
+      const clientSecretSyncOptions = buildSecretSyncOptions(formData);
 
       const serverEntryForSave: ServerWithName = {
         name: formData.name,

--- a/mcpjam-inspector/shared/types.ts
+++ b/mcpjam-inspector/shared/types.ts
@@ -801,6 +801,28 @@ export interface ServerFormData {
   url?: string;
   headers?: Record<string, string>;
   env?: Record<string, string>;
+  /**
+   * EXPLICIT secret write. The plain `env` / `headers` above feed the
+   * in-memory connect only — persistence (Convex) writes secrets exclusively
+   * from this patch, via `buildSecretSyncOptions`, and reads key PRESENCE as
+   * intent:
+   *
+   * - key ABSENT       → leave the stored value untouched (an edit that never
+   *                      opened the secrets section must not clobber it);
+   * - key present `{}`  → explicitly CLEAR the stored value;
+   * - key present, set  → replace the stored value.
+   *
+   * That three-state contract is why the plain fields cannot simply be
+   * persisted as a fallback: there, an untouched edit form and a deliberate
+   * clear are indistinguishable.
+   *
+   * The consequence for producers: anything holding REAL secret values — a JSON
+   * import, a bundle install, a deep link — has to set this too, and only when
+   * the values are non-empty (an empty patch would wipe the credentials of an
+   * existing server with the same name). Setting just `env` / `headers` yields
+   * a server that connects once from memory and comes back credential-less
+   * after a reload, with nothing to indicate anything was dropped.
+   */
   secretPatch?: {
     env?: Record<string, string>;
     headers?: Record<string, string>;


### PR DESCRIPTION
Follow-up to #3444, which fixed the imported-secrets bug itself (`32ea8bc`). This adds the two pieces that keep the next producer from re-introducing it — no behavior change.

**The trap.** Persistence writes `env`/`headers` only from `secretPatch`; the plain `formData.env`/`formData.headers` configure the in-memory connection only. A producer that sets just the plain fields gets a server that connects once and comes back credential-less after a reload, with nothing indicating anything was dropped. That is exactly how the JSON import path went wrong, and the shape of it is not guessable from the type.

**`ServerFormData.secretPatch` had no doc comment at all**, despite encoding a three-state contract: key absent leaves the stored value untouched, `{}` clears it, a value replaces it. It now documents that, why the plain fields cannot simply be persisted as a fallback (an untouched edit form and a deliberate clear are indistinguishable there), and what it obliges of producers holding real secrets — including that an empty patch would wipe the credentials of an existing server with the same name.

**`buildSecretSyncOptions` is extracted from `handleConnect` and exported**, so the persistence half of the contract is unit-testable in one place instead of being re-derived inline in a 3000-line hook. Same object, same keys, same conditions.

**Tests** (6): explicit patch forwarded on both channels; explicit clear preserved as distinct from absence; no patch leaves stored secrets alone — with the plain fields deliberately populated, to prove they are not a fallback; OAuth client-secret operations stay independent of the patch.

136 tests green across the three affected suites; client typecheck clean.

Left **open** for review — no merge/approve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor plus documentation and tests only; secret sync logic is unchanged, with lower risk of regressing credential persistence.
> 
> **Overview**
> This PR **documents and locks in** how server `env` / `headers` get persisted: Convex only sees secrets via `secretPatch` through **`buildSecretSyncOptions`**, not from plain `formData.env` / `formData.headers` (those are in-memory connect only).
> 
> **`ServerFormData.secretPatch`** now has a doc comment describing the three-state intent: absent key leaves stored secrets alone, `{}` clears, a value replaces. Producers like JSON import must set `secretPatch` when they have real secrets.
> 
> **`buildSecretSyncOptions`** is extracted from `handleConnect`, exported, and wired the same way—so the persistence mapping is testable in one place.
> 
> **New unit tests** (`secret-sync-options.test.ts`) cover patch forwarding, explicit clear vs absence, no fallback from plain fields, import-shaped stamping, and OAuth client-secret flags staying independent of the patch.
> 
> No intended runtime behavior change; follow-up hardening after the imported-secrets fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e65775b207bde3c7066f405b7ebbd153431c87f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the form-data → persistence secret contract explicit to prevent future secret drops on reload. Extract `buildSecretSyncOptions` and document the three‑state `secretPatch`; behavior is unchanged.

- **Refactors**
  - Extracted and exported `buildSecretSyncOptions` to centralize secret syncing (absent=keep, `{}`=clear, value=replace).
  - Documented `ServerFormData.secretPatch`; plain `env`/`headers` configure in-memory only and are not persisted.
  - Added unit tests to pin the contract and keep OAuth client-secret operations independent.

<sup>Written for commit e65775b207bde3c7066f405b7ebbd153431c87f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

