### PR TITLE
feat(environments): environment-first eval results (Phase 3)

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/__tests__/run-context-fixtures.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/run-context-fixtures.ts
@@ -1,0 +1,107 @@
+/**
+ * Shared run fixtures for the Phase 3 run-identity tests. Lives outside the
+ * spec files because the flag-ON and flag-OFF (kill-switch) suites must assert
+ * against IDENTICAL data — the only difference between them is the mocked
+ * `project-environments-enabled` value.
+ */
+import type { EvalSuite, EvalSuiteRun } from "../types";
+
+export function envRun(
+  id: string,
+  environmentId: string,
+  name: string,
+  revision: number,
+  overrides: Partial<EvalSuiteRun> = {}
+): EvalSuiteRun {
+  return {
+    _id: id,
+    suiteId: "suite-1",
+    createdBy: "user-1",
+    runNumber: 1,
+    configRevision: "1",
+    configSnapshot: {
+      tests: [],
+      // NOTE: `environment.servers` is the unrelated legacy server-name bag —
+      // it must never be read as environment identity.
+      environment: { servers: ["server-1"] },
+      environmentRef: { environmentId, name, revision },
+    },
+    status: "completed",
+    result: "passed",
+    createdAt: 1_000,
+    completedAt: 2_000,
+    summary: { total: 1, passed: 1, failed: 0, passRate: 100 },
+    ...overrides,
+  } as EvalSuiteRun;
+}
+
+export function hostRun(
+  id: string,
+  namedHostId: string | undefined,
+  overrides: Partial<EvalSuiteRun> = {}
+): EvalSuiteRun {
+  return {
+    _id: id,
+    suiteId: "suite-1",
+    createdBy: "user-1",
+    runNumber: 1,
+    configRevision: "1",
+    configSnapshot: { tests: [], environment: { servers: ["server-1"] } },
+    status: "completed",
+    result: "passed",
+    createdAt: 1_000,
+    completedAt: 2_000,
+    summary: { total: 1, passed: 1, failed: 0, passRate: 100 },
+    ...(namedHostId ? { namedHostId } : {}),
+    ...overrides,
+  } as EvalSuiteRun;
+}
+
+export const contextSuite: EvalSuite = {
+  _id: "suite-1",
+  createdBy: "user-1",
+  name: "Suite",
+  description: "",
+  configRevision: "1",
+  environment: { servers: [] },
+  createdAt: 1,
+  updatedAt: 1,
+  source: "ui",
+} as EvalSuite;
+
+/**
+ * One environment, three runs in a single launch group — the shape that made
+ * a row-count header claim "3 environments". Spans revisions 2→4 so a group
+ * header must summarise a RANGE, never one arbitrary revision.
+ */
+export const oneEnvironmentThreeRuns: EvalSuiteRun[] = [
+  envRun("oneenv01", "env-a", "Staging", 2, {
+    runGroupId: "g-one",
+    createdAt: 20_000,
+    completedAt: 21_000,
+  }),
+  envRun("oneenv02", "env-a", "Staging", 3, {
+    runGroupId: "g-one",
+    createdAt: 20_100,
+    completedAt: 21_100,
+  }),
+  envRun("oneenv03", "env-a", "Staging", 4, {
+    runGroupId: "g-one",
+    createdAt: 20_200,
+    completedAt: 21_200,
+  }),
+];
+
+/** Two distinct environments in one launch group. */
+export const twoEnvironmentsOneGroup: EvalSuiteRun[] = [
+  envRun("twoenv01", "env-a", "Staging", 2, {
+    runGroupId: "g-two",
+    createdAt: 20_000,
+    completedAt: 21_000,
+  }),
+  envRun("twoenv02", "env-b", "Prod", 7, {
+    runGroupId: "g-two",
+    createdAt: 20_100,
+    completedAt: 21_100,
+  }),
+];

--- a/mcpjam-inspector/client/src/components/evals/__tests__/run-context-identity.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/run-context-identity.test.tsx
@@ -26,7 +26,15 @@ import {
 } from "../helpers";
 import { resolveCaseRunBatchHost } from "../runs/group-case-iterations";
 import { SuiteRunsList } from "../suite-runs-list";
-import type { EvalIteration, EvalSuiteRun } from "../types";
+import { SuiteResultsSplit } from "../suite-results-split";
+import { CaseRunsHistory } from "../runs/case-runs-history";
+import {
+  contextSuite,
+  envRun,
+  hostRun,
+  oneEnvironmentThreeRuns,
+} from "./run-context-fixtures";
+import type { EvalIteration } from "../types";
 
 // The chips are flag-gated exactly like the run-detail "Environment" row.
 // Flag ON is the state under test; the OFF path is asserted separately below
@@ -36,57 +44,6 @@ vi.mock("@/hooks/useProjectEnvironmentsEnabled", () => ({
   useProjectEnvironmentsEnabledState: () => true,
   PROJECT_ENVIRONMENTS_FEATURE_FLAG: "project-environments-enabled",
 }));
-
-function envRun(
-  id: string,
-  environmentId: string,
-  name: string,
-  revision: number,
-  overrides: Partial<EvalSuiteRun> = {}
-): EvalSuiteRun {
-  return {
-    _id: id,
-    suiteId: "suite-1",
-    createdBy: "user-1",
-    runNumber: 1,
-    configRevision: "1",
-    configSnapshot: {
-      tests: [],
-      // NOTE: `environment.servers` is the unrelated legacy server-name bag —
-      // it must never be read as environment identity.
-      environment: { servers: ["server-1"] },
-      environmentRef: { environmentId, name, revision },
-    },
-    status: "completed",
-    result: "passed",
-    createdAt: 1_000,
-    completedAt: 2_000,
-    summary: { total: 1, passed: 1, failed: 0, passRate: 100 },
-    ...overrides,
-  } as EvalSuiteRun;
-}
-
-function hostRun(
-  id: string,
-  namedHostId: string | undefined,
-  overrides: Partial<EvalSuiteRun> = {}
-): EvalSuiteRun {
-  return {
-    _id: id,
-    suiteId: "suite-1",
-    createdBy: "user-1",
-    runNumber: 1,
-    configRevision: "1",
-    configSnapshot: { tests: [], environment: { servers: ["server-1"] } },
-    status: "completed",
-    result: "passed",
-    createdAt: 1_000,
-    completedAt: 2_000,
-    summary: { total: 1, passed: 1, failed: 0, passRate: 100 },
-    ...(namedHostId ? { namedHostId } : {}),
-    ...overrides,
-  } as EvalSuiteRun;
-}
 
 describe("runContextKey", () => {
   it("keys an environment run by environment id, NOT by revision", () => {
@@ -312,6 +269,82 @@ describe("SuiteRunsList mixed host/environment history", () => {
     // single environment standing in for the whole group.
     expect(header!.textContent).toContain("2 environments");
     expect(header!.textContent).not.toMatch(/rev \d/);
+  });
+});
+
+/**
+ * The group-header count is a count of CONTEXTS, not of run rows. Re-running
+ * one environment (each run pinning a fresh revision, since an environment is
+ * live-editable) must stay "1 environment". This is the bug Phase 3 fixed in
+ * the rail's `RailGroup.hostCount`; it is pinned on BOTH surfaces here so it
+ * cannot be reintroduced in one of them.
+ */
+describe("CaseRunsHistory environment batch header", () => {
+  it("renders the environment name + its exact revision via the shared chip", () => {
+    // Same `EnvironmentChip` the results surfaces use, so the two renderings
+    // of environment identity cannot drift apart.
+    const iterations = [
+      {
+        _id: "it-1",
+        testCaseId: "case-1",
+        suiteRunId: "envrun00",
+        iterationNumber: 1,
+        result: "passed",
+        createdAt: 1_000,
+        actualToolCalls: [],
+        tokensUsed: 0,
+      },
+    ] as unknown as EvalIteration[];
+
+    renderWithProviders(
+      <CaseRunsHistory
+        iterations={iterations}
+        onSelectIteration={vi.fn()}
+        suiteRuns={[envRun("envrun00", "env-a", "Staging", 6)]}
+      />
+    );
+
+    const chip = screen.getByTitle("Staging · env-a");
+    expect(chip).toBeInTheDocument();
+    expect(chip.textContent).toContain("Staging");
+    expect(chip.textContent).toContain("rev 6");
+  });
+});
+
+describe("group header counts CONTEXTS, not run rows", () => {
+  it("runs list: one environment re-run three times reads '1 environment'", () => {
+    renderWithProviders(
+      <SuiteRunsList
+        runs={oneEnvironmentThreeRuns}
+        allIterations={[]}
+        onRunClick={vi.fn()}
+      />
+    );
+
+    const header = screen.getByText(/Run group g/i).closest("button");
+    expect(header!.textContent).toContain("1 environment");
+    expect(header!.textContent).not.toContain("3 environments");
+  });
+
+  it("results rail: the same group never claims three environments", () => {
+    renderWithProviders(
+      <SuiteResultsSplit
+        suite={contextSuite}
+        cases={[]}
+        runs={oneEnvironmentThreeRuns}
+        allIterations={[]}
+        hostNamesById={new Map()}
+        allRunsPane={<div />}
+        onTestCaseClick={vi.fn()}
+        onRunClick={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByText(/3 environments/)).not.toBeInTheDocument();
+    // One context ⇒ its NAME, plus the RANGE its runs spanned. Never one
+    // arbitrary revision.
+    expect(screen.getByText("Staging · rev 2–4")).toBeInTheDocument();
+    expect(screen.queryByText(/rev 3$/)).not.toBeInTheDocument();
   });
 });
 

--- a/mcpjam-inspector/client/src/components/evals/__tests__/run-context-identity.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/run-context-identity.test.tsx
@@ -1,0 +1,340 @@
+/**
+ * Environment-first run identity (Project Environments, Phase 3).
+ *
+ * The results surfaces used to key and label every run by `namedHostId`, so
+ * two environments resolving to the same host were indistinguishable and an
+ * environment run was labelled by its host. These tests pin the replacement
+ * semantics:
+ *
+ *   - the grouping key is the ENVIRONMENT ID, never the revision (an
+ *     environment is live-editable, so every edit bumps the revision — keying
+ *     on it would shatter a suite's history into singletons);
+ *   - the exact revision belongs on an individual RUN row;
+ *   - a group header never claims one arbitrary revision;
+ *   - legacy runs with no `environmentRef` keep today's host label.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { renderWithProviders, screen } from "@/test";
+import {
+  hasEnvironmentRun,
+  runContextKey,
+  runContextKeys,
+  runContextLabel,
+  runContextRevisionSummary,
+  runRevisionLabel,
+  getEnvironmentConflictMessage,
+} from "../helpers";
+import { resolveCaseRunBatchHost } from "../runs/group-case-iterations";
+import { SuiteRunsList } from "../suite-runs-list";
+import type { EvalIteration, EvalSuiteRun } from "../types";
+
+// The chips are flag-gated exactly like the run-detail "Environment" row.
+// Flag ON is the state under test; the OFF path is asserted separately below
+// via the pure helpers, which are never gated.
+vi.mock("@/hooks/useProjectEnvironmentsEnabled", () => ({
+  useProjectEnvironmentsEnabled: () => true,
+  useProjectEnvironmentsEnabledState: () => true,
+  PROJECT_ENVIRONMENTS_FEATURE_FLAG: "project-environments-enabled",
+}));
+
+function envRun(
+  id: string,
+  environmentId: string,
+  name: string,
+  revision: number,
+  overrides: Partial<EvalSuiteRun> = {}
+): EvalSuiteRun {
+  return {
+    _id: id,
+    suiteId: "suite-1",
+    createdBy: "user-1",
+    runNumber: 1,
+    configRevision: "1",
+    configSnapshot: {
+      tests: [],
+      // NOTE: `environment.servers` is the unrelated legacy server-name bag —
+      // it must never be read as environment identity.
+      environment: { servers: ["server-1"] },
+      environmentRef: { environmentId, name, revision },
+    },
+    status: "completed",
+    result: "passed",
+    createdAt: 1_000,
+    completedAt: 2_000,
+    summary: { total: 1, passed: 1, failed: 0, passRate: 100 },
+    ...overrides,
+  } as EvalSuiteRun;
+}
+
+function hostRun(
+  id: string,
+  namedHostId: string | undefined,
+  overrides: Partial<EvalSuiteRun> = {}
+): EvalSuiteRun {
+  return {
+    _id: id,
+    suiteId: "suite-1",
+    createdBy: "user-1",
+    runNumber: 1,
+    configRevision: "1",
+    configSnapshot: { tests: [], environment: { servers: ["server-1"] } },
+    status: "completed",
+    result: "passed",
+    createdAt: 1_000,
+    completedAt: 2_000,
+    summary: { total: 1, passed: 1, failed: 0, passRate: 100 },
+    ...(namedHostId ? { namedHostId } : {}),
+    ...overrides,
+  } as EvalSuiteRun;
+}
+
+describe("runContextKey", () => {
+  it("keys an environment run by environment id, NOT by revision", () => {
+    const rev1 = envRun("r1", "env-a", "Staging", 1);
+    const rev9 = envRun("r2", "env-a", "Staging", 9);
+    expect(runContextKey(rev1)).toBe("environment:env-a");
+    expect(runContextKey(rev9)).toBe("environment:env-a");
+    expect(runContextKey(rev1)).toBe(runContextKey(rev9));
+  });
+
+  it("keeps ONE group for one environment across several revisions", () => {
+    const runs = [
+      envRun("r1", "env-a", "Staging", 1),
+      envRun("r2", "env-a", "Staging", 2),
+      envRun("r3", "env-a", "Staging", 7),
+    ];
+    expect(runContextKeys(runs)).toEqual(["environment:env-a"]);
+  });
+
+  it("keeps two environments that resolve to the SAME host in SEPARATE groups", () => {
+    // Both environments point at host-claude; only the environment id differs.
+    const runs = [
+      envRun("r1", "env-a", "Staging", 3, { namedHostId: "host-claude" }),
+      envRun("r2", "env-b", "Prod", 3, { namedHostId: "host-claude" }),
+    ];
+    expect(runContextKeys(runs)).toEqual([
+      "environment:env-a",
+      "environment:env-b",
+    ]);
+    expect(runContextKeys(runs)).toHaveLength(2);
+  });
+
+  it("falls back to namedHostId for legacy runs, and to a stable sentinel with neither", () => {
+    expect(runContextKey(hostRun("r1", "host-claude"))).toBe(
+      "host:host-claude"
+    );
+    expect(runContextKey(hostRun("r2", undefined))).toBe("host:none");
+  });
+
+  it("does not conflate a host-keyed run with an environment-keyed one", () => {
+    expect(runContextKey(hostRun("r1", "host-claude"))).not.toBe(
+      runContextKey(envRun("r2", "host-claude", "Staging", 1))
+    );
+  });
+});
+
+describe("runContextLabel / runRevisionLabel", () => {
+  it("labels an environment run by its frozen environment name", () => {
+    expect(runContextLabel(envRun("r1", "env-a", "Staging", 4))).toBe(
+      "Staging"
+    );
+  });
+
+  it("labels a legacy run by the resolved host name", () => {
+    const names = new Map<string, string | null>([["host-claude", "Claude"]]);
+    expect(runContextLabel(hostRun("r1", "host-claude"), names)).toBe("Claude");
+  });
+
+  it("falls back to a truncated host id when the host name is unresolvable", () => {
+    // Unattached / deleted host: not in the map, and a `null` entry must fall
+    // through too (Map.get returning null is not "no name available").
+    expect(runContextLabel(hostRun("r1", "host-claude-0123456789"))).toBe(
+      "host-cla"
+    );
+    expect(
+      runContextLabel(
+        hostRun("r1", "host-claude-0123456789"),
+        new Map([["host-claude-0123456789", null]])
+      )
+    ).toBe("host-cla");
+  });
+
+  it("returns null when a run names neither an environment nor a host", () => {
+    expect(runContextLabel(hostRun("r1", undefined))).toBeNull();
+  });
+
+  it("puts the exact revision on the run — and never on a legacy run", () => {
+    expect(runRevisionLabel(envRun("r1", "env-a", "Staging", 4))).toBe("rev 4");
+    expect(runRevisionLabel(hostRun("r2", "host-claude"))).toBeNull();
+  });
+});
+
+describe("runContextRevisionSummary (group header)", () => {
+  it("never claims one arbitrary revision when the group spans several", () => {
+    const summary = runContextRevisionSummary([
+      envRun("r1", "env-a", "Staging", 2),
+      envRun("r2", "env-a", "Staging", 5),
+      envRun("r3", "env-a", "Staging", 7),
+    ]);
+    expect(summary).toBe("rev 2–7");
+    // Explicitly NOT any single member revision.
+    expect(summary).not.toBe("rev 2");
+    expect(summary).not.toBe("rev 5");
+    expect(summary).not.toBe("rev 7");
+  });
+
+  it("shows a single revision only when every run agrees", () => {
+    expect(
+      runContextRevisionSummary([
+        envRun("r1", "env-a", "Staging", 3),
+        envRun("r2", "env-b", "Prod", 3),
+      ])
+    ).toBe("rev 3");
+  });
+
+  it("is null for a legacy group", () => {
+    expect(
+      runContextRevisionSummary([
+        hostRun("r1", "host-a"),
+        hostRun("r2", "host-b"),
+      ])
+    ).toBeNull();
+    expect(hasEnvironmentRun([hostRun("r1", "host-a")])).toBe(false);
+    expect(hasEnvironmentRun([envRun("r1", "env-a", "Staging", 1)])).toBe(true);
+  });
+});
+
+describe("resolveCaseRunBatchHost (case history)", () => {
+  const batch = { key: "suite:run-1", iterations: [] as EvalIteration[] };
+
+  it("names an environment batch by the environment + its exact revision", () => {
+    const resolved = resolveCaseRunBatchHost(batch, {
+      runsById: new Map([["run-1", envRun("run-1", "env-a", "Staging", 6)]]),
+    });
+    expect(resolved).toEqual({
+      hostName: "Staging",
+      environmentId: "env-a",
+      revisionLabel: "rev 6",
+    });
+  });
+
+  it("prefers the environment over the host the environment resolved to", () => {
+    const resolved = resolveCaseRunBatchHost(batch, {
+      runsById: new Map([
+        [
+          "run-1",
+          envRun("run-1", "env-a", "Staging", 6, {
+            namedHostId: "host-claude",
+          }),
+        ],
+      ]),
+      hostNamesById: new Map([["host-claude", "Claude"]]),
+    });
+    expect(resolved?.hostName).toBe("Staging");
+    expect(resolved?.environmentId).toBe("env-a");
+  });
+
+  it("keeps the legacy host label for a run with no environmentRef", () => {
+    const resolved = resolveCaseRunBatchHost(batch, {
+      runsById: new Map([["run-1", hostRun("run-1", "host-claude")]]),
+      hostNamesById: new Map([["host-claude", "Claude"]]),
+    });
+    expect(resolved).toEqual({ hostId: "host-claude", hostName: "Claude" });
+  });
+
+  it("suppresses environment identity when the kill-switch is off", () => {
+    const resolved = resolveCaseRunBatchHost(batch, {
+      runsById: new Map([
+        [
+          "run-1",
+          envRun("run-1", "env-a", "Staging", 6, {
+            namedHostId: "host-claude",
+          }),
+        ],
+      ]),
+      hostNamesById: new Map([["host-claude", "Claude"]]),
+      projectEnvironmentsEnabled: false,
+    });
+    expect(resolved).toEqual({ hostId: "host-claude", hostName: "Claude" });
+  });
+});
+
+describe("SuiteRunsList mixed host/environment history", () => {
+  it("renders both, each labelled by its own context", () => {
+    renderWithProviders(
+      <SuiteRunsList
+        runs={[
+          envRun("envrun00", "env-a", "Staging", 4, {
+            createdAt: 20_000,
+            completedAt: 21_000,
+          }),
+          hostRun("hostrun0", "host-claude", {
+            createdAt: 10_000,
+            completedAt: 11_000,
+          }),
+        ]}
+        allIterations={[]}
+        hostNamesById={new Map([["host-claude", "Claude"]])}
+        onRunClick={vi.fn()}
+      />
+    );
+
+    // Environment run → environment name + its exact revision.
+    expect(screen.getByText("Staging")).toBeInTheDocument();
+    expect(screen.getByText("rev 4")).toBeInTheDocument();
+    // Legacy run → today's host label, unchanged.
+    expect(screen.getByText("Claude")).toBeInTheDocument();
+  });
+
+  it("labels a multi-environment launch group by its axis, claiming no revision", () => {
+    renderWithProviders(
+      <SuiteRunsList
+        runs={[
+          envRun("grpa0000", "env-a", "Staging", 2, {
+            runGroupId: "g-1",
+            createdAt: 20_000,
+            completedAt: 21_000,
+          }),
+          envRun("grpb0000", "env-b", "Prod", 7, {
+            runGroupId: "g-1",
+            createdAt: 20_100,
+            completedAt: 21_100,
+          }),
+        ]}
+        allIterations={[]}
+        onRunClick={vi.fn()}
+      />
+    );
+
+    const header = screen.getByText(/Run group g/i).closest("button");
+    expect(header).not.toBeNull();
+    // The collapsed group header names the axis only — no revision, and no
+    // single environment standing in for the whole group.
+    expect(header!.textContent).toContain("2 environments");
+    expect(header!.textContent).not.toMatch(/rev \d/);
+  });
+});
+
+describe("getEnvironmentConflictMessage", () => {
+  it("recognises the environment-drift 409 and returns its readable message", () => {
+    const error = Object.assign(
+      new Error("Environment changed — retry the run."),
+      {
+        code: "ENVIRONMENT_REVISION_CONFLICT",
+      }
+    );
+    expect(getEnvironmentConflictMessage(error)).toBe(
+      "Environment changed — retry the run."
+    );
+  });
+
+  it("ignores unrelated failures", () => {
+    expect(getEnvironmentConflictMessage(new Error("boom"))).toBeNull();
+    expect(
+      getEnvironmentConflictMessage(
+        Object.assign(new Error("nope"), { code: "VALIDATION_ERROR" })
+      )
+    ).toBeNull();
+    expect(getEnvironmentConflictMessage(undefined)).toBeNull();
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/__tests__/run-context-kill-switch.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/run-context-kill-switch.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * `project-environments-enabled` OFF — the rollback kill switch.
+ *
+ * The posture these tests pin, and the reason they live in their own file (the
+ * flag is mocked at module scope):
+ *
+ *   - environment NAMES and REVISIONS are gated. With the flag off, no
+ *     environment identity may appear on ANY surface that renders a retained
+ *     historical run — and in particular must not leak back in disguised as a
+ *     host label, which is what happens when a "host" fallback re-derives its
+ *     text from a helper that reads `environmentRef`;
+ *   - the COUNT and the axis NOUN are NOT gated — they leak no identity, and
+ *     gating them made the results rail and the flat runs list disagree about
+ *     the same runs;
+ *   - legacy host-backed runs keep exactly today's host label.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { renderWithProviders, screen } from "@/test";
+import { SuiteRunsList } from "../suite-runs-list";
+import { SuiteResultsSplit } from "../suite-results-split";
+import { CaseRunsHistory } from "../runs/case-runs-history";
+import {
+  contextSuite,
+  envRun,
+  hostRun,
+  oneEnvironmentThreeRuns,
+  twoEnvironmentsOneGroup,
+} from "./run-context-fixtures";
+import type { EvalIteration } from "../types";
+
+vi.mock("@/hooks/useProjectEnvironmentsEnabled", () => ({
+  useProjectEnvironmentsEnabled: () => false,
+  useProjectEnvironmentsEnabledState: () => false,
+  PROJECT_ENVIRONMENTS_FEATURE_FLAG: "project-environments-enabled",
+}));
+
+/** No environment name and no revision, anywhere in the rendered tree. */
+function expectNoEnvironmentIdentity() {
+  expect(screen.queryByText("Staging")).not.toBeInTheDocument();
+  expect(screen.queryByText("Prod")).not.toBeInTheDocument();
+  expect(screen.queryByText(/rev \d/)).not.toBeInTheDocument();
+  expect(document.body.textContent).not.toMatch(/Staging|Prod|rev \d/);
+}
+
+function renderRail(runs = twoEnvironmentsOneGroup) {
+  return renderWithProviders(
+    <SuiteResultsSplit
+      suite={contextSuite}
+      cases={[]}
+      runs={runs}
+      allIterations={[]}
+      hostNamesById={new Map()}
+      allRunsPane={<div />}
+      onTestCaseClick={vi.fn()}
+      onRunClick={vi.fn()}
+    />
+  );
+}
+
+describe("kill switch off — no environment identity renders", () => {
+  it("runs list: an environment-backed run exposes no name and no revision", () => {
+    renderWithProviders(
+      <SuiteRunsList
+        runs={[
+          envRun("envrun00", "env-a", "Staging", 4, {
+            createdAt: 20_000,
+            completedAt: 21_000,
+          }),
+        ]}
+        allIterations={[]}
+        onRunClick={vi.fn()}
+      />
+    );
+
+    // The run still renders — only its environment identity is suppressed.
+    expect(screen.getByText(/envrun00/i)).toBeInTheDocument();
+    expectNoEnvironmentIdentity();
+  });
+
+  it("runs list: a legacy host run keeps today's host label", () => {
+    renderWithProviders(
+      <SuiteRunsList
+        runs={[
+          hostRun("hostrun0", "host-claude", {
+            createdAt: 10_000,
+            completedAt: 11_000,
+          }),
+        ]}
+        allIterations={[]}
+        hostNamesById={new Map([["host-claude", "Claude"]])}
+        onRunClick={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("Claude")).toBeInTheDocument();
+  });
+
+  it("results rail: a group of environment runs names none of them", () => {
+    renderRail();
+    expectNoEnvironmentIdentity();
+  });
+
+  it("case run history: an environment-backed batch names no environment", () => {
+    const iterations = [
+      {
+        _id: "it-1",
+        testCaseId: "case-1",
+        suiteRunId: "envrun00",
+        iterationNumber: 1,
+        result: "passed",
+        createdAt: 1_000,
+        actualToolCalls: [],
+        tokensUsed: 0,
+      },
+    ] as unknown as EvalIteration[];
+
+    renderWithProviders(
+      <CaseRunsHistory
+        iterations={iterations}
+        onSelectIteration={vi.fn()}
+        suiteRuns={[envRun("envrun00", "env-a", "Staging", 4)]}
+      />
+    );
+
+    expectNoEnvironmentIdentity();
+  });
+});
+
+describe("kill switch off — the count and axis noun stay ungated", () => {
+  it("runs list and results rail agree on '2 environments'", () => {
+    const list = renderWithProviders(
+      <SuiteRunsList
+        runs={twoEnvironmentsOneGroup}
+        allIterations={[]}
+        onRunClick={vi.fn()}
+      />
+    );
+    const listHeader = screen.getByText(/Run group g/i).closest("button");
+    expect(listHeader!.textContent).toContain("2 environments");
+    list.unmount();
+
+    renderRail();
+    // Identical wording on the rail: gating the noun on one surface but not
+    // the other made the kill switch produce two answers for one dataset.
+    expect(screen.getByText("2 environments")).toBeInTheDocument();
+  });
+
+  it("counts CONTEXTS, so one environment re-run three times stays '1 environment'", () => {
+    const list = renderWithProviders(
+      <SuiteRunsList
+        runs={oneEnvironmentThreeRuns}
+        allIterations={[]}
+        onRunClick={vi.fn()}
+      />
+    );
+    const listHeader = screen.getByText(/Run group g/i).closest("button");
+    expect(listHeader!.textContent).toContain("1 environment");
+    expect(listHeader!.textContent).not.toContain("3 environments");
+    list.unmount();
+
+    renderRail(oneEnvironmentThreeRuns);
+    expect(screen.getByText("1 environment")).toBeInTheDocument();
+    expect(screen.queryByText(/3 environments/)).not.toBeInTheDocument();
+    // …and with the flag off the single context is still not NAMED.
+    expectNoEnvironmentIdentity();
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/__tests__/use-eval-handlers.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/use-eval-handlers.test.ts
@@ -812,6 +812,67 @@ describe("useEvalHandlers", () => {
       expect(body.runGroupId).toBeUndefined();
       expect(body.namedHostId).toBe("host-mcpjam");
     });
+
+    it("surfaces an environment-drift 409 carried by a LATER plan when every plan fails", async () => {
+      // The drift 409 is the retry-able, actionable cause. Selecting
+      // `failures[0]` blind buries it behind whichever generic error happened
+      // to come first — the partial-failure branch already prefers the
+      // conflict, and the all-failed branch must agree.
+      mockAuthFetch.mockImplementation(
+        async (path: string, init: { body: string }) => {
+          if (path !== "/api/mcp/evals/run") {
+            return createFetchResponse({ success: true });
+          }
+          const body = JSON.parse(init.body);
+          return body.namedHostId === "host-claude"
+            ? createFetchResponse(
+                {
+                  code: "ENVIRONMENT_REVISION_CONFLICT",
+                  message: "Environment changed — retry the run.",
+                },
+                409,
+              )
+            : createFetchResponse({ message: "Upstream exploded" }, 500);
+        },
+      );
+
+      const { result } = renderHook(() =>
+        useEvalHandlers({
+          ...defaultProps,
+          connectedServerNames: new Set(["server-a", "server-b"]),
+        }),
+      );
+
+      await act(async () => {
+        await result.current.handleRerun({
+          _id: "suite-all-failed",
+          name: "Multi-host suite",
+          environment: { servers: ["server-a", "server-b"] },
+          hostAttachments: [
+            // Ordered so the conflict is NOT `failures[0]`.
+            {
+              namedHostId: "host-mcpjam",
+              hostName: "MCPJam",
+              enabledOptionalServerIds: [],
+              resolvedServerNames: ["server-a"],
+            },
+            {
+              namedHostId: "host-claude",
+              hostName: "Claude",
+              enabledOptionalServerIds: [],
+              resolvedServerNames: ["server-b"],
+            },
+          ],
+        } as any);
+      });
+
+      const errorToasts = vi
+        .mocked(toast.error)
+        .mock.calls.map((call) => String(call[0]))
+        .join(" | ");
+      expect(errorToasts).toContain("Environment changed — retry the run.");
+      expect(errorToasts).not.toContain("Upstream exploded");
+    });
   });
 
   describe("handleRunTestCase", () => {

--- a/mcpjam-inspector/client/src/components/evals/helpers.ts
+++ b/mcpjam-inspector/client/src/components/evals/helpers.ts
@@ -210,6 +210,133 @@ export function formatRunId(runId: string): string {
   return runId.substring(0, 8);
 }
 
+// ─── Run execution context (Project Environments, Phase 3) ───────────────────
+
+/**
+ * The launch provenance the context helpers below read. Structurally narrower
+ * than `EvalSuiteRun` on purpose: case-history and rail code carries partial
+ * run rows, and every call site only ever needs these two fields.
+ *
+ * NOTE `configSnapshot.environment` (the flat `{ servers }` bag) is a THIRD,
+ * unrelated meaning of the word "environment" — a raw server-name list. It is
+ * deliberately not read here; only `configSnapshot.environmentRef` identifies
+ * a Project Environment.
+ */
+export type RunContextSource = {
+  namedHostId?: string;
+  configSnapshot?: {
+    environmentRef?: {
+      environmentId: string;
+      name: string;
+      revision: number;
+    };
+  };
+};
+
+/** The Project Environment this run resolved at start, or `null` (legacy run). */
+export function runEnvironmentRef(
+  run: RunContextSource,
+): NonNullable<
+  NonNullable<RunContextSource["configSnapshot"]>["environmentRef"]
+> | null {
+  return run.configSnapshot?.environmentRef ?? null;
+}
+
+/**
+ * Canonical identity for "which context produced this run" — the unit every
+ * user-visible run grouping/labelling keys on.
+ *
+ * Keyed by the environment ID, **never** the revision. An environment is
+ * live-editable, so every edit bumps `revision`; keying on it would shatter a
+ * suite's history into singletons on each edit. Two environments that resolve
+ * to the SAME host stay distinct because the ids differ. Legacy/host-backed
+ * runs key on `namedHostId` exactly as before.
+ *
+ * This is NOT the host dimension: cross-host comparison code that deliberately
+ * compares resolved hosts must keep using `namedHostId`.
+ */
+export function runContextKey(run: RunContextSource): string {
+  const ref = runEnvironmentRef(run);
+  return ref
+    ? `environment:${ref.environmentId}`
+    : `host:${run.namedHostId ?? "none"}`;
+}
+
+/**
+ * Display name for a run's context: the environment name for environment-backed
+ * runs, the resolved host name (falling back to a truncated id) for legacy runs.
+ * `null` when the run names neither — the caller decides what to show instead.
+ */
+export function runContextLabel(
+  run: RunContextSource,
+  hostNamesById?: Map<string, string | null>,
+): string | null {
+  const ref = runEnvironmentRef(run);
+  if (ref) return ref.name;
+  if (!run.namedHostId) return null;
+  return hostNamesById?.get(run.namedHostId) ?? formatRunId(run.namedHostId);
+}
+
+/**
+ * The exact revision this run pinned, e.g. `"rev 4"`. Belongs on an individual
+ * RUN row only — a group header spans many revisions and must never claim one
+ * arbitrary revision of them.
+ */
+export function runRevisionLabel(run: RunContextSource): string | null {
+  const ref = runEnvironmentRef(run);
+  return ref ? `rev ${ref.revision}` : null;
+}
+
+/** Distinct context keys across a set of runs, in first-seen order. */
+export function runContextKeys(runs: RunContextSource[]): string[] {
+  const seen = new Set<string>();
+  const keys: string[] = [];
+  for (const run of runs) {
+    const key = runContextKey(run);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    keys.push(key);
+  }
+  return keys;
+}
+
+/** True when any run in the set launched against a Project Environment. */
+export function hasEnvironmentRun(runs: RunContextSource[]): boolean {
+  return runs.some((run) => runEnvironmentRef(run) !== null);
+}
+
+/**
+ * Group-level revision summary — a RANGE or count, never a single arbitrary
+ * revision. `"rev 4"` only when every environment run in the group agrees;
+ * `"rev 2–7"` when they span. `null` when the group has no environment runs.
+ */
+export function runContextRevisionSummary(
+  runs: RunContextSource[],
+): string | null {
+  const revisions = runs
+    .map((run) => runEnvironmentRef(run)?.revision)
+    .filter((revision): revision is number => typeof revision === "number");
+  if (revisions.length === 0) return null;
+  const min = Math.min(...revisions);
+  const max = Math.max(...revisions);
+  return min === max ? `rev ${min}` : `rev ${min}–${max}`;
+}
+
+/**
+ * The launch-time environment-drift 409 (`ENVIRONMENT_REVISION_CONFLICT`),
+ * distinguished from a generic run failure so the retry-able cause is visible.
+ * Returns the server's readable message ("Environment changed — retry the run.")
+ * or `null` when this isn't a drift conflict.
+ */
+export function getEnvironmentConflictMessage(error: unknown): string | null {
+  const code = (error as { code?: unknown } | null | undefined)?.code;
+  if (code !== "ENVIRONMENT_REVISION_CONFLICT") return null;
+  const message = error instanceof Error ? error.message : null;
+  return message && message.length > 0
+    ? message
+    : "Environment changed since the suite was configured — retry the run.";
+}
+
 /**
  * Compute summary statistics for a list of iterations
  */

--- a/mcpjam-inspector/client/src/components/evals/helpers.ts
+++ b/mcpjam-inspector/client/src/components/evals/helpers.ts
@@ -263,9 +263,30 @@ export function runContextKey(run: RunContextSource): string {
 }
 
 /**
+ * The run's resolved HOST name only — never its environment name. Falls back to
+ * a truncated host id, and returns `null` when the run names no host.
+ *
+ * This is the branch the `project-environments-enabled` kill-switch falls back
+ * to. An environment-backed run carries no `namedHostId`, so with the flag off
+ * it yields `null` here and the caller shows a neutral placeholder rather than
+ * leaking the environment name through a host-shaped chip.
+ */
+export function runHostLabel(
+  run: RunContextSource,
+  hostNamesById?: Map<string, string | null>,
+): string | null {
+  if (!run.namedHostId) return null;
+  return hostNamesById?.get(run.namedHostId) ?? formatRunId(run.namedHostId);
+}
+
+/**
  * Display name for a run's context: the environment name for environment-backed
  * runs, the resolved host name (falling back to a truncated id) for legacy runs.
  * `null` when the run names neither — the caller decides what to show instead.
+ *
+ * This CAN return environment identity, so every call site must sit behind
+ * `project-environments-enabled`; the flag-off branch uses
+ * {@link runHostLabel} instead.
  */
 export function runContextLabel(
   run: RunContextSource,
@@ -273,8 +294,7 @@ export function runContextLabel(
 ): string | null {
   const ref = runEnvironmentRef(run);
   if (ref) return ref.name;
-  if (!run.namedHostId) return null;
-  return hostNamesById?.get(run.namedHostId) ?? formatRunId(run.namedHostId);
+  return runHostLabel(run, hostNamesById);
 }
 
 /**

--- a/mcpjam-inspector/client/src/components/evals/run-context-chip.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-context-chip.tsx
@@ -1,0 +1,61 @@
+/**
+ * One chip naming the CONTEXT a run executed against (Project Environments,
+ * Phase 3). An environment-backed run shows the environment name plus its
+ * exact pinned revision; a legacy/host-backed run keeps today's `HostChip`
+ * unchanged.
+ *
+ * Flag-gated identically to the run-detail "Environment" row: the rollback
+ * kill-switch hides environment names/revisions on retained historical runs
+ * too, falling back to the host rendering.
+ */
+import { cn } from "@/lib/utils";
+import { HostChip } from "@/components/hosts/host-chip";
+import { useProjectEnvironmentsEnabled } from "@/hooks/useProjectEnvironmentsEnabled";
+import {
+  runEnvironmentRef,
+  runContextLabel,
+  runRevisionLabel,
+  type RunContextSource,
+} from "./helpers";
+
+export function RunContextChip({
+  run,
+  hostNamesById,
+  fallbackName,
+  className,
+}: {
+  run: RunContextSource;
+  /** namedHostId → display name, for legacy host-backed runs. */
+  hostNamesById?: Map<string, string | null>;
+  /** Shown when the run names neither an environment nor a host. */
+  fallbackName?: string | null;
+  className?: string;
+}) {
+  const projectEnvironmentsEnabled = useProjectEnvironmentsEnabled();
+  const environmentRef = projectEnvironmentsEnabled
+    ? runEnvironmentRef(run)
+    : null;
+
+  if (environmentRef) {
+    return (
+      <span
+        className={cn(
+          "inline-flex shrink-0 items-center gap-1.5 rounded-md border border-border/60 px-2 py-0.5 text-xs",
+          className
+        )}
+        title={`${environmentRef.name} · ${environmentRef.environmentId}`}
+      >
+        <span className="truncate text-foreground">{environmentRef.name}</span>
+        <span className="shrink-0 font-mono text-[10px] text-muted-foreground">
+          {runRevisionLabel(run)}
+        </span>
+      </span>
+    );
+  }
+
+  const name = runContextLabel(run, hostNamesById) ?? fallbackName;
+  if (!name) return null;
+  return (
+    <HostChip name={name} hostId={run.namedHostId} className={className} />
+  );
+}

--- a/mcpjam-inspector/client/src/components/evals/run-context-chip.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-context-chip.tsx
@@ -6,17 +6,59 @@
  *
  * Flag-gated identically to the run-detail "Environment" row: the rollback
  * kill-switch hides environment names/revisions on retained historical runs
- * too, falling back to the host rendering.
+ * too. With the flag off this chip is HOST-ONLY — an environment run (which
+ * carries no `namedHostId`) falls through to the caller's neutral
+ * `fallbackName`, never to the environment name wearing a host chip.
  */
 import { cn } from "@/lib/utils";
 import { HostChip } from "@/components/hosts/host-chip";
 import { useProjectEnvironmentsEnabled } from "@/hooks/useProjectEnvironmentsEnabled";
 import {
   runEnvironmentRef,
-  runContextLabel,
+  runHostLabel,
   runRevisionLabel,
   type RunContextSource,
 } from "./helpers";
+
+/**
+ * The environment chip's presentation, shared by {@link RunContextChip} and the
+ * case-run history batch header so the two cannot drift. Renders environment
+ * identity unconditionally — every caller must have already checked the
+ * `project-environments-enabled` flag.
+ */
+export function EnvironmentChip({
+  name,
+  environmentId,
+  revisionLabel,
+  className,
+  nameClassName,
+}: {
+  name: string;
+  environmentId: string;
+  /** The exact revision this run pinned, e.g. `"rev 4"`. */
+  revisionLabel?: string | null;
+  className?: string;
+  nameClassName?: string;
+}) {
+  return (
+    <span
+      className={cn(
+        "inline-flex shrink-0 items-center gap-1.5 rounded-md border border-border/60 px-2 py-0.5 text-xs",
+        className
+      )}
+      title={`${name} · ${environmentId}`}
+    >
+      <span className={cn("truncate text-foreground", nameClassName)}>
+        {name}
+      </span>
+      {revisionLabel ? (
+        <span className="shrink-0 font-mono text-[10px] text-muted-foreground">
+          {revisionLabel}
+        </span>
+      ) : null}
+    </span>
+  );
+}
 
 export function RunContextChip({
   run,
@@ -38,22 +80,20 @@ export function RunContextChip({
 
   if (environmentRef) {
     return (
-      <span
-        className={cn(
-          "inline-flex shrink-0 items-center gap-1.5 rounded-md border border-border/60 px-2 py-0.5 text-xs",
-          className
-        )}
-        title={`${environmentRef.name} · ${environmentRef.environmentId}`}
-      >
-        <span className="truncate text-foreground">{environmentRef.name}</span>
-        <span className="shrink-0 font-mono text-[10px] text-muted-foreground">
-          {runRevisionLabel(run)}
-        </span>
-      </span>
+      <EnvironmentChip
+        name={environmentRef.name}
+        environmentId={environmentRef.environmentId}
+        revisionLabel={runRevisionLabel(run)}
+        className={className}
+      />
     );
   }
 
-  const name = runContextLabel(run, hostNamesById) ?? fallbackName;
+  // The legacy/host branch — and where the kill-switch lands. Deliberately
+  // `runHostLabel` and NOT `runContextLabel`: the latter re-derives the
+  // environment name internally, which would put environment identity back on
+  // screen (mislabelled as a host) with the flag off.
+  const name = runHostLabel(run, hostNamesById) ?? fallbackName;
   if (!name) return null;
   return (
     <HostChip name={name} hostId={run.namedHostId} className={className} />

--- a/mcpjam-inspector/client/src/components/evals/run-detail-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-detail-view.tsx
@@ -709,13 +709,12 @@ export function RunDetailView({
           </div>
         )}
 
-      {runClient && !showAccuracyHero && !embeddedInResultsSplit ? (
-        <div className="mb-4 flex flex-wrap items-center gap-2">
-          <span className={runDetailMetaLabelClass}>Client</span>
-          <HostChip name={runClient.displayName} hostId={runClient.hostId} />
-        </div>
-      ) : null}
-
+      {/* Run IDENTITY, in precedence order. When the run launched from a
+          project environment, the ENVIRONMENT is what produced it — the host
+          below is a detail of how the environment resolved, not the run's
+          identity. Two environments can resolve to the same host, so the host
+          alone cannot name the run. `rev N` is the exact revision THIS run
+          pinned; grouping elsewhere keys on the environment id, never this. */}
       {runProjectEnvironmentRef ? (
         <div className="mb-4 flex flex-wrap items-center gap-2">
           <span className={runDetailMetaLabelClass}>Environment</span>
@@ -730,6 +729,13 @@ export function RunDetailView({
               rev {runProjectEnvironmentRef.revision}
             </span>
           </span>
+        </div>
+      ) : null}
+
+      {runClient && !showAccuracyHero && !embeddedInResultsSplit ? (
+        <div className="mb-4 flex flex-wrap items-center gap-2">
+          <span className={runDetailMetaLabelClass}>Client</span>
+          <HostChip name={runClient.displayName} hostId={runClient.hostId} />
         </div>
       ) : null}
 

--- a/mcpjam-inspector/client/src/components/evals/runs/case-runs-history.tsx
+++ b/mcpjam-inspector/client/src/components/evals/runs/case-runs-history.tsx
@@ -9,6 +9,7 @@ import { useMemo, useState } from "react";
 import { ChevronDown, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { HostChip } from "@/components/hosts/host-chip";
+import { useProjectEnvironmentsEnabled } from "@/hooks/useProjectEnvironmentsEnabled";
 import { CaseMetricStrip } from "../case-metric-strip";
 import { computeIterationResult } from "../pass-criteria";
 import {
@@ -64,6 +65,7 @@ function RunBatchGroup({
   hostNamesById,
   defaultHostLabel,
   hasHostAttachments,
+  projectEnvironmentsEnabled,
 }: {
   batch: CaseRunBatch;
   expanded: boolean;
@@ -74,12 +76,14 @@ function RunBatchGroup({
   hostNamesById?: Map<string, string | null>;
   defaultHostLabel?: string | null;
   hasHostAttachments?: boolean;
+  projectEnvironmentsEnabled?: boolean;
 }) {
   const batchHost = resolveCaseRunBatchHost(batch, {
     runsById,
     hostNamesById,
     defaultHostLabel,
     hasHostAttachments,
+    projectEnvironmentsEnabled,
   });
   const total = batch.iterations.length;
   const decided = batch.iterations.filter((i) => {
@@ -138,7 +142,23 @@ function RunBatchGroup({
         <span className="text-[12px] text-muted-foreground">
           {formatTimeAgo(batch.createdAt)}
         </span>
-        {batchHost ? (
+        {batchHost?.environmentId ? (
+          // Environment-backed batch: the environment NAMES the batch, and the
+          // exact revision this one run pinned rides alongside it.
+          <span
+            className="inline-flex shrink-0 items-center gap-1.5 rounded-md border border-border/60 px-2 py-0.5 text-[10px]"
+            title={`${batchHost.hostName} · ${batchHost.environmentId}`}
+          >
+            <span className="max-w-[120px] truncate text-foreground">
+              {batchHost.hostName}
+            </span>
+            {batchHost.revisionLabel ? (
+              <span className="shrink-0 font-mono text-[10px] text-muted-foreground">
+                {batchHost.revisionLabel}
+              </span>
+            ) : null}
+          </span>
+        ) : batchHost ? (
           <HostChip
             name={batchHost.hostName}
             hostId={batchHost.hostId}
@@ -231,6 +251,7 @@ export function CaseRunsHistory({
   defaultHostLabel?: string | null;
   hasHostAttachments?: boolean;
 }) {
+  const projectEnvironmentsEnabled = useProjectEnvironmentsEnabled();
   const batches = useMemo(() => groupCaseIterations(iterations), [iterations]);
   const runsById = useMemo(
     () => new Map(suiteRuns.map((run) => [run._id, run])),
@@ -274,6 +295,7 @@ export function CaseRunsHistory({
             hostNamesById={hostNamesById}
             defaultHostLabel={defaultHostLabel}
             hasHostAttachments={hasHostAttachments}
+            projectEnvironmentsEnabled={projectEnvironmentsEnabled}
           />
         ))}
       </div>

--- a/mcpjam-inspector/client/src/components/evals/runs/case-runs-history.tsx
+++ b/mcpjam-inspector/client/src/components/evals/runs/case-runs-history.tsx
@@ -10,6 +10,7 @@ import { ChevronDown, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { HostChip } from "@/components/hosts/host-chip";
 import { useProjectEnvironmentsEnabled } from "@/hooks/useProjectEnvironmentsEnabled";
+import { EnvironmentChip } from "../run-context-chip";
 import { CaseMetricStrip } from "../case-metric-strip";
 import { computeIterationResult } from "../pass-criteria";
 import {
@@ -144,20 +145,17 @@ function RunBatchGroup({
         </span>
         {batchHost?.environmentId ? (
           // Environment-backed batch: the environment NAMES the batch, and the
-          // exact revision this one run pinned rides alongside it.
-          <span
-            className="inline-flex shrink-0 items-center gap-1.5 rounded-md border border-border/60 px-2 py-0.5 text-[10px]"
-            title={`${batchHost.hostName} · ${batchHost.environmentId}`}
-          >
-            <span className="max-w-[120px] truncate text-foreground">
-              {batchHost.hostName}
-            </span>
-            {batchHost.revisionLabel ? (
-              <span className="shrink-0 font-mono text-[10px] text-muted-foreground">
-                {batchHost.revisionLabel}
-              </span>
-            ) : null}
-          </span>
+          // exact revision this one run pinned rides alongside it. Shares
+          // `EnvironmentChip` with `RunContextChip` so the two renderings of
+          // environment identity cannot drift. `resolveCaseRunBatchHost` has
+          // already applied the kill-switch, so reaching here means it is on.
+          <EnvironmentChip
+            name={batchHost.hostName}
+            environmentId={batchHost.environmentId}
+            revisionLabel={batchHost.revisionLabel}
+            className="text-[10px]"
+            nameClassName="max-w-[120px]"
+          />
         ) : batchHost ? (
           <HostChip
             name={batchHost.hostName}

--- a/mcpjam-inspector/client/src/components/evals/runs/group-case-iterations.ts
+++ b/mcpjam-inspector/client/src/components/evals/runs/group-case-iterations.ts
@@ -10,7 +10,12 @@
  * Batches are newest-first (by latest iteration createdAt); iterations within a
  * batch are ordered by `iterationNumber` (falling back to createdAt).
  */
-import { formatRunId } from "../helpers";
+import {
+  formatRunId,
+  runEnvironmentRef,
+  runRevisionLabel,
+  type RunContextSource,
+} from "../helpers";
 import type { EvalIteration } from "../types";
 
 export interface CaseRunBatch {
@@ -60,9 +65,20 @@ export function caseRunBatchTrigger(
   return batch.key.startsWith("suite:") ? "suite" : "quick";
 }
 
+/**
+ * Which CONTEXT produced a run batch. Named `…Host` for continuity, but the
+ * identity is the run's execution context: a project environment when the
+ * parent run carries `configSnapshot.environmentRef`, otherwise the legacy
+ * host. Two environments sharing a host stay distinct here because
+ * `environmentId` differs.
+ */
 export type CaseRunBatchHost = {
   hostId?: string;
   hostName: string;
+  /** Set only for environment-backed batches; the grouping identity. */
+  environmentId?: string;
+  /** The exact revision this batch's run pinned, e.g. `"rev 4"`. */
+  revisionLabel?: string;
 };
 
 /** Parse the suite run id embedded in a batch key (`suite:<id>`). */
@@ -73,19 +89,27 @@ export function suiteRunIdFromBatchKey(key: string): string | null {
 }
 
 /**
- * Resolve which host produced a run batch, when we can do so confidently.
+ * Resolve which CONTEXT produced a run batch, when we can do so confidently.
  *
- * - Suite batches: read `namedHostId` from the parent suite run.
+ * - Suite batches launched from a project environment: the environment's frozen
+ *   name + the exact revision the run pinned. Takes precedence over the host —
+ *   an environment run carries no `namedHostId`, and two environments resolving
+ *   to the same host must not collapse into one label.
+ * - Suite batches (legacy): read `namedHostId` from the parent suite run.
  * - Attachment-less suites: fall back to the suite's default host label.
  * - Quick runs on multi-host suites: omitted (no durable host stamp on iterations).
+ *
+ * `projectEnvironmentsEnabled` mirrors the run-detail kill-switch: with it off,
+ * environment identity is suppressed and the legacy host path applies.
  */
 export function resolveCaseRunBatchHost(
   batch: Pick<CaseRunBatch, "key" | "iterations">,
   options: {
-    runsById?: Map<string, { namedHostId?: string }>;
+    runsById?: Map<string, RunContextSource>;
     hostNamesById?: Map<string, string | null>;
     defaultHostLabel?: string | null;
     hasHostAttachments?: boolean;
+    projectEnvironmentsEnabled?: boolean;
   } = {},
 ): CaseRunBatchHost | null {
   const {
@@ -93,11 +117,21 @@ export function resolveCaseRunBatchHost(
     hostNamesById,
     defaultHostLabel,
     hasHostAttachments = false,
+    projectEnvironmentsEnabled = true,
   } = options;
 
   const suiteRunId = suiteRunIdFromBatchKey(batch.key);
   if (suiteRunId && runsById) {
     const run = runsById.get(suiteRunId);
+    const environmentRef =
+      run && projectEnvironmentsEnabled ? runEnvironmentRef(run) : null;
+    if (run && environmentRef) {
+      return {
+        hostName: environmentRef.name,
+        environmentId: environmentRef.environmentId,
+        revisionLabel: runRevisionLabel(run) ?? undefined,
+      };
+    }
     if (run?.namedHostId) {
       const hostName =
         hostNamesById?.get(run.namedHostId) ?? formatRunId(run.namedHostId);

--- a/mcpjam-inspector/client/src/components/evals/suite-results-split.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-results-split.tsx
@@ -2,10 +2,16 @@
  * Master-detail results surface for a multi-host suite. Replaces the
  * Runs ⟷ Cases tab switcher with one screen:
  *   • Left rail  — the run timeline. The unit is a RUN GROUP (one launch across
- *                  N hosts; child runs share `runGroupId`, differ by
- *                  `namedHostId`). Single-host launches render as standalone
- *                  items. A pinned "All runs" item sits on top, and an optional
- *                  "Monitoring" item at the bottom.
+ *                  N execution CONTEXTS; child runs share `runGroupId` and
+ *                  differ by {@link runContextKey} — a project environment when
+ *                  the run carries `configSnapshot.environmentRef`, otherwise
+ *                  the legacy `namedHostId`). Single-context launches render as
+ *                  standalone items. A pinned "All runs" item sits on top, and
+ *                  an optional "Monitoring" item at the bottom.
+ *
+ *                  A group header never claims one revision: an environment is
+ *                  live-editable, so a group can legitimately span several. The
+ *                  exact revision lives on the individual run row.
  *   • Right pane — scoped to the selection, all sharing one case×host matrix:
  *       · "All runs"  → `CrossHostDashboard` across every run (latest per host
  *                       + historical columns). Falls back to the authoring case
@@ -43,10 +49,18 @@ import {
   DialogTitle,
 } from "@mcpjam/design-system/dialog";
 import { cn } from "@/lib/utils";
-import { HostChip } from "@/components/hosts/host-chip";
+import { RunContextChip } from "./run-context-chip";
 import type { EvalCase, EvalIteration, EvalSuite, EvalSuiteRun } from "./types";
 import { computeRunEffectiveStats } from "./suite-runs-list";
-import { formatRelativeTime, formatRunId } from "./helpers";
+import {
+  formatRelativeTime,
+  formatRunId,
+  hasEnvironmentRun,
+  runContextKeys,
+  runContextLabel,
+  runContextRevisionSummary,
+} from "./helpers";
+import { useProjectEnvironmentsEnabled } from "@/hooks/useProjectEnvironmentsEnabled";
 import { CrossHostDashboard } from "./cross-host/cross-host-dashboard";
 import { GroupCrossHostDashboard } from "./group-cross-host-dashboard";
 import {
@@ -121,7 +135,19 @@ type RailGroup = {
   runs: EvalSuiteRun[];
   timestamp: number;
   passRate: number | null;
-  hostCount: number;
+  /**
+   * Distinct execution contexts in the group (environments, or legacy hosts).
+   * Counting `namedHostId` here undercounted environment fan-outs to 1, since
+   * environment runs carry no `namedHostId`.
+   */
+  contextCount: number;
+  /** "environment" when any run in the group is environment-backed. */
+  contextNoun: "environment" | "client";
+  /**
+   * Revision RANGE (or single agreed revision) across the group's environment
+   * runs — never one arbitrary revision. `null` for legacy groups.
+   */
+  revisionSummary: string | null;
 };
 
 const runTimestamp = (r: EvalSuiteRun): number =>
@@ -227,6 +253,31 @@ function PinnedItem({
   );
 }
 
+/**
+ * The rail item's context line. One context ⇒ its NAME (environment name, or
+ * the resolved host name for a legacy run); several ⇒ a count on the right
+ * axis. A revision RANGE may ride along, but the header never claims one
+ * arbitrary revision — that belongs on the individual run row below.
+ *
+ * With the Project Environments kill-switch off this collapses to the
+ * pre-Phase-3 host wording, so retained historical runs leak no env identity.
+ */
+function groupContextSummary(
+  group: RailGroup,
+  hostNamesById: Map<string, string | null>,
+  projectEnvironmentsEnabled: boolean,
+): string {
+  const plural = group.contextCount === 1 ? "" : "s";
+  if (!projectEnvironmentsEnabled) {
+    return `${group.contextCount} client${plural}`;
+  }
+  const countText = `${group.contextCount} ${group.contextNoun}${plural}`;
+  const onlyRun = group.contextCount === 1 ? group.runs[0] : undefined;
+  const base =
+    (onlyRun ? runContextLabel(onlyRun, hostNamesById) : null) ?? countText;
+  return group.revisionSummary ? `${base} · ${group.revisionSummary}` : base;
+}
+
 function RunGroupItem({
   group,
   iterationsByRun,
@@ -261,13 +312,19 @@ function RunGroupItem({
 }) {
   const rate = group.passRate;
   const delta = rate == null || prevPassRate == null ? null : rate - prevPassRate;
+  const projectEnvironmentsEnabled = useProjectEnvironmentsEnabled();
+  const contextSummary = groupContextSummary(
+    group,
+    hostNamesById,
+    projectEnvironmentsEnabled,
+  );
 
   if (collapsed) {
     return (
       <button
         type="button"
         onClick={onSelect}
-        title={`${group.label} · ${rate ?? "—"}% · ${group.hostCount} client${group.hostCount > 1 ? "s" : ""} · ${formatRelativeTime(group.timestamp)}`}
+        title={`${group.label} · ${rate ?? "—"}% · ${contextSummary} · ${formatRelativeTime(group.timestamp)}`}
         className={cn(
           "flex h-9 w-9 items-center justify-center rounded-md transition-colors",
           active ? "bg-primary/10 ring-1 ring-primary/40" : "hover:bg-muted",
@@ -318,8 +375,8 @@ function RunGroupItem({
             )}
           </div>
           <div className="mt-1 flex items-center gap-2">
-            <span className="text-[11px] text-muted-foreground">
-              {group.hostCount} client{group.hostCount > 1 ? "s" : ""}
+            <span className="truncate text-[11px] text-muted-foreground">
+              {contextSummary}
             </span>
             {delta != null && delta !== 0 ? (
               <span
@@ -355,9 +412,6 @@ function RunGroupItem({
         <div className="space-y-0.5 border-t border-border/40 px-2 py-1.5">
           {group.runs.map((run) => {
             const childRate = computeRunEffectiveStats(run, iterationsByRun.get(run._id) ?? []).passRate;
-            const hostName = run.namedHostId
-              ? hostNamesById.get(run.namedHostId) ?? formatRunId(run.namedHostId)
-              : formatRunId(run._id);
             const runActive = selectedRunId === run._id;
             return (
               <div
@@ -373,10 +427,13 @@ function RunGroupItem({
                   className="flex min-w-0 flex-1 items-center justify-between gap-2 px-2 py-1"
                   title={`Open run ${formatRunId(run._id)}`}
                 >
-                  <HostChip
-                    name={hostName}
-                    hostId={run.namedHostId}
-                    className="max-w-[130px] gap-1 px-2 py-0.5 text-[10px] shadow-none"
+                  {/* The RUN row is where the exact environment revision
+                      belongs — the group header above spans all of them. */}
+                  <RunContextChip
+                    run={run}
+                    hostNamesById={hostNamesById}
+                    fallbackName={formatRunId(run._id)}
+                    className="max-w-[170px] gap-1 px-2 py-0.5 text-[10px] shadow-none"
                   />
                   <span className="flex items-center gap-1.5">
                     <span className="font-mono text-[10px] text-muted-foreground">{formatRunId(run._id)}</span>
@@ -535,9 +592,20 @@ export function SuiteResultsSplit({
       }
       return total > 0 ? Math.round((passed / total) * 100) : null;
     };
-    const distinctHosts = (groupRuns: EvalSuiteRun[]): number => {
-      const set = new Set(groupRuns.map((r) => r.namedHostId).filter(Boolean));
-      return set.size || 1;
+    // Distinct execution CONTEXTS, keyed by environment id when the run is
+    // environment-backed. Environment runs carry no `namedHostId`, so the old
+    // `namedHostId` count reported a 3-environment fan-out as "1 client"; and
+    // two environments sharing one host must still count as two.
+    const contextFacts = (groupRuns: EvalSuiteRun[]) => {
+      const count = runContextKeys(groupRuns).length || 1;
+      const noun: RailGroup["contextNoun"] = hasEnvironmentRun(groupRuns)
+        ? "environment"
+        : "client";
+      return {
+        contextCount: count,
+        contextNoun: noun,
+        revisionSummary: runContextRevisionSummary(groupRuns),
+      };
     };
 
     const nodes: RailGroup[] = [];
@@ -554,7 +622,7 @@ export function SuiteResultsSplit({
         runs: sorted,
         timestamp: sorted.reduce((m, r) => Math.max(m, runTimestamp(r)), 0),
         passRate: aggregate(sorted),
-        hostCount: distinctHosts(sorted),
+        ...contextFacts(sorted),
       });
     }
     for (const run of standalones) {
@@ -565,7 +633,7 @@ export function SuiteResultsSplit({
         runs: [run],
         timestamp: runTimestamp(run),
         passRate: aggregate([run]),
-        hostCount: distinctHosts([run]),
+        ...contextFacts([run]),
       });
     }
     return nodes.sort((a, b) => b.timestamp - a.timestamp);
@@ -766,22 +834,18 @@ export function SuiteResultsSplit({
         {/* Compare owns its own header (the pickers). */}
         {view.kind === "run" && selectedRun ? (
           // Slim run-identity header — the run's KPIs live in the shared metric
-          // strip above, so this just names the run + status + host.
+          // strip above, so this just names the run + status + the context it
+          // ran against (environment + revision, or the legacy host).
           <div className="flex items-center gap-2 border-b border-border/60 px-4 py-2.5">
             <span className="font-mono text-sm font-semibold text-foreground">
               Run {formatRunId(selectedRun._id)}
             </span>
             <RunStatusBadge run={selectedRun} />
-            {selectedRun.namedHostId ? (
-              <HostChip
-                name={
-                  hostNamesById.get(selectedRun.namedHostId) ??
-                  formatRunId(selectedRun.namedHostId)
-                }
-                hostId={selectedRun.namedHostId}
-                className="gap-1 px-2 py-0.5 text-[11px] shadow-none"
-              />
-            ) : null}
+            <RunContextChip
+              run={selectedRun}
+              hostNamesById={hostNamesById}
+              className="gap-1 px-2 py-0.5 text-[11px] shadow-none"
+            />
           </div>
         ) : view.kind !== "compare" ? (
           <div className="flex items-center justify-between border-b border-border/60 px-4 py-2.5">

--- a/mcpjam-inspector/client/src/components/evals/suite-results-split.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-results-split.tsx
@@ -59,6 +59,7 @@ import {
   runContextKeys,
   runContextLabel,
   runContextRevisionSummary,
+  runHostLabel,
 } from "./helpers";
 import { useProjectEnvironmentsEnabled } from "@/hooks/useProjectEnvironmentsEnabled";
 import { CrossHostDashboard } from "./cross-host/cross-host-dashboard";
@@ -259,8 +260,11 @@ function PinnedItem({
  * axis. A revision RANGE may ride along, but the header never claims one
  * arbitrary revision — that belongs on the individual run row below.
  *
- * With the Project Environments kill-switch off this collapses to the
- * pre-Phase-3 host wording, so retained historical runs leak no env identity.
+ * The Project Environments kill-switch gates NAMES and REVISIONS only — those
+ * are the environment's identity. The count and the axis NOUN stay ungated
+ * (they leak no identity), which is also what `GroupRunRows` in
+ * suite-runs-list does for the same data; gating the noun here made the rail
+ * and the flat runs list disagree on identical runs.
  */
 function groupContextSummary(
   group: RailGroup,
@@ -268,11 +272,13 @@ function groupContextSummary(
   projectEnvironmentsEnabled: boolean,
 ): string {
   const plural = group.contextCount === 1 ? "" : "s";
-  if (!projectEnvironmentsEnabled) {
-    return `${group.contextCount} client${plural}`;
-  }
   const countText = `${group.contextCount} ${group.contextNoun}${plural}`;
   const onlyRun = group.contextCount === 1 ? group.runs[0] : undefined;
+  if (!projectEnvironmentsEnabled) {
+    // Host-only: a legacy group keeps its host name; an environment group has
+    // none, so it degrades to the bare count rather than naming the env.
+    return (onlyRun ? runHostLabel(onlyRun, hostNamesById) : null) ?? countText;
+  }
   const base =
     (onlyRun ? runContextLabel(onlyRun, hostNamesById) : null) ?? countText;
   return group.revisionSummary ? `${base} · ${group.revisionSummary}` : base;

--- a/mcpjam-inspector/client/src/components/evals/suite-runs-list.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-runs-list.tsx
@@ -18,6 +18,7 @@ import {
   formatRunId,
   formatTime,
   hasEnvironmentRun,
+  runContextKeys,
 } from "./helpers";
 import { computeIterationResult } from "./pass-criteria";
 import type { EvalCase, EvalIteration, EvalSuite, EvalSuiteRun } from "./types";
@@ -522,6 +523,13 @@ function GroupRunRows({
         : [],
     [shouldRenderMatrix, allIterations, groupRunIds],
   );
+  // Distinct execution CONTEXTS in the group, matching the results rail's
+  // `contextCount`. Counting rows instead would report one environment re-run
+  // three times (or fanned out across revisions) as "3 environments" — the
+  // same miscount Phase 3 fixed in `RailGroup.hostCount`.
+  const contextCount = runContextKeys(group.runs).length;
+  const contextNoun = hasEnvironmentRun(group.runs) ? "environment" : "client";
+
   // Per-child effective stats — same source the standalone rows use.
   const childStats = group.runs.map((run) => ({
     run,
@@ -634,8 +642,8 @@ function GroupRunRows({
               several revisions of the same environment, so no revision is
               claimed here. The exact revision lives on each child run row. */}
           <span className="shrink-0 rounded-full border border-border bg-muted/40 px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
-            {group.runs.length}{" "}
-            {hasEnvironmentRun(group.runs) ? "environments" : "clients"}
+            {contextCount} {contextNoun}
+            {contextCount === 1 ? "" : "s"}
           </span>
         </div>
         <div className={RUNS_LIST_METRIC_CELL_CLASS}>

--- a/mcpjam-inspector/client/src/components/evals/suite-runs-list.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-runs-list.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
 import { ChevronDown, ChevronRight } from "lucide-react";
-import { HostChip } from "@/components/hosts/host-chip";
+import { RunContextChip } from "./run-context-chip";
 import { cn, getInitials } from "@/lib/utils";
 import {
   Avatar,
@@ -17,6 +17,7 @@ import {
   formatDuration,
   formatRunId,
   formatTime,
+  hasEnvironmentRun,
 } from "./helpers";
 import { computeIterationResult } from "./pass-criteria";
 import type { EvalCase, EvalIteration, EvalSuite, EvalSuiteRun } from "./types";
@@ -78,9 +79,12 @@ export interface SuiteRunsListProps {
   maxVisibleRuns?: number;
   runsLoading?: boolean;
   /**
-   * Resolves `namedHostId` → display name for runs that were triggered
+   * Resolves `namedHostId` → display name for LEGACY runs that were triggered
    * against a specific attached host. When omitted, host badges show
    * truncated IDs instead. Pass the suite's `hostAttachments` to feed it.
+   *
+   * Environment-backed runs never consult this map — they label from their own
+   * frozen `configSnapshot.environmentRef`.
    */
   hostNamesById?: Map<string, string | null>;
   className?: string;
@@ -377,16 +381,13 @@ function StandaloneRunRow({
               Scheduled
             </span>
           ) : null}
-          {run.namedHostId ? (
-            <HostChip
-              name={
-                hostNamesById?.get(run.namedHostId) ??
-                formatRunId(run.namedHostId)
-              }
-              hostId={run.namedHostId}
-              className="shrink-0 max-w-[140px] gap-1 border-primary/35 bg-primary/10 px-2 py-0.5 text-[10px] text-primary shadow-none"
-            />
-          ) : null}
+          {/* Which CONTEXT produced this run — the environment (name + its
+              exact revision) or, for legacy runs, the resolved host. */}
+          <RunContextChip
+            run={run}
+            hostNamesById={hostNamesById}
+            className="shrink-0 max-w-[180px] gap-1 border-primary/35 bg-primary/10 px-2 py-0.5 text-[10px] text-primary shadow-none"
+          />
           {creator ? (
             <Tooltip>
               <TooltipTrigger asChild>
@@ -629,8 +630,12 @@ function GroupRunRows({
               {groupBadge.label}
             </span>
           ) : null}
+          {/* Names the fan-out AXIS, not any one target — a group can span
+              several revisions of the same environment, so no revision is
+              claimed here. The exact revision lives on each child run row. */}
           <span className="shrink-0 rounded-full border border-border bg-muted/40 px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
-            {group.runs.length} clients
+            {group.runs.length}{" "}
+            {hasEnvironmentRun(group.runs) ? "environments" : "clients"}
           </span>
         </div>
         <div className={RUNS_LIST_METRIC_CELL_CLASS}>

--- a/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
@@ -19,6 +19,7 @@ import { getSuiteReplayEligibility } from "./replay-eligibility";
 import {
   buildSuiteRunPlans,
   getEffectiveSuiteServers,
+  getEnvironmentConflictMessage,
   getSelectedSuiteHostRunPlan,
 } from "./helpers";
 import { useProjectEnvironments } from "@/hooks/useProjectEnvironments";
@@ -850,8 +851,15 @@ export function useEvalHandlers({
                 "(unnamed client)"
             )
             .join(", ");
+          // An environment-drift 409 is retry-able and has a specific cause;
+          // the generic "N of M runs failed" summary buries it, so name it.
+          const conflict = failures
+            .map((failure) => getEnvironmentConflictMessage(failure.reason))
+            .find((message): message is string => message !== null);
           toast.error(
-            `${failures.length} of ${runPlans.length} ${targetNoun} runs failed: ${failedHostNames}`
+            conflict
+              ? `${failures.length} of ${runPlans.length} ${targetNoun} runs failed (${failedHostNames}): ${conflict}`
+              : `${failures.length} of ${runPlans.length} ${targetNoun} runs failed: ${failedHostNames}`
           );
         } else {
           // All failed — surface the first error for actionable detail.
@@ -862,7 +870,10 @@ export function useEvalHandlers({
         }
       } catch (error) {
         console.error("Failed to rerun evals:", error);
-        toast.error(getBillingErrorMessage(error, "Failed to start eval run"));
+        toast.error(
+          getEnvironmentConflictMessage(error) ??
+            getBillingErrorMessage(error, "Failed to start eval run")
+        );
       } finally {
         setRerunningSuiteId(null);
       }

--- a/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
@@ -862,8 +862,15 @@ export function useEvalHandlers({
               : `${failures.length} of ${runPlans.length} ${targetNoun} runs failed: ${failedHostNames}`
           );
         } else {
-          // All failed — surface the first error for actionable detail.
-          const firstError = failures[0]?.reason;
+          // All failed — surface one error for actionable detail. Prefer an
+          // environment-drift 409 wherever it sits in the list, exactly as the
+          // partial-failure branch above does: throwing `failures[0]` blind
+          // would bury a retry-able ENVIRONMENT_REVISION_CONFLICT carried by a
+          // later plan behind whatever generic error happened to come first.
+          const conflictFailure = failures.find(
+            (failure) => getEnvironmentConflictMessage(failure.reason) !== null
+          );
+          const firstError = (conflictFailure ?? failures[0])?.reason;
           throw firstError instanceof Error
             ? firstError
             : new Error(String(firstError ?? `All ${targetNoun} runs failed`));

--- a/mcpjam-inspector/client/src/lib/apis/evals-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/evals-api.ts
@@ -344,7 +344,17 @@ async function postEvalRequest<TResponse>(
           ? limitKind
           : undefined,
     });
-    throw new Error(message);
+    // Carry the route's machine-readable `code` onto the Error. The message
+    // alone can't be branched on (it's prose the server may reword), and the
+    // eval fan-out summarises failures per plan — without this, a launch
+    // rejected by the environment-drift 409
+    // (ENVIRONMENT_REVISION_CONFLICT) is indistinguishable from any other
+    // failure. Purely additive: `message` is unchanged.
+    const error = new Error(message);
+    if (typeof errorBody?.code === "string") {
+      (error as Error & { code?: string }).code = errorBody.code;
+    }
+    throw error;
   }
 
   return body as TResponse;


### PR DESCRIPTION
Eval results identified every run by `namedHostId`. An environment-backed run was therefore labelled by its **host**, and two different environments resolving to the same host were indistinguishable. `environmentRef` was already on the run snapshot but rendered only as a decorative chip.

Client-only. No server or Convex changes.

## The change

Three pure helpers derive a run's identity — `runContextKey`, `runContextLabel`, `runRevisionLabel` — and the user-visible grouping sites use them: the results rail, the runs list, case-run history, and run detail.

**The grouping key is the environment ID, never the revision.** An environment is live-editable, so every edit bumps it; keying on revision would shatter a suite's history into singletons. A group header therefore never claims one arbitrary revision — the exact revision belongs on the run row, and a group summarizes a **range** when its runs span several. There's a test asserting exactly that.

Run detail now puts the Environment block **above** the Client block: the environment is the run's identity, and the resolved host is a detail of how it resolved. The host alone cannot name the run.

## A pre-existing bug this fixes

`RailGroup.hostCount` counted distinct `namedHostId`s — and environment runs carry **none** (`buildSuiteRunPlans` leaves it undefined). So a three-environment fan-out reported **"1 client"**. It now counts distinct contexts and says "3 environments".

## Drift now reads as itself

The backend's `ENVIRONMENT_REVISION_CONFLICT` 409 carried a readable message, but `postEvalRequest` threw a bare `Error` and dropped the structured `code`, so a stale environment surfaced as the opaque *"N of M runs failed: Staging"*. The code is now attached (purely additive — `message` unchanged) and the launch path prefers the conflict message over the generic billing fallback.

## Flag posture

Name and revision exposure stays behind `project-environments-enabled`, matching the kill switch run-detail already had. Counts and the axis noun (`N environments`) are ungated — they leak no identity.

## ⚠️ Not fixed here — worth its own change

`cross-host/use-cross-host-data.ts` builds columns from `suite.hostAttachments` and indexes runs via `run.namedHostId` (~lines 263–291). Environment runs have no `namedHostId`, so they land in **no column** and their iterations are invisible in the CrossHost matrix — **including the "All runs" pane, which is the default results surface for an env-backed suite.**

That's a real gap, and arguably more user-visible than what this PR fixes. I left it deliberately: it's the *"which host?"* question rather than *"which context?"*, and reshaping the matrix axis is a larger change than this phase. Flagging it prominently so it gets its own issue rather than living in a PR body.

## Verification

- `npx vitest run` — **10,152 passed**, 6 skipped, **0 failures** (21 new)
- `tsc -p server/tsconfig.json` — **83 vs. an 83 baseline**, sorted error lists identical
- `npm run typecheck:client` — clean

Tests cover: mixed host/environment history; one environment across several revisions staying **one** group; two environments on the **same host** staying **separate** groups; a legacy run falling back to the host label; and no group header claiming a single arbitrary revision.

Note: one test run showed 11 unhandled teardown errors from the pre-existing `mcp-app-browser-harness` Playwright suite — absent on re-run, zero test failures in all three runs, unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches many user-visible eval surfaces and feature-flag behavior for historical runs; logic is well-tested but incorrect gating could hide or mislabel environment identity.
> 
> **Overview**
> **Environment-first run identity** replaces host-only grouping across eval results: runs with `configSnapshot.environmentRef` are keyed by **environment id** (never revision), labeled with frozen name + **rev N** on each row, and grouped headers show a revision **range** or distinct context counts (`N environments`) instead of counting rows or distinct `namedHostId`s.
> 
> New shared helpers (`runContextKey`, `runContextLabel`, `runRevisionLabel`, etc.) and **`RunContextChip`** / **`EnvironmentChip`** wire this through the results rail, runs list, case-run history, and run-detail header (Environment block moved above Client).
> 
> **`project-environments-enabled` kill-switch:** environment names/revisions are hidden on historical runs without leaking via host fallbacks; context counts and axis nouns stay visible so rail and list stay consistent.
> 
> **Error handling:** `postEvalRequest` preserves API `code` on thrown errors; rerun fan-out prefers **`ENVIRONMENT_REVISION_CONFLICT`** in toasts when all or partial plans fail.
> 
> Extensive Vitest coverage (fixtures, flag on/off suites). Client-only; cross-host matrix column indexing for env runs is explicitly out of scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2da0a7b924510b1837eaf5dbd01183f6bb3a679b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make eval results environment‑first across rail, runs list, case history, and run detail, with group headers summarizing revision ranges and run rows showing exact revisions. The kill switch now fully hides environment names/revisions while keeping context counts; environment‑drift errors are surfaced reliably in fan‑outs. Client‑only; no server changes.

- **New Features**
  - Shared `EnvironmentChip` renders environment name + exact `rev N`; used by `RunContextChip` and case history.
  - Rail group headers show a context summary (name when single, otherwise count) plus a revision range; child rows use `RunContextChip` for the exact context.
  - Helpers expanded: `runContextKey`, `runContextLabel`, `runRevisionLabel`, `runContextKeys`, `runContextRevisionSummary`.

- **Bug Fixes**
  - Fixed kill‑switch leak in `RunContextChip` by adding `runHostLabel` (host‑only fallback); with the flag off, no environment identity renders anywhere.
  - Made rail and runs list agree on the axis and count: both derive distinct context keys and display “N environment(s)/client(s)”; runs list no longer miscounts repeated environment runs.
  - Case history now uses `EnvironmentChip` and suppresses environment identity when the flag is off.
  - When all plans fail, prefer an `ENVIRONMENT_REVISION_CONFLICT` message over generic errors; preserved `code` from `postEvalRequest` enables this.

<sup>Written for commit 2da0a7b924510b1837eaf5dbd01183f6bb3a679b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

