### PR TITLE
feat(plugins): Connect Add-plugin UX (INS-2)

### DIFF
--- a/mcpjam-inspector/client/src/components/ServersTab.tsx
+++ b/mcpjam-inspector/client/src/components/ServersTab.tsx
@@ -38,6 +38,9 @@ import {
 import { ActiveMcpProfileProvider } from "@/contexts/active-mcp-profile-context";
 
 import { JsonImportModal } from "./connection/JsonImportModal";
+import { AddPluginModal } from "./plugins/AddPluginModal";
+import { PluginsSection } from "./plugins/PluginsSection";
+import { usePluginsEnabled } from "@/hooks/usePluginsEnabled";
 import { ServerFormData } from "@/shared/types.js";
 import {
   createInspectorCommandClientError,
@@ -885,6 +888,11 @@ export function ServersTab({
     Partial<ServerFormData> | undefined
   >(undefined);
   const [isImportingJson, setIsImportingJson] = useState(false);
+  // Connect → Add plugin (INS-2). Flag-gated behind `plugins-enabled`
+  // (fail-closed); the modal itself stays MOUNTED while the flag is on so an
+  // in-flight import survives closing the dialog and resumes on reopen.
+  const isPluginsEnabled = usePluginsEnabled();
+  const [isAddingPlugin, setIsAddingPlugin] = useState(false);
   const [isActionMenuOpen, setIsActionMenuOpen] = useState(false);
   const [activeId, setActiveId] = useState<string | null>(null);
   const persistedLoggerFocus = readPersistedLoggerFocus(activeProjectId);
@@ -1647,6 +1655,16 @@ export function ServersTab({
     setIsActionMenuOpen(false);
   };
 
+  // Deliberately NOT behind `serverCreationGate`: importing a plugin creates
+  // plugin-component servers, which are a plugin version's read-only
+  // projection rather than standalone catalog servers, and the backend gates
+  // import on project-admin authorization instead.
+  const handleAddPluginClick = () => {
+    track("add_plugin_button_clicked", { location: "servers_tab" });
+    setIsAddingPlugin(true);
+    setIsActionMenuOpen(false);
+  };
+
   const renderServerActionsMenu = () => (
     <>
       <HoverCard
@@ -1683,6 +1701,17 @@ export function ServersTab({
               <FileText className="h-4 w-4 mr-2" />
               Import JSON
             </Button>
+            {isPluginsEnabled ? (
+              <Button
+                variant="ghost"
+                className="justify-start"
+                onClick={handleAddPluginClick}
+                data-testid="servers-tab-add-plugin"
+              >
+                <Package className="h-4 w-4 mr-2" />
+                Add plugin
+              </Button>
+            ) : null}
           </div>
         </HoverCardContent>
       </HoverCard>
@@ -1822,6 +1851,15 @@ export function ServersTab({
     );
   };
 
+  // Installed plugin GROUP cards, above the standalone server grid. Plugin
+  // component servers never appear in that grid (the backend excludes
+  // `lifecycleScope: 'plugin_component'` rows from the standalone list), so
+  // this section is the only place their health is visible on Connect.
+  const renderPluginsSection = () =>
+    isPluginsEnabled ? (
+      <PluginsSection projectId={sharedProjectIdForHostScope} />
+    ) : null;
+
   const renderConnectedContent = () => (
     <ResizablePanelGroup direction="horizontal" className="flex-1">
       {/* Main Server List Panel */}
@@ -1855,6 +1893,8 @@ export function ServersTab({
           </div>
 
           {renderQuickConnectSection()}
+
+          {renderPluginsSection()}
 
           {/* Server Cards Grid (drag-and-drop reorderable, order saved to localStorage only) */}
           <DndContext
@@ -1990,6 +2030,8 @@ export function ServersTab({
 
       {renderQuickConnectSection()}
 
+      {renderPluginsSection()}
+
       {/* Empty State */}
       <Card className="p-12 text-center">
         <div className="mx-auto max-w-sm">
@@ -2112,6 +2154,17 @@ export function ServersTab({
         onClose={() => setIsImportingJson(false)}
         onImport={handleJsonImport}
       />
+
+      {/* Add Plugin Modal. Mounted (not conditionally rendered) while the
+          flag is on so an import in flight — or a preview awaiting a
+          decision — survives closing the dialog and resumes on reopen. */}
+      {isPluginsEnabled ? (
+        <AddPluginModal
+          isOpen={isAddingPlugin}
+          onClose={() => setIsAddingPlugin(false)}
+          projectId={sharedProjectIdForHostScope}
+        />
+      ) : null}
 
       {detailModalServer && (
         <ServerDetailModal

--- a/mcpjam-inspector/client/src/components/plugins/AddPluginModal.tsx
+++ b/mcpjam-inspector/client/src/components/plugins/AddPluginModal.tsx
@@ -1,0 +1,761 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  CheckCircle2,
+  FileArchive,
+  FolderOpen,
+  Loader2,
+  TriangleAlert,
+} from "lucide-react";
+import { Button } from "@mcpjam/design-system/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@mcpjam/design-system/dialog";
+import { Badge } from "@mcpjam/design-system/badge";
+import type { PluginValidationIssue } from "@mcpjam/sdk/plugin-bundle";
+import { PluginBundleError } from "@mcpjam/sdk/plugin-bundle";
+import {
+  folderSelectionToPluginZip,
+  parsePluginBundleFromZip,
+  readSelectedFileBytes,
+} from "@/lib/plugins/folder-bundle";
+import {
+  PluginApiError,
+  type PluginCommitResult,
+} from "@/lib/plugins/plugin-api-types";
+import {
+  pluginPreviewAnalyticsProps,
+  sanitizePluginCode,
+} from "@/lib/plugins/plugin-analytics";
+import {
+  usePluginImport,
+  usePluginImportActions,
+  usePluginSetupStatus,
+} from "@/hooks/usePluginImportApi";
+import { track } from "@/lib/analytics";
+import { cn } from "@/lib/utils";
+import { PluginImportPreviewContent } from "./PluginImportPreviewContent";
+import {
+  describePluginReadiness,
+  pluralize,
+  shortBundleHash,
+} from "./plugin-presentation";
+
+/**
+ * Connect → **Add plugin** (PR INS-2 of
+ * docs/plans/openai-plugin-import-cross-repo.md).
+ *
+ * One dialog walks the whole backend import state machine — source selection →
+ * upload/inspect progress → preview → confirmation → post-install setup — on
+ * top of the INS-1 client (`usePluginImportApi`). Nothing here re-implements
+ * validation, hashing, or upload; the SDK parser judges the bundle client-side
+ * before an upload URL is minted, and the backend re-judges the same bytes.
+ *
+ * Three invariants this component is responsible for:
+ *
+ * 1. **Installed means the import ROW reached `completed`.** The success view
+ *    is gated on the reactive row, never on the local commit promise or on a
+ *    component count we computed ourselves — no component of a plugin is
+ *    runtime-visible until the version is flipped ready during finalize.
+ * 2. **Retry resumes.** The dialog stays mounted across close/open and keeps
+ *    its `importId`, so a failed commit or a closed dialog resumes from the
+ *    existing `preview_ready` import instead of re-uploading. `createImport`
+ *    does NOT auto-schedule inspection, so an import stuck at `uploaded`
+ *    resumes by re-driving `inspectImport` — not by starting over.
+ * 3. **`reused: true` is not a fresh install.** Re-importing identical bytes
+ *    is content-addressed and returns the SAME ready version; the summary says
+ *    so rather than implying a new revision was created.
+ */
+
+type Busy = "preflight" | "importing" | "committing" | null;
+
+interface SelectedBundle {
+  kind: "zip" | "folder";
+  /** File or folder name — never a path. Used as the backend `sourceLabel`. */
+  label: string;
+  zipBytes: Uint8Array;
+  /** Content-defined identity the backend will recompute on the same bytes. */
+  bundleHash: string;
+  /** Non-fatal parser findings, shown before the upload is offered. */
+  warnings: PluginValidationIssue[];
+}
+
+interface UiFailure {
+  code: string;
+  message: string;
+  issues?: PluginValidationIssue[];
+}
+
+function toUiFailure(error: unknown, fallback: string): UiFailure {
+  if (error instanceof PluginBundleError) {
+    // The parser collects every issue before throwing, so the preflight panel
+    // can list them all rather than only the first fatal one.
+    return {
+      code: error.code,
+      message: error.issues.find((i) => i.severity === "error")?.message ??
+        fallback,
+      issues: error.issues,
+    };
+  }
+  if (error instanceof PluginApiError) {
+    return { code: error.code, message: error.message };
+  }
+  return {
+    code: "UNKNOWN",
+    message: error instanceof Error ? error.message : fallback,
+  };
+}
+
+function IssueList({ issues }: { issues: PluginValidationIssue[] }) {
+  return (
+    <ul className="mt-2 space-y-1">
+      {issues.map((issue, index) => (
+        <li key={`${issue.code}-${index}`} className="text-xs">
+          <code className="text-[11px]">{issue.code}</code>
+          {issue.path ? (
+            <span className="ml-1 text-[11px] text-muted-foreground">
+              {issue.path}
+            </span>
+          ) : null}
+          <span
+            className={cn(
+              "ml-1",
+              issue.severity === "error"
+                ? "text-destructive"
+                : "text-muted-foreground",
+            )}
+          >
+            {issue.message}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export interface AddPluginModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  /**
+   * The CONVEX project id (`sharedProjectId`). Null in local/unsynced mode —
+   * import is a cloud operation, so the dialog explains that instead of
+   * offering a picker that cannot succeed.
+   */
+  projectId: string | null;
+  /** Fired after an import reaches `completed`, with the new version id. */
+  onInstalled?: (result: { pluginId: string; pluginVersionId: string }) => void;
+}
+
+export function AddPluginModal({
+  isOpen,
+  onClose,
+  projectId,
+  onInstalled,
+}: AddPluginModalProps) {
+  const actions = usePluginImportActions();
+  const [selected, setSelected] = useState<SelectedBundle | null>(null);
+  const [importId, setImportId] = useState<string | null>(null);
+  const [busy, setBusy] = useState<Busy>(null);
+  const [failure, setFailure] = useState<UiFailure | null>(null);
+  const [commitResult, setCommitResult] = useState<PluginCommitResult | null>(
+    null,
+  );
+  const zipInputRef = useRef<HTMLInputElement>(null);
+  const folderInputRef = useRef<HTMLInputElement>(null);
+
+  const row = usePluginImport(importId);
+  // Post-install component health. Only meaningful once the row completed —
+  // before that there is no ready version to ask about.
+  const setupStatus = usePluginSetupStatus(
+    row?.status === "completed" ? (row.pluginVersionId ?? null) : null,
+  );
+
+  // A plugin is installed when the IMPORT ROW says so. Deriving it from the
+  // local commit promise (or from any client-side component tally) would let
+  // the UI claim an install before the version was flipped ready.
+  const isInstalled = row?.status === "completed" && !!row.pluginVersionId;
+
+  const previewedRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!row?.preview || row.status !== "preview_ready") return;
+    if (previewedRef.current === row.importId) return;
+    previewedRef.current = row.importId;
+    track("plugin_import_previewed", {
+      location: "add_plugin_modal",
+      ...pluginPreviewAnalyticsProps(row.preview),
+    });
+  }, [row?.importId, row?.status, row?.preview]);
+
+  const installedRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!isInstalled || !row) return;
+    if (installedRef.current === row.importId) return;
+    installedRef.current = row.importId;
+    onInstalled?.({
+      pluginId: row.pluginId!,
+      pluginVersionId: row.pluginVersionId!,
+    });
+  }, [isInstalled, row, onInstalled]);
+
+  const reset = useCallback(() => {
+    setSelected(null);
+    setImportId(null);
+    setBusy(null);
+    setFailure(null);
+    setCommitResult(null);
+    previewedRef.current = null;
+    installedRef.current = null;
+    if (zipInputRef.current) zipInputRef.current.value = "";
+    if (folderInputRef.current) folderInputRef.current.value = "";
+  }, []);
+
+  // Switching projects invalidates an in-flight import: the row belongs to the
+  // old project and a commit would target it. Start clean.
+  useEffect(() => {
+    reset();
+  }, [projectId, reset]);
+
+  const handleZipPicked = useCallback(
+    async (file: File) => {
+      setFailure(null);
+      setBusy("preflight");
+      try {
+        const zipBytes = await readSelectedFileBytes(file);
+        const parsed = await parsePluginBundleFromZip(zipBytes);
+        setSelected({
+          kind: "zip",
+          label: file.name,
+          zipBytes,
+          bundleHash: parsed.bundleHash,
+          warnings: parsed.warnings,
+        });
+      } catch (error) {
+        setSelected(null);
+        setFailure(toUiFailure(error, "That ZIP is not a valid plugin bundle."));
+      } finally {
+        setBusy(null);
+      }
+    },
+    [],
+  );
+
+  const handleFolderPicked = useCallback(async (files: File[]) => {
+    setFailure(null);
+    setBusy("preflight");
+    try {
+      // Validates AND builds the uploadable ZIP from exactly the entries the
+      // parser judged, so the backend inspects the same facts.
+      const { parsed, zipBytes } = await folderSelectionToPluginZip(files);
+      const rootName =
+        (files[0] as { webkitRelativePath?: string })?.webkitRelativePath?.split(
+          "/",
+        )[0] ?? parsed.manifest.name;
+      setSelected({
+        kind: "folder",
+        label: rootName,
+        zipBytes,
+        bundleHash: parsed.bundleHash,
+        warnings: parsed.warnings,
+      });
+    } catch (error) {
+      setSelected(null);
+      setFailure(
+        toUiFailure(error, "That folder is not a valid plugin bundle."),
+      );
+    } finally {
+      setBusy(null);
+    }
+  }, []);
+
+  const startImport = useCallback(async () => {
+    if (!selected || !projectId) return;
+    setFailure(null);
+    setBusy("importing");
+    track("plugin_import_started", {
+      location: "add_plugin_modal",
+      source_kind: selected.kind,
+      bundle_bytes: selected.zipBytes.byteLength,
+    });
+    try {
+      const result = await actions.startImport({
+        projectId,
+        bundle: selected.zipBytes,
+        sourceLabel: selected.label,
+      });
+      setImportId(result.importId);
+      if (result.inspect.status === "failed") {
+        const code = result.inspect.failureCode ?? "INSPECT_FAILED";
+        track("plugin_import_failed", {
+          location: "add_plugin_modal",
+          phase: "inspect",
+          code: sanitizePluginCode(code),
+        });
+        // The row carries the sanitized message; keep the code as the fallback
+        // so the panel is never empty while the subscription catches up.
+        setFailure({ code, message: "The bundle could not be inspected." });
+      }
+    } catch (error) {
+      const uiFailure = toUiFailure(error, "The plugin import failed.");
+      track("plugin_import_failed", {
+        location: "add_plugin_modal",
+        phase: "upload",
+        code: sanitizePluginCode(uiFailure.code),
+      });
+      setFailure(uiFailure);
+    } finally {
+      setBusy(null);
+    }
+  }, [actions, projectId, selected]);
+
+  const resumeInspect = useCallback(async () => {
+    if (!importId) return;
+    setFailure(null);
+    setBusy("importing");
+    try {
+      const result = await actions.inspectImport(importId);
+      if (result.status === "failed") {
+        setFailure({
+          code: result.failureCode ?? "INSPECT_FAILED",
+          message: "The bundle could not be inspected.",
+        });
+      }
+    } catch (error) {
+      setFailure(toUiFailure(error, "The bundle could not be inspected."));
+    } finally {
+      setBusy(null);
+    }
+  }, [actions, importId]);
+
+  const commit = useCallback(
+    async (setActive: boolean) => {
+      if (!importId) return;
+      setFailure(null);
+      setBusy("committing");
+      try {
+        const result = await actions.commitImport(importId, { setActive });
+        setCommitResult(result);
+        if (result.status === "failed") {
+          const code = result.failureCode ?? "COMMIT_FAILED";
+          track("plugin_import_failed", {
+            location: "add_plugin_modal",
+            phase: "commit",
+            code: sanitizePluginCode(code),
+          });
+          setFailure({ code, message: "The plugin could not be installed." });
+          return;
+        }
+        track("plugin_import_completed", {
+          location: "add_plugin_modal",
+          set_active: setActive,
+          reused: result.reused === true,
+          ...(row?.preview ? pluginPreviewAnalyticsProps(row.preview) : {}),
+        });
+      } catch (error) {
+        const uiFailure = toUiFailure(error, "The plugin could not be installed.");
+        track("plugin_import_failed", {
+          location: "add_plugin_modal",
+          phase: "commit",
+          code: sanitizePluginCode(uiFailure.code),
+        });
+        setFailure(uiFailure);
+      } finally {
+        setBusy(null);
+      }
+    },
+    [actions, importId, row?.preview],
+  );
+
+  /**
+   * What "try again" means depends on how far the import got. Resuming an
+   * existing `preview_ready` import (rather than re-uploading) is an explicit
+   * acceptance criterion; `uploaded` resumes by driving the inspect action the
+   * client owns.
+   */
+  const retry = useMemo(() => {
+    if (!importId || !row) {
+      return selected ? { label: "Try again", run: startImport } : null;
+    }
+    if (row.status === "preview_ready") {
+      return { label: "Retry install", run: () => commit(true) };
+    }
+    if (row.status === "uploaded" || row.status === "inspecting") {
+      return { label: "Resume inspection", run: resumeInspect };
+    }
+    // `failed` is terminal for this import row (the backend refuses to commit
+    // anything that is not `preview_ready`), so a retry has to be a new
+    // import of the same bytes.
+    return selected
+      ? {
+          label: "Start a new import",
+          run: async () => {
+            setImportId(null);
+            setCommitResult(null);
+            previewedRef.current = null;
+            await startImport();
+          },
+        }
+      : null;
+  }, [commit, importId, resumeInspect, row, selected, startImport]);
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) {
+      // Deliberately does NOT reset: an import in flight (or a preview waiting
+      // for a decision) survives a close so reopening resumes it. A finished
+      // import is cleared, because its dialog has nothing left to resume.
+      if (isInstalled) reset();
+      onClose();
+    }
+  };
+
+  const rowFailure = row?.failure;
+  const activeFailure: UiFailure | null =
+    failure ??
+    (rowFailure ? { code: rowFailure.code, message: rowFailure.message } : null);
+
+  const isBusy = busy !== null;
+  const progressLabel =
+    busy === "preflight"
+      ? "Checking the bundle…"
+      : busy === "importing"
+        ? "Uploading and inspecting…"
+        : busy === "committing"
+          ? "Installing…"
+          : row?.status === "inspecting"
+            ? "Inspecting…"
+            : row?.status === "committing"
+              ? "Installing…"
+              : null;
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+      <DialogContent
+        className="flex max-h-[85vh] flex-col sm:max-w-2xl"
+        data-testid="add-plugin-modal"
+      >
+        <DialogHeader>
+          <DialogTitle>Add plugin</DialogTitle>
+          <DialogDescription>
+            Import an OpenAI plugin bundle. MCPJam stores the original archive
+            and creates a versioned, read-only projection of its skills and MCP
+            servers.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex-1 space-y-3 overflow-y-auto">
+          {projectId === null ? (
+            <p
+              className="rounded-md border border-border/60 bg-muted/20 px-3 py-2 text-sm text-muted-foreground"
+              data-testid="add-plugin-no-project"
+            >
+              Plugin import needs a synced cloud project. Sign in and select a
+              project to import a plugin.
+            </p>
+          ) : isInstalled ? (
+            <InstalledSummary
+              commitResult={commitResult}
+              bundleHash={row?.preview?.bundleHash}
+              setupComponents={setupStatus?.components}
+            />
+          ) : (
+            <>
+              {/* Source selection is always available until an import starts. */}
+              {!importId ? (
+                <SourcePicker
+                  selected={selected}
+                  disabled={isBusy}
+                  zipInputRef={zipInputRef}
+                  folderInputRef={folderInputRef}
+                  onZip={handleZipPicked}
+                  onFolder={handleFolderPicked}
+                  onClear={reset}
+                />
+              ) : null}
+
+              {progressLabel ? (
+                <div
+                  className="flex items-center gap-2 rounded-md border border-border/60 px-3 py-2 text-sm text-muted-foreground"
+                  data-testid="add-plugin-progress"
+                  role="status"
+                >
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
+                  {progressLabel}
+                </div>
+              ) : null}
+
+              {activeFailure ? (
+                <div
+                  className="rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2"
+                  data-testid="add-plugin-failure"
+                >
+                  <div className="flex items-center gap-2 text-sm font-medium text-destructive">
+                    <TriangleAlert className="h-3.5 w-3.5" aria-hidden />
+                    {activeFailure.message}
+                  </div>
+                  <code className="mt-1 block text-[11px] text-muted-foreground">
+                    {activeFailure.code}
+                  </code>
+                  {activeFailure.issues ? (
+                    <IssueList issues={activeFailure.issues} />
+                  ) : null}
+                </div>
+              ) : null}
+
+              {/* Client-side warnings on a bundle that PASSED preflight — the
+                  backend will re-derive its own warning list at inspect. */}
+              {selected && !importId && selected.warnings.length > 0 ? (
+                <div
+                  className="rounded-md border border-amber-500/30 bg-amber-500/5 px-3 py-2"
+                  data-testid="add-plugin-preflight-warnings"
+                >
+                  <div className="text-xs font-medium text-amber-700 dark:text-amber-300">
+                    {pluralize(selected.warnings.length, "warning")}
+                  </div>
+                  <IssueList issues={selected.warnings} />
+                </div>
+              ) : null}
+
+              {row?.status === "preview_ready" && row.preview ? (
+                <PluginImportPreviewContent preview={row.preview} />
+              ) : null}
+            </>
+          )}
+        </div>
+
+        <div className="flex items-center justify-end gap-2 border-t pt-3">
+          {isInstalled ? (
+            <Button
+              onClick={() => {
+                reset();
+                onClose();
+              }}
+            >
+              Done
+            </Button>
+          ) : (
+            <>
+              <Button variant="outline" onClick={() => onClose()}>
+                Close
+              </Button>
+              {activeFailure && retry ? (
+                <Button
+                  variant="outline"
+                  disabled={isBusy}
+                  onClick={() => void retry.run()}
+                  data-testid="add-plugin-retry"
+                >
+                  {retry.label}
+                </Button>
+              ) : null}
+              {row?.status === "preview_ready" ? (
+                <>
+                  {/* Install-only vs install-and-connect is the backend's
+                      `setActive` choice: both materialize the version, but only
+                      install-and-connect points the plugin at it, which is what
+                      makes the revision the one new attachments offer. */}
+                  <Button
+                    variant="outline"
+                    disabled={isBusy}
+                    onClick={() => void commit(false)}
+                    data-testid="add-plugin-install-only"
+                  >
+                    Install only
+                  </Button>
+                  <Button
+                    disabled={isBusy}
+                    onClick={() => void commit(true)}
+                    data-testid="add-plugin-install-connect"
+                  >
+                    Install and connect
+                  </Button>
+                </>
+              ) : !importId ? (
+                <Button
+                  disabled={!selected || isBusy || !projectId}
+                  onClick={() => void startImport()}
+                  data-testid="add-plugin-continue"
+                >
+                  Continue
+                </Button>
+              ) : null}
+            </>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function SourcePicker({
+  selected,
+  disabled,
+  zipInputRef,
+  folderInputRef,
+  onZip,
+  onFolder,
+  onClear,
+}: {
+  selected: SelectedBundle | null;
+  disabled: boolean;
+  zipInputRef: React.RefObject<HTMLInputElement | null>;
+  folderInputRef: React.RefObject<HTMLInputElement | null>;
+  onZip: (file: File) => void | Promise<void>;
+  onFolder: (files: File[]) => void | Promise<void>;
+  onClear: () => void;
+}) {
+  if (selected) {
+    return (
+      <div
+        className="flex items-center gap-3 rounded-md border border-border/60 bg-muted/20 px-3 py-2"
+        data-testid="add-plugin-selected-source"
+      >
+        {selected.kind === "zip" ? (
+          <FileArchive className="h-4 w-4 shrink-0 text-muted-foreground" />
+        ) : (
+          <FolderOpen className="h-4 w-4 shrink-0 text-muted-foreground" />
+        )}
+        <div className="min-w-0">
+          <p className="truncate text-sm font-medium">{selected.label}</p>
+          <p className="text-[11px] text-muted-foreground">
+            Revision {shortBundleHash(selected.bundleHash)}
+          </p>
+        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="ml-auto"
+          disabled={disabled}
+          onClick={onClear}
+        >
+          Change
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-2 sm:grid-cols-2">
+      <input
+        ref={zipInputRef}
+        type="file"
+        accept=".zip,application/zip"
+        className="hidden"
+        onChange={(event) => {
+          const file = event.target.files?.[0];
+          if (file) void onZip(file);
+        }}
+      />
+      <input
+        ref={folderInputRef}
+        type="file"
+        // @ts-expect-error webkitdirectory is not in the DOM type definitions
+        webkitdirectory=""
+        directory=""
+        multiple
+        className="hidden"
+        onChange={(event) => {
+          const files = Array.from(event.target.files ?? []);
+          if (files.length > 0) void onFolder(files);
+        }}
+      />
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={() => zipInputRef.current?.click()}
+        className="flex flex-col items-center gap-2 rounded-lg border-2 border-dashed border-muted-foreground/25 p-6 text-center transition-colors hover:border-muted-foreground/50 disabled:opacity-50"
+        data-testid="add-plugin-choose-zip"
+      >
+        <FileArchive className="h-5 w-5 text-muted-foreground" aria-hidden />
+        <span className="text-sm font-medium">Choose a ZIP</span>
+        <span className="text-[11px] text-muted-foreground">
+          Up to 25 MB compressed
+        </span>
+      </button>
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={() => folderInputRef.current?.click()}
+        className="flex flex-col items-center gap-2 rounded-lg border-2 border-dashed border-muted-foreground/25 p-6 text-center transition-colors hover:border-muted-foreground/50 disabled:opacity-50"
+        data-testid="add-plugin-choose-folder"
+      >
+        <FolderOpen className="h-5 w-5 text-muted-foreground" aria-hidden />
+        <span className="text-sm font-medium">Choose a folder</span>
+        <span className="text-[11px] text-muted-foreground">
+          Zipped locally before upload
+        </span>
+      </button>
+    </div>
+  );
+}
+
+function InstalledSummary({
+  commitResult,
+  bundleHash,
+  setupComponents,
+}: {
+  commitResult: PluginCommitResult | null;
+  bundleHash?: string;
+  setupComponents?: Array<{
+    componentKey: string;
+    readiness: Parameters<typeof describePluginReadiness>[0];
+  }>;
+}) {
+  // Content-addressed re-import: the same bytes always resolve to the SAME
+  // ready version, so claiming a fresh install here would be a lie.
+  const reused = commitResult?.reused === true;
+  return (
+    <div className="space-y-3" data-testid="add-plugin-installed">
+      <div className="flex items-center gap-2">
+        <CheckCircle2
+          className="h-4 w-4 text-emerald-600 dark:text-emerald-400"
+          aria-hidden
+        />
+        <span className="text-sm font-medium">
+          {reused ? "Already imported" : "Plugin installed"}
+        </span>
+        {bundleHash ? (
+          <code className="ml-auto rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground">
+            {shortBundleHash(bundleHash)}
+          </code>
+        ) : null}
+      </div>
+      <p className="text-xs text-muted-foreground">
+        {reused
+          ? "These exact bytes were already imported, so the existing revision was reused instead of creating a new one."
+          : "The revision is stored and its components are available to this project."}
+      </p>
+
+      {setupComponents && setupComponents.length > 0 ? (
+        <div className="space-y-1.5">
+          <p className="text-xs font-medium">Component setup</p>
+          <ul className="space-y-1">
+            {setupComponents.map((component) => {
+              const described = describePluginReadiness(component.readiness);
+              return (
+                <li
+                  key={component.componentKey}
+                  className="flex items-center gap-2 text-xs"
+                >
+                  <span className="font-medium">{component.componentKey}</span>
+                  <Badge
+                    variant={
+                      described.tone === "ready" ? "secondary" : "outline"
+                    }
+                    className="font-normal"
+                  >
+                    {described.label}
+                  </Badge>
+                  <span className="ml-auto text-[11px] text-muted-foreground">
+                    {described.detail}
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/plugins/AddPluginModal.tsx
+++ b/mcpjam-inspector/client/src/components/plugins/AddPluginModal.tsx
@@ -22,6 +22,7 @@ import {
   parsePluginBundleFromZip,
   readSelectedFileBytes,
 } from "@/lib/plugins/folder-bundle";
+import { assertPluginBundleWithinCap } from "@/lib/plugins/plugin-api";
 import {
   PluginApiError,
   type PluginCommitResult,
@@ -68,6 +69,13 @@ import {
  * 3. **`reused: true` is not a fresh install.** Re-importing identical bytes
  *    is content-addressed and returns the SAME ready version; the summary says
  *    so rather than implying a new revision was created.
+ *
+ * Every async step is generation-guarded (`runRef`). `reset()` bumps the
+ * generation, and each post-await state write is dropped when the generation
+ * moved — otherwise an in-flight `startImport` settling AFTER a project switch
+ * would write the OLD project's import id back into a modal now bound to a new
+ * project, and the user (still an admin there) could preview and commit it
+ * into the wrong project.
  */
 
 type Busy = "preflight" | "importing" | "committing" | null;
@@ -163,8 +171,21 @@ export function AddPluginModal({
   const [commitResult, setCommitResult] = useState<PluginCommitResult | null>(
     null,
   );
+  /**
+   * The `setActive` of the most recent commit ATTEMPT, so a retry repeats the
+   * user's choice. Hardcoding `true` here would silently upgrade an
+   * "Install only" into an activation the moment a commit had to be retried.
+   */
+  const [lastCommitSetActive, setLastCommitSetActive] = useState(true);
   const zipInputRef = useRef<HTMLInputElement>(null);
   const folderInputRef = useRef<HTMLInputElement>(null);
+  /**
+   * Generation token for every async step. Bumped by `reset()`; each async op
+   * captures it before its first await and drops all later state writes when
+   * it no longer matches. `useState` cannot do this — a settled promise would
+   * still write with the closure's stale values.
+   */
+  const runRef = useRef(0);
 
   const row = usePluginImport(importId);
   // Post-install component health. Only meaningful once the row completed —
@@ -176,7 +197,10 @@ export function AddPluginModal({
   // A plugin is installed when the IMPORT ROW says so. Deriving it from the
   // local commit promise (or from any client-side component tally) would let
   // the UI claim an install before the version was flipped ready.
-  const isInstalled = row?.status === "completed" && !!row.pluginVersionId;
+  // Both ids are required: the completion callback hands them out, and a
+  // guard that only checked one would leave the other's read unearned.
+  const isInstalled =
+    row?.status === "completed" && !!row.pluginId && !!row.pluginVersionId;
 
   const previewedRef = useRef<string | null>(null);
   useEffect(() => {
@@ -201,11 +225,15 @@ export function AddPluginModal({
   }, [isInstalled, row, onInstalled]);
 
   const reset = useCallback(() => {
+    // Invalidate anything already in flight before clearing state, so a
+    // promise that settles later cannot repopulate what we just cleared.
+    runRef.current += 1;
     setSelected(null);
     setImportId(null);
     setBusy(null);
     setFailure(null);
     setCommitResult(null);
+    setLastCommitSetActive(true);
     previewedRef.current = null;
     installedRef.current = null;
     if (zipInputRef.current) zipInputRef.current.value = "";
@@ -218,37 +246,55 @@ export function AddPluginModal({
     reset();
   }, [projectId, reset]);
 
-  const handleZipPicked = useCallback(
-    async (file: File) => {
-      setFailure(null);
-      setBusy("preflight");
-      try {
-        const zipBytes = await readSelectedFileBytes(file);
-        const parsed = await parsePluginBundleFromZip(zipBytes);
-        setSelected({
-          kind: "zip",
-          label: file.name,
-          zipBytes,
-          bundleHash: parsed.bundleHash,
-          warnings: parsed.warnings,
-        });
-      } catch (error) {
-        setSelected(null);
-        setFailure(toUiFailure(error, "That ZIP is not a valid plugin bundle."));
-      } finally {
-        setBusy(null);
-      }
-    },
-    [],
-  );
-
-  const handleFolderPicked = useCallback(async (files: File[]) => {
+  const handleZipPicked = useCallback(async (file: File) => {
+    const run = runRef.current;
     setFailure(null);
     setBusy("preflight");
     try {
+      // Size-gate on the File's OWN metadata, before a single byte is read.
+      // Reading then parsing materializes the whole archive (twice, once
+      // inflated), so a multi-GB pick would exhaust the renderer preflighting
+      // a bundle the 25 MB compressed cap could never have accepted. A File
+      // IS a Blob, so this is the same helper — and the same
+      // ARCHIVE_TOO_LARGE_COMPRESSED code — `startImport` applies before
+      // minting an upload URL.
+      assertPluginBundleWithinCap(file);
+      const zipBytes = await readSelectedFileBytes(file);
+      const parsed = await parsePluginBundleFromZip(zipBytes);
+      if (runRef.current !== run) return;
+      setSelected({
+        kind: "zip",
+        label: file.name,
+        zipBytes,
+        bundleHash: parsed.bundleHash,
+        warnings: parsed.warnings,
+      });
+    } catch (error) {
+      if (runRef.current !== run) return;
+      setSelected(null);
+      setFailure(toUiFailure(error, "That ZIP is not a valid plugin bundle."));
+    } finally {
+      if (runRef.current === run) setBusy(null);
+    }
+  }, []);
+
+  const handleFolderPicked = useCallback(async (files: File[]) => {
+    const run = runRef.current;
+    setFailure(null);
+    setBusy("preflight");
+    try {
+      // No size pre-gate here, unlike the ZIP path, and deliberately so: the
+      // folder source's `list()` reports `File.size` METADATA with no read,
+      // and the SDK parser's phase 1 (`validateBundleEntries`) throws on entry
+      // count, per-file size, and total uncompressed size before phase 2 reads
+      // any content. The selection is therefore already bounded by the shared
+      // limits, and a second cap here would be a redundant rule that could
+      // drift from them.
+      //
       // Validates AND builds the uploadable ZIP from exactly the entries the
       // parser judged, so the backend inspects the same facts.
       const { parsed, zipBytes } = await folderSelectionToPluginZip(files);
+      if (runRef.current !== run) return;
       const rootName =
         (files[0] as { webkitRelativePath?: string })?.webkitRelativePath?.split(
           "/",
@@ -261,17 +307,19 @@ export function AddPluginModal({
         warnings: parsed.warnings,
       });
     } catch (error) {
+      if (runRef.current !== run) return;
       setSelected(null);
       setFailure(
         toUiFailure(error, "That folder is not a valid plugin bundle."),
       );
     } finally {
-      setBusy(null);
+      if (runRef.current === run) setBusy(null);
     }
   }, []);
 
   const startImport = useCallback(async () => {
     if (!selected || !projectId) return;
+    const run = runRef.current;
     setFailure(null);
     setBusy("importing");
     track("plugin_import_started", {
@@ -284,7 +332,18 @@ export function AddPluginModal({
         projectId,
         bundle: selected.zipBytes,
         sourceLabel: selected.label,
+        // Adopt the id the MOMENT the row exists, not when the whole
+        // upload→inspect sequence resolves. `startImport` drives inspection
+        // itself, so a transient inspect rejection would otherwise take the
+        // id down with it and the only "retry" left would be a second upload
+        // creating a second import row — exactly the resume this dialog
+        // promises not to lose.
+        onImportCreated: (createdImportId) => {
+          if (runRef.current !== run) return;
+          setImportId(createdImportId);
+        },
       });
+      if (runRef.current !== run) return;
       setImportId(result.importId);
       if (result.inspect.status === "failed") {
         const code = result.inspect.failureCode ?? "INSPECT_FAILED";
@@ -298,24 +357,29 @@ export function AddPluginModal({
         setFailure({ code, message: "The bundle could not be inspected." });
       }
     } catch (error) {
+      if (runRef.current !== run) return;
       const uiFailure = toUiFailure(error, "The plugin import failed.");
       track("plugin_import_failed", {
         location: "add_plugin_modal",
+        // The upload/createImport steps happen before an id exists, so the id's
+        // presence is what distinguishes an inspect failure from an earlier one.
         phase: "upload",
         code: sanitizePluginCode(uiFailure.code),
       });
       setFailure(uiFailure);
     } finally {
-      setBusy(null);
+      if (runRef.current === run) setBusy(null);
     }
   }, [actions, projectId, selected]);
 
   const resumeInspect = useCallback(async () => {
     if (!importId) return;
+    const run = runRef.current;
     setFailure(null);
     setBusy("importing");
     try {
       const result = await actions.inspectImport(importId);
+      if (runRef.current !== run) return;
       if (result.status === "failed") {
         setFailure({
           code: result.failureCode ?? "INSPECT_FAILED",
@@ -323,19 +387,25 @@ export function AddPluginModal({
         });
       }
     } catch (error) {
+      if (runRef.current !== run) return;
       setFailure(toUiFailure(error, "The bundle could not be inspected."));
     } finally {
-      setBusy(null);
+      if (runRef.current === run) setBusy(null);
     }
   }, [actions, importId]);
 
   const commit = useCallback(
     async (setActive: boolean) => {
       if (!importId) return;
+      const run = runRef.current;
       setFailure(null);
+      // Remembered BEFORE the await so a retry repeats this choice even if the
+      // attempt never comes back.
+      setLastCommitSetActive(setActive);
       setBusy("committing");
       try {
         const result = await actions.commitImport(importId, { setActive });
+        if (runRef.current !== run) return;
         setCommitResult(result);
         if (result.status === "failed") {
           const code = result.failureCode ?? "COMMIT_FAILED";
@@ -354,6 +424,7 @@ export function AddPluginModal({
           ...(row?.preview ? pluginPreviewAnalyticsProps(row.preview) : {}),
         });
       } catch (error) {
+        if (runRef.current !== run) return;
         const uiFailure = toUiFailure(error, "The plugin could not be installed.");
         track("plugin_import_failed", {
           location: "add_plugin_modal",
@@ -362,7 +433,7 @@ export function AddPluginModal({
         });
         setFailure(uiFailure);
       } finally {
-        setBusy(null);
+        if (runRef.current === run) setBusy(null);
       }
     },
     [actions, importId, row?.preview],
@@ -379,7 +450,12 @@ export function AddPluginModal({
       return selected ? { label: "Try again", run: startImport } : null;
     }
     if (row.status === "preview_ready") {
-      return { label: "Retry install", run: () => commit(true) };
+      // Repeat the FAILED attempt's choice: retrying an "Install only" must
+      // not quietly activate the revision.
+      return {
+        label: "Retry install",
+        run: () => commit(lastCommitSetActive),
+      };
     }
     if (row.status === "uploaded" || row.status === "inspecting") {
       return { label: "Resume inspection", run: resumeInspect };
@@ -398,7 +474,15 @@ export function AddPluginModal({
           },
         }
       : null;
-  }, [commit, importId, resumeInspect, row, selected, startImport]);
+  }, [
+    commit,
+    importId,
+    lastCommitSetActive,
+    resumeInspect,
+    row,
+    selected,
+    startImport,
+  ]);
 
   const handleOpenChange = (next: boolean) => {
     if (!next) {

--- a/mcpjam-inspector/client/src/components/plugins/PluginGroupCard.tsx
+++ b/mcpjam-inspector/client/src/components/plugins/PluginGroupCard.tsx
@@ -1,0 +1,368 @@
+import { useState } from "react";
+import {
+  ChevronRight,
+  Loader2,
+  MoreVertical,
+  Package,
+  Wrench,
+} from "lucide-react";
+import { Badge } from "@mcpjam/design-system/badge";
+import { Button } from "@mcpjam/design-system/button";
+import { Card } from "@mcpjam/design-system/card";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@mcpjam/design-system/dropdown-menu";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@mcpjam/design-system/alert-dialog";
+import { toast } from "@/lib/toast";
+import { cn } from "@/lib/utils";
+import { track } from "@/lib/analytics";
+import type { PluginSummary } from "@/lib/plugins/plugin-api-types";
+import {
+  useProjectPlugin,
+  usePluginManagementActions,
+  usePluginSetupStatus,
+  usePluginVersion,
+} from "@/hooks/usePluginImportApi";
+import {
+  describePluginHealth,
+  describePluginPlacement,
+  describePluginReadiness,
+  pluralize,
+  rollUpPluginHealth,
+  shortBundleHash,
+} from "./plugin-presentation";
+
+/**
+ * A plugin GROUP card (PR INS-2). A plugin is not a server card: it is a
+ * bundle whose component servers and skills belong to an immutable revision.
+ * Collapsed, it shows identity + rolled-up health; expanded, it shows the
+ * revision's components with per-component health.
+ *
+ * Removing a component is deliberately absent — the plan requires that
+ * "removing a component routes to the plugin rather than deleting it", and
+ * plugin projections are read-only by construction (the backend rejects
+ * structural edits to `lifecycleScope: 'plugin_component'` rows). The kebab
+ * therefore offers only plugin-level lifecycle actions.
+ */
+
+const TONE_CLASSES: Record<string, string> = {
+  ready:
+    "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+  attention:
+    "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+  info: "border-blue-500/30 bg-blue-500/10 text-blue-700 dark:text-blue-300",
+  muted: "border-border/60 bg-muted/30 text-muted-foreground",
+};
+
+export function PluginGroupCard({ plugin }: { plugin: PluginSummary }) {
+  const [expanded, setExpanded] = useState(false);
+  const [pendingAction, setPendingAction] = useState(false);
+  const [confirmUninstall, setConfirmUninstall] = useState(false);
+  const management = usePluginManagementActions();
+
+  const activeVersionId = plugin.activeVersionId ?? null;
+  const setupStatus = usePluginSetupStatus(activeVersionId);
+  // Component projections only matter once the card is opened; skip the
+  // subscription while collapsed.
+  const version = usePluginVersion(expanded ? activeVersionId : null);
+  const detail = useProjectPlugin(expanded ? plugin.pluginId : null);
+
+  const health = rollUpPluginHealth(plugin, setupStatus);
+  const healthPresentation = describePluginHealth(health);
+
+  const runAction = async (label: string, run: () => Promise<void>) => {
+    setPendingAction(true);
+    try {
+      await run();
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : `Could not ${label}.`,
+      );
+    } finally {
+      setPendingAction(false);
+    }
+  };
+
+  return (
+    <Card className="p-0" data-testid="plugin-group-card">
+      <div className="flex items-start gap-3 p-4">
+        <button
+          type="button"
+          className="flex min-w-0 flex-1 items-start gap-3 text-left"
+          aria-expanded={expanded}
+          onClick={() => setExpanded((prev) => !prev)}
+        >
+          <ChevronRight
+            className={cn(
+              "mt-1 h-4 w-4 shrink-0 text-muted-foreground transition-transform",
+              expanded && "rotate-90",
+            )}
+            aria-hidden
+          />
+          <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-muted">
+            <Package className="h-4 w-4 text-muted-foreground" aria-hidden />
+          </div>
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="truncate text-sm font-medium">
+                {plugin.displayName || plugin.name}
+              </span>
+              <Badge
+                variant="outline"
+                className={cn(
+                  "font-normal",
+                  TONE_CLASSES[healthPresentation.tone],
+                )}
+                data-testid="plugin-health-badge"
+              >
+                {healthPresentation.label}
+              </Badge>
+            </div>
+            {plugin.description ? (
+              <p className="mt-0.5 line-clamp-1 text-xs text-muted-foreground">
+                {plugin.description}
+              </p>
+            ) : null}
+          </div>
+        </button>
+
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={pendingAction}
+              aria-label={`Plugin actions for ${plugin.displayName || plugin.name}`}
+            >
+              {pendingAction ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <MoreVertical className="h-4 w-4" />
+              )}
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem
+              onClick={() =>
+                void runAction(
+                  plugin.enabled ? "disable the plugin" : "enable the plugin",
+                  async () => {
+                    await management.setEnabled(
+                      plugin.pluginId,
+                      !plugin.enabled,
+                    );
+                    if (plugin.enabled) {
+                      track("plugin_disabled", { location: "plugin_card" });
+                    }
+                  },
+                )
+              }
+            >
+              {plugin.enabled ? "Disable" : "Enable"}
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => setConfirmUninstall(true)}>
+              Uninstall
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      {expanded ? (
+        <div
+          className="space-y-3 border-t border-border/60 px-4 py-3"
+          data-testid="plugin-group-card-detail"
+        >
+          {activeVersionId === null ? (
+            <p className="text-xs text-muted-foreground">
+              No revision is active yet. Import this plugin again and choose
+              “Install and connect” to activate a revision.
+            </p>
+          ) : version === undefined ? (
+            <p className="text-xs text-muted-foreground">Loading components…</p>
+          ) : (
+            <>
+              <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                <span>
+                  Revision{" "}
+                  <code className="rounded bg-muted px-1 py-0.5">
+                    {shortBundleHash(version.bundleHash)}
+                  </code>
+                </span>
+                {version.declaredVersion ? (
+                  <span>v{version.declaredVersion}</span>
+                ) : null}
+              </div>
+
+              {version.servers.length > 0 ? (
+                <div className="space-y-1.5">
+                  <p className="text-xs font-medium">
+                    {pluralize(version.servers.length, "MCP server")}
+                  </p>
+                  <ul className="space-y-1">
+                    {version.servers.map((component) => {
+                      const readiness = setupStatus?.components.find(
+                        (c) => c.componentKey === component.componentKey,
+                      )?.readiness;
+                      const described = readiness
+                        ? describePluginReadiness(readiness)
+                        : null;
+                      return (
+                        <li
+                          key={component.componentId}
+                          className="flex items-center gap-2 text-xs"
+                        >
+                          <Wrench
+                            className="h-3 w-3 shrink-0 text-muted-foreground"
+                            aria-hidden
+                          />
+                          <span className="truncate font-medium">
+                            {component.declaredName}
+                          </span>
+                          <span className="text-muted-foreground">
+                            {describePluginPlacement(component.placement)}
+                          </span>
+                          {described ? (
+                            <Badge
+                              variant="outline"
+                              className={cn(
+                                "ml-auto font-normal",
+                                TONE_CLASSES[described.tone],
+                              )}
+                            >
+                              {described.label}
+                            </Badge>
+                          ) : null}
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </div>
+              ) : null}
+
+              {version.skills.length > 0 ? (
+                <div className="space-y-1.5">
+                  <p className="text-xs font-medium">
+                    {pluralize(version.skills.length, "skill")}
+                  </p>
+                  <ul className="space-y-1">
+                    {version.skills.map((component) => (
+                      <li
+                        key={component.componentId}
+                        className="text-xs text-muted-foreground"
+                      >
+                        <code className="rounded bg-muted px-1 py-0.5">
+                          {component.modelRef}
+                        </code>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
+
+              {version.componentCounts.unsupported > 0 ? (
+                <p className="text-[11px] text-muted-foreground">
+                  {pluralize(
+                    version.componentCounts.unsupported,
+                    "component",
+                  )}{" "}
+                  in this bundle are preserved but not run by MCPJam.
+                </p>
+              ) : null}
+
+              {/* Other ready revisions of the same plugin. Activating one only
+                  changes what NEW attachments offer — environments that
+                  already pin a version keep it until upgraded explicitly. */}
+              {detail && detail.versions.length > 1 ? (
+                <div className="space-y-1.5">
+                  <p className="text-xs font-medium">Other revisions</p>
+                  <ul className="space-y-1">
+                    {detail.versions
+                      .filter(
+                        (v) =>
+                          v.status === "ready" &&
+                          v.pluginVersionId !== activeVersionId,
+                      )
+                      .map((v) => (
+                        <li
+                          key={v.pluginVersionId}
+                          className="flex items-center gap-2 text-xs"
+                        >
+                          <code className="rounded bg-muted px-1 py-0.5">
+                            {shortBundleHash(v.bundleHash)}
+                          </code>
+                          {v.declaredVersion ? (
+                            <span className="text-muted-foreground">
+                              v{v.declaredVersion}
+                            </span>
+                          ) : null}
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="ml-auto h-6 px-2 text-xs"
+                            disabled={pendingAction}
+                            onClick={() =>
+                              void runAction("activate that revision", async () => {
+                                await management.activateVersion(
+                                  plugin.pluginId,
+                                  v.pluginVersionId,
+                                );
+                                track("plugin_version_upgraded", {
+                                  location: "plugin_card",
+                                });
+                              })
+                            }
+                          >
+                            Activate
+                          </Button>
+                        </li>
+                      ))}
+                  </ul>
+                </div>
+              ) : null}
+            </>
+          )}
+        </div>
+      ) : null}
+
+      <AlertDialog open={confirmUninstall} onOpenChange={setConfirmUninstall}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              Uninstall {plugin.displayName || plugin.name}?
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              Revisions already used by runs and sessions are preserved, so
+              existing history stays reproducible. Uninstall is blocked while a
+              live environment still pins one of this plugin's versions.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() =>
+                void runAction("uninstall the plugin", async () => {
+                  await management.softDeletePlugin(plugin.pluginId);
+                  track("plugin_uninstalled", { location: "plugin_card" });
+                })
+              }
+            >
+              Uninstall
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </Card>
+  );
+}

--- a/mcpjam-inspector/client/src/components/plugins/PluginImportPreviewContent.tsx
+++ b/mcpjam-inspector/client/src/components/plugins/PluginImportPreviewContent.tsx
@@ -1,0 +1,353 @@
+import { useState } from "react";
+import { ChevronRight, TriangleAlert } from "lucide-react";
+import { Badge } from "@mcpjam/design-system/badge";
+import { cn } from "@/lib/utils";
+import type {
+  PluginImportPreview,
+  PluginSetupRequirement,
+} from "@/lib/plugins/plugin-api-types";
+import {
+  PLUGIN_UNSUPPORTED_EXPLANATION,
+  describeUnsupportedKind,
+  formatByteSize,
+  pluralize,
+  shortBundleHash,
+} from "./plugin-presentation";
+
+/**
+ * The sanitized import preview, rendered for review BEFORE anything is
+ * installed (PR INS-2).
+ *
+ * Two rules drive the layout:
+ *
+ *  1. Render only what the bundle actually declares. The backend preview omits
+ *     empty component groups' contents, and an absent group means the plugin
+ *     does not have one — so a section with nothing in it is not rendered at
+ *     all rather than shown as an empty shell with a "0" placeholder.
+ *  2. Headline first, specifics behind expanders. The primary view is
+ *     identity + census + anything requiring attention (warnings, unsupported
+ *     components, setup requirements); the per-component detail is one click
+ *     away.
+ */
+
+function CountChip({ label, value }: { label: string; value: number }) {
+  // Absence is semantic: a plugin with no skills should not advertise
+  // "0 skills" as though that were a property of the bundle.
+  if (value === 0) return null;
+  return (
+    <Badge variant="secondary" className="font-normal">
+      {pluralize(value, label)}
+    </Badge>
+  );
+}
+
+function Section({
+  title,
+  summary,
+  defaultOpen = false,
+  testId,
+  children,
+}: {
+  title: string;
+  summary?: string;
+  defaultOpen?: boolean;
+  testId?: string;
+  children: React.ReactNode;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <div className="rounded-md border border-border/60" data-testid={testId}>
+      <button
+        type="button"
+        className="flex w-full items-center gap-2 px-3 py-2 text-left"
+        aria-expanded={open}
+        onClick={() => setOpen((prev) => !prev)}
+      >
+        <ChevronRight
+          className={cn(
+            "h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform",
+            open && "rotate-90",
+          )}
+          aria-hidden
+        />
+        <span className="text-sm font-medium">{title}</span>
+        {summary ? (
+          <span className="ml-auto text-xs text-muted-foreground">
+            {summary}
+          </span>
+        ) : null}
+      </button>
+      {open ? (
+        <div className="border-t border-border/60 px-3 py-2">{children}</div>
+      ) : null}
+    </div>
+  );
+}
+
+function RequirementLine({ requirement }: { requirement: PluginSetupRequirement }) {
+  const kindLabel =
+    requirement.kind === "env"
+      ? "env"
+      : requirement.kind === "header"
+        ? "header"
+        : "oauth";
+  return (
+    <li className="flex items-center gap-2 text-xs">
+      <code className="rounded bg-muted px-1 py-0.5">{requirement.name}</code>
+      <span className="text-muted-foreground">{kindLabel}</span>
+      {requirement.required ? null : (
+        <span className="text-muted-foreground">optional</span>
+      )}
+      <span className="ml-auto text-muted-foreground">
+        {requirement.serverKey}
+      </span>
+    </li>
+  );
+}
+
+export function PluginImportPreviewContent({
+  preview,
+}: {
+  preview: PluginImportPreview;
+}) {
+  const { identity, counts } = preview;
+
+  return (
+    <div className="space-y-3" data-testid="plugin-import-preview">
+      {/* Identity */}
+      <div className="space-y-1">
+        <div className="flex flex-wrap items-baseline gap-2">
+          <h3 className="text-base font-semibold">
+            {identity.displayName || identity.name}
+          </h3>
+          {identity.version ? (
+            <span className="text-xs text-muted-foreground">
+              v{identity.version}
+            </span>
+          ) : null}
+          <code
+            className="ml-auto rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground"
+            title="Content-addressed revision identity"
+          >
+            {shortBundleHash(preview.bundleHash)}
+          </code>
+        </div>
+        {identity.description ? (
+          <p className="text-xs leading-relaxed text-muted-foreground">
+            {identity.description}
+          </p>
+        ) : null}
+      </div>
+
+      {/* Census */}
+      <div className="flex flex-wrap gap-1.5">
+        <CountChip label="skill" value={counts.skills} />
+        <CountChip label="MCP server" value={counts.servers} />
+        <CountChip label="app mapping" value={counts.apps} />
+        <CountChip label="asset" value={counts.assets} />
+      </div>
+
+      {/* Warnings — surfaced without an expander: they are the reason a user
+          would decline the import. */}
+      {preview.warnings.length > 0 ? (
+        <div
+          className="rounded-md border border-amber-500/30 bg-amber-500/5 px-3 py-2"
+          data-testid="plugin-preview-warnings"
+        >
+          <div className="flex items-center gap-2 text-xs font-medium text-amber-700 dark:text-amber-300">
+            <TriangleAlert className="h-3.5 w-3.5" aria-hidden />
+            {pluralize(preview.warnings.length, "warning")}
+          </div>
+          <ul className="mt-1.5 space-y-1">
+            {preview.warnings.map((warning, index) => (
+              <li
+                key={`${warning.code}-${index}`}
+                className="text-xs text-muted-foreground"
+              >
+                <code className="text-[11px]">{warning.code}</code>
+                {warning.componentKey ? (
+                  <span className="ml-1 text-[11px]">
+                    ({warning.componentKey})
+                  </span>
+                ) : null}
+                <span className="ml-1">{warning.message}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {/* Unsupported components. Always visible when present, and always
+          described as preserved-not-executed — never as something MCPJam
+          runs. */}
+      {preview.unsupported.length > 0 ? (
+        <div
+          className="rounded-md border border-border/60 bg-muted/20 px-3 py-2"
+          data-testid="plugin-preview-unsupported"
+        >
+          <div className="text-xs font-medium">
+            {pluralize(preview.unsupported.length, "unsupported component")}
+          </div>
+          <p className="mt-0.5 text-[11px] text-muted-foreground">
+            {PLUGIN_UNSUPPORTED_EXPLANATION}
+          </p>
+          <ul className="mt-1.5 space-y-1">
+            {preview.unsupported.map((entry, index) => (
+              <li
+                key={`${entry.kind}-${entry.key}-${index}`}
+                className="text-xs text-muted-foreground"
+              >
+                <span className="font-medium text-foreground">
+                  {describeUnsupportedKind(entry.kind)}
+                </span>
+                <span className="ml-1">{entry.key}</span>
+                <span className="ml-1">— {entry.reason}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {/* Setup requirements: names only, values never leave the user's hands. */}
+      {preview.setupRequirements.length > 0 ? (
+        <Section
+          title="Setup required"
+          summary={pluralize(preview.setupRequirements.length, "value")}
+          defaultOpen
+          testId="plugin-preview-setup"
+        >
+          <p className="mb-1.5 text-[11px] text-muted-foreground">
+            The bundle declares these names. MCPJam never reads values from the
+            bundle — you provide them per server after installing.
+          </p>
+          <ul className="space-y-1">
+            {preview.setupRequirements.map((requirement, index) => (
+              <RequirementLine
+                key={`${requirement.serverKey}-${requirement.name}-${index}`}
+                requirement={requirement}
+              />
+            ))}
+          </ul>
+        </Section>
+      ) : null}
+
+      {preview.skills.length > 0 ? (
+        <Section
+          title="Skills"
+          summary={pluralize(preview.skills.length, "skill")}
+          testId="plugin-preview-skills"
+        >
+          <ul className="space-y-2">
+            {preview.skills.map((skill) => (
+              <li key={skill.modelRef} className="text-xs">
+                <code className="rounded bg-muted px-1 py-0.5">
+                  {skill.modelRef}
+                </code>
+                <p className="mt-0.5 text-muted-foreground">
+                  {skill.description}
+                </p>
+                {skill.supportingFileCount > 0 ? (
+                  <p className="text-[11px] text-muted-foreground">
+                    {pluralize(skill.supportingFileCount, "supporting file")}
+                  </p>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        </Section>
+      ) : null}
+
+      {preview.servers.length > 0 ? (
+        <Section
+          title="MCP servers"
+          summary={pluralize(preview.servers.length, "server")}
+          testId="plugin-preview-servers"
+        >
+          <ul className="space-y-2">
+            {preview.servers.map((server) => (
+              <li key={server.key} className="text-xs">
+                <div className="flex items-center gap-2">
+                  <span className="font-medium">{server.key}</span>
+                  <Badge variant="outline" className="font-normal">
+                    {server.transport}
+                  </Badge>
+                  {server.oauth?.timing ? (
+                    <span className="text-muted-foreground">
+                      OAuth {server.oauth.timing.replace("_", " ")}
+                    </span>
+                  ) : null}
+                </div>
+                {server.envRequirements?.length ? (
+                  <p className="mt-0.5 text-[11px] text-muted-foreground">
+                    env: {server.envRequirements.map((e) => e.name).join(", ")}
+                  </p>
+                ) : null}
+                {server.headerRequirements?.length ? (
+                  <p className="mt-0.5 text-[11px] text-muted-foreground">
+                    headers:{" "}
+                    {server.headerRequirements.map((h) => h.name).join(", ")}
+                  </p>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        </Section>
+      ) : null}
+
+      {preview.apps.length > 0 ? (
+        <Section
+          title="App mappings"
+          summary={pluralize(preview.apps.length, "mapping")}
+          testId="plugin-preview-apps"
+        >
+          {/* `.app.json` entries are preserved metadata: no component rows, no
+              binding, no runtime code (see the plan's "App mappings are
+              metadata, not components"). */}
+          <p className="mb-1.5 text-[11px] text-muted-foreground">
+            Preserved as metadata. App UI still comes from whatever UI
+            resources the plugin's MCP servers serve at runtime.
+          </p>
+          <ul className="space-y-1">
+            {preview.apps.map((app, index) => (
+              <li
+                key={`${app.appId}-${index}`}
+                className="flex items-center gap-2 text-xs"
+              >
+                <code className="rounded bg-muted px-1 py-0.5">
+                  {app.appId}
+                </code>
+                <span className="text-muted-foreground">{app.binding}</span>
+                <span className="ml-auto text-muted-foreground">
+                  {app.status}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </Section>
+      ) : null}
+
+      {preview.assets.length > 0 ? (
+        <Section
+          title="Assets"
+          summary={pluralize(preview.assets.length, "asset")}
+          testId="plugin-preview-assets"
+        >
+          <ul className="space-y-1">
+            {preview.assets.map((asset, index) => (
+              <li
+                key={`${asset.kind}-${index}`}
+                className="flex items-center gap-2 text-xs text-muted-foreground"
+              >
+                <span className="font-medium text-foreground">
+                  {asset.kind}
+                </span>
+                <span>{asset.contentType}</span>
+                <span className="ml-auto">{formatByteSize(asset.size)}</span>
+              </li>
+            ))}
+          </ul>
+        </Section>
+      ) : null}
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/plugins/PluginImportPreviewContent.tsx
+++ b/mcpjam-inspector/client/src/components/plugins/PluginImportPreviewContent.tsx
@@ -85,16 +85,13 @@ function Section({
 }
 
 function RequirementLine({ requirement }: { requirement: PluginSetupRequirement }) {
-  const kindLabel =
-    requirement.kind === "env"
-      ? "env"
-      : requirement.kind === "header"
-        ? "header"
-        : "oauth";
   return (
     <li className="flex items-center gap-2 text-xs">
       <code className="rounded bg-muted px-1 py-0.5">{requirement.name}</code>
-      <span className="text-muted-foreground">{kindLabel}</span>
+      {/* Echo the declared kind verbatim. Mapping it through a ternary meant
+          any kind this client does not know yet fell through to "oauth" —
+          claiming an authorization requirement the bundle never declared. */}
+      <span className="text-muted-foreground">{requirement.kind}</span>
       {requirement.required ? null : (
         <span className="text-muted-foreground">optional</span>
       )}

--- a/mcpjam-inspector/client/src/components/plugins/PluginsSection.tsx
+++ b/mcpjam-inspector/client/src/components/plugins/PluginsSection.tsx
@@ -1,0 +1,38 @@
+import { useProjectPlugins } from "@/hooks/usePluginImportApi";
+import { pluralize } from "./plugin-presentation";
+import { PluginGroupCard } from "./PluginGroupCard";
+
+/**
+ * The installed-plugins group on the Connect surface (PR INS-2).
+ *
+ * Renders nothing at all when the project has no plugins — plugin import is
+ * behind `plugins-enabled` and is a new surface, so an empty section would be
+ * chrome for a feature most projects are not using. The **Add plugin** entry
+ * point lives in the Connect actions menu, which is always available while the
+ * flag is on.
+ *
+ * Callers must gate this on `usePluginsEnabled()`; the query hooks fail closed
+ * on their own, but the heading should not render either.
+ */
+export function PluginsSection({ projectId }: { projectId: string | null }) {
+  const plugins = useProjectPlugins(projectId);
+  if (!plugins || plugins.length === 0) return null;
+
+  return (
+    <div className="space-y-2" data-testid="plugins-section">
+      <div className="flex items-baseline gap-2">
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Plugins
+        </h3>
+        <span className="text-[11px] text-muted-foreground">
+          {pluralize(plugins.length, "installed")}
+        </span>
+      </div>
+      <div className="grid grid-cols-1 gap-3 xl:grid-cols-2">
+        {plugins.map((plugin) => (
+          <PluginGroupCard key={plugin.pluginId} plugin={plugin} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/plugins/__tests__/AddPluginModal.test.tsx
+++ b/mcpjam-inspector/client/src/components/plugins/__tests__/AddPluginModal.test.tsx
@@ -1,0 +1,308 @@
+/**
+ * Connect → Add plugin dialog (INS-2).
+ *
+ * The three acceptance criteria are covered directly: nothing is called
+ * installed before the import row reaches `completed`, a retry resumes an
+ * existing `preview_ready` import instead of re-uploading, and unsupported
+ * components are visible and never described as executable.
+ */
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PluginImportPreview } from "@/lib/plugins/plugin-api-types";
+
+const h = vi.hoisted(() => ({
+  row: { value: undefined as unknown },
+  setupStatus: { value: undefined as unknown },
+  startImport: vi.fn(),
+  inspectImport: vi.fn(),
+  commitImport: vi.fn(),
+  track: vi.fn(),
+  parseZip: vi.fn(),
+}));
+
+vi.mock("@/hooks/usePluginImportApi", () => ({
+  usePluginImport: () => h.row.value,
+  usePluginSetupStatus: () => h.setupStatus.value,
+  usePluginImportActions: () => ({
+    startImport: h.startImport,
+    inspectImport: h.inspectImport,
+    commitImport: h.commitImport,
+    generateBundleUploadUrl: vi.fn(),
+    createImport: vi.fn(),
+  }),
+}));
+vi.mock("@/lib/analytics", () => ({ track: h.track }));
+vi.mock("@/lib/plugins/folder-bundle", () => ({
+  parsePluginBundleFromZip: h.parseZip,
+  folderSelectionToPluginZip: vi.fn(),
+  readSelectedFileBytes: async () => new Uint8Array([1, 2, 3]),
+}));
+
+import { AddPluginModal } from "../AddPluginModal";
+
+const preview: PluginImportPreview = {
+  identity: { name: "demo", displayName: "Demo", version: "1.0.0" },
+  bundleHash: "aa11bb22cc33dd44",
+  manifestHash: "ff00",
+  counts: {
+    skills: 1,
+    servers: 1,
+    apps: 0,
+    assets: 0,
+    unsupported: 1,
+    warnings: 0,
+  },
+  skills: [
+    {
+      modelRef: "demo/triage",
+      name: "triage",
+      description: "Triage",
+      supportingFileCount: 0,
+      mcpToolDependencyCount: 0,
+      hasOpenaiMetadata: false,
+    },
+  ],
+  servers: [{ key: "api", transport: "http" }],
+  apps: [],
+  assets: [],
+  setupRequirements: [],
+  unsupported: [
+    {
+      kind: "hook",
+      key: "postinstall",
+      reason: "hooks are never executed",
+      pathCount: 1,
+    },
+  ],
+  warnings: [],
+};
+
+function importRow(overrides: Record<string, unknown>) {
+  return {
+    importId: "imp_1",
+    projectId: "p_1",
+    status: "preview_ready",
+    preview,
+    createdAt: 1,
+    updatedAt: 1,
+    expiresAt: 2,
+    ...overrides,
+  };
+}
+
+/** Pick a ZIP and reach the preview phase. */
+async function reachPreview() {
+  const view = render(
+    <AddPluginModal isOpen onClose={vi.fn()} projectId="p_1" />,
+  );
+  const file = new File([new Uint8Array([1, 2, 3])], "demo.zip", {
+    type: "application/zip",
+  });
+  const input = document.querySelector(
+    'input[type="file"][accept*="zip"]',
+  ) as HTMLInputElement;
+  await act(async () => {
+    fireEvent.change(input, { target: { files: [file] } });
+  });
+  await screen.findByTestId("add-plugin-selected-source");
+  await act(async () => {
+    fireEvent.click(screen.getByTestId("add-plugin-continue"));
+  });
+  h.row.value = importRow({});
+  view.rerender(<AddPluginModal isOpen onClose={vi.fn()} projectId="p_1" />);
+  return view;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.row.value = undefined;
+  h.setupStatus.value = undefined;
+  h.parseZip.mockResolvedValue({ bundleHash: "aa11bb22cc33dd44", warnings: [] });
+  h.startImport.mockResolvedValue({
+    importId: "imp_1",
+    inspect: { importId: "imp_1", status: "preview_ready" },
+  });
+  h.commitImport.mockResolvedValue({
+    importId: "imp_1",
+    status: "completed",
+    pluginVersionId: "pv_1",
+  });
+});
+
+describe("AddPluginModal — install is gated on version finalize", () => {
+  it("shows the preview without claiming the plugin is installed", async () => {
+    await reachPreview();
+    expect(screen.getByTestId("plugin-import-preview")).toBeTruthy();
+    expect(screen.queryByTestId("add-plugin-installed")).toBeNull();
+  });
+
+  it("still does not say installed while the row is committing", async () => {
+    const view = await reachPreview();
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("add-plugin-install-connect"));
+    });
+    // The commit action already resolved "completed", but the ROW is the
+    // authority and it has not finalized yet.
+    h.row.value = importRow({ status: "committing" });
+    view.rerender(<AddPluginModal isOpen onClose={vi.fn()} projectId="p_1" />);
+    expect(screen.queryByTestId("add-plugin-installed")).toBeNull();
+
+    h.row.value = importRow({
+      status: "completed",
+      pluginId: "pl_1",
+      pluginVersionId: "pv_1",
+    });
+    view.rerender(<AddPluginModal isOpen onClose={vi.fn()} projectId="p_1" />);
+    expect(screen.getByTestId("add-plugin-installed")).toBeTruthy();
+    expect(screen.getByText("Plugin installed")).toBeTruthy();
+  });
+
+  it("install-only commits with setActive false", async () => {
+    await reachPreview();
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("add-plugin-install-only"));
+    });
+    expect(h.commitImport).toHaveBeenCalledWith("imp_1", { setActive: false });
+  });
+
+  it("install-and-connect commits with setActive true", async () => {
+    await reachPreview();
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("add-plugin-install-connect"));
+    });
+    expect(h.commitImport).toHaveBeenCalledWith("imp_1", { setActive: true });
+  });
+});
+
+describe("AddPluginModal — content-addressed re-import", () => {
+  it("reports a reused version as already imported, not a fresh install", async () => {
+    h.commitImport.mockResolvedValue({
+      importId: "imp_1",
+      status: "completed",
+      pluginVersionId: "pv_1",
+      reused: true,
+    });
+    const view = await reachPreview();
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("add-plugin-install-connect"));
+    });
+    h.row.value = importRow({
+      status: "completed",
+      pluginId: "pl_1",
+      pluginVersionId: "pv_1",
+    });
+    view.rerender(<AddPluginModal isOpen onClose={vi.fn()} projectId="p_1" />);
+    expect(screen.getByText("Already imported")).toBeTruthy();
+    expect(screen.queryByText("Plugin installed")).toBeNull();
+  });
+});
+
+describe("AddPluginModal — retry resumes", () => {
+  it("retries the commit against the existing preview-ready import", async () => {
+    h.commitImport.mockRejectedValueOnce(new Error("network blip"));
+    await reachPreview();
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("add-plugin-install-connect"));
+    });
+    await screen.findByTestId("add-plugin-failure");
+
+    h.startImport.mockClear();
+    h.commitImport.mockResolvedValue({
+      importId: "imp_1",
+      status: "completed",
+      pluginVersionId: "pv_1",
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("add-plugin-retry"));
+    });
+    // Resumed from the SAME import: no second upload.
+    expect(h.startImport).not.toHaveBeenCalled();
+    expect(h.commitImport).toHaveBeenLastCalledWith("imp_1", {
+      setActive: true,
+    });
+  });
+
+  it("resumes inspection for an import that never got inspected", async () => {
+    h.startImport.mockResolvedValue({
+      importId: "imp_1",
+      inspect: { importId: "imp_1", status: "failed", failureCode: "TIMEOUT" },
+    });
+    const view = render(
+      <AddPluginModal isOpen onClose={vi.fn()} projectId="p_1" />,
+    );
+    const file = new File([new Uint8Array([1])], "demo.zip");
+    const input = document.querySelector(
+      'input[type="file"][accept*="zip"]',
+    ) as HTMLInputElement;
+    await act(async () => {
+      fireEvent.change(input, { target: { files: [file] } });
+    });
+    await screen.findByTestId("add-plugin-selected-source");
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("add-plugin-continue"));
+    });
+    h.row.value = importRow({ status: "uploaded", preview: undefined });
+    view.rerender(<AddPluginModal isOpen onClose={vi.fn()} projectId="p_1" />);
+
+    h.inspectImport.mockResolvedValue({
+      importId: "imp_1",
+      status: "preview_ready",
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("add-plugin-retry"));
+    });
+    expect(h.inspectImport).toHaveBeenCalledWith("imp_1");
+  });
+});
+
+describe("AddPluginModal — validation and unsupported components", () => {
+  it("lists every parser issue when preflight rejects the bundle", async () => {
+    const { PluginBundleError } = await import("@mcpjam/sdk/plugin-bundle");
+    h.parseZip.mockRejectedValue(
+      new PluginBundleError([
+        {
+          code: "PATH_TRAVERSAL",
+          severity: "error",
+          message: "entry escapes the bundle root",
+          path: "../evil",
+        },
+        {
+          code: "MANIFEST_UNKNOWN_FIELD",
+          severity: "warning",
+          message: "unknown field",
+        },
+      ]),
+    );
+    render(<AddPluginModal isOpen onClose={vi.fn()} projectId="p_1" />);
+    const input = document.querySelector(
+      'input[type="file"][accept*="zip"]',
+    ) as HTMLInputElement;
+    await act(async () => {
+      fireEvent.change(input, {
+        target: { files: [new File([new Uint8Array([1])], "bad.zip")] },
+      });
+    });
+    const panel = await screen.findByTestId("add-plugin-failure");
+    expect(panel.textContent).toContain("PATH_TRAVERSAL");
+    expect(panel.textContent).toContain("MANIFEST_UNKNOWN_FIELD");
+    // Nothing was uploaded — preflight rejected before minting an upload URL.
+    expect(h.startImport).not.toHaveBeenCalled();
+  });
+
+  it("shows unsupported components as preserved, never as executable", async () => {
+    await reachPreview();
+    const block = screen.getByTestId("plugin-preview-unsupported");
+    expect(block.textContent).toContain("Lifecycle hooks");
+    expect(block.textContent).toMatch(/does not run/i);
+  });
+});
+
+describe("AddPluginModal — local mode", () => {
+  it("explains that import needs a synced project instead of offering a picker", async () => {
+    render(<AddPluginModal isOpen onClose={vi.fn()} projectId={null} />);
+    await waitFor(() =>
+      expect(screen.getByTestId("add-plugin-no-project")).toBeTruthy(),
+    );
+    expect(screen.queryByTestId("add-plugin-choose-zip")).toBeNull();
+  });
+});

--- a/mcpjam-inspector/client/src/components/plugins/__tests__/AddPluginModal.test.tsx
+++ b/mcpjam-inspector/client/src/components/plugins/__tests__/AddPluginModal.test.tsx
@@ -18,10 +18,16 @@ const h = vi.hoisted(() => ({
   commitImport: vi.fn(),
   track: vi.fn(),
   parseZip: vi.fn(),
+  readBytes: vi.fn(),
+  /** Every id the modal actually subscribed with, in order. */
+  usedImportIds: [] as Array<string | null | undefined>,
 }));
 
 vi.mock("@/hooks/usePluginImportApi", () => ({
-  usePluginImport: () => h.row.value,
+  usePluginImport: (importId?: string | null) => {
+    h.usedImportIds.push(importId);
+    return h.row.value;
+  },
   usePluginSetupStatus: () => h.setupStatus.value,
   usePluginImportActions: () => ({
     startImport: h.startImport,
@@ -35,7 +41,7 @@ vi.mock("@/lib/analytics", () => ({ track: h.track }));
 vi.mock("@/lib/plugins/folder-bundle", () => ({
   parsePluginBundleFromZip: h.parseZip,
   folderSelectionToPluginZip: vi.fn(),
-  readSelectedFileBytes: async () => new Uint8Array([1, 2, 3]),
+  readSelectedFileBytes: h.readBytes,
 }));
 
 import { AddPluginModal } from "../AddPluginModal";
@@ -117,10 +123,15 @@ beforeEach(() => {
   vi.clearAllMocks();
   h.row.value = undefined;
   h.setupStatus.value = undefined;
+  h.usedImportIds.length = 0;
+  h.readBytes.mockResolvedValue(new Uint8Array([1, 2, 3]));
   h.parseZip.mockResolvedValue({ bundleHash: "aa11bb22cc33dd44", warnings: [] });
-  h.startImport.mockResolvedValue({
-    importId: "imp_1",
-    inspect: { importId: "imp_1", status: "preview_ready" },
+  h.startImport.mockImplementation(async (args: any) => {
+    args?.onImportCreated?.("imp_1");
+    return {
+      importId: "imp_1",
+      inspect: { importId: "imp_1", status: "preview_ready" },
+    };
   });
   h.commitImport.mockResolvedValue({
     importId: "imp_1",
@@ -223,9 +234,12 @@ describe("AddPluginModal — retry resumes", () => {
   });
 
   it("resumes inspection for an import that never got inspected", async () => {
-    h.startImport.mockResolvedValue({
-      importId: "imp_1",
-      inspect: { importId: "imp_1", status: "failed", failureCode: "TIMEOUT" },
+    h.startImport.mockImplementation(async (args: any) => {
+      args?.onImportCreated?.("imp_1");
+      return {
+        importId: "imp_1",
+        inspect: { importId: "imp_1", status: "failed", failureCode: "TIMEOUT" },
+      };
     });
     const view = render(
       <AddPluginModal isOpen onClose={vi.fn()} projectId="p_1" />,
@@ -304,5 +318,135 @@ describe("AddPluginModal — local mode", () => {
       expect(screen.getByTestId("add-plugin-no-project")).toBeTruthy(),
     );
     expect(screen.queryByTestId("add-plugin-choose-zip")).toBeNull();
+  });
+});
+
+describe("AddPluginModal — oversized bundles never reach the renderer", () => {
+  it("rejects a ZIP over the compressed cap before reading or parsing it", async () => {
+    render(<AddPluginModal isOpen onClose={vi.fn()} projectId="p_1" />);
+    const huge = new File([new Uint8Array([1])], "huge.zip");
+    // A real multi-GB File cannot be constructed in jsdom; the cap reads
+    // `Blob.size`, so overriding it exercises the same branch.
+    Object.defineProperty(huge, "size", { value: 26 * 1024 * 1024 });
+    const input = document.querySelector(
+      'input[type="file"][accept*="zip"]',
+    ) as HTMLInputElement;
+    await act(async () => {
+      fireEvent.change(input, { target: { files: [huge] } });
+    });
+    const panel = await screen.findByTestId("add-plugin-failure");
+    expect(panel.textContent).toContain("ARCHIVE_TOO_LARGE_COMPRESSED");
+    // Neither the read nor the parse ran: no bytes were materialized.
+    expect(h.readBytes).not.toHaveBeenCalled();
+    expect(h.parseZip).not.toHaveBeenCalled();
+  });
+});
+
+describe("AddPluginModal — a stale import cannot resurface under a new project", () => {
+  it("drops an import that resolves after the project changed", async () => {
+    let releaseImport: (() => void) | null = null;
+    h.startImport.mockImplementation(async (args: any) => {
+      await new Promise<void>((resolve) => {
+        releaseImport = resolve;
+      });
+      args?.onImportCreated?.("imp_old_project");
+      return {
+        importId: "imp_old_project",
+        inspect: { importId: "imp_old_project", status: "preview_ready" },
+      };
+    });
+
+    const view = render(
+      <AddPluginModal isOpen onClose={vi.fn()} projectId="p_old" />,
+    );
+    const input = document.querySelector(
+      'input[type="file"][accept*="zip"]',
+    ) as HTMLInputElement;
+    await act(async () => {
+      fireEvent.change(input, {
+        target: { files: [new File([new Uint8Array([1])], "demo.zip")] },
+      });
+    });
+    await screen.findByTestId("add-plugin-selected-source");
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("add-plugin-continue"));
+    });
+
+    // Switch projects while the import is still in flight, then let it land.
+    view.rerender(<AddPluginModal isOpen onClose={vi.fn()} projectId="p_new" />);
+    await act(async () => {
+      releaseImport?.();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // The old project's row must not be adopted, from the callback OR the
+    // resolved result: the source picker is back and nothing is subscribed.
+    expect(h.usedImportIds).not.toContain("imp_old_project");
+    expect(screen.getByTestId("add-plugin-choose-zip")).toBeTruthy();
+    expect(screen.queryByTestId("add-plugin-progress")).toBeNull();
+  });
+});
+
+describe("AddPluginModal — the import id survives an inspect failure", () => {
+  it("resumes the created import instead of uploading a second one", async () => {
+    // `startImport` drives inspection, so a rejecting inspect rejects the
+    // whole call — the id must still have arrived via onImportCreated.
+    h.startImport.mockImplementation(async (args: any) => {
+      args?.onImportCreated?.("imp_1");
+      throw new Error("inspect action timed out");
+    });
+    const view = render(
+      <AddPluginModal isOpen onClose={vi.fn()} projectId="p_1" />,
+    );
+    const input = document.querySelector(
+      'input[type="file"][accept*="zip"]',
+    ) as HTMLInputElement;
+    await act(async () => {
+      fireEvent.change(input, {
+        target: { files: [new File([new Uint8Array([1])], "demo.zip")] },
+      });
+    });
+    await screen.findByTestId("add-plugin-selected-source");
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("add-plugin-continue"));
+    });
+    await screen.findByTestId("add-plugin-failure");
+
+    h.row.value = importRow({ status: "uploaded", preview: undefined });
+    view.rerender(<AddPluginModal isOpen onClose={vi.fn()} projectId="p_1" />);
+    h.startImport.mockClear();
+    h.inspectImport.mockResolvedValue({
+      importId: "imp_1",
+      status: "preview_ready",
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("add-plugin-retry"));
+    });
+    expect(h.inspectImport).toHaveBeenCalledWith("imp_1");
+    expect(h.startImport).not.toHaveBeenCalled();
+  });
+});
+
+describe("AddPluginModal — retry repeats the chosen install mode", () => {
+  it("does not activate the revision when the failed attempt was Install only", async () => {
+    h.commitImport.mockRejectedValueOnce(new Error("network blip"));
+    await reachPreview();
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("add-plugin-install-only"));
+    });
+    await screen.findByTestId("add-plugin-failure");
+
+    h.commitImport.mockResolvedValue({
+      importId: "imp_1",
+      status: "completed",
+      pluginVersionId: "pv_1",
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("add-plugin-retry"));
+    });
+    expect(h.commitImport).toHaveBeenLastCalledWith("imp_1", {
+      setActive: false,
+    });
   });
 });

--- a/mcpjam-inspector/client/src/components/plugins/__tests__/PluginGroupCard.test.tsx
+++ b/mcpjam-inspector/client/src/components/plugins/__tests__/PluginGroupCard.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * Plugin GROUP card: the card is a bundle, not a server. It must never claim a
+ * plugin is ready while a component is not, it must show the components of the
+ * ACTIVE revision when expanded, and it must not offer to delete a component
+ * (plugin projections are read-only; removal routes through the plugin).
+ */
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PluginSummary } from "@/lib/plugins/plugin-api-types";
+
+const h = vi.hoisted(() => ({
+  version: { value: undefined as unknown },
+  setupStatus: { value: undefined as unknown },
+  detail: { value: undefined as unknown },
+  setEnabled: vi.fn(),
+  activateVersion: vi.fn(),
+  softDeletePlugin: vi.fn(),
+  restorePlugin: vi.fn(),
+  track: vi.fn(),
+  toastError: vi.fn(),
+}));
+
+vi.mock("@/hooks/usePluginImportApi", () => ({
+  usePluginVersion: () => h.version.value,
+  usePluginSetupStatus: () => h.setupStatus.value,
+  useProjectPlugin: () => h.detail.value,
+  usePluginManagementActions: () => ({
+    setEnabled: h.setEnabled,
+    activateVersion: h.activateVersion,
+    softDeletePlugin: h.softDeletePlugin,
+    restorePlugin: h.restorePlugin,
+  }),
+}));
+vi.mock("@/lib/analytics", () => ({ track: h.track }));
+vi.mock("@/lib/toast", () => ({ toast: { error: h.toastError } }));
+
+import { PluginGroupCard } from "../PluginGroupCard";
+
+const plugin: PluginSummary = {
+  pluginId: "pl_1",
+  projectId: "p_1",
+  name: "demo",
+  displayName: "Demo",
+  enabled: true,
+  activeVersionId: "pv_1",
+  createdAt: 1,
+  updatedAt: 1,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.detail.value = undefined;
+  h.setupStatus.value = {
+    pluginVersionId: "pv_1",
+    status: "ready",
+    components: [
+      {
+        componentKey: "server:api",
+        placement: "remote",
+        authenticationPolicy: "on_install",
+        readiness: "needs_auth",
+      },
+    ],
+  };
+  h.version.value = {
+    pluginVersionId: "pv_1",
+    pluginId: "pl_1",
+    bundleHash: "aa11bb22cc33dd44",
+    declaredVersion: "1.0.0",
+    status: "ready",
+    manifestHash: "ff",
+    componentCounts: {
+      skills: 1,
+      servers: 1,
+      apps: 0,
+      assets: 0,
+      unsupported: 2,
+    },
+    createdAt: 1,
+    servers: [
+      {
+        componentId: "c_1",
+        componentKey: "server:api",
+        declaredName: "api",
+        placement: "remote",
+        authenticationPolicy: "on_install",
+        materializedServerId: "s_1",
+      },
+    ],
+    skills: [
+      {
+        componentId: "c_2",
+        componentKey: "skill:triage",
+        declaredName: "triage",
+        modelRef: "demo/triage",
+        materializedSkillId: "sk_1",
+      },
+    ],
+  };
+});
+
+describe("PluginGroupCard", () => {
+  it("rolls a component that needs auth up into the card's health", () => {
+    render(<PluginGroupCard plugin={plugin} />);
+    expect(screen.getByTestId("plugin-health-badge").textContent).toBe(
+      "Needs auth",
+    );
+  });
+
+  it("reports a disabled plugin as disabled regardless of component health", () => {
+    h.setupStatus.value = {
+      pluginVersionId: "pv_1",
+      status: "ready",
+      components: [],
+    };
+    render(<PluginGroupCard plugin={{ ...plugin, enabled: false }} />);
+    expect(screen.getByTestId("plugin-health-badge").textContent).toBe(
+      "Disabled",
+    );
+  });
+
+  it("shows the active revision's components when expanded, without a delete action", () => {
+    render(<PluginGroupCard plugin={plugin} />);
+    // The first collapsible control is the card header; the kebab trigger is
+    // also a collapsed-state button.
+    fireEvent.click(screen.getAllByRole("button", { expanded: false })[0]);
+    const detail = screen.getByTestId("plugin-group-card-detail");
+    expect(detail.textContent).toContain("api");
+    expect(detail.textContent).toContain("demo/triage");
+    expect(detail.textContent).toContain("aa11bb22cc33");
+    // Unsupported components are named as preserved, never as executed.
+    expect(detail.textContent).toMatch(/not run by MCPJam/i);
+    expect(detail.textContent).not.toMatch(/remove|delete/i);
+  });
+
+  it("surfaces the backend's environment-pin conflict when uninstall is blocked", async () => {
+    h.softDeletePlugin.mockRejectedValue(
+      new Error('still pinned by environment "Staging"'),
+    );
+    render(<PluginGroupCard plugin={plugin} />);
+    // Radix opens its dropdown on pointerdown, not click.
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: /Plugin actions for Demo/ }),
+      { button: 0, ctrlKey: false, pointerType: "mouse" },
+    );
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Uninstall" }));
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole("button", { name: "Uninstall" }),
+      );
+    });
+    expect(h.toastError).toHaveBeenCalledWith(
+      'still pinned by environment "Staging"',
+    );
+    expect(h.track).not.toHaveBeenCalled();
+  });
+});

--- a/mcpjam-inspector/client/src/components/plugins/__tests__/plugin-presentation.test.ts
+++ b/mcpjam-inspector/client/src/components/plugins/__tests__/plugin-presentation.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import type { PluginSetupStatus } from "@/lib/plugins/plugin-api-types";
+import {
+  PLUGIN_UNSUPPORTED_EXPLANATION,
+  describePluginHealth,
+  describePluginReadiness,
+  rollUpPluginHealth,
+} from "../plugin-presentation";
+
+function status(
+  readinesses: Array<PluginSetupStatus["components"][number]["readiness"]>,
+  overrides: Partial<PluginSetupStatus> = {},
+): PluginSetupStatus {
+  return {
+    pluginVersionId: "v_1",
+    status: "ready",
+    components: readinesses.map((readiness, index) => ({
+      componentKey: `server:${index}`,
+      placement: "remote",
+      authenticationPolicy: "on_use",
+      readiness,
+    })),
+    ...overrides,
+  };
+}
+
+const installed = { enabled: true, activeVersionId: "v_1" };
+
+describe("rollUpPluginHealth", () => {
+  it("is ready only when every component is", () => {
+    expect(rollUpPluginHealth(installed, status(["ready", "ready"]))).toEqual({
+      kind: "ready",
+      componentCount: 2,
+    });
+  });
+
+  it("never reports ready while one component needs auth", () => {
+    expect(
+      rollUpPluginHealth(installed, status(["ready", "needs_auth"])),
+    ).toEqual({ kind: "needs_attention", readiness: "needs_auth" });
+  });
+
+  it("prefers needs_auth over a placement constraint", () => {
+    expect(
+      rollUpPluginHealth(
+        installed,
+        status(["local_runtime_required", "needs_auth"]),
+      ),
+    ).toEqual({ kind: "needs_attention", readiness: "needs_auth" });
+  });
+
+  it("treats a component-less ready version as ready", () => {
+    expect(rollUpPluginHealth(installed, status([]))).toEqual({
+      kind: "ready",
+      componentCount: 0,
+    });
+  });
+
+  it("does not claim readiness before setup status loads", () => {
+    expect(rollUpPluginHealth(installed, undefined)).toEqual({
+      kind: "unknown",
+    });
+  });
+
+  it("does not claim readiness for a staging (not finalized) version", () => {
+    expect(
+      rollUpPluginHealth(installed, status(["ready"], { status: "staging" })),
+    ).toEqual({ kind: "unknown" });
+  });
+
+  it("reports disabled and not-activated before anything else", () => {
+    expect(
+      rollUpPluginHealth(
+        { enabled: false, activeVersionId: "v_1" },
+        status(["ready"]),
+      ),
+    ).toEqual({ kind: "disabled" });
+    expect(
+      rollUpPluginHealth(
+        { enabled: true, activeVersionId: undefined },
+        status(["ready"]),
+      ),
+    ).toEqual({ kind: "not_activated" });
+  });
+});
+
+describe("describePluginHealth", () => {
+  it("only ever says Ready for the ready rollup", () => {
+    const labels = (
+      [
+        { kind: "disabled" },
+        { kind: "not_activated" },
+        { kind: "unknown" },
+        { kind: "needs_attention", readiness: "needs_auth" },
+      ] as const
+    ).map((health) => describePluginHealth(health).label);
+    expect(labels).not.toContain("Ready");
+    expect(
+      describePluginHealth({ kind: "ready", componentCount: 1 }).label,
+    ).toBe("Ready");
+  });
+});
+
+describe("unsupported component wording", () => {
+  it("never describes an unsupported component as executable", () => {
+    expect(PLUGIN_UNSUPPORTED_EXPLANATION).toMatch(/does not run/i);
+    expect(PLUGIN_UNSUPPORTED_EXPLANATION).not.toMatch(
+      /\bruns\b|\bexecut(e|es|able)\b|\bsupported\b/i,
+    );
+  });
+});
+
+describe("describePluginReadiness", () => {
+  it("reports an unknown readiness code without claiming it is ready", () => {
+    const described = describePluginReadiness(
+      "some_future_state" as unknown as Parameters<
+        typeof describePluginReadiness
+      >[0],
+    );
+    expect(described.tone).toBe("attention");
+    expect(described.label).toBe("some_future_state");
+  });
+});

--- a/mcpjam-inspector/client/src/components/plugins/plugin-presentation.ts
+++ b/mcpjam-inspector/client/src/components/plugins/plugin-presentation.ts
@@ -1,0 +1,212 @@
+/**
+ * Pure presentation helpers shared by the Connect plugin surfaces (PR INS-2).
+ *
+ * Kept separate from the components so the wording rules that MATTER can be
+ * unit-tested directly:
+ *
+ *  - an unsupported component is never described as something MCPJam runs;
+ *  - a component's health is derived from the backend's `readiness` enum, not
+ *    guessed from local state; and
+ *  - a plugin's rolled-up health never reports "ready" while any component is
+ *    not, and never reports anything at all before a version is finalized.
+ */
+
+import type {
+  PluginComponentReadiness,
+  PluginSetupStatus,
+  PluginSummary,
+} from "@/lib/plugins/plugin-api-types";
+
+// ---------------------------------------------------------------------------
+// Component readiness.
+// ---------------------------------------------------------------------------
+
+export interface PluginReadinessPresentation {
+  label: string;
+  /** One-line explanation of what the user has to do, if anything. */
+  detail: string;
+  tone: "ready" | "attention" | "info";
+}
+
+/**
+ * Backend `PluginComponentReadiness` → user-facing wording.
+ *
+ * `local_runtime_required` / `computer_required` are placement facts, not
+ * failures: the component is fine, this client just cannot be the one to run
+ * it. They read as informational rather than as errors.
+ */
+export function describePluginReadiness(
+  readiness: PluginComponentReadiness,
+): PluginReadinessPresentation {
+  switch (readiness) {
+    case "ready":
+      return {
+        label: "Ready",
+        detail: "No setup required before use.",
+        tone: "ready",
+      };
+    case "needs_auth":
+      return {
+        label: "Needs auth",
+        detail: "Authorize this server before its first tool call.",
+        tone: "attention",
+      };
+    case "local_runtime_required":
+      return {
+        label: "Local runtime",
+        detail: "Runs only from a local MCPJam process.",
+        tone: "info",
+      };
+    case "computer_required":
+      return {
+        label: "Computer required",
+        detail: "Runs only inside a Project Computer.",
+        tone: "info",
+      };
+    default:
+      // A readiness value this client does not know yet. Report the raw code
+      // rather than inventing a friendly label that might claim readiness.
+      return {
+        label: String(readiness),
+        detail: "Unrecognized component state.",
+        tone: "attention",
+      };
+  }
+}
+
+export function describePluginPlacement(
+  placement: "remote" | "local" | "computer",
+): string {
+  switch (placement) {
+    case "remote":
+      return "Remote";
+    case "local":
+      return "Local";
+    case "computer":
+      return "Computer";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Plugin-level health rollup.
+// ---------------------------------------------------------------------------
+
+export type PluginHealth =
+  | { kind: "disabled" }
+  /** Installed, but no revision has been made active yet. */
+  | { kind: "not_activated" }
+  /** Setup status has not loaded (or the version is still staging). */
+  | { kind: "unknown" }
+  | { kind: "ready"; componentCount: number }
+  | { kind: "needs_attention"; readiness: PluginComponentReadiness };
+
+/**
+ * Roll a plugin's server components up into one status line.
+ *
+ * Ordering is deliberately pessimistic: `needs_auth` beats the placement
+ * states, which beat `ready`. A plugin is only "Ready" when EVERY component
+ * is, so the card can never imply a plugin is usable while one of its servers
+ * still needs authorization.
+ */
+const READINESS_SEVERITY: Record<string, number> = {
+  needs_auth: 3,
+  computer_required: 2,
+  local_runtime_required: 2,
+  ready: 0,
+};
+
+export function rollUpPluginHealth(
+  plugin: Pick<PluginSummary, "enabled" | "activeVersionId">,
+  setupStatus: PluginSetupStatus | undefined,
+): PluginHealth {
+  if (!plugin.enabled) return { kind: "disabled" };
+  if (!plugin.activeVersionId) return { kind: "not_activated" };
+  // `undefined` is "still loading"; a staging version is not runtime-visible,
+  // so neither state may be rendered as ready.
+  if (setupStatus === undefined) return { kind: "unknown" };
+  if (setupStatus.status !== "ready") return { kind: "unknown" };
+
+  let worst: PluginComponentReadiness | null = null;
+  let worstScore = -1;
+  for (const component of setupStatus.components) {
+    const score = READINESS_SEVERITY[component.readiness] ?? 4;
+    if (score > worstScore) {
+      worstScore = score;
+      worst = component.readiness;
+    }
+  }
+  if (worst === null || worstScore === 0) {
+    return { kind: "ready", componentCount: setupStatus.components.length };
+  }
+  return { kind: "needs_attention", readiness: worst };
+}
+
+export function describePluginHealth(health: PluginHealth): {
+  label: string;
+  tone: "ready" | "attention" | "info" | "muted";
+} {
+  switch (health.kind) {
+    case "disabled":
+      return { label: "Disabled", tone: "muted" };
+    case "not_activated":
+      return { label: "No active revision", tone: "info" };
+    case "unknown":
+      return { label: "Checking…", tone: "muted" };
+    case "ready":
+      return { label: "Ready", tone: "ready" };
+    case "needs_attention": {
+      const described = describePluginReadiness(health.readiness);
+      return { label: described.label, tone: described.tone };
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Unsupported components.
+// ---------------------------------------------------------------------------
+
+/**
+ * The ONE sentence that describes what MCPJam does with a component it does
+ * not run. Centralized so the "preserved, never executed" promise cannot drift
+ * between the preview and the post-install summary — the plan forbids claiming
+ * OpenAI runtime parity for components MCPJam preserves but does not execute.
+ */
+export const PLUGIN_UNSUPPORTED_EXPLANATION =
+  "Kept in the stored bundle for fidelity. MCPJam does not run these.";
+
+/** Human label for a parser `unsupported.kind`, defaulting to the raw kind. */
+export function describeUnsupportedKind(kind: string): string {
+  switch (kind) {
+    case "hook":
+    case "hooks":
+      return "Lifecycle hooks";
+    case "browser_extension":
+      return "Browser extension";
+    case "scheduled_task":
+      return "Scheduled task template";
+    case "unknown_field":
+      return "Unrecognized manifest field";
+    default:
+      return kind;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Misc formatting.
+// ---------------------------------------------------------------------------
+
+/** Short, copy-friendly revision label for a version's content identity. */
+export function shortBundleHash(bundleHash: string): string {
+  return bundleHash.slice(0, 12);
+}
+
+export function formatByteSize(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) return "—";
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export function pluralize(count: number, singular: string, plural?: string) {
+  return `${count} ${count === 1 ? singular : (plural ?? `${singular}s`)}`;
+}

--- a/mcpjam-inspector/client/src/hooks/usePluginImportApi.ts
+++ b/mcpjam-inspector/client/src/hooks/usePluginImportApi.ts
@@ -316,3 +316,103 @@ export function usePluginImportActions(): PluginImportActions {
     ],
   );
 }
+
+export interface PluginManagementActions {
+  /** Reversible kill switch (`plugins.setEnabled`). */
+  setEnabled: (pluginId: string, enabled: boolean) => Promise<void>;
+  /**
+   * Point the plugin at a different ready version (`plugins.activateVersion`).
+   * Affects which version NEW attachments offer; environments that already pin
+   * a version keep it until they are explicitly upgraded.
+   */
+  activateVersion: (pluginId: string, pluginVersionId: string) => Promise<void>;
+  /**
+   * Soft uninstall (`plugins.softDeletePlugin`). Rejects with `CONFLICT` while
+   * a live environment still pins one of the plugin's versions — surface that
+   * message rather than retrying.
+   */
+  softDeletePlugin: (pluginId: string) => Promise<void>;
+  /** Undo a soft uninstall (`plugins.restorePlugin`). */
+  restorePlugin: (pluginId: string) => Promise<void>;
+}
+
+/**
+ * Guarded wrappers around the plugin LIFECYCLE mutations (project-admin gated
+ * backend-side). Same fail-closed flag gate and structured-error mapping as
+ * {@link usePluginImportActions}; kept in this module so there is one plugin
+ * client, not an import client plus a parallel management client.
+ */
+export function usePluginManagementActions(): PluginManagementActions {
+  const enabled = usePluginsEnabled();
+  const setEnabledMutation = useMutation("plugins:setEnabled" as any);
+  const activateVersionMutation = useMutation("plugins:activateVersion" as any);
+  const softDeleteMutation = useMutation("plugins:softDeletePlugin" as any);
+  const restoreMutation = useMutation("plugins:restorePlugin" as any);
+
+  const requireEnabled = useCallback(() => {
+    if (!enabled) {
+      throw new PluginApiError(
+        "PLUGINS_DISABLED",
+        "Plugin management is not enabled for this account.",
+      );
+    }
+  }, [enabled]);
+
+  const setEnabled = useCallback(
+    async (pluginId: string, nextEnabled: boolean): Promise<void> => {
+      requireEnabled();
+      try {
+        await setEnabledMutation({ pluginId, enabled: nextEnabled } as any);
+      } catch (err) {
+        throw toPluginApiError(
+          err,
+          nextEnabled
+            ? "Could not enable the plugin"
+            : "Could not disable the plugin",
+        );
+      }
+    },
+    [requireEnabled, setEnabledMutation],
+  );
+
+  const activateVersion = useCallback(
+    async (pluginId: string, pluginVersionId: string): Promise<void> => {
+      requireEnabled();
+      try {
+        await activateVersionMutation({ pluginId, pluginVersionId } as any);
+      } catch (err) {
+        throw toPluginApiError(err, "Could not activate that plugin version");
+      }
+    },
+    [requireEnabled, activateVersionMutation],
+  );
+
+  const softDeletePlugin = useCallback(
+    async (pluginId: string): Promise<void> => {
+      requireEnabled();
+      try {
+        await softDeleteMutation({ pluginId } as any);
+      } catch (err) {
+        throw toPluginApiError(err, "Could not uninstall the plugin");
+      }
+    },
+    [requireEnabled, softDeleteMutation],
+  );
+
+  const restorePlugin = useCallback(
+    async (pluginId: string): Promise<void> => {
+      requireEnabled();
+      try {
+        await restoreMutation({ pluginId } as any);
+      } catch (err) {
+        throw toPluginApiError(err, "Could not restore the plugin");
+      }
+    },
+    [requireEnabled, restoreMutation],
+  );
+
+  return useMemo(
+    () => ({ setEnabled, activateVersion, softDeletePlugin, restorePlugin }),
+    [setEnabled, activateVersion, softDeletePlugin, restorePlugin],
+  );
+}

--- a/mcpjam-inspector/client/src/hooks/usePluginImportApi.ts
+++ b/mcpjam-inspector/client/src/hooks/usePluginImportApi.ts
@@ -152,6 +152,18 @@ export interface StartPluginImportArgs {
    * caps length, so passing a file/folder name is safe.
    */
   sourceLabel?: string;
+  /**
+   * Called with the new import id the moment `createImport` resolves —
+   * BEFORE inspection runs.
+   *
+   * `startImport` drives inspection itself (the backend does not schedule it),
+   * so an inspect rejection rejects the whole call and the caller would never
+   * learn the id of the row that WAS created. Without it there is nothing to
+   * resume and the only recovery is a second upload creating a second import
+   * row. Callers that offer "retry" must adopt the id from here, not only from
+   * the resolved result.
+   */
+  onImportCreated?: (importId: string) => void;
 }
 
 export interface StartPluginImportResult {
@@ -293,6 +305,14 @@ export function usePluginImportActions(): PluginImportActions {
         bundleStorageId,
         sourceLabel: args.sourceLabel,
       });
+      // Hand the id over before inspection can throw (see `onImportCreated`).
+      // A caller-thrown callback must not swallow an import that DID get
+      // created, so its failure is contained rather than propagated.
+      try {
+        args.onImportCreated?.(importId);
+      } catch {
+        // ignore — the id is still returned below on the success path.
+      }
       const inspect = await inspectImport(importId);
       return { importId, inspect };
     },

--- a/mcpjam-inspector/client/src/lib/plugins/__tests__/plugin-analytics.test.ts
+++ b/mcpjam-inspector/client/src/lib/plugins/__tests__/plugin-analytics.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Plugin telemetry must never carry bundle paths, server URLs, env/header
+ * names or values, skill content, or the plugin's own authored name. These
+ * tests pin that: the builder's OUTPUT is checked as a whole, so a future
+ * field that leaks user content fails here rather than in production.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  pluginBundleHashPrefix,
+  pluginPreviewAnalyticsProps,
+  sanitizePluginCode,
+} from "../plugin-analytics";
+import type { PluginImportPreview } from "../plugin-api-types";
+
+const preview: PluginImportPreview = {
+  identity: {
+    name: "acme-secret-plugin",
+    displayName: "ACME Secret Plugin",
+    version: "1.2.3",
+    description: "Internal ACME tooling",
+  },
+  bundleHash: "abcdef0123456789abcdef0123456789",
+  manifestHash: "0123456789abcdef",
+  counts: {
+    skills: 2,
+    servers: 3,
+    apps: 1,
+    assets: 4,
+    unsupported: 5,
+    warnings: 6,
+  },
+  skills: [
+    {
+      modelRef: "acme-secret-plugin/triage",
+      name: "triage",
+      description: "Triage things",
+      supportingFileCount: 2,
+      mcpToolDependencyCount: 1,
+      hasOpenaiMetadata: false,
+    },
+  ],
+  servers: [
+    { key: "local-cli", transport: "stdio" },
+    { key: "api", transport: "http" },
+    { key: "api2", transport: "http" },
+  ],
+  apps: [{ appId: "app_1", binding: "server", status: "declared" }],
+  assets: [{ kind: "icon", contentType: "image/png", size: 100 }],
+  setupRequirements: [
+    { serverKey: "api", kind: "header", name: "X-Acme-Token", required: true },
+  ],
+  unsupported: [
+    { kind: "hook", key: "postinstall", reason: "not executed", pathCount: 1 },
+  ],
+  warnings: [
+    { code: "MANIFEST_UNKNOWN_FIELD", severity: "warning", message: "unknown" },
+  ],
+};
+
+describe("pluginPreviewAnalyticsProps", () => {
+  it("emits the component census and nothing authored by the bundle", () => {
+    const props = pluginPreviewAnalyticsProps(preview);
+    expect(props).toEqual({
+      bundle_hash_prefix: "abcdef012345",
+      skill_count: 2,
+      server_count: 3,
+      app_count: 1,
+      asset_count: 4,
+      unsupported_count: 5,
+      warning_count: 6,
+      setup_requirement_count: 1,
+      stdio_server_count: 1,
+      http_server_count: 2,
+    });
+  });
+
+  it("leaks no name, description, path, or requirement name", () => {
+    const serialized = JSON.stringify(pluginPreviewAnalyticsProps(preview));
+    for (const forbidden of [
+      "acme-secret-plugin",
+      "ACME Secret Plugin",
+      "Internal ACME tooling",
+      "X-Acme-Token",
+      "triage",
+      "local-cli",
+      "postinstall",
+    ]) {
+      expect(serialized).not.toContain(forbidden);
+    }
+  });
+});
+
+describe("sanitizePluginCode", () => {
+  it("passes stable machine codes through", () => {
+    expect(sanitizePluginCode("ARCHIVE_TOO_LARGE_COMPRESSED")).toBe(
+      "ARCHIVE_TOO_LARGE_COMPRESSED",
+    );
+  });
+
+  it("replaces anything that could carry a message or path", () => {
+    expect(sanitizePluginCode("failed reading /Users/me/plugin.zip")).toBe(
+      "UNKNOWN",
+    );
+    expect(sanitizePluginCode("https://internal.example.com")).toBe("UNKNOWN");
+    expect(sanitizePluginCode(undefined)).toBe("UNKNOWN");
+    expect(sanitizePluginCode("A".repeat(65))).toBe("UNKNOWN");
+  });
+});
+
+describe("pluginBundleHashPrefix", () => {
+  it("returns a bounded hex prefix", () => {
+    expect(pluginBundleHashPrefix("ABCDEF0123456789")).toBe("abcdef012345");
+  });
+
+  it("refuses anything that is not a hex digest", () => {
+    expect(pluginBundleHashPrefix("../../etc/passwd")).toBeUndefined();
+    expect(pluginBundleHashPrefix(undefined)).toBeUndefined();
+  });
+});

--- a/mcpjam-inspector/client/src/lib/plugins/folder-bundle.ts
+++ b/mcpjam-inspector/client/src/lib/plugins/folder-bundle.ts
@@ -63,8 +63,13 @@ function issueError(
   ]);
 }
 
-/** `Blob.arrayBuffer` with a `FileReader` fallback (older WebKit/jsdom). */
-async function readFileBytes(file: File): Promise<Uint8Array> {
+/**
+ * `Blob.arrayBuffer` with a `FileReader` fallback (older WebKit/jsdom).
+ * Exported because the Add-plugin dialog reads a user-picked `.zip` through
+ * the same path before handing the bytes to the ZIP source — one file-reading
+ * behavior, one fallback.
+ */
+export async function readSelectedFileBytes(file: File): Promise<Uint8Array> {
   if (typeof file.arrayBuffer === "function") {
     return new Uint8Array(await file.arrayBuffer());
   }
@@ -168,7 +173,7 @@ export function createFolderPluginFileSource(
           `selected file ${path} exceeds the ${maxBytes}-byte read limit`,
         );
       }
-      const bytes = await readFileBytes(file);
+      const bytes = await readSelectedFileBytes(file);
       if (bytes.byteLength > maxBytes) {
         throw new Error(
           `selected file ${path} exceeds the ${maxBytes}-byte read limit`,

--- a/mcpjam-inspector/client/src/lib/plugins/plugin-analytics.ts
+++ b/mcpjam-inspector/client/src/lib/plugins/plugin-analytics.ts
@@ -1,0 +1,77 @@
+/**
+ * Analytics prop builders for the Connect "Add plugin" surface (PR INS-2 of
+ * docs/plans/openai-plugin-import-cross-repo.md).
+ *
+ * THE RULE THIS FILE EXISTS TO ENFORCE: a plugin bundle is user content, so
+ * plugin telemetry must never carry "paths, manifest bodies, skill content,
+ * environment values, header values, OAuth tokens, or source ZIP names that
+ * may contain user information". Everything emitted from here is a COUNT, a
+ * BOOLEAN, a byte size, a closed enum, or a stable machine code — never a
+ * bundle path, server URL, env/header name, skill name, or the plugin's own
+ * display name.
+ *
+ * The `bundleHash` prefix is the one identifier that ships: it is a content
+ * digest (not a name), it is what the backend's own structured logs record,
+ * and it is what makes "this import" joinable across client and server events.
+ */
+
+import type { PluginImportPreview } from "./plugin-api-types";
+
+/** Characters allowed in an emitted machine code. */
+const CODE_SHAPE = /^[A-Z0-9_]{1,64}$/;
+
+/** How much of a bundle hash rides along (matches the backend log prefix). */
+export const PLUGIN_BUNDLE_HASH_PREFIX_LENGTH = 12;
+
+/**
+ * Reduce an arbitrary error/issue code to a stable emittable token.
+ *
+ * Codes reaching the UI are not all backend-authored: `toPluginApiError`
+ * falls back to `UNKNOWN` but SDK parser issues and future backend codes
+ * arrive as free strings, and a code is exactly the kind of field a message
+ * (with a path or URL inside it) could be misrouted into. Anything that is
+ * not already an uppercase machine token is reported as `UNKNOWN` rather than
+ * emitted verbatim.
+ */
+export function sanitizePluginCode(code: string | undefined | null): string {
+  if (typeof code !== "string") return "UNKNOWN";
+  const trimmed = code.trim();
+  return CODE_SHAPE.test(trimmed) ? trimmed : "UNKNOWN";
+}
+
+/** First {@link PLUGIN_BUNDLE_HASH_PREFIX_LENGTH} hex chars of a bundle hash. */
+export function pluginBundleHashPrefix(
+  bundleHash: string | undefined | null,
+): string | undefined {
+  if (typeof bundleHash !== "string") return undefined;
+  const hex = bundleHash.trim().toLowerCase();
+  if (!/^[0-9a-f]+$/.test(hex)) return undefined;
+  return hex.slice(0, PLUGIN_BUNDLE_HASH_PREFIX_LENGTH);
+}
+
+/**
+ * Shape-only description of a preview: the component census plus the content
+ * digest prefix. Deliberately drops `preview.identity` entirely — a plugin
+ * name/description is authored by whoever wrote the bundle.
+ */
+export function pluginPreviewAnalyticsProps(
+  preview: PluginImportPreview,
+): Record<string, unknown> {
+  const counts = preview.counts;
+  return {
+    bundle_hash_prefix: pluginBundleHashPrefix(preview.bundleHash),
+    skill_count: counts.skills,
+    server_count: counts.servers,
+    app_count: counts.apps,
+    asset_count: counts.assets,
+    unsupported_count: counts.unsupported,
+    warning_count: counts.warnings,
+    setup_requirement_count: preview.setupRequirements.length,
+    // Transports are a closed enum from the parser, so the mix is safe and
+    // is the single most useful signal for "which runtimes must work next".
+    stdio_server_count: preview.servers.filter((s) => s.transport === "stdio")
+      .length,
+    http_server_count: preview.servers.filter((s) => s.transport === "http")
+      .length,
+  };
+}

--- a/mcpjam-inspector/shared/analytics-events.ts
+++ b/mcpjam-inspector/shared/analytics-events.ts
@@ -190,6 +190,19 @@ export const ANALYTICS_EVENTS = {
   playground_tool_run_clicked: { source: "client" },
   playground_tools_pane_tab_changed: { source: "client" },
   playground_tools_refresh_clicked: { source: "client" },
+  // --- OpenAI plugin import (Connect "Add plugin", INS-2) ---
+  // Props are built by `client/src/lib/plugins/plugin-analytics.ts`, which
+  // exists to keep bundle paths, server URLs, env/header names, and plugin
+  // display names OUT of these payloads: counts, closed enums, stable codes,
+  // and a bundle-hash prefix only.
+  add_plugin_button_clicked: { source: "client" },
+  plugin_disabled: { source: "client" },
+  plugin_import_completed: { source: "client" },
+  plugin_import_failed: { source: "client" },
+  plugin_import_previewed: { source: "client" },
+  plugin_import_started: { source: "client" },
+  plugin_uninstalled: { source: "client" },
+  plugin_version_upgraded: { source: "client" },
   project_invite_sent: { source: "client" },
   project_member_removed: { source: "client" },
   project_members_facepile_clicked: { source: "client" },


### PR DESCRIPTION
INS-2 of `docs/plans/openai-plugin-import-cross-repo.md` (mcpjam-backend), on
top of the INS-1 plumbing merged in #3421 + #3444. This is the UX layer only —
it builds on the existing import client rather than adding a second one.

## What's here

- **`lib/plugins/plugin-analytics.ts`** — the single place plugin event props
  are built. Emits counts, the stdio/http transport mix, and a bounded hex
  `bundle_hash_prefix`. `sanitizePluginCode` shape-checks codes
  (`^[A-Z0-9_]{1,64}$`) so a free-form message carrying a path or URL cannot
  ride in as a `code`. A test asserts the serialized payload contains none of
  the authored strings (plugin name, description, header name, skill name,
  server key).
- **`hooks/usePluginImportApi.ts`** — adds `usePluginManagementActions()`
  (setEnabled / activateVersion / softDeletePlugin / restorePlugin) into the
  existing module, same fail-closed flag gate and error mapping. INS-1 covered
  import only; this was the real plumbing gap.
- **`components/plugins/plugin-presentation.ts`** — pure readiness/health
  helpers, unit-tested. Pessimistic rollup (`needs_auth` > placement >
  `ready`), `unknown` for unloaded or `staging`.
- **`components/plugins/AddPluginModal.tsx`** — source selection (ZIP/folder) →
  SDK preflight → upload + inspect progress → preview → confirm → post-install
  setup summary.
- **`PluginImportPreviewContent.tsx` / `PluginGroupCard.tsx` /
  `PluginsSection.tsx`** — preview rendering, group cards with component
  health, revision activation, disable/uninstall.
- **`ServersTab.tsx`** — "Add plugin" in the existing actions hovercard and the
  plugins section above the server grid.

## Acceptance

- **Never marks a plugin installed before finalize** — `isInstalled` derives
  from the reactive import row (`status === "completed" && pluginVersionId`),
  not from the commit promise or local state. A test pins the intermediate
  `committing` state.
- **Retry resumes from an existing preview-ready import** — `preview_ready`
  recommits the same importId with no re-upload; `uploaded`/`inspecting`
  re-drives `inspectImport` (real, because `createImport` does not
  auto-schedule inspection); `failed` offers a new import, because
  `beginCommit` refuses anything not `preview_ready`, making that row terminal.
- **Unsupported components are visible and never described as executable** —
  always rendered, never behind an expander, with one shared explanation
  string: "Kept in the stored bundle for fidelity. MCPJam does not run these."

`commitImport` returning `reused: true` on a content-addressed re-import is
surfaced as "already imported" rather than reported as a fresh install.

## Decisions worth a reviewer's attention

1. **No credential collection.** There is no backend mutation for attaching
   secrets to a plugin component, and `servers.ts` filters
   `lifecycleScope === 'plugin_component'` out of every standalone listing, so
   the client cannot read the component's config. Setup is therefore
   *reported* — requested env/header names, per-component readiness — and never
   collected. If the plan's "setup dialogs" means collection, that needs
   backend work that is not scoped anywhere yet.
2. **"Install and connect" = `commitImport({setActive: true})`**, "Install
   only" = `setActive: false`. That is the only install/connect distinction the
   backend records today; real attachment means pinning a version on a
   `projectEnvironment`, which is the still-open INS-4 pin-carrier decision, so
   it is not decided here. Open question: is "connect" honest wording for
   "activate this revision"?
3. **Version activation shipped in the card** — slightly beyond the literal
   INS-2 bullet list, but it makes the multi-revision card and the
   `plugin_version_upgraded` event non-vestigial.
4. **Not behind `BILLING_GATES.serverCreation`** — plugin component servers are
   a version's read-only projection, not catalog servers, and the backend gates
   on project-admin. Say the word if you want the gate anyway.
5. **`PluginsSection` renders nothing when the project has zero plugins** — no
   empty-state chrome for a flag-gated surface.

## Out of scope

Playground/environment pinning and live connection to plugin components
(INS-3/INS-4 own runtime resolution); detach-as-copy (belongs on Servers/Skills
per the plan); restore of a soft-uninstalled plugin (`listProjectPlugins`
filters tombstones, so there is no surface to restore from — the hook exists
for whoever adds one); drag-and-drop upload.

## Verification

Re-run independently of the authoring agent, from a clean worktree at
`main@22d01ede93`:

- `npx vitest run --project client` → exit 0, **6313 passed** / 6 skipped
  (635 files), 20 of them new.
- `npx tsc --noEmit -p client/tsconfig.typecheck.json` → exit 0, clean.
- `npm run build:client` → exit 0.

Not manually exercised in a running app — the flag-gated surface has no
Playwright coverage yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new client surface for cloud plugin import and project-admin lifecycle mutations; correctness hinges on import-state gating and project-switch invalidation, though risk is mitigated by feature flag, tests, and no credential handling in this PR.
> 
> **Overview**
> Adds **Connect → Add plugin** behind the `plugins-enabled` flag: an **Add plugin** action in the server menu, a **Plugins** section above the server grid, and a full import dialog (ZIP/folder → client preflight → upload/inspect → preview → install-only or install-and-connect).
> 
> **`AddPluginModal`** drives the backend import flow on top of existing hooks, with generation guards on async work, import state that survives close/reopen, and retries that resume the same import (re-commit, re-inspect, or new import when terminal). Success is shown only when the import row reaches **`completed`**; content-addressed **`reused`** installs read as “already imported.” Setup is **report-only** (no credential collection).
> 
> New **plugin group cards** show rolled-up health, expandable revision/components, enable/disable, activate other revisions, and soft uninstall. Shared **`plugin-presentation`** helpers encode pessimistic health rollup and “unsupported = preserved, not executed” copy.
> 
> **`usePluginImportApi`** gains **`onImportCreated`** (so inspect failures still retain an import id) and **`usePluginManagementActions`**. **`plugin-analytics`** and new analytics events emit counts and bounded hash prefixes only (no bundle paths or names).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da67f3a98c99927f736a1ebdebbc4855e2b2e64e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Connect → Add plugin UX (INS-2) to import and manage OpenAI plugins with source selection, preview, and install/activate, plus plugin cards and sanitized analytics. Also fixes preflight limits, safe resume, and install-mode persistence.

- **New Features**
  - `AddPluginModal`: ZIP/folder pick → SDK preflight → upload/inspect → preview → confirm; supports install-only vs install-and-connect; retries resume existing imports; surfaces `reused: true` as “already imported”.
  - Plugin cards: rolled-up health, expand to components, enable/disable, activate version, soft uninstall/restore.
  - Connect updates: “Add plugin” entry and `Plugins` section in ServersTab behind `plugins-enabled`.
  - Hooks/analytics: `usePluginManagementActions()` and `plugin-analytics` (counts/enums/byte sizes + bounded bundle-hash prefix only).

- **Bug Fixes**
  - Bound ZIP preflight before reading bytes using `assertPluginBundleWithinCap` to prevent OOM on oversized archives.
  - Guard stale imports across project changes with a generation token so old async completions don’t write into a new project.
  - Preserve import id via `onImportCreated` so retries resume without re-upload; keep the user’s chosen install mode on retry.
  - Minor correctness: installed state requires `completed` with ids present; setup requirement text echoes declared `kind`.

<sup>Written for commit da67f3a98c99927f736a1ebdebbc4855e2b2e64e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

