### PR TITLE
feat(plugins): plugin snapshots in evals and simulations (INS-5)

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/run-detail-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-detail-view.tsx
@@ -1,4 +1,10 @@
-import { useEffect, useMemo, useState, type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
 import { Button } from "@mcpjam/design-system/button";
 import {
   DropdownMenu,
@@ -9,6 +15,11 @@ import {
 } from "@mcpjam/design-system/dropdown-menu";
 import { cn } from "@/lib/utils";
 import { formatRunId } from "./helpers";
+import {
+  buildOpenAiSubmissionReport,
+  renderOpenAiSubmissionReport,
+} from "@/lib/evals/openai-submission-report";
+import { buildSubmissionCasesFromRun } from "./run-submission";
 import { computeIterationPassed } from "./pass-criteria";
 import { EvalIteration, EvalJudgeConfig, EvalSuiteRun } from "./types";
 import { CiMetadataDisplay } from "./ci-metadata-display";
@@ -48,6 +59,7 @@ import {
   type RunTrendPoint,
 } from "./run-insight-rail";
 import { runDetailMetaLabelClass } from "./run-detail-typography";
+import { RunPluginSnapshot } from "./run-plugin-snapshot";
 import { useSandboxImages } from "@/hooks/useSandboxImages";
 import { useProjectEnvironmentsEnabled } from "@/hooks/useProjectEnvironmentsEnabled";
 import {
@@ -443,6 +455,44 @@ export function RunDetailView({
   const runProjectEnvironmentRef = projectEnvironmentsEnabled
     ? selectedRunDetails.configSnapshot?.environmentRef ?? null
     : null;
+  // OpenAI submission evidence (INS-5). Offered only when the run pinned a
+  // plugin: the document's value is naming the exact bundle it is evidence
+  // about, which a plugin-free run cannot do.
+  const pluginSubmissionVersions =
+    selectedRunDetails.configSnapshot?.environmentPluginVersions ?? [];
+  const downloadSubmissionReport = useCallback(() => {
+    const report = buildOpenAiSubmissionReport({
+      // The run row carries no suite NAME (CI/commit-detail parents have no
+      // live suite handle), so title the document by suite id rather than
+      // guessing a name that might not be the suite's.
+      suiteName: `Suite ${formatRunId(selectedRunDetails.suiteId)}`,
+      runLabel: `Run ${formatRunId(selectedRunDetails._id)} (#${selectedRunDetails.runNumber})`,
+      cases: buildSubmissionCasesFromRun(caseGroupsForSelectedRun),
+      pluginVersions: pluginSubmissionVersions.map((version) => ({
+        name: version.name,
+        pluginVersionId: version.pluginVersionId,
+        bundleHash: version.bundleHash,
+      })),
+      skillsExcluded: selectedRunDetails.configSnapshot?.skillsExcluded,
+    });
+    const blob = new Blob([renderOpenAiSubmissionReport(report)], {
+      type: "text/markdown;charset=utf-8",
+    });
+    const url = URL.createObjectURL(blob);
+    const anchorEl = document.createElement("a");
+    anchorEl.href = url;
+    anchorEl.download = `openai-submission-${formatRunId(selectedRunDetails._id)}.md`;
+    anchorEl.click();
+    URL.revokeObjectURL(url);
+  }, [
+    caseGroupsForSelectedRun,
+    pluginSubmissionVersions,
+    selectedRunDetails._id,
+    selectedRunDetails.configSnapshot?.skillsExcluded,
+    selectedRunDetails.runNumber,
+    selectedRunDetails.suiteId,
+  ]);
+
   const {
     result: goalCompletionResult,
     pending: goalCompletionPending,
@@ -732,6 +782,15 @@ export function RunDetailView({
         </div>
       ) : null}
 
+      {/* The plugin surface, directly under the environment that pinned it:
+          a plugin reaches a run only through an environment, so the two are
+          one fact read top to bottom. Renders nothing when no plugin was
+          pinned. */}
+      <RunPluginSnapshot
+        pluginVersions={selectedRunDetails.configSnapshot?.environmentPluginVersions}
+        skillsExcluded={selectedRunDetails.configSnapshot?.skillsExcluded}
+      />
+
       {runClient && !showAccuracyHero && !embeddedInResultsSplit ? (
         <div className="mb-4 flex flex-wrap items-center gap-2">
           <span className={runDetailMetaLabelClass}>Client</span>
@@ -834,20 +893,37 @@ export function RunDetailView({
         omitIterationList && "px-3 py-3"
       )}
     >
-      {onExportTraces ? (
-        // Always-on run-level action — placed here (not the accuracy hero) so it
-        // survives the folded run-detail layout that hides the hero.
-        <div className="mb-3 flex shrink-0 justify-end">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={onExportTraces}
-            className="gap-1.5"
-            data-testid="run-detail-export-traces"
-          >
-            <Download className="h-3.5 w-3.5" />
-            Export
-          </Button>
+      {onExportTraces || pluginSubmissionVersions.length > 0 ? (
+        // Always-on run-level actions — placed here (not the accuracy hero) so
+        // they survive the folded run-detail layout that hides the hero.
+        <div className="mb-3 flex shrink-0 justify-end gap-2">
+          {pluginSubmissionVersions.length > 0 ? (
+            // Offered only for a run that pinned a plugin. The document's
+            // entire value is naming the bundle it is evidence about, so on a
+            // plugin-free run there is nothing to submit and no button.
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={downloadSubmissionReport}
+              className="gap-1.5"
+              data-testid="run-detail-openai-submission"
+            >
+              <Download className="h-3.5 w-3.5" />
+              Submission report
+            </Button>
+          ) : null}
+          {onExportTraces ? (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onExportTraces}
+              className="gap-1.5"
+              data-testid="run-detail-export-traces"
+            >
+              <Download className="h-3.5 w-3.5" />
+              Export
+            </Button>
+          ) : null}
         </div>
       ) : null}
 

--- a/mcpjam-inspector/client/src/components/evals/run-plugin-snapshot.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-plugin-snapshot.tsx
@@ -1,0 +1,69 @@
+/**
+ * The plugin surface a run executed with (INS-5).
+ *
+ * A pinned plugin is invisible everywhere else on a run: its MCP servers appear
+ * as ordinary servers and its skills as ordinary skills, so "which bundle
+ * produced this transcript?" had no answer once the plugin was re-imported. The
+ * run snapshot has carried the answer since BE-5; this is where it is said.
+ *
+ * PROVENANCE, NOT A PIN. Everything rendered here is the run's immutable
+ * record — `configSnapshot.environmentPluginVersions`, exactly as frozen. It is
+ * deliberately read-only and deliberately offers no "restore these versions"
+ * affordance: a run records what ran, and treating that record as a restorable
+ * pin is how the ephemeral Playground override would quietly become persistent.
+ *
+ * The bundle hash is what makes it useful. Two runs of the "same" plugin are
+ * the same run only if the hashes match, and a name plus a version id cannot
+ * tell you that — a re-import mints a new version id for identical content, and
+ * an edit changes content under an unchanged name.
+ */
+import { shortBundleHash } from "@/components/plugins/plugin-presentation";
+import { runDetailMetaLabelClass } from "./run-detail-typography";
+
+export type RunPluginVersionRef = {
+  pluginId: string;
+  pluginVersionId: string;
+  name: string;
+  bundleHash: string;
+};
+
+export function RunPluginSnapshot({
+  pluginVersions,
+  skillsExcluded,
+}: {
+  pluginVersions?: RunPluginVersionRef[];
+  skillsExcluded?: boolean;
+}) {
+  const versions = pluginVersions ?? [];
+  // Absence is semantic: a run with no pinned plugins should say nothing, not
+  // render an empty "Plugins" row that reads like a failure to load one.
+  if (versions.length === 0) return null;
+
+  return (
+    <div className="mb-4 flex flex-wrap items-center gap-2">
+      <span className={runDetailMetaLabelClass}>Plugins</span>
+      {versions.map((version) => (
+        <span
+          key={version.pluginVersionId}
+          className="inline-flex items-center gap-1.5 rounded-md border border-border/60 px-2 py-0.5 text-xs"
+          title={`Plugin version ${version.pluginVersionId} · bundle ${version.bundleHash}`}
+        >
+          <span className="text-foreground">{version.name}</span>
+          <span className="font-mono text-[10px] text-muted-foreground">
+            {shortBundleHash(version.bundleHash)}
+          </span>
+        </span>
+      ))}
+      {skillsExcluded ? (
+        // A skill-less run and a run whose skills failed to load look identical
+        // in a transcript. Say which this is.
+        <span
+          className="inline-flex items-center rounded-md border border-border/60 px-2 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground"
+          title="This run is the 'without skills' arm of a compare: no skills were pinned from any channel. The plugins' MCP servers were still connected."
+        >
+          skills excluded
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/evals/run-submission.ts
+++ b/mcpjam-inspector/client/src/components/evals/run-submission.ts
@@ -1,0 +1,62 @@
+/**
+ * Adapter: one run's iterations → the case list an OpenAI submission report is
+ * built from (INS-5).
+ *
+ * A case may run several iterations. The submission speaks about CASES, so the
+ * iterations are folded per case and a case counts as passing only when EVERY
+ * iteration of it passed. Taking the first iteration, or "any passed", would
+ * let a flaky prompt be submitted as evidence of a reliable one — and flakiness
+ * is exactly what a reviewer is trying to detect.
+ *
+ * Everything comes from `testCaseSnapshot`, the frozen per-iteration record,
+ * never from the live suite: the report is about what this run executed.
+ */
+import type { EvalIteration } from "./types";
+import type { SubmissionRunCase } from "@/lib/evals/openai-submission-report";
+
+/** Identity for folding iterations of one case together. */
+function caseKeyOf(iteration: EvalIteration): string {
+  return (
+    iteration.testCaseId ??
+    iteration.testCaseSnapshot?.caseKey ??
+    iteration.testCaseSnapshot?.title ??
+    iteration._id
+  );
+}
+
+export function buildSubmissionCasesFromRun(
+  iterations: EvalIteration[]
+): SubmissionRunCase[] {
+  const byCase = new Map<string, EvalIteration[]>();
+  for (const iteration of iterations) {
+    if (!iteration.testCaseSnapshot) continue;
+    const key = caseKeyOf(iteration);
+    const existing = byCase.get(key);
+    if (existing) existing.push(iteration);
+    else byCase.set(key, [iteration]);
+  }
+
+  const cases: SubmissionRunCase[] = [];
+  for (const group of byCase.values()) {
+    const first = group[0];
+    const snapshot = first.testCaseSnapshot!;
+    cases.push({
+      title: snapshot.title,
+      query: snapshot.query,
+      isNegativeTest: snapshot.isNegativeTest === true,
+      ...(snapshot.scenario ? { scenario: snapshot.scenario } : {}),
+      expectedToolCalls: (snapshot.expectedToolCalls ?? []).map(
+        (call) => call.toolName
+      ),
+      actualToolCalls: (first.actualToolCalls ?? []).map(
+        (call) => call.toolName
+      ),
+      // Every iteration, not the first: a case that passed 2 of 3 times is not
+      // evidence of a case that passes.
+      passed: group.every((iteration) => iteration.result === "passed"),
+      ...(snapshot.model ? { model: snapshot.model } : {}),
+      ...(snapshot.provider ? { provider: snapshot.provider } : {}),
+    });
+  }
+  return cases;
+}

--- a/mcpjam-inspector/client/src/components/evals/types.ts
+++ b/mcpjam-inspector/client/src/components/evals/types.ts
@@ -516,6 +516,42 @@ export type EvalSuiteRun = {
     /** The environment's standalone server-group pointer at resolve time. */
     environmentServerAttachmentId?: string;
     /**
+     * Plugin provenance for this run (BE-5): identity + `bundleHash` of every
+     * plugin version the environment pinned, in pin order.
+     *
+     * EXACT AND IMMUTABLE. It records which bundles executed, so nothing may
+     * re-resolve it to the plugin's current active version — that is the whole
+     * reason a re-import cannot change what an in-flight run or a replay means.
+     * It is provenance, not a restorable pin: no surface may offer to "restore"
+     * these versions, or the ephemeral Playground override becomes persistent
+     * through the back door.
+     *
+     * Absent on a legacy run, a plugin-free environment, or a pre-BE-5 backend.
+     */
+    environmentPluginVersions?: Array<{
+      pluginId: string;
+      pluginVersionId: string;
+      name: string;
+      bundleHash: string;
+    }>;
+    /**
+     * The servers those versions materialized at launch — the suite twin of a
+     * journey target's `pluginServerIds`. Cross-checked at execution, never
+     * trusted: a recorded id the live resolution no longer contributes fails
+     * the run rather than silently shrinking it.
+     */
+    environmentPluginServerIds?: string[];
+    /**
+     * This run is the "without skills" arm of an A/B compare: no skills were
+     * pinned from ANY channel (host, environment, or plugin).
+     *
+     * Worth showing, because a skill-less run and a run whose skills failed to
+     * load look identical in the transcript. Note the deliberate backend
+     * asymmetry — the arm drops plugin SKILLS, not plugin SERVERS, so
+     * `environmentPluginVersions` above is still populated for it.
+     */
+    skillsExcluded?: boolean;
+    /**
      * Suite-level judge config snapshotted at run-create. The run-detail
      * card reads `modelUsed` / `threshold` from here when displaying the
      * judge config, so a config edit after the run started doesn't

--- a/mcpjam-inspector/client/src/components/swarms/journey-run-results.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/journey-run-results.tsx
@@ -20,6 +20,7 @@ import {
 } from "./use-journey-run-stream";
 import { summaryTargetKey, type SwarmTargetColumn } from "./swarm-targets";
 import { usePersistedSessionTrace } from "./use-persisted-session-trace";
+import { shortBundleHash } from "@/components/plugins/plugin-presentation";
 
 export type SwarmMatrixCellOutcome =
   | "pending"
@@ -363,6 +364,31 @@ export function SwarmLiveStreamPane({
               : null)}
         </p>
       )}
+
+      {/* Which plugin bundle produced this transcript. A swarm transcript is
+          the only record of what a simulated session ran with, and a plugin
+          re-import silently changed the answer until the run snapshot started
+          carrying it. Read-only provenance, not a restorable pin — and shown
+          only when the target pinned one. */}
+      {persisted.pluginVersions.length > 0 ? (
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+            Plugins
+          </span>
+          {persisted.pluginVersions.map((version) => (
+            <span
+              key={version.pluginVersionId}
+              className="inline-flex items-center gap-1 rounded-md border border-border/60 px-1.5 py-0.5 text-[11px]"
+              title={`Plugin version ${version.pluginVersionId} · bundle ${version.bundleHash}`}
+            >
+              <span className="text-foreground">{version.name}</span>
+              <span className="font-mono text-[10px] text-muted-foreground">
+                {shortBundleHash(version.bundleHash)}
+              </span>
+            </span>
+          ))}
+        </div>
+      ) : null}
 
       <div data-testid="swarm-live-trace-view-tabs">
         <TraceViewModeTabs

--- a/mcpjam-inspector/client/src/components/swarms/use-persisted-session-trace.ts
+++ b/mcpjam-inspector/client/src/components/swarms/use-persisted-session-trace.ts
@@ -7,6 +7,14 @@ import {
 import type { TraceEnvelope } from "@/components/evals/trace-viewer-adapter";
 import type { EvalTraceSpan } from "@/shared/eval-trace";
 
+/** One pinned plugin version recorded on a synthetic session's resume config. */
+export type SessionPluginVersion = {
+  pluginId: string;
+  pluginVersionId: string;
+  name: string;
+  bundleHash: string;
+};
+
 /**
  * Fetch span blobs from turn trace URLs and flatten into a single span array.
  * Same contract as ShareUsageThreadDetail's hydrateSpans.
@@ -51,6 +59,14 @@ export function usePersistedSessionTrace(threadId: string | null): {
   trace: TraceEnvelope | null;
   loading: boolean;
   error: string | null;
+  /**
+   * The plugin versions this synthetic session's journey target pinned (BE-5),
+   * derived server-side from the run snapshot. Returned from THIS hook rather
+   * than a second query because the session document it comes from is already
+   * loaded here — and because a transcript and the bundle that produced it are
+   * one answer, not two.
+   */
+  pluginVersions: SessionPluginVersion[];
 } {
   const { thread } = useSharedChatThread({ threadId });
   const { traces: turnTraces } = useSharedChatTurnTraces({ threadId });
@@ -146,5 +162,10 @@ export function usePersistedSessionTrace(threadId: string | null): {
           ...(spans.length > 0 ? { spans } : {}),
         };
 
-  return { trace, loading, error };
+  return {
+    trace,
+    loading,
+    error,
+    pluginVersions: thread?.resumeConfig?.pluginVersions ?? [],
+  };
 }

--- a/mcpjam-inspector/client/src/hooks/useSharedChatThreads.ts
+++ b/mcpjam-inspector/client/src/hooks/useSharedChatThreads.ts
@@ -48,6 +48,31 @@ export interface SharedChatThread {
    * to model / server / etc.
    */
   hostConfigIdAtStart?: string;
+  /**
+   * Replay configuration recorded on the session. For a SYNTHETIC (swarm)
+   * session, BE-5 derives the plugin fields SERVER-SIDE from the journey run's
+   * immutable target snapshot — never from anything the runner sends — so they
+   * are provenance about the run, not a claim the caller could make.
+   *
+   * Only the plugin fields are declared: `getSession` spreads the whole
+   * session document, and re-mirroring the rest of the resume config here
+   * would create a second, drifting copy of a contract that already has one.
+   *
+   * `pluginServerIds` is a SIBLING of the ordinary server selection, never
+   * merged into it, for the same reason it is on the journey snapshot: a
+   * plugin-materialized id inside a resumable selection would outlive the
+   * plugin's own lifecycle controls. Anything that resumes must re-gate them
+   * (decision D2) rather than reconnecting on the strength of this record.
+   */
+  resumeConfig?: {
+    pluginVersions?: Array<{
+      pluginId: string;
+      pluginVersionId: string;
+      name: string;
+      bundleHash: string;
+    }>;
+    pluginServerIds?: string[];
+  };
   /** AI-generated chatbox session. Drives the "Synthetic" badge + filter. */
   synthetic?: boolean;
   personaId?: string;

--- a/mcpjam-inspector/client/src/lib/evals/__tests__/openai-submission-report.test.ts
+++ b/mcpjam-inspector/client/src/lib/evals/__tests__/openai-submission-report.test.ts
@@ -1,0 +1,199 @@
+// The submission report's only job is to be honest about a run. Every case
+// below is a way it could quietly stop being.
+
+import { describe, expect, it } from "vitest";
+import {
+  buildOpenAiSubmissionReport,
+  renderOpenAiSubmissionReport,
+  type SubmissionRunCase,
+} from "../openai-submission-report";
+
+function testCase(
+  overrides: Partial<SubmissionRunCase> & { title: string }
+): SubmissionRunCase {
+  return {
+    query: "do the thing",
+    isNegativeTest: false,
+    expectedToolCalls: ["acme_search"],
+    actualToolCalls: ["acme_search"],
+    passed: true,
+    ...overrides,
+  };
+}
+
+const BUNDLE = {
+  name: "acme",
+  pluginVersionId: "pv1",
+  bundleHash: "a".repeat(64),
+};
+
+function positives(count: number, passed = true): SubmissionRunCase[] {
+  return Array.from({ length: count }, (_unused, i) =>
+    testCase({ title: `pos-${i}`, passed })
+  );
+}
+function negatives(count: number, passed = true): SubmissionRunCase[] {
+  return Array.from({ length: count }, (_unused, i) =>
+    testCase({
+      title: `neg-${i}`,
+      isNegativeTest: true,
+      expectedToolCalls: [],
+      actualToolCalls: [],
+      passed,
+    })
+  );
+}
+
+describe("buildOpenAiSubmissionReport", () => {
+  it("selects OpenAI's 5 positive / 3 negative shape", () => {
+    const report = buildOpenAiSubmissionReport({
+      suiteName: "S",
+      runLabel: "Run 1",
+      cases: [...positives(7), ...negatives(4)],
+      pluginVersions: [BUNDLE],
+    });
+    expect(report.positive).toHaveLength(5);
+    expect(report.negative).toHaveLength(3);
+    expect(report.readiness).toEqual([]);
+  });
+
+  it("reports a shortfall rather than padding with the wrong kind", () => {
+    const report = buildOpenAiSubmissionReport({
+      suiteName: "S",
+      runLabel: "Run 1",
+      cases: [...positives(3), ...negatives(1)],
+      pluginVersions: [BUNDLE],
+    });
+    expect(report.positive).toHaveLength(3);
+    expect(report.readiness).toEqual([
+      { code: "insufficient_positive", have: 3, need: 5 },
+      { code: "insufficient_negative", have: 1, need: 3 },
+    ]);
+  });
+
+  // THE case that decides whether this tool can be used to launder a run:
+  // there are enough passing positives to fill the quota, so the failing one
+  // must not be silently dropped in favour of them... except there aren't, and
+  // it must be included AND reported.
+  it("includes a failing case when it is needed to reach the quota, and says so", () => {
+    const report = buildOpenAiSubmissionReport({
+      suiteName: "S",
+      runLabel: "Run 1",
+      cases: [
+        ...positives(4),
+        testCase({ title: "flaky", passed: false }),
+        ...negatives(3),
+      ],
+      pluginVersions: [BUNDLE],
+    });
+    expect(report.positive.map((c) => c.title)).toContain("flaky");
+    expect(report.readiness).toEqual([
+      { code: "failing_cases", titles: ["flaky"] },
+    ]);
+  });
+
+  // ...and when there ARE enough passing ones, passing cases win the slots.
+  // That is a selection preference, not concealment: nothing failing was needed.
+  it("prefers passing cases when the quota can be filled without a failure", () => {
+    const report = buildOpenAiSubmissionReport({
+      suiteName: "S",
+      runLabel: "Run 1",
+      cases: [
+        testCase({ title: "flaky", passed: false }),
+        ...positives(5),
+        ...negatives(3),
+      ],
+      pluginVersions: [BUNDLE],
+    });
+    expect(report.positive.map((c) => c.title)).not.toContain("flaky");
+    expect(report.readiness).toEqual([]);
+  });
+
+  it("refuses to imply a bundle when the run pinned none", () => {
+    const report = buildOpenAiSubmissionReport({
+      suiteName: "S",
+      runLabel: "Run 1",
+      cases: [...positives(5), ...negatives(3)],
+      pluginVersions: [],
+    });
+    expect(report.readiness).toEqual([{ code: "no_plugin_pinned" }]);
+  });
+
+  // The "without skills" A/B arm produces real results about a deliberately
+  // reduced configuration. Submitting it as evidence for the plugin is wrong.
+  it("flags the skills-excluded arm", () => {
+    const report = buildOpenAiSubmissionReport({
+      suiteName: "S",
+      runLabel: "Run 1",
+      cases: [...positives(5), ...negatives(3)],
+      pluginVersions: [BUNDLE],
+      skillsExcluded: true,
+    });
+    expect(report.readiness).toEqual([{ code: "skills_excluded" }]);
+  });
+
+  it("is stable: the same run renders the same document", () => {
+    const args = {
+      suiteName: "S",
+      runLabel: "Run 1",
+      cases: [...positives(6), ...negatives(3)],
+      pluginVersions: [BUNDLE],
+      now: 1,
+    };
+    expect(
+      renderOpenAiSubmissionReport(buildOpenAiSubmissionReport(args))
+    ).toBe(renderOpenAiSubmissionReport(buildOpenAiSubmissionReport(args)));
+  });
+});
+
+describe("renderOpenAiSubmissionReport", () => {
+  it("states the full bundle hash — the thing the report is evidence about", () => {
+    const md = renderOpenAiSubmissionReport(
+      buildOpenAiSubmissionReport({
+        suiteName: "S",
+        runLabel: "Run 1",
+        cases: [...positives(5), ...negatives(3)],
+        pluginVersions: [BUNDLE],
+        now: 1,
+      })
+    );
+    expect(md).toContain(BUNDLE.bundleHash);
+    expect(md).toContain("**acme**");
+  });
+
+  it("puts readiness problems above the results, not in a footnote", () => {
+    const md = renderOpenAiSubmissionReport(
+      buildOpenAiSubmissionReport({
+        suiteName: "S",
+        runLabel: "Run 1",
+        cases: positives(1),
+        pluginVersions: [BUNDLE],
+        now: 1,
+      })
+    );
+    expect(md.indexOf("## Not ready to submit")).toBeLessThan(
+      md.indexOf("## Should invoke")
+    );
+  });
+
+  it("carries the negative case's scenario, which is what a reviewer reads", () => {
+    const md = renderOpenAiSubmissionReport(
+      buildOpenAiSubmissionReport({
+        suiteName: "S",
+        runLabel: "Run 1",
+        cases: [
+          testCase({
+            title: "unrelated",
+            isNegativeTest: true,
+            expectedToolCalls: [],
+            actualToolCalls: [],
+            scenario: "A weather question has nothing to do with invoicing.",
+          }),
+        ],
+        pluginVersions: [BUNDLE],
+        now: 1,
+      })
+    );
+    expect(md).toContain("A weather question has nothing to do with invoicing.");
+  });
+});

--- a/mcpjam-inspector/client/src/lib/evals/openai-submission-report.ts
+++ b/mcpjam-inspector/client/src/lib/evals/openai-submission-report.ts
@@ -1,0 +1,252 @@
+/**
+ * OpenAI plugin-submission report (INS-5).
+ *
+ * OpenAI's directory review asks for a fixed evidence shape: FIVE prompts where
+ * the plugin should be invoked and THREE where it must stay out of the way.
+ * MCPJam suites already carry that distinction — `isNegativeTest` marks the
+ * "should not trigger" cases, and `scenario` is the field authors use to say
+ * why — so a submission is a projection of a run, not a new authoring flow.
+ *
+ * The report is built from ONE run, and it names the exact plugin bundle that
+ * run executed. That is the whole reason it lives here rather than over "the
+ * suite": a suite is live and editable, so "these 8 prompts pass" is only a
+ * claim about a specific bundle if it comes from the immutable record of a
+ * single execution.
+ *
+ * IT DOES NOT LAUNDER A FAILING RUN. `readiness` reports every shortfall —
+ * too few cases of either kind, any failing selection, no plugin pinned, the
+ * skills-excluded arm — and the rendered document states them at the top rather
+ * than omitting the offending case to make the counts work. A report that
+ * silently dropped a failure would be the most expensive kind of green.
+ */
+
+export interface SubmissionRunCase {
+  title: string;
+  /** The prompt as executed, from the iteration's frozen snapshot. */
+  query: string;
+  isNegativeTest: boolean;
+  /** Author's note on why the plugin should not trigger (negative cases). */
+  scenario?: string;
+  expectedToolCalls: string[];
+  actualToolCalls: string[];
+  passed: boolean;
+  model?: string;
+  provider?: string;
+}
+
+export interface SubmissionPluginVersion {
+  name: string;
+  pluginVersionId: string;
+  bundleHash: string;
+}
+
+/** How many of each kind OpenAI asks for. */
+export const OPENAI_POSITIVE_TARGET = 5;
+export const OPENAI_NEGATIVE_TARGET = 3;
+
+export type SubmissionReadinessIssue =
+  | { code: "insufficient_positive"; have: number; need: number }
+  | { code: "insufficient_negative"; have: number; need: number }
+  | { code: "failing_cases"; titles: string[] }
+  | { code: "no_plugin_pinned" }
+  | { code: "skills_excluded" };
+
+export interface OpenAiSubmissionReport {
+  suiteName: string;
+  runLabel: string;
+  generatedAt: number;
+  pluginVersions: SubmissionPluginVersion[];
+  positive: SubmissionRunCase[];
+  negative: SubmissionRunCase[];
+  /** Empty ⇒ this run satisfies OpenAI's evidence shape as-is. */
+  readiness: SubmissionReadinessIssue[];
+}
+
+/**
+ * Pick the cases to submit.
+ *
+ * PASSING CASES FIRST, then failing ones, and the selection is truncated to the
+ * target count only AFTER that ordering — so a suite with six passing positives
+ * submits five passing ones, while a suite with four passing and two failing
+ * submits four passing plus one failing AND reports the failure. Dropping the
+ * failing case instead would produce a clean-looking report from a run that is
+ * not clean, which is precisely the document nobody should be able to generate
+ * by accident.
+ *
+ * Stable within each group: input order (the run's own case order) is
+ * preserved, so regenerating a report for the same run yields the same
+ * document.
+ */
+function selectCases(
+  cases: SubmissionRunCase[],
+  target: number
+): SubmissionRunCase[] {
+  const passing = cases.filter((entry) => entry.passed);
+  const failing = cases.filter((entry) => !entry.passed);
+  return [...passing, ...failing].slice(0, target);
+}
+
+export function buildOpenAiSubmissionReport(args: {
+  suiteName: string;
+  runLabel: string;
+  cases: SubmissionRunCase[];
+  pluginVersions: SubmissionPluginVersion[];
+  skillsExcluded?: boolean;
+  now?: number;
+}): OpenAiSubmissionReport {
+  const positive = selectCases(
+    args.cases.filter((entry) => !entry.isNegativeTest),
+    OPENAI_POSITIVE_TARGET
+  );
+  const negative = selectCases(
+    args.cases.filter((entry) => entry.isNegativeTest),
+    OPENAI_NEGATIVE_TARGET
+  );
+
+  const readiness: SubmissionReadinessIssue[] = [];
+  if (positive.length < OPENAI_POSITIVE_TARGET) {
+    readiness.push({
+      code: "insufficient_positive",
+      have: positive.length,
+      need: OPENAI_POSITIVE_TARGET,
+    });
+  }
+  if (negative.length < OPENAI_NEGATIVE_TARGET) {
+    readiness.push({
+      code: "insufficient_negative",
+      have: negative.length,
+      need: OPENAI_NEGATIVE_TARGET,
+    });
+  }
+  const failingTitles = [...positive, ...negative]
+    .filter((entry) => !entry.passed)
+    .map((entry) => entry.title);
+  if (failingTitles.length > 0) {
+    readiness.push({ code: "failing_cases", titles: failingTitles });
+  }
+  if (args.pluginVersions.length === 0) {
+    // Without a pinned bundle the document is evidence about nothing in
+    // particular: the plugin it describes is whatever was installed that day.
+    readiness.push({ code: "no_plugin_pinned" });
+  }
+  if (args.skillsExcluded) {
+    // The "without skills" A/B arm. Its results are real, but they are not
+    // evidence about a plugin whose value is partly its skills.
+    readiness.push({ code: "skills_excluded" });
+  }
+
+  return {
+    suiteName: args.suiteName,
+    runLabel: args.runLabel,
+    generatedAt: args.now ?? Date.now(),
+    pluginVersions: args.pluginVersions,
+    positive,
+    negative,
+    readiness,
+  };
+}
+
+export function describeSubmissionIssue(issue: SubmissionReadinessIssue): string {
+  switch (issue.code) {
+    case "insufficient_positive":
+      return `Only ${issue.have} of the ${issue.need} required "should invoke" prompts ran in this run. Add cases to the suite and re-run.`;
+    case "insufficient_negative":
+      return `Only ${issue.have} of the ${issue.need} required "should NOT invoke" prompts ran in this run. Mark cases as negative tests and re-run.`;
+    case "failing_cases":
+      return `These selected cases FAILED in this run and are included as-is: ${issue.titles.join(
+        ", "
+      )}.`;
+    case "no_plugin_pinned":
+      return "This run pinned no plugin version, so the report cannot state which bundle was evaluated. Run the suite against an environment that pins the plugin.";
+    case "skills_excluded":
+      return "This run is the 'without skills' arm of a compare — no skills were delivered from any channel. Submit the arm that includes them.";
+  }
+}
+
+function renderCase(entry: SubmissionRunCase, index: number): string {
+  const lines = [
+    `${index + 1}. **${entry.title}** — ${entry.passed ? "PASS" : "FAIL"}`,
+    "",
+    `   Prompt: ${entry.query}`,
+  ];
+  if (entry.model) {
+    lines.push(
+      `   Model: ${entry.provider ? `${entry.provider}/` : ""}${entry.model}`
+    );
+  }
+  if (entry.scenario) lines.push(`   Why it should not trigger: ${entry.scenario}`);
+  lines.push(
+    `   Expected tool calls: ${
+      entry.expectedToolCalls.length > 0
+        ? entry.expectedToolCalls.join(", ")
+        : "none"
+    }`
+  );
+  lines.push(
+    `   Actual tool calls: ${
+      entry.actualToolCalls.length > 0
+        ? entry.actualToolCalls.join(", ")
+        : "none"
+    }`
+  );
+  return lines.join("\n");
+}
+
+/** Markdown rendering of a report — the artifact a submitter attaches. */
+export function renderOpenAiSubmissionReport(
+  report: OpenAiSubmissionReport
+): string {
+  const sections: string[] = [
+    `# OpenAI submission evidence — ${report.suiteName}`,
+    "",
+    `Run: ${report.runLabel}`,
+    `Generated: ${new Date(report.generatedAt).toISOString()}`,
+    "",
+    "## Plugin bundle evaluated",
+    "",
+  ];
+
+  if (report.pluginVersions.length === 0) {
+    sections.push("_No plugin version was pinned by this run._", "");
+  } else {
+    for (const version of report.pluginVersions) {
+      sections.push(
+        `- **${version.name}** — bundle \`${version.bundleHash}\` (version ${version.pluginVersionId})`
+      );
+    }
+    sections.push("");
+  }
+
+  if (report.readiness.length > 0) {
+    // At the TOP, never a footnote: this is what a reviewer needs before they
+    // read a single result.
+    sections.push("## Not ready to submit", "");
+    for (const issue of report.readiness) {
+      sections.push(`- ${describeSubmissionIssue(issue)}`);
+    }
+    sections.push("");
+  }
+
+  sections.push(
+    `## Should invoke (${report.positive.length}/${OPENAI_POSITIVE_TARGET})`,
+    ""
+  );
+  sections.push(
+    report.positive.length > 0
+      ? report.positive.map(renderCase).join("\n\n")
+      : "_None._"
+  );
+  sections.push(
+    "",
+    `## Should NOT invoke (${report.negative.length}/${OPENAI_NEGATIVE_TARGET})`,
+    ""
+  );
+  sections.push(
+    report.negative.length > 0
+      ? report.negative.map(renderCase).join("\n\n")
+      : "_None._"
+  );
+  sections.push("");
+
+  return sections.join("\n");
+}

--- a/mcpjam-inspector/server/routes/shared/evals.ts
+++ b/mcpjam-inspector/server/routes/shared/evals.ts
@@ -334,6 +334,26 @@ export const RunEvalsRequestSchema = z.object({
    * unknown keys are stripped silently.
    */
   environmentId: z.string().optional(),
+  /**
+   * The "without skills" arm of an A/B compare (INS-5). `'exclude'` runs this
+   * suite with skills DELIBERATELY off: the backend pins nothing from ANY of
+   * the three channels — host `skillSelection`, the environment's standalone
+   * selection, and the PLUGIN channel — and marks the run `skillsExcluded`, so
+   * the comparison arm is honestly labelled rather than just quietly skill-free.
+   *
+   * KNOWN AND DELIBERATE ASYMMETRY, inherited verbatim from the backend
+   * (`convex/testSuites.ts`, `resolveEnvironmentPinnedSkills`): this drops
+   * plugin SKILLS, not plugin SERVERS. The flag is scoped to skill delivery, so
+   * a pinned plugin's MCP servers stay connected and stay in the run's
+   * `environmentPluginVersions` provenance. Dropping them too would change
+   * which servers the arm connects, which is the one variable a skills A/B has
+   * to hold fixed. A genuinely plugin-free comparison arm needs a backend
+   * override that does not exist yet — see the INS-5 notes.
+   *
+   * Must be declared explicitly on every Zod boundary in the wire path;
+   * unknown keys are stripped silently.
+   */
+  skillsOverride: z.literal("exclude").optional(),
 });
 
 export type RunEvalsRequest = z.infer<typeof RunEvalsRequestSchema>;
@@ -1494,6 +1514,7 @@ export async function prepareEvalRun(
     resolvedEnvironment,
     source,
     idempotencyKey,
+    skillsOverride,
   } = request;
 
   if (!suiteId && (!suiteName || suiteName.trim().length === 0)) {
@@ -1664,6 +1685,7 @@ export async function prepareEvalRun(
       : undefined,
     source,
     idempotencyKey,
+    skillsOverride,
   });
   const suiteHostConfig =
     runHostConfigSnapshot ??

--- a/mcpjam-inspector/server/routes/shared/evals.ts
+++ b/mcpjam-inspector/server/routes/shared/evals.ts
@@ -24,6 +24,7 @@ import {
   resolveSteps,
   runEvalSuiteWithAiSdk,
   streamTestCase,
+  type EvalPinnedSkillSource,
 } from "../../services/evals-runner";
 import type { EvalStreamEvent } from "@/shared/eval-stream-events";
 import {
@@ -33,7 +34,6 @@ import {
   type TestCaseType,
 } from "@/shared/probe-config";
 import { logger } from "../../utils/logger";
-import type { PinnableSkill } from "../../../shared/skill-types.js";
 import { ErrorCode, WebRouteError } from "../web/errors.js";
 import {
   resolveOrgModelConfig,
@@ -47,9 +47,17 @@ import { sanitizeForConvexTransport } from "../../services/evals/convex-sanitize
 import {
   environmentEffectiveServerIds,
   environmentServerIds,
+  environmentServerNames,
   resolveEnvironmentForLaunch,
   type ResolvedEnvironmentForLaunch,
 } from "../../services/environments/resolve.js";
+import { resolveSuiteRunPluginServers } from "../../services/plugins/run-plugin-servers.js";
+import {
+  assertPinnedSkillFilesReachable,
+  buildRunCapabilitySet,
+  runNeedsEffectiveSkillSurface,
+  type RunPinnedSkill,
+} from "../../services/evals/run-plugin-snapshot.js";
 import {
   countModelSteps,
   isModelFree,
@@ -1395,6 +1403,16 @@ const RUN_PINNED_SKILLS_RETRY_DELAYS_MS = [250, 1_000] as const;
  * were in play; silently executing without them would grade a run against
  * skills it never had. Returns `undefined` when the run has no pins.
  * `sleep` is injectable for tests.
+ *
+ * INS-5: the rows are returned WHOLE. This used to project each pin down to
+ * `{name, description, content, contentHash}`, which was lossless while every
+ * pinnable skill was SKILL.md-only — and became a silent truncation the moment
+ * BE-5 started pinning folder skills. `modelRef` is how a plugin skill is
+ * ADDRESSED (two plugins may declare the same `name`), `aggregateHash`
+ * identifies the complete artifact rather than just the markdown envelope, and
+ * `files` is the frozen `scripts/`/`references/` the run is supposed to
+ * reproduce. Dropping them at the boundary meant a plugin run delivered a
+ * script-less skill under an ambiguous name and reported success.
  */
 export async function fetchRunPinnedSkillsWithRetry(
   // Structural: satisfied by ConvexHttpClient (whose `query` takes a typed
@@ -1405,7 +1423,7 @@ export async function fetchRunPinnedSkillsWithRetry(
   runId: string,
   sleep: (ms: number) => Promise<void> = (ms) =>
     new Promise((resolve) => setTimeout(resolve, ms))
-): Promise<PinnableSkill[] | undefined> {
+): Promise<RunPinnedSkill[] | undefined> {
   const attempts = RUN_PINNED_SKILLS_RETRY_DELAYS_MS.length + 1;
   for (let attempt = 0; attempt < attempts; attempt++) {
     try {
@@ -1413,21 +1431,11 @@ export async function fetchRunPinnedSkillsWithRetry(
         "testSuites:getRunPinnedSkills" as any,
         { runId }
       )) as {
-        pinnedSkills?: Array<{
-          name: string;
-          description: string;
-          content: string;
-          contentHash: string;
-        }>;
+        pinnedSkills?: RunPinnedSkill[];
       };
       const list = res?.pinnedSkills ?? [];
       if (list.length === 0) return undefined;
-      return list.map((s) => ({
-        name: s.name,
-        description: s.description,
-        content: s.content,
-        contentHash: s.contentHash,
-      }));
+      return list;
     } catch (error) {
       logger.warn("[evals] getRunPinnedSkills failed", {
         runId,
@@ -1627,6 +1635,7 @@ export async function prepareEvalRun(
     config,
     recorder,
     hostConfig: runHostConfigSnapshot,
+    pluginVersions: runEnvironmentPluginVersions = [],
   } = await startSuiteRunWithRecorder({
     convexClient,
     suiteId: resolvedSuiteId,
@@ -1730,18 +1739,77 @@ export async function prepareEvalRun(
     }
   }
 
-  // Pinned skills for this run (PR-E3). Suite runs only — quick-run (runId null)
-  // has no run row to carry pins, so it stays skill-free. STRICT: the fetch is
-  // retried (250ms/1s backoff) and a persistent failure FAILS run preparation.
-  // Silently degrading to "no skills" would let the run execute while the
-  // configSnapshot and the judge still claim the pinned skills were available.
-  let runPinnedSkills: PinnableSkill[] | undefined;
+  // SETUP phase for this run's pinned capabilities (PR-E3, extended by INS-5).
+  // Suite runs only — quick-run (runId null) has no run row to carry pins, so
+  // it stays skill-free. STRICT throughout: the pin fetch is retried (250ms/1s
+  // backoff), plugin pins are re-gated against the live plugin lifecycle, and
+  // every pinned supporting file must be readable. Any of those failing FAILS
+  // run preparation. Silently degrading to "no skills" or "fewer servers" would
+  // let the run execute while the configSnapshot and the judge still claim the
+  // full pinned surface was available — a green run measuring a configuration
+  // that never existed.
+  //
+  // Everything here happens BEFORE `execute()`, which is the whole point: a
+  // setup failure must precede model execution and name the component that
+  // caused it.
+  let pinnedSkillSource: EvalPinnedSkillSource | undefined;
   if (runId) {
     // The run row already exists (startSuiteRunWithRecorder created it), so a
-    // persistent pin-fetch failure would otherwise strand the run as
+    // persistent setup failure would otherwise strand the run as
     // running/pending forever. Finalize it as failed before rethrowing.
     try {
-      runPinnedSkills = await fetchRunPinnedSkillsWithRetry(convexClient, runId);
+      const runPinnedSkills = await fetchRunPinnedSkillsWithRetry(
+        convexClient,
+        runId
+      );
+
+      // INS-5 — decision D2, at the last moment before execution.
+      //
+      // The run snapshot records which plugin VERSIONS the environment pinned.
+      // That is provenance, never a standing grant: the backend re-resolves the
+      // live plugin rows on every call, so a plugin disabled or uninstalled
+      // since the launch resolution (seconds ago, but a race is a race) reports
+      // here and stops the run. Failing NOW is the point — the run row exists,
+      // no model has been called, and the failure names the component.
+      //
+      // Called for every run with a runId, including plugin-free ones: the
+      // backend's all-clear for "pinned nothing" is the same empty envelope, so
+      // there is no snapshot read to do first. A LEGACY (non-environment) run
+      // cannot carry a pin at all — the environment is the only pin carrier —
+      // so it tolerates a backend that predates BE-5 rather than failing for a
+      // capability it structurally cannot have.
+      const runPluginServers = await resolveSuiteRunPluginServers(
+        () => convexClient,
+        {
+          runId,
+          allowUndeployedBackend: !environmentLaunch,
+        }
+      );
+
+      if (runPinnedSkills?.length) {
+        // A pinned supporting file whose blob is gone fails the run BEFORE the
+        // model runs, attributed to the skill and the path. `url: null` is an
+        // unreachable blob, never "no file" — see the assertion's own note.
+        assertPinnedSkillFilesReachable(runPinnedSkills);
+        pinnedSkillSource = runNeedsEffectiveSkillSurface(runPinnedSkills)
+          ? {
+              kind: "pinned-effective",
+              capabilities: buildRunCapabilitySet({
+                pins: runPinnedSkills,
+                // Straight from `configSnapshot.environmentPluginVersions` —
+                // the run's own record. NOT re-resolved to the plugin's active
+                // version, which is what would let a mid-run re-import change
+                // an in-flight run.
+                pluginVersions: runEnvironmentPluginVersions,
+                pluginServers: runPluginServers,
+                effectiveServerIds: resolvedServerIds,
+                serverNames: environmentLaunch
+                  ? environmentServerNames(environmentLaunch)
+                  : serverNames,
+              }),
+            }
+          : { kind: "pinned", skills: runPinnedSkills };
+      }
     } catch (error) {
       const cause = (
         error instanceof Error ? error.message : String(error)
@@ -1759,7 +1827,7 @@ export async function prepareEvalRun(
         })
         .catch((cleanupError: unknown) =>
           logger.warn(
-            "[evals] Failed to fail pending iterations after pin-fetch abort",
+            "[evals] Failed to fail pending iterations after setup abort",
             {
               runId,
               error:
@@ -1773,7 +1841,7 @@ export async function prepareEvalRun(
         .finalize({ status: "failed", notes: cause })
         .catch((finalizeError: unknown) =>
           logger.warn(
-            "[evals] Failed to finalize run after pin-fetch abort",
+            "[evals] Failed to finalize run after setup abort",
             {
               runId,
               error:
@@ -1807,7 +1875,7 @@ export async function prepareEvalRun(
       // `selectedServerIds`) via `resolveExecutionContext`. `hostPolicy`
       // is the POLICY subset extracted upstream; this is the rest.
       suiteHostConfig,
-      ...(runPinnedSkills ? { pinnedSkills: runPinnedSkills } : {}),
+      ...(pinnedSkillSource ? { pinnedSkillSource } : {}),
     });
   };
 

--- a/mcpjam-inspector/server/services/environments/effective-capabilities.ts
+++ b/mcpjam-inspector/server/services/environments/effective-capabilities.ts
@@ -143,6 +143,21 @@ function toRuntimePluginVersion(
 }
 
 /**
+ * Exactly the parts of a resolved environment this projection reads.
+ *
+ * Narrower than `ResolvedEnvironmentRuntime` on purpose. A `ResolvedEnvironmentRuntime`
+ * still satisfies it structurally, so the interactive caller is unchanged — but
+ * a caller with a run SNAPSHOT rather than a live environment (INS-5) can now
+ * supply what it genuinely has instead of fabricating an `environmentRef` and a
+ * `host.runtimeConfig` this function never looks at. A fabricated host field is
+ * a lie that only reads as one at the next person to grep for it.
+ */
+export type EffectiveCapabilityInput = Pick<
+  ResolvedEnvironmentRuntime,
+  "servers" | "skills" | "pluginVersions"
+>;
+
+/**
  * Project one resolved environment spec into the turn's capability set.
  *
  * `attribution` is `null` when `fetchPluginRuntimeAttribution` could not read
@@ -151,7 +166,7 @@ function toRuntimePluginVersion(
  * of which come straight from the spec.
  */
 export function resolveEffectiveCapabilities(
-  spec: ResolvedEnvironmentRuntime,
+  spec: EffectiveCapabilityInput,
   attribution: PluginRuntimeAttribution | null
 ): EffectiveCapabilitySet {
   const problems: RuntimeCapabilityProblem[] = [];

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -234,6 +234,32 @@ export type EvalTestCase = {
   probeConfig?: import("@/shared/probe-config").ProbeConfig;
 };
 
+/**
+ * How a run delivers its PINNED skills to the model (INS-5).
+ *
+ * Both variants are frozen snapshot content and both bypass approval — an eval
+ * run is auto-deny, and these are pure reads of content that cannot change
+ * mid-run. They differ only in the tool SURFACE, and which one a run needs is a
+ * property of what it pinned:
+ *
+ *  - `pinned` — bare-name tools over SKILL.md bodies. Every eval run that
+ *    predates plugins, unchanged: same tool names, same prompt stanza, and no
+ *    supporting-file tools advertised for files that cannot exist.
+ *  - `pinned-effective` — INS-3's ref-addressed surface, for a run whose pins
+ *    carry a plugin `modelRef` (two plugins may declare the same skill name, so
+ *    a bare name cannot identify one) or supporting FILES (the bare-name
+ *    surface has no tool to read them with).
+ *
+ * Decided ONCE, at the boundary that read the run's pins, so no iteration can
+ * disagree with another about the surface the suite was measured on.
+ */
+export type EvalPinnedSkillSource =
+  | { kind: "pinned"; skills: PinnableSkill[] }
+  | {
+      kind: "pinned-effective";
+      capabilities: import("./environments/effective-capabilities.js").EffectiveCapabilitySet;
+    };
+
 export type RunEvalSuiteOptions = {
   suiteId: string;
   runId: string | null; // null for quick runs
@@ -286,13 +312,17 @@ export type RunEvalSuiteOptions = {
    */
   suiteHostConfig?: Record<string, unknown> | null;
   /**
-   * Skills PINNED for this run (from `startTestSuiteRun`'s `pinnedSkills`,
-   * content joined from `evalSkillSnapshots`). Threaded into every iteration
-   * runner as `skillsSource: pinned`. Absent ⇒ the runners pass
-   * `skillsSource: none` (eval runs never use local-FS skills — decision 10);
-   * quick-run stays `none` (no run row = no pinning carrier).
+   * The skill delivery this run's PINS resolved to, decided once at the
+   * boundary (`prepareEvalRun`) and forwarded verbatim by every iteration
+   * runner. Absent ⇒ the runners pass `skillsSource: none` (eval runs never use
+   * local-FS skills — decision 10); quick-run stays absent (no run row = no
+   * pinning carrier).
+   *
+   * A SOURCE rather than a skill list because INS-5 gave the pin store two
+   * possible shapes, and which one a run needs is a property of what it pinned,
+   * not a per-iteration choice — see {@link EvalPinnedSkillSource}.
    */
-  pinnedSkills?: PinnableSkill[];
+  pinnedSkillSource?: EvalPinnedSkillSource;
 };
 
 /** One executed iteration inside a suite/quick run (evaluation + optional persisted iteration id). */
@@ -1071,12 +1101,11 @@ type RunIterationBaseParams = {
    * eval sandbox when the suite pins a computerEnvironment. */
   convexAuthToken: string;
   /**
-   * Skills PINNED for this run (frozen SKILL.md content from the run's
-   * `configSnapshot.pinnedSkills`). When present, the runner mints in-memory
-   * pinned skill tools (zero network). Eval runs NEVER use local-FS skills
-   * (decision 10) — the runner always passes `skillsSource: pinned|none`.
+   * The skill delivery this run's PINS resolved to (see
+   * {@link RunEvalSuiteOptions.pinnedSkillSource}). Eval runs NEVER use local-FS
+   * skills (decision 10) — the runner passes this or `skillsSource: none`.
    */
-  pinnedSkills?: PinnableSkill[];
+  pinnedSkillSource?: EvalPinnedSkillSource;
 };
 
 type RunIterationAiSdkParams = RunIterationBaseParams & {
@@ -1434,8 +1463,8 @@ const executeTestCase = async (params: {
    * receives its servers pre-resolved via `selectedServers`.
    */
   environment?: RunEvalSuiteOptions["config"]["environment"];
-  /** Pinned skills for this run (see RunEvalSuiteOptions.pinnedSkills). */
-  pinnedSkills?: PinnableSkill[];
+  /** Pinned skill delivery for this run (see RunEvalSuiteOptions.pinnedSkillSource). */
+  pinnedSkillSource?: EvalPinnedSkillSource;
 }) => {
   const {
     test,
@@ -1461,7 +1490,7 @@ const executeTestCase = async (params: {
     toolSignals,
     suiteHostConfig,
     environment,
-    pinnedSkills,
+    pinnedSkillSource,
   } = params;
   const testCaseId = test.testCaseId || parentTestCaseId;
   const streaming = emit != null;
@@ -1543,7 +1572,7 @@ const executeTestCase = async (params: {
         toolSignals,
         suiteHostConfig,
         environment,
-        pinnedSkills,
+        pinnedSkillSource,
       };
       outcomes.push(
         await runSingleIteration(
@@ -1666,7 +1695,7 @@ const executeTestCase = async (params: {
         toolSignals,
         suiteHostConfig,
         environment,
-        pinnedSkills,
+        pinnedSkillSource,
       };
       const iterationOutcome = await runSingleIteration(
         () =>
@@ -1714,7 +1743,7 @@ const executeTestCase = async (params: {
         toolSignals,
         suiteHostConfig,
         environment,
-        pinnedSkills,
+        pinnedSkillSource,
       };
       const iterationOutcome = await runSingleIteration(
         () =>
@@ -1759,7 +1788,7 @@ const executeTestCase = async (params: {
       // for prompt-only cases.
       environment,
       convexAuthToken,
-      pinnedSkills,
+      pinnedSkillSource,
     };
     const iterationOutcome = await runSingleIteration(
       () =>
@@ -1800,7 +1829,7 @@ export const runEvalSuiteWithAiSdk = async ({
   suiteInjectOpenAiCompat,
   hostExecutionPolicy,
   suiteHostConfig,
-  pinnedSkills,
+  pinnedSkillSource,
 }: RunEvalSuiteOptions): Promise<RunEvalSuiteWithAiSdkResult | undefined> => {
   const injectOpenAiCompat = suiteInjectOpenAiCompat === true;
   const tests = config.tests ?? [];
@@ -1925,7 +1954,7 @@ export const runEvalSuiteWithAiSdk = async ({
         toolSignals: resolvedToolSignals,
         suiteHostConfig,
         environment: config.environment,
-        ...(pinnedSkills ? { pinnedSkills } : {}),
+        ...(pinnedSkillSource ? { pinnedSkillSource } : {}),
       });
     const testPromises = tests.map((test) =>
       // Cap concurrent headless browsers for every model-free render check
@@ -2175,15 +2204,13 @@ const runLocalIteration = async ({
   suiteHostConfig,
   environment,
   convexAuthToken,
-  pinnedSkills,
+  pinnedSkillSource,
 }: RunIterationAiSdkParams & {
   emit?: StreamEmit;
 }): Promise<EvalIterationOutcome> => {
   const resolvedTest = resolveEvalTestCase(test);
   // Eval runs NEVER use local-FS skills (decision 10): always explicit.
-  const skillsSource = pinnedSkills?.length
-    ? ({ kind: "pinned", skills: pinnedSkills } as const)
-    : ({ kind: "none" } as const);
+  const skillsSource = pinnedSkillSource ?? ({ kind: "none" } as const);
 
   // Check if run was cancelled before starting iteration
   if (runId !== null) {
@@ -3075,7 +3102,7 @@ const runHostedIterationWithBrowser = async (
     // iteration eval-sandbox provisioning + the bash tool (hosted parity with
     // the local runner).
     environment,
-    pinnedSkills,
+    pinnedSkillSource,
   }: RunIterationBackendParams & {
     emit?: StreamEmit;
   },
@@ -3083,9 +3110,7 @@ const runHostedIterationWithBrowser = async (
 ): Promise<EvalIterationOutcome> => {
   const resolvedTest = resolveEvalTestCase(test);
   // Eval runs NEVER use local-FS skills (decision 10): always explicit.
-  const skillsSource = pinnedSkills?.length
-    ? ({ kind: "pinned", skills: pinnedSkills } as const)
-    : ({ kind: "none" } as const);
+  const skillsSource = pinnedSkillSource ?? ({ kind: "none" } as const);
 
   // Check if run was cancelled before starting iteration
   if (runId !== null) {

--- a/mcpjam-inspector/server/services/evals/__tests__/run-plugin-snapshot.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/run-plugin-snapshot.test.ts
@@ -1,0 +1,286 @@
+// INS-5 — a run's plugin surface must come from the run's own snapshot.
+//
+// The cases below are the three ways that stops being true: addressing a plugin
+// skill by its (non-unique) name, reading an unreachable pinned blob as "no
+// file", and re-deriving the version list from something other than the record.
+
+import { describe, expect, it } from "vitest";
+import {
+  RunPluginSnapshotError,
+  assertPinnedSkillFilesReachable,
+  buildRunCapabilitySet,
+  runNeedsEffectiveSkillSurface,
+  runPluginVersions,
+  type RunPinnedSkill,
+} from "../run-plugin-snapshot.js";
+import type { RunPluginServer } from "../../plugins/run-plugin-servers.js";
+
+const ACME = {
+  pluginId: "p_acme",
+  pluginVersionId: "pv_acme_1",
+  name: "acme",
+  bundleHash: "a".repeat(64),
+};
+const BETA = {
+  pluginId: "p_beta",
+  pluginVersionId: "pv_beta_1",
+  name: "beta",
+  bundleHash: "b".repeat(64),
+};
+
+function pin(overrides: Partial<RunPinnedSkill> = {}): RunPinnedSkill {
+  return {
+    skillId: "sk1",
+    name: "summarize",
+    description: "d",
+    content: "body",
+    contentHash: "c1",
+    ...overrides,
+  };
+}
+
+function server(overrides: Partial<RunPluginServer> = {}): RunPluginServer {
+  return {
+    serverId: "srv_acme",
+    name: "acme-api",
+    pluginVersionId: ACME.pluginVersionId,
+    pluginId: ACME.pluginId,
+    pluginName: ACME.name,
+    componentKey: "api",
+    ...overrides,
+  };
+}
+
+describe("assertPinnedSkillFilesReachable", () => {
+  it("passes a body-only pin", () => {
+    expect(() => assertPinnedSkillFilesReachable([pin()])).not.toThrow();
+  });
+
+  it("passes when every pinned file has a signed url", () => {
+    expect(() =>
+      assertPinnedSkillFilesReachable([
+        pin({
+          files: [
+            { path: "scripts/run.py", contentHash: "f1", size: 10, url: "u" },
+          ],
+        }),
+      ])
+    ).not.toThrow();
+  });
+
+  // THE inversion this module exists to prevent. `url: null` means the pinned
+  // blob is gone; reading it as "this skill has no scripts" replays the run
+  // with the assets missing and still reports the skill as delivered.
+  it("fails the run on a null url instead of reading it as 'no file'", () => {
+    expect(() =>
+      assertPinnedSkillFilesReachable([
+        pin({
+          modelRef: "acme/summarize",
+          files: [
+            {
+              path: "scripts/run.py",
+              contentHash: "f1",
+              size: 10,
+              url: null,
+            },
+          ],
+        }),
+      ])
+    ).toThrow(RunPluginSnapshotError);
+  });
+
+  it("names the skill ref and the path so the failure is attributable", () => {
+    try {
+      assertPinnedSkillFilesReachable([
+        pin({
+          modelRef: "acme/summarize",
+          files: [
+            { path: "scripts/run.py", contentHash: "f1", size: 10, url: null },
+          ],
+        }),
+      ]);
+      throw new Error("expected a throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(RunPluginSnapshotError);
+      expect((error as RunPluginSnapshotError).component).toBe(
+        "acme/summarize"
+      );
+      expect((error as Error).message).toMatch(/scripts\/run\.py/);
+    }
+  });
+
+  // The pin store is shared with file-bearing STANDALONE skills, and an
+  // unreachable blob is exactly as wrong there.
+  it("applies to standalone pins too", () => {
+    expect(() =>
+      assertPinnedSkillFilesReachable([
+        pin({
+          files: [
+            { path: "refs/notes.md", contentHash: "f1", size: 4, url: "" },
+          ],
+        }),
+      ])
+    ).toThrow(RunPluginSnapshotError);
+  });
+});
+
+describe("runNeedsEffectiveSkillSurface", () => {
+  it("keeps the legacy bare-name surface for body-only pins", () => {
+    expect(runNeedsEffectiveSkillSurface([pin(), pin({ skillId: "sk2" })])).toBe(
+      false
+    );
+  });
+
+  it("switches surfaces for a plugin ref (a bare name cannot identify one)", () => {
+    expect(
+      runNeedsEffectiveSkillSurface([pin({ modelRef: "acme/summarize" })])
+    ).toBe(true);
+  });
+
+  it("switches surfaces for supporting files (no bare-name tool reads them)", () => {
+    expect(
+      runNeedsEffectiveSkillSurface([
+        pin({
+          files: [
+            { path: "scripts/run.py", contentHash: "f1", size: 1, url: "u" },
+          ],
+        }),
+      ])
+    ).toBe(true);
+  });
+
+  // Deploy skew: a plugin-channel pin from a backend that predates `modelRef`.
+  it("switches surfaces on the plugin channel alone", () => {
+    expect(runNeedsEffectiveSkillSurface([pin({ channels: ["plugin"] })])).toBe(
+      true
+    );
+  });
+});
+
+describe("buildRunCapabilitySet", () => {
+  it("addresses plugin skills by modelRef, so two plugins may share a name", () => {
+    const set = buildRunCapabilitySet({
+      pins: [
+        pin({ skillId: "sk1", modelRef: "acme/summarize", channels: ["plugin"] }),
+        pin({ skillId: "sk2", modelRef: "beta/summarize", channels: ["plugin"] }),
+      ],
+      pluginVersions: [ACME, BETA],
+      pluginServers: [],
+      effectiveServerIds: [],
+    });
+    expect(set.pluginSkills.map((s) => s.ref)).toEqual([
+      "acme/summarize",
+      "beta/summarize",
+    ]);
+    // Both survive: keyed by name they would have collided and one would be
+    // unreachable — the collision BE-5 re-keyed its own gate to allow.
+    expect(set.problems).toEqual([]);
+  });
+
+  it("carries the pinned bundleHash onto each skill's plugin origin", () => {
+    const set = buildRunCapabilitySet({
+      pins: [pin({ modelRef: "acme/summarize", channels: ["plugin"] })],
+      pluginVersions: [ACME],
+      pluginServers: [],
+      effectiveServerIds: [],
+    });
+    expect(set.pluginSkills[0]?.plugin?.bundleHash).toBe(ACME.bundleHash);
+  });
+
+  it("classifies servers from the D2 answer, not from the snapshot", () => {
+    const set = buildRunCapabilitySet({
+      pins: [],
+      pluginVersions: [ACME],
+      pluginServers: [server()],
+      effectiveServerIds: ["srv_host", "srv_acme"],
+      serverNames: ["host-api", "ignored"],
+    });
+    expect(set.explicitServerIds).toEqual(["srv_host"]);
+    expect(set.pluginServerIds).toEqual(["srv_acme"]);
+    expect(set.servers[1]?.plugin?.pluginVersionId).toBe(ACME.pluginVersionId);
+    // The D2 row's live name wins over a stale index-aligned launch name.
+    expect(set.servers[1]?.name).toBe("acme-api");
+  });
+
+  it("reports a pinned version nothing attributed to, rather than staying silent", () => {
+    const set = buildRunCapabilitySet({
+      pins: [],
+      pluginVersions: [ACME, BETA],
+      pluginServers: [server()],
+      effectiveServerIds: ["srv_acme"],
+    });
+    expect(set.problems.map((p) => p.code)).toEqual([
+      "plugin_origin_unavailable",
+    ]);
+  });
+
+  // Provenance is exact and immutable. Nothing here may swap in the plugin's
+  // current active version.
+  it("returns the pinned versions verbatim, in pin order", () => {
+    expect(runPluginVersions([BETA, ACME])).toEqual([
+      { ...BETA, bundleHash: BETA.bundleHash },
+      { ...ACME, bundleHash: ACME.bundleHash },
+    ]);
+  });
+
+  it("reports a missing bundleHash as null rather than synthesizing one", () => {
+    const [only] = runPluginVersions([
+      { pluginId: "p", pluginVersionId: "pv", name: "n" },
+    ]);
+    expect(only.bundleHash).toBeNull();
+  });
+
+  it("uses aggregateHash as the artifact identity, falling back to contentHash", () => {
+    const set = buildRunCapabilitySet({
+      pins: [
+        pin({ skillId: "sk1", aggregateHash: "agg1" }),
+        pin({ skillId: "sk2", name: "other" }),
+      ],
+      pluginVersions: [],
+      pluginServers: [],
+      effectiveServerIds: [],
+    });
+    expect(set.standaloneSkills.map((s) => s.aggregateHash)).toEqual([
+      "agg1",
+      "c1",
+    ]);
+  });
+
+  it("passes pinned file urls through untouched for the ref-addressed tools", () => {
+    const set = buildRunCapabilitySet({
+      pins: [
+        pin({
+          modelRef: "acme/summarize",
+          channels: ["plugin"],
+          files: [
+            { path: "scripts/run.py", contentHash: "f1", size: 3, url: "u1" },
+          ],
+        }),
+      ],
+      pluginVersions: [ACME],
+      pluginServers: [],
+      effectiveServerIds: [],
+    });
+    expect(set.pluginSkills[0]?.files).toEqual([
+      { path: "scripts/run.py", size: 3, url: "u1" },
+    ]);
+  });
+
+  // Pre-BE-5 pins carry no skillId. Keying attribution and collisions by
+  // `undefined` would collapse every such pin onto one entry.
+  it("gives an id-less legacy pin a stable stand-in id", () => {
+    const set = buildRunCapabilitySet({
+      pins: [
+        pin({ skillId: undefined, name: "a" }),
+        pin({ skillId: undefined, name: "b" }),
+      ],
+      pluginVersions: [],
+      pluginServers: [],
+      effectiveServerIds: [],
+    });
+    expect(set.standaloneSkills.map((s) => s.skillId)).toEqual([
+      "pin:a",
+      "pin:b",
+    ]);
+  });
+});

--- a/mcpjam-inspector/server/services/evals/recorder.ts
+++ b/mcpjam-inspector/server/services/evals/recorder.ts
@@ -333,6 +333,7 @@ export const startSuiteRunWithRecorder = async ({
   expectedEnvironmentServerIds,
   source,
   idempotencyKey,
+  skillsOverride,
 }: {
   convexClient: ConvexHttpClient;
   suiteId: string;
@@ -430,6 +431,13 @@ export const startSuiteRunWithRecorder = async ({
    * interactive paths — the mutation's fingerprint window covers those.
    */
   idempotencyKey?: string;
+  /**
+   * The A/B "without skills" arm. `'exclude'` tells `startTestSuiteRun` to pin
+   * NO skills from any channel and to mark the run `skillsExcluded`, so the
+   * comparison arm is labelled rather than merely empty. See the wire schema
+   * for the deliberate plugin-servers asymmetry.
+   */
+  skillsOverride?: "exclude";
 }) => {
   let response: any;
   try {
@@ -461,6 +469,7 @@ export const startSuiteRunWithRecorder = async ({
           : {}),
         ...(source ? { source } : {}),
         ...(idempotencyKey ? { idempotencyKey } : {}),
+        ...(skillsOverride ? { skillsOverride } : {}),
       }
     );
   } catch (error) {

--- a/mcpjam-inspector/server/services/evals/recorder.ts
+++ b/mcpjam-inspector/server/services/evals/recorder.ts
@@ -12,6 +12,7 @@ import type { UsageTotals } from "./types";
 import { logger } from "../../utils/logger";
 import type { ServerToolSnapshot } from "../../utils/export-helpers.js";
 import { sanitizeForConvexTransport } from "./convex-sanitize.js";
+import type { RunPinnedPluginVersion } from "./run-plugin-snapshot.js";
 import { finalizeEvalIteration } from "./finalize-iteration.js";
 import { resolveCaseSuccessPredicates } from "@/shared/eval-matching";
 import { ErrorCode, WebRouteError } from "../../routes/web/errors.js";
@@ -685,5 +686,18 @@ export const startSuiteRunWithRecorder = async ({
       | Record<string, unknown>
       | null
       | undefined,
+    /**
+     * `configSnapshot.environmentPluginVersions` (BE-5) — identity +
+     * `bundleHash` of every plugin version this run pinned, in pin order.
+     *
+     * Surfaced from the RUN row rather than re-read from the environment
+     * resolution that preceded it. The two agree by construction (the mutation
+     * rejects any drift between them via the `expectedEnvironment*` echoes),
+     * but only one of them is the run's own immutable record, and provenance
+     * that is displayed and reported should come from the record. Absent on a
+     * legacy run, a plugin-free environment, or an older backend.
+     */
+    pluginVersions: (response?.configSnapshot as any)
+      ?.environmentPluginVersions as RunPinnedPluginVersion[] | undefined,
   };
 };

--- a/mcpjam-inspector/server/services/evals/run-plugin-snapshot.ts
+++ b/mcpjam-inspector/server/services/evals/run-plugin-snapshot.ts
@@ -1,0 +1,323 @@
+/**
+ * INS-5 — a suite run's plugin surface, read from the RUN SNAPSHOT.
+ *
+ * An eval exists to answer "did this configuration behave?", so every input to
+ * the answer has to be the one the run froze. BE-5 made that possible for
+ * plugins: `configSnapshot.environmentPluginVersions` records exactly which
+ * bundles the launch resolved, and the pinned-skill store now freezes a plugin
+ * skill's SUPPORTING FILES alongside its SKILL.md. This module turns those two
+ * frozen records into the object the turn already knows how to consume.
+ *
+ * It re-derives nothing:
+ *
+ *   - which versions ran        → the run snapshot, verbatim. Re-resolving a
+ *                                 plugin to its ACTIVE version would quietly
+ *                                 replace an in-flight run's bundle, which is
+ *                                 the acceptance criterion this work exists for.
+ *   - which servers may run     → `services/plugins/run-plugin-servers.ts` (D2),
+ *                                 which re-gates lifecycle at execution.
+ *   - the capability projection → `resolveEffectiveCapabilities` (INS-3),
+ *                                 unchanged. Ref namespacing, the
+ *                                 plugin/standalone split, and the `problems`
+ *                                 reporting are INS-3's rules; a second copy
+ *                                 here would be a second set of them.
+ *
+ * Address by `modelRef`, never by `name`. A plugin skill's `name` is its
+ * declared name and two plugins may legitimately share one — BE-5 re-keyed the
+ * backend's collision gate to `modelRef ?? name` for exactly that reason. The
+ * pinned metadata carries `modelRef`, so it flows straight into INS-3's
+ * attribution map and the model addresses `<plugin>/<skill>`.
+ *
+ * `aggregateHash` is the COMPLETE artifact (SKILL.md + every supporting file);
+ * `contentHash` identifies only the SKILL.md envelope. Anything reasoning about
+ * "is this the same skill the run used?" wants the former.
+ */
+import {
+  resolveEffectiveCapabilities,
+  type EffectiveCapabilitySet,
+  type RuntimePluginVersion,
+} from "../environments/effective-capabilities.js";
+import type {
+  AttributedPluginVersion,
+  PluginRuntimeAttribution,
+} from "../environments/plugin-attribution.js";
+import type { RunPluginServer } from "../plugins/run-plugin-servers.js";
+import type { RuntimeSkillChannel } from "../environments/runtime.js";
+
+/**
+ * One pinned supporting file, as BE-5's `joinPinnedSkillFileDelivery` serves it.
+ *
+ * `url` is a signed, time-limited blob URL. **`null` means the pinned blob is
+ * UNREACHABLE** — see {@link assertPinnedSkillFilesReachable}.
+ */
+export interface RunPinnedSkillFile {
+  path: string;
+  contentHash: string;
+  size: number;
+  url: string | null;
+}
+
+/**
+ * The full pinned-skill row `testSuites:getRunPinnedSkills` returns.
+ *
+ * Every field past `contentHash` is optional because the shipped backend served
+ * the SKILL.md-only subset before BE-5, and a run started then must still
+ * replay. Absent is read as absent — never synthesized.
+ */
+export interface RunPinnedSkill {
+  skillId?: string;
+  name: string;
+  description: string;
+  content: string;
+  contentHash: string;
+  /** Complete-artifact identity; absent ⇒ equal to `contentHash` (body-only). */
+  aggregateHash?: string;
+  /** `<plugin>/<skill>` for a plugin-channel entry; absent for the others. */
+  modelRef?: string;
+  sharing?: "user" | "project";
+  channels?: RuntimeSkillChannel[];
+  extraFrontmatter?: Record<string, unknown>;
+  files?: RunPinnedSkillFile[];
+}
+
+/** The `configSnapshot.environmentPluginVersions` row shape. */
+export interface RunPinnedPluginVersion {
+  pluginId: string;
+  pluginVersionId: string;
+  name: string;
+  /** Optional for deploy skew only; never synthesized when absent. */
+  bundleHash?: string;
+}
+
+/**
+ * Thrown when a run's frozen plugin surface cannot be delivered as recorded.
+ *
+ * Deliberately its own type and NOT a degradation: every caller finalizes the
+ * run as a setup failure before a single model call. `component` names what
+ * could not be delivered so the failure is attributable rather than a bare
+ * "skills unavailable".
+ */
+export class RunPluginSnapshotError extends Error {
+  readonly component: string;
+  constructor(component: string, message: string) {
+    super(message);
+    this.name = "RunPluginSnapshotError";
+    this.component = component;
+  }
+}
+
+/**
+ * Every pinned supporting file must be REACHABLE before the run executes.
+ *
+ * A `url: null` is not "this skill has no file". It is a blob the pin store
+ * points at and storage can no longer serve — only possible for bytes deleted
+ * before BE-5's retention rule existed, or by a direct dashboard delete.
+ * Treating it as absence is the precise inversion that makes a replay run
+ * silently script-less while still reporting the skill as delivered, which is
+ * the failure the pin store was built to prevent. So it fails the run, and it
+ * fails it HERE — before model execution — naming the skill and the path.
+ *
+ * Checked for standalone pins too, not just plugin ones: the same store backs
+ * both, and an unreachable file is exactly as wrong either way.
+ */
+export function assertPinnedSkillFilesReachable(
+  pins: readonly RunPinnedSkill[]
+): void {
+  for (const pin of pins) {
+    for (const file of pin.files ?? []) {
+      if (typeof file.url === "string" && file.url.length > 0) continue;
+      const ref = pin.modelRef ?? pin.name;
+      throw new RunPluginSnapshotError(
+        ref,
+        `This run pinned the skill "${ref}", but its supporting file "${file.path}" is no longer readable from the run snapshot. The run was stopped rather than executed with the file missing. Re-import the plugin (or re-create the skill) and start a new run.`
+      );
+    }
+  }
+}
+
+/** A pin the model must address by its namespaced plugin ref. */
+function isPluginPin(pin: RunPinnedSkill): boolean {
+  return pin.modelRef !== undefined || (pin.channels ?? []).includes("plugin");
+}
+
+/**
+ * Rebuild INS-3's attribution map from FROZEN records instead of a live probe.
+ *
+ * `fetchPluginRuntimeAttribution` exists because an interactive turn has to ask
+ * the plugin registry which component contributed what. A run does not: its
+ * snapshot already recorded the version list, its pins already carry
+ * `modelRef`, and D2 already returned per-server plugin identity. Probing live
+ * would reintroduce exactly the drift the snapshot removes.
+ *
+ * `unattributedVersionIds` keeps its meaning — a pinned version we could not
+ * connect to any server or skill — so INS-3 reports the same
+ * `plugin_origin_unavailable` problem it would for a live turn.
+ */
+function attributionFromSnapshot(args: {
+  pluginVersions: readonly RunPinnedPluginVersion[];
+  pluginServers: readonly RunPluginServer[];
+  pins: readonly RunPinnedSkill[];
+}): PluginRuntimeAttribution {
+  const byVersionId = new Map<string, AttributedPluginVersion>();
+  for (const version of args.pluginVersions) {
+    byVersionId.set(version.pluginVersionId, {
+      pluginId: version.pluginId,
+      pluginVersionId: version.pluginVersionId,
+      name: version.name,
+      // Deploy skew only. `null` is INS-3's "we do not know", and it renders as
+      // an omitted revision rather than a made-up one.
+      bundleHash: version.bundleHash ?? null,
+    });
+  }
+
+  const attributedVersionIds = new Set<string>();
+  const serverOrigins = new Map<string, AttributedPluginVersion>();
+  for (const server of args.pluginServers) {
+    const version = byVersionId.get(server.pluginVersionId);
+    // A D2 row naming a version the snapshot never recorded is a torn view, not
+    // an origin: label nothing rather than inventing a pin the run never made.
+    if (!version) continue;
+    serverOrigins.set(server.serverId, version);
+    attributedVersionIds.add(version.pluginVersionId);
+  }
+
+  const skillOrigins = new Map<
+    string,
+    { modelRef: string; plugin: AttributedPluginVersion }
+  >();
+  for (const pin of args.pins) {
+    if (!pin.skillId || !pin.modelRef) continue;
+    // The pin records the ref but not which VERSION minted it. Recover it from
+    // the plugin-name namespace the ref carries — the same namespace the
+    // backend builds `modelRef` from — and only when it is unambiguous.
+    const namespace = pin.modelRef.split("/")[0];
+    const matches = args.pluginVersions.filter(
+      (version) => version.name === namespace
+    );
+    if (matches.length !== 1) continue;
+    const version = byVersionId.get(matches[0].pluginVersionId);
+    if (!version) continue;
+    skillOrigins.set(pin.skillId, { modelRef: pin.modelRef, plugin: version });
+    attributedVersionIds.add(version.pluginVersionId);
+  }
+
+  return {
+    serverOrigins,
+    skillOrigins,
+    unattributedVersionIds: args.pluginVersions
+      .map((version) => version.pluginVersionId)
+      .filter((id) => !attributedVersionIds.has(id)),
+  };
+}
+
+/**
+ * Project a suite run's frozen plugin surface into the capability set a turn
+ * consumes.
+ *
+ * `effectiveServerIds` is the set the run actually connected, in connection
+ * order; `pluginServers` is D2's verified subset of it. Classification comes
+ * from the D2 answer, never from the snapshot's own server list — the snapshot
+ * says what was pinned, D2 says what may run.
+ */
+export function buildRunCapabilitySet(args: {
+  pins: readonly RunPinnedSkill[];
+  pluginVersions: readonly RunPinnedPluginVersion[];
+  pluginServers: readonly RunPluginServer[];
+  effectiveServerIds: readonly string[];
+  /** Display names index-aligned with `effectiveServerIds`; may be empty. */
+  serverNames?: readonly string[];
+}): EffectiveCapabilitySet {
+  const pluginServerIds = new Set(args.pluginServers.map((s) => s.serverId));
+  const nameById = new Map(args.pluginServers.map((s) => [s.serverId, s.name]));
+  args.effectiveServerIds.forEach((serverId, index) => {
+    const name = args.serverNames?.[index];
+    if (name && !nameById.has(serverId)) nameById.set(serverId, name);
+  });
+
+  return resolveEffectiveCapabilities(
+    {
+      servers: {
+        effectiveServerIds: [...args.effectiveServerIds],
+        pluginServerIds: [...pluginServerIds],
+        connectable: args.effectiveServerIds.map((serverId) => ({
+          serverId,
+          // Absence of a name is semantic (the manager shows the id); never
+          // guess one.
+          name: nameById.get(serverId) ?? serverId,
+          source: pluginServerIds.has(serverId)
+            ? ("plugin" as const)
+            : ("host_or_group" as const),
+        })),
+      },
+      skills: args.pins.map((pin) => ({
+        // A pre-BE-5 pin may carry no `skillId`. INS-3 keys attribution and
+        // collision reporting by it, so mint a stable stand-in from the ref
+        // rather than colliding every such pin on `undefined`.
+        skillId: pin.skillId ?? `pin:${pin.modelRef ?? pin.name}`,
+        name: pin.name,
+        description: pin.description,
+        content: pin.content,
+        // Body-only pins legitimately have no aggregate hash; it equals the
+        // content hash by definition there.
+        aggregateHash: pin.aggregateHash ?? pin.contentHash,
+        ...(pin.extraFrontmatter
+          ? { extraFrontmatter: pin.extraFrontmatter }
+          : {}),
+        // Channels drive INS-3's plugin/standalone split. A pin that carries a
+        // `modelRef` but no channels (deploy skew) is still a plugin skill.
+        channels:
+          pin.channels ?? (isPluginPin(pin) ? ["plugin" as const] : []),
+        files: (pin.files ?? []).map((file) => ({
+          path: file.path,
+          size: file.size,
+          url: file.url,
+        })),
+      })),
+      pluginVersions: args.pluginVersions.map((version) => ({
+        pluginId: version.pluginId,
+        pluginVersionId: version.pluginVersionId,
+        name: version.name,
+        ...(version.bundleHash ? { bundleHash: version.bundleHash } : {}),
+      })),
+    },
+    attributionFromSnapshot({
+      pluginVersions: args.pluginVersions,
+      pluginServers: args.pluginServers,
+      pins: args.pins,
+    })
+  );
+}
+
+/**
+ * Does this run's pinned set need the ref-addressed skill surface?
+ *
+ * Body-only, bare-name pins — every eval run that existed before plugins — keep
+ * the legacy pinned tool set byte for byte: same tool names, same prompt
+ * stanza, no supporting-file tools to advertise for files that cannot exist.
+ * Changing that surface for every eval user in order to serve plugin runs would
+ * be a behaviour change nobody asked for, measured by suites that have been
+ * running against the old one.
+ *
+ * A pin with a plugin ref or a supporting file cannot be served by that surface
+ * at all, so those runs get INS-3's.
+ */
+export function runNeedsEffectiveSkillSurface(
+  pins: readonly RunPinnedSkill[]
+): boolean {
+  return pins.some((pin) => isPluginPin(pin) || (pin.files ?? []).length > 0);
+}
+
+/**
+ * The versions a run actually executed with, for provenance display and the
+ * submission report. Straight from the snapshot, in pin order.
+ */
+export function runPluginVersions(
+  pluginVersions: readonly RunPinnedPluginVersion[]
+): RuntimePluginVersion[] {
+  return pluginVersions.map((version) => ({
+    pluginId: version.pluginId,
+    pluginVersionId: version.pluginVersionId,
+    name: version.name,
+    bundleHash: version.bundleHash ?? null,
+  }));
+}

--- a/mcpjam-inspector/server/services/journeys/plugin-servers.ts
+++ b/mcpjam-inspector/server/services/journeys/plugin-servers.ts
@@ -21,67 +21,51 @@
  * server set runs an environment nobody configured, and does it silently. "I
  * couldn't check" must never be delivered as "nothing to add".
  *
+ * The shape validation, the reason-code prose, and the "which problems mean
+ * stop?" rule now live in `services/plugins/run-plugin-servers.ts`, shared with
+ * the suite twin BE-5 added. Only the journey-shaped envelope (`{ targets: [] }`,
+ * with a per-target id to cross-check) and the journey wording are here.
+ *
  * Hand-mirrored contract (no codegen; string function refs like the rest of the
  * inspector→Convex surface).
  */
 import type { ConvexHttpClient } from "convex/browser";
-
-/** One connectable server contributed by a still-valid pin. */
-export interface RunPluginServer {
-  serverId: string;
-  name: string;
-  pluginVersionId: string;
-  pluginId: string;
-  pluginName: string;
-  componentKey: string;
-}
-
-interface RunPluginServerUnavailable {
-  pluginVersionId: string;
-  reason: string;
-  pluginName?: string;
-  componentKey?: string;
-}
+import {
+  RunPluginServersUnavailableError,
+  assertRunPluginResolutionShape,
+  assertRunPluginResolutionUsable,
+  queryRunPluginResolution,
+  readRunPluginServerIds,
+  type RunPluginServer,
+  type RunPluginServerResolution,
+} from "../plugins/run-plugin-servers.js";
 
 interface JourneyRunPluginServerResolution {
-  targets: Array<{
-    targetId?: string;
-    servers: RunPluginServer[];
-    unavailable: RunPluginServerUnavailable[];
-    droppedSnapshotServerIds: string[];
-  }>;
+  targets: Array<Partial<RunPluginServerResolution> & { targetId?: string }>;
 }
 
-/** Thrown when a target's pins cannot be verified as still-connectable. */
-export class JourneyPluginServersUnavailableError extends Error {
+/**
+ * Thrown when a target's pins cannot be verified as still-connectable.
+ *
+ * Extends the shared error so a caller may catch either, and every shared throw
+ * is re-wrapped into it below so journey callers keep seeing exactly one type.
+ */
+export class JourneyPluginServersUnavailableError extends RunPluginServersUnavailableError {
   constructor(message: string) {
     super(message);
     this.name = "JourneyPluginServersUnavailableError";
   }
 }
 
-function describeUnavailable(entry: RunPluginServerUnavailable): string {
-  const who = entry.pluginName ?? entry.pluginVersionId;
-  switch (entry.reason) {
-    case "disabled":
-      return `"${who}" is disabled`;
-    case "uninstalled":
-      return `"${who}" was uninstalled`;
-    case "not_found":
-      return `"${who}" no longer exists in this project`;
-    case "not_ready":
-      return `"${who}" has not finished importing`;
-    case "server_missing":
-      return `"${who}" no longer provides its server${
-        entry.componentKey ? ` "${entry.componentKey}"` : ""
-      }`;
-    case "unsupported_placement":
-      return `"${who}" provides a server that can't run in a hosted journey`;
-    case "unresolvable_scope":
-      return `"${who}" could not be resolved in this project`;
-    default:
-      return `"${who}" is unavailable (${entry.reason})`;
+/** Re-wrap a shared-core failure without altering its (journey-worded) message. */
+function asJourneyError(error: unknown): unknown {
+  if (
+    error instanceof RunPluginServersUnavailableError &&
+    !(error instanceof JourneyPluginServersUnavailableError)
+  ) {
+    return new JourneyPluginServersUnavailableError(error.message);
   }
+  return error;
 }
 
 /**
@@ -111,6 +95,26 @@ export async function resolveTargetPluginServerIds(
     snapshotPluginServerIds?: string[];
   }
 ): Promise<string[]> {
+  return (await resolveTargetPluginServers(getConvexClient, args)).map(
+    (server) => server.serverId
+  );
+}
+
+/**
+ * The same re-gate, returning the RICH rows (plugin id / version / name /
+ * component key) rather than bare ids. Internal for now: the journey connect
+ * path needs only the ids, and a synthetic session's plugin provenance is
+ * derived server-side by Convex from the run snapshot (BE-5), never sent up
+ * from here.
+ */
+async function resolveTargetPluginServers(
+  getConvexClient: () => ConvexHttpClient,
+  args: {
+    runId: string;
+    targetId?: string;
+    snapshotPluginServerIds?: string[];
+  }
+): Promise<RunPluginServer[]> {
   const pinned = args.snapshotPluginServerIds ?? [];
   if (pinned.length === 0) return [];
 
@@ -123,85 +127,45 @@ export async function resolveTargetPluginServerIds(
     );
   }
 
-  let raw: unknown;
   try {
-    raw = await getConvexClient().query(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- string
-      // function refs are the established inspector→Convex pattern (see
-      // services/environments/resolve.ts); there is no codegen here.
-      "journeyRuns:resolveJourneyRunPluginServersForExecution" as any,
-      { runId: args.runId, targetId: args.targetId }
+    const raw = (await queryRunPluginResolution(
+      getConvexClient,
+      "journeyRuns:resolveJourneyRunPluginServersForExecution",
+      { runId: args.runId, targetId: args.targetId },
+      "This deployment can't verify pinned plugins yet, so the journey was stopped rather than run without them. Retry after the backend deploys."
+    )) as JourneyRunPluginServerResolution | null;
+
+    // `null` is the backend's "no answer" (run gone, or this target isn't in
+    // the run) — deliberately NOT the same shape as "no plugins".
+    if (!raw || !Array.isArray(raw.targets)) {
+      throw new JourneyPluginServersUnavailableError(
+        "This journey run's pinned plugins could not be resolved. Re-launch the journey."
+      );
+    }
+    const target = raw.targets[0];
+    const unrecognized =
+      "This journey target's pinned plugins could not be resolved (unrecognized response). Retry after the backend deploys, or re-launch the journey.";
+    assertRunPluginResolutionShape(target, unrecognized);
+
+    // A response for a DIFFERENT target would apply the wrong plugin set to
+    // this one. The backend echoes `targetId`; when it does, it must match.
+    const echoedTargetId = (target as { targetId?: string }).targetId;
+    if (echoedTargetId !== undefined && echoedTargetId !== args.targetId) {
+      throw new JourneyPluginServersUnavailableError(
+        "This journey target's pinned plugins resolved against a different target. Re-launch the journey."
+      );
+    }
+
+    assertRunPluginResolutionUsable(target, {
+      surfaceNoun: "journey",
+      remedy: "Update the environment's plugin pins and re-launch.",
+    });
+    readRunPluginServerIds(
+      target,
+      "This journey target's pinned plugins resolved to an unrecognized server entry. Retry after the backend deploys, or re-launch the journey."
     );
+    return target.servers;
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    if (/could not find public function/i.test(message)) {
-      throw new JourneyPluginServersUnavailableError(
-        "This deployment can't verify pinned plugins yet, so the journey was stopped rather than run without them. Retry after the backend deploys."
-      );
-    }
-    throw error;
+    throw asJourneyError(error);
   }
-
-  const resolution = raw as JourneyRunPluginServerResolution | null;
-  // `null` is the backend's "no answer" (run gone, or this target isn't in the
-  // run) — deliberately NOT the same shape as "no plugins".
-  if (!resolution || !Array.isArray(resolution.targets)) {
-    throw new JourneyPluginServersUnavailableError(
-      "This journey run's pinned plugins could not be resolved. Re-launch the journey."
-    );
-  }
-  const target = resolution.targets[0];
-
-  // Validate the SHAPE before trusting it. This crosses a deploy boundary, so
-  // an incompatible or truncated payload is a live possibility during skew —
-  // and a permissive read of one is indistinguishable from a clean all-clear.
-  // `{ targets: [{}] }` would satisfy every check above and then fall through
-  // three `?? []` defaults to "no plugins, proceed", silently shrinking the
-  // environment: the exact failure this whole module exists to prevent. The
-  // three arrays are REQUIRED, not optional-with-a-default, because an absent
-  // `unavailable` is "I didn't get told about problems", never "there are
-  // none".
-  if (
-    !target ||
-    !Array.isArray(target.servers) ||
-    !Array.isArray(target.unavailable) ||
-    !Array.isArray(target.droppedSnapshotServerIds)
-  ) {
-    throw new JourneyPluginServersUnavailableError(
-      "This journey target's pinned plugins could not be resolved (unrecognized response). Retry after the backend deploys, or re-launch the journey."
-    );
-  }
-  // A response for a DIFFERENT target would apply the wrong plugin set to this
-  // one. The backend echoes `targetId`; when it does, it must match.
-  if (target.targetId !== undefined && target.targetId !== args.targetId) {
-    throw new JourneyPluginServersUnavailableError(
-      "This journey target's pinned plugins resolved against a different target. Re-launch the journey."
-    );
-  }
-
-  const problems = [
-    ...target.unavailable.map(describeUnavailable),
-    ...target.droppedSnapshotServerIds.map(
-      (id) => `a pinned plugin server (${id}) is no longer provided`
-    ),
-  ];
-  if (problems.length > 0) {
-    throw new JourneyPluginServersUnavailableError(
-      `This journey pins plugins that can't be used right now: ${problems.join(
-        "; "
-      )}. Update the environment's plugin pins and re-launch.`
-    );
-  }
-
-  // Each entry must actually carry an id. A malformed row would otherwise map
-  // to `undefined` and be handed to the connection manager as a server.
-  return target.servers.map((server) => {
-    const serverId = server?.serverId;
-    if (typeof serverId !== "string" || serverId.length === 0) {
-      throw new JourneyPluginServersUnavailableError(
-        "This journey target's pinned plugins resolved to an unrecognized server entry. Retry after the backend deploys, or re-launch the journey."
-      );
-    }
-    return serverId;
-  });
 }

--- a/mcpjam-inspector/server/services/plugins/__tests__/run-plugin-servers.test.ts
+++ b/mcpjam-inspector/server/services/plugins/__tests__/run-plugin-servers.test.ts
@@ -1,0 +1,191 @@
+// Decision D2 for SUITE runs (BE-5). Same bar as the journey twin: the run
+// snapshot still names the plugin, and the resolution must either verify it
+// live or refuse. Returning `[]` on an unverifiable run would silently shrink
+// the environment the eval measured — which is the failure the re-gate exists
+// to prevent, and the one that makes a green run a lie.
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  RunPluginServersUnavailableError,
+  resolveSuiteRunPluginServers,
+} from "../run-plugin-servers.js";
+
+function clientReturning(value: unknown) {
+  const client = { query: vi.fn().mockResolvedValue(value) };
+  const get = () => client as never;
+  return Object.assign(get, { client });
+}
+function clientThrowing(error: Error) {
+  const client = { query: vi.fn().mockRejectedValue(error) };
+  const get = () => client as never;
+  return Object.assign(get, { client });
+}
+
+const CLEAN = { servers: [], unavailable: [], droppedSnapshotServerIds: [] };
+
+describe("resolveSuiteRunPluginServers", () => {
+  it("returns the rich rows on a clean resolution", async () => {
+    const client = clientReturning({
+      ...CLEAN,
+      servers: [
+        {
+          serverId: "s1",
+          name: "acme-api",
+          pluginVersionId: "pv1",
+          pluginId: "p1",
+          pluginName: "acme",
+          componentKey: "api",
+        },
+      ],
+    });
+    await expect(
+      resolveSuiteRunPluginServers(client, { runId: "run1" })
+    ).resolves.toEqual([
+      {
+        serverId: "s1",
+        name: "acme-api",
+        pluginVersionId: "pv1",
+        pluginId: "p1",
+        pluginName: "acme",
+        componentKey: "api",
+      },
+    ]);
+    expect(client.client.query).toHaveBeenCalledWith(
+      "testSuites:resolveRunPluginServersForExecution",
+      { runId: "run1" }
+    );
+  });
+
+  // The backend's documented all-clear for a run that pinned nothing (every
+  // legacy run included). This is what lets the caller invoke it
+  // unconditionally instead of first reading the snapshot back.
+  it("treats the empty three-list envelope as a genuine all-clear", async () => {
+    await expect(
+      resolveSuiteRunPluginServers(clientReturning(CLEAN), { runId: "run1" })
+    ).resolves.toEqual([]);
+  });
+
+  it.each([
+    ["null", null],
+    ["an empty object", {}],
+    ["servers only", { servers: [] }],
+    // The one that motivates requiring all three: two lists present reads as a
+    // clean answer if the third is allowed to default.
+    [
+      "a missing unavailable list",
+      { servers: [], droppedSnapshotServerIds: [] },
+    ],
+    [
+      "a missing dropped list",
+      { servers: [], unavailable: [] },
+    ],
+  ])("rejects %s rather than reading it as 'no plugins'", async (_label, value) => {
+    await expect(
+      resolveSuiteRunPluginServers(clientReturning(value), { runId: "run1" })
+    ).rejects.toThrow(RunPluginServersUnavailableError);
+  });
+
+  it("names the plugin and the reason so the failure is attributable", async () => {
+    await expect(
+      resolveSuiteRunPluginServers(
+        clientReturning({
+          ...CLEAN,
+          unavailable: [
+            { pluginVersionId: "pv1", reason: "uninstalled", pluginName: "acme" },
+          ],
+        }),
+        { runId: "run1" }
+      )
+    ).rejects.toThrow(/"acme" was uninstalled/);
+  });
+
+  it("names the component when the backend identified one", async () => {
+    await expect(
+      resolveSuiteRunPluginServers(
+        clientReturning({
+          ...CLEAN,
+          unavailable: [
+            {
+              pluginVersionId: "pv1",
+              reason: "server_missing",
+              pluginName: "acme",
+              componentKey: "api",
+            },
+          ],
+        }),
+        { runId: "run1" }
+      )
+    ).rejects.toThrow(/"acme" no longer provides its server "api"/);
+  });
+
+  // Reason codes are a backend-owned union that will grow. An unknown one must
+  // still stop the run and say what it was.
+  it("stops on an unrecognized reason code and reports it verbatim", async () => {
+    await expect(
+      resolveSuiteRunPluginServers(
+        clientReturning({
+          ...CLEAN,
+          unavailable: [{ pluginVersionId: "pv1", reason: "quarantined" }],
+        }),
+        { runId: "run1" }
+      )
+    ).rejects.toThrow(/is unavailable \(quarantined\)/);
+  });
+
+  // The backend suppresses this list whenever `unavailable` already explains
+  // the shrinkage, so a non-empty one here always means a server vanished with
+  // NO version-level explanation.
+  it("stops on a dropped snapshot server id with no unavailable entry", async () => {
+    await expect(
+      resolveSuiteRunPluginServers(
+        clientReturning({ ...CLEAN, droppedSnapshotServerIds: ["s9"] }),
+        { runId: "run1" }
+      )
+    ).rejects.toThrow(/a pinned plugin server \(s9\) is no longer provided/);
+  });
+
+  it("rejects a server entry with no usable id", async () => {
+    await expect(
+      resolveSuiteRunPluginServers(
+        clientReturning({ ...CLEAN, servers: [{ name: "acme-api" }] }),
+        { runId: "run1" }
+      )
+    ).rejects.toThrow(/unrecognized server entry/);
+  });
+
+  it("fails closed when the backend has not deployed the query", async () => {
+    await expect(
+      resolveSuiteRunPluginServers(
+        clientThrowing(
+          new Error("Could not find public function for 'testSuites:x'")
+        ),
+        { runId: "run1" }
+      )
+    ).rejects.toThrow(/can't verify this run's pinned plugins yet/);
+  });
+
+  // A legacy (non-environment) suite run cannot carry a pin at all — the
+  // environment is the only pin carrier — so failing it for a capability it
+  // structurally cannot have would break every such run on an older backend.
+  it("allows an undeployed backend ONLY for a run that cannot pin plugins", async () => {
+    await expect(
+      resolveSuiteRunPluginServers(
+        clientThrowing(
+          new Error("Could not find public function for 'testSuites:x'")
+        ),
+        { runId: "run1", allowUndeployedBackend: true }
+      )
+    ).resolves.toEqual([]);
+  });
+
+  // ...and that escape hatch must not swallow anything else. A transport
+  // failure is not evidence that there are no plugins.
+  it("still throws a non-deploy-skew error under allowUndeployedBackend", async () => {
+    await expect(
+      resolveSuiteRunPluginServers(clientThrowing(new Error("network down")), {
+        runId: "run1",
+        allowUndeployedBackend: true,
+      })
+    ).rejects.toThrow(/network down/);
+  });
+});

--- a/mcpjam-inspector/server/services/plugins/run-plugin-servers.ts
+++ b/mcpjam-inspector/server/services/plugins/run-plugin-servers.ts
@@ -1,0 +1,269 @@
+/**
+ * Decision D2 — the SHARED execution-time re-gate for a run's pinned plugin
+ * servers, for both run products.
+ *
+ * Journeys got this first (`services/journeys/plugin-servers.ts`). BE-5 shipped
+ * the suite twin (`testSuites:resolveRunPluginServersForExecution`) with the
+ * same contract, resolved by the same backend module
+ * (`convex/lib/runPluginServers.ts`). Two copies of "which of these problems
+ * means stop?" would be two chances to relax one of them, so the rules live
+ * here once and each product supplies only its own query name, arguments, and
+ * response envelope.
+ *
+ * The contract, restated because every line below exists to hold it:
+ *
+ *   A run snapshot's `environmentPluginVersions` / `pluginServerIds` is
+ *   PROVENANCE — a record of what was pinned, never a grant to connect it
+ *   again. The backend re-resolves the live plugin rows on every call, so
+ *   disabling or uninstalling a plugin changes the answer with no snapshot
+ *   rewrite. A non-empty `unavailable` OR `droppedSnapshotServerIds` means the
+ *   execution MUST NOT PROCEED.
+ *
+ * FAIL CLOSED IS THE WHOLE POINT. Every path that cannot produce a verified
+ * list throws rather than returning `[]`: a run that connects a shrunken server
+ * set runs an environment nobody configured, and does it silently. "I couldn't
+ * check" must never be delivered as "nothing to add".
+ *
+ * Hand-mirrored contract (no codegen; string function refs like the rest of the
+ * inspector→Convex surface).
+ */
+import type { ConvexHttpClient } from "convex/browser";
+
+/** One connectable server contributed by a still-valid pin. */
+export interface RunPluginServer {
+  serverId: string;
+  name: string;
+  pluginVersionId: string;
+  pluginId: string;
+  pluginName: string;
+  componentKey: string;
+}
+
+/** Why one pinned version contributes nothing to THIS execution. */
+export interface RunPluginServerUnavailable {
+  pluginVersionId: string;
+  /** Backend-authored reason code; unknown values are reported verbatim. */
+  reason: string;
+  pluginName?: string;
+  componentKey?: string;
+}
+
+/** The three-list envelope both products' queries return. */
+export interface RunPluginServerResolution {
+  servers: RunPluginServer[];
+  unavailable: RunPluginServerUnavailable[];
+  droppedSnapshotServerIds: string[];
+}
+
+/**
+ * Thrown when a run's pins cannot be verified as still-connectable — including
+ * "the backend could not tell us". Callers turn this into a SETUP failure that
+ * finalizes the run before any model executes.
+ */
+export class RunPluginServersUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RunPluginServersUnavailableError";
+  }
+}
+
+/**
+ * One human sentence per unavailable pin, naming the plugin (and the component
+ * when the backend could identify it) so a setup failure is ATTRIBUTABLE rather
+ * than a bare "plugins unavailable".
+ *
+ * The `default` arm matters: reason codes are a backend-owned union that will
+ * grow, and an unrecognized code must still stop the run and say what it was.
+ */
+export function describeRunPluginUnavailable(
+  entry: RunPluginServerUnavailable,
+  /** How to name this execution in prose — "journey" or "run". */
+  surfaceNoun: string
+): string {
+  const who = entry.pluginName ?? entry.pluginVersionId;
+  switch (entry.reason) {
+    case "disabled":
+      return `"${who}" is disabled`;
+    case "uninstalled":
+      return `"${who}" was uninstalled`;
+    case "not_found":
+      return `"${who}" no longer exists in this project`;
+    case "not_ready":
+      return `"${who}" has not finished importing`;
+    case "server_missing":
+      return `"${who}" no longer provides its server${
+        entry.componentKey ? ` "${entry.componentKey}"` : ""
+      }`;
+    case "unsupported_placement":
+      return `"${who}" provides a server that can't run in a hosted ${surfaceNoun}`;
+    case "unresolvable_scope":
+      return `"${who}" could not be resolved in this project`;
+    default:
+      return `"${who}" is unavailable (${entry.reason})`;
+  }
+}
+
+/**
+ * Validate the SHAPE of one resolution before trusting it.
+ *
+ * This crosses a deploy boundary, so an incompatible or truncated payload is a
+ * live possibility during skew — and a permissive read of one is
+ * indistinguishable from a clean all-clear. `{}` would satisfy a naive check
+ * and then fall through three `?? []` defaults to "no plugins, proceed",
+ * silently shrinking the environment: the exact failure this module prevents.
+ * All three arrays are REQUIRED, not optional-with-a-default, because an absent
+ * `unavailable` is "I wasn't told about problems", never "there are none".
+ */
+export function assertRunPluginResolutionShape(
+  value: unknown,
+  unrecognizedMessage: string
+): asserts value is RunPluginServerResolution {
+  const candidate = value as Partial<RunPluginServerResolution> | null;
+  if (
+    !candidate ||
+    !Array.isArray(candidate.servers) ||
+    !Array.isArray(candidate.unavailable) ||
+    !Array.isArray(candidate.droppedSnapshotServerIds)
+  ) {
+    throw new RunPluginServersUnavailableError(unrecognizedMessage);
+  }
+}
+
+/**
+ * Throw unless the resolution is a clean all-clear.
+ *
+ * `droppedSnapshotServerIds` is folded into the same failure as `unavailable`
+ * on purpose: the backend suppresses it whenever `unavailable` already explains
+ * the shrinkage, so a non-empty list here always means a server went missing
+ * with NO version-level explanation — the case that would otherwise read as a
+ * clean, quietly smaller environment.
+ */
+export function assertRunPluginResolutionUsable(
+  resolution: RunPluginServerResolution,
+  copy: {
+    /** How to name this execution in prose — "journey" or "run". */
+    surfaceNoun: string;
+    /** What the operator should do about it, appended verbatim. */
+    remedy: string;
+  }
+): void {
+  const problems = [
+    ...resolution.unavailable.map((entry) =>
+      describeRunPluginUnavailable(entry, copy.surfaceNoun)
+    ),
+    ...resolution.droppedSnapshotServerIds.map(
+      (id) => `a pinned plugin server (${id}) is no longer provided`
+    ),
+  ];
+  if (problems.length > 0) {
+    throw new RunPluginServersUnavailableError(
+      `This ${copy.surfaceNoun} pins plugins that can't be used right now: ${problems.join(
+        "; "
+      )}. ${copy.remedy}`
+    );
+  }
+}
+
+/**
+ * The verified server ids, one per row. Each entry must actually carry an id: a
+ * malformed row would otherwise map to `undefined` and be handed to the
+ * connection manager as a server.
+ */
+export function readRunPluginServerIds(
+  resolution: RunPluginServerResolution,
+  unrecognizedMessage: string
+): string[] {
+  return resolution.servers.map((server) => {
+    const serverId = server?.serverId;
+    if (typeof serverId !== "string" || serverId.length === 0) {
+      throw new RunPluginServersUnavailableError(unrecognizedMessage);
+    }
+    return serverId;
+  });
+}
+
+/**
+ * Run one D2 query, mapping the undeployed-function rejection to a fail-closed
+ * error. A backend that cannot answer must stop the run: we would otherwise be
+ * guessing about a capability we are about to hand an agent.
+ */
+export async function queryRunPluginResolution(
+  getConvexClient: () => ConvexHttpClient,
+  functionRef: string,
+  args: Record<string, unknown>,
+  deploySkewMessage: string
+): Promise<unknown> {
+  try {
+    return await getConvexClient().query(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- string
+      // function refs are the established inspector→Convex pattern (see
+      // services/environments/resolve.ts); there is no codegen here.
+      functionRef as any,
+      args
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (/could not find public function/i.test(message)) {
+      throw new RunPluginServersUnavailableError(deploySkewMessage);
+    }
+    throw error;
+  }
+}
+
+/**
+ * Decision D2 for a SUITE (eval) run — BE-5's
+ * `testSuites:resolveRunPluginServersForExecution`.
+ *
+ * Unlike the journey twin there is no "skip the call when the snapshot pinned
+ * nothing" shortcut available to the caller: a suite run's pins live in
+ * `configSnapshot.environmentPluginVersions`, which `prepareEvalRun` never
+ * reads back. So the query is ALWAYS called for an environment run, and the
+ * backend's documented all-clear (`servers: []` with both failure lists empty
+ * for a run that pinned no plugins, including every legacy run) is what makes
+ * that safe.
+ *
+ * `allowUndeployedBackend` exists for exactly one caller shape: a NON-environment
+ * (legacy host) suite run, which structurally cannot pin a plugin — the
+ * environment is the only pin carrier. Calling anyway on a deployment that
+ * predates BE-5 would fail every legacy run for a capability it cannot have.
+ *
+ * Returns the rich rows, not just ids: a caller reports plugin origin per
+ * connected server, and re-deriving that from an id would need a second read.
+ */
+export async function resolveSuiteRunPluginServers(
+  getConvexClient: () => ConvexHttpClient,
+  args: { runId: string; allowUndeployedBackend?: boolean }
+): Promise<RunPluginServer[]> {
+  let raw: unknown;
+  try {
+    raw = await queryRunPluginResolution(
+      getConvexClient,
+      "testSuites:resolveRunPluginServersForExecution",
+      { runId: args.runId },
+      "This deployment can't verify this run's pinned plugins yet, so the run was stopped rather than executed without them. Retry after the backend deploys."
+    );
+  } catch (error) {
+    if (
+      args.allowUndeployedBackend &&
+      error instanceof RunPluginServersUnavailableError
+    ) {
+      // Only reachable for a run that cannot carry pins at all (see above).
+      return [];
+    }
+    throw error;
+  }
+
+  assertRunPluginResolutionShape(
+    raw,
+    "This run's pinned plugins could not be resolved (unrecognized response). Retry after the backend deploys, or re-run the suite."
+  );
+  assertRunPluginResolutionUsable(raw, {
+    surfaceNoun: "run",
+    remedy: "Update the environment's plugin pins and re-run the suite.",
+  });
+  readRunPluginServerIds(
+    raw,
+    "This run's pinned plugins resolved to an unrecognized server entry. Retry after the backend deploys, or re-run the suite."
+  );
+  return raw.servers;
+}

--- a/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
+++ b/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
@@ -701,14 +701,30 @@ export interface PrepareChatV2Options {
    *    (INS-3) because the tools address skills by REF: a plugin skill is
    *    `<plugin>/<skill>`, and the origin/file metadata the ref surface needs
    *    lives on the set, not on a flattened `PinnableSkill`.
+   *  - `pinned-effective` — EVAL RUNNERS ONLY, for a run whose pins carry a
+   *    plugin `modelRef` or supporting FILES (INS-5). Same frozen-content,
+   *    approval-exempt policy as `pinned`; the ref-addressed `resolved` tool
+   *    surface, because a bare-name surface cannot express `<plugin>/<skill>`
+   *    and has no file tools to serve a pinned `scripts/` directory with. The
+   *    set is built from the RUN SNAPSHOT, so "in-memory over frozen content"
+   *    still holds — the only network is the signed `_storage` GET for a file
+   *    the model actually asks for, and that URL was minted against the pinned
+   *    blob, not the live one.
    *  - `none`     — suppress skills entirely.
    *
-   * `resolved` and `pinned` are separate kinds rather than one "in-memory" kind
-   * with a flag precisely because that approval divergence is the whole
-   * distinction, and a shared kind would make it a caller's job to remember.
+   * `resolved` and the two pinned kinds are separate kinds rather than one
+   * "in-memory" kind with a flag precisely because that approval divergence is
+   * the whole distinction, and a shared kind would make it a caller's job to
+   * remember.
    */
   skillsSource?:
     | { kind: "pinned"; skills: PinnableSkill[] }
+    | {
+        kind: "pinned-effective";
+        capabilities: EffectiveCapabilitySet;
+        /** See `resolved` below — same reason, same lifetime. */
+        abortSignal?: AbortSignal;
+      }
     | {
         kind: "resolved";
         capabilities: EffectiveCapabilitySet;
@@ -960,7 +976,9 @@ export async function prepareChatV2(
   //      with a provisioned computer. Lazy discovery (no upfront wake).
   //   2. HOSTED_MODE without a computer ⇒ no skills (local FS unavailable).
   //   3. local ⇒ the inspector's own filesystem.
-  const skillsArePinned = skillsSource?.kind === "pinned";
+  const skillsArePinned =
+    skillsSource?.kind === "pinned" ||
+    skillsSource?.kind === "pinned-effective";
   // Decision 11: harness eval turns live-fetch skills, so a pinned set would
   // falsify the snapshot claim. Harness is stripped from suite configs already;
   // this throw is belt-and-suspenders at the single point both paths funnel through.
@@ -973,7 +991,8 @@ export async function prepareChatV2(
     skillsSource
       ? skillsSource.kind === "pinned"
         ? getPinnedSkillToolsAndPrompt(skillsSource.skills)
-        : skillsSource.kind === "resolved"
+        : skillsSource.kind === "resolved" ||
+            skillsSource.kind === "pinned-effective"
           ? getEffectiveSkillToolsAndPrompt(skillsSource.capabilities, {
               ...(skillsSource.abortSignal
                 ? { signal: skillsSource.abortSignal }

--- a/mcpjam-inspector/server/utils/computers/cloud-skill-tools.ts
+++ b/mcpjam-inspector/server/utils/computers/cloud-skill-tools.ts
@@ -178,8 +178,10 @@ const SKILLS_PROMPT_BASE =
   `what's available, then \`loadSkill\` to load a skill's full instructions when ` +
   `a task matches its purpose.`;
 // File-tools sentence — only for paths that ALSO expose listSkillFiles/readSkillFile
-// (the live cloud path). Pinned eval skills are supporting-file-free by design
-// (decision 8c), so the pinned path omits this to avoid advertising absent tools.
+// (the live cloud path). The tools BELOW are the bare-name pinned surface, which
+// serves only file-free pins (decision 8c), so it omits this to avoid
+// advertising absent tools. A run whose pins DO carry files takes the
+// ref-addressed surface instead (INS-5 — `skillsSource: pinned-effective`).
 const SKILLS_FILE_TOOLS_SENTENCE =
   ` If a loaded skill references supporting files, use \`listSkillFiles\` and ` +
   `\`readSkillFile\` to access them.`;
@@ -211,9 +213,11 @@ export function getCloudSkillToolsAndPrompt(ctx: CloudSkillsContext): {
  * `execute()` does ZERO network I/O (a mid-run skill edit can't change behavior
  * between iterations, which is the whole point of pinning). The supporting-file
  * tools (`listSkillFiles`/`readSkillFile`) are intentionally OMITTED: pinned
- * eval skills are file-free by design (decision 8c), and the pinned prompt omits
- * the file-tools guidance to match. Never `needsApproval` — pure reads of frozen
- * content under an auto-deny eval run.
+ * eval skills reaching THIS surface are file-free (decision 8c), and the pinned
+ * prompt omits the file-tools guidance to match. A run whose pins carry
+ * supporting files or a plugin ref is routed to the ref-addressed surface in
+ * `./effective-skill-tools.ts` instead (INS-5), which can serve both. Never
+ * `needsApproval` — pure reads of frozen content under an auto-deny eval run.
  */
 export function createPinnedSkillTools(skills: PinnableSkill[]) {
   const byName = new Map(skills.map((s) => [s.name, s]));
@@ -262,9 +266,10 @@ export function getPinnedSkillToolsAndPrompt(skills: PinnableSkill[]): {
 } {
   return {
     tools: createPinnedSkillTools(skills),
-    // Pinned skills have no supporting files (decision 8c blocks file-backed
-    // skills from eval selection), so the pinned tool set omits the file tools —
-    // and the prompt omits the file-tools sentence to match (no absent-tool ask).
+    // Pins reaching this surface have no supporting files (decision 8c blocks
+    // file-backed skills from eval selection; INS-5 routes the ones BE-5 made
+    // pinnable elsewhere), so the tool set omits the file tools — and the prompt
+    // omits the file-tools sentence to match (no absent-tool ask).
     systemPromptSection: SKILLS_PROMPT_BASE,
   };
 }


### PR DESCRIPTION
INS-5 — the **final step** of `docs/plans/openai-plugin-import-cross-repo.md`.
Consumes the backend half (BE-5, mcpjam-backend #796, merged) and builds on
INS-1..4 and INS-6..8, all merged.

## What's here

- **`server/services/plugins/run-plugin-servers.ts`** (new) — one Decision-D2
  execution-time re-gate for both run products. Shape validation, reason-code
  prose, the "which problems mean stop?" rule, and the fail-closed deploy-skew
  mapping live here once; each product supplies only its query name and envelope.
- **`server/services/journeys/plugin-servers.ts`** — rewritten as a thin adapter
  over that core. Every exported name, error class, and user-facing sentence is
  preserved; its 18 existing tests pass untouched.
- **`server/services/evals/run-plugin-snapshot.ts`** (new) — projects a run's
  FROZEN plugin surface into an `EffectiveCapabilitySet`. It rebuilds INS-3's
  attribution map from the frozen records rather than probing live, then calls
  `resolveEffectiveCapabilities` unchanged, so ref namespacing / plugin-standalone
  split / `problems` are not re-implemented. Includes
  `assertPinnedSkillFilesReachable`.
- **`server/routes/shared/evals.ts`** — `fetchRunPinnedSkillsWithRetry` now
  returns pins WHOLE (it was projecting away `modelRef`, `aggregateHash`,
  `channels`, `files`, `extraFrontmatter`). `prepareEvalRun` re-gates plugin
  servers, asserts file reachability, and builds the skill source — all BEFORE
  `execute()`, inside the existing fail-the-run cleanup.
- **Orchestration** — new `skillsSource: "pinned-effective"` (the `pinned`
  approval exemption plus `resolved`'s ref-addressed surface);
  `pinnedSkills?: PinnableSkill[]` became a closed `pinnedSkillSource` union
  decided once at the boundary.
- **Client** — run-detail plugin bundle chips, `skills excluded` badge, the
  OpenAI 5-positive/3-negative submission report, and the session's pinned
  bundles in the journey pane.

## Acceptance

- **A new plugin revision cannot alter an in-flight run or replay** — the
  surface is rebuilt from frozen records; `pluginVersions` is never re-resolved
  to the plugin's active version.
- **Run assets resolve from the snapshot** — and a pinned file with `url: null`
  means the blob is UNREACHABLE: the run is stopped with a named, attributable
  error rather than executed with the file missing. This applies to standalone
  pins too — same store, same wrongness.
- **Setup failures precede model execution** and name the component.

## Two things are blocked on the backend — reported, not faked

1. **The plugin-EXCLUDED A/B arm.** `startTestSuiteRun` has no `pluginsOverride`,
   and `skillsOverride: 'exclude'` deliberately does NOT drop plugin servers —
   `convex/testSuites.ts:5519` documents this as a KNOWN ASYMMETRY, because
   dropping them would change the one variable a skills A/B holds fixed. The
   inspector cannot fake it: a reduced server list fails the
   `expectedEnvironmentServerIds` drift check, and the snapshot would still
   record `environmentPluginVersions` — i.e. a run claiming plugins ran when
   they didn't, the exact dishonesty this PR exists to prevent. The **skills**
   half is wired end-to-end; the server half needs BE.
2. **Per-turn plugin provenance in traces.** BE-5 writes
   `chatSessionTurnTraces.pluginVersionsAtTurn`, but
   `chatSessions:getSessionTurnTraces` does not project it, so it is unreadable.
   Shipped session-level display instead, which is genuinely coarser — per-turn
   is the point of that field. Fix is a one-line projection.

## Decisions worth challenging

1. **Two pinned-skill surfaces, not one.** Body-only runs keep the bare-name
   surface byte-for-byte (tool names *and* prompt stanza); only a run whose pins
   carry `modelRef` or `files` gets the ref-addressed one. Unifying would have
   changed the tool surface for every existing eval suite — including suites
   whose baselines were measured against the old one.
2. **The D2 re-gate runs for every suite run with a `runId`**, not only
   environment runs, because the backend's "pinned nothing" all-clear is the same
   empty envelope. `allowUndeployedBackend` is set only for non-environment runs
   (which structurally cannot pin) and swallows nothing but the
   undeployed-function rejection.
3. **Provenance is read off `configSnapshot.environmentPluginVersions`**, not
   `environmentLaunch.pluginVersions` — they agree by construction, but only one
   is the run's own record.
4. **Skill→version attribution comes from the `modelRef` namespace**, and only
   when exactly one pinned version matches that plugin name. Ambiguity yields no
   origin (INS-3 then reports `plugin_origin_unavailable`) rather than a guess.
5. **The submission report cannot launder a run.** Passing cases win slots, but a
   failing case needed to reach quota is included *and* named at the top; a case
   passes only if every iteration passed.
6. `assertRunPluginResolutionShape` requires all three arrays — `{}` would
   otherwise read as a clean all-clear.

## Verification (re-run independently of the authoring agent)

- `npx vitest run` → exit 0, **10641 passed** / 6 skipped (969 files), +43 new
- `npx tsc --noEmit -p client/tsconfig.typecheck.json` → exit 0, clean
- `npm run build:client` → exit 0
- `npx tsc -p server/tsconfig.json` → **135 baseline → 132**. No new errors;
  three dropped incidentally. (Note: the plan's "~84" figure is stale.)

Both blocked claims above were verified against the merged backend source, not
taken on trust.

Not manually exercised in a running app.

## Plan corrections found while implementing

- Server-typecheck baseline is **135**, not ~84.
- "Remaining work is INS-2..8" — all of INS-2/3/4/6/7/8 are merged.
- "Use effective server IDs for tool snapshots and runners" was already satisfied;
  what was missing was the re-gate, which is what this adds.
- "plus BE-5's pin-store expansion" — BE-5 shipped it (`evalSkillPinStore.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches eval run setup, skill/tool surfaces, and plugin lifecycle gating before model execution; mistakes could fail runs incorrectly or change measured behavior for plugin-backed suites, but behavior is heavily tested and fails closed on ambiguity.
> 
> **Overview**
> **INS-5** surfaces frozen plugin provenance on eval and swarm runs and wires execution to honor that snapshot instead of live plugin state.
> 
> **Server:** A shared **D2 re-gate** (`run-plugin-servers.ts`) validates suite and journey plugin-server resolution fail-closed; journeys delegate to it. **`run-plugin-snapshot.ts`** builds an `EffectiveCapabilitySet` from frozen pins and `environmentPluginVersions`, asserts pinned skill files are reachable, and chooses **`pinned-effective`** vs legacy bare-name **`pinned`** skill delivery. **`prepareEvalRun`** returns full pin rows (no truncation), re-gates plugins, runs setup before `execute()`, and threads **`pinnedSkillSource`** through the runner and **`skillsSource: pinned-effective`** in chat orchestration. Wire path adds **`skillsOverride: 'exclude'`** for the skills-off A/B arm.
> 
> **Client:** Run detail shows **plugin bundle chips** (hash + **skills excluded**), downloads an **OpenAI 5+/3− submission markdown** with explicit readiness gaps (shortfalls, failing cases, no plugin, skills-excluded), and swarm transcripts show session **plugin versions** from `resumeConfig`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2afab938f0e57bc3b77abab9b259e836e5a03f1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the run snapshot for plugins in evals and swarm simulations (INS-5) so runs use the exact pinned bundle and assets. Adds clear plugin provenance in the UI and a one-click OpenAI submission report, and stops runs early when pins are invalid.

- New Features
  - Evals and simulations resolve plugin servers and skill tools from the run snapshot, so a plugin re-import can’t change an in-flight run or a replay.
  - Shared execution-time re-gate verifies pinned plugin servers; any unavailable or dropped server stops the run before model execution.
  - Enforce pinned skill files: unreachable blobs stop the run with a named error.
  - Skill surface selection: pinned (bare-name) for body-only pins; pinned-effective (ref-addressed + file tools) when pins include a plugin ref or files.
  - UI: run detail and swarm panes show pinned plugin bundles (name + short bundle hash); generate an OpenAI submission report (5 positive / 3 negative) from a single run, including failing cases when needed.

- Refactors
  - Centralized plugin-server gating for journeys and suites; journey API unchanged, suite entry added with the same rules.
  - Build capabilities from the snapshot; full pins returned for eval prep; `resolveEffectiveCapabilities` now accepts a narrowed `EffectiveCapabilityInput`.
  - Wire: `skillsOverride: 'exclude'` is forwarded (drops skills only; servers unchanged). Backend follow-ups: plugin-excluded arm needs a `pluginsOverride`; per-turn plugin provenance exists in storage but isn’t projected yet.

<sup>Written for commit 2afab938f0e57bc3b77abab9b259e836e5a03f1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

