### PR TITLE
feat(plugins): effective capability resolution (INS-3)

### DIFF
--- a/mcpjam-inspector/server/routes/web/__tests__/chat-v2.environment.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chat-v2.environment.test.ts
@@ -445,3 +445,170 @@ describe("web chat-v2 — environment execution target", () => {
     expect(handleMCPJamFreeChatModelMock).not.toHaveBeenCalled();
   });
 });
+
+// INS-3: a turn whose environment pins plugins must be able to SAY where each
+// server and skill came from. The runtime spec carries the pins and the plugin
+// server ids as two flat lists with no edge between them, so the route asks the
+// per-version probe to recover it — and must degrade, never fail, if it can't.
+describe("web chat-v2 — plugin capability attribution", () => {
+  const originalConvexHttpUrl = process.env.CONVEX_HTTP_URL;
+  const originalConvexUrl = process.env.CONVEX_URL;
+  const originalFetch = global.fetch;
+
+  const PLUGIN_SPEC = {
+    ...ENV_SPEC,
+    skills: [
+      {
+        skillId: "sk_plugin",
+        name: "summarize",
+        description: "Summarize",
+        content: "plugin skill body",
+        aggregateHash: "agg_plugin",
+        channels: ["plugin"],
+        files: [],
+      },
+    ],
+  };
+
+  const PREVIEW_RESPONSE = {
+    pluginVersions: [
+      {
+        pluginId: "pl_1",
+        pluginVersionId: "pv_1",
+        name: "linear",
+        bundleHash: "abc",
+      },
+    ],
+    effectiveServerIds: ["env-server-2"],
+    pluginSkills: [
+      { modelRef: "linear/summarize", materializedSkillId: "sk_plugin" },
+    ],
+    unavailableComponents: [],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CONVEX_HTTP_URL = "https://example.convex.site";
+    process.env.CONVEX_URL = "https://example.convex.cloud";
+    prepareChatV2Mock.mockResolvedValue({
+      allTools: {},
+      enhancedSystemPrompt: "system",
+      resolvedTemperature: 0.7,
+    });
+    handleMCPJamFreeChatModelMock.mockResolvedValue(
+      new Response("ok", { status: 200 })
+    );
+    global.fetch = vi.fn(async (input: any, init: any) => {
+      if (String(input).endsWith("/web/authorize-batch")) {
+        const payload = JSON.parse(String(init?.body ?? "{}"));
+        const serverIds: string[] = Array.isArray(payload?.serverIds)
+          ? payload.serverIds
+          : [];
+        return new Response(
+          JSON.stringify({
+            results: Object.fromEntries(
+              serverIds.map((serverId) => [
+                serverId,
+                {
+                  ok: true,
+                  role: "member",
+                  accessLevel: "shared_chat",
+                  permissions: { chatOnly: false },
+                  internalLogContext: {
+                    authType: "signedIn",
+                    userId: "u-alice",
+                    projectId: payload.projectId ?? null,
+                  },
+                  serverConfig: {
+                    transportType: "http",
+                    url: `https://${serverId}.example.com/mcp`,
+                    headers: {},
+                    useOAuth: false,
+                  },
+                },
+              ])
+            ),
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        );
+      }
+      throw new Error(`Unexpected fetch: ${String(input)}`);
+    }) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    process.env.CONVEX_HTTP_URL = originalConvexHttpUrl;
+    process.env.CONVEX_URL = originalConvexUrl;
+  });
+
+  it("namespaces the plugin skill and attributes its server to the pinned version", async () => {
+    convexQueryMock.mockImplementation(async (ref: string) =>
+      ref === "plugins:resolvePluginRuntimePreview"
+        ? PREVIEW_RESPONSE
+        : PLUGIN_SPEC
+    );
+    const { app, token } = createWebTestApp();
+    await postJson(
+      app,
+      "/api/web/chat-v2",
+      {
+        ...BASE_BODY,
+        executionTarget: { kind: "environment", environmentId: "env_1" },
+      },
+      token
+    );
+
+    const capabilities =
+      prepareChatV2Mock.mock.calls.at(-1)![0].skillsSource.capabilities;
+    expect(capabilities.pluginSkills).toEqual([
+      expect.objectContaining({
+        ref: "linear/summarize",
+        content: "plugin skill body",
+        plugin: expect.objectContaining({
+          pluginVersionId: "pv_1",
+          bundleHash: "abc",
+        }),
+      }),
+    ]);
+    expect(capabilities.standaloneSkills).toEqual([]);
+    expect(capabilities.explicitServerIds).toEqual(["env-server-1"]);
+    expect(capabilities.pluginServerIds).toEqual(["env-server-2"]);
+    expect(
+      capabilities.servers.find((s: any) => s.serverId === "env-server-2")
+        .plugin.name
+    ).toBe("linear");
+    expect(capabilities.problems).toEqual([]);
+  });
+
+  it("still runs the turn — with origin unreported — when the probe fails", async () => {
+    convexQueryMock.mockImplementation(async (ref: string) => {
+      if (ref === "plugins:resolvePluginRuntimePreview") {
+        throw new Error("Could not find public function");
+      }
+      return PLUGIN_SPEC;
+    });
+    const { app, token } = createWebTestApp();
+    const response = await postJson(
+      app,
+      "/api/web/chat-v2",
+      {
+        ...BASE_BODY,
+        executionTarget: { kind: "environment", environmentId: "env_1" },
+      },
+      token
+    );
+
+    expect(response.status).toBe(200);
+    const capabilities =
+      prepareChatV2Mock.mock.calls.at(-1)![0].skillsSource.capabilities;
+    // The server set is untouched; only what we can SAY about it degraded.
+    expect(capabilities.pluginServerIds).toEqual(["env-server-2"]);
+    expect(capabilities.pluginSkills[0].ref).toBe("summarize");
+    expect(capabilities.pluginSkills[0].plugin).toBeUndefined();
+    expect(capabilities.problems.map((p: any) => p.code)).toEqual([
+      "plugin_origin_unavailable",
+      "plugin_skill_ref_unavailable",
+    ]);
+  });
+});

--- a/mcpjam-inspector/server/routes/web/__tests__/chat-v2.environment.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chat-v2.environment.test.ts
@@ -538,8 +538,13 @@ describe("web chat-v2 — plugin capability attribution", () => {
 
   afterEach(() => {
     global.fetch = originalFetch;
-    process.env.CONVEX_HTTP_URL = originalConvexHttpUrl;
-    process.env.CONVEX_URL = originalConvexUrl;
+    // `delete` on absent, never assignment: Node coerces an assigned
+    // `undefined` to the literal string "undefined", which a later test in the
+    // same worker would happily build a Convex client against.
+    if (originalConvexHttpUrl === undefined) delete process.env.CONVEX_HTTP_URL;
+    else process.env.CONVEX_HTTP_URL = originalConvexHttpUrl;
+    if (originalConvexUrl === undefined) delete process.env.CONVEX_URL;
+    else process.env.CONVEX_URL = originalConvexUrl;
   });
 
   it("namespaces the plugin skill and attributes its server to the pinned version", async () => {

--- a/mcpjam-inspector/server/routes/web/__tests__/chat-v2.environment.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chat-v2.environment.test.ts
@@ -363,18 +363,25 @@ describe("web chat-v2 — environment execution target", () => {
     const args = prepareChatV2Mock.mock.calls.at(-1)![0];
     // Project-wide cloud skills would double-deliver alongside the resolved set.
     expect(args.cloudSkills).toBeUndefined();
-    expect(args.skillsSource).toEqual({
-      kind: "resolved",
-      skills: [
-        {
-          name: "release-notes",
-          description: "Write release notes",
-          content: "env skill body",
-          contentHash: "agg_env",
-          provenance: "authored",
-        },
-      ],
-    });
+    // INS-3: the emulated engine now receives the whole EffectiveCapabilitySet
+    // rather than a flat skill list, because its tools address skills by REF
+    // (`<plugin>/<skill>` for a plugin skill). This environment pins no
+    // plugins, so the one resolved skill is standalone and its ref is its name.
+    expect(args.skillsSource.kind).toBe("resolved");
+    expect(args.skillsSource.capabilities.standaloneSkills).toEqual([
+      {
+        ref: "release-notes",
+        skillId: "sk_env",
+        name: "release-notes",
+        description: "Write release notes",
+        content: "env skill body",
+        aggregateHash: "agg_env",
+        channels: ["environment"],
+        files: [],
+      },
+    ]);
+    expect(args.skillsSource.capabilities.pluginSkills).toEqual([]);
+    expect(args.skillsSource.capabilities.problems).toEqual([]);
   });
 
   it("hands the resolved skills to the HARNESS engine instead when the host runs one", async () => {

--- a/mcpjam-inspector/server/routes/web/__tests__/rpc-logs.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/rpc-logs.test.ts
@@ -379,3 +379,45 @@ describe("bridgeHarnessRpcLogsToCollector", () => {
     expect(collector.hasLogs()).toBe(false);
   });
 });
+
+// INS-3: a trace frame for a plugin-contributed server must name the exact
+// revision that served it, so "which plugin version made this call" is
+// answerable from the trace alone.
+describe("HostedRpcLogCollector — plugin origin", () => {
+  const ORIGIN = {
+    pluginId: "pl_1",
+    pluginVersionId: "pv_1",
+    name: "linear",
+    bundleHash: "abc123",
+  };
+
+  it("stamps frames from a plugin server and leaves ordinary servers alone", () => {
+    const collector = createHostedRpcLogCollector({
+      serverIds: ["srv_host", "srv_plugin"],
+      serverNames: ["Host", "Plugin"],
+    });
+    collector.setPluginOriginByServerId({ srv_plugin: ORIGIN });
+
+    collector.rpcLogger({
+      direction: "send",
+      message: {},
+      serverId: "srv_plugin",
+    });
+    collector.rpcLogger({
+      direction: "send",
+      message: {},
+      serverId: "srv_host",
+    });
+
+    const [pluginFrame, hostFrame] = collector.getLogs();
+    expect(pluginFrame.pluginOrigin).toEqual(ORIGIN);
+    // Absence is semantic — an ordinary server carries no origin key at all.
+    expect("pluginOrigin" in hostFrame).toBe(false);
+  });
+
+  it("carries no origin at all when attribution never arrived", () => {
+    const collector = createHostedRpcLogCollector({ serverIds: ["srv"] });
+    collector.rpcLogger({ direction: "send", message: {}, serverId: "srv" });
+    expect("pluginOrigin" in collector.getLogs()[0]).toBe(false);
+  });
+});

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -60,6 +60,12 @@ import {
   runtimeSkills as environmentRuntimeSkills,
   type ResolvedEnvironmentRuntime,
 } from "../../services/environments/runtime.js";
+import { fetchPluginRuntimeAttribution } from "../../services/environments/plugin-attribution.js";
+import {
+  pluginOriginByServerId,
+  resolveEffectiveCapabilities,
+  type EffectiveCapabilitySet,
+} from "../../services/environments/effective-capabilities.js";
 import { resolveExecutionContext } from "../../utils/host-execution-context.js";
 import { resolveHostTools } from "../../utils/built-in-tools/registry.js";
 import { buildMcpjamPlatformClient } from "./mcpjam-platform-client.js";
@@ -193,24 +199,56 @@ chatV2.post("/", async (c) => {
     // source for this turn's host config, server set, and skills — nothing
     // downstream may fall back to the body's `selectedServerIds`.
     let environmentSpec: ResolvedEnvironmentRuntime | null = null;
+    // INS-3: the turn's one answer to "what may this run reach?" — the split
+    // explicit/plugin server sets, ref-addressed skills, and plugin origin.
+    // Derived from `environmentSpec`, never from the body or a HostConfig
+    // (hosts are plugin-blind), and never persisted: it is provenance for this
+    // launch, not a restorable pin.
+    let effectiveCapabilities: EffectiveCapabilitySet | null = null;
     if (executionTarget.kind === "environment") {
+      // `sk_…` API-key bearers can't query Convex directly; this resolves the
+      // delegated JWT (and passes JWTs through untouched), same as the eval
+      // launch path.
+      const convexClient = createConvexClient(
+        await getConvexBearerForRequest(c),
+      );
       // One atomic member-read: host runtime config + closed server set +
       // composed skill union + pinned plugin versions, at one revision. The
       // browser never supplies any of it.
-      environmentSpec = await resolveEnvironmentForRuntime(
-        // `sk_…` API-key bearers can't query Convex directly; this resolves the
-        // delegated JWT (and passes JWTs through untouched), same as the eval
-        // launch path.
-        createConvexClient(await getConvexBearerForRequest(c)),
-        {
-          projectId: hostedBody.projectId,
-          environmentId: executionTarget.environmentId,
-          ...(executionTarget.overrides
-            ? { overrides: executionTarget.overrides }
-            : {}),
-        },
-      );
+      environmentSpec = await resolveEnvironmentForRuntime(convexClient, {
+        projectId: hostedBody.projectId,
+        environmentId: executionTarget.environmentId,
+        ...(executionTarget.overrides
+          ? { overrides: executionTarget.overrides }
+          : {}),
+      });
       hostRuntimeConfig = environmentSpec.host.runtimeConfig;
+      // Attribution is a SECOND read and deliberately cannot fail the turn:
+      // the environment already decided what runs, and a probe blip must
+      // degrade origin reporting, not stop a send. Costs nothing when the
+      // environment pins no plugins.
+      const attribution = await fetchPluginRuntimeAttribution(convexClient, {
+        projectId: hostedBody.projectId,
+        pluginVersionIds: (environmentSpec.pluginVersions ?? []).map(
+          (plugin) => plugin.pluginVersionId,
+        ),
+      });
+      effectiveCapabilities = resolveEffectiveCapabilities(
+        environmentSpec,
+        attribution,
+      );
+      for (const problem of effectiveCapabilities.problems) {
+        logger.warn("[chat-v2] effective capability problem", {
+          environmentId: environmentSpec.environmentRef.environmentId,
+          code: problem.code,
+          message: problem.message,
+        });
+      }
+      // Plugin origin on every RPC frame this turn produces, so a trace answers
+      // "which plugin revision served this tool call" without a second lookup.
+      rpcCollector?.setPluginOriginByServerId(
+        pluginOriginByServerId(effectiveCapabilities),
+      );
     } else if (isChatboxSession && chatboxId) {
       const runtime = await fetchChatboxRuntimeConfig({
         chatboxId,
@@ -695,6 +733,20 @@ chatV2.post("/", async (c) => {
               environment_plugin_version_ids: (
                 environmentSpec.pluginVersions ?? []
               ).map((plugin) => plugin.pluginVersionId),
+              // INS-3 provenance. Bundle hashes are content addresses, not
+              // user data, and are what makes a run attributable to an exact
+              // revision. Plugin NAMES are deliberately not emitted (telemetry
+              // must carry no user-authored strings).
+              environment_plugin_bundle_hashes: (
+                environmentSpec.pluginVersions ?? []
+              ).map((plugin) => plugin.bundleHash ?? null),
+              environment_plugin_server_count:
+                effectiveCapabilities?.pluginServerIds.length ?? 0,
+              environment_plugin_skill_count:
+                effectiveCapabilities?.pluginSkills.length ?? 0,
+              environment_capability_problems: (
+                effectiveCapabilities?.problems ?? []
+              ).map((problem) => problem.code),
             }
           : {}),
       });
@@ -740,8 +792,15 @@ chatV2.post("/", async (c) => {
           // Emulated-engine delivery of the environment's resolved skills.
           // Mutually exclusive with `cloudSkills` above (gated on the same
           // `environmentSpec`), and ignored by the helper on a harness turn.
+          //
+          // Both are set for an environment turn: the capability set drives the
+          // emulated ref-addressed tools (INS-3), the flat list stays for the
+          // harness adapter, which writes name/description/content to disk.
           ...(environmentSkills !== undefined
             ? { runtimeSkillsOverride: environmentSkills }
+            : {}),
+          ...(effectiveCapabilities
+            ? { effectiveCapabilities }
             : {}),
         },
         persist: {

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -237,11 +237,20 @@ chatV2.post("/", async (c) => {
         environmentSpec,
         attribution,
       );
-      for (const problem of effectiveCapabilities.problems) {
-        logger.warn("[chat-v2] effective capability problem", {
+      if (effectiveCapabilities.problems.length > 0) {
+        // Codes and ids only, never `problem.message` — those messages
+        // interpolate the skill's own NAME, which is user-authored content and
+        // is held out of the provenance telemetry below for the same reason.
+        // One aggregated line, so a collision-heavy environment does not emit
+        // an entry per problem per turn.
+        logger.warn("[chat-v2] effective capability problems", {
           environmentId: environmentSpec.environmentRef.environmentId,
-          code: problem.code,
-          message: problem.message,
+          codes: effectiveCapabilities.problems.map(
+            (problem) => problem.code,
+          ),
+          skillIds: effectiveCapabilities.problems.flatMap((problem) =>
+            "skillId" in problem ? [problem.skillId] : [],
+          ),
         });
       }
       // Plugin origin on every RPC frame this turn produces, so a trace answers

--- a/mcpjam-inspector/server/routes/web/hosted-rpc-logs.ts
+++ b/mcpjam-inspector/server/routes/web/hosted-rpc-logs.ts
@@ -8,6 +8,7 @@ import {
 } from "../../utils/harness/harness-rpc-log-sink.js";
 import type {
   HostedRpcLogEvent,
+  HostedRpcLogPluginOrigin,
   HostedRpcLogsEnvelope,
 } from "@/shared/hosted-rpc-log";
 
@@ -98,15 +99,32 @@ export class HostedRpcLogCollector {
   private streamedCount = 0;
   private writer: HostedRpcChunkWriter | null = null;
 
+  /**
+   * INS-3 plugin provenance, keyed by server id. Set AFTER construction
+   * because the collector is built from the raw body (before auth) while
+   * plugin origin only exists once the environment has resolved. Frames logged
+   * before that point simply carry no origin — absence is honest, and no MCP
+   * traffic can precede manager construction anyway.
+   */
+  private pluginOriginByServerId: Record<string, HostedRpcLogPluginOrigin> = {};
+
   constructor(private readonly serverNamesById: Record<string, string>) {}
 
+  setPluginOriginByServerId(
+    origins: Record<string, HostedRpcLogPluginOrigin>
+  ): void {
+    this.pluginOriginByServerId = origins;
+  }
+
   readonly rpcLogger: RpcLogger = ({ direction, message, serverId }) => {
+    const pluginOrigin = this.pluginOriginByServerId[serverId];
     const event: HostedRpcLogEvent = {
       serverId,
       serverName: normalizeServerName(serverId, this.serverNamesById),
       direction,
       timestamp: new Date().toISOString(),
       message,
+      ...(pluginOrigin ? { pluginOrigin } : {}),
     };
 
     this.logs.push(event);

--- a/mcpjam-inspector/server/services/environments/__tests__/effective-capabilities.test.ts
+++ b/mcpjam-inspector/server/services/environments/__tests__/effective-capabilities.test.ts
@@ -1,0 +1,280 @@
+import { describe, expect, it } from "vitest";
+import {
+  allEffectiveSkills,
+  pluginOriginByServerId,
+  resolveEffectiveCapabilities,
+} from "../effective-capabilities";
+import type { PluginRuntimeAttribution } from "../plugin-attribution";
+import type { ResolvedEnvironmentRuntime } from "../runtime";
+
+const PLUGIN_A = {
+  pluginId: "p_a",
+  pluginVersionId: "pv_a",
+  name: "alpha",
+  bundleHash: "aaaa1111",
+};
+const PLUGIN_B = {
+  pluginId: "p_b",
+  pluginVersionId: "pv_b",
+  name: "beta",
+  bundleHash: "bbbb2222",
+};
+
+function spec(
+  overrides: Partial<ResolvedEnvironmentRuntime> = {}
+): ResolvedEnvironmentRuntime {
+  return {
+    specVersion: 1,
+    environmentRef: { environmentId: "env_1", name: "Staging", revision: 3 },
+    host: { hostId: "host_1", runtimeConfig: { modelId: "m" } },
+    servers: { effectiveServerIds: [] },
+    ...overrides,
+  };
+}
+
+function attribution(
+  overrides: Partial<PluginRuntimeAttribution> = {}
+): PluginRuntimeAttribution {
+  return {
+    serverOrigins: new Map(),
+    skillOrigins: new Map(),
+    ...overrides,
+  };
+}
+
+describe("resolveEffectiveCapabilities — servers", () => {
+  it("splits the connectable set into explicit and plugin-contributed ids", () => {
+    const set = resolveEffectiveCapabilities(
+      spec({
+        servers: {
+          selectedServerIds: ["srv_host"],
+          pluginServerIds: ["srv_plugin"],
+          baseEffectiveServerIds: ["srv_host", "srv_plugin"],
+          effectiveServerIds: ["srv_host", "srv_plugin"],
+          connectable: [
+            { serverId: "srv_host", name: "Host", source: "host_or_group" },
+            { serverId: "srv_plugin", name: "Plugin", source: "plugin" },
+          ],
+        },
+        pluginVersions: [PLUGIN_A],
+      }),
+      attribution({
+        serverOrigins: new Map([["srv_plugin", PLUGIN_A]]),
+      })
+    );
+
+    expect(set.explicitServerIds).toEqual(["srv_host"]);
+    expect(set.pluginServerIds).toEqual(["srv_plugin"]);
+    // Connection order is preserved — the manager connects this list verbatim.
+    expect(set.effectiveServerIds).toEqual(["srv_host", "srv_plugin"]);
+    expect(pluginOriginByServerId(set)).toEqual({ srv_plugin: PLUGIN_A });
+  });
+
+  it("classifies by the backend's own `source` before falling back to the id hint", () => {
+    // An override kept a plugin server; `pluginServerIds` is the BASE set, so
+    // the hint alone would be wrong for anything the override introduced.
+    const set = resolveEffectiveCapabilities(
+      spec({
+        servers: {
+          pluginServerIds: ["srv_plugin", "srv_dropped"],
+          baseEffectiveServerIds: ["srv_plugin", "srv_dropped"],
+          effectiveServerIds: ["srv_plugin", "srv_extra"],
+          connectable: [
+            { serverId: "srv_plugin", name: "Plugin", source: "plugin" },
+            { serverId: "srv_extra", name: "Extra", source: "override" },
+          ],
+        },
+        pluginVersions: [PLUGIN_A],
+      }),
+      attribution()
+    );
+
+    expect(set.pluginServerIds).toEqual(["srv_plugin"]);
+    expect(set.explicitServerIds).toEqual(["srv_extra"]);
+  });
+
+  it("falls back to raw ids when an older backend omits the connectable projection", () => {
+    const set = resolveEffectiveCapabilities(
+      spec({
+        servers: {
+          pluginServerIds: ["srv_plugin"],
+          effectiveServerIds: ["srv_host", "srv_plugin"],
+        },
+      }),
+      attribution()
+    );
+
+    expect(set.effectiveServerIds).toEqual(["srv_host", "srv_plugin"]);
+    expect(set.pluginServerIds).toEqual(["srv_plugin"]);
+    expect(set.servers.map((entry) => entry.source)).toEqual([null, null]);
+  });
+});
+
+describe("resolveEffectiveCapabilities — skills", () => {
+  const pluginSkill = (skillId: string) => ({
+    skillId,
+    name: "summarize",
+    description: "Summarize things",
+    content: `body ${skillId}`,
+    aggregateHash: `agg_${skillId}`,
+    channels: ["plugin" as const],
+    files: [],
+  });
+
+  it("namespaces two plugins declaring the same skill name onto distinct refs", () => {
+    const set = resolveEffectiveCapabilities(
+      spec({
+        skills: [pluginSkill("sk_a"), pluginSkill("sk_b")],
+        pluginVersions: [PLUGIN_A, PLUGIN_B],
+      }),
+      attribution({
+        skillOrigins: new Map([
+          ["sk_a", { modelRef: "alpha/summarize", plugin: PLUGIN_A }],
+          ["sk_b", { modelRef: "beta/summarize", plugin: PLUGIN_B }],
+        ]),
+      })
+    );
+
+    expect(set.pluginSkills.map((skill) => skill.ref)).toEqual([
+      "alpha/summarize",
+      "beta/summarize",
+    ]);
+    // Each ref keeps ITS OWN content and originating version.
+    expect(set.pluginSkills[0].content).toBe("body sk_a");
+    expect(set.pluginSkills[0].plugin).toEqual(PLUGIN_A);
+    expect(set.pluginSkills[1].content).toBe("body sk_b");
+    expect(set.pluginSkills[1].plugin).toEqual(PLUGIN_B);
+    expect(set.problems).toEqual([]);
+  });
+
+  it("advertises ONLY the resolved set — an isolated plugin-only turn has no standalone skills", () => {
+    const set = resolveEffectiveCapabilities(
+      spec({
+        skills: [pluginSkill("sk_a")],
+        pluginVersions: [PLUGIN_A],
+      }),
+      attribution({
+        skillOrigins: new Map([
+          ["sk_a", { modelRef: "alpha/summarize", plugin: PLUGIN_A }],
+        ]),
+      })
+    );
+
+    expect(set.standaloneSkills).toEqual([]);
+    expect(allEffectiveSkills(set).map((skill) => skill.ref)).toEqual([
+      "alpha/summarize",
+    ]);
+  });
+
+  it("keeps standalone skills on their bare name and records their channels", () => {
+    const set = resolveEffectiveCapabilities(
+      spec({
+        skills: [
+          {
+            skillId: "sk_std",
+            name: "release-notes",
+            description: "Write release notes",
+            content: "body",
+            aggregateHash: "agg",
+            channels: ["host", "environment"],
+            files: [{ path: "scripts/run.py", size: 12, url: "https://x/1" }],
+          },
+        ],
+      }),
+      attribution()
+    );
+
+    expect(set.standaloneSkills).toEqual([
+      {
+        ref: "release-notes",
+        skillId: "sk_std",
+        name: "release-notes",
+        description: "Write release notes",
+        content: "body",
+        aggregateHash: "agg",
+        channels: ["host", "environment"],
+        files: [{ path: "scripts/run.py", size: 12, url: "https://x/1" }],
+      },
+    ]);
+    expect(set.pluginSkills).toEqual([]);
+  });
+
+  it("reports a plugin skill it could not namespace instead of hiding the ambiguity", () => {
+    const set = resolveEffectiveCapabilities(
+      spec({ skills: [pluginSkill("sk_a")], pluginVersions: [PLUGIN_A] }),
+      attribution()
+    );
+
+    expect(set.pluginSkills[0].ref).toBe("summarize");
+    expect(set.pluginSkills[0].plugin).toBeUndefined();
+    expect(set.problems).toEqual([
+      expect.objectContaining({
+        code: "plugin_skill_ref_unavailable",
+        skillId: "sk_a",
+      }),
+    ]);
+  });
+
+  it("drops the second of two colliding refs and says so", () => {
+    const set = resolveEffectiveCapabilities(
+      spec({ skills: [pluginSkill("sk_a"), pluginSkill("sk_b")] }),
+      attribution()
+    );
+
+    expect(set.pluginSkills).toHaveLength(1);
+    expect(set.problems.map((problem) => problem.code)).toEqual([
+      "plugin_skill_ref_unavailable",
+      "plugin_skill_ref_unavailable",
+      "skill_ref_collision",
+    ]);
+  });
+});
+
+describe("resolveEffectiveCapabilities — degraded attribution", () => {
+  it("still runs every server and skill when attribution is unavailable", () => {
+    const set = resolveEffectiveCapabilities(
+      spec({
+        servers: {
+          pluginServerIds: ["srv_plugin"],
+          effectiveServerIds: ["srv_plugin"],
+          connectable: [
+            { serverId: "srv_plugin", name: "Plugin", source: "plugin" },
+          ],
+        },
+        pluginVersions: [PLUGIN_A],
+      }),
+      null
+    );
+
+    expect(set.effectiveServerIds).toEqual(["srv_plugin"]);
+    expect(set.pluginServerIds).toEqual(["srv_plugin"]);
+    expect(set.servers[0].plugin).toBeUndefined();
+    expect(set.problems).toEqual([
+      expect.objectContaining({ code: "plugin_origin_unavailable" }),
+    ]);
+  });
+
+  it("reports no problem when there was nothing to attribute", () => {
+    const set = resolveEffectiveCapabilities(spec(), null);
+    expect(set.problems).toEqual([]);
+    expect(set.pluginVersions).toEqual([]);
+  });
+
+  it("carries pin order and bundle hashes from the spec, not from attribution", () => {
+    const set = resolveEffectiveCapabilities(
+      spec({ pluginVersions: [PLUGIN_B, PLUGIN_A] }),
+      attribution()
+    );
+    expect(set.pluginVersions).toEqual([PLUGIN_B, PLUGIN_A]);
+  });
+
+  it("normalizes a missing bundleHash to null rather than synthesizing one", () => {
+    const set = resolveEffectiveCapabilities(
+      spec({
+        pluginVersions: [{ pluginId: "p", pluginVersionId: "pv", name: "x" }],
+      }),
+      attribution()
+    );
+    expect(set.pluginVersions[0].bundleHash).toBeNull();
+  });
+});

--- a/mcpjam-inspector/server/services/environments/__tests__/effective-capabilities.test.ts
+++ b/mcpjam-inspector/server/services/environments/__tests__/effective-capabilities.test.ts
@@ -38,6 +38,7 @@ function attribution(
   return {
     serverOrigins: new Map(),
     skillOrigins: new Map(),
+    unattributedVersionIds: [],
     ...overrides,
   };
 }
@@ -91,6 +92,58 @@ describe("resolveEffectiveCapabilities — servers", () => {
 
     expect(set.pluginServerIds).toEqual(["srv_plugin"]);
     expect(set.explicitServerIds).toEqual(["srv_extra"]);
+  });
+
+  it("never lets a stale attribution reclassify a server the backend called non-plugin", () => {
+    // Attribution decides what we SAY about a server, never what it IS. A torn
+    // or stale map that still lists an id the backend explicitly labelled
+    // `host_or_group` must not move it into the plugin set.
+    const set = resolveEffectiveCapabilities(
+      spec({
+        servers: {
+          pluginServerIds: [],
+          effectiveServerIds: ["srv_host"],
+          connectable: [
+            { serverId: "srv_host", name: "Host", source: "host_or_group" },
+          ],
+        },
+      }),
+      attribution({ serverOrigins: new Map([["srv_host", PLUGIN_A]]) })
+    );
+
+    expect(set.pluginServerIds).toEqual([]);
+    expect(set.explicitServerIds).toEqual(["srv_host"]);
+    expect(set.servers[0].plugin).toBeUndefined();
+  });
+
+  it("does the same for an override-sourced server", () => {
+    const set = resolveEffectiveCapabilities(
+      spec({
+        servers: {
+          effectiveServerIds: ["srv_extra"],
+          connectable: [
+            { serverId: "srv_extra", name: "Extra", source: "override" },
+          ],
+        },
+      }),
+      attribution({ serverOrigins: new Map([["srv_extra", PLUGIN_A]]) })
+    );
+    expect(set.pluginServerIds).toEqual([]);
+    expect(set.servers[0].plugin).toBeUndefined();
+  });
+
+  it("uses attribution to classify only when the backend omitted `source`", () => {
+    const set = resolveEffectiveCapabilities(
+      spec({
+        servers: {
+          effectiveServerIds: ["srv_x"],
+          connectable: [{ serverId: "srv_x", name: "X", source: undefined }],
+        },
+      }),
+      attribution({ serverOrigins: new Map([["srv_x", PLUGIN_A]]) })
+    );
+    expect(set.pluginServerIds).toEqual(["srv_x"]);
+    expect(set.servers[0].plugin).toEqual(PLUGIN_A);
   });
 
   it("falls back to raw ids when an older backend omits the connectable projection", () => {
@@ -252,6 +305,26 @@ describe("resolveEffectiveCapabilities — degraded attribution", () => {
     expect(set.problems).toEqual([
       expect.objectContaining({ code: "plugin_origin_unavailable" }),
     ]);
+  });
+
+  it("reports a PARTIAL attribution instead of passing a short map off as complete", () => {
+    // pv_b resolved for the environment but not for the probe. Its components
+    // still run; losing their provenance silently is the exact failure
+    // `problems` exists to prevent.
+    const set = resolveEffectiveCapabilities(
+      spec({ pluginVersions: [PLUGIN_A, PLUGIN_B] }),
+      attribution({
+        serverOrigins: new Map([["srv_a", PLUGIN_A]]),
+        unattributedVersionIds: ["pv_b"],
+      })
+    );
+
+    expect(set.problems).toEqual([
+      expect.objectContaining({ code: "plugin_origin_unavailable" }),
+    ]);
+    expect(set.problems[0].message).toContain("1 of this turn's 2");
+    // The attribution we DID get is still used.
+    expect(set.pluginVersions).toEqual([PLUGIN_A, PLUGIN_B]);
   });
 
   it("reports no problem when there was nothing to attribute", () => {

--- a/mcpjam-inspector/server/services/environments/__tests__/plugin-attribution.test.ts
+++ b/mcpjam-inspector/server/services/environments/__tests__/plugin-attribution.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ConvexHttpClient } from "convex/browser";
+import { fetchPluginRuntimeAttribution } from "../plugin-attribution";
+
+function clientWith(
+  query: (ref: string, args: { pluginVersionIds: string[] }) => unknown
+): ConvexHttpClient {
+  return { query: vi.fn(query) } as unknown as ConvexHttpClient;
+}
+
+const PREVIEW = "plugins:resolvePluginRuntimePreview";
+
+describe("fetchPluginRuntimeAttribution", () => {
+  it("costs zero reads when the environment pins no plugins", async () => {
+    const query = vi.fn();
+    const result = await fetchPluginRuntimeAttribution(
+      { query } as unknown as ConvexHttpClient,
+      { projectId: "prj", pluginVersionIds: [] }
+    );
+    expect(query).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      serverOrigins: new Map(),
+      skillOrigins: new Map(),
+    });
+  });
+
+  it("probes ONE version per call so components are attributable to a version", async () => {
+    const client = clientWith((_ref, args) => {
+      const id = args.pluginVersionIds[0];
+      return {
+        pluginVersions: [
+          {
+            pluginId: `p_${id}`,
+            pluginVersionId: id,
+            name: id === "pv_a" ? "alpha" : "beta",
+            bundleHash: `hash_${id}`,
+          },
+        ],
+        effectiveServerIds: [`srv_${id}`],
+        pluginSkills: [
+          {
+            modelRef: `${id === "pv_a" ? "alpha" : "beta"}/summarize`,
+            materializedSkillId: `sk_${id}`,
+          },
+        ],
+        unavailableComponents: [],
+      };
+    });
+
+    const result = await fetchPluginRuntimeAttribution(client, {
+      projectId: "prj",
+      pluginVersionIds: ["pv_a", "pv_b"],
+    });
+
+    expect(client.query).toHaveBeenCalledTimes(2);
+    expect(client.query).toHaveBeenCalledWith(PREVIEW, {
+      projectId: "prj",
+      pluginVersionIds: ["pv_a"],
+    });
+    expect(result?.serverOrigins.get("srv_pv_a")).toEqual({
+      pluginId: "p_pv_a",
+      pluginVersionId: "pv_a",
+      name: "alpha",
+      bundleHash: "hash_pv_a",
+    });
+    expect(result?.skillOrigins.get("sk_pv_b")).toEqual({
+      modelRef: "beta/summarize",
+      plugin: {
+        pluginId: "p_pv_b",
+        pluginVersionId: "pv_b",
+        name: "beta",
+        bundleHash: "hash_pv_b",
+      },
+    });
+  });
+
+  it("returns null — never a partial map — when a probe fails", async () => {
+    let calls = 0;
+    const client = clientWith(() => {
+      calls += 1;
+      if (calls === 2) throw new Error("Could not find public function");
+      return {
+        pluginVersions: [
+          {
+            pluginId: "p",
+            pluginVersionId: "pv_a",
+            name: "alpha",
+            bundleHash: "h",
+          },
+        ],
+        effectiveServerIds: ["srv_a"],
+        pluginSkills: [],
+      };
+    });
+
+    const result = await fetchPluginRuntimeAttribution(client, {
+      projectId: "prj",
+      pluginVersionIds: ["pv_a", "pv_b"],
+    });
+    expect(result).toBeNull();
+  });
+
+  it("skips a version the probe reports as unavailable rather than inventing an origin", async () => {
+    const client = clientWith((_ref, args) =>
+      args.pluginVersionIds[0] === "pv_a"
+        ? {
+            pluginVersions: [],
+            effectiveServerIds: [],
+            pluginSkills: [],
+            unavailableComponents: [
+              { pluginVersionId: "pv_a", reason: "disabled" },
+            ],
+          }
+        : {
+            pluginVersions: [
+              {
+                pluginId: "p_b",
+                pluginVersionId: "pv_b",
+                name: "beta",
+                bundleHash: "h_b",
+              },
+            ],
+            effectiveServerIds: ["srv_b"],
+            pluginSkills: [],
+          }
+    );
+
+    const result = await fetchPluginRuntimeAttribution(client, {
+      projectId: "prj",
+      pluginVersionIds: ["pv_a", "pv_b"],
+    });
+    expect(result?.serverOrigins.size).toBe(1);
+    expect(result?.serverOrigins.has("srv_b")).toBe(true);
+  });
+
+  it("tolerates a missing bundleHash without dropping the origin", async () => {
+    const client = clientWith(() => ({
+      pluginVersions: [
+        { pluginId: "p", pluginVersionId: "pv_a", name: "alpha" },
+      ],
+      effectiveServerIds: ["srv_a"],
+      pluginSkills: [],
+    }));
+    const result = await fetchPluginRuntimeAttribution(client, {
+      projectId: "prj",
+      pluginVersionIds: ["pv_a"],
+    });
+    expect(result?.serverOrigins.get("srv_a")?.bundleHash).toBeNull();
+  });
+});

--- a/mcpjam-inspector/server/services/environments/__tests__/plugin-attribution.test.ts
+++ b/mcpjam-inspector/server/services/environments/__tests__/plugin-attribution.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ConvexHttpClient } from "convex/browser";
 import { fetchPluginRuntimeAttribution } from "../plugin-attribution";
 
@@ -21,6 +21,7 @@ describe("fetchPluginRuntimeAttribution", () => {
     expect(result).toEqual({
       serverOrigins: new Map(),
       skillOrigins: new Map(),
+      unattributedVersionIds: [],
     });
   });
 
@@ -131,6 +132,27 @@ describe("fetchPluginRuntimeAttribution", () => {
     });
     expect(result?.serverOrigins.size).toBe(1);
     expect(result?.serverOrigins.has("srv_b")).toBe(true);
+    // The short map must ANNOUNCE that it is short — a caller that read only
+    // `serverOrigins` would otherwise present pv_a's servers as origin-free.
+    expect(result?.unattributedVersionIds).toEqual(["pv_a"]);
+  });
+
+  it("gives up on a read that never settles instead of hanging the turn", async () => {
+    vi.useFakeTimers();
+    try {
+      // A Convex query that never resolves — the failure the deadline exists
+      // for. Without it the chat route blocks forever before the turn starts.
+      const client = clientWith(() => new Promise(() => {}));
+      const pending = fetchPluginRuntimeAttribution(client, {
+        projectId: "prj",
+        pluginVersionIds: ["pv_a"],
+      });
+      await vi.advanceTimersByTimeAsync(5_000);
+      // Fails CLOSED, exactly like every other probe failure.
+      await expect(pending).resolves.toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("tolerates a missing bundleHash without dropping the origin", async () => {
@@ -146,5 +168,10 @@ describe("fetchPluginRuntimeAttribution", () => {
       pluginVersionIds: ["pv_a"],
     });
     expect(result?.serverOrigins.get("srv_a")?.bundleHash).toBeNull();
+    expect(result?.unattributedVersionIds).toEqual([]);
   });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });

--- a/mcpjam-inspector/server/services/environments/effective-capabilities.ts
+++ b/mcpjam-inspector/server/services/environments/effective-capabilities.ts
@@ -157,11 +157,20 @@ export function resolveEffectiveCapabilities(
   const problems: RuntimeCapabilityProblem[] = [];
   const pinned = spec.pluginVersions ?? [];
 
-  if (attribution === null && pinned.length > 0) {
+  // Both "no attribution at all" and "attribution missing some pins" are the
+  // same fact to a consumer: some of what runs has no stated origin. A short
+  // map reported as complete is the silence `problems` exists to prevent.
+  const unattributedCount =
+    attribution === null
+      ? pinned.length
+      : attribution.unattributedVersionIds.length;
+  if (unattributedCount > 0) {
     problems.push({
       code: "plugin_origin_unavailable",
       message:
-        "This turn's pinned plugin versions could not be attributed to their servers and skills. Tools and skills still run; their plugin origin is not shown.",
+        unattributedCount === pinned.length
+          ? "This turn's pinned plugin versions could not be attributed to their servers and skills. Tools and skills still run; their plugin origin is not shown."
+          : `${unattributedCount} of this turn's ${pinned.length} pinned plugin versions could not be attributed to their servers and skills. Those tools and skills still run; their plugin origin is not shown.`,
     });
   }
 
@@ -198,12 +207,16 @@ export function resolveEffectiveCapabilities(
   const pluginServerIds: string[] = [];
   for (const entry of connectable) {
     const origin = attribution?.serverOrigins.get(entry.serverId);
-    // `source === 'plugin'` is the backend's own verdict and outranks our
-    // hint; the hint covers older backends that omit `source`.
+    // The backend's `source` is the verdict, in BOTH directions: an entry it
+    // labelled `host_or_group` or `override` stays non-plugin even if a stale
+    // or torn attribution map still has an entry for that id. Attribution feeds
+    // what we SAY about a server, never how we classify it. Our own signals —
+    // the attribution map and the base `pluginServerIds` hint — apply only when
+    // an older backend omitted `source` entirely.
     const isPlugin =
       entry.source === "plugin" ||
-      origin !== undefined ||
-      (entry.source === undefined && pluginIdHint.has(entry.serverId));
+      (entry.source === undefined &&
+        (origin !== undefined || pluginIdHint.has(entry.serverId)));
     if (isPlugin) {
       pluginServerIds.push(entry.serverId);
     } else {
@@ -213,7 +226,12 @@ export function resolveEffectiveCapabilities(
       serverId: entry.serverId,
       name: entry.name,
       source: entry.source ?? null,
-      ...(origin ? { plugin: toRuntimePluginVersion(origin) } : {}),
+      // Gated on `isPlugin` for the same reason the classification is: a stale
+      // attribution entry must not stamp a plugin origin onto the trace frames
+      // of a server the backend called `host_or_group` or `override`.
+      ...(isPlugin && origin
+        ? { plugin: toRuntimePluginVersion(origin) }
+        : {}),
     });
   }
 

--- a/mcpjam-inspector/server/services/environments/effective-capabilities.ts
+++ b/mcpjam-inspector/server/services/environments/effective-capabilities.ts
@@ -1,0 +1,315 @@
+/**
+ * `EffectiveCapabilitySet` — the ONE object a turn asks "what may this run
+ * reach?" (INS-3).
+ *
+ * It is a PROJECTION, not a resolver. Every lifecycle decision — which pinned
+ * versions are usable, which servers they contribute, which skills compose from
+ * which channel — was already made backend-side by
+ * `lib/pluginRuntimeResolution.resolvePluginVersionsRuntime` and
+ * `lib/projectEnvironments.resolveEnvironment`, and re-made on EVERY launch so
+ * disable/uninstall bite immediately. Nothing here re-decides any of it; doing
+ * so would fork the rules that exist precisely so they cannot fork.
+ *
+ * What this adds is the shape the runtime needs and the wire does not carry:
+ *
+ *   - the explicit / plugin / effective server SPLIT, so a consumer can say
+ *     which servers a plugin brought without re-deriving it;
+ *   - per-server and per-skill PLUGIN ORIGIN (from `./plugin-attribution`), so
+ *     a tool call or trace frame names the version it came from;
+ *   - NAMESPACED skill refs (`<plugin>/<skill>`), so two plugins declaring the
+ *     same skill name stay distinguishable at load time;
+ *   - `problems` — provenance we could NOT establish, surfaced instead of
+ *     silently rendered as absence.
+ *
+ * `problems` is deliberately NOT an error channel. Anything that makes a turn
+ * unrunnable already threw backend-side as a structured `ENV_*` failure before
+ * this module ever sees a spec. These are degradations in what we can SAY,
+ * never in what runs.
+ *
+ * Hosts stay plugin-blind throughout: the pin lives on the environment, this
+ * set is assembled per turn from the environment's own resolution, and nothing
+ * here is persisted. Recording which versions ran is provenance; it is not a
+ * restorable pin.
+ */
+import type {
+  ResolvedEnvironmentRuntime,
+  RuntimeServerSource,
+  RuntimeSkillChannel,
+} from "./runtime.js";
+import type {
+  AttributedPluginVersion,
+  PluginRuntimeAttribution,
+} from "./plugin-attribution.js";
+
+/** Identity + reproducibility anchor of one version that contributed to a turn. */
+export interface RuntimePluginVersion {
+  pluginId: string;
+  pluginVersionId: string;
+  name: string;
+  /** `null` only under deploy skew; never synthesized. */
+  bundleHash: string | null;
+}
+
+/** A connectable server plus where it came from. */
+export interface RuntimeServerOrigin {
+  serverId: string;
+  name: string;
+  /** `null` when an older backend omits the name-carrying projection. */
+  source: RuntimeServerSource | null;
+  /** Present only for a server a pinned plugin version contributed. */
+  plugin?: RuntimePluginVersion;
+}
+
+/** A supporting file reachable for this turn. */
+export interface RuntimeSkillFile {
+  path: string;
+  size: number;
+  /** Signed, short-lived. `null` when the backend could not mint one. */
+  url: string | null;
+}
+
+interface RuntimeSkillBase {
+  /**
+   * The identity the model uses in `loadSkill` / `listSkillFiles` /
+   * `readSkillFile`: the bare name for a standalone skill, `<plugin>/<skill>`
+   * for a plugin one. Refs are unique within a set.
+   */
+  ref: string;
+  skillId: string;
+  /** The materialized skill's own name — NOT unique across plugins. */
+  name: string;
+  description: string;
+  content: string;
+  /** Folds supporting files; equals the content hash when there are none. */
+  aggregateHash: string;
+  files: RuntimeSkillFile[];
+}
+
+export interface RuntimePluginSkill extends RuntimeSkillBase {
+  /** `undefined` when attribution was unavailable — see `problems`. */
+  plugin?: RuntimePluginVersion;
+}
+
+export interface RuntimeStandaloneSkill extends RuntimeSkillBase {
+  /** Which channel(s) delivered it; `[]` under deploy skew. */
+  channels: RuntimeSkillChannel[];
+}
+
+export type RuntimeCapabilityProblem =
+  | {
+      /** Pins exist but their component→version edges could not be read. */
+      code: "plugin_origin_unavailable";
+      message: string;
+    }
+  | {
+      /** A plugin-channel skill with no namespaced ref — it keeps its bare name. */
+      code: "plugin_skill_ref_unavailable";
+      message: string;
+      skillId: string;
+    }
+  | {
+      /** Two skills resolved to one ref; the later one is unreachable by ref. */
+      code: "skill_ref_collision";
+      message: string;
+      ref: string;
+      skillId: string;
+    };
+
+export interface EffectiveCapabilitySet {
+  /** Servers the host/group selected — no plugin contributed them. */
+  explicitServerIds: string[];
+  /** Servers contributed by pinned plugin versions. */
+  pluginServerIds: string[];
+  /** The set this turn actually connects, in connection order. */
+  effectiveServerIds: string[];
+  /** `effectiveServerIds` with display name and origin, index-aligned. */
+  servers: RuntimeServerOrigin[];
+  pluginSkills: RuntimePluginSkill[];
+  standaloneSkills: RuntimeStandaloneSkill[];
+  /** Every version that contributed to this turn, in pin order. */
+  pluginVersions: RuntimePluginVersion[];
+  problems: RuntimeCapabilityProblem[];
+}
+
+function toRuntimePluginVersion(
+  attributed: AttributedPluginVersion
+): RuntimePluginVersion {
+  return {
+    pluginId: attributed.pluginId,
+    pluginVersionId: attributed.pluginVersionId,
+    name: attributed.name,
+    bundleHash: attributed.bundleHash,
+  };
+}
+
+/**
+ * Project one resolved environment spec into the turn's capability set.
+ *
+ * `attribution` is `null` when `fetchPluginRuntimeAttribution` could not read
+ * the component→version edges. That degrades origin reporting and namespacing —
+ * it never changes which servers connect or which skills are advertised, both
+ * of which come straight from the spec.
+ */
+export function resolveEffectiveCapabilities(
+  spec: ResolvedEnvironmentRuntime,
+  attribution: PluginRuntimeAttribution | null
+): EffectiveCapabilitySet {
+  const problems: RuntimeCapabilityProblem[] = [];
+  const pinned = spec.pluginVersions ?? [];
+
+  if (attribution === null && pinned.length > 0) {
+    problems.push({
+      code: "plugin_origin_unavailable",
+      message:
+        "This turn's pinned plugin versions could not be attributed to their servers and skills. Tools and skills still run; their plugin origin is not shown.",
+    });
+  }
+
+  // Pin order, straight from the spec — the authoritative list of what ran.
+  // Enriched only where attribution agrees on identity; never replaced by it.
+  const pluginVersions: RuntimePluginVersion[] = pinned.map((entry) => ({
+    pluginId: entry.pluginId,
+    pluginVersionId: entry.pluginVersionId,
+    name: entry.name,
+    bundleHash: entry.bundleHash ?? null,
+  }));
+
+  // ── Servers ────────────────────────────────────────────────────────────────
+  // `connectable` is the healed, ordered projection the backend already built;
+  // fall back to raw ids under deploy skew, where absence of a name is
+  // semantic (the manager shows the id) rather than a reason to guess.
+  const connectable = Array.isArray(spec.servers.connectable)
+    ? spec.servers.connectable
+    : spec.servers.effectiveServerIds.map((serverId) => ({
+        serverId,
+        name: serverId,
+        source: undefined as RuntimeServerSource | undefined,
+      }));
+
+  // `servers.pluginServerIds` is the BASE plugin set: it predates any per-turn
+  // override, so an override that dropped a plugin server would still list it.
+  // Membership is therefore tested against what we are actually connecting.
+  const pluginIdHint = new Set(
+    (spec.servers.pluginServerIds ?? []).map(String)
+  );
+
+  const servers: RuntimeServerOrigin[] = [];
+  const explicitServerIds: string[] = [];
+  const pluginServerIds: string[] = [];
+  for (const entry of connectable) {
+    const origin = attribution?.serverOrigins.get(entry.serverId);
+    // `source === 'plugin'` is the backend's own verdict and outranks our
+    // hint; the hint covers older backends that omit `source`.
+    const isPlugin =
+      entry.source === "plugin" ||
+      origin !== undefined ||
+      (entry.source === undefined && pluginIdHint.has(entry.serverId));
+    if (isPlugin) {
+      pluginServerIds.push(entry.serverId);
+    } else {
+      explicitServerIds.push(entry.serverId);
+    }
+    servers.push({
+      serverId: entry.serverId,
+      name: entry.name,
+      source: entry.source ?? null,
+      ...(origin ? { plugin: toRuntimePluginVersion(origin) } : {}),
+    });
+  }
+
+  // ── Skills ─────────────────────────────────────────────────────────────────
+  const pluginSkills: RuntimePluginSkill[] = [];
+  const standaloneSkills: RuntimeStandaloneSkill[] = [];
+  const usedRefs = new Set<string>();
+
+  for (const skill of spec.skills ?? []) {
+    const channels = Array.isArray(skill.channels) ? skill.channels : [];
+    const attributed = attribution?.skillOrigins.get(skill.skillId);
+    // A skill can arrive through several channels at once (the same row pinned
+    // by an environment AND carried by a plugin). Plugin origin wins the
+    // namespace: it is the more specific identity, and it is the one that has
+    // to survive two plugins declaring the same name.
+    const isPlugin = attributed !== undefined || channels.includes("plugin");
+
+    const base = {
+      skillId: skill.skillId,
+      name: skill.name,
+      description: skill.description,
+      content: skill.content,
+      aggregateHash: skill.aggregateHash,
+      files: Array.isArray(skill.files) ? skill.files : [],
+    };
+
+    if (isPlugin) {
+      if (attributed === undefined) {
+        problems.push({
+          code: "plugin_skill_ref_unavailable",
+          message: `Plugin skill "${skill.name}" has no namespaced reference; it is offered under its bare name.`,
+          skillId: skill.skillId,
+        });
+      }
+      const ref = attributed?.modelRef ?? skill.name;
+      if (usedRefs.has(ref)) {
+        problems.push({
+          code: "skill_ref_collision",
+          message: `Two skills resolved to the reference "${ref}"; only the first is loadable.`,
+          ref,
+          skillId: skill.skillId,
+        });
+        continue;
+      }
+      usedRefs.add(ref);
+      pluginSkills.push({
+        ...base,
+        ref,
+        ...(attributed ? { plugin: toRuntimePluginVersion(attributed.plugin) } : {}),
+      });
+      continue;
+    }
+
+    const ref = skill.name;
+    if (usedRefs.has(ref)) {
+      problems.push({
+        code: "skill_ref_collision",
+        message: `Two skills resolved to the reference "${ref}"; only the first is loadable.`,
+        ref,
+        skillId: skill.skillId,
+      });
+      continue;
+    }
+    usedRefs.add(ref);
+    standaloneSkills.push({ ...base, ref, channels });
+  }
+
+  return {
+    explicitServerIds,
+    pluginServerIds,
+    effectiveServerIds: servers.map((entry) => entry.serverId),
+    servers,
+    pluginSkills,
+    standaloneSkills,
+    pluginVersions,
+    problems,
+  };
+}
+
+/**
+ * Plugin origin keyed by server id — the lookup the RPC-trace collector and any
+ * approval surface needs. Only servers a plugin contributed appear.
+ */
+export function pluginOriginByServerId(
+  set: EffectiveCapabilitySet
+): Record<string, RuntimePluginVersion> {
+  const byId: Record<string, RuntimePluginVersion> = {};
+  for (const entry of set.servers) {
+    if (entry.plugin) byId[entry.serverId] = entry.plugin;
+  }
+  return byId;
+}
+
+/** Every skill in the set, plugin channel first (stable advertisement order). */
+export function allEffectiveSkills(
+  set: EffectiveCapabilitySet
+): Array<RuntimePluginSkill | RuntimeStandaloneSkill> {
+  return [...set.pluginSkills, ...set.standaloneSkills];
+}

--- a/mcpjam-inspector/server/services/environments/plugin-attribution.ts
+++ b/mcpjam-inspector/server/services/environments/plugin-attribution.ts
@@ -60,7 +60,36 @@ export interface PluginRuntimeAttribution {
   serverOrigins: Map<string, AttributedPluginVersion>;
   /** Materialized skill id → its namespaced ref + contributing version. */
   skillOrigins: Map<string, AttributedPluginSkill>;
+  /**
+   * Pinned versions the probe could not attribute — because they became
+   * unavailable between the environment resolution and this read, or answered
+   * in a shape we could not parse.
+   *
+   * NON-EMPTY MEANS THE MAPS ABOVE ARE INCOMPLETE. A caller must surface that
+   * (as a capability problem), never treat a short map as a complete answer:
+   * the affected servers and skills still run, and silently losing their
+   * provenance is exactly the failure `problems` exists to prevent.
+   */
+  unattributedVersionIds: string[];
 }
+
+/**
+ * How long the whole attribution fan-out may take before we give up.
+ *
+ * `ConvexHttpClient.query` has no per-call deadline, so without this a Convex
+ * read that never settles blocks the chat route BEFORE the turn starts — the
+ * user's send hangs forever for the sake of a provenance LABEL. Five seconds is
+ * far beyond a small indexed read and far below anything a person would wait
+ * through; on expiry we return `null` and the turn runs with origin unreported,
+ * the same as every other failure here.
+ *
+ * The timed-out queries are left to settle on their own rather than aborted via
+ * `setFetchOptions`: that setter mutates the SHARED client the route also uses
+ * for the environment resolution, so an attribution deadline would silently
+ * become that read's deadline too. Dangling reads are harmless — they are pure
+ * queries whose results we drop.
+ */
+const ATTRIBUTION_TIMEOUT_MS = 5_000;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
@@ -143,19 +172,33 @@ export async function fetchPluginRuntimeAttribution(
   args: { projectId: string; pluginVersionIds: string[] }
 ): Promise<PluginRuntimeAttribution | null> {
   if (args.pluginVersionIds.length === 0) {
-    return { serverOrigins: new Map(), skillOrigins: new Map() };
+    return {
+      serverOrigins: new Map(),
+      skillOrigins: new Map(),
+      unattributedVersionIds: [],
+    };
   }
   let probed: Array<Awaited<ReturnType<typeof probeOneVersion>>>;
   try {
-    probed = await Promise.all(
-      args.pluginVersionIds.map((id) =>
-        probeOneVersion(client, args.projectId, id)
-      )
-    );
+    probed = await Promise.race([
+      Promise.all(
+        args.pluginVersionIds.map((id) =>
+          probeOneVersion(client, args.projectId, id)
+        )
+      ),
+      // Rejects on expiry, landing in the same catch as any other failure.
+      new Promise<never>((_resolve, reject) => {
+        const timer = setTimeout(
+          () => reject(new Error("attribution probe timed out")),
+          ATTRIBUTION_TIMEOUT_MS
+        );
+        timer.unref?.();
+      }),
+    ]);
   } catch (error) {
-    // Includes the deploy-skew case (`Could not find public function`). One
-    // failed probe poisons the whole map: a partial map would silently present
-    // an unattributed plugin server as an ordinary one.
+    // Includes the deploy-skew case (`Could not find public function`) and the
+    // deadline above. One failed probe poisons the whole map: a partial map
+    // would silently present an unattributed plugin server as an ordinary one.
     logger.warn(
       "[plugin-attribution] probe failed; running without plugin origin",
       { error: error instanceof Error ? error.message : String(error) }
@@ -165,8 +208,14 @@ export async function fetchPluginRuntimeAttribution(
 
   const serverOrigins = new Map<string, AttributedPluginVersion>();
   const skillOrigins = new Map<string, AttributedPluginSkill>();
-  for (const result of probed) {
-    if (!result) continue;
+  const unattributedVersionIds: string[] = [];
+  for (const [index, result] of probed.entries()) {
+    if (!result) {
+      // The version resolved for the environment but not for this probe — a
+      // torn read. Its components still run; we just cannot name their origin.
+      unattributedVersionIds.push(args.pluginVersionIds[index]);
+      continue;
+    }
     for (const serverId of result.serverIds) {
       // First pin wins, matching the backend's dedupe of `effectiveServerIds`
       // in pin order. Two versions of the same plugin can materialize the same
@@ -185,5 +234,5 @@ export async function fetchPluginRuntimeAttribution(
       }
     }
   }
-  return { serverOrigins, skillOrigins };
+  return { serverOrigins, skillOrigins, unattributedVersionIds };
 }

--- a/mcpjam-inspector/server/services/environments/plugin-attribution.ts
+++ b/mcpjam-inspector/server/services/environments/plugin-attribution.ts
@@ -1,0 +1,189 @@
+/**
+ * Per-VERSION plugin attribution for a resolved environment turn (INS-3).
+ *
+ * `resolveEnvironmentForRuntime` tells us WHICH plugin versions are pinned and
+ * WHICH server ids they contributed — but as two flat lists
+ * (`pluginVersions`, `servers.pluginServerIds`), with no edge between them. It
+ * also carries no `modelRef`, so a plugin skill arrives under its bare
+ * materialized name. Two pinned plugins therefore look identical at the point
+ * where a tool call or a skill load has to say where it came from.
+ *
+ * The edge exists backend-side (`pluginServerComponents` /
+ * `pluginSkillComponents` both key on `pluginVersionId`), and
+ * `lib/pluginRuntimeResolution.resolvePluginVersionsRuntime` returns it — but
+ * the INS-facing probe `plugins.resolvePluginRuntimePreview` FLATTENS it into
+ * `effectiveServerIds` / `pluginSkills` across every version it was asked
+ * about. So we recover the edge the only way the deployed API allows: ask the
+ * probe about ONE version at a time. Each response is then unambiguously that
+ * version's components.
+ *
+ * That is deliberately a consumption trick, not a reimplementation: every
+ * lifecycle rule (ready + installed + enabled + same-project, never a fallback
+ * to `activeVersionId`) still runs backend-side inside the probe, and the
+ * `modelRef` we read is the one `pluginSkillComponents` stored at
+ * materialization — never a `<name>/<name>` string we assembled here.
+ *
+ * FOLLOW-UP: a probe that returned component rows (pluginVersionId +
+ * componentKey per server) would collapse this to one call. Worth doing when
+ * pin counts grow; today a pinned set is a handful of versions read in
+ * parallel.
+ *
+ * ATTRIBUTION IS PROVENANCE, NEVER A GATE. Every failure mode returns `null`
+ * (tri-state — never a half-filled map, which would label some plugin servers
+ * as ordinary ones), and every caller must degrade to "origin unknown" rather
+ * than dropping a capability. The environment resolution already decided what
+ * runs; this only decides what we can honestly say about it.
+ */
+import type { ConvexHttpClient } from "convex/browser";
+import { logger } from "../../utils/logger.js";
+
+const PREVIEW_FUNCTION_REF = "plugins:resolvePluginRuntimePreview" as const;
+
+/** Identity + reproducibility anchor of one pinned version. */
+export interface AttributedPluginVersion {
+  pluginId: string;
+  pluginVersionId: string;
+  /** Normalized kebab-case plugin name — the `modelRef` namespace. */
+  name: string;
+  /** Absent only under deploy skew; never synthesized. */
+  bundleHash: string | null;
+}
+
+export interface AttributedPluginSkill {
+  /** `<plugin-name>/<declared-skill-name>`, straight from the component row. */
+  modelRef: string;
+  plugin: AttributedPluginVersion;
+}
+
+export interface PluginRuntimeAttribution {
+  /** Materialized server id → the pinned version that contributed it. */
+  serverOrigins: Map<string, AttributedPluginVersion>;
+  /** Materialized skill id → its namespaced ref + contributing version. */
+  skillOrigins: Map<string, AttributedPluginSkill>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+/**
+ * One probe call, scoped to a single pinned version.
+ *
+ * Returns `null` when the probe reports the version as unavailable or answers
+ * in a shape we cannot read. That is NOT an error: the environment resolution
+ * and this probe are separate reads, so a plugin disabled between them is a
+ * torn view, and the environment's answer is the one the turn already
+ * committed to. Reporting no origin is honest; inventing one is not.
+ */
+async function probeOneVersion(
+  client: ConvexHttpClient,
+  projectId: string,
+  pluginVersionId: string
+): Promise<{
+  plugin: AttributedPluginVersion;
+  serverIds: string[];
+  skills: Array<{ skillId: string; modelRef: string }>;
+} | null> {
+  const raw: unknown = await client.query(PREVIEW_FUNCTION_REF as any, {
+    projectId,
+    pluginVersionIds: [pluginVersionId],
+  } as any);
+  if (!isRecord(raw)) return null;
+
+  const versions = Array.isArray(raw.pluginVersions) ? raw.pluginVersions : [];
+  const version = versions.find(
+    (entry) =>
+      isRecord(entry) && readString(entry.pluginVersionId) === pluginVersionId
+  );
+  // Absent ⇒ the probe put it in `unavailableComponents`. Nothing to attribute.
+  if (!isRecord(version)) return null;
+  const pluginId = readString(version.pluginId);
+  const name = readString(version.name);
+  if (!pluginId || !name) return null;
+
+  const plugin: AttributedPluginVersion = {
+    pluginId,
+    pluginVersionId,
+    name,
+    bundleHash: readString(version.bundleHash),
+  };
+
+  const serverIds = (
+    Array.isArray(raw.effectiveServerIds) ? raw.effectiveServerIds : []
+  )
+    .map(readString)
+    .filter((id): id is string => id !== null);
+
+  const skills: Array<{ skillId: string; modelRef: string }> = [];
+  for (const entry of Array.isArray(raw.pluginSkills) ? raw.pluginSkills : []) {
+    if (!isRecord(entry)) continue;
+    const skillId = readString(entry.materializedSkillId);
+    const modelRef = readString(entry.modelRef);
+    if (skillId && modelRef) skills.push({ skillId, modelRef });
+  }
+
+  return { plugin, serverIds, skills };
+}
+
+/**
+ * Build the server/skill → pinned-version edges for a turn.
+ *
+ * `null` means "no attribution available" and MUST be treated as such by
+ * callers — see the module note. An empty pin list short-circuits to empty maps
+ * (a no-plugin environment costs zero extra reads, which is what keeps
+ * `resolveEnvironmentForRuntime`'s one-atomic-read guarantee meaningful for the
+ * overwhelmingly common case).
+ */
+export async function fetchPluginRuntimeAttribution(
+  client: ConvexHttpClient,
+  args: { projectId: string; pluginVersionIds: string[] }
+): Promise<PluginRuntimeAttribution | null> {
+  if (args.pluginVersionIds.length === 0) {
+    return { serverOrigins: new Map(), skillOrigins: new Map() };
+  }
+  let probed: Array<Awaited<ReturnType<typeof probeOneVersion>>>;
+  try {
+    probed = await Promise.all(
+      args.pluginVersionIds.map((id) =>
+        probeOneVersion(client, args.projectId, id)
+      )
+    );
+  } catch (error) {
+    // Includes the deploy-skew case (`Could not find public function`). One
+    // failed probe poisons the whole map: a partial map would silently present
+    // an unattributed plugin server as an ordinary one.
+    logger.warn(
+      "[plugin-attribution] probe failed; running without plugin origin",
+      { error: error instanceof Error ? error.message : String(error) }
+    );
+    return null;
+  }
+
+  const serverOrigins = new Map<string, AttributedPluginVersion>();
+  const skillOrigins = new Map<string, AttributedPluginSkill>();
+  for (const result of probed) {
+    if (!result) continue;
+    for (const serverId of result.serverIds) {
+      // First pin wins, matching the backend's dedupe of `effectiveServerIds`
+      // in pin order. Two versions of the same plugin can materialize the same
+      // component only across a re-import, which the environment's own dedupe
+      // already collapsed.
+      if (!serverOrigins.has(serverId)) {
+        serverOrigins.set(serverId, result.plugin);
+      }
+    }
+    for (const skill of result.skills) {
+      if (!skillOrigins.has(skill.skillId)) {
+        skillOrigins.set(skill.skillId, {
+          modelRef: skill.modelRef,
+          plugin: result.plugin,
+        });
+      }
+    }
+  }
+  return { serverOrigins, skillOrigins };
+}

--- a/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
+++ b/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
@@ -709,7 +709,18 @@ export interface PrepareChatV2Options {
    */
   skillsSource?:
     | { kind: "pinned"; skills: PinnableSkill[] }
-    | { kind: "resolved"; capabilities: EffectiveCapabilitySet }
+    | {
+        kind: "resolved";
+        capabilities: EffectiveCapabilitySet;
+        /**
+         * The turn's abort signal. Carried HERE rather than added to
+         * `PrepareChatV2Options` because this is the only consumer: a skill
+         * supporting-file read fetches a signed `_storage` URL, and without it
+         * that fetch runs its full 30s timeout after the client has already
+         * disconnected.
+         */
+        abortSignal?: AbortSignal;
+      }
     | { kind: "none" };
 }
 
@@ -964,6 +975,9 @@ export async function prepareChatV2(
         ? getPinnedSkillToolsAndPrompt(skillsSource.skills)
         : skillsSource.kind === "resolved"
           ? getEffectiveSkillToolsAndPrompt(skillsSource.capabilities, {
+              ...(skillsSource.abortSignal
+                ? { signal: skillsSource.abortSignal }
+                : {}),
               // The discovery listing is budgeted against THIS model's context
               // (INS-3 / OpenAI's 2% rule). `contextLength` is optional on a
               // model definition; the budget helper falls back to 8,000 chars.

--- a/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
+++ b/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
@@ -34,8 +34,9 @@ import { getSkillToolsAndPrompt } from "./skill-tools.js";
 import {
   getCloudSkillToolsAndPrompt,
   getPinnedSkillToolsAndPrompt,
-  getResolvedSkillToolsAndPrompt,
 } from "./computers/cloud-skill-tools.js";
+import { getEffectiveSkillToolsAndPrompt } from "./computers/effective-skill-tools.js";
+import type { EffectiveCapabilitySet } from "../services/environments/effective-capabilities.js";
 import type { PinnableSkill } from "../../shared/skill-types.js";
 import { logger } from "./logger.js";
 import { isGPT5Model, type ModelDefinition } from "@/shared/types";
@@ -691,11 +692,15 @@ export interface PrepareChatV2Options {
    *  - `pinned`   — EVAL RUNNERS ONLY. Frozen in-memory tools over snapshotted
    *    content (zero network in execute). Tools bypass approval: pure reads of
    *    frozen content under an auto-deny eval run.
-   *  - `resolved` — a Project-Environment turn (Phase 1.4). Same in-memory
-   *    delivery, DIFFERENT policy: this is an ordinary interactive turn, so the
-   *    skill tools follow the host's normal `requireToolApproval` rule. The eval
+   *  - `resolved` — a Project-Environment turn. Same in-memory delivery,
+   *    DIFFERENT policy: this is an ordinary interactive turn, so the skill
+   *    tools follow the host's normal `requireToolApproval` rule. The eval
    *    approval exemption is deliberately NOT inherited — a user watching their
-   *    own turn should still get the approval prompt they configured.
+   *    own turn should still get the approval prompt they configured. It
+   *    carries the whole `EffectiveCapabilitySet` rather than a skill list
+   *    (INS-3) because the tools address skills by REF: a plugin skill is
+   *    `<plugin>/<skill>`, and the origin/file metadata the ref surface needs
+   *    lives on the set, not on a flattened `PinnableSkill`.
    *  - `none`     — suppress skills entirely.
    *
    * `resolved` and `pinned` are separate kinds rather than one "in-memory" kind
@@ -704,7 +709,7 @@ export interface PrepareChatV2Options {
    */
   skillsSource?:
     | { kind: "pinned"; skills: PinnableSkill[] }
-    | { kind: "resolved"; skills: PinnableSkill[] }
+    | { kind: "resolved"; capabilities: EffectiveCapabilitySet }
     | { kind: "none" };
 }
 
@@ -958,7 +963,14 @@ export async function prepareChatV2(
       ? skillsSource.kind === "pinned"
         ? getPinnedSkillToolsAndPrompt(skillsSource.skills)
         : skillsSource.kind === "resolved"
-          ? getResolvedSkillToolsAndPrompt(skillsSource.skills)
+          ? getEffectiveSkillToolsAndPrompt(skillsSource.capabilities, {
+              // The discovery listing is budgeted against THIS model's context
+              // (INS-3 / OpenAI's 2% rule). `contextLength` is optional on a
+              // model definition; the budget helper falls back to 8,000 chars.
+              ...(modelDefinition.contextLength !== undefined
+                ? { modelContextTokens: modelDefinition.contextLength }
+                : {}),
+            })
           : { tools: {}, systemPromptSection: "" }
       : cloudSkills
         ? getCloudSkillToolsAndPrompt({

--- a/mcpjam-inspector/server/utils/computers/__tests__/effective-skill-tools.test.ts
+++ b/mcpjam-inspector/server/utils/computers/__tests__/effective-skill-tools.test.ts
@@ -95,6 +95,27 @@ describe("listSkills", () => {
     );
   });
 
+  it("still calls an unattributed plugin skill a plugin skill, not a project one", async () => {
+    // Mislabelling it "project" would be a false claim about where the model's
+    // instructions came from.
+    const { tools } = getEffectiveSkillToolsAndPrompt(
+      set({
+        pluginSkills: [
+          {
+            ref: "summarize",
+            skillId: "sk_a",
+            name: "summarize",
+            description: "Summarize",
+            content: "body",
+            aggregateHash: "agg",
+            files: [],
+          },
+        ],
+      })
+    );
+    expect(await run(tools.listSkills, {})).toContain("**summarize** (plugin)");
+  });
+
   it("says the turn has no skills rather than inventing a project-wide list", async () => {
     const { tools } = getEffectiveSkillToolsAndPrompt(set());
     expect(await run(tools.listSkills, {})).toBe(

--- a/mcpjam-inspector/server/utils/computers/__tests__/effective-skill-tools.test.ts
+++ b/mcpjam-inspector/server/utils/computers/__tests__/effective-skill-tools.test.ts
@@ -1,0 +1,254 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getEffectiveSkillToolsAndPrompt } from "../effective-skill-tools";
+import type { EffectiveCapabilitySet } from "../../../services/environments/effective-capabilities";
+
+const PLUGIN_A = {
+  pluginId: "p_a",
+  pluginVersionId: "pv_a",
+  name: "alpha",
+  bundleHash: "aaaa1111bbbb",
+};
+const PLUGIN_B = {
+  pluginId: "p_b",
+  pluginVersionId: "pv_b",
+  name: "beta",
+  bundleHash: "bbbb2222cccc",
+};
+
+function set(overrides: Partial<EffectiveCapabilitySet> = {}) {
+  return {
+    explicitServerIds: [],
+    pluginServerIds: [],
+    effectiveServerIds: [],
+    servers: [],
+    pluginSkills: [],
+    standaloneSkills: [],
+    pluginVersions: [],
+    problems: [],
+    ...overrides,
+  } satisfies EffectiveCapabilitySet;
+}
+
+/** The AI SDK tool shape exposes `execute`; call it the way streamText would. */
+async function run(tool: unknown, input: unknown): Promise<string> {
+  const execute = (tool as { execute: (i: unknown) => Promise<string> })
+    .execute;
+  return execute(input);
+}
+
+const DUPLICATE_NAME_SET = set({
+  pluginSkills: [
+    {
+      ref: "alpha/summarize",
+      skillId: "sk_a",
+      name: "summarize",
+      description: "Alpha's summarizer",
+      content: "ALPHA BODY",
+      aggregateHash: "agg_a",
+      files: [],
+      plugin: PLUGIN_A,
+    },
+    {
+      ref: "beta/summarize",
+      skillId: "sk_b",
+      name: "summarize",
+      description: "Beta's summarizer",
+      content: "BETA BODY",
+      aggregateHash: "agg_b",
+      files: [],
+      plugin: PLUGIN_B,
+    },
+  ],
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("listSkills", () => {
+  it("advertises refs and origins, not bare names", async () => {
+    const { tools } = getEffectiveSkillToolsAndPrompt(DUPLICATE_NAME_SET);
+    const listing = await run(tools.listSkills, {});
+    expect(listing).toContain("**alpha/summarize** (plugin alpha@aaaa1111)");
+    expect(listing).toContain("**beta/summarize** (plugin beta@bbbb2222)");
+  });
+
+  it("labels a standalone skill as a project skill", async () => {
+    const { tools } = getEffectiveSkillToolsAndPrompt(
+      set({
+        standaloneSkills: [
+          {
+            ref: "release-notes",
+            skillId: "sk",
+            name: "release-notes",
+            description: "Write release notes",
+            content: "body",
+            aggregateHash: "agg",
+            files: [],
+            channels: ["environment"],
+          },
+        ],
+      })
+    );
+    expect(await run(tools.listSkills, {})).toContain(
+      "**release-notes** (project)"
+    );
+  });
+
+  it("says the turn has no skills rather than inventing a project-wide list", async () => {
+    const { tools } = getEffectiveSkillToolsAndPrompt(set());
+    expect(await run(tools.listSkills, {})).toBe(
+      "No skills are available for this turn."
+    );
+  });
+
+  it("states that skills were dropped when the metadata budget omits them", async () => {
+    const many = Array.from({ length: 40 }, (_, index) => ({
+      ref: `skill-${index}`,
+      skillId: `sk_${index}`,
+      name: `skill-${index}`,
+      description: "d".repeat(400),
+      content: "body",
+      aggregateHash: "agg",
+      files: [],
+      channels: ["environment" as const],
+    }));
+    const { tools } = getEffectiveSkillToolsAndPrompt(
+      set({ standaloneSkills: many }),
+      // A tiny context makes the 2% budget bite deterministically.
+      { modelContextTokens: 1_000 }
+    );
+    const listing = await run(tools.listSkills, {});
+    expect(listing).toMatch(/could not be listed within this model's skill-metadata budget/);
+  });
+});
+
+describe("loadSkill", () => {
+  it("loads the correct content for each of two plugins declaring one name", async () => {
+    const { tools } = getEffectiveSkillToolsAndPrompt(DUPLICATE_NAME_SET);
+    expect(await run(tools.loadSkill, { name: "alpha/summarize" })).toContain(
+      "ALPHA BODY"
+    );
+    expect(await run(tools.loadSkill, { name: "beta/summarize" })).toContain(
+      "BETA BODY"
+    );
+  });
+
+  it("refuses an ambiguous bare name and names both refs", async () => {
+    const { tools } = getEffectiveSkillToolsAndPrompt(DUPLICATE_NAME_SET);
+    const result = await run(tools.loadSkill, { name: "summarize" });
+    expect(result).toContain("ambiguous");
+    expect(result).toContain('"alpha/summarize"');
+    expect(result).toContain('"beta/summarize"');
+    // Crucially: it did NOT silently pick one.
+    expect(result).not.toContain("ALPHA BODY");
+  });
+
+  it("accepts a bare name when it is unambiguous", async () => {
+    const { tools } = getEffectiveSkillToolsAndPrompt(
+      set({ pluginSkills: [DUPLICATE_NAME_SET.pluginSkills[0]] })
+    );
+    expect(await run(tools.loadSkill, { name: "summarize" })).toContain(
+      "ALPHA BODY"
+    );
+  });
+
+  it("rejects a malformed reference", async () => {
+    const { tools } = getEffectiveSkillToolsAndPrompt(DUPLICATE_NAME_SET);
+    expect(await run(tools.loadSkill, { name: "../etc/passwd" })).toContain(
+      "Invalid skill reference"
+    );
+  });
+
+  it("reports an unknown reference", async () => {
+    const { tools } = getEffectiveSkillToolsAndPrompt(DUPLICATE_NAME_SET);
+    expect(await run(tools.loadSkill, { name: "gamma/thing" })).toContain(
+      "not found"
+    );
+  });
+});
+
+describe("supporting files", () => {
+  const fileSet = set({
+    pluginSkills: [
+      {
+        ref: "alpha/report",
+        skillId: "sk_a",
+        name: "report",
+        description: "Reporting",
+        content: "body",
+        aggregateHash: "agg",
+        files: [
+          { path: "scripts/fill.py", size: 11, url: "https://blob/fill" },
+          { path: "assets/logo.png", size: 9, url: "https://blob/logo" },
+          { path: "no-url.txt", size: 4, url: null },
+        ],
+        plugin: PLUGIN_A,
+      },
+    ],
+  });
+
+  it("lists a skill's files through its ref", async () => {
+    const { tools } = getEffectiveSkillToolsAndPrompt(fileSet);
+    const listed = await run(tools.listSkillFiles, { name: "alpha/report" });
+    expect(listed).toContain("scripts/fill.py (11 bytes)");
+  });
+
+  it("reads a text file from the signed URL the environment already minted", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        new Response(new TextEncoder().encode("print(1)"), { status: 200 })
+      );
+    const { tools } = getEffectiveSkillToolsAndPrompt(fileSet);
+    const result = await run(tools.readSkillFile, {
+      name: "alpha/report",
+      path: "scripts/fill.py",
+    });
+    expect(fetchMock.mock.calls[0][0]).toBe("https://blob/fill");
+    expect(result).toContain("print(1)");
+  });
+
+  it("refuses a path that is not a file of that skill — refs bound file reads", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    const { tools } = getEffectiveSkillToolsAndPrompt(fileSet);
+    const result = await run(tools.readSkillFile, {
+      name: "alpha/report",
+      path: "../other/secret.txt",
+    });
+    expect(result).toContain("is not a supporting file");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("reports a binary file rather than returning garbage text", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(new Uint8Array([0, 1, 2]), { status: 200 })
+    );
+    const { tools } = getEffectiveSkillToolsAndPrompt(fileSet);
+    expect(
+      await run(tools.readSkillFile, {
+        name: "alpha/report",
+        path: "assets/logo.png",
+      })
+    ).toContain("is binary");
+  });
+
+  it("says so when no download URL was issued", async () => {
+    const { tools } = getEffectiveSkillToolsAndPrompt(fileSet);
+    expect(
+      await run(tools.readSkillFile, {
+        name: "alpha/report",
+        path: "no-url.txt",
+      })
+    ).toContain("no download URL");
+  });
+
+  it("advertises the file tools only when the set has a file-bearing skill", () => {
+    expect(
+      getEffectiveSkillToolsAndPrompt(fileSet).systemPromptSection
+    ).toContain("listSkillFiles");
+    expect(
+      getEffectiveSkillToolsAndPrompt(DUPLICATE_NAME_SET).systemPromptSection
+    ).not.toContain("listSkillFiles");
+  });
+});

--- a/mcpjam-inspector/server/utils/computers/__tests__/effective-skill-tools.test.ts
+++ b/mcpjam-inspector/server/utils/computers/__tests__/effective-skill-tools.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { getEffectiveSkillToolsAndPrompt } from "../effective-skill-tools";
+import { skillMetadataBudgetChars } from "../skill-metadata-budget";
 import type { EffectiveCapabilitySet } from "../../../services/environments/effective-capabilities";
 
 const PLUGIN_A = {
@@ -121,6 +122,38 @@ describe("listSkills", () => {
     expect(await run(tools.listSkills, {})).toBe(
       "No skills are available for this turn."
     );
+  });
+
+  it("emits a listing that actually fits the budget, origin labels included", async () => {
+    // The accounting is only worth having if the STRING obeys it. Plugin
+    // origins ("plugin alpha@aaaa1111") are ~25 chars each, so an uncharged
+    // origin overshoots by an amount that grows with the plugin-skill count.
+    const many = Array.from({ length: 30 }, (_, index) => ({
+      ref: `alpha/skill-${index}`,
+      skillId: `sk_${index}`,
+      name: `skill-${index}`,
+      description: "d".repeat(120),
+      content: "body",
+      aggregateHash: "agg",
+      files: [],
+      plugin: PLUGIN_A,
+    }));
+    const modelContextTokens = 25_000; // 2% × 4 chars/token = 2,000 chars.
+    const budgetChars = skillMetadataBudgetChars(modelContextTokens);
+    const { tools } = getEffectiveSkillToolsAndPrompt(
+      set({ pluginSkills: many }),
+      { modelContextTokens }
+    );
+
+    const listing = await run(tools.listSkills, {});
+    // The omission notice is deliberately outside the budget (it reports that
+    // the budget bit), as is the "Available skills:" header; measure the lines.
+    const body = listing
+      .replace(/^Available skills:\n\n/, "")
+      .replace(/\n\n\(\d+ more skills? could not be listed[^)]*\)$/, "");
+    expect(body.length).toBeLessThanOrEqual(budgetChars);
+    // And the origin really is in the measured text, or the assertion is empty.
+    expect(body).toContain("(plugin alpha@aaaa1111)");
   });
 
   it("states that skills were dropped when the metadata budget omits them", async () => {

--- a/mcpjam-inspector/server/utils/computers/__tests__/skill-metadata-budget.test.ts
+++ b/mcpjam-inspector/server/utils/computers/__tests__/skill-metadata-budget.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import {
+  applySkillMetadataBudget,
+  SKILL_METADATA_FALLBACK_BUDGET_CHARS,
+  skillMetadataBudgetChars,
+} from "../skill-metadata-budget";
+
+describe("skillMetadataBudgetChars", () => {
+  it("spends 2% of the model's context", () => {
+    // 200k tokens × 2% = 4,000 tokens ≈ 16,000 chars.
+    expect(skillMetadataBudgetChars(200_000)).toBe(16_000);
+  });
+
+  it("falls back to 8,000 chars when the context size is unknown", () => {
+    expect(skillMetadataBudgetChars(undefined)).toBe(
+      SKILL_METADATA_FALLBACK_BUDGET_CHARS
+    );
+  });
+
+  it("treats a nonsensical context length as unknown, never as zero budget", () => {
+    // Zero budget would silently advertise no skills at all.
+    expect(skillMetadataBudgetChars(0)).toBe(
+      SKILL_METADATA_FALLBACK_BUDGET_CHARS
+    );
+    expect(skillMetadataBudgetChars(Number.NaN)).toBe(
+      SKILL_METADATA_FALLBACK_BUDGET_CHARS
+    );
+    expect(skillMetadataBudgetChars(-1)).toBe(
+      SKILL_METADATA_FALLBACK_BUDGET_CHARS
+    );
+  });
+});
+
+describe("applySkillMetadataBudget", () => {
+  it("passes a listing that fits through untouched", () => {
+    const entries = [
+      { ref: "alpha", description: "does alpha" },
+      { ref: "beta", description: "does beta" },
+    ];
+    const result = applySkillMetadataBudget(entries, 8_000);
+    expect(result.entries).toEqual(entries);
+    expect(result.truncatedRefs).toEqual([]);
+    expect(result.omittedRefs).toEqual([]);
+  });
+
+  it("truncates a description before omitting the skill", () => {
+    const result = applySkillMetadataBudget(
+      [{ ref: "alpha", description: "x".repeat(500) }],
+      200
+    );
+    expect(result.omittedRefs).toEqual([]);
+    expect(result.truncatedRefs).toEqual(["alpha"]);
+    expect(result.entries[0].description.length).toBeLessThan(500);
+    // The ellipsis tells the model the text was cut, so it knows `loadSkill`
+    // still has the whole thing.
+    expect(result.entries[0].description.endsWith("…")).toBe(true);
+  });
+
+  it("omits an entry only when what remains cannot describe anything", () => {
+    const result = applySkillMetadataBudget(
+      [
+        { ref: "alpha", description: "x".repeat(200) },
+        { ref: "beta", description: "y".repeat(200) },
+      ],
+      210
+    );
+    expect(result.truncatedRefs).toEqual(["alpha"]);
+    expect(result.omittedRefs).toEqual(["beta"]);
+  });
+
+  it("keeps trying later entries after an omission", () => {
+    // A long entry exhausting the budget must not hide a short one behind it.
+    const result = applySkillMetadataBudget(
+      [
+        { ref: "alpha", description: "a".repeat(60) },
+        { ref: "big", description: "b".repeat(400) },
+        { ref: "small", description: "c" },
+      ],
+      100
+    );
+    expect(result.entries.map((entry) => entry.ref)).toEqual([
+      "alpha",
+      "small",
+    ]);
+    expect(result.omittedRefs).toEqual(["big"]);
+  });
+
+  it("preserves extra fields on the entries it admits", () => {
+    const result = applySkillMetadataBudget(
+      [{ ref: "alpha", description: "x".repeat(500), origin: "plugin a" }],
+      200
+    );
+    expect(result.entries[0].origin).toBe("plugin a");
+  });
+});

--- a/mcpjam-inspector/server/utils/computers/__tests__/skill-metadata-budget.test.ts
+++ b/mcpjam-inspector/server/utils/computers/__tests__/skill-metadata-budget.test.ts
@@ -85,6 +85,30 @@ describe("applySkillMetadataBudget", () => {
     expect(result.omittedRefs).toEqual(["big"]);
   });
 
+  it("charges the origin label, not just ref + description", () => {
+    // Same ref and description, one with an origin: the origin must cost.
+    const withoutOrigin = applySkillMetadataBudget(
+      [
+        { ref: "a", description: "x".repeat(50) },
+        { ref: "b", description: "y".repeat(50) },
+      ],
+      140
+    );
+    const withOrigin = applySkillMetadataBudget(
+      [
+        { ref: "a", description: "x".repeat(50), origin: "plugin alpha@aaaa1111" },
+        { ref: "b", description: "y".repeat(50), origin: "plugin alpha@aaaa1111" },
+      ],
+      140
+    );
+    expect(withoutOrigin.truncatedRefs).toEqual([]);
+    expect(withoutOrigin.omittedRefs).toEqual([]);
+    // The uncharged version fit both entries; charging the origin does not.
+    expect(
+      withOrigin.truncatedRefs.length + withOrigin.omittedRefs.length
+    ).toBeGreaterThan(0);
+  });
+
   it("preserves extra fields on the entries it admits", () => {
     const result = applySkillMetadataBudget(
       [{ ref: "alpha", description: "x".repeat(500), origin: "plugin a" }],

--- a/mcpjam-inspector/server/utils/computers/cloud-skill-tools.ts
+++ b/mcpjam-inspector/server/utils/computers/cloud-skill-tools.ts
@@ -269,23 +269,8 @@ export function getPinnedSkillToolsAndPrompt(skills: PinnableSkill[]): {
   };
 }
 
-/**
- * RESOLVED skill tools for a Project-Environment turn (Phase 1.4). Structurally
- * identical to the pinned set — an in-memory closure over exactly the artifacts
- * the environment resolved, with no live project-pool read — because the
- * environment's set is authoritative for the turn and a live `listSkills` would
- * advertise skills the environment deliberately excluded.
- *
- * The behavioral difference lives at the CALL SITE, not here: `prepareChatV2`
- * wraps these with `needsApproval` under the host's ordinary
- * `requireToolApproval`, whereas pinned tools bypass approval. Same reason the
- * file tools stay omitted: an environment turn delivers SKILL.md bodies through
- * `loadSkill`; supporting files reach a harness box through materialization, not
- * through emulated tool calls.
- */
-export function getResolvedSkillToolsAndPrompt(skills: PinnableSkill[]): {
-  tools: ReturnType<typeof createPinnedSkillTools>;
-  systemPromptSection: string;
-} {
-  return getPinnedSkillToolsAndPrompt(skills);
-}
+// The Project-Environment turn used to reuse the pinned tools verbatim
+// (`getResolvedSkillToolsAndPrompt`). INS-3 replaced that with
+// `./effective-skill-tools.ts`, which addresses skills by REF rather than bare
+// name so two plugins may declare the same skill name, and which exposes the
+// supporting-file tools an environment turn genuinely can serve.

--- a/mcpjam-inspector/server/utils/computers/effective-skill-tools.ts
+++ b/mcpjam-inspector/server/utils/computers/effective-skill-tools.ts
@@ -1,0 +1,330 @@
+/**
+ * Skill tools over an `EffectiveCapabilitySet` (INS-3).
+ *
+ * This is the EXPLICIT skill source: an in-memory closure over exactly the
+ * skills one turn resolved, addressed by REF rather than by bare name.
+ *
+ * Why refs. `pluginSkillComponents.modelRef` namespaces a plugin skill as
+ * `<plugin>/<skill>` precisely so two installed plugins may each declare
+ * `summarize` without colliding in project-level skill identity. A bare-name
+ * tool surface throws that away at the last step: the model would ask for
+ * `summarize` and get whichever row we happened to index first. Every tool here
+ * — `loadSkill`, `listSkillFiles`, `readSkillFile` — resolves through the same
+ * ref, so a duplicate declared name cannot cross a plugin boundary.
+ *
+ * Bare names still work, and must: standalone project skills have no namespace,
+ * and a model that read `summarize` in a prompt should be able to load it. A
+ * bare name is accepted when it identifies exactly ONE skill in the set; when
+ * it is ambiguous the tool refuses and names both refs rather than guessing.
+ *
+ * Supporting files come from the signed URLs the environment resolution already
+ * minted in the SAME read as the skill body (see the backend's note on why a
+ * separate `listSkillFilesForRuntime` call would let a body from one revision
+ * pair with files from another). No extra network round-trip to Convex happens
+ * here — only the `_storage` GET for a file the model actually asked for.
+ *
+ * Approval policy is the CALLER's: `prepareChatV2` wraps these with the host's
+ * ordinary `requireToolApproval`. Plugin origin never bypasses approval.
+ */
+import { tool } from "ai";
+import { z } from "zod";
+import { getMimeType, isTextMimeType } from "../skill-parser.js";
+import { logger } from "../logger.js";
+import {
+  MAX_SKILL_FILE_TEXT_BYTES,
+  SKILL_FILE_MAX_READ_BYTES,
+} from "./cloud-skills.js";
+import {
+  allEffectiveSkills,
+  type EffectiveCapabilitySet,
+  type RuntimePluginSkill,
+  type RuntimeStandaloneSkill,
+} from "../../services/environments/effective-capabilities.js";
+import {
+  applySkillMetadataBudget,
+  skillMetadataBudgetChars,
+} from "./skill-metadata-budget.js";
+
+type EffectiveSkill = RuntimePluginSkill | RuntimeStandaloneSkill;
+
+/** Bare standalone name, or a `<plugin>/<skill>` namespaced plugin ref. */
+const REF_RE = /^[a-z0-9-]+(\/[a-z0-9-]+)?$/;
+
+function pluginOf(skill: EffectiveSkill): RuntimePluginSkill["plugin"] {
+  return (skill as RuntimePluginSkill).plugin;
+}
+
+/** Human-readable provenance for the discovery listing. */
+function originLabel(skill: EffectiveSkill): string {
+  const plugin = pluginOf(skill);
+  if (plugin) {
+    // A short bundle-hash prefix, not the full hash: enough to tell two
+    // revisions apart in a listing without spending the budget on 64 chars.
+    const revision = plugin.bundleHash
+      ? `@${plugin.bundleHash.slice(0, 8)}`
+      : "";
+    return `plugin ${plugin.name}${revision}`;
+  }
+  return "project";
+}
+
+interface SkillLookup {
+  byRef: Map<string, EffectiveSkill>;
+  /** Bare name → every ref carrying it. Length > 1 ⇒ ambiguous. */
+  refsByName: Map<string, string[]>;
+}
+
+function buildLookup(skills: EffectiveSkill[]): SkillLookup {
+  const byRef = new Map<string, EffectiveSkill>();
+  const refsByName = new Map<string, string[]>();
+  for (const skill of skills) {
+    byRef.set(skill.ref, skill);
+    const refs = refsByName.get(skill.name) ?? [];
+    refs.push(skill.ref);
+    refsByName.set(skill.name, refs);
+  }
+  return { byRef, refsByName };
+}
+
+type Resolution =
+  | { ok: true; skill: EffectiveSkill }
+  | { ok: false; error: string };
+
+/**
+ * Resolve a model-supplied reference.
+ *
+ * Exact ref first, then the bare-name shortcut — and ONLY when unambiguous.
+ * Refusing an ambiguous bare name is the point of the whole module: silently
+ * picking one of two same-named plugin skills is the failure this replaces.
+ */
+function resolveRef(lookup: SkillLookup, raw: string): Resolution {
+  if (!REF_RE.test(raw)) {
+    return {
+      ok: false,
+      error: `Error: Invalid skill reference "${raw}". Use a skill name (e.g. 'pdf-processing') or a plugin reference (e.g. 'my-plugin/pdf-processing').`,
+    };
+  }
+  const exact = lookup.byRef.get(raw);
+  if (exact) return { ok: true, skill: exact };
+
+  const refs = lookup.refsByName.get(raw);
+  if (refs && refs.length === 1) {
+    const skill = lookup.byRef.get(refs[0]);
+    if (skill) return { ok: true, skill };
+  }
+  if (refs && refs.length > 1) {
+    return {
+      ok: false,
+      error: `Error: "${raw}" is ambiguous — it matches ${refs
+        .map((ref) => `"${ref}"`)
+        .join(" and ")}. Use the full reference.`,
+    };
+  }
+  return { ok: false, error: `Error: Skill "${raw}" not found.` };
+}
+
+function findFile(
+  skill: EffectiveSkill,
+  path: string
+): { path: string; size: number; url: string | null } | undefined {
+  return skill.files.find((file) => file.path === path);
+}
+
+/**
+ * Build the discovery listing under the metadata budget, plus the refs that had
+ * to be dropped. Computed ONCE at tool-construction time so every `listSkills`
+ * call in a turn describes the same set (and so omissions are traced once).
+ */
+function buildListing(
+  skills: EffectiveSkill[],
+  modelContextTokens: number | undefined
+): { text: string; omittedRefs: string[] } {
+  if (skills.length === 0) {
+    return { text: "No skills are available for this turn.", omittedRefs: [] };
+  }
+  const budgetChars = skillMetadataBudgetChars(modelContextTokens);
+  const { entries, omittedRefs } = applySkillMetadataBudget(
+    skills.map((skill) => ({
+      ref: skill.ref,
+      description: skill.description,
+      origin: originLabel(skill),
+    })),
+    budgetChars
+  );
+
+  const lines = entries.map(
+    (entry) => `- **${entry.ref}** (${entry.origin}): ${entry.description}`
+  );
+  // Absence is semantic: say that skills were dropped rather than presenting a
+  // short list as if it were the whole set.
+  const notice =
+    omittedRefs.length > 0
+      ? `\n\n(${omittedRefs.length} more skill${
+          omittedRefs.length === 1 ? "" : "s"
+        } could not be listed within this model's skill-metadata budget.)`
+      : "";
+  return {
+    text: `Available skills:\n\n${lines.join("\n")}${notice}`,
+    omittedRefs,
+  };
+}
+
+export function createEffectiveSkillTools(args: {
+  skills: EffectiveSkill[];
+  modelContextTokens?: number;
+  signal?: AbortSignal;
+}) {
+  const lookup = buildLookup(args.skills);
+  const listing = buildListing(args.skills, args.modelContextTokens);
+  if (listing.omittedRefs.length > 0) {
+    logger.warn(
+      "[effective-skills] skill metadata budget exceeded; skills omitted from discovery",
+      {
+        omitted: listing.omittedRefs,
+        total: args.skills.length,
+      }
+    );
+  }
+
+  return {
+    listSkills: tool({
+      description:
+        "List the skills available to you for this turn. Returns each skill's reference, origin, and description. Call this first, then `loadSkill` with the reference.",
+      inputSchema: z.object({}),
+      execute: async () => listing.text,
+    }),
+
+    loadSkill: tool({
+      description:
+        "Load a skill's full instructions by reference. Use when a task matches a skill's purpose.",
+      inputSchema: z.object({
+        name: z
+          .string()
+          .describe(
+            "The skill reference from `listSkills` — a bare name ('pdf-processing') or a plugin reference ('my-plugin/pdf-processing')."
+          ),
+      }),
+      execute: async ({ name }) => {
+        const resolved = resolveRef(lookup, name);
+        if (!resolved.ok) return resolved.error;
+        const { skill } = resolved;
+        return `# Skill: ${skill.ref}\n\n${skill.content}`;
+      },
+    }),
+
+    listSkillFiles: tool({
+      description:
+        "List a skill's supporting files (scripts, references, assets). Use after `loadSkill` when a skill mentions supporting files.",
+      inputSchema: z.object({
+        name: z.string().describe("The skill reference."),
+      }),
+      execute: async ({ name }) => {
+        const resolved = resolveRef(lookup, name);
+        if (!resolved.ok) return resolved.error;
+        const { skill } = resolved;
+        if (skill.files.length === 0) {
+          return `Skill "${skill.ref}" has no supporting files.`;
+        }
+        return (
+          `Supporting files for "${skill.ref}":\n\n` +
+          skill.files.map((f) => `- ${f.path} (${f.size} bytes)`).join("\n") +
+          `\n\nUse \`readSkillFile\` to read one.`
+        );
+      },
+    }),
+
+    readSkillFile: tool({
+      description:
+        "Read the contents of a skill's supporting file by its relative path (e.g., 'scripts/fill.py').",
+      inputSchema: z.object({
+        name: z.string().describe("The skill reference."),
+        path: z
+          .string()
+          .describe("Relative path within the skill (e.g., 'scripts/fill.py')."),
+      }),
+      execute: async ({ name, path }) => {
+        const resolved = resolveRef(lookup, name);
+        if (!resolved.ok) return resolved.error;
+        const { skill } = resolved;
+        const file = findFile(skill, path);
+        if (!file) {
+          return `Error: "${path}" is not a supporting file of "${skill.ref}".`;
+        }
+        if (!file.url) {
+          return `Error: "${path}" could not be read (no download URL was issued for it).`;
+        }
+        // Guard on the SERVER-verified size before fetching, mirroring
+        // `readCloudSkillFile` — a large blob must not be buffered to discover
+        // it was too large.
+        if (file.size > SKILL_FILE_MAX_READ_BYTES) {
+          return `Error: "${path}" is too large to read (${file.size} bytes).`;
+        }
+        try {
+          const timeout = AbortSignal.timeout(30_000);
+          const signal = args.signal
+            ? AbortSignal.any([args.signal, timeout])
+            : timeout;
+          const res = await fetch(file.url, { signal });
+          if (!res.ok) {
+            return `Error reading "${path}" from "${skill.ref}" (${res.status}).`;
+          }
+          const bytes = new Uint8Array(await res.arrayBuffer());
+          const mimeType = getMimeType(path);
+          if (
+            !isTextMimeType(mimeType) ||
+            bytes.byteLength > MAX_SKILL_FILE_TEXT_BYTES
+          ) {
+            return `File "${path}" is binary (${mimeType}, ${bytes.byteLength} bytes) and can't be shown as text.`;
+          }
+          return `# ${path}\n\n${new TextDecoder().decode(bytes)}`;
+        } catch (error) {
+          return `Error reading "${path}" from "${skill.ref}": ${
+            error instanceof Error ? error.message : "Unknown error"
+          }`;
+        }
+      },
+    }),
+  };
+}
+
+const EFFECTIVE_SKILLS_PROMPT_BASE =
+  `\n\n## Skills\n\n` +
+  `This turn has a fixed set of skills — reusable instruction packages for ` +
+  `specific tasks. Call the \`listSkills\` tool to see them, then \`loadSkill\` ` +
+  `with a skill's reference to load its full instructions when a task matches. ` +
+  `A reference is either a bare name or \`<plugin>/<skill>\` for a skill a ` +
+  `plugin provides; always pass the reference exactly as \`listSkills\` returned it.`;
+
+const EFFECTIVE_SKILLS_FILE_TOOLS_SENTENCE =
+  ` If a loaded skill references supporting files, use \`listSkillFiles\` and ` +
+  `\`readSkillFile\` with the same reference to access them.`;
+
+/**
+ * Tools + prompt section for a turn driven by an `EffectiveCapabilitySet`.
+ *
+ * The file-tools sentence is advertised only when the set actually contains a
+ * file-bearing skill: promising tools for files that do not exist invites the
+ * model to go looking for them.
+ */
+export function getEffectiveSkillToolsAndPrompt(
+  capabilities: EffectiveCapabilitySet,
+  options?: { modelContextTokens?: number; signal?: AbortSignal }
+): {
+  tools: ReturnType<typeof createEffectiveSkillTools>;
+  systemPromptSection: string;
+} {
+  const skills = allEffectiveSkills(capabilities);
+  const hasFiles = skills.some((skill) => skill.files.length > 0);
+  return {
+    tools: createEffectiveSkillTools({
+      skills,
+      ...(options?.modelContextTokens !== undefined
+        ? { modelContextTokens: options.modelContextTokens }
+        : {}),
+      ...(options?.signal ? { signal: options.signal } : {}),
+    }),
+    systemPromptSection:
+      EFFECTIVE_SKILLS_PROMPT_BASE +
+      (hasFiles ? EFFECTIVE_SKILLS_FILE_TOOLS_SENTENCE : ""),
+  };
+}

--- a/mcpjam-inspector/server/utils/computers/effective-skill-tools.ts
+++ b/mcpjam-inspector/server/utils/computers/effective-skill-tools.ts
@@ -54,18 +54,22 @@ function pluginOf(skill: EffectiveSkill): RuntimePluginSkill["plugin"] {
   return (skill as RuntimePluginSkill).plugin;
 }
 
-/** Human-readable provenance for the discovery listing. */
-function originLabel(skill: EffectiveSkill): string {
+/**
+ * Human-readable provenance for the discovery listing.
+ *
+ * `isPlugin` is passed rather than inferred from `skill.plugin`, because a
+ * plugin skill whose attribution failed has no `plugin` — labelling it
+ * "project" would be a false claim about where the model's instructions came
+ * from. It says "plugin" with the revision omitted instead.
+ */
+function originLabel(skill: EffectiveSkill, isPlugin: boolean): string {
+  if (!isPlugin) return "project";
   const plugin = pluginOf(skill);
-  if (plugin) {
-    // A short bundle-hash prefix, not the full hash: enough to tell two
-    // revisions apart in a listing without spending the budget on 64 chars.
-    const revision = plugin.bundleHash
-      ? `@${plugin.bundleHash.slice(0, 8)}`
-      : "";
-    return `plugin ${plugin.name}${revision}`;
-  }
-  return "project";
+  if (!plugin) return "plugin";
+  // A short bundle-hash prefix, not the full hash: enough to tell two revisions
+  // apart in a listing without spending the budget on 64 chars.
+  const revision = plugin.bundleHash ? `@${plugin.bundleHash.slice(0, 8)}` : "";
+  return `plugin ${plugin.name}${revision}`;
 }
 
 interface SkillLookup {
@@ -137,6 +141,7 @@ function findFile(
  */
 function buildListing(
   skills: EffectiveSkill[],
+  pluginRefs: Set<string>,
   modelContextTokens: number | undefined
 ): { text: string; omittedRefs: string[] } {
   if (skills.length === 0) {
@@ -147,7 +152,7 @@ function buildListing(
     skills.map((skill) => ({
       ref: skill.ref,
       description: skill.description,
-      origin: originLabel(skill),
+      origin: originLabel(skill, pluginRefs.has(skill.ref)),
     })),
     budgetChars
   );
@@ -171,11 +176,17 @@ function buildListing(
 
 export function createEffectiveSkillTools(args: {
   skills: EffectiveSkill[];
+  /** Refs that came through the PLUGIN channel — see {@link originLabel}. */
+  pluginRefs: Set<string>;
   modelContextTokens?: number;
   signal?: AbortSignal;
 }) {
   const lookup = buildLookup(args.skills);
-  const listing = buildListing(args.skills, args.modelContextTokens);
+  const listing = buildListing(
+    args.skills,
+    args.pluginRefs,
+    args.modelContextTokens
+  );
   if (listing.omittedRefs.length > 0) {
     logger.warn(
       "[effective-skills] skill metadata budget exceeded; skills omitted from discovery",
@@ -318,6 +329,9 @@ export function getEffectiveSkillToolsAndPrompt(
   return {
     tools: createEffectiveSkillTools({
       skills,
+      pluginRefs: new Set(
+        capabilities.pluginSkills.map((skill) => skill.ref)
+      ),
       ...(options?.modelContextTokens !== undefined
         ? { modelContextTokens: options.modelContextTokens }
         : {}),

--- a/mcpjam-inspector/server/utils/computers/effective-skill-tools.ts
+++ b/mcpjam-inspector/server/utils/computers/effective-skill-tools.ts
@@ -161,7 +161,9 @@ function buildListing(
     (entry) => `- **${entry.ref}** (${entry.origin}): ${entry.description}`
   );
   // Absence is semantic: say that skills were dropped rather than presenting a
-  // short list as if it were the whole set.
+  // short list as if it were the whole set. This notice is deliberately emitted
+  // OUTSIDE the budget — it exists precisely to report that the budget bit, so
+  // suppressing it to fit would hide the omission it announces.
   const notice =
     omittedRefs.length > 0
       ? `\n\n(${omittedRefs.length} more skill${

--- a/mcpjam-inspector/server/utils/computers/skill-metadata-budget.ts
+++ b/mcpjam-inspector/server/utils/computers/skill-metadata-budget.ts
@@ -1,0 +1,123 @@
+/**
+ * Skill-metadata context budget (INS-3).
+ *
+ * OpenAI's plugin guidance caps the skill DISCOVERY listing — the names and
+ * descriptions every turn pays for, before the model has chosen anything — at
+ * 2% of the model's context. MCPJam adopts that number directly rather than
+ * inventing one: a plugin authored against OpenAI's budget must behave the same
+ * here, or an eval run in MCPJam stops predicting the plugin's real behavior.
+ *
+ * The budget is stated in TOKENS and enforced here in CHARACTERS, because the
+ * listing is assembled as a string long before any tokenizer sees it. We use
+ * the conventional ~4 chars/token English approximation. It is an
+ * approximation on purpose: exact tokenization would need the model's own
+ * tokenizer at list time, and the failure it would prevent (a listing a few
+ * percent over budget) is not worth a per-model tokenizer dependency.
+ *
+ * Ordering of the two remedies is the load-bearing part, and comes from the
+ * plan: TRUNCATE descriptions before OMITTING skills. A truncated description
+ * still lets the model find the skill and call `loadSkill`, which delivers the
+ * full body; an omitted skill is invisible and unreachable. Omission is the
+ * last resort and is always reported.
+ */
+
+/** OpenAI's cap on discovery metadata, as a fraction of model context. */
+export const SKILL_METADATA_CONTEXT_FRACTION = 0.02;
+/** The plan's fallback when the model's context size is unknown. */
+export const SKILL_METADATA_FALLBACK_BUDGET_CHARS = 8_000;
+/** Conventional English approximation used to spend a token budget on chars. */
+const CHARS_PER_TOKEN = 4;
+/**
+ * Below this, a description is not worth truncating further — the remaining
+ * text would not describe anything. Entries that cannot fit even this are
+ * omitted instead.
+ */
+const MIN_DESCRIPTION_CHARS = 40;
+
+export interface SkillMetadataEntry {
+  /** The model-facing identity (bare name or `<plugin>/<skill>`). */
+  ref: string;
+  description: string;
+}
+
+export interface SkillMetadataBudgetResult<T extends SkillMetadataEntry> {
+  /** Entries to advertise, in input order, descriptions possibly truncated. */
+  entries: T[];
+  /** Refs whose description was shortened to fit. */
+  truncatedRefs: string[];
+  /** Refs dropped entirely — the model cannot see or load these. */
+  omittedRefs: string[];
+  budgetChars: number;
+}
+
+/**
+ * The character budget for a model's discovery listing.
+ *
+ * A non-finite or non-positive context length is treated as UNKNOWN, not as
+ * zero: a model definition missing `contextLength` must fall back to the
+ * documented 8,000 characters, never silently advertise nothing.
+ */
+export function skillMetadataBudgetChars(modelContextTokens?: number): number {
+  if (
+    typeof modelContextTokens !== "number" ||
+    !Number.isFinite(modelContextTokens) ||
+    modelContextTokens <= 0
+  ) {
+    return SKILL_METADATA_FALLBACK_BUDGET_CHARS;
+  }
+  return Math.floor(
+    modelContextTokens * SKILL_METADATA_CONTEXT_FRACTION * CHARS_PER_TOKEN
+  );
+}
+
+/**
+ * Fit a discovery listing into `budgetChars`.
+ *
+ * Cost is charged per entry as `ref + description` plus a small fixed overhead
+ * for the line's own punctuation, so the accounting tracks what is actually
+ * emitted rather than the raw description length.
+ *
+ * Two passes, in the plan's order:
+ *   1. Admit entries at full description while they fit.
+ *   2. On the first entry that does not fit, truncate its description to the
+ *      remaining budget; if what remains cannot carry a useful description,
+ *      omit that entry and keep trying the rest (a later short entry may still
+ *      fit, and dropping it too would hide a skill for no gain).
+ */
+export function applySkillMetadataBudget<T extends SkillMetadataEntry>(
+  entries: T[],
+  budgetChars: number
+): SkillMetadataBudgetResult<T> {
+  /** Bullet, bold markers, parentheses and the ": " separator of one line. */
+  const LINE_OVERHEAD_CHARS = 12;
+
+  const admitted: T[] = [];
+  const truncatedRefs: string[] = [];
+  const omittedRefs: string[] = [];
+  let spent = 0;
+
+  for (const entry of entries) {
+    const fixed = entry.ref.length + LINE_OVERHEAD_CHARS;
+    const full = fixed + entry.description.length;
+    if (spent + full <= budgetChars) {
+      admitted.push(entry);
+      spent += full;
+      continue;
+    }
+    const room = budgetChars - spent - fixed;
+    if (room < MIN_DESCRIPTION_CHARS) {
+      omittedRefs.push(entry.ref);
+      continue;
+    }
+    // `…` signals the truncation to the model, which can still call
+    // `loadSkill` for the whole thing.
+    admitted.push({
+      ...entry,
+      description: `${entry.description.slice(0, room - 1)}…`,
+    });
+    truncatedRefs.push(entry.ref);
+    spent += fixed + room;
+  }
+
+  return { entries: admitted, truncatedRefs, omittedRefs, budgetChars };
+}

--- a/mcpjam-inspector/server/utils/computers/skill-metadata-budget.ts
+++ b/mcpjam-inspector/server/utils/computers/skill-metadata-budget.ts
@@ -38,6 +38,15 @@ export interface SkillMetadataEntry {
   /** The model-facing identity (bare name or `<plugin>/<skill>`). */
   ref: string;
   description: string;
+  /**
+   * Provenance rendered in the same line (`plugin alpha@aaaa1111`, `project`).
+   *
+   * Charged as part of the entry's fixed cost. It is NOT decoration: a plugin
+   * origin runs 20-30 characters, so leaving it uncharged overshoots the cap by
+   * an amount that GROWS with the number of plugin skills — the exact case the
+   * budget exists for.
+   */
+  origin?: string;
 }
 
 export interface SkillMetadataBudgetResult<T extends SkillMetadataEntry> {
@@ -73,9 +82,10 @@ export function skillMetadataBudgetChars(modelContextTokens?: number): number {
 /**
  * Fit a discovery listing into `budgetChars`.
  *
- * Cost is charged per entry as `ref + description` plus a small fixed overhead
- * for the line's own punctuation, so the accounting tracks what is actually
- * emitted rather than the raw description length.
+ * Cost is charged per entry as `ref + origin + description` plus the line's own
+ * punctuation, matching the emitted `- **<ref>** (<origin>): <description>\n`
+ * exactly — the accounting must track what is actually emitted, or the budget
+ * silently permits more than it claims.
  *
  * Two passes, in the plan's order:
  *   1. Admit entries at full description while they fit.
@@ -88,8 +98,11 @@ export function applySkillMetadataBudget<T extends SkillMetadataEntry>(
   entries: T[],
   budgetChars: number
 ): SkillMetadataBudgetResult<T> {
-  /** Bullet, bold markers, parentheses and the ": " separator of one line. */
-  const LINE_OVERHEAD_CHARS = 12;
+  /**
+   * The punctuation of `- **<ref>** (<origin>): <description>\n`:
+   * `- **` + `** (` + `): ` + the newline = 12 characters.
+   */
+  const LINE_PUNCTUATION_CHARS = 12;
 
   const admitted: T[] = [];
   const truncatedRefs: string[] = [];
@@ -97,7 +110,10 @@ export function applySkillMetadataBudget<T extends SkillMetadataEntry>(
   let spent = 0;
 
   for (const entry of entries) {
-    const fixed = entry.ref.length + LINE_OVERHEAD_CHARS;
+    const fixed =
+      entry.ref.length +
+      (entry.origin?.length ?? 0) +
+      LINE_PUNCTUATION_CHARS;
     const full = fixed + entry.description.length;
     if (spent + full <= budgetChars) {
       admitted.push(entry);

--- a/mcpjam-inspector/server/utils/web-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/web-chat-turn.ts
@@ -65,10 +65,8 @@ import {
   type PersistedTurnTrace,
 } from "./chat-ingestion.js";
 import type { HarnessSessionCommitPayload } from "./harness/harness-session-state.js";
-import {
-  toPinnableSkill,
-  type RuntimeSkill,
-} from "./harness/runtime-skills.js";
+import { type RuntimeSkill } from "./harness/runtime-skills.js";
+import type { EffectiveCapabilitySet } from "../services/environments/effective-capabilities.js";
 import { exportConnectedServerToolSnapshotForEvalAuthoring } from "./export-helpers.js";
 import { ErrorCode, WebRouteError } from "./../routes/web/errors.js";
 import { readUrlElicitations } from "@/shared/http-tool-calls";
@@ -221,8 +219,22 @@ export interface WebChatTurnPrepareInputs {
    * Ignored when `harness` is set: a harness turn delivers skills natively
    * through the adapter (see `WebChatTurnPersistContext.runtimeSkillsOverride`),
    * and advertising emulated skill tools there is a prompt/tool mismatch.
+   *
+   * INS-3: this stays the HARNESS-shaped list (name/description/content, which
+   * is all an adapter writes to disk). The emulated side takes
+   * {@link WebChatTurnPrepareInput.effectiveCapabilities} instead, because its
+   * tools address skills by ref and need the plugin origin this list drops.
    */
   runtimeSkillsOverride?: RuntimeSkill[];
+  /**
+   * The turn's resolved `EffectiveCapabilitySet` (INS-3). Set alongside
+   * `runtimeSkillsOverride` for an environment turn; drives the EMULATED skill
+   * tools (ref-addressed, plugin-origin-aware, supporting-file capable).
+   *
+   * Presence is what makes it authoritative — a set that resolves zero skills
+   * advertises zero, and never falls back to the project-wide pool.
+   */
+  effectiveCapabilities?: EffectiveCapabilitySet;
 }
 
 /** Runtime knobs (auth, abort, rpc collector, Hono context for cleanup). */
@@ -365,11 +377,11 @@ export async function streamWebChatTurn(
       // EMULATED engine only. On a harness turn the adapter delivers them
       // natively, so advertising `listSkills`/`loadSkill` on top would describe
       // a second, different delivery of the same set to the same model.
-      ...(prepare.runtimeSkillsOverride !== undefined && !prepare.harness
+      ...(prepare.effectiveCapabilities !== undefined && !prepare.harness
         ? {
             skillsSource: {
               kind: "resolved" as const,
-              skills: prepare.runtimeSkillsOverride.map(toPinnableSkill),
+              capabilities: prepare.effectiveCapabilities,
             },
           }
         : {}),

--- a/mcpjam-inspector/server/utils/web-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/web-chat-turn.ts
@@ -382,6 +382,11 @@ export async function streamWebChatTurn(
             skillsSource: {
               kind: "resolved" as const,
               capabilities: prepare.effectiveCapabilities,
+              // So a supporting-file read stops when the client disconnects
+              // instead of holding a worker for its full fetch timeout.
+              ...(runtime.abortSignal
+                ? { abortSignal: runtime.abortSignal }
+                : {}),
             },
           }
         : {}),

--- a/mcpjam-inspector/shared/hosted-rpc-log.ts
+++ b/mcpjam-inspector/shared/hosted-rpc-log.ts
@@ -1,9 +1,27 @@
+/**
+ * The plugin revision that contributed the server a frame belongs to (INS-3).
+ *
+ * Present ONLY for a server a pinned plugin version brought into the turn, and
+ * only when the backend could attribute it — absence means "not a plugin
+ * server, or origin unknown", never "no plugin". Consumers must render it only
+ * when it is there.
+ */
+export interface HostedRpcLogPluginOrigin {
+  pluginId: string;
+  pluginVersionId: string;
+  /** Normalized plugin name — the `<plugin>/<skill>` namespace. */
+  name: string;
+  /** Content-addressed bundle identity; `null` under deploy skew. */
+  bundleHash: string | null;
+}
+
 export interface HostedRpcLogEvent {
   serverId: string;
   serverName: string;
   direction: "send" | "receive";
   timestamp: string;
   message: unknown;
+  pluginOrigin?: HostedRpcLogPluginOrigin;
 }
 
 export interface HostedRpcLogsEnvelope {


### PR DESCRIPTION
INS-3 of `docs/plans/openai-plugin-import-cross-repo.md` (mcpjam-backend),
following INS-1 (#3421 + #3444) and INS-2 (#3451).

Per the plan's 2026-07-25 amendment, this **consumes** the backend resolver
(`resolvePluginVersionsRuntime` / `resolveEnvironmentForLaunch`) rather than
inventing a parallel HostConfig-side one. Hosts stay plugin-blind; nothing is
persisted; every launch re-resolves so disable/uninstall take effect at once.

## What's here

- **`server/services/environments/effective-capabilities.ts`** — the
  `EffectiveCapabilitySet` type and a pure projection of the spec
  `resolveEnvironmentForRuntime` already returns: explicit/plugin/effective
  server split, per-server plugin origin, namespaced skill refs,
  `pluginVersions` in pin order, and `problems`.
- **`server/services/environments/plugin-attribution.ts`** — recovers the
  component→version edge (see decision 1). Tri-state: any failure yields
  `null`, never a partial map. Zero reads when no plugins are pinned.
- **`server/utils/computers/skill-metadata-budget.ts`** — OpenAI's
  2%-of-context budget (8,000-char fallback), truncate-before-omit.
- **`server/utils/computers/effective-skill-tools.ts`** — ref-addressed
  `listSkills` / `loadSkill` / `listSkillFiles` / `readSkillFile`, reading
  supporting files from the signed URLs the environment resolution already
  minted.
- **Wiring** — `chat-v2-orchestration.ts`, `web-chat-turn.ts`,
  `routes/web/chat-v2.ts`, `hosted-rpc-logs.ts` + `shared/hosted-rpc-log.ts`
  (`pluginOrigin` on trace frames). Removes the now-vestigial
  `getResolvedSkillToolsAndPrompt`.

## Two acceptance criteria are blocked upstream — stated, not faked

- **"Two plugins may declare the same skill name."** The backend *fails
  closed* on exactly that configuration
  (`ENV_PLUGIN_SKILL_NAME_CONFLICT`, `convex/lib/projectEnvironments.ts:392`),
  and its own comment defers namespacing to BE-5/INS-5 because `name` cannot
  be rewritten to `modelRef` while `contentHash` folds it. What ships here is
  the ref-addressed surface that makes this correct **once the backend stops
  refusing**; the criterion is proven at the resolver/tool level, not through
  a live two-plugin environment.
- **"Thread exact plugin versions through *local* runtime config."**
  `server/routes/mcp/chat-v2.ts:308` rejects any `executionTarget` at ingress
  ("Project Environments can't run on local /api/mcp execution"). There is no
  local plugin channel to thread anything through — that is INS-6. No
  client-side substitute was invented.

## Design decisions worth challenging

1. **A second backend read, one version at a time.**
   `resolvePluginRuntimePreview` *flattens* `effectiveServerIds` /
   `pluginSkills` across every version it is asked about, and
   `resolveEnvironmentForRuntime` returns `pluginVersions` and
   `pluginServerIds` as two unlinked flat lists with **no `modelRef`**. So
   per-server attribution is not obtainable in one call from the deployed API.
   Asking per version (in parallel, a handful at most) beats reimplementing
   the edge client-side. **The clean fix is backend-side** — have the probe
   return component rows (`pluginVersionId` + `componentKey`) — and is flagged
   as a follow-up in the module doc.
2. **That second read sits against #3446's "one atomic read" guarantee.** It
   costs nothing when no plugins are pinned, cannot fail the turn, and feeds
   only what we *say*, never what runs: a torn read degrades a label, not a
   capability.
3. **`problems` is not an error channel.** Anything unrunnable already threw
   backend-side as `ENV_*`; `problems` records provenance we could not
   establish.
4. **`skillsSource: "resolved"` changed shape** rather than gaining a fourth
   kind — it had exactly one call site, and two ways to build the same tools
   is how vestigial adapters start. `runtimeSkillsOverride` stays for the
   harness (on-disk name/description/content shape).
5. **Ambiguous bare skill names are refused**, not resolved to the first
   match — that is the point of a ref surface.
6. **Nothing persisted.** Telemetry carries bundle hashes (content addresses)
   and counts, never plugin names.

## Also delivered differently than the plan's wording

"Plugin origin in tool metadata" ships as trace-frame origin keyed by
`serverId` plus `source: "plugin"` on the connectable projection. Annotating
each AI-SDK tool entry would mean changing `MCPClientManager.getToolsForAiSdk`
in the SDK — wrong repo layer for this PR. The "Plugin / Server / Tool"
approvals UI is client-side and not delivered here.

Much of "expand effective server IDs before manager construction" already
shipped in #3446; INS-3 names and splits the set rather than re-introducing
the expansion.

## Verification (re-run independently of the authoring agent)

- `npx vitest run` (all projects) → exit 0, **10122 passed**, 6 skipped (926 files)
- `npx tsc --noEmit -p client/tsconfig.typecheck.json` → exit 0
- `npm run build:client` → exit 0

`server/tsconfig.json` is **not** clean on main (86 pre-existing errors); the
count is identical before and after, and none are in files added here. The
suite needs `npm run bundle:browser-harness` + `bundle:sandbox-proxies` first
or ~60 files fail to collect — a pre-existing setup step, not a regression.

Not manually exercised in a running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the environment chat launch path (extra Convex reads, skill tool surface, RPC trace shape) but attribution and problems are explicitly non-gating; mis-attribution degrades labels rather than dropping servers or skills.
> 
> **Overview**
> **INS-3** adds a per-turn **`EffectiveCapabilitySet`** for hosted **environment** chat: what servers connect (explicit vs plugin), ref-addressed skills (`<plugin>/<skill>`), plugin revision provenance, and non-fatal **`problems`** when attribution is incomplete.
> 
> After `resolveEnvironmentForRuntime`, the route optionally runs **`fetchPluginRuntimeAttribution`** (one Convex preview query per pinned plugin version, 5s cap). Failures return **`null`** and **do not block** the turn—capabilities still run; origin and namespacing degrade. **`resolveEffectiveCapabilities`** projects the spec plus attribution into the set; **`pluginOriginByServerId`** stamps **`HostedRpcLogCollector`** frames with **`pluginOrigin`**.
> 
> The emulated engine no longer uses a flat **`PinnableSkill`** list for environment turns: **`skillsSource.resolved`** now carries **`capabilities`**, wired through **`getEffectiveSkillToolsAndPrompt`** (ref-based **`listSkills` / `loadSkill` / `listSkillFiles` / `readSkillFile`**, OpenAI-style 2% metadata budget). Harness turns still use **`runtimeSkillsOverride`**. **`getResolvedSkillToolsAndPrompt`** is removed.
> 
> Telemetry gains bundle hashes, plugin server/skill counts, and capability problem codes (not user-authored plugin names).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c47dc02bfe52e61913bfe226574bb7c6bc3e17ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements INS-3: effective capability resolution for environment turns. Adds a single capability set with plugin origin and ref-addressed skill tools; recent fixes bound attribution reads, tightened budget accounting, and made backend classification authoritative.

- New Features
  - Added `EffectiveCapabilitySet` over `resolveEnvironmentForRuntime`: explicit/plugin/effective server split, `<plugin>/<skill>` refs, per-server/per-skill origin, and non-fatal `problems`.
  - Per-version attribution via `plugins:resolvePluginRuntimePreview`: zero reads when no pins; tri-state `null` on failure so turns still run.
  - Ref-addressed skill tools (`listSkills`, `loadSkill`, `listSkillFiles`, `readSkillFile`) using signed URLs; bare names only when unambiguous. Enforces OpenAI’s 2% metadata budget (8,000-char fallback), truncating descriptions before omitting skills.
  - Wired into `web/chat-v2`: passes `skillsSource: { kind: "resolved", capabilities }`, keeps `runtimeSkillsOverride` for harness only, stamps hosted RPC trace frames with plugin origin, and extends telemetry with bundle hashes, plugin counts, and capability problem codes. Removed `getResolvedSkillToolsAndPrompt`.

- Bug Fixes
  - Bounded attribution read to 5s and fail closed to `null`; avoids mutating the shared Convex client; late results are dropped.
  - Budget accounting now includes origin text; tests assert the emitted listing fits the cap.
  - Backend classification wins; stale attribution cannot reclassify servers, and plugin origin is only attached to plugin servers.
  - Partial attribution reports `unattributedVersionIds` and logs `plugin_origin_unavailable`; capability-problem logs aggregate codes and skill ids, not names.
  - `readSkillFile` honors the turn’s abort signal for signed-URL fetches; test env var cleanup fixed.

<sup>Written for commit c47dc02bfe52e61913bfe226574bb7c6bc3e17ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

