### PR TITLE
fix(sidebar): center collapsed-rail icon in guest and loading footer

### DIFF
--- a/mcpjam-inspector/client/src/components/sidebar/sidebar-user.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/sidebar-user.tsx
@@ -104,10 +104,17 @@ export function SidebarUser({ onBeforeSignOut }: SidebarUserProps = {}) {
 
   const avatarUrl = profilePictureUrl;
 
+  // `size="lg"` drops its icon-mode padding so a 32px avatar can fill the
+  // button; the loading/guest branches hold a bare 16px icon instead, so they
+  // must center it explicitly or it parks 8px left of the rail centerline.
   const loadingState = (
     <SidebarMenu>
       <SidebarMenuItem>
-        <SidebarMenuButton size="lg" disabled>
+        <SidebarMenuButton
+          size="lg"
+          disabled
+          className="group-data-[collapsible=icon]:justify-center"
+        >
           <RefreshCw className="size-4 animate-spin" />
           <span className="truncate group-data-[collapsible=icon]:hidden">
             Loading...
@@ -140,7 +147,7 @@ export function SidebarUser({ onBeforeSignOut }: SidebarUserProps = {}) {
             size="lg"
             onClick={() => signIn()}
             aria-label="Sign in"
-            className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+            className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground group-data-[collapsible=icon]:justify-center"
           >
             <LogIn className="size-4" />
             <span className="truncate group-data-[collapsible=icon]:hidden">

--- a/mcpjam-inspector/e2e/sidebar-rail-alignment.spec.ts
+++ b/mcpjam-inspector/e2e/sidebar-rail-alignment.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "@playwright/test";
+
+// Guards the collapsed (icon-mode) sidebar rail: every icon-only control in
+// the footer must sit on the rail's horizontal centerline. This is geometry
+// the vitest suite can't see (jsdom has no layout engine). Regression context:
+// the signed-out "Sign in" footer button uses a `size="lg"` menu button, which
+// drops its padding in icon mode so a 32px avatar can fill it — with a 16px
+// icon instead, the icon parked 8px left of the centerline.
+test("collapsed sidebar rail centers the footer icons", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.getByTestId("app-shell")).toBeVisible({ timeout: 30_000 });
+
+  // Guest footer (local mode and hosted signed-out): Sign in + Support and
+  // Settings utility buttons. Waiting for Sign in also waits out authResolving.
+  const signInButton = page.locator('button[aria-label="Sign in"]');
+  await expect(signInButton).toBeVisible({ timeout: 30_000 });
+
+  const sidebar = page.locator('[data-slot="sidebar"][data-state]');
+  if ((await sidebar.getAttribute("data-state")) !== "collapsed") {
+    await page.keyboard.press("Control+b");
+  }
+  await expect(sidebar).toHaveAttribute("data-state", "collapsed");
+
+  // Let the 200ms width transition settle before measuring geometry.
+  const rail = page.locator('[data-slot="sidebar-container"]');
+  await expect
+    .poll(async () => (await rail.boundingBox())?.width ?? 0)
+    .toBeLessThan(60);
+
+  const railBox = await rail.boundingBox();
+  expect(railBox).not.toBeNull();
+  const railCenter = railBox!.x + railBox!.width / 2;
+
+  for (const label of ["Sign in", "Support", "Settings"]) {
+    const icon = page.locator(`button[aria-label="${label}"] svg`).first();
+    await expect(
+      icon,
+      `${label} icon should be visible in the collapsed rail`
+    ).toBeVisible();
+    const box = (await icon.boundingBox())!;
+    const iconCenter = box.x + box.width / 2;
+    expect(
+      Math.abs(iconCenter - railCenter),
+      `${label} icon center (${iconCenter}px) should sit on the rail centerline (${railCenter}px)`
+    ).toBeLessThanOrEqual(1.5);
+  }
+});


### PR DESCRIPTION
## Problem

With the sidebar collapsed and no user signed in, the footer **Sign in** icon on app.mcpjam.com sits ~8px left of the rail centerline, visibly misaligned with the Support/Settings icons above it. The loading-spinner state has the same latent offset.

Measured on production (icon horizontal centers, px from viewport left):

| Element | Center |
|---|---|
| Settings / Support icons | 23.5 |
| Sign in icon | **16.0** |

## Root cause

The footer uses `SidebarMenuButton size="lg"`. In icon mode the `lg` variant strips the button padding (`group-data-[collapsible=icon]:p-0!` overrides the base `p-2!`) so a 32px avatar can fill the 32px square — which is why signed-in users never see this. Signed out (and while loading), the button holds a bare 16px icon instead, and the left-justified flex content parks it 8px off center.

## Fix

Add `group-data-[collapsible=icon]:justify-center` to the guest and loading branches of `SidebarUser`. The avatar branch is untouched.

## Regression coverage

New `e2e/sidebar-rail-alignment.spec.ts` collapses the sidebar and asserts every footer icon center sits within 1.5px of the rail centerline. Geometry is invisible to the jsdom unit suite, so this lives in the Playwright lane (runs in `test.yml` and the post-deploy staging lane).

- Spec vs. production (unfixed): fails with `Sign in icon center (16px) should sit on the rail centerline (24px)`
- Full e2e suite vs. local build with fix: 4/4 pass
- `sidebar-user` unit tests: 7/7 pass

After the fix the Sign in icon measures 24.0px — on the centerline.
<img width="566" height="641" alt="image" src="https://github.com/user-attachments/assets/cddce6af-4e41-4d79-8f4b-ccde6abdcab8" />
<img width="2545" height="1298" alt="image" src="https://github.com/user-attachments/assets/359d9e54-f19b-43cb-81b8-8b42c885dbf1" />
<img width="2558" height="1297" alt="image" src="https://github.com/user-attachments/assets/bda8c69d-a614-4460-9bac-69b75ab17297" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centers the collapsed sidebar footer icons for guest and loading states so they align with Support/Settings. Adds an e2e check to prevent regressions.

- **Bug Fixes**
  - Center icon-mode content in `SidebarUser` guest/loading by adding `group-data-[collapsible=icon]:justify-center` to `SidebarMenuButton size="lg"`.
  - New Playwright spec `e2e/sidebar-rail-alignment.spec.ts` collapses the sidebar and asserts each footer icon center is within 1.5px of the rail centerline.

<sup>Written for commit 3f32fabe5f2ada85bd0cee84dc70579a2a22427c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3509?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

