### PR TITLE
feat(environments): Playground environment mode + Connect entry point (Phase 2)

### DIFF
--- a/mcpjam-inspector/client/src/components/ServersTab.tsx
+++ b/mcpjam-inspector/client/src/components/ServersTab.tsx
@@ -98,6 +98,7 @@ import {
 } from "@/hooks/useAutoConnectProjectServers";
 import { useHost } from "@/hooks/useClients";
 import { usePreviewedHostId } from "@/hooks/use-previewed-client-id";
+import { ConnectEnvironmentsStrip } from "./project-environments/ConnectEnvironmentsStrip";
 import { useProjectServers as useViewProjectServers } from "@/hooks/useViews";
 import { Project } from "@/state/app-types";
 import {
@@ -1856,6 +1857,8 @@ export function ServersTab({
 
           {renderQuickConnectSection()}
 
+          <ConnectEnvironmentsStrip projectId={sharedProjectIdForHostScope} />
+
           {/* Server Cards Grid (drag-and-drop reorderable, order saved to localStorage only) */}
           <DndContext
             sensors={sensors}
@@ -1989,6 +1992,8 @@ export function ServersTab({
       </div>
 
       {renderQuickConnectSection()}
+
+      <ConnectEnvironmentsStrip projectId={sharedProjectIdForHostScope} />
 
       {/* Empty State */}
       <Card className="p-12 text-center">

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/chat-helpers.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/chat-helpers.ts
@@ -88,7 +88,9 @@ const normalizeDetails = (details: unknown): string | undefined => {
 const lowercaseFirst = (value: string) =>
   value.length > 0 ? value[0].toLowerCase() + value.slice(1) : value;
 
-const pluralize = (value: number, unit: string) =>
+/** `1 server`, `0 servers`. Exported so other count strips reuse this instead
+ *  of re-deriving the same `s` suffix. */
+export const pluralize = (value: number, unit: string) =>
   `${value} ${unit}${value === 1 ? "" : "s"}`;
 
 const collectStringValues = (

--- a/mcpjam-inspector/client/src/components/playground/PlaygroundEnvironmentSection.tsx
+++ b/mcpjam-inspector/client/src/components/playground/PlaygroundEnvironmentSection.tsx
@@ -1,0 +1,218 @@
+import { useEffect, useRef } from "react";
+import { AlertTriangle, Loader2, RotateCcw, X } from "lucide-react";
+import { Checkbox } from "@mcpjam/design-system/checkbox";
+import { Label } from "@mcpjam/design-system/label";
+import { cn } from "@/lib/utils";
+import { track } from "@/lib/analytics";
+import { EnvironmentPicker } from "@/components/project-environments/environment-picker";
+import type { PlaygroundEnvironmentState } from "@/hooks/use-playground-environment";
+
+/**
+ * Playground "Environments" section (Project Environments — Phase 2.5).
+ *
+ * Rendered by {@link import("./PlaygroundHostPicker").PlaygroundHostPicker} and
+ * by the Playground header's leading slot. Flag gating is the CALLER's job (see
+ * `useProjectEnvironmentsEnabled`, fail-closed) — this component renders nothing
+ * on its own when no environment is selected beyond the picker itself.
+ *
+ * Scope discipline, worth stating because the surrounding surface looks like it
+ * contradicts it: model, temperature, system prompt and approval remain
+ * EPHEMERAL Playground controls. Touching them here does not edit the
+ * environment, and the server keeps `override-wins` for exactly those fields on
+ * an environment turn. Editing an environment happens on `/environments`.
+ *
+ * The server list is rendered ID-FIRST from the preview's `{ serverId, name,
+ * source }` entries and is never merged into the ordinary project-server list:
+ * plugin-contributed servers are deliberately hidden from
+ * `servers:getProjectServers`, so the name-keyed catalog cannot represent them.
+ */
+export function PlaygroundEnvironmentSection({
+  projectId,
+  environment,
+  disabled = false,
+  className,
+}: {
+  projectId: string | null;
+  environment: PlaygroundEnvironmentState;
+  disabled?: boolean;
+  className?: string;
+}) {
+  const {
+    isEnvironmentMode,
+    environmentId,
+    preview,
+    isPreviewLoading,
+    previewError,
+    hasExplicitOverride,
+    servers,
+    selectEnvironment,
+    clearEnvironment,
+    resetServersToEnvironment,
+    setServerEnabled,
+  } = environment;
+
+  // Telemetry: an environment resolving is also a host becoming the presented
+  // client, so it reports through the same `client_selected` event as every
+  // other host-choosing surface — with the `project_environments` location the
+  // `HostPickerLocation` enum already reserves. Deduped on the host id so a
+  // preview refresh doesn't re-emit.
+  const lastTrackedHostIdRef = useRef<string | null>(null);
+  const resolvedHostId = preview?.host.hostId ?? null;
+  useEffect(() => {
+    if (!isEnvironmentMode || !resolvedHostId) return;
+    if (lastTrackedHostIdRef.current === resolvedHostId) return;
+    lastTrackedHostIdRef.current = resolvedHostId;
+    try {
+      track("client_selected", {
+        location: "project_environments",
+        client_id: resolvedHostId,
+      });
+    } catch {
+      // swallow — analytics must never block the selection
+    }
+  }, [isEnvironmentMode, resolvedHostId]);
+
+  if (!projectId) return null;
+
+  return (
+    <div
+      className={cn("flex min-w-0 flex-col gap-1.5", className)}
+      data-testid="playground-environment-section"
+    >
+      <div className="flex min-w-0 items-center gap-1.5">
+        <EnvironmentPicker
+          projectId={projectId}
+          value={environmentId}
+          onChange={(next: string | null) => selectEnvironment(next)}
+          multi={false}
+          disabled={disabled}
+          emptyLabel="Environment · none"
+        />
+        {isEnvironmentMode ? (
+          <button
+            type="button"
+            onClick={clearEnvironment}
+            disabled={disabled}
+            className="inline-flex h-6 items-center gap-1 rounded-full border border-border/60 px-2 text-[11px] text-muted-foreground hover:bg-muted/60 disabled:opacity-60"
+            data-testid="playground-environment-clear"
+          >
+            <X className="size-3" aria-hidden />
+            Clear
+          </button>
+        ) : null}
+      </div>
+
+      {isEnvironmentMode && isPreviewLoading && !preview ? (
+        <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+          <Loader2 className="size-3 animate-spin" aria-hidden />
+          Resolving environment…
+        </div>
+      ) : null}
+
+      {isEnvironmentMode && previewError ? (
+        <p
+          className="text-[11px] text-destructive"
+          data-testid="playground-environment-error"
+        >
+          {previewError}
+        </p>
+      ) : null}
+
+      {isEnvironmentMode && preview ? (
+        <div className="flex min-w-0 flex-col gap-1">
+          <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-0.5 text-[11px] text-muted-foreground">
+            <span className="font-medium text-foreground">
+              Environment: {preview.environment.name}
+            </span>
+            <span className="font-mono">
+              rev {preview.environment.revision}
+            </span>
+            <span>·</span>
+            <span data-testid="playground-environment-host">
+              {preview.host.hostName ?? preview.host.hostId}
+            </span>
+            <span>·</span>
+            <span data-testid="playground-environment-counts">
+              {preview.capabilities.serverCount} servers ·{" "}
+              {preview.capabilities.skillCount} skills ·{" "}
+              {preview.capabilities.pluginCount} plugins
+            </span>
+            {hasExplicitOverride ? (
+              <span
+                className="rounded-full bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-amber-600 dark:text-amber-400"
+                data-testid="playground-environment-modified-badge"
+              >
+                Modified
+              </span>
+            ) : null}
+            {hasExplicitOverride ? (
+              <button
+                type="button"
+                onClick={resetServersToEnvironment}
+                disabled={disabled}
+                className="inline-flex items-center gap-1 rounded px-1 text-[11px] text-primary underline-offset-4 hover:underline disabled:opacity-60"
+                data-testid="playground-environment-reset"
+              >
+                <RotateCcw className="size-3" aria-hidden />
+                Reset to environment
+              </button>
+            ) : null}
+          </div>
+
+          {/* Skills exist but this client's harness has no skill channel, so
+              they would NOT be delivered. Said out loud rather than shown as a
+              non-zero skill count the model never sees. */}
+          {preview.capabilities.skillDelivery === "unsupported" &&
+          preview.capabilities.skillCount > 0 ? (
+            <p
+              className="flex items-start gap-1 text-[11px] text-amber-600 dark:text-amber-400"
+              data-testid="playground-environment-skill-limitation"
+            >
+              <AlertTriangle className="mt-[1px] size-3 shrink-0" aria-hidden />
+              <span>
+                {preview.host.hostName ?? "This client"} can't consume skills —
+                the {preview.capabilities.skillCount} skill
+                {preview.capabilities.skillCount === 1 ? "" : "s"} in this
+                environment won't reach the model on these turns.
+              </span>
+            </p>
+          ) : null}
+
+          {servers.length > 0 ? (
+            <div
+              className="flex flex-wrap items-center gap-1.5"
+              data-testid="playground-environment-servers"
+            >
+              {servers.map((server) => (
+                <Label
+                  key={server.serverId}
+                  className={cn(
+                    "flex cursor-pointer items-center gap-1 rounded-full border border-border/60 px-1.5 py-0.5 text-[11px] font-normal",
+                    server.enabled ? "bg-muted/40" : "opacity-55",
+                    disabled && "cursor-not-allowed opacity-60"
+                  )}
+                  data-testid={`playground-environment-server-${server.serverId}`}
+                >
+                  <Checkbox
+                    checked={server.enabled}
+                    onCheckedChange={(next) =>
+                      setServerEnabled(server.serverId, next === true)
+                    }
+                    disabled={disabled}
+                    aria-label={server.name}
+                  />
+                  <span className="max-w-[160px] truncate">{server.name}</span>
+                  {server.source === "plugin" ? (
+                    <span className="rounded-full bg-muted px-1 text-[9px] uppercase tracking-wide text-muted-foreground">
+                      plugin
+                    </span>
+                  ) : null}
+                </Label>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/playground/PlaygroundEnvironmentSection.tsx
+++ b/mcpjam-inspector/client/src/components/playground/PlaygroundEnvironmentSection.tsx
@@ -26,6 +26,11 @@ import type { PlaygroundEnvironmentState } from "@/hooks/use-playground-environm
  * plugin-contributed servers are deliberately hidden from
  * `servers:getProjectServers`, so the name-keyed catalog cannot represent them.
  */
+/** `1 server`, `0 servers` — the counts strip renders three of these. */
+function plural(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? "" : "s"}`;
+}
+
 export function PlaygroundEnvironmentSection({
   projectId,
   environment,
@@ -59,7 +64,13 @@ export function PlaygroundEnvironmentSection({
   const lastTrackedHostIdRef = useRef<string | null>(null);
   const resolvedHostId = preview?.host.hostId ?? null;
   useEffect(() => {
-    if (!isEnvironmentMode || !resolvedHostId) return;
+    if (!isEnvironmentMode || !resolvedHostId) {
+      // Leaving environment mode CLOSES the dedupe window. Without this,
+      // select A → clear → select A again emits once, quietly undercounting
+      // adoption of the very surface this event measures.
+      if (!isEnvironmentMode) lastTrackedHostIdRef.current = null;
+      return;
+    }
     if (lastTrackedHostIdRef.current === resolvedHostId) return;
     lastTrackedHostIdRef.current = resolvedHostId;
     try {
@@ -133,9 +144,9 @@ export function PlaygroundEnvironmentSection({
             </span>
             <span>·</span>
             <span data-testid="playground-environment-counts">
-              {preview.capabilities.serverCount} servers ·{" "}
-              {preview.capabilities.skillCount} skills ·{" "}
-              {preview.capabilities.pluginCount} plugins
+              {plural(preview.capabilities.serverCount, "server")} ·{" "}
+              {plural(preview.capabilities.skillCount, "skill")} ·{" "}
+              {plural(preview.capabilities.pluginCount, "plugin")}
             </span>
             {hasExplicitOverride ? (
               <span

--- a/mcpjam-inspector/client/src/components/playground/PlaygroundEnvironmentSection.tsx
+++ b/mcpjam-inspector/client/src/components/playground/PlaygroundEnvironmentSection.tsx
@@ -5,6 +5,7 @@ import { Label } from "@mcpjam/design-system/label";
 import { cn } from "@/lib/utils";
 import { track } from "@/lib/analytics";
 import { EnvironmentPicker } from "@/components/project-environments/environment-picker";
+import { pluralize } from "@/components/chat-v2/shared/chat-helpers";
 import type { PlaygroundEnvironmentState } from "@/hooks/use-playground-environment";
 
 /**
@@ -26,11 +27,6 @@ import type { PlaygroundEnvironmentState } from "@/hooks/use-playground-environm
  * plugin-contributed servers are deliberately hidden from
  * `servers:getProjectServers`, so the name-keyed catalog cannot represent them.
  */
-/** `1 server`, `0 servers` — the counts strip renders three of these. */
-function plural(count: number, noun: string): string {
-  return `${count} ${noun}${count === 1 ? "" : "s"}`;
-}
-
 export function PlaygroundEnvironmentSection({
   projectId,
   environment,
@@ -87,7 +83,15 @@ export function PlaygroundEnvironmentSection({
 
   return (
     <div
-      className={cn("flex min-w-0 flex-col gap-1.5", className)}
+      // Hard width cap, because the header slot that renders this is
+      // `shrink-0`: without one, an environment with many server chips grows
+      // the section until the Clear control and the header's trailing controls
+      // are pushed out of the viewport. Capped here rather than in the header
+      // so the section stays self-contained wherever it is slotted.
+      className={cn(
+        "flex w-full min-w-0 max-w-[26rem] flex-col gap-1.5",
+        className
+      )}
       data-testid="playground-environment-section"
     >
       <div className="flex min-w-0 items-center gap-1.5">
@@ -144,9 +148,9 @@ export function PlaygroundEnvironmentSection({
             </span>
             <span>·</span>
             <span data-testid="playground-environment-counts">
-              {plural(preview.capabilities.serverCount, "server")} ·{" "}
-              {plural(preview.capabilities.skillCount, "skill")} ·{" "}
-              {plural(preview.capabilities.pluginCount, "plugin")}
+              {pluralize(preview.capabilities.serverCount, "server")} ·{" "}
+              {pluralize(preview.capabilities.skillCount, "skill")} ·{" "}
+              {pluralize(preview.capabilities.pluginCount, "plugin")}
             </span>
             {hasExplicitOverride ? (
               <span
@@ -182,23 +186,26 @@ export function PlaygroundEnvironmentSection({
               <AlertTriangle className="mt-[1px] size-3 shrink-0" aria-hidden />
               <span>
                 {preview.host.hostName ?? "This client"} can't consume skills —
-                the {preview.capabilities.skillCount} skill
-                {preview.capabilities.skillCount === 1 ? "" : "s"} in this
-                environment won't reach the model on these turns.
+                the {pluralize(preview.capabilities.skillCount, "skill")} in
+                this environment won't reach the model on these turns.
               </span>
             </p>
           ) : null}
 
           {servers.length > 0 ? (
             <div
-              className="flex flex-wrap items-center gap-1.5"
+              // One scrolling row instead of an unbounded wrap: an environment
+              // can resolve to a dozen servers (host picks + plugin-contributed
+              // ones), and stacking them would push the chat surface down the
+              // page on every render of the header.
+              className="flex max-w-full flex-nowrap items-center gap-1.5 overflow-x-auto pb-0.5"
               data-testid="playground-environment-servers"
             >
               {servers.map((server) => (
                 <Label
                   key={server.serverId}
                   className={cn(
-                    "flex cursor-pointer items-center gap-1 rounded-full border border-border/60 px-1.5 py-0.5 text-[11px] font-normal",
+                    "flex shrink-0 cursor-pointer items-center gap-1 rounded-full border border-border/60 px-1.5 py-0.5 text-[11px] font-normal",
                     server.enabled ? "bg-muted/40" : "opacity-55",
                     disabled && "cursor-not-allowed opacity-60"
                   )}

--- a/mcpjam-inspector/client/src/components/playground/PlaygroundHostPicker.tsx
+++ b/mcpjam-inspector/client/src/components/playground/PlaygroundHostPicker.tsx
@@ -2,6 +2,9 @@ import { useConvexAuth } from "convex/react";
 import { useHostList } from "@/hooks/useClients";
 import { usePreviewedHostId } from "@/hooks/use-previewed-client-id";
 import { MultiHostPicker } from "@/components/hosts/MultiHostPicker";
+import { PlaygroundEnvironmentSection } from "@/components/playground/PlaygroundEnvironmentSection";
+import { useProjectEnvironmentsEnabled } from "@/hooks/useProjectEnvironmentsEnabled";
+import type { PlaygroundEnvironmentState } from "@/hooks/use-playground-environment";
 
 interface PlaygroundHostPickerProps {
   /**
@@ -44,6 +47,18 @@ interface PlaygroundHostPickerProps {
    * scope between the promote write and the array read.
    */
   onPromoteLead: (hostId: string) => void;
+  /**
+   * Project Environments (Phase 2.5). When supplied AND the
+   * `project-environments-enabled` flag is on, an Environments section renders
+   * above the host controls.
+   *
+   * Environment mode is mutually exclusive with multi-host comparison in v1: an
+   * environment pins exactly one host, and comparison exists to run one turn
+   * against several. The owner of the state (PlaygroundMain) enforces the exit
+   * from comparison; this component only hides the comparison affordance while
+   * an environment is active so the two can't be driven into conflict.
+   */
+  environment?: PlaygroundEnvironmentState;
 }
 
 /**
@@ -63,6 +78,7 @@ export function PlaygroundHostPicker({
   onSelectedHostIdsChange,
   onMultiHostEnabledChange,
   onPromoteLead,
+  environment,
 }: PlaygroundHostPickerProps) {
   const { isAuthenticated } = useConvexAuth();
   const { hosts, isLoading } = useHostList({
@@ -70,19 +86,37 @@ export function PlaygroundHostPicker({
     projectId,
   });
   const [previewedHostId] = usePreviewedHostId(projectId);
+  const environmentsEnabled = useProjectEnvironmentsEnabled();
+  const showEnvironments = environmentsEnabled && !!environment;
+  const inEnvironmentMode = showEnvironments && environment.isEnvironmentMode;
 
   return (
-    <MultiHostPicker
-      projectId={projectId}
-      hosts={hosts}
-      currentHostId={previewedHostId}
-      selectedHostIds={selectedHostIds}
-      multiHostEnabled={multiHostEnabled}
-      onMultiHostEnabledChange={onMultiHostEnabledChange}
-      onSelectedHostIdsChange={onSelectedHostIdsChange}
-      onPromoteLead={onPromoteLead}
-      disabled={disabled || !projectId}
-      isLoading={isLoading}
-    />
+    <div className="flex min-w-0 flex-col gap-1.5">
+      {showEnvironments ? (
+        <PlaygroundEnvironmentSection
+          projectId={projectId}
+          environment={environment}
+          disabled={disabled}
+        />
+      ) : null}
+      {/* Comparison is hidden — not merely disabled — while an environment is
+          selected: an environment resolves to ONE host, so a comparison grid
+          driven from it would either duplicate the same column or silently run
+          hosts the environment never named. */}
+      {inEnvironmentMode ? null : (
+        <MultiHostPicker
+          projectId={projectId}
+          hosts={hosts}
+          currentHostId={previewedHostId}
+          selectedHostIds={selectedHostIds}
+          multiHostEnabled={multiHostEnabled}
+          onMultiHostEnabledChange={onMultiHostEnabledChange}
+          onSelectedHostIdsChange={onSelectedHostIdsChange}
+          onPromoteLead={onPromoteLead}
+          disabled={disabled || !projectId}
+          isLoading={isLoading}
+        />
+      )}
+    </div>
   );
 }

--- a/mcpjam-inspector/client/src/components/playground/__tests__/PlaygroundEnvironmentSection.test.tsx
+++ b/mcpjam-inspector/client/src/components/playground/__tests__/PlaygroundEnvironmentSection.test.tsx
@@ -113,6 +113,24 @@ beforeEach(() => {
 });
 
 describe("PlaygroundEnvironmentSection", () => {
+  it("disables every control while a turn is in flight", () => {
+    // Switching environments forks the chat scope and exits comparison mode.
+    // Mid-turn that strands the in-flight request: its results vanish and the
+    // Stop control goes with them. PlaygroundMain passes
+    // `isStreamingActive || isPreparingServerForSend` here.
+    render(
+      <PlaygroundEnvironmentSection
+        projectId="p1"
+        environment={environmentState()}
+        disabled
+      />
+    );
+    for (const button of screen.getAllByRole("button")) {
+      expect(button).toBeDisabled();
+    }
+  });
+
+
   it("names the environment, its revision, its client and its counts", () => {
     render(
       <PlaygroundEnvironmentSection
@@ -133,7 +151,11 @@ describe("PlaygroundEnvironmentSection", () => {
     ).toContain("4 skills");
     expect(
       screen.getByTestId("playground-environment-counts").textContent
-    ).toContain("1 plugins");
+    ).toContain("1 plugin");
+    // Singular, not "1 plugins" — three counts render through the same helper.
+    expect(
+      screen.getByTestId("playground-environment-counts").textContent
+    ).not.toContain("1 plugins");
   });
 
   it("shows no modified badge and no reset until an override exists", () => {

--- a/mcpjam-inspector/client/src/components/playground/__tests__/PlaygroundEnvironmentSection.test.tsx
+++ b/mcpjam-inspector/client/src/components/playground/__tests__/PlaygroundEnvironmentSection.test.tsx
@@ -93,6 +93,7 @@ function environmentState(
     preview,
     isPreviewLoading: false,
     previewError: null,
+    isResolutionPending: false,
     refreshPreview: vi.fn(),
     serverOverrideIds: null,
     hasExplicitOverride: false,
@@ -156,6 +157,34 @@ describe("PlaygroundEnvironmentSection", () => {
     expect(
       screen.getByTestId("playground-environment-counts").textContent
     ).not.toContain("1 plugins");
+  });
+
+  it("stays within a bounded width no matter how many servers resolve", () => {
+    // The header slot that renders this section is `shrink-0`, so an unbounded
+    // section pushes the Clear control and the header's trailing controls out
+    // of reach. The cap lives here (self-contained) and the server chips scroll
+    // inside it instead of wrapping the chat surface down the page.
+    const servers = Array.from({ length: 12 }, (_, index) => ({
+      serverId: `srv_${index}`,
+      name: `Server number ${index}`,
+      source: "host_or_group" as const,
+      enabled: true,
+    }));
+    render(
+      <PlaygroundEnvironmentSection
+        projectId="proj_1"
+        environment={environmentState({ servers })}
+      />
+    );
+
+    const section = screen.getByTestId("playground-environment-section");
+    expect(section.className).toContain("max-w-[26rem]");
+    const serverRow = screen.getByTestId("playground-environment-servers");
+    expect(serverRow.className).toContain("overflow-x-auto");
+    expect(serverRow.className).toContain("flex-nowrap");
+    expect(serverRow.className).not.toContain("flex-wrap");
+    // Every chip is still reachable — clamped, not truncated away.
+    expect(serverRow.children.length).toBe(12);
   });
 
   it("shows no modified badge and no reset until an override exists", () => {

--- a/mcpjam-inspector/client/src/components/playground/__tests__/PlaygroundEnvironmentSection.test.tsx
+++ b/mcpjam-inspector/client/src/components/playground/__tests__/PlaygroundEnvironmentSection.test.tsx
@@ -1,0 +1,291 @@
+/**
+ * Playground Environments section + the host-picker wrapper that hosts it
+ * (Project Environments — Phase 2.5).
+ *
+ * Covers the parts that are UI decisions rather than state decisions (the
+ * override tri-state itself lives in `use-playground-environment.test.tsx`):
+ * the modified/reset affordances, the skill-delivery honesty notice, and the
+ * mutual exclusion between environment mode and multi-host comparison.
+ */
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockFlagValue, mockTrack, mockMultiHostPicker } = vi.hoisted(() => ({
+  mockFlagValue: { value: true as boolean | undefined },
+  mockTrack: vi.fn(),
+  mockMultiHostPicker: vi.fn(() => <div data-testid="multi-host-picker" />),
+}));
+
+vi.mock("posthog-js/react", () => ({
+  useFeatureFlagEnabled: () => mockFlagValue.value,
+}));
+vi.mock("@/lib/analytics", () => ({ track: mockTrack }));
+vi.mock("convex/react", () => ({
+  useConvexAuth: () => ({ isAuthenticated: true, isLoading: false }),
+}));
+vi.mock("@/hooks/useClients", () => ({
+  useHostList: () => ({ hosts: [], isLoading: false }),
+}));
+vi.mock("@/hooks/use-previewed-client-id", () => ({
+  usePreviewedHostId: () => [null, vi.fn()] as const,
+}));
+vi.mock("@/hooks/useProjectEnvironments", () => ({
+  useProjectEnvironments: () => [
+    {
+      environmentId: "env_1",
+      projectId: "proj_1",
+      name: "Staging",
+      hostId: "host_1",
+      revision: 3,
+      createdAt: 1,
+      updatedAt: 1,
+    },
+  ],
+}));
+vi.mock("@/lib/app-navigation", () => ({
+  navigateApp: vi.fn(),
+  routePaths: { environments: "/environments", playground: "/playground" },
+}));
+vi.mock("@/components/hosts/MultiHostPicker", () => ({
+  MultiHostPicker: mockMultiHostPicker,
+}));
+
+import { PlaygroundEnvironmentSection } from "../PlaygroundEnvironmentSection";
+import { PlaygroundHostPicker } from "../PlaygroundHostPicker";
+import type { PlaygroundEnvironmentState } from "@/hooks/use-playground-environment";
+
+function environmentState(
+  overrides: Partial<PlaygroundEnvironmentState> = {}
+): PlaygroundEnvironmentState {
+  const preview = {
+    specVersion: 1,
+    environment: { environmentId: "env_1", name: "Staging", revision: 3 },
+    host: {
+      hostId: "host_1",
+      hostName: "Codex",
+      hostConfigId: "cfg_1",
+      modelId: null,
+      hostStyle: null,
+      harness: "codex",
+    },
+    servers: [
+      { serverId: "srv_a", name: "Alpha", source: "host_or_group" as const },
+      { serverId: "srv_plugin", name: "Docs", source: "plugin" as const },
+    ],
+    skills: [],
+    plugins: [],
+    capabilities: {
+      requireToolApproval: null,
+      respectToolVisibility: null,
+      progressiveToolDiscovery: null,
+      builtInToolIds: [],
+      hasComputer: false,
+      serverCount: 2,
+      skillCount: 4,
+      skillDelivery: "harness" as const,
+      pluginCount: 1,
+      serversOverridden: false,
+    },
+  };
+  return {
+    isEnvironmentMode: true,
+    environmentId: "env_1",
+    preview,
+    isPreviewLoading: false,
+    previewError: null,
+    refreshPreview: vi.fn(),
+    serverOverrideIds: null,
+    hasExplicitOverride: false,
+    servers: preview.servers.map((s) => ({ ...s, enabled: true })),
+    executionTarget: { kind: "environment", environmentId: "env_1" },
+    environmentOverrides: undefined,
+    selectEnvironment: vi.fn(),
+    clearEnvironment: vi.fn(),
+    resetServersToEnvironment: vi.fn(),
+    setServerEnabled: vi.fn(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFlagValue.value = true;
+});
+
+describe("PlaygroundEnvironmentSection", () => {
+  it("names the environment, its revision, its client and its counts", () => {
+    render(
+      <PlaygroundEnvironmentSection
+        projectId="proj_1"
+        environment={environmentState()}
+      />
+    );
+    expect(screen.getByText("Environment: Staging")).toBeTruthy();
+    expect(screen.getByText("rev 3")).toBeTruthy();
+    expect(screen.getByTestId("playground-environment-host").textContent).toBe(
+      "Codex"
+    );
+    expect(
+      screen.getByTestId("playground-environment-counts").textContent
+    ).toContain("2 servers");
+    expect(
+      screen.getByTestId("playground-environment-counts").textContent
+    ).toContain("4 skills");
+    expect(
+      screen.getByTestId("playground-environment-counts").textContent
+    ).toContain("1 plugins");
+  });
+
+  it("shows no modified badge and no reset until an override exists", () => {
+    render(
+      <PlaygroundEnvironmentSection
+        projectId="proj_1"
+        environment={environmentState()}
+      />
+    );
+    expect(
+      screen.queryByTestId("playground-environment-modified-badge")
+    ).toBeNull();
+    expect(screen.queryByTestId("playground-environment-reset")).toBeNull();
+  });
+
+  it("shows a modified badge and a reset action once the user overrides", () => {
+    const resetServersToEnvironment = vi.fn();
+    render(
+      <PlaygroundEnvironmentSection
+        projectId="proj_1"
+        environment={environmentState({
+          hasExplicitOverride: true,
+          serverOverrideIds: ["srv_plugin"],
+          resetServersToEnvironment,
+        })}
+      />
+    );
+    expect(
+      screen.getByTestId("playground-environment-modified-badge")
+    ).toBeTruthy();
+    fireEvent.click(screen.getByTestId("playground-environment-reset"));
+    expect(resetServersToEnvironment).toHaveBeenCalled();
+  });
+
+  it("says out loud when the client cannot consume this environment's skills", () => {
+    // The count is real but the harness has no skill channel, so the skills
+    // would NOT reach the model. Showing "4 skills" alone would be a lie of
+    // omission.
+    const state = environmentState();
+    render(
+      <PlaygroundEnvironmentSection
+        projectId="proj_1"
+        environment={environmentState({
+          preview: {
+            ...state.preview!,
+            capabilities: {
+              ...state.preview!.capabilities,
+              skillDelivery: "unsupported",
+            },
+          },
+        })}
+      />
+    );
+    expect(
+      screen.getByTestId("playground-environment-skill-limitation").textContent
+    ).toContain("can't consume skills");
+  });
+
+  it("does not show the limitation notice when skills are deliverable", () => {
+    render(
+      <PlaygroundEnvironmentSection
+        projectId="proj_1"
+        environment={environmentState()}
+      />
+    );
+    expect(
+      screen.queryByTestId("playground-environment-skill-limitation")
+    ).toBeNull();
+  });
+
+  it("renders environment servers id-first, marking plugin-owned ones", () => {
+    render(
+      <PlaygroundEnvironmentSection
+        projectId="proj_1"
+        environment={environmentState()}
+      />
+    );
+    // Keyed and testid'd by serverId, not by name — plugin servers have no
+    // entry in the browser's name-keyed project-server catalog.
+    expect(
+      screen.getByTestId("playground-environment-server-srv_plugin").textContent
+    ).toContain("plugin");
+  });
+
+  it("emits client_selected from the project_environments location", () => {
+    render(
+      <PlaygroundEnvironmentSection
+        projectId="proj_1"
+        environment={environmentState()}
+      />
+    );
+    expect(mockTrack).toHaveBeenCalledWith("client_selected", {
+      location: "project_environments",
+      client_id: "host_1",
+    });
+  });
+
+  it("clearing exits environment mode through the caller", () => {
+    const clearEnvironment = vi.fn();
+    render(
+      <PlaygroundEnvironmentSection
+        projectId="proj_1"
+        environment={environmentState({ clearEnvironment })}
+      />
+    );
+    fireEvent.click(screen.getByTestId("playground-environment-clear"));
+    expect(clearEnvironment).toHaveBeenCalled();
+  });
+});
+
+describe("PlaygroundHostPicker — environment mode is exclusive with comparison", () => {
+  const hostProps = {
+    projectId: "proj_1",
+    selectedHostIds: ["host_1"],
+    multiHostEnabled: false,
+    onSelectedHostIdsChange: vi.fn(),
+    onMultiHostEnabledChange: vi.fn(),
+    onPromoteLead: vi.fn(),
+  };
+
+  it("keeps the comparison picker when no environment is selected", () => {
+    render(
+      <PlaygroundHostPicker
+        {...hostProps}
+        environment={environmentState({
+          isEnvironmentMode: false,
+          environmentId: null,
+          preview: null,
+          executionTarget: undefined,
+        })}
+      />
+    );
+    expect(screen.getByTestId("multi-host-picker")).toBeTruthy();
+  });
+
+  it("withdraws the comparison picker while an environment is active", () => {
+    // An environment resolves to ONE host; a comparison grid driven from it
+    // would either duplicate a column or run hosts the environment never named.
+    render(
+      <PlaygroundHostPicker {...hostProps} environment={environmentState()} />
+    );
+    expect(screen.queryByTestId("multi-host-picker")).toBeNull();
+    expect(screen.getByTestId("playground-environment-section")).toBeTruthy();
+  });
+
+  it("hides the Environments section entirely when the flag is off", () => {
+    mockFlagValue.value = false;
+    render(
+      <PlaygroundHostPicker {...hostProps} environment={environmentState()} />
+    );
+    expect(screen.queryByTestId("playground-environment-section")).toBeNull();
+    // …and the ordinary host controls are back.
+    expect(screen.getByTestId("multi-host-picker")).toBeTruthy();
+  });
+});

--- a/mcpjam-inspector/client/src/components/project-environments/ConnectEnvironmentsStrip.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/ConnectEnvironmentsStrip.tsx
@@ -1,0 +1,134 @@
+import { useMemo } from "react";
+import { useConvexAuth } from "convex/react";
+import { ArrowRight, Layers } from "lucide-react";
+import { Button } from "@mcpjam/design-system/button";
+import { useHostList } from "@/hooks/useClients";
+import { useProjectEnvironments } from "@/hooks/useProjectEnvironments";
+import { useProjectEnvironmentsEnabled } from "@/hooks/useProjectEnvironmentsEnabled";
+import { usePreviewedEnvironmentId } from "@/hooks/use-previewed-environment-id";
+import { navigateApp, routePaths } from "@/lib/app-navigation";
+import { cn } from "@/lib/utils";
+
+/**
+ * Connect-canvas Environments strip (Project Environments — Phase 2.6).
+ *
+ * A compact entry point, not a management surface: editing stays on
+ * `/environments`, and the ONE action here is "Open in Playground".
+ *
+ * ## Why the cards look thin
+ *
+ * Every field shown comes from the environment ROW that
+ * `projectEnvironments:listEnvironments` already returns, plus the host name
+ * from the hosts query Connect already runs. Nothing here triggers a runtime
+ * resolve, because a resolve is one round trip PER ENVIRONMENT — an N+1 on a
+ * list that renders on every Connect visit.
+ *
+ * That is also why there is no resolved server count on a row. The row stores a
+ * `serverAttachmentId` (a scope), not a server set; the actual set folds in the
+ * host's own picks and any plugin-contributed servers, both of which are LIVE.
+ * Printing a number here would mean either lying or paying the N+1, so the card
+ * says whether a server group is attached and stops there. The real count shows
+ * up in the Playground, where exactly one environment is resolved for real.
+ *
+ * Skill and plugin counts ARE honest row data: `skillSelection.skillIds` is the
+ * explicit pinned selection and `pluginVersionIds` are pinned version ids —
+ * both stored, both exact. They are labeled as PINS, not as totals, because the
+ * host and plugin channels contribute more skills at resolve time.
+ */
+export function ConnectEnvironmentsStrip({
+  projectId,
+  className,
+}: {
+  projectId: string | null;
+  className?: string;
+}) {
+  const enabled = useProjectEnvironmentsEnabled();
+  const { isAuthenticated } = useConvexAuth();
+  // Live rows only — an archived environment can't be launched.
+  const environments = useProjectEnvironments(enabled ? projectId : null);
+  const { hosts } = useHostList({
+    isAuthenticated,
+    projectId: enabled ? projectId : null,
+  });
+  const [, setPreviewedEnvironmentId] = usePreviewedEnvironmentId(projectId);
+
+  const hostNamesById = useMemo(
+    () => new Map(hosts.map((host) => [host.hostId, host.name])),
+    [hosts]
+  );
+
+  // Render nothing at all when there is nothing to offer: an empty strip on the
+  // Connect canvas is pure noise for the (currently large) majority of projects
+  // with no environments.
+  if (!enabled || !projectId) return null;
+  if (!environments || environments.length === 0) return null;
+
+  return (
+    <div
+      className={cn(
+        "rounded-lg border border-border/50 bg-muted/15 space-y-2 p-3",
+        className
+      )}
+      data-testid="connect-environments-strip"
+    >
+      <div className="flex items-center justify-between gap-3">
+        <h3 className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          <Layers className="size-3.5" aria-hidden />
+          Environments
+        </h3>
+        <Button
+          variant="link"
+          size="sm"
+          className="h-auto shrink-0 p-0 text-xs"
+          onClick={() => navigateApp(routePaths.environments)}
+          data-testid="connect-environments-manage"
+        >
+          Manage
+          <ArrowRight className="ml-1 h-3 w-3" />
+        </Button>
+      </div>
+      <div className="flex gap-2 overflow-x-auto pb-0.5">
+        {environments.map((environment) => {
+          const hostName =
+            hostNamesById.get(environment.hostId) ?? "Unknown client";
+          const pinnedSkillCount =
+            environment.skillSelection?.skillIds.length ?? 0;
+          const pluginPinCount = environment.pluginVersionIds?.length ?? 0;
+          return (
+            <div
+              key={environment.environmentId}
+              className="flex min-w-[240px] shrink-0 flex-col gap-1.5 rounded-md border border-border/40 bg-background/60 p-2.5"
+              data-testid={`connect-environment-card-${environment.environmentId}`}
+            >
+              <p className="truncate text-sm font-medium">{environment.name}</p>
+              <p className="truncate text-[11px] text-muted-foreground">
+                {hostName}
+              </p>
+              <p className="text-[11px] text-muted-foreground">
+                {environment.serverAttachmentId
+                  ? "Server group attached"
+                  : "Client's own servers"}
+                {" · "}
+                {pinnedSkillCount} skill pin{pinnedSkillCount === 1 ? "" : "s"}
+                {" · "}
+                {pluginPinCount} plugin pin{pluginPinCount === 1 ? "" : "s"}
+              </p>
+              <Button
+                variant="outline"
+                size="sm"
+                className="mt-0.5 h-7 w-full text-xs"
+                onClick={() => {
+                  setPreviewedEnvironmentId(environment.environmentId);
+                  navigateApp(routePaths.playground);
+                }}
+                data-testid={`connect-environment-open-${environment.environmentId}`}
+              >
+                Open in Playground
+              </Button>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/project-environments/ConnectEnvironmentsStrip.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/ConnectEnvironmentsStrip.tsx
@@ -44,13 +44,22 @@ export function ConnectEnvironmentsStrip({
 }) {
   const enabled = useProjectEnvironmentsEnabled();
   const { isAuthenticated } = useConvexAuth();
+  // Normalize ONCE, then feed every hook the same value. `useProjectEnvironments`
+  // trims internally, so a whitespace-padded id renders rows — while `useHostList`
+  // and the previewed-environment storage would key off the raw string, leaving
+  // every card labeled "Unknown client" and writing the selection under a scope
+  // the Playground never reads.
+  const normalizedProjectId = projectId?.trim() || null;
   // Live rows only — an archived environment can't be launched.
-  const environments = useProjectEnvironments(enabled ? projectId : null);
+  const environments = useProjectEnvironments(
+    enabled ? normalizedProjectId : null
+  );
   const { hosts } = useHostList({
     isAuthenticated,
-    projectId: enabled ? projectId : null,
+    projectId: enabled ? normalizedProjectId : null,
   });
-  const [, setPreviewedEnvironmentId] = usePreviewedEnvironmentId(projectId);
+  const [, setPreviewedEnvironmentId] =
+    usePreviewedEnvironmentId(normalizedProjectId);
 
   const hostNamesById = useMemo(
     () => new Map(hosts.map((host) => [host.hostId, host.name])),
@@ -60,7 +69,7 @@ export function ConnectEnvironmentsStrip({
   // Render nothing at all when there is nothing to offer: an empty strip on the
   // Connect canvas is pure noise for the (currently large) majority of projects
   // with no environments.
-  if (!enabled || !projectId) return null;
+  if (!enabled || !normalizedProjectId) return null;
   if (!environments || environments.length === 0) return null;
 
   return (

--- a/mcpjam-inspector/client/src/components/project-environments/__tests__/connect-environments-strip.test.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/__tests__/connect-environments-strip.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * Connect-canvas Environments strip (Project Environments — Phase 2.6).
+ *
+ * The two things worth pinning: the flag gate (fail-closed, like every other
+ * client exposure of this feature) and the ONE action — "Open in Playground"
+ * must both set the previewed environment AND navigate, because either half
+ * alone lands the user on a Playground running something else.
+ */
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockFlagValue, mockEnvironments, mockHosts, mockNavigateApp } =
+  vi.hoisted(() => ({
+    mockFlagValue: { value: true as boolean | undefined },
+    mockEnvironments: { value: undefined as unknown },
+    mockHosts: { value: [] as Array<{ hostId: string; name: string }> },
+    mockNavigateApp: vi.fn(),
+  }));
+
+vi.mock("posthog-js/react", () => ({
+  useFeatureFlagEnabled: () => mockFlagValue.value,
+}));
+vi.mock("convex/react", () => ({
+  useConvexAuth: () => ({ isAuthenticated: true, isLoading: false }),
+}));
+vi.mock("@/hooks/useProjectEnvironments", () => ({
+  useProjectEnvironments: (projectId: string | null) =>
+    projectId ? mockEnvironments.value : undefined,
+}));
+vi.mock("@/hooks/useClients", () => ({
+  useHostList: () => ({ hosts: mockHosts.value, isLoading: false }),
+}));
+vi.mock("@/lib/app-navigation", () => ({
+  navigateApp: mockNavigateApp,
+  routePaths: { environments: "/environments", playground: "/playground" },
+}));
+
+import { ConnectEnvironmentsStrip } from "../ConnectEnvironmentsStrip";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  mockFlagValue.value = true;
+  mockHosts.value = [{ hostId: "host_1", name: "Claude Code" }];
+  mockEnvironments.value = [
+    {
+      environmentId: "env_1",
+      projectId: "proj_1",
+      name: "Staging",
+      hostId: "host_1",
+      serverAttachmentId: "grp_1",
+      skillSelection: { mode: "explicit", skillIds: ["sk_a", "sk_b"] },
+      pluginVersionIds: ["pv_1"],
+      revision: 3,
+      createdAt: 1,
+      updatedAt: 1,
+    },
+  ];
+});
+
+describe("ConnectEnvironmentsStrip", () => {
+  it("renders nothing when the feature flag is off", () => {
+    mockFlagValue.value = false;
+    const { container } = render(
+      <ConnectEnvironmentsStrip projectId="proj_1" />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when the project has no environments", () => {
+    mockEnvironments.value = [];
+    const { container } = render(
+      <ConnectEnvironmentsStrip projectId="proj_1" />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows only row-available data — never a resolved server count", () => {
+    render(<ConnectEnvironmentsStrip projectId="proj_1" />);
+
+    expect(screen.getByText("Staging")).toBeTruthy();
+    // Client name comes from the hosts query Connect already runs.
+    expect(screen.getByText("Claude Code")).toBeTruthy();
+    // Server GROUP presence (a stored scope), pinned skill count and plugin-pin
+    // count are all exact row data. A resolved server count is deliberately
+    // absent: it would need one runtime resolve per row (an N+1) and would still
+    // be a guess, because host and plugin contributions are live.
+    const card = screen.getByTestId("connect-environment-card-env_1");
+    expect(card.textContent).toContain("Server group attached");
+    expect(card.textContent).toContain("2 skill pins");
+    expect(card.textContent).toContain("1 plugin pin");
+  });
+
+  it("opens the selected environment in the Playground", () => {
+    render(<ConnectEnvironmentsStrip projectId="proj_1" />);
+    fireEvent.click(screen.getByTestId("connect-environment-open-env_1"));
+
+    // Both halves, in this order: the Playground reads the previewed
+    // environment on mount, so navigating without setting it lands on the
+    // previous target.
+    expect(
+      JSON.parse(localStorage.getItem("mcp-previewed-environment-id") ?? "{}")
+    ).toEqual({ proj_1: "env_1" });
+    expect(mockNavigateApp).toHaveBeenCalledWith("/playground");
+  });
+
+  it("sends editing to /environments, not to an inline editor", () => {
+    render(<ConnectEnvironmentsStrip projectId="proj_1" />);
+    fireEvent.click(screen.getByTestId("connect-environments-manage"));
+    expect(mockNavigateApp).toHaveBeenCalledWith("/environments");
+  });
+});

--- a/mcpjam-inspector/client/src/components/project-environments/__tests__/connect-environments-strip.test.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/__tests__/connect-environments-strip.test.tsx
@@ -9,13 +9,19 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockFlagValue, mockEnvironments, mockHosts, mockNavigateApp } =
-  vi.hoisted(() => ({
-    mockFlagValue: { value: true as boolean | undefined },
-    mockEnvironments: { value: undefined as unknown },
-    mockHosts: { value: [] as Array<{ hostId: string; name: string }> },
-    mockNavigateApp: vi.fn(),
-  }));
+const {
+  mockFlagValue,
+  mockEnvironments,
+  mockHosts,
+  mockNavigateApp,
+  mockUseHostList,
+} = vi.hoisted(() => ({
+  mockFlagValue: { value: true as boolean | undefined },
+  mockEnvironments: { value: undefined as unknown },
+  mockHosts: { value: [] as Array<{ hostId: string; name: string }> },
+  mockNavigateApp: vi.fn(),
+  mockUseHostList: vi.fn(),
+}));
 
 vi.mock("posthog-js/react", () => ({
   useFeatureFlagEnabled: () => mockFlagValue.value,
@@ -24,11 +30,17 @@ vi.mock("convex/react", () => ({
   useConvexAuth: () => ({ isAuthenticated: true, isLoading: false }),
 }));
 vi.mock("@/hooks/useProjectEnvironments", () => ({
+  // Mirrors the real hook: it trims before querying, so a padded id still
+  // returns rows. That asymmetry is exactly what the normalization test below
+  // guards against.
   useProjectEnvironments: (projectId: string | null) =>
-    projectId ? mockEnvironments.value : undefined,
+    projectId?.trim() ? mockEnvironments.value : undefined,
 }));
 vi.mock("@/hooks/useClients", () => ({
-  useHostList: () => ({ hosts: mockHosts.value, isLoading: false }),
+  useHostList: (args: { projectId: string | null }) => {
+    mockUseHostList(args);
+    return { hosts: mockHosts.value, isLoading: false };
+  },
 }));
 vi.mock("@/lib/app-navigation", () => ({
   navigateApp: mockNavigateApp,
@@ -102,6 +114,24 @@ describe("ConnectEnvironmentsStrip", () => {
       JSON.parse(localStorage.getItem("mcp-previewed-environment-id") ?? "{}")
     ).toEqual({ proj_1: "env_1" });
     expect(mockNavigateApp).toHaveBeenCalledWith("/playground");
+  });
+
+  it("normalizes a padded project id for EVERY hook, not just the rows query", () => {
+    // `useProjectEnvironments` trims internally, so a padded id renders cards
+    // regardless. `useHostList` and the previewed-environment storage do not —
+    // untrimmed they would label every card "Unknown client" and write the
+    // selection under a scope the Playground never reads back.
+    render(<ConnectEnvironmentsStrip projectId="  proj_1  " />);
+
+    expect(mockUseHostList).toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: "proj_1" })
+    );
+    expect(screen.getByText("Claude Code")).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId("connect-environment-open-env_1"));
+    expect(
+      JSON.parse(localStorage.getItem("mcp-previewed-environment-id") ?? "{}")
+    ).toEqual({ proj_1: "env_1" });
   });
 
   it("sends editing to /environments, not to an inline editor", () => {

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -856,6 +856,14 @@ export function PlaygroundMain({
             // Deliberately NO `ensureServerIds`: resolving environment servers
             // by NAME would fail for plugin-contributed ones and bypass plugin
             // lifecycle semantics for the rest.
+            //
+            // NOT a second execution pointer — a client-side cache key. The
+            // environment's host is already the previewed host (presentation
+            // only), and host-keyed client caches (the harness workdir the
+            // Shell opens a terminal in) are read by that id, so the write side
+            // has to know it. The server still resolves the host from the
+            // environment.
+            ...(previewedHostId ? { presentationHostId: previewedHostId } : {}),
           }
         : {
             // Resolve/persist selected server names → Convex ids before a hosted
@@ -1554,6 +1562,19 @@ export function PlaygroundMain({
     isThreadEmpty: !effectiveHasMessages,
   });
   composerOnResetRef.current = composer.onSessionReset;
+  // Project Environments (Phase 2). Selecting an environment activates the new
+  // `executionTarget` synchronously, but the things that must agree with it do
+  // not land in the same tick: the chat scope re-keys on the new target, and
+  // the environment's host only becomes the previewed host once the preview
+  // resolves. A turn submitted inside that window carries the NEW environment
+  // id with the PREVIOUS host's model, system prompt and approval setting, and
+  // the scope reset that follows can drop the in-flight message. Block SENDS
+  // (not typing) until the transition has settled.
+  const isEnvironmentTargetPending =
+    isEnvironmentMode &&
+    (playgroundEnvironment.isResolutionPending ||
+      !isSessionBootstrapComplete ||
+      (!!environmentHostId && previewedHostId !== environmentHostId));
   const { composerDisabled, sendBlocked } = getChatComposerInteractivity({
     isStreamingActive: isStreamingActive || isPreparingServerForSend,
     composerDisabled:
@@ -1562,7 +1583,8 @@ export function PlaygroundMain({
       disableChatInput ||
       submitBlocked ||
       composer.submitGatedByServer ||
-      isPreparingServerForSend,
+      isPreparingServerForSend ||
+      isEnvironmentTargetPending,
   });
 
   // Mirror of the `canEnableMultiModel` cleanup below: when the multi-host
@@ -3450,7 +3472,9 @@ export function PlaygroundMain({
       disableChatInput ||
       submitBlocked ||
       composer.submitGatedByServer ||
-      isPreparingServerForSend,
+      isPreparingServerForSend ||
+      // Same environment-transition gate as `sharedChatInputProps` above.
+      isEnvironmentTargetPending,
     tokenUsage,
     selectedServers,
     mcpToolsTokenCount,

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -1087,8 +1087,17 @@ export function PlaygroundMain({
 
     return selectedModel ? [selectedModel] : [];
   }, [multiModelAvailableModels, selectedModel, selectedModelIds]);
+  // `!isEnvironmentMode`: like multi-HOST below, model comparison is mutually
+  // exclusive with environment mode in v1. Each comparison card runs its own
+  // request against `hostId`, so leaving it enabled would silently execute the
+  // cards against the host instead of the environment. Withdrawing the
+  // affordance also drives the "reset a stale persisted multiModelEnabled"
+  // effect below, so it cannot be re-enabled behind the environment's back.
   const canEnableMultiModel =
-    enableMultiModelChat && availableModels.length > 1 && !isSharedSession;
+    enableMultiModelChat &&
+    availableModels.length > 1 &&
+    !isSharedSession &&
+    !isEnvironmentMode;
 
   // Phase 4 (multi-host plan): read multi-host state in parallel to
   // multi-model. Lead host is derived inside `usePersistedHost` from the
@@ -3819,6 +3828,12 @@ export function PlaygroundMain({
                 <PlaygroundEnvironmentSection
                   projectId={multiHostProjectId}
                   environment={playgroundEnvironment}
+                  // Switching environments forks the chat scope and exits
+                  // comparison mode. Doing that mid-turn would strand the
+                  // in-flight request — its results vanish from the UI and the
+                  // Stop control goes with them. Same gate the chat-input
+                  // client selector uses.
+                  disabled={isStreamingActive || isPreparingServerForSend}
                 />
               ) : null
             }

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -1570,9 +1570,20 @@ export function PlaygroundMain({
   // id with the PREVIOUS host's model, system prompt and approval setting, and
   // the scope reset that follows can drop the in-flight message. Block SENDS
   // (not typing) until the transition has settled.
+  //
+  // `isPreviewLoading` is load-bearing separately from `isResolutionPending`
+  // and the host comparison, and covers the case neither can see: a live EDIT
+  // of the SELECTED environment. That refetch deliberately KEEPS the previous
+  // body on screen (live-config semantics), so mid-flight `preview` is the
+  // STALE one — `isResolutionPending` is false because a preview exists, and
+  // `environmentHostId` still reads the OLD host, which the previewed host
+  // already matches. If the edit repointed the environment at a different
+  // host, every clause would read "settled" while the next turn resolves
+  // server-side against the new host.
   const isEnvironmentTargetPending =
     isEnvironmentMode &&
     (playgroundEnvironment.isResolutionPending ||
+      playgroundEnvironment.isPreviewLoading ||
       !isSessionBootstrapComplete ||
       (!!environmentHostId && previewedHostId !== environmentHostId));
   const { composerDisabled, sendBlocked } = getChatComposerInteractivity({

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -112,6 +112,9 @@ import {
   gateMcpToolResultImageRenderingByModelVisibility,
 } from "@/lib/client-config-v2";
 import { usePreviewedHostId } from "@/hooks/use-previewed-client-id";
+import { usePlaygroundEnvironment } from "@/hooks/use-playground-environment";
+import { useProjectEnvironmentsEnabled } from "@/hooks/useProjectEnvironmentsEnabled";
+import { PlaygroundEnvironmentSection } from "@/components/playground/PlaygroundEnvironmentSection";
 import { useHarnessBuiltinTools } from "@/hooks/useHarnessBuiltinTools";
 import { useComputersEnabled } from "@/hooks/useComputersEnabled";
 import { useComputerAttachmentUpload } from "@/hooks/useComputerAttachmentUpload";
@@ -734,6 +737,16 @@ export function PlaygroundMain({
   const [previewedHostId, setPreviewedHostId] = usePreviewedHostId(
     convexProjectId ?? activeProjectId
   );
+  // Same storage scope as `usePersistedHost` / `usePreviewedHostId` below.
+  // Hoisted above `useChatSession` because the environment target has to be in
+  // the hosted context before the first transport body is built.
+  const multiHostProjectId = convexProjectId ?? activeProjectId ?? null;
+  // Project Environments (Phase 2). Flag-gated and fail-closed inside the hook;
+  // outside environment mode every field below is inert and the Playground
+  // behaves exactly as it does today.
+  const playgroundEnvironment = usePlaygroundEnvironment(multiHostProjectId);
+  const isEnvironmentMode = playgroundEnvironment.isEnvironmentMode;
+  const environmentsEnabled = useProjectEnvironmentsEnabled();
   const { host: previewedHost } = useHost({
     isAuthenticated: isConvexAuthenticated,
     hostId: previewedHostId,
@@ -822,20 +835,44 @@ export function PlaygroundMain({
       projectId: convexProjectId,
       selectedServerIds: hostedSelectedServerIds,
       oauthTokens: hostedOAuthTokens,
-      // Resolve/persist selected server names → Convex ids before a hosted
-      // harness send (ad-hoc/App servers included), so the proxy never sees a
-      // display name. Absent in isolated embeds → falls back to the
-      // pre-resolved selection above.
-      ...(playgroundServerActions?.ensureHostedServerIdsForNames
+      // ENVIRONMENT MODE (Phase 2) and host mode are mutually exclusive on the
+      // wire — `normalizeExecutionTarget` 400s a body carrying both pointers.
+      ...(isEnvironmentMode
         ? {
-            ensureServerIds:
-              playgroundServerActions.ensureHostedServerIdsForNames,
+            executionTarget: playgroundEnvironment.executionTarget,
+            // Only present when the user explicitly overrode the server set.
+            ...(playgroundEnvironment.environmentOverrides
+              ? {
+                  environmentOverrides:
+                    playgroundEnvironment.environmentOverrides,
+                }
+              : {}),
+            // The environment's servers resolve by Convex id server-side (and
+            // some are plugin-contributed, i.e. invisible to the browser's
+            // catalog), so the turn MUST go through /api/web/chat-v2 — the local
+            // /api/mcp engine cannot connect them and rejects the target
+            // outright.
+            requiresWebChatApi: true,
+            // Deliberately NO `ensureServerIds`: resolving environment servers
+            // by NAME would fail for plugin-contributed ones and bypass plugin
+            // lifecycle semantics for the rest.
           }
-        : {}),
-      // Forward the previewed host id so the server re-resolves its
-      // authoritative runtime config (harness/computer) for this direct
-      // session, and so switching hosts forks the chat session.
-      ...(previewedHostId ? { hostId: previewedHostId } : {}),
+        : {
+            // Resolve/persist selected server names → Convex ids before a hosted
+            // harness send (ad-hoc/App servers included), so the proxy never
+            // sees a display name. Absent in isolated embeds → falls back to the
+            // pre-resolved selection above.
+            ...(playgroundServerActions?.ensureHostedServerIdsForNames
+              ? {
+                  ensureServerIds:
+                    playgroundServerActions.ensureHostedServerIdsForNames,
+                }
+              : {}),
+            // Forward the previewed host id so the server re-resolves its
+            // authoritative runtime config (harness/computer) for this direct
+            // session, and so switching hosts forks the chat session.
+            ...(previewedHostId ? { hostId: previewedHostId } : {}),
+          }),
     },
     // Source the host-level toggle from the previewed host's resolved
     // DTO so flipping it in the host's Agent → Behavior tab takes
@@ -1065,13 +1102,39 @@ export function PlaygroundMain({
   // dispatch same-tab events on `saveSelectedHostIds` (deliberate, per
   // the Phase-1 multi-select regression fix); lifting state to this
   // common parent is the correct fix instead of adding event traffic.
-  const multiHostProjectId = convexProjectId ?? activeProjectId ?? null;
   const {
     selectedHostIds,
     setSelectedHostIds,
     multiHostEnabled,
     setMultiHostEnabled,
   } = usePersistedHost(multiHostProjectId);
+
+  // Environment mode ⇒ single host, always.
+  //
+  //  1. Multi-host comparison is switched OFF. Comparison runs one turn against
+  //     several hosts; an environment names exactly one, so the two states
+  //     cannot both be true without one of them lying about what ran.
+  //  2. The environment's host becomes the PREVIEWED host — for PRESENTATION
+  //     only (model chip, harness built-ins, host chrome). It is not sent as a
+  //     `hostId` on the wire; `executionTarget` is the single statement about
+  //     what executes, and the server re-resolves this host from the
+  //     environment itself.
+  const environmentHostId = playgroundEnvironment.preview?.host.hostId ?? null;
+  useEffect(() => {
+    if (!isEnvironmentMode) return;
+    if (multiHostEnabled) setMultiHostEnabled(false);
+    if (environmentHostId && previewedHostId !== environmentHostId) {
+      setPreviewedHostId(environmentHostId);
+    }
+  }, [
+    isEnvironmentMode,
+    environmentHostId,
+    multiHostEnabled,
+    setMultiHostEnabled,
+    previewedHostId,
+    setPreviewedHostId,
+  ]);
+
   const { hosts: hostList, isLoading: hostListLoading } = useHostList({
     isAuthenticated: isConvexAuthenticated,
     projectId: multiHostProjectId,
@@ -1165,7 +1228,12 @@ export function PlaygroundMain({
         .filter((host): host is HostDetail => host !== null),
     [hostSlots, selectedHostIds.length]
   );
-  const canEnableMultiHost = hostList.length > 1 && !isSharedSession;
+  // `!isEnvironmentMode`: comparison and environment mode are mutually
+  // exclusive in v1 (see the effect above). Withdrawing the affordance also
+  // drives the existing "reset a stale persisted multiHostEnabled" effect
+  // below, so the two can't be re-enabled behind the environment's back.
+  const canEnableMultiHost =
+    hostList.length > 1 && !isSharedSession && !isEnvironmentMode;
 
   // Lead identity check — we cannot compact away the lead slot. If
   // `selectedHostIds[0]` is still loading from Convex, the resolved
@@ -3740,6 +3808,19 @@ export function PlaygroundMain({
             isMultiModelLayoutMode={isMultiModelLayoutMode}
             leadHostInMultiHost={
               isMultiHostMode ? leadHost?.name ?? null : null
+            }
+            // Project Environments (Phase 2.5). The header's leading slot is the
+            // Playground's only always-rendered chrome row, so the Environments
+            // section lives here rather than beside the run pill's client chip
+            // (which is a popover and would hide the resolved bundle behind a
+            // click). Flag-gated, fail-closed.
+            leading={
+              environmentsEnabled && !isSharedSession ? (
+                <PlaygroundEnvironmentSection
+                  projectId={multiHostProjectId}
+                  environment={playgroundEnvironment}
+                />
+              ) : null
             }
             // The standalone "Compare" host picker moved into the chat-input
             // run pill (see `hostCompare` in `sharedChatInputProps`). Single-host

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.multi-host.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.multi-host.test.tsx
@@ -114,9 +114,31 @@ vi.mock("@/lib/mcp-ui/mcp-apps-utils", () => ({
   },
 }));
 
+// Project Environments (Phase 2) is flag-gated; default OFF so every existing
+// multi-host assertion keeps exercising the unchanged host path.
+const { environmentsFlag, environmentPreviewFixture } = vi.hoisted(() => ({
+  environmentsFlag: { value: false as boolean | undefined },
+  environmentPreviewFixture: { value: null as unknown },
+}));
 vi.mock("posthog-js/react", () => ({
   usePostHog: () => ({ capture: vi.fn() }),
-  useFeatureFlagEnabled: () => false,
+  useFeatureFlagEnabled: (flag: string) =>
+    flag === "project-environments-enabled" ? environmentsFlag.value : false,
+}));
+// The preview is a network read (`/api/web/environments/:id/preview`); the
+// fixture stands in for the resolver so the test drives what the environment
+// resolves to.
+vi.mock("@/hooks/use-environment-preview", () => ({
+  useEnvironmentPreview: (
+    projectId: string | null,
+    environmentId: string | null,
+  ) => ({
+    preview:
+      projectId && environmentId ? environmentPreviewFixture.value : null,
+    isLoading: false,
+    error: null,
+    refresh: vi.fn(),
+  }),
 }));
 vi.mock("@/lib/analytics", () => ({ track: vi.fn() }));
 
@@ -231,8 +253,12 @@ const mockUseChatSession = {
   submitBlocked: false,
 } as any;
 
+let capturedChatSessionOptions: any = null;
 vi.mock("@/hooks/use-chat-session", () => ({
-  useChatSession: () => mockUseChatSession,
+  useChatSession: (options: any) => {
+    capturedChatSessionOptions = options;
+    return mockUseChatSession;
+  },
 }));
 
 vi.mock("use-stick-to-bottom", () => {
@@ -547,6 +573,9 @@ describe("PlaygroundMain — multi-host render path", () => {
     // test mutates this to force `convexProjectId !== activeProjectId`.
     mockSharedAppState.projects = {};
     mockSharedAppState.activeProjectId = "default";
+    capturedChatSessionOptions = null;
+    environmentsFlag.value = false;
+    environmentPreviewFixture.value = null;
   });
 
   it("selects MCPJam as the previewed client when no current client is selected", async () => {
@@ -1405,5 +1434,110 @@ describe("PlaygroundMain — multi-host render path", () => {
     render(<PlaygroundMain {...defaultProps} />);
 
     expect(screen.queryByTestId("playground-multi-host-grid")).toBeNull();
+  });
+});
+
+// ── Project Environments — Phase 2 (Playground integration) ────────────────
+describe("PlaygroundMain — environment mode", () => {
+  const defaultProps = {
+    activeProjectId: "default",
+    serverName: "test-server",
+    pendingExecution: null,
+    onExecutionInjected: vi.fn(),
+  };
+
+  const preview = {
+    specVersion: 1,
+    environment: { environmentId: "env_1", name: "Staging", revision: 3 },
+    host: {
+      hostId: "h-A",
+      hostName: "Host A",
+      hostConfigId: "cfg_1",
+      modelId: null,
+      hostStyle: null,
+      harness: null,
+    },
+    servers: [
+      { serverId: "srv_plugin", name: "Docs", source: "plugin" as const },
+    ],
+    skills: [],
+    plugins: [],
+    capabilities: {
+      requireToolApproval: null,
+      respectToolVisibility: null,
+      progressiveToolDiscovery: null,
+      builtInToolIds: [],
+      hasComputer: false,
+      serverCount: 1,
+      skillCount: 0,
+      skillDelivery: "emulated" as const,
+      pluginCount: 0,
+      serversOverridden: false,
+    },
+  };
+
+  function selectEnvironment() {
+    environmentsFlag.value = true;
+    environmentPreviewFixture.value = preview;
+    localStorage.setItem(
+      "mcp-previewed-environment-id",
+      JSON.stringify({ default: "env_1" }),
+    );
+  }
+
+  it("does not touch the hosted context while the flag is off", () => {
+    // Everything shipped before this phase was inert; that must stay true for
+    // users without the flag even if they somehow have a persisted selection.
+    localStorage.setItem(
+      "mcp-previewed-environment-id",
+      JSON.stringify({ default: "env_1" }),
+    );
+    environmentPreviewFixture.value = preview;
+    multiHostFixture.hostList = [{ hostId: "h-A", name: "Host A" }];
+
+    render(<PlaygroundMain {...defaultProps} />);
+
+    expect(capturedChatSessionOptions?.hostedContext?.executionTarget).toBe(
+      undefined,
+    );
+  });
+
+  it("targets the environment and stops sending a legacy hostId", () => {
+    selectEnvironment();
+    multiHostFixture.hostList = [{ hostId: "h-A", name: "Host A" }];
+
+    render(<PlaygroundMain {...defaultProps} />);
+
+    const hostedContext = capturedChatSessionOptions?.hostedContext;
+    expect(hostedContext?.executionTarget).toEqual({
+      kind: "environment",
+      environmentId: "env_1",
+    });
+    // `hostId` + `executionTarget` in one body is a 400, not a precedence
+    // question — the environment's host is presentation only.
+    expect(hostedContext?.hostId).toBeUndefined();
+    // No override until the user asks for one.
+    expect(hostedContext?.environmentOverrides).toBeUndefined();
+    // The environment's servers resolve server-side (some are plugin-owned and
+    // invisible to the browser catalog), so the turn must use /api/web/chat-v2
+    // and must NOT run the name→id persistence preflight.
+    expect(hostedContext?.requiresWebChatApi).toBe(true);
+    expect(hostedContext?.ensureServerIds).toBeUndefined();
+  });
+
+  it("exits multi-host comparison when an environment is selected", () => {
+    // An environment names exactly one host; comparison exists to run one turn
+    // against several. Both being true would misreport what ran.
+    selectEnvironment();
+    multiHostFixture.multiHostEnabled = true;
+    multiHostFixture.hostList = [
+      { hostId: "h-A", name: "Host A" },
+      { hostId: "h-B", name: "Host B" },
+    ];
+    multiHostFixture.selectedHostIds = ["h-A", "h-B"];
+
+    render(<PlaygroundMain {...defaultProps} />);
+
+    expect(mockSetMultiHostEnabled).toHaveBeenCalledWith(false);
   });
 });

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.multi-host.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.multi-host.test.tsx
@@ -116,9 +116,18 @@ vi.mock("@/lib/mcp-ui/mcp-apps-utils", () => ({
 
 // Project Environments (Phase 2) is flag-gated; default OFF so every existing
 // multi-host assertion keeps exercising the unchanged host path.
-const { environmentsFlag, environmentPreviewFixture } = vi.hoisted(() => ({
+const {
+  environmentsFlag,
+  environmentPreviewFixture,
+  environmentPreviewLoading,
+} = vi.hoisted(() => ({
   environmentsFlag: { value: false as boolean | undefined },
   environmentPreviewFixture: { value: null as unknown },
+  // Separate from the body on purpose: a live EDIT of the SELECTED
+  // environment refetches while KEEPING the previous body on screen, so
+  // "loading" and "has a preview" are simultaneously true and the fixture
+  // has to be able to express that pair.
+  environmentPreviewLoading: { value: false },
 }));
 vi.mock("posthog-js/react", () => ({
   usePostHog: () => ({ capture: vi.fn() }),
@@ -131,11 +140,11 @@ vi.mock("posthog-js/react", () => ({
 vi.mock("@/hooks/use-environment-preview", () => ({
   useEnvironmentPreview: (
     projectId: string | null,
-    environmentId: string | null,
+    environmentId: string | null
   ) => ({
     preview:
       projectId && environmentId ? environmentPreviewFixture.value : null,
-    isLoading: false,
+    isLoading: environmentPreviewLoading.value,
     error: null,
     refresh: vi.fn(),
   }),
@@ -323,7 +332,7 @@ vi.mock(
   "@/components/chat-v2/chat-input/dialogs/confirm-chat-reset-dialog",
   () => ({
     ConfirmChatResetDialog: () => null,
-  }),
+  })
 );
 
 vi.mock("@/components/chat-v2/fullscreen-chat-overlay", () => ({
@@ -416,10 +425,9 @@ vi.mock("@/state/app-state-context", () => ({
 }));
 
 vi.mock("@/components/chat-v2/shared/chat-helpers", async (importOriginal) => {
-  const actual =
-    await importOriginal<
-      typeof import("@/components/chat-v2/shared/chat-helpers")
-    >();
+  const actual = await importOriginal<
+    typeof import("@/components/chat-v2/shared/chat-helpers")
+  >();
   return {
     ...actual,
     formatErrorMessage: (error: any) =>
@@ -464,7 +472,7 @@ vi.mock("@/hooks/use-persisted-host", () => ({
 vi.mock("@/hooks/use-playground-host-slots", () => ({
   usePlaygroundHostSlots: (
     _isAuthenticated: boolean,
-    ids: (string | null | undefined)[],
+    ids: (string | null | undefined)[]
   ) => {
     const resolve = (id: string | null | undefined) =>
       id ? multiHostFixture.hosts[id] ?? null : null;
@@ -499,7 +507,7 @@ function readPreviewedHostId(projectId = "default"): string | null {
 function makeHost(
   id: string,
   name: string,
-  config: Partial<HostConfigDtoV2>,
+  config: Partial<HostConfigDtoV2>
 ): HostDetail {
   return {
     hostId: id,
@@ -576,6 +584,7 @@ describe("PlaygroundMain — multi-host render path", () => {
     capturedChatSessionOptions = null;
     environmentsFlag.value = false;
     environmentPreviewFixture.value = null;
+    environmentPreviewLoading.value = false;
   });
 
   it("selects MCPJam as the previewed client when no current client is selected", async () => {
@@ -608,7 +617,7 @@ describe("PlaygroundMain — multi-host render path", () => {
         expect.objectContaining({
           projectId: "default",
           name: "MCPJam",
-        }),
+        })
       );
     });
     await waitFor(() => {
@@ -641,7 +650,7 @@ describe("PlaygroundMain — multi-host render path", () => {
           input: expect.objectContaining({
             modelId: "anthropic/claude-haiku-4.5",
           }),
-        }),
+        })
       );
     });
     await waitFor(() => {
@@ -655,7 +664,7 @@ describe("PlaygroundMain — multi-host render path", () => {
         expect.objectContaining({
           projectId: "second",
           name: "MCPJam",
-        }),
+        })
       );
     });
     await waitFor(() => {
@@ -685,9 +694,7 @@ describe("PlaygroundMain — multi-host render path", () => {
     multiHostFixture.selectedHostIds = ["h-A", "h-B"];
     multiHostFixture.multiHostEnabled = true;
 
-    render(
-      <PlaygroundMain {...defaultProps} />,
-    );
+    render(<PlaygroundMain {...defaultProps} />);
 
     const grid = screen.getByTestId("playground-multi-host-grid");
     expect(grid).toBeTruthy();
@@ -903,7 +910,7 @@ describe("PlaygroundMain — multi-host render path", () => {
         .clientSelector;
     expect(clientSelector).toBeDefined();
     expect(clientSelector.selectedHostIds).toBe(
-      multiHostFixture.selectedHostIds,
+      multiHostFixture.selectedHostIds
     );
     expect(clientSelector.multiHostEnabled).toBe(true);
     expect(typeof clientSelector.onSelectedHostIdsChange).toBe("function");
@@ -942,10 +949,7 @@ describe("PlaygroundMain — multi-host render path", () => {
     multiHostFixture.selectedHostIds = ["h-A", "h-B"];
 
     render(
-      <PlaygroundMain
-        {...defaultProps}
-        activeProjectId="local-project"
-      />,
+      <PlaygroundMain {...defaultProps} activeProjectId="local-project" />
     );
 
     // Grid's `usePersistedHost` is scoped to `convexProjectId`.
@@ -957,7 +961,7 @@ describe("PlaygroundMain — multi-host render path", () => {
       mockChatInput.mock.calls[mockChatInput.mock.calls.length - 1][0]
         .clientSelector;
     expect(clientSelector?.selectedHostIds).toBe(
-      multiHostFixture.selectedHostIds,
+      multiHostFixture.selectedHostIds
     );
   });
 
@@ -1029,10 +1033,10 @@ describe("PlaygroundMain — multi-host render path", () => {
       requireToolApproval: false,
     };
     expect(lastByCompareId.get("h-A").executionConfig).toEqual(
-      expectedExecutionConfig,
+      expectedExecutionConfig
     );
     expect(lastByCompareId.get("h-C").executionConfig).toEqual(
-      expectedExecutionConfig,
+      expectedExecutionConfig
     );
   });
 
@@ -1260,7 +1264,7 @@ describe("PlaygroundMain — multi-host render path", () => {
 
     const { rerender } = render(<PlaygroundMain {...defaultProps} />);
     rerender(
-      <PlaygroundMain {...defaultProps} pendingExecution={pendingExecution} />,
+      <PlaygroundMain {...defaultProps} pendingExecution={pendingExecution} />
     );
 
     // Every visible card should have received the broadcast.
@@ -1313,7 +1317,7 @@ describe("PlaygroundMain — multi-host render path", () => {
       });
 
       const compareSection = screen.getByTestId(
-        "playground-multi-host-compare-section",
+        "playground-multi-host-compare-section"
       );
       expect(compareSection).toHaveAttribute("aria-hidden", "false");
 
@@ -1334,7 +1338,7 @@ describe("PlaygroundMain — multi-host render path", () => {
       rerender(<PlaygroundMain {...defaultProps} />);
 
       expect(
-        screen.getByTestId("playground-multi-host-compare-section"),
+        screen.getByTestId("playground-multi-host-compare-section")
       ).toHaveAttribute("aria-hidden", "false");
     } finally {
       mockUseChatSession.selectedModel = previousSelectedModel;
@@ -1359,10 +1363,9 @@ describe("PlaygroundMain — multi-host render path", () => {
     render(<PlaygroundMain {...defaultProps} />);
 
     const stopRequestIdsBefore = mockMultiModelPlaygroundCard.mock.calls.map(
-      ([props]) => props.stopRequestId,
+      ([props]) => props.stopRequestId
     );
-    const baselineStopRequestId =
-      stopRequestIdsBefore.at(-1) ?? 0;
+    const baselineStopRequestId = stopRequestIdsBefore.at(-1) ?? 0;
 
     const inputProps = mockChatInput.mock.calls.at(-1)![0];
     act(() => {
@@ -1481,7 +1484,7 @@ describe("PlaygroundMain — environment mode", () => {
     environmentPreviewFixture.value = preview;
     localStorage.setItem(
       "mcp-previewed-environment-id",
-      JSON.stringify({ default: "env_1" }),
+      JSON.stringify({ default: "env_1" })
     );
   }
 
@@ -1490,7 +1493,7 @@ describe("PlaygroundMain — environment mode", () => {
     // users without the flag even if they somehow have a persisted selection.
     localStorage.setItem(
       "mcp-previewed-environment-id",
-      JSON.stringify({ default: "env_1" }),
+      JSON.stringify({ default: "env_1" })
     );
     environmentPreviewFixture.value = preview;
     multiHostFixture.hostList = [{ hostId: "h-A", name: "Host A" }];
@@ -1498,7 +1501,7 @@ describe("PlaygroundMain — environment mode", () => {
     render(<PlaygroundMain {...defaultProps} />);
 
     expect(capturedChatSessionOptions?.hostedContext?.executionTarget).toBe(
-      undefined,
+      undefined
     );
   });
 
@@ -1535,7 +1538,7 @@ describe("PlaygroundMain — environment mode", () => {
     environmentPreviewFixture.value = null;
     localStorage.setItem(
       "mcp-previewed-environment-id",
-      JSON.stringify({ default: "env_1" }),
+      JSON.stringify({ default: "env_1" })
     );
     multiHostFixture.hostList = [{ hostId: "h-A", name: "Host A" }];
 
@@ -1553,6 +1556,23 @@ describe("PlaygroundMain — environment mode", () => {
     render(<PlaygroundMain {...defaultProps} />);
 
     expect(mockChatInput.mock.calls.at(-1)![0].submitDisabled).toBe(false);
+  });
+
+  it("blocks sends while a live EDIT of the selected environment is refetching", () => {
+    // The gap the other two gates cannot see. Editing the SELECTED environment
+    // refetches without blanking the panel (live-config semantics), so the
+    // preview on screen is the STALE one: a preview exists, so nothing is
+    // "resolving", and the previewed host still matches the OLD host id the
+    // stale body reports. If that edit repointed the environment at another
+    // host, a turn sent here resolves server-side against the NEW host while
+    // carrying the PREVIOUS host's model, system prompt and approval setting.
+    selectEnvironment();
+    environmentPreviewLoading.value = true;
+    multiHostFixture.hostList = [{ hostId: "h-A", name: "Host A" }];
+
+    render(<PlaygroundMain {...defaultProps} />);
+
+    expect(mockChatInput.mock.calls.at(-1)![0].submitDisabled).toBe(true);
   });
 
   it("exits multi-host comparison when an environment is selected", () => {

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.multi-host.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.multi-host.test.tsx
@@ -1525,6 +1525,36 @@ describe("PlaygroundMain — environment mode", () => {
     expect(hostedContext?.ensureServerIds).toBeUndefined();
   });
 
+  it("blocks sends while the selected environment is still resolving", () => {
+    // Activating the target is synchronous; the scope re-key and the
+    // preview→previewed-host sync are not. A turn submitted in that window
+    // carries the NEW environment id with the PREVIOUS host's model, system
+    // prompt and approval setting, and the scope reset that follows can drop
+    // the in-flight message.
+    environmentsFlag.value = true;
+    environmentPreviewFixture.value = null;
+    localStorage.setItem(
+      "mcp-previewed-environment-id",
+      JSON.stringify({ default: "env_1" }),
+    );
+    multiHostFixture.hostList = [{ hostId: "h-A", name: "Host A" }];
+
+    render(<PlaygroundMain {...defaultProps} />);
+
+    expect(mockChatInput.mock.calls.at(-1)![0].submitDisabled).toBe(true);
+  });
+
+  it("re-opens sends once the environment has resolved", () => {
+    // Control for the gate above — it must be a transition gate, not a
+    // permanent block on environment mode.
+    selectEnvironment();
+    multiHostFixture.hostList = [{ hostId: "h-A", name: "Host A" }];
+
+    render(<PlaygroundMain {...defaultProps} />);
+
+    expect(mockChatInput.mock.calls.at(-1)![0].submitDisabled).toBe(false);
+  });
+
   it("exits multi-host comparison when an environment is selected", () => {
     // An environment names exactly one host; comparison exists to run one turn
     // against several. Both being true would misreport what ran.

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session-scope.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session-scope.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   areHostedSessionScopesEqual,
+  hostedTargetKey,
   isSuccessfulRpcResponse,
   reconcileChatToolCallStepUp,
   rpcMessageId,
@@ -103,37 +104,92 @@ describe("tools/call reset correlation helpers (SEP-2350)", () => {
 // must FORK the session — otherwise turns under host B append onto host A's
 // transcript while resolving against B (mis-attribution). The chat-reset path
 // keys off this comparison, so hostId must be a scope dimension.
-describe("areHostedSessionScopesEqual — host switch forks the session", () => {
+describe("areHostedSessionScopesEqual — target switch forks the session", () => {
+  const scope = (input: Parameters<typeof hostedTargetKey>[0]) => ({
+    projectId: input.projectId,
+    targetKey: hostedTargetKey(input),
+  });
   const base = { projectId: "p1", chatboxId: undefined, hostId: "host-a" };
 
   it("treats a different previewed hostId as a different scope (⇒ reset)", () => {
-    expect(areHostedSessionScopesEqual(base, { ...base, hostId: "host-b" })).toBe(
-      false
-    );
+    expect(
+      areHostedSessionScopesEqual(scope(base), scope({ ...base, hostId: "host-b" }))
+    ).toBe(false);
   });
 
   it("treats identical scope as equal (⇒ keep the conversation)", () => {
-    expect(areHostedSessionScopesEqual(base, { ...base })).toBe(true);
+    expect(areHostedSessionScopesEqual(scope(base), scope({ ...base }))).toBe(
+      true
+    );
   });
 
   it("a different project forks; a different chatbox forks", () => {
     expect(
-      areHostedSessionScopesEqual(base, { ...base, projectId: "p2" })
+      areHostedSessionScopesEqual(scope(base), scope({ ...base, projectId: "p2" }))
     ).toBe(false);
     expect(
-      areHostedSessionScopesEqual(base, { ...base, chatboxId: "cbx" })
+      areHostedSessionScopesEqual(
+        scope({ projectId: "p1" }),
+        scope({ projectId: "p1", chatboxId: "cbx" })
+      )
     ).toBe(false);
   });
 
   it("does not consider accessVersion (not part of the scope shape)", () => {
-    // Only the three identity dims matter — an accessVersion bump elsewhere
-    // keeps the same scope and must not tear down the chat.
+    // Only project + target matter — an accessVersion bump elsewhere keeps the
+    // same scope and must not tear down the chat.
     expect(
       areHostedSessionScopesEqual(
-        { projectId: "p1", hostId: "h" },
-        { projectId: "p1", hostId: "h" }
+        scope({ projectId: "p1", hostId: "h" }),
+        scope({ projectId: "p1", hostId: "h" })
       )
     ).toBe(true);
+  });
+});
+
+// Project Environments Phase 2.3: the target key is what forks a session.
+describe("hostedTargetKey", () => {
+  it("namespaces each target kind so id spaces cannot collide", () => {
+    // Same raw id string, different Convex tables — these must never compare
+    // equal, or selecting an environment whose id matched a host id would
+    // silently continue the host's transcript.
+    expect(hostedTargetKey({ hostId: "x" })).toBe("host:x");
+    expect(
+      hostedTargetKey({ executionTarget: { kind: "environment", environmentId: "x" } })
+    ).toBe("environment:x");
+    expect(hostedTargetKey({ chatboxId: "x" })).toBe("chatbox:x");
+    expect(hostedTargetKey({ projectId: "x" })).toBe("adhoc:x");
+  });
+
+  it("an explicit executionTarget wins over the legacy pointers", () => {
+    expect(
+      hostedTargetKey({
+        projectId: "p1",
+        hostId: "host-a",
+        executionTarget: { kind: "environment", environmentId: "env-1" },
+      })
+    ).toBe("environment:env-1");
+  });
+
+  it("selecting a DIFFERENT environment forks; editing the same one does not", () => {
+    const atRevision1 = hostedTargetKey({
+      projectId: "p1",
+      executionTarget: { kind: "environment", environmentId: "env-1" },
+    });
+    // An edit bumps the environment's `revision`, which is deliberately absent
+    // from the key: environments are live config, so the next turn resolves
+    // against the new revision inside the SAME conversation.
+    const afterAnEdit = hostedTargetKey({
+      projectId: "p1",
+      executionTarget: { kind: "environment", environmentId: "env-1" },
+    });
+    expect(afterAnEdit).toBe(atRevision1);
+    expect(
+      hostedTargetKey({
+        projectId: "p1",
+        executionTarget: { kind: "environment", environmentId: "env-2" },
+      })
+    ).not.toBe(atRevision1);
   });
 });
 

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.hosted.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.hosted.test.tsx
@@ -3,6 +3,7 @@ import { generateId } from "ai";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useChatSession } from "../use-chat-session";
 import { useTrafficLogStore } from "@/stores/traffic-log-store";
+import { useHarnessWorkdirStore } from "@/stores/harness-workdir-store";
 import { useUiToolsRegistry } from "@/lib/webmcp/ui-tools-registry";
 
 const mockState = vi.hoisted(() => ({
@@ -1353,6 +1354,88 @@ describe("useChatSession — environment execution target", () => {
     );
     expect(hostMode.result.current.submitBlocked).toBe(true);
     hostMode.unmount();
+    unmount();
+  });
+
+  it("caches the harness workdir under the PRESENTATION host, not the project fallback", () => {
+    // An environment target carries no `hostId` on the wire (the server
+    // re-resolves the host from the environment), so the workdir cache used to
+    // land under the project key — while the Playground Shell reads it by the
+    // environment's resolved host id. The terminal then opened at the box home
+    // instead of inside the harness session directory.
+    useHarnessWorkdirStore.setState({ byKey: {} });
+    const { unmount } = renderHook(() =>
+      useChatSession({
+        selectedServers: [],
+        hostedContext: {
+          ...environmentContext,
+          presentationHostId: "host_env",
+        },
+      })
+    );
+
+    act(() => {
+      mockState.latestOnData?.({
+        type: "data-harness-session",
+        data: { workdir: "/home/user/claude-code-abc" },
+      });
+    });
+
+    // `h:<hostId>` is the store's own key shape, and the rail reads it with the
+    // previewed host id — which in environment mode IS the environment's host.
+    expect(useHarnessWorkdirStore.getState().byKey["h:host_env"]).toBe(
+      "/home/user/claude-code-abc"
+    );
+    unmount();
+  });
+
+  it("aborts a send whose target changed while the name→id preflight was in flight", async () => {
+    // The preflight is async and the transport body is built from the LATEST
+    // props when the request finally goes out. A message composed against a
+    // host would otherwise resume into the environment the user just selected
+    // and run against a different bundle entirely.
+    let resolvePreflight!: (value: Array<{ serverId: string }>) => void;
+    const ensureServerIds = vi.fn(
+      () =>
+        new Promise<Array<{ serverId: string }>>((resolve) => {
+          resolvePreflight = resolve;
+        })
+    );
+
+    const { result, rerender, unmount } = renderHook(
+      ({ inEnvironment }: { inEnvironment: boolean }) =>
+        useChatSession({
+          selectedServers: ["server-a"],
+          hostedContext: inEnvironment
+            ? environmentContext
+            : {
+                projectId: "project-1",
+                selectedServerIds: [],
+                requiresWebChatApi: true,
+                hostId: "host_1",
+                ensureServerIds,
+              },
+        }),
+      { initialProps: { inEnvironment: false } }
+    );
+    mockState.authFetch.mockClear();
+
+    let sendPromise: Promise<void> | undefined;
+    act(() => {
+      sendPromise = result.current.sendMessage({ text: "hi" });
+    });
+    expect(ensureServerIds).toHaveBeenCalledWith(["server-a"]);
+
+    // The user switches to an environment before the preflight settles.
+    rerender({ inEnvironment: true });
+    resolvePreflight([{ serverId: "id-a" }]);
+    await act(async () => {
+      await sendPromise;
+    });
+
+    // Fail CLOSED: nothing goes out. The user resends against the target they
+    // can actually see.
+    expect(mockState.authFetch).not.toHaveBeenCalled();
     unmount();
   });
 });

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.hosted.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.hosted.test.tsx
@@ -1216,3 +1216,143 @@ describe("useChatSession hosted mode", () => {
     unmount();
   });
 });
+
+// ── Project Environments — Phase 2.3 (request serialization) ────────────────
+//
+// The wire contract these cover is not "an extra optional field". It is a
+// closed union that `normalizeExecutionTarget` REJECTS ambiguity in, plus an
+// override envelope whose absent / `[]` distinction is load-bearing all the way
+// to the backend resolver. Both are exactly the kind of thing that regresses
+// silently — a body that still carries `hostId` 400s, and a body that always
+// carries `environmentOverrides` would pin the environment's own set as if the
+// user had chosen it.
+describe("useChatSession — environment execution target", () => {
+  const environmentContext = {
+    projectId: "project-1",
+    selectedServerIds: ["server-id-1"],
+    requiresWebChatApi: true,
+    executionTarget: { kind: "environment" as const, environmentId: "env_1" },
+  };
+
+  it("sends executionTarget and NEVER a legacy hostId alongside it", () => {
+    const { unmount } = renderHook(() =>
+      useChatSession({
+        selectedServers: ["server-1"],
+        hostedContext: environmentContext,
+      })
+    );
+
+    const body = lastTransportOptions.body();
+    expect(body).toMatchObject({
+      executionTarget: { kind: "environment", environmentId: "env_1" },
+    });
+    // `hostId` + `executionTarget` is a 400, not a precedence question.
+    expect(body).not.toHaveProperty("hostId");
+    unmount();
+  });
+
+  it("omits environmentOverrides entirely before the user overrides anything", () => {
+    const { unmount } = renderHook(() =>
+      useChatSession({
+        selectedServers: ["server-1"],
+        hostedContext: environmentContext,
+      })
+    );
+
+    // Absent ⇒ "resolve the environment's own server set". Sending an envelope
+    // here would freeze whatever the set happened to be at page load.
+    expect(lastTransportOptions.body()).not.toHaveProperty(
+      "environmentOverrides"
+    );
+    unmount();
+  });
+
+  it("sends an EMPTY explicit override as an override, not as absence", () => {
+    const { unmount } = renderHook(() =>
+      useChatSession({
+        selectedServers: ["server-1"],
+        hostedContext: {
+          ...environmentContext,
+          environmentOverrides: { serverIds: [] },
+        },
+      })
+    );
+
+    // `[]` means "run this turn with no MCP servers" and must survive the trip.
+    expect(lastTransportOptions.body()).toMatchObject({
+      environmentOverrides: { serverIds: [] },
+    });
+    unmount();
+  });
+
+  it("forwards an explicit narrowing by id", () => {
+    const { unmount } = renderHook(() =>
+      useChatSession({
+        selectedServers: ["server-1"],
+        hostedContext: {
+          ...environmentContext,
+          environmentOverrides: { serverIds: ["srv_a", "srv_b"] },
+        },
+      })
+    );
+
+    expect(lastTransportOptions.body()).toMatchObject({
+      environmentOverrides: { serverIds: ["srv_a", "srv_b"] },
+    });
+    unmount();
+  });
+
+  it("never runs the name→id persistence preflight for an environment turn", async () => {
+    // Environment servers already carry authoritative Convex ids, and
+    // plugin-contributed ones are deliberately hidden from
+    // `servers:getProjectServers` — resolving them BY NAME would fail outright
+    // or persist a shadow copy that bypasses plugin lifecycle semantics.
+    const ensureServerIds = vi.fn(async () => [
+      { serverName: "server-1", serverId: "server-id-1" },
+    ]);
+    const { result, unmount } = renderHook(() =>
+      useChatSession({
+        selectedServers: ["server-1"],
+        hostedContext: { ...environmentContext, ensureServerIds },
+      })
+    );
+
+    await act(async () => {
+      await result.current.sendMessage("hello");
+    });
+
+    expect(ensureServerIds).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it("does not gate submit on browser-resolved server ids", async () => {
+    // The hosted environment path is server-connected: the backend resolves and
+    // connects the set. Requiring one browser-known id per selected server would
+    // never open for a plugin-contributed environment.
+    const { result, unmount } = renderHook(() =>
+      useChatSession({
+        selectedServers: ["server-1", "hidden-plugin-server"],
+        hostedContext: { ...environmentContext, selectedServerIds: [] },
+      })
+    );
+
+    await waitFor(() => expect(result.current.submitBlocked).toBe(false));
+
+    // Control: the same shape WITHOUT an environment target stays blocked,
+    // because that path really does need one Convex id per selected server.
+    const hostMode = renderHook(() =>
+      useChatSession({
+        selectedServers: ["server-1", "hidden-plugin-server"],
+        hostedContext: {
+          projectId: "project-1",
+          selectedServerIds: [],
+          requiresWebChatApi: true,
+          hostId: "host_1",
+        },
+      })
+    );
+    expect(hostMode.result.current.submitBlocked).toBe(true);
+    hostMode.unmount();
+    unmount();
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-playground-environment.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-playground-environment.test.tsx
@@ -13,15 +13,21 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockFlagValue, mockFetch } = vi.hoisted(() => ({
+const { mockFlagValue, mockFetch, mockEnvironments } = vi.hoisted(() => ({
   mockFlagValue: { value: true as boolean | undefined },
   mockFetch: vi.fn(),
+  mockEnvironments: { value: [] as Array<Record<string, unknown>> },
 }));
 
 vi.mock("posthog-js/react", () => ({
   useFeatureFlagEnabled: () => mockFlagValue.value,
 }));
 vi.mock("@/lib/session-token", () => ({ authFetch: mockFetch }));
+// The hook reads the selected row's `revision` from the reactive list so an
+// edit elsewhere refetches the preview; the list is Convex-backed, so stub it.
+vi.mock("@/hooks/useProjectEnvironments", () => ({
+  useProjectEnvironments: () => mockEnvironments.value,
+}));
 
 import { usePlaygroundEnvironment } from "../use-playground-environment";
 
@@ -209,6 +215,31 @@ describe("usePlaygroundEnvironment — the override tri-state", () => {
 });
 
 describe("usePlaygroundEnvironment — select vs edit", () => {
+  it("refetches when the selected row's revision moves (edited elsewhere)", async () => {
+    // Another tab or a collaborator edits the environment. Without watching
+    // the revision, the next turn resolves server-side against the NEW
+    // revision while the UI still shows the old servers — and toggling one of
+    // those stale checkboxes would build an override from obsolete ids.
+    mockEnvironments.value = [{ environmentId: "env_1", revision: 1 }];
+    const { result, rerender } = await renderEnvironment();
+    act(() => result.current.selectEnvironment("env_1"));
+    await waitFor(() => expect(result.current.preview).not.toBeNull());
+    const callsAfterSelect = mockFetch.mock.calls.length;
+
+    respondWith(
+      previewPayload("env_1", [{ serverId: "srv_a", name: "Alpha" }], 2)
+    );
+    mockEnvironments.value = [{ environmentId: "env_1", revision: 2 }];
+    rerender();
+
+    await waitFor(() =>
+      expect(mockFetch.mock.calls.length).toBeGreaterThan(callsAfterSelect)
+    );
+    await waitFor(() =>
+      expect(result.current.preview?.environment.revision).toBe(2)
+    );
+  });
+
   it("selecting a DIFFERENT environment clears the override", async () => {
     const { result } = await renderEnvironment();
     act(() => result.current.selectEnvironment("env_1"));

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-playground-environment.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-playground-environment.test.tsx
@@ -365,11 +365,84 @@ describe("usePlaygroundEnvironment — nothing stale across a transition", () =>
     }
   });
 
-  it("refetches on tab focus, because the row revision isn't the whole truth", async () => {
+  it("refetches on return to the tab, because the row revision isn't the whole truth", async () => {
     // A rotated host config or a changed server-group membership does not bump
     // the environment row's revision, so the revision dependency alone can't
-    // see them. A focus refetch closes the common "edited in another tab" case
-    // without a subscription or a poll.
+    // see them. A refetch on return closes the common "edited in another tab"
+    // case without a subscription or a poll.
+    const { result } = await renderEnvironment();
+    act(() => result.current.selectEnvironment("env_1"));
+    await waitFor(() => expect(result.current.preview).not.toBeNull());
+    const callsBefore = mockFetch.mock.calls.length;
+
+    // Switching to another APPLICATION: the tab stays visible, so only the
+    // window blur/focus pair fires.
+    act(() => {
+      window.dispatchEvent(new Event("blur"));
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    await waitFor(() =>
+      expect(mockFetch.mock.calls.length).toBeGreaterThan(callsBefore)
+    );
+  });
+
+  it("returning from a backgrounded tab refetches ONCE, not once per event", async () => {
+    // Backgrounding and returning fires BOTH `visibilitychange` and `focus`.
+    // Refetching per event would issue two requests for one return, and the
+    // loser isn't free: it flips `isLoading` a second time, which gates sends.
+    const { result } = await renderEnvironment();
+    act(() => result.current.selectEnvironment("env_1"));
+    await waitFor(() => expect(result.current.preview).not.toBeNull());
+    const callsBefore = mockFetch.mock.calls.length;
+
+    const visibility = { value: "visible" };
+    const original = Object.getOwnPropertyDescriptor(
+      Document.prototype,
+      "visibilityState"
+    );
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => visibility.value,
+    });
+    try {
+      act(() => {
+        visibility.value = "hidden";
+        window.dispatchEvent(new Event("blur"));
+        document.dispatchEvent(new Event("visibilitychange"));
+      });
+      // Two SEPARATE `act` blocks on purpose. The browser delivers
+      // `visibilitychange` and `focus` as distinct tasks, so React commits
+      // between them — batching them into one block would let a
+      // refetch-per-event implementation collapse to a single effect run and
+      // pass this test without coalescing anything.
+      visibility.value = "visible";
+      act(() => {
+        document.dispatchEvent(new Event("visibilitychange"));
+      });
+      act(() => {
+        window.dispatchEvent(new Event("focus"));
+      });
+
+      await waitFor(() =>
+        expect(mockFetch.mock.calls.length).toBe(callsBefore + 1)
+      );
+      // Hold past any second in-flight request the pair could have started.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(mockFetch.mock.calls.length).toBe(callsBefore + 1);
+    } finally {
+      if (original) {
+        Object.defineProperty(document, "visibilityState", original);
+      } else {
+        delete (document as unknown as Record<string, unknown>).visibilityState;
+      }
+    }
+  });
+
+  it("does not refetch on a focus event the tab never left", async () => {
+    // A bare `focus` with no preceding away signal is not a return — e.g. a
+    // window that was already frontmost. Treating it as one would refetch on
+    // incidental focus churn and flip the send gate each time.
     const { result } = await renderEnvironment();
     act(() => result.current.selectEnvironment("env_1"));
     await waitFor(() => expect(result.current.preview).not.toBeNull());
@@ -378,9 +451,8 @@ describe("usePlaygroundEnvironment — nothing stale across a transition", () =>
     act(() => {
       window.dispatchEvent(new Event("focus"));
     });
+    await new Promise((resolve) => setTimeout(resolve, 0));
 
-    await waitFor(() =>
-      expect(mockFetch.mock.calls.length).toBeGreaterThan(callsBefore)
-    );
+    expect(mockFetch.mock.calls.length).toBe(callsBefore);
   });
 });

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-playground-environment.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-playground-environment.test.tsx
@@ -1,0 +1,266 @@
+/**
+ * Playground environment mode — the override tri-state and the
+ * select-vs-edit distinction (Project Environments, Phase 2.1).
+ *
+ * These two rules are the whole reason this hook exists, and both are the kind
+ * that a "simplifying" refactor breaks silently:
+ *
+ *   - `null` (follow the environment) and `[]` (explicitly no servers) are
+ *     DIFFERENT. Collapsing them re-enables servers the user just turned off.
+ *   - Selecting a different environment clears the override; a live EDIT of the
+ *     same environment does not. Environments are live config.
+ */
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockFlagValue, mockFetch } = vi.hoisted(() => ({
+  mockFlagValue: { value: true as boolean | undefined },
+  mockFetch: vi.fn(),
+}));
+
+vi.mock("posthog-js/react", () => ({
+  useFeatureFlagEnabled: () => mockFlagValue.value,
+}));
+vi.mock("@/lib/session-token", () => ({ authFetch: mockFetch }));
+
+import { usePlaygroundEnvironment } from "../use-playground-environment";
+
+function previewPayload(
+  environmentId: string,
+  servers: Array<{ serverId: string; name: string; source?: string }>,
+  revision = 1
+) {
+  return {
+    specVersion: 1,
+    environment: { environmentId, name: `Env ${environmentId}`, revision },
+    host: {
+      hostId: "host_1",
+      hostName: "Claude Code",
+      hostConfigId: "cfg_1",
+      modelId: null,
+      hostStyle: null,
+      harness: "claude_code",
+    },
+    servers: servers.map((s) => ({
+      ...s,
+      source: s.source ?? "host_or_group",
+    })),
+    skills: [],
+    plugins: [],
+    capabilities: {
+      requireToolApproval: null,
+      respectToolVisibility: null,
+      progressiveToolDiscovery: null,
+      builtInToolIds: [],
+      hasComputer: false,
+      serverCount: servers.length,
+      skillCount: 0,
+      skillDelivery: "harness",
+      pluginCount: 0,
+      serversOverridden: false,
+    },
+  };
+}
+
+function respondWith(payload: unknown) {
+  mockFetch.mockResolvedValue({
+    ok: true,
+    json: async () => payload,
+  } as unknown as Response);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  mockFlagValue.value = true;
+  respondWith(
+    previewPayload("env_1", [
+      { serverId: "srv_a", name: "Alpha" },
+      // Plugin-contributed: intentionally absent from
+      // `servers:getProjectServers`, so it can only ever travel by id.
+      { serverId: "srv_plugin", name: "Docs", source: "plugin" },
+    ])
+  );
+});
+
+async function renderEnvironment(projectId: string | null = "proj_1") {
+  const rendered = renderHook(() => usePlaygroundEnvironment(projectId));
+  return rendered;
+}
+
+describe("usePlaygroundEnvironment — mode", () => {
+  it("is inert until an environment is selected", async () => {
+    const { result } = await renderEnvironment();
+    expect(result.current.isEnvironmentMode).toBe(false);
+    expect(result.current.executionTarget).toBeUndefined();
+    expect(result.current.environmentOverrides).toBeUndefined();
+  });
+
+  it("fails closed when the feature flag is off, even with a persisted id", async () => {
+    localStorage.setItem(
+      "mcp-previewed-environment-id",
+      JSON.stringify({ proj_1: "env_1" })
+    );
+    mockFlagValue.value = false;
+    const { result } = await renderEnvironment();
+    expect(result.current.isEnvironmentMode).toBe(false);
+    expect(result.current.executionTarget).toBeUndefined();
+    // And it never even asks the server what the environment resolves to.
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("selecting an environment produces exactly one environment target", async () => {
+    const { result } = await renderEnvironment();
+    act(() => result.current.selectEnvironment("env_1"));
+    await waitFor(() => expect(result.current.preview).not.toBeNull());
+    expect(result.current.isEnvironmentMode).toBe(true);
+    expect(result.current.executionTarget).toEqual({
+      kind: "environment",
+      environmentId: "env_1",
+    });
+    // Reads go through the browser-reachable preview route — never /api/v1.
+    expect(String(mockFetch.mock.calls[0][0])).toBe(
+      "/api/web/environments/env_1/preview?projectId=proj_1"
+    );
+  });
+
+  it("clearing the environment returns to host/ad-hoc mode", async () => {
+    const { result } = await renderEnvironment();
+    act(() => result.current.selectEnvironment("env_1"));
+    await waitFor(() => expect(result.current.isEnvironmentMode).toBe(true));
+    act(() => result.current.clearEnvironment());
+    await waitFor(() => expect(result.current.isEnvironmentMode).toBe(false));
+    expect(result.current.executionTarget).toBeUndefined();
+  });
+});
+
+describe("usePlaygroundEnvironment — the override tri-state", () => {
+  it("sends no override at all until the user touches a server", async () => {
+    const { result } = await renderEnvironment();
+    act(() => result.current.selectEnvironment("env_1"));
+    await waitFor(() => expect(result.current.preview).not.toBeNull());
+
+    expect(result.current.serverOverrideIds).toBeNull();
+    expect(result.current.hasExplicitOverride).toBe(false);
+    expect(result.current.environmentOverrides).toBeUndefined();
+    // Every environment server shows enabled — that's the environment's own set.
+    expect(result.current.servers.map((s) => s.enabled)).toEqual([true, true]);
+  });
+
+  it("turning one server off materializes the FULL set minus that server", async () => {
+    // Not `[srv_plugin]`. The first toggle has to seed from the environment's
+    // own set or "turn one off" would silently read as "keep only this one".
+    const { result } = await renderEnvironment();
+    act(() => result.current.selectEnvironment("env_1"));
+    await waitFor(() => expect(result.current.preview).not.toBeNull());
+
+    act(() => result.current.setServerEnabled("srv_a", false));
+    expect(result.current.serverOverrideIds).toEqual(["srv_plugin"]);
+    expect(result.current.hasExplicitOverride).toBe(true);
+    expect(result.current.environmentOverrides).toEqual({
+      serverIds: ["srv_plugin"],
+    });
+  });
+
+  it("turning every server off is an EMPTY override, not an absent one", async () => {
+    const { result } = await renderEnvironment();
+    act(() => result.current.selectEnvironment("env_1"));
+    await waitFor(() => expect(result.current.preview).not.toBeNull());
+
+    act(() => result.current.setServerEnabled("srv_a", false));
+    act(() => result.current.setServerEnabled("srv_plugin", false));
+
+    expect(result.current.serverOverrideIds).toEqual([]);
+    expect(result.current.hasExplicitOverride).toBe(true);
+    // `{ serverIds: [] }` — the turn runs with no MCP servers, which is a
+    // choice the user made and not the same as "use the environment's set".
+    expect(result.current.environmentOverrides).toEqual({ serverIds: [] });
+  });
+
+  it("reset returns to null (follow the environment), not to an empty array", async () => {
+    const { result } = await renderEnvironment();
+    act(() => result.current.selectEnvironment("env_1"));
+    await waitFor(() => expect(result.current.preview).not.toBeNull());
+
+    act(() => result.current.setServerEnabled("srv_a", false));
+    act(() => result.current.resetServersToEnvironment());
+
+    expect(result.current.serverOverrideIds).toBeNull();
+    expect(result.current.hasExplicitOverride).toBe(false);
+    expect(result.current.environmentOverrides).toBeUndefined();
+  });
+
+  it("carries plugin-contributed servers by ID, never by name", async () => {
+    const { result } = await renderEnvironment();
+    act(() => result.current.selectEnvironment("env_1"));
+    await waitFor(() => expect(result.current.preview).not.toBeNull());
+
+    act(() => result.current.setServerEnabled("srv_a", false));
+    // The hidden plugin server survives the override as a Convex id. It has no
+    // representation in the browser's name-keyed project-server catalog, so a
+    // name-shaped override would have dropped it here.
+    expect(result.current.environmentOverrides?.serverIds).toEqual([
+      "srv_plugin",
+    ]);
+    expect(
+      result.current.servers.find((s) => s.serverId === "srv_plugin")?.source
+    ).toBe("plugin");
+  });
+});
+
+describe("usePlaygroundEnvironment — select vs edit", () => {
+  it("selecting a DIFFERENT environment clears the override", async () => {
+    const { result } = await renderEnvironment();
+    act(() => result.current.selectEnvironment("env_1"));
+    await waitFor(() => expect(result.current.preview).not.toBeNull());
+    act(() => result.current.setServerEnabled("srv_a", false));
+    expect(result.current.hasExplicitOverride).toBe(true);
+
+    respondWith(previewPayload("env_2", [{ serverId: "srv_z", name: "Zeta" }]));
+    act(() => result.current.selectEnvironment("env_2"));
+    await waitFor(() =>
+      expect(result.current.preview?.environment.environmentId).toBe("env_2")
+    );
+
+    expect(result.current.serverOverrideIds).toBeNull();
+    expect(result.current.environmentOverrides).toBeUndefined();
+  });
+
+  it("a live EDIT of the same environment keeps the override and updates the base", async () => {
+    const { result } = await renderEnvironment();
+    act(() => result.current.selectEnvironment("env_1"));
+    await waitFor(() => expect(result.current.preview).not.toBeNull());
+    act(() => result.current.setServerEnabled("srv_a", false));
+
+    // Someone edits the environment on /environments: new revision, a server
+    // added. Live-config semantics — the conversation and the user's per-turn
+    // narrowing both survive.
+    respondWith(
+      previewPayload(
+        "env_1",
+        [
+          { serverId: "srv_a", name: "Alpha" },
+          { serverId: "srv_plugin", name: "Docs", source: "plugin" },
+          { serverId: "srv_new", name: "New" },
+        ],
+        2
+      )
+    );
+    act(() => result.current.refreshPreview());
+    await waitFor(() =>
+      expect(result.current.preview?.environment.revision).toBe(2)
+    );
+
+    // The refreshed base is visible…
+    expect(result.current.servers.map((s) => s.serverId)).toEqual([
+      "srv_a",
+      "srv_plugin",
+      "srv_new",
+    ]);
+    // …and the override was NOT erased.
+    expect(result.current.serverOverrideIds).toEqual(["srv_plugin"]);
+    expect(
+      result.current.servers.find((s) => s.serverId === "srv_a")?.enabled
+    ).toBe(false);
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-playground-environment.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-playground-environment.test.tsx
@@ -294,4 +294,93 @@ describe("usePlaygroundEnvironment — select vs edit", () => {
       result.current.servers.find((s) => s.serverId === "srv_a")?.enabled
     ).toBe(false);
   });
+
+  it("re-selecting the environment that is ALREADY selected keeps the override", async () => {
+    // Picking the current entry out of the picker is a no-op selection, not an
+    // environment change. Clearing the per-turn narrowing on it would discard a
+    // choice the user never asked to undo.
+    const { result } = await renderEnvironment();
+    act(() => result.current.selectEnvironment("env_1"));
+    await waitFor(() => expect(result.current.preview).not.toBeNull());
+    act(() => result.current.setServerEnabled("srv_a", false));
+    expect(result.current.serverOverrideIds).toEqual(["srv_plugin"]);
+
+    act(() => result.current.selectEnvironment("env_1"));
+
+    expect(result.current.serverOverrideIds).toEqual(["srv_plugin"]);
+    expect(result.current.environmentOverrides).toEqual({
+      serverIds: ["srv_plugin"],
+    });
+  });
+});
+
+describe("usePlaygroundEnvironment — nothing stale across a transition", () => {
+  it("blanks the previous environment's preview the instant the id changes", async () => {
+    const { result } = await renderEnvironment();
+    act(() => result.current.selectEnvironment("env_1"));
+    await waitFor(() =>
+      expect(result.current.preview?.environment.environmentId).toBe("env_1")
+    );
+
+    // env_2's resolve never lands. The panel must NOT keep describing env_1 in
+    // the meantime: its name, host, counts and — worst — its server checkboxes
+    // belong to a different bundle, and a click on one of those would build an
+    // override out of the wrong environment's server ids.
+    mockFetch.mockReturnValue(new Promise(() => {}));
+    act(() => result.current.selectEnvironment("env_2"));
+
+    expect(result.current.preview).toBeNull();
+    expect(result.current.servers).toEqual([]);
+    expect(result.current.isPreviewLoading).toBe(true);
+    // …and the caller can see the target isn't ready, so sends stay gated.
+    expect(result.current.isResolutionPending).toBe(true);
+  });
+
+  it("never reports one project's environment under another project's id", async () => {
+    localStorage.setItem(
+      "mcp-previewed-environment-id",
+      JSON.stringify({ proj_1: "env_1" })
+    );
+    const seen: Array<string | null> = [];
+    const { rerender } = renderHook(
+      ({ projectId }: { projectId: string }) => {
+        const state = usePlaygroundEnvironment(projectId);
+        seen.push(state.environmentId);
+        return state;
+      },
+      { initialProps: { projectId: "proj_1" } }
+    );
+    await waitFor(() => expect(seen).toContain("env_1"));
+
+    const before = seen.length;
+    rerender({ projectId: "proj_2" });
+
+    // proj_2 has no previewed environment. Carrying proj_1's id through even
+    // one committed render would put the Playground into environment mode for
+    // an environment the new project doesn't own — and ask the server to
+    // resolve it under the new project id.
+    expect(seen.slice(before)).not.toContain("env_1");
+    for (const call of mockFetch.mock.calls) {
+      expect(String(call[0])).not.toContain("projectId=proj_2");
+    }
+  });
+
+  it("refetches on tab focus, because the row revision isn't the whole truth", async () => {
+    // A rotated host config or a changed server-group membership does not bump
+    // the environment row's revision, so the revision dependency alone can't
+    // see them. A focus refetch closes the common "edited in another tab" case
+    // without a subscription or a poll.
+    const { result } = await renderEnvironment();
+    act(() => result.current.selectEnvironment("env_1"));
+    await waitFor(() => expect(result.current.preview).not.toBeNull());
+    const callsBefore = mockFetch.mock.calls.length;
+
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    await waitFor(() =>
+      expect(mockFetch.mock.calls.length).toBeGreaterThan(callsBefore)
+    );
+  });
 });

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -137,6 +137,7 @@ import type {
   ModelVisibleMcpToolResults,
 } from "@/lib/client-config-v2";
 import type { HostedRuntimeContext } from "@/lib/hosted-runtime-context";
+import type { HostedExecutionTarget } from "@/shared/execution-target";
 import {
   buildResolvedServerBatchRequest,
   getApiContextRevision,
@@ -1192,9 +1193,42 @@ function areAuthHeadersEqual(
 
 type HostedSessionScope = {
   projectId?: string | null;
+  /**
+   * ONE stable key for "what this session executes against", replacing the
+   * previous pair of independently-compared `chatboxId` / `hostId` fields:
+   *
+   *   `host:<hostId>` | `environment:<environmentId>` |
+   *   `chatbox:<chatboxId>` | `adhoc:<projectId>`
+   *
+   * Namespacing matters — the id spaces are different Convex tables, and a bare
+   * id comparison would call a host and an environment that happen to share an
+   * id string the same session.
+   *
+   * What is deliberately NOT in the key:
+   *   - the environment `revision`. Environments are LIVE config: editing one
+   *     mid-conversation changes what the next turn resolves to, which is the
+   *     feature. Only changing WHICH environment is selected forks.
+   *   - `accessVersion` (see below).
+   */
+  targetKey?: string;
+};
+
+/** Build the {@link HostedSessionScope} target key. Exported for tests. */
+export function hostedTargetKey(input: {
+  projectId?: string | null;
   chatboxId?: string;
   hostId?: string;
-};
+  executionTarget?: HostedExecutionTarget;
+}): string {
+  if (input.executionTarget) {
+    return input.executionTarget.kind === "environment"
+      ? `environment:${input.executionTarget.environmentId}`
+      : `host:${input.executionTarget.hostId}`;
+  }
+  if (input.chatboxId) return `chatbox:${input.chatboxId}`;
+  if (input.hostId) return `host:${input.hostId}`;
+  return `adhoc:${input.projectId ?? ""}`;
+}
 
 // `accessVersion` is intentionally NOT part of the scope. The chat-reset
 // path uses this comparison to decide when to blow away `chatSessionId` /
@@ -1204,18 +1238,15 @@ type HostedSessionScope = {
 // keeps the same chatbox and the same conversation; tearing the chat down on
 // those bumps would defeat the purpose of the recovery path.
 //
-// `hostId` IS part of the scope: switching the previewed host in the Playground
-// (same project, no chatbox) resolves future turns against a different host —
-// so the transcript must fork rather than append host B's turns onto host A's.
+// The execution TARGET is part of the scope: switching the previewed host — or,
+// from Phase 2, the previewed environment — in the Playground (same project)
+// resolves future turns against a different configuration, so the transcript
+// must fork rather than append target B's turns onto target A's.
 export function areHostedSessionScopesEqual(
   a: HostedSessionScope,
   b: HostedSessionScope
 ): boolean {
-  return (
-    a.projectId === b.projectId &&
-    a.chatboxId === b.chatboxId &&
-    a.hostId === b.hostId
-  );
+  return a.projectId === b.projectId && a.targetKey === b.targetKey;
 }
 
 function isAuthDeniedError(error: unknown): boolean {
@@ -1252,6 +1283,38 @@ export function useChatSession(
   const hostedOAuthTokens = hostedContext?.oauthTokens;
   const hostedChatboxId = hostedContext?.chatboxId;
   const hostedHostId = hostedContext?.hostId;
+  // Project Environments (Phase 2). When present this REPLACES the legacy
+  // `hostId` pointer on the wire — `normalizeExecutionTarget` rejects a body
+  // carrying both rather than shadowing one with the other.
+  const hostedExecutionTarget = hostedContext?.executionTarget;
+  const hostedEnvironmentId =
+    hostedExecutionTarget?.kind === "environment"
+      ? hostedExecutionTarget.environmentId
+      : undefined;
+  // Only ever sent when the caller explicitly overrode. Absent and
+  // `{ serverIds: [] }` mean different things all the way down to the backend
+  // resolver, so this must never be defaulted to an empty envelope.
+  const hostedEnvironmentOverrides = hostedContext?.environmentOverrides;
+  const hostedTargetHostId =
+    hostedExecutionTarget?.kind === "host"
+      ? hostedExecutionTarget.hostId
+      : undefined;
+  // Derived from PRIMITIVES, not from the `executionTarget` object: callers
+  // build that object inline, so a fresh identity every render would churn any
+  // effect that depended on it.
+  const hostedTargetKeyValue = hostedTargetKey({
+    projectId: hostedProjectId,
+    chatboxId: hostedChatboxId,
+    hostId: hostedTargetHostId ?? hostedHostId,
+    ...(hostedEnvironmentId
+      ? {
+          executionTarget: {
+            kind: "environment" as const,
+            environmentId: hostedEnvironmentId,
+          },
+        }
+      : {}),
+  });
   const hostedAccessVersion = hostedContext?.accessVersion;
   const hostedChatboxSurface = hostedContext?.chatboxSurface;
   // Published-chatbox runtime sessions must use the org-aware web engine
@@ -1432,7 +1495,7 @@ export function useChatSession(
   );
   const lastResolvedHostedScopeRef = useRef<HostedSessionScope>({
     projectId: undefined,
-    chatboxId: undefined,
+    targetKey: undefined,
   });
   const pendingSessionHydrationRef = useRef<PendingSessionHydration | null>(
     null
@@ -1892,11 +1955,32 @@ export function useChatSession(
         // and therefore only advertises `elicitation` — when it sees this.
         hostedElicitationVersion: HOSTED_ELICITATION_VERSION,
         ...(isHostedDirectChat ? { directVisibility } : {}),
-        // Host-bound direct preview: forward the saved host id so the server
-        // re-resolves the host's authoritative runtime config (harness/computer
-        // included). Only on the direct path — chatbox sessions own their host
-        // via chatboxId and the server ignores hostId when chatboxId is set.
-        ...(isHostedDirectChat && hostedHostId ? { hostId: hostedHostId } : {}),
+        // What this turn executes against. EXACTLY ONE of these two shapes ever
+        // ships: `normalizeExecutionTarget` 400s on `hostId` + `executionTarget`
+        // rather than picking a winner, because a body with both is a client bug
+        // and silently honoring one is how a user ends up watching a turn run
+        // against a configuration they didn't choose.
+        //
+        // Environment target: `environmentOverrides` rides along ONLY when the
+        // caller explicitly overrode. `selectedServerIds` above still describes
+        // the UI selection during migration, and the server deliberately ignores
+        // it for an environment target — override intent is never inferred from
+        // it.
+        ...(hostedExecutionTarget
+          ? {
+              executionTarget: hostedExecutionTarget,
+              ...(hostedEnvironmentId && hostedEnvironmentOverrides
+                ? { environmentOverrides: hostedEnvironmentOverrides }
+                : {}),
+            }
+          : // Host-bound direct preview: forward the saved host id so the server
+            // re-resolves the host's authoritative runtime config (harness /
+            // computer included). Only on the direct path — chatbox sessions own
+            // their host via chatboxId and the server ignores hostId when
+            // chatboxId is set.
+            isHostedDirectChat && hostedHostId
+            ? { hostId: hostedHostId }
+            : {}),
         ...(hostedChatboxId && hostedChatboxSurface
           ? { surface: hostedChatboxSurface }
           : {}),
@@ -1934,7 +2018,16 @@ export function useChatSession(
                 // Host-bound direct preview: forward the saved host id so the
                 // server re-resolves harness/computer authoritatively. Direct
                 // path only — omitted when a chatbox owns the host.
-                ...(!hostedChatboxId && hostedHostId
+                //
+                // NO `executionTarget` here, by design: the local /api/mcp
+                // engine cannot resolve an environment (it has no Convex read
+                // for the bundle) and 400s on the target. Environment-mode
+                // surfaces set `requiresWebChatApi`, which routes them to
+                // /api/web/chat-v2 above, so this branch is unreachable in
+                // environment mode — and if a caller ever gets it wrong, the
+                // turn runs as a plain host turn rather than silently claiming
+                // to be an environment run.
+                ...(!hostedChatboxId && !hostedExecutionTarget && hostedHostId
                   ? { hostId: hostedHostId }
                   : {}),
                 // Pass projectId for BYOK direct-chat history persistence
@@ -2045,6 +2138,9 @@ export function useChatSession(
     hostedOAuthTokens,
     hostedChatboxId,
     hostedHostId,
+    hostedExecutionTarget,
+    hostedEnvironmentId,
+    hostedEnvironmentOverrides,
     hostedAccessVersion,
     hostedChatboxSurface,
     getOllamaBaseUrl,
@@ -2568,8 +2664,15 @@ export function useChatSession(
         // names they were resolved from, even if the user edits the selection
         // while the preflight is in flight.
         const serverNamesSnapshot = selectedServers;
+        // NEVER for an environment target. The environment's servers already
+        // carry authoritative Convex ids and are re-resolved server-side; some
+        // of them are plugin-contributed and deliberately absent from
+        // `servers:getProjectServers`, so resolving them BY NAME would either
+        // fail outright or persist a shadow copy that bypasses plugin lifecycle
+        // semantics. Environment servers travel by id or not at all.
         if (
           usesWebEngine &&
+          !hostedEnvironmentId &&
           hostedEnsureServerIds &&
           serverNamesSnapshot.length > 0
         ) {
@@ -2607,6 +2710,7 @@ export function useChatSession(
     [
       baseSendMessage,
       hostedEnsureServerIds,
+      hostedEnvironmentId,
       selectedServers,
       selectedModelUsesOrgRuntime,
       hostedRequiresWebChatApi,
@@ -2865,10 +2969,9 @@ export function useChatSession(
       if (active) {
         const previousAuthHeaders = lastResolvedAuthHeadersRef.current;
         const previousHostedScope = lastResolvedHostedScopeRef.current;
-        const currentHostedScope = {
+        const currentHostedScope: HostedSessionScope = {
           projectId: hostedProjectId,
-          chatboxId: hostedChatboxId,
-          hostId: hostedHostId,
+          targetKey: hostedTargetKeyValue,
         };
         const hasResolvedBefore = hasResolvedAuthHeadersRef.current;
         const authHeadersChanged =
@@ -2908,9 +3011,18 @@ export function useChatSession(
     // version, and the scope-equality check inside the effect no longer
     // reads it either, so the effect body is exhaustive-deps-clean
     // without it.
+    //
+    // `hostedEnvironmentId` IS a dependency: the effect is the only path that
+    // acts on a scope change, so without it selecting a different environment
+    // would resolve the next turn against the new bundle while appending to the
+    // previous one's transcript. (`hostedHostId` is a long-standing omission
+    // here — adding it is a behavior change for host switching and is out of
+    // scope for Phase 2; the target key covers it the moment it lands.)
   }, [
     getAccessToken,
     hostedChatboxId,
+    hostedEnvironmentId,
+    hostedTargetKeyValue,
     hostedProjectId,
     isAuthenticated,
     isHostedGuest,
@@ -3125,10 +3237,18 @@ export function useChatSession(
   // pre-resolved id per selected server is NOT required up front — requiring
   // it would keep submit blocked forever for servers the preflight exists to
   // persist (they only get ids once a send runs).
+  // An ENVIRONMENT target is server-connected: the backend resolves and
+  // connects the server set itself from one atomic read, so there is no browser
+  // connection state to wait on and no name→id preflight to run. Gating submit
+  // on `hostedSelectedServerIds` here would block environments whose servers are
+  // plugin-contributed — those are intentionally hidden from
+  // `servers:getProjectServers`, so they can never appear in the browser's
+  // name-keyed catalog and the gate would never open.
   const hostedContextNotReady =
     orgOrHostedContextRequired &&
     (!hostedProjectId ||
-      (selectedServerIdsRequired &&
+      (!hostedEnvironmentId &&
+        selectedServerIdsRequired &&
         selectedServers.length > 0 &&
         !hostedEnsureServerIds &&
         hostedSelectedServerIds.length !== selectedServers.length));

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -1283,6 +1283,10 @@ export function useChatSession(
   const hostedOAuthTokens = hostedContext?.oauthTokens;
   const hostedChatboxId = hostedContext?.chatboxId;
   const hostedHostId = hostedContext?.hostId;
+  // CACHE KEYING ONLY — see `HostedRuntimeContext.presentationHostId`. Never
+  // added to a request body or to `hostedTargetKey`: the execution target must
+  // stay a single statement.
+  const hostedPresentationHostId = hostedContext?.presentationHostId ?? null;
   // Project Environments (Phase 2). When present this REPLACES the legacy
   // `hostId` pointer on the wire — `normalizeExecutionTarget` rejects a body
   // carrying both rather than shadowing one with the other.
@@ -1315,6 +1319,12 @@ export function useChatSession(
         }
       : {}),
   });
+  // Always-current mirror of the target key, read at both ends of the send-time
+  // preflight await. The transport body is built from the LATEST props when the
+  // request finally goes out, so a target the user changed mid-preflight would
+  // silently receive a message composed for the previous one.
+  const hostedTargetKeyRef = useRef(hostedTargetKeyValue);
+  hostedTargetKeyRef.current = hostedTargetKeyValue;
   const hostedAccessVersion = hostedContext?.accessVersion;
   const hostedChatboxSurface = hostedContext?.chatboxSurface;
   // Published-chatbox runtime sessions must use the org-aware web engine
@@ -1628,12 +1638,16 @@ export function useChatSession(
           }
         } else if (isHarnessSessionDataPart(part)) {
           // Cache the harness workdir so the Playground Shell can open a
-          // terminal there. Keyed by project + host (both known here).
+          // terminal there. Keyed by project + host — and on an ENVIRONMENT
+          // turn there is no `hostedHostId` (the target carries no host
+          // pointer), so fall back to the presentation host: that is the id the
+          // rail reads by, and without it the workdir lands under the project
+          // key and the terminal opens at the box home instead.
           useHarnessWorkdirStore
             .getState()
             .setWorkdir(
               hostedProjectId ?? null,
-              hostedHostId ?? null,
+              hostedHostId ?? hostedPresentationHostId ?? null,
               part.data.workdir,
             );
         } else if (isHarnessResetDataPart(part)) {
@@ -1648,7 +1662,7 @@ export function useChatSession(
 
       setLiveTraceState((current) => applyLiveTraceEvent(current, part.data));
     },
-    [hostedProjectId, hostedHostId, appState],
+    [hostedProjectId, hostedHostId, hostedPresentationHostId, appState],
   );
 
   const syncResumedVersion = useCallback((version: number | null) => {
@@ -2676,8 +2690,22 @@ export function useChatSession(
           hostedEnsureServerIds &&
           serverNamesSnapshot.length > 0
         ) {
+          const targetAtSend = hostedTargetKeyRef.current;
           try {
             const resolved = await hostedEnsureServerIds(serverNamesSnapshot);
+            // The user changed what this Playground runs against (host → an
+            // environment, or a different host) while the preflight was in
+            // flight. The transport that would now carry this message belongs
+            // to the NEW target, so sending would run a message composed for
+            // one bundle against another. Fail closed and let the user resend.
+            if (hostedTargetKeyRef.current !== targetAtSend) {
+              pendingWidgetModelContextRef.current = undefined;
+              resolvedHostedServersRef.current = null;
+              toast.error(
+                "The chat target changed while this message was being prepared. Send it again to run it against the current selection.",
+              );
+              return;
+            }
             resolvedHostedServersRef.current = {
               serverIds: resolved.map((r) => r.serverId),
               serverNames: serverNamesSnapshot,

--- a/mcpjam-inspector/client/src/hooks/use-environment-preview.ts
+++ b/mcpjam-inspector/client/src/hooks/use-environment-preview.ts
@@ -111,36 +111,66 @@ export function useEnvironmentPreview(
    * against the NEW revision while the UI still displayed the old host,
    * counts and server checkboxes, and toggling one of those stale boxes
    * would materialize an override out of obsolete server ids.
+   *
+   * It is NOT a complete staleness signal, and deliberately so: the referenced
+   * host's config and an attached server group's membership are both live and
+   * neither bumps this revision. See the focus-refetch effect below for why
+   * that residual window is bounded and left to a refetch rather than a
+   * subscription.
    */
   revision?: number | null
 ): UseEnvironmentPreviewResult {
-  const [preview, setPreview] = useState<EnvironmentPreview | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  // Committed state carries the TARGET it describes. Everything returned below
+  // is derived by comparing that target against the current one, so an
+  // environment-id change blanks the preview in the very same render that
+  // changes the id — a `useEffect` that cleared it afterwards would still let
+  // one committed frame show the previous environment's name, host, counts and
+  // server checkboxes, and a click landing on those stale checkboxes would
+  // materialize an override out of another environment's server ids.
+  //
+  // The key deliberately excludes `revision`: a live EDIT of the SAME
+  // environment must not blank the panel (live-config semantics), it must swap
+  // the contents when the new body arrives.
+  const [committed, setCommitted] = useState<{
+    key: string | null;
+    preview: EnvironmentPreview | null;
+    error: string | null;
+    isLoading: boolean;
+  }>({ key: null, preview: null, error: null, isLoading: false });
   const [refreshToken, setRefreshToken] = useState(0);
   // Guards against a slow response for environment A landing after the user
   // already switched to B — the stale body would describe the wrong bundle.
   const requestSeqRef = useRef(0);
 
+  const normalizedProjectId = projectId?.trim() || null;
+  const normalizedEnvironmentId = environmentId?.trim() || null;
+  const targetKey =
+    normalizedProjectId &&
+    shouldQueryProjectId(normalizedProjectId) &&
+    normalizedEnvironmentId
+      ? `${normalizedProjectId}::${normalizedEnvironmentId}`
+      : null;
+
   useEffect(() => {
-    const normalizedProjectId = projectId?.trim() || null;
-    const normalizedEnvironmentId = environmentId?.trim() || null;
     const seq = ++requestSeqRef.current;
     // `shouldQueryProjectId`, not a bare truthiness check: a local/placeholder
     // project id during a project transition is well-formed but not
     // queryable, and would surface as a spurious "couldn't be resolved" error.
-    if (
-      !normalizedProjectId ||
-      !shouldQueryProjectId(normalizedProjectId) ||
-      !normalizedEnvironmentId
-    ) {
-      setPreview(null);
-      setError(null);
-      setIsLoading(false);
+    if (!targetKey || !normalizedProjectId || !normalizedEnvironmentId) {
+      setCommitted({
+        key: null,
+        preview: null,
+        error: null,
+        isLoading: false,
+      });
       return;
     }
     let active = true;
-    setIsLoading(true);
+    setCommitted((current) =>
+      current.key === targetKey
+        ? { ...current, isLoading: true }
+        : { key: targetKey, preview: null, error: null, isLoading: true }
+    );
     (async () => {
       try {
         const response = await authFetch(
@@ -151,32 +181,87 @@ export function useEnvironmentPreview(
         const payload = await response.json().catch(() => null);
         if (!active || seq !== requestSeqRef.current) return;
         if (!response.ok) {
-          setPreview(null);
-          setError(
-            readErrorMessage(payload, "This environment couldn't be resolved.")
-          );
+          setCommitted({
+            key: targetKey,
+            preview: null,
+            error: readErrorMessage(
+              payload,
+              "This environment couldn't be resolved."
+            ),
+            isLoading: false,
+          });
           return;
         }
-        setPreview(payload as EnvironmentPreview);
-        setError(null);
+        setCommitted({
+          key: targetKey,
+          preview: payload as EnvironmentPreview,
+          error: null,
+          isLoading: false,
+        });
       } catch (caught) {
         if (!active || seq !== requestSeqRef.current) return;
-        setPreview(null);
-        setError(
-          caught instanceof Error
-            ? caught.message
-            : "This environment couldn't be resolved."
-        );
-      } finally {
-        if (active && seq === requestSeqRef.current) setIsLoading(false);
+        setCommitted({
+          key: targetKey,
+          preview: null,
+          error:
+            caught instanceof Error
+              ? caught.message
+              : "This environment couldn't be resolved.",
+          isLoading: false,
+        });
       }
     })();
     return () => {
       active = false;
     };
-  }, [projectId, environmentId, revision, refreshToken]);
+  }, [
+    targetKey,
+    normalizedProjectId,
+    normalizedEnvironmentId,
+    revision,
+    refreshToken,
+  ]);
 
   const refresh = useCallback(() => setRefreshToken((n) => n + 1), []);
+
+  // Refetch when the tab regains focus.
+  //
+  // The `revision` dependency above only catches edits to the environment ROW.
+  // It does NOT catch the two other things a preview depends on: the referenced
+  // host's config rotating, or an attached server group's membership changing —
+  // neither bumps the environment's revision. That residual staleness is
+  // bounded rather than silent: a per-turn override naming a server that is no
+  // longer resolvable is REJECTED by the backend's runtime override validation
+  // (`validateRuntimeServerOverride` — an id must be in the freshly resolved
+  // base or an ordinary live project server), so the worst case is a stale
+  // DISPLAY followed by a refused turn, never a turn that quietly runs the
+  // wrong bundle. That is why this is a focus refetch and not a subscription or
+  // a poll: it closes the common "edited in another tab, came back" case for
+  // one request, and the expensive mechanism would buy only a faster redraw.
+  useEffect(() => {
+    if (!targetKey) return;
+    const onFocus = () => {
+      if (document.visibilityState === "hidden") return;
+      setRefreshToken((n) => n + 1);
+    };
+    window.addEventListener("focus", onFocus);
+    document.addEventListener("visibilitychange", onFocus);
+    return () => {
+      window.removeEventListener("focus", onFocus);
+      document.removeEventListener("visibilitychange", onFocus);
+    };
+  }, [targetKey]);
+
+  const matchesTarget = committed.key === targetKey;
+  const preview = matchesTarget ? committed.preview : null;
+  const error = matchesTarget ? committed.error : null;
+  // Pending-for-a-new-target counts as loading, so the section shows
+  // "Resolving environment…" across the switch instead of an empty gap.
+  const isLoading = targetKey
+    ? matchesTarget
+      ? committed.isLoading
+      : true
+    : false;
 
   return { preview, isLoading, error, refresh };
 }

--- a/mcpjam-inspector/client/src/hooks/use-environment-preview.ts
+++ b/mcpjam-inspector/client/src/hooks/use-environment-preview.ts
@@ -238,17 +238,36 @@ export function useEnvironmentPreview(
   // wrong bundle. That is why this is a focus refetch and not a subscription or
   // a poll: it closes the common "edited in another tab, came back" case for
   // one request, and the expensive mechanism would buy only a faster redraw.
+  //
+  // Both signals are needed and neither subsumes the other: backgrounding the
+  // tab fires only `visibilitychange`, switching to another application leaves
+  // the tab "visible" and fires only `blur`/`focus`. Returning from a
+  // backgrounded tab, though, fires BOTH — so the refetch is driven off an
+  // explicit away→back EDGE rather than off either event directly. Refetching
+  // per event would issue two requests for one return, and the loser is not
+  // free: it flips `isLoading` a second time, which now gates sends.
   useEffect(() => {
     if (!targetKey) return;
-    const onFocus = () => {
-      if (document.visibilityState === "hidden") return;
+    let isAway = false;
+    const markAway = () => {
+      isAway = true;
+    };
+    const onReturn = () => {
+      if (document.visibilityState === "hidden") {
+        isAway = true;
+        return;
+      }
+      if (!isAway) return;
+      isAway = false;
       setRefreshToken((n) => n + 1);
     };
-    window.addEventListener("focus", onFocus);
-    document.addEventListener("visibilitychange", onFocus);
+    window.addEventListener("blur", markAway);
+    window.addEventListener("focus", onReturn);
+    document.addEventListener("visibilitychange", onReturn);
     return () => {
-      window.removeEventListener("focus", onFocus);
-      document.removeEventListener("visibilitychange", onFocus);
+      window.removeEventListener("blur", markAway);
+      window.removeEventListener("focus", onReturn);
+      document.removeEventListener("visibilitychange", onReturn);
     };
   }, [targetKey]);
 

--- a/mcpjam-inspector/client/src/hooks/use-environment-preview.ts
+++ b/mcpjam-inspector/client/src/hooks/use-environment-preview.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { authFetch } from "@/lib/session-token";
+import { shouldQueryProjectId } from "@/hooks/useProjects";
 
 /**
  * Client mirror of the server's `EnvironmentPreview`
@@ -102,7 +103,16 @@ function readErrorMessage(payload: unknown, fallback: string): string {
  */
 export function useEnvironmentPreview(
   projectId: string | null,
-  environmentId: string | null
+  environmentId: string | null,
+  /**
+   * The selected row's current `revision`, from the reactive Convex list.
+   * Passing it makes an edit — in another tab, or by a collaborator —
+   * refetch the preview. Without it the next turn would resolve server-side
+   * against the NEW revision while the UI still displayed the old host,
+   * counts and server checkboxes, and toggling one of those stale boxes
+   * would materialize an override out of obsolete server ids.
+   */
+  revision?: number | null
 ): UseEnvironmentPreviewResult {
   const [preview, setPreview] = useState<EnvironmentPreview | null>(null);
   const [isLoading, setIsLoading] = useState(false);
@@ -116,7 +126,14 @@ export function useEnvironmentPreview(
     const normalizedProjectId = projectId?.trim() || null;
     const normalizedEnvironmentId = environmentId?.trim() || null;
     const seq = ++requestSeqRef.current;
-    if (!normalizedProjectId || !normalizedEnvironmentId) {
+    // `shouldQueryProjectId`, not a bare truthiness check: a local/placeholder
+    // project id during a project transition is well-formed but not
+    // queryable, and would surface as a spurious "couldn't be resolved" error.
+    if (
+      !normalizedProjectId ||
+      !shouldQueryProjectId(normalizedProjectId) ||
+      !normalizedEnvironmentId
+    ) {
       setPreview(null);
       setError(null);
       setIsLoading(false);
@@ -157,7 +174,7 @@ export function useEnvironmentPreview(
     return () => {
       active = false;
     };
-  }, [projectId, environmentId, refreshToken]);
+  }, [projectId, environmentId, revision, refreshToken]);
 
   const refresh = useCallback(() => setRefreshToken((n) => n + 1), []);
 

--- a/mcpjam-inspector/client/src/hooks/use-environment-preview.ts
+++ b/mcpjam-inspector/client/src/hooks/use-environment-preview.ts
@@ -1,0 +1,165 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { authFetch } from "@/lib/session-token";
+
+/**
+ * Client mirror of the server's `EnvironmentPreview`
+ * (`server/services/environments/runtime.ts` → `toEnvironmentPreview`).
+ *
+ * Hand-mirrored rather than imported: `runtime.ts` is a server module (Convex
+ * client, Hono route errors) and pulling its types across would drag the module
+ * into the browser graph. It is NOT a second copy of `ProjectEnvironmentView`
+ * either — that mirrors the stored Convex ROW; this mirrors what the row
+ * currently RESOLVES to, which is live (a host can change, a plugin can be
+ * disabled) and therefore only obtainable from the runtime resolver.
+ *
+ * Deploy-skew posture matches the rest of the environment contracts: identity
+ * fields are required, everything additive is optional/defaulted.
+ */
+export type EnvironmentPreviewServerSource =
+  | "host_or_group"
+  | "plugin"
+  | "override";
+
+export type EnvironmentPreviewSkillChannel = "host" | "environment" | "plugin";
+
+export type EnvironmentSkillDelivery = "emulated" | "harness" | "unsupported";
+
+export interface EnvironmentPreviewServer {
+  serverId: string;
+  name: string;
+  source: EnvironmentPreviewServerSource | null;
+}
+
+export interface EnvironmentPreview {
+  specVersion: number | null;
+  environment: { environmentId: string; name: string; revision: number };
+  host: {
+    hostId: string;
+    hostName: string | null;
+    hostConfigId: string | null;
+    modelId: string | null;
+    hostStyle: string | null;
+    harness: string | null;
+  };
+  servers: EnvironmentPreviewServer[];
+  skills: Array<{
+    skillId: string;
+    name: string;
+    description: string;
+    channels: EnvironmentPreviewSkillChannel[];
+    hasFiles: boolean;
+  }>;
+  plugins: Array<{ pluginId: string; pluginVersionId: string; name: string }>;
+  capabilities: {
+    requireToolApproval: boolean | null;
+    respectToolVisibility: boolean | null;
+    progressiveToolDiscovery: boolean | null;
+    builtInToolIds: string[];
+    hasComputer: boolean;
+    serverCount: number;
+    skillCount: number;
+    skillDelivery: EnvironmentSkillDelivery;
+    pluginCount: number;
+    serversOverridden: boolean;
+  };
+}
+
+export interface UseEnvironmentPreviewResult {
+  preview: EnvironmentPreview | null;
+  isLoading: boolean;
+  /** Human-readable failure, or `null`. Never a thrown error — a Playground
+   *  that can't preview must still render its host-mode chrome. */
+  error: string | null;
+  refresh: () => void;
+}
+
+function readErrorMessage(payload: unknown, fallback: string): string {
+  if (payload && typeof payload === "object") {
+    const error = (payload as { error?: unknown }).error;
+    if (typeof error === "string" && error.length > 0) return error;
+    if (error && typeof error === "object") {
+      const message = (error as { message?: unknown }).message;
+      if (typeof message === "string" && message.length > 0) return message;
+    }
+    const message = (payload as { message?: unknown }).message;
+    if (typeof message === "string" && message.length > 0) return message;
+  }
+  return fallback;
+}
+
+/**
+ * Read what an environment currently resolves to.
+ *
+ * Goes through `GET /api/web/environments/:environmentId/preview` — the ONE
+ * browser-reachable read path for this. The browser must never call `/api/v1`
+ * (`session-token.ts` allowlists only `/api/v1/harness/`), and adding a second
+ * read path would mean two projections of the same spec drifting apart.
+ *
+ * The route deliberately never applies a per-turn server override, so what
+ * comes back is always the environment's OWN set — which is exactly why a
+ * refreshed preview can update the displayed base without any risk of erasing
+ * an explicit override the user set locally.
+ */
+export function useEnvironmentPreview(
+  projectId: string | null,
+  environmentId: string | null
+): UseEnvironmentPreviewResult {
+  const [preview, setPreview] = useState<EnvironmentPreview | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshToken, setRefreshToken] = useState(0);
+  // Guards against a slow response for environment A landing after the user
+  // already switched to B — the stale body would describe the wrong bundle.
+  const requestSeqRef = useRef(0);
+
+  useEffect(() => {
+    const normalizedProjectId = projectId?.trim() || null;
+    const normalizedEnvironmentId = environmentId?.trim() || null;
+    const seq = ++requestSeqRef.current;
+    if (!normalizedProjectId || !normalizedEnvironmentId) {
+      setPreview(null);
+      setError(null);
+      setIsLoading(false);
+      return;
+    }
+    let active = true;
+    setIsLoading(true);
+    (async () => {
+      try {
+        const response = await authFetch(
+          `/api/web/environments/${encodeURIComponent(
+            normalizedEnvironmentId
+          )}/preview?projectId=${encodeURIComponent(normalizedProjectId)}`
+        );
+        const payload = await response.json().catch(() => null);
+        if (!active || seq !== requestSeqRef.current) return;
+        if (!response.ok) {
+          setPreview(null);
+          setError(
+            readErrorMessage(payload, "This environment couldn't be resolved.")
+          );
+          return;
+        }
+        setPreview(payload as EnvironmentPreview);
+        setError(null);
+      } catch (caught) {
+        if (!active || seq !== requestSeqRef.current) return;
+        setPreview(null);
+        setError(
+          caught instanceof Error
+            ? caught.message
+            : "This environment couldn't be resolved."
+        );
+      } finally {
+        if (active && seq === requestSeqRef.current) setIsLoading(false);
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, [projectId, environmentId, refreshToken]);
+
+  const refresh = useCallback(() => setRefreshToken((n) => n + 1), []);
+
+  return { preview, isLoading, error, refresh };
+}

--- a/mcpjam-inspector/client/src/hooks/use-playground-environment.ts
+++ b/mcpjam-inspector/client/src/hooks/use-playground-environment.ts
@@ -10,6 +10,7 @@ import {
   type EnvironmentPreviewServer,
 } from "@/hooks/use-environment-preview";
 import { useProjectEnvironmentsEnabled } from "@/hooks/useProjectEnvironmentsEnabled";
+import { useProjectEnvironments } from "@/hooks/useProjectEnvironments";
 
 /**
  * Playground "environment mode" (Project Environments — Phase 2.1).
@@ -104,9 +105,24 @@ export function usePlaygroundEnvironment(
     setServerOverrideIds(null);
   }, [environmentId]);
 
+  // The reactive list is already the client's source of truth for environment
+  // rows, so the selected row's `revision` comes for free — no extra query.
+  // Feeding it to the preview makes an edit elsewhere (another tab, a
+  // collaborator) refetch, instead of leaving the UI describing a bundle the
+  // next turn will no longer run.
+  const environments = useProjectEnvironments(flagEnabled ? projectId : null);
+  const selectedRevision = useMemo(() => {
+    if (!environmentId) return null;
+    return (
+      environments?.find((env) => env.environmentId === environmentId)
+        ?.revision ?? null
+    );
+  }, [environments, environmentId]);
+
   const { preview, isLoading, error, refresh } = useEnvironmentPreview(
     flagEnabled ? projectId : null,
-    environmentId
+    environmentId,
+    selectedRevision
   );
 
   const servers = useMemo(() => {

--- a/mcpjam-inspector/client/src/hooks/use-playground-environment.ts
+++ b/mcpjam-inspector/client/src/hooks/use-playground-environment.ts
@@ -1,0 +1,187 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type {
+  EnvironmentOverrides,
+  HostedExecutionTarget,
+} from "@/shared/execution-target";
+import { usePreviewedEnvironmentId } from "@/hooks/use-previewed-environment-id";
+import {
+  useEnvironmentPreview,
+  type EnvironmentPreview,
+  type EnvironmentPreviewServer,
+} from "@/hooks/use-environment-preview";
+import { useProjectEnvironmentsEnabled } from "@/hooks/useProjectEnvironmentsEnabled";
+
+/**
+ * Playground "environment mode" (Project Environments — Phase 2.1).
+ *
+ * The Playground has exactly two mutually exclusive modes in v1:
+ *
+ *   HOST / AD-HOC — today's behavior. One or more previewed hosts, servers
+ *     selected from the browser's connected set, names resolved to Convex ids
+ *     by the send-time preflight.
+ *   ENVIRONMENT   — one named bundle. The SERVER re-resolves everything (host
+ *     runtime config, server set, three-channel skills, pinned plugins) from
+ *     one atomic read; the browser only points at it and, optionally, narrows
+ *     the server set for the turn.
+ *
+ * Environment mode is deliberately incompatible with multi-host comparison:
+ * comparison exists to run the same turn against several hosts, and an
+ * environment already pins exactly one. The caller enforces that (it owns the
+ * multi-host state) — this hook just reports which mode is active.
+ *
+ * ## The override tri-state, which is the whole point of this hook
+ *
+ * `serverOverrideIds` is `string[] | null`, and `null` is NOT "empty":
+ *
+ *   null  ⇒ follow the environment. No `environmentOverrides` field is sent at
+ *           all, so the backend resolves the environment's own set.
+ *   []    ⇒ an EXPLICIT override meaning "run this turn with no MCP servers".
+ *   [ids] ⇒ an explicit narrowing.
+ *
+ * Collapsing `[]` into `null` would silently re-enable servers the user just
+ * turned off, so the two never share a representation anywhere on the path from
+ * this hook to `normalizeExecutionTarget`.
+ *
+ * A refreshed preview updates the displayed BASE (the preview route never
+ * applies an override, so what it returns is always the environment's own set)
+ * and never touches `serverOverrideIds`. The override is cleared on exactly one
+ * event: the selected environment CHANGES. An environment EDIT — a new revision
+ * of the same environment — is live-config semantics and leaves the user's
+ * per-turn narrowing intact.
+ */
+export interface PlaygroundEnvironmentState {
+  /** True when the flag is on AND an environment is selected. */
+  isEnvironmentMode: boolean;
+  environmentId: string | null;
+  preview: EnvironmentPreview | null;
+  isPreviewLoading: boolean;
+  previewError: string | null;
+  refreshPreview: () => void;
+  /** `null` ⇒ follow the environment. An array (INCLUDING `[]`) ⇒ explicit. */
+  serverOverrideIds: string[] | null;
+  /** True iff the user explicitly overrode — i.e. `serverOverrideIds !== null`. */
+  hasExplicitOverride: boolean;
+  /**
+   * The environment-owned server entries to render, id-first. Base entries come
+   * from the preview; `enabled` folds in the local override. These are NEVER
+   * merged into the ordinary project-server list: plugin-contributed servers are
+   * intentionally hidden from `servers:getProjectServers`, so a name-keyed
+   * catalog cannot represent them.
+   */
+  servers: Array<EnvironmentPreviewServer & { enabled: boolean }>;
+  /** The wire target, or `undefined` outside environment mode. */
+  executionTarget: HostedExecutionTarget | undefined;
+  /** Sent ONLY when the user explicitly overrode; `undefined` otherwise. */
+  environmentOverrides: EnvironmentOverrides | undefined;
+  selectEnvironment: (environmentId: string | null) => void;
+  clearEnvironment: () => void;
+  /** Back to "follow the environment" (`serverOverrideIds` → `null`). */
+  resetServersToEnvironment: () => void;
+  setServerEnabled: (serverId: string, enabled: boolean) => void;
+}
+
+export function usePlaygroundEnvironment(
+  projectId: string | null
+): PlaygroundEnvironmentState {
+  const flagEnabled = useProjectEnvironmentsEnabled();
+  const [storedEnvironmentId, setStoredEnvironmentId] =
+    usePreviewedEnvironmentId(projectId);
+  // Fail closed: a persisted id must not resurrect the mode for a user whose
+  // flag was turned back off.
+  const environmentId = flagEnabled ? storedEnvironmentId : null;
+
+  const [serverOverrideIds, setServerOverrideIds] = useState<string[] | null>(
+    null
+  );
+
+  // Clear the override when — and ONLY when — the SELECTED environment changes.
+  // Keyed on the id, never on the preview object or its revision: a re-fetch or
+  // a live edit must not discard what the user chose for this turn.
+  const lastEnvironmentIdRef = useRef<string | null>(environmentId);
+  useEffect(() => {
+    if (lastEnvironmentIdRef.current === environmentId) return;
+    lastEnvironmentIdRef.current = environmentId;
+    setServerOverrideIds(null);
+  }, [environmentId]);
+
+  const { preview, isLoading, error, refresh } = useEnvironmentPreview(
+    flagEnabled ? projectId : null,
+    environmentId
+  );
+
+  const servers = useMemo(() => {
+    const base = preview?.servers ?? [];
+    if (serverOverrideIds === null) {
+      return base.map((server) => ({ ...server, enabled: true }));
+    }
+    const enabledIds = new Set(serverOverrideIds);
+    return base.map((server) => ({
+      ...server,
+      enabled: enabledIds.has(server.serverId),
+    }));
+  }, [preview, serverOverrideIds]);
+
+  const selectEnvironment = useCallback(
+    (next: string | null) => {
+      if (!flagEnabled) return;
+      // The effect above also clears on the resulting id change; doing it here
+      // too keeps the transition atomic for a caller that reads the state in
+      // the same tick (and is idempotent).
+      setServerOverrideIds(null);
+      setStoredEnvironmentId(next);
+    },
+    [flagEnabled, setStoredEnvironmentId]
+  );
+
+  const clearEnvironment = useCallback(() => {
+    setServerOverrideIds(null);
+    setStoredEnvironmentId(null);
+  }, [setStoredEnvironmentId]);
+
+  const resetServersToEnvironment = useCallback(
+    () => setServerOverrideIds(null),
+    []
+  );
+
+  const setServerEnabled = useCallback(
+    (serverId: string, enabled: boolean) => {
+      setServerOverrideIds((current) => {
+        // First interaction: materialize the override from the environment's
+        // own set, so turning ONE server off doesn't read as "only this one".
+        const base =
+          current ?? (preview?.servers ?? []).map((server) => server.serverId);
+        if (enabled) {
+          return base.includes(serverId) ? [...base] : [...base, serverId];
+        }
+        return base.filter((id) => id !== serverId);
+      });
+    },
+    [preview]
+  );
+
+  const isEnvironmentMode = flagEnabled && !!environmentId;
+
+  return {
+    isEnvironmentMode,
+    environmentId,
+    preview: isEnvironmentMode ? preview : null,
+    isPreviewLoading: isEnvironmentMode && isLoading,
+    previewError: isEnvironmentMode ? error : null,
+    refreshPreview: refresh,
+    serverOverrideIds,
+    hasExplicitOverride: serverOverrideIds !== null,
+    servers,
+    executionTarget:
+      isEnvironmentMode && environmentId
+        ? { kind: "environment", environmentId }
+        : undefined,
+    environmentOverrides:
+      isEnvironmentMode && serverOverrideIds !== null
+        ? { serverIds: serverOverrideIds }
+        : undefined,
+    selectEnvironment,
+    clearEnvironment,
+    resetServersToEnvironment,
+    setServerEnabled,
+  };
+}

--- a/mcpjam-inspector/client/src/hooks/use-playground-environment.ts
+++ b/mcpjam-inspector/client/src/hooks/use-playground-environment.ts
@@ -57,6 +57,22 @@ export interface PlaygroundEnvironmentState {
   preview: EnvironmentPreview | null;
   isPreviewLoading: boolean;
   previewError: string | null;
+  /**
+   * True while an environment is selected but has not yet resolved to a usable
+   * preview (initial resolve, or the gap after switching to a different one).
+   *
+   * The caller GATES SENDS on this. Activating the target is synchronous but
+   * everything that has to agree with it is not: the chat scope re-keys on the
+   * new `executionTarget`, and the environment's host only becomes the
+   * previewed host once the preview lands. A turn submitted inside that window
+   * would carry the new environment id together with the PREVIOUS host's model,
+   * system prompt and approval setting, and the scope reset that follows can
+   * discard the in-flight message.
+   *
+   * A preview ERROR does not count as pending: there is nothing left to wait
+   * for, and the backend is the authority on whether that environment can run.
+   */
+  isResolutionPending: boolean;
   refreshPreview: () => void;
   /** `null` ⇒ follow the environment. An array (INCLUDING `[]`) ⇒ explicit. */
   serverOverrideIds: string[] | null;
@@ -142,11 +158,14 @@ export function usePlaygroundEnvironment(
       if (!flagEnabled) return;
       // The effect above also clears on the resulting id change; doing it here
       // too keeps the transition atomic for a caller that reads the state in
-      // the same tick (and is idempotent).
-      setServerOverrideIds(null);
+      // the same tick. CONDITIONAL on the id actually changing, though —
+      // re-picking the environment that is already selected is a no-op
+      // selection, and clearing an explicit server override on it would throw
+      // away a per-turn choice the user never asked to undo.
+      if (next !== environmentId) setServerOverrideIds(null);
       setStoredEnvironmentId(next);
     },
-    [flagEnabled, setStoredEnvironmentId]
+    [flagEnabled, environmentId, setStoredEnvironmentId]
   );
 
   const clearEnvironment = useCallback(() => {
@@ -183,6 +202,7 @@ export function usePlaygroundEnvironment(
     preview: isEnvironmentMode ? preview : null,
     isPreviewLoading: isEnvironmentMode && isLoading,
     previewError: isEnvironmentMode ? error : null,
+    isResolutionPending: isEnvironmentMode && !preview && !error,
     refreshPreview: refresh,
     serverOverrideIds,
     hasExplicitOverride: serverOverrideIds !== null,

--- a/mcpjam-inspector/client/src/hooks/use-previewed-environment-id.ts
+++ b/mcpjam-inspector/client/src/hooks/use-previewed-environment-id.ts
@@ -7,29 +7,56 @@ import {
 
 /**
  * React subscription to the "previewed environment" for a project (Phase 2).
- * Mirrors {@link import("./use-previewed-client-id").usePreviewedHostId}
- * exactly, including its persistence pattern: multiple surfaces (Connect's
- * environments strip, the Playground host picker) call this, and a write from
- * any one of them reaches the others through the same-tab
- * `previewed-environment-changed` event.
+ * Shares the persistence pattern of
+ * {@link import("./use-previewed-client-id").usePreviewedHostId}: multiple
+ * surfaces (Connect's environments strip, the Playground host picker) call
+ * this, and a write from any one of them reaches the others through the
+ * same-tab `previewed-environment-changed` event.
+ *
+ * It differs in one respect on purpose — the returned id is SCOPED to the
+ * `projectId` it was read for (see below). Selecting a stale host id merely
+ * previews the wrong host; reporting a stale ENVIRONMENT id flips the
+ * Playground into environment mode and points a turn at another project's
+ * bundle, so the transition has to be closed synchronously.
  */
 export function usePreviewedEnvironmentId(
   projectId: string | null
 ): readonly [string | null, (next: string | null) => void] {
-  const [environmentId, setEnvironmentIdState] = useState<string | null>(() =>
-    projectId ? loadPreviewedEnvironmentId(projectId) : null
-  );
+  // The stored value is kept together with the project it was READ FOR, and
+  // the returned id is derived by comparing that against the current project.
+  // Repairing the mismatch in the effect instead would leave one committed
+  // render in which the PREVIOUS project's environment id is reported under the
+  // NEW project id — long enough for the Playground to enter environment mode
+  // and request an environment that doesn't belong to the project it is asking
+  // about.
+  const [scoped, setScoped] = useState<{
+    projectId: string | null;
+    environmentId: string | null;
+  }>(() => ({
+    projectId: projectId ?? null,
+    environmentId: projectId ? loadPreviewedEnvironmentId(projectId) : null,
+  }));
 
   useEffect(() => {
     if (!projectId) {
-      setEnvironmentIdState(null);
+      setScoped({ projectId: null, environmentId: null });
       return;
     }
-    setEnvironmentIdState(loadPreviewedEnvironmentId(projectId));
+    setScoped({
+      projectId,
+      environmentId: loadPreviewedEnvironmentId(projectId),
+    });
     return subscribePreviewedEnvironmentId(projectId, () => {
-      setEnvironmentIdState(loadPreviewedEnvironmentId(projectId));
+      setScoped({
+        projectId,
+        environmentId: loadPreviewedEnvironmentId(projectId),
+      });
     });
   }, [projectId]);
+
+  // Null until the new project's own value has loaded — never the old one.
+  const environmentId =
+    scoped.projectId === (projectId ?? null) ? scoped.environmentId : null;
 
   const setEnvironmentId = useCallback(
     (next: string | null) => {

--- a/mcpjam-inspector/client/src/hooks/use-previewed-environment-id.ts
+++ b/mcpjam-inspector/client/src/hooks/use-previewed-environment-id.ts
@@ -1,0 +1,43 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  loadPreviewedEnvironmentId,
+  savePreviewedEnvironmentId,
+  subscribePreviewedEnvironmentId,
+} from "@/lib/previewed-environment-storage";
+
+/**
+ * React subscription to the "previewed environment" for a project (Phase 2).
+ * Mirrors {@link import("./use-previewed-client-id").usePreviewedHostId}
+ * exactly, including its persistence pattern: multiple surfaces (Connect's
+ * environments strip, the Playground host picker) call this, and a write from
+ * any one of them reaches the others through the same-tab
+ * `previewed-environment-changed` event.
+ */
+export function usePreviewedEnvironmentId(
+  projectId: string | null
+): readonly [string | null, (next: string | null) => void] {
+  const [environmentId, setEnvironmentIdState] = useState<string | null>(() =>
+    projectId ? loadPreviewedEnvironmentId(projectId) : null
+  );
+
+  useEffect(() => {
+    if (!projectId) {
+      setEnvironmentIdState(null);
+      return;
+    }
+    setEnvironmentIdState(loadPreviewedEnvironmentId(projectId));
+    return subscribePreviewedEnvironmentId(projectId, () => {
+      setEnvironmentIdState(loadPreviewedEnvironmentId(projectId));
+    });
+  }, [projectId]);
+
+  const setEnvironmentId = useCallback(
+    (next: string | null) => {
+      if (!projectId) return;
+      savePreviewedEnvironmentId(projectId, next);
+    },
+    [projectId]
+  );
+
+  return [environmentId, setEnvironmentId] as const;
+}

--- a/mcpjam-inspector/client/src/lib/hosted-runtime-context.ts
+++ b/mcpjam-inspector/client/src/lib/hosted-runtime-context.ts
@@ -17,6 +17,19 @@ export type HostedRuntimeContext = {
    */
   hostId?: string;
   /**
+   * The host this surface PRESENTS as (Playground's previewed host). Purely a
+   * client-side cache key — it is never put on the request wire, never part of
+   * the session scope, and makes no statement about what executes.
+   *
+   * It exists because an environment target deliberately omits `hostId` (the
+   * server re-resolves the host from the environment), which left client caches
+   * keyed by host — the harness workdir cache the Playground Shell reads —
+   * writing under the project fallback while the reader looked under the
+   * environment's resolved host id, so the terminal opened outside the harness
+   * session directory. In host mode this is simply the same value as `hostId`.
+   */
+  presentationHostId?: string | null;
+  /**
    * Project Environments (Phase 2). What this session executes against, as ONE
    * serializable pointer. Mutually exclusive with `hostId` and `chatboxId`:
    * `normalizeExecutionTarget` REJECTS a body carrying both rather than picking

--- a/mcpjam-inspector/client/src/lib/hosted-runtime-context.ts
+++ b/mcpjam-inspector/client/src/lib/hosted-runtime-context.ts
@@ -1,3 +1,8 @@
+import type {
+  EnvironmentOverrides,
+  HostedExecutionTarget,
+} from "@/shared/execution-target";
+
 export type HostedRuntimeContext = {
   projectId?: string | null;
   selectedServerIds?: string[];
@@ -11,6 +16,29 @@ export type HostedRuntimeContext = {
    * previewed host forks the chat session.
    */
   hostId?: string;
+  /**
+   * Project Environments (Phase 2). What this session executes against, as ONE
+   * serializable pointer. Mutually exclusive with `hostId` and `chatboxId`:
+   * `normalizeExecutionTarget` REJECTS a body carrying both rather than picking
+   * a winner, so a surface that sets an environment target must stop sending
+   * `hostId` (the environment's host is still fine to use for *presentation* —
+   * model chip, harness built-ins — it just must not be a second statement
+   * about what to run).
+   *
+   * Absent ⇒ unchanged legacy behavior (`hostId` / `chatboxId` / ad-hoc).
+   */
+  executionTarget?: HostedExecutionTarget;
+  /**
+   * Per-turn narrowing of an environment's server set. Sent ONLY when the user
+   * explicitly overrode the environment: `undefined` means "follow the
+   * environment", `{ serverIds: [] }` means "run with no MCP servers", and the
+   * backend keeps those distinct. Never inferred from `selectedServerIds` —
+   * that field describes the UI selection, not override intent.
+   *
+   * Only meaningful alongside an `executionTarget` of kind `"environment"`;
+   * ingress rejects it otherwise.
+   */
+  environmentOverrides?: EnvironmentOverrides;
   /**
    * Resolved chatbox identity (post-redeem). Threaded into every
    * chatbox-aware request body and cache key.

--- a/mcpjam-inspector/client/src/lib/previewed-environment-storage.ts
+++ b/mcpjam-inspector/client/src/lib/previewed-environment-storage.ts
@@ -1,0 +1,77 @@
+/**
+ * "Previewed environment" — the Project Environment the user has currently
+ * chosen for a given project (Phase 2). Exact structural mirror of
+ * `previewed-client-storage.ts`: `localStorage` under
+ * `mcp-previewed-environment-id` (an object keyed by `projectId` →
+ * `environmentId`), same-tab propagation through a custom
+ * `previewed-environment-changed` event, cross-tab through `storage`.
+ *
+ * A SEPARATE key from the previewed host on purpose. The two are not
+ * alternatives stored in one slot: selecting an environment does adjust the
+ * previewed host (the environment's host drives presentation), and collapsing
+ * them would make "clear the environment" indistinguishable from "clear the
+ * host", stranding the Playground with no host at all.
+ */
+
+const STORAGE_KEY = "mcp-previewed-environment-id";
+const EVENT_NAME = "previewed-environment-changed";
+
+interface PreviewedEnvironmentChangedDetail {
+  projectId: string;
+  environmentId: string | null;
+}
+
+export function loadPreviewedEnvironmentId(projectId: string): string | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const all = JSON.parse(raw) as Record<string, string | null>;
+    const value = all[projectId];
+    return typeof value === "string" && value.length > 0 ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+export function savePreviewedEnvironmentId(
+  projectId: string,
+  environmentId: string | null
+): void {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    const all = raw ? (JSON.parse(raw) as Record<string, string | null>) : {};
+    if (environmentId) {
+      all[projectId] = environmentId;
+    } else {
+      delete all[projectId];
+    }
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(all));
+    const detail: PreviewedEnvironmentChangedDetail = {
+      projectId,
+      environmentId,
+    };
+    window.dispatchEvent(new CustomEvent(EVENT_NAME, { detail }));
+  } catch {
+    // ignore
+  }
+}
+
+export function subscribePreviewedEnvironmentId(
+  projectId: string,
+  callback: () => void
+): () => void {
+  const onCustom = (event: Event) => {
+    const detail = (event as CustomEvent<PreviewedEnvironmentChangedDetail>)
+      .detail;
+    if (!detail || detail.projectId === projectId) callback();
+  };
+  const onStorage = (event: StorageEvent) => {
+    if (event.key === STORAGE_KEY) callback();
+  };
+  window.addEventListener(EVENT_NAME, onCustom as EventListener);
+  window.addEventListener("storage", onStorage);
+  return () => {
+    window.removeEventListener(EVENT_NAME, onCustom as EventListener);
+    window.removeEventListener("storage", onStorage);
+  };
+}


### PR DESCRIPTION
The first **user-visible** Project Environments surface. Phases 0 and 1 shipped inert; selecting an environment in the Playground now actually runs the turn against it. All behind `project-environments-enabled` (fail-closed).

## Behavior

Selecting an environment presets the execution context and exits multi-host comparison. The user can still tweak model, prompt, temperature and approval for that turn — ephemeral, never written back — while the server keeps the environment authoritative for servers, skills and capabilities. That split is deliberate and matches what Phase 1 enforces server-side.

**Overrides are an explicit signal, not an inference.** `null` = follow the environment; an array, *including `[]`*, = the user overrode it. `environmentOverrides` is only sent once the user actually touches the selection, so the server never has to guess intent from `selectedServerIds`. A preview refresh updates the displayed base but does **not** erase an explicit override; the override clears only when the environment ID itself changes.

**Environment servers travel by ID** and skip the name-to-ID persistence preflight. Plugin-contributed servers are hidden from `servers:getProjectServers`, so resolving them by name would either fail or route around plugin lifecycle. The submit gate no longer waits on browser-resolved server ids in environment mode — that path is server-connected.

**Session scope** keys on a target (`host:` / `environment:` / `chatbox:` / `adhoc:`), so switching environments forks the conversation. Revision is deliberately *absent* from the key: editing an environment affects the next turn without forking, matching live-config semantics.

**Connect** gets a flag-gated strip built only from list-row data — no N+1 runtime resolve — whose single action opens the environment in the Playground. Editing stays on `/environments`.

## Two things found on the way — both worth a look

**1. `PlaygroundHostPicker` is dead code.** Nothing renders it; the live affordance is the chat-input run pill's `clientSelector`. The environment section is wired there (it's the named seam, and it's tested) **and** into `PlaygroundCenterHeaderBar`'s previously-unused `leading` slot, which is the only always-rendered Playground chrome. Without that second wiring this entire deliverable would have been invisible. Reviewers may prefer a different permanent home.

**2. Pre-existing bug, not fixed here.** `hostedHostId` is missing from the dependency array of the auth-bootstrap effect — the one effect that reacts to a scope change. So the documented "switching the previewed host forks the session" does **not** fire today for a bare host switch. Phase 2 adds `hostedEnvironmentId` and the target key to that array (required for environment switching to work), leaves host behavior untouched, and documents the omission in place. Worth its own fix.

## Verification

- `npx vitest run` — **10,008 passed**, 6 skipped, **0 failures** (100 new)
- `tsc -p server/tsconfig.json` — **83 vs. an 83 baseline**, full error lists diffed and byte-identical
- `npm run typecheck:client` — clean

Tests cover: environment selection exits multi-host and forks the session; an environment *edit* does not fork; no override field is sent before user interaction; toggling and resetting create/clear explicit override state with `[]` surviving as distinct from absent; hidden plugin servers travel by id and `ensureServerIds` is asserted **not** called on an environment send; and the Connect card opens the environment in the Playground.

## Deliberately not in scope

- **Adding a plain project server as an override.** The backend permits it, but there's no UI affordance today and an add button needs its own authorization-aware resolve pass. Override editing is currently narrowing-only (toggle off, toggle back on within the environment's own set), which the tri-state and backend both support cleanly.
- **Replacing the Playground's browser server chips in environment mode.** `selectedServers` still reflects browser-connected servers; the server ignores it entirely for an environment target and the environment's real set renders id-first in the section. Rewiring the chip/tools pane to be environment-sourced would touch token counting and the docked panels — larger than Phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Playground chat targeting, session forking, and submit gating on a new execution path; mistakes could send turns against the wrong bundle or mix host/environment on the wire, though behavior is flag-gated and heavily tested.
> 
> **Overview**
> Behind **`project-environments-enabled`** (fail-closed), this ships the first user-visible **Project Environments** flow: the Playground can run turns against a named environment bundle, and Connect surfaces a compact launcher strip.
> 
> **Playground** wires `usePlaygroundEnvironment` into `PlaygroundMain`: hosted chat sends **`executionTarget`** (never alongside legacy **`hostId`**), optional **`environmentOverrides`** only after explicit server toggles, and **`requiresWebChatApi`** so plugin/id-resolved servers skip the name→id preflight. Session scope now keys on a namespaced **target** (`environment:` / `host:` / …) so switching environments forks the transcript without forking on environment **revision** edits. UI adds **`PlaygroundEnvironmentSection`** (picker, preview, per-server checkboxes, skill-delivery warning) in the header **`leading`** slot and in **`PlaygroundHostPicker`** (hides multi-host compare while an environment is active). Sends are blocked during target transitions (preview pending, host sync, refetch after live edits) and comparison/multi-model modes are disabled in environment mode.
> 
> **Connect** adds **`ConnectEnvironmentsStrip`** on **`ServersTab`** (list-row metadata only, no per-row resolve) with **Open in Playground** (sets previewed environment + navigates) and **Manage** → `/environments`.
> 
> Supporting pieces: per-project **`mcp-previewed-environment-id`** storage, **`useEnvironmentPreview`** against `/api/web/.../preview`, exported **`pluralize`**, and broad Vitest coverage for tri-state overrides, wire serialization, and transition safety.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7440fcf516bcf012dd75fd420198e9e38b047218. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the first user-visible Project Environments flow: the Playground runs turns against a selected environment and Connect adds an “Open in Playground” entry point; now also gates sends during preview refetch and coalesces tab-return refetches. All behind `project-environments-enabled`.

- **New Features**
  - Playground environment mode: selecting an environment sets the execution target and exits multi-host and multi-model comparison; model/prompt/temp/approval remain per-turn only.
  - Explicit overrides: `environmentOverrides` is only sent after user interaction; `null` follows the environment and `[]` means no servers; overrides persist across preview refresh and clear only on environment change.
  - Server handling: environment servers are sent by ID; the client skips name-to-ID preflight and the submit gate doesn’t wait for local resolution in environment mode.
  - Session scoping: sessions key by target (`host:`, `environment:`, `chatbox:`, `adhoc:`); switching environments forks the session; environment revision is not part of the key.
  - Connect entry point: `ConnectEnvironmentsStrip` on the Servers tab with “Open in Playground” that sets the previewed environment and navigates; normalized project id, capped strip width, and shared `pluralize`; placed after Quick Connect in both connected and empty paths.

- **Bug Fixes**
  - Transition safety: disable environment switching while streaming/preparing; hold submit while an environment target is pending, including while a preview refetch is loading; snapshot the target key during preflight and fail closed on change to prevent cross-target sends.
  - Preview freshness: refetch on environment `revision` changes and on return to the tab (coalesced to a single refetch); gate preview fetches on valid project IDs; preview cache keyed by project+environment so switching shows a resolving state; re-selecting the same environment keeps user overrides.
  - Project scope: the previewed environment id is stored with its project and derives null on mismatch.
  - Multi-model: block comparison in environment mode and reset any stale persisted state.
  - Harness and telemetry: key workdir caches by `presentationHostId` so terminals open in the right directory; fix telemetry dedupe when leaving environment mode.

<sup>Written for commit 7440fcf516bcf012dd75fd420198e9e38b047218. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

