### PR TITLE
Workstream A: MCP tasks protocol boundary — unblock the 2026 wire, discriminate validation, correct conformance

### DIFF
--- a/cli/src/commands/tasks.ts
+++ b/cli/src/commands/tasks.ts
@@ -41,6 +41,26 @@ const TASKS_CHECK_IDS_BY_CATEGORY: Record<
   ],
 };
 
+/**
+ * Exit code for a finished run.
+ *
+ * `incomplete` gets its own code because "the server violated the spec" and
+ * "we never established anything" are different failures with different fixes,
+ * and a run that skipped its task-dependent checks must never look like a pass.
+ * `2` is taken by usage errors, so the new state is `3`.
+ *
+ * The result is read structurally rather than by SDK type so an older
+ * `@mcpjam/sdk` (no `outcome`) still maps cleanly through `passed`.
+ */
+export function tasksConformanceExitCode(result: {
+  passed: boolean;
+  outcome?: "passed" | "failed" | "incomplete";
+}): number {
+  if (result.outcome === "incomplete") return 3;
+  if (result.outcome === "failed") return 1;
+  return result.passed ? 0 : 1;
+}
+
 export interface TasksConformanceOptions extends SharedServerTargetOptions {
   category?: string[];
   checkId?: string[];
@@ -185,8 +205,17 @@ export function registerTasksCommands(program: Command): void {
     const output = renderConformanceForCli(outputResult, reporter, format);
     process.stdout.write(output.endsWith("\n") ? output : `${output}\n`);
 
-    if (!result.passed) {
-      setProcessExitCode(1);
+    const incompleteReason = (result as { incompleteReason?: string })
+      .incompleteReason;
+    if (incompleteReason && !globalOptions.quiet) {
+      // The JSON payload carries it too, but a human running this in a terminal
+      // must not have to dig for the reason six checks never ran.
+      process.stderr.write(`Run incomplete: ${incompleteReason}\n`);
+    }
+
+    const exitCode = tasksConformanceExitCode(result);
+    if (exitCode !== 0) {
+      setProcessExitCode(exitCode);
     }
   });
 }

--- a/cli/src/commands/tasks.ts
+++ b/cli/src/commands/tasks.ts
@@ -31,12 +31,13 @@ const TASKS_CHECK_IDS_BY_CATEGORY: Record<
   dispatch: ["tasks-wire-resolvable", "tasks-declaration-hygiene"],
   creation: [
     "tasks-result-type-discipline",
-    "tasks-undeclared-capability-rejected",
+    "tasks-undeclared-creation-refused",
   ],
   lifecycle: [
     "tasks-ttl-shape",
     "tasks-inline-result",
     "tasks-mcp-name-routing",
+    "tasks-undeclared-capability-rejected",
   ],
 };
 

--- a/cli/tests/tasks-conformance.test.ts
+++ b/cli/tests/tasks-conformance.test.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { MCP_TASKS_CHECK_IDS } from "@mcpjam/sdk";
-import { buildTasksConformanceConfig } from "../src/commands/tasks.js";
+import {
+  buildTasksConformanceConfig,
+  tasksConformanceExitCode,
+} from "../src/commands/tasks.js";
 import { CliError } from "../src/lib/output.js";
 
 test("buildTasksConformanceConfig rejects unknown categories and check ids", () => {
@@ -80,6 +83,22 @@ test("buildTasksConformanceConfig lets explicit check ids override categories", 
   });
 
   assert.deepEqual(config.checkIds, ["tasks-inline-result"]);
+});
+
+test("tasksConformanceExitCode separates a violation from a run that established nothing", () => {
+  assert.equal(tasksConformanceExitCode({ passed: true, outcome: "passed" }), 0);
+  assert.equal(tasksConformanceExitCode({ passed: false, outcome: "failed" }), 1);
+  // An incomplete run is NOT a pass and NOT a spec violation: its own code, and
+  // never 2 (reserved for usage errors).
+  assert.equal(
+    tasksConformanceExitCode({ passed: false, outcome: "incomplete" }),
+    3,
+  );
+});
+
+test("tasksConformanceExitCode falls back to passed for a result with no outcome", () => {
+  assert.equal(tasksConformanceExitCode({ passed: true }), 0);
+  assert.equal(tasksConformanceExitCode({ passed: false }), 1);
 });
 
 test("buildTasksConformanceConfig forwards the tool probe options", () => {

--- a/cli/tests/tasks-conformance.test.ts
+++ b/cli/tests/tasks-conformance.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { MCP_TASKS_CHECK_IDS } from "@mcpjam/sdk";
 import { buildTasksConformanceConfig } from "../src/commands/tasks.js";
 import { CliError } from "../src/lib/output.js";
 
@@ -35,6 +36,40 @@ test("buildTasksConformanceConfig expands categories into check ids", () => {
     "tasks-wire-resolvable",
     "tasks-declaration-hygiene",
   ]);
+});
+
+test("buildTasksConformanceConfig maps the undeclared-capability checks to their categories", () => {
+  const creation = buildTasksConformanceConfig({
+    url: "https://example.com/mcp",
+    category: ["creation"],
+  });
+  assert.deepEqual(creation.checkIds, [
+    "tasks-result-type-discipline",
+    "tasks-undeclared-creation-refused",
+  ]);
+
+  const lifecycle = buildTasksConformanceConfig({
+    url: "https://example.com/mcp",
+    category: ["lifecycle"],
+  });
+  assert.deepEqual(lifecycle.checkIds, [
+    "tasks-ttl-shape",
+    "tasks-inline-result",
+    "tasks-mcp-name-routing",
+    "tasks-undeclared-capability-rejected",
+  ]);
+});
+
+test("every tasks check id is reachable through some category", () => {
+  const config = buildTasksConformanceConfig({
+    url: "https://example.com/mcp",
+    category: ["dispatch", "creation", "lifecycle"],
+  });
+
+  assert.deepEqual(
+    [...(config.checkIds ?? [])].sort(),
+    [...MCP_TASKS_CHECK_IDS].sort()
+  );
 });
 
 test("buildTasksConformanceConfig lets explicit check ids override categories", () => {

--- a/docs/cli/tasks-conformance.mdx
+++ b/docs/cli/tasks-conformance.mdx
@@ -23,13 +23,15 @@ For a local stdio server:
 mcpjam tasks conformance --command node --args server.js --cwd /path/to/project
 ```
 
-When your server's tools carry no task metadata (the extension wire), pass the tool name explicitly:
+On the extension wire you must name the probe tool. Auto-selection reads `execution.taskSupport`, which the 2026-07-28 `ToolSchema` strips, so a tasks-extension server cannot advertise which tool creates a task. Without `--tool-name` the six task-dependent checks cannot run and the command reports `"outcome": "incomplete"` (exit code `3`) rather than a green run:
 
 ```bash
 mcpjam tasks conformance \
   --url https://your-server.com/mcp \
   --tool-name long_job
 ```
+
+A `--tool-name` the server does not list is treated the same way: the run is incomplete, and the message names both the tool you asked for and the tools the server actually lists.
 
 Emit CI-friendly JUnit XML:
 
@@ -105,7 +107,8 @@ Typical success summary:
 ```json
 {
   "passed": true,
-  "summary": "8/8 checks passed, 0 failed, 0 skipped",
+  "outcome": "passed",
+  "summary": "8/8 checks passed, 0 failed, 0 could not run, 0 not applicable",
   "discovery": {
     "protocolVersion": "2026-07-28",
     "wire": "extension",
@@ -116,6 +119,23 @@ Typical success summary:
   }
 }
 ```
+
+## Outcomes: passed, failed, incomplete
+
+A run reports one of three outcomes, and `passed` is `true` only for the first:
+
+| `outcome` | Exit code | Meaning |
+|---|---|---|
+| `passed` | `0` | Every selected check either ran and passed, or does not apply to this server. |
+| `failed` | `1` | At least one check found a violation. |
+| `incomplete` | `3` | Nothing failed, but at least one selected check could not be run, so the run does not establish conformance. |
+
+Every skipped check says which kind of skip it is in `skipReason`:
+
+- `not-applicable` — the check cannot apply here (an extension-only check on a legacy connection, `Mcp-Name` routing over stdio, any task check on a connection with no tasks wire). These never hold a run back.
+- `could-not-run` — the check applies but was never exercised (no probe tool resolved, the named tool is not listed, the tool produced no task, the task never became readable). These make the run `incomplete`.
+
+An incomplete run carries a root `incompleteReason` naming the checks that did not run and what to change; non-quiet runs also print it to stderr. A skipped check can never add up to a passing verdict.
 
 ## Shared connection flags
 
@@ -142,12 +162,12 @@ Typical success summary:
 
 ## Notes
 
-- Exit codes are CI-friendly: `0` when all selected checks pass, `1` when any check fails, and `2` for invalid command usage.
+- Exit codes are CI-friendly: `0` when all selected checks pass, `1` when any check fails, `2` for invalid command usage, and `3` when the run is incomplete because a selected check could not be run.
 - Declaration hygiene is asserted against captured outbound JSON-RPC bytes, not re-derived from intent.
 - The undeclared-request checks (`tasks-undeclared-creation-refused`, `tasks-undeclared-capability-rejected`) apply to the extension wire only and are skipped on the legacy wire.
-- `tasks-undeclared-capability-rejected` needs a live task to probe with, so it is skipped when the run could not provoke one. Its probes run last, after every check that reads the task, because a server that wrongly accepts an undeclared `tasks/update` or `tasks/cancel` would otherwise mutate the very task the other checks inspect. If the server does not implement `subscriptions/listen` at all (`-32601`), that sub-probe is reported as a warning instead of a failure.
+- `tasks-undeclared-capability-rejected` needs a live task to probe with, so it is reported as `could-not-run` (and the run as incomplete) when no task could be provoked. Its probes run last, after every check that reads the task, because a server that wrongly accepts an undeclared `tasks/update` or `tasks/cancel` would otherwise mutate the very task the other checks inspect. If the server does not implement `subscriptions/listen` at all (`-32601`), that sub-probe is reported as a warning instead of a failure.
 - The `tasks-mcp-name-routing` check applies to HTTP transports only and is skipped for stdio servers.
-- Checks that require a created task are skipped when no task-capable tool is found and no `--tool-name` is provided.
+- Checks that require a created task cannot run when no probe tool resolves. That is a `could-not-run` skip, so the command exits `3` instead of reporting a pass — pass `--tool-name` to fix it.
 
 ## Related commands
 

--- a/docs/cli/tasks-conformance.mdx
+++ b/docs/cli/tasks-conformance.mdx
@@ -4,7 +4,7 @@ description: "Validate MCP Tasks wire behavior — legacy and SEP-2663 extension
 icon: "list-checks"
 ---
 
-The `tasks conformance` command validates the MCP Tasks wire your server exposes: which wire the connection resolves to, whether declaration hygiene holds for that wire, and whether the server honours the observable parts of the contract (result-type discipline, undeclared capability handling, TTL shapes, inline results, and `Mcp-Name` routing for HTTP transports).
+The `tasks conformance` command validates the MCP Tasks wire your server exposes: which wire the connection resolves to, whether declaration hygiene holds for that wire, and whether the server honours the observable parts of the contract (result-type discipline, `-32003` on undeclared requests, TTL shapes, inline results, and `Mcp-Name` routing for HTTP transports).
 
 <Note>
   Tasks conformance provokes and then polls a real task, so it requires a
@@ -45,11 +45,12 @@ mcpjam tasks conformance \
 |---|---|---|
 | `tasks-wire-resolvable` | `dispatch` | The negotiated protocol version and capabilities resolve to exactly one tasks wire. |
 | `tasks-declaration-hygiene` | `dispatch` | Outbound requests carry `params.task` only on the legacy wire and the extension declaration only on the extension wire. |
-| `tasks-result-type-discipline` | `creation` | A task-eligible `tools/call` returns either a normal tool result or a flat `CreateTaskResult` with `resultType: "task"` and a non-empty `taskId`. |
-| `tasks-undeclared-capability-rejected` | `creation` | On the extension wire, an undeclared `tools/call` must not come back as a task; the server must answer normally or reject with `-32003`. |
+| `tasks-result-type-discipline` | `creation` | A task-eligible `tools/call` returns either a normal tool result or a flat `CreateTaskResult` with `resultType: "task"` and a non-empty `taskId`. The discriminator is required whether absent or wrong — it is the only signal that separates a task from a standard result. |
+| `tasks-undeclared-creation-refused` | `creation` | On the extension wire, a `tools/call` that did not carry the extension declaration must not come back as a `CreateTaskResult`; the server must answer normally or reject with `-32003`. |
 | `tasks-ttl-shape` | `lifecycle` | TTL and poll interval use the era-native shapes: `ttlMs`/`pollIntervalMs` on the extension, `ttl`/`pollInterval` on the legacy wire. |
 | `tasks-inline-result` | `lifecycle` | A completed extension task carries its result inline on `tasks/get`; a legacy task exposes it via `tasks/result`. |
 | `tasks-mcp-name-routing` | `lifecycle` | Over HTTP, `tasks/get` is sent with `Mcp-Name` set to the task id. |
+| `tasks-undeclared-capability-rejected` | `lifecycle` | `tasks/get`, `tasks/update`, `tasks/cancel` and a task-filtered `subscriptions/listen` sent WITHOUT the extension declaration must each be rejected with `-32003`. |
 
 ## Categories and check ids
 
@@ -104,7 +105,7 @@ Typical success summary:
 ```json
 {
   "passed": true,
-  "summary": "7/7 checks passed, 0 failed, 0 skipped",
+  "summary": "8/8 checks passed, 0 failed, 0 skipped",
   "discovery": {
     "protocolVersion": "2026-07-28",
     "wire": "extension",
@@ -143,7 +144,8 @@ Typical success summary:
 
 - Exit codes are CI-friendly: `0` when all selected checks pass, `1` when any check fails, and `2` for invalid command usage.
 - Declaration hygiene is asserted against captured outbound JSON-RPC bytes, not re-derived from intent.
-- The undeclared-capability check (`tasks-undeclared-capability-rejected`) applies to the extension wire only and is skipped on the legacy wire.
+- The undeclared-request checks (`tasks-undeclared-creation-refused`, `tasks-undeclared-capability-rejected`) apply to the extension wire only and are skipped on the legacy wire.
+- `tasks-undeclared-capability-rejected` needs a live task to probe with, so it is skipped when the run could not provoke one. Its probes run last, after every check that reads the task, because a server that wrongly accepts an undeclared `tasks/update` or `tasks/cancel` would otherwise mutate the very task the other checks inspect. If the server does not implement `subscriptions/listen` at all (`-32601`), that sub-probe is reported as a warning instead of a failure.
 - The `tasks-mcp-name-routing` check applies to HTTP transports only and is skipped for stdio servers.
 - Checks that require a created task are skipped when no task-capable tool is found and no `--tool-name` is provided.
 

--- a/docs/mcp-tasks-full-support-plan.md
+++ b/docs/mcp-tasks-full-support-plan.md
@@ -560,9 +560,16 @@ wire
 taskId
 createdAt
 updatedAt
+lastObservedAt
 lastKnownStatus
 terminalAt?
 ```
+
+`lastObservedAt` is the last time a live `tasks/get` under the same
+authorization context answered for this handle at all — any status, including a
+`-32602`. It is the retention clock's only input for a non-terminal row, and it
+is distinct from `updatedAt`, which moves on any row write. `terminalAt` is
+stamped when the task reaches a terminal status or is marked expired.
 
 Do not store result/error payloads, `statusMessage`, tool arguments,
 `inputRequests`, input responses, sampling content, roots, or model output.
@@ -572,7 +579,7 @@ Use:
 
 - an exact identity index including owner and auth context;
 - an owner/context list index;
-- a retention scan index;
+- retention scan indexes on `terminalAt` and on `lastObservedAt`;
 - a 200-row cap per owner/server/auth-context and a defensive 2,000-row global
   project cap.
 
@@ -580,16 +587,58 @@ Use:
 
 Implement:
 
-- `upsertHostedTask`: transactional insert-or-update and bounded FIFO eviction;
+- `upsertHostedTask`: transactional insert-or-update and bounded eviction. Evict
+  in this order — expired rows, then terminal rows by oldest `terminalAt`, then
+  non-terminal rows by oldest `lastObservedAt`. Do not evict by oldest
+  `createdAt`: the oldest row is often the longest-running live task, which is
+  the one the registry exists to recover;
 - `listHostedTasks`: exact owner/context only;
 - `reportHostedTaskStatuses`: patch-only and exact owner/context only;
 - `pruneHostedTasks`: bounded, cursor-driven draining until the backlog is
   empty.
 
-Do not prune from `ttlMs` observed only at creation. The extension permits TTL
-changes and `null`. Use a seven-day registry maximum age and 24-hour terminal
-retention; mark a task expired only after a live `-32602` result under the same
-authorization context.
+Do not prune from `ttlMs` observed only at creation. `ttlMs` is `number | null`
+and `null` means unlimited, the value MAY change over the task's lifetime, and
+the server — not the client — is the party permitted to discard the task once a
+TTL elapses (`tasks.md:136-140`, `tasks.md:340`). An elapsed TTL is therefore a
+revalidation hint, never a deletion trigger: it may raise a handle's poll
+priority, and nothing more.
+
+Retention runs from the end of a task's life, not from its beginning. There is
+no registry maximum age measured from `createdAt`. Concretely:
+
+- the retention clock starts at `terminalAt` — set when a live `tasks/get`
+  reports a terminal status (`completed`, `failed`, `cancelled`) or when the
+  task is marked expired — and a terminal or expired row is deleted 24 hours
+  later;
+- a non-terminal row is never deleted for being old. A task may legitimately
+  still be `working` or `input_required` after seven days, and dropping its
+  handle would destroy exactly the durability the registry exists to provide.
+
+Mark a task expired only after a live `-32602` on `tasks/get` under the same
+authorization context. The method pinning is load-bearing and matches §3: only
+`tasks/get` carries the `MUST` for `-32602`, while `tasks/update` and
+`tasks/cancel` carry a `SHOULD` (`tasks.md:793-795`), so a `-32602` from update
+or cancel is a warning that triggers a confirming `tasks/get`, never proof on
+its own.
+
+Growth is still bounded, by unobservability rather than by age. `lastObservedAt`
+advances whenever a live `tasks/get` answers for the handle, so a genuinely
+long-running task that is being polled keeps refreshing it. A non-terminal row
+whose `lastObservedAt` is older than seven days is dormant: nobody has been able
+to confirm it for a week, which is the signature of a server that vanished, a
+revoked credential, or an abandoned handle. The pruner attempts one bounded
+revalidation for such a row when a live client context is available, and reaps
+it otherwise. An orphaned row therefore ages out on a fixed seven-day bound
+after the last contact, while a live, polled task never does. The per-owner and
+per-project caps in D2 remain the hard backstop.
+
+MCPJam is deliberately **not** defining a maximum task lifetime here. If it ever
+wants one — for storage cost or compliance reasons — that must be written down
+as an explicit product decision with its consequence stated plainly: recovery
+handles for tasks that are still running are dropped at the cutoff, and those
+tasks become invisible and uncancellable from any device that did not create
+them. It must not arrive disguised as a retention default.
 
 Validate and cap every identifier and batch. `lastKnownStatus` is an enum plus
 MCPJam's local `expired` tombstone. Reporting an unknown identity never
@@ -692,7 +741,10 @@ fetched task only when the caller explicitly requests a refresh. Never return
 Add stable error codes:
 
 - `TASKS_UNSUPPORTED` — 422, never retry;
-- `TASK_NOT_FOUND` — 404 for task `-32602`, stop polling;
+- `TASK_NOT_FOUND` — 404 for a `-32602` on `tasks/get`, stop polling. A
+  `-32602` on `tasks/update` or `tasks/cancel` is only a `SHOULD`
+  (`tasks.md:793-795`), so it maps to the operation's own failure and does not
+  by itself retire the handle;
 - `TASK_INPUT_REQUIRED` — automation cannot fulfill input;
 - existing `VALIDATION_ERROR`, `TIMEOUT`, and `RATE_LIMITED`.
 
@@ -884,10 +936,55 @@ Roll out in this order:
 7. guests only after mixed-client risk is gone and a durable recovery decision
    is documented.
 
-Rollback disables new per-request declarations and registry/API gates without
-removing stored browser handles or changing legacy `2025-11-25` behavior.
-Registry rows age out under retention and never need to be exposed
-project-wide.
+Rollback must not be described as "disable the per-request declaration". The
+extension requires the declaration on the lifecycle methods themselves: a
+non-declaring client issuing `tasks/get`, `tasks/update`, or `tasks/cancel`
+**MUST** receive `-32003` (`tasks.md:797-799`). A blanket declaration kill would
+therefore keep every stored handle while making it unpollable, unanswerable, and
+uncancellable — the tasks keep running and consuming server resources, invisible
+to the user and to MCPJam.
+
+MCPJam's position is **lifecycle-only continuation**. Rollback disables task
+*creation* and leaves the *drain* path intact:
+
+- surfaces stop declaring `io.modelcontextprotocol/tasks` on `tools/call`, and
+  task affordances disappear from creation UI, so no new handles are minted;
+- surfaces keep declaring the extension on `tasks/get`, `tasks/update`, and
+  `tasks/cancel` for handles that already exist, for exactly as long as any
+  outstanding handle is non-terminal;
+- registry and public-API gates close for writes but keep serving reads of
+  existing handles, so a user on another device can still find and cancel work
+  they started.
+
+Explicit cancellation is the operator escalation, not the default. If the
+rollback is caused by a defect in creation or product policy, draining is
+correct and cancelling would destroy work the user asked for. If the rollback is
+caused by a defect in the lifecycle wire itself — where continuing to speak
+`tasks/*` is what is unsafe — the procedure inverts to cancel-then-disable:
+`tasks/cancel` every outstanding handle first, verify terminal status with
+`tasks/get`, then drop the declaration entirely.
+
+In-flight `input_required` tasks get an explicit rule, because they never reach
+a terminal status on their own. During a drain they remain answerable: the
+handle is shown read-only with two actions, respond (`tasks/update`) or cancel
+(`tasks/cancel`), both of which still carry the declaration under
+lifecycle-only continuation. When the rolled-back defect is in the input path
+itself — elicitation, roots, or sampling handling — MCPJam does not offer
+respond and cancels instead. An unattended drain that reaches its deadline
+cancels rather than abandons.
+
+Abandonment is the residual case, and it is bounded rather than silent. Anything
+still non-terminal after cancel-then-disable is marked locally as unrecoverable
+with the reason shown; MCPJam stops polling; and the registry row ages out under
+the D3 unobservability bound, since `lastObservedAt` stops advancing once
+polling stops. Stored browser handles are never removed as part of rollback, and
+registry rows are never exposed project-wide.
+
+Legacy `2025-11-25` behavior is unaffected by any of this. The legacy wire
+carries no per-request extension declaration, so a creation-scoped or
+declaration-scoped gate cannot reach it; legacy tasks continue to be created,
+polled, and cancelled exactly as before. Every gate above is scoped to the
+extension declaration specifically, not to Tasks as a product concept.
 
 ## 13. Final release checklist
 
@@ -908,6 +1005,11 @@ project-wide.
       extension field.
 - [ ] Hosted registry is owner- and authorization-context-scoped.
 - [ ] No registry result, status-message, input, or model payload is stored.
+- [ ] Registry retention starts at terminal status or a confirmed `tasks/get`
+      `-32602`, never at creation or at an elapsed `ttlMs`, and an unobservable
+      row still ages out.
+- [ ] Rollback is creation-scoped: the drain path keeps declaring on
+      `tasks/get`/`tasks/update`/`tasks/cancel`, and no handle is stranded.
 - [ ] Public envelopes include `wire` and `lastUpdatedAt` and are
       status-discriminated.
 - [ ] Preview polling endpoints ship with rate limiting and `Retry-After`.

--- a/docs/mcp-tasks-full-support-plan.md
+++ b/docs/mcp-tasks-full-support-plan.md
@@ -1,0 +1,923 @@
+# MCP Tasks full-support implementation plan
+
+Status: implementation-ready source of truth
+
+Owners: MCPJam SDK, Inspector, hosted backend, public API, and CLI
+
+Protocol baseline: MCP `2025-11-25` legacy Tasks plus the official
+`io.modelcontextprotocol/tasks` extension for `2026-07-28`
+
+This plan supersedes these three drafts. Do not implement them independently:
+
+- `/Users/marcelojimenezrocabado/.claude/plans/hosted-tasks-convex-registry.md`
+- `/Users/marcelojimenezrocabado/.claude/plans/hostconfig-tasks-capability.md`
+- `/Users/marcelojimenezrocabado/.claude/plans/api-v1-tasks-contract.md`
+
+The drafts contain useful product work, but completing only those drafts would
+not produce full Tasks support. Protocol validation, notification delivery,
+poll scheduling, durable input-request deduplication, authorization-context
+isolation, and several public-contract details must land first or alongside
+them.
+
+## 1. Normative baseline
+
+Use these as the implementation sources of truth:
+
+- Official extension listing:
+  <https://modelcontextprotocol.io/extensions/overview>
+- SEP-2663, Final, extension identifier `io.modelcontextprotocol/tasks`:
+  <https://github.com/modelcontextprotocol/ext-tasks/blob/main/seps/2663-tasks-extension.md>
+- Extension specification and schema pinned to
+  `modelcontextprotocol/ext-tasks@2c1425d9a288b9b1f489430fe1e00bb392b47e48`:
+  `specification/draft/tasks.md`, `schema/draft/schema.ts`, and
+  `schema/draft/schema.json`
+- Legacy compatibility specification:
+  <https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks>
+
+The extension is official and SEP-2663 is Final (`seps/2663-tasks-extension.md:3`,
+Status: Final). Remove language that calls SEP-2663 a draft or makes acceptance
+of the SEP a release condition. Its repository paths still contain `draft`;
+pinning the exact commit prevents that path name from becoming an ambiguous
+compatibility claim.
+
+One caveat when citing sources: the ext-tasks `README.md:1` still titles the
+repository "MCP Tasks Extension (Experimental)" and `README.md:4` still says it
+is "**not** an official extension." That README is stale and is contradicted by
+both the official extension listing on modelcontextprotocol.io — which lists MCP
+Tasks under "Official Extension Repositories", while experimental extensions use
+an `experimental-ext-` repository prefix that ext-tasks does not carry — and by
+the SEP body itself (`seps/2663-tasks-extension.md:16`), which describes moving
+tasks to "an official extension." Cite the site and the SEP, never the README.
+
+Keep the two wires strictly separated:
+
+| Negotiated protocol                   | Valid Tasks wire           |
+| ------------------------------------- | -------------------------- |
+| Before `2025-11-25`                   | none                       |
+| `2025-11-25`                          | legacy core primitive only |
+| `2026-07-28` and later known versions | official extension only    |
+| Missing or unknown version            | none; fail closed          |
+
+Continue vendoring the extension types while no supported package is
+published. Add a CI drift job that diffs the vendored types, runtime schemas,
+and conformance fixtures against the pinned commit. Moving to a published
+package is a separate, test-preserving change.
+
+## 2. Definition of full support
+
+MCPJam can call Tasks fully implemented only when all of the following are
+true:
+
+1. The SDK selects exactly one wire from the negotiated protocol and server
+   capability and never mixes legacy and extension fields or methods.
+2. Extension eligibility is declared in the per-request client capabilities
+   only for a request whose host surface is ready to receive either a normal
+   result or `CreateTaskResult`.
+3. Every extension response is runtime-validated as the correct
+   status-discriminated shape before it reaches a route or UI.
+4. Task handles survive reloads and reconnects, and an authenticated hosted
+   user can resume only tasks created under the same user and authorization
+   context.
+5. Polling honors each task's dynamic `pollIntervalMs`; optional task
+   notifications reduce polling but are never required for correctness.
+6. `input_required` supports the same elicitation, roots, and sampling trust
+   and fulfillment rules as the corresponding standalone requests. Requests
+   are durably deduplicated by task and input key.
+7. Local Tools, hosted Tools, chat/playground, agent execution, public API,
+   and CLI have an explicit, tested Tasks behavior. Replay-only surfaces never
+   create new work.
+8. Public contracts are wire-neutral where possible, preserve the wire in the
+   task handle, rate-limit polling, and expose stable task-specific errors.
+9. The conformance suite proves the protocol MUSTs below against independent
+   legacy and extension fixtures.
+10. Disabling Tasks removes the per-request declaration and returns every
+    affected surface to its pre-Tasks behavior.
+
+Optional `notifications/tasks` support is required on persistent local/live
+connections for feature completeness. Hosted reconnect-per-operation paths may
+use polling because the extension makes notifications optional, but must not
+claim that a notification stream exists.
+
+## 3. Non-negotiable extension invariants
+
+Implement and test these at the SDK boundary, not separately in each route:
+
+- The server extension capability value must be a non-array object. A missing,
+  `null`, boolean, string, or array value is not a declaration. The pinned
+  conformance check reports non-empty settings because the pinned extension
+  defines `{}`, while runtime detection may retain unknown object keys for
+  forward compatibility.
+- `tools/call` may return either a normal `CallToolResult` or a flat
+  `CreateTaskResult` with `resultType: "task"`.
+- A server must not return `CreateTaskResult` for a request that did not carry
+  the extension declaration. If Tasks are mandatory for the operation, the
+  expected error is `-32003`.
+- `tasks/get`, `tasks/update`, `tasks/cancel`, and a task-filtered
+  `subscriptions/listen` request carry the extension declaration on that
+  request. A non-declaring client must receive `-32003`.
+- Streamable HTTP calls to `tasks/get`, `tasks/update`, and `tasks/cancel`
+  carry `Mcp-Name: <taskId>` and the correct `Mcp-Method`.
+- `CreateTaskResult` is not returned before the handle is durably readable from
+  a fresh `tasks/get` connection.
+- `tasks/get` returns a discriminated state. Prose requires `resultType:
+  "complete"` on the result (`tasks.md:338`), but the pinned JSON Schema never
+  defines the field — `resultType` appears nowhere in `schema/draft/schema.json`
+  — and each `DetailedTask` variant sets `additionalProperties: false`
+  (`schema.json:329`, `:385`, `:435`, `:485`, `:527`), so a validator generated
+  faithfully from the schema would reject the very key the prose mandates. Prose
+  and schema contradict each other. Accept the response with or without
+  `resultType`; discriminate on `status`:
+
+  | Status           | Required payload           |
+  | ---------------- | -------------------------- |
+  | `working`        | no status-specific payload |
+  | `input_required` | `inputRequests`            |
+  | `completed`      | `result`                   |
+  | `failed`         | JSON-RPC `error`           |
+  | `cancelled`      | no status-specific payload |
+
+- A tool result with `isError: true` is still a `completed` task. Only an
+  underlying JSON-RPC error produces `failed`.
+- `tasks/update` and `tasks/cancel` return an empty acknowledgement. Prose
+  requires `resultType: "complete"` on both (`tasks.md:381`, `tasks.md:410`),
+  and the same prose/schema conflict applies, so accept the acknowledgement
+  either way. They do not return task state. Update callers
+  continue observing the task; cancellation callers may stop immediately or
+  explicitly refresh, but never infer `cancelled` from the acknowledgement.
+- Unknown or expired task IDs return `-32602` for `tasks/get` and should do so
+  for update/cancel. The requirement levels differ and the difference is
+  load-bearing: `MUST` for `tasks/get`, `SHOULD` for `tasks/update` and
+  `tasks/cancel` (`tasks.md:793-795`). MCPJam maps this independently from a
+  missing project or server.
+- `ttlMs` is required and may be `null`; both `ttlMs` and `pollIntervalMs` may
+  change during the task lifetime (`tasks.md:340`, `tasks.md:308`).
+- There is no extension `tasks/list`, `tasks/result`, task request parameter,
+  or server-provided `model-immediate-response`.
+- `notifications/tasks`, when used, arrive through `subscriptions/listen`,
+  include a full `DetailedTask`, and are validated identically to
+  `tasks/get`.
+
+## 4. Workstream A — protocol boundary and conformance corrections
+
+This is the blocking first PR. Product expansion must not ship before it.
+
+### A0. Unblock the extension methods on the 2026-07-28 wire era
+
+This is the true first item, ahead of validation. With
+`@modelcontextprotocol/client@2.0.0-beta.4`, the extension methods cannot reach
+a conforming server at all on a `2026-07-28` connection. No amount of schema
+correctness matters until this is resolved.
+
+What the client does:
+
+- `isSpecRequestMethod(method)` returns true if **either** era registry defines
+  the method — it is a union across `ALL_CODECS = [rev2025Codec, rev2026Codec]`.
+- `tasks/get`, `tasks/result`, `tasks/list`, and `tasks/cancel` are defined in
+  the `rev2025-11-25` registry **only**. The `rev2026-07-28` registry defines no
+  tasks methods at all. `tasks/update` is in neither registry.
+- `_assertOutboundRequestInEra(codec, method)` throws
+  `SdkErrorCode.MethodNotSupportedByProtocolVersion`
+  (`METHOD_NOT_SUPPORTED_BY_PROTOCOL_VERSION`) when a method is spec-known but
+  absent from the resolved era's codec. It throws locally, before anything
+  reaches the transport.
+- The assertion runs on **both** `request()` and `requestWithSchema()`. Passing
+  an explicit result schema is not an escape hatch; the client's own comment
+  says "an explicit schema never smuggles a deleted method onto the wire."
+
+Net effect: a `tasks/get` on a `2026-07-28` connection is rejected client-side
+as a deleted 2025-era method, even though on that connection it is an
+**extension** method that the era registry has no opinion about.
+
+Root cause: the extension reuses method names that the 2025 core owned, and the
+era gate is a **v2-only** construct. ext-tasks itself devDepends on
+`@modelcontextprotocol/sdk ^1.29.0` (ext-tasks `package.json:18`), a v1 SDK with
+no era gate, so this interaction was never exercised upstream.
+
+This is deliberate upstream behavior, not an oversight: the `SdkErrorCode`
+documentation for `MethodNotSupportedByProtocolVersion` names `tasks/get`
+toward a `2026-07-28` peer as its canonical example. Verified unchanged in
+`2.0.0-beta.5` — the registries and the assertion are byte-identical.
+
+Resolution taken:
+
+- Route `tasks/get`, `tasks/update`, and `tasks/cancel` through
+  `requestWithSchema` with a loose result schema, so result decoding does not
+  depend on an era registry entry that does not exist.
+- Add a narrowly scoped, per-instance override of the era assertion that
+  returns early **only** for those three method names and **only** on the
+  `2026-07-28` era. Every other method keeps the stock gate.
+- Fail loud if the seam disappears on a client bump: the override must assert
+  that the method it patches still exists, rather than silently becoming a
+  no-op.
+
+Two things to state plainly:
+
+- Every merged extension test before this used mocked or seeded client
+  managers, which never execute the era gate. That is why CI was green while no
+  extension call could reach a real `2026-07-28` server.
+- The exit condition for the override is an **upstream** change — either the
+  era registries gaining extension-awareness or the gate exempting
+  extension-owned methods. Until then the override stays, and the drift check
+  in §1 must cover it.
+
+### A1. Make runtime schemas status-discriminated
+
+Update:
+
+- `sdk/src/mcp-client-manager/tasks-ext-types.ts`
+- `sdk/src/mcp-client-manager/tasks-ext-schemas.ts`
+- `sdk/src/mcp-client-manager/tasks-ext-guards.ts`
+- `sdk/src/mcp-client-manager/tasks-ext.ts`
+- `sdk/src/mcp-client-manager/tasks-dispatch.ts`
+
+Required changes:
+
+- Replace the optional-field `DetailedTaskExt` interface with a union of
+  working, input-required, completed, failed, and cancelled task types.
+- Accept get/update/cancel responses **with or without** `resultType:
+  "complete"`. Do not require it. The prose mandates it (`tasks.md:338`,
+  `:381`, `:410`) but `resultType` is defined nowhere in
+  `schema/draft/schema.json`, and every `DetailedTask` variant is
+  `additionalProperties: false` (`schema.json:329`, `:385`, `:435`, `:485`,
+  `:527`) — a strict validator built from the schema would actively reject the
+  key. Record this prose/schema conflict in a code comment and in the
+  conformance notes so the next reader does not "fix" it back to a hard
+  requirement. Keep `resultType: "task"` on `CreateTaskResult` required: that
+  one is a genuine MUST (`tasks.md:102`) and it is the discriminator the whole
+  task-detection path keys on.
+- Validate timestamps as plain strings. `createdAt` and `lastUpdatedAt` are
+  `"type": "string"` with no `format: "date-time"` and no pattern anywhere in
+  `schema.json`; "ISO 8601" appears only in a JSDoc comment
+  (`schema.ts:69`, `:74`). Do not reject a non-ISO-8601 timestamp.
+- Validate `ttlMs` and `pollIntervalMs` as numbers, not as non-negative safe
+  integers. The schema is plain `"number"` (`ttlMs` is `number | null`);
+  "integer milliseconds" is doc-comment prose with no RFC 2119 keyword
+  (`schema.ts:79`, `:87`). Both values **MAY** change over a task's lifetime
+  (`tasks.md:340` for `ttlMs`, `tasks.md:308` for `pollIntervalMs`), so a
+  changed — including a shrinking — value is normal and must never be surfaced
+  as an anomaly, a validation failure, or a debugger warning.
+- Preserve unknown fields for debugger display after the required shape passes.
+- Validate `inputRequests` against the MRTR request union, including safe
+  handling of hostile object keys.
+- Validate empty acknowledgements instead of returning arbitrary raw objects.
+- Require an object value for the advertised extension capability.
+- Retain the wire value as part of every internal task handle.
+
+Do not turn validation failures into generic “unsupported” responses. Raise a
+typed invalid-server-response error carrying the method, wire, and safe
+violation summary.
+
+### A2. Correct the conformance verdicts
+
+Update `sdk/src/tasks-conformance/runner.ts` so the extension test for
+undeclared capability covers all required operations:
+
+- undeclared eligible `tools/call` must not produce a task;
+- undeclared `tasks/get`, `tasks/update`, and `tasks/cancel` must receive
+  `-32003`;
+- undeclared task-filtered `subscriptions/listen` must receive `-32003`.
+
+The current interpretation that a bare `tasks/get` may succeed is incorrect
+for the pinned extension and must be removed from code, docs, and fixtures.
+
+### A3. Verify headers and connection durability
+
+Add wire-capture assertions for:
+
+- `Mcp-Name` and `Mcp-Method` on all three task methods;
+- no task routing headers on legacy calls;
+- no loss of unrelated client capabilities when the task declaration is
+  merged into per-request `_meta`;
+- a returned handle being readable after disconnect/reconnect.
+
+### A4. Acceptance gate
+
+No downstream PR may merge until:
+
+- SDK unit and type tests pass;
+- the extension fixture passes the corrected required-capability checks;
+- malformed status variants are rejected at the SDK boundary;
+- the legacy fixture remains byte-for-byte free of extension fields.
+
+## 5. Workstream B — one lifecycle engine
+
+Create a shared lifecycle engine in the SDK instead of letting the Tasks tab,
+chat, API, and CLI each implement polling and state transitions.
+
+Suggested modules:
+
+- `sdk/src/mcp-client-manager/task-lifecycle.ts`
+- `sdk/src/mcp-client-manager/task-input-driver.ts`
+- extensions to `subscription-coordinator.ts`
+
+The engine owns:
+
+- stable identity `(scope, serverId, wire, taskId)`;
+- the latest validated state and dynamic TTL/poll interval;
+- per-task `nextPollAt`, exponential error backoff, and `Retry-After`;
+- terminal-state handling and typed expiration/not-found handling;
+- notification reconciliation;
+- durable input-request key state;
+- cancellation-requested state;
+- callbacks for state, task-created, input-required, and terminal events.
+
+### B1. Poll scheduling
+
+Replace the current shared `Math.min(...)` interval behavior with a per-task
+due-time scheduler. No task may be polled faster than its latest advertised
+`pollIntervalMs`, including when requests are batched or a user enters a
+shorter interval.
+
+This critique is confirmed in code. `mcpjam-inspector/client/src/components/TasksTab.tsx:187`
+collapses every active task to a single `Math.min(...)` across their poll
+intervals, so the fastest task's floor is applied to all of them. Worse,
+`mcpjam-inspector/client/src/components/TasksTab.tsx:258` resolves the interval
+as `userOverride ?? serverSuggestedPollInterval ?? userPollInterval` — a `??`
+chain, not a `max`, so a user override replaces the server's floor entirely
+rather than being clamped by it. Only the hosted path applies any floor at all.
+
+The user setting is a minimum preferred interval, not permission to violate the
+server floor:
+
+```text
+effective interval = max(
+  server pollIntervalMs,
+  user minimum,
+  retry backoff,
+  Retry-After
+)
+```
+
+Batch only tasks that are due. If a surface cannot schedule individually, the
+batch interval is the maximum floor among members, not the minimum.
+
+### B2. Notifications with polling fallback
+
+Extend the modern subscription coordinator with:
+
+- desired and acknowledged `taskIds`;
+- a `tasks` notification kind and handler;
+- full `DetailedTask` validation;
+- per-request task capability injection on `subscriptions/listen`;
+- filter-change close/relisten behavior;
+- automatic removal of terminal or dismissed task IDs.
+
+On a persistent local/live connection, subscribe when the server and
+transport support `subscriptions/listen`. Reconcile notifications into the
+same lifecycle engine. If the stream is rejected, closes, or does not
+acknowledge a task, resume polling without losing the handle.
+
+Keep the existing legacy `notifications/tasks/status` adapter intact. Legacy
+notifications and extension notifications enter the same normalized lifecycle
+engine but retain their wire-specific validators.
+
+Hosted reconnect-per-poll remains polling-only until MCPJam has a real
+long-lived hosted connection. Do not emulate notifications with registry
+status updates.
+
+### B3. Complete `input_required`
+
+Use the extension's complete input request union:
+
+- `elicitation/create`;
+- `roots/list`;
+- `sampling/createMessage`.
+
+Route each through the same policy, consent, schema validation, and handler as
+its standalone counterpart. A task channel is not more trusted than a direct
+server-to-client request.
+
+Rules:
+
+- Persist key states by `(scope, serverId, wire, taskId, inputKey)` so reloads
+  do not re-prompt for a request already answered.
+- Store key state and timestamps, never elicitation content, sampling prompts,
+  roots, or responses.
+- Support partial `tasks/update` responses.
+- Mark a key responded only after the update acknowledgement succeeds.
+- Keep unanswered/unsupported keys visible; never mark them handled merely
+  because the UI cannot render them.
+- Reject a request method the client did not declare with a typed protocol
+  error and an actionable UI. Do not hang indefinitely.
+- Apply size/count limits to keys, request maps, and response maps before
+  rendering or forwarding them.
+
+An execution surface may declare the Tasks extension only when it has a
+complete handler path for the standalone capabilities it declares. Add fixture
+coverage for all three request methods and for an undeclared method.
+
+### B4. Durable tracker
+
+Upgrade `client/src/lib/task-tracker.ts` through a versioned migration:
+
+- preserve `wire` in identity;
+- persist `lastUpdatedAt`, latest `ttlMs`, latest `pollIntervalMs`, and next
+  due time;
+- persist responded input-key state without payloads;
+- enforce per-scope count, age, string-length, and serialized-size limits;
+- safely ignore corrupted or future-version records;
+- never infer deletion solely from the TTL captured at creation.
+
+The browser tracker remains authoritative for anonymous/local use and is also
+the immediate write path for authenticated users. The hosted registry is a
+best-effort recovery index, not the only copy.
+
+## 6. Workstream C — host policy and execution surfaces
+
+Keep product policy separate from the wire extension:
+
+```text
+hostConfig.mcpProfile.extensions["com.mcpjam/tasks"] = { enabled: boolean }
+```
+
+`com.mcpjam/tasks` is MCPJam configuration. It must never be advertised to an
+MCP server. The wire declaration is always
+`io.modelcontextprotocol/tasks: {}` in the request's client capabilities.
+
+### C1. Tri-state policy
+
+Add `sdk/src/host-config/tasks-policy.ts` with:
+
+- `readTasksPolicy(...) -> unset | on | off | invalid`;
+- `setTasksPolicy(..., true | false)`;
+- `clearTasksPolicy(...)`;
+- `taskModeForSurface(...) -> off | expose | await`.
+
+Semantics:
+
+- unset: preserve today's Tools-tab explicit task controls; all newly enabled
+  surfaces remain off;
+- on: enable only the surfaces listed as supported below;
+- off or invalid: remove task affordances and declarations everywhere;
+- invalid: fail closed and show an editor repair warning.
+
+The editor must offer On, Off, and Use default/reset. A binary switch cannot
+represent all three valid states. Labels must say “supported interactive
+surfaces,” not “all surfaces.”
+
+### C2. Surface matrix
+
+| Surface                               | Unset             | On               | Wire behavior                                         |
+| ------------------------------------- | ----------------- | ---------------- | ----------------------------------------------------- |
+| Local/hosted Tools                    | explicit controls | expose           | legacy explicit TTL or extension declaration          |
+| Local/hosted/BYOK chat and playground | off               | expose           | extension only                                        |
+| MCPJam agent                          | off               | expose           | extension only                                        |
+| Eval execution                        | off               | await            | extension task is driven to a bounded terminal result |
+| Protocol/conformance harness          | explicit test     | explicit test    | test owns exact wire                                  |
+| Saved-result replay/pinned replay     | off               | off              | never creates new work                                |
+| Public API/CLI                        | explicit request  | explicit request | API opt-in is its policy boundary                     |
+
+For `await` mode, the shared lifecycle engine polls to terminal within the
+evaluation timeout and uses configured input handlers. If required human input
+cannot be fulfilled, return a deterministic `TASK_INPUT_REQUIRED` outcome
+rather than hanging.
+
+### C3. One tool-execution seam
+
+Extend `getToolsForAiSdk`/`convertMCPToolsToVercelTools` with:
+
+- a resolved task mode, not a raw policy boolean;
+- `onTaskCreated(event): void | Promise<void>`;
+- a shared lifecycle driver for `await` mode.
+
+The task-created event is the single fan-out point for:
+
+1. immediate durable browser tracking;
+2. hosted chat stream delivery;
+3. best-effort hosted registry recording;
+4. analytics/diagnostics.
+
+A registry failure must never convert a successful tool call into a failure.
+Tracking and client event delivery are functional paths and must not be hidden
+inside an unobserved promise.
+
+For chat/agent `expose` mode, MCPJam may return an MCPJam-authored synthetic
+tool result to the model and surface a “View task” affordance. The extension
+does not define `model-immediate-response`; do not read or document such a
+server field for the extension. A legacy compatibility value may be labeled
+explicitly as legacy-server-supplied.
+
+Policy off/unset means no extension declaration. If the server requires Tasks
+and returns `-32003`, show an actionable message that names the host setting.
+
+### C4. Hosted mixed-version rollout
+
+Add a hosted client feature/version handshake for the `data-task-created`
+stream part. A hosted route may declare Tasks only when the connected client
+can persist the event. Keep Tasks disabled for guests during the mixed-bundle
+rollout because guests have no registry recovery path.
+
+Tests must prove:
+
+- unknown stream parts still degrade safely;
+- old clients are not offered task results;
+- chatbox/environment turns use authoritative host policy and cannot enable
+  Tasks from request-body tampering;
+- direct owner turns cannot override an explicit Off policy;
+- each supported route includes or omits the per-request declaration exactly
+  as the matrix says.
+
+## 7. Workstream D — secure hosted task registry
+
+The extension removed `tasks/list` because task IDs may be bearer-like handles
+and a safe cross-caller listing scope cannot be assumed. The hosted registry
+must not recreate a project-wide `tasks/list`.
+
+### D1. Ownership and authorization-context identity
+
+Create rows only for authenticated, non-guest users. Required identity:
+
+```text
+(projectId, serverId, ownerUserId, authContextKey, wire, taskId)
+```
+
+`authContextKey` is a stable, non-secret fingerprint of the server credential
+or account binding used to create the task. Never hash or store a bearer token
+directly. Listing, status reporting, and dismissal must resolve the current
+user and current authorization context server-side and query the exact
+identity prefix.
+
+Assign the key when a credential binding is created. Preserve it across token
+refreshes for the same binding, rotate it on explicit reauthorization or
+account replacement, and use a documented `public` sentinel for servers with
+no authentication. This makes the key reproducible across devices without
+coupling registry identity to short-lived access tokens.
+
+Team-wide sharing is out of scope until it has an explicit grant model. A
+project member must not discover, poll, mark expired, update, or cancel another
+member's task merely because both can access the project.
+
+### D2. Minimal schema
+
+Store only recovery metadata:
+
+```text
+projectId
+serverId
+ownerUserId
+authContextKey
+wire
+taskId
+createdAt
+updatedAt
+lastKnownStatus
+terminalAt?
+```
+
+Do not store result/error payloads, `statusMessage`, tool arguments,
+`inputRequests`, input responses, sampling content, roots, or model output.
+Do not store `toolName` unless a later privacy review gives it a concrete need.
+
+Use:
+
+- an exact identity index including owner and auth context;
+- an owner/context list index;
+- a retention scan index;
+- a 200-row cap per owner/server/auth-context and a defensive 2,000-row global
+  project cap.
+
+### D3. Internal operations
+
+Implement:
+
+- `upsertHostedTask`: transactional insert-or-update and bounded FIFO eviction;
+- `listHostedTasks`: exact owner/context only;
+- `reportHostedTaskStatuses`: patch-only and exact owner/context only;
+- `pruneHostedTasks`: bounded, cursor-driven draining until the backlog is
+  empty.
+
+Do not prune from `ttlMs` observed only at creation. The extension permits TTL
+changes and `null`. Use a seven-day registry maximum age and 24-hour terminal
+retention; mark a task expired only after a live `-32602` result under the same
+authorization context.
+
+Validate and cap every identifier and batch. `lastKnownStatus` is an enum plus
+MCPJam's local `expired` tombstone. Reporting an unknown identity never
+inserts.
+
+### D4. Internal HTTP boundary
+
+The internal routes remain service-token protected, but service-token
+possession is not permission to choose an arbitrary browser-supplied owner.
+The Inspector must resolve the authenticated owner and authorization context,
+and the backend must accept only the verified internal representation.
+
+Use a request-lifetime background primitive such as `waitUntil` for registry
+writes, or a short bounded await if the runtime has no safe background work.
+Do not rely on a detached `void fetch(...)` after the response ends.
+
+Deploy and probe the backend routes before enabling the Inspector integration.
+Routing 404, timeout, or registry outage degrades to the browser tracker and is
+observable, never fatal to task creation or polling.
+
+### D5. Integration point
+
+Record task creation at the shared event seam so Tools, chat, agent, eval, and
+public API do not drift. Merge registry handles into the hosted task view as a
+separate recovery source, deduplicated by full identity, then fetch live state
+from the MCP server.
+
+Never write registry rows into another user's browser tracker. A user's local
+dismissal is a view preference; global deletion requires a separately
+authorized operation.
+
+## 8. Workstream E — public API contract
+
+Ship Tasks as a preview namespace, but make identity and error semantics stable
+from day one.
+
+### E1. Stable task handle and envelope
+
+Every follow-up request accepts:
+
+```ts
+type PublicTaskHandle = {
+  taskId: string;
+  wire: "legacy" | "extension";
+};
+```
+
+Requiring `wire` prevents a stored handle from silently switching behavior
+after a server configuration or protocol-version change.
+
+The response is a discriminated union with this base:
+
+```ts
+type PublicTaskBase = {
+  taskId: string;
+  wire: "legacy" | "extension";
+  status: "working" | "input_required" | "completed" | "failed" | "cancelled";
+  statusMessage?: string;
+  createdAt: string;
+  lastUpdatedAt: string;
+  ttlMs: number | null;
+  pollIntervalMs?: number;
+  raw: unknown;
+};
+```
+
+Status variants require the same `inputRequests`, `result`, or JSON-RPC
+`error` fields as the SDK union. `raw` is era-native, preview, size-limited,
+and excluded from the additive-only stability promise.
+
+### E2. Endpoints
+
+Add `server/routes/v1/tasks.ts`:
+
+| Route                | Legacy                  | Extension               |
+| -------------------- | ----------------------- | ----------------------- |
+| `tasks/get`          | yes                     | yes                     |
+| `tasks/result`       | yes                     | `422 TASKS_UNSUPPORTED` |
+| `tasks/cancel`       | yes                     | yes                     |
+| `tasks/update`       | `422 TASKS_UNSUPPORTED` | yes                     |
+| `tasks/list`         | yes                     | `422 TASKS_UNSUPPORTED` |
+| `tasks/capabilities` | yes                     | yes                     |
+
+Use the shared task-aware execution helper for `tools/call`:
+
+- legacy: explicit mutually exclusive `taskOptions`;
+- extension: explicit `allowTaskResult`;
+- normal synchronous results retain the existing response shape;
+- task creation returns the normalized envelope and full handle;
+- authenticated creation emits the shared task-created event;
+- guests cannot opt into durable work they cannot poll.
+
+For extension update/cancel, return
+`{ wire: "extension", acknowledged: true }`, optionally with a separately
+fetched task only when the caller explicitly requests a refresh. Never return
+`task: null` as if null were extension state.
+
+### E3. Errors, limits, and rate limiting
+
+Add stable error codes:
+
+- `TASKS_UNSUPPORTED` — 422, never retry;
+- `TASK_NOT_FOUND` — 404 for task `-32602`, stop polling;
+- `TASK_INPUT_REQUIRED` — automation cannot fulfill input;
+- existing `VALIDATION_ERROR`, `TIMEOUT`, and `RATE_LIMITED`.
+
+Map both `MCPTasksWireError`/Tasks feature errors and unknown-task errors;
+do not rely on one guard. Keep `TASK_NOT_FOUND` distinct from a missing project
+or server.
+
+Ship per-key and per-user polling limits in the first preview release, with
+`Retry-After`. Enforce:
+
+- task ID, cursor, input key, and JSON body size limits;
+- maximum input responses per update;
+- JSON-object validation that rejects arrays and prototype-pollution keys;
+- bounded operation timeouts and connection cleanup.
+
+Mirror the public contract and fixtures byte-for-byte in
+`mcpjam-backend/convex/publicApi/contract.ts`, update OpenAPI in the same PR,
+and keep drift tests blocking.
+
+## 9. Workstream F — CLI
+
+`cli/src/commands/tasks.ts` already exists for conformance. Extend that module;
+do not create a second Tasks command implementation.
+
+Add cloud commands:
+
+- `mcpjam tasks get`
+- `mcpjam tasks result`
+- `mcpjam tasks cancel`
+- `mcpjam tasks update`
+- `mcpjam tasks list`
+- `mcpjam tasks capabilities`
+- `mcpjam tasks watch`
+
+`watch` must:
+
+- require or retain the handle's wire;
+- use the lifecycle engine's dynamic interval and `Retry-After`;
+- persist/reload the handle when requested;
+- render transitions on stderr and the final envelope on stdout;
+- terminate predictably for completed, failed, cancelled, timeout,
+  not-found, and input-required states;
+- never poll faster than the server floor.
+
+Add matching explicit Tasks flags to cloud `tools call` and local-direct
+`tools call`, preserving the legacy/extension XOR. Do not expose an extension
+`modelImmediateResponse` field.
+
+## 10. Workstream G — fixtures, tests, docs, and observability
+
+### G1. Independent fixtures
+
+Maintain two runnable fixtures:
+
+- exact legacy `2025-11-25`;
+- exact extension `2026-07-28` pinned to the ext-tasks commit.
+
+The extension fixture needs configurable cases for:
+
+- normal synchronous response;
+- task creation and fresh-connection durability;
+- every status variant;
+- dynamic TTL and poll interval;
+- partial and repeated input requests;
+- elicitation, roots, and sampling input;
+- update and cancel eventual consistency;
+- unknown/expired ID;
+- task notification acknowledgement, delivery, and disconnect;
+- required-capability errors;
+- invalid shapes and hostile input keys;
+- `isError: true` completed result versus JSON-RPC failed task.
+
+### G2. Conformance matrix
+
+The conformance suite must prove:
+
+| Area          | Required assertions                                                                          |
+| ------------- | -------------------------------------------------------------------------------------------- |
+| Dispatch      | version/capability matrix; malformed capability; unknown version fails closed                |
+| Declaration   | eligible requests declare once; ineligible requests do not; unrelated capabilities preserved |
+| Creation      | `resultType: task`; normal result fallback; durable handle                                   |
+| Get           | discriminated payload; `resultType: complete` accepted but not required (§4/A1); dynamic TTL/poll interval accepted in both directions |
+| Update        | partial/full responses; empty ack accepted with or without `resultType`; dedupe; eventual re-observation |
+| Cancel        | empty ack accepted with or without `resultType`; no inferred state; optional refresh         |
+| Errors        | `-32003` undeclared (fail); `-32602` unknown — fail for `tasks/get` (MUST), **warn-only** for `tasks/update`/`tasks/cancel` (SHOULD, `tasks.md:793-795`); typed malformed response |
+| Methods       | extension list/result absent; legacy-only fields absent on extension                         |
+| HTTP          | `Mcp-Name` and `Mcp-Method` on get/update/cancel                                             |
+| Notifications | taskIds filter; capability declaration; ack subset; full detailed task; polling fallback     |
+| Security      | owner/auth-context isolation; guest refusal; size limits; no payload persistence             |
+| Recovery      | reload, reconnect, cross-device same owner/context, no cross-owner recovery                  |
+
+### G3. Product end-to-end matrix
+
+Run both supported wires, where applicable, through:
+
+- local Tools;
+- hosted Tools;
+- local chat/playground;
+- hosted emulated and BYOK chat/playground;
+- MCPJam agent;
+- eval `await` mode;
+- public API;
+- CLI create/watch/update/cancel;
+- authenticated registry recovery;
+- guest/no-registry behavior.
+
+For every surface, assert both policy-on and policy-off traffic at the raw RPC
+layer.
+
+### G4. Documentation
+
+Update:
+
+- SDK Tasks concepts and API reference;
+- Inspector Tools, Tasks, chat/playground, agent, host policy, and protocol
+  version docs;
+- public API preview docs and OpenAPI;
+- CLI reference;
+- conformance check reference;
+- troubleshooting for `-32003`, `-32602`, rate limits, unsupported input, and
+  lost authorization context.
+
+Documentation must call the extension official, distinguish it from the
+legacy experimental primitive, state the pinned revision, and identify
+polling-only hosted paths.
+
+### G5. Operational signals
+
+Emit bounded, payload-free metrics for:
+
+- created tasks by wire and surface;
+- schema rejection by method/reason;
+- poll frequency, backoff, and rate-limit responses;
+- notification subscription/ack/fallback;
+- input-required method and outcome;
+- unknown/expired tasks;
+- registry write/read degradation;
+- blocked ownership/auth-context mismatches;
+- terminal outcome and time-to-terminal.
+
+Never log task result/error payloads, input payloads/responses, sampling
+content, roots, bearer tokens, or raw task IDs. Use a request-scoped hash when
+correlation is necessary.
+
+## 11. PR and deployment order
+
+Land in this order:
+
+1. **SDK correctness:** Workstream A — the A0 era-gate unblock first, since
+   nothing else in the extension path can be exercised against a real
+   `2026-07-28` server until it lands — then the corrected schemas, corrected
+   conformance verdicts, and the vendored schema drift check.
+2. **Lifecycle engine:** Workstream B polling, notification integration,
+   complete input driver, tracker migration.
+3. **Host policy:** tri-state resolver/editor and raw-wire policy tests.
+4. **Interactive/automation surfaces:** Tools, chat/playground, agent, eval
+   await mode, shared task-created event.
+5. **Backend registry:** owner/auth-context schema, internal operations,
+   retention, and security tests; deploy and probe.
+6. **Inspector registry integration:** shared event sink, recovery merge, and
+   degradation behavior.
+7. **Public API contract:** routes, limits, rate limiter, OpenAPI, and backend
+   contract mirror.
+8. **CLI:** extend the existing Tasks module and add lifecycle/watch tests.
+9. **Release gate:** full conformance/E2E matrix, docs, metrics, and staged
+   rollout.
+
+If a PR needs an SDK bump, publish and consume that SDK before merging routes
+that depend on its validation or lifecycle behavior. Deploy backend internal
+routes before enabling their Inspector callers.
+
+## 12. Rollout and rollback
+
+Use separate server-controlled gates for:
+
+- extension support on new host surfaces;
+- hosted registry reads/writes;
+- public API preview;
+- automated eval `await` mode.
+
+Roll out in this order:
+
+1. local Tools and corrected conformance;
+2. hosted Tools with browser tracking;
+3. authenticated chat/playground and agent with client-version handshake;
+4. registry recovery;
+5. eval await mode;
+6. public API and CLI preview;
+7. guests only after mixed-client risk is gone and a durable recovery decision
+   is documented.
+
+Rollback disables new per-request declarations and registry/API gates without
+removing stored browser handles or changing legacy `2025-11-25` behavior.
+Registry rows age out under retention and never need to be exposed
+project-wide.
+
+## 13. Final release checklist
+
+- [ ] Ext-tasks commit pin and drift check are recorded in code and docs.
+- [ ] The A0 era-gate override lets `tasks/get`, `tasks/update`, and
+      `tasks/cancel` reach a real `2026-07-28` server, is scoped to those three
+      methods, and fails loud on a client bump.
+- [ ] Extension coverage is proven against a real fixture connection, not a
+      mocked or seeded client manager.
+- [ ] Corrected SDK schemas and `-32003` conformance checks pass.
+- [ ] All task methods carry the right extension declaration and HTTP headers.
+- [ ] Per-task scheduling never violates `pollIntervalMs`.
+- [ ] Notifications work on persistent connections and fall back to polling.
+- [ ] Elicitation, roots, and sampling task inputs use standalone trust rules.
+- [ ] Input keys survive reload without persisting payloads.
+- [ ] Host policy is tri-state and every surface matches the published matrix.
+- [ ] Extension chat uses MCPJam-authored immediate text, not a nonexistent
+      extension field.
+- [ ] Hosted registry is owner- and authorization-context-scoped.
+- [ ] No registry result, status-message, input, or model payload is stored.
+- [ ] Public envelopes include `wire` and `lastUpdatedAt` and are
+      status-discriminated.
+- [ ] Preview polling endpoints ship with rate limiting and `Retry-After`.
+- [ ] Existing CLI Tasks code is extended, not duplicated.
+- [ ] Independent legacy and extension fixtures pass SDK, route, API, CLI, and
+      UI suites.
+- [ ] Policy-off and guest paths prove no task declaration leaves MCPJam.
+- [ ] Docs consistently distinguish legacy Tasks from the official extension.
+
+Only after every item is complete should MCPJam describe Tasks as fully
+implemented. Earlier milestones should be labeled “legacy compatible”,
+“extension core lifecycle”, or “preview”, according to what has actually
+shipped.

--- a/docs/sdk/reference/tasks-conformance.mdx
+++ b/docs/sdk/reference/tasks-conformance.mdx
@@ -35,7 +35,7 @@ const test = new MCPTasksConformanceTest({
 const result = await test.run();
 
 console.log(result.passed);              // true
-console.log(result.summary);            // "7/7 checks passed, 0 failed, 0 skipped"
+console.log(result.summary);            // "8/8 checks passed, 0 failed, 0 skipped"
 console.log(result.discovery.wire);     // "extension" | "legacy" | "none"
 ```
 
@@ -90,11 +90,12 @@ const test = new MCPTasksConformanceTest({
 |---|---|---|
 | `tasks-wire-resolvable` | `dispatch` | The negotiated protocol version and capabilities resolve to exactly one tasks wire. |
 | `tasks-declaration-hygiene` | `dispatch` | Outbound requests carry `params.task` only on the legacy wire and the extension declaration only on the extension wire. |
-| `tasks-result-type-discipline` | `creation` | A task-eligible `tools/call` returns either a normal tool result or a flat `CreateTaskResult` with `resultType: "task"` and a non-empty `taskId`. |
-| `tasks-undeclared-capability-rejected` | `creation` | On the extension wire, an undeclared `tools/call` must not come back as a task. |
+| `tasks-result-type-discipline` | `creation` | A task-eligible `tools/call` returns either a normal tool result or a flat `CreateTaskResult` with `resultType: "task"` and a non-empty `taskId`. The discriminator is required whether absent or wrong — it is the only signal that separates a task from a standard result. |
+| `tasks-undeclared-creation-refused` | `creation` | On the extension wire, a `tools/call` that did not carry the extension declaration must not come back as a `CreateTaskResult`. |
 | `tasks-ttl-shape` | `lifecycle` | TTL and poll interval use the era-native shapes: `ttlMs`/`pollIntervalMs` on the extension, `ttl`/`pollInterval` on the legacy wire. |
 | `tasks-inline-result` | `lifecycle` | A completed extension task carries its result inline on `tasks/get`; a legacy task exposes it via `tasks/result`. |
 | `tasks-mcp-name-routing` | `lifecycle` | Over HTTP, `tasks/get` is sent with `Mcp-Name` set to the task id. |
+| `tasks-undeclared-capability-rejected` | `lifecycle` | `tasks/get`, `tasks/update`, `tasks/cancel` and a task-filtered `subscriptions/listen` sent WITHOUT the extension declaration must each be rejected with `-32003`. Per-method outcomes are reported in the check's `details.probes`. |
 
 ## Result shape
 
@@ -163,7 +164,8 @@ writeFileSync(
 ## Notes
 
 - Declaration hygiene is asserted against captured outbound JSON-RPC bytes, not re-derived from intent.
-- The `tasks-undeclared-capability-rejected` check applies to the extension wire only and is skipped on the legacy wire.
+- The `tasks-undeclared-creation-refused` and `tasks-undeclared-capability-rejected` checks apply to the extension wire only and are skipped on the legacy wire.
+- `tasks-undeclared-capability-rejected` needs a live task to probe with, and its probes run after every check that reads that task so a wrongly-accepted `tasks/update` or `tasks/cancel` cannot corrupt the rest of the run. A server with no `subscriptions/listen` (`-32601`) gets that sub-probe reported as a warning rather than a failure.
 - The `tasks-mcp-name-routing` check applies to HTTP transports only and is skipped for stdio servers.
 - Checks that require a created task are skipped when no task-capable tool is found and no `toolName` is provided.
 - Exit code from the CLI is `1` when `result.passed` is `false`.

--- a/docs/sdk/reference/tasks-conformance.mdx
+++ b/docs/sdk/reference/tasks-conformance.mdx
@@ -35,11 +35,12 @@ const test = new MCPTasksConformanceTest({
 const result = await test.run();
 
 console.log(result.passed);              // true
-console.log(result.summary);            // "8/8 checks passed, 0 failed, 0 skipped"
+console.log(result.outcome);            // "passed" | "failed" | "incomplete"
+console.log(result.summary);            // "8/8 checks passed, 0 failed, 0 could not run, 0 not applicable"
 console.log(result.discovery.wire);     // "extension" | "legacy" | "none"
 ```
 
-Pass a tool name when your server's tools carry no task metadata (the extension wire):
+Pass a tool name on the extension wire. Auto-selection reads `execution.taskSupport`, which the 2026-07-28 `ToolSchema` strips, so without `toolName` the task-dependent checks cannot run and `run()` returns `outcome: "incomplete"` with `passed: false`:
 
 ```typescript
 const test = new MCPTasksConformanceTest({
@@ -68,7 +69,7 @@ Additional properties:
 | Property | Type | Required | Default | Description |
 |----------|------|----------|---------|-------------|
 | `checkIds` | `MCPTasksCheckId[]` | No | all checks | Run only the selected checks. |
-| `toolName` | `string` | No | auto-detected | Tool used to provoke a task. Required for servers whose tools carry no task metadata (the extension wire). |
+| `toolName` | `string` | No | auto-detected on the legacy wire only | Tool used to provoke a task. Required on the extension wire: auto-selection reads `execution.taskSupport`, which the 2026-07-28 `ToolSchema` strips. A name the server does not list is an error, not a silent miss — the run comes back `incomplete`. |
 | `toolArguments` | `Record<string, unknown>` | No | `{}` | Arguments passed to the probe tool. |
 | `pollTimeoutMs` | `number` | No | `30000` | Upper bound on polling a created task to a terminal status. |
 
@@ -103,12 +104,14 @@ const test = new MCPTasksConformanceTest({
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `passed` | `boolean` | Whether all selected checks passed (no failures). |
+| `passed` | `boolean` | True only when `outcome` is `"passed"`. A check that could not run keeps this `false`. |
+| `outcome` | `"passed" \| "failed" \| "incomplete"` | `"failed"` on any violation; `"incomplete"` when nothing failed but a selected check never ran. |
+| `incompleteReason` | `string \| undefined` | Present when `outcome` is `"incomplete"`: which checks did not run and what to change. |
 | `target` | `string` | URL or stdio command under test. |
 | `checks` | `MCPTasksCheckResult[]` | Individual check results. |
 | `summary` | `string` | Human-readable summary. |
 | `durationMs` | `number` | Total duration. |
-| `categorySummary` | `Record<"dispatch" \| "creation" \| "lifecycle", ...>` | Pass/fail counts by category. |
+| `categorySummary` | `Record<"dispatch" \| "creation" \| "lifecycle", ...>` | Per-category `total`, `passed`, `failed`, `skipped`, and `couldNotRun` counts. |
 | `discovery` | object | Wire, protocol version, and tool counts discovered during the run. |
 
 The `discovery` object includes:
@@ -129,6 +132,7 @@ Each `MCPTasksCheckResult` includes:
 - `title`
 - `description`
 - `status` — `"passed"`, `"failed"`, or `"skipped"`
+- `skipReason` — set whenever `status` is `"skipped"`: `"not-applicable"` (the check cannot apply to this server, so it does not hold the run back) or `"could-not-run"` (the check applies but was never exercised, which makes the run `incomplete`)
 - `durationMs`
 - optional `details`
 - optional `warnings`
@@ -167,5 +171,5 @@ writeFileSync(
 - The `tasks-undeclared-creation-refused` and `tasks-undeclared-capability-rejected` checks apply to the extension wire only and are skipped on the legacy wire.
 - `tasks-undeclared-capability-rejected` needs a live task to probe with, and its probes run after every check that reads that task so a wrongly-accepted `tasks/update` or `tasks/cancel` cannot corrupt the rest of the run. A server with no `subscriptions/listen` (`-32601`) gets that sub-probe reported as a warning rather than a failure.
 - The `tasks-mcp-name-routing` check applies to HTTP transports only and is skipped for stdio servers.
-- Checks that require a created task are skipped when no task-capable tool is found and no `toolName` is provided.
-- Exit code from the CLI is `1` when `result.passed` is `false`.
+- Checks that require a created task report `skipReason: "could-not-run"` when no probe tool resolves, when the named tool is not listed, when the probed call produced no task, or when the task never became readable. Any of those makes the run `incomplete`; a skip can never add up to a pass.
+- CLI exit codes: `0` for `passed`, `1` for `failed`, `3` for `incomplete` (`2` stays reserved for usage errors).

--- a/sdk/src/http-server-doctor.ts
+++ b/sdk/src/http-server-doctor.ts
@@ -443,6 +443,10 @@ async function connectHttpDoctorClient(
     );
   }
 
+  // No `io.modelcontextprotocol/tasks` era-gate shadow here: this client is
+  // never wrapped as a `ManagedMcpClient` and the doctor issues no `tasks/*`
+  // request at all (its `BrowserDoctorClient` surface is capabilities + the
+  // three list calls), so there is nothing for the gate to block.
   const client = new Client(
     {
       name: "mcpjam",

--- a/sdk/src/http-server-doctor.ts
+++ b/sdk/src/http-server-doctor.ts
@@ -443,8 +443,8 @@ async function connectHttpDoctorClient(
     );
   }
 
-  // No `io.modelcontextprotocol/tasks` era-gate shadow here: this client is
-  // never wrapped as a `ManagedMcpClient` and the doctor issues no `tasks/*`
+  // No `io.modelcontextprotocol/tasks` era-gate shadow here: it is installed
+  // from the extension's own send path, and the doctor issues no `tasks/*`
   // request at all (its `BrowserDoctorClient` surface is capabilities + the
   // three list calls), so there is nothing for the gate to block.
   const client = new Client(

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -650,10 +650,14 @@ export type {
   MCPTasksCheckStatus,
   MCPTasksConformanceConfig,
   MCPTasksConformanceResult,
+  MCPTasksRunOutcome,
+  MCPTasksSkipReason,
 } from "./tasks-conformance/index.js";
 export {
+  decideOutcome,
   MCP_TASKS_CHECK_CATEGORIES,
   MCP_TASKS_CHECK_IDS,
+  resolveProbeTool,
 } from "./tasks-conformance/index.js";
 
 export type {

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -1925,6 +1925,10 @@ export class MCPClientManager {
       // Wire the modern per-request logging opt-in. The provider reads the
       // per-server level live, so `setPerRequestLogLevel` takes effect with no
       // reconnect; the decorator itself only injects on the modern era.
+      // `wrapLegacyClient` also installs the `io.modelcontextprotocol/tasks`
+      // era-gate shadow on this instance — the extension methods this manager
+      // exposes (`getTaskExt` / `updateTask` / `cancelTaskExt`) cannot reach a
+      // 2026-07-28 server without it. See `tasks-ext-era-gate.ts`.
       const managedClient: ManagedMcpClient = wrapLegacyClient(
         upstreamClient,
         () => this.perRequestLogLevels.get(serverId),

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -1656,8 +1656,13 @@ export class MCPClientManager {
   private assertExtensionTasksWire(serverId: string, method: string): void {
     const wire = this.getTasksWire(serverId);
     if (wire !== "extension") {
-      throw new TypeError(
-        `Server "${serverId}" does not speak the io.modelcontextprotocol/tasks extension (resolved wire: "${wire}"); refusing to send ${method}.`
+      // Typed, NOT a bare TypeError: routes map `isMCPTasksWireError` onto a
+      // 400 `TASKS_UNSUPPORTED` (a permanent, non-retryable condition). A
+      // TypeError becomes a 500, which hosted clients treat as transient and
+      // retry forever against a server that can never serve the request.
+      throw new MCPTasksWireError(
+        `Server "${serverId}" does not speak the io.modelcontextprotocol/tasks extension (resolved wire: "${wire}"); refusing to send ${method}.`,
+        wire
       );
     }
   }
@@ -1687,8 +1692,9 @@ export class MCPClientManager {
       // `task: {ttl?}` instead. Nothing to add.
       return callParams;
     }
-    throw new TypeError(
-      `Server "${serverId}" has no tasks wire (resolved wire: "none"); refusing to declare task eligibility on tools/call.`
+    throw new MCPTasksWireError(
+      `Server "${serverId}" has no tasks wire (resolved wire: "none"); refusing to declare task eligibility on tools/call.`,
+      wire
     );
   }
 

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -1925,10 +1925,12 @@ export class MCPClientManager {
       // Wire the modern per-request logging opt-in. The provider reads the
       // per-server level live, so `setPerRequestLogLevel` takes effect with no
       // reconnect; the decorator itself only injects on the modern era.
-      // `wrapLegacyClient` also installs the `io.modelcontextprotocol/tasks`
-      // era-gate shadow on this instance — the extension methods this manager
-      // exposes (`getTaskExt` / `updateTask` / `cancelTaskExt`) cannot reach a
-      // 2026-07-28 server without it. See `tasks-ext-era-gate.ts`.
+      // `wrapLegacyClient` also registers this instance for the
+      // `io.modelcontextprotocol/tasks` era-gate shadow, which the extension
+      // methods this manager exposes (`getTaskExt` / `updateTask` /
+      // `cancelTaskExt`) need to reach a 2026-07-28 server. Registration is
+      // inert: the shadow is installed on the first such call, never at
+      // connect. See `tasks-ext-era-gate.ts`.
       const managedClient: ManagedMcpClient = wrapLegacyClient(
         upstreamClient,
         () => this.perRequestLogLevels.get(serverId),

--- a/sdk/src/mcp-client-manager/index.ts
+++ b/sdk/src/mcp-client-manager/index.ts
@@ -189,6 +189,11 @@ export type {
   TaskExtStatus,
   TaskExtError,
   DetailedTaskExt,
+  WorkingTaskExt,
+  InputRequiredTaskExt,
+  CompletedTaskExt,
+  FailedTaskExt,
+  CancelledTaskExt,
   CreateTaskExtResult,
   GetTaskExtResult,
   UpdateTaskExtResult,
@@ -199,12 +204,20 @@ export type {
 export { TERMINAL_TASK_EXT_STATUSES } from "./tasks-ext-types.js";
 export {
   InvalidTaskExtPayloadError,
+  isInvalidTaskExtPayloadError,
   isCreateTaskExtResult,
   assertCreateTaskExtResult,
   assertGetTaskExtResult,
   assertDetailedTaskExt,
+  assertTaskExtAck,
   parseTaskExtNotificationParams,
 } from "./tasks-ext-guards.js";
+export {
+  TASK_EXT_INPUT_REQUEST_METHODS,
+  isRecognizedInputRequestMethod,
+  describeTaskExtInputRequests,
+} from "./tasks-ext-schemas.js";
+export type { TaskExtInputRequestMethod } from "./tasks-ext-schemas.js";
 export {
   TASK_CREATED_META_KEY,
   wrapFetchForTaskRouting,

--- a/sdk/src/mcp-client-manager/managed-mcp-client-factory.ts
+++ b/sdk/src/mcp-client-manager/managed-mcp-client-factory.ts
@@ -23,6 +23,7 @@ import {
   type LogLevelProvider,
 } from "./log-level-meta-client.js";
 import type { McpProtocolVersion } from "./mcp-protocol-version.js";
+import { installTasksExtensionEraGateShadow } from "./tasks-ext-era-gate.js";
 import type { RpcLogger } from "./types.js";
 
 export type { LogLevelProvider };
@@ -39,6 +40,28 @@ function withLogLevelMeta(
   return logLevelProvider
     ? new LogLevelMetaClient(adapter, logLevelProvider)
     : adapter;
+}
+
+/**
+ * The single seam at which an upstream `Client` becomes a `ManagedMcpClient`,
+ * and therefore the single place the `io.modelcontextprotocol/tasks` era-gate
+ * shadow is installed: `tasks-ext.ts`'s three extension calls are typed
+ * against `ManagedMcpClient`, so every client that can ever issue them passes
+ * through here (both entry points below, including the manager's own
+ * `new Client(...)`, which arrives via `wrapLegacyClient`).
+ *
+ * The shadow is narrowly scoped and throws if upstream's private member moved
+ * — see `tasks-ext-era-gate.ts` for the full rationale and the bump checklist.
+ */
+function manage(
+  client: Client,
+  logLevelProvider?: LogLevelProvider,
+): ManagedMcpClient {
+  installTasksExtensionEraGateShadow(client);
+  return withLogLevelMeta(
+    new OfficialSdkClientAdapter(client),
+    logLevelProvider,
+  );
 }
 
 // Re-export so consumers can `import { McpProtocolVersion } from "@mcpjam/sdk"`
@@ -81,10 +104,7 @@ export function createManagedMcpClient(
       args.clientOptions.jsonSchemaValidator ??
       new DialectAwareJsonSchemaValidator(),
   });
-  return withLogLevelMeta(
-    new OfficialSdkClientAdapter(inner),
-    args.logLevelProvider,
-  );
+  return manage(inner, args.logLevelProvider);
 }
 
 /**
@@ -96,10 +116,7 @@ export function wrapLegacyClient(
   client: Client,
   logLevelProvider?: LogLevelProvider,
 ): ManagedMcpClient {
-  return withLogLevelMeta(
-    new OfficialSdkClientAdapter(client),
-    logLevelProvider,
-  );
+  return manage(client, logLevelProvider);
 }
 
 export type { RpcLogger };

--- a/sdk/src/mcp-client-manager/managed-mcp-client-factory.ts
+++ b/sdk/src/mcp-client-manager/managed-mcp-client-factory.ts
@@ -23,7 +23,7 @@ import {
   type LogLevelProvider,
 } from "./log-level-meta-client.js";
 import type { McpProtocolVersion } from "./mcp-protocol-version.js";
-import { installTasksExtensionEraGateShadow } from "./tasks-ext-era-gate.js";
+import { registerTasksExtensionEraGateTarget } from "./tasks-ext-era-gate.js";
 import type { RpcLogger } from "./types.js";
 
 export type { LogLevelProvider };
@@ -45,23 +45,27 @@ function withLogLevelMeta(
 /**
  * The single seam at which an upstream `Client` becomes a `ManagedMcpClient`,
  * and therefore the single place the `io.modelcontextprotocol/tasks` era-gate
- * shadow is installed: `tasks-ext.ts`'s three extension calls are typed
- * against `ManagedMcpClient`, so every client that can ever issue them passes
- * through here (both entry points below, including the manager's own
- * `new Client(...)`, which arrives via `wrapLegacyClient`).
+ * shadow can learn which upstream instance sits behind a managed one: every
+ * client that can ever issue an extension request passes through here (both
+ * entry points below, including the manager's own `new Client(...)`, which
+ * arrives via `wrapLegacyClient`).
  *
- * The shadow is narrowly scoped and throws if upstream's private member moved
- * — see `tasks-ext-era-gate.ts` for the full rationale and the bump checklist.
+ * Registration only — it installs nothing and cannot throw. The shadow goes on
+ * lazily, on the first extension tasks call, so a future client build that
+ * renamed the private member breaks tasks rather than every connection. See
+ * `tasks-ext-era-gate.ts` for the full rationale and the bump checklist.
  */
 function manage(
   client: Client,
   logLevelProvider?: LogLevelProvider,
 ): ManagedMcpClient {
-  installTasksExtensionEraGateShadow(client);
-  return withLogLevelMeta(
-    new OfficialSdkClientAdapter(client),
-    logLevelProvider,
-  );
+  const adapter = new OfficialSdkClientAdapter(client);
+  const managed = withLogLevelMeta(adapter, logLevelProvider);
+  // Both the adapter and the (possibly decorated) value handed back, so the
+  // lookup works whichever one a caller ends up passing to `tasks-ext.ts`.
+  registerTasksExtensionEraGateTarget(adapter, client);
+  registerTasksExtensionEraGateTarget(managed, client);
+  return managed;
 }
 
 // Re-export so consumers can `import { McpProtocolVersion } from "@mcpjam/sdk"`

--- a/sdk/src/mcp-client-manager/tasks-dispatch.ts
+++ b/sdk/src/mcp-client-manager/tasks-dispatch.ts
@@ -72,13 +72,29 @@ function isRecord(value: unknown): value is Record<string, unknown> {
  * Whether a server advertises `io.modelcontextprotocol/tasks` in
  * `capabilities.extensions`. Only `tasks-dispatch` and `tasks-ext` may
  * consult this — the "treat as absent on 2025-11-25" rule lives here.
+ *
+ * The VALUE must itself be a non-array object: the capability map is
+ * `{ [extensionId]: settingsObject }`, so `true` / `"x"` / `[]` / `null` are
+ * malformed and do NOT count as a declaration (key presence alone would let a
+ * garbage value route real `tasks/*` traffic). A NON-EMPTY object is accepted:
+ * SEP-2663 says the settings are "not currently defined", so rejecting unknown
+ * settings would be forward-incompatible.
  */
 export function serverDeclaresTasksExtension(
   capabilities: ServerCapabilities | undefined
 ): boolean {
   const extensions = (capabilities as { extensions?: unknown } | undefined)
     ?.extensions;
-  return isRecord(extensions) && MCP_TASKS_EXTENSION_ID in extensions;
+  if (!isRecord(extensions)) {
+    return false;
+  }
+  const settings = Object.prototype.hasOwnProperty.call(
+    extensions,
+    MCP_TASKS_EXTENSION_ID
+  )
+    ? extensions[MCP_TASKS_EXTENSION_ID]
+    : undefined;
+  return isRecord(settings);
 }
 
 /**

--- a/sdk/src/mcp-client-manager/tasks-ext-era-gate.ts
+++ b/sdk/src/mcp-client-manager/tasks-ext-era-gate.ts
@@ -1,0 +1,162 @@
+/**
+ * Per-instance shadow of the upstream client's OUTBOUND era gate, scoped to
+ * the three `io.modelcontextprotocol/tasks` (SEP-2663) extension methods.
+ *
+ * ## What upstream does
+ *
+ * `@modelcontextprotocol/client@2.0.0-beta.4` derives a "spec method universe"
+ * from the UNION of its two era registries
+ * (`isSpecRequestMethod`, `src-*.mjs:3964`: `ALL_CODECS.some(c =>
+ * c.hasRequestMethod(m))`, with `ALL_CODECS = [rev2025Codec, rev2026Codec]`).
+ * `Protocol._assertOutboundRequestInEra` (`src-*.mjs:5932`) then throws
+ * `METHOD_NOT_SUPPORTED_BY_PROTOCOL_VERSION` for any member of that union that
+ * the NEGOTIATED era's codec does not define. It is called from all three send
+ * paths: `request()` (`:5886`), `_requestWithSchema()` (`:5951`) and
+ * `ctx.mcpReq.send` (`:5791`) — "an explicit schema never smuggles a deleted
+ * method onto the wire".
+ *
+ * ## Why that is wrong for this extension
+ *
+ * `tasks/get`, `tasks/result`, `tasks/list` and `tasks/cancel` are members of
+ * the union solely via the **2025-11-25** registry (`src-*.mjs:2048-2051`),
+ * which is where the *in-core* tasks utility lived. The 2026-07-28 registry
+ * (`:3685-3695`) has none of them, because that utility was DELETED from core
+ * and reborn as this extension — which reuses two of the same method names.
+ * So on a 2026-07-28 connection the client refuses to send the EXTENSION's
+ * `tasks/get` / `tasks/cancel`, reading them as deleted core methods. They are
+ * collateral damage of a name collision, not of a real deletion. (`tasks/update`
+ * is in neither registry, so it is era-blind and needs nothing from here — it
+ * is listed anyway so the exemption set is exactly the extension's method set
+ * rather than a hand-picked subset that would rot the moment a registry moves.)
+ *
+ * The era gate is a v2-only construct; the extension was authored against SDK
+ * v1, where no such gate exists. There is no public seam to fix this properly:
+ * the registries are module-private, the codec surface is function-only, and
+ * `Protocol` is not exported — so this installs an own-property shadow on the
+ * one instance we constructed.
+ *
+ * ## Why it is provably inert on the legacy revisions
+ *
+ * The early return requires `codec.era === "2026-07-28"`. `codecForVersion`
+ * (`src-*.mjs:3942`) maps every legacy revision — 2025-03-26, 2025-06-18,
+ * 2025-11-25, and `undefined` — to `rev2025Codec`, whose `era` is
+ * `"2025-11-25"` (`:2214`). On any of those connections the shadow delegates
+ * unconditionally, so `tasks/get`/`tasks/cancel` keep taking the legacy
+ * in-core path (`tasks.ts`) with byte-identical behavior.
+ *
+ * `codec.era` is compared rather than our own negotiated-version constant on
+ * purpose: upstream resolves ANY modern revision (including a pinned draft
+ * that is not the literal `2026-07-28`) to `rev2026Codec`, and the era string
+ * is what the gate itself reads. Comparing a protocol-version constant would
+ * miss those and silently re-block the extension.
+ *
+ * ## What is deliberately NOT done
+ *
+ * Pinning the tasks methods to the 2025 codec instead. `rev2025Codec
+ * .outboundEnvelope` returns `undefined` (`:2240`) whereas `rev2026Codec
+ * .outboundEnvelope` (`:3800`) attaches the
+ * `io.modelcontextprotocol/clientCapabilities` `_meta` envelope that the
+ * extension's per-request eligibility declaration rides in — a codec swap
+ * would silently strip the declaration and earn a `-32003` from every
+ * conforming server.
+ *
+ * ## Maintenance
+ *
+ * REVISIT ON EVERY `@modelcontextprotocol/client` BUMP. If the private member
+ * is renamed or removed, {@link installTasksExtensionEraGateShadow} throws at
+ * wrap time (i.e. at connect) rather than silently no-opping, so a bump that
+ * re-blocks the extension fails loudly instead of shipping a dead debugger
+ * surface. Delete this module once the client package stops era-gating the
+ * extension's method names (or exposes a real seam).
+ */
+
+import type { Client } from "@modelcontextprotocol/client";
+import { TasksExtRequestMethods } from "./tasks-ext.js";
+
+/**
+ * The private upstream member being shadowed. Named once so the fail-loud
+ * error and the override cannot disagree.
+ */
+const ERA_GATE_MEMBER = "_assertOutboundRequestInEra" as const;
+
+/** Client package version this shadow was verified against. */
+const VERIFIED_CLIENT_VERSION = "2.0.0-beta.4 / 2.0.0-beta.5";
+
+/**
+ * `rev2026Codec.era` (`src-*.mjs:3790`) — the ONLY era on which the exemption
+ * applies. Read off the dist, not guessed from a protocol-version constant.
+ */
+const MODERN_WIRE_ERA = "2026-07-28";
+
+const EXEMPT_METHODS: ReadonlySet<string> = new Set(TasksExtRequestMethods);
+
+/**
+ * Instances already shadowed. Tracked here rather than by sniffing for an own
+ * property on the client: an upstream that moved the gate from the prototype
+ * to an own instance field must still be WRAPPED (and must still fail loud if
+ * it is not a function), which an own-property check would silently skip.
+ */
+const shadowed = new WeakSet<object>();
+
+/** Thrown when the upstream member this shadow overrides is no longer there. */
+export class TasksExtEraGateSeamError extends Error {
+  constructor(reason: string) {
+    super(
+      `Cannot install the io.modelcontextprotocol/tasks era-gate shadow: ${reason}. ` +
+        `\`Protocol.${ERA_GATE_MEMBER}\` is a private member of @modelcontextprotocol/client ` +
+        `(verified against ${VERIFIED_CLIENT_VERSION}); a rename or removal means the tasks ` +
+        `extension's ${TasksExtRequestMethods.join(", ")} would be silently blocked on a ` +
+        `${MODERN_WIRE_ERA} connection. Re-verify sdk/src/mcp-client-manager/tasks-ext-era-gate.ts ` +
+        `against the new client build.`
+    );
+    this.name = "TasksExtEraGateSeamError";
+  }
+}
+
+type EraGate = (codec: { era?: unknown }, method: unknown) => void;
+
+/**
+ * Installs the shadow on ONE client instance. Idempotent: a second call on the
+ * same instance is a no-op.
+ *
+ * @throws {TasksExtEraGateSeamError} when the inherited member is missing or
+ * is not a function — see the module comment's maintenance note.
+ */
+export function installTasksExtensionEraGateShadow(client: Client): void {
+  const target = client as unknown as Record<string, unknown>;
+  if (shadowed.has(target)) {
+    return;
+  }
+  const original = target[ERA_GATE_MEMBER];
+  if (original === undefined) {
+    throw new TasksExtEraGateSeamError("the member is absent");
+  }
+  if (typeof original !== "function") {
+    throw new TasksExtEraGateSeamError(
+      `the member is a ${typeof original}, not a function`
+    );
+  }
+  const inherited = original as EraGate;
+  Object.defineProperty(target, ERA_GATE_MEMBER, {
+    value: function shadowedAssertOutboundRequestInEra(
+      this: unknown,
+      codec: { era?: unknown },
+      method: unknown
+    ): void {
+      // BOTH conditions, never one: a non-tasks method on the modern era, and
+      // every method on a legacy era, still go through upstream's gate.
+      if (
+        codec?.era === MODERN_WIRE_ERA &&
+        typeof method === "string" &&
+        EXEMPT_METHODS.has(method)
+      ) {
+        return;
+      }
+      inherited.call(this, codec, method);
+    },
+    writable: true,
+    configurable: true,
+    enumerable: false,
+  });
+  shadowed.add(target);
+}

--- a/sdk/src/mcp-client-manager/tasks-ext-era-gate.ts
+++ b/sdk/src/mcp-client-manager/tasks-ext-era-gate.ts
@@ -60,17 +60,41 @@
  * would silently strip the declaration and earn a `-32003` from every
  * conforming server.
  *
+ * ## When it is installed, and why not at connect
+ *
+ * LAZILY, on the first `io.modelcontextprotocol/tasks` operation — never at
+ * client construction or connect. The factory only *registers* the upstream
+ * instance behind its `ManagedMcpClient`
+ * ({@link registerTasksExtensionEraGateTarget}); the shadow itself is put on
+ * by {@link ensureTasksExtensionEraGateShadow}, which `tasks-ext.ts` calls
+ * from the single send path shared by `tasks/get`, `tasks/update` and
+ * `tasks/cancel`.
+ *
+ * The reason is blast radius. This module probes a PRIVATE upstream member,
+ * and a bump that renames it must fail loudly (see Maintenance) — but that
+ * failure has to land on the feature that depends on the probe, not on the
+ * transport. Installing at connect would put a private-member probe on the
+ * critical path of EVERY connection: a renamed member would break 2025-03-26,
+ * 2025-06-18, 2025-11-25 and 2026-07-28 servers alike, including the vast
+ * majority that never speak this extension. So we do NOT gate connections on
+ * it. A connection is never denied because of a seam we only need for tasks;
+ * the seam error can only ever surface on a tasks request.
+ *
  * ## Maintenance
  *
  * REVISIT ON EVERY `@modelcontextprotocol/client` BUMP. If the private member
- * is renamed or removed, {@link installTasksExtensionEraGateShadow} throws at
- * wrap time (i.e. at connect) rather than silently no-opping, so a bump that
- * re-blocks the extension fails loudly instead of shipping a dead debugger
- * surface. Delete this module once the client package stops era-gating the
- * extension's method names (or exposes a real seam).
+ * is renamed or removed, {@link installTasksExtensionEraGateShadow} throws on
+ * the first extension tasks operation rather than silently no-opping, so a
+ * bump that re-blocks the extension fails loudly instead of shipping a dead
+ * debugger surface. Delete this module once the client package stops
+ * era-gating the extension's method names (or exposes a real seam).
  */
 
 import type { Client } from "@modelcontextprotocol/client";
+// Runtime import, and `tasks-ext.ts` imports this module back for the lazy
+// install. Everything derived from `TasksExtRequestMethods` is therefore read
+// at CALL time, never at module-evaluation time, so neither module can observe
+// the other in its temporal dead zone whichever one the bundler loads first.
 import { TasksExtRequestMethods } from "./tasks-ext.js";
 
 /**
@@ -87,8 +111,6 @@ const VERIFIED_CLIENT_VERSION = "2.0.0-beta.4 / 2.0.0-beta.5";
  * applies. Read off the dist, not guessed from a protocol-version constant.
  */
 const MODERN_WIRE_ERA = "2026-07-28";
-
-const EXEMPT_METHODS: ReadonlySet<string> = new Set(TasksExtRequestMethods);
 
 /**
  * Instances already shadowed. Tracked here rather than by sniffing for an own
@@ -127,6 +149,10 @@ export function installTasksExtensionEraGateShadow(client: Client): void {
   if (shadowed.has(target)) {
     return;
   }
+  // Built here rather than at module scope: this module and `tasks-ext.ts`
+  // import each other (see the note on the import), so the method list is only
+  // safe to read once someone actually calls in.
+  const exemptMethods: ReadonlySet<string> = new Set(TasksExtRequestMethods);
   const original = target[ERA_GATE_MEMBER];
   if (original === undefined) {
     throw new TasksExtEraGateSeamError("the member is absent");
@@ -148,7 +174,7 @@ export function installTasksExtensionEraGateShadow(client: Client): void {
       if (
         codec?.era === MODERN_WIRE_ERA &&
         typeof method === "string" &&
-        EXEMPT_METHODS.has(method)
+        exemptMethods.has(method)
       ) {
         return;
       }
@@ -159,4 +185,50 @@ export function installTasksExtensionEraGateShadow(client: Client): void {
     enumerable: false,
   });
   shadowed.add(target);
+}
+
+/**
+ * `ManagedMcpClient` (or any decorator around one) → the upstream `Client`
+ * instance whose gate would have to be shadowed for it.
+ *
+ * The extension helpers in `tasks-ext.ts` hold a `ManagedMcpClient`, which is
+ * an interface with no route back to the upstream instance (and may be a
+ * decorator chain). Rather than have them guess at a private `.inner` chain,
+ * the factory — the one place an upstream `Client` becomes a
+ * `ManagedMcpClient` — records the pairing here.
+ */
+const eraGateTargets = new WeakMap<object, Client>();
+
+/**
+ * Record that `managed` speaks for `client`, so a later tasks operation can
+ * find the instance to shadow. Registration alone installs NOTHING and cannot
+ * throw — see the module comment on why connections are not gated on the
+ * private-member probe.
+ */
+export function registerTasksExtensionEraGateTarget(
+  managed: object,
+  client: Client
+): void {
+  eraGateTargets.set(managed, client);
+}
+
+/**
+ * Install the shadow for `managed`, if it has not been installed already.
+ * Called from the single send path every extension tasks request goes through.
+ *
+ * An unregistered `managed` is a client that never came from the factory (a
+ * test double, or a hand-rolled `ManagedMcpClient`); it has no upstream era
+ * gate to shadow, so there is nothing to do and nothing to fail about. A
+ * REGISTERED one whose seam has moved throws — that is the loud failure the
+ * probe exists for, now scoped to tasks traffic.
+ *
+ * @throws {TasksExtEraGateSeamError} when the registered instance no longer
+ * carries the private member.
+ */
+export function ensureTasksExtensionEraGateShadow(managed: object): void {
+  const client = eraGateTargets.get(managed);
+  if (client === undefined) {
+    return;
+  }
+  installTasksExtensionEraGateShadow(client);
 }

--- a/sdk/src/mcp-client-manager/tasks-ext-guards.ts
+++ b/sdk/src/mcp-client-manager/tasks-ext-guards.ts
@@ -11,31 +11,82 @@ import {
   createTaskExtResultSchema,
   detailedTaskExtSchema,
   getTaskExtResultSchema,
+  taskExtAckSchema,
   taskExtNotificationParamsSchema,
 } from "./tasks-ext-schemas.js";
 import type {
+  CancelTaskExtResult,
   CreateTaskExtResult,
   DetailedTaskExt,
   GetTaskExtResult,
   TaskExtNotificationParams,
 } from "./tasks-ext-types.js";
 
-/** Thrown when a server sends a task payload that fails validation. */
+/** Max issues / characters kept in the human-facing violation summary. */
+const MAX_SUMMARY_ISSUES = 5;
+const MAX_SUMMARY_LENGTH = 500;
+const MAX_SEGMENT_LENGTH = 64;
+
+/**
+ * Server-controlled text (an `inputRequests` key becomes an issue path
+ * segment) is truncated and stripped of control characters before it reaches a
+ * message or a log line.
+ */
+function safeText(value: string, maxLength = MAX_SEGMENT_LENGTH): string {
+  // Control characters would corrupt a terminal / log line.
+  const cleaned = value.replace(/[\u0000-\u001f\u007f]/g, " ");
+  return cleaned.length > maxLength
+    ? `${cleaned.slice(0, maxLength)}…`
+    : cleaned;
+}
+
+/**
+ * Thrown when a server sends a task payload that fails validation.
+ *
+ * This is an INVALID-SERVER-RESPONSE condition, distinct from "this connection
+ * does not speak the tasks extension" (`MCPTasksWireError`). Routes must not
+ * collapse the two: an unsupported wire is permanent, whereas a bad payload is
+ * a server bug worth surfacing with its method and violations.
+ */
 export class InvalidTaskExtPayloadError extends TypeError {
   readonly issues: string[];
-  constructor(context: string, issues: string[]) {
+  /** The extension method whose response failed, e.g. `"tasks/get"`. */
+  readonly method?: string;
+  /** Always the extension wire — the legacy guards live in `result-guards.ts`. */
+  readonly wire: "extension" = "extension";
+  /** Truncated, control-character-free violation summary, safe to log. */
+  readonly summary: string;
+
+  constructor(
+    context: string,
+    issues: string[],
+    options?: { method?: string }
+  ) {
+    const summary = safeText(
+      issues.slice(0, MAX_SUMMARY_ISSUES).join("; "),
+      MAX_SUMMARY_LENGTH
+    );
     super(
-      `${context} is not a valid io.modelcontextprotocol/tasks payload: ${issues.join("; ")}`
+      `${context} is not a valid io.modelcontextprotocol/tasks payload: ${summary}`
     );
     this.name = "InvalidTaskExtPayloadError";
     this.issues = issues;
+    this.method = options?.method;
+    this.summary = summary;
   }
+}
+
+/** Type guard for {@link InvalidTaskExtPayloadError}. */
+export function isInvalidTaskExtPayloadError(
+  error: unknown
+): error is InvalidTaskExtPayloadError {
+  return error instanceof InvalidTaskExtPayloadError;
 }
 
 function issuesOf(error: { issues: Array<{ path: PropertyKey[]; message: string }> }) {
   return error.issues.map(
     (issue) =>
-      `${issue.path.length > 0 ? issue.path.map(String).join(".") : "<root>"}: ${issue.message}`
+      `${issue.path.length > 0 ? issue.path.map((segment) => safeText(String(segment))).join(".") : "<root>"}: ${safeText(issue.message)}`
   );
 }
 
@@ -56,35 +107,68 @@ export function isCreateTaskExtResult(
 
 export function assertCreateTaskExtResult(
   value: unknown,
-  context = "tools/call task result"
+  context = "tools/call task result",
+  method = "tools/call"
 ): CreateTaskExtResult {
   const parsed = createTaskExtResultSchema.safeParse(value);
   if (!parsed.success) {
-    throw new InvalidTaskExtPayloadError(context, issuesOf(parsed.error));
+    throw new InvalidTaskExtPayloadError(context, issuesOf(parsed.error), {
+      method,
+    });
   }
   return parsed.data as CreateTaskExtResult;
 }
 
 export function assertGetTaskExtResult(
   value: unknown,
-  context = "tasks/get result"
+  context = "tasks/get result",
+  method = "tasks/get"
 ): GetTaskExtResult {
   const parsed = getTaskExtResultSchema.safeParse(value);
   if (!parsed.success) {
-    throw new InvalidTaskExtPayloadError(context, issuesOf(parsed.error));
+    throw new InvalidTaskExtPayloadError(context, issuesOf(parsed.error), {
+      method,
+    });
   }
   return parsed.data as GetTaskExtResult;
 }
 
 export function assertDetailedTaskExt(
   value: unknown,
-  context = "task"
+  context = "task",
+  method?: string
 ): DetailedTaskExt {
   const parsed = detailedTaskExtSchema.safeParse(value);
   if (!parsed.success) {
-    throw new InvalidTaskExtPayloadError(context, issuesOf(parsed.error));
+    throw new InvalidTaskExtPayloadError(context, issuesOf(parsed.error), {
+      method,
+    });
   }
   return parsed.data as DetailedTaskExt;
+}
+
+/**
+ * `tasks/update` / `tasks/cancel` acknowledgement. The ack is a bare `Result`
+ * and carries NO task state — it is validated as an object only, and callers
+ * must re-poll `tasks/get` for the post-operation status. `undefined` (a
+ * transport that surfaced an empty result as nothing) is normalized to `{}`;
+ * any other non-object is a wire violation.
+ */
+export function assertTaskExtAck(
+  value: unknown,
+  context: string,
+  method?: string
+): CancelTaskExtResult {
+  if (value === undefined) {
+    return {};
+  }
+  const parsed = taskExtAckSchema.safeParse(value);
+  if (!parsed.success) {
+    throw new InvalidTaskExtPayloadError(context, issuesOf(parsed.error), {
+      method,
+    });
+  }
+  return parsed.data as CancelTaskExtResult;
 }
 
 export function parseTaskExtNotificationParams(

--- a/sdk/src/mcp-client-manager/tasks-ext-guards.ts
+++ b/sdk/src/mcp-client-manager/tasks-ext-guards.ts
@@ -150,18 +150,24 @@ export function assertDetailedTaskExt(
 /**
  * `tasks/update` / `tasks/cancel` acknowledgement. The ack is a bare `Result`
  * and carries NO task state — it is validated as an object only, and callers
- * must re-poll `tasks/get` for the post-operation status. `undefined` (a
- * transport that surfaced an empty result as nothing) is normalized to `{}`;
- * any other non-object is a wire violation.
+ * must re-poll `tasks/get` for the post-operation status. Any non-object,
+ * INCLUDING `undefined`, is a wire violation.
+ *
+ * `undefined` used to be normalized to `{}` on the theory that a transport may
+ * surface an empty result as nothing. It cannot: beta.4's 2026 codec rejects a
+ * non-object `result` outright (`decodeResult`, client `src-*.mjs:3828-3835`),
+ * a well-formed empty ack arrives as `{"resultType":"complete"}` and is lifted
+ * to `{}` (`src-*.mjs:3878-3884`), and the complete branch only ever resolves
+ * what the caller's result schema accepted (`src-*.mjs:6045-6049`) — the
+ * schema these calls pass is `z.looseObject({})`, which rejects `undefined`.
+ * So `undefined` here means a malformed or missing result and must not be
+ * laundered into a valid empty ack.
  */
 export function assertTaskExtAck(
   value: unknown,
   context: string,
   method?: string
 ): CancelTaskExtResult {
-  if (value === undefined) {
-    return {};
-  }
   const parsed = taskExtAckSchema.safeParse(value);
   if (!parsed.success) {
     throw new InvalidTaskExtPayloadError(context, issuesOf(parsed.error), {

--- a/sdk/src/mcp-client-manager/tasks-ext-schemas.ts
+++ b/sdk/src/mcp-client-manager/tasks-ext-schemas.ts
@@ -251,7 +251,54 @@ export const createTaskExtResultSchema = taskExtSchema.extend({
   resultType: z.literal("task"),
 });
 
-export const getTaskExtResultSchema = detailedTaskExtSchema;
+/**
+ * `resultType` on a `tasks/get` / `tasks/update` / `tasks/cancel` response:
+ * OPTIONAL, but when present it MUST be exactly `"complete"`.
+ *
+ * ABSENT is tolerated because schema and prose conflict at pin 2c1425d9:
+ * tasks.md:338 / :381 / :410 state the key as a MUST, yet `resultType` appears
+ * ZERO times in `schema.json` and every `DetailedTask` variant is
+ * `additionalProperties: false` — a schema-faithful server omits it. beta.4
+ * makes this concrete: its 2026 codec STRIPS `resultType` off the decoded
+ * result before the guards ever see it (client `src-*.mjs:3878-3884`), so on
+ * the real transport the field is always absent. See `GetTaskExtResult`.
+ *
+ * PRESENT-BUT-WRONG is a violation: a `"banana"` (or a `"task"` on a
+ * `tasks/get`) actively misleads a reader and contradicts the public
+ * `GetTaskExtResult` type, which promises `"complete"`. Same shape of rule as
+ * `validateCreateTaskShape` in `tasks-conformance/runner.ts`, which rejects a
+ * `CreateTaskResult` whose `resultType` is present but not `"task"` — except
+ * that there omission is ALSO a violation, because `resultType: "task"` is the
+ * only signal distinguishing a task creation from an ordinary tool result
+ * (tasks.md:102) and the whole detection path keys on it. On a completion
+ * response the field carries no information the `status` union does not
+ * already carry, so its absence is harmless.
+ */
+function checkOptionalCompleteResultType(
+  value: unknown,
+  ctx: z.RefinementCtx
+): void {
+  if (!isPlainRecord(value)) return;
+  const resultType = Object.getOwnPropertyDescriptor(
+    value,
+    "resultType"
+  )?.value;
+  if (resultType === undefined || resultType === "complete") return;
+  ctx.addIssue({
+    code: "custom",
+    path: ["resultType"],
+    // Server-controlled: never interpolate a non-string body into the message.
+    message: `expected resultType "complete" when present, got ${
+      typeof resultType === "string"
+        ? JSON.stringify(resultType.slice(0, 32))
+        : `a value of type ${typeof resultType}`
+    }`,
+  });
+}
+
+export const getTaskExtResultSchema = detailedTaskExtSchema.superRefine(
+  checkOptionalCompleteResultType
+);
 
 /**
  * `notifications/tasks` params. SEP-2663 delivers a full `DetailedTask`, so the
@@ -265,5 +312,13 @@ export const taskExtNotificationParamsSchema = detailedTaskExtSchema;
  * ack carries NO task state, so it is validated only as an object: a non-object
  * (array, string, `null`) is a wire violation, while any object — empty or not
  * — is accepted and passed through verbatim. Callers must re-poll `tasks/get`.
+ *
+ * The one exception is `resultType`, which tasks.md:381 / :410 mandate as
+ * `"complete"` here just as tasks.md:338 does for `tasks/get`: absent is
+ * tolerated, present-but-wrong is rejected. See
+ * {@link checkOptionalCompleteResultType}.
  */
-export const taskExtAckSchema = z.object({}).loose();
+export const taskExtAckSchema = z
+  .object({})
+  .loose()
+  .superRefine(checkOptionalCompleteResultType);

--- a/sdk/src/mcp-client-manager/tasks-ext-schemas.ts
+++ b/sdk/src/mcp-client-manager/tasks-ext-schemas.ts
@@ -20,6 +20,7 @@
  */
 
 import { z } from "zod";
+import type { InputRequests } from "./tasks-ext-types.js";
 
 export const taskExtStatusSchema = z.enum([
   "working",
@@ -42,9 +43,16 @@ export const taskExtSchema = z
     taskId: z.string().min(1),
     status: taskExtStatusSchema,
     statusMessage: z.string().optional(),
+    // Plain strings on purpose. "ISO 8601" is a JSDoc comment in schema.ts;
+    // `schema.json` carries ZERO `format: date-time` constraints, so adding
+    // `.datetime()` here would reject servers the spec accepts.
     createdAt: z.string(),
     lastUpdatedAt: z.string(),
     // `null` means "no expiry" and is distinct from an absent field.
+    // Deliberately NOT `.int()` / `.nonnegative()`: `schema.json` says plain
+    // `"number"`, and both `ttlMs` and `pollIntervalMs` MAY change (including
+    // shrink) over a task's lifetime (tasks.md:304, :340) — a changed value is
+    // never an anomaly.
     ttlMs: z.number().nullable(),
     pollIntervalMs: z.number().optional(),
     _meta: z.record(z.string(), z.unknown()).optional(),
@@ -52,23 +60,193 @@ export const taskExtSchema = z
   .loose();
 
 /**
- * `inputRequests` is a keyed snapshot map re-sent on every poll. The values
- * are the same `InputRequest` objects the MRTR driver already handles, so they
- * are validated only as method-bearing objects here — the driver owns the
- * per-method (Decision-8) checks.
+ * The three request methods `InputRequest` unions in `schema.ts:111-118`
+ * (`CreateMessageRequest | ListRootsRequest | ElicitRequest`).
+ *
+ * They are a RECOGNITION list, not a validation list: `schema.json` renders
+ * the union as `anyOf: [{}, {}, {}]` (fully unconstrained), and this is a
+ * draft extension, so drift is expected. An unrecognized method therefore
+ * never invalidates the payload — the entry is kept and callers mark it via
+ * {@link isRecognizedInputRequestMethod}. Discarding the task (or the entry)
+ * would hide work the user is waiting on; the MRTR driver's
+ * "reject what this client cannot answer" rule (`mrtr-driver.ts:357`) is
+ * deliberately NOT applied here, because a tasks input request must stay
+ * VISIBLE-but-unanswerable rather than vanish.
  */
-export const inputRequestsSchema = z.record(
-  z.string(),
-  z.object({ method: z.string() }).loose()
-);
+export const TASK_EXT_INPUT_REQUEST_METHODS = [
+  "sampling/createMessage",
+  "roots/list",
+  "elicitation/create",
+] as const;
 
-export const detailedTaskExtSchema = taskExtSchema.extend({
-  result: z.unknown().optional(),
-  error: taskExtErrorSchema.optional(),
-  inputRequests: inputRequestsSchema.optional(),
+export type TaskExtInputRequestMethod =
+  (typeof TASK_EXT_INPUT_REQUEST_METHODS)[number];
+
+export function isRecognizedInputRequestMethod(
+  method: unknown
+): method is TaskExtInputRequestMethod {
+  return (
+    typeof method === "string" &&
+    (TASK_EXT_INPUT_REQUEST_METHODS as readonly string[]).includes(method)
+  );
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Own, enumerable entries of an untrusted object — read through property
+ * descriptors so a `__proto__` / `constructor` / `prototype` key is returned
+ * as DATA rather than resolved through the prototype chain.
+ */
+function ownEntries(value: Record<string, unknown>): Array<[string, unknown]> {
+  const entries: Array<[string, unknown]> = [];
+  for (const key of Object.getOwnPropertyNames(value)) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (!descriptor || !descriptor.enumerable || !("value" in descriptor)) {
+      continue;
+    }
+    entries.push([key, descriptor.value]);
+  }
+  return entries;
+}
+
+/**
+ * Copies the keyed map onto a NULL-PROTOTYPE object with `defineProperty`, the
+ * same hostile-key defence `mrtr-driver.ts:271 toSafeMap` applies. Server-chosen
+ * keys are arbitrary strings, so `__proto__` must land as an ordinary own
+ * property (visible in the UI) and must not touch any prototype.
+ */
+function toSafeInputRequests(value: Record<string, unknown>): InputRequests {
+  const safe = Object.create(null) as InputRequests;
+  for (const [key, entry] of ownEntries(value)) {
+    Object.defineProperty(safe, key, {
+      value: entry,
+      enumerable: true,
+      writable: true,
+      configurable: true,
+    });
+  }
+  return safe;
+}
+
+/**
+ * `inputRequests` is a keyed snapshot map re-sent on every poll. Hand-rolled
+ * rather than `z.record(...)` for two reasons: zod's record silently DROPS a
+ * `__proto__` key (the entry would disappear from the debugger), and the
+ * per-entry method check has to be non-fatal.
+ */
+export const inputRequestsSchema = z
+  .unknown()
+  .superRefine((value, ctx) => {
+    if (!isPlainRecord(value)) {
+      ctx.addIssue({
+        code: "custom",
+        message: "expected an object of input requests",
+      });
+      return;
+    }
+    for (const [key, entry] of ownEntries(value)) {
+      if (!isPlainRecord(entry)) {
+        ctx.addIssue({
+          code: "custom",
+          path: [key],
+          message: "expected an input request object",
+        });
+        continue;
+      }
+      const method = Object.getOwnPropertyDescriptor(entry, "method")?.value;
+      if (typeof method !== "string" || method.length === 0) {
+        ctx.addIssue({
+          code: "custom",
+          path: [key, "method"],
+          message: "expected a non-empty string method",
+        });
+      }
+      // An unrecognized method is intentionally NOT an issue — see the
+      // TASK_EXT_INPUT_REQUEST_METHODS comment.
+    }
+  })
+  .transform((value) => toSafeInputRequests(value as Record<string, unknown>));
+
+/** A key/method/recognized view of an `inputRequests` map, for UI + logs. */
+export function describeTaskExtInputRequests(
+  requests: InputRequests | undefined
+): Array<{ key: string; method: string; recognized: boolean }> {
+  if (!requests) return [];
+  return ownEntries(requests as unknown as Record<string, unknown>).map(
+    ([key, entry]) => {
+      const method = isPlainRecord(entry)
+        ? Object.getOwnPropertyDescriptor(entry, "method")?.value
+        : undefined;
+      const methodText = typeof method === "string" ? method : "";
+      return {
+        key,
+        method: methodText,
+        recognized: isRecognizedInputRequestMethod(methodText),
+      };
+    }
+  );
+}
+
+/*
+ * The five status variants. `schema.json` renders `DetailedTask` as an `anyOf`
+ * with per-variant `required`, and tasks.md:330-336 states each as a MUST:
+ * `working` / `cancelled` carry no status payload, `input_required` REQUIRES
+ * `inputRequests`, `completed` REQUIRES `result`, `failed` REQUIRES `error`
+ * (`statusMessage` is only a SHOULD, so it stays optional everywhere).
+ *
+ * Unknown keys still pass through (`.loose()` is inherited from
+ * `taskExtSchema`) even though the JSON Schema marks the variants
+ * `additionalProperties: false` — a debugger must render what the server
+ * actually sent, and this is also what lets the prose-only
+ * `resultType: "complete"` key through. See `GetTaskExtResult` for that
+ * schema-vs-prose conflict.
+ */
+export const workingTaskExtSchema = taskExtSchema.extend({
+  status: z.literal("working"),
 });
 
-/** Flat `CreateTaskResult` (`resultType: "task"`). */
+export const inputRequiredTaskExtSchema = taskExtSchema.extend({
+  status: z.literal("input_required"),
+  inputRequests: inputRequestsSchema,
+});
+
+export const completedTaskExtSchema = taskExtSchema.extend({
+  status: z.literal("completed"),
+  // `{ [key: string]: unknown }` in schema.ts — the original request's result.
+  // A tool result with `isError: true` is a COMPLETED task, never a failed one
+  // (tasks.md:837, :891-892); nothing here reclassifies it.
+  result: z.record(z.string(), z.unknown()),
+});
+
+export const failedTaskExtSchema = taskExtSchema.extend({
+  status: z.literal("failed"),
+  // JSON-RPC error object. `schema.json` only says `"type": "object"` (that is
+  // ts-to-zod's rendering of an index signature), but JSON-RPC itself requires
+  // `code` + `message`, which is what every consumer renders.
+  error: taskExtErrorSchema,
+});
+
+export const cancelledTaskExtSchema = taskExtSchema.extend({
+  status: z.literal("cancelled"),
+});
+
+/** `DetailedTask` (schema.ts:217-222) — discriminated on `status`. */
+export const detailedTaskExtSchema = z.discriminatedUnion("status", [
+  workingTaskExtSchema,
+  inputRequiredTaskExtSchema,
+  completedTaskExtSchema,
+  failedTaskExtSchema,
+  cancelledTaskExtSchema,
+]);
+
+/**
+ * Flat `CreateTaskResult` (`resultType: "task"`). `Result & Task` is NOT a
+ * DetailedTask: it never carries a status payload, so the union above must not
+ * be applied to it.
+ */
 export const createTaskExtResultSchema = taskExtSchema.extend({
   resultType: z.literal("task"),
 });
@@ -80,3 +258,12 @@ export const getTaskExtResultSchema = detailedTaskExtSchema;
  * notification body validates against the same schema as `tasks/get`.
  */
 export const taskExtNotificationParamsSchema = detailedTaskExtSchema;
+
+/**
+ * `UpdateTaskResult` / `CancelTaskResult` — both are a bare `Result`
+ * (`{"type": "object", "additionalProperties": {}}`, no required fields). The
+ * ack carries NO task state, so it is validated only as an object: a non-object
+ * (array, string, `null`) is a wire violation, while any object — empty or not
+ * — is accepted and passed through verbatim. Callers must re-poll `tasks/get`.
+ */
+export const taskExtAckSchema = z.object({}).loose();

--- a/sdk/src/mcp-client-manager/tasks-ext-types.ts
+++ b/sdk/src/mcp-client-manager/tasks-ext-types.ts
@@ -72,17 +72,72 @@ export interface TaskExt {
 }
 
 /**
- * `tasks/get` response. Beyond the task handle it carries, per status:
- *   - `completed` → `result` INLINE (the original request's result);
- *   - `failed` → `error` (a JSON-RPC error object);
- *   - `input_required` → `inputRequests`, a keyed snapshot map re-sent on
- *     every poll (dedupe by key; partial responses are allowed).
+ * The five `DetailedTask` variants (`schema/draft/schema.ts:217-222`, rendered
+ * in `schema.json` as an `anyOf` with per-variant `required`). The status is
+ * the discriminator and the status payload is NOT optional:
+ * `specification/draft/tasks.md:330-336` states each as a MUST.
+ *
+ * Fields a variant does not carry are declared `?: undefined` rather than
+ * omitted so that reading `task.result` / `task.error` / `task.inputRequests`
+ * off the bare union still type-checks (narrowing on `status` gives the
+ * precise type). Runtime passthrough is unaffected — a server that sends an
+ * extra key still has it preserved, because a debugger must show what was
+ * actually sent.
  */
-export interface DetailedTaskExt extends TaskExt {
-  result?: unknown;
-  error?: TaskExtError;
-  inputRequests?: InputRequests;
+export interface WorkingTaskExt extends TaskExt {
+  status: "working";
+  result?: undefined;
+  error?: undefined;
+  inputRequests?: undefined;
 }
+
+export interface InputRequiredTaskExt extends TaskExt {
+  status: "input_required";
+  /**
+   * Keyed snapshot map re-sent on every poll (dedupe by key; partial
+   * responses are allowed).
+   */
+  inputRequests: InputRequests;
+  result?: undefined;
+  error?: undefined;
+}
+
+export interface CompletedTaskExt extends TaskExt {
+  status: "completed";
+  /** The original request's result, INLINE (there is no `tasks/result`). */
+  result: Record<string, unknown>;
+  error?: undefined;
+  inputRequests?: undefined;
+}
+
+export interface FailedTaskExt extends TaskExt {
+  status: "failed";
+  /**
+   * The JSON-RPC error that caused the failure. `failed` is ONLY for
+   * protocol-level faults: a tool result with `isError: true` is a `completed`
+   * task (tasks.md:837, :891-892).
+   */
+  error: TaskExtError;
+  result?: undefined;
+  inputRequests?: undefined;
+}
+
+export interface CancelledTaskExt extends TaskExt {
+  status: "cancelled";
+  result?: undefined;
+  error?: undefined;
+  inputRequests?: undefined;
+}
+
+/**
+ * `tasks/get` / `notifications/tasks` body — the status-discriminated union.
+ */
+export type DetailedTaskExt =
+  | WorkingTaskExt
+  | InputRequiredTaskExt
+  | CompletedTaskExt
+  | FailedTaskExt
+  | CancelledTaskExt;
 
 /** Discriminator shared by every 2026-07-28 result. */
 export type TaskExtResultType = "complete" | "input_required" | "task";
@@ -91,15 +146,27 @@ export type TaskExtResultType = "complete" | "input_required" | "task";
  * The flat `CreateTaskResult` a server MAY return in place of the requested
  * result. MUST NOT be returned before the task is durably readable via
  * `tasks/get`.
+ *
+ * `CreateTaskResult = Result & Task` is FLAT (schema.ts:232): it legitimately
+ * never carries `result` / `error` / `inputRequests`, so the DetailedTask
+ * union does NOT apply to it. `resultType: "task"` stays required — it is the
+ * documented discriminator (tasks.md:102, MUST).
  */
 export interface CreateTaskExtResult extends TaskExt {
   resultType: "task";
 }
 
-/** `tasks/get` result. */
-export interface GetTaskExtResult extends DetailedTaskExt {
-  resultType?: "complete";
-}
+/**
+ * `tasks/get` result.
+ *
+ * SPEC CONFLICT (pin 2c1425d9): tasks.md:338 says `resultType` **MUST** be
+ * `"complete"` here, but `resultType` appears in `schema.json` nowhere, and
+ * every DetailedTask variant is `additionalProperties: false` — so a validator
+ * built from the JSON Schema would REJECT the key the prose mandates. We
+ * therefore accept the response with OR without it and never require it. Do
+ * not "fix" this by making it required until the two agree upstream.
+ */
+export type GetTaskExtResult = DetailedTaskExt & { resultType?: "complete" };
 
 /**
  * `tasks/update` result — per SEP-2663 `UpdateTaskResult = Result`: an EMPTY,
@@ -120,6 +187,6 @@ export type CancelTaskExtResult = Record<string, unknown>;
  * SEP-2663 carries a full `DetailedTask`, so the extra task fields are part of
  * the payload rather than an unrelated envelope.
  */
-export interface TaskExtNotificationParams extends DetailedTaskExt {
+export type TaskExtNotificationParams = DetailedTaskExt & {
   _meta?: Record<string, unknown>;
-}
+};

--- a/sdk/src/mcp-client-manager/tasks-ext.ts
+++ b/sdk/src/mcp-client-manager/tasks-ext.ts
@@ -35,9 +35,20 @@
  * entry is dropped. The protocol-version and client-info envelope keys are
  * never written here, so beta.4's auto-generated values for them survive
  * untouched. `tasks-ext.test.ts` pins the no-clobbering property.
+ *
+ * ## Getting the three methods onto the wire at all
+ *
+ * Two separate upstream constructs stand between these helpers and a socket,
+ * and BOTH have to be dealt with:
+ *
+ * 1. the result-schema seam — solved here, by sending every extension request
+ *    through `requestWithSchema` (see {@link TASKS_EXT_WIRE_RESULT_SCHEMA});
+ * 2. the outbound era gate — solved at connect time in
+ *    `tasks-ext-era-gate.ts`, which is where the reasoning lives.
  */
 
 import { CLIENT_CAPABILITIES_META_KEY } from "@modelcontextprotocol/client";
+import { z } from "zod";
 import { mergeClientCapabilities } from "./capabilities.js";
 import type { ManagedMcpClient } from "./managed-mcp-client.js";
 import type { ClientCapabilityOptions, ClientRequestOptions } from "./types.js";
@@ -63,6 +74,42 @@ export const TasksExtUpdateMethod = "tasks/update" as const;
 export const TasksExtCancelMethod = "tasks/cancel" as const;
 /** Optional server→client task notification (delivered via `subscriptions/listen`). */
 export const TasksExtNotificationMethod = "notifications/tasks" as const;
+
+/**
+ * The three extension REQUEST methods, as one list. Derived from the constants
+ * above so it can never drift from them.
+ *
+ * Two consumers depend on this being exactly the extension's method set:
+ * `tasks-ext-era-gate.ts` (which exempts them from the client's outbound era
+ * gate) and the request helpers below. `notifications/tasks` is deliberately
+ * absent — it is inbound and never era-gated on send.
+ */
+export const TasksExtRequestMethods = [
+  TasksExtGetMethod,
+  TasksExtUpdateMethod,
+  TasksExtCancelMethod,
+] as const;
+
+export type TasksExtRequestMethod = (typeof TasksExtRequestMethods)[number];
+
+/**
+ * Wire-level result schema for every extension request.
+ *
+ * Deliberately loose, exactly like the legacy wire's
+ * `LEGACY_TASKS_RESULT_SCHEMA` (`tasks.ts:20`): the real validation is the
+ * zod mirror in `tasks-ext-guards.ts`, which discriminates on `status` and
+ * produces `InvalidTaskExtPayloadError` with a per-field issue list. A strict
+ * schema here would instead surface upstream's generic "invalid result" and
+ * lose that diagnosis.
+ *
+ * Passing it is NOT optional. All three methods must ride the
+ * explicit-result-schema overload of upstream `Protocol.request`
+ * (`requestWithSchema`, see `official-sdk-client-adapter.ts:114`), because the
+ * schema-less overload resolves its validator from the negotiated era's
+ * registry (`codecResultValidator`) and that returns `undefined` for every
+ * extension method — the call then throws "'…' is not a spec method".
+ */
+const TASKS_EXT_WIRE_RESULT_SCHEMA = z.looseObject({});
 
 /**
  * The `_meta` fragment declaring task eligibility for ONE request. Merges the
@@ -107,7 +154,7 @@ export async function getTaskExt(
   ctx: TasksExtCallContext,
   taskId: string
 ): Promise<GetTaskExtResult> {
-  const raw = await ctx.client.request(
+  const raw = await ctx.client.requestWithSchema(
     {
       method: TasksExtGetMethod,
       params: withTasksExtensionDeclaration(
@@ -115,6 +162,7 @@ export async function getTaskExt(
         ctx.declaredCapabilities
       ),
     },
+    TASKS_EXT_WIRE_RESULT_SCHEMA,
     ctx.options
   );
   return assertGetTaskExtResult(raw);
@@ -130,7 +178,7 @@ export async function updateTaskExt(
   taskId: string,
   inputResponses: InputResponses
 ): Promise<UpdateTaskExtResult> {
-  const raw = await ctx.client.request<UpdateTaskExtResult>(
+  const raw = await ctx.client.requestWithSchema(
     {
       method: TasksExtUpdateMethod,
       params: withTasksExtensionDeclaration(
@@ -138,6 +186,7 @@ export async function updateTaskExt(
         ctx.declaredCapabilities
       ),
     },
+    TASKS_EXT_WIRE_RESULT_SCHEMA,
     ctx.options
   );
   // Validated as an object only: the ack carries no task state, so anything
@@ -154,7 +203,7 @@ export async function cancelTaskExt(
   ctx: TasksExtCallContext,
   taskId: string
 ): Promise<CancelTaskExtResult> {
-  const raw = await ctx.client.request<CancelTaskExtResult>(
+  const raw = await ctx.client.requestWithSchema(
     {
       method: TasksExtCancelMethod,
       params: withTasksExtensionDeclaration(
@@ -162,6 +211,7 @@ export async function cancelTaskExt(
         ctx.declaredCapabilities
       ),
     },
+    TASKS_EXT_WIRE_RESULT_SCHEMA,
     ctx.options
   );
   return assertTaskExtAck(raw, "tasks/cancel result", TasksExtCancelMethod);

--- a/sdk/src/mcp-client-manager/tasks-ext.ts
+++ b/sdk/src/mcp-client-manager/tasks-ext.ts
@@ -41,7 +41,10 @@ import { CLIENT_CAPABILITIES_META_KEY } from "@modelcontextprotocol/client";
 import { mergeClientCapabilities } from "./capabilities.js";
 import type { ManagedMcpClient } from "./managed-mcp-client.js";
 import type { ClientCapabilityOptions, ClientRequestOptions } from "./types.js";
-import { assertGetTaskExtResult } from "./tasks-ext-guards.js";
+import {
+  assertGetTaskExtResult,
+  assertTaskExtAck,
+} from "./tasks-ext-guards.js";
 import type {
   CancelTaskExtResult,
   GetTaskExtResult,
@@ -137,7 +140,9 @@ export async function updateTaskExt(
     },
     ctx.options
   );
-  return raw ?? {};
+  // Validated as an object only: the ack carries no task state, so anything
+  // that is not an object is a wire violation rather than a task to render.
+  return assertTaskExtAck(raw, "tasks/update result", TasksExtUpdateMethod);
 }
 
 /**
@@ -159,5 +164,5 @@ export async function cancelTaskExt(
     },
     ctx.options
   );
-  return raw ?? {};
+  return assertTaskExtAck(raw, "tasks/cancel result", TasksExtCancelMethod);
 }

--- a/sdk/src/mcp-client-manager/tasks-ext.ts
+++ b/sdk/src/mcp-client-manager/tasks-ext.ts
@@ -43,13 +43,17 @@
  *
  * 1. the result-schema seam — solved here, by sending every extension request
  *    through `requestWithSchema` (see {@link TASKS_EXT_WIRE_RESULT_SCHEMA});
- * 2. the outbound era gate — solved at connect time in
- *    `tasks-ext-era-gate.ts`, which is where the reasoning lives.
+ * 2. the outbound era gate — solved by `tasks-ext-era-gate.ts`, which is where
+ *    the reasoning lives. Its shadow is installed LAZILY, from
+ *    {@link sendTasksExtRequest} below: it probes a private upstream member,
+ *    so it must not sit on the connect path of servers that never speak this
+ *    extension.
  */
 
 import { CLIENT_CAPABILITIES_META_KEY } from "@modelcontextprotocol/client";
 import { z } from "zod";
 import { mergeClientCapabilities } from "./capabilities.js";
+import { ensureTasksExtensionEraGateShadow } from "./tasks-ext-era-gate.js";
 import type { ManagedMcpClient } from "./managed-mcp-client.js";
 import type { ClientCapabilityOptions, ClientRequestOptions } from "./types.js";
 import {
@@ -149,22 +153,43 @@ export interface TasksExtCallContext {
   options?: ClientRequestOptions;
 }
 
+/**
+ * The ONE send path for the extension: all three request helpers below build
+ * their params and then come through here, and nothing else in the SDK issues
+ * a `TasksExtRequestMethod`. That makes it the only choke point where the
+ * era-gate shadow has to be installed — and, because the exemption set IS
+ * `TasksExtRequestMethods`, a request that never passes through here is by
+ * definition a request the shadow would not have exempted anyway.
+ *
+ * The install is idempotent per client instance, so the cost after the first
+ * extension call is a `WeakMap`/`WeakSet` hit.
+ *
+ * @throws {TasksExtEraGateSeamError} when this client's upstream era-gate
+ * member has moved — loud here, where the extension actually depends on it,
+ * and nowhere near a connect.
+ */
+async function sendTasksExtRequest(
+  ctx: TasksExtCallContext,
+  method: TasksExtRequestMethod,
+  params: Record<string, unknown>
+): Promise<unknown> {
+  ensureTasksExtensionEraGateShadow(ctx.client);
+  return ctx.client.requestWithSchema(
+    {
+      method,
+      params: withTasksExtensionDeclaration(params, ctx.declaredCapabilities),
+    },
+    TASKS_EXT_WIRE_RESULT_SCHEMA,
+    ctx.options
+  );
+}
+
 /** `tasks/get` — a completed task carries its `result` INLINE. */
 export async function getTaskExt(
   ctx: TasksExtCallContext,
   taskId: string
 ): Promise<GetTaskExtResult> {
-  const raw = await ctx.client.requestWithSchema(
-    {
-      method: TasksExtGetMethod,
-      params: withTasksExtensionDeclaration(
-        { taskId },
-        ctx.declaredCapabilities
-      ),
-    },
-    TASKS_EXT_WIRE_RESULT_SCHEMA,
-    ctx.options
-  );
+  const raw = await sendTasksExtRequest(ctx, TasksExtGetMethod, { taskId });
   return assertGetTaskExtResult(raw);
 }
 
@@ -178,17 +203,10 @@ export async function updateTaskExt(
   taskId: string,
   inputResponses: InputResponses
 ): Promise<UpdateTaskExtResult> {
-  const raw = await ctx.client.requestWithSchema(
-    {
-      method: TasksExtUpdateMethod,
-      params: withTasksExtensionDeclaration(
-        { taskId, inputResponses },
-        ctx.declaredCapabilities
-      ),
-    },
-    TASKS_EXT_WIRE_RESULT_SCHEMA,
-    ctx.options
-  );
+  const raw = await sendTasksExtRequest(ctx, TasksExtUpdateMethod, {
+    taskId,
+    inputResponses,
+  });
   // Validated as an object only: the ack carries no task state, so anything
   // that is not an object is a wire violation rather than a task to render.
   return assertTaskExtAck(raw, "tasks/update result", TasksExtUpdateMethod);
@@ -203,16 +221,6 @@ export async function cancelTaskExt(
   ctx: TasksExtCallContext,
   taskId: string
 ): Promise<CancelTaskExtResult> {
-  const raw = await ctx.client.requestWithSchema(
-    {
-      method: TasksExtCancelMethod,
-      params: withTasksExtensionDeclaration(
-        { taskId },
-        ctx.declaredCapabilities
-      ),
-    },
-    TASKS_EXT_WIRE_RESULT_SCHEMA,
-    ctx.options
-  );
+  const raw = await sendTasksExtRequest(ctx, TasksExtCancelMethod, { taskId });
   return assertTaskExtAck(raw, "tasks/cancel result", TasksExtCancelMethod);
 }

--- a/sdk/src/tasks-conformance/index.ts
+++ b/sdk/src/tasks-conformance/index.ts
@@ -1,10 +1,16 @@
 export {
   MCPTasksConformanceTest,
+  describeUndeclaredProbe,
   findDeclarationViolations,
   pickProbeTool,
   toolTaskSupport,
   validateCreateTaskShape,
   validateTaskTtlShape,
+} from "./runner.js";
+
+export type {
+  UndeclaredProbe,
+  UndeclaredProbeOutcome,
 } from "./runner.js";
 
 export { normalizeMCPTasksConformanceConfig } from "./validation.js";

--- a/sdk/src/tasks-conformance/index.ts
+++ b/sdk/src/tasks-conformance/index.ts
@@ -1,14 +1,17 @@
 export {
   MCPTasksConformanceTest,
+  decideOutcome,
   describeUndeclaredProbe,
   findDeclarationViolations,
   pickProbeTool,
+  resolveProbeTool,
   toolTaskSupport,
   validateCreateTaskShape,
   validateTaskTtlShape,
 } from "./runner.js";
 
 export type {
+  ProbeToolResolution,
   UndeclaredProbe,
   UndeclaredProbeOutcome,
 } from "./runner.js";
@@ -22,6 +25,8 @@ export type {
   MCPTasksCheckStatus,
   MCPTasksConformanceConfig,
   MCPTasksConformanceResult,
+  MCPTasksRunOutcome,
+  MCPTasksSkipReason,
   NormalizedMCPTasksConformanceConfig,
 } from "./types.js";
 

--- a/sdk/src/tasks-conformance/runner.ts
+++ b/sdk/src/tasks-conformance/runner.ts
@@ -57,12 +57,19 @@ const CHECK_METADATA: Record<
     description:
       'A task-eligible tools/call returns either a normal tool result or a flat CreateTaskResult with resultType "task" and a server-generated taskId.',
   },
+  "tasks-undeclared-creation-refused": {
+    id: "tasks-undeclared-creation-refused",
+    category: "creation",
+    title: "Undeclared Task Creation Refused",
+    description:
+      "On the extension wire, a tools/call that did not carry the extension declaration must not come back as a CreateTaskResult: the server either answers normally or rejects with -32003.",
+  },
   "tasks-undeclared-capability-rejected": {
     id: "tasks-undeclared-capability-rejected",
-    category: "creation",
-    title: "Undeclared Capability Handling",
+    category: "lifecycle",
+    title: "Undeclared Capability Rejected",
     description:
-      "On the extension wire, an undeclared tools/call must not come back as a task: the server either answers normally or rejects with -32003. How the server treats a bare undeclared tasks/get is reported as a note, since the spec mandates no rejection for reads.",
+      "tasks/get, tasks/update, tasks/cancel and a task-filtered subscriptions/listen sent WITHOUT the extension declaration must each be rejected with -32003 (Missing Required Client Capability).",
   },
   "tasks-ttl-shape": {
     id: "tasks-ttl-shape",
@@ -256,6 +263,23 @@ export interface ShapeVerdict {
  * Extra fields the spec does not define (e.g. a redundant nested `task`
  * object) are WARNINGS, not violations — the spec does not forbid additional
  * fields, so an otherwise-valid result must not fail conformance for them.
+ *
+ * `resultType` is REQUIRED here, present or absent (tasks.md:102): "Servers
+ * MUST set `resultType` to `"task"` when returning a `CreateTaskResult` so
+ * that clients can distinguish it from a standard result." The MUST states
+ * its own purpose and that purpose is the whole mechanism — `CreateTaskResult
+ * = Result & Task` is flat, so the discriminator is the ONLY signal. A server
+ * that omits it does not deviate cosmetically: this SDK's task detection is
+ * keyed on `resultType === "task"` end to end (`rewriteTaskResultMessage` at
+ * the transport seam, then `isCreateTaskExtResult`), so the response is taken
+ * for an ordinary `CallToolResult`, the task is never tracked, and the work
+ * runs to completion with no handle. Omission and a wrong value are both
+ * violations.
+ *
+ * The extension's machine-readable schema never declares the field (`Task`
+ * sets `additionalProperties: false`), which is an argument about the OTHER
+ * direction only: we must not reject a payload for CARRYING `resultType`.
+ * Nothing in that silence licenses a server to omit it.
  */
 export function validateCreateTaskShape(result: unknown): ShapeVerdict {
   const violations: string[] = [];
@@ -265,9 +289,11 @@ export function validateCreateTaskShape(result: unknown): ShapeVerdict {
   }
   if (result.resultType !== "task") {
     violations.push(
-      `task creation result must carry resultType "task" (got ${JSON.stringify(
-        result.resultType
-      )})`
+      result.resultType === undefined
+        ? 'task creation result carries no resultType "task" discriminator, the only signal that distinguishes it from a standard result; a client reads it as an ordinary tool result and never tracks the task'
+        : `task creation result must carry resultType "task" (got ${JSON.stringify(
+            result.resultType
+          )})`
     );
   }
   if (typeof result.taskId !== "string" || result.taskId.length === 0) {
@@ -374,6 +400,105 @@ async function captureTaskRequestHeaders(
 // "canceled" (single-l) is not a spec status on either wire; a server
 // emitting it fails status validation rather than being silently accepted.
 const TERMINAL_STATUSES = new Set(["completed", "failed", "cancelled"]);
+
+/** Missing Required Client Capability — the only conformant answer here. */
+const MISSING_REQUIRED_CLIENT_CAPABILITY = -32003;
+/** Method not found: the server does not implement the method at all. */
+const METHOD_NOT_FOUND = -32601;
+/** The client gave up waiting — the server never refused the request. */
+const REQUEST_TIMEOUT = -32001;
+
+/**
+ * Cap on the undeclared `subscriptions/listen` probe. A conforming server
+ * refuses it immediately with `-32003`; one that wrongly accepts opens a
+ * long-lived stream, so the probe — not the server — decides when to stop.
+ */
+const LISTEN_PROBE_TIMEOUT_MS = 5_000;
+
+/** What a server did with a request that carried no extension declaration. */
+export type UndeclaredProbeOutcome =
+  /** Rejected with -32003: the required behavior. */
+  | "rejected"
+  /** The server served the request. */
+  | "answered"
+  /** Rejected, but with some other error code. */
+  | "wrong-code"
+  /** No answer arrived before the probe's own deadline. */
+  | "no-response"
+  /** -32601: the method does not exist here, so the rule cannot be probed. */
+  | "unsupported";
+
+export interface UndeclaredProbe {
+  method: string;
+  outcome: UndeclaredProbeOutcome;
+  code?: number;
+  message?: string;
+}
+
+/** One line of per-method detail for the check's failure message. */
+export function describeUndeclaredProbe(probe: UndeclaredProbe): string {
+  switch (probe.outcome) {
+    case "answered":
+      return `${probe.method} was answered instead of rejected`;
+    case "wrong-code":
+      return `${probe.method} was rejected with ${probe.code} rather than -32003`;
+    case "no-response":
+      return `${probe.method} produced no JSON-RPC rejection (${
+        probe.message ?? "no answer"
+      }); a conforming server refuses it immediately with -32003`;
+    case "unsupported":
+      return `${probe.method} is not implemented (-32601)`;
+    case "rejected":
+      return `${probe.method} was rejected with -32003`;
+  }
+}
+
+/** A raw JSON-RPC request seam: the manager's public APIs always declare. */
+type RawRequest = (
+  payload: { method: string; params: Record<string, unknown> },
+  options?: { timeout?: number }
+) => Promise<unknown>;
+
+/**
+ * Sends one request WITHOUT the extension declaration and classifies what
+ * came back. `listenProbe` marks the sub-probe whose absence is a skip rather
+ * than a violation: `subscriptions/listen` is a core method the tasks
+ * extension only borrows, so a server that lacks it cannot be judged on it.
+ */
+async function runUndeclaredProbe(
+  request: RawRequest,
+  method: string,
+  params: Record<string, unknown>,
+  options?: { timeout?: number; listenProbe?: boolean }
+): Promise<UndeclaredProbe> {
+  try {
+    await request(
+      { method, params },
+      options?.timeout === undefined ? undefined : { timeout: options.timeout }
+    );
+    return { method, outcome: "answered" };
+  } catch (error) {
+    const code = errorCode(error);
+    const message = errorMessage(error);
+    if (code === MISSING_REQUIRED_CLIENT_CAPABILITY) {
+      return { method, outcome: "rejected", code };
+    }
+    if (code === METHOD_NOT_FOUND && options?.listenProbe) {
+      return { method, outcome: "unsupported", code, message };
+    }
+    if (code === undefined || code === REQUEST_TIMEOUT) {
+      // No refusal reached us: a transport failure, or a stream the server
+      // held open past the probe deadline. Either way it is not a rejection.
+      return {
+        method,
+        outcome: "no-response",
+        ...(code === undefined ? {} : { code }),
+        message,
+      };
+    }
+    return { method, outcome: "wrong-code", code, message };
+  }
+}
 
 export class MCPTasksConformanceTest {
   private readonly config: NormalizedMCPTasksConformanceConfig;
@@ -501,6 +626,17 @@ export class MCPTasksConformanceTest {
             } else if (createdTaskId === undefined) {
               // Server-decided: declining to produce a task is conformant, as
               // long as what comes back is a normal tool result.
+              //
+              // KNOWN BLIND SPOT: a CreateTaskResult that omits `resultType`
+              // also lands here. Task detection is keyed on
+              // `resultType === "task"` at the transport seam
+              // (`rewriteTaskResultMessage`), so a discriminator-less creation
+              // never reaches this runner AS a task — it arrives as an
+              // ordinary result (or fails result decoding upstream and lands
+              // in the branch above). Catching that omission needs the RAW
+              // response, which this runner does not observe; the assertion
+              // lives in `validateCreateTaskShape` for the payloads that do
+              // reach it and for direct callers of the exported validator.
               checks.push(
                 isRecord(creationResult)
                   ? passed(
@@ -540,57 +676,41 @@ export class MCPTasksConformanceTest {
             }
           }
 
-          if (selected.has("tasks-undeclared-capability-rejected")) {
+          if (selected.has("tasks-undeclared-creation-refused")) {
             const stepStartedAt = Date.now();
-            if (wire !== "extension" || !createdTaskId || !probeTool) {
+            if (wire !== "extension" || !probeTool) {
               checks.push(
                 skipped(
-                  "tasks-undeclared-capability-rejected",
+                  "tasks-undeclared-creation-refused",
                   wire === "extension"
-                    ? "no task was created to probe with"
+                    ? "no task-capable tool to probe (pass toolName to choose one)"
                     : "check applies to the extension wire only"
                 )
               );
             } else {
-              const outcome = await this.probeUndeclaredGet(
-                manager,
-                serverId,
-                createdTaskId
-              );
-              // Answering a bare `tasks/get` is CONFORMANT: the spec mandates
-              // `-32003` only where the server cannot avoid returning
-              // `CreateTaskResult` to an undeclared client (tasks.md §61-63)
-              // or for undeclared notification subscriptions — never for a
-              // bare read. The mandated case IS observable though, so the
-              // check's verdict comes from an undeclared tools/call: a server
-              // must not create a task for a client that never declared
-              // eligibility. The read outcome only adds a note.
+              // tasks.md:61 — a server MUST NOT return `CreateTaskResult` to a
+              // client that did not include the extension capability ON THAT
+              // REQUEST, regardless of prior declarations.
               const creation = await this.probeUndeclaredCreation(
                 manager,
                 serverId,
                 probeTool.name
               );
-              const readNote = outcome.rejected
-                ? `server rejected a bare tasks/get with -32003 (stricter than required)`
-                : outcome.code === undefined
-                  ? "server answered a bare tasks/get without the capability declaration — allowed (the spec requires -32003 only when the server cannot avoid returning CreateTaskResult to an undeclared client)"
-                  : `server rejected a bare tasks/get with ${outcome.code} rather than -32003 — allowed (no rejection is mandated for reads)`;
               checks.push(
                 creation.taskCreated
                   ? failed(
-                      "tasks-undeclared-capability-rejected",
+                      "tasks-undeclared-creation-refused",
                       Date.now() - stepStartedAt,
                       "an undeclared tools/call returned a CreateTaskResult; a server must not create a task for a client that never declared the tasks capability (it must answer normally or reject with -32003)",
-                      { taskId: creation.taskId, bareReadCode: outcome.code }
+                      { tool: probeTool.name, taskId: creation.taskId }
                     )
                   : passed(
-                      "tasks-undeclared-capability-rejected",
+                      "tasks-undeclared-creation-refused",
                       Date.now() - stepStartedAt,
                       {
+                        tool: probeTool.name,
                         undeclaredCreationCode: creation.code,
-                        bareReadCode: outcome.code,
-                      },
-                      [readNote]
+                      }
                     )
               );
             }
@@ -754,6 +874,80 @@ export class MCPTasksConformanceTest {
             }
           }
 
+          // ORDERING: the undeclared probes run LAST of the task-touching
+          // checks, and deliberately so. `tasks/update` and `tasks/cancel`
+          // MUTATE a task, and this check exists precisely because a server
+          // may wrongly accept them — so they must not be able to corrupt any
+          // other check's subject. By this point the task has already been
+          // polled to a terminal status and read by tasks-ttl-shape,
+          // tasks-inline-result and tasks-mcp-name-routing, so nothing left in
+          // the run depends on its state. Only tasks-declaration-hygiene
+          // follows, and it inspects captured outbound traffic (where an
+          // undeclared probe is, correctly, no violation at all).
+          if (selected.has("tasks-undeclared-capability-rejected")) {
+            const stepStartedAt = Date.now();
+            if (wire !== "extension" || !createdTaskId) {
+              checks.push(
+                skipped(
+                  "tasks-undeclared-capability-rejected",
+                  wire === "extension"
+                    ? "no task was created to probe with"
+                    : "check applies to the extension wire only"
+                )
+              );
+            } else {
+              const probes = await this.probeUndeclaredTaskMethods(
+                manager,
+                serverId,
+                createdTaskId
+              );
+              if (probes === undefined) {
+                checks.push(
+                  skipped(
+                    "tasks-undeclared-capability-rejected",
+                    "the connection exposes no raw request seam, so an undeclared call cannot be sent"
+                  )
+                );
+              } else {
+                // tasks.md:797-799 — the server MUST answer -32003 for a
+                // non-declaring client on tasks/get, tasks/update,
+                // tasks/cancel and on task notifications requested through
+                // subscriptions/listen. This is UNCONDITIONAL; anything else
+                // (an answer, or another error code) is a violation.
+                const offenders = probes.filter(
+                  (probe) =>
+                    probe.outcome !== "rejected" &&
+                    probe.outcome !== "unsupported"
+                );
+                const warnings = probes
+                  .filter((probe) => probe.outcome === "unsupported")
+                  .map(
+                    (probe) =>
+                      `${probe.method} is not implemented by this server (-32601), so its undeclared-request requirement was not probed`
+                  );
+                checks.push(
+                  offenders.length === 0
+                    ? passed(
+                        "tasks-undeclared-capability-rejected",
+                        Date.now() - stepStartedAt,
+                        { taskId: createdTaskId, probes },
+                        warnings
+                      )
+                    : failed(
+                        "tasks-undeclared-capability-rejected",
+                        Date.now() - stepStartedAt,
+                        `${
+                          offenders.length
+                        } undeclared request(s) were not rejected with -32003 (Missing Required Client Capability): ${offenders
+                          .map(describeUndeclaredProbe)
+                          .join("; ")}`,
+                        { taskId: createdTaskId, probes }
+                      )
+                );
+              }
+            }
+          }
+
           if (selected.has("tasks-declaration-hygiene")) {
             const stepStartedAt = Date.now();
             const violations = findDeclarationViolations(wire, sent);
@@ -821,6 +1015,11 @@ export class MCPTasksConformanceTest {
     }
   }
 
+  /**
+   * Task id out of a creation result. Shape-based (`taskId`), but it reads a
+   * result the manager has ALREADY discriminated on `resultType === "task"`,
+   * so it identifies the task rather than detecting one.
+   */
   private extractTaskId(wire: TasksWire, result: unknown): string | undefined {
     if (!isRecord(result)) return undefined;
     if (wire === "extension") {
@@ -830,10 +1029,6 @@ export class MCPTasksConformanceTest {
     return typeof task?.taskId === "string" ? task.taskId : undefined;
   }
 
-  /**
-   * Sends a raw `tasks/get` WITHOUT the extension declaration. The manager
-   * always declares, so this goes through the connection's client directly.
-   */
   /**
    * Runs a `tools/call` WITHOUT the extension declaration (`allowTaskResult`
    * omitted, so the manager sends no capability envelope) and reports whether
@@ -860,30 +1055,53 @@ export class MCPTasksConformanceTest {
     }
   }
 
-  private async probeUndeclaredGet(
+  /**
+   * Sends every request the extension requires a server to refuse from a
+   * non-declaring client, WITHOUT the declaration, and reports each outcome.
+   * The manager's task APIs always attach the declaration, so these go through
+   * the connection's raw request seam; `undefined` means there is no such seam.
+   *
+   * Probe order is least- to most-invasive against the (already terminal)
+   * task: read, then a no-op update, then the listen subscription, and
+   * `tasks/cancel` last — a server that wrongly accepts one of these must not
+   * change what the next one observes.
+   */
+  private async probeUndeclaredTaskMethods(
     manager: MCPClientManager,
     serverId: string,
     taskId: string
-  ): Promise<{ rejected: boolean; code?: number }> {
-    // The public task APIs always attach the extension declaration, so the
-    // undeclared probe goes through the raw client.
+  ): Promise<UndeclaredProbe[] | undefined> {
     const client = manager.getClient(serverId) as
-      | { request?: (payload: unknown, schema?: unknown) => Promise<unknown> }
+      | { request?: (payload: unknown, options?: unknown) => Promise<unknown> }
       | undefined;
-    const request = client?.request;
+    const clientRequest = client?.request;
+    if (!clientRequest) return undefined;
 
-    if (!request) return { rejected: false };
+    const request: RawRequest = (payload, options) =>
+      options === undefined
+        ? clientRequest.call(client, payload)
+        : clientRequest.call(client, payload, options);
 
-    try {
-      await request.call(client, { method: "tasks/get", params: { taskId } });
-      return { rejected: false };
-    } catch (error) {
-      const code = errorCode(error);
-      return {
-        rejected: code === -32003,
-        ...(code === undefined ? {} : { code }),
-      };
-    }
+    const probes: UndeclaredProbe[] = [];
+    probes.push(await runUndeclaredProbe(request, "tasks/get", { taskId }));
+    // An EMPTY `inputResponses` map submits nothing, so even a server that
+    // wrongly accepts this update cannot advance the task with it.
+    probes.push(
+      await runUndeclaredProbe(request, "tasks/update", {
+        taskId,
+        inputResponses: {},
+      })
+    );
+    probes.push(
+      await runUndeclaredProbe(
+        request,
+        "subscriptions/listen",
+        { notifications: { taskIds: [taskId] } },
+        { timeout: LISTEN_PROBE_TIMEOUT_MS, listenProbe: true }
+      )
+    );
+    probes.push(await runUndeclaredProbe(request, "tasks/cancel", { taskId }));
+    return probes;
   }
 
   private async pollToTerminal(

--- a/sdk/src/tasks-conformance/runner.ts
+++ b/sdk/src/tasks-conformance/runner.ts
@@ -12,6 +12,7 @@
  * a single provoked task, so running the suite costs one server session.
  */
 
+import { z } from "zod";
 import type { MCPClientManager } from "../mcp-client-manager/MCPClientManager.js";
 import type {
   ListToolsResult,
@@ -20,6 +21,8 @@ import type {
 import { MCP_TASKS_EXTENSION_ID } from "../mcp-client-manager/tasks-dispatch.js";
 import type { TasksWire } from "../mcp-client-manager/tasks-dispatch.js";
 import { CLIENT_CAPABILITIES_META_KEY } from "../mcp-client-manager/tasks-ext.js";
+import { ensureTasksExtensionEraGateShadow } from "../mcp-client-manager/tasks-ext-era-gate.js";
+import { TASK_CREATED_META_KEY } from "../mcp-client-manager/transport-utils.js";
 import { withEphemeralClient } from "../operations.js";
 import {
   MCP_TASKS_CHECK_IDS,
@@ -425,6 +428,13 @@ export type UndeclaredProbeOutcome =
   | "wrong-code"
   /** No answer arrived before the probe's own deadline. */
   | "no-response"
+  /**
+   * The request never reached the server at all — it died locally (upstream's
+   * outbound era gate, a missing result schema) or the transport failed before
+   * a JSON-RPC response existed. NOT a verdict on the server, and never a pass:
+   * a probe that cannot execute must not be reported as conformance.
+   */
+  | "probe-failed"
   /** -32601: the method does not exist here, so the rule cannot be probed. */
   | "unsupported";
 
@@ -433,6 +443,12 @@ export interface UndeclaredProbe {
   outcome: UndeclaredProbeOutcome;
   code?: number;
   message?: string;
+  /**
+   * Whether an outbound JSON-RPC request for this method was observed on the
+   * connection's rpc log. This is what separates "the server misbehaved" from
+   * "the probe never got onto the wire".
+   */
+  reachedWire?: boolean;
 }
 
 /** One line of per-method detail for the check's failure message. */
@@ -446,6 +462,10 @@ export function describeUndeclaredProbe(probe: UndeclaredProbe): string {
       return `${probe.method} produced no JSON-RPC rejection (${
         probe.message ?? "no answer"
       }); a conforming server refuses it immediately with -32003`;
+    case "probe-failed":
+      return `${probe.method} never reached the server (${
+        probe.message ?? "no answer"
+      }), so the undeclared-request requirement was NOT tested`;
     case "unsupported":
       return `${probe.method} is not implemented (-32601)`;
     case "rejected":
@@ -453,50 +473,132 @@ export function describeUndeclaredProbe(probe: UndeclaredProbe): string {
   }
 }
 
-/** A raw JSON-RPC request seam: the manager's public APIs always declare. */
+/**
+ * The task id a server smuggled into an UNDECLARED `tools/call`, or
+ * `undefined` if it produced an ordinary result.
+ *
+ * Two places have to be read, and the second is the one that matters. Without
+ * `allowTaskResult`, `MCPClientManager` does not hand a `CreateTaskResult`
+ * back at the top level at all: the transport wrapper rewrites the response
+ * into a minimal valid `CallToolResult` and parks the original payload under
+ * `_meta[TASK_CREATED_META_KEY]` (`transport-utils.ts:300`). A detector that
+ * only read `result.taskId` would therefore see a plain tool result from EVERY
+ * server — conformant or not — and the check would pass vacuously against the
+ * exact violation it exists to catch.
+ */
+export function extractUndeclaredCreationTaskId(
+  result: unknown
+): string | undefined {
+  if (!isRecord(result)) return undefined;
+  if (typeof result.taskId === "string" && result.taskId.length > 0) {
+    return result.taskId;
+  }
+  const meta = isRecord(result._meta) ? result._meta : undefined;
+  const stashed = meta?.[TASK_CREATED_META_KEY];
+  if (!isRecord(stashed)) return undefined;
+  // A `taskId`-less stash is still a task the server created; name it rather
+  // than let the absent id downgrade the failure to a pass.
+  return typeof stashed.taskId === "string" && stashed.taskId.length > 0
+    ? stashed.taskId
+    : "(CreateTaskResult with no taskId)";
+}
+
+/**
+ * A raw JSON-RPC request seam: the manager's public tasks APIs always attach
+ * the extension declaration, which is exactly what these probes must omit.
+ *
+ * The seam MUST carry an explicit result schema. `Protocol.request`'s
+ * schema-less overload resolves its validator from the negotiated era's method
+ * registry, and no `tasks/*` method has an entry there on the 2026 wire — so a
+ * schema-less call dies LOCALLY ("pass a result schema as the second
+ * argument") and the probe tests nothing. Same reasoning, same fix as
+ * `tasks-ext.ts` / `tasks.ts`, which is why the schema below is the same
+ * deliberately-loose `z.looseObject({})`: this probe asserts on the JSON-RPC
+ * *envelope* (rejected vs answered), never on a payload's shape.
+ */
 type RawRequest = (
   payload: { method: string; params: Record<string, unknown> },
   options?: { timeout?: number }
 ) => Promise<unknown>;
+
+/** See {@link RawRequest} — loose on purpose. */
+const RAW_PROBE_RESULT_SCHEMA = z.looseObject({});
+
+/** Outbound requests for `method` seen on the connection's rpc log. */
+function countSentRequests(sent: unknown[], method: string): number {
+  return sent.filter(
+    (message) => isRecord(message) && message.method === method
+  ).length;
+}
 
 /**
  * Sends one request WITHOUT the extension declaration and classifies what
  * came back. `listenProbe` marks the sub-probe whose absence is a skip rather
  * than a violation: `subscriptions/listen` is a core method the tasks
  * extension only borrows, so a server that lacks it cannot be judged on it.
+ *
+ * `sent` is the run's captured outbound rpc log; the probe reads it before and
+ * after so a failure can say whether the request ever left the process.
+ *
+ * In `@modelcontextprotocol/client` v2 a NUMERIC `code` on the thrown error is
+ * itself the discriminator: `ProtocolError` (numeric code) is minted only from
+ * a server's JSON-RPC error response (`src-*.mjs:5873`), while every local and
+ * transport fault — the era gate, timeouts, a closed connection — is an
+ * `SdkError` whose `code` is a STRING. So "no numeric code" means "no server
+ * verdict", and it is reported as `probe-failed`, not as a pass.
  */
 async function runUndeclaredProbe(
   request: RawRequest,
+  sent: unknown[],
   method: string,
   params: Record<string, unknown>,
   options?: { timeout?: number; listenProbe?: boolean }
 ): Promise<UndeclaredProbe> {
+  const sentBefore = countSentRequests(sent, method);
+  const reachedWire = () => countSentRequests(sent, method) > sentBefore;
   try {
     await request(
       { method, params },
       options?.timeout === undefined ? undefined : { timeout: options.timeout }
     );
-    return { method, outcome: "answered" };
+    return { method, outcome: "answered", reachedWire: reachedWire() };
   } catch (error) {
     const code = errorCode(error);
     const message = errorMessage(error);
     if (code === MISSING_REQUIRED_CLIENT_CAPABILITY) {
-      return { method, outcome: "rejected", code };
+      return { method, outcome: "rejected", code, reachedWire: true };
     }
     if (code === METHOD_NOT_FOUND && options?.listenProbe) {
-      return { method, outcome: "unsupported", code, message };
+      return {
+        method,
+        outcome: "unsupported",
+        code,
+        message,
+        reachedWire: true,
+      };
     }
-    if (code === undefined || code === REQUEST_TIMEOUT) {
-      // No refusal reached us: a transport failure, or a stream the server
-      // held open past the probe deadline. Either way it is not a rejection.
+    if (code === undefined) {
+      // No JSON-RPC response exists, so there is no server verdict. The rpc log
+      // decides which kind of nothing this is: a request that DID leave the
+      // process and was never answered (a stream the server held open past the
+      // probe deadline) is a server-side `no-response`; one that never left is
+      // the probe's own failure and must not be graded as conformance.
+      return reachedWire()
+        ? { method, outcome: "no-response", message, reachedWire: true }
+        : { method, outcome: "probe-failed", message, reachedWire: false };
+    }
+    if (code === REQUEST_TIMEOUT) {
+      // A server-sent -32001: the request reached it and it declined to answer
+      // within the deadline — a verdict, just not the required one.
       return {
         method,
         outcome: "no-response",
-        ...(code === undefined ? {} : { code }),
+        code,
         message,
+        reachedWire: true,
       };
     }
-    return { method, outcome: "wrong-code", code, message };
+    return { method, outcome: "wrong-code", code, message, reachedWire: true };
   }
 }
 
@@ -696,36 +798,70 @@ export class MCPTasksConformanceTest {
                 serverId,
                 probeTool.name
               );
-              checks.push(
-                creation.taskCreated
-                  ? failed(
-                      "tasks-undeclared-creation-refused",
-                      Date.now() - stepStartedAt,
-                      "an undeclared tools/call returned a CreateTaskResult; a server must not create a task for a client that never declared the tasks capability (it must answer normally or reject with -32003)",
-                      { tool: probeTool.name, taskId: creation.taskId }
-                    )
-                  : passed(
-                      "tasks-undeclared-creation-refused",
-                      Date.now() - stepStartedAt,
-                      {
-                        tool: probeTool.name,
-                        undeclaredCreationCode: creation.code,
-                      }
-                    )
-              );
+              const stepDurationMs = Date.now() - stepStartedAt;
+              if (creation.outcome === "created") {
+                checks.push(
+                  failed(
+                    "tasks-undeclared-creation-refused",
+                    stepDurationMs,
+                    "an undeclared tools/call returned a CreateTaskResult; a server must not create a task for a client that never declared the tasks capability (it must answer normally or reject with -32003)",
+                    { tool: probeTool.name, taskId: creation.taskId }
+                  )
+                );
+              } else if (creation.outcome === "errored") {
+                // Not a pass: the probe never obtained a server response, so
+                // tasks.md:61 was not exercised at all.
+                checks.push(
+                  failed(
+                    "tasks-undeclared-creation-refused",
+                    stepDurationMs,
+                    `the undeclared tools/call produced no JSON-RPC response (${creation.message}), so the server was never tested; re-run against a reachable server`,
+                    { tool: probeTool.name, outcome: creation.outcome }
+                  )
+                );
+              } else {
+                checks.push(
+                  passed(
+                    "tasks-undeclared-creation-refused",
+                    stepDurationMs,
+                    {
+                      tool: probeTool.name,
+                      outcome: creation.outcome,
+                      ...(creation.outcome === "refused"
+                        ? { undeclaredCreationCode: creation.code }
+                        : {}),
+                    },
+                    creation.outcome === "refused" &&
+                      creation.code !== MISSING_REQUIRED_CLIENT_CAPABILITY
+                      ? [
+                          `the undeclared tools/call was rejected with ${creation.code} rather than -32003; no task was created (which is what tasks.md:61 requires) but the refusal is not the one the extension names`,
+                        ]
+                      : undefined
+                  )
+                );
+              }
             }
           }
 
-          const finalTask = createdTaskId
+          const polled = createdTaskId
             ? await this.pollToTerminal(manager, serverId, wire, createdTaskId)
-            : undefined;
+            : {};
+          const finalTask = polled.task;
+          // Distinguishes "there was never a task" from "polling the task
+          // failed", so no dependent check skips under a message that hides a
+          // broken read.
+          const noTaskReason = createdTaskId
+            ? polled.error === undefined
+              ? `task ${createdTaskId} was never readable within ${this.config.pollTimeoutMs}ms`
+              : `polling task ${createdTaskId} failed: ${errorMessage(
+                  polled.error
+                )}`
+            : "no task was created to inspect";
 
           if (selected.has("tasks-ttl-shape")) {
             const stepStartedAt = Date.now();
             if (!finalTask) {
-              checks.push(
-                skipped("tasks-ttl-shape", "no task was created to inspect")
-              );
+              checks.push(skipped("tasks-ttl-shape", noTaskReason));
             } else {
               const verdict = validateTaskTtlShape(wire, finalTask);
               checks.push(
@@ -749,9 +885,7 @@ export class MCPTasksConformanceTest {
           if (selected.has("tasks-inline-result")) {
             const stepStartedAt = Date.now();
             if (!finalTask || !createdTaskId) {
-              checks.push(
-                skipped("tasks-inline-result", "no task was created to inspect")
-              );
+              checks.push(skipped("tasks-inline-result", noTaskReason));
             } else if (!TERMINAL_STATUSES.has(String(finalTask.status))) {
               checks.push(
                 skipped(
@@ -899,7 +1033,8 @@ export class MCPTasksConformanceTest {
               const probes = await this.probeUndeclaredTaskMethods(
                 manager,
                 serverId,
-                createdTaskId
+                createdTaskId,
+                sent
               );
               if (probes === undefined) {
                 checks.push(
@@ -1031,27 +1166,51 @@ export class MCPTasksConformanceTest {
 
   /**
    * Runs a `tools/call` WITHOUT the extension declaration (`allowTaskResult`
-   * omitted, so the manager sends no capability envelope) and reports whether
-   * the server nonetheless created a task.
+   * omitted, so the manager sends no capability envelope) and reports what the
+   * server did.
+   *
+   * The outcome is deliberately four-valued rather than a boolean. A boolean
+   * `taskCreated: false` collapses "the server honoured tasks.md:61" with "the
+   * probe blew up before it proved anything", and the check counted BOTH as a
+   * pass. Only an actual server response can pass here:
+   *
+   *   - `created`  — a `CreateTaskResult` came back: the violation.
+   *   - `answered` — a normal tool result: conformant.
+   *   - `refused`  — a JSON-RPC error response: also conformant (no task was
+   *     handed to a non-declaring client), with `-32003` being the refusal the
+   *     spec names and any other code carried through as a warning.
+   *   - `errored`  — no JSON-RPC response exists at all. Same v2 discriminator
+   *     as {@link runUndeclaredProbe}: `ProtocolError` carries a NUMERIC code
+   *     and is minted only from a server error response, while local and
+   *     transport faults are `SdkError`s with STRING codes. This is a check
+   *     FAILURE, because nothing about the server was observed.
    */
   private async probeUndeclaredCreation(
     manager: MCPClientManager,
     serverId: string,
     toolName: string
-  ): Promise<{ taskCreated: boolean; taskId?: string; code?: number }> {
+  ): Promise<
+    | { outcome: "created"; taskId: string }
+    | { outcome: "answered" }
+    | { outcome: "refused"; code: number; message: string }
+    | { outcome: "errored"; message: string }
+  > {
     try {
       const result = await manager.executeTool(
         serverId,
         toolName,
         this.config.toolArguments ?? {}
       );
-      const taskId = this.extractTaskId("extension", result);
+      const taskId = extractUndeclaredCreationTaskId(result);
       return taskId === undefined
-        ? { taskCreated: false }
-        : { taskCreated: true, taskId };
+        ? { outcome: "answered" }
+        : { outcome: "created", taskId };
     } catch (error) {
       const code = errorCode(error);
-      return { taskCreated: false, ...(code === undefined ? {} : { code }) };
+      const message = errorMessage(error);
+      return code === undefined
+        ? { outcome: "errored", message }
+        : { outcome: "refused", code, message };
     }
   }
 
@@ -1065,29 +1224,51 @@ export class MCPTasksConformanceTest {
    * task: read, then a no-op update, then the listen subscription, and
    * `tasks/cancel` last — a server that wrongly accepts one of these must not
    * change what the next one observes.
+   *
+   * ERA GATE: on a 2026-07-28 connection, upstream refuses to SEND `tasks/get`
+   * and `tasks/cancel` (they are 2025-registry members the modern registry
+   * dropped); `tasks-ext-era-gate.ts` shadows that gate, and installs the shadow
+   * LAZILY on the first extension tasks operation. These probes bypass the
+   * manager's tasks APIs, so they must ask for the shadow themselves rather
+   * than lean on an earlier `getTaskExt` having triggered it — `ensure…` is
+   * idempotent and a no-op for a client the factory never registered.
+   * Belt and braces: if the gate ever did fire, it throws an `SdkError` with a
+   * STRING code, so the probe reports `probe-failed` (an offender), never a pass.
    */
   private async probeUndeclaredTaskMethods(
     manager: MCPClientManager,
     serverId: string,
-    taskId: string
+    taskId: string,
+    sent: unknown[]
   ): Promise<UndeclaredProbe[] | undefined> {
-    const client = manager.getClient(serverId) as
-      | { request?: (payload: unknown, options?: unknown) => Promise<unknown> }
-      | undefined;
-    const clientRequest = client?.request;
-    if (!clientRequest) return undefined;
+    // `getManagedClient()`, not `getClient()`: the raw upstream `Client`'s
+    // `request()` has no explicit-schema form on this SDK's surface, and its
+    // schema-less form cannot carry a `tasks/*` method (see {@link RawRequest}).
+    // The managed client's `requestWithSchema` is the same seam `tasks-ext.ts`
+    // uses for the DECLARING calls, minus the declaration — which is precisely
+    // the probe. Nothing in the wrapper chain adds the tasks capability: the
+    // only `_meta` a wrapper injects is `LogLevelMetaClient`'s log level.
+    const client = manager.getManagedClient(serverId);
+    if (typeof client?.requestWithSchema !== "function") return undefined;
+    // See the ERA GATE note above: the declaring path installs this on its own
+    // first send, the probes must ask.
+    ensureTasksExtensionEraGateShadow(client);
 
     const request: RawRequest = (payload, options) =>
-      options === undefined
-        ? clientRequest.call(client, payload)
-        : clientRequest.call(client, payload, options);
+      client.requestWithSchema(
+        payload as never,
+        RAW_PROBE_RESULT_SCHEMA,
+        options as never
+      );
 
     const probes: UndeclaredProbe[] = [];
-    probes.push(await runUndeclaredProbe(request, "tasks/get", { taskId }));
+    probes.push(
+      await runUndeclaredProbe(request, sent, "tasks/get", { taskId })
+    );
     // An EMPTY `inputResponses` map submits nothing, so even a server that
     // wrongly accepts this update cannot advance the task with it.
     probes.push(
-      await runUndeclaredProbe(request, "tasks/update", {
+      await runUndeclaredProbe(request, sent, "tasks/update", {
         taskId,
         inputResponses: {},
       })
@@ -1095,21 +1276,32 @@ export class MCPTasksConformanceTest {
     probes.push(
       await runUndeclaredProbe(
         request,
+        sent,
         "subscriptions/listen",
         { notifications: { taskIds: [taskId] } },
         { timeout: LISTEN_PROBE_TIMEOUT_MS, listenProbe: true }
       )
     );
-    probes.push(await runUndeclaredProbe(request, "tasks/cancel", { taskId }));
+    probes.push(
+      await runUndeclaredProbe(request, sent, "tasks/cancel", { taskId })
+    );
     return probes;
   }
 
+  /**
+   * Polls until terminal, the deadline, or the first poll error.
+   *
+   * The poll error is RETURNED rather than swallowed: a `tasks/get` that throws
+   * is the difference between "the server never produced a task to inspect"
+   * (a genuine skip) and "the task exists but reading it failed" (which the
+   * dependent checks must name, not silently skip past).
+   */
   private async pollToTerminal(
     manager: MCPClientManager,
     serverId: string,
     wire: TasksWire,
     taskId: string
-  ): Promise<Record<string, unknown> | undefined> {
+  ): Promise<{ task?: Record<string, unknown>; error?: unknown }> {
     const deadline = Date.now() + this.config.pollTimeoutMs;
     let last: Record<string, unknown> | undefined;
 
@@ -1120,11 +1312,12 @@ export class MCPTasksConformanceTest {
             ? ((await manager.getTaskExt(serverId, taskId)) as unknown)
             : ((await manager.getTask(serverId, taskId)) as unknown);
         last = isRecord(task) ? task : undefined;
-      } catch {
-        return last;
+      } catch (error) {
+        return { task: last, error };
       }
 
-      if (last && TERMINAL_STATUSES.has(String(last.status))) return last;
+      if (last && TERMINAL_STATUSES.has(String(last.status)))
+        return { task: last };
 
       const suggested = last
         ? Number(last.pollIntervalMs ?? last.pollInterval)
@@ -1134,6 +1327,6 @@ export class MCPTasksConformanceTest {
       await new Promise((resolve) => setTimeout(resolve, waitMs));
     }
 
-    return last;
+    return { task: last };
   }
 }

--- a/sdk/src/tasks-conformance/runner.ts
+++ b/sdk/src/tasks-conformance/runner.ts
@@ -31,6 +31,7 @@ import {
   type MCPTasksCheckResult,
   type MCPTasksConformanceConfig,
   type MCPTasksConformanceResult,
+  type MCPTasksRunOutcome,
   type NormalizedMCPTasksConformanceConfig,
 } from "./types.js";
 import { normalizeMCPTasksConformanceConfig } from "./validation.js";
@@ -146,7 +147,13 @@ function failed(
   };
 }
 
-function skipped(
+/**
+ * A check that cannot apply to THIS server: an extension-only requirement on a
+ * legacy connection, an HTTP-only requirement over stdio, a task check on a
+ * connection with no tasks wire. Nothing is left unverified, so this does not
+ * hold the run back.
+ */
+function notApplicable(
   id: MCPTasksCheckId,
   message: string,
   details?: Record<string, unknown>
@@ -154,10 +161,38 @@ function skipped(
   return {
     ...CHECK_METADATA[id],
     status: "skipped",
+    skipReason: "not-applicable",
     durationMs: 0,
     error: { message },
     ...(details ? { details } : {}),
   };
+}
+
+/**
+ * A check that DOES apply here but the run could not exercise — no probe tool,
+ * a probe tool the server does not list, no task to inspect. The requirement
+ * was not tested, so the run is `incomplete`: this must never be summed into a
+ * passing verdict, which is exactly the bug where six task-dependent checks
+ * silently skipped and the suite still reported success.
+ */
+function couldNotRun(
+  id: MCPTasksCheckId,
+  message: string,
+  details?: Record<string, unknown>
+): MCPTasksCheckResult {
+  return {
+    ...CHECK_METADATA[id],
+    status: "skipped",
+    skipReason: "could-not-run",
+    durationMs: 0,
+    error: { message },
+    ...(details ? { details } : {}),
+  };
+}
+
+/** Selected, applicable, and never exercised. */
+function isUnrun(check: MCPTasksCheckResult): boolean {
+  return check.status === "skipped" && check.skipReason === "could-not-run";
 }
 
 function summarizeChecks(checks: MCPTasksCheckResult[]) {
@@ -171,6 +206,7 @@ function summarizeChecks(checks: MCPTasksCheckResult[]) {
           passed: inCategory.filter((c) => c.status === "passed").length,
           failed: inCategory.filter((c) => c.status === "failed").length,
           skipped: inCategory.filter((c) => c.status === "skipped").length,
+          couldNotRun: inCategory.filter(isUnrun).length,
         },
       ];
     })
@@ -180,8 +216,49 @@ function summarizeChecks(checks: MCPTasksCheckResult[]) {
 function buildSummary(checks: MCPTasksCheckResult[]): string {
   const passedCount = checks.filter((c) => c.status === "passed").length;
   const failedCount = checks.filter((c) => c.status === "failed").length;
-  const skippedCount = checks.filter((c) => c.status === "skipped").length;
-  return `${passedCount}/${checks.length} checks passed, ${failedCount} failed, ${skippedCount} skipped`;
+  const unrunCount = checks.filter(isUnrun).length;
+  const inapplicableCount = checks.filter(
+    (c) => c.status === "skipped" && c.skipReason !== "could-not-run"
+  ).length;
+  return `${passedCount}/${checks.length} checks passed, ${failedCount} failed, ${unrunCount} could not run, ${inapplicableCount} not applicable`;
+}
+
+/**
+ * The run's verdict, plus the reason when it is `incomplete`.
+ *
+ * `passed` requires that every SELECTED check actually produced a verdict —
+ * either it ran, or it was inapplicable to this server. A check that could not
+ * run is neither a violation nor a pass, and collapsing it into "not failed"
+ * is what let a two-of-eight run report success.
+ */
+export function decideOutcome(checks: MCPTasksCheckResult[]): {
+  outcome: MCPTasksRunOutcome;
+  incompleteReason?: string;
+} {
+  if (checks.some((check) => check.status === "failed")) {
+    return { outcome: "failed" };
+  }
+  const unrun = checks.filter(isUnrun);
+  if (unrun.length === 0) {
+    return checks.length === 0
+      ? {
+          outcome: "incomplete",
+          incompleteReason:
+            "no checks were selected, so this run establishes nothing",
+        }
+      : { outcome: "passed" };
+  }
+  const reasons = Array.from(
+    new Set(unrun.map((check) => check.error?.message ?? "reason unavailable"))
+  );
+  return {
+    outcome: "incomplete",
+    incompleteReason: `${unrun.length} of ${
+      checks.length
+    } selected check(s) could not run, so this run does not establish conformance (${unrun
+      .map((check) => check.id)
+      .join(", ")}): ${reasons.join(" ")}`,
+  };
 }
 
 /** `execution.taskSupport` on a listed tool (legacy 2025-11-25 metadata). */
@@ -205,6 +282,84 @@ export function pickProbeTool(
     tools.find((tool) => toolTaskSupport(tool) === "required") ??
     tools.find((tool) => toolTaskSupport(tool) === "optional")
   );
+}
+
+/** How many listed tool names a resolution message names before eliding. */
+const NAMED_TOOLS_LIMIT = 10;
+
+function describeListedTools(tools: MCPListedTool[]): string {
+  if (tools.length === 0) return "the server lists no tools at all";
+  const named = tools.slice(0, NAMED_TOOLS_LIMIT).map((tool) => tool.name);
+  const rest = tools.length - named.length;
+  return `listed tools: ${named.join(", ")}${
+    rest > 0 ? `, +${rest} more` : ""
+  }`;
+}
+
+/**
+ * The outcome of choosing a tool to provoke a task with.
+ *
+ * The FAILURE half is the point. `pickProbeTool` alone cannot say why it came
+ * back empty, and the caller treated "no tool" as a skip — so on the extension
+ * wire, where `execution.taskSupport` is stripped by the 2026 `ToolSchema` and
+ * auto-selection can therefore NEVER succeed, six task-dependent checks skipped
+ * and the run still reported `passed: true`. A resolution carries both a
+ * user-actionable reason and whether that reason leaves work untested
+ * (`blocking`) or is simply inapplicable (no tasks wire at all).
+ */
+export interface ProbeToolResolution {
+  tool?: MCPListedTool;
+  /** Why no tool resolved, in terms the caller can act on. */
+  reason?: string;
+  /** True when the missing tool leaves applicable checks unexercised. */
+  blocking?: boolean;
+}
+
+/**
+ * Resolves the probe tool, or explains — actionably — why it could not.
+ *
+ * An explicit `requestedName` that the server does not list is a resolution
+ * FAILURE, not a silent miss: a typo would otherwise skip every task-dependent
+ * check while the run still read as conformant.
+ */
+export function resolveProbeTool(
+  wire: TasksWire,
+  tools: MCPListedTool[],
+  requestedName?: string
+): ProbeToolResolution {
+  if (wire === "none") {
+    return {
+      reason:
+        "connection resolves to no tasks wire, so there is no task behavior to probe",
+      blocking: false,
+    };
+  }
+
+  const tool = pickProbeTool(tools, requestedName);
+  if (tool) return { tool };
+
+  if (requestedName) {
+    return {
+      reason: `the requested probe tool ${JSON.stringify(
+        requestedName
+      )} is not listed by this server, so no task could be provoked (${describeListedTools(
+        tools
+      )}); pass --tool-name (SDK: toolName) with a tool the server lists`,
+      blocking: true,
+    };
+  }
+
+  return {
+    reason:
+      wire === "extension"
+        ? `no probe tool could be selected automatically: tools are chosen by \`execution.taskSupport\`, which the 2026-07-28 ToolSchema strips, so a tasks-extension server cannot advertise which tool creates a task. Pass --tool-name (SDK: toolName) naming a task-creating tool (${describeListedTools(
+            tools
+          )})`
+        : `no listed tool advertises \`execution.taskSupport\`, so no task could be provoked (${describeListedTools(
+            tools
+          )}); pass --tool-name (SDK: toolName) naming a task-creating tool`,
+    blocking: true,
+  };
 }
 
 /**
@@ -669,7 +824,14 @@ export class MCPTasksConformanceTest {
           const taskCapableTools = tools.filter(
             (tool) => toolTaskSupport(tool) !== undefined
           );
-          const probeTool = pickProbeTool(tools, this.config.toolName);
+          const probe = resolveProbeTool(wire, tools, this.config.toolName);
+          const probeTool = probe.tool;
+          /** The check verdict for "there is no probe tool", per resolution. */
+          const missingProbeTool = (id: MCPTasksCheckId) =>
+            (probe.blocking ? couldNotRun : notApplicable)(
+              id,
+              probe.reason ?? "no probe tool resolved"
+            );
 
           let createdTaskId: string | undefined;
           let creationResult: unknown;
@@ -699,20 +861,8 @@ export class MCPTasksConformanceTest {
 
           if (selected.has("tasks-result-type-discipline")) {
             const stepStartedAt = Date.now();
-            if (wire === "none") {
-              checks.push(
-                skipped(
-                  "tasks-result-type-discipline",
-                  "connection resolves to no tasks wire"
-                )
-              );
-            } else if (!probeTool) {
-              checks.push(
-                skipped(
-                  "tasks-result-type-discipline",
-                  "no task-capable tool to probe (pass toolName to choose one)"
-                )
-              );
+            if (!probeTool) {
+              checks.push(missingProbeTool("tasks-result-type-discipline"));
             } else if (creationResult instanceof Error) {
               checks.push(
                 failed(
@@ -780,15 +930,15 @@ export class MCPTasksConformanceTest {
 
           if (selected.has("tasks-undeclared-creation-refused")) {
             const stepStartedAt = Date.now();
-            if (wire !== "extension" || !probeTool) {
+            if (wire !== "extension") {
               checks.push(
-                skipped(
+                notApplicable(
                   "tasks-undeclared-creation-refused",
-                  wire === "extension"
-                    ? "no task-capable tool to probe (pass toolName to choose one)"
-                    : "check applies to the extension wire only"
+                  "check applies to the extension wire only"
                 )
               );
+            } else if (!probeTool) {
+              checks.push(missingProbeTool("tasks-undeclared-creation-refused"));
             } else {
               // tasks.md:61 — a server MUST NOT return `CreateTaskResult` to a
               // client that did not include the extension capability ON THAT
@@ -849,19 +999,34 @@ export class MCPTasksConformanceTest {
           const finalTask = polled.task;
           // Distinguishes "there was never a task" from "polling the task
           // failed", so no dependent check skips under a message that hides a
-          // broken read.
-          const noTaskReason = createdTaskId
-            ? polled.error === undefined
-              ? `task ${createdTaskId} was never readable within ${this.config.pollTimeoutMs}ms`
-              : `polling task ${createdTaskId} failed: ${errorMessage(
-                  polled.error
-                )}`
-            : "no task was created to inspect";
+          // broken read. Every branch here leaves the check UNEXERCISED, so the
+          // verdict is `could-not-run` — except when no probe tool resolved at
+          // all, where the resolution already decided whether that is a gap or
+          // an inapplicability (no tasks wire).
+          const noTask = (id: MCPTasksCheckId): MCPTasksCheckResult => {
+            if (!probeTool) return missingProbeTool(id);
+            if (!createdTaskId) {
+              return couldNotRun(
+                id,
+                `the probed tool ${JSON.stringify(
+                  probeTool.name
+                )} returned a normal result, so no task existed to inspect; name a task-creating tool with --tool-name (SDK: toolName) or supply --tool-args (SDK: toolArguments) that provoke one`
+              );
+            }
+            return couldNotRun(
+              id,
+              polled.error === undefined
+                ? `task ${createdTaskId} was never readable within ${this.config.pollTimeoutMs}ms`
+                : `polling task ${createdTaskId} failed: ${errorMessage(
+                    polled.error
+                  )}`
+            );
+          };
 
           if (selected.has("tasks-ttl-shape")) {
             const stepStartedAt = Date.now();
             if (!finalTask) {
-              checks.push(skipped("tasks-ttl-shape", noTaskReason));
+              checks.push(noTask("tasks-ttl-shape"));
             } else {
               const verdict = validateTaskTtlShape(wire, finalTask);
               checks.push(
@@ -885,14 +1050,16 @@ export class MCPTasksConformanceTest {
           if (selected.has("tasks-inline-result")) {
             const stepStartedAt = Date.now();
             if (!finalTask || !createdTaskId) {
-              checks.push(skipped("tasks-inline-result", noTaskReason));
+              checks.push(noTask("tasks-inline-result"));
             } else if (!TERMINAL_STATUSES.has(String(finalTask.status))) {
               checks.push(
-                skipped(
+                couldNotRun(
                   "tasks-inline-result",
                   `task did not reach a terminal status within ${
                     this.config.pollTimeoutMs
-                  }ms (last status: ${String(finalTask.status)})`
+                  }ms (last status: ${String(
+                    finalTask.status
+                  )}); raise --poll-timeout (SDK: pollTimeoutMs) or probe a shorter-lived task`
                 )
               );
             } else if (wire === "extension") {
@@ -955,18 +1122,20 @@ export class MCPTasksConformanceTest {
             const isHttp = "url" in this.config.serverConfig;
             if (!isHttp) {
               checks.push(
-                skipped(
+                notApplicable(
                   "tasks-mcp-name-routing",
                   "Mcp-Name routing applies to HTTP transports only"
                 )
               );
-            } else if (!createdTaskId || wire !== "extension") {
+            } else if (wire !== "extension") {
               checks.push(
-                skipped(
+                notApplicable(
                   "tasks-mcp-name-routing",
-                  "no extension task was created to route"
+                  "Mcp-Name task routing applies to the extension wire only"
                 )
               );
+            } else if (!createdTaskId) {
+              checks.push(noTask("tasks-mcp-name-routing"));
             } else {
               // The requirement is about the OUTBOUND request, so the header
               // is captured off the fetch seam rather than inferred from a
@@ -1020,15 +1189,15 @@ export class MCPTasksConformanceTest {
           // undeclared probe is, correctly, no violation at all).
           if (selected.has("tasks-undeclared-capability-rejected")) {
             const stepStartedAt = Date.now();
-            if (wire !== "extension" || !createdTaskId) {
+            if (wire !== "extension") {
               checks.push(
-                skipped(
+                notApplicable(
                   "tasks-undeclared-capability-rejected",
-                  wire === "extension"
-                    ? "no task was created to probe with"
-                    : "check applies to the extension wire only"
+                  "check applies to the extension wire only"
                 )
               );
+            } else if (!createdTaskId) {
+              checks.push(noTask("tasks-undeclared-capability-rejected"));
             } else {
               const probes = await this.probeUndeclaredTaskMethods(
                 manager,
@@ -1038,9 +1207,9 @@ export class MCPTasksConformanceTest {
               );
               if (probes === undefined) {
                 checks.push(
-                  skipped(
+                  couldNotRun(
                     "tasks-undeclared-capability-rejected",
-                    "the connection exposes no raw request seam, so an undeclared call cannot be sent"
+                    "the connection exposes no raw request seam, so an undeclared call could not be sent and the -32003 requirement was not tested"
                   )
                 );
               } else {
@@ -1102,8 +1271,14 @@ export class MCPTasksConformanceTest {
             );
           }
 
+          const verdict = decideOutcome(checks);
+
           return {
-            passed: checks.every((check) => check.status !== "failed"),
+            passed: verdict.outcome === "passed",
+            outcome: verdict.outcome,
+            ...(verdict.incompleteReason
+              ? { incompleteReason: verdict.incompleteReason }
+              : {}),
             target: this.config.target,
             checks,
             summary: buildSummary(checks),
@@ -1136,6 +1311,7 @@ export class MCPTasksConformanceTest {
       );
       return {
         passed: false,
+        outcome: "failed",
         target: this.config.target,
         checks: [failure],
         summary: buildSummary([failure]),

--- a/sdk/src/tasks-conformance/types.ts
+++ b/sdk/src/tasks-conformance/types.ts
@@ -24,12 +24,40 @@ export type MCPTasksCheckId = (typeof MCP_TASKS_CHECK_IDS)[number];
 
 export type MCPTasksCheckStatus = "passed" | "failed" | "skipped";
 
+/**
+ * Why a selected check produced no verdict. Every `skipped` check carries one,
+ * and the two are NOT interchangeable:
+ *
+ *   - `"not-applicable"` — the check cannot apply to THIS server, so there is
+ *     nothing to establish: an extension-only check on a legacy connection, the
+ *     `Mcp-Name` check on stdio, any task check on a connection with no tasks
+ *     wire. A run may still pass with these.
+ *   - `"could-not-run"` — the check DOES apply and was selected, but the run
+ *     could not exercise it: no probe tool resolved, the probe tool is not
+ *     listed, no task was created, the task never became readable. The run is
+ *     then `incomplete`, never `passed` — "did not run" must never be read as
+ *     "conformed".
+ */
+export type MCPTasksSkipReason = "not-applicable" | "could-not-run";
+
+/**
+ * A run's verdict.
+ *
+ *   - `"passed"` — every selected, applicable check ran and passed.
+ *   - `"failed"` — at least one check produced a violation.
+ *   - `"incomplete"` — nothing failed, but at least one selected check could
+ *     not be run, so the run does not establish conformance.
+ */
+export type MCPTasksRunOutcome = "passed" | "failed" | "incomplete";
+
 export interface MCPTasksCheckResult {
   id: MCPTasksCheckId;
   category: MCPTasksCheckCategory;
   title: string;
   description: string;
   status: MCPTasksCheckStatus;
+  /** Always set when `status` is `"skipped"`. */
+  skipReason?: MCPTasksSkipReason;
   durationMs: number;
   error?: {
     message: string;
@@ -42,9 +70,12 @@ export interface MCPTasksCheckResult {
 export type MCPTasksConformanceConfig = MCPServerConfig & {
   checkIds?: MCPTasksCheckId[];
   /**
-   * Tool used to provoke a task. Optional: without it the runner picks the
-   * first tool whose `execution.taskSupport` is `required`, then the first
-   * with `optional`, and skips the creation checks when neither exists.
+   * Tool used to provoke a task. Without it the runner picks the first tool
+   * whose `execution.taskSupport` is `required`, then the first with
+   * `optional` — 2025-11-25 metadata that the 2026-07-28 `ToolSchema` strips,
+   * so auto-selection cannot work on the extension wire. When no probe tool
+   * resolves, every task-dependent check reports `could-not-run` and the run
+   * is `incomplete`; it never passes on skips.
    */
   toolName?: string;
   toolArguments?: Record<string, unknown>;
@@ -63,14 +94,33 @@ export interface NormalizedMCPTasksConformanceConfig {
 }
 
 export interface MCPTasksConformanceResult {
+  /**
+   * True ONLY when `outcome` is `"passed"`: every selected check either ran and
+   * passed or was inapplicable to this server. A check that could not run keeps
+   * this false, so a skip can never add up to a green run.
+   */
   passed: boolean;
+  outcome: MCPTasksRunOutcome;
+  /**
+   * Present when `outcome` is `"incomplete"`: which checks did not run and what
+   * the caller has to change to make them run.
+   */
+  incompleteReason?: string;
   target: string;
   checks: MCPTasksCheckResult[];
   summary: string;
   durationMs: number;
   categorySummary: Record<
     MCPTasksCheckCategory,
-    { total: number; passed: number; failed: number; skipped: number }
+    {
+      total: number;
+      passed: number;
+      failed: number;
+      /** Every skip, of either reason. */
+      skipped: number;
+      /** The subset of `skipped` that is `"could-not-run"`. */
+      couldNotRun: number;
+    }
   >;
   discovery: {
     protocolVersion?: string;

--- a/sdk/src/tasks-conformance/types.ts
+++ b/sdk/src/tasks-conformance/types.ts
@@ -13,6 +13,7 @@ export const MCP_TASKS_CHECK_IDS = [
   "tasks-wire-resolvable",
   "tasks-declaration-hygiene",
   "tasks-result-type-discipline",
+  "tasks-undeclared-creation-refused",
   "tasks-undeclared-capability-rejected",
   "tasks-ttl-shape",
   "tasks-inline-result",

--- a/sdk/tests/extension-tasks-wire.integration.test.ts
+++ b/sdk/tests/extension-tasks-wire.integration.test.ts
@@ -1,0 +1,822 @@
+/**
+ * `io.modelcontextprotocol/tasks` (SEP-2663) extension wire, driven against the
+ * raw HTTP fixture in `support/extension-tasks-fixture.ts`.
+ *
+ * PIN: modelcontextprotocol/ext-tasks @ 2c1425d9a288b9b1f489430fe1e00bb392b47e48.
+ *
+ * Everything that CAN go through the real client (`MCPClientManager`, no mocked
+ * `ManagedMcpClient`) does — negotiation, `tools/call` task creation, the
+ * per-request declaration, the `CreateTaskResult` unwrap.
+ *
+ * The `tasks/get|update|cancel` legs currently cannot: see the
+ * "client-side blocker" describe below, which pins the exact beta.4 behavior
+ * that stops them. Until that is resolved those MUSTs are proved with
+ * {@link RawTasksWire} — a hand-built JSON-RPC driver that emits the same bytes
+ * `tasks-ext.ts` + `wrapFetchForTaskRouting` would (per-request capability
+ * declaration in `_meta`, `Mcp-Name`/`Mcp-Method` routing headers), so the
+ * server-side contract is genuinely exercised end-to-end over a socket.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { MCPClientManager } from "../src/mcp-client-manager/index.js";
+import {
+  DEFAULT_INPUT_REQUEST_KEY,
+  EXTENSION_PROTOCOL_VERSION,
+  HOSTILE_INPUT_REQUESTS,
+  PARTIAL_INPUT_REQUESTS,
+  SYNC_TOOL_NAME,
+  TASK_TOOL_NAME,
+  TASKS_EXTENSION_ID,
+  cancellablePhases,
+  failedTaskPhases,
+  isErrorCompletedPhases,
+  oddNumbersPhases,
+  serveExtensionTasksFixture,
+  taskTool,
+  type ExtensionTasksFixtureOptions,
+  type ServedExtensionTasksFixture,
+} from "./support/extension-tasks-fixture.js";
+
+const SERVER_ID = "ext";
+
+/** The per-request declaration the spec requires (tasks.md:27-41). */
+const DECLARING_META = {
+  "io.modelcontextprotocol/clientCapabilities": {
+    extensions: { [TASKS_EXTENSION_ID]: {} },
+  },
+};
+
+/** Everything a test opened, torn down unconditionally in `afterEach`. */
+const opened: {
+  managers: MCPClientManager[];
+  fixtures: ServedExtensionTasksFixture[];
+} = { managers: [], fixtures: [] };
+
+afterEach(async () => {
+  for (const manager of opened.managers.splice(0)) {
+    await manager.disconnectAllServers().catch(() => {});
+  }
+  for (const fixture of opened.fixtures.splice(0)) {
+    await fixture.close().catch(() => {});
+  }
+});
+
+async function serve(
+  options: ExtensionTasksFixtureOptions = {}
+): Promise<ServedExtensionTasksFixture> {
+  const fixture = await serveExtensionTasksFixture(options);
+  opened.fixtures.push(fixture);
+  return fixture;
+}
+
+async function connect(
+  url: string,
+  serverId = SERVER_ID
+): Promise<MCPClientManager> {
+  const manager = new MCPClientManager();
+  opened.managers.push(manager);
+  await manager.connectToServer(serverId, {
+    url,
+    mcpProtocolVersion: EXTENSION_PROTOCOL_VERSION,
+    timeout: 10_000,
+  });
+  return manager;
+}
+
+/** Starts a task through the real `tools/call` path and returns its handle. */
+async function createTask(
+  manager: MCPClientManager,
+  toolName = TASK_TOOL_NAME,
+  serverId = SERVER_ID
+): Promise<Record<string, unknown>> {
+  return (await manager.executeTool(
+    serverId,
+    toolName,
+    {},
+    {
+      allowTaskResult: true,
+    }
+  )) as Record<string, unknown>;
+}
+
+interface RawResponse {
+  result?: Record<string, unknown>;
+  error?: { code: number; message: string; data?: unknown };
+}
+
+/**
+ * A minimal JSON-RPC driver for the extension methods, byte-compatible with
+ * what the SDK emits: the capability declaration rides in `params._meta`, and
+ * `tasks/*` carries `Mcp-Name: <taskId>` (tasks.md:511).
+ */
+class RawTasksWire {
+  private nextId = 1;
+  constructor(private readonly url: string) {}
+
+  async send(
+    method: string,
+    params: Record<string, unknown> = {},
+    options: { declare?: boolean; routeBy?: string } = {}
+  ): Promise<RawResponse> {
+    const declare = options.declare !== false;
+    const headers: Record<string, string> = {
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+      "mcp-protocol-version": EXTENSION_PROTOCOL_VERSION,
+      "mcp-method": method,
+    };
+    if (options.routeBy) headers["mcp-name"] = options.routeBy;
+    const response = await fetch(this.url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: this.nextId++,
+        method,
+        params: declare ? { ...params, _meta: DECLARING_META } : params,
+      }),
+    });
+    return (await response.json()) as RawResponse;
+  }
+
+  /** `tasks/get`, asserting it succeeded, and returning the task. */
+  async get(taskId: string): Promise<Record<string, unknown>> {
+    const response = await this.send(
+      "tasks/get",
+      { taskId },
+      { routeBy: taskId }
+    );
+    expect(response.error, `tasks/get(${taskId})`).toBeUndefined();
+    return response.result as Record<string, unknown>;
+  }
+
+  update(taskId: string, inputResponses: Record<string, unknown>) {
+    return this.send(
+      "tasks/update",
+      { taskId, inputResponses },
+      { routeBy: taskId }
+    );
+  }
+
+  cancel(taskId: string) {
+    return this.send("tasks/cancel", { taskId }, { routeBy: taskId });
+  }
+}
+
+function inputRequestsOf(task: Record<string, unknown>) {
+  return (task.inputRequests ?? undefined) as
+    | Record<string, unknown>
+    | undefined;
+}
+
+describe("tasks extension wire — negotiation (real client)", () => {
+  it("resolves the extension wire from the advertised capability", async () => {
+    const fixture = await serve();
+    const manager = await connect(fixture.url);
+
+    expect(manager.getNegotiatedProtocolVersion(SERVER_ID)).toBe(
+      EXTENSION_PROTOCOL_VERSION
+    );
+    expect(manager.getTasksWire(SERVER_ID)).toBe("extension");
+    expect(manager.getTasksSupport(SERVER_ID)).toMatchObject({
+      wire: "extension",
+      toolCalls: true,
+      update: true,
+      cancel: true,
+      inlineResult: true,
+      list: false,
+    });
+  });
+
+  it("treats a non-empty extension capability value as support", async () => {
+    // `schema.json` renders the capability as an empty object, but the prose
+    // only says no settings are "currently" defined — forward compat.
+    const fixture = await serve({
+      tasksExtensionCapability: { someFutureSetting: true },
+    });
+    const manager = await connect(fixture.url);
+    expect(manager.getTasksWire(SERVER_ID)).toBe("extension");
+  });
+
+  it("resolves no wire when the server does not advertise the extension", async () => {
+    const fixture = await serve({ advertiseTasksExtension: false });
+    const manager = await connect(fixture.url);
+
+    expect(manager.getTasksWire(SERVER_ID)).toBe("none");
+    await expect(manager.getTaskExt(SERVER_ID, "ext-task-1")).rejects.toThrow(
+      /does not speak the io\.modelcontextprotocol\/tasks extension/
+    );
+    // Nothing was probed on the wire.
+    expect(fixture.received.some((r) => r.method.startsWith("tasks/"))).toBe(
+      false
+    );
+  });
+});
+
+describe("tasks extension wire — task creation (real client)", () => {
+  it("returns a plain result when the server declines to make a task", async () => {
+    const fixture = await serve();
+    const manager = await connect(fixture.url);
+
+    const result = (await manager.executeTool(
+      SERVER_ID,
+      SYNC_TOOL_NAME,
+      {},
+      {
+        allowTaskResult: true,
+      }
+    )) as Record<string, unknown>;
+
+    expect(result.resultType).not.toBe("task");
+    expect(result).toMatchObject({
+      content: [{ type: "text", text: "sync result" }],
+    });
+    expect(fixture.tasks()).toHaveLength(0);
+  });
+
+  it("creates a task and surfaces the flat CreateTaskResult", async () => {
+    const fixture = await serve();
+    const manager = await connect(fixture.url);
+
+    const created = await createTask(manager);
+
+    expect(created).toMatchObject({
+      resultType: "task",
+      taskId: "ext-task-1",
+      status: "working",
+      ttlMs: 60_000,
+      pollIntervalMs: 10,
+    });
+    expect(typeof created.createdAt).toBe("string");
+    expect(typeof created.lastUpdatedAt).toBe("string");
+    // `CreateTaskResult = Result & Task` — bare Task fields only.
+    expect(created.inputRequests).toBeUndefined();
+    expect(created.result).toBeUndefined();
+    expect(created.error).toBeUndefined();
+  });
+
+  it("declares the extension in the tools/call _meta, and only when eligible", async () => {
+    const fixture = await serve();
+    const manager = await connect(fixture.url);
+
+    await createTask(manager);
+    await manager.executeTool(SERVER_ID, TASK_TOOL_NAME, {});
+
+    const calls = fixture.received.filter((r) => r.method === "tools/call");
+    expect(calls).toHaveLength(2);
+    const declared = (calls[0].params?._meta as Record<string, unknown>)[
+      "io.modelcontextprotocol/clientCapabilities"
+    ] as { extensions?: Record<string, unknown> };
+    expect(declared.extensions).toHaveProperty(TASKS_EXTENSION_ID);
+
+    const undeclared = (calls[1].params?._meta as Record<string, unknown>)[
+      "io.modelcontextprotocol/clientCapabilities"
+    ] as { extensions?: Record<string, unknown> };
+    expect(undeclared.extensions ?? {}).not.toHaveProperty(TASKS_EXTENSION_ID);
+  });
+
+  it("is never handed a CreateTaskResult on an undeclared call", async () => {
+    const fixture = await serve();
+    const manager = await connect(fixture.url);
+
+    const result = (await manager.executeTool(
+      SERVER_ID,
+      TASK_TOOL_NAME,
+      {}
+    )) as Record<string, unknown>;
+
+    expect(result.resultType).not.toBe("task");
+    expect(result.taskId).toBeUndefined();
+    expect(fixture.tasks()).toHaveLength(0);
+  });
+
+  it("rejects a task-shaped result that omits resultType: task", async () => {
+    const fixture = await serve({
+      misbehave: { createResultType: "complete" },
+    });
+    const manager = await connect(fixture.url);
+
+    // tasks.md:102 — without the discriminator there is no task, and the
+    // payload is not a valid `CallToolResult` either, so the call must fail
+    // rather than silently produce a half-interpreted handle.
+    await expect(createTask(manager)).rejects.toThrow(
+      /Invalid result for tools\/call/
+    );
+    // The handle nonetheless exists server-side: it was leaked into a shape
+    // the client is not allowed to read as a task.
+    expect(fixture.tasks()).toHaveLength(1);
+  });
+});
+
+/**
+ * KNOWN CLIENT-SIDE BLOCKER (report, do not fix here — `sdk/src` is owned by
+ * another agent).
+ *
+ * `@modelcontextprotocol/client` beta.4 derives its "spec method universe"
+ * from the union of the era registries and era-gates every member at send
+ * time (`_assertOutboundRequestInEra`). `tasks/get`, `tasks/cancel`,
+ * `tasks/result` and `tasks/list` are members via the **2025-11-25** registry
+ * and are absent from the 2026-07-28 registry, so on an extension-era
+ * connection the client refuses to put them on the wire — the extension's own
+ * `tasks/get` and `tasks/cancel` are collateral damage of the in-core
+ * utility's deletion. `_requestWithSchema` asserts too ("an explicit schema
+ * never smuggles a deleted method onto the wire"), so passing a result schema
+ * is not a way out for those two.
+ *
+ * `tasks/update` is in NEITHER registry, so it is era-blind — but
+ * `client.request()` refuses non-spec methods without an explicit result
+ * schema, and `tasks-ext.ts` calls the schema-less overload.
+ *
+ * Net effect today: `MCPClientManager.getTaskExt` / `updateTask` /
+ * `cancelTaskExt` cannot reach a conforming SEP-2663 server at all. These
+ * tests pin the current behavior so the fix is visible when it lands.
+ */
+describe("tasks extension wire — client-side blocker (beta.4)", () => {
+  it("blocks tasks/get and tasks/cancel as methods deleted from the 2026 era", async () => {
+    const fixture = await serve();
+    const manager = await connect(fixture.url);
+    const taskId = (await createTask(manager)).taskId as string;
+
+    await expect(manager.getTaskExt(SERVER_ID, taskId)).rejects.toMatchObject({
+      code: "METHOD_NOT_SUPPORTED_BY_PROTOCOL_VERSION",
+    });
+    await expect(
+      manager.cancelTaskExt(SERVER_ID, taskId)
+    ).rejects.toMatchObject({
+      code: "METHOD_NOT_SUPPORTED_BY_PROTOCOL_VERSION",
+    });
+  });
+
+  it("blocks tasks/update for want of an explicit result schema", async () => {
+    const fixture = await serve();
+    const manager = await connect(fixture.url);
+    const taskId = (await createTask(manager)).taskId as string;
+
+    await expect(
+      manager.updateTask(SERVER_ID, taskId, {} as never)
+    ).rejects.toThrow(/'tasks\/update' is not a spec method/);
+  });
+
+  it("leaves the server untouched — nothing reached the wire", async () => {
+    const fixture = await serve();
+    const manager = await connect(fixture.url);
+    const taskId = (await createTask(manager)).taskId as string;
+
+    await manager.getTaskExt(SERVER_ID, taskId).catch(() => {});
+    await manager.updateTask(SERVER_ID, taskId, {} as never).catch(() => {});
+    await manager.cancelTaskExt(SERVER_ID, taskId).catch(() => {});
+
+    expect(
+      fixture.received.filter((r) => r.method.startsWith("tasks/"))
+    ).toEqual([]);
+  });
+});
+
+describe("tasks extension wire — full lifecycle", () => {
+  it("drives create → poll → input_required → update → completed → cancel", async () => {
+    const fixture = await serve();
+    const manager = await connect(fixture.url);
+    const wire = new RawTasksWire(fixture.url);
+
+    // Creation goes through the REAL client.
+    const taskId = (await createTask(manager)).taskId as string;
+
+    // Poll 1: still working, no status payload.
+    const first = await wire.get(taskId);
+    expect(first).toMatchObject({ resultType: "complete", status: "working" });
+    expect(first.result).toBeUndefined();
+    expect(first.inputRequests).toBeUndefined();
+    expect(first.error).toBeUndefined();
+
+    // Poll 2: input_required, carrying the keyed snapshot.
+    const second = await wire.get(taskId);
+    expect(second.status).toBe("input_required");
+    expect(Object.keys(inputRequestsOf(second) ?? {})).toEqual([
+      DEFAULT_INPUT_REQUEST_KEY,
+    ]);
+    expect(inputRequestsOf(second)?.[DEFAULT_INPUT_REQUEST_KEY]).toMatchObject({
+      method: "elicitation/create",
+    });
+    // `ttlMs` / `pollIntervalMs` legitimately changed across polls.
+    expect(second.ttlMs).toBe(45_000);
+    expect(second.pollIntervalMs).toBe(20);
+
+    // Poll 3: the SAME snapshot is re-sent while the request is outstanding.
+    const third = await wire.get(taskId);
+    expect(third.status).toBe("input_required");
+    expect(third.inputRequests).toEqual(second.inputRequests);
+
+    // tasks/update — an EMPTY acknowledgement, not a task.
+    const ack = await wire.update(taskId, {
+      [DEFAULT_INPUT_REQUEST_KEY]: {
+        action: "accept",
+        content: { input: "Luca" },
+      },
+    });
+    expect(ack.error).toBeUndefined();
+    expect(ack.result).toEqual({ resultType: "complete" });
+
+    // Eventual consistency: the status moves only on a LATER poll.
+    const fourth = await wire.get(taskId);
+    expect(fourth.status).toBe("working");
+    expect(fourth.inputRequests).toBeUndefined();
+
+    // Completed, with the tool result INLINE (there is no tasks/result).
+    const fifth = await wire.get(taskId);
+    expect(fifth.status).toBe("completed");
+    expect(fifth.result).toEqual({
+      content: [{ type: "text", text: "Hello, Luca!" }],
+      isError: false,
+    });
+
+    // A terminal task sticks.
+    expect((await wire.get(taskId)).status).toBe("completed");
+
+    // tasks/cancel is likewise an empty ack.
+    const cancelAck = await wire.cancel(taskId);
+    expect(cancelAck.error).toBeUndefined();
+    expect(cancelAck.result).toEqual({ resultType: "complete" });
+  });
+
+  it("carries Mcp-Name: <taskId> on every routed tasks/* request", async () => {
+    const fixture = await serve();
+    const manager = await connect(fixture.url);
+    const wire = new RawTasksWire(fixture.url);
+
+    const taskId = (await createTask(manager)).taskId as string;
+    await wire.get(taskId);
+    await wire.update(taskId, {});
+    await wire.cancel(taskId);
+
+    const routed = fixture.received.filter((r) =>
+      ["tasks/get", "tasks/update", "tasks/cancel"].includes(r.method)
+    );
+    expect(routed.map((r) => r.method)).toEqual([
+      "tasks/get",
+      "tasks/update",
+      "tasks/cancel",
+    ]);
+    for (const request of routed) {
+      // tasks.md:511 — the Streamable HTTP routing binding.
+      expect(request.headers["mcp-name"]).toBe(taskId);
+      expect(request.headers["mcp-method"]).toBe(request.method);
+    }
+  });
+
+  it("reads a task created on a previous connection (durability)", async () => {
+    const fixture = await serve();
+    const first = await connect(fixture.url, "first");
+    const taskId = (await createTask(first, TASK_TOOL_NAME, "first"))
+      .taskId as string;
+
+    // Drop the connection entirely, then read the handle from a fresh one.
+    await first.disconnectAllServers();
+    const second = await connect(fixture.url, "second");
+    expect(second.getTasksWire("second")).toBe("extension");
+
+    const task = await new RawTasksWire(fixture.url).get(taskId);
+    expect(task).toMatchObject({ taskId, status: "working" });
+  });
+});
+
+describe("tasks extension wire — status variants", () => {
+  it("reports a JSON-RPC execution fault as failed + error", async () => {
+    const fixture = await serve({
+      tools: { [TASK_TOOL_NAME]: taskTool(failedTaskPhases()) },
+    });
+    const manager = await connect(fixture.url);
+    const taskId = (await createTask(manager)).taskId as string;
+
+    const task = await new RawTasksWire(fixture.url).get(taskId);
+    expect(task.status).toBe("failed");
+    expect(task.error).toEqual({
+      code: -32603,
+      message: "API rate limit exceeded",
+    });
+    expect(task.result).toBeUndefined();
+    expect(task.statusMessage).toContain("rate limit");
+  });
+
+  it("reports a tool result with isError: true as COMPLETED, not failed", async () => {
+    const fixture = await serve({
+      tools: { [TASK_TOOL_NAME]: taskTool(isErrorCompletedPhases()) },
+    });
+    const manager = await connect(fixture.url);
+    const taskId = (await createTask(manager)).taskId as string;
+
+    const task = await new RawTasksWire(fixture.url).get(taskId);
+    // tasks.md:837 — `failed` is strictly for JSON-RPC-level faults.
+    expect(task.status).toBe("completed");
+    expect(task.error).toBeUndefined();
+    expect(task.result).toMatchObject({ isError: true });
+  });
+
+  it("reaches cancelled only after the cancel is acknowledged", async () => {
+    const fixture = await serve({
+      tools: { [TASK_TOOL_NAME]: taskTool(cancellablePhases()) },
+    });
+    const manager = await connect(fixture.url);
+    const wire = new RawTasksWire(fixture.url);
+    const taskId = (await createTask(manager)).taskId as string;
+
+    expect((await wire.get(taskId)).status).toBe("working");
+    const ack = await wire.cancel(taskId);
+    expect(ack.result).toEqual({ resultType: "complete" });
+
+    const task = await wire.get(taskId);
+    expect(task.status).toBe("cancelled");
+    expect(task.result).toBeUndefined();
+    expect(task.error).toBeUndefined();
+  });
+
+  it("accepts legal-but-unusual ttlMs / pollIntervalMs that change per poll", async () => {
+    const fixture = await serve({
+      tools: { [TASK_TOOL_NAME]: taskTool(oddNumbersPhases()) },
+    });
+    const manager = await connect(fixture.url);
+    const wire = new RawTasksWire(fixture.url);
+    const taskId = (await createTask(manager)).taskId as string;
+
+    const ttls: unknown[] = [];
+    const intervals: unknown[] = [];
+    for (let i = 0; i < 4; i += 1) {
+      const task = await wire.get(taskId);
+      ttls.push(task.ttlMs);
+      intervals.push(task.pollIntervalMs);
+    }
+
+    // Neither integrality nor a minimum is constrained by the schema, and
+    // `null` means unlimited (distinct from absent).
+    expect(ttls).toEqual([1234.567, Number.MAX_SAFE_INTEGER, null, -1]);
+    expect(intervals).toEqual([0.5, 1, 2, 2]);
+  });
+});
+
+describe("tasks extension wire — input requests", () => {
+  it("keeps unanswered keys outstanding across a partial update", async () => {
+    const fixture = await serve({
+      tools: {
+        [TASK_TOOL_NAME]: taskTool([
+          {
+            status: "input_required",
+            inputRequests: PARTIAL_INPUT_REQUESTS,
+            awaitInputKeys: [DEFAULT_INPUT_REQUEST_KEY, "city"],
+          },
+          {
+            status: "completed",
+            result: { content: [{ type: "text", text: "both answered" }] },
+          },
+        ]),
+      },
+    });
+    const manager = await connect(fixture.url);
+    const wire = new RawTasksWire(fixture.url);
+    const taskId = (await createTask(manager)).taskId as string;
+
+    const first = await wire.get(taskId);
+    expect(Object.keys(inputRequestsOf(first) ?? {}).sort()).toEqual([
+      "city",
+      DEFAULT_INPUT_REQUEST_KEY,
+    ]);
+
+    // Answer one key, plus a key that was never issued: tasks.md:379 says the
+    // server ignores unknown keys, and the task stays `input_required`.
+    await wire.update(taskId, {
+      [DEFAULT_INPUT_REQUEST_KEY]: { action: "accept", content: {} },
+      never_issued: { action: "accept", content: {} },
+    });
+
+    const second = await wire.get(taskId);
+    expect(second.status).toBe("input_required");
+    expect(Object.keys(inputRequestsOf(second) ?? {})).toEqual(["city"]);
+    expect(fixture.task(taskId)?.answeredKeys).toEqual([
+      DEFAULT_INPUT_REQUEST_KEY,
+    ]);
+
+    await wire.update(taskId, { city: { action: "accept", content: {} } });
+    expect((await wire.get(taskId)).status).toBe("completed");
+  });
+
+  it("surfaces unknown-method and prototype-polluting keys without polluting", async () => {
+    const fixture = await serve({
+      tools: {
+        [TASK_TOOL_NAME]: taskTool([
+          {
+            status: "input_required",
+            inputRequests: HOSTILE_INPUT_REQUESTS,
+            polls: 99,
+          },
+        ]),
+      },
+    });
+    const manager = await connect(fixture.url);
+    const taskId = (await createTask(manager)).taskId as string;
+
+    const task = await new RawTasksWire(fixture.url).get(taskId);
+    const requests = inputRequestsOf(task) ?? {};
+    expect(Object.keys(requests).sort()).toEqual([
+      "__proto__",
+      "constructor",
+      "unknown_method",
+    ]);
+    // The unknown method is visible verbatim rather than dropped.
+    expect(requests.unknown_method).toMatchObject({
+      method: "tasks/definitely-not-a-real-method",
+    });
+    // Nothing leaked onto a prototype.
+    expect(({} as Record<string, unknown>).method).toBeUndefined();
+    expect(Object.getPrototypeOf(requests)).not.toHaveProperty("method");
+  });
+});
+
+describe("tasks extension wire — protocol errors", () => {
+  it("raises -32602 for an unknown task id on tasks/get", async () => {
+    const fixture = await serve();
+    const response = await new RawTasksWire(fixture.url).send(
+      "tasks/get",
+      { taskId: "no-such-task" },
+      { routeBy: "no-such-task" }
+    );
+    expect(response.error?.code).toBe(-32602);
+    expect(response.error?.message).toMatch(/Task not found/);
+  });
+
+  it("allows a non--32602 code on tasks/update and tasks/cancel (SHOULD only)", async () => {
+    // tasks.md:795 — `-32602` is a MUST for `tasks/get` but only a SHOULD for
+    // the mutations, so a different code there is still compliant.
+    const fixture = await serve({ unknownTaskCodeForMutations: -32603 });
+    const wire = new RawTasksWire(fixture.url);
+
+    expect((await wire.update("no-such-task", {})).error?.code).toBe(-32603);
+    expect((await wire.cancel("no-such-task")).error?.code).toBe(-32603);
+  });
+
+  it("rejects undeclared tasks/get, tasks/update and tasks/cancel with -32003", async () => {
+    const fixture = await serve();
+    const wire = new RawTasksWire(fixture.url);
+
+    for (const method of ["tasks/get", "tasks/update", "tasks/cancel"]) {
+      const response = await wire.send(
+        method,
+        { taskId: "ext-task-1", inputResponses: {} },
+        { declare: false, routeBy: "ext-task-1" }
+      );
+      expect(response.error?.code, method).toBe(-32003);
+      expect(response.error?.data).toEqual({
+        requiredCapabilities: { extensions: { [TASKS_EXTENSION_ID]: {} } },
+      });
+    }
+  });
+
+  it("rejects an undeclared task-filtered subscriptions/listen with -32003", async () => {
+    const fixture = await serve();
+    const wire = new RawTasksWire(fixture.url);
+
+    const rejected = await wire.send(
+      "subscriptions/listen",
+      { notifications: { taskIds: ["ext-task-1"] } },
+      { declare: false }
+    );
+    expect(rejected.error?.code).toBe(-32003);
+
+    // A declaring listen is accepted…
+    const declared = await wire.send("subscriptions/listen", {
+      notifications: { taskIds: ["ext-task-1"] },
+    });
+    expect(declared.error).toBeUndefined();
+
+    // …and a listen with no taskIds is not gated on the extension at all.
+    const unrelated = await wire.send(
+      "subscriptions/listen",
+      { notifications: { resources: true } },
+      { declare: false }
+    );
+    expect(unrelated.error).toBeUndefined();
+  });
+});
+
+describe("tasks extension wire — misbehaving server", () => {
+  it("can answer an undeclared tasks/get (negative case for the -32003 rule)", async () => {
+    const fixture = await serve({
+      misbehave: { answerUndeclaredTaskRequests: true },
+    });
+    const manager = await connect(fixture.url);
+    const taskId = (await createTask(manager)).taskId as string;
+
+    const response = await new RawTasksWire(fixture.url).send(
+      "tasks/get",
+      { taskId },
+      { declare: false, routeBy: taskId }
+    );
+    expect(response.error).toBeUndefined();
+    expect(response.result).toMatchObject({ taskId, status: "working" });
+  });
+
+  it("can hand a CreateTaskResult to an undeclared tools/call", async () => {
+    const fixture = await serve({
+      misbehave: { createTaskForUndeclaredCall: true },
+    });
+    const response = await new RawTasksWire(fixture.url).send(
+      "tools/call",
+      { name: TASK_TOOL_NAME, arguments: {} },
+      { declare: false }
+    );
+    expect(response.result).toMatchObject({ resultType: "task" });
+    expect(fixture.tasks()).toHaveLength(1);
+  });
+
+  it("can emit an invalid status, and the real client refuses it at creation", async () => {
+    const fixture = await serve({ misbehave: { status: "in_progress" } });
+    const manager = await connect(fixture.url);
+
+    await expect(createTask(manager)).rejects.toThrow(
+      /not a valid io\.modelcontextprotocol\/tasks payload.*status/s
+    );
+  });
+
+  it("can omit a required task field, and the real client refuses it", async () => {
+    // `ttlMs` is required and nullable — absent is NOT the same as null.
+    const fixture = await serve({ misbehave: { omitTaskFields: ["ttlMs"] } });
+    const manager = await connect(fixture.url);
+
+    await expect(createTask(manager)).rejects.toThrow(
+      /not a valid io\.modelcontextprotocol\/tasks payload.*ttlMs/s
+    );
+  });
+
+  it("can turn a healthy task malformed mid-flight", async () => {
+    const fixture = await serve();
+    const manager = await connect(fixture.url);
+    const taskId = (await createTask(manager)).taskId as string;
+    const wire = new RawTasksWire(fixture.url);
+
+    expect((await wire.get(taskId)).status).toBe("working");
+    fixture.misbehave({ status: "in_progress", omitTaskFields: ["ttlMs"] });
+
+    const task = await wire.get(taskId);
+    expect(task.status).toBe("in_progress");
+    expect(task).not.toHaveProperty("ttlMs");
+  });
+
+  it("can send resultType: task on a tasks/get result", async () => {
+    const fixture = await serve({ misbehave: { getResultType: "task" } });
+    const manager = await connect(fixture.url);
+    const taskId = (await createTask(manager)).taskId as string;
+
+    const task = await new RawTasksWire(fixture.url).get(taskId);
+    // tasks.md:102 — `"task"` MUST NOT appear on anything but CreateTaskResult.
+    expect(task.resultType).toBe("task");
+  });
+
+  it("can drop the status payload a status requires", async () => {
+    const fixture = await serve({
+      tools: { [TASK_TOOL_NAME]: taskTool(isErrorCompletedPhases()) },
+      misbehave: { omitStatusPayload: true },
+    });
+    const manager = await connect(fixture.url);
+    const taskId = (await createTask(manager)).taskId as string;
+
+    const task = await new RawTasksWire(fixture.url).get(taskId);
+    expect(task.status).toBe("completed");
+    // A `completed` task MUST carry `result` (tasks.md:330).
+    expect(task.result).toBeUndefined();
+  });
+
+  it("can fabricate a task for an id that was never issued", async () => {
+    const fixture = await serve({ misbehave: { answerUnknownTaskId: true } });
+    const task = await new RawTasksWire(fixture.url).get("never-issued");
+    expect(task.taskId).toBe("never-issued");
+  });
+});
+
+describe("tasks extension wire — resultType on tasks/* results", () => {
+  it("carries resultType: complete by default (the prose MUST)", async () => {
+    const fixture = await serve();
+    const manager = await connect(fixture.url);
+    const taskId = (await createTask(manager)).taskId as string;
+    const wire = new RawTasksWire(fixture.url);
+
+    expect((await wire.get(taskId)).resultType).toBe("complete");
+    expect((await wire.update(taskId, {})).result).toEqual({
+      resultType: "complete",
+    });
+    expect((await wire.cancel(taskId)).result).toEqual({
+      resultType: "complete",
+    });
+  });
+
+  it("can omit it entirely (the schema-literal reading)", async () => {
+    // `resultType` appears nowhere in the pinned schema, and each
+    // `DetailedTask` variant is rendered `additionalProperties: false`.
+    const fixture = await serve({ emitTaskResultType: false });
+    const manager = await connect(fixture.url);
+    const taskId = (await createTask(manager)).taskId as string;
+    const wire = new RawTasksWire(fixture.url);
+
+    const task = await wire.get(taskId);
+    expect(task).not.toHaveProperty("resultType");
+    expect(task.status).toBe("working");
+    expect((await wire.update(taskId, {})).result).toEqual({});
+    expect((await wire.cancel(taskId)).result).toEqual({});
+  });
+});

--- a/sdk/tests/extension-tasks-wire.integration.test.ts
+++ b/sdk/tests/extension-tasks-wire.integration.test.ts
@@ -6,15 +6,21 @@
  *
  * Everything that CAN go through the real client (`MCPClientManager`, no mocked
  * `ManagedMcpClient`) does — negotiation, `tools/call` task creation, the
- * per-request declaration, the `CreateTaskResult` unwrap.
+ * per-request declaration, the `CreateTaskResult` unwrap, and — since the
+ * explicit-result-schema carrier (`tasks-ext.ts`) plus the era-gate shadow
+ * (`tasks-ext-era-gate.ts`) landed — the whole `tasks/get|update|cancel`
+ * lifecycle.
  *
- * The `tasks/get|update|cancel` legs currently cannot: see the
- * "client-side blocker" describe below, which pins the exact beta.4 behavior
- * that stops them. Until that is resolved those MUSTs are proved with
- * {@link RawTasksWire} — a hand-built JSON-RPC driver that emits the same bytes
- * `tasks-ext.ts` + `wrapFetchForTaskRouting` would (per-request capability
- * declaration in `_meta`, `Mcp-Name`/`Mcp-Method` routing headers), so the
- * server-side contract is genuinely exercised end-to-end over a socket.
+ * {@link RawTasksWire} survives for the cases the real client CANNOT produce
+ * by construction, each marked at its use site:
+ *   - undeclared requests (`-32003`): our client always attaches the
+ *     per-request eligibility declaration, so an undeclared extension request
+ *     is unreachable through it;
+ *   - payloads beta.4's decoder rewrites or refuses before `tasks-ext.ts` sees
+ *     them (`resultType: "task"` on a `tasks/get`, or an absent `resultType`),
+ *     where the point of the test is the bytes on the wire.
+ * It emits the same bytes the SDK does (declaration in `params._meta`,
+ * `Mcp-Name`/`Mcp-Method` routing headers).
  */
 
 import { afterEach, describe, expect, it } from "vitest";
@@ -169,6 +175,22 @@ function inputRequestsOf(task: Record<string, unknown>) {
     | undefined;
 }
 
+/**
+ * `tasks/get` through the REAL client, widened to a bag so a test can assert
+ * on fields the status-discriminated union hides (a `working` task has no
+ * `result` in the type, and a debugger test wants to prove that on the value).
+ */
+async function getTask(
+  manager: MCPClientManager,
+  taskId: string,
+  serverId = SERVER_ID
+): Promise<Record<string, unknown>> {
+  return (await manager.getTaskExt(serverId, taskId)) as unknown as Record<
+    string,
+    unknown
+  >;
+}
+
 describe("tasks extension wire — negotiation (real client)", () => {
   it("resolves the extension wire from the advertised capability", async () => {
     const fixture = await serve();
@@ -308,88 +330,26 @@ describe("tasks extension wire — task creation (real client)", () => {
   });
 });
 
-/**
- * KNOWN CLIENT-SIDE BLOCKER (report, do not fix here — `sdk/src` is owned by
- * another agent).
- *
- * `@modelcontextprotocol/client` beta.4 derives its "spec method universe"
- * from the union of the era registries and era-gates every member at send
- * time (`_assertOutboundRequestInEra`). `tasks/get`, `tasks/cancel`,
- * `tasks/result` and `tasks/list` are members via the **2025-11-25** registry
- * and are absent from the 2026-07-28 registry, so on an extension-era
- * connection the client refuses to put them on the wire — the extension's own
- * `tasks/get` and `tasks/cancel` are collateral damage of the in-core
- * utility's deletion. `_requestWithSchema` asserts too ("an explicit schema
- * never smuggles a deleted method onto the wire"), so passing a result schema
- * is not a way out for those two.
- *
- * `tasks/update` is in NEITHER registry, so it is era-blind — but
- * `client.request()` refuses non-spec methods without an explicit result
- * schema, and `tasks-ext.ts` calls the schema-less overload.
- *
- * Net effect today: `MCPClientManager.getTaskExt` / `updateTask` /
- * `cancelTaskExt` cannot reach a conforming SEP-2663 server at all. These
- * tests pin the current behavior so the fix is visible when it lands.
- */
-describe("tasks extension wire — client-side blocker (beta.4)", () => {
-  it("blocks tasks/get and tasks/cancel as methods deleted from the 2026 era", async () => {
-    const fixture = await serve();
-    const manager = await connect(fixture.url);
-    const taskId = (await createTask(manager)).taskId as string;
-
-    await expect(manager.getTaskExt(SERVER_ID, taskId)).rejects.toMatchObject({
-      code: "METHOD_NOT_SUPPORTED_BY_PROTOCOL_VERSION",
-    });
-    await expect(
-      manager.cancelTaskExt(SERVER_ID, taskId)
-    ).rejects.toMatchObject({
-      code: "METHOD_NOT_SUPPORTED_BY_PROTOCOL_VERSION",
-    });
-  });
-
-  it("blocks tasks/update for want of an explicit result schema", async () => {
-    const fixture = await serve();
-    const manager = await connect(fixture.url);
-    const taskId = (await createTask(manager)).taskId as string;
-
-    await expect(
-      manager.updateTask(SERVER_ID, taskId, {} as never)
-    ).rejects.toThrow(/'tasks\/update' is not a spec method/);
-  });
-
-  it("leaves the server untouched — nothing reached the wire", async () => {
-    const fixture = await serve();
-    const manager = await connect(fixture.url);
-    const taskId = (await createTask(manager)).taskId as string;
-
-    await manager.getTaskExt(SERVER_ID, taskId).catch(() => {});
-    await manager.updateTask(SERVER_ID, taskId, {} as never).catch(() => {});
-    await manager.cancelTaskExt(SERVER_ID, taskId).catch(() => {});
-
-    expect(
-      fixture.received.filter((r) => r.method.startsWith("tasks/"))
-    ).toEqual([]);
-  });
-});
-
-describe("tasks extension wire — full lifecycle", () => {
+describe("tasks extension wire — full lifecycle (real client)", () => {
   it("drives create → poll → input_required → update → completed → cancel", async () => {
     const fixture = await serve();
     const manager = await connect(fixture.url);
-    const wire = new RawTasksWire(fixture.url);
 
-    // Creation goes through the REAL client.
     const taskId = (await createTask(manager)).taskId as string;
 
     // Poll 1: still working, no status payload.
-    const first = await wire.get(taskId);
-    expect(first).toMatchObject({ resultType: "complete", status: "working" });
+    const first = await getTask(manager, taskId);
+    expect(first).toMatchObject({ taskId, status: "working" });
     expect(first.result).toBeUndefined();
     expect(first.inputRequests).toBeUndefined();
     expect(first.error).toBeUndefined();
+    // beta.4's 2026 decoder consumes `resultType` off every complete result,
+    // so a task read through the real client never carries it (the raw wire
+    // value is asserted in the `resultType on tasks/* results` describe).
+    expect(first).not.toHaveProperty("resultType");
 
     // Poll 2: input_required, carrying the keyed snapshot.
-    const second = await wire.get(taskId);
+    const second = await getTask(manager, taskId);
     expect(second.status).toBe("input_required");
     expect(Object.keys(inputRequestsOf(second) ?? {})).toEqual([
       DEFAULT_INPUT_REQUEST_KEY,
@@ -402,27 +362,26 @@ describe("tasks extension wire — full lifecycle", () => {
     expect(second.pollIntervalMs).toBe(20);
 
     // Poll 3: the SAME snapshot is re-sent while the request is outstanding.
-    const third = await wire.get(taskId);
+    const third = await getTask(manager, taskId);
     expect(third.status).toBe("input_required");
-    expect(third.inputRequests).toEqual(second.inputRequests);
+    expect(inputRequestsOf(third)).toEqual(inputRequestsOf(second));
 
     // tasks/update — an EMPTY acknowledgement, not a task.
-    const ack = await wire.update(taskId, {
+    const ack = await manager.updateTask(SERVER_ID, taskId, {
       [DEFAULT_INPUT_REQUEST_KEY]: {
         action: "accept",
         content: { input: "Luca" },
       },
-    });
-    expect(ack.error).toBeUndefined();
-    expect(ack.result).toEqual({ resultType: "complete" });
+    } as never);
+    expect(ack).toEqual({});
 
     // Eventual consistency: the status moves only on a LATER poll.
-    const fourth = await wire.get(taskId);
+    const fourth = await getTask(manager, taskId);
     expect(fourth.status).toBe("working");
     expect(fourth.inputRequests).toBeUndefined();
 
     // Completed, with the tool result INLINE (there is no tasks/result).
-    const fifth = await wire.get(taskId);
+    const fifth = await getTask(manager, taskId);
     expect(fifth.status).toBe("completed");
     expect(fifth.result).toEqual({
       content: [{ type: "text", text: "Hello, Luca!" }],
@@ -430,23 +389,45 @@ describe("tasks extension wire — full lifecycle", () => {
     });
 
     // A terminal task sticks.
-    expect((await wire.get(taskId)).status).toBe("completed");
+    expect((await getTask(manager, taskId)).status).toBe("completed");
 
     // tasks/cancel is likewise an empty ack.
-    const cancelAck = await wire.cancel(taskId);
-    expect(cancelAck.error).toBeUndefined();
-    expect(cancelAck.result).toEqual({ resultType: "complete" });
+    expect(await manager.cancelTaskExt(SERVER_ID, taskId)).toEqual({});
+  });
+
+  it("declares the extension on every tasks/* request it sends", async () => {
+    const fixture = await serve();
+    const manager = await connect(fixture.url);
+    const taskId = (await createTask(manager)).taskId as string;
+
+    await manager.getTaskExt(SERVER_ID, taskId);
+    await manager.updateTask(SERVER_ID, taskId, {} as never);
+    await manager.cancelTaskExt(SERVER_ID, taskId);
+
+    const routed = fixture.received.filter((r) =>
+      r.method.startsWith("tasks/")
+    );
+    expect(routed).toHaveLength(3);
+    for (const request of routed) {
+      // tasks.md:27-41 — the eligibility declaration is required on EVERY
+      // extension operation, not just the `tools/call` that creates the task.
+      const declared = (request.params?._meta as Record<string, unknown>)[
+        "io.modelcontextprotocol/clientCapabilities"
+      ] as { extensions?: Record<string, unknown> };
+      expect(declared.extensions, request.method).toHaveProperty(
+        TASKS_EXTENSION_ID
+      );
+    }
   });
 
   it("carries Mcp-Name: <taskId> on every routed tasks/* request", async () => {
     const fixture = await serve();
     const manager = await connect(fixture.url);
-    const wire = new RawTasksWire(fixture.url);
 
     const taskId = (await createTask(manager)).taskId as string;
-    await wire.get(taskId);
-    await wire.update(taskId, {});
-    await wire.cancel(taskId);
+    await manager.getTaskExt(SERVER_ID, taskId);
+    await manager.updateTask(SERVER_ID, taskId, {} as never);
+    await manager.cancelTaskExt(SERVER_ID, taskId);
 
     const routed = fixture.received.filter((r) =>
       ["tasks/get", "tasks/update", "tasks/cancel"].includes(r.method)
@@ -457,9 +438,12 @@ describe("tasks extension wire — full lifecycle", () => {
       "tasks/cancel",
     ]);
     for (const request of routed) {
-      // tasks.md:511 — the Streamable HTTP routing binding.
-      expect(request.headers["mcp-name"]).toBe(taskId);
-      expect(request.headers["mcp-method"]).toBe(request.method);
+      // tasks.md:511 — the Streamable HTTP routing binding, a MUST for all
+      // three methods.
+      expect(request.headers["mcp-name"], request.method).toBe(taskId);
+      expect(request.headers["mcp-method"], request.method).toBe(
+        request.method
+      );
     }
   });
 
@@ -474,12 +458,12 @@ describe("tasks extension wire — full lifecycle", () => {
     const second = await connect(fixture.url, "second");
     expect(second.getTasksWire("second")).toBe("extension");
 
-    const task = await new RawTasksWire(fixture.url).get(taskId);
+    const task = await getTask(second, taskId, "second");
     expect(task).toMatchObject({ taskId, status: "working" });
   });
 });
 
-describe("tasks extension wire — status variants", () => {
+describe("tasks extension wire — status variants (real client)", () => {
   it("reports a JSON-RPC execution fault as failed + error", async () => {
     const fixture = await serve({
       tools: { [TASK_TOOL_NAME]: taskTool(failedTaskPhases()) },
@@ -487,7 +471,7 @@ describe("tasks extension wire — status variants", () => {
     const manager = await connect(fixture.url);
     const taskId = (await createTask(manager)).taskId as string;
 
-    const task = await new RawTasksWire(fixture.url).get(taskId);
+    const task = await getTask(manager, taskId);
     expect(task.status).toBe("failed");
     expect(task.error).toEqual({
       code: -32603,
@@ -504,7 +488,7 @@ describe("tasks extension wire — status variants", () => {
     const manager = await connect(fixture.url);
     const taskId = (await createTask(manager)).taskId as string;
 
-    const task = await new RawTasksWire(fixture.url).get(taskId);
+    const task = await getTask(manager, taskId);
     // tasks.md:837 — `failed` is strictly for JSON-RPC-level faults.
     expect(task.status).toBe("completed");
     expect(task.error).toBeUndefined();
@@ -516,14 +500,12 @@ describe("tasks extension wire — status variants", () => {
       tools: { [TASK_TOOL_NAME]: taskTool(cancellablePhases()) },
     });
     const manager = await connect(fixture.url);
-    const wire = new RawTasksWire(fixture.url);
     const taskId = (await createTask(manager)).taskId as string;
 
-    expect((await wire.get(taskId)).status).toBe("working");
-    const ack = await wire.cancel(taskId);
-    expect(ack.result).toEqual({ resultType: "complete" });
+    expect((await getTask(manager, taskId)).status).toBe("working");
+    expect(await manager.cancelTaskExt(SERVER_ID, taskId)).toEqual({});
 
-    const task = await wire.get(taskId);
+    const task = await getTask(manager, taskId);
     expect(task.status).toBe("cancelled");
     expect(task.result).toBeUndefined();
     expect(task.error).toBeUndefined();
@@ -534,13 +516,12 @@ describe("tasks extension wire — status variants", () => {
       tools: { [TASK_TOOL_NAME]: taskTool(oddNumbersPhases()) },
     });
     const manager = await connect(fixture.url);
-    const wire = new RawTasksWire(fixture.url);
     const taskId = (await createTask(manager)).taskId as string;
 
     const ttls: unknown[] = [];
     const intervals: unknown[] = [];
     for (let i = 0; i < 4; i += 1) {
-      const task = await wire.get(taskId);
+      const task = await getTask(manager, taskId);
       ttls.push(task.ttlMs);
       intervals.push(task.pollIntervalMs);
     }
@@ -552,7 +533,7 @@ describe("tasks extension wire — status variants", () => {
   });
 });
 
-describe("tasks extension wire — input requests", () => {
+describe("tasks extension wire — input requests (real client)", () => {
   it("keeps unanswered keys outstanding across a partial update", async () => {
     const fixture = await serve({
       tools: {
@@ -570,10 +551,9 @@ describe("tasks extension wire — input requests", () => {
       },
     });
     const manager = await connect(fixture.url);
-    const wire = new RawTasksWire(fixture.url);
     const taskId = (await createTask(manager)).taskId as string;
 
-    const first = await wire.get(taskId);
+    const first = await getTask(manager, taskId);
     expect(Object.keys(inputRequestsOf(first) ?? {}).sort()).toEqual([
       "city",
       DEFAULT_INPUT_REQUEST_KEY,
@@ -581,20 +561,22 @@ describe("tasks extension wire — input requests", () => {
 
     // Answer one key, plus a key that was never issued: tasks.md:379 says the
     // server ignores unknown keys, and the task stays `input_required`.
-    await wire.update(taskId, {
+    await manager.updateTask(SERVER_ID, taskId, {
       [DEFAULT_INPUT_REQUEST_KEY]: { action: "accept", content: {} },
       never_issued: { action: "accept", content: {} },
-    });
+    } as never);
 
-    const second = await wire.get(taskId);
+    const second = await getTask(manager, taskId);
     expect(second.status).toBe("input_required");
     expect(Object.keys(inputRequestsOf(second) ?? {})).toEqual(["city"]);
     expect(fixture.task(taskId)?.answeredKeys).toEqual([
       DEFAULT_INPUT_REQUEST_KEY,
     ]);
 
-    await wire.update(taskId, { city: { action: "accept", content: {} } });
-    expect((await wire.get(taskId)).status).toBe("completed");
+    await manager.updateTask(SERVER_ID, taskId, {
+      city: { action: "accept", content: {} },
+    } as never);
+    expect((await getTask(manager, taskId)).status).toBe("completed");
   });
 
   it("surfaces unknown-method and prototype-polluting keys without polluting", async () => {
@@ -612,7 +594,7 @@ describe("tasks extension wire — input requests", () => {
     const manager = await connect(fixture.url);
     const taskId = (await createTask(manager)).taskId as string;
 
-    const task = await new RawTasksWire(fixture.url).get(taskId);
+    const task = await getTask(manager, taskId);
     const requests = inputRequestsOf(task) ?? {};
     expect(Object.keys(requests).sort()).toEqual([
       "__proto__",
@@ -623,35 +605,46 @@ describe("tasks extension wire — input requests", () => {
     expect(requests.unknown_method).toMatchObject({
       method: "tasks/definitely-not-a-real-method",
     });
-    // Nothing leaked onto a prototype.
+    // Nothing leaked onto a prototype: the guard rebuilds the map on a NULL
+    // prototype (`tasks-ext-schemas.ts toSafeInputRequests`).
     expect(({} as Record<string, unknown>).method).toBeUndefined();
-    expect(Object.getPrototypeOf(requests)).not.toHaveProperty("method");
+    expect(Object.getPrototypeOf(requests)).toBeNull();
   });
 });
 
 describe("tasks extension wire — protocol errors", () => {
-  it("raises -32602 for an unknown task id on tasks/get", async () => {
+  it("surfaces -32602 for an unknown task id on tasks/get (real client)", async () => {
     const fixture = await serve();
-    const response = await new RawTasksWire(fixture.url).send(
-      "tasks/get",
-      { taskId: "no-such-task" },
-      { routeBy: "no-such-task" }
+    const manager = await connect(fixture.url);
+
+    // tasks.md:795 — a MUST for `tasks/get`. The server error must reach the
+    // caller as a typed rejection, not as a task.
+    await expect(
+      manager.getTaskExt(SERVER_ID, "no-such-task")
+    ).rejects.toMatchObject({ code: -32602 });
+    await expect(manager.getTaskExt(SERVER_ID, "no-such-task")).rejects.toThrow(
+      /Task not found/
     );
-    expect(response.error?.code).toBe(-32602);
-    expect(response.error?.message).toMatch(/Task not found/);
   });
 
-  it("allows a non--32602 code on tasks/update and tasks/cancel (SHOULD only)", async () => {
-    // tasks.md:795 — `-32602` is a MUST for `tasks/get` but only a SHOULD for
-    // the mutations, so a different code there is still compliant.
+  it("surfaces a non--32602 code on tasks/update and tasks/cancel (SHOULD only, real client)", async () => {
+    // tasks.md:795 — `-32602` is only a SHOULD for the mutations, so a
+    // different code there is still compliant and must pass through verbatim.
     const fixture = await serve({ unknownTaskCodeForMutations: -32603 });
-    const wire = new RawTasksWire(fixture.url);
+    const manager = await connect(fixture.url);
 
-    expect((await wire.update("no-such-task", {})).error?.code).toBe(-32603);
-    expect((await wire.cancel("no-such-task")).error?.code).toBe(-32603);
+    await expect(
+      manager.updateTask(SERVER_ID, "no-such-task", {} as never)
+    ).rejects.toMatchObject({ code: -32603 });
+    await expect(
+      manager.cancelTaskExt(SERVER_ID, "no-such-task")
+    ).rejects.toMatchObject({ code: -32603 });
   });
 
   it("rejects undeclared tasks/get, tasks/update and tasks/cancel with -32003", async () => {
+    // RAW BY CONSTRUCTION: `tasks-ext.ts` attaches the eligibility declaration
+    // to every extension request, so the real client can never emit an
+    // undeclared one. The server-side MUST is still worth pinning.
     const fixture = await serve();
     const wire = new RawTasksWire(fixture.url);
 
@@ -669,6 +662,8 @@ describe("tasks extension wire — protocol errors", () => {
   });
 
   it("rejects an undeclared task-filtered subscriptions/listen with -32003", async () => {
+    // RAW BY CONSTRUCTION: same reason as above — the undeclared leg is
+    // unreachable through our client.
     const fixture = await serve();
     const wire = new RawTasksWire(fixture.url);
 
@@ -695,6 +690,15 @@ describe("tasks extension wire — protocol errors", () => {
   });
 });
 
+/**
+ * Server-side misbehavior. The cases that stay on {@link RawTasksWire} are the
+ * ones whose POINT is the bytes: beta.4's 2026 decoder consumes/validates
+ * `resultType` before `tasks-ext.ts` can see the payload (it rejects an absent
+ * one outright, and `wrapTransportForTaskResults` rewrites `resultType:
+ * "task"` into a create-task envelope), so reading them through the real
+ * client would assert the SDK's reaction, not what the server sent. Where the
+ * SDK's reaction IS the interesting property, the test uses the real client.
+ */
 describe("tasks extension wire — misbehaving server", () => {
   it("can answer an undeclared tasks/get (negative case for the -32003 rule)", async () => {
     const fixture = await serve({
@@ -744,18 +748,23 @@ describe("tasks extension wire — misbehaving server", () => {
     );
   });
 
-  it("can turn a healthy task malformed mid-flight", async () => {
+  it("can turn a healthy task malformed mid-flight, and the real client refuses the poll", async () => {
     const fixture = await serve();
     const manager = await connect(fixture.url);
     const taskId = (await createTask(manager)).taskId as string;
-    const wire = new RawTasksWire(fixture.url);
 
-    expect((await wire.get(taskId)).status).toBe("working");
+    expect((await getTask(manager, taskId)).status).toBe("working");
     fixture.misbehave({ status: "in_progress", omitTaskFields: ["ttlMs"] });
 
-    const task = await wire.get(taskId);
-    expect(task.status).toBe("in_progress");
-    expect(task).not.toHaveProperty("ttlMs");
+    // A connection that was healthy a poll ago is not trusted afterwards: the
+    // guard re-validates every `tasks/get` result.
+    await expect(manager.getTaskExt(SERVER_ID, taskId)).rejects.toThrow(
+      /not a valid io\.modelcontextprotocol\/tasks payload/
+    );
+    // …and the raw wire confirms what the server actually sent.
+    const raw = await new RawTasksWire(fixture.url).get(taskId);
+    expect(raw.status).toBe("in_progress");
+    expect(raw).not.toHaveProperty("ttlMs");
   });
 
   it("can send resultType: task on a tasks/get result", async () => {
@@ -763,6 +772,9 @@ describe("tasks extension wire — misbehaving server", () => {
     const manager = await connect(fixture.url);
     const taskId = (await createTask(manager)).taskId as string;
 
+    // RAW: `wrapTransportForTaskResults` rewrites any `resultType: "task"`
+    // response before the client decodes it, so the wire value is only
+    // observable off the socket.
     const task = await new RawTasksWire(fixture.url).get(taskId);
     // tasks.md:102 — `"task"` MUST NOT appear on anything but CreateTaskResult.
     expect(task.resultType).toBe("task");
@@ -776,10 +788,15 @@ describe("tasks extension wire — misbehaving server", () => {
     const manager = await connect(fixture.url);
     const taskId = (await createTask(manager)).taskId as string;
 
-    const task = await new RawTasksWire(fixture.url).get(taskId);
-    expect(task.status).toBe("completed");
+    const raw = await new RawTasksWire(fixture.url).get(taskId);
+    expect(raw.status).toBe("completed");
     // A `completed` task MUST carry `result` (tasks.md:330).
-    expect(task.result).toBeUndefined();
+    expect(raw.result).toBeUndefined();
+    // The real client refuses the variant-incomplete payload rather than
+    // rendering a completed task with no result.
+    await expect(manager.getTaskExt(SERVER_ID, taskId)).rejects.toThrow(
+      /not a valid io\.modelcontextprotocol\/tasks payload/
+    );
   });
 
   it("can fabricate a task for an id that was never issued", async () => {
@@ -791,6 +808,8 @@ describe("tasks extension wire — misbehaving server", () => {
 
 describe("tasks extension wire — resultType on tasks/* results", () => {
   it("carries resultType: complete by default (the prose MUST)", async () => {
+    // RAW: the decoder strips `resultType` off a complete result, so the real
+    // client can never observe it (the lifecycle test pins that absence).
     const fixture = await serve();
     const manager = await connect(fixture.url);
     const taskId = (await createTask(manager)).taskId as string;
@@ -808,6 +827,8 @@ describe("tasks extension wire — resultType on tasks/* results", () => {
   it("can omit it entirely (the schema-literal reading)", async () => {
     // `resultType` appears nowhere in the pinned schema, and each
     // `DetailedTask` variant is rendered `additionalProperties: false`.
+    // RAW: beta.4's 2026 decoder REQUIRES `resultType` on every result
+    // ("missing-resultType"), so this reading is only observable off the wire.
     const fixture = await serve({ emitTaskResultType: false });
     const manager = await connect(fixture.url);
     const taskId = (await createTask(manager)).taskId as string;

--- a/sdk/tests/support/extension-tasks-fixture.ts
+++ b/sdk/tests/support/extension-tasks-fixture.ts
@@ -237,6 +237,8 @@ export interface TaskInspection {
   toolName: string;
   phaseIndex: number;
   polls: number;
+  /** Current TTL, `null` meaning unlimited — distinct from an absent one. */
+  ttlMs: number | null;
   /** `inputRequests` keys answered so far via `tasks/update`. */
   answeredKeys: string[];
   cancelRequested: boolean;
@@ -550,7 +552,16 @@ export async function serveExtensionTasksFixture(
       pollsOnPhase: 0,
       createdAt,
       lastUpdatedAt: createdAt,
-      ttlMs: phases[0].ttlMs ?? behavior.ttlMs ?? 60_000,
+      // `null` is "unlimited" and is NOT absence — the same distinction the
+      // SDK's task validation preserves — so a `??` chain here would silently
+      // turn a deliberate unlimited-TTL phase into 60s and the fixture could
+      // never emit the shape it exists to exercise. Only `undefined` inherits.
+      ttlMs:
+        phases[0].ttlMs !== undefined
+          ? phases[0].ttlMs
+          : behavior.ttlMs !== undefined
+            ? behavior.ttlMs
+            : 60_000,
       pollIntervalMs: phases[0].pollIntervalMs ?? behavior.pollIntervalMs ?? 10,
       answered: new Set(),
       cancelRequested: false,
@@ -912,6 +923,7 @@ export async function serveExtensionTasksFixture(
     toolName: entry.toolName,
     phaseIndex: entry.phaseIndex,
     polls: entry.pollsOnPhase,
+    ttlMs: entry.ttlMs,
     answeredKeys: [...entry.answered],
     cancelRequested: entry.cancelRequested,
   });

--- a/sdk/tests/support/extension-tasks-fixture.ts
+++ b/sdk/tests/support/extension-tasks-fixture.ts
@@ -71,6 +71,15 @@ export const INVALID_PARAMS = -32602;
 /** The first protocol version that can carry the extension. */
 export const EXTENSION_PROTOCOL_VERSION = "2026-07-28";
 
+/**
+ * `CacheableResult` fields the modern wire REQUIRES on `tools/list` (SEP-2549).
+ * Values are arbitrary-but-valid: a non-negative integer and one of the two
+ * `cacheScope` literals. They are not part of any tasks assertion — they exist
+ * so the fixture's `tools/list` decodes at all.
+ */
+export const LIST_RESULT_TTL_MS = 60_000;
+export const LIST_RESULT_CACHE_SCOPE = "private" as const;
+
 /** Default tool that only ever answers synchronously. */
 export const SYNC_TOOL_NAME = "sync_tool";
 /** Default tool that answers with a `CreateTaskResult` to a declaring caller. */
@@ -706,6 +715,16 @@ export async function serveExtensionTasksFixture(
       case "tools/list":
         return {
           resultType: "complete",
+          // SEP-2549 (`draft/changelog.mdx:36`) made `ttlMs` + `cacheScope`
+          // REQUIRED on `tools/list`, and beta.4's 2026 decoder enforces both
+          // without a `.catch()` fallback (`ListToolsResultSchema` /
+          // `dispatchResultSchemas["tools/list"]`, `src-CMjk3S93.mjs:2778`,
+          // `:3036`). Omitting them makes every consumer — including the tasks
+          // conformance runner — fail during DISCOVERY, before any tasks
+          // behavior is reached. `server/discover` is NOT in the same boat: its
+          // two fields carry `.catch()` defaults (`:3074`).
+          ttlMs: LIST_RESULT_TTL_MS,
+          cacheScope: LIST_RESULT_CACHE_SCOPE,
           tools: Object.entries(tools).map(([name, behavior]) => ({
             name,
             description: behavior.description ?? name,

--- a/sdk/tests/support/extension-tasks-fixture.ts
+++ b/sdk/tests/support/extension-tasks-fixture.ts
@@ -1,0 +1,916 @@
+/**
+ * A raw `io.modelcontextprotocol/tasks` (SEP-2663) extension-wire fixture
+ * server, spoken over Streamable HTTP on a real socket.
+ *
+ * PIN: modelcontextprotocol/ext-tasks @ 2c1425d9a288b9b1f489430fe1e00bb392b47e48
+ * (`specification/draft/tasks.md`, `schema/draft/schema.ts`). Every wire shape
+ * below is copied from that commit — re-diff when re-syncing.
+ *
+ * Why hand-rolled JSON-RPC rather than `@modelcontextprotocol/server`: beta.4
+ * implements neither the extension's `resultType: "task"` discriminator nor the
+ * `tasks/*` methods, and the point of this fixture is to drive the REAL client
+ * against wire bytes we control byte-for-byte — including bytes that VIOLATE
+ * the spec, so client-side validation and the conformance suite have something
+ * to fail against. HTTP (not in-memory) because the extension's `Mcp-Name`
+ * routing header only exists on the Streamable HTTP binding (tasks.md:511).
+ *
+ * The fixture is stateless per connection and keeps its task store in the
+ * server closure, so a task created on one connection is readable from a fresh
+ * one — that is what makes the durability MUST (tasks.md:300) testable.
+ *
+ * ## Spec MUSTs enforced by default
+ *   - `resultType: "task"` on `CreateTaskResult` (tasks.md:102) — the real
+ *     discriminator, always on outside misbehaving mode;
+ *   - `resultType: "complete"` on `tasks/get|update|cancel` (tasks.md:338,
+ *     :381, :410) — prose-only: `resultType` appears NOWHERE in the pinned
+ *     `schema.ts`/`schema.json`, and each `DetailedTask` variant is rendered
+ *     with `additionalProperties: false`, which would reject the key. It is
+ *     therefore a TOGGLE ({@link ExtensionTasksFixtureOptions.emitTaskResultType},
+ *     default on) so both directions are testable;
+ *   - never a `CreateTaskResult` to a `tools/call` that did not declare the
+ *     extension in `_meta` (tasks.md:61);
+ *   - `-32003` for `tasks/get|update|cancel` and task-filtered
+ *     `subscriptions/listen` from a non-declaring client (tasks.md:797-799);
+ *   - `-32602` for an unknown/expired `taskId` (tasks.md:793);
+ *   - per-status payloads: `inputRequests` on `input_required`, inline
+ *     `result` on `completed`, JSON-RPC `error` on `failed` (tasks.md:326-332);
+ *   - empty acknowledgements for `tasks/update` / `tasks/cancel`, with the
+ *     observable status changing only on a LATER poll (tasks.md:377, :404);
+ *   - `inputRequests` re-sent verbatim on every poll while outstanding
+ *     (tasks.md:637), keys unique over the task's lifetime (tasks.md:350).
+ *
+ * ## Deliberately UNconstrained (the schema does not constrain them either)
+ *   - timestamps are plain strings — "ISO 8601" is a JSDoc comment, there is
+ *     no `format: date-time` anywhere in `schema.json`;
+ *   - `ttlMs` / `pollIntervalMs` are plain numbers with no integer or minimum
+ *     constraint, and both MAY change across polls (tasks.md:308, :340) — see
+ *     {@link oddNumbersPhases};
+ *   - `inputRequests` values render as an unconstrained `anyOf` in
+ *     `schema.json`, so an unknown method or a hostile key is representable —
+ *     see {@link HOSTILE_INPUT_REQUESTS}.
+ *
+ * ## Spec MUSTs it can deliberately violate
+ * Everything under {@link ExtensionTasksMisbehavior} — see that type.
+ */
+
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+
+/** The extension identifier (tasks.md:21). */
+export const TASKS_EXTENSION_ID = "io.modelcontextprotocol/tasks";
+
+/** Where a client declares its per-request capabilities (tasks.md:33). */
+export const CLIENT_CAPABILITIES_META_KEY =
+  "io.modelcontextprotocol/clientCapabilities";
+
+/** `MISSING_REQUIRED_CLIENT_CAPABILITY` (tasks.md:63). */
+export const MISSING_REQUIRED_CLIENT_CAPABILITY = -32003;
+/** `INVALID_PARAMS`, used for unknown/expired task ids (tasks.md:793). */
+export const INVALID_PARAMS = -32602;
+
+/** The first protocol version that can carry the extension. */
+export const EXTENSION_PROTOCOL_VERSION = "2026-07-28";
+
+/** Default tool that only ever answers synchronously. */
+export const SYNC_TOOL_NAME = "sync_tool";
+/** Default tool that answers with a `CreateTaskResult` to a declaring caller. */
+export const TASK_TOOL_NAME = "task_tool";
+
+export type TaskStatus =
+  | "working"
+  | "input_required"
+  | "completed"
+  | "failed"
+  | "cancelled";
+
+/**
+ * One observable state of a task's lifetime. The fixture serves phases in
+ * order: each `tasks/get` first advances past an exhausted phase, then renders
+ * the current one, so a phase gated on `awaitInputKeys` / `awaitCancel` becomes
+ * visible only on the poll AFTER the gating request — which is exactly the
+ * eventual consistency the spec requires of `tasks/update` and `tasks/cancel`.
+ * The last phase sticks forever.
+ */
+export interface TaskPhase {
+  status: TaskStatus;
+  statusMessage?: string;
+  /** `null` = unlimited. Omitted → inherits the previous phase's value. */
+  ttlMs?: number | null;
+  /** Omitted → inherits the previous phase's value. */
+  pollIntervalMs?: number;
+  /** Required on `input_required`; a keyed snapshot re-sent on every poll. */
+  inputRequests?: Record<string, unknown>;
+  /** Required on `completed` — the original request's result, INLINE. */
+  result?: unknown;
+  /** Required on `failed` — a JSON-RPC error object. */
+  error?: { code: number; message: string; data?: unknown };
+  /** How many polls render this phase before it may advance. Default 1. */
+  polls?: number;
+  /** Hold this phase until `tasks/update` has answered all of these keys. */
+  awaitInputKeys?: string[];
+  /** Hold this phase until a `tasks/cancel` arrives for the task. */
+  awaitCancel?: boolean;
+  /** Extra keys merged onto the emitted task object (raw-wire escape hatch). */
+  extra?: Record<string, unknown>;
+  /** Keys deleted from the emitted task object (missing-required-field cases). */
+  omit?: string[];
+}
+
+export interface ToolBehavior {
+  /**
+   * `"sync"` — always a plain `CallToolResult`.
+   * `"task"` — a `CreateTaskResult` when (and only when) the caller declared
+   * the extension; a plain result otherwise (tasks.md:61).
+   */
+  mode: "sync" | "task";
+  /** The plain result for `"sync"` mode (and for undeclared `"task"` calls). */
+  result?: Record<string, unknown>;
+  /** The lifecycle served for `"task"` mode. Must be non-empty. */
+  phases?: TaskPhase[];
+  /** Seed `ttlMs` for the created task when phase 0 omits it. Default 60000. */
+  ttlMs?: number | null;
+  /** Seed `pollIntervalMs` when phase 0 omits it. Default 10. */
+  pollIntervalMs?: number;
+  /** Tool metadata for `tools/list`. */
+  description?: string;
+}
+
+/**
+ * Deliberate spec violations, for driving NEGATIVE tests of client-side
+ * validation and of the conformance suite. Each flag is off by default.
+ */
+export interface ExtensionTasksMisbehavior {
+  /**
+   * Answer `tasks/get|update|cancel` normally even when the request carried no
+   * extension declaration — violates tasks.md:799.
+   */
+  answerUndeclaredTaskRequests?: boolean;
+  /**
+   * Answer a task-filtered `subscriptions/listen` from a non-declaring client
+   * — violates tasks.md:798.
+   */
+  answerUndeclaredTaskSubscription?: boolean;
+  /**
+   * Return a `CreateTaskResult` to a `tools/call` that did NOT declare the
+   * extension — violates tasks.md:61.
+   */
+  createTaskForUndeclaredCall?: boolean;
+  /** Emit this literal in `status` on every emitted task (invalid enum value). */
+  status?: string;
+  /** Delete these fields from every emitted task (missing required fields). */
+  omitTaskFields?: string[];
+  /** `resultType` on `CreateTaskResult`. Spec requires `"task"` (MUST). */
+  createResultType?: string;
+  /**
+   * `resultType` on `tasks/get`. The prose requires `"complete"`; setting it
+   * to `"task"` is the "wrong discriminator" case. To OMIT it instead (which
+   * is arguably schema-conformant, not misbehavior) use
+   * {@link ExtensionTasksFixtureOptions.emitTaskResultType}.
+   */
+  getResultType?: string;
+  /**
+   * Drop the status-specific payload: no `inputRequests` on `input_required`,
+   * no `result` on `completed`, no `error` on `failed` — violates
+   * tasks.md:326-332.
+   */
+  omitStatusPayload?: boolean;
+  /** Serve a fabricated task for an unknown id instead of `-32602`. */
+  answerUnknownTaskId?: boolean;
+}
+
+export interface ExtensionTasksFixtureOptions {
+  /** Advertised in `server/discover`. Default `["2026-07-28"]`. */
+  supportedVersions?: string[];
+  /**
+   * Advertise `capabilities.extensions["io.modelcontextprotocol/tasks"]`.
+   * Set false to prove the client refuses to speak the wire at all.
+   */
+  advertiseTasksExtension?: boolean;
+  /**
+   * The VALUE advertised under the extension key. `schema.json` renders
+   * `TasksExtensionCapability` as an object with zero properties, but the
+   * prose only says no settings are "currently" defined — so a non-empty
+   * object must still read as support (forward compat). Non-object values
+   * (`true`, `"x"`, `[]`, `null`) are the malformed-declaration cases.
+   * Default `{}`.
+   */
+  tasksExtensionCapability?: unknown;
+  /**
+   * Emit `resultType: "complete"` on `tasks/get|update|cancel`. Default true
+   * (the prose MUST). Set false for the schema-literal reading, in which the
+   * `DetailedTask` variants' `additionalProperties: false` forbids the key.
+   */
+  emitTaskResultType?: boolean;
+  /**
+   * JSON-RPC code for an unknown/expired `taskId` on `tasks/update` and
+   * `tasks/cancel`. `-32602` is only a SHOULD there (tasks.md:795), so another
+   * code is still compliant; on `tasks/get` it is a MUST and is not
+   * configurable. Default `-32602`.
+   */
+  unknownTaskCodeForMutations?: number;
+  serverInfo?: { name: string; version: string };
+  /** Replaces the default tool set entirely when provided. */
+  tools?: Record<string, ToolBehavior>;
+  misbehave?: ExtensionTasksMisbehavior;
+  /** Task ids handed out, in order. Default `ext-task-1`, `ext-task-2`, … */
+  taskIds?: string[];
+}
+
+export interface ReceivedRequest {
+  method: string;
+  params: Record<string, unknown> | undefined;
+  /** Lower-cased HTTP request headers — `mcp-name` lives here. */
+  headers: Record<string, string>;
+}
+
+export interface TaskInspection {
+  taskId: string;
+  toolName: string;
+  phaseIndex: number;
+  polls: number;
+  /** `inputRequests` keys answered so far via `tasks/update`. */
+  answeredKeys: string[];
+  cancelRequested: boolean;
+}
+
+export interface ServedExtensionTasksFixture {
+  url: string;
+  received: ReceivedRequest[];
+  /** Every task the fixture has created, in creation order. */
+  tasks: () => TaskInspection[];
+  task: (taskId: string) => TaskInspection | undefined;
+  /** Mutate the misbehavior toggles mid-test. */
+  misbehave: (patch: ExtensionTasksMisbehavior) => void;
+  close: () => Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Default surface
+// ---------------------------------------------------------------------------
+
+/** The elicitation the default task tool blocks on, keyed `name`. */
+export const DEFAULT_INPUT_REQUEST_KEY = "name";
+
+export const DEFAULT_INPUT_REQUESTS: Record<string, unknown> = {
+  [DEFAULT_INPUT_REQUEST_KEY]: {
+    method: "elicitation/create",
+    params: {
+      mode: "form",
+      message: "Please enter your name.",
+      requestedSchema: {
+        type: "object",
+        properties: { name: { type: "string" } },
+        required: ["name"],
+      },
+    },
+  },
+};
+
+/**
+ * working → input_required (re-sent while outstanding) → working → completed,
+ * with `ttlMs` and `pollIntervalMs` CHANGING across polls (tasks.md:140-147).
+ * Mirrors the spec's own example message flow (tasks.md:513-780).
+ */
+export function defaultTaskPhases(): TaskPhase[] {
+  return [
+    {
+      status: "working",
+      statusMessage: "The operation is now in progress.",
+      ttlMs: 60_000,
+      pollIntervalMs: 10,
+    },
+    {
+      status: "input_required",
+      statusMessage: "Waiting on the user's name.",
+      inputRequests: DEFAULT_INPUT_REQUESTS,
+      // Rendered on at least two polls so the repeated-snapshot rule is
+      // observable, and held until the client answers the `name` key.
+      polls: 2,
+      awaitInputKeys: [DEFAULT_INPUT_REQUEST_KEY],
+      ttlMs: 45_000,
+      pollIntervalMs: 20,
+    },
+    {
+      status: "working",
+      statusMessage: "Input accepted; finishing up.",
+      ttlMs: 30_000,
+      pollIntervalMs: 30,
+    },
+    {
+      status: "completed",
+      statusMessage: "Done.",
+      result: {
+        content: [{ type: "text", text: "Hello, Luca!" }],
+        isError: false,
+      },
+    },
+  ];
+}
+
+/**
+ * Two outstanding requests, so a `tasks/update` answering only one exercises
+ * the partial-response rule (tasks.md:379): the task stays `input_required`
+ * and the remaining key keeps being re-sent.
+ */
+export const PARTIAL_INPUT_REQUESTS: Record<string, unknown> = {
+  ...DEFAULT_INPUT_REQUESTS,
+  city: {
+    method: "elicitation/create",
+    params: {
+      mode: "form",
+      message: "Which city?",
+      requestedSchema: {
+        type: "object",
+        properties: { city: { type: "string" } },
+        required: ["city"],
+      },
+    },
+  },
+};
+
+/**
+ * `inputRequests` the JSON Schema permits but the TypeScript union does not:
+ * an UNKNOWN method (the schema renders the value as an unconstrained
+ * `anyOf`), plus prototype-pollution keys. A client must keep these
+ * visible-but-unanswerable and must never let the keys reach an object
+ * prototype.
+ */
+// Built with `Object.fromEntries` on purpose: in an object literal a
+// `__proto__:` key sets the prototype instead of defining an own property, so
+// the hostile key would never reach the wire.
+export const HOSTILE_INPUT_REQUESTS: Record<string, unknown> =
+  Object.fromEntries([
+    [
+      "unknown_method",
+      { method: "tasks/definitely-not-a-real-method", params: {} },
+    ],
+    [
+      "__proto__",
+      { method: "elicitation/create", params: { message: "polluted" } },
+    ],
+    ["constructor", { method: "roots/list", params: {} }],
+  ]);
+
+/**
+ * `ttlMs` / `pollIntervalMs` that are legal but unusual — non-integer, huge,
+ * and CHANGING across polls — plus a `ttlMs: null` (unlimited) phase. Nothing
+ * here is an anomaly: the schema types both as plain numbers and the prose
+ * explicitly allows them to change (tasks.md:308, :340).
+ */
+export function oddNumbersPhases(): TaskPhase[] {
+  return [
+    { status: "working", ttlMs: 1234.567, pollIntervalMs: 0.5 },
+    { status: "working", ttlMs: Number.MAX_SAFE_INTEGER, pollIntervalMs: 1 },
+    { status: "working", ttlMs: null, pollIntervalMs: 2 },
+    {
+      status: "completed",
+      ttlMs: -1,
+      result: { content: [{ type: "text", text: "odd but legal" }] },
+    },
+  ];
+}
+
+/**
+ * A tool result with `isError: true`. The task MUST be `completed`, not
+ * `failed` — `failed` is strictly for JSON-RPC-level faults
+ * (tasks.md:837, :891-892).
+ */
+export function isErrorCompletedPhases(): TaskPhase[] {
+  return [
+    {
+      status: "completed",
+      statusMessage: "The tool reported an error.",
+      result: {
+        content: [
+          { type: "text", text: "Failed to process request: invalid input" },
+        ],
+        isError: true,
+      },
+    },
+  ];
+}
+
+/** A genuine JSON-RPC fault during execution → `failed` + `error`. */
+export function failedTaskPhases(): TaskPhase[] {
+  return [
+    {
+      status: "failed",
+      statusMessage: "Tool execution failed: API rate limit exceeded",
+      error: { code: -32603, message: "API rate limit exceeded" },
+    },
+  ];
+}
+
+/** `working` until a `tasks/cancel` arrives, then `cancelled` on a later poll. */
+export function cancellablePhases(): TaskPhase[] {
+  return [
+    { status: "working", awaitCancel: true, pollIntervalMs: 10 },
+    {
+      status: "cancelled",
+      statusMessage: "Cancelled at the client's request.",
+    },
+  ];
+}
+
+function defaultTools(): Record<string, ToolBehavior> {
+  return {
+    [SYNC_TOOL_NAME]: {
+      mode: "sync",
+      description: "Always answers synchronously.",
+      result: { content: [{ type: "text", text: "sync result" }] },
+    },
+    [TASK_TOOL_NAME]: {
+      mode: "task",
+      description: "Answers with a task handle when the client declares tasks.",
+      phases: defaultTaskPhases(),
+      result: { content: [{ type: "text", text: "undeclared sync fallback" }] },
+    },
+  };
+}
+
+/** A `"task"` tool with a caller-supplied lifecycle. */
+export function taskTool(
+  phases: TaskPhase[],
+  overrides: Partial<ToolBehavior> = {}
+): ToolBehavior {
+  return {
+    mode: "task",
+    description: "Scripted task tool.",
+    result: { content: [{ type: "text", text: "undeclared sync fallback" }] },
+    phases,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+interface TaskEntry {
+  taskId: string;
+  toolName: string;
+  phases: TaskPhase[];
+  phaseIndex: number;
+  pollsOnPhase: number;
+  createdAt: string;
+  lastUpdatedAt: string;
+  ttlMs: number | null;
+  pollIntervalMs: number | undefined;
+  answered: Set<string>;
+  cancelRequested: boolean;
+}
+
+class JsonRpcFailure extends Error {
+  constructor(readonly code: number, message: string, readonly data?: unknown) {
+    super(message);
+  }
+}
+
+function missingCapabilityFailure(): JsonRpcFailure {
+  return new JsonRpcFailure(
+    MISSING_REQUIRED_CLIENT_CAPABILITY,
+    "Missing required client capability",
+    { requiredCapabilities: { extensions: { [TASKS_EXTENSION_ID]: {} } } }
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Whether THIS request declared the tasks extension in its per-request
+ * capabilities (tasks.md:27-41). Prior declarations do not count.
+ */
+export function declaresTasksExtension(
+  params: Record<string, unknown> | undefined
+): boolean {
+  const meta = params?._meta;
+  if (!isRecord(meta)) return false;
+  const capabilities = meta[CLIENT_CAPABILITIES_META_KEY];
+  if (!isRecord(capabilities)) return false;
+  const extensions = capabilities.extensions;
+  return isRecord(extensions) && TASKS_EXTENSION_ID in extensions;
+}
+
+export async function serveExtensionTasksFixture(
+  options: ExtensionTasksFixtureOptions = {}
+): Promise<ServedExtensionTasksFixture> {
+  const supportedVersions = options.supportedVersions ?? [
+    EXTENSION_PROTOCOL_VERSION,
+  ];
+  const advertiseExtension = options.advertiseTasksExtension !== false;
+  const extensionCapability =
+    options.tasksExtensionCapability === undefined
+      ? {}
+      : options.tasksExtensionCapability;
+  const emitTaskResultType = options.emitTaskResultType !== false;
+  const unknownTaskCodeForMutations =
+    options.unknownTaskCodeForMutations ?? INVALID_PARAMS;
+  const serverInfo = options.serverInfo ?? {
+    name: "extension-tasks-fixture",
+    version: "1.0.0",
+  };
+  const tools = options.tools ?? defaultTools();
+  const misbehavior: ExtensionTasksMisbehavior = { ...options.misbehave };
+
+  const received: ReceivedRequest[] = [];
+  const store = new Map<string, TaskEntry>();
+  const order: string[] = [];
+  const reservedIds = [...(options.taskIds ?? [])];
+  let idCounter = 0;
+
+  // A deterministic clock keeps timestamps stable for golden comparisons.
+  const clockStart = Date.parse("2026-07-28T10:00:00.000Z");
+  let ticks = 0;
+  const nowIso = () => new Date(clockStart + ticks++ * 1000).toISOString();
+
+  const nextTaskId = () => reservedIds.shift() ?? `ext-task-${++idCounter}`;
+
+  function createTask(toolName: string, behavior: ToolBehavior): TaskEntry {
+    const phases = behavior.phases ?? defaultTaskPhases();
+    if (phases.length === 0) {
+      throw new Error(`Task tool "${toolName}" has no phases.`);
+    }
+    const createdAt = nowIso();
+    const entry: TaskEntry = {
+      taskId: nextTaskId(),
+      toolName,
+      phases,
+      phaseIndex: 0,
+      pollsOnPhase: 0,
+      createdAt,
+      lastUpdatedAt: createdAt,
+      ttlMs: phases[0].ttlMs ?? behavior.ttlMs ?? 60_000,
+      pollIntervalMs: phases[0].pollIntervalMs ?? behavior.pollIntervalMs ?? 10,
+      answered: new Set(),
+      cancelRequested: false,
+    };
+    store.set(entry.taskId, entry);
+    order.push(entry.taskId);
+    return entry;
+  }
+
+  /** Gates satisfied → the phase may retire. */
+  function phaseExhausted(entry: TaskEntry): boolean {
+    const phase = entry.phases[entry.phaseIndex];
+    if (entry.pollsOnPhase < (phase.polls ?? 1)) return false;
+    if (phase.awaitCancel && !entry.cancelRequested) return false;
+    for (const key of phase.awaitInputKeys ?? []) {
+      if (!entry.answered.has(key)) return false;
+    }
+    return true;
+  }
+
+  function advanceIfDue(entry: TaskEntry): void {
+    const isLast = entry.phaseIndex >= entry.phases.length - 1;
+    if (isLast || !phaseExhausted(entry)) return;
+    entry.phaseIndex += 1;
+    entry.pollsOnPhase = 0;
+    entry.lastUpdatedAt = nowIso();
+    const phase = entry.phases[entry.phaseIndex];
+    if (phase.ttlMs !== undefined) entry.ttlMs = phase.ttlMs;
+    if (phase.pollIntervalMs !== undefined) {
+      entry.pollIntervalMs = phase.pollIntervalMs;
+    }
+  }
+
+  /** The bare `Task` fields, shared by `CreateTaskResult` and `tasks/get`. */
+  function taskFields(entry: TaskEntry): Record<string, unknown> {
+    const phase = entry.phases[entry.phaseIndex];
+    const task: Record<string, unknown> = {
+      taskId: entry.taskId,
+      status: misbehavior.status ?? phase.status,
+      createdAt: entry.createdAt,
+      lastUpdatedAt: entry.lastUpdatedAt,
+      ttlMs: entry.ttlMs,
+    };
+    if (phase.statusMessage !== undefined) {
+      task.statusMessage = phase.statusMessage;
+    }
+    if (entry.pollIntervalMs !== undefined) {
+      task.pollIntervalMs = entry.pollIntervalMs;
+    }
+    return applyRawOverrides(task, phase);
+  }
+
+  /**
+   * The prose-mandated `resultType: "complete"` on the `tasks/*` results, or
+   * nothing when {@link ExtensionTasksFixtureOptions.emitTaskResultType} is
+   * off — the key is absent from the pinned schema entirely.
+   */
+  function taskResultTypeField(): Record<string, unknown> {
+    if (misbehavior.getResultType !== undefined) {
+      return { resultType: misbehavior.getResultType };
+    }
+    return emitTaskResultType ? { resultType: "complete" } : {};
+  }
+
+  /** `Task` plus the status-specific payload (tasks.md:326-332). */
+  function detailedTaskFields(entry: TaskEntry): Record<string, unknown> {
+    const phase = entry.phases[entry.phaseIndex];
+    const task = taskFields(entry);
+    if (!misbehavior.omitStatusPayload) {
+      if (phase.status === "input_required") {
+        // A point-in-time snapshot: re-sent verbatim on every poll while the
+        // requests stay outstanding (tasks.md:637). Answered keys drop out.
+        // `Object.fromEntries` defines own properties, so a hostile
+        // `__proto__` key survives to the wire instead of mutating a
+        // prototype (see HOSTILE_INPUT_REQUESTS).
+        task.inputRequests = Object.fromEntries(
+          Object.entries(phase.inputRequests ?? DEFAULT_INPUT_REQUESTS).filter(
+            ([key]) => !entry.answered.has(key)
+          )
+        );
+      } else if (phase.status === "completed") {
+        task.result = phase.result ?? { content: [], isError: false };
+      } else if (phase.status === "failed") {
+        task.error = phase.error ?? {
+          code: -32603,
+          message: "Internal error",
+        };
+      }
+    }
+    return applyRawOverrides(task, phase);
+  }
+
+  function applyRawOverrides(
+    task: Record<string, unknown>,
+    phase: TaskPhase
+  ): Record<string, unknown> {
+    for (const key of phase.omit ?? []) delete task[key];
+    for (const key of misbehavior.omitTaskFields ?? []) delete task[key];
+    return phase.extra ? { ...task, ...phase.extra } : task;
+  }
+
+  function requireTask(
+    taskId: unknown,
+    notFoundCode = INVALID_PARAMS
+  ): TaskEntry {
+    const entry = typeof taskId === "string" ? store.get(taskId) : undefined;
+    if (entry) return entry;
+    if (misbehavior.answerUnknownTaskId) {
+      // Fabricate a task for an id that was never issued.
+      const behavior = tools[TASK_TOOL_NAME] ?? {
+        mode: "task" as const,
+        phases: defaultTaskPhases(),
+      };
+      const fabricated = createTask(TASK_TOOL_NAME, behavior);
+      fabricated.taskId = String(taskId);
+      return fabricated;
+    }
+    throw new JsonRpcFailure(
+      notFoundCode,
+      `Failed to retrieve task: Task not found (${String(taskId)})`
+    );
+  }
+
+  function requireDeclaration(params: Record<string, unknown> | undefined) {
+    if (misbehavior.answerUndeclaredTaskRequests) return;
+    if (!declaresTasksExtension(params)) throw missingCapabilityFailure();
+  }
+
+  function handle(
+    method: string,
+    params: Record<string, unknown> | undefined
+  ): Record<string, unknown> {
+    switch (method) {
+      case "server/discover":
+        return {
+          resultType: "complete",
+          supportedVersions,
+          capabilities: {
+            tools: {},
+            ...(advertiseExtension
+              ? { extensions: { [TASKS_EXTENSION_ID]: extensionCapability } }
+              : {}),
+          },
+          serverInfo,
+        };
+
+      case "initialize":
+        // Present so a mis-pinned client gets a coherent refusal rather than a
+        // socket error; the extension only exists on the modern wire.
+        return {
+          resultType: "complete",
+          protocolVersion: supportedVersions[0],
+          capabilities: {
+            tools: {},
+            ...(advertiseExtension
+              ? { extensions: { [TASKS_EXTENSION_ID]: extensionCapability } }
+              : {}),
+          },
+          serverInfo,
+        };
+
+      case "tools/list":
+        return {
+          resultType: "complete",
+          tools: Object.entries(tools).map(([name, behavior]) => ({
+            name,
+            description: behavior.description ?? name,
+            inputSchema: { type: "object", properties: {} },
+          })),
+        };
+
+      case "tools/call": {
+        const name = params?.name;
+        const behavior =
+          typeof name === "string" ? tools[name] : (undefined as undefined);
+        if (!behavior) {
+          throw new JsonRpcFailure(
+            INVALID_PARAMS,
+            `Unknown tool: ${String(name)}`
+          );
+        }
+        const declared = declaresTasksExtension(params);
+        const wantsTask =
+          behavior.mode === "task" &&
+          // tasks.md:61 — a non-declaring caller MUST NOT be handed a task.
+          (declared || misbehavior.createTaskForUndeclaredCall === true);
+        if (!wantsTask) {
+          return {
+            resultType: "complete",
+            ...(behavior.result ?? {
+              content: [{ type: "text", text: "plain call" }],
+            }),
+          };
+        }
+        const entry = createTask(name as string, behavior);
+        // `CreateTaskResult = Result & Task` — flat, and bare `Task` fields
+        // only (no inputRequests/result/error).
+        return {
+          resultType: misbehavior.createResultType ?? "task",
+          ...taskFields(entry),
+        };
+      }
+
+      case "tasks/get": {
+        requireDeclaration(params);
+        // `-32602` on an unknown id is a MUST for `tasks/get` (tasks.md:794),
+        // so this one is not configurable.
+        const entry = requireTask(params?.taskId);
+        advanceIfDue(entry);
+        entry.pollsOnPhase += 1;
+        return {
+          ...taskResultTypeField(),
+          ...detailedTaskFields(entry),
+        };
+      }
+
+      case "tasks/update": {
+        requireDeclaration(params);
+        const entry = requireTask(params?.taskId, unknownTaskCodeForMutations);
+        const phase = entry.phases[entry.phaseIndex];
+        const outstanding = new Set(
+          Object.keys(
+            phase.status === "input_required"
+              ? phase.inputRequests ?? DEFAULT_INPUT_REQUESTS
+              : {}
+          )
+        );
+        const responses = params?.inputResponses;
+        if (isRecord(responses)) {
+          for (const key of Object.keys(responses)) {
+            // tasks.md:379 — unknown / already-answered keys are ignored.
+            if (outstanding.has(key)) entry.answered.add(key);
+          }
+        }
+        // An EMPTY, eventually-consistent acknowledgement (tasks.md:374-381):
+        // the observable status does not move until a later `tasks/get`.
+        return { ...taskResultTypeField() };
+      }
+
+      case "tasks/cancel": {
+        requireDeclaration(params);
+        const entry = requireTask(params?.taskId, unknownTaskCodeForMutations);
+        entry.cancelRequested = true;
+        // Empty ack; cancellation is cooperative (tasks.md:400-406).
+        return { ...taskResultTypeField() };
+      }
+
+      case "subscriptions/listen": {
+        const notifications = params?.notifications;
+        const taskIds = isRecord(notifications)
+          ? notifications.taskIds
+          : undefined;
+        const wantsTaskNotifications =
+          Array.isArray(taskIds) && taskIds.length > 0;
+        if (
+          wantsTaskNotifications &&
+          !misbehavior.answerUndeclaredTaskSubscription &&
+          !declaresTasksExtension(params)
+        ) {
+          // tasks.md:457, :798.
+          throw missingCapabilityFailure();
+        }
+        // This fixture never opens an SSE stream, so it acknowledges the
+        // subscription without agreeing to any task ids.
+        return { resultType: "complete" };
+      }
+
+      default:
+        return { resultType: "complete" };
+    }
+  }
+
+  const httpServer = http.createServer((req, res) => {
+    let body = "";
+    req.on("data", (chunk) => {
+      body += chunk;
+    });
+    req.on("end", () => {
+      if (req.method !== "POST") {
+        res.writeHead(405).end();
+        return;
+      }
+      let message: {
+        id?: unknown;
+        method?: string;
+        params?: Record<string, unknown>;
+      };
+      try {
+        message = JSON.parse(body);
+      } catch {
+        res.writeHead(400).end();
+        return;
+      }
+      if (typeof message.method === "string") {
+        received.push({
+          method: message.method,
+          params: message.params,
+          headers: Object.fromEntries(
+            Object.entries(req.headers).map(([key, value]) => [
+              key,
+              Array.isArray(value) ? value.join(", ") : String(value ?? ""),
+            ])
+          ),
+        });
+      }
+      if (message.id === undefined) {
+        res.writeHead(202).end();
+        return;
+      }
+
+      let payload: Record<string, unknown>;
+      try {
+        payload = {
+          jsonrpc: "2.0",
+          id: message.id,
+          result: handle(message.method as string, message.params),
+        };
+      } catch (error) {
+        const failure =
+          error instanceof JsonRpcFailure
+            ? error
+            : new JsonRpcFailure(-32603, String(error));
+        payload = {
+          jsonrpc: "2.0",
+          id: message.id,
+          error: {
+            code: failure.code,
+            message: failure.message,
+            ...(failure.data === undefined ? {} : { data: failure.data }),
+          },
+        };
+      }
+
+      res.writeHead(200, {
+        "content-type": "application/json",
+        "mcp-protocol-version": supportedVersions[0],
+      });
+      res.end(JSON.stringify(payload));
+    });
+  });
+
+  await new Promise<void>((resolve) =>
+    httpServer.listen(0, "127.0.0.1", resolve)
+  );
+  const address = httpServer.address() as AddressInfo;
+
+  const inspect = (entry: TaskEntry): TaskInspection => ({
+    taskId: entry.taskId,
+    toolName: entry.toolName,
+    phaseIndex: entry.phaseIndex,
+    polls: entry.pollsOnPhase,
+    answeredKeys: [...entry.answered],
+    cancelRequested: entry.cancelRequested,
+  });
+
+  return {
+    url: `http://127.0.0.1:${address.port}/mcp`,
+    received,
+    tasks: () =>
+      order
+        .map((id) => store.get(id))
+        .filter((entry): entry is TaskEntry => entry !== undefined)
+        .map(inspect),
+    task: (taskId) => {
+      const entry = store.get(taskId);
+      return entry ? inspect(entry) : undefined;
+    },
+    misbehave: (patch) => Object.assign(misbehavior, patch),
+    close: () =>
+      new Promise<void>((resolve) => httpServer.close(() => resolve())),
+  };
+}

--- a/sdk/tests/tasks-conformance/runner-fixture.integration.test.ts
+++ b/sdk/tests/tasks-conformance/runner-fixture.integration.test.ts
@@ -1,0 +1,256 @@
+/**
+ * The Tasks conformance runner driven END TO END against the raw extension
+ * fixture over a real socket — no mocked `withEphemeralClient`, no mocked
+ * `ManagedMcpClient`.
+ *
+ * `runner.test.ts` covers the runner's decision logic against a hand-built
+ * fake manager. That is necessary but not sufficient: it cannot catch a probe
+ * that never reaches the wire, because a fake manager answers whatever the
+ * test wants. Both bugs this file exists to pin were exactly that shape —
+ * a `tools/list` the modern decoder refused (so DISCOVERY died before any
+ * Tasks check ran) and an undeclared-capability probe that threw locally (so
+ * the `-32003` requirement was never put to the server).
+ *
+ * So the assertions here are deliberately about the WIRE: the fixture's
+ * `received` log is the witness that each probe actually left the process,
+ * and each check's verdict is asserted in BOTH directions — conformant
+ * fixture passes, misbehaving fixture fails and names the offending method.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { MCPTasksConformanceTest } from "../../src/tasks-conformance/index.js";
+import type {
+  MCPTasksCheckId,
+  MCPTasksCheckResult,
+  MCPTasksConformanceResult,
+} from "../../src/tasks-conformance/index.js";
+import {
+  EXTENSION_PROTOCOL_VERSION,
+  TASK_TOOL_NAME,
+  declaresTasksExtension,
+  serveExtensionTasksFixture,
+  taskTool,
+  type ExtensionTasksFixtureOptions,
+  type ServedExtensionTasksFixture,
+} from "../support/extension-tasks-fixture.js";
+
+/**
+ * A lifecycle that reaches `completed` on the second poll with no elicitation
+ * gate — the conformance runner never answers `inputRequests`, so the default
+ * phases would stall it against `pollTimeoutMs`.
+ */
+function quickPhases() {
+  return [
+    { status: "working" as const, ttlMs: 60_000, pollIntervalMs: 5 },
+    {
+      status: "completed" as const,
+      ttlMs: 30_000,
+      result: { content: [{ type: "text", text: "done" }], isError: false },
+    },
+  ];
+}
+
+const opened: ServedExtensionTasksFixture[] = [];
+
+afterEach(async () => {
+  // Unconditional teardown: a leaked HTTP server keeps the event loop alive
+  // and makes vitest exit non-zero AFTER printing a green summary.
+  for (const fixture of opened.splice(0)) {
+    await fixture.close().catch(() => {});
+  }
+});
+
+async function serve(
+  options: ExtensionTasksFixtureOptions = {}
+): Promise<ServedExtensionTasksFixture> {
+  const fixture = await serveExtensionTasksFixture({
+    tools: { [TASK_TOOL_NAME]: taskTool(quickPhases()) },
+    ...options,
+  });
+  opened.push(fixture);
+  return fixture;
+}
+
+function runAgainst(
+  fixture: ServedExtensionTasksFixture
+): Promise<MCPTasksConformanceResult> {
+  return new MCPTasksConformanceTest({
+    url: fixture.url,
+    mcpProtocolVersion: EXTENSION_PROTOCOL_VERSION,
+    timeout: 10_000,
+    // The fixture's tools carry no `execution.taskSupport` metadata (that is
+    // 2025-11-25 shape, and the 2026 `ToolSchema` would strip it), so the
+    // probe tool is named rather than auto-picked.
+    toolName: TASK_TOOL_NAME,
+    pollTimeoutMs: 5_000,
+  }).run();
+}
+
+function check(
+  result: MCPTasksConformanceResult,
+  id: MCPTasksCheckId
+): MCPTasksCheckResult {
+  const found = result.checks.find((entry) => entry.id === id);
+  if (!found) throw new Error(`check ${id} was not produced`);
+  return found;
+}
+
+/** Requests the fixture received for `method` that carried NO declaration. */
+function undeclaredRequests(
+  fixture: ServedExtensionTasksFixture,
+  method: string
+) {
+  return fixture.received.filter(
+    (entry) => entry.method === method && !declaresTasksExtension(entry.params)
+  );
+}
+
+describe("MCPTasksConformanceTest against the extension fixture", () => {
+  it("completes discovery and reaches every Tasks check", async () => {
+    const fixture = await serve();
+    const result = await runAgainst(fixture);
+
+    // Discovery is the gate the missing `ttlMs`/`cacheScope` on `tools/list`
+    // used to slam shut: without it the runner returns a single synthetic
+    // connect failure and no Tasks check exists at all.
+    expect(result.discovery).toMatchObject({
+      protocolVersion: EXTENSION_PROTOCOL_VERSION,
+      wire: "extension",
+      toolCount: 1,
+      probedTool: TASK_TOOL_NAME,
+    });
+    expect(result.discovery.createdTaskId).toBeTruthy();
+    expect(result.checks).toHaveLength(8);
+    expect(
+      result.checks.filter((entry) => entry.status === "skipped")
+    ).toHaveLength(0);
+  });
+
+  it("passes the undeclared-capability checks against a conformant fixture, having actually sent the probes", async () => {
+    const fixture = await serve();
+    const result = await runAgainst(fixture);
+
+    expect(check(result, "tasks-undeclared-capability-rejected").status).toBe(
+      "passed"
+    );
+    expect(check(result, "tasks-undeclared-creation-refused").status).toBe(
+      "passed"
+    );
+
+    // The whole point: the probes are only meaningful if the SERVER saw them.
+    for (const method of [
+      "tasks/get",
+      "tasks/update",
+      "tasks/cancel",
+      "subscriptions/listen",
+    ]) {
+      expect(
+        undeclaredRequests(fixture, method).length,
+        `${method} never reached the fixture without a declaration`
+      ).toBeGreaterThan(0);
+    }
+    // …and the runner agrees, per probe, that it did.
+    const probes = check(result, "tasks-undeclared-capability-rejected").details
+      ?.probes as Array<{
+      method: string;
+      outcome: string;
+      reachedWire?: boolean;
+    }>;
+    expect(probes.map((probe) => probe.outcome)).toEqual([
+      "rejected",
+      "rejected",
+      "rejected",
+      "rejected",
+    ]);
+    expect(probes.every((probe) => probe.reachedWire === true)).toBe(true);
+
+    // The undeclared tools/call reached it too, and produced no task.
+    expect(undeclaredRequests(fixture, "tools/call").length).toBeGreaterThan(0);
+    expect(fixture.tasks()).toHaveLength(1);
+  });
+
+  it("passes the rest of the suite against a conformant fixture", async () => {
+    const fixture = await serve();
+    const result = await runAgainst(fixture);
+
+    const verdicts = Object.fromEntries(
+      result.checks.map((entry) => [entry.id, entry.status])
+    );
+    expect(verdicts).toEqual({
+      "tasks-wire-resolvable": "passed",
+      "tasks-declaration-hygiene": "passed",
+      "tasks-result-type-discipline": "passed",
+      "tasks-undeclared-creation-refused": "passed",
+      "tasks-undeclared-capability-rejected": "passed",
+      "tasks-ttl-shape": "passed",
+      "tasks-inline-result": "passed",
+      "tasks-mcp-name-routing": "passed",
+    });
+    expect(result.passed).toBe(true);
+  });
+
+  it("fails the undeclared-capability check when the fixture answers undeclared task requests, naming every offending method", async () => {
+    const fixture = await serve({
+      misbehave: {
+        answerUndeclaredTaskRequests: true,
+        answerUndeclaredTaskSubscription: true,
+      },
+    });
+    const result = await runAgainst(fixture);
+
+    const rejected = check(result, "tasks-undeclared-capability-rejected");
+    expect(rejected.status).toBe("failed");
+    for (const method of [
+      "tasks/get",
+      "tasks/update",
+      "tasks/cancel",
+      "subscriptions/listen",
+    ]) {
+      expect(rejected.error?.message).toContain(
+        `${method} was answered instead of rejected`
+      );
+    }
+    expect(result.passed).toBe(false);
+  });
+
+  it("fails the undeclared-creation check when the fixture hands a task to a non-declaring caller", async () => {
+    const fixture = await serve({
+      misbehave: { createTaskForUndeclaredCall: true },
+    });
+    const result = await runAgainst(fixture);
+
+    const creation = check(result, "tasks-undeclared-creation-refused");
+    expect(creation.status).toBe("failed");
+    expect(creation.error?.message).toContain("CreateTaskResult");
+    expect(creation.details).toMatchObject({ tool: TASK_TOOL_NAME });
+    // The violation is real on the wire, not inferred: the fixture minted a
+    // second task for the call that carried no declaration.
+    expect(fixture.tasks().length).toBeGreaterThan(1);
+    expect(result.passed).toBe(false);
+  });
+
+  it("reports a connect failure as one failed run, not a green suite", async () => {
+    // The other direction of the discovery gate: nothing to talk to at all
+    // must surface as a failure, never as "no Tasks check ran, so nothing
+    // failed". (Probe-level "could not execute" is pinned deterministically in
+    // `runner.test.ts`, which can inject the exception; a live socket cannot
+    // be torn down at a reproducible point mid-run.)
+    const fixture = await serve();
+    const url = fixture.url;
+    await fixture.close();
+    opened.splice(0);
+
+    const result = await new MCPTasksConformanceTest({
+      url,
+      mcpProtocolVersion: EXTENSION_PROTOCOL_VERSION,
+      timeout: 2_000,
+      toolName: TASK_TOOL_NAME,
+      pollTimeoutMs: 1_000,
+    }).run();
+
+    expect(result.passed).toBe(false);
+    expect(result.checks.every((entry) => entry.status !== "passed")).toBe(
+      true
+    );
+  }, 20_000);
+});

--- a/sdk/tests/tasks-conformance/runner-fixture.integration.test.ts
+++ b/sdk/tests/tasks-conformance/runner-fixture.integration.test.ts
@@ -72,7 +72,8 @@ async function serve(
 }
 
 function runAgainst(
-  fixture: ServedExtensionTasksFixture
+  fixture: ServedExtensionTasksFixture,
+  overrides: Record<string, unknown> = {}
 ): Promise<MCPTasksConformanceResult> {
   return new MCPTasksConformanceTest({
     url: fixture.url,
@@ -83,7 +84,14 @@ function runAgainst(
     // probe tool is named rather than auto-picked.
     toolName: TASK_TOOL_NAME,
     pollTimeoutMs: 5_000,
-  }).run();
+    ...overrides,
+  } as never).run();
+}
+
+function unrunChecks(result: MCPTasksConformanceResult) {
+  return result.checks.filter(
+    (entry) => entry.status === "skipped" && entry.skipReason === "could-not-run"
+  );
 }
 
 function check(
@@ -227,6 +235,104 @@ describe("MCPTasksConformanceTest against the extension fixture", () => {
     // second task for the call that carried no declaration.
     expect(fixture.tasks().length).toBeGreaterThan(1);
     expect(result.passed).toBe(false);
+  });
+
+  it("reports INCOMPLETE, not success, when no toolName is given on the extension wire", async () => {
+    // The false green this suite exists to make impossible: auto-selection
+    // reads `execution.taskSupport`, which the 2026 ToolSchema strips, so
+    // without a `toolName` six task-dependent checks never run. Two of eight
+    // passing must never be reported as conformance.
+    const fixture = await serve();
+    const result = await runAgainst(fixture, { toolName: undefined });
+
+    expect(result.outcome).toBe("incomplete");
+    expect(result.passed).toBe(false);
+    expect(result.checks.some((entry) => entry.status === "failed")).toBe(false);
+
+    // Only the two wire-level checks genuinely ran; nothing else may read as
+    // a pass, and none of the gaps may be excused as "not applicable".
+    expect(
+      result.checks
+        .filter((entry) => entry.status === "passed")
+        .map((entry) => entry.id)
+        .sort()
+    ).toEqual(["tasks-declaration-hygiene", "tasks-wire-resolvable"]);
+    expect(unrunChecks(result)).toHaveLength(6);
+    expect(
+      result.checks.filter(
+        (entry) =>
+          entry.status === "skipped" && entry.skipReason === "not-applicable"
+      )
+    ).toHaveLength(0);
+
+    // The reason has to tell the user what to do and why the runner could not
+    // do it for them.
+    expect(result.incompleteReason).toContain("could not run");
+    expect(result.incompleteReason).toContain("--tool-name");
+    expect(result.incompleteReason).toContain("execution.taskSupport");
+    expect(result.incompleteReason).toContain("2026-07-28");
+    expect(result.incompleteReason).toContain(TASK_TOOL_NAME);
+    expect(result.summary).toContain("6 could not run");
+    expect(result.categorySummary.creation.couldNotRun).toBe(2);
+    expect(result.discovery.createdTaskId).toBeUndefined();
+  });
+
+  it("reports INCOMPLETE, naming the tool, when toolName is not listed by the server", async () => {
+    // A typo must not silently skip six checks either.
+    const fixture = await serve();
+    const result = await runAgainst(fixture, { toolName: "task_toool" });
+
+    expect(result.outcome).toBe("incomplete");
+    expect(result.passed).toBe(false);
+    expect(unrunChecks(result)).toHaveLength(6);
+    expect(result.incompleteReason).toContain('"task_toool"');
+    expect(result.incompleteReason).toContain("is not listed by this server");
+    // …and it points at what the server DOES list.
+    expect(result.incompleteReason).toContain(TASK_TOOL_NAME);
+    // No tools/call was attempted with a name the server never advertised.
+    expect(
+      fixture.received.filter((entry) => entry.method === "tools/call")
+    ).toHaveLength(0);
+  });
+
+  it("keeps an unlimited (null) TTL null across the whole round trip", async () => {
+    // `ttlMs: null` means unlimited and is semantically distinct from absent.
+    // A `??` default in the fixture's seed used to turn a deliberate phase-zero
+    // null into 60_000, so the wire shape could never be exercised.
+    const received: unknown[] = [];
+    const fixture = await serve({
+      tools: {
+        [TASK_TOOL_NAME]: taskTool([
+          { status: "working", ttlMs: null, pollIntervalMs: 5 },
+          {
+            status: "completed",
+            ttlMs: null,
+            result: { content: [{ type: "text", text: "done" }] },
+          },
+        ]),
+      },
+    });
+
+    const result = await runAgainst(fixture, {
+      rpcLogger: (event: { direction: string; message: unknown }) => {
+        if (event.direction === "receive") received.push(event.message);
+      },
+    });
+
+    expect(check(result, "tasks-ttl-shape").status).toBe("passed");
+    // The fixture kept the seed rather than defaulting it…
+    expect(fixture.tasks()[0].ttlMs).toBeNull();
+    // …and `null` reached the client as a PRESENT null, not as an absent key.
+    const withTask = received
+      .map((message) => (message as { result?: Record<string, unknown> }).result)
+      .filter(
+        (payload): payload is Record<string, unknown> =>
+          // `taskId` narrows this to task payloads: `tools/list` also carries a
+          // (numeric) `ttlMs` of its own under SEP-2549.
+          !!payload && "taskId" in payload && "ttlMs" in payload
+      );
+    expect(withTask.length).toBeGreaterThan(0);
+    expect(withTask.every((payload) => payload.ttlMs === null)).toBe(true);
   });
 
   it("reports a connect failure as one failed run, not a green suite", async () => {

--- a/sdk/tests/tasks-conformance/runner.test.ts
+++ b/sdk/tests/tasks-conformance/runner.test.ts
@@ -2,11 +2,14 @@ import { beforeEach, describe, expect, it, vi, afterEach } from "vitest";
 import {
   MCPTasksConformanceTest,
   MCP_TASKS_CHECK_IDS,
+  decideOutcome,
   findDeclarationViolations,
   pickProbeTool,
+  resolveProbeTool,
   validateCreateTaskShape,
   validateTaskTtlShape,
 } from "../../src/tasks-conformance/index.js";
+import type { MCPTasksCheckResult } from "../../src/tasks-conformance/index.js";
 import * as operations from "../../src/operations.js";
 
 const EXT_ID = "io.modelcontextprotocol/tasks";
@@ -284,6 +287,94 @@ describe("pickProbeTool", () => {
     expect(pickProbeTool(tools, "plain")?.name).toBe("plain");
     expect(pickProbeTool([tools[0]])).toBeUndefined();
   });
+
+  describe("resolveProbeTool", () => {
+    it("auto-selects on the legacy wire, where taskSupport still exists", () => {
+      const resolved = resolveProbeTool("legacy", tools);
+      expect(resolved.tool?.name).toBe("required_task");
+      expect(resolved.reason).toBeUndefined();
+    });
+
+    it("blocks on the extension wire, naming the flag and why auto-selection cannot work", () => {
+      const resolved = resolveProbeTool("extension", [tools[0]]);
+      expect(resolved.tool).toBeUndefined();
+      expect(resolved.blocking).toBe(true);
+      expect(resolved.reason).toContain("--tool-name");
+      expect(resolved.reason).toContain("execution.taskSupport");
+      expect(resolved.reason).toContain("2026-07-28");
+      // It points at what the server does list.
+      expect(resolved.reason).toContain("plain");
+    });
+
+    it("blocks on a legacy server with no task-capable tool", () => {
+      const resolved = resolveProbeTool("legacy", [tools[0]]);
+      expect(resolved.blocking).toBe(true);
+      expect(resolved.reason).toContain("execution.taskSupport");
+    });
+
+    it("blocks — naming the tool — when the requested name is not listed", () => {
+      const resolved = resolveProbeTool("extension", tools, "typo_task");
+      expect(resolved.tool).toBeUndefined();
+      expect(resolved.blocking).toBe(true);
+      expect(resolved.reason).toContain('"typo_task"');
+      expect(resolved.reason).toContain("is not listed by this server");
+      expect(resolved.reason).toContain("required_task");
+    });
+
+    it("is NOT blocking when there is no tasks wire at all", () => {
+      const resolved = resolveProbeTool("none", tools);
+      expect(resolved.tool).toBeUndefined();
+      expect(resolved.blocking).toBe(false);
+      expect(resolved.reason).toContain("no tasks wire");
+    });
+  });
+});
+
+describe("decideOutcome", () => {
+  const check = (
+    status: MCPTasksCheckResult["status"],
+    skipReason?: MCPTasksCheckResult["skipReason"]
+  ) =>
+    ({
+      id: "tasks-ttl-shape",
+      category: "lifecycle",
+      title: "t",
+      description: "d",
+      status,
+      durationMs: 0,
+      ...(skipReason ? { skipReason } : {}),
+      ...(status === "skipped" ? { error: { message: "why" } } : {}),
+    }) as MCPTasksCheckResult;
+
+  it("passes only when every selected check produced a verdict", () => {
+    expect(decideOutcome([check("passed")]).outcome).toBe("passed");
+    // An inapplicable check establishes nothing but leaves nothing untested.
+    expect(
+      decideOutcome([check("passed"), check("skipped", "not-applicable")])
+        .outcome
+    ).toBe("passed");
+  });
+
+  it("never lets a check that could not run add up to a pass", () => {
+    const verdict = decideOutcome([
+      check("passed"),
+      check("skipped", "could-not-run"),
+    ]);
+    expect(verdict.outcome).toBe("incomplete");
+    expect(verdict.incompleteReason).toContain("1 of 2");
+    expect(verdict.incompleteReason).toContain("why");
+  });
+
+  it("reports a violation as failed even when other checks did not run", () => {
+    expect(
+      decideOutcome([check("failed"), check("skipped", "could-not-run")])
+        .outcome
+    ).toBe("failed");
+  });
+
+  it("treats an empty selection as incomplete rather than vacuously green", () => {
+    expect(decideOutcome([]).outcome).toBe("incomplete");
+  });
 });
 
 describe("MCPTasksConformanceTest", () => {
@@ -505,6 +596,108 @@ describe("MCPTasksConformanceTest", () => {
     expect(statusMap(result)["tasks-mcp-name-routing"]).toBe("skipped");
   });
 
+  it("auto-selects the probe tool on the legacy wire, where taskSupport survives", async () => {
+    // The legacy wire is the one era where `execution.taskSupport` reaches the
+    // client, so a run with NO toolName must still exercise the task checks.
+    const manager = extensionManager({
+      getNegotiatedProtocolVersion: () => "2025-11-25",
+      getServerCapabilities: () => ({
+        tools: {},
+        tasks: { requests: { tools: { call: true } } },
+      }),
+      getTasksSupport: () => ({
+        wire: "legacy",
+        toolCalls: true,
+        list: false,
+        cancel: true,
+        update: false,
+        inlineResult: false,
+      }),
+      listTools: async () => ({
+        tools: [
+          { name: "plain", inputSchema: {} },
+          {
+            name: "long_job",
+            inputSchema: {},
+            execution: { taskSupport: "required" },
+          },
+        ],
+      }),
+      executeTool: async () => ({
+        task: { taskId: "task-1", status: "working", ttl: 60_000 },
+      }),
+      getTask: async () => ({
+        taskId: "task-1",
+        status: "completed",
+        ttl: 60_000,
+      }),
+      getTaskResult: async () => ({ content: [] }),
+    });
+
+    const result = await runAgainst(manager, {
+      config: { pollTimeoutMs: 500 },
+    });
+
+    expect(result.discovery.probedTool).toBe("long_job");
+    expect(result.outcome).toBe("passed");
+    expect(result.passed).toBe(true);
+    expect(statusMap(result)["tasks-result-type-discipline"]).toBe("passed");
+    expect(statusMap(result)["tasks-ttl-shape"]).toBe("passed");
+    expect(statusMap(result)["tasks-inline-result"]).toBe("passed");
+  });
+
+  it("reports INCOMPLETE when the extension wire has no probe tool to select", async () => {
+    // No toolName, and the 2026 ToolSchema strips `execution.taskSupport`, so
+    // nothing can be auto-selected. Six checks never run — and the run must
+    // say so instead of scoring 2/8 as a pass.
+    const result = await runAgainst(extensionManager(), {
+      config: { pollTimeoutMs: 500 },
+    });
+
+    expect(result.outcome).toBe("incomplete");
+    expect(result.passed).toBe(false);
+    expect(result.checks.some((c) => c.status === "failed")).toBe(false);
+    expect(
+      result.checks.filter(
+        (c) => c.status === "skipped" && c.skipReason === "could-not-run"
+      )
+    ).toHaveLength(6);
+    expect(result.incompleteReason).toContain("--tool-name");
+    expect(result.incompleteReason).toContain("long_job");
+  });
+
+  it("reports INCOMPLETE when the requested probe tool is not listed", async () => {
+    const result = await runAgainst(extensionManager(), {
+      config: { toolName: "nope", pollTimeoutMs: 500 },
+    });
+
+    expect(result.outcome).toBe("incomplete");
+    expect(result.passed).toBe(false);
+    expect(result.incompleteReason).toContain('"nope"');
+    expect(result.incompleteReason).toContain("is not listed by this server");
+    expect(result.incompleteReason).toContain("long_job");
+  });
+
+  it("reports INCOMPLETE when the probed tool never produced a task", async () => {
+    const manager = extensionManager({
+      executeTool: async () => ({
+        resultType: "complete",
+        content: [{ type: "text", text: "sync" }],
+      }),
+    });
+
+    const result = await runAgainst(manager, {
+      config: { toolName: "long_job", pollTimeoutMs: 500 },
+    });
+
+    // Result-type discipline DID run (a normal result is conformant); the
+    // lifecycle checks did not, and that is the run's verdict.
+    expect(statusMap(result)["tasks-result-type-discipline"]).toBe("passed");
+    expect(statusMap(result)["tasks-ttl-shape"]).toBe("skipped");
+    expect(result.outcome).toBe("incomplete");
+    expect(result.incompleteReason).toContain("no task existed to inspect");
+  });
+
   it("skips the task checks when the connection has no tasks wire", async () => {
     const manager = extensionManager({
       getNegotiatedProtocolVersion: () => "2025-06-18",
@@ -525,8 +718,15 @@ describe("MCPTasksConformanceTest", () => {
     const result = await runAgainst(manager);
 
     expect(result.passed).toBe(true);
+    expect(result.outcome).toBe("passed");
     expect(statusMap(result)["tasks-result-type-discipline"]).toBe("skipped");
     expect(statusMap(result)["tasks-ttl-shape"]).toBe("skipped");
+    // Inapplicable, not unexercised: there is no tasks behavior to establish.
+    expect(
+      result.checks
+        .filter((c) => c.status === "skipped")
+        .every((c) => c.skipReason === "not-applicable")
+    ).toBe(true);
   });
 
   it("reports a connection failure as a failed run", async () => {
@@ -730,8 +930,13 @@ describe("undeclared task requests (-32003)", () => {
     );
 
     const check = undeclaredCheck(result);
+    // Skipped, but as a GAP: the -32003 requirement was never put to the
+    // server, so the run cannot report conformance.
     expect(check?.status).toBe("skipped");
+    expect(check?.skipReason).toBe("could-not-run");
     expect(check?.error?.message).toContain("raw request seam");
+    expect(result.outcome).toBe("incomplete");
+    expect(result.passed).toBe(false);
   });
 
   it("probes the mutating methods only after every check that reads the task", async () => {

--- a/sdk/tests/tasks-conformance/runner.test.ts
+++ b/sdk/tests/tasks-conformance/runner.test.ts
@@ -17,6 +17,23 @@ function extensionDeclaration() {
 }
 
 /**
+ * The live `rpcLogger` of the run in progress. The runner reads the outbound
+ * rpc log to tell "the server never answered" apart from "the request never
+ * left the process", so a fake seam that wants to model the FORMER has to
+ * announce its send the way a real transport would.
+ */
+let activeRpcLogger: ((event: unknown) => void) | undefined;
+
+/** Announce an outbound request on the run's rpc log, as a transport would. */
+function logSend(method: string) {
+  activeRpcLogger?.({
+    direction: "send",
+    message: { method, params: {} },
+    serverId: "srv",
+  });
+}
+
+/**
  * Runs the conformance test against a fake connection by standing in for
  * `withEphemeralClient`, which is where the runner gets its manager.
  */
@@ -33,6 +50,7 @@ function runAgainst(
     opts: unknown
   ) => {
     const { rpcLogger } = (opts ?? {}) as { rpcLogger?: (e: unknown) => void };
+    activeRpcLogger = rpcLogger;
     for (const message of options.sentMessages ?? []) {
       rpcLogger?.({ direction: "send", message, serverId: "srv" });
     }
@@ -98,8 +116,14 @@ function extensionManager(overrides: Record<string, unknown> = {}) {
     // A conformant server refuses EVERY undeclared task request with -32003
     // (ext-tasks tasks.md:797-799), including a task-filtered
     // subscriptions/listen.
-    getClient: () => ({
-      request: async () => {
+    //
+    // The seam is `getManagedClient().requestWithSchema`, not
+    // `getClient().request`: the schema-less overload cannot carry a `tasks/*`
+    // method on the 2026 wire (it has no era-registry result entry and throws
+    // locally), so the probes ride the explicit-schema seam — the same one
+    // `tasks-ext.ts` uses for the DECLARING calls, minus the declaration.
+    getManagedClient: () => ({
+      requestWithSchema: async () => {
         throw Object.assign(new Error("missing capability"), {
           code: -32003,
         });
@@ -115,7 +139,7 @@ function extensionManager(overrides: Record<string, unknown> = {}) {
  */
 function undeclaredSeam(perMethod: Record<string, () => unknown>) {
   return () => ({
-    request: async (payload: { method: string }) => {
+    requestWithSchema: async (payload: { method: string }) => {
       const behavior = perMethod[payload.method];
       if (behavior) return behavior();
       throw Object.assign(new Error("missing capability"), { code: -32003 });
@@ -335,6 +359,105 @@ describe("MCPTasksConformanceTest", () => {
     expect(result.passed).toBe(false);
   });
 
+  it("fails when an undeclared tools/call smuggles a task through the manager's _meta stash", async () => {
+    // Without `allowTaskResult` the manager never returns a `CreateTaskResult`
+    // at the top level: the transport wrapper rewrites it into a plain
+    // `CallToolResult` and parks the payload under
+    // `_meta["io.mcpjam/tasks/create-task-result"]`. A detector reading only
+    // `result.taskId` sees an ordinary result from EVERY server and passes
+    // against the exact violation it exists to catch.
+    const manager = extensionManager({
+      executeTool: async (
+        _serverId: string,
+        _toolName: string,
+        _args: unknown,
+        options?: { allowTaskResult?: boolean }
+      ) =>
+        options?.allowTaskResult
+          ? { resultType: "task", taskId: "task-1" }
+          : {
+              content: [],
+              _meta: {
+                "io.mcpjam/tasks/create-task-result": {
+                  resultType: "task",
+                  taskId: "smuggled-1",
+                  status: "working",
+                },
+              },
+            },
+    });
+
+    const result = await runAgainst(manager, {
+      config: { toolName: "long_job", pollTimeoutMs: 500 },
+    });
+
+    const check = result.checks.find(
+      (c) => c.id === "tasks-undeclared-creation-refused"
+    );
+    expect(check?.status).toBe("failed");
+    expect(check?.details).toMatchObject({ taskId: "smuggled-1" });
+    expect(result.passed).toBe(false);
+  });
+
+  it("fails, rather than passing, when the undeclared creation probe cannot execute", async () => {
+    // Any exception used to become `taskCreated: false`, which the check
+    // counted as a PASS — so a timeout or a dead connection scored as
+    // conformance. A thrown error with NO numeric code means no JSON-RPC
+    // response exists, so nothing about the server was observed.
+    const manager = extensionManager({
+      executeTool: async (
+        _serverId: string,
+        _toolName: string,
+        _args: unknown,
+        options?: { allowTaskResult?: boolean }
+      ) => {
+        if (options?.allowTaskResult)
+          return { resultType: "task", taskId: "task-1" };
+        throw new Error("Connection closed");
+      },
+    });
+
+    const result = await runAgainst(manager, {
+      config: { toolName: "long_job", pollTimeoutMs: 500 },
+    });
+
+    const check = result.checks.find(
+      (c) => c.id === "tasks-undeclared-creation-refused"
+    );
+    expect(check?.status).toBe("failed");
+    expect(check?.error?.message).toContain("no JSON-RPC response");
+    expect(check?.error?.message).toContain("Connection closed");
+    expect(result.passed).toBe(false);
+  });
+
+  it("passes an undeclared creation the server refused, warning when the code is not -32003", async () => {
+    const manager = extensionManager({
+      executeTool: async (
+        _serverId: string,
+        _toolName: string,
+        _args: unknown,
+        options?: { allowTaskResult?: boolean }
+      ) => {
+        if (options?.allowTaskResult)
+          return { resultType: "task", taskId: "task-1" };
+        throw Object.assign(new Error("nope"), { code: -32602 });
+      },
+    });
+
+    const result = await runAgainst(manager, {
+      config: { toolName: "long_job", pollTimeoutMs: 500 },
+    });
+
+    const check = result.checks.find(
+      (c) => c.id === "tasks-undeclared-creation-refused"
+    );
+    // No task was handed to a non-declaring client, which is what tasks.md:61
+    // requires — but the refusal is not the one the extension names.
+    expect(check?.status).toBe("passed");
+    expect(check?.warnings?.[0]).toContain("-32602");
+    expect(check?.details).toMatchObject({ undeclaredCreationCode: -32602 });
+  });
+
   it("flags a server advertising the extension on 2025-11-25 without failing", async () => {
     const manager = extensionManager({
       getNegotiatedProtocolVersion: () => "2025-11-25",
@@ -427,9 +550,12 @@ describe("MCPTasksConformanceTest", () => {
  */
 describe("undeclared task requests (-32003)", () => {
   const runProbe = (perMethod: Record<string, () => unknown>) =>
-    runAgainst(extensionManager({ getClient: undeclaredSeam(perMethod) }), {
-      config: { toolName: "long_job", pollTimeoutMs: 500 },
-    });
+    runAgainst(
+      extensionManager({ getManagedClient: undeclaredSeam(perMethod) }),
+      {
+        config: { toolName: "long_job", pollTimeoutMs: 500 },
+      }
+    );
 
   it("passes when every undeclared request is rejected with -32003", async () => {
     const result = await runProbe({});
@@ -440,10 +566,30 @@ describe("undeclared task requests (-32003)", () => {
     const check = undeclaredCheck(result);
     expect(check?.warnings ?? []).toEqual([]);
     expect(check?.details?.probes).toEqual([
-      { method: "tasks/get", outcome: "rejected", code: -32003 },
-      { method: "tasks/update", outcome: "rejected", code: -32003 },
-      { method: "subscriptions/listen", outcome: "rejected", code: -32003 },
-      { method: "tasks/cancel", outcome: "rejected", code: -32003 },
+      {
+        method: "tasks/get",
+        outcome: "rejected",
+        code: -32003,
+        reachedWire: true,
+      },
+      {
+        method: "tasks/update",
+        outcome: "rejected",
+        code: -32003,
+        reachedWire: true,
+      },
+      {
+        method: "subscriptions/listen",
+        outcome: "rejected",
+        code: -32003,
+        reachedWire: true,
+      },
+      {
+        method: "tasks/cancel",
+        outcome: "rejected",
+        code: -32003,
+        reachedWire: true,
+      },
     ]);
   });
 
@@ -465,6 +611,7 @@ describe("undeclared task requests (-32003)", () => {
       expect(check?.details?.probes).toContainEqual({
         method,
         outcome: "answered",
+        reachedWire: false,
       });
     });
 
@@ -515,9 +662,13 @@ describe("undeclared task requests (-32003)", () => {
     );
   });
 
-  it("fails a probe that never produces a rejection at all", async () => {
+  it("fails a probe the server received but never answered", async () => {
     const result = await runProbe({
       "subscriptions/listen": () => {
+        // A stream the server held open past the probe deadline: upstream
+        // raises an `SdkError` (STRING code, so no numeric `code` reaches the
+        // runner), but the request DID go out.
+        logSend("subscriptions/listen");
         throw new Error("stream stayed open");
       },
     });
@@ -525,6 +676,41 @@ describe("undeclared task requests (-32003)", () => {
     const check = undeclaredCheck(result);
     expect(check?.status).toBe("failed");
     expect(check?.error?.message).toContain("no JSON-RPC rejection");
+    expect(check?.details?.probes).toContainEqual(
+      expect.objectContaining({
+        method: "subscriptions/listen",
+        outcome: "no-response",
+        reachedWire: true,
+      })
+    );
+  });
+
+  it("fails — and says so — when a probe never reaches the server at all", async () => {
+    // The shape of the bug this seam was rewritten to kill: the request dies
+    // locally (a missing result schema, upstream's outbound era gate), so the
+    // -32003 requirement is never put to the server. It must never read as
+    // conformance, and the failure must say the probe did not run.
+    const result = await runProbe({
+      "tasks/get": () => {
+        throw new Error(
+          "pass a result schema as the second argument to request()"
+        );
+      },
+    });
+
+    const check = undeclaredCheck(result);
+    expect(check?.status).toBe("failed");
+    expect(check?.error?.message).toContain(
+      "tasks/get never reached the server"
+    );
+    expect(check?.error?.message).toContain("was NOT tested");
+    expect(check?.details?.probes).toContainEqual(
+      expect.objectContaining({
+        method: "tasks/get",
+        outcome: "probe-failed",
+        reachedWire: false,
+      })
+    );
   });
 
   it("does not judge the -32601 escape hatch on tasks/* methods", async () => {
@@ -539,7 +725,7 @@ describe("undeclared task requests (-32003)", () => {
 
   it("skips the check when the connection exposes no raw request seam", async () => {
     const result = await runAgainst(
-      extensionManager({ getClient: () => ({}) }),
+      extensionManager({ getManagedClient: () => ({}) }),
       { config: { toolName: "long_job", pollTimeoutMs: 500 } }
     );
 
@@ -560,8 +746,8 @@ describe("undeclared task requests (-32003)", () => {
         order.push("declared:tasks/get");
         return declaredGet(serverId, taskId);
       },
-      getClient: () => ({
-        request: async (payload: { method: string }) => {
+      getManagedClient: () => ({
+        requestWithSchema: async (payload: { method: string }) => {
           order.push(`undeclared:${payload.method}`);
           throw Object.assign(new Error("missing capability"), {
             code: -32003,

--- a/sdk/tests/tasks-conformance/runner.test.ts
+++ b/sdk/tests/tasks-conformance/runner.test.ts
@@ -95,6 +95,9 @@ function extensionManager(overrides: Record<string, unknown> = {}) {
       });
       return task;
     },
+    // A conformant server refuses EVERY undeclared task request with -32003
+    // (ext-tasks tasks.md:797-799), including a task-filtered
+    // subscriptions/listen.
     getClient: () => ({
       request: async () => {
         throw Object.assign(new Error("missing capability"), {
@@ -104,6 +107,34 @@ function extensionManager(overrides: Record<string, unknown> = {}) {
     }),
     ...overrides,
   } as Record<string, unknown>;
+}
+
+/**
+ * A raw request seam whose behavior is set per JSON-RPC method. Anything not
+ * listed gets the conformant answer: rejected with -32003.
+ */
+function undeclaredSeam(perMethod: Record<string, () => unknown>) {
+  return () => ({
+    request: async (payload: { method: string }) => {
+      const behavior = perMethod[payload.method];
+      if (behavior) return behavior();
+      throw Object.assign(new Error("missing capability"), { code: -32003 });
+    },
+  });
+}
+
+function rpcError(code: number, message = "nope") {
+  return () => {
+    throw Object.assign(new Error(message), { code });
+  };
+}
+
+function undeclaredCheck(
+  result: Awaited<ReturnType<MCPTasksConformanceTest["run"]>>
+) {
+  return result.checks.find(
+    (c) => c.id === "tasks-undeclared-capability-rejected"
+  );
 }
 
 // The Mcp-Name check instruments `globalThis.fetch`; no test talks to a real
@@ -158,10 +189,17 @@ describe("shape validators", () => {
     expect(
       validateCreateTaskShape({ resultType: "task", taskId: "t" })
     ).toEqual({ violations: [], warnings: [] });
+    // Present-but-wrong discriminator misleads the client: a violation.
     expect(
       validateCreateTaskShape({ resultType: "complete", taskId: "t" })
         .violations[0]
     ).toContain("resultType");
+    // ABSENT discriminator is equally a violation (tasks.md:102). It is the
+    // ONLY signal separating a CreateTaskResult from a standard result, and
+    // this SDK discriminates on it, so omitting it makes the task invisible.
+    const noDiscriminator = validateCreateTaskShape({ taskId: "t" });
+    expect(noDiscriminator.warnings).toEqual([]);
+    expect(noDiscriminator.violations[0]).toContain("resultType");
     expect(
       validateCreateTaskShape({ resultType: "task" }).violations[0]
     ).toContain("taskId");
@@ -245,6 +283,7 @@ describe("MCPTasksConformanceTest", () => {
       "tasks-wire-resolvable": "passed",
       "tasks-declaration-hygiene": "passed",
       "tasks-result-type-discipline": "passed",
+      "tasks-undeclared-creation-refused": "passed",
       "tasks-undeclared-capability-rejected": "passed",
       "tasks-ttl-shape": "passed",
       "tasks-inline-result": "passed",
@@ -279,30 +318,9 @@ describe("MCPTasksConformanceTest", () => {
     ).toContain("INLINE");
   });
 
-  it("passes WITH a warning when tasks/get without the declaration is answered", async () => {
-    // Answering a bare tasks/get is conformant: -32003 is mandated only when
-    // the server cannot avoid returning CreateTaskResult to an undeclared
-    // client — never for a bare read. Lenient handling surfaces as a warning.
-    const manager = extensionManager({
-      getClient: () => ({ request: async () => ({ taskId: "task-1" }) }),
-    });
-
-    const result = await runAgainst(manager, {
-      config: { toolName: "long_job", pollTimeoutMs: 500 },
-    });
-
-    expect(statusMap(result)["tasks-undeclared-capability-rejected"]).toBe(
-      "passed"
-    );
-    const check = result.checks.find(
-      (c) => c.id === "tasks-undeclared-capability-rejected"
-    );
-    expect(check?.warnings?.[0]).toContain("allowed");
-  });
-
   it("fails when an undeclared tools/call is turned into a task", async () => {
-    // The mandated case: a server must not create a task for a client that
-    // never declared the capability.
+    // tasks.md:61 — a server must not return CreateTaskResult to a client
+    // that did not declare the capability ON THAT REQUEST.
     const manager = extensionManager({
       executeTool: async () => ({ resultType: "task", taskId: "task-1" }),
     });
@@ -311,9 +329,10 @@ describe("MCPTasksConformanceTest", () => {
       config: { toolName: "long_job", pollTimeoutMs: 500 },
     });
 
-    expect(statusMap(result)["tasks-undeclared-capability-rejected"]).toBe(
+    expect(statusMap(result)["tasks-undeclared-creation-refused"]).toBe(
       "failed"
     );
+    expect(result.passed).toBe(false);
   });
 
   it("flags a server advertising the extension on 2025-11-25 without failing", async () => {
@@ -357,6 +376,9 @@ describe("MCPTasksConformanceTest", () => {
     expect(statusMap(result)["tasks-undeclared-capability-rejected"]).toBe(
       "skipped"
     );
+    expect(statusMap(result)["tasks-undeclared-creation-refused"]).toBe(
+      "skipped"
+    );
     expect(statusMap(result)["tasks-mcp-name-routing"]).toBe("skipped");
   });
 
@@ -395,5 +417,179 @@ describe("MCPTasksConformanceTest", () => {
 
     expect(result.passed).toBe(false);
     expect(result.checks[0].error?.message).toContain("connect refused");
+  });
+});
+
+/**
+ * ext-tasks tasks.md:797-799 — servers MUST answer -32003 for a non-declaring
+ * client on tasks/get, tasks/update, tasks/cancel, and on task notifications
+ * requested through subscriptions/listen. Unconditional: anything else fails.
+ */
+describe("undeclared task requests (-32003)", () => {
+  const runProbe = (perMethod: Record<string, () => unknown>) =>
+    runAgainst(extensionManager({ getClient: undeclaredSeam(perMethod) }), {
+      config: { toolName: "long_job", pollTimeoutMs: 500 },
+    });
+
+  it("passes when every undeclared request is rejected with -32003", async () => {
+    const result = await runProbe({});
+
+    expect(statusMap(result)["tasks-undeclared-capability-rejected"]).toBe(
+      "passed"
+    );
+    const check = undeclaredCheck(result);
+    expect(check?.warnings ?? []).toEqual([]);
+    expect(check?.details?.probes).toEqual([
+      { method: "tasks/get", outcome: "rejected", code: -32003 },
+      { method: "tasks/update", outcome: "rejected", code: -32003 },
+      { method: "subscriptions/listen", outcome: "rejected", code: -32003 },
+      { method: "tasks/cancel", outcome: "rejected", code: -32003 },
+    ]);
+  });
+
+  for (const method of [
+    "tasks/get",
+    "tasks/update",
+    "tasks/cancel",
+    "subscriptions/listen",
+  ]) {
+    it(`fails when an undeclared ${method} is answered`, async () => {
+      const result = await runProbe({ [method]: () => ({ taskId: "task-1" }) });
+
+      expect(statusMap(result)["tasks-undeclared-capability-rejected"]).toBe(
+        "failed"
+      );
+      expect(result.passed).toBe(false);
+      const check = undeclaredCheck(result);
+      expect(check?.error?.message).toContain(`${method} was answered`);
+      expect(check?.details?.probes).toContainEqual({
+        method,
+        outcome: "answered",
+      });
+    });
+
+    it(`fails when an undeclared ${method} is rejected with another code`, async () => {
+      const result = await runProbe({ [method]: rpcError(-32602) });
+
+      expect(statusMap(result)["tasks-undeclared-capability-rejected"]).toBe(
+        "failed"
+      );
+      const check = undeclaredCheck(result);
+      expect(check?.error?.message).toContain(
+        `${method} was rejected with -32602`
+      );
+    });
+  }
+
+  it("names every offending method when several misbehave", async () => {
+    const result = await runProbe({
+      "tasks/update": () => ({}),
+      "tasks/cancel": rpcError(-32601),
+    });
+
+    const check = undeclaredCheck(result);
+    expect(check?.status).toBe("failed");
+    expect(check?.error?.message).toContain("2 undeclared request(s)");
+    expect(check?.error?.message).toContain("tasks/update was answered");
+    expect(check?.error?.message).toContain("tasks/cancel was rejected with");
+  });
+
+  it("skips the subscriptions/listen sub-probe when the server lacks the method", async () => {
+    // -32601 on a core method the extension only borrows: not probeable, so
+    // it must not be judged. tasks/* still has to answer -32003.
+    const result = await runProbe({
+      "subscriptions/listen": rpcError(-32601, "Method not found"),
+    });
+
+    expect(statusMap(result)["tasks-undeclared-capability-rejected"]).toBe(
+      "passed"
+    );
+    const check = undeclaredCheck(result);
+    expect(check?.warnings?.[0]).toContain("subscriptions/listen");
+    expect(check?.warnings?.[0]).toContain("not probed");
+    expect(check?.details?.probes).toContainEqual(
+      expect.objectContaining({
+        method: "subscriptions/listen",
+        outcome: "unsupported",
+      })
+    );
+  });
+
+  it("fails a probe that never produces a rejection at all", async () => {
+    const result = await runProbe({
+      "subscriptions/listen": () => {
+        throw new Error("stream stayed open");
+      },
+    });
+
+    const check = undeclaredCheck(result);
+    expect(check?.status).toBe("failed");
+    expect(check?.error?.message).toContain("no JSON-RPC rejection");
+  });
+
+  it("does not judge the -32601 escape hatch on tasks/* methods", async () => {
+    // Only the listen sub-probe may be skipped: a server on the extension wire
+    // declared the whole task method set, so -32601 there is a real failure.
+    const result = await runProbe({ "tasks/get": rpcError(-32601) });
+
+    expect(statusMap(result)["tasks-undeclared-capability-rejected"]).toBe(
+      "failed"
+    );
+  });
+
+  it("skips the check when the connection exposes no raw request seam", async () => {
+    const result = await runAgainst(
+      extensionManager({ getClient: () => ({}) }),
+      { config: { toolName: "long_job", pollTimeoutMs: 500 } }
+    );
+
+    const check = undeclaredCheck(result);
+    expect(check?.status).toBe("skipped");
+    expect(check?.error?.message).toContain("raw request seam");
+  });
+
+  it("probes the mutating methods only after every check that reads the task", async () => {
+    const order: string[] = [];
+    const base = extensionManager();
+    const declaredGet = base.getTaskExt as (
+      serverId: string,
+      taskId: string
+    ) => Promise<unknown>;
+    const manager = extensionManager({
+      getTaskExt: async (serverId: string, taskId: string) => {
+        order.push("declared:tasks/get");
+        return declaredGet(serverId, taskId);
+      },
+      getClient: () => ({
+        request: async (payload: { method: string }) => {
+          order.push(`undeclared:${payload.method}`);
+          throw Object.assign(new Error("missing capability"), {
+            code: -32003,
+          });
+        },
+      }),
+    });
+
+    const result = await runAgainst(manager, {
+      config: { toolName: "long_job", pollTimeoutMs: 500 },
+    });
+
+    // Every declared read (polling + the Mcp-Name routing probe) happens
+    // first; the undeclared probes trail, cancel last of all.
+    expect(order.slice(-4)).toEqual([
+      "undeclared:tasks/get",
+      "undeclared:tasks/update",
+      "undeclared:subscriptions/listen",
+      "undeclared:tasks/cancel",
+    ]);
+    const declaredReads = order.filter((entry) =>
+      entry.startsWith("declared:")
+    );
+    expect(declaredReads.length).toBeGreaterThan(0);
+    expect(order.indexOf("undeclared:tasks/update")).toBeGreaterThan(
+      order.lastIndexOf("declared:tasks/get")
+    );
+    expect(statusMap(result)["tasks-inline-result"]).toBe("passed");
+    expect(statusMap(result)["tasks-mcp-name-routing"]).toBe("passed");
   });
 });

--- a/sdk/tests/tasks-ext-era-gate.test.ts
+++ b/sdk/tests/tasks-ext-era-gate.test.ts
@@ -1,0 +1,151 @@
+/**
+ * The `io.modelcontextprotocol/tasks` era-gate shadow
+ * (`src/mcp-client-manager/tasks-ext-era-gate.ts`).
+ *
+ * These tests drive the REAL upstream gate: they install the shadow on a real
+ * `Client` and then invoke the shadowed member with codec stand-ins carrying
+ * the two real `era` strings (`rev2025Codec.era` / `rev2026Codec.era`) and the
+ * codec's own `hasRequestMethod` answer. The delegation cases therefore run
+ * upstream's actual `isSpecRequestMethod` check rather than a stub of it.
+ */
+
+import { describe, expect, it } from "vitest";
+import { Client } from "@modelcontextprotocol/client";
+import {
+  TasksExtEraGateSeamError,
+  installTasksExtensionEraGateShadow,
+} from "../src/mcp-client-manager/tasks-ext-era-gate.js";
+import { TasksExtRequestMethods } from "../src/mcp-client-manager/tasks-ext.js";
+import { createManagedMcpClient } from "../src/mcp-client-manager/managed-mcp-client-factory.js";
+
+const MODERN_ERA = "2026-07-28";
+const LEGACY_ERA = "2025-11-25";
+const GATE = "_assertOutboundRequestInEra";
+
+type Gate = (codec: { era: string }, method: string) => void;
+
+/** A real client with the shadow installed, plus a handle on the gate. */
+function shadowedClient(): { client: Client; gate: Gate } {
+  const client = new Client({ name: "test", version: "0.0.0" }, {});
+  installTasksExtensionEraGateShadow(client);
+  const gate = (client as unknown as Record<string, unknown>)[GATE] as Gate;
+  return { client, gate: (codec, method) => gate.call(client, codec, method) };
+}
+
+/**
+ * A codec stand-in. `hasRequestMethod` mirrors the real registries for the
+ * methods under test: the 2026 registry has no `tasks/*` at all, and the 2025
+ * registry has `tasks/get|result|list|cancel` but not `tasks/update`.
+ */
+function codecFor(era: string) {
+  const inEra =
+    era === MODERN_ERA
+      ? new Set<string>(["tools/call"])
+      : new Set<string>([
+          "tools/call",
+          "tasks/get",
+          "tasks/result",
+          "tasks/list",
+          "tasks/cancel",
+        ]);
+  return { era, hasRequestMethod: (method: string) => inEra.has(method) };
+}
+
+describe("tasks extension era-gate shadow", () => {
+  it("exempts exactly the three extension methods on the 2026-07-28 era", () => {
+    const { gate } = shadowedClient();
+    for (const method of TasksExtRequestMethods) {
+      expect(() => gate(codecFor(MODERN_ERA), method)).not.toThrow();
+    }
+    expect(TasksExtRequestMethods).toEqual([
+      "tasks/get",
+      "tasks/update",
+      "tasks/cancel",
+    ]);
+  });
+
+  it("still era-gates a NON-tasks method deleted from the 2026 era", () => {
+    const { gate } = shadowedClient();
+    // `tasks/list` is a 2025-registry member with no extension counterpart, so
+    // it must keep dying locally — the shadow is not a blanket bypass.
+    expect(() => gate(codecFor(MODERN_ERA), "tasks/list")).toThrow(
+      /not supported by the negotiated protocol version/
+    );
+    expect(() => gate(codecFor(MODERN_ERA), "tasks/result")).toThrow(
+      /not supported by the negotiated protocol version/
+    );
+  });
+
+  it("is inert on the legacy era — every method delegates", () => {
+    const { gate } = shadowedClient();
+    const legacy = codecFor(LEGACY_ERA);
+    // In-era on 2025-11-25: allowed, exactly as upstream would.
+    expect(() => gate(legacy, "tasks/get")).not.toThrow();
+    expect(() => gate(legacy, "tasks/cancel")).not.toThrow();
+    expect(() => gate(legacy, "tools/call")).not.toThrow();
+    // A method the legacy codec does not define is still refused there: the
+    // shadow never returns early off the modern era.
+    expect(() =>
+      gate({ era: LEGACY_ERA, hasRequestMethod: () => false } as never, "tasks/get")
+    ).toThrow(/not supported by the negotiated protocol version/);
+  });
+
+  it("leaves an unknown extension method era-blind (upstream behavior)", () => {
+    const { gate } = shadowedClient();
+    // Not in either registry → not a spec method → never gated, by upstream.
+    expect(() => gate(codecFor(MODERN_ERA), "io.example/whatever")).not.toThrow();
+  });
+
+  it("installs an own property and is idempotent", () => {
+    const client = new Client({ name: "test", version: "0.0.0" }, {});
+    const target = client as unknown as Record<string, unknown>;
+    expect(Object.prototype.hasOwnProperty.call(target, GATE)).toBe(false);
+
+    installTasksExtensionEraGateShadow(client);
+    const first = target[GATE];
+    installTasksExtensionEraGateShadow(client);
+    expect(target[GATE]).toBe(first);
+  });
+
+  it("is installed by the managed-client factory", () => {
+    const managed = createManagedMcpClient({
+      clientInfo: { name: "test", version: "0.0.0" },
+      clientOptions: {},
+    });
+    const inner = (managed as unknown as { inner: Record<string, unknown> })
+      .inner;
+    expect(Object.prototype.hasOwnProperty.call(inner, GATE)).toBe(true);
+  });
+
+  describe("fail-loud when the upstream seam moves", () => {
+    it("throws when the member is absent (renamed or removed)", () => {
+      // Simulates a client bump that renamed `_assertOutboundRequestInEra`.
+      const renamed = { _assertOutboundRequestInWireEra: () => {} };
+      expect(() =>
+        installTasksExtensionEraGateShadow(renamed as unknown as Client)
+      ).toThrow(TasksExtEraGateSeamError);
+      expect(() =>
+        installTasksExtensionEraGateShadow(renamed as unknown as Client)
+      ).toThrow(/_assertOutboundRequestInEra/);
+    });
+
+    it("throws when the member is no longer a function", () => {
+      const notAFunction = { _assertOutboundRequestInEra: "nope" };
+      expect(() =>
+        installTasksExtensionEraGateShadow(notAFunction as unknown as Client)
+      ).toThrow(/not a function/);
+    });
+
+    it("names the tasks methods and the verified client version", () => {
+      let message = "";
+      try {
+        installTasksExtensionEraGateShadow({} as unknown as Client);
+      } catch (error) {
+        message = (error as Error).message;
+      }
+      expect(message).toContain("tasks/get, tasks/update, tasks/cancel");
+      expect(message).toContain("2.0.0-beta.4");
+      expect(message).toContain(MODERN_ERA);
+    });
+  });
+});

--- a/sdk/tests/tasks-ext-era-gate.test.ts
+++ b/sdk/tests/tasks-ext-era-gate.test.ts
@@ -7,6 +7,10 @@
  * the two real `era` strings (`rev2025Codec.era` / `rev2026Codec.era`) and the
  * codec's own `hasRequestMethod` answer. The delegation cases therefore run
  * upstream's actual `isSpecRequestMethod` check rather than a stub of it.
+ *
+ * They also pin WHEN the shadow goes on: never at construction/connect, always
+ * on the first extension tasks operation, so a client build that moved the
+ * private member can only ever break tasks — not every connection.
  */
 
 import { describe, expect, it } from "vitest";
@@ -15,8 +19,15 @@ import {
   TasksExtEraGateSeamError,
   installTasksExtensionEraGateShadow,
 } from "../src/mcp-client-manager/tasks-ext-era-gate.js";
-import { TasksExtRequestMethods } from "../src/mcp-client-manager/tasks-ext.js";
-import { createManagedMcpClient } from "../src/mcp-client-manager/managed-mcp-client-factory.js";
+import {
+  TasksExtRequestMethods,
+  cancelTaskExt,
+  getTaskExt,
+} from "../src/mcp-client-manager/tasks-ext.js";
+import {
+  createManagedMcpClient,
+  wrapLegacyClient,
+} from "../src/mcp-client-manager/managed-mcp-client-factory.js";
 
 const MODERN_ERA = "2026-07-28";
 const LEGACY_ERA = "2025-11-25";
@@ -107,14 +118,67 @@ describe("tasks extension era-gate shadow", () => {
     expect(target[GATE]).toBe(first);
   });
 
-  it("is installed by the managed-client factory", () => {
+  it("is NOT installed by the factory, but IS by the first extension call", async () => {
     const managed = createManagedMcpClient({
       clientInfo: { name: "test", version: "0.0.0" },
       clientOptions: {},
     });
     const inner = (managed as unknown as { inner: Record<string, unknown> })
       .inner;
+    // Lazy: building (and connecting) a client never touches the private
+    // member — see the module comment on blast radius.
+    expect(Object.prototype.hasOwnProperty.call(inner, GATE)).toBe(false);
+
+    // The extension call itself fails (no transport), but only after the
+    // shadow is on: the install happens before anything reaches the wire.
+    await expect(
+      getTaskExt({ client: managed, declaredCapabilities: undefined }, "t")
+    ).rejects.toThrow();
     expect(Object.prototype.hasOwnProperty.call(inner, GATE)).toBe(true);
+  });
+
+  describe("a client whose seam is missing", () => {
+    /**
+     * Stands in for a future `@modelcontextprotocol/client` that renamed
+     * `_assertOutboundRequestInEra`: everything else works, the private member
+     * is simply not there.
+     */
+    function seamlessClient() {
+      const sent: string[] = [];
+      const stub = {
+        listTools: async () => {
+          sent.push("tools/list");
+          return { tools: [] };
+        },
+        request: async (req: { method: string }) => {
+          sent.push(req.method);
+          return {};
+        },
+      };
+      return {
+        managed: wrapLegacyClient(stub as unknown as Client),
+        sent,
+      };
+    }
+
+    it("still wraps and still serves non-tasks traffic", async () => {
+      const { managed, sent } = seamlessClient();
+      // Wrapping did not throw. Neither does an ordinary request: a server
+      // that never speaks the extension is unaffected by a moved seam.
+      await expect(managed.listTools()).resolves.toEqual({ tools: [] });
+      expect(sent).toEqual(["tools/list"]);
+    });
+
+    it("fails loudly on a tasks operation, before anything is sent", async () => {
+      const { managed, sent } = seamlessClient();
+      await expect(
+        getTaskExt({ client: managed, declaredCapabilities: undefined }, "t")
+      ).rejects.toBeInstanceOf(TasksExtEraGateSeamError);
+      await expect(
+        cancelTaskExt({ client: managed, declaredCapabilities: undefined }, "t")
+      ).rejects.toThrow(/_assertOutboundRequestInEra/);
+      expect(sent).toEqual([]);
+    });
   });
 
   describe("fail-loud when the upstream seam moves", () => {

--- a/sdk/tests/tasks-extension-wire.test.ts
+++ b/sdk/tests/tasks-extension-wire.test.ts
@@ -531,7 +531,7 @@ describe("DetailedTask status union", () => {
   it("accepts the response with AND without resultType:'complete'", () => {
     // tasks.md:338 says MUST, but `resultType` is absent from schema.json and
     // every DetailedTask variant is `additionalProperties: false` — schema and
-    // prose conflict, so neither presence nor absence may be rejected.
+    // prose conflict, so absence may not be rejected.
     const withDiscriminator = assertGetTaskExtResult({
       ...base,
       resultType: "complete",
@@ -541,6 +541,32 @@ describe("DetailedTask status union", () => {
     expect(
       (assertGetTaskExtResult({ ...base, status: "working" }) as any).resultType
     ).toBeUndefined();
+  });
+
+  it("rejects a resultType that is present but not 'complete'", () => {
+    // Absence is tolerated, but a WRONG discriminator misleads and contradicts
+    // the `GetTaskExtResult` type — including `"task"`, which is the creation
+    // discriminator and never valid on a tasks/get.
+    for (const resultType of ["banana", "task", "input_required", 7, null]) {
+      expect(() =>
+        assertGetTaskExtResult({ ...base, status: "working", resultType })
+      ).toThrow(InvalidTaskExtPayloadError);
+    }
+    let captured: unknown;
+    try {
+      assertGetTaskExtResult({
+        ...base,
+        status: "working",
+        resultType: "banana",
+      });
+    } catch (error) {
+      captured = error;
+    }
+    expect(captured).toBeInstanceOf(InvalidTaskExtPayloadError);
+    expect((captured as InvalidTaskExtPayloadError).method).toBe("tasks/get");
+    expect((captured as InvalidTaskExtPayloadError).issues.join()).toContain(
+      "resultType"
+    );
   });
 
   it("keeps isError:true a COMPLETED task, never failed", () => {
@@ -698,12 +724,28 @@ describe("empty acknowledgements", () => {
     expect(assertTaskExtAck({ _meta: { a: 1 } }, "tasks/update result")).toEqual(
       { _meta: { a: 1 } }
     );
-    // A transport that surfaced "no result" as undefined normalizes to `{}`.
-    expect(assertTaskExtAck(undefined, "tasks/update result")).toEqual({});
   });
 
-  it("rejects a non-object ack", () => {
-    for (const bad of [null, [], "ok", 1, true]) {
+  it("accepts an ack carrying resultType:'complete' and rejects a wrong one", () => {
+    // tasks.md:381 / :410 mandate the discriminator on the update/cancel acks
+    // too; beta.4 strips it before the guard sees it, so absence is tolerated
+    // and only a present-but-wrong value is a violation.
+    expect(
+      assertTaskExtAck({ resultType: "complete" }, "tasks/cancel result")
+    ).toEqual({ resultType: "complete" });
+    for (const resultType of ["banana", "task", "input_required"]) {
+      expect(() =>
+        assertTaskExtAck({ resultType }, "tasks/cancel result")
+      ).toThrow(InvalidTaskExtPayloadError);
+    }
+  });
+
+  it("rejects a non-object ack, including undefined", () => {
+    // `undefined` is NOT a transport-flattened empty result: beta.4 rejects a
+    // non-object result in `decodeResult` and only resolves what the caller's
+    // `z.looseObject({})` accepted, so `undefined` means a malformed/missing
+    // result and must not be laundered into a valid empty ack.
+    for (const bad of [undefined, null, [], "ok", 1, true]) {
       expect(() => assertTaskExtAck(bad, "tasks/update result")).toThrow(
         InvalidTaskExtPayloadError
       );

--- a/sdk/tests/tasks-extension-wire.test.ts
+++ b/sdk/tests/tasks-extension-wire.test.ts
@@ -4,13 +4,20 @@ import { MCPClientManager } from "../src/mcp-client-manager";
 import {
   resolveTasksSupport,
   resolveTasksWire,
+  serverDeclaresTasksExtension,
 } from "../src/mcp-client-manager/tasks-dispatch.js";
 import { buildTasksExtensionRequestMeta } from "../src/mcp-client-manager/tasks-ext.js";
 import {
   assertGetTaskExtResult,
+  assertTaskExtAck,
   isCreateTaskExtResult,
   InvalidTaskExtPayloadError,
 } from "../src/mcp-client-manager/tasks-ext-guards.js";
+import {
+  describeTaskExtInputRequests,
+  isRecognizedInputRequestMethod,
+} from "../src/mcp-client-manager/tasks-ext-schemas.js";
+import { MCPTasksWireError } from "../src/mcp-client-manager/errors.js";
 import {
   TASK_CREATED_META_KEY,
   rewriteTaskResultMessage,
@@ -433,6 +440,322 @@ describe("runtime validation", () => {
     expect(isCreateTaskExtResult({ resultType: "task", taskId: "a" })).toBe(true);
     expect(isCreateTaskExtResult({ taskId: "a" })).toBe(false);
     expect(isCreateTaskExtResult({ resultType: "complete" })).toBe(false);
+  });
+});
+
+/**
+ * The status-discriminated union (`DetailedTask`, schema.ts:217-222 /
+ * schema.json `anyOf` with per-variant `required`; tasks.md:330-336 states each
+ * as a MUST).
+ */
+describe("DetailedTask status union", () => {
+  const base = {
+    taskId: "task-1",
+    createdAt: "2026-07-27T00:00:00Z",
+    lastUpdatedAt: "2026-07-27T00:01:00Z",
+    ttlMs: null,
+  };
+
+  const inputRequest = {
+    method: "elicitation/create",
+    params: { message: "need input", requestedSchema: { type: "object" } },
+  };
+
+  it("accepts every variant with its required status payload", () => {
+    expect(assertGetTaskExtResult({ ...base, status: "working" }).status).toBe(
+      "working"
+    );
+    expect(
+      assertGetTaskExtResult({ ...base, status: "cancelled" }).status
+    ).toBe("cancelled");
+
+    const inputRequired = assertGetTaskExtResult({
+      ...base,
+      status: "input_required",
+      inputRequests: { k1: inputRequest },
+    });
+    expect(inputRequired.inputRequests?.k1).toEqual(inputRequest);
+
+    const completed = assertGetTaskExtResult({
+      ...base,
+      status: "completed",
+      result: { content: [{ type: "text", text: "done" }] },
+    });
+    expect(completed.result).toEqual({
+      content: [{ type: "text", text: "done" }],
+    });
+
+    const failed = assertGetTaskExtResult({
+      ...base,
+      status: "failed",
+      statusMessage: "rate limited",
+      error: { code: -32603, message: "API rate limit exceeded" },
+    });
+    expect(failed.error).toEqual({
+      code: -32603,
+      message: "API rate limit exceeded",
+    });
+    // `statusMessage` is only a SHOULD on `failed` — it stays optional.
+    expect(
+      assertGetTaskExtResult({
+        ...base,
+        status: "failed",
+        error: { code: -32603, message: "boom" },
+      }).statusMessage
+    ).toBeUndefined();
+  });
+
+  it("rejects a variant that is missing its required status payload", () => {
+    expect(() =>
+      assertGetTaskExtResult({ ...base, status: "completed" })
+    ).toThrow(InvalidTaskExtPayloadError);
+    expect(() => assertGetTaskExtResult({ ...base, status: "failed" })).toThrow(
+      InvalidTaskExtPayloadError
+    );
+    expect(() =>
+      assertGetTaskExtResult({ ...base, status: "input_required" })
+    ).toThrow(InvalidTaskExtPayloadError);
+  });
+
+  it("rejects a base field that is missing entirely", () => {
+    const { ttlMs: _ttlMs, ...noTtl } = base;
+    expect(() =>
+      assertGetTaskExtResult({ ...noTtl, status: "working" })
+    ).toThrow(InvalidTaskExtPayloadError);
+    const { createdAt: _createdAt, ...noCreatedAt } = base;
+    expect(() =>
+      assertGetTaskExtResult({ ...noCreatedAt, status: "working" })
+    ).toThrow(InvalidTaskExtPayloadError);
+  });
+
+  it("accepts the response with AND without resultType:'complete'", () => {
+    // tasks.md:338 says MUST, but `resultType` is absent from schema.json and
+    // every DetailedTask variant is `additionalProperties: false` — schema and
+    // prose conflict, so neither presence nor absence may be rejected.
+    const withDiscriminator = assertGetTaskExtResult({
+      ...base,
+      resultType: "complete",
+      status: "working",
+    });
+    expect((withDiscriminator as any).resultType).toBe("complete");
+    expect(
+      (assertGetTaskExtResult({ ...base, status: "working" }) as any).resultType
+    ).toBeUndefined();
+  });
+
+  it("keeps isError:true a COMPLETED task, never failed", () => {
+    // tasks.md:837, :891-892 — only an underlying JSON-RPC error is `failed`.
+    const task = assertGetTaskExtResult({
+      ...base,
+      status: "completed",
+      result: {
+        content: [{ type: "text", text: "Failed to process request" }],
+        isError: true,
+      },
+    });
+    expect(task.status).toBe("completed");
+    expect((task.result as any).isError).toBe(true);
+    expect(task.error).toBeUndefined();
+  });
+
+  it("accepts a non-integer, negative or shrinking ttlMs / pollIntervalMs", () => {
+    // schema.json says plain `"number"`, and both MAY change over a task's
+    // lifetime (tasks.md:304, :340) — a changed value is not an anomaly.
+    const first = assertGetTaskExtResult({
+      ...base,
+      status: "working",
+      ttlMs: 1500.5,
+      pollIntervalMs: 250.25,
+    });
+    expect(first.ttlMs).toBe(1500.5);
+
+    const shrunk = assertGetTaskExtResult({
+      ...base,
+      status: "working",
+      ttlMs: -1,
+      pollIntervalMs: 0,
+    });
+    expect(shrunk.ttlMs).toBe(-1);
+    expect(shrunk.pollIntervalMs).toBe(0);
+  });
+
+  it("carries method + wire + a safe summary on an invalid payload", () => {
+    try {
+      assertGetTaskExtResult({ ...base, status: "completed" });
+      throw new Error("expected a throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(InvalidTaskExtPayloadError);
+      const invalid = error as InvalidTaskExtPayloadError;
+      expect(invalid.method).toBe("tasks/get");
+      expect(invalid.wire).toBe("extension");
+      expect(invalid.summary.length).toBeGreaterThan(0);
+      expect(invalid.issues.length).toBeGreaterThan(0);
+      // Not a wire error: an invalid payload must not be collapsed into
+      // "this connection cannot do tasks".
+      expect(invalid).not.toBeInstanceOf(MCPTasksWireError);
+    }
+  });
+});
+
+describe("inputRequests validation", () => {
+  const base = {
+    taskId: "task-1",
+    status: "input_required",
+    createdAt: "2026-07-27T00:00:00Z",
+    lastUpdatedAt: "2026-07-27T00:00:00Z",
+    ttlMs: null,
+  };
+
+  it("preserves an unrecognized method instead of failing the payload", () => {
+    const task = assertGetTaskExtResult({
+      ...base,
+      inputRequests: {
+        k1: { method: "roots/list" },
+        k2: { method: "com.example/futureRequest", params: { x: 1 } },
+      },
+    });
+    expect(Object.keys(task.inputRequests ?? {})).toEqual(["k1", "k2"]);
+    expect(describeTaskExtInputRequests(task.inputRequests)).toEqual([
+      { key: "k1", method: "roots/list", recognized: true },
+      { key: "k2", method: "com.example/futureRequest", recognized: false },
+    ]);
+    expect(isRecognizedInputRequestMethod("sampling/createMessage")).toBe(true);
+    expect(isRecognizedInputRequestMethod("elicitation/create")).toBe(true);
+    expect(isRecognizedInputRequestMethod("nope")).toBe(false);
+  });
+
+  it("rejects an entry without a string method", () => {
+    expect(() =>
+      assertGetTaskExtResult({ ...base, inputRequests: { k1: { method: 7 } } })
+    ).toThrow(InvalidTaskExtPayloadError);
+    expect(() =>
+      assertGetTaskExtResult({ ...base, inputRequests: { k1: "nope" } })
+    ).toThrow(InvalidTaskExtPayloadError);
+    expect(() =>
+      assertGetTaskExtResult({ ...base, inputRequests: [] })
+    ).toThrow(InvalidTaskExtPayloadError);
+  });
+
+  it("keeps hostile keys as data and never pollutes a prototype", () => {
+    // JSON.parse (not an object literal) so `__proto__` arrives as a real own
+    // property, exactly as it would off the wire.
+    const payload = JSON.parse(
+      `{"taskId":"task-1","status":"input_required","createdAt":"t","lastUpdatedAt":"t","ttlMs":null,
+        "inputRequests":{
+          "__proto__":{"method":"roots/list","polluted":true},
+          "constructor":{"method":"roots/list"},
+          "prototype":{"method":"roots/list"},
+          "ok":{"method":"elicitation/create"}
+        }}`
+    );
+    const task = assertGetTaskExtResult(payload);
+    const requests = task.inputRequests as Record<string, unknown>;
+
+    expect(Object.getPrototypeOf(requests)).toBeNull();
+    expect(Object.keys(requests).sort()).toEqual([
+      "__proto__",
+      "constructor",
+      "ok",
+      "prototype",
+    ]);
+    expect(({} as any).polluted).toBeUndefined();
+    expect((Object.prototype as any).polluted).toBeUndefined();
+    expect(Object.getPrototypeOf({})).toBe(Object.prototype);
+  });
+});
+
+describe("server capability declaration", () => {
+  const rows: Array<[string, unknown, boolean]> = [
+    ["empty settings object", {}, true],
+    ["non-empty settings object", { someSetting: 1 }, true],
+    ["boolean true", true, false],
+    ["string", "x", false],
+    ["array", [], false],
+    ["null", null, false],
+    ["number", 1, false],
+  ];
+
+  for (const [label, value, expected] of rows) {
+    it(`${label} → ${expected ? "declared" : "not declared"}`, () => {
+      const caps = { tools: {}, extensions: { [EXT_ID]: value } } as never;
+      expect(serverDeclaresTasksExtension(caps)).toBe(expected);
+      expect(resolveTasksWire("2026-07-28", caps)).toBe(
+        expected ? "extension" : "none"
+      );
+    });
+  }
+
+  it("an absent key is not a declaration", () => {
+    expect(
+      serverDeclaresTasksExtension({ tools: {}, extensions: {} } as never)
+    ).toBe(false);
+  });
+});
+
+describe("empty acknowledgements", () => {
+  it("accepts an empty object and any object body", () => {
+    expect(assertTaskExtAck({}, "tasks/update result")).toEqual({});
+    expect(assertTaskExtAck({ _meta: { a: 1 } }, "tasks/update result")).toEqual(
+      { _meta: { a: 1 } }
+    );
+    // A transport that surfaced "no result" as undefined normalizes to `{}`.
+    expect(assertTaskExtAck(undefined, "tasks/update result")).toEqual({});
+  });
+
+  it("rejects a non-object ack", () => {
+    for (const bad of [null, [], "ok", 1, true]) {
+      expect(() => assertTaskExtAck(bad, "tasks/update result")).toThrow(
+        InvalidTaskExtPayloadError
+      );
+    }
+  });
+
+  it("tasks/update and tasks/cancel reject a non-object server ack", async () => {
+    for (const bad of [[], "ok", null]) {
+      const { manager, serverId } = seedManager({
+        protocolVersion: "2026-07-28",
+        capabilities: EXT_CAPS as never,
+        requestResult: bad,
+      });
+      await expect(
+        manager.updateTask(serverId, "task-7", {} as never)
+      ).rejects.toThrow(InvalidTaskExtPayloadError);
+      await expect(manager.cancelTaskExt(serverId, "task-7")).rejects.toThrow(
+        InvalidTaskExtPayloadError
+      );
+    }
+  });
+});
+
+describe("wire guards raise a typed tasks-wire error", () => {
+  // A bare TypeError would map to a 500, which hosted clients treat as
+  // TRANSIENT and retry forever against a server that can never serve it.
+  it("extension reads/writes on a non-extension wire", async () => {
+    const { manager, serverId } = seedManager({
+      protocolVersion: "2025-11-25",
+      capabilities: LEGACY_CAPS as never,
+    });
+    await expect(manager.getTaskExt(serverId, "t")).rejects.toBeInstanceOf(
+      MCPTasksWireError
+    );
+    await expect(
+      manager.updateTask(serverId, "t", {} as never)
+    ).rejects.toBeInstanceOf(MCPTasksWireError);
+    await expect(manager.cancelTaskExt(serverId, "t")).rejects.toBeInstanceOf(
+      MCPTasksWireError
+    );
+  });
+
+  it("declaring task eligibility with no tasks wire", async () => {
+    const { manager, serverId } = seedManager({
+      protocolVersion: "2026-07-28",
+      capabilities: { tools: {} } as never,
+    });
+    await expect(
+      manager.executeTool(serverId, "slow_tool", {}, {
+        allowTaskResult: true,
+      } as never)
+    ).rejects.toBeInstanceOf(MCPTasksWireError);
   });
 });
 


### PR DESCRIPTION
## Why this exists

While implementing stricter validation for the `io.modelcontextprotocol/tasks` extension, a real-server test found that **the extension cannot reach a conforming server at all** on a `2026-07-28` connection. Every extension test merged so far drove a seeded manager with mocked internals, so CI was green over a wire path that never worked.

`@modelcontextprotocol/client` builds its "spec method universe" from the union of both era registries. `tasks/get|result|list|cancel` live **only** in the rev2025-11-25 registry; the rev2026-07-28 registry has no tasks methods, and `tasks/update` is in neither. `_assertOutboundRequestInEra` therefore throws `METHOD_NOT_SUPPORTED_BY_PROTOCOL_VERSION` before anything reaches the transport — on both `request()` and `requestWithSchema()`, so an explicit schema is not an escape.

Root cause is a name collision: the extension reuses method names the 2025 core owned, and the era gate is a **v2-only** construct. ext-tasks itself devDepends on `@modelcontextprotocol/sdk ^1.29.0` (v1), which has no era gate — so upstream has structurally never exercised these methods through it. Verified **not** fixed in beta.5, and upstream's own `SdkErrorCode` docs cite `tasks/get` toward a 2026 peer as the intended error. This is deliberate upstream behavior, not an oversight.

## What's in here

**A0 — unblock the wire:** route all three extension methods through `requestWithSchema` with a loose result schema, plus a narrowly-scoped per-instance override of the era assertion that returns early only for exactly `tasks/get`, `tasks/update`, `tasks/cancel` on the 2026 era. Fails loud at connect if the seam disappears on a client bump. Provably inert on 2025-03-26 / 2025-06-18 / 2025-11-25.

**A1 — status-discriminated validation.** `DetailedTaskExt` was a flat optional-field interface, so a `completed` task with no `result` or a `failed` task with no `error` passed validation and reached the UI. Now a real `z.discriminatedUnion("status")` matching both prose and schema. Also: the capability check required only key presence, so `{"io.modelcontextprotocol/tasks": true}` counted as a declaration — now requires an object *value*; the empty acks were returned unvalidated; and `inputRequests` used `z.record`, which **silently drops a `__proto__` key** and would have hidden an entry from the debugger — now read through own-property descriptors onto a null-prototype map.

**A2 — correct conformance verdicts.** The runner treated a server that *answers* a bare undeclared `tasks/get` as conformant. `tasks.md:797-799` is unconditional: `-32003` is a MUST for undeclared `tasks/get`, `tasks/update`, `tasks/cancel` and task notifications on `subscriptions/listen`. Split into one check per spec rule, probing all four methods, with the mutating probes sequenced last against an already-terminal task.

**Fixture.** A real Streamable HTTP extension server with configurable status variants, changing `ttlMs`/`pollIntervalMs`, partial/repeated `inputRequests`, hostile keys, and a misbehavior toggle set for negative testing.

## Spec corrections worth reviewing

The plan doc prescribed three tightenings the spec does not have. I did **not** implement them, and corrected the doc with citations:

- **`resultType: "complete"` is not required** on get/update/cancel. It appears zero times in `schema.json`, and all five `DetailedTask` variants are `additionalProperties: false` — a schema-faithful validator would *reject* the key the prose calls a MUST. Accepted either way. (`resultType: "task"` on `CreateTaskResult` **is** kept required — it is the discriminator the whole detection path keys on.)
- **No ISO-8601 enforcement** on timestamps — JSDoc prose only, no format constraint anywhere.
- **No integer/non-negative bounds** on `ttlMs`/`pollIntervalMs` — plain `"number"`, and both MAY change over a task's lifetime, so a shrinking value is never an anomaly.

Each is recorded inline in code so it does not get "fixed" later.

## Testing

164 files / 2831 tests, vitest exit 0, `tsc --noEmit` exit 0. The legacy 2025-11-25 wire keeps its own real-socket integration test and is unaffected — this is a multi-version debugger and older versions are permanent product scope.

## Reviewer attention

1. **The era-gate override depends on a TypeScript-private name.** Mitigated by a fail-loud assertion at connect plus real-socket tests, so a rename breaks immediately rather than silently re-blocking tasks. It is a standing maintenance cost; the honest exit is an upstream change. Worth a second opinion on whether that trade is acceptable.
2. **The method list must stay an explicit three names**, never a `tasks/*` match — the client still ships 2025-only `tasks/list` and `tasks/result` schemas that would otherwise leak onto the 2026 wire.
3. **Known blind spot, documented at the call site:** task detection keys on `resultType` end to end, so a server that omits the discriminator is currently reported as "server declined the task" rather than as the invisible-task interop break it is. Closing it needs a raw-response capture before the transport rewrite — happy to add it here if reviewers prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks the `io.modelcontextprotocol/tasks` extension on the `2026-07-28` wire and tightens validation and conformance. Conformance now reports incomplete runs (`outcome`) and the CLI exits with code 3 when selected checks cannot run.

- **Bug Fixes**
  - Conformance now requires all selected checks to run and pass. Adds `outcome: "passed" | "failed" | "incomplete"` with explicit skip reasons (`"not-applicable"` vs `"could-not-run"`). On the extension wire, automatic probe-tool selection is disabled (the 2026 `ToolSchema` strips `execution.taskSupport`); pass `toolName` or the run is incomplete. CLI prints the reason and exits `3` on incomplete; category/check-id mappings updated.
  - Scoped, lazy era‑gate shadow: installed on first extension call via `sendTasksExtRequest`; only exempts `tasks/get|update|cancel`; inert for non‑tasks and 2025; fails loud with `TasksExtEraGateSeamError` only when used.
  - Conformance probes reach the wire: undeclared `tasks/*` and task notifications use `requestWithSchema`, verify no per‑request declaration, track `reachedWire`, and correctly detect creation refusal and `-32003`.
  - Validation hardened: status‑discriminated task union; object‑valued extension declaration required; validate update/cancel acks (throw on missing); resultType must be `"complete"` when present on get/update/cancel; sanitized error summaries; throw `MCPTasksWireError` for unsupported wires.

- **New Features**
  - Streamable HTTP fixture plus integration tests drive the full lifecycle through the real manager on 2026; raw driver retained only for cases the client cannot produce (e.g., undeclared requests). Conformance is 8 checks and now returns `MCPTasksRunOutcome` with `decideOutcome`; SDK exports `resolveProbeTool`, `MCPTasksSkipReason`, and CLI exposes `tasksConformanceExitCode`. Docs updated to show `outcome`, `8/8` reporting, and to require `toolName` on the extension wire.

<sup>Written for commit 5a91faa20be43660b83db3184ae982fc7fb43726. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches the MCP client protocol boundary via a private upstream era-gate override and changes conformance/CLI exit semantics, which can break CI and any caller assuming `passed` alone or exit `1` for all non-violation failures.
> 
> **Overview**
> **Workstream A** fixes the protocol boundary so `tasks/get`, `tasks/update`, and `tasks/cancel` can reach real `2026-07-28` servers: extension traffic goes through `requestWithSchema` with a loose result schema, and a **lazy, scoped era-gate shadow** exempts only those three methods on the modern era (registered at managed-client creation, installed on first extension send).
> 
> **Validation** is tightened at the SDK boundary: status-discriminated `DetailedTask` types/schemas, extension capability values must be objects (not bare `true`), validated update/cancel acks (no more treating `undefined` as `{}`), safer `inputRequests` handling, and **`MCPTasksWireError`** instead of `TypeError` when the wire does not support extension methods (so routes can map to non-retryable client errors).
> 
> **Conformance** grows to **8 checks**: splits undeclared handling into `tasks-undeclared-creation-refused` (creation) vs `tasks-undeclared-capability-rejected` (lifecycle, probing undeclared `tasks/*` and task-filtered `subscriptions/listen` for `-32003`). Adds **`outcome` / `skipReason`** (`not-applicable` vs `could-not-run`), **`decideOutcome`**, and **`resolveProbeTool`** so extension runs without `--tool-name` are **`incomplete`**, not green. CLI maps that to **exit code `3`** and prints `incompleteReason` on stderr.
> 
> Docs add the full MCP Tasks implementation plan and update CLI/SDK conformance references for the new checks and outcomes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a91faa20be43660b83db3184ae982fc7fb43726. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

