### PR TITLE
fix(connection): read a server's protocol version off the server, not the client-config copy

### DIFF
--- a/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.hosted-oauth.test.tsx
@@ -40,6 +40,9 @@ vi.mock("convex/react", () => ({
   useConvex: () => ({
     query: mockConvexQuery,
   }),
+  // `useServerState` subscribes to `projectServerConfig:getConfig` for
+  // per-server protocol-version pins; these suites don't exercise pins.
+  useQuery: () => undefined,
 }));
 
 vi.mock("@/contexts/db-user-ready-context", () => ({
@@ -99,7 +102,10 @@ vi.mock("sonner", () => ({
   },
 }));
 
-vi.mock("../useProjects", () => ({
+vi.mock("../useProjects", async (importOriginal) => ({
+  shouldQueryProjectId: (
+    await importOriginal<typeof import("../useProjects")>()
+  ).shouldQueryProjectId,
   useServerMutations: mockUseServerMutations,
 }));
 

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.protocol-revalidation.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.protocol-revalidation.test.tsx
@@ -25,6 +25,7 @@ const {
   getInitializationInfoMock,
   mockUseDbUserReady,
   posthogCaptureMock,
+  projectServerConfigDtoMock,
 } = vi.hoisted(() => ({
   reconnectServerMock: vi.fn(),
   tryResolveProjectServerMock: vi.fn<
@@ -34,6 +35,9 @@ const {
   getInitializationInfoMock: vi.fn(),
   mockUseDbUserReady: vi.fn(() => true),
   posthogCaptureMock: vi.fn(),
+  // Stands in for the `projectServerConfig:getConfig` subscription — the
+  // control-plane row the protocol-version pin is written to.
+  projectServerConfigDtoMock: vi.fn<() => unknown>(() => undefined),
 }));
 
 vi.mock("sonner", () => ({
@@ -42,6 +46,10 @@ vi.mock("sonner", () => ({
 
 vi.mock("convex/react", () => ({
   useConvex: () => ({ query: vi.fn() }),
+  // Honor Convex's "skip" sentinel so a test that doesn't provision a
+  // shared project id sees `undefined`, exactly like production.
+  useQuery: (_name: unknown, args: unknown) =>
+    args === "skip" ? undefined : projectServerConfigDtoMock(),
 }));
 
 vi.mock("@/contexts/db-user-ready-context", () => ({
@@ -97,7 +105,12 @@ vi.mock("@/stores/ui-playground-store", () => ({
   },
 }));
 
-vi.mock("../useProjects", () => ({
+vi.mock("../useProjects", async (importOriginal) => ({
+  // Real `shouldQueryProjectId` — the pin subscription gates on it, so
+  // stubbing it would hide a genuine skip.
+  shouldQueryProjectId: (
+    await importOriginal<typeof import("../useProjects")>()
+  ).shouldQueryProjectId,
   useServerMutations: () => ({
     createServer: vi.fn(),
     createServerIfMissing: vi.fn(),
@@ -108,12 +121,17 @@ vi.mock("../useProjects", () => ({
   }),
 }));
 
+// Convex-shaped id: not a UUID, no `local_`/`project_` prefix, so
+// `shouldQueryProjectId` accepts it and the pin subscription runs.
+const SHARED_PROJECT_ID = "jd7demoproject000000000001";
+
 function buildConnectedAppState(): AppState {
   return {
     projects: {
       default: {
         id: "default",
         name: "Default",
+        sharedProjectId: SHARED_PROJECT_ID,
         servers: {
           "demo-server": {
             name: "demo-server",
@@ -235,6 +253,7 @@ beforeEach(() => {
   });
   mockUseDbUserReady.mockReturnValue(true);
   posthogCaptureMock.mockReset();
+  projectServerConfigDtoMock.mockReturnValue(undefined);
 });
 
 describe("useServerState mcpProtocolVersion re-validation", () => {
@@ -439,5 +458,108 @@ describe("useServerState mcpProtocolVersion re-validation", () => {
 
     await flushAsyncWork(10);
     expect(reconnectServerMock).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Regression: issue #3453. The per-server pin is WRITTEN to the
+ * `projectServerConfig` row but only mirrored onto
+ * `activeHostConfig.serverConnectionOverrides` via Convex fan-out, which
+ * lands later. A reconnect fired in that window used to read the stale
+ * mirror and silently connect on the host default — for the reporter, a
+ * legacy handshake instead of the 2026 pin they had just selected.
+ */
+describe("useServerState per-server pin resolution (control-plane first)", () => {
+  function dtoWithOverride(version: string | undefined) {
+    return {
+      serverIds: ["srv_demo"],
+      overrides: version
+        ? { srv_demo: { mcpProtocolVersionOverride: version } }
+        : {},
+    };
+  }
+
+  function lastConnectionDefaults() {
+    const lastCall =
+      reconnectServerMock.mock.calls[reconnectServerMock.mock.calls.length - 1];
+    return lastCall?.[2]?.connectionDefaults;
+  }
+
+  it("connects with the just-saved pin while the host mirror is still stale", async () => {
+    reconnectServerMock.mockResolvedValue({
+      success: true,
+      initInfo: { serverCapabilities: {} },
+    });
+
+    const dispatch = vi.fn();
+    // No pin anywhere yet.
+    const { rerender } = renderRevalidationHook(dispatch, {
+      profile: undefined,
+      hostConfig: buildHostConfig(),
+    });
+    await flushAsyncWork(5);
+    expect(reconnectServerMock).not.toHaveBeenCalled();
+
+    // The save lands on the control-plane row. The host config is
+    // deliberately left WITHOUT the override — this is the fan-out window.
+    projectServerConfigDtoMock.mockReturnValue(dtoWithOverride("2026-07-28"));
+    rerender({ profile: undefined, hostConfig: buildHostConfig() });
+
+    await waitFor(() => {
+      expect(reconnectServerMock).toHaveBeenCalledTimes(1);
+    });
+    expect(lastConnectionDefaults()?.mcpProtocolVersion).toBe("2026-07-28");
+  });
+
+  it("does not let a stale host default override the just-saved pin", async () => {
+    reconnectServerMock.mockResolvedValue({
+      success: true,
+      initInfo: { serverCapabilities: {} },
+    });
+
+    const dispatch = vi.fn();
+    const { rerender } = renderRevalidationHook(dispatch, {
+      profile: { mcpProtocolVersion: "2025-11-25" },
+      hostConfig: buildHostConfig(),
+    });
+    await flushAsyncWork(5);
+
+    projectServerConfigDtoMock.mockReturnValue(dtoWithOverride("2026-07-28"));
+    rerender({
+      profile: { mcpProtocolVersion: "2025-11-25" },
+      hostConfig: buildHostConfig(),
+    });
+
+    await waitFor(() => {
+      expect(reconnectServerMock).toHaveBeenCalledTimes(1);
+    });
+    expect(lastConnectionDefaults()?.mcpProtocolVersion).toBe("2026-07-28");
+  });
+
+  it("falls back to the host mirror while the control-plane row is loading", async () => {
+    reconnectServerMock.mockResolvedValue({
+      success: true,
+      initInfo: { serverCapabilities: {} },
+    });
+
+    const dispatch = vi.fn();
+    // DTO stays `undefined` (query in flight) for the whole test.
+    const { rerender } = renderRevalidationHook(dispatch, {
+      profile: undefined,
+      hostConfig: buildHostConfig(),
+    });
+    await flushAsyncWork(5);
+
+    rerender({
+      profile: undefined,
+      hostConfig: buildHostConfig({
+        srv_demo: { mcpProtocolVersionOverride: "2026-07-28" },
+      }),
+    });
+
+    await waitFor(() => {
+      expect(reconnectServerMock).toHaveBeenCalledTimes(1);
+    });
+    expect(lastConnectionDefaults()?.mcpProtocolVersion).toBe("2026-07-28");
   });
 });

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.protocol-revalidation.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.protocol-revalidation.test.tsx
@@ -188,7 +188,14 @@ function buildHostConfig(overrides?: HostOverrides): any {
 
 function renderRevalidationHook(
   dispatch: (action: AppAction) => void,
-  initial: { profile: Profile; hostConfig: any }
+  initial: { profile: Profile; hostConfig: any },
+  // The `projectServerConfig:getConfig` subscription is gated on auth (it's
+  // a `userQuery`), so control-plane suites must render signed-in. Local
+  // suites keep the unauthenticated default and read the host mirror.
+  auth: { isAuthenticated: boolean; useLocalFallback: boolean } = {
+    isAuthenticated: false,
+    useLocalFallback: true,
+  }
 ) {
   const appState = buildConnectedAppState();
   const state = { ...initial };
@@ -203,11 +210,11 @@ function renderRevalidationHook(
       appState,
       dispatch,
       isLoading: false,
-      isAuthenticated: false,
-      hasSignedInUser: false,
+      isAuthenticated: auth.isAuthenticated,
+      hasSignedInUser: auth.isAuthenticated,
       isAuthLoading: false,
       isLoadingProjects: false,
-      useLocalFallback: true,
+      useLocalFallback: auth.useLocalFallback,
       effectiveProjects: appState.projects,
       effectiveActiveProjectId: appState.activeProjectId,
       activeProjectServersFlat: undefined,
@@ -485,6 +492,9 @@ describe("useServerState per-server pin resolution (control-plane first)", () =>
     return lastCall?.[2]?.connectionDefaults;
   }
 
+  // `getConfig` is a `userQuery`; the subscription only runs signed-in.
+  const SIGNED_IN = { isAuthenticated: true, useLocalFallback: false };
+
   it("connects with the just-saved pin while the host mirror is still stale", async () => {
     reconnectServerMock.mockResolvedValue({
       success: true,
@@ -493,10 +503,14 @@ describe("useServerState per-server pin resolution (control-plane first)", () =>
 
     const dispatch = vi.fn();
     // No pin anywhere yet.
-    const { rerender } = renderRevalidationHook(dispatch, {
-      profile: undefined,
-      hostConfig: buildHostConfig(),
-    });
+    const { rerender } = renderRevalidationHook(
+      dispatch,
+      {
+        profile: undefined,
+        hostConfig: buildHostConfig(),
+      },
+      SIGNED_IN
+    );
     await flushAsyncWork(5);
     expect(reconnectServerMock).not.toHaveBeenCalled();
 
@@ -518,10 +532,14 @@ describe("useServerState per-server pin resolution (control-plane first)", () =>
     });
 
     const dispatch = vi.fn();
-    const { rerender } = renderRevalidationHook(dispatch, {
-      profile: { mcpProtocolVersion: "2025-11-25" },
-      hostConfig: buildHostConfig(),
-    });
+    const { rerender } = renderRevalidationHook(
+      dispatch,
+      {
+        profile: { mcpProtocolVersion: "2025-11-25" },
+        hostConfig: buildHostConfig(),
+      },
+      SIGNED_IN
+    );
     await flushAsyncWork(5);
 
     projectServerConfigDtoMock.mockReturnValue(dtoWithOverride("2026-07-28"));
@@ -536,6 +554,48 @@ describe("useServerState per-server pin resolution (control-plane first)", () =>
     expect(lastConnectionDefaults()?.mcpProtocolVersion).toBe("2026-07-28");
   });
 
+  // A loaded DTO is authoritative, absence included. Clearing the override
+  // writes that absence to the control plane; falling through to the mirror
+  // on a miss would reconnect on the version the user just removed.
+  it("drops back to the host default when the override is cleared, even with a stale mirror", async () => {
+    reconnectServerMock.mockResolvedValue({
+      success: true,
+      initInfo: { serverCapabilities: {} },
+    });
+
+    const dispatch = vi.fn();
+    // Pinned on both layers, connected on the pin.
+    projectServerConfigDtoMock.mockReturnValue(dtoWithOverride("2026-07-28"));
+    const { rerender } = renderRevalidationHook(
+      dispatch,
+      {
+        profile: { mcpProtocolVersion: "2025-11-25" },
+        hostConfig: buildHostConfig({
+          srv_demo: { mcpProtocolVersionOverride: "2026-07-28" },
+        }),
+      },
+      SIGNED_IN
+    );
+    await flushAsyncWork(5);
+    reconnectServerMock.mockClear();
+
+    // Un-pin: the control-plane row loses the override, the mirror hasn't.
+    projectServerConfigDtoMock.mockReturnValue(dtoWithOverride(undefined));
+    rerender({
+      profile: { mcpProtocolVersion: "2025-11-25" },
+      hostConfig: buildHostConfig({
+        srv_demo: { mcpProtocolVersionOverride: "2026-07-28" },
+      }),
+    });
+
+    await waitFor(() => {
+      expect(reconnectServerMock).toHaveBeenCalledTimes(1);
+    });
+    expect(lastConnectionDefaults()?.mcpProtocolVersion).toBe("2025-11-25");
+  });
+
+  // Unauthenticated: the subscription is skipped, so the DTO stays
+  // `undefined` and the mirror is the only readable source.
   it("falls back to the host mirror while the control-plane row is loading", async () => {
     reconnectServerMock.mockResolvedValue({
       success: true,

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
@@ -82,6 +82,9 @@ vi.mock("convex/react", () => ({
   useConvex: () => ({
     query: mockConvexQuery,
   }),
+  // `useServerState` subscribes to `projectServerConfig:getConfig` for
+  // per-server protocol-version pins; these suites don't exercise pins.
+  useQuery: () => undefined,
 }));
 
 vi.mock("@/contexts/db-user-ready-context", () => ({
@@ -159,7 +162,10 @@ vi.mock("@/stores/ui-playground-store", () => ({
   },
 }));
 
-vi.mock("../useProjects", () => ({
+vi.mock("../useProjects", async (importOriginal) => ({
+  shouldQueryProjectId: (
+    await importOriginal<typeof import("../useProjects")>()
+  ).shouldQueryProjectId,
   useServerMutations: () => ({
     createServer: mockCreateServer,
     createServerIfMissing: mockCreateServerIfMissing,

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, type Dispatch } from "react";
-import { useConvex } from "convex/react";
+import { useConvex, useQuery } from "convex/react";
 import { toast } from "@/lib/toast";
 import type {
   HttpServerConfig,
@@ -78,7 +78,12 @@ import {
 } from "@/lib/app-navigation";
 import { useProjectClientConfigSyncPending } from "./use-project-client-config-sync-pending";
 import { useUIPlaygroundStore } from "@/stores/ui-playground-store";
-import { useServerMutations, type RemoteServer } from "./useProjects";
+import {
+  shouldQueryProjectId,
+  useServerMutations,
+  type RemoteServer,
+} from "./useProjects";
+import type { ProjectServerConfigDto } from "@/lib/project-server-config";
 import { writeCliSignInReturnPath } from "@/lib/cli-signin-return-path";
 import {
   CLIENT_CONFIG_SYNC_PENDING_ERROR_MESSAGE,
@@ -1051,6 +1056,48 @@ export function useServerState({
     return activeProject?.servers || {};
   }, [activeProject]);
 
+  // Control-plane source for per-server protocol-version pins. The pin is
+  // WRITTEN here (`projectServerConfig:setConfig`, via the modal's
+  // `applyMcpProtocolVersionOverride`) and only mirrored onto
+  // `activeHostConfig.serverConnectionOverrides` through Convex fan-out —
+  // a separate subscription that lands later. Reading the mirror alone means
+  // a reconnect fired right after a save can miss the pin the user just set
+  // and silently connect on the host default (issue #3453). Convex dedupes
+  // identical subscriptions, so sharing this query with `App.tsx` /
+  // `ServersTab` / `ServerDetailModal` costs no extra traffic.
+  const sharedProjectIdForServerConfig = activeProject?.sharedProjectId ?? null;
+  const projectServerConfigDto = useQuery(
+    "projectServerConfig:getConfig" as never,
+    sharedProjectIdForServerConfig &&
+      shouldQueryProjectId(sharedProjectIdForServerConfig)
+      ? ({ projectId: sharedProjectIdForServerConfig } as never)
+      : "skip"
+  ) as ProjectServerConfigDto | null | undefined;
+
+  /**
+   * Resolve a server's pinned wire version override, control-plane first.
+   *
+   * Precedence mirrors `App.tsx`'s hosted pin map: the `projectServerConfig`
+   * DTO is the row the save actually wrote, so it wins; the host-config
+   * mirror is the fallback for renderers whose DTO hasn't hydrated yet
+   * (`undefined`). Each candidate is membership-gated so a typo on either
+   * layer can't reach the SDK's open-routing predicate.
+   */
+  const resolveServerProtocolOverride = useCallback(
+    (serverId: string | undefined): McpProtocolVersion | undefined => {
+      if (!serverId) return undefined;
+      const raw =
+        projectServerConfigDto?.overrides?.[serverId]
+          ?.mcpProtocolVersionOverride ??
+        activeHostConfig?.serverConnectionOverrides?.[serverId]
+          ?.mcpProtocolVersionOverride;
+      return typeof raw === "string" && isKnownProtocolVersion(raw)
+        ? raw
+        : undefined;
+    },
+    [projectServerConfigDto, activeHostConfig]
+  );
+
   const connectedOrConnectingServerConfigs = useMemo(
     () =>
       Object.fromEntries(
@@ -1307,23 +1354,12 @@ export function useServerState({
           (v): v is string => typeof v === "string" && v.trim() !== ""
         );
       }
-      // Effective pinned MCP protocol version: per-server override
-      // (from `activeHostConfig.serverConnectionOverrides[serverId]
-      // .mcpProtocolVersionOverride`) wins, otherwise the host default
-      // from `mcpProfile.mcpProtocolVersion`, otherwise undefined
-      // (preserves "SDK chooses" semantics). Membership-gate each
-      // candidate via `isKnownProtocolVersion` so a typo on either
-      // layer doesn't slip past to the SDK's open-routing predicate.
-      const rawServerOverride =
-        serverId && activeHostConfig
-          ? activeHostConfig.serverConnectionOverrides?.[serverId]
-              ?.mcpProtocolVersionOverride
-          : undefined;
-      const serverOverride: McpProtocolVersion | undefined =
-        typeof rawServerOverride === "string" &&
-        isKnownProtocolVersion(rawServerOverride)
-          ? rawServerOverride
-          : undefined;
+      // Effective pinned MCP protocol version: per-server override wins,
+      // otherwise the host default from `mcpProfile.mcpProtocolVersion`,
+      // otherwise undefined (preserves "SDK chooses" semantics). The
+      // override is resolved control-plane-first so a reconnect fired
+      // immediately after a save doesn't read a stale host mirror.
+      const serverOverride = resolveServerProtocolOverride(serverId);
       const rawHostPin = mcpProfile?.mcpProtocolVersion;
       const hostPin: McpProtocolVersion | undefined =
         typeof rawHostPin === "string" && isKnownProtocolVersion(rawHostPin)
@@ -1356,7 +1392,7 @@ export function useServerState({
       }
       return Object.keys(defaults).length > 0 ? defaults : undefined;
     },
-    [activeHostConfig]
+    [activeHostConfig, resolveServerProtocolOverride]
   );
 
   const buildStatelessProtocolConnectMetadata = useCallback(
@@ -1373,14 +1409,10 @@ export function useServerState({
         appStateServersRef.current[serverName];
       const usesOAuth = server?.useOAuth === true;
       const hasBearerToken = getServerBearerTokenState(server) === true;
-      const rawServerOverride =
-        activeHostConfig?.serverConnectionOverrides?.[serverId]
-          ?.mcpProtocolVersionOverride;
-      const serverOverride =
-        typeof rawServerOverride === "string" &&
-        isKnownProtocolVersion(rawServerOverride)
-          ? rawServerOverride
-          : undefined;
+      // Same control-plane-first resolution the connect payload used, so
+      // `protocol_pin_source` attributes to `server_override` rather than
+      // falling through to `unknown` while the host mirror catches up.
+      const serverOverride = resolveServerProtocolOverride(serverId);
       const rawHostPin = activeMcpProfile?.mcpProtocolVersion;
       const hostPin =
         typeof rawHostPin === "string" && isKnownProtocolVersion(rawHostPin)
@@ -1422,7 +1454,7 @@ export function useServerState({
         had_synced_oauth_retry: telemetry?.hadSyncedOAuthRetry ?? false,
       };
     },
-    [activeHostConfig, activeMcpProfile]
+    [activeHostConfig, activeMcpProfile, resolveServerProtocolOverride]
   );
 
   const guardedTestConnection = useCallback(
@@ -2313,15 +2345,11 @@ export function useServerState({
 
       const resolved = tryResolveProjectServer(name);
       const serverId = resolved?.serverId;
-      const rawOverride =
-        serverId && activeHostConfig
-          ? activeHostConfig.serverConnectionOverrides?.[serverId]
-              ?.mcpProtocolVersionOverride
-          : undefined;
-      const serverOverride: McpProtocolVersion | undefined =
-        typeof rawOverride === "string" && isKnownProtocolVersion(rawOverride)
-          ? rawOverride
-          : undefined;
+      // Control-plane-first, same as the connect payload — otherwise the
+      // host mirror landing a moment later reads as a version CHANGE and
+      // triggers a redundant re-probe of a server already connected on the
+      // right wire mode.
+      const serverOverride = resolveServerProtocolOverride(serverId);
       // Same precedence as the connect resolver (shared helper) so the
       // "did the effective version change?" decision matches what we would
       // actually connect with — including the config pin and the 2026 era
@@ -2412,6 +2440,7 @@ export function useServerState({
     appState.servers,
     activeMcpProfile?.mcpProtocolVersion,
     activeHostConfig,
+    resolveServerProtocolOverride,
     dispatch,
     guardedReconnectServer,
     storeInitInfo,

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -1065,11 +1065,21 @@ export function useServerState({
   // and silently connect on the host default (issue #3453). Convex dedupes
   // identical subscriptions, so sharing this query with `App.tsx` /
   // `ServersTab` / `ServerDetailModal` costs no extra traffic.
+  // Gated on auth + db-user readiness on top of the id-shape guard:
+  // `getConfig` is a `userQuery` that resolves project membership off
+  // `ctx.actor.userId` and throws "Not a member of this project" without
+  // one. Retained project state can carry a real `sharedProjectId` into a
+  // pre-auth or local-fallback render, so the id guard alone would fire
+  // the query before the scope is authorized. Same gate `ServersTab` uses.
   const sharedProjectIdForServerConfig = activeProject?.sharedProjectId ?? null;
+  const canQueryProjectServerConfig =
+    isAuthenticated &&
+    isUserReady &&
+    !!sharedProjectIdForServerConfig &&
+    shouldQueryProjectId(sharedProjectIdForServerConfig);
   const projectServerConfigDto = useQuery(
     "projectServerConfig:getConfig" as never,
-    sharedProjectIdForServerConfig &&
-      shouldQueryProjectId(sharedProjectIdForServerConfig)
+    canQueryProjectServerConfig
       ? ({ projectId: sharedProjectIdForServerConfig } as never)
       : "skip"
   ) as ProjectServerConfigDto | null | undefined;
@@ -1078,19 +1088,25 @@ export function useServerState({
    * Resolve a server's pinned wire version override, control-plane first.
    *
    * Precedence mirrors `App.tsx`'s hosted pin map: the `projectServerConfig`
-   * DTO is the row the save actually wrote, so it wins; the host-config
-   * mirror is the fallback for renderers whose DTO hasn't hydrated yet
-   * (`undefined`). Each candidate is membership-gated so a typo on either
-   * layer can't reach the SDK's open-routing predicate.
+   * DTO is the row the save actually wrote, so once it has LOADED it is
+   * authoritative — including an explicit absence. Clearing an override
+   * writes that absence to the control plane, so falling through to the
+   * mirror on a miss would keep reconnecting on the version the user just
+   * removed until the host mirror caught up. The mirror is consulted only
+   * while the DTO is `undefined` — still in flight, or skipped entirely in
+   * local/unauthenticated mode, where the control plane isn't readable and
+   * the mirror is the only source. Each candidate is membership-gated so a
+   * typo on either layer can't reach the SDK's open-routing predicate.
    */
   const resolveServerProtocolOverride = useCallback(
     (serverId: string | undefined): McpProtocolVersion | undefined => {
       if (!serverId) return undefined;
       const raw =
-        projectServerConfigDto?.overrides?.[serverId]
-          ?.mcpProtocolVersionOverride ??
-        activeHostConfig?.serverConnectionOverrides?.[serverId]
-          ?.mcpProtocolVersionOverride;
+        projectServerConfigDto === undefined
+          ? activeHostConfig?.serverConnectionOverrides?.[serverId]
+              ?.mcpProtocolVersionOverride
+          : projectServerConfigDto?.overrides?.[serverId]
+              ?.mcpProtocolVersionOverride;
       return typeof raw === "string" && isKnownProtocolVersion(raw)
         ? raw
         : undefined;


### PR DESCRIPTION
When you pick a protocol version for one server (⋮ → Configure → Connection
overrides), MCPJam writes it twice: once on the server, and once as a copy
folded into your Client config. Connecting reads the Client config bundle,
so it was reading the copy.

- This makes connecting read the version off the server directly, instead of
  the copy.
- Both writes happen in the same save, so normally the two agree and nothing
  changes for you. The case they don't: if your Client is pointing at a saved
  snapshot that no longer exists, MCPJam skips updating it, and its copy stays
  stale — so the server would connect on your Client tab default instead of
  the version you picked.
- Telemetry now reports the version came from the server override instead of
  "unknown".
- Merges three copies of the same lookup into one function.