### PR TITLE
feat(subscriptions): HOSTED subscriptions/listen passthrough route (Phase 5 §13.4) [DRAFT — infra gate]

### DIFF
--- a/.changeset/hosted-subscriptions-listen.md
+++ b/.changeset/hosted-subscriptions-listen.md
@@ -1,0 +1,13 @@
+---
+"@mcpjam/inspector": minor
+---
+
+Add the HOSTED `subscriptions/listen` passthrough route (MCP 2026-07-28 §13.4).
+
+`POST /api/web/subscriptions/listen` authorizes + connects a server exactly like an ordinary hosted op, opens a dedicated official-client connection, and drives the era-neutral `SubscriptionCoordinator`. Acknowledgement, notifications, lifecycle status, and safe errors are forwarded downstream over SSE.
+
+- The downstream browser stream and the upstream MCP subscription stay on the same replica for their shared lifetime — no notification is written to Convex to cross replicas (horizontally scalable by construction).
+- Browser abort cancels the upstream listen and disposes the manager in `finally`; upstream graceful vs remote closure is a distinct structured terminal event; the coordinator runs with `maxAttempts: 0` so a remote loss closes downstream and the browser re-opens from the desired filter (no replay).
+- A keepalive comment frame defeats idle proxy teardown; a per-actor concurrent-stream cap protects the replica; stream duration + close reason go to Axiom and payload-free feature usage to PostHog.
+
+Merge-blocked pending the §13.4 hosted-infrastructure investigation gate (LB idle limits, sticky duration, reconnect-after-replica-restart).

--- a/mcpjam-inspector/server/routes/web/__tests__/hosted-subscriptions.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/hosted-subscriptions.test.ts
@@ -1,0 +1,373 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  McpSubscriptionHandle,
+  SubscriptionClientPort,
+  SubscriptionFilterShape,
+} from "@mcpjam/sdk";
+import { SUBSCRIPTION_ID_META_KEY } from "@mcpjam/sdk";
+import type { HostedSubscriptionEvent } from "@/shared/hosted-subscription.js";
+
+// Mock the heavy authorize/connect helper so route-level tests never touch
+// Convex/MCP. `projectServerSchema` (also imported by the route) stays real.
+vi.mock("../auth.js", async (orig) => {
+  const actual = (await orig()) as Record<string, unknown>;
+  return { ...actual, createManualHostedConnection: vi.fn() };
+});
+
+// Stub the PostHog capture so we can assert on its arguments.
+vi.mock("../../../utils/analytics.js", () => ({
+  captureServerEvent: vi.fn(),
+}));
+
+const {
+  driveHostedSubscription,
+  runHostedSubscriptionSession,
+  acquireSubscriptionStreamSlot,
+  releaseSubscriptionStreamSlot,
+  activeSubscriptionStreamCount,
+  resetSubscriptionStreamSlots,
+  MAX_CONCURRENT_SUBSCRIPTION_STREAMS,
+  default: subscriptionsRouter,
+} = await import("../subscriptions.js");
+const { createManualHostedConnection } = await import("../auth.js");
+const { captureServerEvent } = await import("../../../utils/analytics.js");
+const { WebRouteError, ErrorCode } = await import("../errors.js");
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+type NotificationHandler = (n: {
+  method: string;
+  params?: Record<string, unknown>;
+}) => void;
+
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+/**
+ * A fake MODERN `SubscriptionClientPort` whose `listen()` resolves to a handle
+ * we control: `close` is spied, `closed` is a deferred the test resolves to
+ * drive graceful/remote/local closure.
+ */
+function makeFakeModernClient(opts?: { subscriptionId?: string }) {
+  const handlers = new Map<string, NotificationHandler>();
+  const closed = deferred<"local" | "graceful" | "remote">();
+  const close = vi.fn(async () => {});
+  const honoredFilter: SubscriptionFilterShape = { toolsListChanged: true };
+  const handle: McpSubscriptionHandle = {
+    honoredFilter,
+    close,
+    closed: closed.promise,
+    ...(opts?.subscriptionId ? { subscriptionId: opts.subscriptionId } : {}),
+  };
+  const listen = vi.fn(async () => handle);
+
+  const client: SubscriptionClientPort = {
+    getServerCapabilities: () => ({
+      tools: { listChanged: true },
+      resources: { listChanged: true, subscribe: true },
+    }),
+    getProtocolEra: () => "modern",
+    setNotificationHandler: (method, handler) =>
+      handlers.set(method, handler as NotificationHandler),
+    subscribeResource: async () => ({}),
+    unsubscribeResource: async () => ({}),
+    listen,
+  };
+
+  const emit = (method: string, params?: Record<string, unknown>) =>
+    handlers.get(method)?.({ method, params });
+
+  return { client, handle, close, listen, closed, emit };
+}
+
+function makeSink() {
+  const events: HostedSubscriptionEvent[] = [];
+  const closeSpy = vi.fn();
+  const sink = {
+    send: (e: HostedSubscriptionEvent) => events.push(e),
+    close: closeSpy,
+  };
+  return { sink, events, closeSpy };
+}
+
+async function flush() {
+  // Let the coordinator's internal microtask queue (reconcile → listen → ack)
+  // settle.
+  for (let i = 0; i < 5; i++) await Promise.resolve();
+}
+
+beforeEach(() => {
+  resetSubscriptionStreamSlots();
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Driver: open → ack → notification → terminal
+// ---------------------------------------------------------------------------
+
+describe("driveHostedSubscription", () => {
+  it("emits open, forwards the acknowledgement, then a notification with its subscription id", async () => {
+    const { client, emit } = makeFakeModernClient({ subscriptionId: "sub-1" });
+    const { sink, events } = makeSink();
+
+    driveHostedSubscription({
+      client,
+      serverId: "srv",
+      desired: { toolsListChanged: true },
+      sink,
+    });
+    await flush();
+
+    const open = events.find((e) => e.type === "open");
+    expect(open).toMatchObject({
+      type: "open",
+      serverId: "srv",
+      era: "modern",
+      supportsListen: true,
+    });
+
+    // The active stream event carries the acknowledged filter (= the ack).
+    const active = events.find(
+      (e) => e.type === "stream" && e.stream.status === "active",
+    );
+    expect(active).toBeDefined();
+    expect(
+      active?.type === "stream" ? active.stream.acknowledgedFilter : undefined,
+    ).toMatchObject({ toolsListChanged: true });
+
+    // Now a real notification, stamped with the subscription id.
+    emit("notifications/tools/list_changed", {
+      _meta: { [SUBSCRIPTION_ID_META_KEY]: "sub-1" },
+    });
+    await flush();
+
+    const notif = events.find((e) => e.type === "notification");
+    expect(notif).toMatchObject({
+      type: "notification",
+      serverId: "srv",
+      notification: { kind: "tools-list-changed", subscriptionId: "sub-1" },
+    });
+  });
+
+  it("closes with a GRACEFUL structured terminal event when the server completes", async () => {
+    const { client, closed } = makeFakeModernClient({ subscriptionId: "s" });
+    const { sink, events } = makeSink();
+
+    const { done } = driveHostedSubscription({
+      client,
+      serverId: "srv",
+      desired: { toolsListChanged: true },
+      sink,
+    });
+    await flush();
+
+    closed.resolve("graceful");
+    const info = await done;
+
+    expect(info.reason).toBe("graceful");
+    const terminal = events.find((e) => e.type === "terminal");
+    expect(terminal).toMatchObject({ type: "terminal", reason: "graceful" });
+  });
+
+  it("closes with a REMOTE terminal event on unexpected loss — distinct from graceful", async () => {
+    const { client, closed } = makeFakeModernClient({ subscriptionId: "s" });
+    const { sink, events } = makeSink();
+
+    const { done } = driveHostedSubscription({
+      client,
+      serverId: "srv",
+      desired: { toolsListChanged: true },
+      sink,
+    });
+    await flush();
+
+    closed.resolve("remote");
+    const info = await done;
+
+    expect(info.reason).toBe("remote");
+    const terminal = events.find((e) => e.type === "terminal");
+    expect(terminal).toMatchObject({ type: "terminal", reason: "remote" });
+    // maxAttempts:0 → no server-side re-listen; the browser reopens instead.
+    expect(info.reconnectAttempt).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Session: abort cancels upstream + disposes the manager in finally
+// ---------------------------------------------------------------------------
+
+describe("runHostedSubscriptionSession", () => {
+  it("browser abort cancels the upstream stream and disposes the manager in finally", async () => {
+    const { client, close } = makeFakeModernClient({ subscriptionId: "s" });
+    const disconnectAllServers = vi.fn(async () => {});
+    const manager = {
+      getManagedClient: () => client as never,
+      disconnectAllServers,
+    };
+    const { sink, closeSpy } = makeSink();
+    const controller = new AbortController();
+
+    const session = runHostedSubscriptionSession({
+      manager,
+      serverId: "srv",
+      desired: { toolsListChanged: true },
+      sink,
+      signal: controller.signal,
+    });
+    await flush();
+
+    controller.abort();
+    const info = await session;
+
+    expect(info.reason).toBe("local-abort");
+    expect(close).toHaveBeenCalled(); // upstream listen cancelled
+    expect(disconnectAllServers).toHaveBeenCalled(); // disposed in finally
+    expect(closeSpy).toHaveBeenCalled(); // downstream sink closed
+  });
+
+  it("captures a PostHog open event with NO notification payload", async () => {
+    const { client, emit, closed } = makeFakeModernClient({
+      subscriptionId: "s",
+    });
+    const disconnectAllServers = vi.fn(async () => {});
+    const manager = {
+      getManagedClient: () => client as never,
+      disconnectAllServers,
+    };
+    const { sink } = makeSink();
+    const captureOpen = vi.fn();
+    const recordClosed = vi.fn();
+
+    const session = runHostedSubscriptionSession({
+      manager,
+      serverId: "srv",
+      desired: { toolsListChanged: true },
+      sink,
+      seams: { captureOpen, recordClosed },
+    });
+    await flush();
+
+    // A notification arrives while the stream is live...
+    emit("notifications/tools/list_changed", {
+      _meta: { [SUBSCRIPTION_ID_META_KEY]: "s" },
+      // a payload the analytics layer must NEVER see:
+      secretPayload: { uri: "file:///secret", data: "leak" },
+    });
+    await flush();
+    closed.resolve("graceful");
+    await session;
+
+    // The open capture carries only era/transport/support — no payload keys.
+    expect(captureOpen).toHaveBeenCalledTimes(1);
+    const openArg = captureOpen.mock.calls[0][0];
+    expect(openArg).toEqual({
+      serverId: "srv",
+      era: "modern",
+      supportsListen: true,
+      transport: "http",
+    });
+    expect(JSON.stringify(captureOpen.mock.calls)).not.toContain("leak");
+    expect(JSON.stringify(captureOpen.mock.calls)).not.toContain("secret");
+
+    // The close record carries duration + reason + a COUNT, never a payload.
+    expect(recordClosed).toHaveBeenCalledTimes(1);
+    const closeArg = recordClosed.mock.calls[0][0];
+    expect(closeArg.reason).toBe("graceful");
+    expect(closeArg.notificationCount).toBe(1);
+    expect(JSON.stringify(recordClosed.mock.calls)).not.toContain("leak");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Concurrent-stream limit
+// ---------------------------------------------------------------------------
+
+describe("concurrent-stream limit", () => {
+  it("acquires up to the cap then refuses, and releases give the slot back", () => {
+    const key = "actor-1";
+    for (let i = 0; i < MAX_CONCURRENT_SUBSCRIPTION_STREAMS; i++) {
+      expect(acquireSubscriptionStreamSlot(key)).toBe(true);
+    }
+    expect(activeSubscriptionStreamCount(key)).toBe(
+      MAX_CONCURRENT_SUBSCRIPTION_STREAMS,
+    );
+    // Over the cap.
+    expect(acquireSubscriptionStreamSlot(key)).toBe(false);
+    // A different actor has its own bucket.
+    expect(acquireSubscriptionStreamSlot("actor-2")).toBe(true);
+    // Free one and it can be re-acquired.
+    releaseSubscriptionStreamSlot(key);
+    expect(acquireSubscriptionStreamSlot(key)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Route-level: authz mismatch fails closed; over-cap returns 429
+// ---------------------------------------------------------------------------
+
+describe("POST /listen route", () => {
+  function appWithContext() {
+    const { Hono } = require("hono");
+    const app = new Hono();
+    // Provide the request log context the route reads for the actor key.
+    app.use("*", async (c: any, next: () => Promise<void>) => {
+      c.set("requestLogContext", { userExternalId: "user-x" });
+      await next();
+    });
+    app.route("/subscriptions", subscriptionsRouter);
+    return app;
+  }
+
+  const body = JSON.stringify({
+    projectId: "p1",
+    serverId: "s1",
+    desired: { toolsListChanged: true },
+  });
+
+  it("fails closed (403) when authorization is denied, and releases the slot", async () => {
+    (createManualHostedConnection as unknown as ReturnType<typeof vi.fn>)
+      .mockRejectedValueOnce(
+        new WebRouteError(403, ErrorCode.FORBIDDEN, "Authorization denied"),
+      );
+
+    const app = appWithContext();
+    const res = await app.request("/subscriptions/listen", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body,
+    });
+
+    expect(res.status).toBe(403);
+    const json = await res.json();
+    expect(json.code).toBe("FORBIDDEN");
+    // Slot released — a denied request must not leak concurrency budget.
+    expect(activeSubscriptionStreamCount("user-x")).toBe(0);
+    expect(captureServerEvent).not.toHaveBeenCalled();
+  });
+
+  it("returns 429 when the actor is already at the concurrent-stream cap", async () => {
+    for (let i = 0; i < MAX_CONCURRENT_SUBSCRIPTION_STREAMS; i++) {
+      acquireSubscriptionStreamSlot("user-x");
+    }
+
+    const app = appWithContext();
+    const res = await app.request("/subscriptions/listen", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body,
+    });
+
+    expect(res.status).toBe(429);
+    const json = await res.json();
+    expect(json.code).toBe("RATE_LIMITED");
+    // The over-cap request must not have attempted a connection.
+    expect(createManualHostedConnection).not.toHaveBeenCalled();
+  });
+});

--- a/mcpjam-inspector/server/routes/web/index.ts
+++ b/mcpjam-inspector/server/routes/web/index.ts
@@ -29,6 +29,7 @@ import computers from "./computers.js";
 import skills from "./skills.js";
 import caniuse from "./caniuse.js";
 import mrtrContinuation from "./mrtr-continuation.js";
+import subscriptions from "./subscriptions.js";
 import { fetchRemoteGuestJwks } from "../../utils/guest-session-source.js";
 
 const web = new Hono();
@@ -61,6 +62,10 @@ web.use("/checks/*", bearerAuthMiddleware, guestRateLimitMiddleware);
 // guest rate limit like every MCP-operation route; the resume path re-drives a
 // tool/prompt/resource leg against a freshly-authorized manager.
 web.use("/mrtr/*", bearerAuthMiddleware, guestRateLimitMiddleware);
+// Hosted `subscriptions/listen` passthrough (MCP 2026-07-28 §13.4). A long-lived
+// SSE stream — bearer + guest rate limit like every MCP-operation route; the
+// per-actor concurrent-stream cap lives inside the router.
+web.use("/subscriptions/*", bearerAuthMiddleware, guestRateLimitMiddleware);
 web.use("/server/*", bearerAuthMiddleware, guestRateLimitMiddleware);
 // `/computers/exec` runs commands — bearer required. `/computers/config` is
 // deliberately open: it returns only a boolean and a public URL, and the
@@ -106,6 +111,7 @@ web.route("/chat-history", chatHistory);
 web.route("/conformance", conformanceWeb);
 web.route("/checks", checks);
 web.route("/mrtr", mrtrContinuation);
+web.route("/subscriptions", subscriptions);
 // `/computers/terminal` (the WS) is registered on the root app in
 // server/index.ts — only /config and /exec live on this sub-router.
 web.route("/computers", computers);

--- a/mcpjam-inspector/server/routes/web/subscriptions.ts
+++ b/mcpjam-inspector/server/routes/web/subscriptions.ts
@@ -1,0 +1,599 @@
+/**
+ * `subscriptions.ts` (web) — the HOSTED passthrough route for MCP 2026-07-28
+ * `subscriptions/listen` (spec §13.4).
+ *
+ * ## Shape
+ *
+ * A single authenticated endpoint, `POST /api/web/subscriptions/listen`. The
+ * browser sends `{ projectId, serverId, desired }` (plus the usual host pins);
+ * the replica authorizes + connects EXACTLY like an ordinary hosted op (reusing
+ * `createManualHostedConnection` → `createAuthorizedManager` → the Convex
+ * authorize batch), opens a DEDICATED official-client connection, and drives the
+ * SDK's era-neutral `SubscriptionCoordinator`. Acknowledgement, notifications,
+ * lifecycle status, and *safe* errors are forwarded downstream over SSE.
+ *
+ * ## Invariants this route is responsible for (see §13.4 / §5.5)
+ *
+ * - **Same replica for the shared lifetime.** The downstream browser stream and
+ *   the upstream MCP subscription live on THIS replica together. We never write
+ *   notifications to Convex to cross replicas — that is what makes the route
+ *   horizontally scalable.
+ * - **Abort cancels upstream + disposes the manager in `finally`.** A browser
+ *   hang-up aborts `c.req.raw.signal`; the driver disposes the coordinator
+ *   (cancelling the upstream listen) and the session `finally` disconnects the
+ *   manager. No leaked upstream stream, ever.
+ * - **Structured terminal event.** Graceful (server completed) vs remote
+ *   (unexpected loss) vs local-abort vs error are DISTINCT terminal reasons.
+ *   The coordinator is configured with `reconnect: { maxAttempts: 0 }` so a
+ *   remote loss closes downstream rather than silently re-listening server-side
+ *   — the browser re-opens from the desired filter (there is NO replay).
+ * - **Authorization + a concurrent-stream limit.** Authorization is the same
+ *   fail-closed batch every hosted op runs (per user/project/server). On top of
+ *   that a practical per-actor concurrent-stream cap protects the replica from
+ *   an unbounded number of long-lived upstream connections.
+ * - **Telemetry without payloads.** Stream duration + close reason go to Axiom;
+ *   aggregate feature usage goes to PostHog. Neither carries notification
+ *   payloads.
+ *
+ * ## Testability
+ *
+ * The upstream-driving core (`driveHostedSubscription`) and the
+ * session-lifecycle core (`runHostedSubscriptionSession`) are pure and take an
+ * injectable seam bag, so route-level tests drive the REAL coordinator over a
+ * fake `SubscriptionClientPort` and a fake sink without a live Convex/MCP.
+ */
+
+import { Hono } from "hono";
+import { z } from "zod";
+import {
+  SubscriptionCoordinator,
+  type DesiredSubscriptionInterests,
+  type MCPClientManager,
+  type SubscriptionClientPort,
+  type SubscriptionCoordinatorOptions,
+  type SubscriptionStreamRecord,
+} from "@mcpjam/sdk";
+import type {
+  HostedSubscriptionEvent,
+  SubscriptionCloseReasonView,
+  SubscriptionEra,
+  SubscriptionNotificationView,
+  SubscriptionRejectedNotificationView,
+  SubscriptionStreamView,
+} from "@/shared/hosted-subscription.js";
+import { WEB_CALL_TIMEOUT_MS } from "../../config.js";
+import { captureServerEvent } from "../../utils/analytics.js";
+import { getRequestLogger } from "../../utils/request-logger.js";
+import type { RequestLogContext } from "../../utils/log-events.js";
+import { logger } from "../../utils/logger.js";
+import {
+  ErrorCode,
+  WebRouteError,
+  webError,
+  mapRuntimeError,
+  readJsonBody,
+} from "./errors.js";
+import {
+  createManualHostedConnection,
+  projectServerSchema,
+} from "./auth.js";
+
+// ---------------------------------------------------------------------------
+// Request schema
+// ---------------------------------------------------------------------------
+
+const desiredSchema = z
+  .object({
+    toolsListChanged: z.boolean().optional(),
+    promptsListChanged: z.boolean().optional(),
+    resourcesListChanged: z.boolean().optional(),
+    resourceUris: z.array(z.string().min(1)).optional(),
+  })
+  .strict();
+
+/**
+ * Single-server (`projectServerSchema` carries `serverId`) plus the desired
+ * interests. `desired` is the era-neutral statement of what the user wants to
+ * observe; the coordinator turns it into either a modern `subscriptions/listen`
+ * filter or legacy per-URI `resources/subscribe` calls.
+ */
+export const hostedSubscriptionSchema = projectServerSchema.extend({
+  desired: desiredSchema.optional(),
+});
+
+// ---------------------------------------------------------------------------
+// Concurrent-stream limit (per actor, this replica)
+// ---------------------------------------------------------------------------
+
+/**
+ * Max long-lived subscription streams a single actor may hold open on ONE
+ * replica at once. A subscription stream pins an upstream MCP connection for its
+ * whole lifetime, so this is a resource cap, not a rate limit. Deliberately
+ * generous (a debugger legitimately watches several servers) but finite.
+ */
+export const MAX_CONCURRENT_SUBSCRIPTION_STREAMS = 8;
+
+/** actorKey -> live stream count on this replica. */
+const activeStreamCounts = new Map<string, number>();
+
+export function activeSubscriptionStreamCount(actorKey: string): number {
+  return activeStreamCounts.get(actorKey) ?? 0;
+}
+
+/** Reserve a slot; returns false when the actor is already at the cap. */
+export function acquireSubscriptionStreamSlot(actorKey: string): boolean {
+  const current = activeStreamCounts.get(actorKey) ?? 0;
+  if (current >= MAX_CONCURRENT_SUBSCRIPTION_STREAMS) return false;
+  activeStreamCounts.set(actorKey, current + 1);
+  return true;
+}
+
+export function releaseSubscriptionStreamSlot(actorKey: string): void {
+  const current = activeStreamCounts.get(actorKey) ?? 0;
+  if (current <= 1) {
+    activeStreamCounts.delete(actorKey);
+    return;
+  }
+  activeStreamCounts.set(actorKey, current - 1);
+}
+
+/** Test seam: forget every reserved slot. */
+export function resetSubscriptionStreamSlots(): void {
+  activeStreamCounts.clear();
+}
+
+/**
+ * The concurrency key is the authenticated actor (WorkOS user id for signed-in
+ * users, guest id for guests), resolved from the request log context the
+ * authorize exchange populates. Falls back to a per-request-unique token so an
+ * unresolved actor can still open a single stream but can never share a bucket
+ * with anyone else.
+ */
+export function resolveSubscriptionActorKey(c: {
+  var?: { requestLogContext?: RequestLogContext };
+  get?: (k: string) => unknown;
+}): string {
+  const ctx = c.var?.requestLogContext;
+  const external =
+    ctx?.userExternalId ??
+    ctx?.guestExternalId ??
+    (typeof c.get?.("guestId") === "string"
+      ? (c.get!("guestId") as string)
+      : undefined);
+  return external ?? `anon:${crypto.randomUUID()}`;
+}
+
+// ---------------------------------------------------------------------------
+// View mappers (record -> wire view). Mirror the LOCAL bridge's shapes.
+// ---------------------------------------------------------------------------
+
+const TERMINAL_STATUSES: ReadonlySet<SubscriptionStreamRecord["status"]> =
+  new Set(["graceful-closed", "remote-closed", "cancelled", "error"]);
+
+export function isTerminalSubscriptionStatus(
+  status: SubscriptionStreamRecord["status"],
+): boolean {
+  return TERMINAL_STATUSES.has(status);
+}
+
+function toStreamView(stream: SubscriptionStreamRecord): SubscriptionStreamView {
+  return {
+    localId: stream.localId,
+    era: stream.era,
+    ...(stream.mcpSubscriptionId
+      ? { mcpSubscriptionId: stream.mcpSubscriptionId }
+      : {}),
+    ...(stream.idBinding ? { idBinding: stream.idBinding } : {}),
+    requestedFilter: { ...stream.requestedFilter },
+    ...(stream.acknowledgedFilter
+      ? { acknowledgedFilter: { ...stream.acknowledgedFilter } }
+      : {}),
+    rejectedInterests: stream.rejectedInterests.map((r) => ({ ...r })),
+    status: stream.status,
+    ...(stream.closeReason ? { closeReason: stream.closeReason } : {}),
+    ...(stream.error ? { error: stream.error } : {}),
+    openedAt: stream.openedAt,
+    ...(stream.acknowledgedAt ? { acknowledgedAt: stream.acknowledgedAt } : {}),
+    ...(stream.closedAt ? { closedAt: stream.closedAt } : {}),
+    reconnectAttempt: stream.reconnectAttempt,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// SSE sink + driver
+// ---------------------------------------------------------------------------
+
+export interface SubscriptionSink {
+  send(event: HostedSubscriptionEvent): void;
+  close(): void;
+}
+
+/** Everything Axiom + PostHog need at close — never any notification payload. */
+export interface HostedSubscriptionTerminalInfo {
+  serverId: string;
+  reason: SubscriptionCloseReasonView;
+  era: SubscriptionEra;
+  durationMs: number;
+  notificationCount: number;
+  reconnectAttempt: number;
+  supportsListen: boolean;
+}
+
+export interface HostedSubscriptionSeams {
+  /** Override the coordinator constructor (tests inject a fake-client driver). */
+  coordinatorFactory?: (
+    opts: SubscriptionCoordinatorOptions,
+  ) => SubscriptionCoordinator;
+  now?: () => number;
+  /** Aggregate feature-usage capture (PostHog). Payload-free by contract. */
+  captureOpen?: (info: {
+    serverId: string;
+    era: SubscriptionEra;
+    supportsListen: boolean;
+    transport: "http";
+  }) => void;
+  /** Stream duration + close reason (Axiom). Payload-free by contract. */
+  recordClosed?: (info: HostedSubscriptionTerminalInfo) => void;
+}
+
+/**
+ * Wires the era-neutral coordinator to the SSE sink and returns a promise that
+ * resolves when the stream reaches a terminal state (graceful/remote/local-abort
+ * /error) or the caller aborts. Registers the coordinator SYNCHRONOUSLY (its
+ * notification handlers are bound inside `openModernStream` BEFORE the `listen`
+ * RPC opens the upstream, so no notification can be missed) and configures
+ * `maxAttempts: 0` so a remote loss surfaces downstream instead of silently
+ * re-listening on the replica.
+ */
+export function driveHostedSubscription(args: {
+  client: SubscriptionClientPort;
+  serverId: string;
+  desired: DesiredSubscriptionInterests;
+  sink: SubscriptionSink;
+  signal?: AbortSignal;
+  seams?: HostedSubscriptionSeams;
+}): {
+  done: Promise<HostedSubscriptionTerminalInfo>;
+  coordinator: SubscriptionCoordinator;
+  era: SubscriptionEra;
+  supportsListen: boolean;
+} {
+  const { client, serverId, desired, sink, signal, seams } = args;
+  const now = seams?.now ?? (() => Date.now());
+  const startedAt = now();
+  const supportsListen = typeof client.listen === "function";
+
+  let notificationCount = 0;
+  let settled = false;
+  let resolveDone!: (info: HostedSubscriptionTerminalInfo) => void;
+  const done = new Promise<HostedSubscriptionTerminalInfo>((resolve) => {
+    resolveDone = resolve;
+  });
+
+  const finish = (
+    reason: SubscriptionCloseReasonView,
+    era: SubscriptionEra,
+    reconnectAttempt: number,
+  ) => {
+    if (settled) return;
+    settled = true;
+    resolveDone({
+      serverId,
+      reason,
+      era,
+      durationMs: now() - startedAt,
+      notificationCount,
+      reconnectAttempt,
+      supportsListen,
+    });
+  };
+
+  const factory =
+    seams?.coordinatorFactory ??
+    ((opts: SubscriptionCoordinatorOptions) => new SubscriptionCoordinator(opts));
+
+  const coordinator = factory({
+    client,
+    // Re-listen, never resume — but for the HOSTED passthrough a remote loss
+    // closes downstream (the browser re-opens). Server-side re-listen is off.
+    reconnect: { maxAttempts: 0 },
+    ...(seams?.now ? { now: seams.now } : {}),
+    onStreamChange: (stream) => {
+      const view = toStreamView(stream);
+      sink.send({ type: "stream", serverId, stream: view });
+      if (isTerminalSubscriptionStatus(stream.status)) {
+        const reason: SubscriptionCloseReasonView =
+          stream.closeReason ?? "error";
+        sink.send({
+          type: "terminal",
+          serverId,
+          reason,
+          era: stream.era,
+          stream: view,
+        });
+        finish(reason, stream.era, stream.reconnectAttempt);
+      }
+    },
+    onNotification: (event) => {
+      notificationCount += 1;
+      const notification: SubscriptionNotificationView = {
+        method: event.method,
+        kind: event.kind,
+        ...(event.uri ? { uri: event.uri } : {}),
+        ...(event.subscriptionId ? { subscriptionId: event.subscriptionId } : {}),
+        localSubscriptionId: event.localSubscriptionId,
+        at: event.at,
+      };
+      sink.send({ type: "notification", serverId, notification });
+    },
+    onRejectedNotification: (event) => {
+      const rejection: SubscriptionRejectedNotificationView = {
+        method: event.method,
+        ...(event.subscriptionId ? { subscriptionId: event.subscriptionId } : {}),
+        ...(event.localSubscriptionId
+          ? { localSubscriptionId: event.localSubscriptionId }
+          : {}),
+        reason: event.reason,
+        at: event.at,
+      };
+      sink.send({ type: "rejected", serverId, rejection });
+    },
+  });
+
+  const era = coordinator.era;
+
+  // Preamble: confirm acceptance + report era/support before any upstream work.
+  sink.send({ type: "open", serverId, era, supportsListen });
+
+  // Browser abort → dispose the coordinator (cancels the upstream listen). The
+  // resulting `cancelled`/`local-abort` stream change resolves `done`; if the
+  // coordinator never opened a stream (e.g. empty filter), settle explicitly so
+  // the session `finally` still runs.
+  const onAbort = () => {
+    void coordinator.dispose().finally(() => finish("local-abort", era, 0));
+  };
+  if (signal) {
+    if (signal.aborted) onAbort();
+    else signal.addEventListener("abort", onAbort, { once: true });
+  }
+
+  // Open the stream. A synchronous coordinator failure is surfaced as a terminal
+  // stream change already; guard the promise so it can't become an unhandled
+  // rejection.
+  void coordinator.setDesiredInterests(desired).catch((error) => {
+    logger.warn("[subscriptions.hosted] setDesiredInterests failed", {
+      error,
+      serverId,
+    });
+    finish("error", era, 0);
+  });
+
+  return { done, coordinator, era, supportsListen };
+}
+
+/**
+ * Full session lifecycle over an already-connected manager: capture the open
+ * feature-usage event, drive the stream to a terminal state, record the close,
+ * and — CRITICALLY — dispose the manager in `finally` regardless of how the
+ * stream ended (graceful, remote, abort, or throw).
+ */
+export async function runHostedSubscriptionSession(args: {
+  manager: Pick<MCPClientManager, "getManagedClient" | "disconnectAllServers">;
+  serverId: string;
+  desired: DesiredSubscriptionInterests;
+  sink: SubscriptionSink;
+  signal?: AbortSignal;
+  seams?: HostedSubscriptionSeams;
+}): Promise<HostedSubscriptionTerminalInfo> {
+  const { manager, serverId, desired, sink, signal, seams } = args;
+  const client = manager.getManagedClient(serverId) as
+    | SubscriptionClientPort
+    | undefined;
+  if (!client) {
+    throw new WebRouteError(
+      404,
+      ErrorCode.NOT_FOUND,
+      `Server "${serverId}" is not connected`,
+    );
+  }
+
+  const { done, era, supportsListen } = driveHostedSubscription({
+    client,
+    serverId,
+    desired,
+    sink,
+    signal,
+    seams,
+  });
+
+  // Payload-free feature-usage capture.
+  seams?.captureOpen?.({ serverId, era, supportsListen, transport: "http" });
+
+  try {
+    const info = await done;
+    seams?.recordClosed?.(info);
+    return info;
+  } finally {
+    await manager.disconnectAllServers().catch(() => {});
+    sink.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Route
+// ---------------------------------------------------------------------------
+
+const SSE_HEADERS: Record<string, string> = {
+  "Content-Type": "text/event-stream",
+  "Cache-Control": "no-cache, no-transform",
+  Connection: "keep-alive",
+  // Defeat proxy buffering so notifications are flushed promptly.
+  "X-Accel-Buffering": "no",
+};
+
+/** Comment-frame keepalive so an idle proxy/LB can't tear the stream down. */
+const SUBSCRIPTION_KEEPALIVE_MS = 25_000;
+
+const subscriptions = new Hono();
+
+subscriptions.post("/listen", async (c) => {
+  const actorKey = resolveSubscriptionActorKey(c as never);
+  if (!acquireSubscriptionStreamSlot(actorKey)) {
+    return webError(
+      c,
+      429,
+      ErrorCode.RATE_LIMITED,
+      `Too many concurrent subscription streams (limit ${MAX_CONCURRENT_SUBSCRIPTION_STREAMS}). Close one before opening another.`,
+    );
+  }
+
+  let slotReleased = false;
+  const releaseSlot = () => {
+    if (slotReleased) return;
+    slotReleased = true;
+    releaseSubscriptionStreamSlot(actorKey);
+  };
+
+  let manager:
+    | Pick<MCPClientManager, "getManagedClient" | "disconnectAllServers">
+    | undefined;
+  try {
+    const rawBody = await readJsonBody<Record<string, unknown>>(c);
+    const conn = await createManualHostedConnection(
+      c,
+      rawBody,
+      hostedSubscriptionSchema,
+      { timeoutMs: WEB_CALL_TIMEOUT_MS },
+    );
+    manager = conn.manager;
+    const body = conn.body as z.infer<typeof hostedSubscriptionSchema>;
+    const serverId = body.serverId;
+    const desired: DesiredSubscriptionInterests = body.desired ?? {};
+
+    // Connect must have produced a live client, or there is nothing to stream.
+    if (!manager.getManagedClient(serverId)) {
+      throw new WebRouteError(
+        404,
+        ErrorCode.NOT_FOUND,
+        `Server "${serverId}" is not connected`,
+      );
+    }
+
+    const boundManager = manager;
+    const encoder = new TextEncoder();
+
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        let closed = false;
+        const enqueue = (chunk: string) => {
+          if (closed) return;
+          try {
+            controller.enqueue(encoder.encode(chunk));
+          } catch {
+            closed = true;
+          }
+        };
+        const keepAlive = setInterval(() => {
+          enqueue(`: keep-alive\n\n`);
+        }, SUBSCRIPTION_KEEPALIVE_MS);
+        const closeController = () => {
+          if (closed) return;
+          closed = true;
+          clearInterval(keepAlive);
+          try {
+            controller.close();
+          } catch {}
+        };
+
+        const sink: SubscriptionSink = {
+          send: (event) => enqueue(`data: ${JSON.stringify(event)}\n\n`),
+          close: closeController,
+        };
+
+        // Advise the browser's reconnect cadence (re-listen, no replay).
+        enqueue(`retry: 1500\n\n`);
+
+        void runHostedSubscriptionSession({
+          manager: boundManager,
+          serverId,
+          desired,
+          sink,
+          signal: c.req.raw.signal,
+          seams: {
+            captureOpen: (info) => {
+              captureServerEvent(c, "subscription_stream_opened_server", {
+                era: info.era,
+                transport: info.transport,
+                supports_listen: info.supportsListen,
+              });
+            },
+            recordClosed: (info) => recordSubscriptionClosed(c, info),
+          },
+        })
+          .catch((error) => {
+            logger.error("[subscriptions.hosted] session failed", error, {
+              serverId,
+            });
+          })
+          .finally(() => {
+            releaseSlot();
+            closeController();
+          });
+      },
+      cancel() {
+        // The consumer went away without an abort signal firing (rare); the
+        // session's own abort/finally still disposes the manager and releases
+        // the slot, so nothing to do beyond letting it settle.
+      },
+    });
+
+    return new Response(stream, { status: 200, headers: SSE_HEADERS });
+  } catch (error) {
+    // Failure BEFORE the Response is returned (authz mismatch, validation, not
+    // connected): dispose anything we opened, release the slot, map to HTTP.
+    if (manager) {
+      await manager.disconnectAllServers().catch(() => {});
+    }
+    releaseSlot();
+    const routeError = mapRuntimeError(error);
+    return webError(
+      c,
+      routeError.status,
+      routeError.code,
+      routeError.message,
+      routeError.details,
+    );
+  }
+});
+
+/**
+ * Stream duration + close reason to Axiom. Guarded on the request log context so
+ * a misconfigured mount degrades to a warning instead of throwing inside the
+ * stream lifecycle. NEVER carries a notification payload.
+ */
+function recordSubscriptionClosed(
+  c: {
+    var?: { requestLogContext?: RequestLogContext };
+  },
+  info: HostedSubscriptionTerminalInfo,
+): void {
+  if (!c.var?.requestLogContext) return;
+  try {
+    getRequestLogger(c as never, "routes.web.subscriptions").event(
+      "subscription.stream.closed",
+      {
+        era: info.era,
+        closeReason: info.reason,
+        durationMs: info.durationMs,
+        notificationCount: info.notificationCount,
+        reconnectAttempt: info.reconnectAttempt,
+      },
+    );
+  } catch (error) {
+    logger.warn("[subscriptions.hosted] failed to record stream close", {
+      error,
+    });
+  }
+}
+
+export default subscriptions;

--- a/mcpjam-inspector/server/utils/log-events.ts
+++ b/mcpjam-inspector/server/utils/log-events.ts
@@ -147,6 +147,16 @@ export type RequestEventMap = {
     computerId: string;
     errorCode: string;
   };
+  // HOSTED subscription passthrough stream closed (routes/web/subscriptions.ts,
+  // MCP 2026-07-28 §13.4). One line per stream close, carrying duration + close
+  // reason — NEVER a notification payload (§13.4 item 9 / "do not do").
+  "subscription.stream.closed": {
+    era: "legacy" | "modern";
+    closeReason: "graceful" | "remote" | "local-abort" | "error";
+    durationMs: number;
+    notificationCount: number;
+    reconnectAttempt: number;
+  };
 };
 
 export type SystemEventMap = {

--- a/mcpjam-inspector/shared/analytics-events.ts
+++ b/mcpjam-inspector/shared/analytics-events.ts
@@ -37,6 +37,12 @@ export const ANALYTICS_EVENTS = {
   eval_suite_run_started: { source: "client" },
   eval_suite_run_started_server: { source: "server" },
 
+  // --- Subscriptions (MCP 2026-07-28 §13.4 hosted passthrough) ---
+  // Server-only aggregate feature-usage signal, fired when a hosted
+  // subscription stream is accepted. Carries era/transport only — NEVER a
+  // notification payload.
+  subscription_stream_opened_server: { source: "server" },
+
   // --- Skills (exemplar migrated area) ---
   skill_deleted: { source: "client" },
   skill_promoted: { source: "client" },

--- a/mcpjam-inspector/shared/hosted-subscription.ts
+++ b/mcpjam-inspector/shared/hosted-subscription.ts
@@ -1,0 +1,104 @@
+/**
+ * Wire shapes for the HOSTED subscription passthrough stream (MCP 2026-07-28
+ * §13.4).
+ *
+ * ## Why a passthrough, not a shared sink
+ *
+ * The hosted plane is horizontally scaled, but a `subscriptions/listen` stream
+ * is a *long-lived* upstream request. §5.5 / §13.4 make the deliberate choice
+ * that the downstream browser connection and the upstream MCP subscription live
+ * on the SAME replica for their shared lifetime:
+ *
+ * - the browser opens ONE authenticated endpoint (`POST /api/web/subscriptions/
+ *   listen`) with project/server/desired-interests;
+ * - the replica authorizes + connects exactly like an ordinary hosted op, opens
+ *   a dedicated official-client connection, and drives the SDK's
+ *   `SubscriptionCoordinator`;
+ * - acknowledgement, notifications, lifecycle status, and *safe* errors are
+ *   forwarded downstream over SSE;
+ * - browser abort cancels upstream and disposes the manager;
+ * - upstream graceful/remote closure closes downstream with a STRUCTURED
+ *   TERMINAL EVENT (graceful vs remote are distinct);
+ * - a browser reconnect reopens from the desired filter — there is NO replay.
+ *
+ * This is horizontally scalable precisely because nothing crosses replicas: we
+ * do NOT write every notification to Convex to fan across the fleet.
+ *
+ * The observation shapes reuse the era-neutral view types declared for the
+ * LOCAL bridge (`shared/subscription-bridge.ts`) so both surfaces render the
+ * same "what did the server agree to send, on which subscription, why did it
+ * stop" facts; the hosted stream adds an `open` preamble and a `terminal`
+ * closer that the local (already-connected, snapshot-on-connect) channel does
+ * not need.
+ */
+
+import type {
+  SubscriptionCloseReasonView,
+  SubscriptionEra,
+  SubscriptionNotificationView,
+  SubscriptionRejectedNotificationView,
+  SubscriptionStreamView,
+} from "./subscription-bridge.js";
+
+export type {
+  SubscriptionCloseReasonView,
+  SubscriptionEra,
+  SubscriptionNotificationView,
+  SubscriptionRejectedNotificationView,
+  SubscriptionStreamView,
+} from "./subscription-bridge.js";
+
+/**
+ * Wire-contract version. Bump only on an incompatible change to the event
+ * shapes below so a stale browser bundle can degrade rather than misparse.
+ */
+export const HOSTED_SUBSCRIPTION_VERSION = 1;
+
+/** Desired interests the browser POSTs when opening the stream. */
+export interface HostedSubscriptionDesired {
+  toolsListChanged?: boolean;
+  promptsListChanged?: boolean;
+  resourcesListChanged?: boolean;
+  resourceUris?: string[];
+}
+
+export type HostedSubscriptionEvent =
+  /**
+   * Sent once, immediately, before any upstream work — confirms the replica
+   * accepted the stream and reports the negotiated era and whether this
+   * connection can open a modern `subscriptions/listen` stream at all.
+   */
+  | {
+      type: "open";
+      serverId: string;
+      era: SubscriptionEra;
+      supportsListen: boolean;
+    }
+  /** A stream opened, was acknowledged (carries `acknowledgedFilter`), or closed. */
+  | { type: "stream"; serverId: string; stream: SubscriptionStreamView }
+  /** A forwarded notification, stamped with its subscription id. */
+  | {
+      type: "notification";
+      serverId: string;
+      notification: SubscriptionNotificationView;
+    }
+  /** A safe refusal: an unrequested/unknown/inactive notification, shown not dropped. */
+  | {
+      type: "rejected";
+      serverId: string;
+      rejection: SubscriptionRejectedNotificationView;
+    }
+  /**
+   * The structured terminal event. `reason` distinguishes a server-intended
+   * `graceful` close from an unexpected `remote` loss, a local `local-abort`
+   * (browser hung up / disposal), or an `error` open. After this the SSE
+   * closes; a browser that still wants the data re-opens from the desired
+   * filter (no replay).
+   */
+  | {
+      type: "terminal";
+      serverId: string;
+      reason: SubscriptionCloseReasonView;
+      era: SubscriptionEra;
+      stream: SubscriptionStreamView;
+    };


### PR DESCRIPTION
## What

Implements the **HOSTED `subscriptions/listen` passthrough route** for Phase 5 of the MCP `2026-07-28` migration (spec §13.4), on top of the merged era-neutral `SubscriptionCoordinator` (§13.1) and LOCAL bridge (§13.2, #3480).

New endpoint: **`POST /api/web/subscriptions/listen`**.

### Route contract
- **Request** (JSON): `projectServerSchema` fields (`projectId`, `serverId`, host pins, oauth, xaaPolicy, …) + `desired` = `{ toolsListChanged?, promptsListChanged?, resourcesListChanged?, resourceUris? }` (era-neutral interests).
- **Response**: a long-lived `text/event-stream`. Each `data:` frame is a `HostedSubscriptionEvent`:
  - `open` — sent immediately: `{ serverId, era, supportsListen }`.
  - `stream` — a `SubscriptionStreamView` (opening → active carries `acknowledgedFilter` = the ack → terminal).
  - `notification` — a forwarded `SubscriptionNotificationView`, stamped with its subscription id.
  - `rejected` — a safe refusal (unrequested / unknown-id / inactive / request-scoped), shown not dropped.
  - `terminal` — structured close: `reason ∈ { graceful, remote, local-abort, error }`, then the SSE closes.
  - `: keep-alive` comment frames every 25s.

### How it satisfies §13.4
1. Browser opens the authenticated endpoint with project/server/desired-interests.
2. Replica resolves server + authorization via `createManualHostedConnection` → `createAuthorizedManager` → the Convex authorize batch (same fail-closed path as every hosted op).
3. Opens a dedicated official-client connection and drives the coordinator's modern `client.listen(filter)`.
4. Forwards ack, notifications, lifecycle status, and safe errors over SSE; keepalive frames defeat idle proxy teardown.
5. Browser abort cancels the upstream listen and **disposes the manager in `finally`**.
6. Upstream graceful vs remote closure emits a **distinct structured terminal event** (`reconnect: { maxAttempts: 0 }` so a remote loss closes downstream rather than silently re-listening server-side).
7. Browser reconnect reopens from the desired filter — **no event replay**.
8. Per-user/project/server authorization + a **per-actor concurrent-stream cap** (`MAX_CONCURRENT_SUBSCRIPTION_STREAMS = 8`, 429 over cap).
9. Stream duration + close reason → **Axiom** (`subscription.stream.closed`); aggregate feature usage → **PostHog** (`subscription_stream_opened_server`) **without notification payloads**.

**Horizontal-scale invariant:** the downstream stream and upstream subscription stay on the owning replica; nothing is written to Convex per notification.

### Files
- `server/routes/web/subscriptions.ts` — the route + pure, testable driver/session cores + concurrency helpers.
- `shared/hosted-subscription.ts` — wire event shapes (reuse the local bridge's view types).
- `server/utils/log-events.ts` — `subscription.stream.closed` Axiom event.
- `shared/analytics-events.ts` — `subscription_stream_opened_server` PostHog event.
- `server/routes/web/index.ts` — mount + bearer/guest-rate-limit middleware.
- `server/routes/web/__tests__/hosted-subscriptions.test.ts` — 8 tests (all green).

## Tests
`npx vitest run server/routes/web/__tests__/hosted-subscriptions.test.ts` → **8 passed, exit 0**. Covers: open → ack forwarded → notification forwarded with sub id; graceful close = structured terminal event; remote close distinct; browser abort cancels upstream + disposes manager (asserted in `finally`); concurrent-stream limit; authz mismatch fails closed (403, slot released); no notification payloads in PostHog/Axiom. Local bridge suite still green (18 total). `tsc --noEmit`: 0 new errors attributable to changed files.

---

## ⛔ INFRA GATE — DO NOT MERGE UNTIL PROVEN

Per §13.4 "Hosted infrastructure investigation gate", this PR is a **draft** and must not merge until the deployment-infrastructure items below are proven. The code addresses what code *can* address; the rest need a human/infra investigation against the real deployment.

**Addressed in code (verify the assumptions hold on the real deployment):**
- [x] **Keepalive strategy** — 25s `: keep-alive` comment frames + `X-Accel-Buffering: no`, `Cache-Control: no-transform`.
- [x] **Server + client abort propagation** — `c.req.raw.signal` abort → `coordinator.dispose()` cancels the upstream listen; graceful/remote handle-close resolves the session.
- [x] **Process-shutdown disposal** — the manager is disposed in the session `finally` on every terminal path (graceful/remote/abort/error); the concurrency slot is released alongside.
- [x] **Structured terminal event** distinguishing graceful vs remote vs local-abort vs error; **no replay** on reconnect.

**Require human/infra investigation (BLOCKING — cannot be proven from code):**
- [ ] **Proxy/LB support for the long-lived response type + idle duration** — confirm Railway/edge does not idle-kill `text/event-stream` before the keepalive interval, and that the keepalive cadence beats the real idle timeout.
- [ ] **Whether deployments enforce sticky connection duration naturally** — the passthrough assumes the downstream stream and upstream subscription share one replica for the whole lifetime; confirm no max-connection-duration / drain policy severs it mid-stream.
- [ ] **Browser reconnection after a replica restart** — verify the client re-opens from the desired filter cleanly (the route promises no replay); confirm UX on replica bounce.
- [ ] **Maximum open-stream resource cost** — measure per-stream memory/FD cost and validate `MAX_CONCURRENT_SUBSCRIPTION_STREAMS` (per actor) + any needed per-replica global cap against real limits.
- [ ] **Authorization refresh during a long-lived stream** — a stream can outlive an access token; confirm the upstream MCP connection's token-refresh path holds for the stream's full duration (or define a bounded max stream lifetime).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a HOSTED `subscriptions/listen` passthrough route at `POST /api/web/subscriptions/listen` that authorizes like other hosted ops, opens an official client via `@mcpjam/sdk`, and streams acknowledgements, notifications, and terminal events over SSE (modern/legacy via the era-neutral coordinator).

- **New Features**
  - SSE stream with `open`, `stream`, `notification`, `rejected`, and `terminal` events; `retry: 1500` advice and 25s `: keep-alive` frames.
  - Distinct terminal reasons: `graceful`, `remote`, `local-abort`, `error`; no server-side re-listen (`reconnect: { maxAttempts: 0 }`).
  - Per-actor concurrent-stream cap (`MAX_CONCURRENT_SUBSCRIPTION_STREAMS = 8`); over-cap returns 429 and never connects upstream.
  - Browser abort cancels upstream and disposes the manager in `finally`; stream and subscription stay on the same replica (no Convex writes per notification).
  - Analytics: Axiom `subscription.stream.closed` with duration/reason/count; PostHog `subscription_stream_opened_server` without payloads.

- **Migration**
  - Clients POST `{ projectId, serverId, desired }` and consume the SSE; reconnect by reopening with the same `desired` filter (no replay).
  - Infra gate (block merge): verify LB idle handling for SSE, long-lived/sticky connection behavior, per-stream resource cost, and token refresh over long streams.

<sup>Written for commit 7991b9ab5b239fa36fd8810eb1942ffffdb3fcc6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

