### PR TITLE
plugin crash

### DIFF
--- a/mcpjam-inspector/client/src/hooks/usePluginImportApi.ts
+++ b/mcpjam-inspector/client/src/hooks/usePluginImportApi.ts
@@ -24,6 +24,7 @@
 
 import { useCallback, useMemo } from "react";
 import { useAction, useConvexAuth, useMutation, useQuery } from "convex/react";
+import { useAuth } from "@workos-inc/authkit-react";
 import {
   assertPluginBundleWithinCap,
   toPluginApiError,
@@ -46,18 +47,33 @@ import { usePluginsEnabled } from "./usePluginsEnabled";
 // ---------------------------------------------------------------------------
 // Query hooks (reactive Convex subscriptions — the "polling" of the plan's
 // import-progress requirement is a live subscription, not an interval).
-// All skip while `plugins-enabled` is off/loading, auth has not resolved, or
-// arguments are absent. Project-scoped hooks additionally gate on
+// All skip while `plugins-enabled` is off/loading, the actor is a guest, auth
+// has not resolved, or arguments are absent. Project-scoped hooks gate on
 // `shouldQueryProjectId` (the useProjects/useChatboxes convention): a
 // transient LOCAL project id (UUID or `local_`/`project_` placeholder) is
 // truthy but would throw an ArgumentValidationError during hydration.
 // ---------------------------------------------------------------------------
 
-/** Shared gate: `plugins-enabled` (fail-closed) AND Convex auth resolved. */
+/**
+ * Shared gate: `plugins-enabled` (fail-closed) AND a *signed-in* actor.
+ *
+ * `isAuthenticated` alone is not enough: guests authenticate to Convex through
+ * the same provider chain (see `useUnifiedConvexAuth`), so it is true for them
+ * too. Every plugin function is a `signedInQuery`, which rejects guests with
+ * "Authenticated user required" — a render-time throw that takes down the whole
+ * route, since Connect mounts `PluginsSection` inline. The WorkOS user is the
+ * signed-in/guest discriminator (same predicate as `use-project-state`'s
+ * `isAuthenticated && !hasSignedInUser`).
+ *
+ * TEMPORARY: remove the `Boolean(user)` term once the backend serves guests —
+ * this gate exists only because the frontend is ready for guest plugins and the
+ * backend is not.
+ */
 function usePluginQueriesReady(): boolean {
   const enabled = usePluginsEnabled();
   const { isAuthenticated } = useConvexAuth();
-  return enabled && isAuthenticated;
+  const { user } = useAuth();
+  return enabled && isAuthenticated && Boolean(user);
 }
 
 /**


### PR DESCRIPTION
Stop plugins crashing Connect for guests

- Plugin queries only checked for a session, which guests have too.
- Backend is signed-in-only, so guest requests threw and killed the whole tab.
- Gate now requires a real account. Remove when the backend serves guests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents plugin crashes for guests by requiring a signed-in user before running plugin queries. Uses `@workos-inc/authkit-react` to skip subscriptions for guests.

- Bug Fixes
  - Gate `usePluginQueriesReady` on `plugins-enabled && isAuthenticated && Boolean(user)`.
  - Import `useAuth` from `@workos-inc/authkit-react` and combine with `useConvexAuth` from `convex/react` to avoid `signedInQuery` guest throws.

<sup>Written for commit 01ea4e5e45aa18d9dcd53cfe2c0cd3854b918184. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

