### PR TITLE
Tasks conformance: judge the discriminator on the raw wire, resolve the era-gate target

### DIFF
--- a/docs/mcp-tasks-full-support-plan.md
+++ b/docs/mcp-tasks-full-support-plan.md
@@ -159,7 +159,14 @@ Implement and test these at the SDK boundary, not separately in each route:
 
 ## 4. Workstream A — protocol boundary and conformance corrections
 
-This is the blocking first PR. Product expansion must not ship before it.
+**Status: MERGED** — PR [#3511](https://github.com/MCPJam/inspector/pull/3511),
+2026-07-28. A0–A4 landed together, so the blocking gate on downstream
+workstreams is lifted and Workstream B may start. Two review findings landed
+as a follow-up PR rather than in #3511 — see A2 below; neither re-blocks
+downstream work. The subsections are kept as the record of what was decided
+and why, with what actually shipped noted per item.
+
+This was the blocking first PR. Product expansion must not ship before it.
 
 ### A0. Unblock the extension methods on the 2026-07-28 wire era
 
@@ -279,6 +286,38 @@ undeclared capability covers all required operations:
 
 The current interpretation that a bare `tasks/get` may succeed is incorrect
 for the pinned extension and must be removed from code, docs, and fixtures.
+
+Implemented in PR #3511, plus two corrections found in review that the
+original item did not anticipate:
+
+- **A skipped check can no longer produce a green.** The suite returns
+  `outcome: "passed" | "failed" | "incomplete"`, and `passed` is true only when
+  every *selected* check produced a verdict. Every skip carries a `skipReason`:
+  `"not-applicable"` (cannot apply to this server — extension-only checks on a
+  legacy connection, `Mcp-Name` over stdio, any task check when the wire is
+  `none`) never holds a run back; `"could-not-run"` (applies but was never
+  exercised) makes the run `incomplete`. Reported as a root `incompleteReason`,
+  and per-category `couldNotRun` counts.
+  Motivation: against the conformant extension fixture *without* `toolName`,
+  the suite returned `passed: true` on 2 of 8 checks with 6 silently skipped.
+- **Probe-tool selection fails loud.** Auto-selection reads
+  `execution.taskSupport`, which the 2026-07-28 `ToolSchema` strips, so it can
+  never work on the extension wire. No `toolName` — or a `toolName` the server
+  does not list — is now an `incomplete` run naming the flag, the tool, and the
+  tools the server does list. Legacy auto-selection is unchanged.
+- **CLI exit codes:** `0` passed, `1` failed, **`3` incomplete** (`2` stays
+  reserved for usage errors), plus the reason on stderr.
+
+Fixed in the follow-up PR, not in #3511: the discriminator blind spot. A server that
+answers a `tools/call` with a flat task payload carrying **no**
+`resultType: "task"` is invisible to every check that reads the *decoded*
+result — task detection keys on that discriminator at the transport seam — so
+it currently scores green on both `tasks-result-type-discipline` and
+`tasks-undeclared-creation-refused`. Closing it means judging the discriminator
+on the raw inbound JSON-RPC (the run already captures it) for both checks, with
+a failure message that names the consequence: the client cannot discriminate
+the response, so the task is never tracked and the work runs to completion
+server-side with no handle (`tasks.md:102`).
 
 ### A3. Verify headers and connection durability
 
@@ -893,10 +932,11 @@ correlation is necessary.
 
 Land in this order:
 
-1. **SDK correctness:** Workstream A — the A0 era-gate unblock first, since
+1. ~~**SDK correctness:** Workstream A — the A0 era-gate unblock first, since
    nothing else in the extension path can be exercised against a real
    `2026-07-28` server until it lands — then the corrected schemas, corrected
-   conformance verdicts, and the vendored schema drift check.
+   conformance verdicts, and the vendored schema drift check.~~
+   **DONE** — PR #3511, merged 2026-07-28. Step 2 is unblocked.
 2. **Lifecycle engine:** Workstream B polling, notification integration,
    complete input driver, tracker migration.
 3. **Host policy:** tri-state resolver/editor and raw-wire policy tests.

--- a/sdk/src/mcp-client-manager/managed-mcp-client.ts
+++ b/sdk/src/mcp-client-manager/managed-mcp-client.ts
@@ -24,6 +24,7 @@
 import type {
   CacheableRequestOptions,
   CallToolResult,
+  Client,
   CompleteRequest,
   CompleteResult,
   EmptyResult,
@@ -110,6 +111,21 @@ export type ManagedMcpClientRequestHandler = (
  * behavior-agnostic so it never has to know which adapter is wired.
  */
 export interface ManagedMcpClient {
+  /**
+   * The client this one delegates to: the upstream `Client` for
+   * `OfficialSdkClientAdapter`, the wrapped `ManagedMcpClient` for a decorator
+   * such as `LogLevelMetaClient`. OPTIONAL — a hand-rolled implementation or a
+   * test double may bottom out with no delegate at all.
+   *
+   * Declared so the delegation chain is a stated seam rather than a private
+   * detail each consumer re-guesses. `tasks-ext-era-gate.ts` walks it to find
+   * the upstream instance whose outbound era gate must be shadowed, so that a
+   * directly-constructed adapter behaves like one built by
+   * `managed-mcp-client-factory.ts`. Consumers MUST treat an absent `inner` as
+   * "the chain ends here" and degrade, never throw.
+   */
+  readonly inner?: ManagedMcpClient | Client;
+
   // ---- Lifecycle ----
   connect(
     transport: Transport,

--- a/sdk/src/mcp-client-manager/tasks-ext-era-gate.ts
+++ b/sdk/src/mcp-client-manager/tasks-ext-era-gate.ts
@@ -70,6 +70,14 @@
  * from the single send path shared by `tasks/get`, `tasks/update` and
  * `tasks/cancel`.
  *
+ * Registration is a fast path, never a precondition: a `ManagedMcpClient` that
+ * did NOT come from the factory (a directly-constructed
+ * `OfficialSdkClientAdapter`, say) is resolved by walking its public
+ * `ManagedMcpClient.inner` delegation chain, so it gets the same shadow. The
+ * only case that installs nothing is a chain with no upstream client in it at
+ * all — a test double, which has no era gate to shadow. See
+ * {@link resolveTasksExtensionEraGateTarget}.
+ *
  * The reason is blast radius. This module probes a PRIVATE upstream member,
  * and a bump that renames it must fail loudly (see Maintenance) — but that
  * failure has to land on the feature that depends on the probe, not on the
@@ -90,7 +98,10 @@
  * era-gating the extension's method names (or exposes a real seam).
  */
 
-import type { Client } from "@modelcontextprotocol/client";
+// Runtime import: `resolveTasksExtensionEraGateTarget` needs the CLASS to tell
+// a real upstream client apart from a hand-rolled stand-in when walking an
+// unregistered delegation chain (see {@link isUpstreamClient}).
+import { Client } from "@modelcontextprotocol/client";
 // Runtime import, and `tasks-ext.ts` imports this module back for the lazy
 // install. Everything derived from `TasksExtRequestMethods` is therefore read
 // at CALL time, never at module-evaluation time, so neither module can observe
@@ -191,13 +202,75 @@ export function installTasksExtensionEraGateShadow(client: Client): void {
  * `ManagedMcpClient` (or any decorator around one) → the upstream `Client`
  * instance whose gate would have to be shadowed for it.
  *
- * The extension helpers in `tasks-ext.ts` hold a `ManagedMcpClient`, which is
- * an interface with no route back to the upstream instance (and may be a
- * decorator chain). Rather than have them guess at a private `.inner` chain,
- * the factory — the one place an upstream `Client` becomes a
- * `ManagedMcpClient` — records the pairing here.
+ * A FAST PATH, not the only path. The factory — the one place an upstream
+ * `Client` becomes a `ManagedMcpClient` — records the pairing here, which also
+ * makes the pairing authoritative: a registered value is asserted to BE the
+ * upstream client, so a registered instance whose seam has moved throws rather
+ * than being quietly reclassified as "not a real client". A `ManagedMcpClient`
+ * built without the factory is not in here at all, and is resolved structurally
+ * instead — see {@link resolveTasksExtensionEraGateTarget}.
  */
 const eraGateTargets = new WeakMap<object, Client>();
+
+/**
+ * Depth cap on the `inner` delegation walk. Also the cycle guard: a decorator
+ * chain that (wrongly) loops back on itself terminates here instead of hanging
+ * a tasks call. Real chains are 2 links (`LogLevelMetaClient` →
+ * `OfficialSdkClientAdapter` → `Client`).
+ */
+const MAX_DELEGATION_DEPTH = 16;
+
+/**
+ * Is this the upstream client whose gate we shadow?
+ *
+ * `instanceof` is the primary test. The duck-typed fallback covers a
+ * dual-install of `@modelcontextprotocol/client` (two copies in the tree ⇒
+ * `instanceof` is false against a genuine client): an object that carries the
+ * era-gate member as a function is one, whoever's copy built it. The fallback
+ * can only ADD installs, never turn a missing seam into a silent skip — it
+ * requires the member to be present and callable.
+ */
+function isUpstreamClient(value: object): value is Client {
+  return (
+    value instanceof Client ||
+    typeof (value as Record<string, unknown>)[ERA_GATE_MEMBER] === "function"
+  );
+}
+
+/**
+ * The upstream `Client` behind `managed`, or `undefined` when there is none.
+ *
+ * Registered pairing first; otherwise walk the public `inner` delegation chain
+ * that every adapter/decorator in this package exposes
+ * (`ManagedMcpClient.inner`). The walk is what keeps a directly-constructed
+ * `new OfficialSdkClientAdapter(client)` — one that never went through
+ * `managed-mcp-client-factory.ts` — from silently keeping upstream's era gate
+ * and dying with an opaque `METHOD_NOT_SUPPORTED_BY_PROTOCOL_VERSION` on its
+ * first `tasks/get`.
+ *
+ * `undefined` means exactly one thing: nothing in the chain is an upstream
+ * client, i.e. a test double with no era gate to shadow. That is the ONLY
+ * remaining no-op, and it is a true no-op rather than a missed install.
+ */
+function resolveTasksExtensionEraGateTarget(
+  managed: object
+): Client | undefined {
+  const registered = eraGateTargets.get(managed);
+  if (registered !== undefined) {
+    return registered;
+  }
+  let current: unknown = managed;
+  for (let depth = 0; depth < MAX_DELEGATION_DEPTH; depth += 1) {
+    if (typeof current !== "object" || current === null) {
+      return undefined;
+    }
+    if (isUpstreamClient(current)) {
+      return current;
+    }
+    current = (current as { inner?: unknown }).inner;
+  }
+  return undefined;
+}
 
 /**
  * Record that `managed` speaks for `client`, so a later tasks operation can
@@ -216,17 +289,23 @@ export function registerTasksExtensionEraGateTarget(
  * Install the shadow for `managed`, if it has not been installed already.
  * Called from the single send path every extension tasks request goes through.
  *
- * An unregistered `managed` is a client that never came from the factory (a
- * test double, or a hand-rolled `ManagedMcpClient`); it has no upstream era
- * gate to shadow, so there is nothing to do and nothing to fail about. A
- * REGISTERED one whose seam has moved throws — that is the loud failure the
- * probe exists for, now scoped to tasks traffic.
+ * The target is resolved by {@link resolveTasksExtensionEraGateTarget}:
+ * registration first, then the public `inner` delegation chain. Coming from
+ * the factory is therefore an optimization, not a requirement — a
+ * hand-constructed `OfficialSdkClientAdapter` over a real `Client` gets the
+ * same shadow the factory's would.
  *
- * @throws {TasksExtEraGateSeamError} when the registered instance no longer
+ * A `managed` with no upstream client anywhere in its chain (a test double) is
+ * a no-op: there is no era gate to shadow, so there is nothing to do and
+ * nothing to fail about. One that DOES resolve to an upstream client whose
+ * seam has moved throws — that is the loud failure the probe exists for, now
+ * scoped to tasks traffic.
+ *
+ * @throws {TasksExtEraGateSeamError} when the resolved instance no longer
  * carries the private member.
  */
 export function ensureTasksExtensionEraGateShadow(managed: object): void {
-  const client = eraGateTargets.get(managed);
+  const client = resolveTasksExtensionEraGateTarget(managed);
   if (client === undefined) {
     return;
   }

--- a/sdk/src/mcp-client-manager/tasks-ext-schemas.ts
+++ b/sdk/src/mcp-client-manager/tasks-ext-schemas.ts
@@ -273,6 +273,11 @@ export const createTaskExtResultSchema = taskExtSchema.extend({
  * (tasks.md:102) and the whole detection path keys on it. On a completion
  * response the field carries no information the `status` union does not
  * already carry, so its absence is harmless.
+ *
+ * An own `resultType` whose value is literally `undefined` reads as absent
+ * here, deliberately: `JSON.parse` cannot produce one (JSON has no `undefined`,
+ * and a reviver returning `undefined` DELETES the key), so the case exists only
+ * in hand-built objects, where "absent" is the right reading anyway.
  */
 function checkOptionalCompleteResultType(
   value: unknown,

--- a/sdk/src/mcp-client-manager/tasks-ext.ts
+++ b/sdk/src/mcp-client-manager/tasks-ext.ts
@@ -154,10 +154,21 @@ export interface TasksExtCallContext {
 }
 
 /**
- * The ONE send path for the extension: all three request helpers below build
- * their params and then come through here, and nothing else in the SDK issues
- * a `TasksExtRequestMethod`. That makes it the only choke point where the
- * era-gate shadow has to be installed — and, because the exemption set IS
+ * The send path for the extension: all three request helpers below build their
+ * params and then come through here, and every DECLARED extension request in
+ * the SDK does.
+ *
+ * One deliberate exception: the tasks conformance runner
+ * (`tasks-conformance/`) issues its UNDECLARED probes directly, bypassing this
+ * helper. It has to — this helper always attaches the eligibility declaration,
+ * and the whole point of those probes is to observe what a server does when
+ * the declaration is absent (a conforming one answers `-32003`). That bypass
+ * is the test, not a bug. Being off this path, it installs the era-gate shadow
+ * itself before probing (`tasks-conformance/runner.ts`), since the probes still
+ * have to reach the wire on a 2026-07-28 connection to be answered at all.
+ *
+ * For everything else this stays the only choke point where the era-gate
+ * shadow has to be installed — and, because the exemption set IS
  * `TasksExtRequestMethods`, a request that never passes through here is by
  * definition a request the shadow would not have exempted anyway.
  *

--- a/sdk/src/tasks-conformance/runner.ts
+++ b/sdk/src/tasks-conformance/runner.ts
@@ -628,6 +628,62 @@ export function describeUndeclaredProbe(probe: UndeclaredProbe): string {
   }
 }
 
+/** A flat task payload seen on the wire, before any client-side decoding. */
+export interface RawTaskResponse {
+  taskId: string;
+  /** Exactly as it arrived: `undefined` means the key was absent. */
+  resultType: unknown;
+  /** Whether the required `resultType: "task"` discriminator was present. */
+  discriminated: boolean;
+}
+
+/**
+ * Finds a flat task payload in raw inbound JSON-RPC, IGNORING `resultType`.
+ *
+ * This is the only way to see the violation that matters most here. Task
+ * detection is keyed on `resultType === "task"` end to end — the transport
+ * seam's `rewriteTaskResultMessage`, then `isCreateTaskExtResult` — so a
+ * `CreateTaskResult` that omits the discriminator never reaches the runner AS
+ * a task. It arrives looking like an ordinary `CallToolResult`, and every
+ * check that reads the DECODED result therefore scores the server green on the
+ * exact interop break it exists to catch: the client cannot discriminate the
+ * response, so the task is never tracked and the work runs to completion
+ * server-side with no handle to poll, cancel, or read.
+ *
+ * Identification is by shape (`taskId`) rather than by discriminator, which is
+ * the point; callers pass a window of messages received during ONE request so
+ * a later `tasks/get` response cannot be mistaken for a creation.
+ */
+export function findRawTaskResponse(
+  messages: unknown[]
+): RawTaskResponse | undefined {
+  for (const message of messages) {
+    if (!isRecord(message)) continue;
+    const result = isRecord(message.result) ? message.result : undefined;
+    if (!result) continue;
+    if (typeof result.taskId !== "string" || result.taskId.length === 0) {
+      continue;
+    }
+    return {
+      taskId: result.taskId,
+      resultType: result.resultType,
+      discriminated: result.resultType === "task",
+    };
+  }
+  return undefined;
+}
+
+/** The failure a missing/wrong `resultType: "task"` actually causes. */
+function describeUndiscriminatedTask(raw: RawTaskResponse): string {
+  return `the server answered a tools/call with a flat task payload (taskId ${JSON.stringify(
+    raw.taskId
+  )}) that does not carry resultType "task"${
+    raw.resultType === undefined
+      ? ""
+      : ` (got ${JSON.stringify(raw.resultType)})`
+  }; tasks.md:102 makes that discriminator a MUST because it is the ONLY signal separating a CreateTaskResult from a standard result. This client decoded the response as an ordinary tool result, so the task is UNREACHABLE: it is never tracked, and the work runs to completion server-side with no handle to poll, cancel, or read`;
+}
+
 /**
  * The task id a server smuggled into an UNDECLARED `tools/call`, or
  * `undefined` if it produced an ordinary result.
@@ -771,9 +827,15 @@ export class MCPTasksConformanceTest {
     );
     const checks: MCPTasksCheckResult[] = [];
     const sent: unknown[] = [];
+    // The RAW inbound bytes. Every task check that has to judge the
+    // discriminator reads this, because by the time a result reaches the
+    // manager the decoder has already made up its mind — see
+    // {@link findRawTaskResponse}. Captured once, used by both creation checks.
+    const received: unknown[] = [];
 
     const captureRpc = (event: RpcLogEvent) => {
       if (event.direction === "send") sent.push(event.message);
+      else received.push(event.message);
       this.config.serverConfig.rpcLogger?.(event);
     };
 
@@ -835,8 +897,11 @@ export class MCPTasksConformanceTest {
 
           let createdTaskId: string | undefined;
           let creationResult: unknown;
+          /** The creation response as it arrived, before decoding. */
+          let rawCreation: RawTaskResponse | undefined;
 
           if (wire !== "none" && probeTool) {
+            const receivedBefore = received.length;
             try {
               creationResult =
                 wire === "extension"
@@ -857,12 +922,37 @@ export class MCPTasksConformanceTest {
             } catch (error) {
               creationResult = error;
             }
+            // Read the wire regardless of how decoding went: an
+            // undiscriminated task both LOOKS like a plain result and can make
+            // result decoding fail, and neither may be scored as conformance.
+            rawCreation = findRawTaskResponse(received.slice(receivedBefore));
           }
 
           if (selected.has("tasks-result-type-discipline")) {
             const stepStartedAt = Date.now();
             if (!probeTool) {
               checks.push(missingProbeTool("tasks-result-type-discipline"));
+            } else if (
+              wire === "extension" &&
+              rawCreation &&
+              !rawCreation.discriminated
+            ) {
+              // BEFORE the decoded-result branches, and deliberately so: this
+              // is the one violation the decoded result cannot show, because
+              // an undiscriminated task arrives as an ordinary result (or
+              // fails decoding). Judged on the wire, it is unambiguous.
+              checks.push(
+                failed(
+                  "tasks-result-type-discipline",
+                  Date.now() - stepStartedAt,
+                  describeUndiscriminatedTask(rawCreation),
+                  {
+                    tool: probeTool.name,
+                    taskId: rawCreation.taskId,
+                    resultType: rawCreation.resultType ?? null,
+                  }
+                )
+              );
             } else if (creationResult instanceof Error) {
               checks.push(
                 failed(
@@ -879,16 +969,13 @@ export class MCPTasksConformanceTest {
               // Server-decided: declining to produce a task is conformant, as
               // long as what comes back is a normal tool result.
               //
-              // KNOWN BLIND SPOT: a CreateTaskResult that omits `resultType`
-              // also lands here. Task detection is keyed on
-              // `resultType === "task"` at the transport seam
-              // (`rewriteTaskResultMessage`), so a discriminator-less creation
-              // never reaches this runner AS a task — it arrives as an
-              // ordinary result (or fails result decoding upstream and lands
-              // in the branch above). Catching that omission needs the RAW
-              // response, which this runner does not observe; the assertion
-              // lives in `validateCreateTaskShape` for the payloads that do
-              // reach it and for direct callers of the exported validator.
+              // This branch used to be a blind spot: a `CreateTaskResult` with
+              // no `resultType` lands here too, since task detection is keyed
+              // on `resultType === "task"` at the transport seam
+              // (`rewriteTaskResultMessage`), so it arrives as an ordinary
+              // result. It no longer reaches this branch — the raw-wire check
+              // above judges the discriminator on the bytes, so "the server
+              // declined a task" now means the wire carried no task at all.
               checks.push(
                 isRecord(creationResult)
                   ? passed(
@@ -946,7 +1033,8 @@ export class MCPTasksConformanceTest {
               const creation = await this.probeUndeclaredCreation(
                 manager,
                 serverId,
-                probeTool.name
+                probeTool.name,
+                received
               );
               const stepDurationMs = Date.now() - stepStartedAt;
               if (creation.outcome === "created") {
@@ -954,8 +1042,16 @@ export class MCPTasksConformanceTest {
                   failed(
                     "tasks-undeclared-creation-refused",
                     stepDurationMs,
-                    "an undeclared tools/call returned a CreateTaskResult; a server must not create a task for a client that never declared the tasks capability (it must answer normally or reject with -32003)",
-                    { tool: probeTool.name, taskId: creation.taskId }
+                    `an undeclared tools/call returned a CreateTaskResult; a server must not create a task for a client that never declared the tasks capability (it must answer normally or reject with -32003)${
+                      creation.discriminated
+                        ? ""
+                        : '. The payload also carries no resultType "task" discriminator, so it was only visible on the raw wire — a client cannot discriminate it and the task is unreachable (tasks.md:102)'
+                    }`,
+                    {
+                      tool: probeTool.name,
+                      taskId: creation.taskId,
+                      discriminated: creation.discriminated,
+                    }
                   )
                 );
               } else if (creation.outcome === "errored") {
@@ -1360,28 +1456,53 @@ export class MCPTasksConformanceTest {
    *     and is minted only from a server error response, while local and
    *     transport faults are `SdkError`s with STRING codes. This is a check
    *     FAILURE, because nothing about the server was observed.
+   *
+   * THREE places have to be read, and the wire is the last word. Beyond the
+   * decoded result and the manager's `_meta` stash, the RAW response decides:
+   * a task payload with no `resultType: "task"` is invisible to both of the
+   * others (see {@link findRawTaskResponse}), so a server that violates
+   * tasks.md:61 AND tasks.md:102 at once would otherwise score a pass on the
+   * strength of its second violation.
    */
   private async probeUndeclaredCreation(
     manager: MCPClientManager,
     serverId: string,
-    toolName: string
+    toolName: string,
+    received: unknown[]
   ): Promise<
-    | { outcome: "created"; taskId: string }
+    | { outcome: "created"; taskId: string; discriminated: boolean }
     | { outcome: "answered" }
     | { outcome: "refused"; code: number; message: string }
     | { outcome: "errored"; message: string }
   > {
+    const receivedBefore = received.length;
+    const rawTask = () => findRawTaskResponse(received.slice(receivedBefore));
     try {
       const result = await manager.executeTool(
         serverId,
         toolName,
         this.config.toolArguments ?? {}
       );
-      const taskId = extractUndeclaredCreationTaskId(result);
+      const raw = rawTask();
+      const taskId = extractUndeclaredCreationTaskId(result) ?? raw?.taskId;
       return taskId === undefined
         ? { outcome: "answered" }
-        : { outcome: "created", taskId };
+        : {
+            outcome: "created",
+            taskId,
+            discriminated: raw?.discriminated ?? true,
+          };
     } catch (error) {
+      // An undiscriminated task can also blow up result decoding; the wire
+      // still says a task was created, and that is the violation.
+      const raw = rawTask();
+      if (raw) {
+        return {
+          outcome: "created",
+          taskId: raw.taskId,
+          discriminated: raw.discriminated,
+        };
+      }
       const code = errorCode(error);
       const message = errorMessage(error);
       return code === undefined

--- a/sdk/tests/support/extension-tasks-fixture.ts
+++ b/sdk/tests/support/extension-tasks-fixture.ts
@@ -171,6 +171,15 @@ export interface ExtensionTasksMisbehavior {
   /** `resultType` on `CreateTaskResult`. Spec requires `"task"` (MUST). */
   createResultType?: string;
   /**
+   * OMIT `resultType` from `CreateTaskResult` entirely — distinct from
+   * {@link createResultType}, which can only change its VALUE. Absence is the
+   * more dangerous violation of tasks.md:102: a wrong value at least stays
+   * visible, while an absent one makes the task invisible to a client that
+   * discriminates on it, so the response reads as an ordinary tool result.
+   * Wins over `createResultType` when both are set.
+   */
+  omitCreateResultType?: boolean;
+  /**
    * `resultType` on `tasks/get`. The prose requires `"complete"`; setting it
    * to `"task"` is the "wrong discriminator" case. To OMIT it instead (which
    * is arguably schema-conformant, not misbehavior) use
@@ -770,7 +779,9 @@ export async function serveExtensionTasksFixture(
         // `CreateTaskResult = Result & Task` — flat, and bare `Task` fields
         // only (no inputRequests/result/error).
         return {
-          resultType: misbehavior.createResultType ?? "task",
+          ...(misbehavior.omitCreateResultType
+            ? {}
+            : { resultType: misbehavior.createResultType ?? "task" }),
           ...taskFields(entry),
         };
       }

--- a/sdk/tests/tasks-conformance/runner-fixture.integration.test.ts
+++ b/sdk/tests/tasks-conformance/runner-fixture.integration.test.ts
@@ -158,8 +158,8 @@ describe("MCPTasksConformanceTest against the extension fixture", () => {
       ).toBeGreaterThan(0);
     }
     // …and the runner agrees, per probe, that it did.
-    const probes = check(result, "tasks-undeclared-capability-rejected").details
-      ?.probes as Array<{
+    const probes = (check(result, "tasks-undeclared-capability-rejected")
+      .details?.probes ?? []) as Array<{
       method: string;
       outcome: string;
       reachedWire?: boolean;
@@ -233,6 +233,41 @@ describe("MCPTasksConformanceTest against the extension fixture", () => {
     expect(creation.details).toMatchObject({ tool: TASK_TOOL_NAME });
     // The violation is real on the wire, not inferred: the fixture minted a
     // second task for the call that carried no declaration.
+    expect(fixture.tasks().length).toBeGreaterThan(1);
+    expect(result.passed).toBe(false);
+  });
+
+  it("fails the discipline check when a task carries no resultType discriminator", async () => {
+    // The invisible-task break. The server DOES create a task, but omits the
+    // one field that says so, and this client decodes the response as an
+    // ordinary tool result — so the work runs to completion server-side with
+    // no handle. Detection has to read the raw wire, because by the time the
+    // result reaches the runner it no longer looks like a task at all.
+    const fixture = await serve({ misbehave: { omitCreateResultType: true } });
+    const result = await runAgainst(fixture);
+
+    const discipline = check(result, "tasks-result-type-discipline");
+    expect(discipline.status).toBe("failed");
+    expect(discipline.error?.message).toContain('resultType "task"');
+    expect(discipline.error?.message).toContain("UNREACHABLE");
+    // The task really exists on the server — this is a lost handle, not a
+    // server that simply declined to create one.
+    expect(fixture.tasks().length).toBeGreaterThan(0);
+    expect(result.passed).toBe(false);
+  });
+
+  it("fails the creation check when a non-declaring caller gets a task with no discriminator", async () => {
+    // Doubly-misbehaving: violates tasks.md:61 (task for an undeclaring
+    // caller) AND tasks.md:102 (no discriminator) at once. Before the raw
+    // capture this scored a PASS, because the second violation hid the first.
+    const fixture = await serve({
+      misbehave: { createTaskForUndeclaredCall: true, omitCreateResultType: true },
+    });
+    const result = await runAgainst(fixture);
+
+    const creation = check(result, "tasks-undeclared-creation-refused");
+    expect(creation.status).toBe("failed");
+    expect(creation.error?.message).toContain("raw wire");
     expect(fixture.tasks().length).toBeGreaterThan(1);
     expect(result.passed).toBe(false);
   });

--- a/sdk/tests/tasks-ext-era-gate.test.ts
+++ b/sdk/tests/tasks-ext-era-gate.test.ts
@@ -28,6 +28,9 @@ import {
   createManagedMcpClient,
   wrapLegacyClient,
 } from "../src/mcp-client-manager/managed-mcp-client-factory.js";
+import { OfficialSdkClientAdapter } from "../src/mcp-client-manager/official-sdk-client-adapter.js";
+import { LogLevelMetaClient } from "../src/mcp-client-manager/log-level-meta-client.js";
+import type { ManagedMcpClient } from "../src/mcp-client-manager/managed-mcp-client.js";
 
 const MODERN_ERA = "2026-07-28";
 const LEGACY_ERA = "2025-11-25";
@@ -135,6 +138,64 @@ describe("tasks extension era-gate shadow", () => {
       getTaskExt({ client: managed, declaredCapabilities: undefined }, "t")
     ).rejects.toThrow();
     expect(Object.prototype.hasOwnProperty.call(inner, GATE)).toBe(true);
+  });
+
+  describe("resolving the instance to shadow", () => {
+    const hasGate = (target: object) =>
+      Object.prototype.hasOwnProperty.call(target, GATE);
+
+    it("shadows an adapter built WITHOUT the factory", async () => {
+      // The previously-broken case: nothing registered this pairing, so the
+      // lookup used to no-op and upstream's gate went on to refuse the send.
+      const client = new Client({ name: "test", version: "0.0.0" }, {});
+      const adapter = new OfficialSdkClientAdapter(client);
+      expect(hasGate(client)).toBe(false);
+
+      await expect(
+        getTaskExt({ client: adapter, declaredCapabilities: undefined }, "t")
+      ).rejects.toThrow();
+      expect(hasGate(client)).toBe(true);
+    });
+
+    it("walks a decorator chain over an unregistered adapter", async () => {
+      const client = new Client({ name: "test", version: "0.0.0" }, {});
+      const decorated = new LogLevelMetaClient(
+        new OfficialSdkClientAdapter(client),
+        () => "warning"
+      );
+
+      await expect(
+        getTaskExt({ client: decorated, declaredCapabilities: undefined }, "t")
+      ).rejects.toThrow();
+      expect(hasGate(client)).toBe(true);
+    });
+
+    it("stays a silent no-op for a double with no upstream client", async () => {
+      // Nothing in the chain is a client, so there is no era gate to shadow —
+      // that must not be confused with a moved seam.
+      const double = {
+        requestWithSchema: async () => ({}),
+      } as unknown as ManagedMcpClient;
+      await expect(
+        cancelTaskExt({ client: double, declaredCapabilities: undefined }, "t")
+      ).resolves.toEqual({});
+    });
+
+    it("terminates on a self-referential delegation chain", async () => {
+      const looped: Record<string, unknown> = {
+        requestWithSchema: async () => ({}),
+      };
+      looped.inner = looped;
+      await expect(
+        cancelTaskExt(
+          {
+            client: looped as unknown as ManagedMcpClient,
+            declaredCapabilities: undefined,
+          },
+          "t"
+        )
+      ).resolves.toEqual({});
+    });
   });
 
   describe("a client whose seam is missing", () => {


### PR DESCRIPTION
Follow-up to #3511, from the cubic review on that PR. Full suite green: 165 files / 2867 tests, `tsc --noEmit` clean.

## 1. The discriminator blind spot — closed

#3511 shipped with this documented as a KNOWN BLIND SPOT. It has more teeth than that framing gave it.

A server that answers a `tools/call` with a flat task payload carrying **no** `resultType: "task"` was invisible to every check that reads the *decoded* result. Task detection keys on that discriminator at the transport seam, so the payload is never recognised as a task and arrives as an ordinary `CallToolResult` — scoring **green** on both `tasks-result-type-discipline` ("server declined the task") and `tasks-undeclared-creation-refused`.

That's the invisible-task interop break, not a cosmetic deviation: the client cannot discriminate the response, the task is never tracked, and the work runs to completion server-side with no handle to poll, cancel, or read. Worse, a **doubly**-misbehaving server violating tasks.md:61 *and* tasks.md:102 at once passed precisely **because** the second violation concealed the first.

Both checks now judge the discriminator on the raw inbound JSON-RPC, off a single capture rather than two paths, identifying a task by shape (`taskId`) since the discriminator is the thing under test. The failure message names the consequence and cites tasks.md:102 rather than just reporting a missing field.

The fixture gains `omitCreateResultType`, which drops the key entirely — distinct from the existing `createResultType`, which could only change its value. Absence is the more dangerous violation, since a wrong value at least stays visible.

## 2. Era-gate target resolution

The shadow was installed only for clients registered by the factory, so a directly-constructed `OfficialSdkClientAdapter` silently no-opped and the upstream era gate then blocked `tasks/get`/`tasks/cancel` locally with an opaque `METHOD_NOT_SUPPORTED_BY_PROTOCOL_VERSION`. It failed *closed* rather than producing a false pass, but an unregistered client was indistinguishable from a registered one until a tasks call failed.

The `WeakMap` is now a fast path rather than the only path: resolution falls back to walking the public `inner` delegation chain, depth-capped at 16 (doubling as the cycle guard), stopping at the first upstream `Client`. `inner` is promoted to a documented optional member of `ManagedMcpClient` so the walk is a stated seam rather than a guess at a private detail — both existing implementers already exposed it, so no implementation changed.

A remaining `undefined` now means exactly one thing: no upstream client anywhere in the chain, i.e. a test double with no gate to shadow. Every earlier invariant holds — resolution never runs at construct or connect time, the seam-missing case still throws `TasksExtEraGateSeamError` on a tasks operation with nothing sent, the exemption is still the three methods on era `2026-07-28`, and legacy 2025-11-25 is untouched.

## 3. Smaller

Corrects the now-stale "ONE send path" comment: the conformance runner deliberately bypasses that helper for **undeclared** probes, because the helper always attaches the eligibility declaration and the probes exist to observe `-32003`.

One review comment is **recorded rather than fixed**: `resultType: undefined` as an *own* property is unreachable over the wire — JSON has no `undefined` literal, and a reviver returning `undefined` deletes the key. Hand-built test objects only, so a runtime branch would be dead code. Verified empirically, and a comment now says so to stop a future "fix".

## Tests

New integration cases assert both directions the old code got wrong: a declared call returning a flat task with no discriminator fails the discipline check, and a doubly-misbehaving server (undeclared call *and* no discriminator) fails the creation check. Plus four era-gate cases covering an unregistered adapter, a decorator chain over one, a double with no client, and a self-referential `inner` chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect MCP tasks extension conformance verdicts and lazy era-gate installation on real client delegation chains; wrong resolution could block or mis-shadow `tasks/*` on 2026-07-28, but scope is limited to tasks conformance and extension send paths with new tests.
> 
> **Overview**
> Follow-up to Workstream A (#3511): closes the **discriminator blind spot** in tasks conformance and makes the **2026-07-28 era-gate shadow** work for clients not built through the factory.
> 
> **Conformance** now records inbound RPC and uses `findRawTaskResponse` to spot flat task payloads by `taskId` before decoding. `tasks-result-type-discipline` and `tasks-undeclared-creation-refused` fail when `resultType: "task"` is missing—cases that previously looked like a normal tool result or a declined task. The extension fixture adds `omitCreateResultType`; integration tests cover undiscriminated and doubly-misbehaving servers.
> 
> **Era gate**: `ManagedMcpClient.inner` is documented; `resolveTasksExtensionEraGateTarget` walks the `inner` chain (depth 16) after the factory `WeakMap`, with duck-typing for duplicate `@modelcontextprotocol/client` installs. Direct `OfficialSdkClientAdapter` / decorator stacks get the same shadow as factory-built clients.
> 
> Docs note A2’s follow-up fix; `tasks-ext.ts` clarifies undeclared conformance probes bypass the declaring send path; schema comment documents `resultType: undefined` as hand-built-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit effbb0b1b24ad59cbc54486bf75498460b25e454. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the “invisible task” bug by judging the `resultType: "task"` discriminator on the raw JSON‑RPC, so misbehaving servers no longer pass conformance. Also makes era‑gate shadowing work for non‑factory clients by resolving the target via the `inner` delegation chain.

- **Bug Fixes**
  - Conformance: capture inbound JSON‑RPC and detect task creations by shape (`taskId`) to verify the `resultType: "task"` discriminator on the wire; clearer failure explaining the lost handle (tasks.md:102).
  - Fixture: added `omitCreateResultType` to simulate a missing discriminator; new integration tests cover declared and undeclared creations without the discriminator.
  - Era‑gate: resolve the target client via a `WeakMap` fast path or by walking `ManagedMcpClient.inner` (depth cap 16), so a directly constructed `OfficialSdkClientAdapter` gets shadowed; `inner` is now a documented optional member; true doubles with no upstream client remain a no‑op; still throws `TasksExtEraGateSeamError` when the seam is missing.
  - Tasks send path: clarified that undeclared conformance probes bypass the helper (they still install the shadow themselves).
  - Validator/doc: note that JSON cannot carry `resultType: undefined`; validators treat it as absent.

<sup>Written for commit effbb0b1b24ad59cbc54486bf75498460b25e454. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3515?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

