### PR TITLE
fix(oauth): PRM step-up review follow-ups stranded by #3445 squash-merge

### DIFF
--- a/mcpjam-inspector/client/src/state/oauth-orchestrator.ts
+++ b/mcpjam-inspector/client/src/state/oauth-orchestrator.ts
@@ -630,6 +630,20 @@ export async function applyToolCallStepUp(
     challenge.resourceMetadataUrl,
   );
 
+  // A METADATA-ONLY challenge (a `resource_metadata` pointer with NO
+  // `requiredScope`) intentionally re-authorizes with the EXISTING scopes.
+  // `challengedScopes` is empty, so the union below is just the user's
+  // previously-requested/consented scopes, which flow to the fresh grant as its
+  // requested scope value. This is deliberate, not a bug: a metadata-only
+  // `insufficient_scope` names no scope to widen to — it is a "you discovered
+  // PRM from the wrong place, rediscover it here" signal (the corrected
+  // `resourceMetadataUrl` may point at a different issuer/resource). Requesting
+  // the corrected PRM's full `scopes_supported` instead would over-grant scopes
+  // the server never asked for and the user never consented to; re-requesting
+  // the original scopes against the CORRECTED metadata is the least-privilege,
+  // intent-preserving step-up (and is not a no-op — discovery, AS, and token
+  // audience can all change). If the corrected metadata still resolves to the
+  // same insufficient scopes, the bounded retry stops the loop by design.
   const decision = resolveInsufficientScopeStepUp({
     serverName: server.name,
     issuer,

--- a/mcpjam-inspector/server/utils/web-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/web-chat-turn.ts
@@ -468,8 +468,8 @@ export async function streamWebChatTurn(
               // `isActionableStepUpChallenge` gate.
               if (
                 insufficientScope &&
-                (insufficientScope.requiredScope ||
-                  insufficientScope.resourceMetadataUrl)
+                (insufficientScope.requiredScope?.trim() ||
+                  insufficientScope.resourceMetadataUrl?.trim())
               ) {
                 const challenge = {
                   serverId,

--- a/sdk/src/oauth/state-machines/debug-oauth-2025-06-18.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-06-18.ts
@@ -861,13 +861,20 @@ export const createDebugOAuthStateMachine = (
 
             try {
               // Pass an explicit metadata URL to discovery ONLY when it was
-              // header/override-sourced (not derived from the server URL): a
-              // fresh `WWW-Authenticate` header, or a SEP-2350 caller override.
-              // A derived URL is left undefined so discovery keeps its
-              // well-known + fallback behavior.
+              // EXPLICITLY sourced — a SEP-2350 caller override, OR the fresh
+              // `WWW-Authenticate` header's own `resource_metadata` param — not
+              // when it was DERIVED from the server URL. A `WWW-Authenticate`
+              // header can be present yet omit `resource_metadata`, in which
+              // case `state.resourceMetadataUrl` holds the derived well-known
+              // URL; passing that as an explicit option would defeat discovery's
+              // well-known + fallback behavior, so leave `metadataOptions`
+              // undefined for a derived URL.
+              const explicitResourceMetadataUrl =
+                overrideResourceMetadataUrl ||
+                parseBearerAuthenticateParameters(state.wwwAuthenticateHeader)
+                  .resource_metadata;
               const metadataOptions =
-                (state.wwwAuthenticateHeader || overrideResourceMetadataUrl) &&
-                state.resourceMetadataUrl
+                explicitResourceMetadataUrl && state.resourceMetadataUrl
                   ? { resourceMetadataUrl: state.resourceMetadataUrl }
                   : undefined;
 

--- a/sdk/src/oauth/state-machines/debug-oauth-2025-06-18.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-06-18.ts
@@ -696,7 +696,7 @@ export const createDebugOAuthStateMachine = (
             }
             break;
 
-          case "received_401_unauthorized":
+          case "received_401_unauthorized": {
             // Step 3: Extract resource metadata URL and prepare request
             const challengeParams = parseBearerAuthenticateParameters(
               state.wwwAuthenticateHeader,
@@ -746,6 +746,7 @@ export const createDebugOAuthStateMachine = (
             // Automatically proceed to make the actual request
             autoAdvance(50);
             return;
+          }
 
           case "request_resource_metadata":
             // Step 2: Fetch and parse resource metadata using official SDK helper

--- a/sdk/src/oauth/state-machines/debug-oauth-2025-11-25.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-11-25.ts
@@ -813,7 +813,7 @@ export const createDebugOAuthStateMachine = (
             }
             break;
 
-          case "received_401_unauthorized":
+          case "received_401_unauthorized": {
             // Step 3: Extract resource metadata URL and prepare request
             const challengeParams = parseBearerAuthenticateParameters(
               state.wwwAuthenticateHeader,
@@ -863,6 +863,7 @@ export const createDebugOAuthStateMachine = (
             // Automatically proceed to make the actual request
             autoAdvance(50);
             return;
+          }
 
           case "request_resource_metadata":
             // Step 2: Fetch and parse resource metadata using official SDK helper

--- a/sdk/src/oauth/state-machines/debug-oauth-2025-11-25.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-11-25.ts
@@ -954,13 +954,20 @@ export const createDebugOAuthStateMachine = (
 
             try {
               // Pass an explicit metadata URL to discovery ONLY when it was
-              // header/override-sourced (not derived from the server URL): a
-              // fresh `WWW-Authenticate` header, or a SEP-2350 caller override.
-              // A derived URL is left undefined so discovery keeps its
-              // well-known + fallback behavior.
+              // EXPLICITLY sourced — a SEP-2350 caller override, OR the fresh
+              // `WWW-Authenticate` header's own `resource_metadata` param — not
+              // when it was DERIVED from the server URL. A `WWW-Authenticate`
+              // header can be present yet omit `resource_metadata`, in which
+              // case `state.resourceMetadataUrl` holds the derived well-known
+              // URL; passing that as an explicit option would defeat discovery's
+              // well-known + fallback behavior, so leave `metadataOptions`
+              // undefined for a derived URL.
+              const explicitResourceMetadataUrl =
+                overrideResourceMetadataUrl ||
+                parseBearerAuthenticateParameters(state.wwwAuthenticateHeader)
+                  .resource_metadata;
               const metadataOptions =
-                (state.wwwAuthenticateHeader || overrideResourceMetadataUrl) &&
-                state.resourceMetadataUrl
+                explicitResourceMetadataUrl && state.resourceMetadataUrl
                   ? { resourceMetadataUrl: state.resourceMetadataUrl }
                   : undefined;
 

--- a/sdk/src/oauth/state-machines/debug-oauth-2026-07-28.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2026-07-28.ts
@@ -915,7 +915,7 @@ export const createDebugOAuthStateMachine = (
             }
             break;
 
-          case "received_401_unauthorized":
+          case "received_401_unauthorized": {
             // Step 3: Extract resource metadata URL and prepare request
             const challengeParams = parseBearerAuthenticateParameters(
               state.wwwAuthenticateHeader,
@@ -965,6 +965,7 @@ export const createDebugOAuthStateMachine = (
             // Automatically proceed to make the actual request
             autoAdvance(50);
             return;
+          }
 
           case "request_resource_metadata":
             // Step 2: Fetch and parse resource metadata using official SDK helper

--- a/sdk/src/oauth/state-machines/debug-oauth-2026-07-28.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2026-07-28.ts
@@ -1056,13 +1056,20 @@ export const createDebugOAuthStateMachine = (
 
             try {
               // Pass an explicit metadata URL to discovery ONLY when it was
-              // header/override-sourced (not derived from the server URL): a
-              // fresh `WWW-Authenticate` header, or a SEP-2350 caller override.
-              // A derived URL is left undefined so discovery keeps its
-              // well-known + fallback behavior.
+              // EXPLICITLY sourced — a SEP-2350 caller override, OR the fresh
+              // `WWW-Authenticate` header's own `resource_metadata` param — not
+              // when it was DERIVED from the server URL. A `WWW-Authenticate`
+              // header can be present yet omit `resource_metadata`, in which
+              // case `state.resourceMetadataUrl` holds the derived well-known
+              // URL; passing that as an explicit option would defeat discovery's
+              // well-known + fallback behavior, so leave `metadataOptions`
+              // undefined for a derived URL.
+              const explicitResourceMetadataUrl =
+                overrideResourceMetadataUrl ||
+                parseBearerAuthenticateParameters(state.wwwAuthenticateHeader)
+                  .resource_metadata;
               const metadataOptions =
-                (state.wwwAuthenticateHeader || overrideResourceMetadataUrl) &&
-                state.resourceMetadataUrl
+                explicitResourceMetadataUrl && state.resourceMetadataUrl
                   ? { resourceMetadataUrl: state.resourceMetadataUrl }
                   : undefined;
 

--- a/sdk/tests/oauth/discovery-challenge-conformance.test.ts
+++ b/sdk/tests/oauth/discovery-challenge-conformance.test.ts
@@ -219,4 +219,118 @@ describe("OAuth escalation conformance to the original WWW-Authenticate challeng
     expect(state.resourceMetadataUrl).not.toBe(FRESH_401_RESOURCE_METADATA_URL);
     expect(state.lastRequest?.url).toBe(OVERRIDE_RESOURCE_METADATA_URL);
   });
+
+  // Explicit-vs-derived metadata URL (coderabbit Major / cubic P2). When the
+  // fresh `WWW-Authenticate` header carries NO `resource_metadata` param and
+  // there is NO SEP-2350 override, `state.resourceMetadataUrl` holds the
+  // DERIVED well-known URL. Discovery MUST treat that as implicit (no explicit
+  // `metadataOptions`) so it keeps its well-known + fallback behavior — a header
+  // being present must NOT flip a derived URL into an explicit one.
+  it("treats a header-without-resource_metadata URL as DERIVED, keeping discovery's well-known fallback (2025-11-25)", async () => {
+    const SERVER_WITH_PATH = "https://mcp.example.com/mcp";
+    const DERIVED_PATH_URL =
+      "https://mcp.example.com/.well-known/oauth-protected-resource/mcp";
+    const ROOT_FALLBACK_URL =
+      "https://mcp.example.com/.well-known/oauth-protected-resource";
+
+    let state = {
+      ...EMPTY_OAUTH_FLOW_STATE,
+      currentStep: "request_without_token" as const,
+      serverUrl: SERVER_WITH_PATH,
+      httpHistory: [
+        {
+          step: "request_without_token" as const,
+          timestamp: Date.now(),
+          request: {
+            method: "POST",
+            url: SERVER_WITH_PATH,
+            headers: {},
+            body: { method: "initialize" },
+          },
+        },
+      ],
+      infoLogs: [],
+    };
+
+    const requestExecutor = jest.fn().mockImplementation((request: any) => {
+      // Unauthenticated re-probe: 401 whose WWW-Authenticate omits
+      // `resource_metadata` (only a scope), so the machine derives the PRM URL.
+      if (request.url === SERVER_WITH_PATH) {
+        return Promise.resolve({
+          ok: false,
+          status: 401,
+          statusText: "Unauthorized",
+          headers: {
+            "www-authenticate": `Bearer scope="files:read"`,
+          },
+          body: null,
+        });
+      }
+      // Path-based well-known 404s — discovery must FALL BACK to the root
+      // well-known, which only happens when the URL was NOT passed explicitly.
+      if (request.url === DERIVED_PATH_URL) {
+        return Promise.resolve({
+          ok: false,
+          status: 404,
+          statusText: "Not Found",
+          headers: {},
+          body: null,
+        });
+      }
+      // Root well-known succeeds. Reaching this proves discovery fell back,
+      // i.e. the derived URL was treated as implicit (the fix).
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/json" },
+        body: {
+          resource: SERVER_WITH_PATH,
+          authorization_servers: ["https://auth.example.com"],
+          scopes_supported: ["files:read", "files:write"],
+        },
+      });
+    });
+
+    let machine = createOAuthStateMachine({
+      protocolVersion: "2025-11-25",
+      registrationStrategy: "dcr",
+      state,
+      getState: () => state,
+      updateState: (updates) => {
+        state = { ...state, ...updates };
+      },
+      serverUrl: SERVER_WITH_PATH,
+      serverName: "Test Server",
+      redirectUrl: REDIRECT_URI,
+      requestExecutor,
+      // No resourceMetadataUrl override — the derived path must stay implicit.
+      dynamicRegistration: {
+        client_name: "Test Client",
+      },
+    });
+
+    // request_without_token -> received_401_unauthorized
+    await machine.proceedToNextStep();
+    expect(state.currentStep).toBe("received_401_unauthorized");
+
+    // received_401_unauthorized -> prepares request_resource_metadata. The URL
+    // is DERIVED (built from the server URL), since the header carried none.
+    await machine.proceedToNextStep();
+    expect(state.resourceMetadataUrl).toBe(DERIVED_PATH_URL);
+
+    // request_resource_metadata -> runs discovery. Because the URL was derived
+    // (not header/override-sourced), discovery is invoked WITHOUT an explicit
+    // metadataUrl and so falls back from the 404 path-based well-known to the
+    // root well-known.
+    await machine.proceedToNextStep();
+
+    const fetchedUrls = requestExecutor.mock.calls.map((c: any[]) => c[0].url);
+    // First attempt hit the derived path (404)...
+    expect(fetchedUrls).toContain(DERIVED_PATH_URL);
+    // ...then discovery FELL BACK to the root well-known (200). This fallback
+    // only happens when the URL is implicit — with the pre-fix behavior the
+    // derived URL was passed as explicit and discovery would never reach here.
+    expect(fetchedUrls).toContain(ROOT_FALLBACK_URL);
+  });
 });


### PR DESCRIPTION
## What

Follow-up to #3445, which was **squash-merged before its review-fixer finished** — so four review fixes (one a real spec-conformance bug) never made it into `main`. This PR brings them in.

## Fixes

- **`8acdb39d71` — PRM discovery: pass the metadata URL only when explicitly sourced.** The state machines passed a *derived* protected-resource-metadata URL as if it were explicit even when the `WWW-Authenticate` header omitted `resource_metadata`, defeating the RFC 9728 `.well-known` fallback. Now gated on an explicit-source signal (`override || header's resource_metadata`), applied across the three PRM-capable forks (2025-06-18 / 2025-11-25 / 2026-07-28). Verified against the MCP spec authorization flow ("Extract resource_metadata URL from WWW-Authenticate → Request Protected Resource Metadata"; clients **MUST** use RFC 9728 PRM discovery). Conformance test added.
- **`9ac9c0f211` — lint:** wrap the `received_401_unauthorized` switch-case body in braces (biome `noSwitchDeclarations` on the new `let`).
- **`67ffceff6b` — server emit gate trims** `requiredScope`/`resourceMetadataUrl`, matching the client `isActionableStepUpChallenge` predicate so whitespace-only values don't emit an event the client rejects.
- **`04205cb5e3` — docs:** explain why a metadata-only step-up reuses the user's existing scopes (spec: re-auth scope = union of previous + challenged; a metadata-only challenge names no new scope, so the union is the existing set — least-privilege, not a no-op).

## Notes

Already-correct items from the same review round needed no change: the same-origin relaxation (RFC 9728 imposes no same-origin constraint) landed in #3445; metadata-only-reuses-scopes is deliberate. All four commits were tested in the fixer's worktree (SDK `tests/oauth` 379 passed, client + SDK typecheck clean) before the squash-merge stranded them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OAuth PRM discovery behavior on 401 challenges without `resource_metadata`, which affects connect and step-up flows; scope is limited to three state-machine copies plus a server emit guard.
> 
> **Overview**
> **OAuth PRM discovery (SDK)** — Protected-resource metadata discovery no longer treats a URL derived from the server path as an explicit `resourceMetadataUrl` when the 401 only has `WWW-Authenticate` without `resource_metadata`. Explicit options are limited to a SEP-2350 override or the header’s own `resource_metadata` param, so implicit discovery can still fall back from a path-based `.well-known` 404 to the root well-known. Same logic is applied in the three debug OAuth state-machine forks; `received_401_unauthorized` cases are braced for lint.
> 
> **Hosted chat step-up** — `insufficient_scope` out-of-band events are emitted only when `requiredScope` or `resourceMetadataUrl` is non-empty after `.trim()`, matching the client `isActionableStepUpChallenge` gate so whitespace-only hints do not burn the step-up budget.
> 
> **Client docs** — Comments in `applyToolCallStepUp` explain that a metadata-only challenge re-authorizes with existing scopes (least-privilege PRM rediscovery, not a no-op).
> 
> **Tests** — Conformance test asserts derived-URL implicit discovery reaches root well-known fallback after path 404.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04205cb5e37e0087340b9f813108f264db2c89a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores four missed review fixes from #3445 for the OAuth PRM step-up flow, including a spec-conformance fix to PRM discovery. Preserves RFC 9728 fallback behavior and prevents no-op step-up events; adds a conformance test.

- **Bug Fixes**
  - Pass the PRM metadata URL to discovery only when explicitly provided (override or `WWW-Authenticate` `resource_metadata`); keep derived URLs implicit so `.well-known` fallback works (applied to the 2025-06-18, 2025-11-25, and 2026-07-28 state machines; new conformance test verifies fallback).
  - Trim `requiredScope` and `resourceMetadataUrl` before emitting step-up events to avoid whitespace-only challenges that clients ignore.
  - Scope `received_401_unauthorized` switch cases with braces to satisfy `noSwitchDeclarations` (no behavior change).
  - Clarify in comments that a metadata-only challenge reuses existing scopes by design (least privilege, not a no-op).

<sup>Written for commit 04205cb5e37e0087340b9f813108f264db2c89a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

